### PR TITLE
fix ddl sync for table drop and truncate

### DIFF
--- a/dbms/src/Storages/Transaction/TiDBSchemaSyncer.h
+++ b/dbms/src/Storages/Transaction/TiDBSchemaSyncer.h
@@ -99,6 +99,7 @@ struct TiDBSchemaSyncer : public SchemaSyncer
             builder.updateDB(db);
             db_ids.insert(db->id);
         }
+        // Drop databases;
         for (auto it = databases.begin(); it != databases.end(); it++)
         {
             if (db_ids.count(it->first) == 0)


### PR DESCRIPTION
* when we drop a table when flash server is closed, we should sync this
drop when restart flash server.