### PR TITLE
Fix float value in create statement

### DIFF
--- a/dbms/src/Common/FieldVisitors.cpp
+++ b/dbms/src/Common/FieldVisitors.cpp
@@ -21,6 +21,14 @@ static inline String formatQuoted(T x)
 }
 
 template <typename T>
+static inline void writeQuoted(const DecimalField<T> & x, WriteBuffer & buf)
+{
+    writeChar('\'', buf);
+    writeText(x.getValue(), x.getScale(), buf);
+    writeChar('\'', buf);
+}
+
+template <typename T>
 static inline String formatQuotedWithPrefix(T x, const char * prefix)
 {
     WriteBufferFromOwnString wb;
@@ -108,10 +116,10 @@ String FieldVisitorToString::operator() (const UInt64 & x) const { return format
 String FieldVisitorToString::operator() (const Int64 & x) const { return formatQuoted(x); }
 String FieldVisitorToString::operator() (const Float64 & x) const { return formatFloat(x); }
 String FieldVisitorToString::operator() (const String & x) const { return formatQuoted(x); }
-String FieldVisitorToString::operator() (const DecimalField<Decimal32> & x) const { return "Decimal32_" + x.toString(); }
-String FieldVisitorToString::operator() (const DecimalField<Decimal64> & x) const { return "Decimal64_" + x.toString(); }
-String FieldVisitorToString::operator() (const DecimalField<Decimal128> & x) const { return "Decimal128_" + x.toString(); }
-String FieldVisitorToString::operator() (const DecimalField<Decimal256> & x) const { return "Decimal256_" + x.toString(); }
+String FieldVisitorToString::operator() (const DecimalField<Decimal32> & x) const { return formatQuoted(x); }
+String FieldVisitorToString::operator() (const DecimalField<Decimal64> & x) const { return formatQuoted(x); }
+String FieldVisitorToString::operator() (const DecimalField<Decimal128> & x) const { return formatQuoted(x); }
+String FieldVisitorToString::operator() (const DecimalField<Decimal256> & x) const { return formatQuoted(x); }
 
 
 String FieldVisitorToString::operator() (const Array & x) const


### PR DESCRIPTION
If we create a table with float devalue value
```
create table tt(i Int32) engine = Null
alter table tt add column f32 Float32 default 1.234
```

We get a schema like this: `db/metadata/default/tt.sql`
```
ATTACH TABLE tt
(
    i Int32,
    f32 Float32 DEFAULT CAST(Decimal32_1.234 AS Float32)
)
ENGINE = Null
```

If we stop and start TiFlash again, we get exception when loading table schema from disk
```
2019.08.23 22:32:12.919765 [ 1 ] <Error> Application: DB::Exception: Cannot create table from metadata file /Users/jayson/Projects
/pingcap/algernon/log/tiflash0/data/db/metadata/default//tt.sql, error: DB::Exception: Unknown identifier: Decimal32_1, stack trac
e:
0. 0   theflash                            0x00000001083d9b1e _ZN10StackTraceC2Ev + 30
1. 1   theflash                            0x00000001083d9b55 _ZN10StackTraceC1Ev + 21
2. 2   theflash                            0x00000001085a1903 _ZN2DB9ExceptionC2ERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEEi + 83
3. 3   theflash                            0x000000010859e3a3 _ZN2DB9ExceptionC1ERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEEi + 35
4. 4   theflash                            0x000000010fb5f67e _ZN2DB18ExpressionAnalyzer18collectUsedColumnsEv + 3646
5. 5   theflash                            0x000000010fb5b79e _ZN2DB18ExpressionAnalyzerC2ERKNSt3__110shared_ptrINS_4IASTEEERKNS_7ContextERKNS2_INS_8IStorageEEERKNS_17NamesAndTypesListERKNS1_6vectorINS1_12basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEENSL_ISN_EEEEmbRKNS1_13unordered_mapISN_NS_14SubqueryForSetENS1_4hashISN_EENS1_8equal_toISN_EENSL_INS1_4pairIKSN_ST_EEEEEE + 2094
6. 6   theflash                            0x000000010fb603b0 _ZN2DB18ExpressionAnalyzerC1ERKNSt3__110shared_ptrINS_4IASTEEERKNS_7ContextERKNS2_INS_8IStorageEEERKNS_17NamesAndTypesListERKNS1_6vectorINS1_12basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEENSL_ISN_EEEEmbRKNS1_13unordered_mapISN_NS_14SubqueryForSetENS1_4hashISN_EENS1_8equal_toISN_EENSL_INS1_4pairIKSN_ST_EEEEEE + 128
7. 7   theflash                            0x000000010fc331e0 _ZN2DBL12parseColumnsERKNS_17ASTExpressionListERKNS_7ContextE + 2304
```


This PR make decimal value wrote as a string in `CAST` statement.

```
ATTACH TABLE tt
(
    i Int32,
    f32 Float32 DEFAULT CAST('1.234' AS Float32)
)
ENGINE = Null
```