### PR TITLE
Fix bug about filter marks in tmt select executor

### DIFF
--- a/dbms/src/Storages/MergeTree/MergeTreeDataSelectExecutorCommon.hpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataSelectExecutorCommon.hpp
@@ -87,7 +87,7 @@ static inline MarkRanges markRangesFromRegionRange(const MergeTreeData::DataPart
         if (range.end != marks_count)
             index_right_handle = static_cast<TargetType>(index[0]->getUInt(range.end));
 
-        if (handle_begin >= index_right_handle || index_left_handle >= handle_end)
+        if (handle_begin > index_right_handle || index_left_handle >= handle_end)
             continue;
 
         if (range.end == range.begin + 1)


### PR DESCRIPTION
Because there may be multi different version for same handle, so only when start key is bigger than the right handle of index.

I found this bug a few months ago, but forgot to fix it later.