### PR TITLE
[FLASH-513] Refactor region mapping in RegionTable

### DIFF
--- a/dbms/src/Debug/MockTiDB.cpp
+++ b/dbms/src/Debug/MockTiDB.cpp
@@ -51,7 +51,7 @@ TablePtr MockTiDB::dropTableInternal(Context & context, const String & database_
             {
                 for (auto & e : region_table.getRegionsByTable(partition.id))
                     kvstore->removeRegion(e.first, &region_table, kvstore->genTaskLock());
-                region_table.mockDropRegionsInTable(partition.id);
+                region_table.removeTable(partition.id);
             }
         }
     }
@@ -63,7 +63,7 @@ TablePtr MockTiDB::dropTableInternal(Context & context, const String & database_
     {
         for (auto & e : region_table.getRegionsByTable(table->id()))
             kvstore->removeRegion(e.first, &region_table, kvstore->genTaskLock());
-        region_table.mockDropRegionsInTable(table->id());
+        region_table.removeTable(table->id());
     }
 
     return table;

--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -1422,13 +1422,12 @@ void Context::createTMTContext(const std::vector<std::string> & pd_addrs,
                                const std::string & learner_key,
                                const std::string & learner_value,
                                const std::unordered_set<std::string> & ignore_databases,
-                               const std::string & kvstore_path,
-                               const std::string & region_mapping_path)
+                               const std::string & kvstore_path)
 {
     auto lock = getLock();
     if (shared->tmt_context)
         throw Exception("TMTContext has already existed", ErrorCodes::LOGICAL_ERROR);
-    shared->tmt_context = std::make_shared<TMTContext>(*this, pd_addrs, learner_key, learner_value, ignore_databases, kvstore_path, region_mapping_path);
+    shared->tmt_context = std::make_shared<TMTContext>(*this, pd_addrs, learner_key, learner_value, ignore_databases, kvstore_path);
 }
 
 void Context::initializePartPathSelector(const std::vector<std::string> & all_path)

--- a/dbms/src/Interpreters/Context.h
+++ b/dbms/src/Interpreters/Context.h
@@ -366,8 +366,7 @@ public:
                           const std::string & learner_key,
                           const std::string & learner_value,
                           const std::unordered_set<std::string> & ignore_databases,
-                          const std::string & kvstore_path,
-                          const std::string & region_mapping_path);
+                          const std::string & kvstore_path);
     RaftService & getRaftService();
 
     void initializeSchemaSyncService();

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -335,7 +335,6 @@ int Server::main(const std::vector<std::string> & /*args*/)
     std::string learner_value;
     std::unordered_set<std::string> ignore_databases{"system"};
     std::string kvstore_path = path + "kvstore/";
-    std::string region_mapping_path = path + "regmap/";
 
     if (config().has("raft"))
     {
@@ -392,16 +391,11 @@ int Server::main(const std::vector<std::string> & /*args*/)
         {
             kvstore_path = config().getString("raft.kvstore_path");
         }
-
-        if (config().has("raft.regmap"))
-        {
-            region_mapping_path = config().getString("raft.regmap");
-        }
     }
 
     {
         /// create TMTContext
-        global_context->createTMTContext(pd_addrs, learner_key, learner_value, ignore_databases, kvstore_path, region_mapping_path);
+        global_context->createTMTContext(pd_addrs, learner_key, learner_value, ignore_databases, kvstore_path);
     }
 
     /// Then, load remaining databases

--- a/dbms/src/Storages/Transaction/KVStore.cpp
+++ b/dbms/src/Storages/Transaction/KVStore.cpp
@@ -411,14 +411,6 @@ void KVStore::removeRegion(const RegionID region_id, RegionTable * region_table,
     LOG_INFO(log, "Remove [region " << region_id << "] done");
 }
 
-void KVStore::updateRegionTableBySnapshot(RegionTable & region_table)
-{
-    auto manage_lock = genRegionManageLock();
-    LOG_INFO(log, "start to update RegionTable by snapshot");
-    region_table.applySnapshotRegions(regions());
-    LOG_INFO(log, "update RegionTable done");
-}
-
 KVStoreTaskLock KVStore::genTaskLock() const { return KVStoreTaskLock(task_mutex); }
 RegionMap & KVStore::regionsMut() { return region_manager.regions; }
 const RegionMap & KVStore::regions() const { return region_manager.regions; }

--- a/dbms/src/Storages/Transaction/KVStore.h
+++ b/dbms/src/Storages/Transaction/KVStore.h
@@ -61,8 +61,6 @@ public:
 
     size_t regionSize() const;
 
-    void updateRegionTableBySnapshot(RegionTable & region_table);
-
 private:
     friend class MockTiDB;
     friend struct MockTiDBTable;

--- a/dbms/src/Storages/Transaction/RegionTable.h
+++ b/dbms/src/Storages/Transaction/RegionTable.h
@@ -117,15 +117,13 @@ public:
     };
 
 private:
-    const std::string parent_path;
-
     TableMap tables;
     RegionInfoMap regions;
     std::unordered_set<RegionID> dirty_regions;
 
     FlushThresholds flush_thresholds;
 
-    Context & context;
+    Context * const context;
 
     mutable std::mutex mutex;
     Logger * log;
@@ -139,17 +137,13 @@ private:
 
     bool shouldFlush(const InternalRegion & region) const;
 
-    void flushRegion(TableID table_id, RegionID region_id, const bool try_persist = true);
+    void flushRegion(TableID table_id, RegionID region_id, const bool try_persist = true) const;
 
-    // For debug
-    friend class MockTiDB;
-    friend struct MockTiDBTable;
-
-    void mockDropRegionsInTable(TableID table_id);
     void doShrinkRegionRange(const Region & region);
+    void doUpdateRegion(const Region & region, TableID table_id);
 
 public:
-    RegionTable(Context & context_, const std::string & parent_path_);
+    RegionTable(Context & context_);
     void restore();
 
     void setFlushThresholds(const FlushThresholds::FlushThresholdsData & flush_thresholds_);
@@ -161,7 +155,6 @@ public:
     void updateRegion(const Region & region, const TableIDSet & relative_table_ids);
     /// A new region arrived by apply snapshot command, this function store the region into selected partitions.
     void applySnapshotRegion(const Region & region);
-    void applySnapshotRegions(const RegionMap & regions);
 
     void updateRegionForSplit(const Region & split_region, const RegionID source_region);
 
@@ -179,8 +172,8 @@ public:
     void tryFlushRegion(RegionID region_id);
     void tryFlushRegion(RegionID region_id, TableID table_id, const bool try_persist);
 
-    void traverseInternalRegionsByTable(const TableID table_id, std::function<void(const InternalRegion &)> && callback);
-    std::vector<std::pair<RegionID, RegionPtr>> getRegionsByTable(const TableID table_id);
+    void traverseInternalRegionsByTable(const TableID table_id, std::function<void(const InternalRegion &)> && callback) const;
+    std::vector<std::pair<RegionID, RegionPtr>> getRegionsByTable(const TableID table_id) const;
 
     /// Write the data of the given region into the table with the given table ID, fill the data list for outer to remove.
     /// Will trigger schema sync on read error for only once,

--- a/dbms/src/Storages/Transaction/TMTContext.cpp
+++ b/dbms/src/Storages/Transaction/TMTContext.cpp
@@ -11,10 +11,9 @@ namespace DB
 {
 
 TMTContext::TMTContext(Context & context, const std::vector<std::string> & addrs, const std::string & learner_key,
-    const std::string & learner_value, const std::unordered_set<std::string> & ignore_databases_, const std::string & kvstore_path,
-    const std::string & region_mapping_path)
+    const std::string & learner_value, const std::unordered_set<std::string> & ignore_databases_, const std::string & kvstore_path)
     : kvstore(std::make_shared<KVStore>(kvstore_path)),
-      region_table(context, region_mapping_path),
+      region_table(context),
       pd_client(addrs.size() == 0 ? static_cast<pingcap::pd::IClient *>(new pingcap::pd::MockPDClient())
                                   : static_cast<pingcap::pd::IClient *>(new pingcap::pd::Client(addrs))),
       region_cache(std::make_shared<pingcap::kv::RegionCache>(pd_client, learner_key, learner_value)),
@@ -29,7 +28,6 @@ void TMTContext::restore()
 {
     kvstore->restore([&](pingcap::kv::RegionVerID id) -> pingcap::kv::RegionClientPtr { return this->createRegionClient(id); });
     region_table.restore();
-    kvstore->updateRegionTableBySnapshot(region_table);
     initialized = true;
 }
 

--- a/dbms/src/Storages/Transaction/TMTContext.h
+++ b/dbms/src/Storages/Transaction/TMTContext.h
@@ -37,8 +37,7 @@ public:
 
     // TODO: get flusher args from config file
     explicit TMTContext(Context & context, const std::vector<std::string> & addrs, const std::string & learner_key,
-        const std::string & learner_value, const std::unordered_set<std::string> & ignore_databases_, const std::string & kv_store_path,
-        const std::string & region_mapping_path);
+        const std::string & learner_value, const std::unordered_set<std::string> & ignore_databases_, const std::string & kv_store_path);
 
     SchemaSyncerPtr getSchemaSyncer() const;
     void setSchemaSyncer(SchemaSyncerPtr);


### PR DESCRIPTION
* Optimize flushing regions by import dirty map and reduce state variables.

* Remove the way to use empty file to store table id in RegionTable and get table from TMTStorages.