### PR TITLE
change decimal(0,0) from TiDB to decimal(1,0) in TiFlash

### DIFF
--- a/dbms/src/Storages/Transaction/TypeMapping.cpp
+++ b/dbms/src/Storages/Transaction/TypeMapping.cpp
@@ -117,7 +117,7 @@ std::enable_if_t<IsSignedType<T>, DataTypePtr> getDataTypeByColumnInfoBase(const
 template <typename T, bool should_widen>
 std::enable_if_t<IsDecimalType<T>, DataTypePtr> getDataTypeByColumnInfoBase(const ColumnInfo & column_info, const T *)
 {
-    DataTypePtr t = createDecimal(column_info.flen, column_info.decimal);
+    DataTypePtr t = createDecimal(column_info.flen == 0 && column_info.decimal == 0 ? 1 : column_info.flen, column_info.decimal);
 
     if (should_widen)
     {


### PR DESCRIPTION
 In TiDB decimal(0,0) is a valid type, but in TiFlash decimal's min precision is 1, this pr change decimal(0,0) to decimal(1,0) in TiFlash