### PR TITLE
[FLASH-306] Try to optimize table if replica is removed

### DIFF
--- a/dbms/src/Storages/Transaction/RegionDataMover.h
+++ b/dbms/src/Storages/Transaction/RegionDataMover.h
@@ -14,4 +14,6 @@ using HandleMap = std::unordered_map<HandleID, std::tuple<UInt64, UInt8>>;
 template <typename HandleType>
 void getHandleMapByRange(Context &, StorageMergeTree &, const HandleRange<HandleType> &, HandleMap &);
 
+void tryOptimizeStorageFinal(Context &, TableID);
+
 } // namespace DB

--- a/dbms/src/Storages/Transaction/RegionTable.h
+++ b/dbms/src/Storages/Transaction/RegionTable.h
@@ -120,6 +120,7 @@ private:
     TableMap tables;
     RegionInfoMap regions;
     std::unordered_set<RegionID> dirty_regions;
+    std::unordered_set<TableID> table_to_clean;
 
     FlushThresholds flush_thresholds;
 
@@ -162,6 +163,8 @@ public:
     void shrinkRegionRange(const Region & region);
 
     void removeRegion(const RegionID region_id);
+
+    TableID popOneTableToClean();
 
     /// Try pick some regions and flush.
     /// Note that flush is organized by partition. i.e. if a regions is selected to be flushed, all regions belong to its partition will also flushed.

--- a/dbms/src/Storages/Transaction/applySnapshot.cpp
+++ b/dbms/src/Storages/Transaction/applySnapshot.cpp
@@ -77,7 +77,9 @@ bool applySnapshot(const KVStorePtr & kvstore, RegionPtr new_region, Context * c
                 continue;
             {
                 auto merge_tree = std::dynamic_pointer_cast<StorageMergeTree>(storage);
-                auto table_lock = merge_tree->lockStructure(true, __PRETTY_FUNCTION__);
+                auto table_lock = merge_tree->lockStructure(false, __PRETTY_FUNCTION__);
+                if (merge_tree->is_dropped)
+                    continue;
 
                 const bool pk_is_uint64 = getTMTPKType(*merge_tree->getData().primary_key_data_types[0]) == TMTPKType::UINT64;
 


### PR DESCRIPTION
DDL syntax: `ALTER TABLE [table_name] SET FLASH REPLICA [count] LOCATION LABELS [location_labels]`

if all corresponding regions of a table are removed, flash should optimize data parts. 