### PR TITLE
FLASH-568: Fix schema version setting to -1 when bootstrap

### DIFF
--- a/dbms/src/Storages/Transaction/SchemaBuilder.h
+++ b/dbms/src/Storages/Transaction/SchemaBuilder.h
@@ -50,7 +50,7 @@ private:
 
     void applyAlterPartition(TiDB::DBInfoPtr db_info, Int64 table_id);
 
-    void applyCreatePhysicalTableImpl(const TiDB::DBInfo & db_info, const TiDB::TableInfo & table_info);
+    void applyCreatePhysicalTableImpl(const TiDB::DBInfo & db_info, TiDB::TableInfo & table_info);
 
     void applyCreateTableImpl(const TiDB::DBInfo & db_info, TiDB::TableInfo & table_info);
 


### PR DESCRIPTION
When bootstrap doing schema syncing, schema version of the new created table will not be correctly set.