### PR TITLE
Adding set type support

### DIFF
--- a/dbms/src/Storages/Transaction/TiDB.h
+++ b/dbms/src/Storages/Transaction/TiDB.h
@@ -183,6 +183,7 @@ struct ColumnInfo
     CodecFlag getCodecFlag() const;
     DB::Field getDecimalValue(const String &) const;
     Int64 getEnumIndex(const String &) const;
+    UInt64 getSetValue(const String & set_str) const;
 };
 
 enum PartitionType


### PR DESCRIPTION
```
MySQL [test]> create table t_set (a set('1', '4', '10', '21') default 3);
MySQL [test]>  insert into t_set values();
MySQL [test]>  insert into t_set values();
MySQL [test]> explain select /*+ read_from_storage(tiflash[t_set])*/ * from t_set;
+-------------------+-------+--------------+----------------------------------------------------------------+
| id                | count | task         | operator info                                                  |
+-------------------+-------+--------------+----------------------------------------------------------------+
| TableReader_5     | 2.00  | root         | data:TableScan_4                                               |
| └─TableScan_4     | 2.00  | cop[tiflash] | table:t_set, range:[-inf,+inf], keep order:false, stats:pseudo |
+-------------------+-------+--------------+----------------------------------------------------------------+
2 rows in set (0.00 sec)

MySQL [test]> select /*+ read_from_storage(tiflash[t_set])*/ * from t_set;
+------+
| a    |
+------+
| 1,4  |
| 1,4  |
+------+
2 rows in set (0.01 sec)
```

This PR is tested on arrow_encode branch. 

TiColumnInfo.h needs add a check when there are unsupported field type such as set type, DAGDriver should use default encode rather than arrow encode. 