### PR TITLE
Reduce pressure for asking gc safe point from PD

### DIFF
--- a/dbms/src/Interpreters/Settings.h
+++ b/dbms/src/Interpreters/Settings.h
@@ -33,6 +33,7 @@ struct Settings
     M(SettingString, dag_planner, "optree", "planner for DAG query, sql builds the SQL string, optree builds the internal operator(stream) tree.") \
     M(SettingBool, dag_expr_field_type_strict_check, true, "when set to true, every expr in the dag request must provide field type, otherwise only the result expr will be checked.") \
     M(SettingInt64, schema_version, DEFAULT_UNSPECIFIED_SCHEMA_VERSION, "tmt schema version.") \
+    M(SettingInt64, safe_point_update_interval_seconds, 60, "The interval in seconds to update safe point from PD.")\
     M(SettingUInt64, batch_commands_threads, 0, "Number of threads to use for handling batch commands concurrently. 0 means - same as 'max_threads'.") \
     M(SettingUInt64, min_compress_block_size, DEFAULT_MIN_COMPRESS_BLOCK_SIZE, "The actual size of the block to compress, if the uncompressed data less than max_compress_block_size is no less than this value and no less than the volume of data for one mark.") \
     M(SettingUInt64, max_compress_block_size, DEFAULT_MAX_COMPRESS_BLOCK_SIZE, "The maximum size of blocks of uncompressed data before compressing for writing to a table.") \

--- a/dbms/src/Storages/MergeTree/MergeTreeDataMerger.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataMerger.cpp
@@ -700,14 +700,14 @@ MergeTreeData::MutableDataPartPtr MergeTreeDataMerger::mergePartsToTemporaryPart
                 CHTableHandle::merge_ranges(new_ranges);
                 merged_stream = std::make_unique<ReplacingTMTSortedBlockInputStream<UInt64>>(
                     new_ranges, src_streams, sort_desc, data.merging_params.version_column, MutableSupport::delmark_column_name,
-                    handle_col_name, DEFAULT_MERGE_BLOCK_SIZE, tmt.getPDClient()->getGCSafePoint(), data.table_info->id, final);
+                    handle_col_name, DEFAULT_MERGE_BLOCK_SIZE, PDClientHelper::getGCSafePointWithCache(tmt.getPDClient()), data.table_info->id, final);
             }
             else
             {
                 CHTableHandle::merge_ranges(ranges);
                 merged_stream = std::make_unique<ReplacingTMTSortedBlockInputStream<Int64>>(
                     ranges, src_streams, sort_desc, data.merging_params.version_column, MutableSupport::delmark_column_name,
-                    handle_col_name, DEFAULT_MERGE_BLOCK_SIZE, tmt.getPDClient()->getGCSafePoint(), data.table_info->id, final);
+                    handle_col_name, DEFAULT_MERGE_BLOCK_SIZE, PDClientHelper::getGCSafePointWithCache(tmt.getPDClient()), data.table_info->id, final);
             }
 
             break;

--- a/dbms/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -832,7 +832,7 @@ BlockInputStreams MergeTreeDataSelectExecutor::read(const Names & column_names_t
     {
         TMTContext & tmt = context.getTMTContext();
 
-        auto safe_point = tmt.getPDClient()->getGCSafePoint();
+        auto safe_point = PDClientHelper::getGCSafePointWithCache(tmt.getPDClient(), settings.safe_point_update_interval_seconds);
         if (mvcc_query_info.read_tso < safe_point)
             throw Exception("query id: " + context.getCurrentQueryId() + ", read tso: " + toString(mvcc_query_info.read_tso)
                     + " is smaller than tidb gc safe point: " + toString(safe_point),

--- a/dbms/src/Storages/Transaction/PDTiKVClient.cpp
+++ b/dbms/src/Storages/Transaction/PDTiKVClient.cpp
@@ -11,6 +11,9 @@ namespace ErrorCodes
 extern const int LOGICAL_ERROR;
 }
 
+Timestamp PDClientHelper::cached_gc_safe_point = 0;
+std::chrono::time_point<std::chrono::system_clock> PDClientHelper::safe_point_last_update_time;
+
 std::string getIP(const std::string & address)
 {
     if (address.size() == 0)

--- a/dbms/src/Storages/Transaction/PDTiKVClient.h
+++ b/dbms/src/Storages/Transaction/PDTiKVClient.h
@@ -8,6 +8,8 @@
 
 #pragma GCC diagnostic pop
 
+#include <Core/Types.h>
+#include <Storages/Transaction/Types.h>
 #include <common/logger_useful.h>
 
 namespace DB
@@ -42,14 +44,42 @@ struct PDClientHelper
 
     static constexpr int get_safepoint_maxtime = 120000; // 120s. waiting pd recover.
 
-    static uint64_t getGCSafePointWithRetry(pingcap::pd::ClientPtr pd_client)
+    static Timestamp getGCSafePointWithCache(const pingcap::pd::ClientPtr & pd_client, Int64 safe_point_update_interval_seconds = 30)
     {
+        // In case we cost too much to update safe point from PD.
+        std::chrono::time_point<std::chrono::system_clock> now = std::chrono::system_clock::now();
+        const auto duration = std::chrono::duration_cast<std::chrono::seconds>(now - safe_point_last_update_time);
+        const auto min_interval = std::max(Int64(1), safe_point_update_interval_seconds); // at least one second
+        if (duration.count() < min_interval)
+            return cached_gc_safe_point;
+
+        auto safe_point = pd_client->getGCSafePoint();
+        cached_gc_safe_point = safe_point;
+        safe_point_last_update_time = std::chrono::system_clock::now();
+        return safe_point;
+    }
+
+    static Timestamp getGCSafePointWithRetry(
+        const pingcap::pd::ClientPtr & pd_client, bool ignore_cache = false, Int64 safe_point_update_interval_seconds = 30)
+    {
+        if (!ignore_cache)
+        {
+            // In case we cost too much to update safe point from PD.
+            std::chrono::time_point<std::chrono::system_clock> now = std::chrono::system_clock::now();
+            const auto duration = std::chrono::duration_cast<std::chrono::seconds>(now - safe_point_last_update_time);
+            const auto min_interval = std::max(Int64(1), safe_point_update_interval_seconds); // at least one second
+            if (duration.count() < min_interval)
+                return cached_gc_safe_point;
+        }
+
         pingcap::kv::Backoffer bo(get_safepoint_maxtime);
         for (;;)
         {
             try
             {
                 auto safe_point = pd_client->getGCSafePoint();
+                cached_gc_safe_point = safe_point;
+                safe_point_last_update_time = std::chrono::system_clock::now();
                 return safe_point;
             }
             catch (pingcap::Exception & e)
@@ -58,6 +88,10 @@ struct PDClientHelper
             }
         }
     }
+
+private:
+    static Timestamp cached_gc_safe_point;
+    static std::chrono::time_point<std::chrono::system_clock> safe_point_last_update_time;
 };
 
 

--- a/dbms/src/Storages/Transaction/applySnapshot.cpp
+++ b/dbms/src/Storages/Transaction/applySnapshot.cpp
@@ -40,7 +40,8 @@ bool applySnapshot(const KVStorePtr & kvstore, RegionPtr new_region, Context * c
     if (context)
     {
         auto & tmt = context->getTMTContext();
-        Timestamp safe_point = PDClientHelper::getGCSafePointWithRetry(tmt.getPDClient());
+        Timestamp safe_point = PDClientHelper::getGCSafePointWithRetry(
+            tmt.getPDClient(), /* ignore_cache= */ false, context->getSettingsRef().safe_point_update_interval_seconds);
 
         std::unordered_map<TableID, HandleMap> handle_maps;
 


### PR DESCRIPTION
Each time a TxnMergeTree merge task starts, it will ask PD for gc safe point. If there are hundreds of tables of TxnMergeTree, it may cause PD busy.

Add cached for gc safe point to reduce the num of request to PD.