### PR TITLE
Log warning instead of throw exception when meets big region

### DIFF
--- a/dbms/src/Storages/Transaction/RegionPersister.cpp
+++ b/dbms/src/Storages/Transaction/RegionPersister.cpp
@@ -26,10 +26,10 @@ void RegionPersister::computeRegionWriteBuffer(const Region & region, RegionCach
     std::tie(region_size, applied_index) = region.serialize(buffer);
     if (unlikely(region_size > static_cast<size_t>(std::numeric_limits<UInt32>::max())))
     {
-        LOG_ERROR(&Logger::get("RegionPersister"),
-            region.toString() << " with data info: " << region.dataInfo() << ", serialized size " << region_size
-                              << " is too big to persist");
-        throw Exception("Region is too big to persist", ErrorCodes::LOGICAL_ERROR);
+        LOG_WARNING(&Logger::get("RegionPersister"),
+            "Persisting big region: " << region.toString() << " with data info: " << region.dataInfo() << ", serialized size "
+                                      << region_size);
+        //throw Exception("Region is too big to persist", ErrorCodes::LOGICAL_ERROR);
     }
 }
 


### PR DESCRIPTION
## Bug fix
Now PageStorage support region with size over 4GB, but `RegionPersister` still throw exception when meets big region.
This PR log warnings instead of throw exception.

## Related PR
https://github.com/pingcap/tics/pull/301