### PR TITLE
[FLASH-629] Add concurrency for wait index while doing learner read

### DIFF
--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -858,6 +858,28 @@ DeltaMergeStoreStat DeltaMergeStore::getStat()
     stat.avg_chunk_rows_in_stable  = (Float64)stat.total_stable_rows / stat.total_chunk_count_in_stable;
     stat.avg_chunk_bytes_in_stable = (Float64)stat.total_stable_bytes / stat.total_chunk_count_in_stable;
 
+    {
+        stat.storage_stable_num_snapshots        = storage_pool.data().getNumSnapshots();
+        PageStorage::SnapshotPtr stable_snapshot = storage_pool.data().getSnapshot();
+        stat.storage_stable_num_pages            = stable_snapshot->version()->numPages();
+        stat.storage_stable_num_normal_pages     = stable_snapshot->version()->numNormalPages();
+        stat.storage_stable_max_page_id          = stable_snapshot->version()->maxId();
+    }
+    {
+        stat.storage_delta_num_snapshots      = storage_pool.log().getNumSnapshots();
+        PageStorage::SnapshotPtr log_snapshot = storage_pool.log().getSnapshot();
+        stat.storage_delta_num_pages          = log_snapshot->version()->numPages();
+        stat.storage_delta_num_normal_pages   = log_snapshot->version()->numNormalPages();
+        stat.storage_delta_max_page_id        = log_snapshot->version()->maxId();
+    }
+    {
+        stat.storage_meta_num_snapshots        = storage_pool.meta().getNumSnapshots();
+        PageStorage::SnapshotPtr meta_snapshot = storage_pool.meta().getSnapshot();
+        stat.storage_meta_num_pages            = meta_snapshot->version()->numPages();
+        stat.storage_meta_num_normal_pages     = meta_snapshot->version()->numNormalPages();
+        stat.storage_meta_max_page_id          = meta_snapshot->version()->maxId();
+    }
+
     return stat;
 }
 

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
@@ -57,6 +57,21 @@ struct DeltaMergeStoreStat
     Float64 avg_chunk_count_in_stable   = 0;
     Float64 avg_chunk_rows_in_stable    = 0;
     Float64 avg_chunk_bytes_in_stable   = 0;
+
+    UInt64 storage_stable_num_snapshots    = 0;
+    UInt64 storage_stable_num_pages        = 0;
+    UInt64 storage_stable_num_normal_pages = 0;
+    UInt64 storage_stable_max_page_id      = 0;
+
+    UInt64 storage_delta_num_snapshots    = 0;
+    UInt64 storage_delta_num_pages        = 0;
+    UInt64 storage_delta_num_normal_pages = 0;
+    UInt64 storage_delta_max_page_id      = 0;
+
+    UInt64 storage_meta_num_snapshots    = 0;
+    UInt64 storage_meta_num_pages        = 0;
+    UInt64 storage_meta_num_normal_pages = 0;
+    UInt64 storage_meta_max_page_id      = 0;
 };
 
 

--- a/dbms/src/Storages/Page/PageStorage.cpp
+++ b/dbms/src/Storages/Page/PageStorage.cpp
@@ -194,6 +194,11 @@ PageStorage::SnapshotPtr PageStorage::getSnapshot()
     return versioned_page_entries.getSnapshot();
 }
 
+size_t PageStorage::getNumSnapshots() const
+{
+    return versioned_page_entries.size();
+}
+
 Page PageStorage::read(PageId page_id, SnapshotPtr snapshot)
 {
     if (!snapshot)

--- a/dbms/src/Storages/Page/PageStorage.h
+++ b/dbms/src/Storages/Page/PageStorage.h
@@ -65,6 +65,7 @@ public:
     void write(const WriteBatch & write_batch);
 
     SnapshotPtr getSnapshot();
+    size_t      getNumSnapshots() const;
 
     PageEntry getEntry(PageId page_id, SnapshotPtr snapshot = {});
     Page      read(PageId page_id, SnapshotPtr snapshot = {});

--- a/dbms/src/Storages/Page/VersionSet/PageEntriesView.cpp
+++ b/dbms/src/Storages/Page/VersionSet/PageEntriesView.cpp
@@ -153,4 +153,32 @@ PageId PageEntriesView::maxId() const
     return max_id;
 }
 
+size_t PageEntriesView::numPages() const
+{
+    std::unordered_set<PageId>                        page_ids;
+    std::vector<std::shared_ptr<PageEntriesForDelta>> nodes;
+    for (auto node = tail; node != nullptr; node = node->prev)
+        nodes.emplace_back(node);
+
+    for (auto node = nodes.rbegin(); node != nodes.rend(); ++node)
+    {
+        for (const auto & pair : (*node)->page_ref)
+        {
+            page_ids.insert(pair.first);
+        }
+        for (const auto & page_id_to_del : (*node)->ref_deletions)
+        {
+            page_ids.erase(page_id_to_del);
+        }
+    }
+
+    return page_ids.size();
+}
+
+size_t PageEntriesView::numNormalPages() const
+{
+    auto normal_ids = validNormalPageIds();
+    return normal_ids.size();
+}
+
 } // namespace DB

--- a/dbms/src/Storages/Page/VersionSet/PageEntriesView.h
+++ b/dbms/src/Storages/Page/VersionSet/PageEntriesView.h
@@ -39,6 +39,9 @@ public:
         return owned_ptr;
     }
 
+    size_t numPages() const;
+    size_t numNormalPages() const;
+
 private:
     PageId resolveRefId(PageId page_id) const;
 

--- a/dbms/src/Storages/Page/mvcc/VersionSetWithDelta.h
+++ b/dbms/src/Storages/Page/mvcc/VersionSetWithDelta.h
@@ -301,7 +301,7 @@ public:
 
     size_t size() const
     {
-        std::unique_lock read_lock(read_mutex);
+        std::shared_lock read_lock(read_mutex);
         return sizeUnlocked();
     }
 

--- a/dbms/src/Storages/StorageDeltaMerge.cpp
+++ b/dbms/src/Storages/StorageDeltaMerge.cpp
@@ -816,6 +816,21 @@ BlockInputStreamPtr StorageDeltaMerge::status()
     INSERT_FLOAT(avg_chunk_rows_in_stable)
     INSERT_FLOAT(avg_chunk_bytes_in_stable)
 
+    INSERT_INT(storage_stable_num_snapshots);
+    INSERT_INT(storage_stable_num_pages);
+    INSERT_INT(storage_stable_num_normal_pages)
+    INSERT_INT(storage_stable_max_page_id);
+
+    INSERT_INT(storage_delta_num_snapshots);
+    INSERT_INT(storage_delta_num_pages);
+    INSERT_INT(storage_delta_num_normal_pages)
+    INSERT_INT(storage_delta_max_page_id);
+
+    INSERT_INT(storage_meta_num_snapshots);
+    INSERT_INT(storage_meta_num_pages);
+    INSERT_INT(storage_meta_num_normal_pages)
+    INSERT_INT(storage_meta_max_page_id);
+
 #undef INSERT_INT
 #undef INSERT_FLOAT
 


### PR DESCRIPTION
* Add concurrency for waiting region index while doing learner read
* Add some status about StoragePool
  Use `manage table <[database_name.]table_name> status` to show status of specify table