### PR TITLE
FLASH-760: Fix region data not properly released caused by not pre-decoding snapshot regions

### DIFF
--- a/dbms/src/Storages/Transaction/KVStore.cpp
+++ b/dbms/src/Storages/Transaction/KVStore.cpp
@@ -94,6 +94,8 @@ bool KVStore::onSnapshot(RegionPtr new_region, Context * context, const RegionsA
 {
     RegionID region_id = new_region->id();
 
+    new_region->tryPreDecodeTiKVValue();
+
     if (context)
     {
         const auto range = new_region->getRange();

--- a/dbms/src/Storages/Transaction/RegionHelper.hpp
+++ b/dbms/src/Storages/Transaction/RegionHelper.hpp
@@ -3,11 +3,12 @@
 namespace DB
 {
 
-inline void tryPreDecodeTiKVValue(std::optional<ExtraCFDataQueue> && values)
+inline size_t tryPreDecodeTiKVValue(std::optional<ExtraCFDataQueue> && values)
 {
     if (!values)
-        return;
+        return 0;
 
+    size_t cnt = 0;
     for (const auto & val : *values)
     {
         auto & decoded_row_info = val->extraInfo();
@@ -15,7 +16,10 @@ inline void tryPreDecodeTiKVValue(std::optional<ExtraCFDataQueue> && values)
             continue;
         DecodedRow * decoded_row = ValueExtraInfo<>::computeDecodedRow(val->getStr());
         decoded_row_info.atomicUpdate(decoded_row);
+        cnt++;
     }
+
+    return cnt;
 }
 
 inline const metapb::Peer & findPeer(const metapb::Region & region, UInt64 store_id)


### PR DESCRIPTION
1. Fix region data caused not properly released caused by not pre-decoding snapshot regions;
2. Add some log messages;
3. Fix a mis-used mutex.