### PR TITLE
[FLASH-733] Fix segment fault in removing invalid iterator

### DIFF
--- a/dbms/src/Storages/Transaction/RegionTable.h
+++ b/dbms/src/Storages/Transaction/RegionTable.h
@@ -165,8 +165,9 @@ private:
     RegionID pickRegionToFlush();
     RegionDataReadInfoList flushRegion(const RegionPtr & region, bool try_persist) const;
 
+    void incrDirtyFlag(RegionID region_id);
     void clearDirtyFlag(RegionID region_id);
-    DirtyRegions::iterator clearDirtyFlag(const RegionTable::DirtyRegions::iterator & region_iter);
+    DirtyRegions::iterator clearDirtyFlag(const RegionTable::DirtyRegions::iterator & region_iter, std::lock_guard<std::mutex> &);
 
 private:
     TableMap tables;

--- a/dbms/src/Storages/Transaction/TypeMapping.cpp
+++ b/dbms/src/Storages/Transaction/TypeMapping.cpp
@@ -222,7 +222,7 @@ ColumnInfo reverseGetColumnInfo(const NameAndTypePair & column, ColumnID id, con
     ColumnInfo column_info;
     column_info.id = id;
     column_info.name = column.name;
-    const IDataType *nested_type = column.type.get();
+    const IDataType * nested_type = column.type.get();
 
     // Fill not null.
     if (!column.type->isNullable())
@@ -292,8 +292,7 @@ ColumnInfo reverseGetColumnInfo(const NameAndTypePair & column, ColumnID id, con
             column_info.tp = TiDB::TypeEnum;
             break;
         default:
-            throw DB::Exception("Unable reverse map TiFlash type " + nested_type->getName() + " to TiDB type",
-                                ErrorCodes::LOGICAL_ERROR);
+            throw DB::Exception("Unable reverse map TiFlash type " + nested_type->getName() + " to TiDB type", ErrorCodes::LOGICAL_ERROR);
     }
 
     // Fill unsigned flag.
@@ -318,7 +317,7 @@ ColumnInfo reverseGetColumnInfo(const NameAndTypePair & column, ColumnID id, con
     if (checkDataType<DataTypeEnum16>(nested_type))
     {
         auto enum16_type = checkAndGetDataType<DataTypeEnum16>(nested_type);
-        for (auto &element : enum16_type->getValues())
+        for (auto & element : enum16_type->getValues())
         {
             column_info.elems.emplace_back(element.first, element.second);
         }


### PR DESCRIPTION
https://zh.cppreference.com/w/cpp/container/unordered_set/erase

std::unordered_set.erase can not accpept invalid iterator as param.