### PR TITLE
[FLASH-834] Fix: add timeout for request in cluster manager

### DIFF
--- a/cluster_manage/flash_tools.py
+++ b/cluster_manage/flash_tools.py
@@ -11,7 +11,6 @@ class FlashConfig:
         self.conf_toml = toml.load(self.conf_file_path, _dict=dict)
         self.pd_addrs = util.compute_addr_list(self.conf_toml['raft']['pd_addr'])
         self.http_port = self.conf_toml['http_port']
-        self.data_path = self.conf_toml['path']
         tmp_path = self.conf_toml['tmp_path']
 
         p = self.conf_toml['flash']
@@ -29,7 +28,6 @@ class FlashConfig:
 
 
 def main():
-    conf = FlashConfig('../running/config/config.xml')
     pass
 
 

--- a/cluster_manage/util.py
+++ b/cluster_manage/util.py
@@ -37,17 +37,20 @@ class FLOCK(object):
 def curl_http(uri, params=None):
     if params is None:
         params = {}
-    r = requests.get('http://{}'.format(uri), params)
+    import conf
+    r = requests.get('http://{}'.format(uri), params, timeout=conf.flash_conf.update_rule_interval)
     return r
 
 
 def post_http(uri, params):
-    r = requests.post('http://{}'.format(uri), json=params)
+    import conf
+    r = requests.post('http://{}'.format(uri), json=params, timeout=conf.flash_conf.update_rule_interval)
     return r
 
 
 def delete_http(uri):
-    r = requests.delete('http://{}'.format(uri))
+    import conf
+    r = requests.delete('http://{}'.format(uri), timeout=conf.flash_conf.update_rule_interval)
     return r
 
 


### PR DESCRIPTION
- By default, module `requests.get/put/delete` will wait infinitely until target return data. If target is down, process of cluster manager will not exit.