### PR TITLE
Disable link to libodbc by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,13 +253,17 @@ include (cmake/find_boost.cmake)
 # openssl, zlib before poco
 include (cmake/find_zlib.cmake)
 include (cmake/find_zstd.cmake)
-include (cmake/find_ltdl.cmake) # for odbc
-if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/contrib/poco/cmake/FindODBC.cmake)
-    include (${CMAKE_CURRENT_SOURCE_DIR}/contrib/poco/cmake/FindODBC.cmake) # for poco
-else ()
-    include (cmake/find_odbc.cmake)
-endif ()
-message (STATUS "Using odbc: ${ODBC_INCLUDE_DIRECTORIES} : ${ODBC_LIBRARIES}")
+option (ENABLE_ODBC "Set to ON to link odbc libraries if exists" OFF)
+message(STATUS "enalbe odbc: ${ENABLE_ODBC}")
+if (ENABLE_ODBC)
+    include (cmake/find_ltdl.cmake) # for odbc
+    if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/contrib/poco/cmake/FindODBC.cmake)
+        include (${CMAKE_CURRENT_SOURCE_DIR}/contrib/poco/cmake/FindODBC.cmake) # for poco
+    else ()
+        include (cmake/find_odbc.cmake)
+    endif ()
+    message (STATUS "Using odbc: ${ODBC_INCLUDE_DIRECTORIES} : ${ODBC_LIBRARIES}")
+endif()
 include (cmake/find_poco.cmake)
 include (cmake/find_lz4.cmake)
 include (cmake/find_sparsehash.cmake)


### PR DESCRIPTION
In machine 85 we install libodbc for other tests. But it make binary `theflash` link to libodbc.so and libltdl.so by default, which we don't actually need.

In this PR I disable link to libodbc by default.