### PR TITLE
[flash-585] fix the atomic problem of alter table (#443)

### DIFF
--- a/dbms/CMakeLists.txt
+++ b/dbms/CMakeLists.txt
@@ -249,6 +249,9 @@ if (NOT USE_INTERNAL_ZSTD_LIBRARY)
     target_include_directories (dbms BEFORE PRIVATE ${ZSTD_INCLUDE_DIR})
 endif ()
 
+#use libfiu
+target_include_directories(dbms PUBLIC ${fiu_include_dirs})
+
 target_include_directories (dbms PUBLIC ${DBMS_INCLUDE_DIR})
 target_include_directories (clickhouse_common_io PUBLIC ${DBMS_INCLUDE_DIR})
 target_include_directories (clickhouse_common_io PUBLIC ${PCG_RANDOM_INCLUDE_DIR})
@@ -262,6 +265,8 @@ add_subdirectory (tests)
 
 if (ENABLE_TESTS)
     include (${ClickHouse_SOURCE_DIR}/cmake/find_gtest.cmake)
+
+    add_definitions(-DFIU_ENABLE)
 
     if (USE_INTERNAL_GTEST_LIBRARY)
         # Google Test from sources

--- a/dbms/src/Common/ErrorCodes.cpp
+++ b/dbms/src/Common/ErrorCodes.cpp
@@ -396,6 +396,7 @@ namespace ErrorCodes
     extern const int SCHEMA_VERSION_ERROR = 10004;
     extern const int DDL_ERROR = 10005;
     extern const int COP_BAD_DAG_REQUEST = 10006;
+    extern const int FAIL_POINT_ERROR = 10007;
 }
 
 }

--- a/dbms/src/Common/FailPoint.h
+++ b/dbms/src/Common/FailPoint.h
@@ -1,0 +1,39 @@
+#pragma once
+#include <Common/Exception.h>
+#include <Core/Types.h>
+#include <fiu-control.h>
+#include <fiu-local.h>
+#include <fiu.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+extern const int FAIL_POINT_ERROR;
+};
+
+#define FAIL_POINT_REGISTER(name) static constexpr char name[] = #name "";
+
+#define FAIL_POINT_ENABLE(trigger, name) else if (trigger == name) fiu_enable(name, 1, nullptr, FIU_ONETIME);
+
+FAIL_POINT_REGISTER(exception_between_drop_meta_and_data)
+FAIL_POINT_REGISTER(exception_between_alter_data_and_meta)
+FAIL_POINT_REGISTER(exception_drop_table_during_remove_meta)
+
+#define FAIL_POINT_TRIGGER_EXCEPTION(fail_point) \
+    fiu_do_on(fail_point, throw Exception("Fail point " #fail_point " is triggered.", ErrorCodes::FAIL_POINT_ERROR);)
+
+class FailPointHelper
+{
+public:
+    static void enableFailPoint(const String & fail_point_name)
+    {
+        if (false) {}
+        FAIL_POINT_ENABLE(fail_point_name, exception_between_alter_data_and_meta)
+        FAIL_POINT_ENABLE(fail_point_name, exception_between_drop_meta_and_data)
+        FAIL_POINT_ENABLE(fail_point_name, exception_drop_table_during_remove_meta)
+        else throw Exception("Cannot find fail point " + fail_point_name, ErrorCodes::FAIL_POINT_ERROR);
+    }
+};
+} // namespace DB

--- a/dbms/src/Databases/DatabaseOrdinary.cpp
+++ b/dbms/src/Databases/DatabaseOrdinary.cpp
@@ -5,6 +5,7 @@
 #include <Databases/DatabaseMemory.h>
 #include <Databases/DatabasesCommon.h>
 #include <Common/escapeForFileName.h>
+#include <Common/FailPoint.h>
 #include <Common/StringUtils/StringUtils.h>
 #include <Common/Stopwatch.h>
 #include <common/ThreadPool.h>
@@ -327,6 +328,7 @@ void DatabaseOrdinary::removeTable(
 
     try
     {
+        FAIL_POINT_TRIGGER_EXCEPTION(exception_drop_table_during_remove_meta);
         Poco::File(table_metadata_path).remove();
     }
     catch (...)

--- a/dbms/src/Debug/DBGInvoker.cpp
+++ b/dbms/src/Debug/DBGInvoker.cpp
@@ -10,6 +10,7 @@
 #include <Debug/dbgFuncMockTiDBTable.h>
 #include <Debug/dbgFuncRegion.h>
 #include <Debug/dbgFuncSchema.h>
+#include <Debug/dbgFuncFailPoint.h>
 #include <Parsers/ASTLiteral.h>
 
 namespace DB
@@ -81,6 +82,9 @@ DBGInvoker::DBGInvoker()
     regSchemalessFunc("region_prepare_merge", MockRaftCommand::dbgFuncPrepareMerge);
     regSchemalessFunc("region_commit_merge", MockRaftCommand::dbgFuncCommitMerge);
     regSchemalessFunc("region_rollback_merge", MockRaftCommand::dbgFuncRollbackMerge);
+
+    regSchemalessFunc("init_fail_point", DbgFailPointFunc::dbgInitFailPoint);
+    regSchemalessFunc("enable_fail_point", DbgFailPointFunc::dbgEnableFailPoint);
 
     regSchemafulFunc("dag", dbgFuncDAG);
     regSchemafulFunc("mock_dag", dbgFuncMockDAG);

--- a/dbms/src/Debug/dbgFuncFailPoint.cpp
+++ b/dbms/src/Debug/dbgFuncFailPoint.cpp
@@ -1,0 +1,16 @@
+#include <Common/FailPoint.h>
+#include <Debug/dbgFuncFailPoint.h>
+#include <Parsers/ASTIdentifier.h>
+
+namespace DB
+{
+
+void DbgFailPointFunc::dbgInitFailPoint(Context &, const ASTs &, DBGInvoker::Printer) { fiu_init(0); }
+
+void DbgFailPointFunc::dbgEnableFailPoint(Context &, const ASTs & args, DBGInvoker::Printer)
+{
+    const String & fail_name = static_cast<const ASTIdentifier &>(*args[0]).name;
+    FailPointHelper::enableFailPoint(fail_name.data());
+}
+
+} // namespace DB

--- a/dbms/src/Debug/dbgFuncFailPoint.h
+++ b/dbms/src/Debug/dbgFuncFailPoint.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <Debug/DBGInvoker.h>
+
+namespace DB
+{
+
+struct DbgFailPointFunc
+{
+
+    static void dbgEnableFailPoint(Context & context, const ASTs & args, DBGInvoker::Printer output);
+
+    static void dbgInitFailPoint(Context & context, const ASTs & args, DBGInvoker::Printer output);
+};
+
+} // namespace DB

--- a/dbms/src/Server/TCPHandler.cpp
+++ b/dbms/src/Server/TCPHandler.cpp
@@ -124,10 +124,9 @@ void TCPHandler::runImpl()
         if (!connection_context.isDatabaseExist(default_database))
         {
             Exception e("Database " + default_database + " doesn't exist", ErrorCodes::UNKNOWN_DATABASE);
-            LOG_ERROR(log, "Code: " << e.code() << ", e.displayText() = " << e.displayText()
+            LOG_WARNING(log, "Code: " << e.code() << ", e.displayText() = " << e.displayText()
                 << ", Stack trace:\n\n" << e.getStackTrace().toString());
-            sendException(e);
-            return;
+            default_database = "test";
         }
 
         connection_context.setCurrentDatabase(default_database);

--- a/dbms/src/Storages/StorageMergeTree.h
+++ b/dbms/src/Storages/StorageMergeTree.h
@@ -33,6 +33,7 @@ class StorageMergeTree : public ext::shared_ptr_helper<StorageMergeTree>, public
 public:
     void startup() override;
     void shutdown() override;
+    void removeFromTMTContext();
     ~StorageMergeTree() override;
 
     std::string getName() const override { return data.merging_params.getModeName() + "MergeTree"; }

--- a/dbms/src/Storages/Transaction/SchemaBuilder.cpp
+++ b/dbms/src/Storages/Transaction/SchemaBuilder.cpp
@@ -212,7 +212,8 @@ void SchemaBuilder<Getter>::applyAlterTableImpl(TableInfoPtr table_info, const S
 
     // Call storage alter to apply schema changes.
     for (const auto & alter_commands : commands_vec)
-        storage->alterFromTiDB(alter_commands, *table_info, db_name, context);
+        if (!alter_commands.empty())
+            storage->alterFromTiDB(alter_commands, *table_info, db_name, context);
 
     auto & tmt_context = context.getTMTContext();
 
@@ -876,6 +877,7 @@ void SchemaBuilder<Getter>::syncAllSchema()
         std::vector<TableInfoPtr> tables = getter.listTables(db->id);
         for (const auto & table : tables)
         {
+            LOG_DEBUG(log, "collect table: " << table->name << " with id "<< table->id);
             all_tables.emplace_back(table, db);
             if (table->isLogicalPartitionTable())
             {

--- a/dbms/src/Storages/Transaction/TiDBSchemaSyncer.h
+++ b/dbms/src/Storages/Transaction/TiDBSchemaSyncer.h
@@ -121,7 +121,19 @@ struct TiDBSchemaSyncer : public SchemaSyncer
         catch (Exception & e)
         {
             GET_METRIC(context.getTiFlashMetrics(), tiflash_schema_apply_count, type_failed).Increment();
-            LOG_ERROR(log, "apply diff meets exception : " << e.displayText() << " \n stack is " << e.getStackTrace().toString());
+            LOG_WARNING(log, "apply diff meets exception : " << e.displayText() << " \n stack is " << e.getStackTrace().toString());
+            return false;
+        }
+        catch (Poco::Exception & e)
+        {
+            GET_METRIC(context.getTiFlashMetrics(), tiflash_schema_apply_count, type_failed).Increment();
+            LOG_WARNING(log, "apply diff meets exception : " << e.displayText() << " \n");
+            return false;
+        }
+        catch (std::exception & e)
+        {
+            GET_METRIC(context.getTiFlashMetrics(), tiflash_schema_apply_count, type_failed).Increment();
+            LOG_WARNING(log, "apply diff meets exception : " << e.what() << " \n");
             return false;
         }
         return true;

--- a/tests/fullstack-test/fault-inject/alter-table.test
+++ b/tests/fullstack-test/fault-inject/alter-table.test
@@ -1,0 +1,29 @@
+mysql> drop table if exists test.t
+mysql> create table test.t(a int not null, b int not null)
+mysql> alter table test.t set tiflash replica 1 location labels 'rack', 'host', 'abc'
+
+SLEEP 15
+
+
+mysql> insert into test.t values (1, 1)
+mysql> insert into test.t values (1, 2)
+
+SLEEP 15
+
+>> DBGInvoke __try_flush()
+>> DBGInvoke __init_fail_point()
+>> DBGInvoke __enable_fail_point(exception_between_alter_data_and_meta)
+
+mysql> alter table test.t change a c int
+
+SLEEP 15
+
+mysql> select /*+ read_from_storage(tiflash[t]) */ * from test.t;
++---+---+
+| c | b |
++---+---+
+| 1 | 1 |
+| 1 | 2 |
++---+---+
+
+mysql> drop table if exists test.t

--- a/tests/fullstack-test/fault-inject/drop-table.test
+++ b/tests/fullstack-test/fault-inject/drop-table.test
@@ -1,0 +1,50 @@
+
+mysql> drop table if exists test.t
+mysql> create table test.t(a int not null, b int not null)
+mysql> alter table test.t set tiflash replica 1 location labels 'rack', 'host', 'abc'
+
+SLEEP 15
+
+
+mysql> insert into test.t values (1, 1)
+mysql> insert into test.t values (1, 2)
+
+SLEEP 15
+
+>> DBGInvoke __try_flush()
+>> DBGInvoke __init_fail_point()
+>> DBGInvoke __enable_fail_point(exception_between_drop_meta_and_data)
+
+mysql> truncate table test.t ;
+
+SLEEP 15
+
+mysql> insert into test.t values (1, 1)
+mysql> insert into test.t values (1, 2)
+mysql> select /*+ read_from_storage(tiflash[t]) */ * from test.t;
+
++---+---+
+| a | b |
++---+---+
+| 1 | 1 |
+| 1 | 2 |
++---+---+
+
+>> DBGInvoke __enable_fail_point(exception_drop_table_during_remove_meta)
+mysql> truncate table test.t ;
+
+SLEEP 15
+
+mysql> insert into test.t values (1, 1)
+mysql> insert into test.t values (1, 2)
+mysql> select /*+ read_from_storage(tiflash[t]) */ * from test.t;
+
++---+---+
+| a | b |
++---+---+
+| 1 | 1 |
+| 1 | 2 |
++---+---+
+
+mysql> drop table if exists test.t
+


### PR DESCRIPTION
This PR introduces a method of fault injection to test the case of server recover.
We can use commands lik

fail_point_init
fail_point_enable(fail point name)
to trigger a pre-setted fail point.
Then , If crashed after changing data, we still can recover the system.