### PR TITLE
FLASH-928: Fix year type codec in new row format

### DIFF
--- a/dbms/src/Storages/Transaction/RowCodec.cpp
+++ b/dbms/src/Storages/Transaction/RowCodec.cpp
@@ -235,6 +235,7 @@ TiKVValue::Base encodeNotNullColumn(const Field & field, const ColumnInfo & colu
             break;
         case TiDB::TypeYear:
             encodeIntWithLength(field.safeGet<Int64>(), ss);
+            break;
         case TiDB::TypeFloat:
         case TiDB::TypeDouble:
             EncodeFloat64(field.safeGet<Float64>(), ss);


### PR DESCRIPTION
See this bug: https://internal.pingcap.net/jira/browse/FLASH-927

And this PR: https://github.com/pingcap/tidb/pull/14717