### PR TITLE
[WIP] [FLASH-941] Reduce PageStorage gc lock  critical section

### DIFF
--- a/dbms/src/Storages/Page/PageStorage.cpp
+++ b/dbms/src/Storages/Page/PageStorage.cpp
@@ -300,7 +300,7 @@ PageStorage::SnapshotPtr PageStorage::getSnapshot()
 
 size_t PageStorage::getNumSnapshots() const
 {
-    return versioned_page_entries.size();
+    return versioned_page_entries.numSnapshots();
 }
 
 Page PageStorage::read(PageId page_id, SnapshotPtr snapshot)

--- a/dbms/src/Storages/Page/VersionSet/PageEntriesVersionSetWithDelta.h
+++ b/dbms/src/Storages/Page/VersionSet/PageEntriesVersionSetWithDelta.h
@@ -33,8 +33,8 @@ public:
     std::pair<std::set<PageFileIdAndLevel>, std::set<PageId>> gcApply(PageEntriesEdit & edit, bool need_scan_page_ids = true);
 
     /// List all PageFile that are used by any version
-    std::pair<std::set<PageFileIdAndLevel>, std::set<PageId>> listAllLiveFiles(const std::unique_lock<std::shared_mutex> &,
-                                                                               bool need_scan_page_ids = true) const;
+    std::pair<std::set<PageFileIdAndLevel>, std::set<PageId>> //
+    listAllLiveFiles(std::unique_lock<std::shared_mutex> &&, bool need_scan_page_ids = true);
 
 private:
     void collectLiveFilesFromVersionList(const PageEntriesView &        view,

--- a/dbms/src/Storages/Page/mvcc/VersionSetWithDelta.h
+++ b/dbms/src/Storages/Page/mvcc/VersionSetWithDelta.h
@@ -1,18 +1,19 @@
 #pragma once
 
+#include <Common/CurrentMetrics.h>
+#include <Common/ProfileEvents.h>
+#include <IO/WriteHelpers.h>
+#include <Storages/Page/mvcc/VersionSet.h>
 #include <stdint.h>
+
 #include <boost/core/noncopyable.hpp>
 #include <cassert>
+#include <list>
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
 #include <stack>
 #include <unordered_set>
-
-#include <Common/CurrentMetrics.h>
-#include <Common/ProfileEvents.h>
-#include <IO/WriteHelpers.h>
-#include <Storages/Page/mvcc/VersionSet.h>
 
 namespace ProfileEvents
 {
@@ -64,23 +65,22 @@ public:
 
 public:
     explicit VersionSetWithDelta(const ::DB::MVCC::VersionSetConfig & config_, Poco::Logger * log_)
-        : current(std::move(VersionType::createBase())),                   //
-          snapshots(std::move(std::make_shared<Snapshot>(this, nullptr))), //
+        : current(std::move(VersionType::createBase())), //
+          snapshots(),                                   //
           config(config_),
           log(log_)
     {
-        // The placeholder snapshot should not be counted.
-        CurrentMetrics::sub(CurrentMetrics::PSMVCCNumSnapshots);
     }
 
     virtual ~VersionSetWithDelta()
     {
         current.reset();
-        // snapshot list is empty
-        assert(snapshots->prev == snapshots.get());
 
-        // Ignore the destructor of placeholder snapshot
-        CurrentMetrics::add(CurrentMetrics::PSMVCCNumSnapshots);
+        std::unique_lock lock(read_write_mutex);
+        removeExpiredSnapshots(lock);
+
+        // snapshot list is empty
+        assert(snapshots.empty());
     }
 
     void apply(TVersionEdit & edit)
@@ -115,18 +115,15 @@ public:
 public:
     /// Snapshot.
     /// When snapshot object is free, it will call `view.release()` to compact VersionList,
-    /// and remove itself from VersionSet's snapshots list.
+    /// and its weak_ptr will be from VersionSet's snapshots list.
     class Snapshot : private boost::noncopyable
     {
     public:
         VersionSetWithDelta * vset;
         TVersionView          view;
 
-        Snapshot * prev;
-        Snapshot * next;
-
     public:
-        Snapshot(VersionSetWithDelta * vset_, VersionPtr tail_) : vset(vset_), view(std::move(tail_)), prev(this), next(this)
+        Snapshot(VersionSetWithDelta * vset_, VersionPtr tail_) : vset(vset_), view(std::move(tail_))
         {
             CurrentMetrics::add(CurrentMetrics::PSMVCCNumSnapshots);
         }
@@ -135,9 +132,10 @@ public:
         {
             vset->compactOnDeltaRelease(view.transferTailVersionOwn());
             // Remove snapshot from linked list
-            std::unique_lock lock = vset->acquireForLock();
-            prev->next            = next;
-            next->prev            = prev;
+
+            // TODO: maybe do this? We should investigate how many invalid snapshot removed in gcApply with high read / write pressure.
+            // if (rand % 100) == 0, lock and call `vset->removeExpiredSnapshots` ??
+            // std::unique_lock lock = vset->acquireForLock();
 
             CurrentMetrics::sub(CurrentMetrics::PSMVCCNumSnapshots);
         }
@@ -148,7 +146,8 @@ public:
         friend class VersionSetWithDelta;
     };
 
-    using SnapshotPtr = std::shared_ptr<Snapshot>;
+    using SnapshotPtr     = std::shared_ptr<Snapshot>;
+    using SnapshotWeakPtr = std::weak_ptr<Snapshot>;
 
     /// Create a snapshot for current version.
     /// call `snapshot.reset()` or let `snapshot` gone if you don't need it anymore.
@@ -159,10 +158,7 @@ public:
 
         auto s = std::make_shared<Snapshot>(this, current);
         // Register snapshot to VersionSet
-        s->prev               = snapshots->prev;
-        s->next               = snapshots.get();
-        snapshots->prev->next = s.get();
-        snapshots->prev       = s.get();
+        snapshots.emplace_back(SnapshotWeakPtr(s));
         return s;
     }
 
@@ -293,6 +289,23 @@ protected:
         tail.reset();
     }
 
+private:
+    void removeExpiredSnapshots(const std::unique_lock<std::shared_mutex> &) const
+    {
+        for (auto iter = snapshots.begin(); iter != snapshots.end(); /* empty */)
+        {
+            if (iter->expired())
+            {
+                // Clear free snapshots
+                iter = snapshots.erase(iter);
+            }
+            else
+            {
+                iter++;
+            }
+        }
+    }
+
 public:
     /// Some helper functions
 
@@ -310,6 +323,14 @@ public:
             sz += 1;
         }
         return sz;
+    }
+
+    size_t numSnapshots() const
+    {
+        // Note: this will scan and remove expired weak_ptr to snapshot
+        std::unique_lock lock(read_write_mutex);
+        removeExpiredSnapshots(lock);
+        return snapshots.size();
     }
 
     std::string toDebugString() const
@@ -342,11 +363,11 @@ public:
     }
 
 protected:
-    mutable std::shared_mutex    read_write_mutex;
-    VersionPtr                   current;
-    SnapshotPtr                  snapshots;
-    ::DB::MVCC::VersionSetConfig config;
-    Poco::Logger *               log;
+    mutable std::shared_mutex          read_write_mutex;
+    VersionPtr                         current;
+    mutable std::list<SnapshotWeakPtr> snapshots;
+    ::DB::MVCC::VersionSetConfig       config;
+    Poco::Logger *                     log;
 };
 
 } // namespace MVCC


### PR DESCRIPTION
Now gcApply acquire lock to iterate all snapshots to count valid normal pages. Which is expensive if there are millions of pages.

We can try to use `std::list<std::weak_ptr<Snapshot>>` for `snapshots`.
In gcApply, acquire for shared_ptr for all valid snapshots, remove invalid weak pointers.
Then release lock and collect all valid normal pages.

TODO:
- [ ] investigate how many invalid snapshots removed in  `listAllLiveFiles` under frequently write/read, decide whether need to random clean up in `~Snapshot()`