### PR TITLE
Prevent exceptions in TOMLConfiguration

### DIFF
--- a/dbms/src/Common/Config/TOMLConfiguration.cpp
+++ b/dbms/src/Common/Config/TOMLConfiguration.cpp
@@ -15,6 +15,8 @@ bool TOMLConfiguration::getRaw(const std::string & key, std::string & value) con
 {
     try
     {
+        if (!root->contains_qualified(key))
+            return false;
         auto node = root->get_qualified(key);
         if (auto str_node = std::dynamic_pointer_cast<cpptoml::value<std::string>>(node))
         {


### PR DESCRIPTION
TOMLConfiguration: check key's existence before get, prevent throwing exception