### PR TITLE
[FLASH-1066] Fix bug for accessing invalid address of PODArray after its padding

### DIFF
--- a/dbms/src/DataTypes/DataTypeString.cpp
+++ b/dbms/src/DataTypes/DataTypeString.cpp
@@ -130,7 +130,7 @@ static NO_INLINE void deserializeBinarySSE2(ColumnString::Chars_t & data, Column
         {
 #if __SSE2__
             /// An optimistic branch in which more efficient copying is possible.
-            if (offset + 16 * UNROLL_TIMES <= data.allocated_bytes() && istr.position() + size + 16 * UNROLL_TIMES <= istr.buffer().end())
+            if (offset + 16 * UNROLL_TIMES <= data.capacity() && istr.position() + size + 16 * UNROLL_TIMES <= istr.buffer().end())
             {
                 const __m128i * sse_src_pos = reinterpret_cast<const __m128i *>(istr.position());
                 const __m128i * sse_src_end = sse_src_pos + (size + (16 * UNROLL_TIMES - 1)) / 16 / UNROLL_TIMES * UNROLL_TIMES;


### PR DESCRIPTION
We have ported [PODArray padding](https://github.com/ClickHouse/ClickHouse/pull/3920), but left [its bugfix](https://github.com/ClickHouse/ClickHouse/pull/4623) behind.

Without this fix, process will coredump if there are long string column (tpch.partsupp for example)