### PR TITLE
FLASH-1071: Ignore sequence

### DIFF
--- a/dbms/src/Storages/Transaction/SchemaBuilder.cpp
+++ b/dbms/src/Storages/Transaction/SchemaBuilder.cpp
@@ -632,9 +632,9 @@ String createTableStmt(const DBInfo & db_info, const TableInfo & table_info, Log
 template <typename Getter>
 void SchemaBuilder<Getter>::applyCreatePhysicalTableImpl(const TiDB::DBInfo & db_info, TiDB::TableInfo & table_info)
 {
-    if (table_info.is_view)
+    if (table_info.is_view || table_info.is_sequence)
     {
-        LOG_INFO(log, "Table " << table_info.name << " is a view table, ignore it.");
+        LOG_INFO(log, "Table " << table_info.name << " is a view or sequence, ignoring it.");
         return;
     }
 

--- a/dbms/src/Storages/Transaction/TiDB.cpp
+++ b/dbms/src/Storages/Transaction/TiDB.cpp
@@ -450,11 +450,14 @@ try
 
     auto cols_arr = obj->getArray("cols");
     columns.clear();
-    for (size_t i = 0; i < cols_arr->size(); i++)
+    if (!cols_arr.isNull())
     {
-        auto col_json = cols_arr->getObject(i);
-        ColumnInfo column_info(col_json);
-        columns.emplace_back(column_info);
+        for (size_t i = 0; i < cols_arr->size(); i++)
+        {
+            auto col_json = cols_arr->getObject(i);
+            ColumnInfo column_info(col_json);
+            columns.emplace_back(column_info);
+        }
     }
 
     state = static_cast<SchemaState>(obj->getValue<Int32>("state"));
@@ -476,6 +479,10 @@ try
     if (obj->has("view") && !obj->getObject("view").isNull())
     {
         is_view = true;
+    }
+    if (obj->has("sequence") && !obj->getObject("sequence").isNull())
+    {
+        is_sequence = true;
     }
 }
 catch (const Poco::Exception & e)

--- a/dbms/src/Storages/Transaction/TiDB.h
+++ b/dbms/src/Storages/Transaction/TiDB.h
@@ -281,6 +281,8 @@ struct TableInfo
     PartitionInfo partition;
     // If the table is view, we should ignore it.
     bool is_view = false;
+    // If the table is sequence, we should ignore it.
+    bool is_sequence = false;
     Int64 schema_version = DEFAULT_UNSPECIFIED_SCHEMA_VERSION;
 
     ::TiDB::StorageEngine engine_type = ::TiDB::StorageEngine::UNSPECIFIED;


### PR DESCRIPTION
TiDB's sequence shares and extends table info (thus is still a table and can be seen when listing tables from a db). Sequence definition is stored in an extra "sequence" object in table info json, and "column" will be set to null.

Current code assumes "column" not being null, and NPE will be thrown when deserializing a sequence table info json.

Fix by explicitly checking the null-ness of "column" and "sequence" objects, and ignore any sequences.

This only affects TiDB 4.0+.

Fixes https://github.com/pingcap/tidb/issues/15957