### PR TITLE
Optimize delta index

### DIFF
--- a/dbms/src/Storages/DeltaMerge/DMVersionFilterBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/DMVersionFilterBlockInputStream.h
@@ -74,7 +74,6 @@ private:
         }
         else if constexpr (MODE == DM_VERSION_FILTER_MODE_COMPACT)
         {
-            //            filter[i]    = cur_version >= version_limit || (cur_handle != next_handle && !deleted);
             filter[i]    = cur_version >= version_limit || ((cur_handle != next_handle || next_version > version_limit) && !deleted);
             not_clean[i] = filter[i] && (cur_handle == next_handle || deleted);
         }

--- a/dbms/src/Storages/DeltaMerge/Delta/CompactDelta.cpp
+++ b/dbms/src/Storages/DeltaMerge/Delta/CompactDelta.cpp
@@ -2,7 +2,6 @@
 #include <Storages/DeltaMerge/DMContext.h>
 #include <Storages/DeltaMerge/Delta/Pack.h>
 #include <Storages/DeltaMerge/DeltaValueSpace.h>
-#include <Storages/DeltaMerge/StoragePool.h>
 #include <Storages/DeltaMerge/WriteBatches.h>
 #include <Storages/Page/PageStorage.h>
 

--- a/dbms/src/Storages/DeltaMerge/Delta/Pack.cpp
+++ b/dbms/src/Storages/DeltaMerge/Delta/Pack.cpp
@@ -169,7 +169,7 @@ Block readPackFromCache(const PackPtr & pack)
     auto &         cache_block = pack->cache->block;
     MutableColumns columns     = cache_block.cloneEmptyColumns();
     for (size_t i = 0; i < cache_block.columns(); ++i)
-        columns[i]->insertRangeFrom(*cache_block.getByPosition(i).column, pack->cache_offset, pack->rows);
+        columns[i]->insertRangeFrom(*cache_block.getByPosition(i).column, 0, pack->rows);
     return cache_block.cloneWithColumns(std::move(columns));
 }
 
@@ -206,14 +206,14 @@ Columns readPackFromCache(const PackPtr & pack, const ColumnDefines & column_def
             auto col_offset = it->second;
             // Copy data from cache
             auto [type, col_data] = pack->getDataTypeAndEmptyColumn(cd.id);
-            col_data->insertRangeFrom(*cache_block.getByPosition(col_offset).column, pack->cache_offset, pack->rows);
+            col_data->insertRangeFrom(*cache_block.getByPosition(col_offset).column, 0, pack->rows);
             // Cast if need
             auto col_converted = convertColumnByColumnDefineIfNeed(type, std::move(col_data), cd);
             columns.push_back(std::move(col_converted));
         }
         else
         {
-            ColumnPtr column = createColumnWithDefaultValue(cd, pack->rows - pack->cache_offset);
+            ColumnPtr column = createColumnWithDefaultValue(cd, pack->rows);
             columns.emplace_back(std::move(column));
         }
     }

--- a/dbms/src/Storages/DeltaMerge/DeltaIndex.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaIndex.h
@@ -1,0 +1,155 @@
+#pragma once
+
+#include <Storages/DeltaMerge/DeltaMergeDefines.h>
+#include <Storages/DeltaMerge/DeltaTree.h>
+
+namespace DB
+{
+namespace DM
+{
+
+class DeltaIndex;
+using DeltaIndexPtr = std::shared_ptr<DeltaIndex>;
+
+class DeltaIndex
+{
+private:
+    DeltaTreePtr delta_tree;
+
+    size_t placed_rows;
+    size_t placed_deletes;
+
+    mutable std::mutex mutex;
+
+public:
+    struct Update
+    {
+        size_t delete_ranges_offset;
+        size_t rows_offset;
+        // old index -> new index
+        TupleRefs idx_mapping;
+
+        Update(size_t delete_ranges_offset_, size_t rows_offset_, const IColumn::Permutation & sort_perm)
+            : delete_ranges_offset(delete_ranges_offset_), rows_offset(rows_offset_), idx_mapping(sort_perm.size())
+        {
+            for (size_t pos = 0; pos < sort_perm.size(); ++pos)
+                idx_mapping[sort_perm[pos]] = pos;
+        }
+    };
+    using Updates = std::vector<Update>;
+
+private:
+    void applyUpdates(const Updates & updates)
+    {
+        for (auto & update : updates)
+        {
+            if (placed_rows <= update.rows_offset)
+            {
+                // Current index does not contain any inserts which go shuffled.
+                break;
+            }
+            else if (placed_rows < update.rows_offset + update.idx_mapping.size())
+            {
+                // Current index contains part of inserts which go shuffled, they should be removed.
+                delta_tree->removeInsertsStartFrom(update.rows_offset);
+                placed_rows = update.rows_offset;
+                break;
+            }
+            else
+            {
+                // Current index contains all inserts which go shuffled, let's update them directly.
+                delta_tree->updateTupleId(update.idx_mapping, update.rows_offset);
+            }
+        }
+    }
+
+public:
+    DeltaIndex() : delta_tree(std::make_shared<DefaultDeltaTree>()), placed_rows(0), placed_deletes(0) {}
+    DeltaIndex(const DeltaIndex & o)
+    {
+        DeltaTreePtr delta_tree_copy;
+        {
+            std::scoped_lock lock(o.mutex);
+            delta_tree_copy = o.delta_tree;
+            placed_rows     = o.placed_rows;
+            placed_deletes  = o.placed_deletes;
+        }
+        delta_tree = std::make_shared<DefaultDeltaTree>(*delta_tree_copy);
+    }
+    String toString()
+    {
+        std::stringstream s;
+        s << "{placed rows:" << placed_rows << ", deletes:" << placed_deletes << ", delta tree: " << delta_tree->numEntries() << "|"
+          << delta_tree->numInserts() << "|" << delta_tree->numDeletes() << "}";
+        return s.str();
+    }
+
+    std::pair<size_t, size_t> getPlacedStatus()
+    {
+        std::scoped_lock lock(mutex);
+        return {placed_rows, placed_deletes};
+    }
+
+    DeltaTreePtr getDeltaTree()
+    {
+        std::scoped_lock lock(mutex);
+        return delta_tree;
+    }
+
+    void update(const DeltaTreePtr & delta_tree_, size_t placed_rows_, size_t placed_deletes_)
+    {
+        std::scoped_lock lock(mutex);
+        delta_tree     = delta_tree_;
+        placed_rows    = placed_rows_;
+        placed_deletes = placed_deletes_;
+    }
+
+    bool updateIfAdvanced(const DeltaIndex & maybe_advanced)
+    {
+        std::scoped_lock lock(mutex);
+
+        if ((maybe_advanced.placed_rows >= placed_rows && maybe_advanced.placed_deletes >= placed_deletes)
+            && !(maybe_advanced.placed_rows == placed_rows && maybe_advanced.placed_deletes == placed_deletes))
+        {
+            delta_tree     = maybe_advanced.delta_tree;
+            placed_rows    = maybe_advanced.placed_rows;
+            placed_deletes = maybe_advanced.placed_deletes;
+            return true;
+        }
+        return false;
+    }
+
+    DeltaIndexPtr tryClone(size_t /*rows*/, size_t deletes)
+    {
+        // Delete ranges can break MVCC view.
+        {
+            std::scoped_lock lock(mutex);
+
+            if (placed_deletes > deletes)
+                return std::make_shared<DeltaIndex>();
+        }
+        // Otherwise, clone it.
+        return std::make_shared<DeltaIndex>(*this);
+    }
+
+    DeltaIndexPtr cloneWithUpdates(const Updates & updates)
+    {
+        if (unlikely(updates.empty()))
+            throw Exception("Unexpected empty updates");
+
+        {
+            std::scoped_lock lock(mutex);
+            // If inserts shuffled before delete range, the old index cannot used any more.
+            if (placed_deletes > updates.front().delete_ranges_offset)
+                return std::make_shared<DeltaIndex>();
+        }
+
+        // Otherwise clone a new index, and do some updates.
+        auto new_index = std::make_shared<DeltaIndex>(*this);
+        new_index->applyUpdates(updates);
+        return new_index;
+    }
+};
+
+} // namespace DM
+} // namespace DB

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeDefines.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeDefines.h
@@ -48,17 +48,13 @@ struct RefTuple;
 
 struct EmptyValueSpace
 {
-    void   removeFromInsert(UInt64) {}
-    void   removeFromModify(UInt64, size_t) {}
-    UInt64 withModify(UInt64, const EmptyValueSpace &, const RefTuple &) { throw Exception("Unsupported operation"); }
+    void removeFromInsert(UInt64) {}
 };
 
-using EntryIterator    = DTEntryIterator<DT_M, DT_F, DT_S>;
-using DefaultDeltaTree = DeltaTree<EmptyValueSpace, DT_M, DT_F, DT_S, ArenaWithFreeLists>;
-using DeltaTreePtr     = std::shared_ptr<DefaultDeltaTree>;
-using DeltaIndex       = DTEntriesCopy<DT_M, DT_F, DT_S>;
-using DeltaIndexPtr    = std::shared_ptr<DeltaIndex>;
-using BlockPtr         = std::shared_ptr<Block>;
+using EntryIterator     = DTEntryIterator<DT_M, DT_F, DT_S>;
+using DefaultDeltaTree  = DeltaTree<EmptyValueSpace, DT_M, DT_F, DT_S, ArenaWithFreeLists>;
+using DeltaTreePtr      = std::shared_ptr<DefaultDeltaTree>;
+using BlockPtr          = std::shared_ptr<Block>;
 
 using RowId = UInt64;
 using ColId = DB::ColumnID;

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
@@ -126,6 +126,7 @@ public:
 
     enum ThreadType
     {
+        Init,
         Write,
         Read,
         BG_Split,
@@ -142,12 +143,15 @@ public:
         MergeDelta,
         Compact,
         Flush,
+        PlaceIndex,
     };
 
     static std::string toString(ThreadType type)
     {
         switch (type)
         {
+        case Init:
+            return "Init";
         case Write:
             return "Write";
         case Read:
@@ -181,6 +185,8 @@ public:
             return "Compact";
         case Flush:
             return "Flush";
+        case PlaceIndex:
+            return "PlaceIndex";
         default:
             return "Unknown";
         }
@@ -222,6 +228,8 @@ public:
                     const ColumnDefine &  handle,
                     const Settings &      settings_);
     ~DeltaMergeStore();
+
+    void setUpBackgroundTask(const DMContextPtr & dm_context);
 
     const String & getDatabaseName() const { return db_name; }
     const String & getTableName() const { return table_name; }
@@ -299,10 +307,6 @@ private:
     SegmentPair segmentSplit(DMContext & dm_context, const SegmentPtr & segment);
     void        segmentMerge(DMContext & dm_context, const SegmentPtr & left, const SegmentPtr & right);
     SegmentPtr  segmentMergeDelta(DMContext & dm_context, const SegmentPtr & segment, bool is_foreground);
-
-    SegmentPtr segmentForegroundMergeDelta(DMContext & dm_context, const SegmentPtr & segment);
-    void       segmentBackgroundMergeDelta(DMContext & dm_context, const SegmentPtr & segment);
-    void       segmentForegroundMerge(DMContext & dm_context, const SegmentPtr & segment);
 
     bool handleBackgroundTask();
 

--- a/dbms/src/Storages/DeltaMerge/File/DMFileReader.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileReader.cpp
@@ -308,6 +308,9 @@ Block DMFileReader::read()
             }
             else
             {
+                LOG_TRACE(log,
+                          "Column [id:" << cd.id << ",name:" << cd.name << ",type:" << cd.type->getName()
+                                        << "] not found, use default value. DMFile: " << dmfile->path());
                 // New column after ddl is not exist in this DMFile, fill with default value
                 ColumnPtr column = createColumnWithDefaultValue(cd, read_rows);
                 res.insert(ColumnWithTypeAndName{std::move(column), cd.type, cd.name, cd.id});

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_tree.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_tree.cpp
@@ -53,7 +53,7 @@ protected:
     FakeDeltaTree tree;
 };
 
-void printTree(FakeDeltaTree & tree)
+void printTree(const FakeDeltaTree & tree)
 {
     print(tree.getHeight());
     for (auto it = tree.begin(), end = tree.end(); it != end; ++it)
@@ -64,7 +64,7 @@ void printTree(FakeDeltaTree & tree)
     std::cout << std::endl;
 }
 
-std::string treeToString(FakeDeltaTree & tree)
+std::string treeToString(const FakeDeltaTree & tree)
 {
     std::string result = "";
     std::string temp;
@@ -87,6 +87,12 @@ std::string treeToString(FakeDeltaTree & tree)
     return result;
 }
 
+void checkCopy(FakeDeltaTree & tree)
+{
+    FakeDeltaTree copy(tree);
+    ASSERT_EQ(treeToString(copy), treeToString(tree));
+    tree.swap(copy);
+}
 
 TEST_F(DeltaTree_test, Insert)
 {
@@ -98,6 +104,7 @@ TEST_F(DeltaTree_test, Insert)
     }
     std::cout << "a====\n";
     printTree(tree);
+    checkCopy(tree);
 
     // delete 100 items
     for (int i = 0; i < 100; ++i)
@@ -107,6 +114,7 @@ TEST_F(DeltaTree_test, Insert)
     }
     std::cout << "b====\n";
     printTree(tree);
+    checkCopy(tree);
 
     // insert 100 items
     for (int i = 0; i < 100; ++i)
@@ -116,6 +124,7 @@ TEST_F(DeltaTree_test, Insert)
     }
     std::cout << "1111====\n";
     printTree(tree);
+    checkCopy(tree);
 
     // delete
     for (int i = 0; i < 100; ++i)
@@ -125,6 +134,7 @@ TEST_F(DeltaTree_test, Insert)
     }
     std::cout << "c====\n";
     printTree(tree);
+    checkCopy(tree);
 
     // delete
     for (int i = 5; i <= 8; ++i)
@@ -134,6 +144,7 @@ TEST_F(DeltaTree_test, Insert)
     }
     std::cout << "f====\n";
     printTree(tree);
+    checkCopy(tree);
 
     // delete
     tree.addDelete(30);
@@ -153,6 +164,7 @@ TEST_F(DeltaTree_test, Insert)
 
     std::cout << "g111====\n";
     printTree(tree);
+    checkCopy(tree);
 
     // insert
     for (int i = 0; i < 5; ++i)
@@ -161,6 +173,7 @@ TEST_F(DeltaTree_test, Insert)
     }
     std::cout << "h====\n";
     printTree(tree);
+    checkCopy(tree);
 }
 
 TEST_F(DeltaTree_test, DeleteAfterInsert)
@@ -175,6 +188,7 @@ TEST_F(DeltaTree_test, DeleteAfterInsert)
         expectedResult += "(" + std::to_string(i) + "|0|INS|1|" + std::to_string(i) + "),";
         ASSERT_EQ(expectedResult, treeToString(tree));
     }
+    checkCopy(tree);
     std::cout << "after many insert 1\n";
 
     expectedResult = "";
@@ -192,6 +206,7 @@ TEST_F(DeltaTree_test, DeleteAfterInsert)
 
     expectedResult = "";
     ASSERT_EQ(expectedResult, treeToString(tree));
+    checkCopy(tree);
     std::cout << "after many delete 1\n";
 
     for (int i = 0; i < batch_num; ++i)
@@ -205,6 +220,7 @@ TEST_F(DeltaTree_test, DeleteAfterInsert)
         }
         ASSERT_EQ(expectedResult, treeToString(tree));
     }
+    checkCopy(tree);
     std::cout << "after many insert 2\n";
 
     for (int i = batch_num - 1; i >= 0; --i)
@@ -218,6 +234,7 @@ TEST_F(DeltaTree_test, DeleteAfterInsert)
         }
         ASSERT_EQ(expectedResult, treeToString(tree));
     }
+    checkCopy(tree);
     std::cout << "after many delete 2\n";
 }
 
@@ -233,6 +250,7 @@ TEST_F(DeltaTree_test, Delete1)
     }
     std::string expectedResult = "(0|0|DEL|" + DB::toString(batch_num) + "|0),";
     ASSERT_EQ(expectedResult, treeToString(tree));
+    checkCopy(tree);
 }
 
 TEST_F(DeltaTree_test, Delete2)
@@ -254,6 +272,7 @@ TEST_F(DeltaTree_test, Delete2)
 
         ASSERT_EQ(expectedResult, treeToString(tree));
     }
+    checkCopy(tree);
 }
 
 TEST_F(DeltaTree_test, InsertSkipDelete)
@@ -274,6 +293,7 @@ TEST_F(DeltaTree_test, InsertSkipDelete)
         }
         ASSERT_EQ(expectedResult, treeToString(tree));
     }
+    checkCopy(tree);
 }
 
 } // namespace tests


### PR DESCRIPTION
cherry-pick #638 

---

* DeltaTree supports copy
* Sort packs before flush, and do background fully place delta after flush cache.
* Now queries only place the delta index for rows/deletes which included by query range.
* Fix some compile error on Mac with Clang  6.0.1