### PR TITLE
Fix some compile errors about deprecated

### DIFF
--- a/dbms/src/Storages/Transaction/Region.cpp
+++ b/dbms/src/Storages/Transaction/Region.cpp
@@ -303,7 +303,12 @@ void RegionRaftCommandDelegate::handleAdminRaftCmd(const raft_cmdpb::AdminReques
 
             break;
         }
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         case raft_cmdpb::AdminCmdType::Split:
+#pragma clang diagnostic pop
+
         case raft_cmdpb::AdminCmdType::BatchSplit:
         {
             result.ori_region_range = meta.makeRaftCommandDelegate().regionState().getRange();

--- a/dbms/src/Storages/Transaction/RegionMeta.cpp
+++ b/dbms/src/Storages/Transaction/RegionMeta.cpp
@@ -273,10 +273,13 @@ RegionMergeResult MetaRaftCommandDelegate::checkBeforeCommitMerge(
 
 static void CheckRegionForMergeCmd(const raft_cmdpb::AdminResponse & response, const RegionState & region_state)
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     if (response.has_split() && !(response.split().left() == region_state.getRegion()))
         throw Exception(std::string(__PRETTY_FUNCTION__) + ": current region:\n" + region_state.getRegion().DebugString() + "\nexpect:\n"
                 + response.split().left().DebugString() + "\nshould not happen",
             ErrorCodes::LOGICAL_ERROR);
+#pragma clang diagnostic push
 }
 
 void MetaRaftCommandDelegate::execRollbackMerge(


### PR DESCRIPTION
Fix compile errors like below, Apple clang version 11.0.0 (clang-1100.0.33.17)
```
/Users/flow/workspace/github/theflash/storage/ch/dbms/src/Storages/Transaction/Region.cpp:306:40: error: 'Split' is deprecated [-Werror,-Wdeprecated-declarations]
        case raft_cmdpb::AdminCmdType::Split:
                                       ^
/Users/flow/workspace/github/theflash/storage/ch/contrib/kvproto/cpp/./kvproto/raft_cmdpb.pb.h:296:9: note: 'Split' has been explicitly marked deprecated here
  Split PROTOBUF_DEPRECATED_ENUM = 2,
        ^
/usr/local/include/google/protobuf/port_def.inc:152:49: note: expanded from macro 'PROTOBUF_DEPRECATED_ENUM'
#define PROTOBUF_DEPRECATED_ENUM __attribute__((deprecated))
                                                ^
```