### PR TITLE
use hub.pingcap.net/tiflash/centos:centos7.6.1810

### DIFF
--- a/release-centos7/Dockerfile-tiflash-centos7
+++ b/release-centos7/Dockerfile-tiflash-centos7
@@ -1,4 +1,4 @@
-FROM centos:centos7.6.1810
+FROM hub.pingcap.net/tiflash/centos:centos7.6.1810
 
 USER root
 WORKDIR /root/

--- a/release-centos7/Dockerfile-tiflash-ci-base
+++ b/release-centos7/Dockerfile-tiflash-ci-base
@@ -1,4 +1,4 @@
-FROM centos:centos7.6.1810
+FROM hub.pingcap.net/tiflash/centos:centos7.6.1810
 
 USER root
 WORKDIR /root/


### PR DESCRIPTION
dockerhub is not stable

```
16:28:46  Step 1/9 : FROM centos:centos7.6.1810
16:28:56  Get https://registry-1.docker.io/v2/: net/http: TLS handshake timeout
16:28:56  make: *** [Makefile:15: image_tiflash_release] Error 1
```