### PR TITLE
Fix missing of default database

### DIFF
--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -343,8 +343,8 @@ int Server::main(const std::vector<std::string> & /*args*/)
     const std::string path = all_normal_path[0];
     TiFlashRaftConfig raft_config(path, config(), log);
     // Use pd address to define which default_database we use by defauly.
-    // For mock test, we use "default". For deployed with pd/tidb/tikv use "db_1" , whose name is "test" in TiDB.
-    std::string default_database = config().getString("default_database", raft_config.pd_addrs.empty() ? "default" : "db_1");
+    // For mock test, we use "default". For deployed with pd/tidb/tikv use "system", which is always exist in TiFlash.
+    std::string default_database = config().getString("default_database", raft_config.pd_addrs.empty() ? "default" : "system");
     global_context->setPath(path);
     global_context->initializePartPathSelector(std::move(all_normal_path), std::move(all_fast_path));
 


### PR DESCRIPTION
Signed-off-by: JaySon-Huang <tshent@qq.com>

Before we use "db_1" as the default database in TiFlash. Because TiDB will always create a database naming "test" with id = 1 when its first setup.
However, user may drop that database and we never have a database naming "db_1" in TiFlash any longer. This will make TiFlash can not normally restart.

After this PR, for TiFlash deployed with TiDB cluster, we use "system" as the default database, which always exists in TiFlash.