### PR TITLE
[FLASH-1188] Make compact_log_min_period 0 as default

### DIFF
--- a/dbms/src/Storages/Transaction/KVStore.cpp
+++ b/dbms/src/Storages/Transaction/KVStore.cpp
@@ -324,20 +324,20 @@ TiFlashApplyRes KVStore::handleAdminRaftCmd(raft_cmdpb::AdminRequest && request,
             case raft_cmdpb::AdminCmdType::CompactLog:
             {
                 if (curr_region.lastCompactLogTime() + REGION_COMPACT_LOG_PERIOD.load(std::memory_order_relaxed) > Clock::now())
+                {
                     sync_log = false;
+                    LOG_DEBUG(log, curr_region.toString(false) << " ignore compact log cmd");
+                }
                 else
                 {
                     curr_region.markCompactLog();
-                    LOG_INFO(log, curr_region.toString(true) << " make proxy compact log");
                 }
                 break;
             }
             case raft_cmdpb::AdminCmdType::VerifyHash:
             case raft_cmdpb::AdminCmdType::ComputeHash:
             {
-                static const Seconds REGION_MAX_PERSIST_PERIOD(60 * 20);
-                if (curr_region.lastPersistTime() + REGION_MAX_PERSIST_PERIOD > Clock::now())
-                    sync_log = false;
+                sync_log = false;
                 break;
             }
             default:

--- a/dbms/src/Storages/Transaction/Region.cpp
+++ b/dbms/src/Storages/Transaction/Region.cpp
@@ -282,10 +282,6 @@ void RegionRaftCommandDelegate::handleAdminRaftCmd(const raft_cmdpb::AdminReques
     {
         case raft_cmdpb::AdminCmdType::ComputeHash:
         case raft_cmdpb::AdminCmdType::VerifyHash:
-        case raft_cmdpb::AdminCmdType::CompactLog:
-            LOG_INFO(log,
-                toString(false) << " useless admin command " << raft_cmdpb::AdminCmdType_Name(type) << " at [term: " << term
-                                << ", index: " << index << "]");
             break;
         default:
             LOG_INFO(log,
@@ -449,10 +445,6 @@ std::string Region::dataInfo() const
     ss << "]";
     return ss.str();
 }
-
-void Region::markPersisted() const { last_persist_time = Clock::now(); }
-
-Timepoint Region::lastPersistTime() const { return last_persist_time; }
 
 void Region::markCompactLog() const { last_compact_log_time = Clock::now(); }
 

--- a/dbms/src/Storages/Transaction/Region.h
+++ b/dbms/src/Storages/Transaction/Region.h
@@ -122,9 +122,6 @@ public:
     size_t writeCFCount() const;
     std::string dataInfo() const;
 
-    void markPersisted() const;
-    Timepoint lastPersistTime() const;
-
     void markCompactLog() const;
     Timepoint lastCompactLogTime() const;
 

--- a/dbms/src/Storages/Transaction/RegionPersister.cpp
+++ b/dbms/src/Storages/Transaction/RegionPersister.cpp
@@ -47,8 +47,6 @@ void RegionPersister::doPersist(const Region & region, const RegionTaskLock * lo
         doPersist(region_buffer, *lock, region);
     else
         doPersist(region_buffer, region_manager.genRegionTaskLock(region.id()), region);
-
-    region.markPersisted();
 }
 
 void RegionPersister::doPersist(RegionCacheWriteElement & region_write_buffer, const RegionTaskLock &, const Region & region)

--- a/dbms/src/Storages/Transaction/TMTContext.cpp
+++ b/dbms/src/Storages/Transaction/TMTContext.cpp
@@ -89,7 +89,7 @@ void TMTContext::reloadConfig(const Poco::Util::AbstractConfiguration & config)
     static const std::string & COMPACT_LOG_MIN_PERIOD = "flash.compact_log_min_period";
 
     getRegionTable().setTableCheckerThreshold(config.getDouble(TABLE_OVERLAP_THRESHOLD, 0.6));
-    getKVStore()->setRegionCompactLogPeriod(Seconds{config.getUInt64(COMPACT_LOG_MIN_PERIOD, 200)});
+    getKVStore()->setRegionCompactLogPeriod(Seconds{config.getUInt64(COMPACT_LOG_MIN_PERIOD, 0)});
 }
 
 const std::atomic_bool & TMTContext::getTerminated() const { return terminated; }


### PR DESCRIPTION
- Make compact_log_min_period 0 as default.

- Discard `ComputeHash` and `VerifyHash` by default.