### PR TITLE
disable new collation related fullstack tests

### DIFF
--- a/tests/fullstack-test/ddl/default_value.test
+++ b/tests/fullstack-test/ddl/default_value.test
@@ -50,11 +50,12 @@ mysql> set session tidb_isolation_read_engines='tiflash'; select hex(b1), hex(b2
 | 0       | 0       | 10203   | 10203   | 10203   | 10203   | 10203   |
 +---------+---------+---------+---------+---------+---------+---------+
 
-mysql> alter table test.t add column b8 enum('ab','cd','ef') charset utf8mb4 collate utf8mb4_general_ci default 'EF';
-mysql> set session tidb_isolation_read_engines='tiflash'; select b8 from test.t;
-+----+
-| b8 |
-+----+
-| ef |
-| ef |
-+----+
+# new collation is disabled in TiDB by default, need to enable new collation to run this test
+# mysql> alter table test.t add column b8 enum('ab','cd','ef') charset utf8mb4 collate utf8mb4_general_ci default 'EF';
+# mysql> set session tidb_isolation_read_engines='tiflash'; select b8 from test.t;
+# +----+
+# | b8 |
+# +----+
+# | ef |
+# | ef |
+# +----+


### PR DESCRIPTION
TiDB disable new collation by default, so need to disable new collation related fullstack tests to avoid ci test fail. Will add it back after adding new collation enabled TiDB in fullstack tests.