### PR TITLE
Make table structure lock not being held when doing learner read (#864)

### DIFF
--- a/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.cpp
@@ -25,6 +25,7 @@
 #include <Storages/StorageMergeTree.h>
 #include <Storages/Transaction/CHTableHandle.h>
 #include <Storages/Transaction/KVStore.h>
+#include <Storages/Transaction/LearnerRead.h>
 #include <Storages/Transaction/LockException.h>
 #include <Storages/Transaction/Region.h>
 #include <Storages/Transaction/RegionException.h>
@@ -310,6 +311,62 @@ void DAGQueryBlockInterpreter::executeTS(const tipb::TableScan & ts, Pipeline & 
     const Settings & settings = context.getSettingsRef();
     auto & tmt = context.getTMTContext();
 
+    auto mvcc_query_info = std::make_unique<MvccQueryInfo>();
+    mvcc_query_info->resolve_locks = true;
+    mvcc_query_info->read_tso = settings.read_tso;
+    // We need to validate regions snapshot after getting streams from storage.
+    LearnerReadSnapshot learner_read_snapshot;
+    std::unordered_map<RegionID, const RegionInfo &> region_retry;
+    if (!dag.isBatchCop())
+    {
+        if (auto [info_retry, status] = MakeRegionQueryInfos(dag.getRegions(), {}, tmt, *mvcc_query_info, table_id); info_retry)
+            throw RegionException({(*info_retry).begin()->first}, status);
+
+        learner_read_snapshot = doLearnerRead(table_id, *mvcc_query_info, tmt, log);
+    }
+    else
+    {
+        std::unordered_set<RegionID> force_retry;
+        for (;;)
+        {
+            try
+            {
+                region_retry.clear();
+                auto [retry, status] = MakeRegionQueryInfos(dag.getRegions(), force_retry, tmt, *mvcc_query_info, table_id);
+                std::ignore = status;
+                if (retry)
+                {
+                    region_retry = std::move(*retry);
+                    for (auto & r : region_retry)
+                        force_retry.emplace(r.first);
+                }
+                if (mvcc_query_info->regions_query_info.empty())
+                    break;
+                learner_read_snapshot = doLearnerRead(table_id, *mvcc_query_info, tmt, log);
+                break;
+            }
+            catch (const LockException & e)
+            {
+                // We can also use current thread to resolve lock, but it will block next process.
+                // So, force this region retry in another thread in CoprocessorBlockInputStream.
+                force_retry.emplace(e.region_id);
+            }
+            catch (const RegionException & e)
+            {
+                if (tmt.getTerminated())
+                    throw Exception("TiFlash server is terminating", ErrorCodes::LOGICAL_ERROR);
+                // By now, RegionException will contain all region id of MvccQueryInfo, which is needed by CHSpark.
+                // When meeting RegionException, we can let MakeRegionQueryInfos to check in next loop.
+            }
+            catch (DB::Exception & e)
+            {
+                e.addMessage("(while creating InputStreams from storage `" + storage->getDatabaseName() + "`.`" + storage->getTableName()
+                    + "`, table_id: " + DB::toString(table_id) + ")");
+                throw;
+            }
+        }
+    }
+
     if (settings.schema_version == DEFAULT_UNSPECIFIED_SCHEMA_VERSION)
     {
         storage = context.getTMTContext().getStorages().get(table_id);
@@ -402,9 +459,7 @@ void DAGQueryBlockInterpreter::executeTS(const tipb::TableScan & ts, Pipeline & 
     /// to avoid null point exception
     query_info.query = dummy_query;
     query_info.dag_query = std::make_unique<DAGQueryInfo>(conditions, analyzer->getPreparedSets(), analyzer->getCurrentInputColumns());
-    query_info.mvcc_query_info = std::make_unique<MvccQueryInfo>();
-    query_info.mvcc_query_info->resolve_locks = true;
-    query_info.mvcc_query_info->read_tso = settings.read_tso;
+    query_info.mvcc_query_info = std::move(mvcc_query_info);
 
     if (dag.getRegions().empty())
     {
@@ -419,6 +474,8 @@ void DAGQueryBlockInterpreter::executeTS(const tipb::TableScan & ts, Pipeline & 
         try
         {
             pipeline.streams = storage->read(required_columns, query_info, context, from_stage, max_block_size, max_streams);
+            // After getting streams from storage, we need to validate if regions have changed after learner read.
+            validateQueryInfo(*query_info.mvcc_query_info, learner_read_snapshot, tmt, log);
         }
         catch (DB::Exception & e)
         {
@@ -429,48 +486,25 @@ void DAGQueryBlockInterpreter::executeTS(const tipb::TableScan & ts, Pipeline & 
     }
     else
     {
-        std::unordered_map<RegionID, const RegionInfo &> region_retry;
-        std::unordered_set<RegionID> force_retry;
-        for (;;)
+        // TODO: Note that if storage is (Txn)MergeTree, and any region exception thrown, we won't do retry here.
+        // Now we only support DeltaTree in production environment and don't do any extra check for storage type here.
+        try
         {
-            try
-            {
-                region_retry.clear();
-                auto [retry, status] = MakeRegionQueryInfos(dag.getRegions(), force_retry, tmt, *query_info.mvcc_query_info, table_id);
-                std::ignore = status;
-                if (retry)
-                {
-                    region_retry = std::move(*retry);
-                    for (auto & r : region_retry)
-                        force_retry.emplace(r.first);
-                }
-                if (query_info.mvcc_query_info->regions_query_info.empty())
-                    break;
-                pipeline.streams = storage->read(required_columns, query_info, context, from_stage, max_block_size, max_streams);
-                break;
-            }
-            catch (const LockException & e)
-            {
-                // We can also use current thread to resolve lock, but it will block next process.
-                // So, force this region retry in another thread in CoprocessorBlockInputStream.
-                force_retry.emplace(e.region_id);
-            }
-            catch (const RegionException & e)
-            {
-                if (tmt.getTerminated())
-                    throw Exception("TiFlash server is terminating", ErrorCodes::LOGICAL_ERROR);
-                // By now, RegionException will contain all region id of MvccQueryInfo, which is needed by CHSpark.
-                // When meeting RegionException, we can let MakeRegionQueryInfos to check in next loop.
-            }
-            catch (DB::Exception & e)
-            {
-                e.addMessage("(while creating InputStreams from storage `" + storage->getDatabaseName() + "`.`" + storage->getTableName()
-                    + "`, table_id: " + DB::toString(table_id) + ")");
-                throw;
-            }
+            pipeline.streams = storage->read(required_columns, query_info, context, from_stage, max_block_size, max_streams);
+            // After getting streams from storage, we need to validate whether regions have changed or not after learner read.
+            // In case the versions of regions have changed, those `streams` may contain different data other than expected.
+            // Like after region merge/split.
+            validateQueryInfo(*query_info.mvcc_query_info, learner_read_snapshot, tmt, log);
+        }
+        catch (DB::Exception & e)
+        {
+            e.addMessage("(while creating InputStreams from storage `" + storage->getDatabaseName() + "`.`" + storage->getTableName()
+                + "`, table_id: " + DB::toString(table_id) + ")");
+            throw;
         }
 
-        if (region_retry.size())
+        // For those regions which are not presented in this tiflash node, we will try to fetch streams from other tiflash nodes.
+        if (!region_retry.empty())
         {
             LOG_DEBUG(log, ({
                 std::stringstream ss;
@@ -997,13 +1031,13 @@ SortDescription DAGQueryBlockInterpreter::getSortDescription(std::vector<NameAnd
     order_descr.reserve(topn.order_by_size());
     for (int i = 0; i < topn.order_by_size(); i++)
     {
-	String name = order_columns[i].name;
+        const auto & name = order_columns[i].name;
         int direction = topn.order_by(i).desc() ? -1 : 1;
         // MySQL/TiDB treats NULL as "minimum".
         int nulls_direction = -1;
-	std::shared_ptr<ICollator> collator = nullptr;
-	if (removeNullable(order_columns[i].type)->isString())
-	    collator = getCollatorFromExpr(topn.order_by(i).expr());
+        std::shared_ptr<ICollator> collator = nullptr;
+        if (removeNullable(order_columns[i].type)->isString())
+            collator = getCollatorFromExpr(topn.order_by(i).expr());
 
         order_descr.emplace_back(name, direction, nulls_direction, collator);
     }

--- a/dbms/src/Flash/Coprocessor/InterpreterDAGHelper.hpp
+++ b/dbms/src/Flash/Coprocessor/InterpreterDAGHelper.hpp
@@ -24,9 +24,9 @@ RegionException::RegionReadStatus GetRegionReadStatus(
     return RegionException::OK;
 }
 
-std::tuple<std::optional<std::unordered_map<RegionID, const RegionInfo &>>, RegionException::RegionReadStatus> MakeRegionQueryInfos(
-    const std::unordered_map<RegionID, RegionInfo> & dag_region_infos, const std::unordered_set<RegionID> & region_force_retry,
-    TMTContext & tmt, MvccQueryInfo & mvcc_info, TableID table_id)
+std::tuple<std::optional<std::unordered_map<RegionID, const RegionInfo &>>, RegionException::RegionReadStatus> //
+MakeRegionQueryInfos(const std::unordered_map<RegionID, RegionInfo> & dag_region_infos,
+    const std::unordered_set<RegionID> & region_force_retry, TMTContext & tmt, MvccQueryInfo & mvcc_info, TableID table_id)
 {
     mvcc_info.regions_query_info.clear();
     std::unordered_map<RegionID, const RegionInfo &> region_need_retry;

--- a/dbms/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterSelectQuery.cpp
@@ -38,6 +38,8 @@
 #include <Storages/Transaction/TiKVRange.h>
 #include <Storages/Transaction/TMTContext.h>
 #include <Storages/Transaction/RegionRangeKeys.h>
+#include <Storages/Transaction/LearnerRead.h>
+#include <Storages/Transaction/StorageEngineType.h>
 
 #include <Storages/IStorage.h>
 #include <Storages/StorageMergeTree.h>
@@ -845,7 +847,36 @@ QueryProcessingStage::Enum InterpreterSelectQuery::executeFetchColumns(Pipeline 
         }
 
         if (!dry_run)
+        {
+            LearnerReadSnapshot learner_read_snapshot;
+            // TODO: Note that we should do learner read without holding table's structure lock,
+            // or there will be deadlocks between learner read and raft threads (#815).
+            // Here we do not follow the rule because this is not use in production environment 
+            // and it is hard to move learner read before acuqiring table's lock.
+
+            // Do learner read only For DeltaTree.
+            auto & tmt = context.getTMTContext();
+            if (auto managed_storage = std::dynamic_pointer_cast<IManageableStorage>(storage);
+                managed_storage && managed_storage->engineType() == TiDB::StorageEngine::DT)
+            {
+                if (const ASTSelectQuery * select_query = typeid_cast<const ASTSelectQuery *>(query_info.query.get()))
+                {
+                    // With `no_kvsotre` is true, we do not do learner read
+                    if (likely(!select_query->no_kvstore))
+                    {
+                        auto table_info = managed_storage->getTableInfo();
+                        learner_read_snapshot = doLearnerRead(table_info.id, *query_info.mvcc_query_info, tmt, log);
+                    }
+                }
+            }
+
             pipeline.streams = storage->read(required_columns, query_info, context, from_stage, max_block_size, max_streams);
+
+            if (!learner_read_snapshot.empty())
+            {
+                validateQueryInfo(*query_info.mvcc_query_info, learner_read_snapshot, tmt, log);
+            }
+        }
 
         if (pipeline.streams.empty())
             pipeline.streams.emplace_back(std::make_shared<NullBlockInputStream>(storage->getSampleBlockForColumns(required_columns)));

--- a/dbms/src/Storages/StorageDeltaMerge.cpp
+++ b/dbms/src/Storages/StorageDeltaMerge.cpp
@@ -24,7 +24,6 @@
 #include <Storages/StorageDeltaMergeHelpers.h>
 #include <Storages/Transaction/KVStore.h>
 #include <Storages/Transaction/Region.h>
-#include <Storages/Transaction/RegionException.h>
 #include <Storages/Transaction/SchemaNameMapper.h>
 #include <Storages/Transaction/TMTContext.h>
 #include <Storages/Transaction/TypeMapping.h>
@@ -316,240 +315,6 @@ void StorageDeltaMerge::write(Block && block, const Settings & settings)
     store->write(global_context, settings, block);
 }
 
-namespace
-{
-
-void throwRetryRegion(const MvccQueryInfo::RegionsQueryInfo & regions_info, RegionException::RegionReadStatus status)
-{
-    std::vector<RegionID> region_ids;
-    region_ids.reserve(regions_info.size());
-    for (const auto & info : regions_info)
-        region_ids.push_back(info.region_id);
-    throw RegionException(std::move(region_ids), status);
-}
-
-/// Check if region is invalid.
-RegionException::RegionReadStatus isValidRegion(const RegionQueryInfo & region_to_query, const RegionPtr & region_in_mem)
-{
-    if (region_in_mem->peerState() != raft_serverpb::PeerState::Normal)
-        return RegionException::RegionReadStatus::NOT_FOUND;
-
-    const auto & [version, conf_ver, key_range] = region_in_mem->dumpVersionRange();
-    (void)key_range;
-    if (version != region_to_query.version || conf_ver != region_to_query.conf_version)
-        return RegionException::RegionReadStatus::VERSION_ERROR;
-
-    return RegionException::RegionReadStatus::OK;
-}
-
-struct RegionMapNode : RegionPtr
-{
-    UInt64 snapshot_event_flag{0};
-
-    RegionMapNode() = default;
-    RegionMapNode(const RegionPtr & region) : RegionPtr(region), snapshot_event_flag(region->getSnapshotEventFlag()) {}
-    bool operator!=(const RegionPtr & tar) const { return (tar != *this) || (tar && snapshot_event_flag != tar->getSnapshotEventFlag()); }
-};
-
-using InternalRegionMap = std::unordered_map<RegionID, RegionMapNode>;
-
-InternalRegionMap doLearnerRead(const TiDB::TableID table_id,   //
-    const MvccQueryInfo::RegionsQueryInfo & regions_query_info, //
-    const bool resolve_locks, const Timestamp start_ts,
-    size_t concurrent_num, //
-    TMTContext & tmt, Poco::Logger * log)
-{
-    assert(log != nullptr);
-
-    MvccQueryInfo::RegionsQueryInfo regions_info;
-    if (!regions_query_info.empty())
-    {
-        regions_info = regions_query_info;
-    }
-    else
-    {
-        // Only for test, because regions_query_info should never be empty if query is from TiDB or TiSpark.
-        auto regions = tmt.getRegionTable().getRegionsByTable(table_id);
-        regions_info.reserve(regions.size());
-        for (const auto & [id, region] : regions)
-        {
-            if (region == nullptr)
-                continue;
-            regions_info.emplace_back(
-                RegionQueryInfo{id, region->version(), region->confVer(), region->getHandleRangeByTable(table_id), {}});
-        }
-    }
-
-    // adjust concurrency by num of regions
-    concurrent_num = std::max(1, std::min(concurrent_num, regions_info.size()));
-
-    KVStorePtr & kvstore = tmt.getKVStore();
-    Context & context = tmt.getContext();
-    InternalRegionMap kvstore_region;
-    // check region is not null and store region map.
-    for (const auto & info : regions_info)
-    {
-        auto region = kvstore->getRegion(info.region_id);
-        if (region == nullptr)
-        {
-            LOG_WARNING(log, "[region " << info.region_id << "] is not found in KVStore, try again");
-            throwRetryRegion(regions_info, RegionException::RegionReadStatus::NOT_FOUND);
-        }
-        kvstore_region.emplace(info.region_id, std::move(region));
-    }
-    // make sure regions are not duplicated.
-    if (unlikely(kvstore_region.size() != regions_info.size()))
-        throw Exception("Duplicate region id", ErrorCodes::LOGICAL_ERROR);
-
-    auto metrics = context.getTiFlashMetrics();
-    const size_t num_regions = regions_info.size();
-    const size_t batch_size = num_regions / concurrent_num;
-    std::atomic_uint8_t region_status = RegionException::RegionReadStatus::OK;
-    const auto batch_wait_index = [&, resolve_locks, start_ts](const size_t region_begin_idx) -> void {
-        const size_t region_end_idx = std::min(region_begin_idx + batch_size, num_regions);
-        for (size_t region_idx = region_begin_idx; region_idx < region_end_idx; ++region_idx)
-        {
-            // If any threads meets an error, just return.
-            if (region_status != RegionException::RegionReadStatus::OK)
-                return;
-
-            RegionQueryInfo & region_to_query = regions_info[region_idx];
-            const RegionID region_id = region_to_query.region_id;
-            auto region = kvstore_region[region_id];
-
-            auto status = isValidRegion(region_to_query, region);
-            if (status != RegionException::RegionReadStatus::OK)
-            {
-                region_status = status;
-                LOG_WARNING(log,
-                    "Check memory cache, region " << region_id << ", version " << region_to_query.version << ", handle range ["
-                                                  << region_to_query.range_in_table.first.toString() << ", "
-                                                  << region_to_query.range_in_table.second.toString() << ") , status "
-                                                  << RegionException::RegionReadStatusString(status));
-                return;
-            }
-
-            GET_METRIC(metrics, tiflash_raft_read_index_count).Increment();
-            Stopwatch read_index_watch;
-
-            /// Blocking learner read. Note that learner read must be performed ahead of data read,
-            /// otherwise the desired index will be blocked by the lock of data read.
-            auto read_index_result = region->learnerRead();
-            GET_METRIC(metrics, tiflash_raft_read_index_duration_seconds).Observe(read_index_watch.elapsedSeconds());
-            if (read_index_result.region_unavailable)
-            {
-                // client-c detect region removed. Set region_status and continue.
-                region_status = RegionException::RegionReadStatus::NOT_FOUND;
-                continue;
-            }
-            else if (read_index_result.region_epoch_not_match)
-            {
-                region_status = RegionException::RegionReadStatus::VERSION_ERROR;
-                continue;
-            }
-            else
-            {
-                Stopwatch wait_index_watch;
-                if (region->waitIndex(read_index_result.read_index, tmt.getTerminated()))
-                {
-                    region_status = RegionException::RegionReadStatus::NOT_FOUND;
-                    continue;
-                }
-                GET_METRIC(metrics, tiflash_raft_wait_index_duration_seconds).Observe(wait_index_watch.elapsedSeconds());
-            }
-            if (resolve_locks)
-            {
-                status = RegionTable::resolveLocksAndWriteRegion( //
-                    tmt,                                          //
-                    table_id,                                     //
-                    region,                                       //
-                    start_ts,                                     //
-                    region_to_query.bypass_lock_ts,               //
-                    region_to_query.version,                      //
-                    region_to_query.conf_version,                 //
-                    region_to_query.range_in_table, log);
-
-                if (status != RegionException::RegionReadStatus::OK)
-                {
-                    LOG_WARNING(log,
-                        "Check memory cache, region " << region_id << ", version " << region_to_query.version << ", handle range ["
-                                                      << region_to_query.range_in_table.first.toString() << ", "
-                                                      << region_to_query.range_in_table.second.toString() << ") , status "
-                                                      << RegionException::RegionReadStatusString(status));
-                    region_status = status;
-                }
-            }
-        }
-    };
-    auto start_time = Clock::now();
-    if (concurrent_num <= 1)
-    {
-        batch_wait_index(0);
-    }
-    else
-    {
-        ::ThreadPool pool(concurrent_num);
-        for (size_t region_begin_idx = 0; region_begin_idx < num_regions; region_begin_idx += batch_size)
-        {
-            pool.schedule([&batch_wait_index, region_begin_idx] { batch_wait_index(region_begin_idx); });
-        }
-        pool.wait();
-    }
-
-    // Check if any region is invalid, TiDB / TiSpark should refresh region cache and retry.
-    if (region_status != RegionException::RegionReadStatus::OK)
-        throwRetryRegion(regions_info, static_cast<RegionException::RegionReadStatus>(region_status.load()));
-
-    auto end_time = Clock::now();
-    LOG_DEBUG(log,
-        "[Learner Read] wait index cost " << std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count() << " ms");
-
-    /// If background flush is disabled, we don't need to do both flushing KVStore or waiting for background tasks.
-    if (!tmt.isBgFlushDisabled())
-    {
-        // After raft index is satisfied, we flush region to StorageDeltaMerge so that we can read all data
-        start_time = Clock::now();
-        std::set<RegionID> regions_flushing_in_bg_threads;
-        auto & region_table = tmt.getRegionTable();
-        for (auto && [region_id, region] : kvstore_region)
-        {
-            if (!region->dataSize())
-                continue;
-            auto to_remove_data = region_table.tryFlushRegion(region, false);
-            // If region is flushing by other bg threads, we should mark those regions to wait.
-            if (to_remove_data.empty())
-            {
-                regions_flushing_in_bg_threads.insert(region_id);
-                LOG_DEBUG(log, "[Learner Read] region " << region_id << " is flushing by other thread.");
-            }
-        }
-        end_time = Clock::now();
-        LOG_DEBUG(log,
-            "[Learner Read] flush " << kvstore_region.size() - regions_flushing_in_bg_threads.size() << " regions of "
-                                    << kvstore_region.size() << " to StorageDeltaMerge cost "
-                                    << std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count() << " ms");
-
-        // Maybe there is some data not flush to store yet, we should wait till all regions is flushed.
-        if (!regions_flushing_in_bg_threads.empty())
-        {
-            start_time = Clock::now();
-            for (const auto & region_id : regions_flushing_in_bg_threads)
-            {
-                region_table.waitTillRegionFlushed(region_id);
-            }
-            end_time = Clock::now();
-            LOG_DEBUG(log,
-                "[Learner Read] wait bg flush " << regions_flushing_in_bg_threads.size() << " regions to StorageDeltaMerge cost "
-                                                << std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count()
-                                                << " ms");
-        }
-    }
-
-    return kvstore_region;
-}
-
-} // namespace
-
 std::unordered_set<UInt64> parseSegmentSet(const ASTPtr & ast)
 {
     if (!ast)
@@ -678,20 +443,10 @@ BlockInputStreams StorageDeltaMerge::read( //
         /// Else a request comes from CH-client, we set `concurrent_num` by num_streams.
         size_t concurrent_num = std::max<size_t>(num_streams * mvcc_query_info.concurrent, 1);
 
-        // With `no_kvstore` is true, we do not do learner read
-        InternalRegionMap regions_in_learner_read;
-        if (likely(!select_query.no_kvstore))
-        {
-            /// Learner read.
-            regions_in_learner_read = doLearnerRead(tidb_table_info.id, mvcc_query_info.regions_query_info, mvcc_query_info.resolve_locks,
-                mvcc_query_info.read_tso, concurrent_num, tmt, log);
-
-            if (likely(!mvcc_query_info.regions_query_info.empty()))
-            {
-                /// For learner read from TiDB/TiSpark, we set num_streams by `concurrent_num`
-                num_streams = concurrent_num;
-            } // else learner read from ch-client, keep num_streams
-        }
+        /// For learner read from TiDB/TiSpark, we set num_streams by `concurrent_num`
+        if (likely(!select_query.no_kvstore && !mvcc_query_info.regions_query_info.empty()))
+            num_streams = concurrent_num;
+        // else learner read from ch-client, keep num_streams
 
         HandleRanges ranges = getQueryRanges(mvcc_query_info.regions_query_info);
 
@@ -763,37 +518,8 @@ BlockInputStreams StorageDeltaMerge::read( //
         auto streams = store->read(context, context.getSettingsRef(), columns_to_read, ranges, num_streams,
             /*max_version=*/mvcc_query_info.read_tso, rs_operator, max_block_size, parseSegmentSet(select_query.segment_expression_list));
 
-        {
-            /// Ensure read_tso and regions' info after read.
-
-            check_read_tso(mvcc_query_info.read_tso);
-
-            for (const auto & region_query_info : mvcc_query_info.regions_query_info)
-            {
-                RegionException::RegionReadStatus status = RegionException::RegionReadStatus::OK;
-                auto region = tmt.getKVStore()->getRegion(region_query_info.region_id);
-                if (regions_in_learner_read[region_query_info.region_id] != region)
-                    status = RegionException::RegionReadStatus::NOT_FOUND;
-                else if (region->version() != region_query_info.version)
-                {
-                    // ABA problem may cause because one region is removed and inserted back.
-                    // if the version of region is changed, the `streams` may has less data because of compaction.
-                    status = RegionException::RegionReadStatus::VERSION_ERROR;
-                }
-
-                if (status != RegionException::RegionReadStatus::OK)
-                {
-                    LOG_WARNING(log,
-                        "Check after read from DeltaMergeStore, region "
-                            << region_query_info.region_id << ", version " << region_query_info.version //
-                            << ", handle range [" << region_query_info.range_in_table.first.toString() << ", "
-                            << region_query_info.range_in_table.second.toString() << "), status "
-                            << RegionException::RegionReadStatusString(status));
-                    // throw region exception and let TiDB retry
-                    throwRetryRegion(mvcc_query_info.regions_query_info, status);
-                }
-            }
-        }
+        /// Ensure read_tso info after read.
+        check_read_tso(mvcc_query_info.read_tso);
 
         return streams;
     }

--- a/dbms/src/Storages/Transaction/LearnerRead.cpp
+++ b/dbms/src/Storages/Transaction/LearnerRead.cpp
@@ -1,0 +1,224 @@
+#include <Common/Stopwatch.h>
+#include <Common/TiFlashMetrics.h>
+#include <Interpreters/Context.h>
+#include <Storages/Transaction/KVStore.h>
+#include <Storages/Transaction/LearnerRead.h>
+#include <Storages/Transaction/RegionException.h>
+#include <Storages/Transaction/TMTContext.h>
+#include <common/ThreadPool.h>
+#include <common/likely.h>
+
+namespace DB
+{
+
+void throwRetryRegion(const MvccQueryInfo::RegionsQueryInfo & regions_info, RegionException::RegionReadStatus status)
+{
+    std::vector<RegionID> region_ids;
+    region_ids.reserve(regions_info.size());
+    for (const auto & info : regions_info)
+        region_ids.push_back(info.region_id);
+    throw RegionException(std::move(region_ids), status);
+}
+
+/// Check whether region is invalid or not.
+RegionException::RegionReadStatus isValidRegion(const RegionQueryInfo & region_to_query, const RegionPtr & region_in_mem)
+{
+    if (region_in_mem->peerState() != raft_serverpb::PeerState::Normal)
+        return RegionException::RegionReadStatus::NOT_FOUND;
+
+    const auto & [version, conf_ver, key_range] = region_in_mem->dumpVersionRange();
+    (void)key_range;
+    if (version != region_to_query.version || conf_ver != region_to_query.conf_version)
+        return RegionException::RegionReadStatus::VERSION_ERROR;
+
+    return RegionException::RegionReadStatus::OK;
+}
+
+LearnerReadSnapshot doLearnerRead(const TiDB::TableID table_id, //
+    const MvccQueryInfo & mvcc_query_info,                      //
+    TMTContext & tmt, Poco::Logger * log)
+{
+    assert(log != nullptr);
+
+    const bool resolve_locks = mvcc_query_info.resolve_locks;
+    const Timestamp start_ts = mvcc_query_info.read_tso;
+    MvccQueryInfo::RegionsQueryInfo regions_info;
+    if (likely(!mvcc_query_info.regions_query_info.empty()))
+    {
+        regions_info = mvcc_query_info.regions_query_info;
+    }
+    else
+    {
+        // Only for test, because regions_query_info should never be empty if query is from TiDB or TiSpark.
+        auto regions = tmt.getRegionTable().getRegionsByTable(table_id);
+        regions_info.reserve(regions.size());
+        for (const auto & [id, region] : regions)
+        {
+            if (region == nullptr)
+                continue;
+            regions_info.emplace_back(
+                RegionQueryInfo{id, region->version(), region->confVer(), region->getHandleRangeByTable(table_id), {}});
+        }
+    }
+
+    // adjust concurrency by num of regions
+    size_t concurrent_num = std::max(1, std::min((size_t)mvcc_query_info.concurrent, regions_info.size()));
+
+    KVStorePtr & kvstore = tmt.getKVStore();
+    LearnerReadSnapshot regions_snapshot;
+    // check region is not null and store region map.
+    for (const auto & info : regions_info)
+    {
+        auto region = kvstore->getRegion(info.region_id);
+        if (region == nullptr)
+        {
+            LOG_WARNING(log, "[region " << info.region_id << "] is not found in KVStore, try again");
+            throwRetryRegion(regions_info, RegionException::RegionReadStatus::NOT_FOUND);
+        }
+        regions_snapshot.emplace(info.region_id, std::move(region));
+    }
+    // make sure regions are not duplicated.
+    if (unlikely(regions_snapshot.size() != regions_info.size()))
+        throw Exception("Duplicate region id", ErrorCodes::LOGICAL_ERROR);
+
+    auto metrics = tmt.getContext().getTiFlashMetrics();
+    const size_t num_regions = regions_info.size();
+    const size_t batch_size = num_regions / concurrent_num;
+    std::atomic_uint8_t region_status = RegionException::RegionReadStatus::OK;
+    const auto batch_wait_index = [&, resolve_locks, start_ts](const size_t region_begin_idx) -> void {
+        const size_t region_end_idx = std::min(region_begin_idx + batch_size, num_regions);
+        for (size_t region_idx = region_begin_idx; region_idx < region_end_idx; ++region_idx)
+        {
+            // If any threads meets an error, just return.
+            if (region_status != RegionException::RegionReadStatus::OK)
+                return;
+
+            RegionQueryInfo & region_to_query = regions_info[region_idx];
+            const RegionID region_id = region_to_query.region_id;
+            auto region = regions_snapshot[region_id];
+
+            auto status = isValidRegion(region_to_query, region);
+            if (status != RegionException::RegionReadStatus::OK)
+            {
+                region_status = status;
+                LOG_WARNING(log,
+                    "Check memory cache, region " << region_id << ", version " << region_to_query.version << ", handle range ["
+                                                  << region_to_query.range_in_table.first.toString() << ", "
+                                                  << region_to_query.range_in_table.second.toString() << ") , status "
+                                                  << RegionException::RegionReadStatusString(status));
+                return;
+            }
+
+            GET_METRIC(metrics, tiflash_raft_read_index_count).Increment();
+            Stopwatch read_index_watch;
+
+            /// Blocking learner read. Note that learner read must be performed ahead of data read,
+            /// otherwise the desired index will be blocked by the lock of data read.
+            auto read_index_result = region->learnerRead();
+            GET_METRIC(metrics, tiflash_raft_read_index_duration_seconds).Observe(read_index_watch.elapsedSeconds());
+            if (read_index_result.region_unavailable)
+            {
+                // client-c detect region removed. Set region_status and continue.
+                region_status = RegionException::RegionReadStatus::NOT_FOUND;
+                continue;
+            }
+            else if (read_index_result.region_epoch_not_match)
+            {
+                region_status = RegionException::RegionReadStatus::VERSION_ERROR;
+                continue;
+            }
+            else
+            {
+                Stopwatch wait_index_watch;
+                if (region->waitIndex(read_index_result.read_index, tmt.getTerminated()))
+                {
+                    region_status = RegionException::RegionReadStatus::NOT_FOUND;
+                    continue;
+                }
+                GET_METRIC(metrics, tiflash_raft_wait_index_duration_seconds).Observe(wait_index_watch.elapsedSeconds());
+            }
+            if (resolve_locks)
+            {
+                status = RegionTable::resolveLocksAndWriteRegion( //
+                    tmt,                                          //
+                    table_id,                                     //
+                    region,                                       //
+                    start_ts,                                     //
+                    region_to_query.bypass_lock_ts,               //
+                    region_to_query.version,                      //
+                    region_to_query.conf_version,                 //
+                    region_to_query.range_in_table, log);
+
+                if (status != RegionException::RegionReadStatus::OK)
+                {
+                    LOG_WARNING(log,
+                        "Check memory cache, region " << region_id << ", version " << region_to_query.version << ", handle range ["
+                                                      << region_to_query.range_in_table.first.toString() << ", "
+                                                      << region_to_query.range_in_table.second.toString() << ") , status "
+                                                      << RegionException::RegionReadStatusString(status));
+                    region_status = status;
+                }
+            }
+        }
+    };
+    auto start_time = Clock::now();
+    if (concurrent_num <= 1)
+    {
+        batch_wait_index(0);
+    }
+    else
+    {
+        ::ThreadPool pool(concurrent_num);
+        for (size_t region_begin_idx = 0; region_begin_idx < num_regions; region_begin_idx += batch_size)
+        {
+            pool.schedule([&batch_wait_index, region_begin_idx] { batch_wait_index(region_begin_idx); });
+        }
+        pool.wait();
+    }
+
+    // Check if any region is invalid, TiDB / TiSpark should refresh region cache and retry.
+    if (region_status != RegionException::RegionReadStatus::OK)
+        throwRetryRegion(regions_info, static_cast<RegionException::RegionReadStatus>(region_status.load()));
+
+    auto end_time = Clock::now();
+    LOG_DEBUG(log,
+        "[Learner Read] wait index cost " << std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count() << " ms");
+
+    return regions_snapshot;
+}
+
+void validateQueryInfo(
+    const MvccQueryInfo & mvcc_query_info, const LearnerReadSnapshot & regions_snapshot, TMTContext & tmt, Poco::Logger * log)
+{
+    const auto & regions_query_info = mvcc_query_info.regions_query_info;
+    /// Ensure regions' info after read.
+    for (const auto & region_query_info : regions_query_info)
+    {
+        RegionException::RegionReadStatus status = RegionException::RegionReadStatus::OK;
+        auto region = tmt.getKVStore()->getRegion(region_query_info.region_id);
+        if (auto iter = regions_snapshot.find(region_query_info.region_id); //
+            iter == regions_snapshot.end() || iter->second != region)
+        {
+            status = RegionException::RegionReadStatus::NOT_FOUND;
+        }
+        else if (region->version() != region_query_info.version)
+        {
+            // ABA problem may cause because one region is removed and inserted back.
+            // if the version of region is changed, the `streams` may has less data because of compaction.
+            status = RegionException::RegionReadStatus::VERSION_ERROR;
+        }
+
+        if (status != RegionException::RegionReadStatus::OK)
+        {
+            LOG_WARNING(log,
+                "Check after read from Storage, region " << region_query_info.region_id << ", version " << region_query_info.version //
+                                                         << ", handle range [" << region_query_info.range_in_table.first.toString() << ", "
+                                                         << region_query_info.range_in_table.second.toString() << "), status "
+                                                         << RegionException::RegionReadStatusString(status));
+            // throw region exception and let TiDB retry
+            throwRetryRegion(regions_query_info, status);
+        }
+    }
+}
+
+} // namespace DB

--- a/dbms/src/Storages/Transaction/LearnerRead.h
+++ b/dbms/src/Storages/Transaction/LearnerRead.h
@@ -1,0 +1,33 @@
+#include <Core/Types.h>
+#include <Storages/RegionQueryInfo.h>
+#include <Storages/Transaction/Region.h>
+#include <Storages/Transaction/Types.h>
+
+#include <unordered_map>
+#include <vector>
+
+
+namespace DB
+{
+
+struct RegionLearnerReadSnapshot : RegionPtr
+{
+    UInt64 snapshot_event_flag{0};
+
+    RegionLearnerReadSnapshot() = default;
+    RegionLearnerReadSnapshot(const RegionPtr & region) : RegionPtr(region), snapshot_event_flag(region->getSnapshotEventFlag()) {}
+    bool operator!=(const RegionPtr & tar) const { return (tar != *this) || (tar && snapshot_event_flag != tar->getSnapshotEventFlag()); }
+};
+using LearnerReadSnapshot = std::unordered_map<RegionID, RegionLearnerReadSnapshot>;
+
+[[nodiscard]] LearnerReadSnapshot           //
+doLearnerRead(const TiDB::TableID table_id, //
+    const MvccQueryInfo & mvcc_query_info,  //
+    TMTContext & tmt, Poco::Logger * log);
+
+// After getting stream from storage, we must make sure regions' version haven't changed after learner read.
+// If some regions' version changed, this function will throw `RegionException`.
+void validateQueryInfo(
+    const MvccQueryInfo & mvcc_query_info, const LearnerReadSnapshot & regions_snapshot, TMTContext & tmt, Poco::Logger * log);
+
+} // namespace DB


### PR DESCRIPTION
cherry-pick #864 to release-4.0

* * *

Signed-off-by: JaySon-Huang <tshent@qq.com>

### What problem does this PR solve?

Issue Number: close #815 

Problem Summary:
Now we hold the table's structure lock then do learner read inside `IStorage::read()`. If wait index of learner read blocks, at the same time raft threads need to remove region. Raft thread will try to acquire for table's structure lock. Finally it will block all raft threads, deadlocks between raft and learner read happens.

### What is changed and how it works?

What's Changed:
Abstract learner read routine, and do learner read before acquiring table's structure lock.

How it works:
To avoid this deadlocks, we can do learner read without holding table's structure lock.

### Related changes

- Need to cherry-pick to the release branch 4.0, 3.1

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
  - Create a partition table
  - 1 thread for adding one partition per minute
  - 1 thread for scanning number of partition, drop old partition to keep 30 partitions in total 
  - 1 thread for writing data into partition table
  - 1 thread for reading data from partition table (scanning all partitions)
  - Run for hours to check if any errors return to the client

Side effects

- None

### Release note <!-- bugfixes or new feature need a release note -->

- Fix the issue that concurrency learner read and remove region may meet deadlocks.
