### PR TITLE
Fix TiFlash crash after renaming primary key column name (#906)

### DIFF
--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
@@ -327,11 +327,13 @@ private:
     String db_name;
     String table_name;
 
-    ColumnDefines      original_table_columns;
-    BlockPtr           original_table_header; // Used to speed up getHeader()
-    const ColumnDefine original_table_handle_define;
+    ColumnDefines original_table_columns;
+    BlockPtr      original_table_header; // Used to speed up getHeader()
+    ColumnDefine  original_table_handle_define;
 
     // The columns we actually store.
+    // First three columns are always _tidb_rowid, _INTERNAL_VERSION, _INTERNAL_DELMARK
+    // No matter `tidb_rowid` exist in `table_columns` or not.
     ColumnDefinesPtr store_columns;
 
     std::atomic<bool> shutdown_called{false};

--- a/dbms/src/Storages/DeltaMerge/registerStorageDeltaMerge.cpp
+++ b/dbms/src/Storages/DeltaMerge/registerStorageDeltaMerge.cpp
@@ -18,8 +18,9 @@ extern const int BAD_ARGUMENTS;
 
 static ASTPtr extractKeyExpressionList(IAST & node)
 {
+    // For multiple primary key, this is a ASTFunction with name "tuple".
+    // For single primary key, this is a ASTExpressionList.
     const ASTFunction * expr_func = typeid_cast<const ASTFunction *>(&node);
-
     if (expr_func && expr_func->name == "tuple")
     {
         /// Primary key is specified in tuple.

--- a/dbms/src/Storages/DeltaMerge/tests/dm_basic_include.h
+++ b/dbms/src/Storages/DeltaMerge/tests/dm_basic_include.h
@@ -63,13 +63,19 @@ public:
      * @param reversed  increasing/decreasing insert `pk`'s value
      * @return
      */
-    static Block prepareSimpleWriteBlock(size_t beg, size_t end, bool reversed, UInt64 tso = 2)
+    static Block prepareSimpleWriteBlock(size_t         beg,
+                                         size_t         end,
+                                         bool           reversed,
+                                         UInt64         tso       = 2,
+                                         const String & pk_name_  = pk_name,
+                                         ColumnID       pk_col_id = EXTRA_HANDLE_COLUMN_ID,
+                                         DataTypePtr    pk_type   = EXTRA_HANDLE_COLUMN_TYPE)
     {
         Block        block;
         const size_t num_rows = (end - beg);
         {
             {
-                ColumnWithTypeAndName col1({}, std::make_shared<DataTypeInt64>(), pk_name, EXTRA_HANDLE_COLUMN_ID);
+                ColumnWithTypeAndName col1({}, pk_type, pk_name_, pk_col_id);
                 IColumn::MutablePtr   m_col = col1.type->createColumn();
                 // insert form large to small
                 for (size_t i = 0; i < num_rows; i++)

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store.cpp
@@ -51,8 +51,6 @@ protected:
 
         context = std::make_unique<Context>(DMTestEnv::getContext());
         store   = reload();
-
-        Logger::get("DeltaMergeStore").setLevel("trace");
     }
 
     DeltaMergeStorePtr reload(const ColumnDefinesPtr & pre_define_columns = {})
@@ -137,8 +135,6 @@ try
         table_column_defines->emplace_back(col_str_define);
         table_column_defines->emplace_back(col_i8_define);
 
-        // TODO: remove this cleanUp() after we support DDL for DMFile.
-        cleanUp();
         store = reload(table_column_defines);
     }
 
@@ -163,7 +159,7 @@ try
         {
             block = DMTestEnv::prepareSimpleWriteBlock(0, num_rows_write, false);
             // Add a column of col2:String for test
-            ColumnWithTypeAndName col2({}, col_str_define.type, col_str_define.name, 2);
+            ColumnWithTypeAndName col2({}, col_str_define.type, col_str_define.name, col_str_define.id);
             {
                 IColumn::MutablePtr m_col2 = col2.type->createColumn();
                 for (size_t i = 0; i < num_rows_write; i++)
@@ -177,7 +173,7 @@ try
             block.insert(std::move(col2));
 
             // Add a column of i8:Int8 for test
-            ColumnWithTypeAndName i8({}, col_i8_define.type, col_i8_define.name, 3);
+            ColumnWithTypeAndName i8({}, col_i8_define.type, col_i8_define.name, col_i8_define.id);
             {
                 IColumn::MutablePtr m_i8 = i8.type->createColumn();
                 for (size_t i = 0; i < num_rows_write; i++)
@@ -781,7 +777,7 @@ try
 }
 CATCH
 
-TEST_F(DeltaMergeStore_test, DISABLED_DDLChanegInt8ToInt32)
+TEST_F(DeltaMergeStore_test, DDLChangeInt8ToInt32)
 try
 {
     const String      col_name_ddl        = "i8";
@@ -811,8 +807,8 @@ try
         Block block;
         {
             block = DMTestEnv::prepareSimpleWriteBlock(0, num_rows_write, false);
-            // Add a column of col2:String for test
-            ColumnWithTypeAndName col2(std::make_shared<DataTypeInt8>(), col_name_ddl);
+            // Add a column of int8 for test
+            ColumnWithTypeAndName col2({}, std::make_shared<DataTypeInt8>(), col_name_ddl, col_id_ddl);
             {
                 IColumn::MutablePtr m_col2 = col2.type->createColumn();
                 for (size_t i = 0; i < num_rows_write; i++)
@@ -869,19 +865,19 @@ try
         while (Block block = in->read())
         {
             num_rows_read += block.rows();
-            for (auto && iter : block)
+            for (size_t i = 0; i < block.rows(); ++i)
             {
-                auto c = iter.column;
-                for (Int64 i = 0; i < Int64(c->size()); ++i)
+                for (auto && iter : block)
                 {
+                    auto c = iter.column;
                     if (iter.name == DMTestEnv::pk_name)
                     {
-                        //printf("pk:%lld\n", c->getInt(i));
-                        EXPECT_EQ(c->getInt(i), i);
+                        // printf("pk:%lld\n", c->getInt(i));
+                        EXPECT_EQ(c->getInt(i), Int64(i));
                     }
                     else if (iter.name == col_name_ddl)
                     {
-                        //printf("col2:%s\n", c->getDataAt(i).data);
+                        // printf("%s:%lld\n", col_name_ddl.c_str(), c->getInt(i));
                         Int64 num = i * (i % 2 == 0 ? -1 : 1);
                         EXPECT_EQ(c->getInt(i), num);
                     }
@@ -895,7 +891,7 @@ try
 CATCH
 
 
-TEST_F(DeltaMergeStore_test, DISABLED_DDLDropColumn)
+TEST_F(DeltaMergeStore_test, DDLDropColumn)
 try
 {
     const String      col_name_to_drop = "i8";
@@ -925,7 +921,7 @@ try
         {
             block = DMTestEnv::prepareSimpleWriteBlock(0, num_rows_write, false);
             // Add a column of col2:String for test
-            ColumnWithTypeAndName col2(std::make_shared<DataTypeInt8>(), col_name_to_drop);
+            ColumnWithTypeAndName col2({}, std::make_shared<DataTypeInt8>(), col_name_to_drop, col_id_to_drop);
             {
                 IColumn::MutablePtr m_col2 = col2.type->createColumn();
                 for (size_t i = 0; i < num_rows_write; i++)
@@ -996,7 +992,7 @@ try
 }
 CATCH
 
-TEST_F(DeltaMergeStore_test, DISABLED_DDLAddColumn)
+TEST_F(DeltaMergeStore_test, DDLAddColumn)
 try
 {
     const String      col_name_c1 = "i8";
@@ -1020,15 +1016,15 @@ try
         {
             block = DMTestEnv::prepareSimpleWriteBlock(0, num_rows_write, false);
             // Add a column of col1:String for test
-            ColumnWithTypeAndName col1(std::make_shared<DataTypeInt8>(), col_name_c1);
+            ColumnWithTypeAndName col1({}, std::make_shared<DataTypeInt8>(), col_name_c1, col_id_c1);
             {
-                IColumn::MutablePtr m_col2 = col1.type->createColumn();
+                IColumn::MutablePtr m_col1 = col1.type->createColumn();
                 for (size_t i = 0; i < num_rows_write; i++)
                 {
                     Int64 num = i * (i % 2 == 0 ? -1 : 1);
-                    m_col2->insert(Field(num));
+                    m_col1->insert(Field(num));
                 }
-                col1.column = std::move(m_col2);
+                col1.column = std::move(m_col1);
             }
             block.insert(col1);
         }
@@ -1111,7 +1107,7 @@ try
 }
 CATCH
 
-TEST_F(DeltaMergeStore_test, DISABLED_DDLAddColumnFloat32)
+TEST_F(DeltaMergeStore_test, DDLAddColumnFloat32)
 try
 {
     const String      col_name_to_add = "f32";
@@ -1187,7 +1183,7 @@ try
 }
 CATCH
 
-TEST_F(DeltaMergeStore_test, DISABLED_DDLAddColumnDateTime)
+TEST_F(DeltaMergeStore_test, DDLAddColumnDateTime)
 try
 {
     const String      col_name_to_add = "dt";
@@ -1259,7 +1255,7 @@ try
 }
 CATCH
 
-TEST_F(DeltaMergeStore_test, DISABLED_DDLRenameColumn)
+TEST_F(DeltaMergeStore_test, DDLRenameColumn)
 try
 {
     const String      col_name_before_ddl = "i8";
@@ -1290,7 +1286,7 @@ try
         {
             block = DMTestEnv::prepareSimpleWriteBlock(0, num_rows_write, false);
             // Add a column for test
-            ColumnWithTypeAndName col2(col_type, col_name_before_ddl);
+            ColumnWithTypeAndName col2({}, col_type, col_name_before_ddl, col_id_ddl);
             {
                 IColumn::MutablePtr m_col2 = col2.type->createColumn();
                 for (size_t i = 0; i < num_rows_write; i++)
@@ -1306,7 +1302,7 @@ try
     }
 
     {
-        // DDL change col from i8 -> i32
+        // DDL change col name from col_name_before_ddl -> col_name_after_ddl
         AlterCommands commands;
         {
             AlterCommand com;
@@ -1375,113 +1371,180 @@ try
 }
 CATCH
 
+// Test rename pk column when pk_is_handle = true.
+TEST_F(DeltaMergeStore_test, DDLRenamePKColumn)
+try
+{
+    const String      col_name_before_ddl = "pk1";
+    const String      col_name_after_ddl  = "pk2";
+    const ColId       col_id_ddl          = 1;
+    const DataTypePtr col_type            = DataTypeFactory::instance().get("Int32");
+    {
+        auto         table_column_defines = DMTestEnv::getDefaultColumns();
+        ColumnDefine cd(col_id_ddl, col_name_before_ddl, col_type);
+        // Use this column as pk
+        (*table_column_defines)[0] = cd;
+        store                      = reload(table_column_defines);
+    }
 
-/// tests for prepare write actions
-//
-//namespace
-//{
-//
-//DeltaMergeStore::SegmentSortedMap prepareSegments(const HandleRanges & ranges)
-//{
-//    DeltaMergeStore::SegmentSortedMap segments;
-//
-//    const UInt64 epoch      = 0;
-//    PageId       segment_id = 0;
-//    PageId       delta_id   = 1024;
-//    PageId       stable_id  = 2048;
-//
-//    auto segment_generator = [&](HandleRange range) -> SegmentPtr {
-//        auto delta  = std::make_shared<DiskValueSpace>(true, delta_id);
-//        auto stable = std::make_shared<StableValueSpace>(stable_id);
-//
-//        SegmentPtr s = std::make_shared<Segment>(
-//            epoch, /* range= */ range, /* segment_id= */ segment_id, /*next_segment_id=*/segment_id + 1, delta, stable);
-//
-//        segment_id++;
-//        delta_id++;
-//        stable_id++;
-//        return s;
-//    };
-//
-//    for (const auto & range : ranges)
-//    {
-//        auto seg = segment_generator(range);
-//        segments.insert({range.end, seg});
-//    }
-//
-//    return segments;
-//}
-//
-//} // namespace
-//
-//TEST(DeltaMergeStoreInternal_test, PrepareWriteForBlock)
-//try
-//{
-//    std::shared_mutex m;
-//
-//    const HandleRanges ranges = {
-//        {-100, -23},
-//        {-23, 25},
-//        {25, 49},
-//        {49, 103},
-//    };
-//
-//    const size_t block_pk_beg = -4;
-//    const size_t block_pk_end = 49;
-//
-//    DeltaMergeStore::SegmentSortedMap segments = prepareSegments(ranges);
-//    Block                             block    = DMTestEnv::prepareSimpleWriteBlock(block_pk_beg, block_pk_end, false);
-//    const String                      pk_name  = EXTRA_HANDLE_COLUMN_NAME;
-//
-//    auto actions = prepareWriteActions(block, segments, pk_name, std::shared_lock(m));
-//    ASSERT_EQ(actions.size(), 2UL);
-//
-//    auto & act0 = actions[0];
-//    ASSERT_NE(act0.segment, nullptr);
-//    ASSERT_RANGE_EQ(act0.segment->getRange(), ranges[1]);
-//    EXPECT_EQ(act0.offset, 0UL);
-//    const size_t end_off_for_act0 = ranges[1].end - block_pk_beg;
-//    EXPECT_EQ(act0.limit, end_off_for_act0);
-//
-//    auto & act1 = actions[1];
-//    ASSERT_NE(act1.segment, nullptr);
-//    ASSERT_RANGE_EQ(act1.segment->getRange(), ranges[2]);
-//    EXPECT_EQ(act1.offset, end_off_for_act0);
-//    EXPECT_EQ(act1.limit, block.rows() - end_off_for_act0);
-//}
-//CATCH
-//
-//TEST(DeltaMergeStoreInternal_test, PrepareWriteForDeleteRange)
-//try
-//{
-//    std::shared_mutex m;
-//
-//    const HandleRanges ranges = {
-//        {-100, -23},
-//        {-23, 25},
-//        {25, 49},
-//        {49, 103},
-//    };
-//
-//    DeltaMergeStore::SegmentSortedMap segments = prepareSegments(ranges);
-//    HandleRange                       delete_range(-4, 49);
-//
-//    auto actions = prepareWriteActions(delete_range, segments, std::shared_lock(m));
-//    ASSERT_EQ(actions.size(), 2UL);
-//
-//    auto & act0 = actions[0];
-//    ASSERT_NE(act0.segment, nullptr);
-//    EXPECT_RANGE_EQ(act0.segment->getRange(), ranges[1]);
-//    ASSERT_FALSE(act0.update.block);                         // no rows in block
-//    EXPECT_RANGE_EQ(act0.update.delete_range, delete_range); // TODO maybe more precise
-//
-//    auto & act1 = actions[1];
-//    ASSERT_NE(act1.segment, nullptr);
-//    EXPECT_RANGE_EQ(act1.segment->getRange(), ranges[2]);
-//    ASSERT_FALSE(act1.update.block); // no rows in block
-//    EXPECT_RANGE_EQ(act1.update.delete_range, delete_range);
-//}
-//CATCH
+    {
+        // check column structure
+        const auto & cols = store->getTableColumns();
+        ASSERT_EQ(cols.size(), 3UL);
+        const auto & str_col = cols[0];
+        ASSERT_EQ(str_col.name, col_name_before_ddl);
+        ASSERT_EQ(str_col.id, col_id_ddl);
+        ASSERT_TRUE(str_col.type->equals(*col_type));
+    }
+    {
+        // check pk name
+        auto pks_desc = store->getPrimarySortDescription();
+        ASSERT_EQ(pks_desc.size(), 1UL);
+        auto pk = pks_desc[0];
+        ASSERT_EQ(pk.column_name, col_name_before_ddl);
+    }
+
+    const size_t num_rows_write = 128;
+    {
+        // write to store
+        Block block = DMTestEnv::prepareSimpleWriteBlock(0, num_rows_write, false, /*tso=*/2, col_name_before_ddl, col_id_ddl, col_type);
+        store->write(*context, context->getSettingsRef(), block);
+    }
+
+    {
+        // DDL change pk col name from col_name_before_ddl -> col_name_after_ddl
+        AlterCommands commands;
+        {
+            AlterCommand com;
+            com.type            = AlterCommand::RENAME_COLUMN;
+            com.data_type       = col_type;
+            com.column_name     = col_name_before_ddl;
+            com.new_column_name = col_name_after_ddl;
+            com.column_id       = col_id_ddl;
+            commands.emplace_back(std::move(com));
+        }
+        ColumnID        _ignored = 0;
+        TiDB::TableInfo table_info;
+        {
+            static const String json_table_info = R"(
+{"cols":[{"comment":"","default":null,"default_bit":null,"id":1,"name":{"L":"pk2","O":"pk2"},"offset":0,"origin_default":null,"state":5,"type":{"Charset":"binary","Collate":"binary","Decimal":0,"Elems":null,"Flag":4099,"Flen":11,"Tp":3}}],"comment":"","id":45,"name":{"L":"t","O":"t"},"partition":null,"pk_is_handle":true,"schema_version":23,"state":5,"update_timestamp":417906423650844680}
+        )";
+            table_info.deserialize(json_table_info);
+            ASSERT_TRUE(table_info.pk_is_handle);
+        }
+        store->applyAlters(commands, table_info, _ignored, *context);
+    }
+
+    {
+        // check pk name after ddl
+        auto pks_desc = store->getPrimarySortDescription();
+        ASSERT_EQ(pks_desc.size(), 1UL);
+        auto pk = pks_desc[0];
+        ASSERT_EQ(pk.column_name, col_name_after_ddl);
+    }
+
+    {
+        // read all columns from store
+        const auto &      columns = store->getTableColumns();
+        BlockInputStreams ins     = store->read(*context,
+                                            context->getSettingsRef(),
+                                            columns,
+                                            {HandleRange::newAll()},
+                                            /* num_streams= */ 1,
+                                            /* max_version= */ std::numeric_limits<UInt64>::max(),
+                                            EMPTY_FILTER,
+                                            /* expected_block_size= */ 1024);
+        ASSERT_EQ(ins.size(), 1UL);
+        BlockInputStreamPtr & in = ins[0];
+        {
+            // check col rename is success
+            const Block  head = in->getHeader();
+            const auto & col  = head.getByName(col_name_after_ddl);
+            ASSERT_EQ(col.name, col_name_after_ddl);
+            ASSERT_EQ(col.column_id, col_id_ddl);
+            ASSERT_TRUE(col.type->equals(*col_type));
+            // check old col name is not exist
+            ASSERT_THROW(head.getByName(col_name_before_ddl), ::DB::Exception);
+        }
+
+        size_t num_rows_read = 0;
+        in->readPrefix();
+        while (Block block = in->read())
+        {
+            num_rows_read += block.rows();
+            for (auto && iter : block)
+            {
+                auto c = iter.column;
+                for (Int64 i = 0; i < Int64(c->size()); ++i)
+                {
+                    if (iter.name == col_name_after_ddl)
+                    {
+                        //printf("col2:%s\n", c->getDataAt(i).data);
+                        EXPECT_EQ(c->getInt(i), Int64(i));
+                    }
+                }
+            }
+        }
+        in->readSuffix();
+        ASSERT_EQ(num_rows_read, num_rows_write);
+    }
+
+    {
+        // write and read with new pk name after ddl
+        {
+            // Then write new block with new pk name
+            Block block = DMTestEnv::prepareSimpleWriteBlock(
+                num_rows_write, num_rows_write * 2, false, /*tso=*/2, col_name_after_ddl, col_id_ddl, col_type);
+            store->write(*context, context->getSettingsRef(), block);
+        }
+        {
+            // read all columns from store
+            const auto &      columns = store->getTableColumns();
+            BlockInputStreams ins     = store->read(*context,
+                                                context->getSettingsRef(),
+                                                columns,
+                                                {HandleRange::newAll()},
+                                                /* num_streams= */ 1,
+                                                /* max_version= */ std::numeric_limits<UInt64>::max(),
+                                                EMPTY_FILTER,
+                                                /* expected_block_size= */ 1024);
+            ASSERT_EQ(ins.size(), 1UL);
+            BlockInputStreamPtr & in = ins[0];
+            {
+                // check col rename is success
+                const Block  head = in->getHeader();
+                const auto & col  = head.getByName(col_name_after_ddl);
+                ASSERT_EQ(col.name, col_name_after_ddl);
+                ASSERT_EQ(col.column_id, col_id_ddl);
+                ASSERT_TRUE(col.type->equals(*col_type));
+                // check old col name is not exist
+                ASSERT_THROW(head.getByName(col_name_before_ddl), ::DB::Exception);
+            }
+
+            size_t num_rows_read = 0;
+            in->readPrefix();
+            while (Block block = in->read())
+            {
+                num_rows_read += block.rows();
+                for (auto && iter : block)
+                {
+                    auto c = iter.column;
+                    for (Int64 i = 0; i < Int64(c->size()); ++i)
+                    {
+                        if (iter.name == col_name_after_ddl)
+                        {
+                            //printf("col2:%s\n", c->getDataAt(i).data);
+                            EXPECT_EQ(c->getInt(i), Int64(i));
+                        }
+                    }
+                }
+            }
+            in->readSuffix();
+            ASSERT_EQ(num_rows_read, num_rows_write * 2);
+        }
+    }
+}
+CATCH
 
 } // namespace tests
 } // namespace DM

--- a/dbms/src/Storages/StorageDeltaMerge.cpp
+++ b/dbms/src/Storages/StorageDeltaMerge.cpp
@@ -891,10 +891,32 @@ void StorageDeltaMerge::alter(
 /// we need to update the create statement in metadata, so that we can restore table structure next time
 static void updateDeltaMergeTableCreateStatement(            //
     const String & database_name, const String & table_name, //
-    const ColumnsDescription & columns,
-    const OrderedNameSet & hidden_columns,                                                         //
-    const OptionTableInfoConstRef table_info_from_tidb, const ColumnDefines & store_table_columns, //
+    const SortDescription & pk_names, const ColumnsDescription & columns,
+    const OrderedNameSet & hidden_columns,    //
+    const OptionTableInfoConstRef table_info, //
     Timestamp tombstone, const Context & context);
+
+inline OptionTableInfoConstRef getTableInfoForCreateStatement( //
+    const OptionTableInfoConstRef table_info_from_tidb,        //
+    TiDB::TableInfo & table_info_from_store, const ColumnDefines & store_table_columns, const OrderedNameSet & hidden_columns)
+{
+    if (likely(table_info_from_tidb))
+        return table_info_from_tidb;
+
+    /// If TableInfo from TiDB is empty, for example, create DM table for test,
+    /// we refine TableInfo from store's table column, so that we can restore column id next time
+    table_info_from_store.schema_version = DEFAULT_UNSPECIFIED_SCHEMA_VERSION;
+    for (const auto & column_define : store_table_columns)
+    {
+        if (hidden_columns.has(column_define.name))
+            continue;
+        TiDB::ColumnInfo column_info = reverseGetColumnInfo( //
+            NameAndTypePair{column_define.name, column_define.type}, column_define.id, column_define.default_value,
+            /* for_test= */ true);
+        table_info_from_store.columns.emplace_back(std::move(column_info));
+    }
+    return std::optional<std::reference_wrapper<const TiDB::TableInfo>>(table_info_from_store);
+}
 
 void StorageDeltaMerge::alterImpl(const AlterCommands & commands,
     const String & database_name,
@@ -952,7 +974,7 @@ void StorageDeltaMerge::alterImpl(const AlterCommands & commands,
             {
                 // check that lossy changes is forbidden
                 // check that changing the UNSIGNED attribute is forbidden
-                throw Exception("Storage engine " + getName() + "doesn't support lossy data type modify from " + col_iter->type->getName()
+                throw Exception("Storage engine " + getName() + " doesn't support lossy data type modify from " + col_iter->type->getName()
                         + " to " + command.data_type->getName(),
                     ErrorCodes::NOT_IMPLEMENTED);
             }
@@ -962,10 +984,14 @@ void StorageDeltaMerge::alterImpl(const AlterCommands & commands,
     commands.apply(new_columns); // apply AlterCommands to `new_columns`
     // apply alter to store's table column in DeltaMergeStore
     store->applyAlters(commands, table_info, max_column_id_used, context);
+
+    SortDescription pk_desc = store->getPrimarySortDescription();
+    TiDB::TableInfo table_info_from_store;
+    table_info_from_store.name = table_name_;
     // after update `new_columns` and store's table columns, we need to update create table statement,
     // so that we can restore table next time.
-    updateDeltaMergeTableCreateStatement(
-        database_name, table_name_, new_columns, hidden_columns, table_info, store->getTableColumns(), tombstone, context);
+    updateDeltaMergeTableCreateStatement(database_name, table_name_, pk_desc, new_columns, hidden_columns,
+        getTableInfoForCreateStatement(table_info, table_info_from_store, store->getTableColumns(), hidden_columns), tombstone, context);
     setColumns(std::move(new_columns));
     if (table_info)
         tidb_table_info = table_info.value();
@@ -1022,9 +1048,9 @@ String StorageDeltaMerge::getDatabaseName() const { return store->getDatabaseNam
 
 void updateDeltaMergeTableCreateStatement(                   //
     const String & database_name, const String & table_name, //
-    const ColumnsDescription & columns,
-    const OrderedNameSet & hidden_columns,                                                         //
-    const OptionTableInfoConstRef table_info_from_tidb, const ColumnDefines & store_table_columns, //
+    const SortDescription & pk_names, const ColumnsDescription & columns,
+    const OrderedNameSet & hidden_columns,    //
+    const OptionTableInfoConstRef table_info, //
     Timestamp tombstone, const Context & context)
 {
     /// Filter out hidden columns in the `create table statement`
@@ -1036,35 +1062,40 @@ void updateDeltaMergeTableCreateStatement(                   //
     columns_without_hidden.aliases = columns.aliases;
     columns_without_hidden.defaults = columns.defaults;
 
-    /// If TableInfo from TiDB is empty, for example, create DM table for test,
-    /// we refine TableInfo from store's table column, so that we can restore column id next time
-    TiDB::TableInfo table_info_from_store;
-    if (!table_info_from_tidb)
-    {
-        table_info_from_store.schema_version = DEFAULT_UNSPECIFIED_SCHEMA_VERSION;
-        table_info_from_store.name = table_name;
-        for (const auto & column_define : store_table_columns)
-        {
-            if (hidden_columns.has(column_define.name))
-                continue;
-            TiDB::ColumnInfo column_info = reverseGetColumnInfo( //
-                NameAndTypePair{column_define.name, column_define.type}, column_define.id, column_define.default_value,
-                /* for_test= */ true);
-            table_info_from_store.columns.emplace_back(std::move(column_info));
-        }
-    }
-
     // We need to update the JSON field in table ast
     // engine = DeltaMerge((CounterID, EventDate), '{JSON format table info}')
     IDatabase::ASTModifier storage_modifier = [&](IAST & ast) {
-        std::shared_ptr<ASTLiteral> literal;
-        if (table_info_from_tidb)
-            literal = std::make_shared<ASTLiteral>(Field(table_info_from_tidb->get().serialize()));
-        else
-            literal = std::make_shared<ASTLiteral>(Field(table_info_from_store.serialize()));
+        std::shared_ptr<ASTLiteral> literal = std::make_shared<ASTLiteral>(Field(table_info->get().serialize()));
+        ASTPtr pk_ast;
+        {
+            if (pk_names.size() > 1)
+            {
+                pk_ast = makeASTFunction("tuple");
+                for (const auto & pk : pk_names)
+                {
+                    pk_ast->children.emplace_back(std::make_shared<ASTLiteral>(pk.column_name));
+                }
+            }
+            else if (pk_names.size() == 1)
+            {
+                pk_ast = std::make_shared<ASTExpressionList>();
+                pk_ast->children.emplace_back(std::make_shared<ASTLiteral>(pk_names[0].column_name));
+            }
+            else
+            {
+                throw Exception("Try to update table(" + database_name + "." + table_name + ") statement with no primary key. ");
+            }
+        }
+
         auto tombstone_ast = std::make_shared<ASTLiteral>(Field(tombstone));
+
         auto & storage_ast = typeid_cast<ASTStorage &>(ast);
         auto & args = typeid_cast<ASTExpressionList &>(*storage_ast.engine->arguments);
+        if (!args.children.empty())
+        {
+            // Refresh primary keys' name
+            args.children[0] = pk_ast;
+        }
         if (args.children.size() == 1)
         {
             args.children.emplace_back(literal);
@@ -1195,6 +1226,7 @@ BlockInputStreamPtr StorageDeltaMerge::status()
     INSERT_INT(background_tasks_length);
 
 #undef INSERT_INT
+#undef INSERT_SIZE
 #undef INSERT_RATE
 #undef INSERT_FLOAT
 

--- a/dbms/src/Storages/Transaction/SchemaBuilder.cpp
+++ b/dbms/src/Storages/Transaction/SchemaBuilder.cpp
@@ -687,6 +687,7 @@ String createTableStmt(const DBInfo & db_info, const TableInfo & table_info, con
         }
     }
 
+    // FIXME: Fix it after cluster index supported in TiDB 5.0
     if (pks.size() != 1 || !table_info.pk_is_handle)
     {
         columns.emplace_back(NameAndTypePair(MutableSupport::tidb_pk_column_name, std::make_shared<DataTypeInt64>()));

--- a/tests/fullstack-test/ddl/rename_pk.test
+++ b/tests/fullstack-test/ddl/rename_pk.test
@@ -1,0 +1,39 @@
+mysql> drop table if exists test.t;
+
+mysql> create table test.t (pk int primary key);
+mysql> alter table test.t set tiflash replica 1;
+
+func> wait_table test t
+
+mysql> insert into test.t values (1), (2);
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t order by pk;
++----+
+| pk |
++----+
+|  1 |
+|  2 |
++----+
+
+# rename table primary key name
+mysql> alter table test.t change pk pk2 int;
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t order by pk2;
++-----+
+| pk2 |
++-----+
+|   1 |
+|   2 |
++-----+
+
+# write / read after pk renamed
+mysql> insert into test.t values (3), (4);
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t order by pk2;
++-----+
+| pk2 |
++-----+
+|   1 |
+|   2 |
+|   3 |
+|   4 |
++-----+
+
+mysql> drop table if exists test.t;


### PR DESCRIPTION
Manually cherry-pick of #906 to release-3.1
* * *

### What problem does this PR solve?

Issue Number: close #839 

Problem Summary:
We did not update primary key name in `ENGINE = DeltaMerge(pk_name, ...)` of table metadata file. Nor the member variable of `DeltaMergeStore` did not get updated.

### What is changed and how it works?

What's Changed:
Use column id instead of column name to get the position of pk column.
Update primary key name in table's metadata file.

How it Works:
Use `DeltaMergeStore::getPrimarySortDescription` to get primary key(s) name after column changes applied. Then update the primary key name in table's metadata file.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- No

### Release note <!-- bugfixes or new feature need a release note -->

- Fix the issue that TiFlash crash after renaming primary key column name.