### PR TITLE
Improve exception message when sync schema failed

### DIFF
--- a/dbms/src/Storages/StorageDeltaMerge.cpp
+++ b/dbms/src/Storages/StorageDeltaMerge.cpp
@@ -732,8 +732,12 @@ try
 }
 catch (Exception & e)
 {
-    e.addMessage(
-        " database name: " + database_name + ", table name: " + table_name_ + ", table id: " + DB::toString(table_info.value().get().id));
+    String table_info_msg;
+    if (table_info)
+        table_info_msg = " table name: " + table_name_ + ", table id: " + toString(table_info.value().get().id);
+    else
+        table_info_msg = " table name: " + table_name_ + ", table id: unknown";
+    e.addMessage(table_info_msg);
     throw;
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

For now we will get a `Storage engine xxx doesn't support doing xxx` if it's failed to alter a table, without explaining which table is altered.

### What is changed and how it works?

What's Changed:

How it Works:

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects
