### PR TITLE
Cherry pick: Improve exception message when sync schema failed (#943)

### DIFF
--- a/dbms/src/Storages/StorageDeltaMerge.cpp
+++ b/dbms/src/Storages/StorageDeltaMerge.cpp
@@ -658,6 +658,7 @@ void StorageDeltaMerge::alterImpl(const AlterCommands & commands,
     const String & table_name_,
     const OptionTableInfoConstRef table_info,
     const Context & context)
+try
 {
     std::unordered_set<String> cols_drop_forbidden;
     cols_drop_forbidden.insert(EXTRA_HANDLE_COLUMN_NAME);
@@ -728,6 +729,16 @@ void StorageDeltaMerge::alterImpl(const AlterCommands & commands,
     if (table_info)
         tidb_table_info = table_info.value();
     setTombstone(tombstone);
+}
+catch (Exception & e)
+{
+    String table_info_msg;
+    if (table_info)
+        table_info_msg = " table name: " + table_name_ + ", table id: " + toString(table_info.value().get().id);
+    else
+        table_info_msg = " table name: " + table_name_ + ", table id: unknown";
+    e.addMessage(table_info_msg);
+    throw;
 }
 
 String StorageDeltaMerge::getName() const { return MutableSupport::delta_tree_storage_name; }


### PR DESCRIPTION
cherry-pick of https://github.com/pingcap/tics/pull/943

* * *

* increase buffer size to avoid overflow

Signed-off-by: leiysky <leiysky@outlook.com>

* add table name for alter exception

Signed-off-by: leiysky <leiysky@outlook.com>

* add error code

Signed-off-by: leiysky <leiysky@outlook.com>

* add dbname

Signed-off-by: leiysky <leiysky@outlook.com>

* fix

Signed-off-by: leiysky <leiysky@outlook.com>

* add table id

Signed-off-by: leiysky <leiysky@outlook.com>

* check table info

Signed-off-by: leiysky <leiysky@outlook.com>

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
