### PR TITLE
Fix minor log formating

### DIFF
--- a/dbms/src/Storages/Page/PageStorage.cpp
+++ b/dbms/src/Storages/Page/PageStorage.cpp
@@ -274,7 +274,7 @@ void PageStorage::restore()
             = PageFile::newPageFile(max_file_id + 1, 0, storage_path, file_provider, PageFile::Type::Formal, page_file_log);
         page_file.createEncryptionInfo();
         LOG_DEBUG(log,
-                storage_name << "No PageFile can be reused for write, create new PageFile_" + DB::toString(max_file_id + 1) + "_0 for write");
+                storage_name << " No PageFile can be reused for write, create new PageFile_" + DB::toString(max_file_id + 1) + "_0 for write");
         write_files[0] = page_file;
     }
     if (global_capacity)


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
```
["PageStorage: db_1.t_45.logNo PageFile can be reused for write, create new PageFile_1_0 for write"] [thread_id=5]
```
There should be a space between storage_name and contents. Introduced by #962 

### What is changed and how it works?

Add space

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- N/A

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
