### PR TITLE
seperate hash commit info in test/docker

### DIFF
--- a/tests/docker/cluster.yaml
+++ b/tests/docker/cluster.yaml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   pd0:
-    image: hub.pingcap.net/qa/pd:${BRANCH:-master}
+    image: hub.pingcap.net/qa/pd:${PD_BRANCH:-master}
     ports:
       - "2379:2379"
     volumes:
@@ -21,7 +21,7 @@ services:
       - --log-file=/log/pd.log
     restart: on-failure
   tikv0:
-    image: hub.pingcap.net/qa/tikv:${BRANCH:-master}
+    image: hub.pingcap.net/qa/tikv:${TIKV_BRANCH:-master}
     ports:
       - "20160:20160"
     volumes:
@@ -39,7 +39,7 @@ services:
       - "pd0"
     restart: on-failure
   tidb0:
-    image: hub.pingcap.net/qa/tidb:${BRANCH:-master}
+    image: hub.pingcap.net/qa/tidb:${TIDB_BRANCH:-master}
     ports:
       - "4000:4000"
       - "10080:10080"

--- a/tests/docker/cluster_new_collation.yaml
+++ b/tests/docker/cluster_new_collation.yaml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   pd0:
-    image: hub.pingcap.net/qa/pd:${BRANCH:-master}
+    image: hub.pingcap.net/qa/pd:${PD_BRANCH:-master}
     ports:
       - "2379:2379"
     volumes:
@@ -21,7 +21,7 @@ services:
       - --log-file=/log/pd.log
     restart: on-failure
   tikv0:
-    image: hub.pingcap.net/qa/tikv:${BRANCH:-master}
+    image: hub.pingcap.net/qa/tikv:${TIKV_BRANCH:-master}
     ports:
       - "20160:20160"
     volumes:
@@ -39,7 +39,7 @@ services:
       - "pd0"
     restart: on-failure
   tidb0:
-    image: hub.pingcap.net/qa/tidb:${BRANCH:-master}
+    image: hub.pingcap.net/qa/tidb:${TIDB_BRANCH:-master}
     ports:
       - "4000:4000"
       - "10080:10080"

--- a/tests/docker/run.sh
+++ b/tests/docker/run.sh
@@ -2,6 +2,16 @@
 
 set -xe
 
+# TAG: tiflash hash, default to `master`
+# XYZ_BRANCH: pd/tikv/tidb hash, default to `master`
+# BRANCH: hash short cut, default to `master`
+
+if [ -n "$BRANCH" ]; then
+  [ -z "$PD_BRANCH" ] && PD_BRANCH="$BRANCH"
+  [ -z "$TIKV_BRANCH" ] && TIKV_BRANCH="$BRANCH"
+  [ -z "$TIDB_BRANCH" ] && TIDB_BRANCH="$BRANCH"
+fi
+
 # Stop all docker instances if exist.
 # tiflash-dt && tiflash-tmt share the same name "tiflash0", we just need one here
 docker-compose -f gtest.yaml -f cluster.yaml -f cluster_new_collation.yaml -f tiflash-dt.yaml -f mock-test-dt.yaml down


### PR DESCRIPTION
* run.sh: set var
* cluster.yaml/cluster_new_collation.yaml: use var

### What problem does this PR solve?

Problem Summary:

To help TiDB integrate TiFlash tests, QA suggests to separate PD/TiKV/TIDB container image hash.

### What is changed and how it works?

How it Works:

Currently CI use `TAG` and `BRANCH` environment variable for testing. For backward compatible, we keep them but `PD_BRANCH`, `TIKV_BRANCH`, `TIDB_BRANCH` env variable have higher priority.
