### PR TITLE
Add mysql-client in tiflash-centos7 image

### DIFF
--- a/release-centos7/Dockerfile-tiflash-centos7
+++ b/release-centos7/Dockerfile-tiflash-centos7
@@ -1,4 +1,4 @@
-FROM hub.pingcap.net/tiflash/centos:centos7.6.1810
+FROM hub.pingcap.net/tiflash/tiflash-ci-base
 
 USER root
 WORKDIR /root/


### PR DESCRIPTION
Problem Summary:

To help TiDB integrate TiFlash tests, we need mysql-client in tiflash-centos7 image to run fullstack test.