### PR TITLE
Fix unsafe wrapping while using FFI

### DIFF
--- a/dbms/src/Storages/Transaction/FileEncryption.h
+++ b/dbms/src/Storages/Transaction/FileEncryption.h
@@ -27,14 +27,17 @@ enum class EncryptionMethod : uint8_t
 
 const char * IntoEncryptionMethodName(EncryptionMethod);
 
-struct FileEncryptionInfo
+struct FileEncryptionInfoRaw
 {
     FileEncryptionRes res;
     EncryptionMethod method;
     TiFlashRawString key;
     TiFlashRawString iv;
     TiFlashRawString erro_msg;
+};
 
+struct FileEncryptionInfo : FileEncryptionInfoRaw
+{
     ~FileEncryptionInfo()
     {
         if (key)
@@ -54,12 +57,13 @@ struct FileEncryptionInfo
         }
     }
 
+    FileEncryptionInfo(const FileEncryptionInfoRaw & src) : FileEncryptionInfoRaw{src} {}
     FileEncryptionInfo(const FileEncryptionRes & res_,
         const EncryptionMethod & method_,
         TiFlashRawString key_,
         TiFlashRawString iv_,
         TiFlashRawString erro_msg_)
-        : res{res_}, method{method_}, key{key_}, iv{iv_}, erro_msg{erro_msg_}
+        : FileEncryptionInfoRaw{res_, method_, key_, iv_, erro_msg_}
     {}
     FileEncryptionInfo(const FileEncryptionInfo &) = delete;
     FileEncryptionInfo(FileEncryptionInfo && src)

--- a/dbms/src/Storages/Transaction/ProxyFFIType.h
+++ b/dbms/src/Storages/Transaction/ProxyFFIType.h
@@ -103,11 +103,11 @@ private:
     uint8_t (*fn_handle_check_service_stopped)(TiFlashRaftProxyPtr);
     uint8_t (*fn_is_encryption_enabled)(TiFlashRaftProxyPtr);
     EncryptionMethod (*fn_encryption_method)(TiFlashRaftProxyPtr);
-    FileEncryptionInfo (*fn_handle_get_file)(TiFlashRaftProxyPtr, BaseBuffView);
-    FileEncryptionInfo (*fn_handle_new_file)(TiFlashRaftProxyPtr, BaseBuffView);
-    FileEncryptionInfo (*fn_handle_delete_file)(TiFlashRaftProxyPtr, BaseBuffView);
-    FileEncryptionInfo (*fn_handle_link_file)(TiFlashRaftProxyPtr, BaseBuffView, BaseBuffView);
-    FileEncryptionInfo (*fn_handle_rename_file)(TiFlashRaftProxyPtr, BaseBuffView, BaseBuffView);
+    FileEncryptionInfoRaw (*fn_handle_get_file)(TiFlashRaftProxyPtr, BaseBuffView);
+    FileEncryptionInfoRaw (*fn_handle_new_file)(TiFlashRaftProxyPtr, BaseBuffView);
+    FileEncryptionInfoRaw (*fn_handle_delete_file)(TiFlashRaftProxyPtr, BaseBuffView);
+    FileEncryptionInfoRaw (*fn_handle_link_file)(TiFlashRaftProxyPtr, BaseBuffView, BaseBuffView);
+    FileEncryptionInfoRaw (*fn_handle_rename_file)(TiFlashRaftProxyPtr, BaseBuffView, BaseBuffView);
 };
 
 enum class TiFlashStatus : uint8_t


### PR DESCRIPTION
Signed-off-by: Tong Zhigao <tongzhigao@pingcap.com>

### What problem does this PR solve?

Problem Summary: wrapping about `FileEncryptionInfo` may be unsafe if change config about compiler

### Related changes

- Need to cherry-pick to the release branch 4.0

### Release note <!-- bugfixes or new feature need a release note -->

- `No release note`
