### PR TITLE
Returned data should keep order for cop request

### DIFF
--- a/dbms/src/Flash/Coprocessor/InterpreterDAG.cpp
+++ b/dbms/src/Flash/Coprocessor/InterpreterDAG.cpp
@@ -31,7 +31,10 @@ InterpreterDAG::InterpreterDAG(Context & context_, const DAGQuerySource & dag_)
       log(&Logger::get("InterpreterDAG"))
 {
     const Settings & settings = context.getSettingsRef();
-    max_streams = settings.max_threads;
+    if (dag.isBatchCop())
+        max_streams = settings.max_threads;
+    else
+        max_streams = 1;
     if (max_streams > 1)
     {
         max_streams *= settings.max_streams_to_max_threads_ratio;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #1065 <!-- REMOVE this line if no issue to close -->

Problem Summary:
TiDB sometimes assume that the result returned from a cop request should be sorted by handle column, but after pr #675, TiFlash may use more than one stream to handle cop request, which means the returned data maybe out of order.

### What is changed and how it works?

What's Changed:

How it Works:
For cop request, set `max_streams` to 1 so TiFlash will only use one stream to handle cop request, and the returned data can keep order.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

### Release note <!-- bugfixes or new feature need a release note -->

- `No release note`
