### PR TITLE
Fix compile error under release mode

### DIFF
--- a/dbms/src/Common/FailPoint.cpp
+++ b/dbms/src/Common/FailPoint.cpp
@@ -100,11 +100,11 @@ class FailPointChannel
 {
 };
 
-void FailPointHelper::enableFailPoint(const String & fail_point_name) {}
+void FailPointHelper::enableFailPoint(const String &) {}
 
-void FailPointHelper::disableFailPoint(const String & fail_point_name) {}
+void FailPointHelper::disableFailPoint(const String &) {}
 
-void FailPointHelper::wait(const String & fail_point_name) {}
+void FailPointHelper::wait(const String &) {}
 #endif
 
 } // namespace DB


### PR DESCRIPTION
Signed-off-by: JaySon-Huang <tshent@qq.com>

### What problem does this PR solve?

Problem Summary:
GCC compile error under release mode.
https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/build_tiflash_multi_branch/detail/v4.0.7/1/pipeline

### What is changed and how it works?

Remove unused param.

### Related changes

- Need to cherry-pick to the release branch 4.0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- N/A

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
