### PR TITLE
Fix: proxy writes too much region state to kv engine while replaying outdated raft log

### DIFF
--- a/dbms/src/Storages/Transaction/Region.cpp
+++ b/dbms/src/Storages/Transaction/Region.cpp
@@ -556,7 +556,7 @@ TiFlashApplyRes Region::handleWriteRaftCmd(const WriteCmdsView & cmds, UInt64 in
     if (index <= appliedIndex())
     {
         LOG_TRACE(log, toString() << " ignore outdated raft log [term: " << term << ", index: " << index << "]");
-        return TiFlashApplyRes::Persist;
+        return TiFlashApplyRes::None;
     }
 
     const auto handle_by_index_func = [&](auto i) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #1130 <!-- REMOVE this line if no issue to close -->

Problem Summary: proxy may write too much region state while replaying outdated raft log

### What is changed and how it works?

What's Changed: do not let proxy persist region state while replaying outdated raft log

### Related changes

- Need to cherry-pick to the release branch 4.0

### Release note <!-- bugfixes or new feature need a release note -->

- `Fix bug: proxy write too much region state info to kv engine while replaying outdated raft log`
