### PR TITLE
Fix the capacity limited by first path capacity

### DIFF
--- a/dbms/src/Storages/PathCapacityMetrics.cpp
+++ b/dbms/src/Storages/PathCapacityMetrics.cpp
@@ -68,7 +68,6 @@ FsStats PathCapacityMetrics::getFsStats() const
     // Now we expect size of path_infos not change, don't acquire hevay lock on `path_infos` now.
     FsStats total_stat;
     double max_used_rate = 0.0;
-    std::optional<uint64_t> first_avail_size = std::nullopt;
     for (size_t i = 0; i < path_infos.size(); ++i)
     {
         FsStats path_stat = path_infos[i].getStats(log);
@@ -82,8 +81,6 @@ FsStats PathCapacityMetrics::getFsStats() const
         total_stat.capacity_size += path_stat.capacity_size;
 
         max_used_rate = std::max(max_used_rate, 1.0 * path_stat.used_size / path_stat.capacity_size);
-        if (!first_avail_size)
-            first_avail_size = path_stat.avail_size;
     }
 
     // appromix used size, make pd happy
@@ -94,7 +91,6 @@ FsStats PathCapacityMetrics::getFsStats() const
 
     // appromix avail size
     total_stat.avail_size = total_stat.capacity_size - total_stat.used_size;
-    total_stat.avail_size = std::min(total_stat.avail_size, *first_avail_size);
 
     const double avail_rate = 1.0 * total_stat.avail_size / total_stat.capacity_size;
     if (avail_rate <= 0.2)


### PR DESCRIPTION
cherry-pick of #1173

* * * 

Signed-off-by: JaySon-Huang <tshent@qq.com>

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
When deployed with multi-paths, the wrong capacity make create TiFlash replicas failed

### What is changed and how it works?

Do not limit the capacity by the capacity of first path

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch 4.0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- Fix the issue that when deployed with multi-paths, the wrong capacity make creating TiFlash replicas failed