### PR TITLE
Support loading latest configure automatically without restart the server

### DIFF
--- a/dbms/src/Flash/BatchCoprocessorHandler.cpp
+++ b/dbms/src/Flash/BatchCoprocessorHandler.cpp
@@ -88,14 +88,12 @@ grpc::Status BatchCoprocessorHandler::execute()
     catch (const Exception & e)
     {
         LOG_ERROR(log, __PRETTY_FUNCTION__ << ": DB Exception: " << e.message() << "\n" << e.getStackTrace().toString());
-        return recordError(
-            e.code() == ErrorCodes::NOT_IMPLEMENTED ? grpc::StatusCode::UNIMPLEMENTED : grpc::StatusCode::INTERNAL, e.message());
+        return recordError(tiflashErrorCodeToGrpcStatusCode(e.code()), e.message());
     }
     catch (const pingcap::Exception & e)
     {
         LOG_ERROR(log, __PRETTY_FUNCTION__ << ": KV Client Exception: " << e.message());
-        return recordError(
-            e.code() == ErrorCodes::NOT_IMPLEMENTED ? grpc::StatusCode::UNIMPLEMENTED : grpc::StatusCode::INTERNAL, e.message());
+        return recordError(grpc::StatusCode::INTERNAL, e.message());
     }
     catch (const std::exception & e)
     {

--- a/dbms/src/Flash/Coprocessor/DAGUtils.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGUtils.cpp
@@ -17,6 +17,11 @@ namespace ErrorCodes
 extern const int COP_BAD_DAG_REQUEST;
 extern const int UNSUPPORTED_METHOD;
 extern const int LOGICAL_ERROR;
+extern const int NOT_IMPLEMENTED;
+extern const int UNKNOWN_USER;
+extern const int WRONG_PASSWORD;
+extern const int REQUIRED_PASSWORD;
+extern const int IP_ADDRESS_NOT_ALLOWED;
 } // namespace ErrorCodes
 
 const Int8 VAR_SIZE = 0;
@@ -384,6 +389,17 @@ std::shared_ptr<TiDB::ITiDBCollator> getCollatorFromFieldType(const tipb::FieldT
 }
 
 bool hasUnsignedFlag(const tipb::FieldType & tp) { return tp.flag() & TiDB::ColumnFlagUnsigned; }
+
+grpc::StatusCode tiflashErrorCodeToGrpcStatusCode(int error_code)
+{
+    /// do not use switch statement because ErrorCodes::XXXX is not a compile time constant
+    if (error_code == ErrorCodes::NOT_IMPLEMENTED)
+        return grpc::StatusCode::UNIMPLEMENTED;
+    if (error_code == ErrorCodes::UNKNOWN_USER || error_code == ErrorCodes::WRONG_PASSWORD || error_code == ErrorCodes::REQUIRED_PASSWORD
+        || error_code == ErrorCodes::IP_ADDRESS_NOT_ALLOWED)
+        return grpc::StatusCode::UNAUTHENTICATED;
+    return grpc::StatusCode::INTERNAL;
+}
 
 extern const String UniqRawResName;
 

--- a/dbms/src/Flash/Coprocessor/DAGUtils.h
+++ b/dbms/src/Flash/Coprocessor/DAGUtils.h
@@ -12,6 +12,7 @@
 #include <Storages/Transaction/Collator.h>
 #include <Storages/Transaction/TiDB.h>
 #include <Storages/Transaction/Types.h>
+#include <grpcpp/impl/codegen/status_code_enum.h>
 
 namespace DB
 {
@@ -42,5 +43,6 @@ bool isUnsupportedEncodeType(const std::vector<tipb::FieldType> & types, tipb::E
 std::shared_ptr<TiDB::ITiDBCollator> getCollatorFromExpr(const tipb::Expr & expr);
 std::shared_ptr<TiDB::ITiDBCollator> getCollatorFromFieldType(const tipb::FieldType & field_type);
 bool hasUnsignedFlag(const tipb::FieldType & tp);
+grpc::StatusCode tiflashErrorCodeToGrpcStatusCode(int error_code);
 
 } // namespace DB

--- a/dbms/src/Flash/CoprocessorHandler.cpp
+++ b/dbms/src/Flash/CoprocessorHandler.cpp
@@ -133,15 +133,13 @@ grpc::Status CoprocessorHandler::execute()
     {
         LOG_ERROR(log, __PRETTY_FUNCTION__ << ": KV Client Exception: " << e.message());
         GET_METRIC(cop_context.metrics, tiflash_coprocessor_request_error, reason_kv_client_error).Increment();
-        return recordError(
-            e.code() == ErrorCodes::NOT_IMPLEMENTED ? grpc::StatusCode::UNIMPLEMENTED : grpc::StatusCode::INTERNAL, e.message());
+        return recordError(grpc::StatusCode::INTERNAL, e.message());
     }
     catch (const Exception & e)
     {
         LOG_ERROR(log, __PRETTY_FUNCTION__ << ": DB Exception: " << e.message() << "\n" << e.getStackTrace().toString());
         GET_METRIC(cop_context.metrics, tiflash_coprocessor_request_error, reason_internal_error).Increment();
-        return recordError(
-            e.code() == ErrorCodes::NOT_IMPLEMENTED ? grpc::StatusCode::UNIMPLEMENTED : grpc::StatusCode::INTERNAL, e.message());
+        return recordError(tiflashErrorCodeToGrpcStatusCode(e.code()), e.message());
     }
     catch (const std::exception & e)
     {

--- a/dbms/src/Flash/FlashService.cpp
+++ b/dbms/src/Flash/FlashService.cpp
@@ -3,6 +3,7 @@
 #include <Core/Types.h>
 #include <Flash/BatchCommandsHandler.h>
 #include <Flash/BatchCoprocessorHandler.h>
+#include <Flash/Coprocessor/DAGUtils.h>
 #include <Flash/FlashService.h>
 #include <Flash/Mpp/MPPHandler.h>
 #include <Interpreters/Context.h>
@@ -270,8 +271,8 @@ std::tuple<Context, grpc::Status> FlashService::createDBContext(const grpc::Serv
     }
     catch (Exception & e)
     {
-        LOG_ERROR(log, __PRETTY_FUNCTION__ << ": DB Exception: " << e.message() << "\n" << e.message());
-        return std::make_tuple(server.context(), grpc::Status(grpc::StatusCode::INTERNAL, e.message()));
+        LOG_ERROR(log, __PRETTY_FUNCTION__ << ": DB Exception: " << e.message());
+        return std::make_tuple(server.context(), grpc::Status(tiflashErrorCodeToGrpcStatusCode(e.code()), e.message()));
     }
     catch (const std::exception & e)
     {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #1187 <!-- REMOVE this line if no issue to close -->

Problem Summary:

as the issue described.
### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
Refine the `createDBContext` logical in `FlashService`, load latest user configure during `createDBContext`.

How it Works:



### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- support loading latest configure automatically without restart the server
