### PR TITLE
RegionData.cf_data_size is wrong after serialized/deserialized

### DIFF
--- a/dbms/src/Storages/Transaction/RegionCFDataBase.cpp
+++ b/dbms/src/Storages/Transaction/RegionCFDataBase.cpp
@@ -310,7 +310,7 @@ RegionDataRes RegionCFDataBase<RegionLockCFDataTrait>::insert(
 {
     // according to the process of pessimistic lock, just overwrite.
     data.insert_or_assign(std::move(kv_pair.first), std::move(kv_pair.second));
-    return true;
+    return 0;
 }
 
 template struct RegionCFDataBase<RegionWriteCFDataTrait>;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #1203 

RegionData.cf_data_size is wrong after serialized/deserialized

### What is changed and how it works?

Fix the RegionDataRes of inserting key-value into lock CF.

https://github.com/pingcap/tics/blob/master/dbms/src/Storages/Transaction/RegionCFDataBase.cpp#L34-L41
According to the code in master, we should always return 0.

### Related changes

- N/A

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test (will be added in later PR)

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
