### PR TITLE
Fix compile error under MacOS X

### DIFF
--- a/dbms/src/Storages/PathPool.cpp
+++ b/dbms/src/Storages/PathPool.cpp
@@ -29,7 +29,8 @@ PathPool::PathPool(const Strings & main_data_paths_, const Strings & latest_data
     : main_data_paths(main_data_paths_),
       latest_data_paths(latest_data_paths_),
       global_capacity(global_capacity_),
-      file_provider(file_provider_)
+      file_provider(file_provider_),
+      log(&Poco::Logger::get("PathPool"))
 {}
 
 StoragePathPool PathPool::withTable(const String & database_, const String & table_, bool path_need_database_name_) const


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/build-darwin-amd64-4.0/detail/build-darwin-amd64-4.0/213/pipeline/

Clang complain that PathPool::log is not used
```
In file included from /Users/pingcap/workspace/build-darwin-amd64-4.0/tics/dbms/src/Storages/PathPool.cpp:10:
/Users/pingcap/workspace/build-darwin-amd64-4.0/tics/dbms/src/Storages/PathPool.h:72:20: error: private field 'log' is not used [-Werror,-Wunused-private-field]
     Poco::Logger * log;
                    ^
1 error generated.
```

### What is changed and how it works?

init PathPool::log

### Related changes

- N/A

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- N/A

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
