### PR TITLE
Fix compile error caused by `-Wrange-loop-analysis` in Apple clang 12.0.0.

### DIFF
--- a/dbms/src/Storages/PathPool.cpp
+++ b/dbms/src/Storages/PathPool.cpp
@@ -199,7 +199,7 @@ void StoragePathPool::drop(bool recursive, bool must_success)
 
                 // update global used size
                 size_t total_bytes = 0;
-                for (const auto [file_id, file_size] : path_info.file_size_map)
+                for (const auto & [file_id, file_size] : path_info.file_size_map)
                 {
                     (void)file_id;
                     total_bytes += file_size;


### PR DESCRIPTION
### What problem does this PR solve?

Fix compile error caused by `-Wrange-loop-analysis` in Apple clang 12.0.0.

### What is changed and how it works?

Use reference instead of value in `for` loop.

### Release note <!-- bugfixes or new feature need a release note -->

No release note
