### PR TITLE
Use background thread of jemalloc to handle purging asynchronously

### DIFF
--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -332,9 +332,13 @@ void UpdateMallocConfig([[maybe_unused]] Logger * log)
         }                                                     \
     } while (0)
 #if USE_JEMALLOC
+    const char * version;
     bool old_b, new_b = true;
     size_t old_max_thd, new_max_thd = 1;
-    size_t sz_b = sizeof(bool), sz_st = sizeof(size_t);
+    size_t sz_b = sizeof(bool), sz_st = sizeof(size_t), sz_ver = sizeof(version);
+
+    RUN_FAIL_RETURN(je_mallctl("version", &version, &sz_ver, nullptr, 0));
+    LOG_INFO(log, "Got jemalloc version: " << version);
 
     auto malloc_conf = getenv("MALLOC_CONF");
     if (malloc_conf)


### PR DESCRIPTION
Signed-off-by: Tong Zhigao <tongzhigao@pingcap.com>

### What problem does this PR solve?

Issue Number: related #1213 

Problem Summary: 

After test, we found that memory usage is high after applying plenty numbers of snapshots. According to mechanism of jemalloc, when alloc memory in provider thread but free it in another customer thread, related memory won't be reclaimed in time until reach threshold (like decay time, size, etc., which might be very high) in customer thread. We can use background thread of jemalloc to handle purging asynchronously.

### What is changed and how it works?

What's Changed: 
- Try to enable background thread of jemalloc and set max thread number to `1` if environment variable `MALLOC_CONF` is not set.

How it Works:

Memory will be reclaimed after approximate time `dirty_decay_ms + muzzy_decay_ms`(both default value is 10sec).
![image](https://user-images.githubusercontent.com/9016847/100598278-78eecb00-3339-11eb-96ef-8694f235c244.png)


### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- Use background thread of jemalloc to handle purging asynchronously
