### PR TITLE
Fix the issue that Snapshot::clone() does not copy is_common_handle and rowkey_column_size

### DIFF
--- a/dbms/src/Storages/DeltaMerge/DeltaValueSpace.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaValueSpace.h
@@ -144,6 +144,9 @@ public:
         size_t bytes;
         size_t deletes;
 
+        bool   is_common_handle;
+        size_t rowkey_column_size;
+
         /// TODO: The members below are not part of the Snapshot, they should not be here.
         /// They are used by the reader of this Snapshot.
 
@@ -157,9 +160,6 @@ public:
         // The data of packs when reading.
         std::vector<Columns> packs_data;
 
-        bool   is_common_handle;
-        size_t rowkey_column_size;
-
         SnapshotPtr clone()
         {
             auto c                = std::make_shared<Snapshot>();
@@ -171,6 +171,8 @@ public:
             c->rows               = rows;
             c->bytes              = bytes;
             c->deletes            = deletes;
+            c->is_common_handle   = is_common_handle;
+            c->rowkey_column_size = rowkey_column_size;
             return c;
         }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #1264

Problem Summary:

### What is changed and how it works?

What's Changed:

Also copy the value of `is_common_handle` and `rowkey_column_size` in `Snapshot::clone()`

How it Works:

### Related changes


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects


### Release note <!-- bugfixes or new feature need a release note -->

- No release note
