### PR TITLE
support NO_ZERO_DATE for ddl

### DIFF
--- a/tests/tidb-ci/fullstack-test/ddl/alter_datetime_default_value.test
+++ b/tests/tidb-ci/fullstack-test/ddl/alter_datetime_default_value.test
@@ -14,7 +14,7 @@ mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t;
 
 mysql> alter table test.t add date_0 DATE NULL DEFAULT '1000-01-01' 
 mysql> alter table test.t add date_1 DATE NULL DEFAULT '9999-12-31' 
-mysql> SET sql_mode=""; alter table test.t add date_a DATE NOT NULL
+mysql> SET sql_mode=''; alter table test.t add date_a DATE NOT NULL
 
 mysql> alter table test.t add time_0 TIME NULL DEFAULT '59' 
 mysql> alter table test.t add time_1 TIME(6) NULL DEFAULT '-838:59:59.000000' 
@@ -25,8 +25,8 @@ mysql> alter table test.t add time_b TIME(6) NOT NULL
 
 mysql> alter table test.t add datetime_0 DATETIME(6) NULL DEFAULT '1000-01-01 00:00:00.000000' 
 mysql> alter table test.t add datetime_1 DATETIME(6) NULL DEFAULT '9999-12-31 23:59:59.000000' 
-mysql> SET sql_mode=""; alter table test.t add datetime_a DATETIME NOT NULL
-mysql> SET sql_mode=""; alter table test.t add datetime_b DATETIME(6) NOT NULL
+mysql> SET sql_mode=''; alter table test.t add datetime_a DATETIME NOT NULL
+mysql> SET sql_mode=''; alter table test.t add datetime_b DATETIME(6) NOT NULL
 
 mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t;
 +------+------------+------------+------------+----------+-------------------+------------------+-----------------+----------+-----------------+----------------------------+----------------------------+---------------------+----------------------------+


### PR DESCRIPTION
### What problem does this PR solve?

This is required for https://github.com/pingcap/tidb/pull/21564 to merge.

I have verified against both this branch, and MySQL 8.0 - they both require exactly the same changes.

Problem Summary:

### What is changed and how it works?

The `ALTER TABLE` to add a column with zero date now requires the `NO_ZERO_DATE` mode unset.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)

Manual verification of SQL statements from this file.

Side effects

- None

### Release note <!-- bugfixes or new feature need a release note -->

- TiDB more correctly supports the SQL mode `NO_ZERO_DATE` as part of adding columns in DDL statements.