### PR TITLE
fix function substr with 3 arguments bug

### DIFF
--- a/dbms/src/Functions/FunctionsString.cpp
+++ b/dbms/src/Functions/FunctionsString.cpp
@@ -1100,7 +1100,7 @@ public:
         }
 
 
-        if (start == 0 || length == 0) {
+        if (start == 0 || (!implicit_length && length == 0)) {
             block.getByPosition(result).column = DataTypeString().createColumnConst(column_string->size(), toField(String("")));
             return;
         }

--- a/tests/fullstack-test/expr/agg_pushdown.test
+++ b/tests/fullstack-test/expr/agg_pushdown.test
@@ -1,0 +1,23 @@
+mysql> drop table if exists test.t
+mysql> create table test.t (c varchar(64))
+mysql> alter table test.t set tiflash replica 1
+
+func> wait_table test t
+
+mysql> insert into test.t values ('ABC'), ('DEF'), ('')
+mysql> insert into test.t select * from test.t;
+mysql> insert into test.t select * from test.t;
+mysql> insert into test.t select * from test.t;
+mysql> insert into test.t select * from test.t;
+mysql> insert into test.t select * from test.t;
+mysql> insert into test.t select * from test.t;
+
+mysql> set @@tidb_isolation_read_engines='tiflash'
+mysql> select substr(c, 2), count(1) from test.t group by substr(c, 2) order by substr(c, 2)
++--------------+----------+
+| substr(c, 2) | count(1) |
++--------------+----------+
+|              |       64 |
+| BC           |       64 |
+| EF           |       64 |
++--------------+----------+


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary: tiflash funcion substr with 3 arguments has bug

```
create table t (c varchar(64));
ALTER TABLE t SET TIFLASH REPLICA 1;
insert into t values ("ABC"), ("DEF"), ("");
insert into t select * from t;
insert into t select * from t;
insert into t select * from t;
insert into t select * from t;
insert into t select * from t;
insert into t select * from t;

analyze table t;
select substr(c, 2), count(1) from t group by substr(c, 2);
```
![image](https://user-images.githubusercontent.com/5574887/102859076-4cc0f880-4466-11eb-9ce5-559c8326c596.png)


### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
