### PR TITLE
[cherry-pick-5.0]Add coprocessor thread pool.  (#1280)

### DIFF
--- a/dbms/src/Flash/FlashService.h
+++ b/dbms/src/Flash/FlashService.h
@@ -2,6 +2,7 @@
 
 #include <Common/TiFlashSecurity.h>
 #include <Interpreters/Context.h>
+#include <common/ThreadPool.h>
 #include <common/logger_useful.h>
 
 #include <boost/noncopyable.hpp>
@@ -32,20 +33,27 @@ public:
         const ::coprocessor::BatchRequest * request,
         ::grpc::ServerWriter<::coprocessor::BatchResponse> * writer) override;
 
-    ::grpc::Status DispatchMPPTask(::grpc::ServerContext* context, const ::mpp::DispatchTaskRequest* request, ::mpp::DispatchTaskResponse* response) override;
+    ::grpc::Status DispatchMPPTask(
+        ::grpc::ServerContext * context, const ::mpp::DispatchTaskRequest * request, ::mpp::DispatchTaskResponse * response) override;
 
-    ::grpc::Status EstablishMPPConnection(::grpc::ServerContext* context, const ::mpp::EstablishMPPConnectionRequest* request, ::grpc::ServerWriter< ::mpp::MPPDataPacket>* writer) override;
+    ::grpc::Status EstablishMPPConnection(::grpc::ServerContext * context,
+        const ::mpp::EstablishMPPConnectionRequest * request,
+        ::grpc::ServerWriter<::mpp::MPPDataPacket> * writer) override;
 
 private:
-    std::tuple<Context, ::grpc::Status> createDBContext(const grpc::ServerContext * grpc_contex) const;
+    std::tuple<Context, ::grpc::Status> createDBContext(const grpc::ServerContext * grpc_context) const;
+
+    // Use executeInThreadPool to submit job to thread pool which return grpc::Status.
+    grpc::Status executeInThreadPool(const std::unique_ptr<ThreadPool> & pool, std::function<grpc::Status()>);
 
 private:
     IServer & server;
     TiFlashMetricsPtr metrics;
-
     const TiFlashSecurityConfig & security_config;
-
     Logger * log;
+
+    // Put thread pool member(s) at the end so that ensure it will be destroyed firstly.
+    std::unique_ptr<ThreadPool> cop_pool, batch_cop_pool;
 };
 
 } // namespace DB

--- a/dbms/src/Interpreters/Settings.h
+++ b/dbms/src/Interpreters/Settings.h
@@ -1,10 +1,9 @@
 #pragma once
 
-#include <Poco/Util/AbstractConfiguration.h>
 #include <Core/Defines.h>
 #include <Core/Field.h>
-
 #include <Interpreters/SettingsCommon.h>
+#include <Poco/Util/AbstractConfiguration.h>
 
 
 namespace DB
@@ -41,7 +40,9 @@ struct Settings
     M(SettingUInt64, max_insert_block_size, DEFAULT_INSERT_BLOCK_SIZE, "The maximum block size for insertion, if we control the creation of blocks for insertion.") \
     M(SettingUInt64, min_insert_block_size_rows, DEFAULT_INSERT_BLOCK_SIZE, "Squash blocks passed to INSERT query to specified size in rows, if blocks are not big enough.") \
     M(SettingUInt64, min_insert_block_size_bytes, (DEFAULT_INSERT_BLOCK_SIZE * 256), "Squash blocks passed to INSERT query to specified size in bytes, if blocks are not big enough.") \
-    M(SettingMaxThreads, max_threads, 0, "The maximum number of threads to execute the request. By default, it is determined automatically.") \
+    M(SettingMaxThreads, max_threads, 0, "The maximum number of threads to execute the request. By default, it is determined automatically.")          \
+    M(SettingUInt64, cop_pool_size, 0, "The number of threads to handle cop requests. By default, it is determined automatically.")                \
+    M(SettingUInt64, batch_cop_pool_size, 0, "The number of threads to handle batch cop requests. By default, it is determined automatically.") \
     M(SettingUInt64, max_read_buffer_size, DBMS_DEFAULT_BUFFER_SIZE, "The maximum size of the buffer to read from the filesystem.") \
     M(SettingUInt64, max_distributed_connections, DEFAULT_MAX_DISTRIBUTED_CONNECTIONS, "The maximum number of connections for distributed processing of one query (should be greater than max_threads).") \
     M(SettingUInt64, max_query_size, DEFAULT_MAX_QUERY_SIZE, "Which part of the query can be read into RAM for parsing (the remaining data for INSERT, if any, is read later)") \
@@ -326,4 +327,4 @@ struct Settings
 };
 
 
-}
+} // namespace DB

--- a/libs/libcommon/include/common/ThreadPool.h
+++ b/libs/libcommon/include/common/ThreadPool.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <cstdint>
-#include <thread>
-#include <mutex>
 #include <condition_variable>
+#include <cstdint>
 #include <functional>
+#include <mutex>
 #include <queue>
+#include <thread>
 #include <vector>
 
 
@@ -20,7 +20,9 @@ public:
     using Job = std::function<void()>;
 
     /// Size is constant, all threads are created immediately.
-    explicit ThreadPool(size_t m_size);
+    /// Every threads will execute pre_worker firstly when they are created.
+    explicit ThreadPool(
+        size_t m_size, Job pre_worker = [] {});
 
     /// Add new job. Locks until free thread in pool become available or exception in one of threads was thrown.
     /// If an exception in some thread was thrown, method silently returns, and exception will be rethrown only on call to 'wait' function.
@@ -57,4 +59,3 @@ private:
 
     void worker();
 };
-

--- a/libs/libcommon/src/ThreadPool.cpp
+++ b/libs/libcommon/src/ThreadPool.cpp
@@ -1,13 +1,16 @@
 #include <common/ThreadPool.h>
+
 #include <iostream>
 
 
-ThreadPool::ThreadPool(size_t m_size)
-    : m_size(m_size)
+ThreadPool::ThreadPool(size_t m_size, Job pre_worker) : m_size(m_size)
 {
     threads.reserve(m_size);
     for (size_t i = 0; i < m_size; ++i)
-        threads.emplace_back([this] { worker(); });
+        threads.emplace_back([this, pre_worker] {
+            pre_worker();
+            worker();
+        });
 }
 
 void ThreadPool::schedule(Job job)
@@ -111,4 +114,3 @@ void ThreadPool::worker()
         has_free_thread.notify_all();
     }
 }
-


### PR DESCRIPTION
cherry-pick from https://github.com/pingcap/tics/pull/1280

### What problem does this PR solve?

Problem Summary: The number of cop handling requests needs to be limited.

### What is changed and how it works?

Proposal: [TiFlash Coprocessor Thread Pool](https://docs.google.com/document/d/1E-fvjTUajkTsDdH2-mtquX-_rq5ICBwkg3kNJfp2e-k/edit#l) <!-- REMOVE this line if not applicable -->

What's Changed:
- Add configs `cop_pool_size` and `batch_cop_pool_size`, default `NumOfPhysicalCores*2`.
- Start two coprocessor thread pools when TiFlashService Start.
- Use these pools to handle cop/batch coprocessor requests relatively.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`: need to update config
- Need to cherry-pick to the release branch: 4.0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test
- Manual test (add detailed scripts or steps below)
[grafana link](http://h81:23310/d/SVbh2xUWk/qz-standalone-tiflash-summary?orgId=1&from=1608717622726&to=1608717838653)
![image](https://user-images.githubusercontent.com/30543181/102999025-42d0ef80-4563-11eb-883f-b6ef328111af.png)

see [TiFlash Coprocessor Thread Pool](https://docs.google.com/document/d/1E-fvjTUajkTsDdH2-mtquX-_rq5ICBwkg3kNJfp2e-k/edit#l) to get more information about the test.


### Release note <!-- bugfixes or new feature need a release note -->

A coprocessor thread pool was added to queue coprocessor requests for execution, which can avoid OOM in some cases. Added two configs cop_pool_size and batch_cop_pool_size, default NumOfPhysicalCores*2.