### PR TITLE
disable tcp port as default config

### DIFF
--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -1024,7 +1024,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
                 }
 
                 /// TCP
-                if (config().has("tcp_port"))
+                if (config().getBool("enable_tcp", false) && config().has("tcp_port"))
                 {
                     if (security_config.has_tls_config)
                     {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary: tiflash's tcp port is not used at all.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed: disable tcp port as default config

How it Works:
add a new config `enable_tcp`, default is `false`

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
