### PR TITLE
Fix oom: reduce memory cache for handling ingest sst

### DIFF
--- a/dbms/src/Storages/Transaction/ApplySnapshot.cpp
+++ b/dbms/src/Storages/Transaction/ApplySnapshot.cpp
@@ -278,7 +278,7 @@ TiFlashApplyRes KVStore::handleIngestSST(UInt64 region_id, const SnapshotViewArr
     // try to flush remain data in memory.
     func_try_flush();
     region->handleIngestSST(snaps, index, term, tmt);
-    region->tryPreDecodeTiKVValue(tmt);
+    region->tryPreDecodeTiKVValue<true>(tmt);
     func_try_flush();
 
     if (region->dataSize())


### PR DESCRIPTION
Signed-off-by: Tong Zhigao <tongzhigao@pingcap.com>

### What problem does this PR solve?

Issue Number: close #1346 <!-- REMOVE this line if no issue to close -->

Problem Summary: tiflash oom while using lighting to load table data.

### What is changed and how it works?

What's Changed:
Do not cache pre-decode fields in memory.

### Related changes

- Need to cherry-pick to the release branch 4.0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- Optimize memory cost for handling ingest SST
