### PR TITLE
Cherry pick bug fixes for PODArray

### DIFF
--- a/dbms/src/Common/tests/gtest_pod_array.cpp
+++ b/dbms/src/Common/tests/gtest_pod_array.cpp
@@ -1,0 +1,67 @@
+#include <Common/PODArray.h>
+#include <gtest/gtest.h>
+
+using namespace DB;
+
+TEST(Common, PODArrayInsert)
+{
+    std::string str = "test_string_abacaba";
+    PODArray<char> chars;
+    chars.insert(chars.end(), str.begin(), str.end());
+    EXPECT_EQ(str, std::string(chars.data(), chars.size()));
+
+    std::string insert_in_the_middle = "insert_in_the_middle";
+    auto pos = str.size() / 2;
+    str.insert(str.begin() + pos, insert_in_the_middle.begin(), insert_in_the_middle.end());
+    chars.insert(chars.begin() + pos, insert_in_the_middle.begin(), insert_in_the_middle.end());
+    EXPECT_EQ(str, std::string(chars.data(), chars.size()));
+
+    std::string insert_with_resize;
+    insert_with_resize.reserve(chars.capacity() * 2);
+    char cur_char = 'a';
+    while (insert_with_resize.size() < insert_with_resize.capacity())
+    {
+        insert_with_resize += cur_char;
+        if (cur_char == 'z')
+            cur_char = 'a';
+        else
+            ++cur_char;
+    }
+    str.insert(str.begin(), insert_with_resize.begin(), insert_with_resize.end());
+    chars.insert(chars.begin(), insert_with_resize.begin(), insert_with_resize.end());
+    EXPECT_EQ(str, std::string(chars.data(), chars.size()));
+}
+
+TEST(Common, PODPushBackRawMany)
+{
+    PODArray<char> chars;
+    chars.push_back_raw_many(5, "first");
+    EXPECT_EQ(std::string("first"), std::string(chars.data(), chars.size()));
+    EXPECT_EQ(5UL, chars.size());
+    EXPECT_LE(chars.capacity() - chars.size(), 10UL);
+    chars.push_back_raw_many(10, "0123456789");
+    EXPECT_EQ(15UL, chars.size());
+    EXPECT_EQ(std::string("first0123456789"), std::string(chars.data(), chars.size()));
+}
+
+TEST(Common, PODNoOverallocation)
+{
+    /// Check that PaddedPODArray allocates for smaller number of elements than the power of two due to padding.
+    /// NOTE: It's Ok to change these numbers if you will modify initial size or padding.
+
+    PaddedPODArray<char> chars;
+    std::vector<size_t> capacities;
+
+    size_t prev_capacity = 0;
+    for (size_t i = 0; i < 1000000; ++i)
+    {
+        chars.emplace_back();
+        if (chars.capacity() != prev_capacity)
+        {
+            prev_capacity = chars.capacity();
+            capacities.emplace_back(prev_capacity);
+        }
+    }
+
+    EXPECT_EQ(capacities, (std::vector<size_t>{4065, 8161, 16353, 32737, 65505, 131041, 262113, 524257, 1048545}));
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: maybe related to https://github.com/pingcap/tidb/issues/22184

Problem Summary: TiFlash crashes when inserting data.

### What is changed and how it works?

Cherry-pick two commits in Clickhouse to fix bugs for PODArray

* https://github.com/ClickHouse/ClickHouse/commit/ea177061e8624611be915d44484b8487b07640b2
* https://github.com/ClickHouse/ClickHouse/commit/c3dbf7d6bffc291d90f83df00b4ae4aa8a5d893c

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- N/A

### Release note <!-- bugfixes or new feature need a release note -->

- Fix the bug that TiFlash may crash when reading data