### PR TITLE
Fix hash join: make probe stage parallel

### DIFF
--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -1265,12 +1265,14 @@ void Join::checkTypesOfKeys(const Block & block_left, const Block & block_right)
 
 void Join::joinBlock(Block & block) const
 {
-//    std::cerr << "joinBlock: " << block.dumpStructure() << "\n";
+    //    std::cerr << "joinBlock: " << block.dumpStructure() << "\n";
 
     // ck will use this function to generate header, that's why here is a check.
-    std::unique_lock lk(build_table_mutex);
+    {
+        std::unique_lock lk(build_table_mutex);
 
-    build_table_cv.wait(lk, [&](){ return have_finish_build; });
+        build_table_cv.wait(lk, [&]() { return have_finish_build; });
+    }
 
     std::shared_lock lock(rwlock);
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
For now Hash join probe stage is running in sequence, which cannot exhaust CPU resource.

### What is changed and how it works?

What's Changed:
- Release mutex as soon as build stage is finished

How it Works:

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

### Release note <!-- bugfixes or new feature need a release note -->

- Fix problem that MPP Hash Join is slower than expected.
