### PR TITLE
metrics: grafana dashboards support multiple cluster

### DIFF
--- a/metrics/grafana/tiflash_proxy_details.json
+++ b/metrics/grafana/tiflash_proxy_details.json
@@ -16767,7 +16767,7 @@
         "options": [
 
         ],
-        "query": "label_values(tiflash_proxy_tikv_engine_block_cache_size_bytes, cluster)",
+        "query": "label_values(tiflash_proxy_tikv_engine_block_cache_size_bytes, tidb_cluster)",
         "refresh": 2,
         "regex": "",
         "sort": 1,

--- a/metrics/grafana/tiflash_proxy_summary.json
+++ b/metrics/grafana/tiflash_proxy_summary.json
@@ -1486,7 +1486,7 @@
         "options": [
 
         ],
-        "query": "label_values(tiflash_proxy_tikv_engine_block_cache_size_bytes, cluster)",
+        "query": "label_values(tiflash_proxy_tikv_engine_block_cache_size_bytes, tidb_cluster)",
         "refresh": 2,
         "regex": "",
         "sort": 1,

--- a/metrics/grafana/tiflash_summary.json
+++ b/metrics/grafana/tiflash_summary.json
@@ -4836,7 +4836,7 @@
         "options": [
 
         ],
-        "query": "label_values(tiflash_proxy_tikv_engine_block_cache_size_bytes, cluster)",
+        "query": "label_values(tiflash_proxy_tikv_engine_block_cache_size_bytes, tidb_cluster)",
         "refresh": 2,
         "regex": "",
         "sort": 1,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
The latest version of tidb-operator will use the instance name as the cluster label. The previous expression uses the cluster label got the value of the tidb_cluster variable. It will cause Grafana can not to display the data.

How it Works:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- No effects

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
