### PR TITLE
Add server info metrics

### DIFF
--- a/dbms/src/Common/TiFlashMetrics.h
+++ b/dbms/src/Common/TiFlashMetrics.h
@@ -1,3 +1,4 @@
+#include <Common/TiFlashBuildInfo.h>
 #include <prometheus/counter.h>
 #include <prometheus/exposer.h>
 #include <prometheus/gateway.h>
@@ -30,7 +31,7 @@ namespace DB
     M(tiflash_coprocessor_executor_count, "Total number of each executor", Counter, F(type_ts, {"type", "table_scan"}),                   \
         F(type_sel, {"type", "selection"}), F(type_agg, {"type", "aggregation"}), F(type_topn, {"type", "top_n"}),                        \
         F(type_limit, {"type", "limit"}), F(type_join, {"type", "join"}), F(type_exchange_sender, {"type", "exchange_sender"}),           \
-        F(type_exchange_receiver, {"type", "exchange_receiver"}), F(type_projection, {"type", "projection"}))                                                                         \
+        F(type_exchange_receiver, {"type", "exchange_receiver"}), F(type_projection, {"type", "projection"}))                             \
     M(tiflash_coprocessor_request_duration_seconds, "Bucketed histogram of request duration", Histogram,                                  \
         F(type_batch, {{"type", "batch"}}, ExpBuckets{0.0005, 2, 20}), F(type_cop, {{"type", "cop"}}, ExpBuckets{0.0005, 2, 20}),         \
         F(type_super_batch, {{"type", "super_batch"}}, ExpBuckets{0.0005, 2, 20}),                                                        \
@@ -119,7 +120,9 @@ namespace DB
     M(tiflash_raft_apply_write_command_duration_seconds, "Bucketed histogram of applying write command Raft logs", Histogram,             \
         F(type_write, {{"type", "write"}}, ExpBuckets{0.0005, 2, 20}))                                                                    \
     M(tiflash_raft_write_data_to_storage_duration_seconds, "Bucketed histogram of writting region into storage layer", Histogram,         \
-        F(type_decode, {{"type", "decode"}}, ExpBuckets{0.0005, 2, 20}), F(type_write, {{"type", "write"}}, ExpBuckets{0.0005, 2, 20}))
+        F(type_decode, {{"type", "decode"}}, ExpBuckets{0.0005, 2, 20}), F(type_write, {{"type", "write"}}, ExpBuckets{0.0005, 2, 20}))   \
+    M(tiflash_server_info, "Indicate the tiflash server info, and the value is the start timestamp (s).", Gauge,                          \
+        F(start_time, {"version", TiFlashBuildInfo::getReleaseVersion()}, {"hash", TiFlashBuildInfo::getGitHash()}))
 
 
 struct ExpBuckets

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -9,6 +9,7 @@
 #include <Common/StringUtils/StringUtils.h>
 #include <Common/TiFlashBuildInfo.h>
 #include <Common/TiFlashException.h>
+#include <Common/TiFlashMetrics.h>
 #include <Common/config.h>
 #include <Common/escapeForFileName.h>
 #include <Common/formatReadable.h>
@@ -34,6 +35,7 @@
 #include <Poco/Net/HTTPServer.h>
 #include <Poco/Net/NetException.h>
 #include <Poco/StringTokenizer.h>
+#include <Poco/Timestamp.h>
 #include <Server/StorageConfigParser.h>
 #include <Storages/MutableSupport.h>
 #include <Storages/PathCapacityMetrics.h>
@@ -1227,6 +1229,13 @@ int Server::main(const std::vector<std::string> & /*args*/)
                 tiflash_instance_wrap.proxy_helper->batchReadIndex(batch_read_index_req);
             }
             LOG_INFO(log, "start to wait for terminal signal");
+        }
+
+        {
+            // Report the unix timestamp, git hash, release version
+            auto metrics = global_context->getTiFlashMetrics();
+            Poco::Timestamp ts;
+            GET_METRIC(metrics, tiflash_server_info, start_time).Set(ts.epochTime());
         }
 
         waitForTerminationRequest();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #1391 

Problem Summary: Report a Gauge with version and git hash label, and the value with the start timestamp for DBaaS metrics

Related PR: https://github.com/pingcap/tidb/pull/22556

### What is changed and how it works?

Report a Gauge after TiFlash is ready.
```
# query the metrics info:
> curl '127.0.0.1:9090/api/v1/query?query=tiflash_server_info&time=2021-01-28T07:16:00.781Z'
{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"tiflash_server_info","hash":"526cf694d5a5d82b61233d968ade0b868dc1d2aa","instance":"172.16.5.85:17512","job":"tiflash","version":"v5.0.0-rc.x-21-g526cf694d-dirty"},"value":[1611818160.781,"1611818134"]}]}}
```

### Related changes

- Need to cherry-pick to the release branch 4.0
- 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

Side effects

- N/A

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
