### PR TITLE
Show environment info before running ci test

### DIFF
--- a/tests/docker/run.sh
+++ b/tests/docker/run.sh
@@ -4,6 +4,9 @@ set -x
 set +e
 
 pwd
+df -h
+grep ^ /sys/block/*/queue/rotational
+
 cat /proc/cpuinfo | grep name | cut -f2 -d: | uniq -c
 cat /proc/meminfo
 uname -a
@@ -11,7 +14,6 @@ hostname
 lsmod
 dmidecode | grep 'Product Name'
 free -mh
-df -h
 cat /proc/loadavg
 
 set -e


### PR DESCRIPTION

### What is changed and how it works?

What's Changed:
- show environment before running ci test

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- No release note