### PR TITLE
Fix alter_exchange_partition test

### DIFF
--- a/tests/fullstack-test/ddl/alter_exchange_partition.test
+++ b/tests/fullstack-test/ddl/alter_exchange_partition.test
@@ -1,6 +1,3 @@
-#TODO: alter table exchagne partition is disabled by default in https://github.com/pingcap/tidb/pull/22638
-#RETURN
-
 >> DBGInvoke __enable_schema_sync_service('true')
 mysql> drop table if exists test.e;
 mysql> drop table if exists test.e2;
@@ -30,7 +27,7 @@ mysql> insert into test_new.e2 values (3, 'a', 'b');
 >> DBGInvoke __refresh_schemas()
 
 # case 1, exchange partition in the same database, no error happens
-mysql> alter table test.e exchange partition p0 with table test.e2
+mysql> set @@tidb_enable_exchange_partition=1; alter table test.e exchange partition p0 with table test.e2
 >> DBGInvoke __refresh_schemas()
 mysql> alter table test.e add column c1 int;
 >> DBGInvoke __refresh_schemas()
@@ -51,7 +48,7 @@ mysql> alter table test.e drop column c1;
 >> DBGInvoke __refresh_schemas()
 
 # case 2, exchange partition across databases, no error happens
-mysql> alter table test.e exchange partition p0 with table test_new.e2
+mysql> set @@tidb_enable_exchange_partition=1; alter table test.e exchange partition p0 with table test_new.e2
 >> DBGInvoke __refresh_schemas()
 mysql> alter table test.e add column c1 int;
 >> DBGInvoke __refresh_schemas()
@@ -73,7 +70,7 @@ mysql> alter table test.e drop column c1;
 
 >> DBGInvoke __init_fail_point()
 # case 3, exchagne partition in the same database, error happens after exchange step 1
-mysql> alter table test.e exchange partition p0 with table test.e2
+mysql> set @@tidb_enable_exchange_partition=1; alter table test.e exchange partition p0 with table test.e2
 >> DBGInvoke __enable_fail_point(exception_after_step_1_in_exchange_partition)
 >> DBGInvoke __refresh_schemas()
 >> DBGInvoke __refresh_schemas()
@@ -96,7 +93,7 @@ mysql> alter table test.e drop column c1;
 >> DBGInvoke __refresh_schemas()
 
 # case 4, exchagne partition in the same database, error happens after exchange step 2
-mysql> alter table test.e exchange partition p0 with table test.e2
+mysql> set @@tidb_enable_exchange_partition=1; alter table test.e exchange partition p0 with table test.e2
 >> DBGInvoke __enable_fail_point(exception_after_step_2_in_exchange_partition)
 >> DBGInvoke __refresh_schemas()
 >> DBGInvoke __refresh_schemas()
@@ -119,7 +116,7 @@ mysql> alter table test.e drop column c1;
 >> DBGInvoke __refresh_schemas()
 
 # case 5, exchagne partition in the same database, error happens after exchange step 3
-mysql> alter table test.e exchange partition p0 with table test.e2
+mysql> set @@tidb_enable_exchange_partition=1; alter table test.e exchange partition p0 with table test.e2
 >> DBGInvoke __enable_fail_point(exception_after_step_3_in_exchange_partition)
 >> DBGInvoke __refresh_schemas()
 >> DBGInvoke __refresh_schemas()
@@ -142,7 +139,7 @@ mysql> alter table test.e drop column c1;
 >> DBGInvoke __refresh_schemas()
 
 # case 6, exchagne partition across databases, error happens after exchange step 1
-mysql> alter table test.e exchange partition p0 with table test_new.e2
+mysql> set @@tidb_enable_exchange_partition=1; alter table test.e exchange partition p0 with table test_new.e2
 >> DBGInvoke __enable_fail_point(exception_after_step_1_in_exchange_partition)
 >> DBGInvoke __refresh_schemas()
 >> DBGInvoke __refresh_schemas()
@@ -165,7 +162,7 @@ mysql> alter table test.e drop column c1;
 >> DBGInvoke __refresh_schemas()
 
 # case 7, exchagne partition across databases, error happens before rename in exchange step 2
-mysql> alter table test.e exchange partition p0 with table test_new.e2
+mysql> set @@tidb_enable_exchange_partition=1; alter table test.e exchange partition p0 with table test_new.e2
 >> DBGInvoke __enable_fail_point(exception_before_step_2_rename_in_exchange_partition)
 >> DBGInvoke __refresh_schemas()
 >> DBGInvoke __refresh_schemas()
@@ -188,7 +185,7 @@ mysql> alter table test.e drop column c1;
 >> DBGInvoke __refresh_schemas()
 
 # case 8, exchagne partition across databases, error happens after exchange step 2
-mysql> alter table test.e exchange partition p0 with table test_new.e2
+mysql> set @@tidb_enable_exchange_partition=1; alter table test.e exchange partition p0 with table test_new.e2
 >> DBGInvoke __enable_fail_point(exception_after_step_2_in_exchange_partition)
 >> DBGInvoke __refresh_schemas()
 >> DBGInvoke __refresh_schemas()
@@ -211,7 +208,7 @@ mysql> alter table test.e drop column c1;
 >> DBGInvoke __refresh_schemas()
 
 # case 9, exchagne partition across databases, error happens before rename in exchange step 3
-mysql> alter table test.e exchange partition p0 with table test_new.e2
+mysql> set @@tidb_enable_exchange_partition=1; alter table test.e exchange partition p0 with table test_new.e2
 >> DBGInvoke __enable_fail_point(exception_before_step_3_rename_in_exchange_partition)
 >> DBGInvoke __refresh_schemas()
 >> DBGInvoke __refresh_schemas()
@@ -234,7 +231,7 @@ mysql> alter table test.e drop column c1;
 >> DBGInvoke __refresh_schemas()
 
 # case 10, exchagne partition across databases, error happens after exchange step 3
-mysql> alter table test.e exchange partition p0 with table test_new.e2
+mysql> set @@tidb_enable_exchange_partition=1; alter table test.e exchange partition p0 with table test_new.e2
 >> DBGInvoke __enable_fail_point(exception_after_step_3_in_exchange_partition)
 >> DBGInvoke __refresh_schemas()
 >> DBGInvoke __refresh_schemas()


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

TiDB disable `alter table exchange partition` ddl by default in this [pr,](https://github.com/pingcap/tidb/pull/22638/files) so need to enable it explicitly when running alter_exchange_partition test

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
