### PR TITLE
Check exact tiflash replica count & Enable optimization about compact raft log

### DIFF
--- a/cluster_manage/conf.py
+++ b/cluster_manage/conf.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
-import logging
 import argparse
+import logging
+
 import version
 
 version_info = ''
@@ -12,6 +13,8 @@ parser = argparse.ArgumentParser(description='TiFlash Cluster Manager', formatte
 parser.add_argument('--version', '-v', help='show version', action='version', version=version_info)
 parser.add_argument('--config', help='path of config file *.toml', required=True)
 parser.add_argument('--log_level', help='log level', default='INFO', choices=['INFO', 'DEBUG', 'WARN'])
+parser.add_argument('--check_online_update', help='check can do online rolling update for TiFlash', action='store_true')
+parser.add_argument('--clean_pd_rules', help='clean all placement rules about tiflash in pd', action='store_true')
 
 args = parser.parse_args()
 

--- a/cluster_manage/flash_cluster_manager.py
+++ b/cluster_manage/flash_cluster_manager.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 import logging
 import os
+import sys
 import time
 from logging.handlers import RotatingFileHandler
 
@@ -114,14 +115,23 @@ class TiFlashClusterManager:
         val = conf.flash_conf.http_addr
         self.pd_client.etcd_client.update(key, val, max(conf.flash_conf.cluster_master_ttl, 120))
 
-    def __init__(self, pd_client: PDClient, tidb_status_addr_list):
-        self.logger = logging.getLogger('TiFlashManager')
+    def __init__(self, pd_client: PDClient, tidb_status_addr_list, logger):
+        self.logger = logger
         self.tidb_status_addr_list = tidb_status_addr_list
         self.pd_client = pd_client
+
+    def run(self):
+        if conf.args.check_online_update:
+            self.check_online_update_available()
+        elif conf.args.clean_pd_rules:
+            self.clean_pd_rules()
+        else:
+            self.run_one_round()
+
+    def run_one_round(self):
         self.stores = {}
         self.cur_store = None
         self._update_cluster()
-
         self.state = [TiFlashClusterManager.ROLE_INIT, 0]
         self._try_refresh()
         self.ddl_global_schema_version = None
@@ -169,10 +179,11 @@ class TiFlashClusterManager:
         else:
             raise Exception('Set placement rule {} fail'.format(rule))
 
-    def compute_sync_data_process(self, table_id, start_key, end_key):
+    def compute_sync_data_process(self, table_id, start_key, end_key, replica_count):
         stats_region: dict = self.pd_client.get_stats_region_by_range_json(start_key, end_key)
         region_count = max(stats_region.get('count', 1), 1)
-        flash_region_count, err = flash_http_client.get_region_count_by_table(self.stores.values(), table_id)
+        flash_region_count, err = flash_http_client.get_region_count_by_table(self.stores.values(), table_id,
+                                                                              replica_count)
         if err:
             self.logger.error('fail to get table replica sync status {}'.format(err))
         return region_count, flash_region_count
@@ -201,6 +212,9 @@ class TiFlashClusterManager:
 
     @wrap_try_get_lock
     def remove_rule(self, rule_id):
+        self._remove_rule(rule_id)
+
+    def _remove_rule(self, rule_id):
         self.pd_client.remove_rule(placement_rule.TIFLASH_GROUP_ID, rule_id)
         self.logger.info('Remove placement rule {}'.format(rule_id))
 
@@ -229,17 +243,49 @@ class TiFlashClusterManager:
 
         return False
 
+    def check_online_update_available(self):
+        from tikv_util import common
+
+        self.stores = {store_id: Store(store) for store_id, store in
+                       self.pd_client.get_store_by_labels(define.TIFLASH_LABEL).items()}
+        table_list = tidb_tools.db_flash_replica(self.tidb_status_addr_list)
+        error_list = []
+        for table in table_list:
+            table_id = table['id']
+            replica_count = table[define.REPLICA_COUNT]
+            st, ed = common.make_table_begin(table_id), common.make_table_end(table_id)
+            start_key, end_key = st.to_bytes(), ed.to_bytes()
+            region_count, flash_region_count = self.compute_sync_data_process(table_id, start_key, end_key,
+                                                                              replica_count)
+            if region_count != flash_region_count:
+                error_list.append(
+                    'Table {}, replica count {}, got {} matched region peers in TiFlash stores, expect {}.'.format(
+                        table_id, replica_count, flash_region_count, region_count))
+        if error_list:
+            self.logger.info('False.')
+            for e in error_list:
+                self.logger.info('    %s' % e)
+        else:
+            self.logger.info('True.')
+
+    def clean_pd_rules(self):
+        all_rules = self.pd_client.get_group_rules(placement_rule.TIFLASH_GROUP_ID)
+        self.logger.info(
+            'There are {} rules in pd with group-id `{}`'.format(len(all_rules), placement_rule.TIFLASH_GROUP_ID))
+        for rule_id in all_rules.keys():
+            self._remove_rule(rule_id)
+
     @wrap_try_get_lock
     def table_update(self):
         if self.escape_table_update():
             return
 
+        from tikv_util import common
+
         all_replica_available = True
         table_list = tidb_tools.db_flash_replica(self.tidb_status_addr_list)
         all_rules = self.pd_client.get_group_rules(placement_rule.TIFLASH_GROUP_ID)
         for table in table_list:
-            from tikv_util import common
-
             table_id = table['id']
             st, ed = common.make_table_begin(table_id), common.make_table_end(table_id)
             start_key, end_key = st.to_bytes(), ed.to_bytes()
@@ -251,7 +297,7 @@ class TiFlashClusterManager:
                     self.pd_client.set_accelerate_schedule(start_key_hex, end_key_hex)
                     self.logger.info('try to accelerate pd schedule for table {}'.format(table_id))
 
-                region_count, flash_region_count = self.compute_sync_data_process(table_id, start_key, end_key)
+                region_count, flash_region_count = self.compute_sync_data_process(table_id, start_key, end_key, 1)
                 self.report_to_tidb(table, region_count, flash_region_count)
                 all_replica_available = False
 
@@ -268,22 +314,31 @@ class TiFlashClusterManager:
 
 def main():
     flash_conf = conf.flash_conf
-    parent_path = os.path.dirname(flash_conf.log_path)
-    if not os.path.exists(parent_path):
-        os.makedirs(parent_path)
 
-    # keep at most 10G log files
-    logging.basicConfig(
-        handlers=[RotatingFileHandler(flash_conf.log_path, maxBytes=1024 * 1024 * 500, backupCount=5)],
-        level=conf.log_level, format='%(asctime)s <%(levelname)s> %(name)s: %(message)s')
-    logging.getLogger("requests").setLevel(logging.WARNING)
-    logging.getLogger("urllib3").setLevel(logging.WARNING)
+    if conf.args.check_online_update or conf.args.clean_pd_rules:
+        root = logging.getLogger()
+        root.setLevel(logging.INFO)
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setLevel(logging.INFO)
+        root.addHandler(handler)
+        logger = root
+    else:
+        parent_path = os.path.dirname(flash_conf.log_path)
+        if not os.path.exists(parent_path):
+            os.makedirs(parent_path)
 
-    logging.debug('\nCluster Manager Version Info\n{}'.format(conf.version_info))
+        # keep at most 10G log files
+        logging.basicConfig(
+            handlers=[RotatingFileHandler(flash_conf.log_path, maxBytes=1024 * 1024 * 500, backupCount=5)],
+            level=conf.log_level, format='%(asctime)s <%(levelname)s> %(name)s: %(message)s')
+        logging.getLogger("requests").setLevel(logging.WARNING)
+        logging.getLogger("urllib3").setLevel(logging.WARNING)
+        logging.debug('\nCluster Manager Version Info\n{}'.format(conf.version_info))
+        logger = logging.getLogger('TiFlashManager')
 
     try:
         pd_client = PDClient(flash_conf.pd_addrs)
-        TiFlashClusterManager(pd_client, conf.flash_conf.tidb_status_addr)
+        TiFlashClusterManager(pd_client, conf.flash_conf.tidb_status_addr, logger).run()
     except Exception as e:
         logging.exception(e)
 

--- a/cluster_manage/flash_http_client.py
+++ b/cluster_manage/flash_http_client.py
@@ -10,7 +10,7 @@ def curl_flash(address, params):
     return r
 
 
-def get_region_count_by_table(store_list, table_id):
+def get_region_count_by_table(store_list, table_id, replica_count):
     from tikv_util import common
 
     checker = common.CheckRegionCnt()
@@ -22,7 +22,7 @@ def get_region_count_by_table(store_list, table_id):
             checker.add(res.content)
         except Exception as e:
             err.append(e)
-    return checker.compute(), err
+    return checker.compute(replica_count), err
 
 
 def get_regions_by_range(address, start_key, end_key):

--- a/cluster_manage/flash_tools.py
+++ b/cluster_manage/flash_tools.py
@@ -33,6 +33,7 @@ class FlashConfig:
             int(flash_cluster.get('refresh_interval', 20)), self.cluster_master_ttl)
         self.update_rule_interval = int(flash_cluster.get('update_rule_interval', 10))
         self.log_path = flash_cluster.get('log', '{}/flash_cluster_manager.log'.format(tmp_path))
+        self.max_time_out = self.cluster_master_ttl
 
         self.enable_tls = False
         if 'security' in self.conf_toml:

--- a/cluster_manage/pd_client.py
+++ b/cluster_manage/pd_client.py
@@ -52,12 +52,12 @@ class EtcdClient:
 
     def __init__(self, host, port):
         self.logger = logging.getLogger('etcd.client')
+        kwargs = {"timeout": conf.flash_conf.max_time_out}
         if conf.flash_conf.enable_tls:
-            self.client = etcd3.client(host=host, port=port, timeout=conf.flash_conf.update_rule_interval,
-                                       ca_cert=conf.flash_conf.ca_path, cert_key=conf.flash_conf.key_path,
-                                       cert_cert=conf.flash_conf.cert_path)
-        else:
-            self.client = etcd3.client(host=host, port=port, timeout=conf.flash_conf.update_rule_interval)
+            kwargs["ca_cert"] = conf.flash_conf.ca_path
+            kwargs["cert_key"] = conf.flash_conf.key_path
+            kwargs["cert_cert"] = conf.flash_conf.cert_path
+        self.client = etcd3.client(host=host, port=port, **kwargs)
 
 
 class PDClient:

--- a/cluster_manage/tikv_util/check_region_cnt.cc
+++ b/cluster_manage/tikv_util/check_region_cnt.cc
@@ -1,5 +1,8 @@
 #include "check_region_cnt.h"
+
 #include <pybind11/pybind11.h>
+
+#include <numeric>
 
 void CheckRegionCnt::Add(std::string_view s) {
   char region_id[20];
@@ -10,7 +13,7 @@ void CheckRegionCnt::Add(std::string_view s) {
   for (size_t i = p1 + 1; i < p2; ++i) {
     if (s[i] == ' ') {
       region_id[id_len] = 0;
-      data_.emplace(std::atoll(region_id));
+      data_[std::atoll(region_id)] += 1;
       id_len = 0;
     } else {
       region_id[id_len++] = s[i];
@@ -18,4 +21,10 @@ void CheckRegionCnt::Add(std::string_view s) {
   }
 }
 
-int CheckRegionCnt::Compute() { return data_.size(); }
+Int64 CheckRegionCnt::Compute(UInt64 expect_cnt) {
+  if (expect_cnt == 1) return data_.size();
+
+  return std::accumulate(
+      data_.begin(), data_.end(), Int64(0),
+      [&](auto sum, const auto & e) { return sum + (e.second >= expect_cnt); });
+}

--- a/cluster_manage/tikv_util/check_region_cnt.h
+++ b/cluster_manage/tikv_util/check_region_cnt.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include <string_view>
-#include <unordered_set>
+#include <unordered_map>
+
 #include "type.h"
 
 namespace pybind11 {
@@ -13,8 +14,10 @@ namespace py = pybind11;
 class CheckRegionCnt {
  public:
   void Add(std::string_view);
-  int Compute();
+  // Count how many regions that the number of TiFlash peers is greater or equal
+  // to replica_count
+  Int64 Compute(UInt64);
 
  private:
-  std::unordered_set<UInt64> data_;
+  std::unordered_map<UInt64, UInt64> data_;
 };

--- a/cluster_manage/tikv_util/codec.h
+++ b/cluster_manage/tikv_util/codec.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "exception_util.h"
-#include "type.h"
-
 #include <cstring>
 #include <sstream>
+
+#include "exception_util.h"
+#include "type.h"
 
 static const size_t kEncGroupSize = 8;
 static const uint8_t kEncMarker = static_cast<uint8_t>(0xff);
@@ -12,7 +12,6 @@ static const char kEncAscPadding[kEncGroupSize] = {0};
 
 static const char kTablePrefix = 't';
 static const char * kRecordPrefixSep = "_r";
-static const char * kRecordPrefixEnd = "_s";
 
 static const UInt64 kSignMark = (UInt64)1 << 63u;
 

--- a/cluster_manage/tikv_util/export.cc
+++ b/cluster_manage/tikv_util/export.cc
@@ -1,7 +1,7 @@
+#include <pybind11/pybind11.h>
+
 #include "check_region_cnt.h"
 #include "tikv_key.h"
-
-#include <pybind11/pybind11.h>
 namespace py = pybind11;
 
 PYBIND11_MODULE(common, m) {

--- a/cluster_manage/tikv_util/test.py
+++ b/cluster_manage/tikv_util/test.py
@@ -50,8 +50,9 @@ class TestTikvKey(unittest.TestCase):
         c = common.CheckRegionCnt()
         c.add(s1)
         c.add(s2)
-        r = c.compute()
-        self.assertEqual(4, r)
+        self.assertEqual(4, c.compute(1))
+        self.assertEqual(2, c.compute(2))
+        self.assertEqual(0, c.compute(3))
 
     def test_exception(self):
         o = b'12345'

--- a/cluster_manage/tikv_util/tikv_key.cc
+++ b/cluster_manage/tikv_util/tikv_key.cc
@@ -1,5 +1,7 @@
 #include "tikv_key.h"
+
 #include <pybind11/pybind11.h>
+
 #include "codec.h"
 namespace py = pybind11;
 

--- a/cluster_manage/tikv_util/tikv_key.h
+++ b/cluster_manage/tikv_util/tikv_key.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+
 #include "type.h"
 
 namespace pybind11 {

--- a/dbms/src/Storages/Transaction/KVStore.h
+++ b/dbms/src/Storages/Transaction/KVStore.h
@@ -82,7 +82,7 @@ public:
     void handlePreApplySnapshot(const RegionPtrWrap &, TMTContext & tmt);
 
     void handleDestroy(UInt64 region_id, TMTContext & tmt);
-    void setRegionCompactLogPeriod(Seconds period);
+    void setRegionCompactLogPeriod(UInt64);
     EngineStoreApplyRes handleIngestSST(UInt64 region_id, const SSTViewVec, UInt64 index, UInt64 term, TMTContext & tmt);
     RegionPtr genRegionPtr(metapb::Region && region, UInt64 peer_id, UInt64 index, UInt64 term);
     const TiFlashRaftProxyHelper * getProxyHelper() const { return proxy_helper; }
@@ -138,7 +138,7 @@ private:
 
     Logger * log;
 
-    std::atomic<Seconds> REGION_COMPACT_LOG_PERIOD;
+    std::atomic<UInt64> REGION_COMPACT_LOG_PERIOD;
 
     mutable std::mutex bg_gc_region_data_mutex;
     std::list<RegionDataReadInfoList> bg_gc_region_data;

--- a/dbms/src/Storages/Transaction/Region.h
+++ b/dbms/src/Storages/Transaction/Region.h
@@ -201,7 +201,6 @@ private:
 
     RegionMeta meta;
 
-    mutable std::atomic<Timepoint> last_persist_time = Timepoint::min();
     mutable std::atomic<Timepoint> last_compact_log_time = Timepoint::min();
 
     // dirty_flag is used to present whether this region need to be persisted.

--- a/dbms/src/Storages/Transaction/TMTContext.cpp
+++ b/dbms/src/Storages/Transaction/TMTContext.cpp
@@ -83,7 +83,7 @@ void TMTContext::reloadConfig(const Poco::Util::AbstractConfiguration & config)
     static const std::string & REPLICA_READ_MAX_THREAD = "flash.replica_read_max_thread";
 
     getRegionTable().setTableCheckerThreshold(config.getDouble(TABLE_OVERLAP_THRESHOLD, 0.6));
-    getKVStore()->setRegionCompactLogPeriod(Seconds{config.getUInt64(COMPACT_LOG_MIN_PERIOD, 0)});
+    getKVStore()->setRegionCompactLogPeriod(std::max(config.getUInt64(COMPACT_LOG_MIN_PERIOD, 120), 1));
     replica_read_max_thread = std::max(config.getUInt64(REPLICA_READ_MAX_THREAD, 1), 1);
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #1436 <!-- REMOVE this line if no issue to close -->

### What is changed and how it works?

What's Changed:

* add option in cluster-manager to check exact tiflash replica count.
* enable optimization about compact raft log by default.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- Add tools to check exact tiflash replica status for online rolling update
