### PR TITLE
Fix compile error under MacOS

### DIFF
--- a/dbms/src/Server/RaftConfigParser.cpp
+++ b/dbms/src/Server/RaftConfigParser.cpp
@@ -97,7 +97,7 @@ TiFlashRaftConfig TiFlashRaftConfig::parseSettings(Poco::Util::LayeredConfigurat
         res.enable_compatible_mode = config.getBool("raft.enable_compatible_mode");
     }
 
-    return std::move(res);
+    return res;
 }
 
 } // namespace DB


### PR DESCRIPTION
Signed-off-by: JaySon-Huang <jayson.hjs@gmail.com>

### What problem does this PR solve?

```
/Users/pingcap/workspace/build-darwin-amd64-4.0/tics/dbms/src/Server/RaftConfigParser.cpp:100:12: error: moving a local object in a return statement prevents copy elision [-Werror,-Wpessimizing-move]
    return std::move(res);
           ^
/Users/pingcap/workspace/build-darwin-amd64-4.0/tics/dbms/src/Server/RaftConfigParser.cpp:100:12: note: remove std::move call here
    return std::move(res);
           ^~~~~~~~~~   ~
1 error generated.
```

### What is changed and how it works?


### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- N/A

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
