### PR TITLE
Add a metrics that show whether schema apply lock is held for a long time or not

### DIFF
--- a/dbms/src/Common/TiFlashMetrics.h
+++ b/dbms/src/Common/TiFlashMetrics.h
@@ -56,6 +56,7 @@ namespace DB
         F(type_cancel_mpp_task, {{"type", "cancel_mpp_task"}}, ExpBuckets{0.0005, 2, 30}))                                                \
     M(tiflash_coprocessor_response_bytes, "Total bytes of response body", Counter)                                                        \
     M(tiflash_schema_version, "Current version of tiflash cached schema", Gauge)                                                          \
+    M(tiflash_schema_applying, "Whether the schema is applying or not (holding lock)", Gauge)                                             \
     M(tiflash_schema_apply_count, "Total number of each kinds of apply", Counter, F(type_diff, {"type", "diff"}),                         \
         F(type_full, {"type", "full"}), F(type_failed, {"type", "failed"}))                                                               \
     M(tiflash_schema_trigger_count, "Total number of each kinds of schema sync trigger", Counter, /**/                                    \

--- a/dbms/src/Storages/Transaction/TiDBSchemaSyncer.h
+++ b/dbms/src/Storages/Transaction/TiDBSchemaSyncer.h
@@ -89,6 +89,11 @@ struct TiDBSchemaSyncer : public SchemaSyncer
         LOG_INFO(log,
             "start to sync schemas. current version is: " + std::to_string(cur_version)
                 + " and try to sync schema version to: " + std::to_string(version));
+
+        // Show whether the schema mutex is held for a long time or not.
+        GET_METRIC(context.getTiFlashMetrics(), tiflash_schema_applying).Set(1.0);
+        SCOPE_EXIT({ GET_METRIC(context.getTiFlashMetrics(), tiflash_schema_applying).Set(0.0); });
+
         GET_METRIC(context.getTiFlashMetrics(), tiflash_schema_apply_count, type_diff).Increment();
         if (!tryLoadSchemaDiffs(getter, version, context))
         {

--- a/metrics/grafana/tiflash_summary.json
+++ b/metrics/grafana/tiflash_summary.json
@@ -2104,7 +2104,8 @@
             "rightSide": false,
             "show": true,
             "total": false,
-            "values": false
+            "values": false,
+            "hideZero": false
           },
           "lines": true,
           "linewidth": 1,
@@ -2114,7 +2115,12 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [],
+          "seriesOverrides": [
+            {
+              "alias": "/^applying/",
+              "yaxis": 2
+            }
+          ],
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
@@ -2146,6 +2152,13 @@
               "intervalFactor": 1,
               "legendFormat": "80",
               "refId": "D"
+            },
+            {
+              "refId": "E",
+              "expr": "sum(tiflash_schema_applying{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance)",
+              "intervalFactor": 1,
+              "format": "time_series",
+              "legendFormat": "applying-{{instance}}"
             }
           ],
           "thresholds": [],
@@ -2179,8 +2192,8 @@
               "format": "short",
               "label": null,
               "logBase": 1,
-              "max": null,
-              "min": null,
+              "max": "2",
+              "min": "0",
               "show": true
             }
           ],


### PR DESCRIPTION
Signed-off-by: JaySon-Huang <jayson.hjs@gmail.com>

### What problem does this PR solve?

`tiflash_schema_apply_duration_seconds` only report the duration after the schema-sync is finished. And it is defined as `ExpBuckets{0.0005, 2, 20}`, which make it can only show 4 minutes even if the schema-sync last for hours. It makes trouble for us for locating problems.

If `syncSchemas` last for a long time, **all coprocessor reads will be blocked by the lock on `schema_mutex`**. It is better to add metrics to show whether schema apply lock is held for a long time or not.

### What is changed and how it works?

Add a metrics that shows right after the `schema_mutex` is locked.
I've tested by adding `std::this_thread::sleep_for(std::chrono::seconds(10 * 60)); // debug`

At 21:23, I mock to block the function by `sleep 60s`.
At 21:47, I mock to block the function by `sleep 10 * 60s`.
We can see that even we block the function for 10 minutes, `tiflash_schema_apply_duration_seconds` shows as "4 minutes" and report it after the blocking is finished.
By adding `tiflash_schema_applying`, we can know which nodes are being blocked and how long they block exactly.
![image](https://user-images.githubusercontent.com/4865550/112789856-a0a83280-9090-11eb-87d0-7be1669e12ba.png)

### Related changes

- Need to cherry-pick to the release branch: 4.0, 5.0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

Side effects


### Release note <!-- bugfixes or new feature need a release note -->

- No release note
