### PR TITLE
Fix pre-decode illegal region snapshot data while using br/lighting

### DIFF
--- a/dbms/src/Storages/Transaction/PartitionStreams.cpp
+++ b/dbms/src/Storages/Transaction/PartitionStreams.cpp
@@ -367,10 +367,21 @@ RegionTable::ResolveLocksAndWriteRegionRes RegionTable::resolveLocksAndWriteRegi
 /// pre-decode region data into block cache and remove
 RegionPtrWrap::CachePtr GenRegionPreDecodeBlockData(const RegionPtr & region, Context & context)
 {
-    auto data_list_read = ReadRegionCommitCache(region);
-
-    if (!data_list_read)
-        return nullptr;
+    std::optional<RegionDataReadInfoList> data_list_read = std::nullopt;
+    try
+    {
+        data_list_read = ReadRegionCommitCache(region);
+        if (!data_list_read)
+            return nullptr;
+    }
+    catch (const Exception & e)
+    {
+        // br or lighting may write illegal data into tikv, skip pre-decode and ingest sst later.
+        LOG_WARNING(&Logger::get(__PRETTY_FUNCTION__),
+            ". Got error while reading region committed cache: " << e.displayText() << ". Skip pre-decode and keep original cache.");
+        // set data_list_read and let apply snapshot process use empty block
+        data_list_read = RegionDataReadInfoList();
+    }
 
     auto metrics = context.getTiFlashMetrics();
     const auto & tmt = context.getTMTContext();


### PR DESCRIPTION
Signed-off-by: Zhigao Tong <tongzhigao@pingcap.com>

### What problem does this PR solve?

Issue Number: close #1691 <!-- REMOVE this line if no issue to close -->

Problem Summary:

* Br ingests sst files of write cf into tikv without default cf, tiflash paniced while pre-decode region snapshot data.

### What is changed and how it works?

What's Changed:

* Skip pre-decode and keep original cache. After sst files about default cf are ingested, committed data will be written into storage.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

### Release note <!-- bugfixes or new feature need a release note -->

- Fix the issue that TiFlash may panic during br restore