### PR TITLE
add retry when decode mpp plan failed

### DIFF
--- a/dbms/src/Flash/Mpp/MPPHandler.cpp
+++ b/dbms/src/Flash/Mpp/MPPHandler.cpp
@@ -79,8 +79,20 @@ void MPPTask::prepare(const mpp::DispatchTaskRequest & task_request)
     dag_req = std::make_unique<tipb::DAGRequest>();
     if (!dag_req->ParseFromString(task_request.encoded_plan()))
     {
-        throw TiFlashException(
-            std::string(__PRETTY_FUNCTION__) + ": Invalid encoded plan: " + task_request.encoded_plan(), Errors::Coprocessor::BadRequest);
+        /// ParseFromString will use the default recursion limit, which is 100 to decode the plan, if the plan tree is too deep,
+        /// it may exceed this limit, so just try again by double the recursion limit
+        ::google::protobuf::io::CodedInputStream coded_input_stream(
+            reinterpret_cast<const UInt8 *>(task_request.encoded_plan().data()), task_request.encoded_plan().size());
+        coded_input_stream.SetRecursionLimit(::google::protobuf::io::CodedInputStream::GetDefaultRecursionLimit() * 2);
+        if (!dag_req->ParseFromCodedStream(&coded_input_stream))
+        {
+            /// just return error if decode failed this time, because it's really a corner case, and even if we can decode the plan
+            /// successfully by using a very large value of the recursion limit, it is kinds of meaningless because the runtime
+            /// performance of this task may be very bad if the plan tree is too deep
+            throw TiFlashException(
+                std::string(__PRETTY_FUNCTION__) + ": Invalid encoded plan, the most likely is that the plan tree is too deep",
+                Errors::Coprocessor::BadRequest);
+        }
     }
     std::unordered_map<RegionID, RegionInfo> regions;
     for (auto & r : task_request.regions())


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #1709 <!-- REMOVE this line if no issue to close -->

Problem Summary:
As the issue described.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

The root cause is when using `ParseFromString` to decode a plan, here is a recursion limit, and the default value of this is  [100](https://github.com/protocolbuffers/protobuf/blob/v3.8.0/src/google/protobuf/io/coded_stream.cc#L84), so when the plan tree is too deep, the pares will fail. In this pr, if `ParseFromString` fails, we will double the recursion liimt and decode the plan again. If it fails again, then error will be thrown.
### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

- support complex query plan tree with a max depth of 100.