### PR TITLE
By default set dt_enable_relevant_place to false

### DIFF
--- a/dbms/src/Interpreters/Settings.h
+++ b/dbms/src/Interpreters/Settings.h
@@ -266,7 +266,7 @@ struct Settings
     M(SettingBool, dt_read_stable_only, false, "Only read stable data in DeltaTree Engine.")\
     M(SettingBool, dt_enable_logical_split, true, "Enable logical split or not in DeltaTree Engine.")\
     M(SettingBool, dt_flush_after_write, false, "Flush cache or not after write in DeltaTree Engine.")\
-    M(SettingBool, dt_enable_relevant_place, true, "Enable relevant place or not in DeltaTree Engine.")\
+    M(SettingBool, dt_enable_relevant_place, false, "Enable relevant place or not in DeltaTree Engine.")\
     M(SettingBool, dt_enable_skippable_place, true, "Enable skippable place or not in DeltaTree Engine.")\
     M(SettingBool, dt_enable_stable_column_cache, true, "Enable column cache for StorageDeltaMerge.") \
     M(SettingBool, dt_enable_single_file_mode_dmfile, false, "Enable write DMFile in single file mode.") \

--- a/dbms/src/Storages/DeltaMerge/Segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/Segment.cpp
@@ -1257,6 +1257,9 @@ std::pair<DeltaIndexPtr, bool> Segment::ensurePlace(const DMContext &           
     auto my_delta_index = delta_snap->getSharedDeltaIndex()->tryClone(delta_snap->getRows(), delta_snap->getDeletes());
     auto my_delta_tree  = my_delta_index->getDeltaTree();
 
+    // Note that, when enable_relevant_place is false , we cannot use the range of this segment.
+    // Because some block / delete ranges could contain some data / range that are not belong to current segment.
+    // If we use the range of this segment as relevant_range, fully_indexed will always be false in those cases.
     RowKeyRange relevant_range = dm_context.enable_relevant_place ? mergeRanges(read_ranges, is_common_handle, rowkey_column_size)
                                                                   : RowKeyRange::newAll(is_common_handle, rowkey_column_size);
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

By default set `dt_enable_relevant_place` to `false`.

### What is changed and how it works?

1. In super batch mode, a segment normally only read by one thread. And this thread read most of the data in this segment. In this case, the relevant place is meaningless.
2. In none super batch mode. If `dt_enable_relevant_place = true`, most of the delta index generated by requests can not be resued by later requests. The default delta index can only be pushed forward by background `PlaceIndex` task. It eliminates the most benefit of delta index.

### Related changes


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

Side effects


### Release note <!-- bugfixes or new feature need a release note -->

- No release note
