### PR TITLE
Fix misplaced Grafana panel (4.0)

### DIFF
--- a/metrics/grafana/tiflash_summary.json
+++ b/metrics/grafana/tiflash_summary.json
@@ -2099,13 +2099,13 @@
             "alignAsTable": false,
             "avg": false,
             "current": false,
+            "hideZero": false,
             "max": false,
             "min": false,
             "rightSide": false,
             "show": true,
             "total": false,
-            "values": false,
-            "hideZero": false
+            "values": false
           },
           "lines": true,
           "linewidth": 1,
@@ -2154,11 +2154,11 @@
               "refId": "D"
             },
             {
-              "refId": "E",
               "expr": "sum(tiflash_schema_applying{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance)",
-              "intervalFactor": 1,
               "format": "time_series",
-              "legendFormat": "applying-{{instance}}"
+              "intervalFactor": 1,
+              "legendFormat": "applying-{{instance}}",
+              "refId": "E"
             }
           ],
           "thresholds": [],
@@ -4783,7 +4783,7 @@
           "heatmap": {},
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 77,
+          "id": 87,
           "legend": {
             "show": true
           },
@@ -4838,25 +4838,21 @@
     "list": [
       {
         "allValue": null,
-        "current": {
-        },
+        "current": {},
         "datasource": "${DS_TEST-CLUSTER}",
+        "definition": "",
         "hide": 2,
         "includeAll": false,
         "label": "tidb_cluster",
         "multi": false,
         "name": "tidb_cluster",
-        "options": [
-
-        ],
+        "options": [],
         "query": "label_values(tiflash_proxy_tikv_engine_block_cache_size_bytes, tidb_cluster)",
         "refresh": 2,
         "regex": "",
         "sort": 1,
         "tagValuesQuery": "",
-        "tags": [
-
-        ],
+        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false


### PR DESCRIPTION
Signed-off-by: JaySon-Huang <jayson.hjs@gmail.com>

### What problem does this PR solve?

cherry-pick of https://github.com/pingcap/tics/pull/1803 to fix the grafana panel

Sometime the panel `Region write Duration (write blocks)` appear in weird places. It is because the panel share a same "id=77" with the panel `Handling Request Number`

### What is changed and how it works?

1. Fix the id of panel and re-export the json file for TiFlash-Summary

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- N/A

### Release note <!-- bugfixes or new feature need a release note -->

- Fix the bug that the Grafana panel `Region write Duration (write blocks)` may be shown in wrong place
