### PR TITLE
[4.0] Fix split on empty segment

### DIFF
--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -1162,13 +1162,17 @@ SegmentPair DeltaMergeStore::segmentSplit(DMContext & dm_context, const SegmentP
     });
 
     WriteBatches wbs(storage_pool);
-    auto         range      = segment->getRange();
-    auto         split_info = segment->prepareSplit(dm_context, schema_snap, segment_snap, wbs);
-    if (!split_info.ok)
+
+    auto range          = segment->getRange();
+    auto split_info_opt = segment->prepareSplit(dm_context, schema_snap, segment_snap, wbs);
+
+    if (!split_info_opt.has_value())
     {
         LOG_WARNING(log, "Give up segment [" << segment->segmentId() << "] split because of prepare split failed");
         return {};
     }
+
+    auto & split_info = split_info_opt.value();
 
     wbs.writeLogAndData();
     split_info.my_stable->enableDMFilesGC();

--- a/dbms/src/Storages/DeltaMerge/Segment.h
+++ b/dbms/src/Storages/DeltaMerge/Segment.h
@@ -66,20 +66,11 @@ public:
 
     struct SplitInfo
     {
-        bool ok;
-
         bool   is_logical;
         Handle split_point;
 
         StableValueSpacePtr my_stable;
         StableValueSpacePtr other_stable;
-
-        SplitInfo() : ok(false) {}
-
-        SplitInfo(bool is_logical_, Handle split_point_, StableValueSpacePtr my_stable_, StableValueSpacePtr other_stable_)
-            : ok(true), is_logical(is_logical_), split_point(split_point_), my_stable(my_stable_), other_stable(other_stable_)
-        {
-        }
     };
 
     Segment(const Segment &) = delete;
@@ -143,11 +134,11 @@ public:
     /// For those split, merge and mergeDelta methods, we should use prepareXXX/applyXXX combo in real production.
     /// split(), merge() and mergeDelta() are only used in test cases.
 
-    SegmentPair split(DMContext & dm_context, const ColumnDefinesPtr & schema_snap) const;
-    SplitInfo   prepareSplit(DMContext &                dm_context,
-                             const ColumnDefinesPtr &   schema_snap,
-                             const SegmentSnapshotPtr & segment_snap,
-                             WriteBatches &             wbs) const;
+    SegmentPair              split(DMContext & dm_context, const ColumnDefinesPtr & schema_snap) const;
+    std::optional<SplitInfo> prepareSplit(DMContext &                dm_context,
+                                          const ColumnDefinesPtr &   schema_snap,
+                                          const SegmentSnapshotPtr & segment_snap,
+                                          WriteBatches &             wbs) const;
     SegmentPair
     applySplit(DMContext & dm_context, const SegmentSnapshotPtr & segment_snap, WriteBatches & wbs, SplitInfo & split_info) const;
 
@@ -249,15 +240,15 @@ private:
     /// Only look up in the stable vs.
     std::optional<Handle> getSplitPointFast(DMContext & dm_context, const StableSnapshotPtr & stable_snap) const;
 
-    SplitInfo prepareSplitLogical(DMContext &                dm_context, //
-                                  const ColumnDefinesPtr &   schema_snap,
-                                  const SegmentSnapshotPtr & segment_snap,
-                                  Handle                     split_point,
-                                  WriteBatches &             wbs) const;
-    SplitInfo prepareSplitPhysical(DMContext &                dm_context,
-                                   const ColumnDefinesPtr &   schema_snap,
-                                   const SegmentSnapshotPtr & segment_snap,
-                                   WriteBatches &             wbs) const;
+    std::optional<SplitInfo> prepareSplitLogical(DMContext &                dm_context, //
+                                                 const ColumnDefinesPtr &   schema_snap,
+                                                 const SegmentSnapshotPtr & segment_snap,
+                                                 Handle                     split_point,
+                                                 WriteBatches &             wbs) const;
+    std::optional<SplitInfo> prepareSplitPhysical(DMContext &                dm_context,
+                                                  const ColumnDefinesPtr &   schema_snap,
+                                                  const SegmentSnapshotPtr & segment_snap,
+                                                  WriteBatches &             wbs) const;
 
 
     /// Make sure that all delta packs have been placed.

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment.cpp
@@ -724,6 +724,26 @@ try
 }
 CATCH
 
+TEST_F(Segment_test, SplitFail)
+try
+{
+    const size_t num_rows_write = 100;
+    {
+        // write to segment
+        Block block = DMTestEnv::prepareSimpleWriteBlock(0, num_rows_write, false);
+        segment->write(dmContext(), std::move(block));
+    }
+
+    // Remove all data
+    segment->write(dmContext(), HandleRange(0, 100));
+    segment->flushCache(dmContext());
+
+    auto [a, b] = segment->split(dmContext(), tableColumns());
+    EXPECT_EQ(a, SegmentPtr{});
+    EXPECT_EQ(b, SegmentPtr{});
+}
+CATCH
+
 TEST_F(Segment_test, Restore)
 try
 {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #1812

Problem Summary:

`getSplitPointSlow` does not properly handle the case that the segment has no rows.

### What is changed and how it works?

What's Changed:

If the segment is empty, refuse to split.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

- Fix a bug that causes TiFlash crash during Segment Split.
