### PR TITLE
Fix bug for gtest memory corruption

### DIFF
--- a/dbms/src/Server/tests/gtest_storage_config.cpp
+++ b/dbms/src/Server/tests/gtest_storage_config.cpp
@@ -15,6 +15,16 @@ namespace DB
 namespace tests
 {
 
+static auto loadConfigFromString(const String & s)
+{
+    std::istringstream ss(s);
+    cpptoml::parser p(ss);
+    auto table = p.parse();
+    Poco::AutoPtr<Poco::Util::LayeredConfiguration> config = new Poco::Util::LayeredConfiguration();
+    config->add(new DB::TOMLConfiguration(table), /*shared=*/false); // Take ownership of TOMLConfig
+    return config;
+}
+
 class StorageConfig_test : public ::testing::Test
 {
 public:
@@ -48,12 +58,7 @@ dir=["/data0/tiflash"]
     for (size_t i = 0; i < tests.size(); ++i)
     {
         const auto & test_case = tests[i];
-        std::istringstream ss(test_case);
-        cpptoml::parser p(ss);
-        auto table = p.parse();
-        std::shared_ptr<Poco::Util::AbstractConfiguration> configuration(new DB::TOMLConfiguration(table));
-        Poco::AutoPtr<Poco::Util::LayeredConfiguration> config = new Poco::Util::LayeredConfiguration();
-        config->add(configuration.get());
+        auto config = loadConfigFromString(test_case);
 
         LOG_INFO(log, "parsing [index=" << i << "] [content=" << test_case << "]");
 
@@ -101,12 +106,7 @@ dir=["/ssd0/tiflash"]
     for (size_t i = 0; i < tests.size(); ++i)
     {
         const auto & test_case = tests[i];
-        std::istringstream ss(test_case);
-        cpptoml::parser p(ss);
-        auto table = p.parse();
-        std::shared_ptr<Poco::Util::AbstractConfiguration> configuration(new DB::TOMLConfiguration(table));
-        Poco::AutoPtr<Poco::Util::LayeredConfiguration> config = new Poco::Util::LayeredConfiguration();
-        config->add(configuration.get());
+        auto config = loadConfigFromString(test_case);
 
         LOG_INFO(log, "parsing [index=" << i << "] [content=" << test_case << "]");
 
@@ -181,12 +181,7 @@ capacity = [ 10737418240 ]
     for (size_t i = 0; i < tests.size(); ++i)
     {
         const auto & test_case = tests[i];
-        std::istringstream ss(test_case);
-        cpptoml::parser p(ss);
-        auto table = p.parse();
-        std::shared_ptr<Poco::Util::AbstractConfiguration> configuration(new DB::TOMLConfiguration(table));
-        Poco::AutoPtr<Poco::Util::LayeredConfiguration> config = new Poco::Util::LayeredConfiguration();
-        config->add(configuration.get());
+        auto config = loadConfigFromString(test_case);
 
         LOG_INFO(log, "parsing [index=" << i << "] [content=" << test_case << "]");
 
@@ -237,12 +232,7 @@ capacity=[ 1024 ]
     for (size_t i = 0; i < tests.size(); ++i)
     {
         const auto & test_case = tests[i];
-        std::istringstream ss(test_case);
-        cpptoml::parser p(ss);
-        auto table = p.parse();
-        std::shared_ptr<Poco::Util::AbstractConfiguration> configuration(new DB::TOMLConfiguration(table));
-        Poco::AutoPtr<Poco::Util::LayeredConfiguration> config = new Poco::Util::LayeredConfiguration();
-        config->add(configuration.get());
+        auto config = loadConfigFromString(test_case);
 
         LOG_INFO(log, "parsing [index=" << i << "] [content=" << test_case << "]");
 
@@ -359,12 +349,7 @@ dt_enable_rough_set_filter = false
     for (size_t i = 0; i < tests.size(); ++i)
     {
         const auto & test_case = tests[i];
-        std::istringstream ss(test_case);
-        cpptoml::parser p(ss);
-        auto table = p.parse();
-        std::shared_ptr<Poco::Util::AbstractConfiguration> configuration(new DB::TOMLConfiguration(table));
-        Poco::AutoPtr<Poco::Util::LayeredConfiguration> config = new Poco::Util::LayeredConfiguration();
-        config->add(configuration.get());
+        auto config = loadConfigFromString(test_case);
 
         LOG_INFO(log, "parsing [index=" << i << "] [content=" << test_case << "]");
 


### PR DESCRIPTION
Signed-off-by: JaySon-Huang <tshent@qq.com>

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tics/issues/1813

Problem Summary: 

https://github.com/pingcap/tics/blob/7981fee8df39a24db3a815256081bcc9b0ce7309/dbms/src/Server/tests/gtest_storage_config.cpp#L359-L373
In this for-loop, we create a shared_ptr `configuration` to hold the TOMLConfiguration, and add it into `config` and assign `config` to `global_ctx`.
But `config` did not take the ownership of `configuration` and `configuration` is released after entering the next round of for-loop.

This bug didn't affect the codes on production environment.

### What is changed and how it works?

To fix this problem, we can make `config` take ownership of `configuration`.

### Related changes

- Need to cherry-pick to the release branch: 4.0, 5.0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- N/A

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
