### PR TITLE
Fix the bug that some decoding is not protected by alter_lock

### DIFF
--- a/dbms/src/Storages/Transaction/ApplySnapshot.cpp
+++ b/dbms/src/Storages/Transaction/ApplySnapshot.cpp
@@ -155,7 +155,7 @@ void KVStore::onSnapshot(const RegionPtrWrap & new_region_wrap, RegionPtr old_re
             try
             {
                 auto & context = tmt.getContext();
-                // Acquire lock so that no other threads can drop storage
+                // Acquire `drop_lock` so that no other threads can drop the storage. `alter_lock` is not required.
                 auto table_lock = storage->lockForShare(getThreadName());
                 auto dm_storage = std::dynamic_pointer_cast<StorageDeltaMerge>(storage);
                 auto key_range = DM::RowKeyRange::fromRegionRange(
@@ -583,13 +583,13 @@ RegionPtr KVStore::handleIngestSSTByDTFile(const RegionPtr & region, const SSTVi
             auto & context = tmt.getContext();
             try
             {
-                // Acquire lock so that no other threads can drop storage
+                // Acquire `drop_lock` so that no other threads can drop the storage. `alter_lock` is not required.
                 auto table_lock = storage->lockForShare(getThreadName());
-                auto dm_storage = std::dynamic_pointer_cast<StorageDeltaMerge>(storage);
                 auto key_range = DM::RowKeyRange::fromRegionRange(
                     region->getRange(), table_id, storage->isCommonHandle(), storage->getRowKeyColumnSize());
                 // Call `ingestFiles` to ingest external DTFiles.
                 // Note that ingest sst won't remove the data in the key range
+                auto dm_storage = std::dynamic_pointer_cast<StorageDeltaMerge>(storage);
                 dm_storage->ingestFiles(key_range, ingest_ids, /*clear_data_in_range=*/false, context.getSettingsRef());
             }
             catch (DB::Exception & e)

--- a/dbms/src/Storages/Transaction/KVStore.cpp
+++ b/dbms/src/Storages/Transaction/KVStore.cpp
@@ -109,7 +109,7 @@ void KVStore::tryFlushRegionCacheInStorage(TMTContext & tmt, const Region & regi
 
         try
         {
-            // Try to get a read lock on `storage` so it won't be dropped during `flushCache`
+            // Acquire `drop_lock` so that no other threads can drop the storage during `flushCache`. `alter_lock` is not required.
             auto storage_lock = storage->lockForShare(getThreadName());
             auto rowkey_range = DM::RowKeyRange::fromRegionRange(
                 region.getRange(), region.getRange()->getMappedTableID(), storage->isCommonHandle(), storage->getRowKeyColumnSize());

--- a/dbms/src/Storages/Transaction/RegionTable.cpp
+++ b/dbms/src/Storages/Transaction/RegionTable.cpp
@@ -238,8 +238,7 @@ void removeObsoleteDataInStorage(
 
     try
     {
-        // acquire a read lock so that no other threads can drop the `storage`
-        // if storage is already dropped, this will throw exception
+        // Acquire a `drop_lock` so that no other threads can drop the `storage`
         auto storage_lock = storage->lockForShare(getThreadName());
 
         auto dm_storage = std::dynamic_pointer_cast<StorageDeltaMerge>(storage);
@@ -254,7 +253,7 @@ void removeObsoleteDataInStorage(
     }
     catch (DB::Exception & e)
     {
-        // We can ignore if storage is already dropped.
+        // We can ignore if the storage is already dropped.
         if (e.code() != ErrorCodes::TABLE_IS_DROPPED)
             throw;
     }


### PR DESCRIPTION
Signed-off-by: JaySon-Huang <jayson.hjs@gmail.com>

### What problem does this PR solve?

Issue Number: close #1944

We should use `lockStructureForShare` instead of `lockForShare` in `GenRegionBlockDatawithSchema` and `AtomicGetStorageSchema`.

### What is changed and how it works?

Review `lockForShare` and `lockStructureForShare` in decoding block phase, fix bugs and comments.

### Related changes

- Need to cherry-pick to the release branch: 5.0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

Side effects

<!--
- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility
-->

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
