### PR TITLE
add a new agg function `first_row` since `any` can not guarrentee all the values returned by multiple `any` function comes from the same row

### DIFF
--- a/dbms/src/AggregateFunctions/AggregateFunctionMinMaxAny.cpp
+++ b/dbms/src/AggregateFunctions/AggregateFunctionMinMaxAny.cpp
@@ -14,6 +14,11 @@ AggregateFunctionPtr createAggregateFunctionAny(const std::string & name, const 
     return AggregateFunctionPtr(createAggregateFunctionSingleValue<AggregateFunctionsSingleValue, AggregateFunctionAnyData>(name, argument_types, parameters));
 }
 
+AggregateFunctionPtr createAggregateFunctionFirstRow(const std::string & name, const DataTypes & argument_types, const Array & parameters)
+{
+    return AggregateFunctionPtr(createAggregateFunctionSingleValue<AggregateFunctionsSingleValue, AggregateFunctionFirstRowData>(name, argument_types, parameters));
+}
+
 AggregateFunctionPtr createAggregateFunctionAnyLast(const std::string & name, const DataTypes & argument_types, const Array & parameters)
 {
     return AggregateFunctionPtr(createAggregateFunctionSingleValue<AggregateFunctionsSingleValue, AggregateFunctionAnyLastData>(name, argument_types, parameters));
@@ -49,6 +54,7 @@ AggregateFunctionPtr createAggregateFunctionArgMax(const std::string & name, con
 void registerAggregateFunctionsMinMaxAny(AggregateFunctionFactory & factory)
 {
     factory.registerFunction("any", createAggregateFunctionAny);
+    factory.registerFunction("first_row", createAggregateFunctionFirstRow);
     factory.registerFunction("anyLast", createAggregateFunctionAnyLast);
     factory.registerFunction("anyHeavy", createAggregateFunctionAnyHeavy);
     factory.registerFunction("min", createAggregateFunctionMin, AggregateFunctionFactory::CaseInsensitive);

--- a/dbms/src/AggregateFunctions/AggregateFunctionMinMaxAny.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionMinMaxAny.h
@@ -638,6 +638,17 @@ struct AggregateFunctionAnyData : Data
 };
 
 template <typename Data>
+struct AggregateFunctionFirstRowData : Data
+{
+    using Self = AggregateFunctionFirstRowData<Data>;
+
+    bool changeIfBetter(const IColumn & column, size_t row_num, Arena * arena) { return this->changeFirstTime(column, row_num, arena); }
+    bool changeIfBetter(const Self & to, Arena * arena)                        { return this->changeFirstTime(to, arena); }
+
+    static const char * name() { return "first_row"; }
+};
+
+template <typename Data>
 struct AggregateFunctionAnyLastData : Data
 {
     using Self = AggregateFunctionAnyLastData<Data>;

--- a/dbms/src/AggregateFunctions/AggregateFunctionNull.cpp
+++ b/dbms/src/AggregateFunctions/AggregateFunctionNull.cpp
@@ -76,6 +76,24 @@ public:
 
         bool return_type_is_nullable = can_output_be_null && nested_function->getReturnType()->canBeInsideNullable();
 
+        if (nested_function && nested_function->getName() == "first_row")
+        {
+            if (return_type_is_nullable)
+            {
+                if (has_nullable_types)
+                    return std::make_shared<AggregateFunctionFirstRowNull<true, true>>(nested_function);
+                else
+                    return std::make_shared<AggregateFunctionFirstRowNull<true, false>>(nested_function);
+            }
+            else
+            {
+                if (has_nullable_types)
+                    return std::make_shared<AggregateFunctionFirstRowNull<false, true>>(nested_function);
+                else
+                    return std::make_shared<AggregateFunctionFirstRowNull<false, false>>(nested_function);
+            }
+        }
+
         if (arguments.size() == 1)
         {
             if (return_type_is_nullable)

--- a/dbms/src/Flash/Coprocessor/DAGUtils.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGUtils.cpp
@@ -487,7 +487,7 @@ extern const String UniqRawResName;
 
 std::unordered_map<tipb::ExprType, String> agg_func_map({
     {tipb::ExprType::Count, "count"}, {tipb::ExprType::Sum, "sum"}, {tipb::ExprType::Min, "min"}, {tipb::ExprType::Max, "max"},
-    {tipb::ExprType::First, "any"}, {tipb::ExprType::ApproxCountDistinct, UniqRawResName},
+    {tipb::ExprType::First, "first_row"}, {tipb::ExprType::ApproxCountDistinct, UniqRawResName},
     //{tipb::ExprType::Avg, ""},
     //{tipb::ExprType::GroupConcat, ""},
     //{tipb::ExprType::Agg_BitAnd, ""},
@@ -529,8 +529,7 @@ std::unordered_map<tipb::ScalarFuncSig, String> scalar_func_map({
     //{tipb::ScalarFuncSig::CastDecimalAsDuration, "cast"},
     //{tipb::ScalarFuncSig::CastDecimalAsJson, "cast"},
 
-    {tipb::ScalarFuncSig::CastStringAsInt, "tidb_cast"},
-    {tipb::ScalarFuncSig::CastStringAsReal, "tidb_cast"},
+    {tipb::ScalarFuncSig::CastStringAsInt, "tidb_cast"}, {tipb::ScalarFuncSig::CastStringAsReal, "tidb_cast"},
     {tipb::ScalarFuncSig::CastStringAsString, "tidb_cast"}, {tipb::ScalarFuncSig::CastStringAsDecimal, "tidb_cast"},
     {tipb::ScalarFuncSig::CastStringAsTime, "tidb_cast"},
     //{tipb::ScalarFuncSig::CastStringAsDuration, "cast"},

--- a/tests/fullstack-test/expr/first_row.test
+++ b/tests/fullstack-test/expr/first_row.test
@@ -1,0 +1,16 @@
+mysql> drop table if exists test.t
+mysql> create table test.t(a int, b int)
+mysql> alter table test.t set tiflash replica 1
+mysql> insert into test.t values(1,null),(null,2),(1,2)
+
+func> wait_table test t
+
+mysql> use test; set @@tidb_isolation_read_engines='tiflash'; select a+b, count(*) from t group by 1
++-----+----------+
+| a+b | count(*) |
++-----+----------+
+|   3 |        1 |
+| NULL |        2 |
++-----+----------+
+
+mysql> drop table if exists test.t


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

<!--
- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility
-->

### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
