### PR TITLE
push down cast as int32

### DIFF
--- a/dbms/src/Functions/FunctionsTiDBConversion.h
+++ b/dbms/src/Functions/FunctionsTiDBConversion.h
@@ -1513,6 +1513,18 @@ private:
                 TiDBConvertToInteger<FromDataType, DataTypeInt64, return_nullable>::execute(
                     block, arguments, result, in_union_, tidb_tp_, context_);
             };
+        if (checkDataType<DataTypeInt32>(to_type.get()))
+            return [](Block & block, const ColumnNumbers & arguments, const size_t result, bool in_union_, const tipb::FieldType & tidb_tp_,
+                       const Context & context_) {
+                TiDBConvertToInteger<FromDataType, DataTypeInt32, return_nullable>::execute(
+                    block, arguments, result, in_union_, tidb_tp_, context_);
+            };
+        if (checkDataType<DataTypeUInt32>(to_type.get()))
+            return [](Block & block, const ColumnNumbers & arguments, const size_t result, bool in_union_, const tipb::FieldType & tidb_tp_,
+                       const Context & context_) {
+                TiDBConvertToInteger<FromDataType, DataTypeUInt32, return_nullable>::execute(
+                    block, arguments, result, in_union_, tidb_tp_, context_);
+            };
         /// cast as decimal
         if (const auto decimal_type = checkAndGetDataType<DataTypeDecimal32>(to_type.get()))
             return [decimal_type](Block & block, const ColumnNumbers & arguments, const size_t result, bool in_union_,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary: a projection introduce cast as int32, but not supported on tiflash. it cause the daily test failed, so fix it.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test
- Manual test (add detailed scripts or steps below)

Side effects

<!--
- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility
-->

### Release note <!-- bugfixes or new feature need a release note -->

- No release note<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
