### PR TITLE
Change the param type of UInt128's compare operators to ref.

### DIFF
--- a/dbms/src/Common/HashTable/HashTable.h
+++ b/dbms/src/Common/HashTable/HashTable.h
@@ -79,7 +79,7 @@ inline bool check(const DB::Int256 & x) {
 template <typename T>
 void set(T & x) { x = 0; }
 
-};
+}
 
 
 /** Compile-time interface for cell of the hash table.

--- a/dbms/src/Common/UInt128.h
+++ b/dbms/src/Common/UInt128.h
@@ -29,23 +29,23 @@ struct UInt128
 
     UInt128() = default;
     explicit UInt128(const UInt64 rhs) : low(rhs), high() {}
-    explicit UInt128(const UInt64 low, const UInt64 high) : low(low), high(high) {}
+    UInt128(const UInt64 low, const UInt64 high) : low(low), high(high) {}
 
     auto tuple() const { return std::tie(high, low); }
 
-    bool inline operator== (const UInt128 rhs) const { return tuple() == rhs.tuple(); }
-    bool inline operator!= (const UInt128 rhs) const { return tuple() != rhs.tuple(); }
-    bool inline operator<  (const UInt128 rhs) const { return tuple() < rhs.tuple(); }
-    bool inline operator<= (const UInt128 rhs) const { return tuple() <= rhs.tuple(); }
-    bool inline operator>  (const UInt128 rhs) const { return tuple() > rhs.tuple(); }
-    bool inline operator>= (const UInt128 rhs) const { return tuple() >= rhs.tuple(); }
+    bool operator== (const UInt128 & rhs) const { return low == rhs.low && high == rhs.high; }
+    bool operator!= (const UInt128 & rhs) const { return !(*this == rhs); }
+    bool operator<  (const UInt128 & rhs) const { return high < rhs.high || (high == rhs.high && low < rhs.low); }
+    bool operator<= (const UInt128 & rhs) const { return high < rhs.high || (high == rhs.high && low <= rhs.low); }
+    bool operator>  (const UInt128 & rhs) const { return !(*this <= rhs); }
+    bool operator>= (const UInt128 & rhs) const { return !(*this < rhs); }
 
-    template <typename T> bool inline operator== (const T rhs) const { return *this == UInt128(rhs); }
-    template <typename T> bool inline operator!= (const T rhs) const { return *this != UInt128(rhs); }
-    template <typename T> bool inline operator>= (const T rhs) const { return *this >= UInt128(rhs); }
-    template <typename T> bool inline operator>  (const T rhs) const { return *this >  UInt128(rhs); }
-    template <typename T> bool inline operator<= (const T rhs) const { return *this <= UInt128(rhs); }
-    template <typename T> bool inline operator<  (const T rhs) const { return *this <  UInt128(rhs); }
+    template <typename T> bool operator== (const T rhs) const { return *this == UInt128(rhs); }
+    template <typename T> bool operator!= (const T rhs) const { return *this != UInt128(rhs); }
+    template <typename T> bool operator>= (const T rhs) const { return *this >= UInt128(rhs); }
+    template <typename T> bool operator>  (const T rhs) const { return *this >  UInt128(rhs); }
+    template <typename T> bool operator<= (const T rhs) const { return *this <= UInt128(rhs); }
+    template <typename T> bool operator<  (const T rhs) const { return *this <  UInt128(rhs); }
 
     template <typename T> explicit operator T() const { return static_cast<T>(low); }
 
@@ -58,19 +58,19 @@ struct UInt128
 
 template <> struct TypeId<UInt128>   { static constexpr const TypeIndex value = TypeIndex::UInt128;  };
 
-template <typename T> bool inline operator== (T a, const UInt128 b) { return UInt128(a) == b; }
-template <typename T> bool inline operator!= (T a, const UInt128 b) { return UInt128(a) != b; }
-template <typename T> bool inline operator>= (T a, const UInt128 b) { return UInt128(a) >= b; }
-template <typename T> bool inline operator>  (T a, const UInt128 b) { return UInt128(a) > b; }
-template <typename T> bool inline operator<= (T a, const UInt128 b) { return UInt128(a) <= b; }
-template <typename T> bool inline operator<  (T a, const UInt128 b) { return UInt128(a) < b; }
+template <typename T> bool inline operator== (T a, const UInt128 & b) { return UInt128(a) == b; }
+template <typename T> bool inline operator!= (T a, const UInt128 & b) { return UInt128(a) != b; }
+template <typename T> bool inline operator>= (T a, const UInt128 & b) { return UInt128(a) >= b; }
+template <typename T> bool inline operator>  (T a, const UInt128 & b) { return UInt128(a) > b; }
+template <typename T> bool inline operator<= (T a, const UInt128 & b) { return UInt128(a) <= b; }
+template <typename T> bool inline operator<  (T a, const UInt128 & b) { return UInt128(a) < b; }
 
 template <> inline constexpr bool IsNumber<UInt128> = true;
 template <> struct TypeName<UInt128> { static const char * get() { return "UInt128"; } };
 
 struct UInt128Hash
 {
-    size_t operator()(UInt128 x) const
+    size_t operator()(const UInt128 & x) const
     {
         return CityHash_v1_0_2::Hash128to64({x.low, x.high});
     }
@@ -80,7 +80,7 @@ struct UInt128Hash
 
 struct UInt128HashCRC32
 {
-    size_t operator()(UInt128 x) const
+    size_t operator()(const UInt128 & x) const
     {
         UInt64 crc = -1ULL;
         crc = _mm_crc32_u64(crc, x.low);
@@ -98,7 +98,7 @@ struct UInt128HashCRC32 : public UInt128Hash {};
 
 struct UInt128TrivialHash
 {
-    size_t operator()(UInt128 x) const { return x.low; }
+    size_t operator()(const UInt128 & x) const { return x.low; }
 };
 
 
@@ -119,7 +119,7 @@ struct UInt256
     UInt64 c;
     UInt64 d;
 
-    bool operator== (const UInt256 rhs) const
+    bool operator== (const UInt256 & rhs) const
     {
         return a == rhs.a && b == rhs.b && c == rhs.c && d == rhs.d;
 
@@ -133,21 +133,21 @@ struct UInt256
                 _mm_loadu_si128(reinterpret_cast<const __m128i *>(&rhs.c)))));*/
     }
 
-    bool operator!= (const UInt256 rhs) const { return !operator==(rhs); }
+    bool operator!= (const UInt256 & rhs) const { return !operator==(rhs); }
 
-    bool operator== (const UInt64 rhs) const { return a == rhs && b == 0 && c == 0 && d == 0; }
-    bool operator!= (const UInt64 rhs) const { return !operator==(rhs); }
+    bool operator== (const UInt64 & rhs) const { return a == rhs && b == 0 && c == 0 && d == 0; }
+    bool operator!= (const UInt64 & rhs) const { return !operator==(rhs); }
 
 #if !__clang__
 #pragma GCC diagnostic pop
 #endif
 
-    UInt256 & operator= (const UInt64 rhs) { a = rhs; b = 0; c = 0; d = 0; return *this; }
+    UInt256 & operator= (const UInt64 & rhs) { a = rhs; b = 0; c = 0; d = 0; return *this; }
 };
 
 struct UInt256Hash
 {
-    size_t operator()(UInt256 x) const
+    size_t operator()(const UInt256 & x) const
     {
         /// NOTE suboptimal
         return CityHash_v1_0_2::Hash128to64({CityHash_v1_0_2::Hash128to64({x.a, x.b}), CityHash_v1_0_2::Hash128to64({x.c, x.d})});
@@ -158,7 +158,7 @@ struct UInt256Hash
 
 struct UInt256HashCRC32
 {
-    size_t operator()(UInt256 x) const
+    size_t operator()(const UInt256 & x) const
     {
         UInt64 crc = -1ULL;
         crc = _mm_crc32_u64(crc, x.a);

--- a/dbms/src/Common/tests/CMakeLists.txt
+++ b/dbms/src/Common/tests/CMakeLists.txt
@@ -83,3 +83,6 @@ target_link_libraries(mytime_test clickhouse_common_io clickhouse_functions gtes
 
 add_executable(rw_lock_test gtest_rw_lock.cpp)
 target_link_libraries(rw_lock_test clickhouse_common_io clickhouse_functions gtest_main)
+
+add_executable (uint128_perf uint128_perf.cpp)
+target_link_libraries (uint128_perf clickhouse_common_io)

--- a/dbms/src/Common/tests/uint128_perf.cpp
+++ b/dbms/src/Common/tests/uint128_perf.cpp
@@ -1,0 +1,86 @@
+#if !defined(__APPLE__) && !defined(__FreeBSD__)
+#include <sched.h>
+#endif
+
+#include <algorithm>
+#include <chrono>
+#include <iostream>
+#include <iomanip>
+#include <random>
+
+#include <Poco/Exception.h>
+#include <Common/UInt128.h>
+#include <Core/Defines.h>
+
+#ifdef __APPLE__
+#include <common/apple_rt.h>
+#endif
+
+namespace
+{
+void setAffinity()
+{
+#if !defined(__APPLE__) && !defined(__FreeBSD__)
+    cpu_set_t mask;
+    CPU_ZERO(&mask);
+    CPU_SET(0, &mask);
+
+    if (-1 == sched_setaffinity(0, sizeof(mask), &mask))
+        throw Poco::Exception("Cannot set CPU affinity");
+#else
+    /** MacOS X by default have THREAD_AFFINITY_NULL
+     *  See: https://developer.apple.com/library/content/releasenotes/Performance/RN-AffinityAPI/
+     */
+#endif
+}
+
+void fill_data(std::vector<DB::UInt128> & data, int count)
+{
+    static std::random_device rd;
+    static std::mt19937 mt(rd());
+    static std::uniform_int_distribution<DB::UInt64> dist;
+
+    data.resize(count);
+    for (int i = 0; i < count; ++i)
+        data[i] = DB::UInt128(dist(mt), dist(mt));
+}
+
+void sort_data(std::vector<DB::UInt128> & data)
+{
+    std::sort(begin(data), end(data));
+}
+} // namespace
+
+int main(int /*argc*/, char ** argv)
+{
+
+#if !__x86_64__
+    std::cerr << "Only for x86_64 arch" << std::endl;
+#endif
+
+    const int count = atoi(argv[1]);
+    const int round = atoi(argv[2]);
+
+    std::cerr << "Count: " << count
+        << ", Round: " << round
+        << "Start" << std::endl << std::endl;
+
+    setAffinity();
+
+    std::vector<DB::UInt128> data;
+    for (int i = 0; i < round; ++i)
+    {
+        std::cerr << "Round " << i + 1;
+        fill_data(data, count);
+        auto start = std::chrono::high_resolution_clock::now();
+        sort_data(data);
+        auto end = std::chrono::high_resolution_clock::now();
+        auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+        std::cerr << ", Time: " << duration.count() << " us." << std::endl;
+    }
+
+    std::cerr << std::endl << "End" << std::endl;
+
+    return 0;
+}
+


### PR DESCRIPTION
Also add a perftest.

On my machine sort a vector of 10M UInt128 use: 16s (before) / 3.4s (after).
