### PR TITLE
increate more threads later in parallel process

### DIFF
--- a/dbms/src/DataStreams/ParallelInputsProcessor.h
+++ b/dbms/src/DataStreams/ParallelInputsProcessor.h
@@ -103,10 +103,11 @@ public:
     /// Start background threads, start work.
     void process()
     {
-        active_threads = max_threads;
+        /// start with one active threads, once the first thread get a block, more threads will be generated in the first thread.
+        active_threads = 1;
+        // must reserve here
         threads.reserve(max_threads);
-        for (size_t i = 0; i < max_threads; ++i)
-            threads.emplace_back(std::bind(&ParallelInputsProcessor::thread, this, current_memory_tracker, i));
+        threads.emplace_back(std::bind(&ParallelInputsProcessor::thread, this, current_memory_tracker, 0));
     }
 
     /// Ask all sources to stop earlier than they run out.
@@ -139,9 +140,11 @@ public:
     {
         if (joined_threads)
             return;
-
-        for (auto & thread : threads)
-            thread.join();
+        /// NOTE: the vector of threads should reserve in advance, otherwise it would cause errors.
+        /// join the first thread, then join rests.
+        threads[0].join();
+        for (unsigned long i = 1;i < threads.size(); ++i)
+            threads[i].join();
 
         threads.clear();
         joined_threads = true;
@@ -272,6 +275,12 @@ private:
             {
                 if (finish)
                     break;
+                /// generate more threads to work after the first one, only do once!
+                std::call_once(oneMore,[&]() {
+                    active_threads = max_threads;
+                    for (size_t i = 1; i < max_threads; ++i)
+                        threads.emplace_back(std::bind(&ParallelInputsProcessor::thread, this, current_memory_tracker, i));
+                });
 
                 /// If this source is not run out yet, then put the resulting block in the ready queue.
                 {
@@ -348,6 +357,7 @@ private:
     std::atomic<bool> joined_threads { false };
 
     Logger * log = &Logger::get("ParallelInputsProcessor");
+    std::once_flag oneMore;
 };
 
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #https://github.com/pingcap/tics/issues/2050<!-- REMOVE this line if no issue to close -->

Problem Summary: the multithreading process is ofter controlled in `ParallelInputsProcessor`, like hash join build, probe, and aggregation build, so at first just start one thread, once the first thread generates a block, then start more threads to work. This can reduce threading num for up plan fragment tasks which does not receive data soon.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

Side effects

<!--
- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility
-->

### Release note <!-- bugfixes or new feature need a release note -->

- increate more threads later in parallel process <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
