### PR TITLE
*: also implement decrement for PKColumnIterator

### DIFF
--- a/dbms/src/DataStreams/PKColumnIterator.hpp
+++ b/dbms/src/DataStreams/PKColumnIterator.hpp
@@ -12,6 +12,12 @@ struct PKColumnIterator : public std::iterator<std::random_access_iterator_tag, 
         return *this;
     }
 
+    PKColumnIterator & operator--()
+    {
+        --pos;
+        return *this;
+    }
+
     PKColumnIterator & operator=(const PKColumnIterator & itr)
     {
         copy(itr);


### PR DESCRIPTION
Signed-off-by: SchrodingerZhu <i@zhuyi.fan>

### What problem does this PR solve?

Issue Number: #2064 

Problem Summary: 
new `libstdc++` requires `operator--` to derive the target iterator trait.

### What is changed and how it works?

What's Changed:
implement decrement for `PKColumnIterator`



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test



### Release note
No release note
