### PR TITLE
*: fix redefinition of 128-bits numeric_limit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,11 @@ if (CMAKE_VERSION VERSION_LESS "3.8.0")
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1z")
 else ()
     set (CMAKE_CXX_STANDARD 17)
-    set (CMAKE_CXX_EXTENSIONS 0) # https://cmake.org/cmake/help/latest/prop_tgt/CXX_EXTENSIONS.html#prop_tgt:CXX_EXTENSIONS
+    if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 8.0)
+        set (CMAKE_CXX_EXTENSIONS ON) # however, for later gcc, we need __int128 related extension macro to be defined properly
+    else()
+        set (CMAKE_CXX_EXTENSIONS OFF) # https://cmake.org/cmake/help/latest/prop_tgt/CXX_EXTENSIONS.html#prop_tgt:CXX_EXTENSIONS
+    endif()
     set (CMAKE_CXX_STANDARD_REQUIRED ON)
     set (CXX_FLAGS_INTERNAL_COMPILER "-std=c++1z")
     # This needs to propagate to vendored projects in contrib


### PR DESCRIPTION
Signed-off-by: SchrodingerZhu <i@zhuyi.fan>

### What problem does this PR solve?

Issue Number: #2064 

Problem Summary:

Related macros is defined only with `gnu c++ extension` now. 


### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

enable gnu extension for modern compilers.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

No release note
