### PR TITLE
Keep "block" as the default snapshot apply method

### DIFF
--- a/dbms/src/Server/RaftConfigParser.cpp
+++ b/dbms/src/Server/RaftConfigParser.cpp
@@ -98,7 +98,7 @@ TiFlashRaftConfig TiFlashRaftConfig::parseSettings(Poco::Util::LayeredConfigurat
 
     if (config.has("raft.snapshot.method"))
     {
-        String snapshot_method = config.getString("raft.snapshot.method", "file1");
+        String snapshot_method = config.getString("raft.snapshot.method", "block");
         std::transform(snapshot_method.begin(), snapshot_method.end(), snapshot_method.begin(), [](char ch) { return std::tolower(ch); });
         if (snapshot_method == "block")
         {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary: rollback the default value to "block" for applying snapshot method because we find https://github.com/pingcap/tics/issues/2118 that will make TiFlash crash when a table "pk is handle" is true.

### What is changed and how it works?

Use "block" instead of "file1" as the default value of apply method

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

<!--
- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility
-->

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
