### PR TITLE
fix gcc-10 boost warnings

### DIFF
--- a/dbms/src/Functions/GeoUtils.h
+++ b/dbms/src/Functions/GeoUtils.h
@@ -14,22 +14,20 @@
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
 
+#pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
-#if defined(__clang__)
 #pragma GCC diagnostic ignored "-Wunknown-warning-option"
 #pragma GCC diagnostic ignored "-Wdeprecated-copy"
-#endif
 
 #include <boost/geometry.hpp>
-
-#pragma GCC diagnostic pop
-
 #include <boost/geometry/geometries/point_xy.hpp>
 #include <boost/geometry/geometries/polygon.hpp>
 #include <boost/geometry/geometries/multi_polygon.hpp>
 #include <boost/geometry/geometries/segment.hpp>
 #include <boost/geometry/algorithms/comparable_distance.hpp>
 #include <boost/geometry/strategies/cartesian/distance_pythagoras.hpp>
+
+#pragma GCC diagnostic pop
 
 #include <array>
 #include <vector>


### PR DESCRIPTION
Signed-off-by: SchrodingerZhu <i@zhuyi.fan>

### What problem does this PR solve?

Problem Summary:
Some warning suppression are not only needed by `clang` but also `gcc` with higher levels.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)


### Release note <!-- bugfixes or new feature need a release note -->

No release note
