### PR TITLE
fix clang build in mac

### DIFF
--- a/dbms/src/Encryption/RateLimiter.cpp
+++ b/dbms/src/Encryption/RateLimiter.cpp
@@ -145,7 +145,11 @@ void RateLimiter::refillAndAlloc()
     }
 }
 
+#if __APPLE__ && __clang__
+extern __thread bool is_background_thread;
+#else
 extern thread_local bool is_background_thread;
+#endif
 
 RateLimiterPtr IORateLimiter::getWriteLimiter()
 {

--- a/dbms/src/Storages/MergeTree/BackgroundProcessingPool.cpp
+++ b/dbms/src/Storages/MergeTree/BackgroundProcessingPool.cpp
@@ -24,7 +24,11 @@ namespace DB
 constexpr double BackgroundProcessingPool::sleep_seconds;
 constexpr double BackgroundProcessingPool::sleep_seconds_random_part;
 
+#if __APPLE__ && __clang__
+__thread bool is_background_thread = false;
+#else
 thread_local bool is_background_thread = false;
+#endif
 
 void BackgroundProcessingPool::TaskInfo::wake()
 {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
After #2184, tics build failed in mac os using clang 12.0.5 because [a thread local variable](https://github.com/pingcap/tics/blob/f3b4b755f06801faee90a7cef82895ce1b69632a/dbms/src/Storages/MergeTree/BackgroundProcessingPool.cpp#L27)
### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
This pr fix it thread local vairable by adopting [the existing solutions](https://github.com/pingcap/tics/blob/f3b4b755f06801faee90a7cef82895ce1b69632a/dbms/src/Common/MemoryTracker.cpp#L142) in Clickhouse.
### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

<!--
- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility
-->

### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
