### PR TITLE
Fix tiflash_linux_arm64_build_daily failed

### DIFF
--- a/libs/libdaemon/src/BaseDaemon.cpp
+++ b/libs/libdaemon/src/BaseDaemon.cpp
@@ -344,7 +344,7 @@ private:
 #elif defined(__aarch64__)
         #if defined(__arm64__) || defined(__arm64) /// Apple arm cpu
             caller_address = reinterpret_cast<void *>(context.uc_mcontext->__ss.__pc);
-        #elif /// arm server
+        #else /// arm server
             caller_address = reinterpret_cast<void *>(context.uc_mcontext.pc);
         #endif
 #endif


### PR DESCRIPTION
Signed-off-by: jiaqizho <zhoujiaqi@pingcap.com>

sorry for careless, #elif without param will failed to build on arm.

### What problem does this PR solve?

Problem Summary:

Proposal: fix #2302  tiflash_linux_arm64_build_daily failed

What's Changed:

### Related changes
#2302
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

### Release note <!-- bugfixes or new feature need a release note -->
None