### PR TITLE
refine dtor for ReadBufferFromFile && PosixRandomAccessFile && PosixW…

### DIFF
--- a/dbms/src/Encryption/PosixRandomAccessFile.cpp
+++ b/dbms/src/Encryption/PosixRandomAccessFile.cpp
@@ -52,13 +52,7 @@ PosixRandomAccessFile::PosixRandomAccessFile(const std::string & file_name_, int
 #endif
 }
 
-PosixRandomAccessFile::~PosixRandomAccessFile()
-{
-    if (fd < 0)
-        return;
-
-    ::close(fd);
-}
+PosixRandomAccessFile::~PosixRandomAccessFile() { close(); }
 
 void PosixRandomAccessFile::close()
 {

--- a/dbms/src/Encryption/PosixWritableFile.cpp
+++ b/dbms/src/Encryption/PosixWritableFile.cpp
@@ -31,10 +31,7 @@ PosixWritableFile::PosixWritableFile(
 PosixWritableFile::~PosixWritableFile()
 {
     metric_increment.destroy();
-    if (fd < 0)
-        return;
-
-    ::close(fd);
+    close();
 }
 
 void PosixWritableFile::open()

--- a/dbms/src/IO/ReadBufferFromFile.cpp
+++ b/dbms/src/IO/ReadBufferFromFile.cpp
@@ -1,15 +1,14 @@
-#include <fcntl.h>
-
+#include <Common/ProfileEvents.h>
 #include <IO/ReadBufferFromFile.h>
 #include <IO/WriteHelpers.h>
-#include <Common/ProfileEvents.h>
+#include <fcntl.h>
 
 
 namespace ProfileEvents
 {
-    extern const Event FileOpen;
-    extern const Event FileOpenFailed;
-}
+extern const Event FileOpen;
+extern const Event FileOpenFailed;
+} // namespace ProfileEvents
 
 
 namespace DB
@@ -17,18 +16,13 @@ namespace DB
 
 namespace ErrorCodes
 {
-    extern const int FILE_DOESNT_EXIST;
-    extern const int CANNOT_OPEN_FILE;
-    extern const int CANNOT_CLOSE_FILE;
-}
+extern const int FILE_DOESNT_EXIST;
+extern const int CANNOT_OPEN_FILE;
+extern const int CANNOT_CLOSE_FILE;
+} // namespace ErrorCodes
 
 
-ReadBufferFromFile::ReadBufferFromFile(
-    const std::string & file_name_,
-    size_t buf_size,
-    int flags,
-    char * existing_memory,
-    size_t alignment)
+ReadBufferFromFile::ReadBufferFromFile(const std::string & file_name_, size_t buf_size, int flags, char * existing_memory, size_t alignment)
     : ReadBufferFromFileDescriptor(-1, buf_size, existing_memory, alignment), file_name(file_name_)
 {
     ProfileEvents::increment(ProfileEvents::FileOpen);
@@ -59,34 +53,24 @@ ReadBufferFromFile::ReadBufferFromFile(
 
 
 ReadBufferFromFile::ReadBufferFromFile(
-    int fd,
-    const std::string & original_file_name,
-    size_t buf_size,
-    char * existing_memory,
-    size_t alignment)
-    :
-    ReadBufferFromFileDescriptor(fd, buf_size, existing_memory, alignment),
-    file_name(original_file_name.empty() ? "(fd = " + toString(fd) + ")" : original_file_name)
-{
-}
+    int fd, const std::string & original_file_name, size_t buf_size, char * existing_memory, size_t alignment)
+    : ReadBufferFromFileDescriptor(fd, buf_size, existing_memory, alignment),
+      file_name(original_file_name.empty() ? "(fd = " + toString(fd) + ")" : original_file_name)
+{}
 
 
-ReadBufferFromFile::~ReadBufferFromFile()
-{
-    if (fd < 0)
-        return;
-
-    ::close(fd);
-}
+ReadBufferFromFile::~ReadBufferFromFile() { close(); }
 
 
 void ReadBufferFromFile::close()
 {
-    if (0 != ::close(fd))
-        throw Exception("Cannot close file", ErrorCodes::CANNOT_CLOSE_FILE);
-
+    if (fd < 0)
+        return;
+    while (0 != ::close(fd))
+        if (errno != EINTR)
+            throwFromErrno("Cannot close file " + file_name, ErrorCodes::CANNOT_CLOSE_FILE);
     fd = -1;
     metric_increment.destroy();
 }
 
-}
+} // namespace DB


### PR DESCRIPTION
…ritableFile

### What problem does this PR solve?

ReadBufferFromFile, PosixRandomAccessFile and PosixWritableFile don't deal with exception in it's dtor and record metrics.

### What is changed and how it works?

What's Changed:

ReadBufferFromFile, PosixRandomAccessFile and PosixWritableFile's dtor just call their close() to close file.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

<!--
- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility
-->

### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
