### PR TITLE
fix(LogSearch): make sure std::tm properly initialized

### DIFF
--- a/dbms/src/Flash/LogSearch.cpp
+++ b/dbms/src/Flash/LogSearch.cpp
@@ -109,7 +109,7 @@ LogIterator::Result<LogIterator::LogEntry> LogIterator::readLog()
         &timezone_hour, &timezone_min, level_buff);
 
     {
-        std::tm time;
+        std::tm time {};
         time.tm_year = year - 1900;
         time.tm_mon = month - 1;
         time.tm_mday = day;


### PR DESCRIPTION
Signed-off-by: Schrodinger ZHU Yifan <i@zhuyi.fan>

### What problem does this PR solve?

Issue Number: close #2363 

Problem Summary: 
zero initialize is needed.
 https://en.cppreference.com/w/cpp/chrono/c/mktime

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)


### Release note <!-- bugfixes or new feature need a release note -->

- Fix potential timestamp parsing error 
