### PR TITLE
Add length check while running PageStorage GC

### DIFF
--- a/dbms/src/Storages/Page/PageStorage.cpp
+++ b/dbms/src/Storages/Page/PageStorage.cpp
@@ -874,6 +874,12 @@ bool PageStorage::gc(const Context & global_context, bool not_skip)
     ListPageFilesOption opt;
     opt.remove_tmp_files = true;
     auto page_files      = PageStorage::listAllPageFiles(file_provider, delegator, page_file_log, opt);
+    if (unlikely(page_files.empty()))
+    {
+        // In case the directory are removed by accident
+        LOG_WARNING(log, storage_name << " There are no page files while running GC");
+        return false;
+    }
 
     GcContext gc_context;
     gc_context.min_file_id    = page_files.begin()->fileIdLevel();


### PR DESCRIPTION
Signed-off-by: JaySon-Huang <jayson.hjs@gmail.com>

### What problem does this PR solve?

Issue Number: related to #2393

Problem Summary:
In https://github.com/pingcap/tics/pull/2356, we assume that `page_files` are not empty. However, unit tests randomly crash after that.

1. A global RegionPersister created with path "./tmp/kvstore" and register a GC task on `BackgroundService`
2. Before some unit test of the storage layer run, they would clean up old files on disk. However, we directly remove the whole "./tmp" for convenience in some tests.
3. The GC task of RegionPersister run, find out that there are no page files on "./tmp/kvstore", and the unit test crash.

### What is changed and how it works?

Add check for the size of `page_files` while running PageStorage::gc

And also we should refine those tests that brutally remove "./tmp", the following fix would be track in #2393


### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)


Side effects

<!--
- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility
-->

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
