### PR TITLE
check return value of grpc method, and throw error explicitly (#2441)

### DIFF
--- a/dbms/src/Flash/Coprocessor/DAGQuerySource.h
+++ b/dbms/src/Flash/Coprocessor/DAGQuerySource.h
@@ -33,11 +33,13 @@ struct StreamWriter
     void write(tipb::SelectResponse & response, [[maybe_unused]] uint16_t id = 0)
     {
         std::string dag_data;
-        response.SerializeToString(&dag_data);
+        if(!response.SerializeToString(&dag_data))
+            throw Exception("Fail to serialize response, response size: " + std::to_string(response.ByteSizeLong()));
         ::coprocessor::BatchResponse resp;
         resp.set_data(dag_data);
         std::lock_guard<std::mutex> lk(write_mutex);
-        writer->Write(resp);
+        if (!writer->Write(resp))
+            throw Exception("Failed to write resp");
     }
     // a helper function
     uint16_t getPartitionNum() { return 0; }

--- a/dbms/src/Flash/Mpp/MPPHandler.cpp
+++ b/dbms/src/Flash/Mpp/MPPHandler.cpp
@@ -78,7 +78,8 @@ void MPPTunnel::close(const String & reason)
             auto err = new mpp::Error();
             err->set_msg(reason);
             data.set_allocated_error(err);
-            writer->Write(data);
+            if (!writer->Write(data))
+                throw Exception("Failed to write err");
         }
         catch (...)
         {

--- a/dbms/src/Flash/Mpp/MPPHandler.h
+++ b/dbms/src/Flash/Mpp/MPPHandler.h
@@ -92,7 +92,8 @@ struct MPPTunnel
         }
         if (finished)
             throw Exception("write to tunnel which is already closed.");
-        writer->Write(data);
+        if (!writer->Write(data))
+            throw Exception("Failed to write data");
         if (close_after_write)
         {
             finished = true;
@@ -184,7 +185,8 @@ struct MPPTunnelSet
     void write(tipb::SelectResponse & response)
     {
         std::string data;
-        response.SerializeToString(&data);
+        if(!response.SerializeToString(&data))
+            throw Exception("Fail to serialize response, response size: " + std::to_string(response.ByteSizeLong()));
         mpp::MPPDataPacket packet;
         packet.set_data(data);
         tunnels[0]->write(packet);
@@ -193,7 +195,8 @@ struct MPPTunnelSet
         {
             clearExecutionSummaries(response);
             data.clear();
-            response.SerializeToString(&data);
+            if(!response.SerializeToString(&data))
+                throw Exception("Fail to serialize response, response size: " + std::to_string(response.ByteSizeLong()));
             packet.set_data(data);
             for (size_t i = 1; i < tunnels.size(); i++)
             {
@@ -210,7 +213,8 @@ struct MPPTunnelSet
             clearExecutionSummaries(response);
         }
         std::string data;
-        response.SerializeToString(&data);
+        if(!response.SerializeToString(&data))
+            throw Exception("Fail to serialize response, response size: " + std::to_string(response.ByteSizeLong()));
         mpp::MPPDataPacket packet;
         packet.set_data(data);
         tunnels[partition_id]->write(packet);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #2445 

Problem Summary:
GRPC is not able to send message with more than 2G, so we need to check the message size and throw error explicitly otherwise, mpp query will return wrong result.
 
### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

<!--
- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility
-->

### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
