### PR TITLE
Fix behavior while shutting down

### DIFF
--- a/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.cpp
@@ -230,7 +230,7 @@ void DAGQueryBlockInterpreter::executeTS(const tipb::TableScan & ts, DAGPipeline
             }
             catch (const RegionException & e)
             {
-                if (tmt.getTerminated())
+                if (tmt.checkShuttingDown())
                     throw TiFlashException("TiFlash server is terminating", Errors::Coprocessor::Internal);
                 // By now, RegionException will contain all region id of MvccQueryInfo, which is needed by CHSpark.
                 // When meeting RegionException, we can let MakeRegionQueryInfos to check in next loop.

--- a/dbms/src/Flash/FlashService.cpp
+++ b/dbms/src/Flash/FlashService.cpp
@@ -156,7 +156,7 @@ grpc::Status FlashService::Coprocessor(
     }
 
     auto & tmt_context = context.getTMTContext();
-    response->set_available(tmt_context.getStoreStatus() == TMTContext::StoreStatus::Running);
+    response->set_available(tmt_context.checkRunning());
     return ::grpc::Status::OK;
 }
 

--- a/dbms/src/Storages/GCManager.cpp
+++ b/dbms/src/Storages/GCManager.cpp
@@ -34,7 +34,7 @@ bool GCManager::work()
     while (true)
     {
         // The TiFlash process receive a signal to terminate.
-        if (global_context.getTMTContext().getTerminated())
+        if (global_context.getTMTContext().checkShuttingDown())
             break;
         // All storages have been checked, stop here
         if (checked_storage_num >= storages.size())

--- a/dbms/src/Storages/Transaction/KVStore.h
+++ b/dbms/src/Storages/Transaction/KVStore.h
@@ -101,6 +101,9 @@ public:
 
     TiDB::SnapshotApplyMethod applyMethod() const { return snapshot_apply_method; }
 
+    void addReadIndexEvent(Int64 f) { read_index_event_flag += f; }
+    Int64 getReadIndexEvent() const { return read_index_event_flag; }
+
 private:
     friend class MockTiDB;
     friend struct MockTiDBTable;
@@ -170,6 +173,7 @@ private:
     std::list<RegionDataReadInfoList> bg_gc_region_data;
 
     const TiFlashRaftProxyHelper * proxy_helper{nullptr};
+    std::atomic_int64_t read_index_event_flag{0};
 };
 
 /// Encapsulation of lock guard of task mutex in KVStore

--- a/dbms/src/Storages/Transaction/LearnerRead.cpp
+++ b/dbms/src/Storages/Transaction/LearnerRead.cpp
@@ -11,10 +11,29 @@
 #include <common/ThreadPool.h>
 #include <common/likely.h>
 
+#include <ext/scope_guard.h>
+
 namespace DB
 {
 
-struct UnavailableRegions
+class LockWrap
+{
+    mutable std::mutex mutex;
+    bool need_lock{true};
+
+protected:
+    std::unique_lock<std::mutex> genLockGuard() const
+    {
+        if (need_lock)
+            return std::unique_lock(mutex);
+        return {};
+    }
+
+public:
+    void setNoNeedLock() { need_lock = false; }
+};
+
+struct UnavailableRegions : public LockWrap
 {
     using Result = RegionException::UnavailableRegions;
 
@@ -22,7 +41,7 @@ struct UnavailableRegions
     {
         status = status_;
         auto _lock = genLockGuard();
-        ids.emplace(id);
+        doAdd(id);
     }
 
     size_t size() const
@@ -37,7 +56,7 @@ struct UnavailableRegions
     {
         auto _lock = genLockGuard();
         region_lock = std::pair(region_id_, std::move(region_lock_));
-        ids.emplace(region_id_);
+        doAdd(region_id_);
     }
 
     void tryThrowRegionException(const MvccQueryInfo::RegionsQueryInfo & regions_info)
@@ -60,22 +79,20 @@ struct UnavailableRegions
     }
 
 private:
-    std::lock_guard<std::mutex> genLockGuard() const { return std::lock_guard(mutex); }
+    inline void doAdd(RegionID id) { ids.emplace(id); }
 
 private:
     RegionException::UnavailableRegions ids;
-    mutable std::mutex mutex;
     std::optional<std::pair<RegionID, LockInfoPtr>> region_lock;
     std::atomic<RegionException::RegionReadStatus> status{RegionException::RegionReadStatus::NOT_FOUND};
 };
 
-class MvccQueryInfoWrap : boost::noncopyable
+class MvccQueryInfoWrap : boost::noncopyable, public LockWrap
 {
     using Base = MvccQueryInfo;
     Base & inner;
     std::optional<Base::RegionsQueryInfo> regions_info;
     Base::RegionsQueryInfo * regions_info_ptr;
-    mutable std::mutex mutex;
 
 public:
     MvccQueryInfoWrap(Base & mvcc_query_info, TMTContext & tmt, const TiDB::TableID table_id) : inner(mvcc_query_info)
@@ -105,12 +122,12 @@ public:
     const Base::RegionsQueryInfo & getRegionsInfo() const { return *regions_info_ptr; }
     void addReadIndexRes(RegionID region_id, UInt64 read_index)
     {
-        std::lock_guard _lock(mutex);
+        auto _lock = genLockGuard();
         inner.read_index_res[region_id] = read_index;
     }
     UInt64 getReadIndexRes(RegionID region_id) const
     {
-        std::lock_guard _lock(mutex);
+        auto _lock = genLockGuard();
         if (auto it = inner.read_index_res.find(region_id); it != inner.read_index_res.end())
             return it->second;
         return 0;
@@ -186,7 +203,26 @@ LearnerReadSnapshot doLearnerRead(const TiDB::TableID table_id, //
 
         GET_METRIC(metrics, tiflash_raft_read_index_count).Increment(batch_read_index_req.size());
 
-        {
+        const auto & make_default_batch_read_index_result = [&]() {
+            for (const auto & req : batch_read_index_req)
+            {
+                batch_read_index_result.emplace(req.context().region_id(), kvrpcpb::ReadIndexResponse());
+            }
+        };
+        [&]() {
+            if (!tmt.checkRunning())
+            {
+                make_default_batch_read_index_result();
+                return;
+            }
+            kvstore->addReadIndexEvent(1);
+            SCOPE_EXIT({ kvstore->addReadIndexEvent(-1); });
+            if (!tmt.checkRunning())
+            {
+                make_default_batch_read_index_result();
+                return;
+            }
+
             /// Blocking learner read. Note that learner read must be performed ahead of data read,
             /// otherwise the desired index will be blocked by the lock of data read.
             if (auto proxy_helper = kvstore->getProxyHelper(); proxy_helper)
@@ -199,12 +235,9 @@ LearnerReadSnapshot doLearnerRead(const TiDB::TableID table_id, //
             }
             else
             {
-                for (const auto & req : batch_read_index_req)
-                {
-                    batch_read_index_result.emplace(req.context().region_id(), kvrpcpb::ReadIndexResponse());
-                }
+                make_default_batch_read_index_result();
             }
-        }
+        }();
 
         {
             GET_METRIC(metrics, tiflash_raft_read_index_duration_seconds).Observe(batch_wait_index_watch.elapsedSeconds());
@@ -255,13 +288,18 @@ LearnerReadSnapshot doLearnerRead(const TiDB::TableID table_id, //
             auto & region = regions_snapshot.find(region_to_query.region_id)->second;
 
             {
-                Stopwatch wait_index_watch;
-                if (region->waitIndex(batch_read_index_result.find(region_to_query.region_id)->second.read_index(), tmt))
+                auto time_cost = region->waitIndex(batch_read_index_result.find(region_to_query.region_id)->second.read_index(), tmt);
+                // If server is being terminated, retry region to other store.
+                if (!tmt.checkRunning(std::memory_order_relaxed))
                 {
                     unavailable_regions.add(region_to_query.region_id, RegionException::RegionReadStatus::NOT_FOUND);
                     continue;
                 }
-                GET_METRIC(metrics, tiflash_raft_wait_index_duration_seconds).Observe(wait_index_watch.elapsedSeconds());
+                if (time_cost > 0)
+                {
+                    // Only record information if wait-index does happen
+                    GET_METRIC(metrics, tiflash_raft_wait_index_duration_seconds).Observe(time_cost);
+                }
             }
             if (mvcc_query_info->resolve_locks)
             {
@@ -301,6 +339,8 @@ LearnerReadSnapshot doLearnerRead(const TiDB::TableID table_id, //
     auto start_time = Clock::now();
     if (concurrent_num <= 1)
     {
+        mvcc_query_info.setNoNeedLock();
+        unavailable_regions.setNoNeedLock();
         batch_wait_index(0);
     }
     else

--- a/dbms/src/Storages/Transaction/ProxyFFI.cpp
+++ b/dbms/src/Storages/Transaction/ProxyFFI.cpp
@@ -127,7 +127,7 @@ EngineStoreApplyRes HandleIngestSST(EngineStoreServerWrap * server, SSTViewVec s
     }
 }
 
-uint8_t HandleCheckTerminated(EngineStoreServerWrap * server) { return server->tmt->getTerminated(std::memory_order_relaxed) ? 1 : 0; }
+uint8_t HandleCheckTerminated(EngineStoreServerWrap * server) { return server->tmt->checkTerminated(std::memory_order_relaxed) ? 1 : 0; }
 
 StoreStats HandleComputeStoreStats(EngineStoreServerWrap * server)
 {

--- a/dbms/src/Storages/Transaction/Region.h
+++ b/dbms/src/Storages/Transaction/Region.h
@@ -143,8 +143,8 @@ public:
 
     ReadIndexResult learnerRead(UInt64 start_ts);
 
-    /// If server is terminating, return true (read logic should throw NOT_FOUND exception and let upper layer retry other store).
-    TerminateWaitIndex waitIndex(UInt64 index, const TMTContext & tmt);
+    // Return time cost(seconds) about wait-index. If peer-state is NOT Normal or store-status is Terminated, wait-index process will be stopped as well.
+    double waitIndex(UInt64 index, const TMTContext & tmt);
 
     UInt64 appliedIndex() const;
 

--- a/dbms/src/Storages/Transaction/RegionMeta.cpp
+++ b/dbms/src/Storages/Transaction/RegionMeta.cpp
@@ -144,12 +144,12 @@ void RegionMeta::setPeerState(const raft_serverpb::PeerState peer_state_)
     region_state.setState(peer_state_);
 }
 
-TerminateWaitIndex RegionMeta::waitIndex(UInt64 index, std::function<bool(void)> && check_terminated) const
+TerminateWaitIndex RegionMeta::waitIndex(UInt64 index, std::function<bool(void)> && check_running) const
 {
     std::unique_lock<std::mutex> lock(mutex);
     TerminateWaitIndex res = false;
     cv.wait(lock, [&] {
-        if (check_terminated())
+        if (!check_running())
         {
             res = true;
             return true;
@@ -167,7 +167,7 @@ bool RegionMeta::checkIndex(UInt64 index) const
 
 bool RegionMeta::doCheckIndex(UInt64 index) const
 {
-    return region_state.getState() == raft_serverpb::PeerState::Tombstone || apply_state.applied_index() >= index;
+    return region_state.getState() != raft_serverpb::PeerState::Normal || apply_state.applied_index() >= index;
 }
 
 UInt64 RegionMeta::version() const

--- a/dbms/src/Storages/Transaction/RegionMeta.h
+++ b/dbms/src/Storages/Transaction/RegionMeta.h
@@ -70,7 +70,7 @@ public:
 
     friend bool operator==(const RegionMeta & meta1, const RegionMeta & meta2);
 
-    TerminateWaitIndex waitIndex(UInt64 index, std::function<bool(void)> && check_terminated) const;
+    TerminateWaitIndex waitIndex(UInt64 index, std::function<bool(void)> &&) const;
     bool checkIndex(UInt64 index) const;
 
     RegionMetaSnapshot dumpRegionMetaSnapshot() const;

--- a/dbms/src/Storages/Transaction/TMTContext.cpp
+++ b/dbms/src/Storages/Transaction/TMTContext.cpp
@@ -66,7 +66,7 @@ Context & TMTContext::getContext() { return context; }
 
 bool TMTContext::isInitialized() const { return getStoreStatus() != StoreStatus::Idle; }
 
-void TMTContext::setStoreStatusRunning() { store_status = StoreStatus::Running; }
+void TMTContext::setStatusRunning() { store_status = StoreStatus::Running; }
 
 TMTContext::StoreStatus TMTContext::getStoreStatus(std::memory_order memory_order) const { return store_status.load(memory_order); }
 
@@ -111,14 +111,18 @@ void TMTContext::reloadConfig(const Poco::Util::AbstractConfiguration & config)
     }
 }
 
-bool TMTContext::getTerminated(std::memory_order memory_order) const { return getStoreStatus(memory_order) == StoreStatus::Terminated; }
+bool TMTContext::checkShuttingDown(std::memory_order memory_order) const { return getStoreStatus(memory_order) >= StoreStatus::Stopping; }
+bool TMTContext::checkTerminated(std::memory_order memory_order) const { return getStoreStatus(memory_order) == StoreStatus::Terminated; }
+bool TMTContext::checkRunning(std::memory_order memory_order) const { return getStoreStatus(memory_order) == StoreStatus::Running; }
 
-void TMTContext::setTerminated()
+void TMTContext::setStatusStopping()
 {
-    store_status = StoreStatus::Terminated;
+    store_status = StoreStatus::Stopping;
     // notify all region to stop learner read.
     kvstore->traverseRegions([](const RegionID, const RegionPtr & region) { region->notifyApplied(); });
 }
+
+void TMTContext::setStatusTerminated() { store_status = StoreStatus::Terminated; }
 
 UInt64 TMTContext::replicaReadMaxThread() const { return replica_read_max_thread.load(std::memory_order::memory_order_relaxed); }
 UInt64 TMTContext::batchReadIndexTimeout() const { return batch_read_index_timeout_ms.load(std::memory_order::memory_order_relaxed); }

--- a/dbms/src/Storages/Transaction/TMTContext.h
+++ b/dbms/src/Storages/Transaction/TMTContext.h
@@ -37,6 +37,7 @@ public:
         Idle = 0,
         Ready,
         Running,
+        Stopping,
         Terminated,
     };
 
@@ -80,9 +81,12 @@ public:
 
     bool isInitialized() const;
     StoreStatus getStoreStatus(std::memory_order = std::memory_order_seq_cst) const;
-    void setStoreStatusRunning();
-    bool getTerminated(std::memory_order = std::memory_order_seq_cst) const;
-    void setTerminated();
+    void setStatusRunning();
+    void setStatusStopping();
+    void setStatusTerminated();
+    bool checkShuttingDown(std::memory_order = std::memory_order_seq_cst) const;
+    bool checkTerminated(std::memory_order = std::memory_order_seq_cst) const;
+    bool checkRunning(std::memory_order = std::memory_order_seq_cst) const;
 
     const KVClusterPtr & getCluster() const { return cluster; }
 

--- a/dbms/src/TestUtils/TiFlashTestBasic.cpp
+++ b/dbms/src/TestUtils/TiFlashTestBasic.cpp
@@ -1,7 +1,7 @@
-#include <TestUtils/TiFlashTestBasic.h>
 #include <Encryption/MockKeyManager.h>
 #include <Server/RaftConfigParser.h>
 #include <Storages/Transaction/TMTContext.h>
+#include <TestUtils/TiFlashTestBasic.h>
 
 namespace DB::tests
 {
@@ -58,7 +58,7 @@ Context TiFlashTestEnv::getContext(const DB::Settings & settings, Strings testda
 
 void TiFlashTestEnv::shutdown()
 {
-    global_context->getTMTContext().setTerminated();
+    global_context->getTMTContext().setStatusTerminated();
     global_context->shutdown();
     global_context.reset();
 }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

TiFlashException("TiFlash server is terminating", Errors::Coprocessor::Internal) may be thrown when executing batch-cop.

### What is changed and how it works?

What's Changed:

* remove exception `TiFlash server is terminating`
* add status `Stopping`
* try to remote read region data while shutting down


### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

<!--
- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility
-->

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
