### PR TITLE
Fix deadlock on `removeExpiredSnapshots`

### DIFF
--- a/dbms/src/Common/FailPoint.cpp
+++ b/dbms/src/Common/FailPoint.cpp
@@ -48,9 +48,11 @@ std::unordered_map<String, std::shared_ptr<FailPointChannel>> FailPointHelper::f
     M(force_formal_page_file_not_exists)                          \
     M(force_legacy_or_checkpoint_page_file_exists)
 
-#define APPLY_FOR_FAILPOINTS(M)        \
-    M(force_set_page_file_write_errno) \
-    M(minimum_block_size_for_cross_join)
+#define APPLY_FOR_FAILPOINTS(M)                          \
+    M(force_set_page_file_write_errno)                   \
+    M(minimum_block_size_for_cross_join)                 \
+    M(random_slow_page_storage_remove_expired_snapshots) \
+    M(random_slow_page_storage_list_all_live_files)
 
 #define APPLY_FOR_FAILPOINTS_ONCE_WITH_CHANNEL(M) \
     M(pause_after_learner_read)                   \


### PR DESCRIPTION
Signed-off-by: JaySon-Huang <jayson.hjs@gmail.com>

### What problem does this PR solve?

Issue Number: close #2456

Problem Summary: 
Similar to issue: #2249 PR: #2277
In `removeExpiredSnapshots`, it may trigger the `~Snapshot` under `read_write_mutex` being locked. It causes incursive deadlock.

And we will call `removeExpiredSnapshots` every minute after #2431 that reports the oldest snapshot to Prometheus.

https://github.com/pingcap/tics/blob/e9f28c717902a4b22855970752a08ceca214cd01/dbms/src/Storages/Page/mvcc/VersionSetWithDelta.h#L313-L340

### What is changed and how it works?

* Save the valid snapshots into a vector under a lock on `read_write_mutex`, and only release those snapshots after the lock gets released
* Add some failpoint to test this case

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
  Tested by the stress testing in #2297 with 4 writers, 128 readers, and failpoint `random_slow_page_storage_remove_expired_snapshots` enabled

Side effects

<!--
- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility
-->

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
