### PR TITLE
fix random terminate without exception error when deconstruct MPPTask

### DIFF
--- a/dbms/src/Common/FailPoint.cpp
+++ b/dbms/src/Common/FailPoint.cpp
@@ -46,7 +46,8 @@ std::unordered_map<String, std::shared_ptr<FailPointChannel>> FailPointHelper::f
     M(force_set_segment_ingest_packs_fail)                        \
     M(segment_merge_after_ingest_packs)                           \
     M(force_formal_page_file_not_exists)                          \
-    M(force_legacy_or_checkpoint_page_file_exists)
+    M(force_legacy_or_checkpoint_page_file_exists)                \
+    M(exception_in_creating_set_input_stream)
 
 #define APPLY_FOR_FAILPOINTS(M)                          \
     M(force_set_page_file_write_errno)                   \

--- a/dbms/src/DataStreams/CreatingSetsBlockInputStream.h
+++ b/dbms/src/DataStreams/CreatingSetsBlockInputStream.h
@@ -29,11 +29,11 @@ public:
         const SizeLimits & network_transfer_limits, Int64 mpp_task_id_);
     ~CreatingSetsBlockInputStream()
     {
-        //for (auto & worker : workers)
-        //{
-        //    if (worker.joinable())
-        //        worker.join();
-        //}
+        for (auto & worker : workers)
+        {
+            if (worker.joinable())
+                worker.join();
+        }
     }
 
     String getName() const override { return "CreatingSets"; }

--- a/tests/fullstack-test/mpp/issue_2471.test
+++ b/tests/fullstack-test/mpp/issue_2471.test
@@ -1,0 +1,43 @@
+# Preparation.
+=> DBGInvoke __init_fail_point()
+
+mysql> drop table if exists test.a
+mysql> create table test.a (pk int not null, id int, value varchar(64))
+mysql> insert into test.a values(0,1,'a'),(1,2,'b')
+
+mysql> alter table test.a set tiflash replica 1
+
+func> wait_table test a
+
+
+mysql> use test; set @@tidb_isolation_read_engines='tiflash'; set @@tidb_opt_broadcast_cartesian_join=2; select * from a as t1 left join a as t2 on t1.id = t2.id;
++----+------+-------+------+------+-------+
+| pk | id   | value | pk   | id   | value |
++----+------+-------+------+------+-------+
+|  0 |    1 | a     |    0 |    1 | a     |
+|  1 |    2 | b     |    1 |    2 | b     |
++----+------+-------+------+------+-------+
+
+=> DBGInvoke __enable_fail_point(exception_in_creating_set_input_stream)
+
+mysql> use test; set @@tidb_isolation_read_engines='tiflash'; set @@tidb_opt_broadcast_cartesian_join=2; select * from a as t1 left join a as t2 on t1.id = t2.id;
+ERROR 1105 (HY000) at line 1: other error for mpp stream: DB::Exception: Fail point FailPoints::exception_in_creating_set_input_stream is triggered.
+
+=> DBGInvoke __disable_fail_point(exception_in_creating_set_input_stream)
+
+mysql> use test; select sleep(5);
++----------+
+| sleep(5) |
++----------+
+|        0 |
++----------+
+mysql> use test; set @@tidb_isolation_read_engines='tiflash'; set @@tidb_opt_broadcast_cartesian_join=2; select * from a as t1 left join a as t2 on t1.id = t2.id;
++----+------+-------+------+------+-------+
+| pk | id   | value | pk   | id   | value |
++----+------+-------+------+------+-------+
+|  0 |    1 | a     |    0 |    1 | a     |
+|  1 |    2 | b     |    1 |    2 | b     |
++----+------+-------+------+------+-------+
+
+# Clean up.
+# mysql> drop table if exists test.a


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #2471 <!-- REMOVE this line if no issue to close -->

Problem Summary:
As the issue described.
### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
The root cause is `thread` in `CreatingSetInputStream` may not be join when it is deconstructed. And this pr fix it by wait the worker thread to be joined in deconstructor of `CreatingSetInputStream`.
### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

<!--
- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility
-->

### Release note <!-- bugfixes or new feature need a release note -->

- fix random terminate without exception error when deconstruct MPPTask