### PR TITLE
Check regions ready before set status to `Running`

### DIFF
--- a/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.cpp
@@ -33,7 +33,6 @@
 #include <Storages/RegionQueryInfo.h>
 #include <Storages/StorageMergeTree.h>
 #include <Storages/Transaction/CHTableHandle.h>
-#include <Storages/Transaction/KVStore.h>
 #include <Storages/Transaction/LearnerRead.h>
 #include <Storages/Transaction/LockException.h>
 #include <Storages/Transaction/Region.h>

--- a/dbms/src/Flash/Coprocessor/InterpreterDAGHelper.hpp
+++ b/dbms/src/Flash/Coprocessor/InterpreterDAGHelper.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Common/TiFlashException.h>
+#include <Storages/Transaction/KVStore.h>
 #include <Storages/Transaction/RegionException.h>
 
 namespace DB

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -1278,16 +1278,8 @@ int Server::main(const std::vector<std::string> & /*args*/)
             tiflash_instance_wrap.status = EngineStoreServerStatus::Running;
             while (tiflash_instance_wrap.proxy_helper->getProxyStatus() == RaftProxyStatus::Idle)
                 std::this_thread::sleep_for(std::chrono::milliseconds(200));
-            LOG_INFO(log, "proxy is ready to serve, try to wake up all region leader by sending read index request");
-            {
-                std::vector<kvrpcpb::ReadIndexRequest> batch_read_index_req;
-                tiflash_instance_wrap.tmt->getKVStore()->traverseRegions([&batch_read_index_req](RegionID, const RegionPtr & region) {
-                    batch_read_index_req.emplace_back(GenRegionReadIndexReq(*region));
-                });
-                tiflash_instance_wrap.proxy_helper->batchReadIndex(
-                    batch_read_index_req, tiflash_instance_wrap.tmt->batchReadIndexTimeout());
-            }
-            LOG_INFO(log, "start to wait for terminal signal");
+            LOG_INFO(log, "tiflash proxy is ready to serve, try to wake up all regions' leader");
+            WaitCheckRegionReady(tmt_context, terminate_signals_counter);
         }
 
         {
@@ -1298,6 +1290,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
         }
 
         tmt_context.setStatusRunning();
+        LOG_INFO(log, "Start to wait for terminal signal");
         waitForTerminationRequest();
 
         {

--- a/dbms/src/Storages/StorageDeltaMerge.cpp
+++ b/dbms/src/Storages/StorageDeltaMerge.cpp
@@ -26,7 +26,6 @@
 #include <Storages/PrimaryKeyNotMatchException.h>
 #include <Storages/StorageDeltaMerge.h>
 #include <Storages/StorageDeltaMergeHelpers.h>
-#include <Storages/Transaction/KVStore.h>
 #include <Storages/Transaction/Region.h>
 #include <Storages/Transaction/SchemaNameMapper.h>
 #include <Storages/Transaction/TMTContext.h>

--- a/dbms/src/Storages/Transaction/KVStore.h
+++ b/dbms/src/Storages/Transaction/KVStore.h
@@ -184,4 +184,6 @@ class KVStoreTaskLock : private boost::noncopyable
     std::lock_guard<std::mutex> lock;
 };
 
+void WaitCheckRegionReady(const TMTContext &, const std::atomic_size_t & terminate_signals_counter);
+
 } // namespace DB

--- a/dbms/src/Storages/Transaction/LearnerRead.cpp
+++ b/dbms/src/Storages/Transaction/LearnerRead.cpp
@@ -210,7 +210,7 @@ LearnerReadSnapshot doLearnerRead(const TiDB::TableID table_id, //
             }
         };
         [&]() {
-            if (!tmt.checkRunning())
+            if (!tmt.checkRunning(std::memory_order_relaxed))
             {
                 make_default_batch_read_index_result();
                 return;

--- a/dbms/src/Storages/Transaction/Region.h
+++ b/dbms/src/Storages/Transaction/Region.h
@@ -211,7 +211,7 @@ private:
 
     std::atomic<UInt64> snapshot_event_flag{1};
     const TiFlashRaftProxyHelper * proxy_helper{nullptr};
-    mutable std::atomic<Timepoint> last_compact_log_time = Timepoint::min();
+    mutable std::atomic<Timepoint> last_compact_log_time{Timepoint::min()};
     mutable std::atomic<size_t> approx_mem_cache_rows{0};
     mutable std::atomic<size_t> approx_mem_cache_bytes{0};
 };

--- a/dbms/src/Storages/Transaction/TMTContext.h
+++ b/dbms/src/Storages/Transaction/TMTContext.h
@@ -34,11 +34,13 @@ class TMTContext : private boost::noncopyable
 public:
     enum class StoreStatus : uint8_t
     {
-        Idle = 0,
+        _MIN = 0,
+        Idle,
         Ready,
         Running,
         Stopping,
         Terminated,
+        _MAX,
     };
 
 public:
@@ -92,6 +94,7 @@ public:
 
     UInt64 replicaReadMaxThread() const;
     UInt64 batchReadIndexTimeout() const;
+    Int64 waitRegionReadyTimeout() const;
 
 private:
     Context & context;
@@ -117,6 +120,9 @@ private:
 
     std::atomic_uint64_t replica_read_max_thread;
     std::atomic_uint64_t batch_read_index_timeout_ms;
+    std::atomic_int64_t wait_region_ready_timeout_sec;
 };
+
+const std::string & IntoStoreStatusName(TMTContext::StoreStatus status);
 
 } // namespace DB


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #2470 <!-- REMOVE this line if no issue to close -->

Problem Summary:

In TiKV, only `leader` can provide R/W services. If there are some stale region peer, they won't be used until catched up latest commit-index and selected as new leader.
However, all region peer in tiflash are equal to upper layer. If one tiflash store is down for a long time, after restarted, it need to catch up latest raft log. More and more threads might be created because of bad mechanism about retry. We should make such tiflash store can't provide any service about region read util most of regions are ready.

Others
* During rolling upgrade/restarting, tiup could call `FlashService::IsAlive`  repeatedly after one tiflash store restarted. It should not restart next tiflash store only after such current one is available to provide service.
* After recovered from network isolation, tidb should not send requests to tiflash store until all regions are ready.

### What is changed and how it works?

What's Changed:

* add config `flash.wait_region_ready_timeout_sec` to set up timeout for checking region ready
* set store status to `Running` after checking
* step: fetch read-index from tikv; make sure region has caught up with latest raft log

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

<!--
- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility
-->

### Release note <!-- bugfixes or new feature need a release note -->

- Fix the potential issue that TiFlash responses slowly for a while after restarted
