### PR TITLE
[WIP]CityHash64 support AVX2

### DIFF
--- a/contrib/libcityhash/CMakeLists.txt
+++ b/contrib/libcityhash/CMakeLists.txt
@@ -1,9 +1,19 @@
 add_library(cityhash
 	src/city.cc
+	src/city_avx2.c
+	src/city_mb_flush_avx2.asm
+	src/city_mb_submit_avx2.asm
+	src/city_mb_mgr_datastruct.asm
+	src/city_mb_x8_avx2.asm
 
 	include/citycrc.h
 	include/city.h
+	include/datastruct.asm
+	include/city_mb.h
 	src/config.h)
+
+add_executable(city_hash_test src/city_hash_test.cc)
+target_link_libraries(city_hash_test cityhash)
 
 target_include_directories (cityhash BEFORE PUBLIC include)
 target_include_directories (cityhash PRIVATE src)

--- a/contrib/libcityhash/include/city_mb.h
+++ b/contrib/libcityhash/include/city_mb.h
@@ -1,0 +1,136 @@
+// Copyright (c) 2021 PingCAP Inc
+// Author: Jiaqi Zhou<zhoujiaqi@pingcap.com>
+#ifndef _CH_AVX2_MB_H_
+#define _CH_AVX2_MB_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define CH_DIGEST_NWORDS 8 /* Word in CH is 32-bit */
+#define CH_X8_LANES 8
+#define CH_BLOCK_SIZE 64
+#define CH_MAX_LANES CH_X8_LANES
+#define CH_LOG2_BLOCK_SIZE 6
+#define CH_PADLENGTHFIELD_SIZE 8
+
+#define CH_INITIAL_DIGEST 0xc3a5c85c, 0x97cb3127, 0xb492b66f, 0xbe98f273, 0x9ae16a3b, 0x2f90404f, 0xc949d7c7, 0x509e6557
+
+typedef uint32_t ch_digest_array[CH_DIGEST_NWORDS][CH_MAX_LANES];
+typedef uint32_t CH_WORD_T;
+
+/**
+ * TODO : should not be here
+ */
+#if defined __unix__ || defined __APPLE__
+#define DECLARE_ALIGNED(decl, alignval) decl __attribute__((aligned(alignval)))
+#define __forceinline static inline
+#define aligned_free(x) free(x)
+#else
+#ifdef __MINGW32__
+#define DECLARE_ALIGNED(decl, alignval) decl __attribute__((aligned(alignval)))
+#define posix_memalign(p, algn, len) (NULL == (*((char **)(p)) = (void *)_aligned_malloc(len, algn)))
+#define aligned_free(x) _aligned_free(x)
+#else
+#define DECLARE_ALIGNED(decl, alignval) __declspec(align(alignval)) decl
+#define posix_memalign(p, algn, len) (NULL == (*((char **)(p)) = (void *)_aligned_malloc(len, algn)))
+#define aligned_free(x) _aligned_free(x)
+#endif
+#endif
+
+typedef enum
+{
+    STS_UNKNOWN = 0,         //!< STS_UNKNOWN
+    STS_BEING_PROCESSED = 1, //!< STS_BEING_PROCESSED
+    STS_COMPLETED = 2,       //!< STS_COMPLETED
+    STS_INTERNAL_ERROR,      //!< STS_INTERNAL_ERROR
+    STS_ERROR                //!< STS_ERROR
+} JOB_STS;
+
+typedef enum
+{
+    HASH_CTX_STS_IDLE = 0x00,       //!< HASH_CTX_STS_IDLE
+    HASH_CTX_STS_PROCESSING = 0x01, //!< HASH_CTX_STS_PROCESSING
+    HASH_CTX_STS_LAST = 0x02,       //!< HASH_CTX_STS_LAST
+    HASH_CTX_STS_COMPLETE = 0x04,   //!< HASH_CTX_STS_COMPLETE
+} HASH_CTX_STS;
+
+typedef enum
+{
+    HASH_CTX_ERROR_NONE = 0,                //!< HASH_CTX_ERROR_NONE
+    HASH_CTX_ERROR_INVALID_FLAGS = -1,      //!< HASH_CTX_ERROR_INVALID_FLAGS
+    HASH_CTX_ERROR_ALREADY_PROCESSING = -2, //!< HASH_CTX_ERROR_ALREADY_PROCESSING
+    HASH_CTX_ERROR_ALREADY_COMPLETED = -3,  //!< HASH_CTX_ERROR_ALREADY_COMPLETED
+    HASH_CTX_ERROR_INVALID_BUFFER_LEN = -4, //!< HASH_CTX_ERROR_INVALID_LEN
+} HASH_CTX_ERROR;
+
+
+typedef enum
+{
+    HASH_UPDATE = 0x00, //!< HASH_UPDATE
+    HASH_FIRST = 0x01,  //!< HASH_FIRST
+    HASH_LAST = 0x02,   //!< HASH_LAST
+    HASH_ENTIRE = 0x03, //!< HASH_ENTIRE
+} HASH_CTX_FLAG;
+
+
+typedef struct
+{
+    uint8_t * buffer; //!< pointer to data buffer for this job
+    uint64_t len;     //!< length of buffer for this job in blocks.
+    DECLARE_ALIGNED(uint32_t result_digest[CH_DIGEST_NWORDS], 64);
+    JOB_STS status;   //!< output job status
+    void * user_data; //!< pointer for user's job-related data
+} CH_JOB;
+
+typedef struct
+{
+    ch_digest_array digest;
+    uint8_t * data_ptr[CH_MAX_LANES];
+} CH_MB_ARGS_X8;
+
+typedef struct
+{
+    CH_JOB * job_in_lane;
+} CH_LANE_DATA;
+
+
+typedef struct
+{
+    CH_MB_ARGS_X8 args;
+    uint32_t lens[CH_MAX_LANES];
+    uint64_t unused_lanes; //!< each nibble is index (0...3 or 0...7) of unused lanes, nibble 4 or 8 is set to F as a flag
+    CH_LANE_DATA ldata[CH_MAX_LANES];
+    uint32_t num_lanes_inuse;
+} CH_MB_JOB_MGR;
+
+typedef struct
+{
+    CH_MB_JOB_MGR mgr;
+} CH_HASH_CTX_MGR;
+
+
+typedef struct
+{
+    CH_JOB job;                                      // Must be at struct offset 0.
+    HASH_CTX_STS status;                             //!< Context status flag
+    HASH_CTX_ERROR error;                            //!< Context error flag
+    uint64_t total_length;                           //!< Running counter of length processed for this CTX's job
+    const void * incoming_buffer;                    //!< pointer to data input buffer for this CTX's job
+    uint32_t incoming_buffer_length;                 //!< length of buffer for this job in bytes.
+    uint8_t partial_block_buffer[CH_BLOCK_SIZE * 2]; //!< CTX partial blocks
+    uint32_t partial_block_buffer_length;
+    void * user_data; //!< pointer for user to keep any job-related data
+} CH_HASH_CTX;
+
+void ch_ctx_mgr_init(CH_HASH_CTX_MGR * mgr);
+CH_HASH_CTX * ch_ctx_mgr_submit(CH_HASH_CTX_MGR * mgr, CH_HASH_CTX * ctx, const void * buffer, uint32_t len, HASH_CTX_FLAG flags);
+CH_HASH_CTX * ch_ctx_mgr_flush(CH_HASH_CTX_MGR * mgr);
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/contrib/libcityhash/include/datastruct.asm
+++ b/contrib/libcityhash/include/datastruct.asm
@@ -1,0 +1,53 @@
+; Copyright (c) 2021 PingCAP Inc 
+; Author: Jiaqi Zhou<zhoujiaqi@pingcap.com>
+
+; Macros for defining data structures
+
+; Usage example
+
+;START_FIELDS	; JOB_AES
+;;;	name		size	align
+;FIELD	_plaintext,	8,	8	; pointer to plaintext
+;FIELD	_ciphertext,	8,	8	; pointer to ciphertext
+;FIELD	_IV,		16,	8	; IV
+;FIELD	_keys,		8,	8	; pointer to keys
+;FIELD	_len,		4,	4	; length in bytes
+;FIELD	_status,	4,	4	; status enumeration
+;FIELD	_user_data,	8,	8	; pointer to user data
+;UNION  _union,         size1,  align1, \
+;	                size2,  align2, \
+;	                size3,  align3, \
+;	                ...
+;END_FIELDS
+;%assign _JOB_AES_size	_FIELD_OFFSET
+;%assign _JOB_AES_align	_STRUCT_ALIGN
+
+%ifndef _DATASTRUCT_ASM_
+%define _DATASTRUCT_ASM_
+
+;; START_FIELDS
+%macro START_FIELDS 0
+%assign _FIELD_OFFSET 0
+%assign _STRUCT_ALIGN 0
+%endm
+
+;; FIELD name size align
+%macro FIELD 3
+%define %%name  %1
+%define %%size  %2
+%define %%align %3
+
+%assign _FIELD_OFFSET (_FIELD_OFFSET + (%%align) - 1) & (~ ((%%align)-1))
+%%name	equ	_FIELD_OFFSET
+%assign _FIELD_OFFSET _FIELD_OFFSET + (%%size)
+%if (%%align > _STRUCT_ALIGN)
+%assign _STRUCT_ALIGN %%align
+%endif
+%endm
+
+;; END_FIELDS
+%macro END_FIELDS 0
+%assign _FIELD_OFFSET (_FIELD_OFFSET + _STRUCT_ALIGN-1) & (~ (_STRUCT_ALIGN-1))
+%endm
+
+%endif ; end ifdef _DATASTRUCT_ASM_

--- a/contrib/libcityhash/src/city_avx2.c
+++ b/contrib/libcityhash/src/city_avx2.c
@@ -1,0 +1,118 @@
+// Copyright (c) 2021 PingCAP Inc
+// Author: Jiaqi Zhou<zhoujiaqi@pingcap.com>
+#include <stddef.h>
+#include <string.h>
+
+#include "city_mb.h"
+
+#ifdef _MSC_VER
+#include <intrin.h>
+#define inline __inline
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+void ch_mb_mgr_init_avx2(CH_MB_JOB_MGR * state);
+CH_JOB * ch_mb_mgr_submit_avx2(CH_MB_JOB_MGR * state, CH_JOB * job);
+CH_JOB * ch_mb_mgr_flush_avx2(CH_MB_JOB_MGR * state);
+
+static inline void hash_init_digest(CH_WORD_T * digest) { memset(digest, 0, sizeof(CH_WORD_T *)); }
+
+void ch_mb_mgr_init_avx2(CH_MB_JOB_MGR * state)
+{
+    unsigned int j;
+    state->unused_lanes = 0xF76543210;
+    state->num_lanes_inuse = 0;
+    for (j = 0; j < CH_X8_LANES; j++)
+    {
+        state->lens[j] = 0;
+        state->ldata[j].job_in_lane = 0;
+    }
+}
+
+void chctx_mgr_init_avx2(CH_HASH_CTX_MGR * mgr) { ch_mb_mgr_init_avx2(&mgr->mgr); }
+
+CH_HASH_CTX * sm3_ctx_mgr_submit_avx2(CH_HASH_CTX_MGR * mgr, CH_HASH_CTX * ctx, const void * buffer, uint32_t len, HASH_CTX_FLAG flags)
+{
+    // Check length is bigger than 64
+    // If not bigger than 64 should direct call cityhash64
+    if (len < CH_BLOCK_SIZE)
+    {
+        ctx->error = HASH_CTX_ERROR_INVALID_BUFFER_LEN;
+        return ctx;
+    }
+
+    if (flags & (~HASH_ENTIRE))
+    {
+        // User should not pass anything other than FIRST, UPDATE, or LAST
+        ctx->error = HASH_CTX_ERROR_INVALID_FLAGS;
+        return ctx;
+    }
+
+    if (ctx->status & HASH_CTX_STS_PROCESSING)
+    {
+        // Cannot submit to a currently processing job.
+        ctx->error = HASH_CTX_ERROR_ALREADY_PROCESSING;
+        return ctx;
+    }
+
+    if ((ctx->status & HASH_CTX_STS_COMPLETE) && !(flags & HASH_FIRST))
+    {
+        // Cannot update a finished job.
+        ctx->error = HASH_CTX_ERROR_ALREADY_COMPLETED;
+        return ctx;
+    }
+
+    if (flags & HASH_FIRST)
+    {
+        // Init digest
+        hash_init_digest(ctx->job.result_digest);
+
+        // Reset byte counter
+        ctx->total_length = 0;
+
+        // Clear extra blocks
+        ctx->partial_block_buffer_length = 0;
+    }
+    // If we made it here, there were no errors during this call to submit
+    ctx->error = HASH_CTX_ERROR_NONE;
+
+    // Store buffer ptr info from user
+    ctx->incoming_buffer = buffer;
+    ctx->incoming_buffer_length = len;
+
+    // Store the user's request flags and mark this ctx as currently being processed.
+    ctx->status = (flags & HASH_LAST) ? (HASH_CTX_STS)(HASH_CTX_STS_PROCESSING | HASH_CTX_STS_LAST) : HASH_CTX_STS_PROCESSING;
+
+    // Advance byte counter
+    ctx->total_length += len;
+
+    ctx->status = (HASH_CTX_STS)(HASH_CTX_STS_PROCESSING | HASH_CTX_STS_COMPLETE);
+    ctx->job.buffer = ctx->incoming_buffer;
+    ctx->job.len = (uint32_t)ctx->incoming_buffer_length;
+
+    ctx = (CH_HASH_CTX *)ch_mb_mgr_submit_avx2(&mgr->mgr, &ctx->job);
+    return ctx;
+}
+
+CH_HASH_CTX * ch_ctx_mgr_flush_avx2(CH_HASH_CTX_MGR * mgr)
+{
+    CH_HASH_CTX * ctx;
+
+    while (1)
+    {
+        ctx = (CH_HASH_CTX *)ch_mb_mgr_flush_avx2(&mgr->mgr);
+
+        // If flush returned 0, there are no more jobs in flight.
+        if (!ctx)
+            return NULL;
+    }
+}
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/contrib/libcityhash/src/city_hash_test.cc
+++ b/contrib/libcityhash/src/city_hash_test.cc
@@ -1,0 +1,15 @@
+#include <iostream>
+
+#include "city.h"
+
+int main(int argc, char * argv[])
+{
+    const size_t buf_sz = 66;
+    char c_buff[buf_sz];
+
+    for (size_t i = 0; i < buf_sz; ++i)
+    {
+        c_buff[i] = i & 0xff;
+    }
+    std::cout << CityHash_v1_0_2::CityHash64(c_buff, buf_sz) << std::endl;
+}

--- a/contrib/libcityhash/src/city_mb_flush_avx2.asm
+++ b/contrib/libcityhash/src/city_mb_flush_avx2.asm
@@ -1,0 +1,229 @@
+; Copyright (c) 2021 PingCAP Inc 
+; Author: Jiaqi Zhou<zhoujiaqi@pingcap.com>
+%include "ch_mb_mgr_datastruct.asm"
+
+%include "reg_sizes.asm"
+
+extern ch_mb_x8_avx2
+
+[bits 64]
+default rel
+section .text
+
+%ifidn __OUTPUT_FORMAT__, elf64
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; LINUX register definitions
+%define arg1    rdi ; rcx
+%define arg2    rsi ; rdx
+
+%define tmp4    rdx
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%else
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; WINDOWS register definitions
+%define arg1    rcx
+%define arg2    rdx
+
+%define tmp4    rsi
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+%endif
+
+; Common register definitions
+
+%define state   arg1
+%define job     arg2
+%define len2    arg2
+
+; idx must be a register not clobberred by ch_mb_x8_avx2
+%define idx             rbp
+
+%define unused_lanes    rbx
+%define lane_data       rbx
+%define tmp2            rbx
+
+%define job_rax         rax
+%define tmp1            rax
+%define size_offset     rax
+%define tmp             rax
+%define start_offset    rax
+
+%define tmp3            arg1
+
+%define extra_blocks    arg2
+%define p               arg2
+
+
+; STACK_SPACE needs to be an odd multiple of 8
+_XMM_SAVE_SIZE  equ 10*16
+_GPR_SAVE_SIZE  equ 8*8
+_ALIGN_SIZE     equ 8
+
+_XMM_SAVE       equ 0
+_GPR_SAVE       equ _XMM_SAVE + _XMM_SAVE_SIZE
+STACK_SPACE     equ _GPR_SAVE + _GPR_SAVE_SIZE + _ALIGN_SIZE
+
+%define APPEND(a,b) a %+ b
+
+; CH_JOB* ch_mb_mgr_flush_avx2(CH_MB_JOB_MGR *state)
+; arg 1 : rcx : state
+ch_mb_mgr_flush_avx2:
+
+	sub     rsp, STACK_SPACE
+	mov     [rsp + _GPR_SAVE + 8*0], rbx
+	mov     [rsp + _GPR_SAVE + 8*3], rbp
+	mov     [rsp + _GPR_SAVE + 8*4], r12
+	mov     [rsp + _GPR_SAVE + 8*5], r13
+	mov     [rsp + _GPR_SAVE + 8*6], r14
+	mov     [rsp + _GPR_SAVE + 8*7], r15
+%ifidn __OUTPUT_FORMAT__, win64
+	mov     [rsp + _GPR_SAVE + 8*1], rsi
+	mov     [rsp + _GPR_SAVE + 8*2], rdi
+	vmovdqa  [rsp + _XMM_SAVE + 16*0], xmm6
+	vmovdqa  [rsp + _XMM_SAVE + 16*1], xmm7
+	vmovdqa  [rsp + _XMM_SAVE + 16*2], xmm8
+	vmovdqa  [rsp + _XMM_SAVE + 16*3], xmm9
+	vmovdqa  [rsp + _XMM_SAVE + 16*4], xmm10
+	vmovdqa  [rsp + _XMM_SAVE + 16*5], xmm11
+	vmovdqa  [rsp + _XMM_SAVE + 16*6], xmm12
+	vmovdqa  [rsp + _XMM_SAVE + 16*7], xmm13
+	vmovdqa  [rsp + _XMM_SAVE + 16*8], xmm14
+	vmovdqa  [rsp + _XMM_SAVE + 16*9], xmm15
+%endif
+
+	; use num_lanes_inuse to judge all lanes are empty
+	cmp	dword [state + _num_lanes_inuse], 0
+	jz	return_null
+
+	; find a lane with a non-null job
+	xor	idx, idx
+	cmp	qword [state + _ldata + 1 * _LANE_DATA_size + _job_in_lane], 0
+	cmovne	idx, [one]
+	cmp	qword [state + _ldata + 2 * _LANE_DATA_size + _job_in_lane], 0
+	cmovne	idx, [two]
+	cmp	qword [state + _ldata + 3 * _LANE_DATA_size + _job_in_lane], 0
+	cmovne	idx, [three]
+	cmp	qword [state + _ldata + 4 * _LANE_DATA_size + _job_in_lane], 0
+	cmovne	idx, [four]
+	cmp	qword [state + _ldata + 5 * _LANE_DATA_size + _job_in_lane], 0
+	cmovne	idx, [five]
+	cmp	qword [state + _ldata + 6 * _LANE_DATA_size + _job_in_lane], 0
+	cmovne	idx, [six]
+	cmp	qword [state + _ldata + 7 * _LANE_DATA_size + _job_in_lane], 0
+	cmovne	idx, [seven]
+
+	; copy idx to empty lanes
+copy_lane_data:
+	mov	tmp, [state + _args + _data_ptr + 8*idx]
+
+%assign I 0
+%rep 8
+	cmp	qword [state + _ldata + I * _LANE_DATA_size + _job_in_lane], 0
+	jne	APPEND(skip_,I)
+	mov	[state + _args + _data_ptr + 8*I], tmp
+	mov	dword [state + _lens + 4*I], 0xFFFFFFFF
+	APPEND(skip_,I):
+%assign I (I+1)
+%endrep
+
+	; Find min length
+	vmovdqa xmm0, [state + _lens + 0*16]
+	vmovdqa xmm1, [state + _lens + 1*16]
+
+	vpminud xmm2, xmm0, xmm1        ; xmm2 has {D,C,B,A}
+	vpalignr xmm3, xmm3, xmm2, 8    ; xmm3 has {x,x,D,C}
+	vpminud xmm2, xmm2, xmm3        ; xmm2 has {x,x,E,F}
+	vpalignr xmm3, xmm3, xmm2, 4    ; xmm3 has {x,x,x,E}
+	vpminud xmm2, xmm2, xmm3        ; xmm2 has min value in low dword
+
+	vmovd   DWORD(idx), xmm2
+	mov	len2, idx
+	and	idx, 0xF
+	shr	len2, 4
+	jz	len_is_0
+
+mb_processing:
+
+	vpand   xmm2, xmm2, [rel clear_low_nibble]
+	vpshufd xmm2, xmm2, 0
+
+	vpsubd  xmm0, xmm0, xmm2
+	vpsubd  xmm1, xmm1, xmm2
+
+	vmovdqa [state + _lens + 0*16], xmm0
+	vmovdqa [state + _lens + 1*16], xmm1
+
+	; "state" and "args" are the same address, arg1
+	; len is arg2
+	call	ch_mb_x8_avx2
+	; state and idx are intact
+
+len_is_0:
+	; process completed job "idx"
+	imul	lane_data, idx, _LANE_DATA_size
+	lea	lane_data, [state + _ldata + lane_data]
+
+	mov	job_rax, [lane_data + _job_in_lane]
+	mov	qword [lane_data + _job_in_lane], 0
+	mov	dword [job_rax + _status], STS_COMPLETED
+	mov	unused_lanes, [state + _unused_lanes]
+	shl	unused_lanes, 4
+	or	unused_lanes, idx
+	mov	[state + _unused_lanes], unused_lanes
+
+	sub     dword [state + _num_lanes_inuse], 1
+
+	vmovd	xmm0, [state + _args_digest + 4*idx + 0*4*8]
+	vpinsrd	xmm0, [state + _args_digest + 4*idx + 1*4*8], 1
+	vpinsrd	xmm0, [state + _args_digest + 4*idx + 2*4*8], 2
+	vpinsrd	xmm0, [state + _args_digest + 4*idx + 3*4*8], 3
+	vmovd	xmm1, [state + _args_digest + 4*idx + 4*4*8]
+	vpinsrd	xmm1, [state + _args_digest + 4*idx + 5*4*8], 1
+	vpinsrd	xmm1, [state + _args_digest + 4*idx + 6*4*8], 2
+	vpinsrd	xmm1, [state + _args_digest + 4*idx + 7*4*8], 3
+
+	vmovdqa	[job_rax + _result_digest + 0*16], xmm0
+	vmovdqa	[job_rax + _result_digest + 1*16], xmm1
+
+return:
+%ifidn __OUTPUT_FORMAT__, win64
+	vmovdqa  xmm6, [rsp + _XMM_SAVE + 16*0]
+	vmovdqa  xmm7, [rsp + _XMM_SAVE + 16*1]
+	vmovdqa  xmm8, [rsp + _XMM_SAVE + 16*2]
+	vmovdqa  xmm9, [rsp + _XMM_SAVE + 16*3]
+	vmovdqa  xmm10, [rsp + _XMM_SAVE + 16*4]
+	vmovdqa  xmm11, [rsp + _XMM_SAVE + 16*5]
+	vmovdqa  xmm12, [rsp + _XMM_SAVE + 16*6]
+	vmovdqa  xmm13, [rsp + _XMM_SAVE + 16*7]
+	vmovdqa  xmm14, [rsp + _XMM_SAVE + 16*8]
+	vmovdqa  xmm15, [rsp + _XMM_SAVE + 16*9]
+	mov     rsi, [rsp + _GPR_SAVE + 8*1]
+	mov     rdi, [rsp + _GPR_SAVE + 8*2]
+%endif
+	mov     rbx, [rsp + _GPR_SAVE + 8*0]
+	mov     rbp, [rsp + _GPR_SAVE + 8*3]
+	mov     r12, [rsp + _GPR_SAVE + 8*4]
+	mov     r13, [rsp + _GPR_SAVE + 8*5]
+	mov     r14, [rsp + _GPR_SAVE + 8*6]
+	mov     r15, [rsp + _GPR_SAVE + 8*7]
+	add     rsp, STACK_SPACE
+
+	ret
+
+return_null:
+	xor	job_rax, job_rax
+	jmp	return
+
+section .data align=16
+
+align 16
+clear_low_nibble:
+	dq 0x00000000FFFFFFF0, 0x0000000000000000
+one:	dq  1
+two:	dq  2
+three:	dq  3
+four:	dq  4
+five:	dq  5
+six:	dq  6
+seven:	dq  7

--- a/contrib/libcityhash/src/city_mb_mgr_datastruct.asm
+++ b/contrib/libcityhash/src/city_mb_mgr_datastruct.asm
@@ -1,0 +1,60 @@
+; Copyright (c) 2021 PingCAP Inc 
+; Author: Jiaqi Zhou<zhoujiaqi@pingcap.com>
+%include "datastruct.asm"
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;; Define City Hash Out Of Order Data Structures
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+START_FIELDS    ; LANE_DATA
+;;;     name            size    align
+FIELD   _job_in_lane,   8,      8       ; pointer to job object
+END_FIELDS
+
+%assign _LANE_DATA_size _FIELD_OFFSET
+%assign _LANE_DATA_align _STRUCT_ALIGN
+
+
+START_FIELDS    ; CH_ARGS_X8
+;;;     name            size    align
+FIELD   _digest,        4*8*16,  4       ; transposed digest
+FIELD   _data_ptr,      8*16,    8       ; array of pointers to data
+END_FIELDS
+
+;; For now , I only have AVX2 machine
+;; Also i don't think support SSE is a good idea for me
+%assign _CH_ARGS_X8_size	_FIELD_OFFSET
+%assign _CH_ARGS_X8_align	_STRUCT_ALIGN
+
+; STS_STATUS
+%define STS_UNKNOWN		0
+%define STS_BEING_PROCESSED	1
+%define STS_COMPLETED		2
+
+START_FIELDS	; CH_JOB
+
+;;;	name				size	align
+FIELD	_buffer,			8,	8	; pointer to buffer
+FIELD	_len,				8,	8	; length in bytes
+FIELD	_result_digest,		8*4,	64	; Digest (output)
+FIELD	_status,			4,	4
+FIELD	_user_data,			8,	8
+
+%assign _CH_JOB_size	_FIELD_OFFSET
+%assign _CH_JOB_align	_STRUCT_ALIGN
+
+
+START_FIELDS    ; MB_MGR
+;;;     name            size    align
+FIELD   _args,          _CH_ARGS_X8_size, _CH_ARGS_X8_align
+FIELD   _lens,          4*16,    8
+FIELD   _unused_lanes,  8,      8
+FIELD   _ldata,         _LANE_DATA_size*16, _LANE_DATA_align
+FIELD   _num_lanes_inuse, 4,    4
+END_FIELDS
+
+%assign _MB_MGR_size    _FIELD_OFFSET
+%assign _MB_MGR_align   _STRUCT_ALIGN
+
+_args_digest    equ     _args + _digest
+_args_data_ptr  equ     _args + _data_ptr

--- a/contrib/libcityhash/src/city_mb_submit_avx2.asm
+++ b/contrib/libcityhash/src/city_mb_submit_avx2.asm
@@ -1,0 +1,214 @@
+; Copyright (c) 2021 PingCAP Inc 
+; Author: Jiaqi Zhou<zhoujiaqi@pingcap.com>
+%include "city_mb_mgr_datastruct.asm"
+
+extern ch_mb_x8_avx2
+
+%ifidn __OUTPUT_FORMAT__, elf64
+; Linux register definitions
+%define arg1    rdi ; rcx
+%define arg2    rsi ; rdx
+
+%define size_offset     rcx ; rdi
+%define tmp2            rcx ; rdi
+
+%else
+; WINDOWS register definitions
+%define arg1    rcx
+%define arg2    rdx
+
+%define size_offset     rdi
+%define tmp2            rdi
+
+%endif
+
+; Common definitions
+%define state   arg1
+%define job     arg2
+%define len2    arg2
+%define p2      arg2
+
+%define idx             r8
+%define last_len        r8
+%define p               r11
+%define start_offset    r11
+
+%define unused_lanes    rbx
+%define job_rax         rax
+%define len             rax
+%define lane            rbp
+%define tmp3            rbp
+%define tmp             r9
+%define lane_data       r10
+
+
+; STACK_SPACE needs to be an odd multiple of 8
+%define STACK_SPACE	8*8 + 16*10 + 8
+
+; STACK_SPACE needs to be an odd multiple of 8
+_XMM_SAVE_SIZE  equ 10*16
+_GPR_SAVE_SIZE  equ 8*8
+_ALIGN_SIZE     equ 8
+
+_XMM_SAVE       equ 0
+_GPR_SAVE       equ _XMM_SAVE + _XMM_SAVE_SIZE
+STACK_SPACE     equ _GPR_SAVE + _GPR_SAVE_SIZE + _ALIGN_SIZE
+
+; CH_JOB *ch_mb_mgr_submit_avx2(CH_MB_JOB_MGR * state, CH_JOB * job);
+; arg 1 : rcx : state
+; arg 2 : rdx : job
+ch_mb_mgr_submit_avx2:
+
+; Save register into stack
+    sub     rsp, STACK_SPACE
+	mov     [rsp + _GPR_SAVE + 8*0], rbx
+	mov     [rsp + _GPR_SAVE + 8*3], rbp
+	mov     [rsp + _GPR_SAVE + 8*4], r12
+	mov     [rsp + _GPR_SAVE + 8*5], r13
+	mov     [rsp + _GPR_SAVE + 8*6], r14
+	mov     [rsp + _GPR_SAVE + 8*7], r15
+%ifidn __OUTPUT_FORMAT__, win64
+	mov     [rsp + _GPR_SAVE + 8*1], rsi
+	mov     [rsp + _GPR_SAVE + 8*2], rdi
+	vmovdqa  [rsp + _XMM_SAVE + 16*0], xmm6
+	vmovdqa  [rsp + _XMM_SAVE + 16*1], xmm7
+	vmovdqa  [rsp + _XMM_SAVE + 16*2], xmm8
+	vmovdqa  [rsp + _XMM_SAVE + 16*3], xmm9
+	vmovdqa  [rsp + _XMM_SAVE + 16*4], xmm10
+	vmovdqa  [rsp + _XMM_SAVE + 16*5], xmm11
+	vmovdqa  [rsp + _XMM_SAVE + 16*6], xmm12
+	vmovdqa  [rsp + _XMM_SAVE + 16*7], xmm13
+	vmovdqa  [rsp + _XMM_SAVE + 16*8], xmm14
+	vmovdqa  [rsp + _XMM_SAVE + 16*9], xmm15
+%endif
+	mov	unused_lanes, [state + _unused_lanes]
+	mov	lane, unused_lanes
+	and	lane, 0xF
+	shr	unused_lanes, 4
+	imul	lane_data, lane, _LANE_DATA_size
+	mov	dword [job + _status], STS_BEING_PROCESSED
+	lea	lane_data, [state + _ldata + lane_data]
+	mov	[state + _unused_lanes], unused_lanes
+	mov	DWORD(len), [job + _len]
+
+	shl	len, 4
+	or	len, lane
+	mov	[state + _lens + 4*lane], DWORD(len)
+
+	mov	[lane_data + _job_in_lane], job
+
+	; Load digest words from result_digest
+	vmovdqu	xmm0, [job + _result_digest + 0*16]
+	vmovdqu xmm1, [job + _result_digest + 1*16]
+	vmovd	[state + _args_digest + 4*lane + 0*4*8], xmm0
+	vpextrd	[state + _args_digest + 4*lane + 1*4*8], xmm0, 1
+	vpextrd	[state + _args_digest + 4*lane + 2*4*8], xmm0, 2
+	vpextrd	[state + _args_digest + 4*lane + 3*4*8], xmm0, 3
+	vmovd	[state + _args_digest + 4*lane + 4*4*8], xmm1
+	vpextrd	[state + _args_digest + 4*lane + 5*4*8], xmm1, 1
+	vpextrd	[state + _args_digest + 4*lane + 6*4*8], xmm1, 2
+	vpextrd	[state + _args_digest + 4*lane + 7*4*8], xmm1, 3
+
+
+	mov	p, [job + _buffer]
+	mov	[state + _args_data_ptr + 8*lane], p
+
+	add	dword [state + _num_lanes_inuse], 1
+	cmp	unused_lanes, 0xf
+	jne	return_null
+
+start_loop:
+	; Find min length
+	vmovdqa xmm0, [state + _lens + 0*16]
+	vmovdqa xmm1, [state + _lens + 1*16]
+
+	vpminud xmm2, xmm0, xmm1        ; xmm2 has {D,C,B,A}
+	vpalignr xmm3, xmm3, xmm2, 8    ; xmm3 has {x,x,D,C}
+	vpminud xmm2, xmm2, xmm3        ; xmm2 has {x,x,E,F}
+	vpalignr xmm3, xmm3, xmm2, 4    ; xmm3 has {x,x,x,E}
+	vpminud xmm2, xmm2, xmm3        ; xmm2 has min value in low dword
+
+	vmovd   DWORD(idx), xmm2
+	mov	len2, idx
+	and	idx, 0xF
+	shr	len2, 4
+	jz	len_is_0
+
+	vpand   xmm2, xmm2, [rel clear_low_nibble]
+	vpshufd xmm2, xmm2, 0
+
+	vpsubd  xmm0, xmm0, xmm2
+	vpsubd  xmm1, xmm1, xmm2
+
+	vmovdqa [state + _lens + 0*16], xmm0
+	vmovdqa [state + _lens + 1*16], xmm1
+
+
+	; "state" and "args" are the same address, arg1
+	; len is arg2
+	call	ch_mb_x8_avx2
+
+	; state and idx are intact
+
+len_is_0:
+	; process completed job "idx"
+	imul	lane_data, idx, _LANE_DATA_size
+	lea	lane_data, [state + _ldata + lane_data]
+
+	mov	job_rax, [lane_data + _job_in_lane]
+	mov	unused_lanes, [state + _unused_lanes]
+	mov	qword [lane_data + _job_in_lane], 0
+	mov	dword [job_rax + _status], STS_COMPLETED
+	shl	unused_lanes, 4
+	or	unused_lanes, idx
+	mov	[state + _unused_lanes], unused_lanes
+
+	sub	dword [state + _num_lanes_inuse], 1
+
+	vmovd	xmm0, [state + _args_digest + 4*idx + 0*4*8]
+	vpinsrd	xmm0, [state + _args_digest + 4*idx + 1*4*8], 1
+	vpinsrd	xmm0, [state + _args_digest + 4*idx + 2*4*8], 2
+	vpinsrd	xmm0, [state + _args_digest + 4*idx + 3*4*8], 3
+	vmovd	xmm1, [state + _args_digest + 4*idx + 4*4*8]
+	vpinsrd	xmm1, [state + _args_digest + 4*idx + 5*4*8], 1
+	vpinsrd	xmm1, [state + _args_digest + 4*idx + 6*4*8], 2
+	vpinsrd	xmm1, [state + _args_digest + 4*idx + 7*4*8], 3
+
+	vmovdqa	[job_rax + _result_digest + 0*16], xmm0
+	vmovdqa	[job_rax + _result_digest + 1*16], xmm1
+
+return:
+
+%ifidn __OUTPUT_FORMAT__, win64
+	vmovdqa  xmm6, [rsp + 8*8 + 16*0]
+	vmovdqa  xmm7, [rsp + 8*8 + 16*1]
+	vmovdqa  xmm8, [rsp + 8*8 + 16*2]
+	vmovdqa  xmm9, [rsp + 8*8 + 16*3]
+	vmovdqa  xmm10, [rsp + 8*8 + 16*4]
+	vmovdqa  xmm11, [rsp + 8*8 + 16*5]
+	vmovdqa  xmm12, [rsp + 8*8 + 16*6]
+	vmovdqa  xmm13, [rsp + 8*8 + 16*7]
+	vmovdqa  xmm14, [rsp + 8*8 + 16*8]
+	vmovdqa  xmm15, [rsp + 8*8 + 16*9]
+	mov     rsi, [rsp + 8*1]
+	mov     rdi, [rsp + 8*2]
+%endif
+	mov     rbx, [rsp + 8*0]
+	mov     rbp, [rsp + 8*3]
+	mov     r12, [rsp + 8*4]
+	mov     r13, [rsp + 8*5]
+	mov     r14, [rsp + 8*6]
+	mov     r15, [rsp + 8*7]
+	add     rsp, STACK_SPACE
+
+	ret
+
+return_null:
+	xor     job_rax, job_rax
+	jmp     return
+
+section .data align=16
+
+align 16
+clear_low_nibble:
+	dq 0x00000000FFFFFFF0, 0x0000000000000000

--- a/contrib/libcityhash/src/city_mb_x8_avx2.asm
+++ b/contrib/libcityhash/src/city_mb_x8_avx2.asm
@@ -1,0 +1,147 @@
+; Copyright (c) 2021 PingCAP Inc 
+; Author: Jiaqi Zhou<zhoujiaqi@pingcap.com>
+%include "ch_mb_mgr_datastruct.asm"
+
+
+%ifidn __OUTPUT_FORMAT__, elf64
+ ; Linux definitions
+     %define arg1 	rdi
+     %define arg2	rsi
+     %define reg3	rcx
+     %define reg4	rdx
+%else
+ ; Windows definitions
+     %define arg1 	rcx
+     %define arg2 	rdx
+     %define reg3	rsi
+     %define reg4	rdi
+%endif
+
+; Common definitions
+%define STATE    arg1
+%define INP_SIZE arg2
+%define SIZE	 INP_SIZE ; rsi
+
+%define IDX     rax
+%define TBL	reg3
+
+%define inp0 r9
+%define inp1 r10
+%define inp2 r11
+%define inp3 r12
+%define inp4 r13
+%define inp5 r14
+%define inp6 r15
+%define inp7 reg4
+
+
+struc stack_frame
+  .data		resb	16*SZ8
+  .digest	resb	8*SZ8
+  .wbtmp	resb	69*SZ8
+  .rsp		resb	8
+endstruc
+
+
+%define FRAMESZ	stack_frame_size
+%define _DIGEST	stack_frame.digest
+%define _WBTMP	stack_frame.wbtmp
+%define _RSP_SAVE	stack_frame.rsp
+
+;;;;;;;;
+; Rolling YMM to right shape
+;;;;;;;;
+%macro TRANSPOSE8 10
+%define %%r0 %1
+%define %%r1 %2
+%define %%r2 %3
+%define %%r3 %4
+%define %%r4 %5
+%define %%r5 %6
+%define %%r6 %7
+%define %%r7 %8
+%define %%t0 %9
+%define %%t1 %10
+	; process top half (r0..r3) {a...d}
+	vshufps	%%t0, %%r0, %%r1, 0x44	; t0 = {b5 b4 a5 a4   b1 b0 a1 a0}
+	vshufps	%%r0, %%r0, %%r1, 0xEE	; r0 = {b7 b6 a7 a6   b3 b2 a3 a2}
+	vshufps %%t1, %%r2, %%r3, 0x44	; t1 = {d5 d4 c5 c4   d1 d0 c1 c0}
+	vshufps	%%r2, %%r2, %%r3, 0xEE	; r2 = {d7 d6 c7 c6   d3 d2 c3 c2}
+	vshufps	%%r3, %%t0, %%t1, 0xDD	; r3 = {d5 c5 b5 a5   d1 c1 b1 a1}
+	vshufps	%%r1, %%r0, %%r2, 0x88	; r1 = {d6 c6 b6 a6   d2 c2 b2 a2}
+	vshufps	%%r0, %%r0, %%r2, 0xDD	; r0 = {d7 c7 b7 a7   d3 c3 b3 a3}
+	vshufps	%%t0, %%t0, %%t1, 0x88	; t0 = {d4 c4 b4 a4   d0 c0 b0 a0}
+
+	; use r2 in place of t0
+	; process bottom half (r4..r7) {e...h}
+	vshufps	%%r2, %%r4, %%r5, 0x44	; r2 = {f5 f4 e5 e4   f1 f0 e1 e0}
+	vshufps	%%r4, %%r4, %%r5, 0xEE	; r4 = {f7 f6 e7 e6   f3 f2 e3 e2}
+	vshufps %%t1, %%r6, %%r7, 0x44	; t1 = {h5 h4 g5 g4   h1 h0 g1 g0}
+	vshufps	%%r6, %%r6, %%r7, 0xEE	; r6 = {h7 h6 g7 g6   h3 h2 g3 g2}
+	vshufps	%%r7, %%r2, %%t1, 0xDD	; r7 = {h5 g5 f5 e5   h1 g1 f1 e1}
+	vshufps	%%r5, %%r4, %%r6, 0x88	; r5 = {h6 g6 f6 e6   h2 g2 f2 e2}
+	vshufps	%%r4, %%r4, %%r6, 0xDD	; r4 = {h7 g7 f7 e7   h3 g3 f3 e3}
+	vshufps	%%t1, %%r2, %%t1, 0x88	; t1 = {h4 g4 f4 e4   h0 g0 f0 e0}
+
+	vperm2f128	%%r6, %%r5, %%r1, 0x13	; h6...a6
+	vperm2f128	%%r2, %%r5, %%r1, 0x02	; h2...a2
+	vperm2f128	%%r5, %%r7, %%r3, 0x13	; h5...a5
+	vperm2f128	%%r1, %%r7, %%r3, 0x02	; h1...a1
+	vperm2f128	%%r7, %%r4, %%r0, 0x13	; h7...a7
+	vperm2f128	%%r3, %%r4, %%r0, 0x02	; h3...a3
+	vperm2f128	%%r4, %%t1, %%t0, 0x13	; h4...a4
+	vperm2f128	%%r0, %%t1, %%t0, 0x02	; h0...a0
+%endmacro
+
+
+;; void sm3_x8_avx2(CH_ARGS *args, uint64_t bytes);
+;; arg 1 : STATE : pointer to input data
+;; arg 2 : INP_SIZE  : size of input in blocks
+ch_mb_x8_avx2:
+
+    ; save rsp, allocate 32-byte aligned for local variables
+	mov	IDX, rsp
+	sub	rsp, FRAMESZ
+	and	rsp, ~31
+	mov	[rsp + _RSP_SAVE], IDX
+
+	lea	TBL,[TABLE]
+
+	;; load the address of each of the 8 message lanes
+	;; getting ready to transpose input onto stack
+	mov	inp0,[STATE + _args_data_ptr + 0*PTR_SZ]
+	mov	inp1,[STATE + _args_data_ptr + 1*PTR_SZ]
+	mov	inp2,[STATE + _args_data_ptr + 2*PTR_SZ]
+	mov	inp3,[STATE + _args_data_ptr + 3*PTR_SZ]
+	mov	inp4,[STATE + _args_data_ptr + 4*PTR_SZ]
+	mov	inp5,[STATE + _args_data_ptr + 5*PTR_SZ]
+	mov	inp6,[STATE + _args_data_ptr + 6*PTR_SZ]
+	mov	inp7,[STATE + _args_data_ptr + 7*PTR_SZ]
+
+	xor	IDX, IDX
+
+    ;;;;;; pre-cal
+
+lloop:
+    
+
+
+align 64
+global TABLE
+TABLE:
+dq 0xc3a5c85cc3a5c85c,0xc3a5c85cc3a5c85c
+dq 0xc3a5c85cc3a5c85c,0xc3a5c85cc3a5c85c
+dq 0x97cb312797cb3127,0x97cb312797cb3127
+dq 0x97cb312797cb3127,0x97cb312797cb3127
+dq 0xb492b66fb492b66f,0xb492b66fb492b66f
+dq 0xb492b66fb492b66f,0xb492b66fb492b66f
+dq 0xbe98f273be98f273,0xbe98f273be98f273
+dq 0xbe98f273be98f273,0xbe98f273be98f273
+dq 0x9ae16a3b9ae16a3b,0x9ae16a3b9ae16a3b
+dq 0x9ae16a3b9ae16a3b,0x9ae16a3b9ae16a3b
+dq 0x2f90404f2f90404f,0x2f90404f2f90404f
+dq 0x2f90404f2f90404f,0x2f90404f2f90404f
+dq 0xc949d7c7c949d7c7,0xc949d7c7c949d7c7
+dq 0xc949d7c7c949d7c7,0xc949d7c7c949d7c7
+dq 0x509e6557509e6557,0x509e6557509e6557
+dq 0x509e6557509e6557,0x509e6557509e6557

--- a/contrib/libcityhash/src/datastruct.asm
+++ b/contrib/libcityhash/src/datastruct.asm
@@ -1,0 +1,33 @@
+// Copyright (c) 2011 Google, Inc.
+// Copyright (c) 2021 PingCAP Inc 
+// Author: Jiaqi Zhou<zhoujiaqi@pingcap.com>
+
+
+%ifndef _DATASTRUCT_ASM_
+%define _DATASTRUCT_ASM_
+
+;; START_FIELDS
+%macro START_FIELDS 0
+%assign _FIELD_OFFSET 0
+%assign _STRUCT_ALIGN 0
+%endm
+
+;; FIELD name size align
+%macro FIELD 3
+%define %%name  %1
+%define %%size  %2
+%define %%align %3
+
+%assign _FIELD_OFFSET (_FIELD_OFFSET + (%%align) - 1) & (~ ((%%align)-1))
+%%name	equ	_FIELD_OFFSET
+%assign _FIELD_OFFSET _FIELD_OFFSET + (%%size)
+%if (%%align > _STRUCT_ALIGN)
+%assign _STRUCT_ALIGN %%align
+%endif
+%endm
+
+%macro END_FIELDS 0
+%assign _FIELD_OFFSET (_FIELD_OFFSET + _STRUCT_ALIGN-1) & (~ (_STRUCT_ALIGN-1))
+%endm
+
+%endif ; end ifdef _DATASTRUCT_ASM_


### PR DESCRIPTION
Signed-off-by: jiaqizho <zhoujiaqi@pingcap.com>
Issue Number: 

Problem Summary:

Multi-buffer can support PageFile. So make it write faster by making CityHash faster.

### What is changed and how it works?

Proposal: Support CityHash64 to avx2

What's Changed:
- based C to asm framework[done]
- support buffer length > 64 [todo]
- add base test && perf[todo]

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch:

### Check List 

Tests

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

### Release note 