### PR TITLE
Fix include auxv.h will cause M1 build failed.

### DIFF
--- a/dbms/src/Core/SIMD.h
+++ b/dbms/src/Core/SIMD.h
@@ -3,7 +3,11 @@
 #if __has_include(<asm/hwcap.h>)
 #include <asm/hwcap.h>
 #endif
-#include <sys/auxv.h>
+// M1 does not support the general ARM instruction set
+// Include auxv.h will cause build error in M1
+#if not defined(__arm64__)
+    #include <sys/auxv.h>
+#endif
 #endif
 namespace DB
 {


### PR DESCRIPTION
Signed-off-by: jiaqizho <zhoujiaqi@pingcap.com>

### What problem does this PR solve?

Issue Number: 
Problem Summary:
```
/dbms/src/Core/SIMD.h:6:10: fatal error: 'sys/auxv.h' file not found
#include <sys/auxv.h>
         ^~~~~~~~~~~~
```

### What is changed and how it works?

Proposal: 

What's Changed:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch:

### Check List 

Tests 

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

### Release note 
