### PR TITLE
Reduce the memory consumption of PageFile::MetaMergingReader

### DIFF
--- a/dbms/src/Storages/Page/PageDefines.h
+++ b/dbms/src/Storages/Page/PageDefines.h
@@ -3,6 +3,7 @@
 #include <Core/Defines.h>
 #include <Core/Types.h>
 
+#include <chrono>
 #include <unordered_set>
 #include <vector>
 

--- a/dbms/src/Storages/Page/PageDefines.h
+++ b/dbms/src/Storages/Page/PageDefines.h
@@ -22,6 +22,7 @@ static constexpr UInt64 PAGE_FILE_MAX_SIZE = 1024 * 2 * MB;
 static constexpr UInt64 PAGE_FILE_SMALL_SIZE = 2 * MB;
 static constexpr UInt64 PAGE_FILE_ROLL_SIZE = 128 * MB;
 static constexpr UInt64 PAGE_META_ROLL_SIZE = 2 * MB;
+static constexpr UInt64 DBMS_DEFAULT_META_READER_BUFFER_SIZE = 1024; // The size of the meta reader buffer by default.
 
 static_assert(PAGE_SIZE_STEP >= ((1 << 10) * 16), "PAGE_SIZE_STEP should be at least 16 KB");
 static_assert((PAGE_SIZE_STEP & (PAGE_SIZE_STEP - 1)) == 0, "PAGE_SIZE_STEP should be power of 2");

--- a/dbms/src/Storages/Page/PageFile.h
+++ b/dbms/src/Storages/Page/PageFile.h
@@ -118,9 +118,18 @@ public:
     class MetaMergingReader : private boost::noncopyable
     {
     public:
-        MetaMergingReader(PageFile & page_file_); // should only called by `createFrom`
-        static MetaMergingReaderPtr createFrom(PageFile & page_file, size_t max_meta_offset, size_t meta_file_buffer_size, const ReadLimiterPtr & read_limiter = nullptr);
-        static MetaMergingReaderPtr createFrom(PageFile & page_file, size_t meta_file_buffer_size, const ReadLimiterPtr & read_limiter = nullptr);
+        // Should only be called by `createFrom`
+        explicit MetaMergingReader(PageFile & page_file_);
+
+        static MetaMergingReaderPtr createFrom(
+            PageFile & page_file,
+            size_t max_meta_offset,
+            size_t meta_file_buffer_size,
+            const ReadLimiterPtr & read_limiter = nullptr);
+        static MetaMergingReaderPtr createFrom(
+            PageFile & page_file,
+            size_t meta_file_buffer_size,
+            const ReadLimiterPtr & read_limiter = nullptr);
 
         ~MetaMergingReader();
 
@@ -169,7 +178,10 @@ public:
     private:
         void close();
 
-        void initialize(std::optional<size_t> max_meta_offset, size_t meta_file_buffer_size, const ReadLimiterPtr & read_limiter);
+        void initialize(
+            std::optional<size_t> max_meta_offset,
+            size_t meta_file_buffer_size,
+            const ReadLimiterPtr & read_limiter);
 
     private:
         PageFile & page_file;

--- a/dbms/src/Storages/Page/PageStorage.cpp
+++ b/dbms/src/Storages/Page/PageStorage.cpp
@@ -119,7 +119,7 @@ PageFormat::Version PageStorage::getMaxDataVersion(const FileProviderPtr & file_
 
         // Simply check the last non-empty PageFile is good enough
         all_empty = false;
-        auto reader = PageFile::MetaMergingReader::createFrom(const_cast<PageFile &>(*iter));
+        auto reader = PageFile::MetaMergingReader::createFrom(const_cast<PageFile &>(*iter), /*meta_file_buffer_size=*/DBMS_DEFAULT_META_READER_BUFFER_SIZE);
         while (reader->hasNext())
         {
             // Continue to read the binary version of next WriteBatch.
@@ -260,7 +260,7 @@ void PageStorage::restore()
               || page_file.getType() == PageFile::Type::Checkpoint))
             throw Exception("Try to recover from " + page_file.toString() + ", illegal type.", ErrorCodes::LOGICAL_ERROR);
 
-        if (auto reader = PageFile::MetaMergingReader::createFrom(const_cast<PageFile &>(page_file));
+        if (auto reader = PageFile::MetaMergingReader::createFrom(const_cast<PageFile &>(page_file), config.meta_file_reading_buf_size);
             reader->hasNext())
         {
             // Read one WriteBatch

--- a/dbms/src/Storages/Page/PageStorage.h
+++ b/dbms/src/Storages/Page/PageStorage.h
@@ -74,7 +74,7 @@ public:
 
         // meta file reading buffer size
         size_t meta_file_reading_buf_size = DBMS_DEFAULT_META_READER_BUFFER_SIZE;
-        
+
         void reload(const Config & rhs);
 
         String toDebugString() const;

--- a/dbms/src/Storages/Page/PageStorage.h
+++ b/dbms/src/Storages/Page/PageStorage.h
@@ -72,6 +72,9 @@ public:
 
         ::DB::MVCC::VersionSetConfig version_set_config;
 
+        // meta file reading buffer size
+        size_t meta_file_reading_buf_size = DBMS_DEFAULT_META_READER_BUFFER_SIZE;
+        
         void reload(const Config & rhs);
 
         String toDebugString() const;

--- a/dbms/src/Storages/Page/PageUtil.h
+++ b/dbms/src/Storages/Page/PageUtil.h
@@ -136,6 +136,16 @@ inline T get(std::conditional_t<advance, char *&, const char *> pos)
         pos += sizeof(T);
     return v;
 }
+
+/// Read and advance sizeof(T) bytes by read buffer.
+/// Return false if there are no enough data.
+/// It may throw an exception, if something is wrong when invoking ReadBuffer::next
+/// How to deal with the case get throws exception in moveNext(), which happens more often than other case?
+template <typename T>
+inline bool get(ReadBuffer * read_buffer, T * const result)
+{
+    return sizeof(T) == read_buffer->read(reinterpret_cast<char *>(result), sizeof(T));
+}
 } // namespace PageUtil
 
 } // namespace DB

--- a/dbms/src/Storages/Page/gc/DataCompactor.cpp
+++ b/dbms/src/Storages/Page/gc/DataCompactor.cpp
@@ -311,7 +311,7 @@ DataCompactor<SnapshotPtr>::migratePages( //
             }
 
             // Create meta reader and update `compact_seq`
-            auto meta_reader = PageFile::MetaMergingReader::createFrom(const_cast<PageFile &>(page_file), read_limiter);
+            auto meta_reader = PageFile::MetaMergingReader::createFrom(const_cast<PageFile &>(page_file), config.meta_file_reading_buf_size, read_limiter);
             while (meta_reader->hasNext())
             {
                 meta_reader->moveNext();

--- a/dbms/src/Storages/Page/gc/DataCompactor.cpp
+++ b/dbms/src/Storages/Page/gc/DataCompactor.cpp
@@ -311,7 +311,10 @@ DataCompactor<SnapshotPtr>::migratePages( //
             }
 
             // Create meta reader and update `compact_seq`
-            auto meta_reader = PageFile::MetaMergingReader::createFrom(const_cast<PageFile &>(page_file), config.meta_file_reading_buf_size, read_limiter);
+            auto meta_reader = PageFile::MetaMergingReader::createFrom(
+                const_cast<PageFile &>(page_file),
+                config.meta_file_reading_buf_size,
+                read_limiter);
             while (meta_reader->hasNext())
             {
                 meta_reader->moveNext();

--- a/dbms/src/Storages/Page/gc/LegacyCompactor.cpp
+++ b/dbms/src/Storages/Page/gc/LegacyCompactor.cpp
@@ -130,11 +130,18 @@ LegacyCompactor::collectPageFilesToCompact(const PageFileSet & page_files, const
         if (auto iter = writing_files.find(page_file.fileIdLevel()); iter != writing_files.end())
         {
             // create reader with max meta reading offset
-            reader = PageFile::MetaMergingReader::createFrom(const_cast<PageFile &>(page_file), iter->second.meta_offset, config.meta_file_reading_buf_size, read_limiter);
+            reader = PageFile::MetaMergingReader::createFrom(
+                const_cast<PageFile &>(page_file),
+                iter->second.meta_offset,
+                config.meta_file_reading_buf_size,
+                read_limiter);
         }
         else
         {
-            reader = PageFile::MetaMergingReader::createFrom(const_cast<PageFile &>(page_file), config.meta_file_reading_buf_size, read_limiter);
+            reader = PageFile::MetaMergingReader::createFrom(
+                const_cast<PageFile &>(page_file),
+                config.meta_file_reading_buf_size,
+                read_limiter);
         }
         if (reader->hasNext())
         {

--- a/dbms/src/Storages/Page/gc/LegacyCompactor.cpp
+++ b/dbms/src/Storages/Page/gc/LegacyCompactor.cpp
@@ -130,11 +130,11 @@ LegacyCompactor::collectPageFilesToCompact(const PageFileSet & page_files, const
         if (auto iter = writing_files.find(page_file.fileIdLevel()); iter != writing_files.end())
         {
             // create reader with max meta reading offset
-            reader = PageFile::MetaMergingReader::createFrom(const_cast<PageFile &>(page_file), iter->second.meta_offset, read_limiter);
+            reader = PageFile::MetaMergingReader::createFrom(const_cast<PageFile &>(page_file), iter->second.meta_offset, config.meta_file_reading_buf_size, read_limiter);
         }
         else
         {
-            reader = PageFile::MetaMergingReader::createFrom(const_cast<PageFile &>(page_file), read_limiter);
+            reader = PageFile::MetaMergingReader::createFrom(const_cast<PageFile &>(page_file), config.meta_file_reading_buf_size, read_limiter);
         }
         if (reader->hasNext())
         {

--- a/dbms/src/Storages/Page/tests/gtest_legacy_compactor.cpp
+++ b/dbms/src/Storages/Page/tests/gtest_legacy_compactor.cpp
@@ -182,7 +182,7 @@ try
 
     PageStorage::MetaMergingQueue mergine_queue;
     {
-        if (auto reader = PageFile::MetaMergingReader::createFrom(page_file, ctx.getReadLimiter());
+        if (auto reader = PageFile::MetaMergingReader::createFrom(page_file, /*meta_file_buffer_size=*/DBMS_DEFAULT_META_READER_BUFFER_SIZE, ctx.getReadLimiter()); //
             reader->hasNext())
         {
             reader->moveNext();

--- a/dbms/src/Storages/Page/tests/gtest_legacy_compactor.cpp
+++ b/dbms/src/Storages/Page/tests/gtest_legacy_compactor.cpp
@@ -182,7 +182,10 @@ try
 
     PageStorage::MetaMergingQueue mergine_queue;
     {
-        if (auto reader = PageFile::MetaMergingReader::createFrom(page_file, /*meta_file_buffer_size=*/DBMS_DEFAULT_META_READER_BUFFER_SIZE, ctx.getReadLimiter()); //
+        if (auto reader = PageFile::MetaMergingReader::createFrom(
+                page_file,
+                /*meta_file_buffer_size=*/DBMS_DEFAULT_META_READER_BUFFER_SIZE,
+                ctx.getReadLimiter());
             reader->hasNext())
         {
             reader->moveNext();

--- a/dbms/src/Storages/Page/tests/gtest_page_util.cpp
+++ b/dbms/src/Storages/Page/tests/gtest_page_util.cpp
@@ -1,5 +1,6 @@
 #include <Encryption/PosixRandomAccessFile.h>
 #include <Encryption/PosixWritableFile.h>
+#include <IO/ReadBufferFromFileDescriptor.h>
 #include <Poco/Logger.h>
 #include <Storages/Page/PageUtil.h>
 #include <TestUtils/TiFlashTestBasic.h>
@@ -89,6 +90,53 @@ TEST(PageUtils_test, BigReadWriteFile)
         FailPointHelper::disableFailPoint(FailPoints::force_split_io_size_4k);
         FAIL() << e.getStackTrace().toString();
     }
+}
+
+TEST(PageUtils_test, GetStrFromBuffer)
+{
+    ::remove(FileName.c_str());
+
+    // data prepare
+    WritableFilePtr file = std::make_shared<PosixWritableFile>(FileName, true, -1, 0666);
+
+    char        file_write[]  = "I want to do excellent jobs.";
+    std::string data_to_write = file_write;
+    int         length        = data_to_write.length();
+#ifndef NDEBUG
+    PageUtil::writeFile(file, 0, data_to_write.data(), 28, nullptr, true);
+    PageUtil::writeFile(file, 28, reinterpret_cast<char *>(&length), sizeof(int), nullptr, true);
+#else
+    PageUtil::writeFile(file, 0, data_to_write.data(), 28, nullptr);
+    PageUtil::writeFile(file, 28, reinterpret_cast<char *>(&length), sizeof(int), nullptr);
+#endif
+    PageUtil::syncFile(file);
+    file->close();
+
+    int fd2 = PageUtil::openFile<true, true>(FileName);
+    ASSERT_GT(fd2, 0);
+
+    size_t                                        buffer_size = 10;
+    std::unique_ptr<ReadBufferFromFileDescriptor> buffer      = std::make_unique<ReadBufferFromFileDescriptor>(fd2, buffer_size);
+
+    // real test
+    char result[28];
+    bool success = PageUtil::get<char[28]>(buffer.get(), &result);
+    ASSERT_TRUE(success);
+    for (int i = 0; i < 28; ++i)
+    {
+        ASSERT_EQ(result[i], file_write[i]);
+    }
+    ASSERT_EQ(buffer->count(), (long unsigned int)28);
+    ASSERT_EQ(buffer->offset(), (long unsigned int)(28 % buffer_size));
+
+    int result2;
+    success = PageUtil::get<int>(buffer.get(), &result2);
+    ASSERT_TRUE(success);
+    ASSERT_EQ(result2, length);
+    ASSERT_TRUE(!buffer->hasPendingData());
+    ASSERT_EQ(buffer->count(), (long unsigned int)(28 + sizeof(int)));
+    ASSERT_EQ(buffer->offset(), (long unsigned int)((28 + sizeof(int)) % buffer_size));
+    ::close(fd2);
 }
 
 } // namespace tests

--- a/dbms/src/Storages/Page/tests/gtest_page_util.cpp
+++ b/dbms/src/Storages/Page/tests/gtest_page_util.cpp
@@ -4,6 +4,7 @@
 #include <Poco/Logger.h>
 #include <Storages/Page/PageUtil.h>
 #include <TestUtils/TiFlashTestBasic.h>
+#include <gtest/gtest.h>
 
 namespace DB
 {
@@ -14,11 +15,11 @@ extern const char force_split_io_size_4k[];
 
 namespace tests
 {
-static const std::string FileName = "page_util_test";
+static const std::string testFilename = "page_util_test";
 
 TEST(PageUtils_test, ReadWriteFile)
 {
-    ::remove(FileName.c_str());
+    ::remove(testFilename.c_str());
 
     size_t buff_size = 1024;
     char buff_write[buff_size];
@@ -27,7 +28,7 @@ TEST(PageUtils_test, ReadWriteFile)
     {
         buff_write[i] = i % 0xFF;
     }
-    WritableFilePtr file_for_write = std::make_shared<PosixWritableFile>(FileName, true, -1, 0666);
+    WritableFilePtr file_for_write = std::make_shared<PosixWritableFile>(testFilename, true, -1, 0666);
 #ifndef NDEBUG
     PageUtil::writeFile(file_for_write, 0, buff_write, buff_size, nullptr, true);
 #else
@@ -37,29 +38,29 @@ TEST(PageUtils_test, ReadWriteFile)
     file_for_write->close();
 
     char buff_read[buff_size];
-    RandomAccessFilePtr file_for_read = std::make_shared<PosixRandomAccessFile>(FileName, -1, nullptr);
+    RandomAccessFilePtr file_for_read = std::make_shared<PosixRandomAccessFile>(testFilename, -1, nullptr);
     PageUtil::readFile(file_for_read, 0, buff_read, buff_size, nullptr);
     ASSERT_EQ(strcmp(buff_write, buff_read), 0);
 
-    ::remove(FileName.c_str());
+    ::remove(testFilename.c_str());
 }
 
 TEST(PageUtils_test, FileNotExists)
 {
-    ::remove(FileName.c_str());
+    ::remove(testFilename.c_str());
 
-    int fd = PageUtil::openFile<true, false>(FileName);
+    int fd = PageUtil::openFile<true, false>(testFilename);
     ASSERT_EQ(fd, 0);
 }
 
 TEST(PageUtils_test, BigReadWriteFile)
 {
-    ::remove(FileName.c_str());
+    ::remove(testFilename.c_str());
 
     FailPointHelper::enableFailPoint(FailPoints::force_split_io_size_4k);
     try
     {
-        WritableFilePtr file_for_write = std::make_shared<PosixWritableFile>(FileName, true, -1, 0666);
+        WritableFilePtr file_for_write = std::make_shared<PosixWritableFile>(testFilename, true, -1, 0666);
         size_t buff_size = 13 * 1024 + 123;
         char buff_write[buff_size];
         char buff_read[buff_size];
@@ -77,65 +78,68 @@ TEST(PageUtils_test, BigReadWriteFile)
         PageUtil::syncFile(file_for_write);
         file_for_write->close();
 
-        RandomAccessFilePtr file_for_read = std::make_shared<PosixRandomAccessFile>(FileName, -1, nullptr);
+        RandomAccessFilePtr file_for_read = std::make_shared<PosixRandomAccessFile>(testFilename, -1, nullptr);
         PageUtil::readFile(file_for_read, 0, buff_read, buff_size, nullptr);
         ASSERT_EQ(strcmp(buff_write, buff_read), 0);
 
-        ::remove(FileName.c_str());
+        ::remove(testFilename.c_str());
         FailPointHelper::disableFailPoint(FailPoints::force_split_io_size_4k);
     }
     catch (DB::Exception & e)
     {
-        ::remove(FileName.c_str());
+        ::remove(testFilename.c_str());
         FailPointHelper::disableFailPoint(FailPoints::force_split_io_size_4k);
         FAIL() << e.getStackTrace().toString();
     }
 }
 
+/// Test PageUtil::get(ReadBuffer * read_buffer, T * const result)
 TEST(PageUtils_test, GetStrFromBuffer)
 {
-    ::remove(FileName.c_str());
+    ::remove(testFilename.c_str());
 
-    // data prepare
-    WritableFilePtr file = std::make_shared<PosixWritableFile>(FileName, true, -1, 0666);
+    using ValueType = size_t;
 
-    char        file_write[]  = "I want to do excellent jobs.";
-    std::string data_to_write = file_write;
-    int         length        = data_to_write.length();
+    const std::vector<ValueType> values = {789, 123, 456, 9876, 54321};
+    {
+        // prepare data
+        WritableFilePtr file = std::make_shared<PosixWritableFile>(testFilename, true, -1, 0666);
+        size_t offset = 0;
+        for (auto v : values)
+        {
+            PageUtil::writeFile(
+                file,
+                offset,
+                reinterpret_cast<char *>(&v),
+                sizeof(v),
+                nullptr
 #ifndef NDEBUG
-    PageUtil::writeFile(file, 0, data_to_write.data(), 28, nullptr, true);
-    PageUtil::writeFile(file, 28, reinterpret_cast<char *>(&length), sizeof(int), nullptr, true);
-#else
-    PageUtil::writeFile(file, 0, data_to_write.data(), 28, nullptr);
-    PageUtil::writeFile(file, 28, reinterpret_cast<char *>(&length), sizeof(int), nullptr);
+                ,
+                false
 #endif
-    PageUtil::syncFile(file);
-    file->close();
+            );
+            offset += sizeof(v);
+        }
+        PageUtil::syncFile(file);
+        file->close();
+    }
 
-    int fd2 = PageUtil::openFile<true, true>(FileName);
+    int fd2 = PageUtil::openFile<true, true>(testFilename);
     ASSERT_GT(fd2, 0);
 
-    size_t                                        buffer_size = 10;
-    std::unique_ptr<ReadBufferFromFileDescriptor> buffer      = std::make_unique<ReadBufferFromFileDescriptor>(fd2, buffer_size);
+    size_t buffer_size = 10;
+    auto buffer = std::make_unique<ReadBufferFromFileDescriptor>(fd2, buffer_size);
 
-    // real test
-    char result[28];
-    bool success = PageUtil::get<char[28]>(buffer.get(), &result);
-    ASSERT_TRUE(success);
-    for (int i = 0; i < 28; ++i)
+    ValueType read_value = 0;
+    size_t read_offset = 0;
+    for (const auto expect_val : values)
     {
-        ASSERT_EQ(result[i], file_write[i]);
+        ASSERT_TRUE(PageUtil::get<ValueType>(buffer.get(), &read_value));
+        ASSERT_EQ(read_value, expect_val);
+        read_offset += sizeof(read_value);
+        ASSERT_EQ(buffer->count(), read_offset);
     }
-    ASSERT_EQ(buffer->count(), (long unsigned int)28);
-    ASSERT_EQ(buffer->offset(), (long unsigned int)(28 % buffer_size));
-
-    int result2;
-    success = PageUtil::get<int>(buffer.get(), &result2);
-    ASSERT_TRUE(success);
-    ASSERT_EQ(result2, length);
-    ASSERT_TRUE(!buffer->hasPendingData());
-    ASSERT_EQ(buffer->count(), (long unsigned int)(28 + sizeof(int)));
-    ASSERT_EQ(buffer->offset(), (long unsigned int)((28 + sizeof(int)) % buffer_size));
+    ASSERT_FALSE(buffer->hasPendingData());
     ::close(fd2);
 }
 

--- a/dbms/src/Storages/Page/tests/page_storage_ctl.cpp
+++ b/dbms/src/Storages/Page/tests/page_storage_ctl.cpp
@@ -230,7 +230,7 @@ void dump_all_entries(DB::PageFileSet & page_files, int32_t mode)
         DB::PageEntriesEdit edit;
         DB::PageIdAndEntries id_and_caches;
 
-        auto reader = DB::PageFile::MetaMergingReader::createFrom(const_cast<DB::PageFile &>(page_file));
+        auto reader = DB::PageFile::MetaMergingReader::createFrom(const_cast<DB::PageFile &>(page_file), /*meta_file_buffer_size=*/DB::DBMS_DEFAULT_META_READER_BUFFER_SIZE);
 
         while (reader->hasNext())
         {

--- a/dbms/src/Storages/Page/tests/page_storage_ctl.cpp
+++ b/dbms/src/Storages/Page/tests/page_storage_ctl.cpp
@@ -230,7 +230,9 @@ void dump_all_entries(DB::PageFileSet & page_files, int32_t mode)
         DB::PageEntriesEdit edit;
         DB::PageIdAndEntries id_and_caches;
 
-        auto reader = DB::PageFile::MetaMergingReader::createFrom(const_cast<DB::PageFile &>(page_file), /*meta_file_buffer_size=*/DB::DBMS_DEFAULT_META_READER_BUFFER_SIZE);
+        auto reader = DB::PageFile::MetaMergingReader::createFrom(
+            const_cast<DB::PageFile &>(page_file),
+            /*meta_file_buffer_size=*/DB::DBMS_DEFAULT_META_READER_BUFFER_SIZE);
 
         while (reader->hasNext())
         {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #2199 

Problem Summary: when gabage collecting is going on, it will read all meta file in all page files and keep them in memory, which costs a lot of memory usage.

### What is changed and how it works?

What's Changed: change the field `meta_buffer` to `meta_read_buffer`. `meta_buffer` holds all meta data in a page file, but `meta_read_buffer` is just a read buffer, so the data is actually on disk. You can also read directly from the file on disk every time you calling `moveNext`, but it will lead to much more syscall. The reading buffer is used to reduce memory usage when gabage collecting, and is more efficient than reading directly from disk.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

<!--
- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility
-->

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Reduce the memory consumption when reading is last for a long time
```
