### PR TITLE
fix bug that exchange receiver may hang forever 

### DIFF
--- a/dbms/src/Flash/Mpp/ExchangeReceiver.cpp
+++ b/dbms/src/Flash/Mpp/ExchangeReceiver.cpp
@@ -34,7 +34,6 @@ void ExchangeReceiver::setUpConnection()
     {
         auto & meta = pb_exchange_receiver.encoded_task_meta(index);
         std::thread t(&ExchangeReceiver::ReadLoop, this, std::ref(meta), index);
-        live_connections++;
         workers.push_back(std::move(t));
     }
 }

--- a/dbms/src/Flash/Mpp/ExchangeReceiver.h
+++ b/dbms/src/Flash/Mpp/ExchangeReceiver.h
@@ -109,7 +109,7 @@ public:
           source_num(pb_exchange_receiver.encoded_task_meta_size()),
           task_meta(meta),
           max_buffer_size(max_buffer_size_),
-          live_connections(0),
+          live_connections(pb_exchange_receiver.encoded_task_meta_size()),
           state(NORMAL),
           log(&Logger::get("exchange_receiver"))
     {


### PR DESCRIPTION
cherry pick #2709 to release-5.0-20210902

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

<!--
- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility
-->

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note, or a 'None' if it is not needed.
```
