### PR TITLE
Update default config of flash.cpu.query_cpu_percent and fix log

### DIFF
--- a/dbms/src/Common/CPUAffinityManager.cpp
+++ b/dbms/src/Common/CPUAffinityManager.cpp
@@ -98,16 +98,22 @@ void CPUAffinityManager::bindOtherThread(pid_t tid) const
 
 void CPUAffinityManager::bindSelfQueryThread() const
 {
-    LOG_INFO(log, "Thread: " << ::getThreadName() << " bindQueryThread.");
-    // If tid is zero, then the calling thread is used.
-    bindQueryThread(0);
+    if (enable())
+    {
+        LOG_INFO(log, "Thread: " << ::getThreadName() << " bindQueryThread.");
+        // If tid is zero, then the calling thread is used.
+        bindQueryThread(0);
+    }
 }
 
 void CPUAffinityManager::bindSelfOtherThread() const
 {
-    LOG_INFO(log, "Thread: " << ::getThreadName() << " bindOtherThread.");
-    // If tid is zero, then the calling thread is used.
-    bindOtherThread(0);
+    if (enable())
+    {
+        LOG_INFO(log, "Thread: " << ::getThreadName() << " bindOtherThread.");
+        // If tid is zero, then the calling thread is used.
+        bindOtherThread(0);
+    }
 }
 
 void CPUAffinityManager::bindSelfGrpcThread() const

--- a/dbms/src/Common/CPUAffinityManager.h
+++ b/dbms/src/Common/CPUAffinityManager.h
@@ -19,7 +19,7 @@ namespace DB
 struct CPUAffinityConfig
 {
     CPUAffinityConfig()
-        : query_cpu_percent(80)
+        : query_cpu_percent(0)
         , cpu_cores(std::thread::hardware_concurrency())
     {}
     // About {cpu_cores * query_cpu_percent / 100} cpu cores are used for running query threads.

--- a/dbms/src/Common/tests/gtest_cpu_affinity_manager.cpp
+++ b/dbms/src/Common/tests/gtest_cpu_affinity_manager.cpp
@@ -39,7 +39,7 @@ R"(
 query_cpu_percent=77
 )",
     };
-    std::vector<int> vi = { /*default*/ 80, 55, 77 };
+    std::vector<int> vi = { /*default*/ 0, 55, 77 };
 
     for (size_t i = 0; i < vs.size(); i++)
     {


### PR DESCRIPTION
### What problem does this PR solve?

1. Update default configuration of flash.cpu.query_cpu_percent from 80 to 0 (disable set thread cpu affinity by default).
2. Fix some out of place log when 'set thread cpu affinity' is disabled.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

<!--
- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility
-->

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
none
```
