### PR TITLE
enable parse bool settings("true" or "false")

### DIFF
--- a/dbms/src/Common/ErrorCodes.cpp
+++ b/dbms/src/Common/ErrorCodes.cpp
@@ -373,7 +373,7 @@ extern const int TOO_MANY_ROWS_OR_BYTES = 396;
 extern const int QUERY_IS_NOT_SUPPORTED_IN_MATERIALIZED_VIEW = 397;
 extern const int CANNOT_MPROTECT = 445;
 extern const int DECIMAL_OVERFLOW = 446;
-
+extern const int CANNOT_PARSE_BOOL = 447;
 
 extern const int KEEPER_EXCEPTION = 999;
 extern const int POCO_EXCEPTION = 1000;

--- a/dbms/src/Interpreters/SettingsCommon.cpp
+++ b/dbms/src/Interpreters/SettingsCommon.cpp
@@ -1,0 +1,97 @@
+#include "SettingsCommon.h"
+
+namespace DB
+{
+template <typename IntType>
+SettingInt<IntType>::SettingInt(const SettingInt & setting)
+{
+    value.store(setting.value.load());
+}
+
+template <typename IntType>
+String SettingInt<IntType>::toString() const
+{
+    return DB::toString(value.load());
+}
+
+template <typename IntType>
+void SettingInt<IntType>::set(IntType x)
+{
+    value.store(x);
+    changed = true;
+}
+
+template <typename IntType>
+void SettingInt<IntType>::set(const Field & x)
+{
+    set(applyVisitor(FieldVisitorConvertToNumber<IntType>(), x));
+}
+
+template <typename IntType>
+void SettingInt<IntType>::set(const String & x)
+{
+    set(parse<IntType>(x));
+}
+
+template <typename IntType>
+void SettingInt<IntType>::set(ReadBuffer & buf)
+{
+    IntType x = 0;
+    readVarT(x, buf);
+    set(x);
+}
+
+template <typename IntType>
+IntType SettingInt<IntType>::get() const
+{
+    return value.load();
+}
+
+template <typename IntType>
+void SettingInt<IntType>::write(WriteBuffer & buf) const
+{
+    writeVarT(value.load(), buf);
+}
+
+template <>
+void SettingInt<bool>::set(const String & x)
+{
+    if (x.size() == 1)
+    {
+        if (x[0] == '0')
+            set(false);
+        else if (x[0] == '1')
+            set(true);
+        else
+            throw Exception("Cannot parse bool from string '" + x + "'", ErrorCodes::CANNOT_PARSE_BOOL);
+    }
+    else
+    {
+        ReadBufferFromString buf(x);
+        if (checkStringCaseInsensitive("true", buf))
+            set(true);
+        else if (checkStringCaseInsensitive("false", buf))
+            set(false);
+        else
+            throw Exception("Cannot parse bool from string '" + x + "'", ErrorCodes::CANNOT_PARSE_BOOL);
+    }
+}
+
+template <>
+void SettingInt<bool>::set(ReadBuffer & buf)
+{
+    UInt64 x = 0;
+    readVarT(x, buf);
+    set(x);
+}
+
+template <>
+void SettingInt<bool>::write(WriteBuffer & buf) const
+{
+    UInt64 val = value.load();
+    writeVarT(val, buf);
+}
+template struct SettingInt<UInt64>;
+template struct SettingInt<Int64>;
+template struct SettingInt<bool>;
+} // namespace DB

--- a/dbms/src/Server/tests/gtest_storage_config.cpp
+++ b/dbms/src/Server/tests/gtest_storage_config.cpp
@@ -799,5 +799,37 @@ dt_page_gc_low_write_prob = 0.2
     global_ctx.setSettings(origin_settings);
 }
 CATCH
+
+
+TEST_F(UsersConfigParser_test, ReloadStorageBoolConfig)
+try
+{
+    Strings tests = {
+        R"(
+[profiles]
+[profiles.default]
+dt_enable_rough_set_filter = false
+dt_raw_filter_range = 0
+dt_read_delta_only = 1
+dt_read_stable_only = true
+        )"};
+
+    auto & global_ctx = TiFlashTestEnv::getGlobalContext();
+    for (size_t i = 0; i < tests.size(); ++i)
+    {
+        const auto & test_case = tests[i];
+        auto config = loadConfigFromString(test_case);
+
+        LOG_INFO(log, "parsing [index=" << i << "] [content=" << test_case << "]");
+
+        global_ctx.reloadDeltaTreeConfig(*config);
+        ASSERT_EQ(global_ctx.getSettingsRef().dt_enable_rough_set_filter, false);
+        ASSERT_EQ(global_ctx.getSettingsRef().dt_raw_filter_range, false);
+        ASSERT_EQ(global_ctx.getSettingsRef().dt_read_delta_only, true);
+        ASSERT_EQ(global_ctx.getSettingsRef().dt_read_stable_only, true);
+    }
+    global_ctx.setSettings(origin_settings);
+}
+CATCH
 } // namespace tests
 } // namespace DB


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #938 

Problem Summary:
Some configurations which type is `SettingBool` can only use "0"/"1" but not "true"/"false".
### What is changed and how it works?

What's Changed:

Similar to the modification of [https://github.com/ClickHouse/ClickHouse/pull/6278](https://github.com/ClickHouse/ClickHouse/pull/6278), `SettingBool = SettingInt<bool>`, and then let SettingInt<bool> be able to parse "0"/"1" and "true"/"false".

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix bool settings parsing
```
