### PR TITLE
Add dt_segment_delta_limit_delete_ranges settings

### DIFF
--- a/dbms/src/Interpreters/Settings.h
+++ b/dbms/src/Interpreters/Settings.h
@@ -245,6 +245,7 @@ struct Settings
     \
     M(SettingUInt64, dt_segment_limit_rows, 1000000, "Base rows of segments in DeltaTree Engine.")\
     M(SettingUInt64, dt_segment_limit_size, 1073741824, "Base size of segments in DeltaTree Engine. 1 GB by default.")\
+    M(SettingUInt64, dt_segment_delta_limit_delete_ranges, 2, "Suggesting delete range numbers")\
     M(SettingUInt64, dt_segment_delta_limit_rows, 80000, "Max rows of segment delta in DeltaTree Engine")\
     M(SettingUInt64, dt_segment_delta_limit_size, 85983232, "Max size of segment delta in DeltaTree Engine. 82 MB by default.")\
     M(SettingUInt64, dt_segment_force_merge_delta_deletes, 10, "Delta delete ranges before force merge into stable.")\

--- a/dbms/src/Storages/DeltaMerge/DMContext.h
+++ b/dbms/src/Storages/DeltaMerge/DMContext.h
@@ -45,6 +45,8 @@ struct DMContext : private boost::noncopyable
     const size_t segment_limit_rows;
     // The base bytes of segment.
     const size_t segment_limit_bytes;
+    // The delete_ranges threshold of delta.
+    const size_t delta_limit_delete_ranges;
     // The rows threshold of delta.
     const size_t delta_limit_rows;
     // The rows threshold of delta.
@@ -93,6 +95,7 @@ public:
         , rowkey_column_size(rowkey_column_size_)
         , segment_limit_rows(settings.dt_segment_limit_rows)
         , segment_limit_bytes(settings.dt_segment_limit_size)
+        , delta_limit_delete_ranges(settings.dt_segment_delta_limit_delete_ranges)
         , delta_limit_rows(settings.dt_segment_delta_limit_rows)
         , delta_limit_bytes(settings.dt_segment_delta_limit_size)
         , delta_cache_limit_rows(settings.dt_segment_delta_cache_limit_rows)

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -1108,6 +1108,7 @@ void DeltaMergeStore::checkSegmentUpdate(const DMContextPtr & dm_context, const 
 
     auto segment_limit_rows = dm_context->segment_limit_rows;
     auto segment_limit_bytes = dm_context->segment_limit_bytes;
+    auto delete_limit_delete_ranges = dm_context->delta_limit_delete_ranges;
     auto delta_limit_rows = dm_context->delta_limit_rows;
     auto delta_limit_bytes = dm_context->delta_limit_bytes;
     auto delta_cache_limit_rows = dm_context->delta_cache_limit_rows;
@@ -1121,7 +1122,7 @@ void DeltaMergeStore::checkSegmentUpdate(const DMContextPtr & dm_context, const 
     bool should_background_merge_delta = ((delta_check_rows >= delta_limit_rows || delta_check_bytes >= delta_limit_bytes) //
                                           && (delta_rows - delta_last_try_merge_delta_rows >= delta_cache_limit_rows
                                               || delta_bytes - delta_last_try_merge_delta_bytes >= delta_cache_limit_bytes))
-        || delta_deletes >= 2;
+        || delta_deletes >= delete_limit_delete_ranges;
     bool should_foreground_merge_delta_by_rows_or_bytes
         = delta_check_rows >= forceMergeDeltaRows(dm_context) || delta_check_bytes >= forceMergeDeltaBytes(dm_context);
     bool should_foreground_merge_delta_by_deletes = delta_deletes >= forceMergeDeltaDeletes(dm_context);


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

### What is changed and how it works?

Add a new setting: `dt_segment_delta_limit_delete_ranges` to determine the threshold of triggering DeltaMerge by delete ranges.

What's Changed:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
- No code

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
'None'
```
