### PR TITLE
[DNM] Avoid thread allocating in constructor

### DIFF
--- a/dbms/src/Common/FailPoint.cpp
+++ b/dbms/src/Common/FailPoint.cpp
@@ -47,7 +47,8 @@ std::unordered_map<String, std::shared_ptr<FailPointChannel>> FailPointHelper::f
     M(segment_merge_after_ingest_packs)                           \
     M(force_formal_page_file_not_exists)                          \
     M(force_legacy_or_checkpoint_page_file_exists)                \
-    M(exception_in_creating_set_input_stream)
+    M(exception_in_creating_set_input_stream)                     \
+    M(exception_in_alloc_thread_in_exchange_receiver)
 
 #define APPLY_FOR_FAILPOINTS(M)                              \
     M(force_set_page_file_write_errno)                       \

--- a/dbms/src/Flash/Coprocessor/InterpreterDAG.cpp
+++ b/dbms/src/Flash/Coprocessor/InterpreterDAG.cpp
@@ -71,12 +71,14 @@ void InterpreterDAG::initMPPExchangeReceiver(const DAGQueryBlock & dag_query_blo
     }
     if (dag_query_block.source->tp() == tipb::ExecType::TypeExchangeReceiver)
     {
-        mpp_exchange_receiver_maps[dag_query_block.source_name] = std::make_shared<ExchangeReceiver>(
+        auto exchange_receiver = std::make_shared<ExchangeReceiver>(
             std::make_shared<GRPCReceiverContext>(context.getTMTContext().getKVCluster()),
             dag_query_block.source->exchange_receiver(),
             dag.getDAGContext().getMPPTaskMeta(),
             max_streams,
             log);
+        exchange_receiver->init();
+        mpp_exchange_receiver_maps[dag_query_block.source_name] = exchange_receiver;
     }
 }
 

--- a/dbms/src/Flash/Coprocessor/InterpreterDAG.cpp
+++ b/dbms/src/Flash/Coprocessor/InterpreterDAG.cpp
@@ -77,6 +77,8 @@ void InterpreterDAG::initMPPExchangeReceiver(const DAGQueryBlock & dag_query_blo
             dag.getDAGContext().getMPPTaskMeta(),
             max_streams,
             log);
+        /// although ExchangeReceiver support lazy init, current implementation require calling `init()` immediately
+        /// otherwise, its down stream task may hit write timeout error
         exchange_receiver->init();
         mpp_exchange_receiver_maps[dag_query_block.source_name] = exchange_receiver;
     }

--- a/dbms/src/Flash/Mpp/ExchangeReceiver.h
+++ b/dbms/src/Flash/Mpp/ExchangeReceiver.h
@@ -79,6 +79,8 @@ public:
 
     ~ExchangeReceiverBase();
 
+    void init();
+
     void cancel();
 
     const DAGSchema & getOutputSchema() const { return schema; }
@@ -89,8 +91,6 @@ public:
     String getName() { return "ExchangeReceiver"; }
 
 private:
-    void setUpConnection();
-
     void readLoop(size_t source_index);
 
     std::shared_ptr<RPCContext> rpc_context;
@@ -111,6 +111,7 @@ private:
     Int32 live_connections;
     ExchangeReceiverState state;
     String err_msg;
+    bool inited = false;
 
     LogWithPrefixPtr log;
 };

--- a/dbms/src/Flash/tests/gtest_fail_to_alloc_thread.cpp
+++ b/dbms/src/Flash/tests/gtest_fail_to_alloc_thread.cpp
@@ -1,0 +1,132 @@
+#include <gtest/gtest.h>
+
+#include <Flash/Mpp/ExchangeReceiver.cpp>
+
+namespace DB
+{
+namespace tests
+{
+using Packet = mpp::MPPDataPacket;
+using PacketPtr = std::shared_ptr<Packet>;
+struct MockReceiverContext
+{
+    struct Status
+    {
+        int status_code = 0;
+        String error_msg;
+
+        bool ok() const
+        {
+            return status_code == 0;
+        }
+
+        const String & error_message() const
+        {
+            return error_msg;
+        }
+    };
+
+    struct Request
+    {
+        String debugString() const
+        {
+            return "{Request}";
+        }
+        int send_task_id = 0;
+    };
+
+    struct Reader
+    {
+        Reader()
+        {
+        }
+
+        void initialize() const
+        {
+        }
+
+        bool read(mpp::MPPDataPacket * packet [[maybe_unused]]) const
+        {
+            return true;
+        }
+
+        Status finish() const
+        {
+            return {0, ""};
+        }
+    };
+
+    MockReceiverContext()
+    {
+    }
+
+    Request makeRequest(
+        int index [[maybe_unused]],
+        const tipb::ExchangeReceiver & pb_exchange_receiver [[maybe_unused]],
+        const ::mpp::TaskMeta & task_meta [[maybe_unused]]) const
+    {
+        return {index};
+    }
+
+    std::shared_ptr<Reader> makeReader(const Request & request [[maybe_unused]])
+    {
+        return std::make_shared<Reader>();
+    }
+
+    static Status getStatusOK()
+    {
+        return {0, ""};
+    }
+};
+using MockExchangeReceiver = ExchangeReceiverBase<MockReceiverContext>;
+class Fail_Alloc_Thread_Test : public ::testing::Test
+{
+public:
+    void SetUp() override {}
+};
+
+TEST_F(Fail_Alloc_Thread_Test, ExchangeReceiver)
+{
+    tipb::ExchangeReceiver pb_exchange_receiver;
+    mpp::TaskMeta task_meta;
+    for (int i = 0; i < 5; ++i)
+    {
+        mpp::TaskMeta task;
+        task.set_start_ts(0);
+        task.set_task_id(i);
+        task.set_partition_id(i);
+        task.set_address("");
+
+        String encoded_task;
+        task.SerializeToString(&encoded_task);
+
+        pb_exchange_receiver.add_encoded_task_meta(encoded_task);
+    }
+    std::vector<tipb::FieldType> fields(3);
+    fields[0].set_tp(TiDB::TypeLongLong);
+    fields[1].set_tp(TiDB::TypeString);
+    fields[2].set_tp(TiDB::TypeLongLong);
+    *pb_exchange_receiver.add_field_types() = fields[0];
+    *pb_exchange_receiver.add_field_types() = fields[1];
+    *pb_exchange_receiver.add_field_types() = fields[2];
+
+    task_meta.set_task_id(100);
+
+    FailPointHelper::enableFailPoint("exception_in_alloc_thread_in_exchange_receiver");
+    try
+    {
+        auto exchange_receiver = std::make_shared<MockExchangeReceiver>(
+            std::make_shared<MockReceiverContext>(),
+            pb_exchange_receiver,
+            task_meta,
+            10,
+            nullptr);
+        exchange_receiver->init();
+    }
+    catch (Exception & e)
+    {
+    }
+}
+
+} // namespace tests
+} // namespace DB

--- a/libs/libcommon/include/common/ThreadPool.h
+++ b/libs/libcommon/include/common/ThreadPool.h
@@ -22,7 +22,8 @@ public:
     /// Size is constant, all threads are created immediately.
     /// Every threads will execute pre_worker firstly when they are created.
     explicit ThreadPool(
-        size_t m_size, Job pre_worker = [] {});
+        size_t m_size,
+        Job pre_worker = [] {});
 
     /// Add new job. Locks until free thread in pool become available or exception in one of threads was thrown.
     /// If an exception in some thread was thrown, method silently returns, and exception will be rethrown only on call to 'wait' function.
@@ -38,6 +39,8 @@ public:
     /// You should not destroy object while calling schedule or wait methods from another threads.
     ~ThreadPool();
 
+    void init();
+
     size_t size() const { return m_size; }
 
     /// Returns number of active jobs.
@@ -51,7 +54,9 @@ private:
     const size_t m_size;
     size_t active_jobs = 0;
     bool shutdown = false;
+    bool inited = false;
 
+    Job pre_worker;
     std::queue<Job> jobs;
     std::vector<std::thread> threads;
     std::exception_ptr first_exception;

--- a/libs/libcommon/src/ThreadPool.cpp
+++ b/libs/libcommon/src/ThreadPool.cpp
@@ -7,7 +7,6 @@ ThreadPool::ThreadPool(size_t m_size_, Job pre_worker_)
     : m_size(m_size_)
     , pre_worker(std::move(pre_worker_))
 {
-    threads.reserve(m_size);
 }
 
 void ThreadPool::init()
@@ -15,6 +14,7 @@ void ThreadPool::init()
     std::unique_lock<std::mutex> lock(mutex);
     if (!inited)
     {
+        threads.reserve(m_size);
         for (size_t i = 0; i < m_size; ++i)
             threads.emplace_back([this] {
                 pre_worker();
@@ -62,8 +62,6 @@ ThreadPool::~ThreadPool()
     {
         std::unique_lock<std::mutex> lock(mutex);
         shutdown = true;
-        if (!inited)
-            return;
     }
 
     has_new_job_or_shutdown.notify_all();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
If TiFlash is running under high load, it will keep crashing with `Terminate called without an active exception`


### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
The  cause of `Terminate called without an active exception` is that there are threads that is deconstructed without joined. In `ThreadPool` and `ExchangeReceiver`, we try to allocating threads in constructor, if allocating failed, there is no chance to join the threads that was allocated before, and this will cause the terminating error. This pr move threads allocating to `init()` 
### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

<!--
- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility
-->

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Avoid TiFlash crashing when fail to allocate new threads.
```
