### PR TITLE
[DNM] Add an option for jemalloc prof

### DIFF
--- a/contrib/jemalloc-cmake/CMakeLists.txt
+++ b/contrib/jemalloc-cmake/CMakeLists.txt
@@ -1,5 +1,8 @@
 set(JEMALLOC_SOURCE_DIR ${ClickHouse_SOURCE_DIR}/contrib/jemalloc)
 
+# TODO: Ensure whether we can enable it by default
+option (ENABLE_JEMALLOC_PROF "Enables jemalloc profiling under release mode" OFF)
+
 set(SRCS
 ${JEMALLOC_SOURCE_DIR}/src/arena.c
 ${JEMALLOC_SOURCE_DIR}/src/background_thread.c
@@ -68,6 +71,21 @@ if (CMAKE_BUILD_TYPE_UC STREQUAL "DEBUG")
     if (USE_UNWIND)
         target_compile_definitions (jemalloc PRIVATE -DJEMALLOC_PROF_LIBUNWIND=1)
         target_include_directories (jemalloc BEFORE PRIVATE ${UNWIND_INCLUDE_DIR})
+        target_include_directories (jemalloc BEFORE PRIVATE ${UNWIND_INCREMENTAL_DIR})
         target_link_libraries (jemalloc PRIVATE ${UNWIND_LIBRARY})
     endif ()
+else ()
+    if (ENABLE_JEMALLOC_PROF)
+        message(STATUS "Building with jemalloc prof is enabled")
+        target_compile_definitions(jemalloc PRIVATE -DJEMALLOC_PROF=1)
+
+        if (USE_UNWIND)
+            target_compile_definitions (jemalloc PRIVATE -DJEMALLOC_PROF_LIBUNWIND=1)
+            target_include_directories (jemalloc BEFORE PRIVATE ${UNWIND_INCLUDE_DIR})
+            target_include_directories (jemalloc BEFORE PRIVATE ${UNWIND_INCREMENTAL_DIR})
+            target_link_libraries (jemalloc PRIVATE ${UNWIND_LIBRARY})
+        endif ()
+    else ()
+        message(STATUS "Building with jemalloc prof is disabled")
+    endif()
 endif ()


### PR DESCRIPTION
Signed-off-by: JaySon-Huang <jayson.hjs@gmail.com>

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

Add an option for enabling jemalloc prof, so that we can dump the heap for profiling when needed.

Adding compile flags simply makes the heap profiling available, but not enable by default.
To enable it, we need to add `export MALLOC_CONF="prof:true,prof_active:true,lg_prof_interval:33"` in the script for starting TiFlash.
After that, every time TiFlash allocate 8G (1 << `lg_prof_interval` bytes) memory, there would be `jeprof.<pid>.*.heap` generated under the running directory. To analyze the result, we need to use the `jeprof` script.

BTW, TiKV always enable this prof, without dumping to file.
https://github.com/pingcap/tiup/blob/2bba74888ecca796faa40497ea0c7ab3036589f8/embed/templates/scripts/run_tikv.sh.tpl#L23

Reference:
* https://github.com/jemalloc/jemalloc/wiki/Use-Case%3A-Heap-Profiling
* https://www.yuanguohuo.com/2019/01/02/jemalloc-heap-profiling/

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

<!--
- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility
-->

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note, or a 'None' if it is not needed.
```
