### PR TITLE
Use bytes(IEC) instead of bytes(SI) in some grafana metric unit

### DIFF
--- a/metrics/grafana/tiflash_summary.json
+++ b/metrics/grafana/tiflash_summary.json
@@ -2490,7 +2490,7 @@
               "show": true
             },
             {
-              "format": "Bps",
+              "format": "binBps",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -3363,7 +3363,7 @@
           },
           "yaxes": [
             {
-              "format": "Bps",
+              "format": "binBps",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -3485,7 +3485,7 @@
           },
           "yaxes": [
             {
-              "format": "Bps",
+              "format": "binBps",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -3899,7 +3899,7 @@
           "yaxes": [
             {
               "decimals": 0,
-              "format": "Bps",
+              "format": "binBps",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -4170,7 +4170,7 @@
           },
           "yaxes": [
             {
-              "format": "Bps",
+              "format": "binBps",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -4374,7 +4374,7 @@
           },
           "yaxes": [
             {
-              "format": "Bps",
+              "format": "binBps",
               "label": null,
               "logBase": 1,
               "max": null,


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: Currently, the `Store size` metric and some other similar metrics's unit using bytes(SI). When using this metric, 1 KB is expected to be 1000 B which is absolutely wrong.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch:

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
