### PR TITLE
[DNM] Introduce UnionWaitInputStream

### DIFF
--- a/dbms/src/DataStreams/UnionWaitInputStream.h
+++ b/dbms/src/DataStreams/UnionWaitInputStream.h
@@ -1,0 +1,248 @@
+#pragma once
+
+#include <Common/ConcurrentBoundedQueue.h>
+#include <DataStreams/IProfilingBlockInputStream.h>
+#include <DataStreams/ParallelInputsProcessor.h>
+#include <Flash/Mpp/getMPPTaskLog.h>
+
+
+namespace DB
+{
+namespace ErrorCodes
+{
+extern const int LOGICAL_ERROR;
+}
+
+
+/** Merges several sources into one.
+  * Blocks from different sources are interleaved with each other in an arbitrary way.
+  * You can specify the number of threads (max_threads),
+  *  in which data will be retrieved from different sources.
+  *
+  * It's managed like this:
+  * - with the help of ParallelInputsProcessor in several threads it takes out blocks from the sources;
+  * - the completed blocks are added to a limited queue of finished blocks;
+  * - the main thread takes out completed blocks from the queue of finished blocks;
+  */
+
+class UnionWaitInputStream final : public IProfilingBlockInputStream
+{
+public:
+    using ExceptionCallback = std::function<void()>;
+
+private:
+    using Self = UnionWaitInputStream;
+
+public:
+    UnionWaitInputStream(
+        BlockInputStreams inputs,
+        BlockInputStreamPtr additional_input_at_end,
+        size_t max_threads,
+        const LogWithPrefixPtr & log_,
+        ExceptionCallback exception_callback_ = ExceptionCallback())
+        : output_queue(std::min(inputs.size(), max_threads))
+        , handler(*this)
+        , processor(inputs, additional_input_at_end, max_threads, handler)
+        , exception_callback(exception_callback_)
+        , log(getMPPTaskLog(log_, getName()))
+    {
+        children = inputs;
+        if (additional_input_at_end)
+            children.push_back(additional_input_at_end);
+
+        size_t num_children = children.size();
+        if (num_children > 1)
+        {
+            Block header = children.at(0)->getHeader();
+            for (size_t i = 1; i < num_children; ++i)
+                assertBlocksHaveEqualStructure(children[i]->getHeader(), header, "UNION_WAIT");
+        }
+    }
+
+    String getName() const override { return "UnionWait"; }
+
+    ~UnionWaitInputStream() override
+    {
+        try
+        {
+            if (!all_read)
+                cancel(false);
+
+            finalize();
+        }
+        catch (...)
+        {
+            tryLogCurrentException(__PRETTY_FUNCTION__);
+        }
+    }
+
+    /** Different from the default implementation by trying to stop all sources,
+      * skipping failed by execution.
+      */
+    void cancel(bool kill) override
+    {
+        if (kill)
+            is_killed = true;
+
+        bool old_val = false;
+        if (!is_cancelled.compare_exchange_strong(old_val, true, std::memory_order_seq_cst, std::memory_order_relaxed))
+            return;
+
+        //std::cerr << "cancelling\n";
+        processor.cancel(kill);
+    }
+
+    Block getHeader() const override { return children.at(0)->getHeader(); }
+
+protected:
+    void finalize()
+    {
+        if (!started)
+            return;
+
+        LOG_TRACE(log, "Waiting for threads to finish");
+
+        std::exception_ptr exception;
+        if (!all_read)
+        {
+            /** Let's read everything up to the end, so that ParallelInputsProcessor is not blocked when trying to insert into the queue.
+              * Maybe there is an exception in the queue.
+              */
+            std::exception_ptr res;
+            while (true)
+            {
+                //std::cerr << "popping\n";
+                output_queue.pop(res);
+
+                if (res)
+                {
+                    if (!exception)
+                        exception = res;
+                    else if (Exception * e = exception_cast<Exception *>(exception))
+                        e->addMessage("\n" + getExceptionMessage(res, false));
+                }
+                else
+                    break;
+            }
+
+            all_read = true;
+        }
+
+        processor.wait();
+
+        LOG_TRACE(log, "Waited for threads to finish");
+
+        if (exception)
+            std::rethrow_exception(exception);
+    }
+
+    /// Do nothing, to make the preparation for the query execution in parallel, in ParallelInputsProcessor.
+    void readPrefix() override
+    {
+    }
+
+    /** The following options are possible:
+      * 1. `readImpl` function is called until it returns an empty block.
+      *  Then `readSuffix` function is called and then destructor.
+      * 2. `readImpl` function is called. At some point, `cancel` function is called perhaps from another thread.
+      *  Then `readSuffix` function is called and then destructor.
+      * 3. At any time, the object can be destroyed (destructor called).
+      */
+
+    Block readImpl() override
+    {
+        if (all_read)
+            return {};
+
+        /// Run threads if this has not already been done.
+        if (!started)
+        {
+            started = true;
+            processor.process();
+        }
+
+        finalize();
+
+        return {};
+    }
+
+    /// Called either after everything is read, or after cancel.
+    void readSuffix() override
+    {
+        //std::cerr << "readSuffix\n";
+        if (!all_read && !isCancelled())
+            throw Exception("readSuffix called before all data is read", ErrorCodes::LOGICAL_ERROR);
+
+        finalize();
+
+        for (size_t i = 0; i < children.size(); ++i)
+            children[i]->readSuffix();
+    }
+
+private:
+    using OutputQueue = ConcurrentBoundedQueue<std::exception_ptr>;
+
+private:
+    /** The queue of the finished blocks. Also, you can put an exception instead of a block.
+      * When data is run out, an empty block is inserted into the queue.
+      * Sooner or later, an empty block is always inserted into the queue (even after exception or query cancellation).
+      * The queue is always (even after exception or canceling the query, even in destructor) you must read up to an empty block,
+      *  otherwise ParallelInputsProcessor can be blocked during insertion into the queue.
+      */
+    OutputQueue output_queue;
+
+    struct Handler
+    {
+        Handler(Self & parent_)
+            : parent(parent_)
+        {}
+
+        void onBlock(Block & /*block*/, size_t /*thread_num*/)
+        {
+        }
+
+        void onBlock(Block & /*block*/, BlockExtraInfo & /*extra_info*/, size_t /*thread_num*/)
+        {
+        }
+
+        void onFinish()
+        {
+            parent.output_queue.push(std::exception_ptr{});
+        }
+
+        void onFinishThread(size_t /*thread_num*/)
+        {
+        }
+
+        void onException(std::exception_ptr & exception, size_t /*thread_num*/)
+        {
+            //std::cerr << "pushing exception\n";
+
+            /// The order of the rows matters. If it is changed, then the situation is possible,
+            ///  when before exception, an empty block (end of data) will be put into the queue,
+            ///  and the exception is lost.
+
+            parent.output_queue.push(exception);
+            parent.cancel(false); /// Does not throw exceptions.
+        }
+
+        String getName() const
+        {
+            return "ParallelUnion";
+        }
+
+        Self & parent;
+    };
+
+    Handler handler;
+    ParallelInputsProcessor<Handler> processor;
+
+    ExceptionCallback exception_callback;
+
+    bool started = false;
+    bool all_read = false;
+
+    LogWithPrefixPtr log;
+};
+
+} // namespace DB

--- a/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.cpp
@@ -14,6 +14,7 @@
 #include <DataStreams/SquashingBlockInputStream.h>
 #include <DataStreams/TiRemoteBlockInputStream.h>
 #include <DataStreams/UnionBlockInputStream.h>
+#include <DataStreams/UnionWaitInputStream.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/getLeastSupertype.h>
 #include <Flash/Coprocessor/DAGCodec.h>
@@ -71,13 +72,18 @@ DAGQueryBlockInterpreter::DAGQueryBlockInterpreter(
     }
 }
 
-BlockInputStreamPtr combinedNonJoinedDataStream(DAGPipeline & pipeline, size_t max_threads, const LogWithPrefixPtr & log)
+BlockInputStreamPtr combinedNonJoinedDataStream(DAGPipeline & pipeline, size_t max_threads, const LogWithPrefixPtr & log, bool need_block = true)
 {
     BlockInputStreamPtr ret = nullptr;
     if (pipeline.streams_with_non_joined_data.size() == 1)
         ret = pipeline.streams_with_non_joined_data.at(0);
     else if (pipeline.streams_with_non_joined_data.size() > 1)
-        ret = std::make_shared<UnionBlockInputStream<>>(pipeline.streams_with_non_joined_data, nullptr, max_threads, log);
+    {
+        if (need_block)
+            ret = std::make_shared<UnionBlockInputStream<>>(pipeline.streams_with_non_joined_data, nullptr, max_threads, log);
+        else
+            ret = std::make_shared<UnionWaitInputStream>(pipeline.streams_with_non_joined_data, nullptr, max_threads, log);
+    }
     pipeline.streams_with_non_joined_data.clear();
     return ret;
 }
@@ -603,7 +609,7 @@ void DAGQueryBlockInterpreter::executeJoin(const tipb::Join & join, DAGPipeline 
     size_t stream_index = 0;
     right_pipeline.transform(
         [&](auto & stream) { stream = std::make_shared<HashJoinBuildBlockInputStream>(stream, joinPtr, stream_index++, log); });
-    executeUnion(right_pipeline, max_streams, log);
+    executeUnion(right_pipeline, max_streams, log, false);
 
     right_query.source = right_pipeline.firstStream();
     right_query.join = joinPtr;
@@ -740,14 +746,17 @@ void DAGQueryBlockInterpreter::executeExpression(DAGPipeline & pipeline, const E
     }
 }
 
-void DAGQueryBlockInterpreter::executeUnion(DAGPipeline & pipeline, size_t max_streams, const LogWithPrefixPtr & log)
+void DAGQueryBlockInterpreter::executeUnion(DAGPipeline & pipeline, size_t max_streams, const LogWithPrefixPtr & log, bool need_block)
 {
     if (pipeline.streams.size() == 1 && pipeline.streams_with_non_joined_data.size() == 0)
         return;
-    auto non_joined_data_stream = combinedNonJoinedDataStream(pipeline, max_streams, log);
+    auto non_joined_data_stream = combinedNonJoinedDataStream(pipeline, max_streams, log, need_block);
     if (pipeline.streams.size() > 0)
     {
-        pipeline.firstStream() = std::make_shared<UnionBlockInputStream<>>(pipeline.streams, non_joined_data_stream, max_streams, log);
+        if (need_block)
+            pipeline.firstStream() = std::make_shared<UnionBlockInputStream<>>(pipeline.streams, non_joined_data_stream, max_streams, log);
+        else
+            pipeline.firstStream() = std::make_shared<UnionWaitInputStream>(pipeline.streams, non_joined_data_stream, max_streams, log);
         pipeline.streams.resize(1);
     }
     else if (non_joined_data_stream != nullptr)

--- a/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.h
+++ b/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.h
@@ -46,7 +46,7 @@ public:
 
     BlockInputStreams execute();
 
-    static void executeUnion(DAGPipeline & pipeline, size_t max_streams, const LogWithPrefixPtr & log);
+    static void executeUnion(DAGPipeline & pipeline, size_t max_streams, const LogWithPrefixPtr & log, bool need_block = true);
 
 private:
     void executeRemoteQuery(DAGPipeline & pipeline);

--- a/dbms/src/Flash/Coprocessor/InterpreterDAG.cpp
+++ b/dbms/src/Flash/Coprocessor/InterpreterDAG.cpp
@@ -145,7 +145,7 @@ BlockIO InterpreterDAG::execute()
     }
 
     /// add union to run in parallel if needed
-    DAGQueryBlockInterpreter::executeUnion(pipeline, max_streams, log);
+    DAGQueryBlockInterpreter::executeUnion(pipeline, max_streams, log, false);
     if (!subqueriesForSets.empty())
     {
         const Settings & settings = context.getSettingsRef();


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

`UnionBlockInputStream` will return all blocks fetched from parallel workers, which is useless for `HashJoinBuildInputStream`'s upstream and `MPPTask`.

The parallelism will drop from n to 1 after a `UnionBlockInputStream`.

### What is changed and how it works?

Introduce `UnionWaitInputStream`. It's very similar to `UnionBlockInputStream`, the only difference is the workers only push one item when finish.

What's Changed:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

<!--
- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility
-->

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note, or a 'None' if it is not needed.
```
