### PR TITLE
Fix GCC-10 Segmentation Fault

### DIFF
--- a/dbms/src/Storages/DeltaMerge/File/DMFileWriter.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileWriter.h
@@ -14,17 +14,6 @@ namespace DB
 {
 namespace DM
 {
-namespace detail
-{
-static inline DB::ChecksumAlgo getAlgorithmOrNone(DMFile & dmfile)
-{
-    return dmfile.getConfiguration() ? dmfile.getConfiguration()->getChecksumAlgorithm() : ChecksumAlgo::None;
-}
-static inline size_t getFrameSizeOrDefault(DMFile & dmfile)
-{
-    return dmfile.getConfiguration() ? dmfile.getConfiguration()->getChecksumFrameLength() : DBMS_DEFAULT_BUFFER_SIZE;
-}
-} // namespace detail
 class DMFileWriter
 {
 public:
@@ -49,8 +38,10 @@ public:
                     false,
                     write_limiter_)
                     .with_buffer_size(max_compress_block_size)
-                    .with_checksum_algorithm(detail::getAlgorithmOrNone(*dmfile))
-                    .with_checksum_frame_size(detail::getFrameSizeOrDefault(*dmfile))
+                    .with_checksum_algorithm(
+                        dmfile->getConfiguration() ? dmfile->getConfiguration()->getChecksumAlgorithm() : ChecksumAlgo::None)
+                    .with_checksum_frame_size(
+                        dmfile->getConfiguration() ? dmfile->getConfiguration()->getChecksumFrameLength() : DBMS_DEFAULT_BUFFER_SIZE)
                     .build())
             , compressed_buf(dmfile->configuration
                                  ? std::unique_ptr<WriteBuffer>(new CompressedWriteBuffer<false>(*plain_file, compression_settings))
@@ -63,8 +54,10 @@ public:
                             dmfile->encryptionMarkPath(file_base_name),
                             false,
                             write_limiter_)
-                            .with_checksum_algorithm(detail::getAlgorithmOrNone(*dmfile))
-                            .with_checksum_frame_size(detail::getFrameSizeOrDefault(*dmfile))
+                            .with_checksum_algorithm(
+                                dmfile->getConfiguration() ? dmfile->getConfiguration()->getChecksumAlgorithm() : ChecksumAlgo::None)
+                            .with_checksum_frame_size(
+                                dmfile->getConfiguration() ? dmfile->getConfiguration()->getChecksumFrameLength() : DBMS_DEFAULT_BUFFER_SIZE)
                             .build())
         {
         }


### PR DESCRIPTION
Signed-off-by: Schrodinger ZHU Yifan <i@zhuyi.fan>
close #3231
```
==93675== 
==93675== HEAP SUMMARY:
==93675==     in use at exit: 130,509 bytes in 914 blocks
==93675==   total heap usage: 74,446 allocs, 73,532 frees, 208,122,487 bytes allocated
==93675== 
==93675== LEAK SUMMARY:
==93675==    definitely lost: 0 bytes in 0 blocks
==93675==    indirectly lost: 0 bytes in 0 blocks
==93675==      possibly lost: 0 bytes in 0 blocks
==93675==    still reachable: 130,509 bytes in 914 blocks
==93675==         suppressed: 0 bytes in 0 blocks
==93675== Rerun with --leak-check=full to see details of leaked memory
==93675== 
==93675== For lists of detected and suppressed errors, rerun with: -s
==93675== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

```
I do not know what triggered the error in #3231. But removing the inlined function fixes the problem.
### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
