### PR TITLE
Add more output on enabled features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,30 +338,38 @@ if (EXISTS ${CLICKHOUSE_PRIVATE_DIR})
     add_subdirectory (${CLICKHOUSE_PRIVATE_DIR})
 endif ()
 
-add_subdirectory (contrib)
-
-option (TEST_COVERAGE "Enables flags for test coverage" OFF)
-option (TEST_COVERAGE_XML "Output XML report for test coverage" OFF)
-
-option (ENABLE_TESTS "Enables tests" ${NOT_MSVC})
-
-# Enable failpoint injection by default if ENABLE_TESTS is turn ON.
-if (ENABLE_TESTS)
-    set (ENABLE_FAILPOINTS_DEFAULT "ON")
+# Enable tests by default when build type is debug
+if (CMAKE_BUILD_TYPE_UC STREQUAL "DEBUG")
+    set (ENABLE_TESTS_DEFAULT ON)
 else ()
-    set (ENABLE_FAILPOINTS_DEFAULT "OFF")
+    set (ENABLE_TESTS_DEFAULT OFF)
+endif ()
+option (ENABLE_TESTS "Enables unit tests" ${ENABLE_TESTS_DEFAULT})
+
+add_subdirectory (contrib) # Should be done after option ENABLE_TESTS, cause we will disable tests under contrib/
+
+# Enable failpoints injection by default when ENABLE_TESTS is turn ON.
+if (ENABLE_TESTS)
+    enable_testing()
+    set (ENABLE_FAILPOINTS_DEFAULT ON)
+    message (STATUS "Tests are enabled")
+else ()
+    set (ENABLE_FAILPOINTS_DEFAULT OFF)
+    message (STATUS "Tests are disabled")
 endif()
 option (ENABLE_FAILPOINTS "Enables failpoints injection" ${ENABLE_FAILPOINTS_DEFAULT})
+if (ENABLE_FAILPOINTS)
+    message (STATUS "Failpoints are enabled")
+else (ENABLE_FAILPOINTS)
+    message (STATUS "Failpoints are disabled")
+endif (ENABLE_FAILPOINTS)
 
 # Flags for test coverage
-if (TEST_COVERAGE AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+option (TEST_COVERAGE "Enables flags for test coverage" OFF)
+option (TEST_COVERAGE_XML "Output XML report for test coverage" OFF)
+if (TEST_COVERAGE AND CMAKE_BUILD_TYPE_UC STREQUAL "DEBUG")
     include(CodeCoverage)
     set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fprofile-arcs -ftest-coverage")
-endif ()
-
-if (ENABLE_TESTS)
-    message (STATUS "Tests are enabled")
-    enable_testing()
 endif ()
 
 if (ARCH_AMD64)

--- a/dbms/src/Common/TiFlashBuildInfo.cpp
+++ b/dbms/src/Common/TiFlashBuildInfo.cpp
@@ -52,7 +52,26 @@ std::string getEnabledFeatures()
 
 // mem-profiling
 #if USE_JEMALLOC_PROF
-            "mem-profiling"
+            "mem-profiling",
+#endif
+
+// failpoints
+#if ENABLE_FAILPOINTS
+            "failpoints",
+#endif
+
+// SIMD related
+#ifdef TIFLASH_ENABLE_AVX_SUPPORT
+            "avx",
+#endif
+#ifdef TIFLASH_ENABLE_AVX512_SUPPORT
+            "avx512",
+#endif
+#ifdef TIFLASH_ENABLE_ASIMD_SUPPORT
+            "asimd",
+#endif
+#ifdef TIFLASH_ENABLE_SVE_SUPPORT
+            "sve",
 #endif
     };
     return fmt::format("{}", fmt::join(features.begin(), features.end(), " "));

--- a/libs/libcommon/include/common/config_common.h.in
+++ b/libs/libcommon/include/common/config_common.h.in
@@ -10,3 +10,4 @@
 #cmakedefine01 USE_READLINE
 #cmakedefine01 USE_LIBEDIT
 #cmakedefine01 HAVE_READLINE_HISTORY
+#cmakedefine01 ENABLE_FAILPOINTS


### PR DESCRIPTION
Signed-off-by: JaySon-Huang <jayson.hjs@gmail.com>

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary: print more values on enabled features

### What is changed and how it works?

```
>  ./dbms/src/Server/tiflash version
TiFlash
Release Version: v5.3.0-alpha-179-g8c2552f5d
Edition:         Community
Git Commit Hash: 8c2552f5daa59c998e0f451b93b54c98d4118ef8
Git Branch:      print_more_features
UTC Build Time:  2021-10-27 09:58:29
Enable Features: jemalloc failpoints avx avx512
Profile:         Release

Raft Proxy
Git Commit Hash:   c11fad8d2f249be23b1fb487ee02c3a2152d057d
Git Commit Branch: HEAD
UTC Build Time:    2021-09-09 16:01:31
Rust Version:      rustc 1.53.0-nightly (16bf626a3 2021-04-14)
Storage Engine:    tiflash
Prometheus Prefix: tiflash_proxy_
Profile:           release
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
  build and check the output of `tiflash version`

Side effects

<!--
- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility
-->

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
