### PR TITLE
Enforce `readPrefixImpl`/`readSuffixImpl` overriding rule for `IProfilingBlockInputStream`

### DIFF
--- a/dbms/src/DataStreams/AsynchronousBlockInputStream.h
+++ b/dbms/src/DataStreams/AsynchronousBlockInputStream.h
@@ -36,7 +36,7 @@ public:
 
     String getName() const override { return "Asynchronous"; }
 
-    void readPrefix() override
+    void readPrefixImpl() override
     {
         /// Do not call `readPrefix` on the child, so that the corresponding actions are performed in a separate thread.
         if (!started)
@@ -46,7 +46,7 @@ public:
         }
     }
 
-    void readSuffix() override
+    void readSuffixImpl() override
     {
         if (started)
         {
@@ -151,4 +151,3 @@ protected:
 };
 
 }
-

--- a/dbms/src/DataStreams/BlockInputStreamFromRowInputStream.h
+++ b/dbms/src/DataStreams/BlockInputStreamFromRowInputStream.h
@@ -24,8 +24,8 @@ public:
         UInt64 allow_errors_num_,
         Float64 allow_errors_ratio_);
 
-    void readPrefix() override { row_input->readPrefix(); }
-    void readSuffix() override { row_input->readSuffix(); }
+    void readPrefixImpl() override { row_input->readPrefix(); }
+    void readSuffixImpl() override { row_input->readSuffix(); }
 
     String getName() const override { return "BlockInputStreamFromRowInputStream"; }
 

--- a/dbms/src/DataStreams/ColumnGathererStream.cpp
+++ b/dbms/src/DataStreams/ColumnGathererStream.cpp
@@ -112,6 +112,8 @@ void ColumnGathererStream::fetchNewBlock(Source & source, size_t source_num)
 
 void ColumnGathererStream::readSuffixImpl()
 {
+    IProfilingBlockInputStream::readSuffixImpl();
+
     const BlockStreamProfileInfo & profile_info = getProfileInfo();
 
     /// Don't print info for small parts (< 10M rows)

--- a/dbms/src/DataStreams/CreatingSetsBlockInputStream.cpp
+++ b/dbms/src/DataStreams/CreatingSetsBlockInputStream.cpp
@@ -84,6 +84,8 @@ Block CreatingSetsBlockInputStream::readImpl()
 void CreatingSetsBlockInputStream::readPrefixImpl()
 {
     createAll();
+
+    IProfilingBlockInputStream::readPrefixImpl();
 }
 
 

--- a/dbms/src/DataStreams/ExchangeSender.h
+++ b/dbms/src/DataStreams/ExchangeSender.h
@@ -19,7 +19,7 @@ public:
     }
     String getName() const override { return "ExchangeSender"; }
     Block getHeader() const override { return children.back()->getHeader(); }
-    void readSuffix() override
+    void readSuffixImpl() override
     {
         writer->finishWrite();
     }

--- a/dbms/src/DataStreams/IProfilingBlockInputStream.cpp
+++ b/dbms/src/DataStreams/IProfilingBlockInputStream.cpp
@@ -105,12 +105,6 @@ void IProfilingBlockInputStream::readPrefix()
 {
     auto start_time = info.total_stopwatch.elapsed();
     readPrefixImpl();
-
-    forEachChild([&] (IBlockInputStream & child)
-    {
-        child.readPrefix();
-        return false;
-    });
     info.updateExecutionTime(info.total_stopwatch.elapsed() - start_time);
 }
 
@@ -118,14 +112,22 @@ void IProfilingBlockInputStream::readPrefix()
 void IProfilingBlockInputStream::readSuffix()
 {
     auto start_time = info.total_stopwatch.elapsed();
-    forEachChild([&] (IBlockInputStream & child)
-    {
-        child.readSuffix();
-        return false;
-    });
-
     readSuffixImpl();
     info.updateExecutionTime(info.total_stopwatch.elapsed() - start_time);
+}
+
+
+void IProfilingBlockInputStream::readPrefixImpl()
+{
+    for (auto & child : children)
+        child->readPrefix();
+}
+
+
+void IProfilingBlockInputStream::readSuffixImpl()
+{
+    for (auto & child : children)
+        child->readSuffix();
 }
 
 

--- a/dbms/src/DataStreams/InputStreamFromASTInsertQuery.h
+++ b/dbms/src/DataStreams/InputStreamFromASTInsertQuery.h
@@ -22,8 +22,20 @@ public:
     InputStreamFromASTInsertQuery(const ASTPtr & ast, ReadBuffer & input_buffer_tail_part, const BlockIO & streams, Context & context);
 
     Block readImpl() override { return res_stream->read(); }
-    void readPrefixImpl() override { return res_stream->readPrefix(); }
-    void readSuffixImpl() override { return res_stream->readSuffix(); }
+
+    void readPrefixImpl() override
+    {
+        res_stream->readPrefix();
+
+        IProfilingBlockInputStream::readPrefixImpl();
+    }
+
+    void readSuffixImpl() override
+    {
+        IProfilingBlockInputStream::readSuffixImpl();
+
+        res_stream->readSuffix();
+    }
 
     String getName() const override { return "InputStreamFromASTInsertQuery"; }
 

--- a/dbms/src/DataStreams/MergingAggregatedMemoryEfficientBlockInputStream.cpp
+++ b/dbms/src/DataStreams/MergingAggregatedMemoryEfficientBlockInputStream.cpp
@@ -96,13 +96,13 @@ Block MergingAggregatedMemoryEfficientBlockInputStream::getHeader() const
 }
 
 
-void MergingAggregatedMemoryEfficientBlockInputStream::readPrefix()
+void MergingAggregatedMemoryEfficientBlockInputStream::readPrefixImpl()
 {
     start();
 }
 
 
-void MergingAggregatedMemoryEfficientBlockInputStream::readSuffix()
+void MergingAggregatedMemoryEfficientBlockInputStream::readSuffixImpl()
 {
     if (!all_read && !isCancelled())
         throw Exception("readSuffix called before all data is read", ErrorCodes::LOGICAL_ERROR);

--- a/dbms/src/DataStreams/MergingAggregatedMemoryEfficientBlockInputStream.h
+++ b/dbms/src/DataStreams/MergingAggregatedMemoryEfficientBlockInputStream.h
@@ -67,10 +67,10 @@ public:
     String getName() const override { return "MergingAggregatedMemoryEfficient"; }
 
     /// Sends the request (initiates calculations) earlier than `read`.
-    void readPrefix() override;
+    void readPrefixImpl() override;
 
     /// Called either after everything is read, or after cancel.
-    void readSuffix() override;
+    void readSuffixImpl() override;
 
     /** Different from the default implementation by trying to stop all sources,
       *  skipping failed by execution.

--- a/dbms/src/DataStreams/MergingSortedBlockInputStream.cpp
+++ b/dbms/src/DataStreams/MergingSortedBlockInputStream.cpp
@@ -307,8 +307,10 @@ void MergingSortedBlockInputStream::merge(MutableColumns & merged_columns, std::
 
 void MergingSortedBlockInputStream::readSuffixImpl()
 {
-     if (quiet)
-         return;
+    IProfilingBlockInputStream::readSuffixImpl();
+
+    if (quiet)
+        return;
 
     const BlockStreamProfileInfo & profile_info = getProfileInfo();
     double seconds = profile_info.total_stopwatch.elapsedSeconds();

--- a/dbms/src/DataStreams/ParallelAggregatingBlockInputStream.h
+++ b/dbms/src/DataStreams/ParallelAggregatingBlockInputStream.h
@@ -38,7 +38,7 @@ public:
 
 protected:
     /// Do nothing that preparation to execution of the query be done in parallel, in ParallelInputsProcessor.
-    void readPrefix() override
+    void readPrefixImpl() override
     {
     }
 

--- a/dbms/src/DataStreams/RemoteBlockInputStream.cpp
+++ b/dbms/src/DataStreams/RemoteBlockInputStream.cpp
@@ -91,7 +91,7 @@ void RemoteBlockInputStream::appendExtraInfo()
     append_extra_info = true;
 }
 
-void RemoteBlockInputStream::readPrefix()
+void RemoteBlockInputStream::readPrefixImpl()
 {
     if (!sent_query)
         sendQuery();
@@ -241,6 +241,8 @@ Block RemoteBlockInputStream::readImpl()
 
 void RemoteBlockInputStream::readSuffixImpl()
 {
+    IProfilingBlockInputStream::readSuffixImpl();
+
     /** If one of:
       * - nothing started to do;
       * - received all packets before EndOfStream;

--- a/dbms/src/DataStreams/RemoteBlockInputStream.h
+++ b/dbms/src/DataStreams/RemoteBlockInputStream.h
@@ -65,7 +65,7 @@ public:
     void appendExtraInfo();
 
     /// Sends query (initiates calculation) before read()
-    void readPrefix() override;
+    void readPrefixImpl() override;
 
     /** Prevent default progress notification because progress' callback is
         called by its own

--- a/dbms/src/DataStreams/SharedQueryBlockInputStream.h
+++ b/dbms/src/DataStreams/SharedQueryBlockInputStream.h
@@ -41,7 +41,7 @@ public:
 
     Block getHeader() const override { return children.back()->getHeader(); }
 
-    void readPrefix() override
+    void readPrefixImpl() override
     {
         std::lock_guard<std::mutex> lock(mutex);
 
@@ -53,7 +53,7 @@ public:
         thread = ThreadFactory(true, "SharedQuery").newThread([this] { fetchBlocks(); });
     }
 
-    void readSuffix() override
+    void readSuffixImpl() override
     {
         std::lock_guard<std::mutex> lock(mutex);
 

--- a/dbms/src/DataStreams/UnionBlockInputStream.h
+++ b/dbms/src/DataStreams/UnionBlockInputStream.h
@@ -186,7 +186,7 @@ protected:
     }
 
     /// Do nothing, to make the preparation for the query execution in parallel, in ParallelInputsProcessor.
-    void readPrefix() override
+    void readPrefixImpl() override
     {
     }
 
@@ -228,7 +228,7 @@ protected:
     }
 
     /// Called either after everything is read, or after cancel.
-    void readSuffix() override
+    void readSuffixImpl() override
     {
         //std::cerr << "readSuffix\n";
         if (!all_read && !isCancelled())

--- a/dbms/src/Dictionaries/ExecutableDictionarySource.cpp
+++ b/dbms/src/Dictionaries/ExecutableDictionarySource.cpp
@@ -27,9 +27,9 @@ public:
     {
     }
 
-    void readSuffix() override
+    void readSuffixImpl() override
     {
-        OwningBlockInputStream<ShellCommand>::readSuffix();
+        OwningBlockInputStream<ShellCommand>::readSuffixImpl();
         own->wait();
     }
 };
@@ -143,9 +143,9 @@ public:
 private:
     Block readImpl() override { return stream->read(); }
 
-    void readSuffix() override
+    void readSuffixImpl() override
     {
-        IProfilingBlockInputStream::readSuffix();
+        IProfilingBlockInputStream::readSuffixImpl();
         if (!wait_called)
         {
             wait_called = true;

--- a/dbms/src/Storages/StorageCatBoostPool.cpp
+++ b/dbms/src/Storages/StorageCatBoostPool.cpp
@@ -47,10 +47,14 @@ public:
     void readPrefixImpl() override
     {
         reader->readPrefix();
+
+        IProfilingBlockInputStream::readPrefixImpl();
     }
 
     void readSuffixImpl() override
     {
+        IProfilingBlockInputStream::readSuffixImpl();
+
         reader->readSuffix();
     }
 

--- a/dbms/src/Storages/StorageFile.cpp
+++ b/dbms/src/Storages/StorageFile.cpp
@@ -171,10 +171,14 @@ public:
     void readPrefixImpl() override
     {
         reader->readPrefix();
+
+        IProfilingBlockInputStream::readPrefixImpl();
     }
 
     void readSuffixImpl() override
     {
+        IProfilingBlockInputStream::readSuffixImpl();
+
         reader->readSuffix();
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #3384

Problem Summary: see issue description.

### What is changed and how it works?

Proposal: mark `readPrefix`/`readSuffix` as `final`, and enforce subclasses overriding `readPrefixImpl`/`readSuffixImpl` instead.

What's Changed:

* change the logic in `IProfilingBlockInputStream`.
* for those who override `readPrefix`/`readSuffix` directly: make them override `readPrefixImpl`/`readSuffixImpl`.
* for those who override `readPrefixImpl`/`readSuffixImpl`: call `IProfilingBlockInputStream::readXXX` at suitable locations.

Goal: enforce overriding rule while not modifying original behavior.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

<!--
- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility
-->

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
