### PR TITLE
[DNM] Make sure that a null field contains reasonable data

### DIFF
--- a/dbms/src/Columns/ColumnNullable.cpp
+++ b/dbms/src/Columns/ColumnNullable.cpp
@@ -130,14 +130,14 @@ MutableColumnPtr ColumnNullable::cloneResized(size_t new_size) const
 
 Field ColumnNullable::operator[](size_t n) const
 {
-    return isNullAt(n) ? Null() : getNestedColumn()[n];
+    return isNullAt(n) ? Field() : getNestedColumn()[n];
 }
 
 
 void ColumnNullable::get(size_t n, Field & res) const
 {
     if (isNullAt(n))
-        res = Null();
+        res = Field();
     else
         getNestedColumn().get(n, res);
 }
@@ -417,8 +417,8 @@ void getExtremesFromNullableContent(const ColumnVector<T> & col, const NullMap &
 
     if (size == 0)
     {
-        min = Null();
-        max = Null();
+        min = Field();
+        max = Field();
         return;
     }
 
@@ -478,8 +478,8 @@ static void castNestedColumn(const IColumn * nested_column, F && f)
 
 void ColumnNullable::getExtremes(Field & min, Field & max) const
 {
-    min = Null();
-    max = Null();
+    min = Field();
+    max = Field();
 
     const auto & null_map = getNullMapData();
 

--- a/dbms/src/Common/FieldVisitors.cpp
+++ b/dbms/src/Common/FieldVisitors.cpp
@@ -37,7 +37,7 @@ static inline String formatQuotedWithPrefix(T x, const char * prefix)
 }
 
 
-String FieldVisitorDump::operator()(const Null &) const
+String FieldVisitorDump::operator()(const Field::Null &) const
 {
     return "NULL";
 }
@@ -134,7 +134,7 @@ static String formatFloat(const Float64 x)
 }
 
 
-String FieldVisitorToString::operator()(const Null &) const
+String FieldVisitorToString::operator()(const Field::Null &) const
 {
     return "NULL";
 }
@@ -205,7 +205,7 @@ String FieldVisitorToString::operator()(const Tuple & x_def) const
 }
 
 
-String FieldVisitorToDebugString::operator()(const Null &) const
+String FieldVisitorToDebugString::operator()(const Field::Null &) const
 {
     if (Redact::REDACT_LOG.load(std::memory_order_relaxed))
         return "?";
@@ -298,7 +298,7 @@ FieldVisitorHash::FieldVisitorHash(SipHash & hash)
     : hash(hash)
 {}
 
-void FieldVisitorHash::operator()(const Null &) const
+void FieldVisitorHash::operator()(const Field::Null &) const
 {
     UInt8 type = Field::Types::Null;
     hash.update(type);

--- a/dbms/src/Common/FieldVisitors.h
+++ b/dbms/src/Common/FieldVisitors.h
@@ -36,7 +36,7 @@ typename std::decay_t<Visitor>::ResultType applyVisitor(Visitor && visitor, F &&
     switch (field.getType())
     {
     case Field::Types::Null:
-        return visitor(field.template get<Null>());
+        return visitor(field.template get<Field::Null>());
     case Field::Types::UInt64:
         return visitor(field.template get<UInt64>());
     case Field::Types::Int64:
@@ -70,7 +70,7 @@ static typename std::decay_t<Visitor>::ResultType applyBinaryVisitorImpl(Visitor
     switch (field2.getType())
     {
     case Field::Types::Null:
-        return visitor(field1, field2.template get<Null>());
+        return visitor(field1, field2.template get<Field::Null>());
     case Field::Types::UInt64:
         return visitor(field1, field2.template get<UInt64>());
     case Field::Types::Int64:
@@ -105,7 +105,7 @@ typename std::decay_t<Visitor>::ResultType applyVisitor(Visitor && visitor, F1 &
     case Field::Types::Null:
         return applyBinaryVisitorImpl(
             std::forward<Visitor>(visitor),
-            field1.template get<Null>(),
+            field1.template get<Field::Null>(),
             std::forward<F2>(field2));
     case Field::Types::UInt64:
         return applyBinaryVisitorImpl(
@@ -168,7 +168,7 @@ typename std::decay_t<Visitor>::ResultType applyVisitor(Visitor && visitor, F1 &
 class FieldVisitorToString : public StaticVisitor<String>
 {
 public:
-    String operator()(const Null & x) const;
+    String operator()(const Field::Null & x) const;
     String operator()(const UInt64 & x) const;
     String operator()(const Int64 & x) const;
     String operator()(const Float64 & x) const;
@@ -185,7 +185,7 @@ public:
 class FieldVisitorToDebugString : public StaticVisitor<String>
 {
 public:
-    String operator()(const Null & x) const;
+    String operator()(const Field::Null & x) const;
     String operator()(const UInt64 & x) const;
     String operator()(const Int64 & x) const;
     String operator()(const Float64 & x) const;
@@ -203,7 +203,7 @@ public:
 class FieldVisitorDump : public StaticVisitor<String>
 {
 public:
-    String operator()(const Null & x) const;
+    String operator()(const Field::Null & x) const;
     String operator()(const UInt64 & x) const;
     String operator()(const Int64 & x) const;
     String operator()(const Float64 & x) const;
@@ -222,7 +222,7 @@ template <typename T>
 class FieldVisitorConvertToNumber : public StaticVisitor<T>
 {
 public:
-    T operator()(const Null &) const
+    T operator()(const Field::Null &) const
     {
         throw Exception("Cannot convert NULL to " + demangle(typeid(T).name()), ErrorCodes::CANNOT_CONVERT_TYPE);
     }
@@ -262,7 +262,7 @@ private:
 public:
     explicit FieldVisitorHash(SipHash & hash);
 
-    void operator()(const Null & x) const;
+    void operator()(const Field::Null & x) const;
     void operator()(const UInt64 & x) const;
     void operator()(const Int64 & x) const;
     void operator()(const Float64 & x) const;
@@ -307,15 +307,15 @@ constexpr bool isDecimalField<DecimalField<Decimal256>>()
 class FieldVisitorAccurateEquals : public StaticVisitor<bool>
 {
 public:
-    bool operator()(const Null &, const Null &) const { return true; }
-    bool operator()(const Null &, const UInt64 &) const { return false; }
-    bool operator()(const Null &, const Int64 &) const { return false; }
-    bool operator()(const Null &, const Float64 &) const { return false; }
-    bool operator()(const Null &, const String &) const { return false; }
-    bool operator()(const Null &, const Array &) const { return false; }
-    bool operator()(const Null &, const Tuple &) const { return false; }
+    bool operator()(const Field::Null &, const Field::Null &) const { return true; }
+    bool operator()(const Field::Null &, const UInt64 &) const { return false; }
+    bool operator()(const Field::Null &, const Int64 &) const { return false; }
+    bool operator()(const Field::Null &, const Float64 &) const { return false; }
+    bool operator()(const Field::Null &, const String &) const { return false; }
+    bool operator()(const Field::Null &, const Array &) const { return false; }
+    bool operator()(const Field::Null &, const Tuple &) const { return false; }
 
-    bool operator()(const UInt64 &, const Null &) const { return false; }
+    bool operator()(const UInt64 &, const Field::Null &) const { return false; }
     bool operator()(const UInt64 & l, const UInt64 & r) const { return l == r; }
     bool operator()(const UInt64 & l, const Int64 & r) const { return accurate::equalsOp(l, r); }
     bool operator()(const UInt64 & l, const Float64 & r) const { return accurate::equalsOp(l, r); }
@@ -323,7 +323,7 @@ public:
     bool operator()(const UInt64 &, const Array &) const { return false; }
     bool operator()(const UInt64 &, const Tuple &) const { return false; }
 
-    bool operator()(const Int64 &, const Null &) const { return false; }
+    bool operator()(const Int64 &, const Field::Null &) const { return false; }
     bool operator()(const Int64 & l, const UInt64 & r) const { return accurate::equalsOp(l, r); }
     bool operator()(const Int64 & l, const Int64 & r) const { return l == r; }
     bool operator()(const Int64 & l, const Float64 & r) const { return accurate::equalsOp(l, r); }
@@ -331,7 +331,7 @@ public:
     bool operator()(const Int64 &, const Array &) const { return false; }
     bool operator()(const Int64 &, const Tuple &) const { return false; }
 
-    bool operator()(const Float64 &, const Null &) const { return false; }
+    bool operator()(const Float64 &, const Field::Null &) const { return false; }
     bool operator()(const Float64 & l, const UInt64 & r) const { return accurate::equalsOp(l, r); }
     bool operator()(const Float64 & l, const Int64 & r) const { return accurate::equalsOp(l, r); }
     bool operator()(const Float64 & l, const Float64 & r) const { return l == r; }
@@ -339,7 +339,7 @@ public:
     bool operator()(const Float64 &, const Array &) const { return false; }
     bool operator()(const Float64 &, const Tuple &) const { return false; }
 
-    bool operator()(const String &, const Null &) const { return false; }
+    bool operator()(const String &, const Field::Null &) const { return false; }
     bool operator()(const String &, const UInt64 &) const { return false; }
     bool operator()(const String &, const Int64 &) const { return false; }
     bool operator()(const String &, const Float64 &) const { return false; }
@@ -347,7 +347,7 @@ public:
     bool operator()(const String &, const Array &) const { return false; }
     bool operator()(const String &, const Tuple &) const { return false; }
 
-    bool operator()(const Array &, const Null &) const { return false; }
+    bool operator()(const Array &, const Field::Null &) const { return false; }
     bool operator()(const Array &, const UInt64 &) const { return false; }
     bool operator()(const Array &, const Int64 &) const { return false; }
     bool operator()(const Array &, const Float64 &) const { return false; }
@@ -355,7 +355,7 @@ public:
     bool operator()(const Array & l, const Array & r) const { return l == r; }
     bool operator()(const Array &, const Tuple &) const { return false; }
 
-    bool operator()(const Tuple &, const Null &) const { return false; }
+    bool operator()(const Tuple &, const Field::Null &) const { return false; }
     bool operator()(const Tuple &, const UInt64 &) const { return false; }
     bool operator()(const Tuple &, const Int64 &) const { return false; }
     bool operator()(const Tuple &, const Float64 &) const { return false; }
@@ -364,9 +364,9 @@ public:
     bool operator()(const Tuple & l, const Tuple & r) const { return l == r; }
 
     template <typename T>
-    bool operator()(const Null &, const T &) const
+    bool operator()(const Field::Null &, const T &) const
     {
-        return std::is_same_v<T, Null>;
+        return std::is_same_v<T, Field::Null>;
     }
 
     template <typename T>
@@ -431,7 +431,7 @@ private:
     template <typename T, typename U>
     bool cantCompare(const T &, const U &) const
     {
-        if constexpr (std::is_same_v<U, Null>)
+        if constexpr (std::is_same_v<U, Field::Null>)
             return false;
         throw Exception("Cannot compare " + demangle(typeid(T).name()) + " with " + demangle(typeid(U).name()),
                         ErrorCodes::BAD_TYPE_OF_FIELD);
@@ -441,15 +441,15 @@ private:
 class FieldVisitorAccurateLess : public StaticVisitor<bool>
 {
 public:
-    bool operator()(const Null &, const Null &) const { return false; }
-    bool operator()(const Null &, const UInt64 &) const { return true; }
-    bool operator()(const Null &, const Int64 &) const { return true; }
-    bool operator()(const Null &, const Float64 &) const { return true; }
-    bool operator()(const Null &, const String &) const { return true; }
-    bool operator()(const Null &, const Array &) const { return true; }
-    bool operator()(const Null &, const Tuple &) const { return true; }
+    bool operator()(const Field::Null &, const Field::Null &) const { return false; }
+    bool operator()(const Field::Null &, const UInt64 &) const { return true; }
+    bool operator()(const Field::Null &, const Int64 &) const { return true; }
+    bool operator()(const Field::Null &, const Float64 &) const { return true; }
+    bool operator()(const Field::Null &, const String &) const { return true; }
+    bool operator()(const Field::Null &, const Array &) const { return true; }
+    bool operator()(const Field::Null &, const Tuple &) const { return true; }
 
-    bool operator()(const UInt64 &, const Null &) const { return false; }
+    bool operator()(const UInt64 &, const Field::Null &) const { return false; }
     bool operator()(const UInt64 & l, const UInt64 & r) const { return l < r; }
     bool operator()(const UInt64 & l, const Int64 & r) const { return accurate::lessOp(l, r); }
     bool operator()(const UInt64 & l, const Float64 & r) const { return accurate::lessOp(l, r); }
@@ -457,7 +457,7 @@ public:
     bool operator()(const UInt64 &, const Array &) const { return true; }
     bool operator()(const UInt64 &, const Tuple &) const { return true; }
 
-    bool operator()(const Int64 &, const Null &) const { return false; }
+    bool operator()(const Int64 &, const Field::Null &) const { return false; }
     bool operator()(const Int64 & l, const UInt64 & r) const { return accurate::lessOp(l, r); }
     bool operator()(const Int64 & l, const Int64 & r) const { return l < r; }
     bool operator()(const Int64 & l, const Float64 & r) const { return accurate::lessOp(l, r); }
@@ -465,7 +465,7 @@ public:
     bool operator()(const Int64 &, const Array &) const { return true; }
     bool operator()(const Int64 &, const Tuple &) const { return true; }
 
-    bool operator()(const Float64 &, const Null &) const { return false; }
+    bool operator()(const Float64 &, const Field::Null &) const { return false; }
     bool operator()(const Float64 & l, const UInt64 & r) const { return accurate::lessOp(l, r); }
     bool operator()(const Float64 & l, const Int64 & r) const { return accurate::lessOp(l, r); }
     bool operator()(const Float64 & l, const Float64 & r) const { return l < r; }
@@ -473,7 +473,7 @@ public:
     bool operator()(const Float64 &, const Array &) const { return true; }
     bool operator()(const Float64 &, const Tuple &) const { return true; }
 
-    bool operator()(const String &, const Null &) const { return false; }
+    bool operator()(const String &, const Field::Null &) const { return false; }
     bool operator()(const String &, const UInt64 &) const { return false; }
     bool operator()(const String &, const Int64 &) const { return false; }
     bool operator()(const String &, const Float64 &) const { return false; }
@@ -481,7 +481,7 @@ public:
     bool operator()(const String &, const Array &) const { return true; }
     bool operator()(const String &, const Tuple &) const { return true; }
 
-    bool operator()(const Array &, const Null &) const { return false; }
+    bool operator()(const Array &, const Field::Null &) const { return false; }
     bool operator()(const Array &, const UInt64 &) const { return false; }
     bool operator()(const Array &, const Int64 &) const { return false; }
     bool operator()(const Array &, const Float64 &) const { return false; }
@@ -489,7 +489,7 @@ public:
     bool operator()(const Array & l, const Array & r) const { return l < r; }
     bool operator()(const Array &, const Tuple &) const { return false; }
 
-    bool operator()(const Tuple &, const Null &) const { return false; }
+    bool operator()(const Tuple &, const Field::Null &) const { return false; }
     bool operator()(const Tuple &, const UInt64 &) const { return false; }
     bool operator()(const Tuple &, const Int64 &) const { return false; }
     bool operator()(const Tuple &, const Float64 &) const { return false; }
@@ -498,9 +498,9 @@ public:
     bool operator()(const Tuple & l, const Tuple & r) const { return l < r; }
 
     template <typename T>
-    bool operator()(const Null &, const T &) const
+    bool operator()(const Field::Null &, const T &) const
     {
-        return !std::is_same_v<T, Null>;
+        return !std::is_same_v<T, Field::Null>;
     }
 
     template <typename T>
@@ -605,7 +605,7 @@ public:
         return x.getValue().value != 0;
     }
 
-    bool operator()(Null &) const { throw Exception("Cannot sum Nulls", ErrorCodes::LOGICAL_ERROR); }
+    bool operator()(Field::Null &) const { throw Exception("Cannot sum Nulls", ErrorCodes::LOGICAL_ERROR); }
     bool operator()(String &) const { throw Exception("Cannot sum Strings", ErrorCodes::LOGICAL_ERROR); }
     bool operator()(Array &) const { throw Exception("Cannot sum Arrays", ErrorCodes::LOGICAL_ERROR); }
 };

--- a/dbms/src/Core/Types.h
+++ b/dbms/src/Core/Types.h
@@ -16,10 +16,6 @@ namespace DB
 {
 /// Data types for representing elementary values from a database in RAM.
 
-struct Null
-{
-};
-
 template <typename T>
 struct TypeName;
 

--- a/dbms/src/Core/tests/field.cpp
+++ b/dbms/src/Core/tests/field.cpp
@@ -1,15 +1,14 @@
-#include <iostream>
-#include <iomanip>
-#include <sstream>
-
-#include <Core/Field.h>
 #include <Common/FieldVisitors.h>
-
 #include <Common/Stopwatch.h>
+#include <Core/Field.h>
 #include <DataStreams/TabSeparatedRowOutputStream.h>
-#include <IO/WriteBufferFromFileDescriptor.h>
-#include <IO/ReadHelpers.h>
 #include <DataTypes/DataTypeString.h>
+#include <IO/ReadHelpers.h>
+#include <IO/WriteBufferFromFileDescriptor.h>
+
+#include <iomanip>
+#include <iostream>
+#include <sstream>
 
 
 int main(int argc, char ** argv)
@@ -24,7 +23,7 @@ int main(int argc, char ** argv)
     field = std::string("Hello, world!");
     std::cerr << applyVisitor(to_string, field) << std::endl;
 
-    field = Null();
+    field = Field();
     std::cerr << applyVisitor(to_string, field) << std::endl;
 
     Field field2;
@@ -62,9 +61,9 @@ int main(int argc, char ** argv)
 
                 watch.stop();
                 std::cerr << std::fixed << std::setprecision(2)
-                    << "Set " << n << " fields (" << n * sizeof(array[0]) / 1000000.0 << " MB) in " << watch.elapsedSeconds() << " sec., "
-                    << n / watch.elapsedSeconds() << " elem/sec. (" << n * sizeof(array[0]) / watch.elapsedSeconds() / 1000000 << " MB/s.)"
-                    << std::endl;
+                          << "Set " << n << " fields (" << n * sizeof(array[0]) / 1000000.0 << " MB) in " << watch.elapsedSeconds() << " sec., "
+                          << n / watch.elapsedSeconds() << " elem/sec. (" << n * sizeof(array[0]) / watch.elapsedSeconds() / 1000000 << " MB/s.)"
+                          << std::endl;
             }
 
             {
@@ -76,9 +75,9 @@ int main(int argc, char ** argv)
 
                 watch.stop();
                 std::cerr << std::fixed << std::setprecision(2)
-                    << "Got " << n << " fields (" << n * sizeof(array[0]) / 1000000.0 << " MB) in " << watch.elapsedSeconds() << " sec., "
-                    << n / watch.elapsedSeconds() << " elem/sec. (" << n * sizeof(array[0]) / watch.elapsedSeconds() / 1000000 << " MB/s.)"
-                    << std::endl;
+                          << "Got " << n << " fields (" << n * sizeof(array[0]) / 1000000.0 << " MB) in " << watch.elapsedSeconds() << " sec., "
+                          << n / watch.elapsedSeconds() << " elem/sec. (" << n * sizeof(array[0]) / watch.elapsedSeconds() / 1000000 << " MB/s.)"
+                          << std::endl;
 
                 std::cerr << sum << std::endl;
             }
@@ -89,9 +88,9 @@ int main(int argc, char ** argv)
         watch.stop();
 
         std::cerr << std::fixed << std::setprecision(2)
-            << "Destroyed " << n << " fields (" << n * sizeof(Array::value_type) / 1000000.0 << " MB) in " << watch.elapsedSeconds() << " sec., "
-            << n / watch.elapsedSeconds() << " elem/sec. (" << n * sizeof(Array::value_type) / watch.elapsedSeconds() / 1000000 << " MB/s.)"
-            << std::endl;
+                  << "Destroyed " << n << " fields (" << n * sizeof(Array::value_type) / 1000000.0 << " MB) in " << watch.elapsedSeconds() << " sec., "
+                  << n / watch.elapsedSeconds() << " elem/sec. (" << n * sizeof(Array::value_type) / watch.elapsedSeconds() / 1000000 << " MB/s.)"
+                  << std::endl;
     }
     catch (const Exception & e)
     {

--- a/dbms/src/Core/tests/gtest_null_field.cpp
+++ b/dbms/src/Core/tests/gtest_null_field.cpp
@@ -33,7 +33,7 @@ void checkNullField(const Field & null)
 TEST_F(TestNullField, NullField)
 try
 {
-    Null null;
+    const Field::Null & null = Field::Null::instance();
     /// case 1: null field from default constructor
     Field f1;
     checkNullField(f1);

--- a/dbms/src/Core/tests/gtest_null_field.cpp
+++ b/dbms/src/Core/tests/gtest_null_field.cpp
@@ -1,5 +1,5 @@
-#include <gtest/gtest.h>
 #include <TestUtils/TiFlashTestBasic.h>
+#include <gtest/gtest.h>
 
 namespace DB
 {
@@ -25,10 +25,10 @@ void checkNullField(const Field & null)
     ASSERT_EQ(null.get<Float32>(), 0);
     ASSERT_EQ(null.get<Float64>(), 0);
     ASSERT_EQ(null.get<String>(), "");
-    ASSERT_EQ(null.get<Decimal32>(), Decimal32(0));
-    ASSERT_EQ(null.get<Decimal64>(), Decimal64(0));
-    ASSERT_EQ(null.get<Decimal128>(), Decimal128(0));
-    ASSERT_EQ(null.get<Decimal256>(), Decimal256(0));
+    ASSERT_EQ(null.get<DecimalField<Decimal32>>(), DecimalField(Decimal32(0), 0));
+    ASSERT_EQ(null.get<DecimalField<Decimal64>>(), DecimalField(Decimal64(0), 0));
+    ASSERT_EQ(null.get<DecimalField<Decimal128>>(), DecimalField(Decimal128(0), 0));
+    ASSERT_EQ(null.get<DecimalField<Decimal256>>(), DecimalField(Decimal256(0), 0));
 }
 TEST_F(TestNullField, NullField)
 try

--- a/dbms/src/Core/tests/gtest_null_field.cpp
+++ b/dbms/src/Core/tests/gtest_null_field.cpp
@@ -1,0 +1,55 @@
+#include <gtest/gtest.h>
+#include <TestUtils/TiFlashTestBasic.h>
+
+namespace DB
+{
+namespace tests
+{
+class TestNullField : public ::testing::Test
+{
+};
+
+void checkNullField(const Field & null)
+{
+    ASSERT_EQ(null.get<UInt8>(), static_cast<UInt64>(0));
+    ASSERT_EQ(null.get<UInt16>(), static_cast<UInt64>(0));
+    ASSERT_EQ(null.get<UInt32>(), static_cast<UInt64>(0));
+    ASSERT_EQ(null.get<UInt64>(), static_cast<UInt64>(0));
+    ASSERT_EQ(null.get<UInt128>(), static_cast<UInt64>(0));
+    ASSERT_EQ(null.get<Int8>(), 0);
+    ASSERT_EQ(null.get<Int16>(), 0);
+    ASSERT_EQ(null.get<Int32>(), 0);
+    ASSERT_EQ(null.get<Int64>(), 0);
+    ASSERT_EQ(null.get<Int128>(), 0);
+    ASSERT_EQ(null.get<Int256>(), 0);
+    ASSERT_EQ(null.get<Float32>(), 0);
+    ASSERT_EQ(null.get<Float64>(), 0);
+    ASSERT_EQ(null.get<String>(), "");
+    ASSERT_EQ(null.get<Decimal32>(), Decimal32(0));
+    ASSERT_EQ(null.get<Decimal64>(), Decimal64(0));
+    ASSERT_EQ(null.get<Decimal128>(), Decimal128(0));
+    ASSERT_EQ(null.get<Decimal256>(), Decimal256(0));
+}
+TEST_F(TestNullField, NullField)
+try
+{
+    Null null;
+    /// case 1: null field from default constructor
+    Field f1;
+    checkNullField(f1);
+    /// case 2: null field constructed from Null
+    checkNullField(null);
+    /// case 3: null field constructed from another null field
+    Field f2(f1);
+    checkNullField(f2);
+    /// case 4: null field from assignment
+    f2 = null;
+    checkNullField(f2);
+    f2 = f1;
+    checkNullField(f2);
+}
+CATCH
+
+} // namespace tests
+
+} // namespace DB

--- a/dbms/src/DataTypes/DataTypeNullable.h
+++ b/dbms/src/DataTypes/DataTypeNullable.h
@@ -4,7 +4,6 @@
 
 namespace DB
 {
-
 /// A nullable data type is an ordinary data type provided with a tag
 /// indicating that it also contains the NULL value. The following class
 /// embodies this concept.
@@ -80,7 +79,7 @@ public:
 
     MutableColumnPtr createColumn() const override;
 
-    Field getDefault() const override { return Null(); }
+    Field getDefault() const override { return Field(); }
 
     bool equals(const IDataType & rhs) const override;
 
@@ -110,4 +109,4 @@ private:
 DataTypePtr makeNullable(const DataTypePtr & type);
 DataTypePtr removeNullable(const DataTypePtr & type);
 
-}
+} // namespace DB

--- a/dbms/src/DataTypes/FieldToDataType.cpp
+++ b/dbms/src/DataTypes/FieldToDataType.cpp
@@ -1,58 +1,64 @@
+#include <Common/Exception.h>
 #include <Common/FieldVisitors.h>
-#include <DataTypes/FieldToDataType.h>
+#include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypeNothing.h>
+#include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypeTuple.h>
 #include <DataTypes/DataTypesNumber.h>
-#include <DataTypes/DataTypeString.h>
-#include <DataTypes/DataTypeArray.h>
-#include <DataTypes/DataTypeNullable.h>
-#include <DataTypes/DataTypeNothing.h>
+#include <DataTypes/FieldToDataType.h>
 #include <DataTypes/getLeastSupertype.h>
 #include <Interpreters/convertFieldToType.h>
-#include <Common/Exception.h>
+
 #include <ext/size.h>
 
 
 namespace DB
 {
-
 namespace ErrorCodes
 {
-    extern const int EMPTY_DATA_PASSED;
+extern const int EMPTY_DATA_PASSED;
 }
 
 
-DataTypePtr FieldToDataType::operator() (const Null &) const
+DataTypePtr FieldToDataType::operator()(const Field::Null &) const
 {
     return std::make_shared<DataTypeNullable>(std::make_shared<DataTypeNothing>());
 }
 
-DataTypePtr FieldToDataType::operator() (const UInt64 & x) const
+DataTypePtr FieldToDataType::operator()(const UInt64 & x) const
 {
-    if (x <= std::numeric_limits<UInt8>::max())  return std::make_shared<DataTypeUInt8>();
-    if (x <= std::numeric_limits<UInt16>::max()) return std::make_shared<DataTypeUInt16>();
-    if (x <= std::numeric_limits<UInt32>::max()) return std::make_shared<DataTypeUInt32>();
+    if (x <= std::numeric_limits<UInt8>::max())
+        return std::make_shared<DataTypeUInt8>();
+    if (x <= std::numeric_limits<UInt16>::max())
+        return std::make_shared<DataTypeUInt16>();
+    if (x <= std::numeric_limits<UInt32>::max())
+        return std::make_shared<DataTypeUInt32>();
     return std::make_shared<DataTypeUInt64>();
 }
 
-DataTypePtr FieldToDataType::operator() (const Int64 & x) const
+DataTypePtr FieldToDataType::operator()(const Int64 & x) const
 {
-    if (x <= std::numeric_limits<Int8>::max() && x >= std::numeric_limits<Int8>::min())   return std::make_shared<DataTypeInt8>();
-    if (x <= std::numeric_limits<Int16>::max() && x >= std::numeric_limits<Int16>::min()) return std::make_shared<DataTypeInt16>();
-    if (x <= std::numeric_limits<Int32>::max() && x >= std::numeric_limits<Int32>::min()) return std::make_shared<DataTypeInt32>();
+    if (x <= std::numeric_limits<Int8>::max() && x >= std::numeric_limits<Int8>::min())
+        return std::make_shared<DataTypeInt8>();
+    if (x <= std::numeric_limits<Int16>::max() && x >= std::numeric_limits<Int16>::min())
+        return std::make_shared<DataTypeInt16>();
+    if (x <= std::numeric_limits<Int32>::max() && x >= std::numeric_limits<Int32>::min())
+        return std::make_shared<DataTypeInt32>();
     return std::make_shared<DataTypeInt64>();
 }
 
-DataTypePtr FieldToDataType::operator() (const Float64 &) const
+DataTypePtr FieldToDataType::operator()(const Float64 &) const
 {
     return std::make_shared<DataTypeFloat64>();
 }
 
-DataTypePtr FieldToDataType::operator() (const String &) const
+DataTypePtr FieldToDataType::operator()(const String &) const
 {
     return std::make_shared<DataTypeString>();
 }
 
-DataTypePtr FieldToDataType::operator() (const Array & x) const
+DataTypePtr FieldToDataType::operator()(const Array & x) const
 {
     DataTypes element_types;
     element_types.reserve(x.size());
@@ -64,7 +70,7 @@ DataTypePtr FieldToDataType::operator() (const Array & x) const
 }
 
 
-DataTypePtr FieldToDataType::operator() (const Tuple & x) const
+DataTypePtr FieldToDataType::operator()(const Tuple & x) const
 {
     auto & tuple = static_cast<const TupleBackend &>(x);
     if (tuple.empty())
@@ -79,4 +85,4 @@ DataTypePtr FieldToDataType::operator() (const Tuple & x) const
     return std::make_shared<DataTypeTuple>(element_types);
 }
 
-}
+} // namespace DB

--- a/dbms/src/DataTypes/FieldToDataType.h
+++ b/dbms/src/DataTypes/FieldToDataType.h
@@ -5,7 +5,6 @@
 
 namespace DB
 {
-
 class IDataType;
 using DataTypePtr = std::shared_ptr<const IDataType>;
 
@@ -17,19 +16,19 @@ using DataTypePtr = std::shared_ptr<const IDataType>;
 class FieldToDataType : public StaticVisitor<DataTypePtr>
 {
 public:
-    DataTypePtr operator() (const Null & x) const;
-    DataTypePtr operator() (const UInt64 & x) const;
-    DataTypePtr operator() (const Int64 & x) const;
-    DataTypePtr operator() (const Float64 & x) const;
-    DataTypePtr operator() (const String & x) const;
-    DataTypePtr operator() (const Array & x) const;
-    DataTypePtr operator() (const Tuple & x) const;
-    template<typename T>
-    DataTypePtr operator() (const DecimalField<T> & x) const {
+    DataTypePtr operator()(const Field::Null & x) const;
+    DataTypePtr operator()(const UInt64 & x) const;
+    DataTypePtr operator()(const Int64 & x) const;
+    DataTypePtr operator()(const Float64 & x) const;
+    DataTypePtr operator()(const String & x) const;
+    DataTypePtr operator()(const Array & x) const;
+    DataTypePtr operator()(const Tuple & x) const;
+    template <typename T>
+    DataTypePtr operator()(const DecimalField<T> & x) const
+    {
         PrecType prec = maxDecimalPrecision<T>();
         return std::make_shared<DataTypeDecimal<T>>(prec, x.getScale());
     }
 };
 
-}
-
+} // namespace DB

--- a/dbms/src/Functions/FunctionBinaryArithmetic.h
+++ b/dbms/src/Functions/FunctionBinaryArithmetic.h
@@ -1010,7 +1010,7 @@ public:
         {
             if (result_type->onlyNull())
             {
-                block.getByPosition(result).column = result_type->createColumnConst(block.rows(), Null());
+                block.getByPosition(result).column = result_type->createColumnConst(block.rows(), Field());
                 return;
             }
         }
@@ -1102,7 +1102,7 @@ public:
                     if (is_left_null_constant || is_right_null_constant)
                     {
                         /// if one of the input is null constant, just return null constant
-                        block.getByPosition(result).column = nullable_result_type->createColumnConst(col_left_raw->size(), Null());
+                        block.getByPosition(result).column = nullable_result_type->createColumnConst(col_left_raw->size(), Field());
                         return true;
                     }
                 }
@@ -1124,7 +1124,7 @@ public:
                             else
                             {
                                 UInt8 res_null = false;
-                                Field result_field = Null();
+                                Field result_field;
                                 auto res = OpImpl::constant_constant_nullable(
                                     col_left->template getValue<T0>(),
                                     col_right->template getValue<T1>(),
@@ -1147,7 +1147,7 @@ public:
                             else
                             {
                                 UInt8 res_null = false;
-                                Field result_field = Null();
+                                Field result_field;
                                 auto res = OpImpl::constant_constant_nullable(
                                     col_left->getField().template safeGet<FieldT0>(),
                                     col_right->getField().template safeGet<FieldT1>(),

--- a/dbms/src/Functions/FunctionsArray.h
+++ b/dbms/src/Functions/FunctionsArray.h
@@ -368,7 +368,7 @@ public:
 
 /// Specialization that catches internal errors.
 template <typename T, typename IndexConv>
-struct ArrayIndexNumImpl<T, Null, IndexConv>
+struct ArrayIndexNumImpl<T, Field::Null, IndexConv>
 {
     template <typename ScalarOrVector>
     static void vector(
@@ -788,7 +788,7 @@ private:
             || executeNumberNumber<T, Int64>(block, arguments, result)
             || executeNumberNumber<T, Float32>(block, arguments, result)
             || executeNumberNumber<T, Float64>(block, arguments, result)
-            || executeNumberNumber<T, Null>(block, arguments, result);
+            || executeNumberNumber<T, Field::Null>(block, arguments, result);
     }
 
     template <typename T, typename U>

--- a/dbms/src/Functions/FunctionsDateTime.h
+++ b/dbms/src/Functions/FunctionsDateTime.h
@@ -1381,7 +1381,7 @@ public:
 
         if (has_null_constant)
         {
-            block.getByPosition(result).column = block.getByPosition(result).type->createColumnConst(block.rows(), Null());
+            block.getByPosition(result).column = block.getByPosition(result).type->createColumnConst(block.rows(), Field());
             return;
         }
 
@@ -1752,7 +1752,7 @@ public:
 
         if (has_null_constant)
         {
-            block.getByPosition(result).column = block.getByPosition(result).type->createColumnConst(block.rows(), Null());
+            block.getByPosition(result).column = block.getByPosition(result).type->createColumnConst(block.rows(), Field());
             return;
         }
 

--- a/dbms/src/Functions/FunctionsLogical.h
+++ b/dbms/src/Functions/FunctionsLogical.h
@@ -418,7 +418,7 @@ public:
                 if (const_val_input_has_null && const_val_res_not_null)
                     Impl::adjustForNullValue(const_val, const_val_input_has_null);
                 if (const_val_input_has_null)
-                    block.getByPosition(result).column = block.getByPosition(result).type->createColumnConst(rows, Null());
+                    block.getByPosition(result).column = block.getByPosition(result).type->createColumnConst(rows, Field());
                 else
                     block.getByPosition(result).column = has_nullable_input_column
                         ? makeNullable(DataTypeUInt8().createColumnConst(rows, toField(const_val)))

--- a/dbms/src/Functions/FunctionsMiscellaneous.cpp
+++ b/dbms/src/Functions/FunctionsMiscellaneous.cpp
@@ -774,7 +774,7 @@ public:
         {
             if (left_arg.type->onlyNull())
             {
-                block.getByPosition(result).column = block.getByPosition(result).type->createColumnConst(block.rows(), Null());
+                block.getByPosition(result).column = block.getByPosition(result).type->createColumnConst(block.rows(), Field());
                 return;
             }
         }

--- a/dbms/src/Functions/IFunction.cpp
+++ b/dbms/src/Functions/IFunction.cpp
@@ -47,7 +47,7 @@ ColumnPtr wrapInNullable(const ColumnPtr & src, Block & block, const ColumnNumbe
 
         /// Const Nullable that are NULL.
         if (elem.column->onlyNull())
-            return block.getByPosition(result).type->createColumnConst(block.rows(), Null());
+            return block.getByPosition(result).type->createColumnConst(block.rows(), Field());
 
         if (elem.column->isColumnConst())
             continue;
@@ -190,7 +190,7 @@ bool IExecutableFunction::defaultImplementationForNulls(Block & block, const Col
 
     if (null_presence.has_null_constant)
     {
-        block.getByPosition(result).column = block.getByPosition(result).type->createColumnConst(block.rows(), Null());
+        block.getByPosition(result).column = block.getByPosition(result).type->createColumnConst(block.rows(), Field());
         return true;
     }
 

--- a/dbms/src/Functions/tests/gtest_arithmetic_functions.cpp
+++ b/dbms/src/Functions/tests/gtest_arithmetic_functions.cpp
@@ -110,7 +110,7 @@ try
     col2_types.push_back(null_type);
 
     std::vector<Field> null_or_zero_field;
-    null_or_zero_field.push_back(Null());
+    null_or_zero_field.push_back(Field());
     null_or_zero_field.push_back(Field(DecimalField<Decimal128>(0, 0)));
 
     std::vector<Int64> values{10, 2, 20, 8, 10, 0, 30, 8, 16, 4};
@@ -138,7 +138,7 @@ try
                     continue;
                 if (!col2_value.isNull() && col2_type->onlyNull())
                     continue;
-                auto c1 = col1_type->createColumnConst(size, Null());
+                auto c1 = col1_type->createColumnConst(size, Field());
                 auto c2 = col2_type->createColumnConst(size, col2_value);
                 auto col1 = ColumnWithTypeAndName(std::move(c1), col1_type, "col1");
                 auto col2 = ColumnWithTypeAndName(std::move(c2), col2_type, "col2");
@@ -157,7 +157,7 @@ try
                 continue;
             if (col2_type->onlyNull())
                 continue;
-            auto c1 = nullable_decimal_type_1->createColumnConst(size, Null());
+            auto c1 = nullable_decimal_type_1->createColumnConst(size, Field());
             auto c2 = col2_type->createColumnConst(size, Field(DecimalField<Decimal128>(2, 0)));
             auto col1 = ColumnWithTypeAndName(std::move(c1), nullable_decimal_type_1, "col1");
             auto col2 = ColumnWithTypeAndName(std::move(c2), col2_type, "col2");
@@ -230,7 +230,7 @@ try
                 for (size_t i = 0; i < values.size(); i++)
                 {
                     if (col1_type->isNullable() && col1_null_map[i])
-                        c1_mutable->insert(Null());
+                        c1_mutable->insert(Field());
                     else
                         c1_mutable->insert(Field(DecimalField<Decimal128>(values[i], 2)));
                 }
@@ -255,7 +255,7 @@ try
             for (size_t i = 0; i < values.size(); i++)
             {
                 if (col1_type->isNullable() && col1_null_map[i])
-                    c1_mutable->insert(Null());
+                    c1_mutable->insert(Field());
                 else
                     c1_mutable->insert(Field(DecimalField<Decimal128>(values[i], 2)));
             }
@@ -291,12 +291,12 @@ try
                 continue;
             if (col2_type->onlyNull())
                 continue;
-            auto c1 = col1_type->createColumnConst(size, Null());
+            auto c1 = col1_type->createColumnConst(size, Field());
             auto c2 = col2_type->createColumn();
             for (size_t i = 0; i < values.size(); i++)
             {
                 if (col2_type->isNullable() && col2_null_map[i])
-                    c2->insert(Null());
+                    c2->insert(Field());
                 else
                     c2->insert(Field(DecimalField<Decimal128>(values[i], 2)));
             }
@@ -325,7 +325,7 @@ try
             for (size_t i = 0; i < values.size(); i++)
             {
                 if (col2_type->isNullable() && col2_null_map[i])
-                    c2->insert(Null());
+                    c2->insert(Field());
                 else
                     c2->insert(Field(DecimalField<Decimal128>(values[i], 0)));
             }
@@ -361,11 +361,11 @@ try
             for (size_t i = 0; i < values.size(); i++)
             {
                 if (col1_type->isNullable() && col1_null_map[i])
-                    c1->insert(Null());
+                    c1->insert(Field());
                 else
                     c1->insert(Field(DecimalField<Decimal128>(values[i], 2)));
                 if (col2_type->isNullable() && col2_null_map[i])
-                    c2->insert(Null());
+                    c2->insert(Field());
                 else
                     c2->insert(Field(DecimalField<Decimal128>(values[i], 0)));
             }
@@ -411,7 +411,7 @@ try
     col2_types.push_back(null_type);
 
     std::vector<Field> null_or_zero_field;
-    null_or_zero_field.push_back(Null());
+    null_or_zero_field.push_back(Field());
     null_or_zero_field.push_back(Field((Float64)0));
 
 
@@ -440,7 +440,7 @@ try
                     continue;
                 if (!col2_value.isNull() && col2_type->onlyNull())
                     continue;
-                auto c1 = col1_type->createColumnConst(size, Null());
+                auto c1 = col1_type->createColumnConst(size, Field());
                 auto c2 = col2_type->createColumnConst(size, col2_value);
                 auto col1 = ColumnWithTypeAndName(std::move(c1), col1_type, "col1");
                 auto col2 = ColumnWithTypeAndName(std::move(c2), col2_type, "col2");
@@ -460,7 +460,7 @@ try
                 continue;
             if (col2_type->onlyNull())
                 continue;
-            auto c1 = col1_type->createColumnConst(size, Null());
+            auto c1 = col1_type->createColumnConst(size, Field());
             auto c2 = col2_type->createColumnConst(size, Field((Float64)2));
             auto col1 = ColumnWithTypeAndName(std::move(c1), col1_type, "col1");
             auto col2 = ColumnWithTypeAndName(std::move(c2), col2_type, "col2");
@@ -535,7 +535,7 @@ try
                 for (size_t i = 0; i < values.size(); i++)
                 {
                     if (col1_type->isNullable() && col1_null_map[i])
-                        c1_mutable->insert(Null());
+                        c1_mutable->insert(Field());
                     else
                         c1_mutable->insert(Field((Float64)values[i]));
                 }
@@ -560,7 +560,7 @@ try
             for (size_t i = 0; i < values.size(); i++)
             {
                 if (col1_type->isNullable() && col1_null_map[i])
-                    c1_mutable->insert(Null());
+                    c1_mutable->insert(Field());
                 else
                     c1_mutable->insert(Field((Float64)values[i]));
             }
@@ -595,12 +595,12 @@ try
                 continue;
             if (col2_type->onlyNull())
                 continue;
-            auto c1 = col1_type->createColumnConst(size, Null());
+            auto c1 = col1_type->createColumnConst(size, Field());
             auto c2 = col2_type->createColumn();
             for (size_t i = 0; i < values.size(); i++)
             {
                 if (col2_type->isNullable() && col2_null_map[i])
-                    c2->insert(Null());
+                    c2->insert(Field());
                 else
                     c2->insert(Field((Float64)values[i]));
             }
@@ -629,7 +629,7 @@ try
             for (size_t i = 0; i < values.size(); i++)
             {
                 if (col2_type->isNullable() && col2_null_map[i])
-                    c2->insert(Null());
+                    c2->insert(Field());
                 else
                     c2->insert(Field((Float64)values[i]));
             }
@@ -664,12 +664,12 @@ try
             for (size_t i = 0; i < values.size(); i++)
             {
                 if (col1_type->isNullable() && col1_null_map[i])
-                    c1->insert(Null());
+                    c1->insert(Field());
                 else
                     c1->insert(Field((Float64)values[i]));
 
                 if (col2_type->isNullable() && col2_null_map[i])
-                    c2->insert(Null());
+                    c2->insert(Field());
                 else
                     c2->insert(Field((Float64)values[i]));
             }

--- a/dbms/src/Functions/tests/gtest_functions_round.cpp
+++ b/dbms/src/Functions/tests/gtest_functions_round.cpp
@@ -210,7 +210,7 @@ try
         if (value.has_value())
             input_column->insert(Field(value.value()));
         else
-            input_column->insert(Null());
+            input_column->insert(Field());
     }
 
     auto input = ColumnWithTypeAndName{std::move(input_column), data_type, "input"};

--- a/dbms/src/Interpreters/ExpressionAnalyzer.cpp
+++ b/dbms/src/Interpreters/ExpressionAnalyzer.cpp
@@ -1226,7 +1226,7 @@ void ExpressionAnalyzer::executeScalarSubqueriesImpl(ASTPtr & ast)
             if (!block)
             {
                 /// Interpret subquery with empty result as Null literal
-                auto ast_new = std::make_unique<ASTLiteral>(Null());
+                auto ast_new = std::make_unique<ASTLiteral>(Field());
                 ast_new->setAlias(ast->tryGetAlias());
                 ast = std::move(ast_new);
                 return;

--- a/dbms/src/Parsers/ExpressionElementParsers.cpp
+++ b/dbms/src/Parsers/ExpressionElementParsers.cpp
@@ -1,36 +1,32 @@
-#include <errno.h>
-#include <cstdlib>
-
-#include <IO/ReadHelpers.h>
 #include <IO/ReadBufferFromMemory.h>
-
-#include <Parsers/IAST.h>
+#include <IO/ReadHelpers.h>
+#include <Parsers/ASTAsterisk.h>
 #include <Parsers/ASTExpressionList.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
-#include <Parsers/ASTAsterisk.h>
-#include <Parsers/ASTQualifiedAsterisk.h>
 #include <Parsers/ASTOrderByElement.h>
+#include <Parsers/ASTQualifiedAsterisk.h>
 #include <Parsers/ASTSubquery.h>
-
 #include <Parsers/CommonParsers.h>
-#include <Parsers/ExpressionListParsers.h>
-#include <Parsers/ParserSelectWithUnionQuery.h>
-#include <Parsers/ParserCase.h>
-
 #include <Parsers/ExpressionElementParsers.h>
+#include <Parsers/ExpressionListParsers.h>
+#include <Parsers/IAST.h>
+#include <Parsers/ParserCase.h>
 #include <Parsers/ParserCreateQuery.h>
+#include <Parsers/ParserSelectWithUnionQuery.h>
+#include <errno.h>
+
+#include <cstdlib>
 
 
 namespace DB
 {
-
 namespace ErrorCodes
 {
-    extern const int SYNTAX_ERROR;
-    extern const int LOGICAL_ERROR;
-}
+extern const int SYNTAX_ERROR;
+extern const int LOGICAL_ERROR;
+} // namespace ErrorCodes
 
 
 bool ParserArray::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
@@ -136,7 +132,7 @@ bool ParserIdentifier::parseImpl(Pos & pos, ASTPtr & node, Expected &)
         else
             readDoubleQuotedStringWithSQLStyle(s, buf);
 
-        if (s.empty())    /// Identifiers "empty string" are not allowed.
+        if (s.empty()) /// Identifiers "empty string" are not allowed.
             return false;
 
         node = std::make_shared<ASTIdentifier>(s);
@@ -158,7 +154,7 @@ bool ParserCompoundIdentifier::parseImpl(Pos & pos, ASTPtr & node, Expected & ex
 {
     ASTPtr id_list;
     if (!ParserList(std::make_unique<ParserIdentifier>(), std::make_unique<ParserToken>(TokenType::Dot), false)
-        .parse(pos, id_list, expected))
+             .parse(pos, id_list, expected))
         return false;
 
     String name;
@@ -230,8 +226,7 @@ bool ParserFunction::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
         && contents_begin[9] >= '0' && contents_begin[9] <= '9')
     {
         std::string contents(contents_begin, contents_end - contents_begin);
-        throw Exception("Argument of function toDate is unquoted: toDate(" + contents + "), must be: toDate('" + contents + "')"
-            , ErrorCodes::SYNTAX_ERROR);
+        throw Exception("Argument of function toDate is unquoted: toDate(" + contents + "), must be: toDate('" + contents + "')", ErrorCodes::SYNTAX_ERROR);
     }
 
     /// The parametric aggregate function has two lists (parameters and arguments) in parentheses. Example: quantile(0.9)(x).
@@ -443,7 +438,7 @@ bool ParserNull::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     ParserKeyword nested_parser("NULL");
     if (nested_parser.parse(pos, node, expected))
     {
-        node = std::make_shared<ASTLiteral>(Null());
+        node = std::make_shared<ASTLiteral>(Field());
         return true;
     }
     else
@@ -460,7 +455,7 @@ bool ParserNumber::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
         ++pos;
         negative = true;
     }
-    else if (pos->type == TokenType::Plus)  /// Leading plus is simply ignored.
+    else if (pos->type == TokenType::Plus) /// Leading plus is simply ignored.
         ++pos;
 
     Field res;
@@ -485,7 +480,7 @@ bool ParserNumber::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     buf[pos->size()] = 0;
 
     char * pos_double = buf;
-    errno = 0;    /// Functions strto* don't clear errno.
+    errno = 0; /// Functions strto* don't clear errno.
     Float64 float_value = std::strtod(buf, &pos_double);
     if (pos_double != buf + pos->size() || errno == ERANGE)
     {
@@ -638,8 +633,7 @@ bool ParserLiteral::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 }
 
 
-const char * ParserAliasBase::restricted_keywords[] =
-{
+const char * ParserAliasBase::restricted_keywords[] = {
     "FROM",
     "FINAL",
     "SAMPLE",
@@ -668,8 +662,7 @@ const char * ParserAliasBase::restricted_keywords[] =
     "INTO",
     "PARTITION",
     "SEGMENT",
-    nullptr
-};
+    nullptr};
 
 template <typename ParserIdentifier>
 bool ParserAliasImpl<ParserIdentifier>::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
@@ -893,5 +886,4 @@ bool ParserOrderByElement::parseImpl(Pos & pos, ASTPtr & node, Expected & expect
     return true;
 }
 
-}
-
+} // namespace DB

--- a/dbms/src/TestUtils/FunctionTestUtils.cpp
+++ b/dbms/src/TestUtils/FunctionTestUtils.cpp
@@ -121,7 +121,7 @@ ColumnWithTypeAndName FunctionTest::executeFunction(const String & func_name, co
 ColumnWithTypeAndName createOnlyNullColumn(size_t size, const String & name)
 {
     DataTypePtr data_type = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeNothing>());
-    return {data_type->createColumnConst(size, Null()), data_type, name};
+    return {data_type->createColumnConst(size, Field()), data_type, name};
 }
 } // namespace tests
 } // namespace DB

--- a/dbms/src/TestUtils/FunctionTestUtils.h
+++ b/dbms/src/TestUtils/FunctionTestUtils.h
@@ -174,7 +174,7 @@ Field makeField(const std::optional<T> & value)
     if (value.has_value())
         return Field(value.value());
     else
-        return Null();
+        return Field();
 }
 
 template <typename T>

--- a/dbms/src/TestUtils/tests/gtest_function_test_utils.cpp
+++ b/dbms/src/TestUtils/tests/gtest_function_test_utils.cpp
@@ -2,10 +2,8 @@
 
 namespace DB
 {
-
 namespace tests
 {
-
 class TestFunctionTestUtils : public ::testing::Test
 {
 };
@@ -50,7 +48,7 @@ try
 
     auto args = std::make_tuple(4, 2);
     auto field = DecimalField64(4200, 2);
-    auto null = Null();
+    auto & null = Field::Null::instance();
 
     {
         std::vector<DecimalField64> vec = {field};


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

In TiFlash, when executing a function, there is a default mode for null value handling. In this mode, function will ignore the null flag at first, treating all the value as not-null, and append null flag afterwards. This mode actually assumes that the data stored in a null field should contains a valid value, otherwise the function may hit random error.

For example: for function `pow(null)`, if the value in null field is negtive, `pow` will throw error.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

When construct a null field, always make sure that a null field contains reasonable data.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

<!--
- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility
-->

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Make sure that a null field contains reasonable data to prevert potential random error while executing function.
```
