### PR TITLE
DAGExpressionAnalyzer: allow empty output offsets for root query block when keep_session_timezone_info

### DIFF
--- a/dbms/src/Flash/Coprocessor/DAGExpressionAnalyzer.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGExpressionAnalyzer.cpp
@@ -1214,11 +1214,21 @@ NamesWithAliases DAGExpressionAnalyzer::appendFinalProjectForRootQueryBlock(
     }
     if (!need_append_timezone_cast && !need_append_type_cast)
     {
-        for (auto i : output_offsets)
+        if (!output_offsets.empty())
         {
-            final_project.emplace_back(
-                current_columns[i].name,
-                unique_name_generator.toUniqueName(column_prefix + current_columns[i].name));
+            for (auto i : output_offsets)
+            {
+                final_project.emplace_back(
+                    current_columns[i].name,
+                    unique_name_generator.toUniqueName(column_prefix + current_columns[i].name));
+            }
+        }
+        else
+        {
+            for (const auto & element : current_columns)
+            {
+                final_project.emplace_back(element.name, unique_name_generator.toUniqueName(column_prefix + element.name));
+            }
         }
     }
     else


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #3577 

Problem Summary:

#3488 asserts that all root query block will have non-empty output offsets, which is wrong.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
