### PR TITLE
split ProfileStreamsInfo from DAGContext and split recordProfileStreams from DAGQueryBlockInterpreter

### DIFF
--- a/dbms/src/Flash/Coprocessor/DAGContext.h
+++ b/dbms/src/Flash/Coprocessor/DAGContext.h
@@ -10,6 +10,7 @@
 #include <Common/LogWithPrefix.h>
 #include <DataStreams/IBlockInputStream.h>
 #include <Flash/Coprocessor/DAGDriver.h>
+#include <Flash/Coprocessor/ProfileStreamsInfo.h>
 #include <Flash/Mpp/MPPTaskId.h>
 #include <Storages/Transaction/TiDB.h>
 
@@ -18,11 +19,6 @@ namespace DB
 class Context;
 class MPPTunnelSet;
 
-struct ProfileStreamsInfo
-{
-    UInt32 qb_id;
-    BlockInputStreams input_streams;
-};
 using MPPTunnelSetPtr = std::shared_ptr<MPPTunnelSet>;
 
 UInt64 inline getMaxErrorCount(const tipb::DAGRequest &)

--- a/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.h
+++ b/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.h
@@ -80,8 +80,6 @@ private:
         AggregateDescriptions & aggregate_descriptions);
     void executeProject(DAGPipeline & pipeline, NamesWithAliases & project_cols);
 
-    void recordProfileStreams(DAGPipeline & pipeline, const String & key);
-
     void executeRemoteQueryImpl(
         DAGPipeline & pipeline,
         const std::vector<pingcap::coprocessor::KeyRange> & cop_key_ranges,

--- a/dbms/src/Flash/Coprocessor/ProfileStreamsInfo.h
+++ b/dbms/src/Flash/Coprocessor/ProfileStreamsInfo.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#pragma once
+
+#include <DataStreams/IBlockInputStream.h>
+#include <common/types.h>
+
+namespace DB
+{
+struct ProfileStreamsInfo
+{
+    UInt32 qb_id = 0;
+    BlockInputStreams input_streams;
+};
+} // namespace DB

--- a/dbms/src/Flash/Coprocessor/recordProfileStreams.cpp
+++ b/dbms/src/Flash/Coprocessor/recordProfileStreams.cpp
@@ -1,0 +1,13 @@
+#include <Flash/Coprocessor/DAGContext.h>
+#include <Flash/Coprocessor/ProfileStreamsInfo.h>
+#include <Flash/Coprocessor/recordProfileStreams.h>
+
+namespace DB
+{
+void recordProfileStreams(DAGContext & dag_context, DAGPipeline & pipeline, const String & key, UInt32 qb_id)
+{
+    auto & profile_streams_info = dag_context.getProfileStreamsMap()[key];
+    profile_streams_info.qb_id = qb_id;
+    pipeline.transform([&](const auto & stream) { profile_streams_info.input_streams.push_back(stream); });
+}
+} // namespace DB

--- a/dbms/src/Flash/Coprocessor/recordProfileStreams.h
+++ b/dbms/src/Flash/Coprocessor/recordProfileStreams.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <Flash/Coprocessor/DAGPipeline.h>
+#include <common/types.h>
+
+#include <map>
+
+namespace DB
+{
+class DAGContext;
+void recordProfileStreams(DAGContext & dag_context, DAGPipeline & pipeline, const String & key, UInt32 qb_id);
+} // namespace DB


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?
split `ProfileStreamsInfo` from `DAGContext` and split `recordProfileStreams` from `DAGQueryBlockInterpreter`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
