### PR TITLE
avoid false alert of wrong encode type in CoprocesorReader

### DIFF
--- a/dbms/src/Flash/Coprocessor/CoprocessorReader.h
+++ b/dbms/src/Flash/Coprocessor/CoprocessorReader.h
@@ -139,14 +139,12 @@ public:
             }
             else if (has_enforce_encode_type && resp->encode_type() != tipb::EncodeType::TypeCHBlock && resp->chunks_size() > 0)
                 return {
-                        nullptr,
-                        true,
-                        "Encode type of coprocessor response is not CHBlock, "
-                        "maybe the version of some TiFlash node in the cluster is not match with this one",
-                        false};
-            else if (resp->chunks_size() == 0)
-                return {resp, false, "", false, 0};
-            Int64 detail = decodeChunks(resp, block_queue, header, schema);
+                    nullptr,
+                    true,
+                    "Encode type of coprocessor response is not CHBlock, "
+                    "maybe the version of some TiFlash node in the cluster is not match with this one",
+                    false};
+            auto detail = decodeChunks(resp, block_queue, header, schema);
             return {resp, false, "", false, detail};
         }
         else


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #3713

Problem Summary:
As the issue described.
### What is changed and how it works?
The root cause is when error happens in during coprocessorHandler, the encode type will be set back to `TypeDefault`, this is acceptable because if error happens, this coprocessor response actually contains no data, so the encode type is useless. This pr only throw error if it need to decode data and the encode type is not `TypeCHBlock` in `CoprocessorReader`.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Avoid false alert of `DB::Exception: Encode type of coprocessor response is not CHBlock`
```
