### PR TITLE
MPP: refine checkPacketSize in MPPTunnelSet.cpp

### DIFF
--- a/dbms/src/Flash/Mpp/MPPTunnelSet.cpp
+++ b/dbms/src/Flash/Mpp/MPPTunnelSet.cpp
@@ -14,11 +14,10 @@ inline mpp::MPPDataPacket serializeToPacket(const tipb::SelectResponse & respons
     return packet;
 }
 
-#define SIZE2GB (1 << 31)
-
-inline void checkPacketSize(size_t size)
+void checkPacketSize(size_t size)
 {
-    if (size >= (size_t)SIZE2GB)
+    static constexpr size_t max_packet_size = 1u << 31;
+    if (size >= max_packet_size)
         throw Exception(fmt::format("Packet is too large to send, size : {}", size));
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:

`SIZE2GB` is actually -1, so `(size_t) SIZE2GB` is actually uint64 max, not 2GB.

And the macro may introduce subtle bugs.

https://godbolt.org/z/dG8jGxnxT

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
