### PR TITLE
*: increase the grow rate of HashTable in smaller size.

### DIFF
--- a/dbms/src/Common/HashTable/HashTable.h
+++ b/dbms/src/Common/HashTable/HashTable.h
@@ -271,7 +271,7 @@ struct HashTableGrower
     /// Increase the size of the hash table.
     void increaseSize()
     {
-        size_degree += size_degree >= 23 ? 1 : 2;
+        size_degree += 2;
     }
 
     /// Set the buffer size by the number of elements in the hash table. Used when deserializing a hash table.

--- a/dbms/src/Common/HashTable/TwoLevelHashMap.h
+++ b/dbms/src/Common/HashTable/TwoLevelHashMap.h
@@ -8,7 +8,7 @@ template <
     typename Key,
     typename Cell,
     typename Hash = DefaultHash<Key>,
-    typename Grower = TwoLevelHashTableGrower<>,
+    typename Grower = HashTableGrower<>,
     typename Allocator = HashTableAllocator,
     template <typename...> typename ImplTable = HashMapTable>
 class TwoLevelHashMapTable : public TwoLevelHashTable<Key, Cell, Hash, Grower, Allocator, ImplTable<Key, Cell, Hash, Grower, Allocator>>
@@ -44,7 +44,7 @@ template <
     typename Key,
     typename Mapped,
     typename Hash = DefaultHash<Key>,
-    typename Grower = TwoLevelHashTableGrower<>,
+    typename Grower = HashTableGrower<>,
     typename Allocator = HashTableAllocator,
     template <typename...> typename ImplTable = HashMapTable>
 using TwoLevelHashMap = TwoLevelHashMapTable<Key, HashMapCell<Key, Mapped, Hash>, Hash, Grower, Allocator, ImplTable>;
@@ -54,7 +54,7 @@ template <
     typename Key,
     typename Mapped,
     typename Hash = DefaultHash<Key>,
-    typename Grower = TwoLevelHashTableGrower<>,
+    typename Grower = HashTableGrower<>,
     typename Allocator = HashTableAllocator,
     template <typename...> typename ImplTable = HashMapTable>
 using TwoLevelHashMapWithSavedHash = TwoLevelHashMapTable<Key, HashMapCellWithSavedHash<Key, Mapped, Hash>, Hash, Grower, Allocator, ImplTable>;

--- a/dbms/src/Common/HashTable/TwoLevelHashTable.h
+++ b/dbms/src/Common/HashTable/TwoLevelHashTable.h
@@ -14,16 +14,6 @@
   * - in theory, resizes are cache-local in a larger range of sizes.
   */
 
-template <size_t initial_size_degree = 8>
-struct TwoLevelHashTableGrower : public HashTableGrower<initial_size_degree>
-{
-    /// Increase the size of the hash table.
-    void increaseSize()
-    {
-        this->size_degree += this->size_degree >= 15 ? 1 : 2;
-    }
-};
-
 template <
     typename Key,
     typename Cell,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?

Now HashTable will grow twice if the element count is smaller than 8M, then grow quadruple. For TwoLevelHashTable the threshold is 32K.

This could introduce unnecessary resize before the threshold.

The pr proposes that we can always grow in quadruple to reduce the cost of resize. The disadvantage is the memory usage would be larger. But it shouldn't be a big matter because only when small HashTables can be affected.

| version | TPCH-Q5 | TPCH-Q9|
|---------|------------|-----------|
| master | 10.59        | 28.47       |
| pr         | 10.12       | 27.26        |

TPCH Q5 and Q9 shows this pr reduces the latency by nearly 5% (single node).

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
