### PR TITLE
Set tiflash-proxy lib no_soname so that cmake will generate path-independent linker command

### DIFF
--- a/contrib/tiflash-proxy-cmake/CMakeLists.txt
+++ b/contrib/tiflash-proxy-cmake/CMakeLists.txt
@@ -13,5 +13,5 @@ add_custom_target(tiflash_proxy ALL
     DEPENDS ${_TIFLASH_PROXY_LIBRARY})
 
 add_library(libtiflash_proxy SHARED IMPORTED GLOBAL)
-set_target_properties(libtiflash_proxy PROPERTIES IMPORTED_LOCATION ${_TIFLASH_PROXY_LIBRARY})
+set_target_properties(libtiflash_proxy PROPERTIES IMPORTED_LOCATION ${_TIFLASH_PROXY_LIBRARY} IMPORTED_NO_SONAME ON)
 add_dependencies(libtiflash_proxy tiflash_proxy)


### PR DESCRIPTION
### What problem does this PR solve?

When using internal tiflash-proxy library, cmake will generate linker command using absolute path. This causes troubles for locating libtiflash-proxy.so when deployed using our customized directory layout.

### What is changed and how it works?

Set tiflash-proxy lib's no_soname property so that cmake will generate path-independent linker command. And this lib will be searched through LD_LIBRARY_PATH.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
