### PR TITLE
Update gtest_mem_utils.cpp

### DIFF
--- a/libs/libcommon/src/tests/gtest_mem_utils.cpp
+++ b/libs/libcommon/src/tests/gtest_mem_utils.cpp
@@ -76,8 +76,8 @@ TEST_P(MemUtilsTest, CompareLongEq)
     std::uniform_int_distribution<char> dist(1, 'z');
     std::string data(1024 * 1024 * 64, ' ');
 
-    auto aligned1_ = AlignedCharArray(1024 * 1024 * 64, std::align_val_t{128});
-    auto aligned2_ = AlignedCharArray(1024 * 1024 * 64 + 23, std::align_val_t{128});
+    auto aligned1_ = AlignedCharArray(1024 * 1024 * 64 + 1, std::align_val_t{128});
+    auto aligned2_ = AlignedCharArray(1024 * 1024 * 64 + 23 + 1, std::align_val_t{128});
     auto aligned1 = aligned1_.data;
     auto aligned2 = aligned2_.data;
     aligned2 += 23;
@@ -103,8 +103,8 @@ TEST_P(MemUtilsTest, CompareLongNe)
     std::uniform_int_distribution<char> dist(1, 'z');
     std::string data(1024 * 1024 * 64, ' ');
 
-    auto aligned1_ = AlignedCharArray(1024 * 1024 * 64, std::align_val_t{128});
-    auto aligned2_ = AlignedCharArray(1024 * 1024 * 64 + 23, std::align_val_t{128});
+    auto aligned1_ = AlignedCharArray(1024 * 1024 * 64 + 1, std::align_val_t{128});
+    auto aligned2_ = AlignedCharArray(1024 * 1024 * 64 + 23 + 1, std::align_val_t{128});
     auto aligned1 = aligned1_.data;
     auto aligned2 = aligned2_.data;
 
@@ -283,8 +283,8 @@ TEST_P(MemUtilsTest, CompareLongEq)
     std::uniform_int_distribution<char> dist(1, 'z');
     std::string data(1024 * 1024 * 64, ' ');
 
-    auto aligned1_ = AlignedCharArray(1024 * 1024 * 64, std::align_val_t{128});
-    auto aligned2_ = AlignedCharArray(1024 * 1024 * 64 + 23, std::align_val_t{128});
+    auto aligned1_ = AlignedCharArray(1024 * 1024 * 64 + 1, std::align_val_t{128});
+    auto aligned2_ = AlignedCharArray(1024 * 1024 * 64 + 23 + 1, std::align_val_t{128});
     auto aligned1 = aligned1_.data;
     auto aligned2 = aligned2_.data;
 
@@ -311,8 +311,8 @@ TEST_P(MemUtilsTest, CompareLongNe)
     std::uniform_int_distribution<char> dist(1, 'z');
     std::string data(1024 * 1024 * 64, ' ');
 
-    auto aligned1_ = AlignedCharArray(1024 * 1024 * 64, std::align_val_t{128});
-    auto aligned2_ = AlignedCharArray(1024 * 1024 * 64 + 23, std::align_val_t{128});
+    auto aligned1_ = AlignedCharArray(1024 * 1024 * 64 + 1, std::align_val_t{128});
+    auto aligned2_ = AlignedCharArray(1024 * 1024 * 64 + 23 + 1, std::align_val_t{128});
     auto aligned1 = aligned1_.data;
     auto aligned2 = aligned2_.data;
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:
Fix the bug detected by asan built
```
[ RUN      ] bool/MemUtilsTest.CompareLongEq/generic
=================================================================
==69407==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x000111e0c800 at pc 0x000104c98218 bp 0x00016bbce5d0 sp 0x00016bbcdd88
WRITE of size 67108865 at 0x000111e0c800 thread T0
    #0 0x104c98214 in wrap_strcpy+0x314 (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x38214)
    #1 0x10426fff8 in MemUtilsTest_CompareLongEq_Test::TestBody() gtest_mem_utils.cpp:298
    #2 0x1042e2674 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) gtest.cc:2437
    #3 0x1042e238c in testing::Test::Run() gtest.cc:2473
    #4 0x1042e6090 in testing::TestInfo::Run() gtest.cc:2655
    #5 0x1042e8560 in testing::TestCase::Run() gtest.cc:2773
    #6 0x104304e2c in testing::internal::UnitTestImpl::RunAllTests() gtest.cc:4673
    #7 0x104303c6c in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) gtest.cc:2437
    #8 0x1043039a0 in testing::UnitTest::Run() gtest.cc:4281
    #9 0x10429b988 in main gtest_main.cc:37
    #10 0x1048b10f0 in start+0x204 (dyld:arm64e+0x50f0)

0x000111e0c800 is located 0 bytes to the right of 67108864-byte region [0x00010de0c800,0x000111e0c800)
allocated by thread T0 here:
    #0 0x104c9d6b8 in wrap_posix_memalign+0xa4 (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x3d6b8)
    #1 0x1ba5179d4 in operator new(unsigned long, std::align_val_t)+0x38 (libc++abi.dylib:arm64e+0x159d4)
    #2 0x10426fef4 in MemUtilsTest_CompareLongEq_Test::TestBody() gtest_mem_utils.cpp:286
    #3 0x1042e2674 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) gtest.cc:2437
    #4 0x1042e238c in testing::Test::Run() gtest.cc:2473
    #5 0x1042e6090 in testing::TestInfo::Run() gtest.cc:2655
    #6 0x1042e8560 in testing::TestCase::Run() gtest.cc:2773
    #7 0x104304e2c in testing::internal::UnitTestImpl::RunAllTests() gtest.cc:4673
    #8 0x104303c6c in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) gtest.cc:2437
    #9 0x1043039a0 in testing::UnitTest::Run() gtest.cc:4281
    #10 0x10429b988 in main gtest_main.cc:37
    #11 0x1048b10f0 in start+0x204 (dyld:arm64e+0x50f0)

SUMMARY: AddressSanitizer: heap-buffer-overflow (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x38214) in wrap_strcpy+0x314
Shadow bytes around the buggy address:
  0x0070223e18b0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0070223e18c0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0070223e18d0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0070223e18e0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0070223e18f0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x0070223e1900:[fa]fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0070223e1910: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0070223e1920: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0070223e1930: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0070223e1940: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0070223e1950: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==69407==ABORTING

```

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
