### PR TITLE
fix date format identifies '\n' as invalid separator (#4046)

### DIFF
--- a/dbms/src/Common/MyTime.cpp
+++ b/dbms/src/Common/MyTime.cpp
@@ -65,7 +65,8 @@ bool isValidSeperator(char c, int previous_parts)
     if (isPunctuation(c))
         return true;
 
-    return previous_parts == 2 && (c == ' ' || c == 'T');
+    // for https://github.com/pingcap/tics/issues/4036
+    return previous_parts == 2 && (c == 'T' || isWhitespaceASCII(c));
 }
 
 std::vector<String> parseDateFormat(String format)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #4036 

Problem Summary:

fix date formate identifies '\n' is invalid separator
### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
fix date format identifies '\n' as invalid separator
```
