### PR TITLE
fix bug && enhance getLeastSuperType to make it more compatiable with TiDB

### DIFF
--- a/dbms/src/DataTypes/getLeastSupertype.cpp
+++ b/dbms/src/DataTypes/getLeastSupertype.cpp
@@ -2,12 +2,14 @@
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeDateTime.h>
 #include <DataTypes/DataTypeMyDateTime.h>
+#include <DataTypes/DataTypeMyDuration.h>
 #include <DataTypes/DataTypeNothing.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypeTuple.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/getLeastSupertype.h>
+#include <Functions/FunctionHelpers.h>
 #include <IO/Operators.h>
 #include <IO/WriteBufferFromString.h>
 
@@ -223,9 +225,39 @@ DataTypePtr getLeastSupertype(const DataTypes & types)
             if (have_date + have_datetime == type_ids.size())
                 return std::make_shared<DataTypeDateTime>();
             if (have_my_date + have_my_datetime == type_ids.size())
-                return std::make_shared<DataTypeMyDateTime>();
+            {
+                int fsp = 0;
+                for (const auto & type : types)
+                {
+                    const auto * datetime_type = checkAndGetDataType<DataTypeMyDateTime>(type.get());
+                    if (datetime_type)
+                        fsp = std::max(fsp, datetime_type->getFraction());
+                }
+                return std::make_shared<DataTypeMyDateTime>(fsp);
+            }
 
             throw Exception(getExceptionMessagePrefix(types) + " because some of them are Date/DateTime and some of them are not",
+                            ErrorCodes::NO_COMMON_TYPE);
+        }
+    }
+
+    /// For Duration, the common type is Duration with bigger fsp. No other types are compatible.
+    {
+        UInt32 have_duration = type_ids.count(TypeIndex::MyTime);
+
+        if (have_duration)
+        {
+            if (have_duration == type_ids.size())
+            {
+                int fsp = 0;
+                for (const auto & type : types)
+                {
+                    fsp = std::max(fsp, checkAndGetDataType<DataTypeMyDuration>(type.get())->getFsp());
+                }
+                return std::make_shared<DataTypeMyDuration>(fsp);
+            }
+
+            throw Exception(getExceptionMessagePrefix(types) + " because some of them are MyDuration and some of them are not",
                             ErrorCodes::NO_COMMON_TYPE);
         }
     }
@@ -260,36 +292,35 @@ DataTypePtr getLeastSupertype(const DataTypes & types)
                                 ErrorCodes::NO_COMMON_TYPE);
 
             UInt32 max_scale = 0;
+            UInt32 max_int_part = 0;
             for (const auto & type : types)
             {
-                UInt32 scale = getDecimalScale(*type, 0);
-                if (scale > max_scale)
-                    max_scale = scale;
+                if (IsDecimalDataType(type))
+                {
+                    UInt32 scale = getDecimalScale(*type, 0);
+                    UInt32 prec = getDecimalPrecision(*type, 0);
+                    if (scale > max_scale)
+                        max_scale = scale;
+                    if (prec - scale > max_int_part)
+                        max_int_part = prec - scale;
+                }
             }
+            max_int_part = std::max(max_int_part, leastDecimalPrecisionFor(max_int));
 
-            UInt32 min_precision = max_scale + leastDecimalPrecisionFor(max_int);
-
-            /// special cases Int32 -> Dec32, Int64 -> Dec64
-            if (max_scale == 0)
-            {
-                if (max_int == TypeIndex::Int32)
-                    min_precision = DataTypeDecimal<Decimal32>::maxPrecision();
-                else if (max_int == TypeIndex::Int64)
-                    min_precision = DataTypeDecimal<Decimal64>::maxPrecision();
-            }
+            UInt32 min_precision = max_scale + max_int_part;
 
             if (min_precision > DataTypeDecimal<Decimal256>::maxPrecision())
                 throw Exception(getExceptionMessagePrefix(types) + " because the least supertype is Decimal(" + toString(min_precision)
                                     + ',' + toString(max_scale) + ')',
                                 ErrorCodes::NO_COMMON_TYPE);
 
-            if (have_decimal256 || min_precision > DataTypeDecimal<Decimal128>::maxPrecision())
-                return std::make_shared<DataTypeDecimal<Decimal256>>(DataTypeDecimal<Decimal256>::maxPrecision(), max_scale);
-            if (have_decimal128 || min_precision > DataTypeDecimal<Decimal64>::maxPrecision())
-                return std::make_shared<DataTypeDecimal<Decimal128>>(DataTypeDecimal<Decimal128>::maxPrecision(), max_scale);
-            if (have_decimal64 || min_precision > DataTypeDecimal<Decimal32>::maxPrecision())
-                return std::make_shared<DataTypeDecimal<Decimal64>>(DataTypeDecimal<Decimal64>::maxPrecision(), max_scale);
-            return std::make_shared<DataTypeDecimal<Decimal32>>(DataTypeDecimal<Decimal32>::maxPrecision(), max_scale);
+            if (min_precision > DataTypeDecimal<Decimal128>::maxPrecision())
+                return std::make_shared<DataTypeDecimal<Decimal256>>(min_precision, max_scale);
+            if (min_precision > DataTypeDecimal<Decimal64>::maxPrecision())
+                return std::make_shared<DataTypeDecimal<Decimal128>>(min_precision, max_scale);
+            if (min_precision > DataTypeDecimal<Decimal32>::maxPrecision())
+                return std::make_shared<DataTypeDecimal<Decimal64>>(min_precision, max_scale);
+            return std::make_shared<DataTypeDecimal<Decimal32>>(min_precision, max_scale);
         }
     }
 

--- a/dbms/src/DataTypes/tests/gtest_data_type_get_common_type.cpp
+++ b/dbms/src/DataTypes/tests/gtest_data_type_get_common_type.cpp
@@ -35,12 +35,60 @@ try
 
     ASSERT_TRUE(getLeastSupertype(typesFromString("MyDate MyDate"))->equals(*typeFromString("MyDate")));
     ASSERT_TRUE(getLeastSupertype(typesFromString("MyDate MyDateTime"))->equals(*typeFromString("MyDateTime")));
+    ASSERT_TRUE(getLeastSupertype(typesFromString("MyDate MyDateTime(3)"))->equals(*typeFromString("MyDateTime(3)")));
+    ASSERT_TRUE(getLeastSupertype(typesFromString("MyDate MyDateTime(6)"))->equals(*typeFromString("MyDateTime(6)")));
 
-    ASSERT_TRUE(getLeastSupertype(typesFromString("MyDate MyDate"))->equals(*typeFromString("MyDate")));
-    ASSERT_TRUE(getLeastSupertype(typesFromString("MyDate MyDateTime"))->equals(*typeFromString("MyDateTime")));
+    /// MyDateTime is MyDateTime(0)
+    ASSERT_TRUE(getLeastSupertype(typesFromString("MyDateTime MyDate"))->equals(*typeFromString("MyDateTime")));
+    ASSERT_TRUE(getLeastSupertype(typesFromString("MyDateTime MyDateTime"))->equals(*typeFromString("MyDateTime")));
+    ASSERT_TRUE(getLeastSupertype(typesFromString("MyDateTime MyDateTime(3)"))->equals(*typeFromString("MyDateTime(3)")));
+    ASSERT_TRUE(getLeastSupertype(typesFromString("MyDateTime MyDateTime(6)"))->equals(*typeFromString("MyDateTime(6)")));
 
-    ASSERT_TRUE(getLeastSupertype(typesFromString("Decimal(43,4) Decimal(20,0)"))->equals(*typeFromString("Decimal(65,4)")));
-    ASSERT_TRUE(getLeastSupertype(typesFromString("Decimal(43,4) Int64"))->equals(*typeFromString("Decimal(65,4)")));
+    ASSERT_TRUE(getLeastSupertype(typesFromString("MyDateTime(3) MyDate"))->equals(*typeFromString("MyDateTime(3)")));
+    ASSERT_TRUE(getLeastSupertype(typesFromString("MyDateTime(3) MyDateTime"))->equals(*typeFromString("MyDateTime(3)")));
+    ASSERT_TRUE(getLeastSupertype(typesFromString("MyDateTime(3) MyDateTime(3)"))->equals(*typeFromString("MyDateTime(3)")));
+    ASSERT_TRUE(getLeastSupertype(typesFromString("MyDateTime(3) MyDateTime(6)"))->equals(*typeFromString("MyDateTime(6)")));
+
+    ASSERT_TRUE(getLeastSupertype(typesFromString("MyDateTime(6) MyDate"))->equals(*typeFromString("MyDateTime(6)")));
+    ASSERT_TRUE(getLeastSupertype(typesFromString("MyDateTime(6) MyDateTime"))->equals(*typeFromString("MyDateTime(6)")));
+    ASSERT_TRUE(getLeastSupertype(typesFromString("MyDateTime(6) MyDateTime(3)"))->equals(*typeFromString("MyDateTime(6)")));
+    ASSERT_TRUE(getLeastSupertype(typesFromString("MyDateTime(6) MyDateTime(6)"))->equals(*typeFromString("MyDateTime(6)")));
+
+    ASSERT_TRUE(getLeastSupertype(typesFromString("MyDuration(0) MyDuration(0)"))->equals(*typeFromString("MyDuration(0)")));
+    ASSERT_TRUE(getLeastSupertype(typesFromString("MyDuration(0) MyDuration(3)"))->equals(*typeFromString("MyDuration(3)")));
+    ASSERT_TRUE(getLeastSupertype(typesFromString("MyDuration(0) MyDuration(6)"))->equals(*typeFromString("MyDuration(6)")));
+
+    ASSERT_TRUE(getLeastSupertype(typesFromString("MyDuration(3) MyDuration(0)"))->equals(*typeFromString("MyDuration(3)")));
+    ASSERT_TRUE(getLeastSupertype(typesFromString("MyDuration(3) MyDuration(3)"))->equals(*typeFromString("MyDuration(3)")));
+    ASSERT_TRUE(getLeastSupertype(typesFromString("MyDuration(3) MyDuration(6)"))->equals(*typeFromString("MyDuration(6)")));
+
+    ASSERT_TRUE(getLeastSupertype(typesFromString("MyDuration(6) MyDuration(0)"))->equals(*typeFromString("MyDuration(6)")));
+    ASSERT_TRUE(getLeastSupertype(typesFromString("MyDuration(6) MyDuration(3)"))->equals(*typeFromString("MyDuration(6)")));
+    ASSERT_TRUE(getLeastSupertype(typesFromString("MyDuration(6) MyDuration(6)"))->equals(*typeFromString("MyDuration(6)")));
+
+    ASSERT_TRUE(getLeastSupertype(typesFromString("Decimal(5,3) Decimal(5,3)"))->equals(*typeFromString("Decimal(5,3)")));
+    ASSERT_TRUE(getLeastSupertype(typesFromString("Decimal(5,3) Decimal(18,2)"))->equals(*typeFromString("Decimal(19,3)")));
+    ASSERT_TRUE(getLeastSupertype(typesFromString("Decimal(5,3) Decimal(20,4)"))->equals(*typeFromString("Decimal(20,4)")));
+    ASSERT_TRUE(getLeastSupertype(typesFromString("Decimal(5,3) Decimal(40,6)"))->equals(*typeFromString("Decimal(40,6)")));
+
+    ASSERT_TRUE(getLeastSupertype(typesFromString("Decimal(18,2) Decimal(5,3)"))->equals(*typeFromString("Decimal(19,3)")));
+    ASSERT_TRUE(getLeastSupertype(typesFromString("Decimal(18,2) Decimal(18,2)"))->equals(*typeFromString("Decimal(18,2)")));
+    ASSERT_TRUE(getLeastSupertype(typesFromString("Decimal(18,2) Decimal(20,4)"))->equals(*typeFromString("Decimal(20,4)")));
+    ASSERT_TRUE(getLeastSupertype(typesFromString("Decimal(18,2) Decimal(40,6)"))->equals(*typeFromString("Decimal(40,6)")));
+
+    ASSERT_TRUE(getLeastSupertype(typesFromString("Decimal(20,4) Decimal(5,3)"))->equals(*typeFromString("Decimal(20,4)")));
+    ASSERT_TRUE(getLeastSupertype(typesFromString("Decimal(20,4) Decimal(18,2)"))->equals(*typeFromString("Decimal(20,4)")));
+    ASSERT_TRUE(getLeastSupertype(typesFromString("Decimal(20,4) Decimal(20,4)"))->equals(*typeFromString("Decimal(20,4)")));
+    ASSERT_TRUE(getLeastSupertype(typesFromString("Decimal(20,4) Decimal(40,6)"))->equals(*typeFromString("Decimal(40,6)")));
+
+    ASSERT_TRUE(getLeastSupertype(typesFromString("Decimal(40,6) Decimal(5,3)"))->equals(*typeFromString("Decimal(40,6)")));
+    ASSERT_TRUE(getLeastSupertype(typesFromString("Decimal(40,6) Decimal(18,2)"))->equals(*typeFromString("Decimal(40,6)")));
+    ASSERT_TRUE(getLeastSupertype(typesFromString("Decimal(40,6) Decimal(20,4)"))->equals(*typeFromString("Decimal(40,6)")));
+    ASSERT_TRUE(getLeastSupertype(typesFromString("Decimal(40,6) Decimal(40,6)"))->equals(*typeFromString("Decimal(40,6)")));
+
+    ASSERT_TRUE(getLeastSupertype(typesFromString("Decimal(43,4) Decimal(20,0)"))->equals(*typeFromString("Decimal(43,4)")));
+    ASSERT_TRUE(getLeastSupertype(typesFromString("Decimal(43,4) Int64"))->equals(*typeFromString("Decimal(43,4)")));
+    ASSERT_TRUE(getLeastSupertype(typesFromString("Decimal(12,0) Int64"))->equals(*typeFromString("Decimal(19,0)")));
 
     ASSERT_TRUE(getLeastSupertype(typesFromString("String FixedString(32) FixedString(8)"))->equals(*typeFromString("String")));
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:
`getLeastSuperType` is widely used to get the common type of multiple types, for functions like `ifnull(col1, col2)`, it uses `getLeastSuperType` to the the return type. However, for decimal type, its behavior is different from TiDB in many cases, for example:
common type of (decimal(40,6), decimal(20,2)) is Decimal(65, 6), so in TiFlash ifnull(decimal(40,6), decimal(20,2)) will return decimal(65, 6). however, in TiDB it returns Decimal(40,6).
 
This will introduce meaningless cast.
### What is changed and how it works?
1. Support `DataTypeMyDuration` in `getLeastSuperType`
2. Set `fsp` correctly if the return type is `DataTypeMyDateTime`
3. Does not always return the max precision for DecimalType in `getLeastSuperType`
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
