### PR TITLE
refine `handleJoin` in `DAGQueryBlockInterpreter`

### DIFF
--- a/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.cpp
@@ -538,6 +538,7 @@ void DAGQueryBlockInterpreter::handleJoin(const tipb::Join & join, DAGPipeline &
     {
         match_helper_name = JoinInterpreterHelper::genMatchHelperNameForLeftSemiFamily(input_streams_vec[0][0]->getHeader(), input_streams_vec[1][0]->getHeader());
         assert(!match_helper_name.empty());
+        assert(!input_streams_vec[0][0]->getHeader().has(match_helper_name) && !input_streams_vec[1][0]->getHeader().has(match_helper_name));
         columns_added_by_join.emplace_back(match_helper_name, Join::match_helper_type);
         join_output_columns.emplace_back(match_helper_name, Join::match_helper_type);
     }

--- a/dbms/src/Flash/Coprocessor/JoinInterpreterHelper.cpp
+++ b/dbms/src/Flash/Coprocessor/JoinInterpreterHelper.cpp
@@ -1,3 +1,4 @@
+#include <Common/FmtUtils.h>
 #include <Common/TiFlashException.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/getLeastSupertype.h>
@@ -114,10 +115,11 @@ TiDB::TiDBCollators getJoinKeyCollators(const tipb::Join & join, const DataTypes
 
 String genMatchHelperNameForLeftSemiFamily(const Block & left_header, const Block & right_header)
 {
-    String match_helper_name = Join::match_helper_prefix;
-    for (int i = 1; left_header.has(match_helper_name) || right_header.has(match_helper_name); ++i)
+    size_t i = 0;
+    String match_helper_name = fmt::format("{}{}", Join::match_helper_prefix, i);
+    while (left_header.has(match_helper_name) || right_header.has(match_helper_name))
     {
-        match_helper_name = Join::match_helper_prefix + std::to_string(i);
+        match_helper_name = fmt::format("{}{}", Join::match_helper_prefix, ++i);
     }
     return match_helper_name;
 }

--- a/dbms/src/Flash/Coprocessor/JoinInterpreterHelper.h
+++ b/dbms/src/Flash/Coprocessor/JoinInterpreterHelper.h
@@ -17,5 +17,6 @@ DataTypes getJoinKeyTypes(const tipb::Join & join);
 
 TiDB::TiDBCollators getJoinKeyCollators(const tipb::Join & join, const DataTypes & join_key_types);
 
+/// generate a name not contained by left_header and right_header.
 String genMatchHelperNameForLeftSemiFamily(const Block & left_header, const Block & right_header);
 } // namespace DB::JoinInterpreterHelper


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #4118

Problem Summary:

### What is changed and how it works?
1、add `JoinInterpreterHelper` to refine the code of `handleJoin`
2、use `join_ptr->createStreamWithNonJoinedRows` to replace `chain.getLastActions()->createStreamWithNonJoinedDataIfFullOrRightJoin`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
