### PR TITLE
Split write and ingest throughput

### DIFF
--- a/metrics/grafana/tiflash_summary.json
+++ b/metrics/grafana/tiflash_summary.json
@@ -14,7 +14,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "6.1.6"
+      "version": "7.5.11"
     },
     {
       "type": "panel",
@@ -52,11 +52,12 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1631518930264,
+  "iteration": 1647230387563,
   "links": [],
   "panels": [
     {
       "collapsed": true,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1035,6 +1036,7 @@
     },
     {
       "collapsed": true,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -2205,6 +2207,7 @@
     },
     {
       "collapsed": true,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -2637,6 +2640,7 @@
     },
     {
       "collapsed": true,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -4467,6 +4471,7 @@
     },
     {
       "collapsed": true,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -4483,7 +4488,12 @@
           "datasource": "${DS_TEST-CLUSTER}",
           "decimals": 1,
           "description": "The throughput of write and  delta's background management",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 9,
             "w": 24,
@@ -4491,6 +4501,7 @@
             "y": 5
           },
           "height": "",
+          "hiddenSeries": false,
           "id": 70,
           "legend": {
             "alignAsTable": true,
@@ -4512,7 +4523,11 @@
           "linewidth": 1,
           "links": [],
           "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
           "percentage": false,
+          "pluginVersion": "7.5.11",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -4528,11 +4543,13 @@
           "steppedLine": false,
           "targets": [
             {
+              "exemplar": true,
               "expr": "sum(rate(tiflash_storage_throughput_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", type=~\"write|ingest\"}[1m]))",
               "format": "time_series",
               "hide": false,
+              "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "throughput_write",
+              "legendFormat": "throughput_write+ingest",
               "refId": "A",
               "step": 10
             },
@@ -4544,10 +4561,12 @@
               "refId": "B"
             },
             {
+              "exemplar": true,
               "expr": "sum(tiflash_storage_throughput_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", type=~\"write|ingest\"})",
               "format": "time_series",
+              "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "total_write",
+              "legendFormat": "total_write+ingest",
               "refId": "C"
             },
             {
@@ -4606,13 +4625,19 @@
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
           "description": "The stall duration of write and delete range",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
             "y": 14
           },
+          "hiddenSeries": false,
           "id": 62,
           "legend": {
             "alignAsTable": true,
@@ -4629,7 +4654,11 @@
           "linewidth": 1,
           "links": [],
           "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true
+          },
           "percentage": false,
+          "pluginVersion": "7.5.11",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -4708,7 +4737,12 @@
           "datasource": "${DS_TEST-CLUSTER}",
           "decimals": 1,
           "description": "The throughput of write by instance",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 9,
             "w": 24,
@@ -4716,6 +4750,7 @@
             "y": 22
           },
           "height": "",
+          "hiddenSeries": false,
           "id": 89,
           "legend": {
             "alignAsTable": true,
@@ -4737,7 +4772,11 @@
           "linewidth": 1,
           "links": [],
           "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
           "percentage": false,
+          "pluginVersion": "7.5.11",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -4753,13 +4792,23 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(tiflash_storage_throughput_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", type=~\"write|ingest\"}[1m])) by (instance)",
+              "exemplar": true,
+              "expr": "sum(rate(tiflash_storage_throughput_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", type=~\"write\"}[1m])) by (instance)",
               "format": "time_series",
               "hide": false,
+              "interval": "",
               "intervalFactor": 1,
               "legendFormat": "throughput_write-{{instance}}",
               "refId": "A",
               "step": 10
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(rate(tiflash_storage_throughput_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", type=~\"ingest\"}[1m])) by (instance)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "throughput_ingest-{{instance}}",
+              "refId": "B"
             }
           ],
           "thresholds": [],
@@ -4810,13 +4859,19 @@
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
           "description": "The total count of different kinds of commands received",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "fill": 0,
+          "fillGradient": 0,
           "gridPos": {
             "h": 9,
             "w": 24,
             "x": 0,
             "y": 31
           },
+          "hiddenSeries": false,
           "id": 90,
           "legend": {
             "alignAsTable": true,
@@ -4833,7 +4888,11 @@
           "linewidth": 1,
           "links": [],
           "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true
+          },
           "percentage": false,
+          "pluginVersion": "7.5.11",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -4912,6 +4971,7 @@
     },
     {
       "collapsed": true,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -6222,6 +6282,7 @@
     },
     {
       "collapsed": true,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -6450,8 +6511,8 @@
       "type": "row"
     }
   ],
-  "refresh": "30s",
-  "schemaVersion": 18,
+  "refresh": false,
+  "schemaVersion": 27,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -6469,7 +6530,10 @@
         "multi": false,
         "name": "k8s_cluster",
         "options": [],
-        "query": "label_values(tiflash_system_profile_event_Query, k8s_cluster)",
+        "query": {
+          "query": "label_values(tiflash_system_profile_event_Query, k8s_cluster)",
+          "refId": "j2-k8s_cluster-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -6493,7 +6557,10 @@
         "multi": false,
         "name": "tidb_cluster",
         "options": [],
-        "query": "label_values(tiflash_system_profile_event_Query{k8s_cluster=\"$k8s_cluster\"}, tidb_cluster)",
+        "query": {
+          "query": "label_values(tiflash_system_profile_event_Query{k8s_cluster=\"$k8s_cluster\"}, tidb_cluster)",
+          "refId": "j2-tidb_cluster-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -6517,7 +6584,10 @@
         "multi": true,
         "name": "instance",
         "options": [],
-        "query": "label_values(tiflash_system_profile_event_Query{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}, instance)",
+        "query": {
+          "query": "label_values(tiflash_system_profile_event_Query{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}, instance)",
+          "refId": "j2-instance-Variable-Query"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,


### PR DESCRIPTION
Signed-off-by: JaySon-Huang <tshent@qq.com>

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/4243

Problem Summary: Now the "Write Throughput By Instance" panel mixes the throughput of write and ingest, which is not easy to check whether the write throughput of each instance is balanced or not. And is not easy to check when we are scaling-in or scaling-out TiFlash instance.

### What is changed and how it works?

* Split "write" and "ingest" into different lines in "Write Throughput By Instance"
* Rename "throughput_write" to "throughput_write+ingest" in "Write & Delta Management Throughput" to indicate that include "write" and "ingest" explicitly. Cause we care about foreground write and background delta-management is matched or not in that panel.

Scale-in one node and scale-out another node
Before this PR
![image](https://user-images.githubusercontent.com/4865550/158104713-b0799439-a9ba-40e7-b488-8080ad779ded.png)

After this PR
![image](https://user-images.githubusercontent.com/4865550/158104605-07345438-3aa5-4cf4-a1a4-9278b39f404a.png)
![image](https://user-images.githubusercontent.com/4865550/158104519-4e6efc53-91a4-4295-845e-ba4da0252130.png)


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
 http://172.16.5.81:21510/d/6svbzVPnk/test-cluster-xxx?orgId=1&from=1646983516172&to=1647007091657
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Make the Grafana panel "Write Throughput By Instance" more explicitly
```
