### PR TITLE
use the right way to wait tiflash replica ready in least_greatest.test

### DIFF
--- a/tests/fullstack-test/expr/least_greatest.test
+++ b/tests/fullstack-test/expr/least_greatest.test
@@ -25,7 +25,7 @@ mysql> create table test.t3 (id1 int, id2 int)
 mysql> alter table test.t3 set tiflash replica 1
 mysql> insert into test.t3 values (NULL, NULL), (NULL, NULL), (NULL, NULL)
 
-func> wait_table test t1, t2
+func> wait_table test t1 t2 t3
 
 # parse error
 mysql> set @@tidb_isolation_read_engines='tiflash'; set tidb_enforce_mpp=1; select least() from test.t1


### PR DESCRIPTION
Signed-off-by: xufei <xufeixw@mail.ustc.edu.cn>

### What problem does this PR solve?

Issue Number: close #4316

Problem Summary:
As the issue described.
### What is changed and how it works?
The root cause is `least_greatest.test` use a wrong way to wait tiflash replica ready, so actually the wait is timeout after 600 seconds.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
