### PR TITLE
Fix data race of DeltaIndexManager

### DIFF
--- a/dbms/src/Storages/DeltaMerge/DeltaIndexManager.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaIndexManager.cpp
@@ -92,9 +92,8 @@ void DeltaIndexManager::refreshRef(const DeltaIndexPtr & index)
         current_size += holder.size;
 
         removeOverflow(removed);
+        CurrentMetrics::set(CurrentMetrics::DT_DeltaIndexCacheSize, current_size);
     }
-
-    CurrentMetrics::set(CurrentMetrics::DT_DeltaIndexCacheSize, current_size);
 }
 
 void DeltaIndexManager::deleteRef(const DeltaIndexPtr & index)
@@ -124,9 +123,8 @@ void DeltaIndexManager::deleteRef(const DeltaIndexPtr & index)
         lru_queue.erase(holder.queue_it);
         // Remove it later
         index_map.erase(it);
+        CurrentMetrics::set(CurrentMetrics::DT_DeltaIndexCacheSize, current_size);
     }
-
-    CurrentMetrics::set(CurrentMetrics::DT_DeltaIndexCacheSize, current_size);
 }
 
 DeltaIndexPtr DeltaIndexManager::getRef(UInt64 index_id)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #4405 

Problem Summary: `current_size` may be read and written concurrently.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
