### PR TITLE
accelerate dumpTree by cache tree_id inside BlockInputStream

### DIFF
--- a/dbms/src/DataStreams/IBlockInputStream.cpp
+++ b/dbms/src/DataStreams/IBlockInputStream.cpp
@@ -30,22 +30,26 @@ extern const int TOO_DEEP_PIPELINE;
 
 String IBlockInputStream::getTreeID() const
 {
-    std::stringstream s;
-    s << getName();
-
-    if (!children.empty())
+    std::lock_guard lock(tree_id_mutex);
+    if (tree_id.empty())
     {
-        s << "(";
-        for (BlockInputStreams::const_iterator it = children.begin(); it != children.end(); ++it)
-        {
-            if (it != children.begin())
-                s << ", ";
-            s << (*it)->getTreeID();
-        }
-        s << ")";
-    }
+        std::stringstream s;
+        s << getName();
 
-    return s.str();
+        if (!children.empty())
+        {
+            s << "(";
+            for (BlockInputStreams::const_iterator it = children.begin(); it != children.end(); ++it)
+            {
+                if (it != children.begin())
+                    s << ", ";
+                s << (*it)->getTreeID();
+            }
+            s << ")";
+        }
+        tree_id = s.str();
+    }
+    return tree_id;
 }
 
 

--- a/dbms/src/DataStreams/IBlockInputStream.h
+++ b/dbms/src/DataStreams/IBlockInputStream.h
@@ -184,8 +184,11 @@ private:
     TableLockHolders table_locks;
 
     size_t checkDepthImpl(size_t max_depth, size_t level) const;
+    mutable std::mutex tree_id_mutex;
+    mutable String tree_id;
 
-    /// Get text with names of this source and the entire subtree.
+    /// Get text with names of this source and the entire subtree, this function should only be called after the
+    /// InputStream tree is constructed.
     String getTreeID() const;
 };
 

--- a/dbms/src/Interpreters/executeQuery.cpp
+++ b/dbms/src/Interpreters/executeQuery.cpp
@@ -386,10 +386,13 @@ std::tuple<ASTPtr, BlockIO> executeQueryImpl(
 
             if (!internal && res.in)
             {
-                std::stringstream log_str;
-                log_str << "Query pipeline:\n";
-                res.in->dumpTree(log_str);
-                LOG_DEBUG(execute_query_logger, log_str.str());
+                if (execute_query_logger->debug())
+                {
+                    std::stringstream log_str;
+                    log_str << "Query pipeline:\n";
+                    res.in->dumpTree(log_str);
+                    LOG_DEBUG(execute_query_logger, log_str.str());
+                }
             }
         }
     }


### PR DESCRIPTION
Signed-off-by: xufei <xufeixw@mail.ustc.edu.cn>

### What problem does this PR solve?

Issue Number: close #4494

Problem Summary:

### What is changed and how it works?
1. accelerate dumpTree by cache tree_id inside `BlockInputStream`
2. only generate the query pipeline if needed.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
