### PR TITLE
*: do not wrap functions into tasks in `DynamicThreadManager::scheduleThenDetach`.

### DIFF
--- a/dbms/src/Common/ThreadManager.cpp
+++ b/dbms/src/Common/ThreadManager.cpp
@@ -48,17 +48,17 @@ class DynamicThreadManager : public ThreadManager
 public:
     void scheduleThenDetach(bool propagate_memory_tracker, String /*thread_name*/, ThreadManager::Job job) override
     {
-        DynamicThreadPool::global_instance->schedule(propagate_memory_tracker, job);
+        DynamicThreadPool::global_instance->scheduleRaw(propagate_memory_tracker, std::move(job));
     }
 
     void schedule(bool propagate_memory_tracker, String /*thread_name*/, ThreadManager::Job job) override
     {
-        futures.push_back(DynamicThreadPool::global_instance->schedule(propagate_memory_tracker, job));
+        futures.push_back(DynamicThreadPool::global_instance->schedule(propagate_memory_tracker, std::move(job)));
     }
 
     void schedule(bool propagate_memory_tracker, ThreadPoolManager::Job job) override
     {
-        futures.push_back(DynamicThreadPool::global_instance->schedule(propagate_memory_tracker, job));
+        futures.push_back(DynamicThreadPool::global_instance->schedule(propagate_memory_tracker, std::move(job)));
     }
 
     void wait() override


### PR DESCRIPTION
Signed-off-by: fuzhe1989 <fuzhe@pingcap.com>

### What problem does this PR solve?

Issue Number: close #4528 

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
