### PR TITLE
[TIFLASH #4562] Remove embedded member function for gtest in `dbms/src/Storages/Page`

### DIFF
--- a/dbms/src/Storages/Page/V2/PageStorage.h
+++ b/dbms/src/Storages/Page/V2/PageStorage.h
@@ -191,22 +191,6 @@ public:
         std::map<PageFileIdAndLevel, PersistState> states;
     };
 
-#ifndef NDEBUG
-    // Just for tests, refactor them out later
-    DB::PageStorage::SnapshotPtr getSnapshot() { return getSnapshot(""); }
-    void write(DB::WriteBatch && wb) { return writeImpl(std::move(wb), nullptr); }
-    DB::PageEntry getEntry(PageId page_id) { return getEntryImpl(TEST_NAMESPACE_ID, page_id, nullptr); }
-    DB::PageEntry getEntry(PageId page_id, SnapshotPtr snapshot) { return getEntryImpl(TEST_NAMESPACE_ID, page_id, snapshot); };
-    DB::Page read(PageId page_id) { return readImpl(TEST_NAMESPACE_ID, page_id, nullptr, nullptr); }
-    DB::Page read(PageId page_id, const ReadLimiterPtr & read_limiter, SnapshotPtr snapshot) { return readImpl(TEST_NAMESPACE_ID, page_id, read_limiter, snapshot); }
-    PageMap read(const std::vector<PageId> & page_ids) { return readImpl(TEST_NAMESPACE_ID, page_ids, nullptr, nullptr); }
-    PageMap read(const std::vector<PageId> & page_ids, const ReadLimiterPtr & read_limiter, SnapshotPtr snapshot) { return readImpl(TEST_NAMESPACE_ID, page_ids, read_limiter, snapshot); };
-    void read(const std::vector<PageId> & page_ids, const PageHandler & handler) { return readImpl(TEST_NAMESPACE_ID, page_ids, handler, nullptr, nullptr); }
-    PageMap read(const std::vector<PageReadFields> & page_fields) { return readImpl(TEST_NAMESPACE_ID, page_fields, nullptr, nullptr); }
-    void traverse(const std::function<void(const DB::Page & page)> & acceptor) { return traverseImpl(acceptor, nullptr); }
-    bool gc() { return gcImpl(false, nullptr, nullptr); }
-#endif
-
 #ifndef DBMS_PUBLIC_GTEST
 private:
 #endif

--- a/dbms/src/Storages/Page/V3/PageDirectory.h
+++ b/dbms/src/Storages/Page/V3/PageDirectory.h
@@ -317,25 +317,6 @@ public:
     {
         return getNormalPageId(page_id, toConcreteSnapshot(snap));
     }
-#ifndef NDEBUG
-    // Just for tests, refactor them out later
-    PageIDAndEntryV3 get(PageId page_id, const PageDirectorySnapshotPtr & snap) const
-    {
-        return get(buildV3Id(TEST_NAMESPACE_ID, page_id), snap);
-    }
-    PageIDAndEntryV3 get(PageId page_id, const DB::PageStorageSnapshotPtr & snap) const
-    {
-        return get(buildV3Id(TEST_NAMESPACE_ID, page_id), toConcreteSnapshot(snap));
-    }
-    PageIdV3Internal getNormalPageId(PageId page_id, const PageDirectorySnapshotPtr & snap) const
-    {
-        return getNormalPageId(buildV3Id(TEST_NAMESPACE_ID, page_id), snap);
-    }
-    PageIdV3Internal getNormalPageId(PageId page_id, const DB::PageStorageSnapshotPtr & snap) const
-    {
-        return getNormalPageId(buildV3Id(TEST_NAMESPACE_ID, page_id), toConcreteSnapshot(snap));
-    }
-#endif
 
     PageId getMaxId(NamespaceId ns_id) const;
 

--- a/dbms/src/Storages/Page/V3/PageEntriesEdit.h
+++ b/dbms/src/Storages/Page/V3/PageEntriesEdit.h
@@ -245,19 +245,6 @@ public:
     EditRecords & getMutRecords() { return records; }
     const EditRecords & getRecords() const { return records; }
 
-#ifndef NDEBUG
-    // Just for tests, refactor them out later
-    void put(PageId page_id, const PageEntryV3 & entry) { put(buildV3Id(TEST_NAMESPACE_ID, page_id), entry); }
-    void putExternal(PageId page_id) { putExternal(buildV3Id(TEST_NAMESPACE_ID, page_id)); }
-    void upsertPage(PageId page_id, const PageVersionType & ver, const PageEntryV3 & entry) { upsertPage(buildV3Id(TEST_NAMESPACE_ID, page_id), ver, entry); }
-    void del(PageId page_id) { del(buildV3Id(TEST_NAMESPACE_ID, page_id)); }
-    void ref(PageId ref_id, PageId page_id) { ref(buildV3Id(TEST_NAMESPACE_ID, ref_id), buildV3Id(TEST_NAMESPACE_ID, page_id)); }
-    void varRef(PageId ref_id, const PageVersionType & ver, PageId ori_page_id) { varRef(buildV3Id(TEST_NAMESPACE_ID, ref_id), ver, buildV3Id(TEST_NAMESPACE_ID, ori_page_id)); }
-    void varExternal(PageId page_id, const PageVersionType & create_ver, Int64 being_ref_count) { varExternal(buildV3Id(TEST_NAMESPACE_ID, page_id), create_ver, being_ref_count); }
-    void varEntry(PageId page_id, const PageVersionType & ver, const PageEntryV3 & entry, Int64 being_ref_count) { varEntry(buildV3Id(TEST_NAMESPACE_ID, page_id), ver, entry, being_ref_count); }
-    void varDel(PageId page_id, const PageVersionType & delete_ver) { varDel(buildV3Id(TEST_NAMESPACE_ID, page_id), delete_ver); }
-#endif
-
 private:
     EditRecords records;
 

--- a/dbms/src/Storages/Page/V3/PageStorageImpl.h
+++ b/dbms/src/Storages/Page/V3/PageStorageImpl.h
@@ -71,16 +71,6 @@ public:
 
     static void createManifestsFileIfNeed(const String & path);
 
-#ifndef NDEBUG
-    // Just for tests, refactor them out later
-    DB::PageStorage::SnapshotPtr getSnapshot() { return getSnapshot(""); }
-    DB::PageEntry getEntry(PageId page_id) { return getEntryImpl(TEST_NAMESPACE_ID, page_id, nullptr); }
-    DB::Page read(PageId page_id) { return readImpl(TEST_NAMESPACE_ID, page_id, nullptr, nullptr); }
-    PageMap read(const std::vector<PageId> & page_ids) { return readImpl(TEST_NAMESPACE_ID, page_ids, nullptr, nullptr); }
-    void read(const std::vector<PageId> & page_ids, const PageHandler & handler) { return readImpl(TEST_NAMESPACE_ID, page_ids, handler, nullptr, nullptr); }
-    PageMap read(const std::vector<PageReadFields> & page_fields) { return readImpl(TEST_NAMESPACE_ID, page_fields, nullptr, nullptr); }
-#endif
-
     friend class PageDirectoryFactory;
 #ifndef DBMS_PUBLIC_GTEST
 private:


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #4562 

Problem Summary: Remove embedded member function for gtest in `dbms/src/Storages/Page`

### What is changed and how it works?

Remove embedded member functions for gtest in `dbms/src/Storages/Page` including `PS::V2::PageStorage`, `PS::V3::PageDirectory`, `PS::V3::PageEntriesEdit` and `PS::V3::PageStorageImpl`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
