### PR TITLE
Fix a bug that MPP tasks may leak threads forever (#4241) 

### DIFF
--- a/dbms/src/Flash/Mpp/MPPTunnel.cpp
+++ b/dbms/src/Flash/Mpp/MPPTunnel.cpp
@@ -224,9 +224,18 @@ std::shared_ptr<mpp::MPPDataPacket> MPPTunnelBase<Writer>::readForLocal()
 template <typename Writer>
 void MPPTunnelBase<Writer>::connect(Writer * writer_)
 {
+<<<<<<< HEAD
     std::lock_guard<std::mutex> lk(mu);
     if (connected)
         throw Exception("has connected");
+=======
+    {
+        std::unique_lock lk(mu);
+        if (connected)
+            throw Exception("MPPTunnel has connected");
+        if (finished)
+            throw Exception("MPPTunnel has finished");
+>>>>>>> b3a2cd587b (Fix a bug that MPP tasks may leak threads forever (#4241))
 
     LOG_DEBUG(log, "ready to connect");
     writer = writer_;


### PR DESCRIPTION
This is an cherry-pick of #4241
Signed-off-by: ti-chi-bot <ti-community-prow-bot@tidb.io>

### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
