### PR TITLE
clear old range before apply snapshot

### DIFF
--- a/dbms/src/Storages/Transaction/ApplySnapshot.cpp
+++ b/dbms/src/Storages/Transaction/ApplySnapshot.cpp
@@ -153,20 +153,30 @@ void KVStore::onSnapshot(const RegionPtrWrap & new_region_wrap, RegionPtr old_re
                 // Acquire `drop_lock` so that no other threads can drop the storage. `alter_lock` is not required.
                 auto table_lock = storage->lockForShare(getThreadName());
                 auto dm_storage = std::dynamic_pointer_cast<StorageDeltaMerge>(storage);
-                auto key_range = DM::RowKeyRange::fromRegionRange(
+                auto old_key_range = DM::RowKeyRange::fromRegionRange(
+                    old_region->getRange(),
+                    table_id,
+                    storage->isCommonHandle(),
+                    storage->getRowKeyColumnSize());
+                auto new_key_range = DM::RowKeyRange::fromRegionRange(
                     new_region_wrap->getRange(),
                     table_id,
                     storage->isCommonHandle(),
                     storage->getRowKeyColumnSize());
+                if (old_key_range != new_key_range)
+                {
+                    LOG_FMT_INFO(log, "clear region {} old range {} before apply snapshot of new range {}", region_id, old_key_range.toDebugString(), new_key_range.toDebugString());
+                    dm_storage->deleteRange(old_key_range, context.getSettingsRef());
+                }
                 if constexpr (std::is_same_v<RegionPtrWrap, RegionPtrWithSnapshotFiles>)
                 {
                     // Call `ingestFiles` to delete data for range and ingest external DTFiles.
-                    dm_storage->ingestFiles(key_range, new_region_wrap.ingest_ids, /*clear_data_in_range=*/true, context.getSettingsRef());
+                    dm_storage->ingestFiles(new_key_range, new_region_wrap.ingest_ids, /*clear_data_in_range=*/true, context.getSettingsRef());
                 }
                 else
                 {
                     // Call `deleteRange` to delete data for range
-                    dm_storage->deleteRange(key_range, context.getSettingsRef());
+                    dm_storage->deleteRange(new_key_range, context.getSettingsRef());
                 }
             }
             catch (DB::Exception & e)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #4414

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
1. load data into tidb cluster with multiple tiflash nodes by import csv file and set tiflash replica to 1;
2. set tiflash replica to 0 and see whether the data can be reclaimed;

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Avoid left data on tiflash node after set tiflash replica to 0
```
