### PR TITLE
Fix pagestorage v3 ddl problem.

### DIFF
--- a/dbms/src/Server/StorageConfigParser.cpp
+++ b/dbms/src/Server/StorageConfigParser.cpp
@@ -202,11 +202,20 @@ void TiFlashStorageConfig::parseMisc(const String & storage_section, Poco::Logge
         lazily_init_store = (*lazily_init != 0);
     }
 
-    // config for experimental feature, may remove later
-    if (auto enable_v3 = table->get_qualified_as<Int32>("enable_ps_v3"); enable_v3)
+
+    if (table->contains("enable_ps_v3"))
     {
-        enable_ps_v3 = (*enable_v3 != 0);
+        if (auto enable_v3 = table->get_qualified_as<Int32>("enable_ps_v3"); enable_v3)
+        {
+            enable_ps_v3 = (*enable_v3 != 0);
+        }
     }
+    else
+    {
+        // default open enable_ps_v3
+        enable_ps_v3 = 1;
+    }
+
 
     LOG_FMT_INFO(log, "format_version {} lazily_init_store {} enable_ps_v3 {}", format_version, lazily_init_store, enable_ps_v3);
 }

--- a/dbms/src/Server/StorageConfigParser.cpp
+++ b/dbms/src/Server/StorageConfigParser.cpp
@@ -213,7 +213,7 @@ void TiFlashStorageConfig::parseMisc(const String & storage_section, Poco::Logge
     else
     {
         // default open enable_ps_v3
-        enable_ps_v3 = 1;
+        enable_ps_v3 = true;
     }
 
 

--- a/dbms/src/Storages/Page/PageDefines.h
+++ b/dbms/src/Storages/Page/PageDefines.h
@@ -80,7 +80,11 @@ struct ByteBuffer
 {
     using Pos = char *;
 
-    ByteBuffer() = default;
+    ByteBuffer()
+        : begin_pos(nullptr)
+        , end_pos(nullptr)
+    {}
+
     ByteBuffer(Pos begin_pos_, Pos end_pos_)
         : begin_pos(begin_pos_)
         , end_pos(end_pos_)

--- a/dbms/src/Storages/Page/V3/LogFile/LogWriter.cpp
+++ b/dbms/src/Storages/Page/V3/LogFile/LogWriter.cpp
@@ -152,7 +152,7 @@ void LogWriter::emitPhysicalRecord(Format::RecordType type, ReadBuffer & payload
     static_assert(Format::RECYCLABLE_HEADER_SIZE > Format::CHECKSUM_FIELD_SIZE, "Header size must be greater than the checksum size");
     static_assert(Format::RECYCLABLE_HEADER_SIZE > Format::HEADER_SIZE, "Ensure the min buffer size for physical record");
     constexpr static size_t HEADER_BUFF_SIZE = Format::RECYCLABLE_HEADER_SIZE - Format::CHECKSUM_FIELD_SIZE;
-    char buf[HEADER_BUFF_SIZE];
+    char buf[HEADER_BUFF_SIZE] = {0};
     WriteBuffer header_buff(buf, HEADER_BUFF_SIZE);
 
     // Format the header

--- a/dbms/src/Storages/Page/V3/PageDirectory.cpp
+++ b/dbms/src/Storages/Page/V3/PageDirectory.cpp
@@ -322,7 +322,7 @@ VersionedPageEntries::resolveToPageId(UInt64 seq, bool check_prev, PageEntryV3 *
     else if (type == EditRecordType::VAR_EXTERNAL)
     {
         // We may add reference to an external id even if it is logically deleted.
-        bool ok = check_prev ? true : (!is_deleted || (is_deleted && seq < delete_ver.sequence));
+        bool ok = check_prev ? true : (!is_deleted || seq < delete_ver.sequence);
         if (create_ver.sequence <= seq && ok)
         {
             return {RESOLVE_TO_NORMAL, buildV3Id(0, 0), PageVersionType(0)};
@@ -330,7 +330,7 @@ VersionedPageEntries::resolveToPageId(UInt64 seq, bool check_prev, PageEntryV3 *
     }
     else if (type == EditRecordType::VAR_REF)
     {
-        if (create_ver.sequence <= seq && (!is_deleted || (is_deleted && seq < delete_ver.sequence)))
+        if (create_ver.sequence <= seq && (!is_deleted || seq < delete_ver.sequence))
         {
             return {RESOLVE_TO_REF, ori_page_id, create_ver};
         }

--- a/dbms/src/Storages/Page/V3/PageEntriesEdit.h
+++ b/dbms/src/Storages/Page/V3/PageEntriesEdit.h
@@ -104,6 +104,8 @@ inline const char * typeToString(EditRecordType t)
         return "VAR_EXT";
     case EditRecordType::VAR_DELETE:
         return "VAR_DEL";
+    default:
+        return "INVALID";
     }
 }
 
@@ -220,6 +222,7 @@ public:
         EditRecord()
             : page_id(0)
             , ori_page_id(0)
+            , version(0, 0)
             , being_ref_count(1)
         {}
     };

--- a/dbms/src/Storages/Page/V3/PageEntry.h
+++ b/dbms/src/Storages/Page/V3/PageEntry.h
@@ -42,10 +42,11 @@ public:
 public:
     size_t getFieldSize(size_t index) const
     {
-        // todo fmt Exception
         if (unlikely(index >= field_offsets.size()))
-            throw Exception("Try to getFieldData of PageEntry" + DB::toString(file_id) + " with invalid index: " + DB::toString(index)
-                                + ", fields size: " + DB::toString(field_offsets.size()),
+            throw Exception(fmt::format("Try to getFieldData of PageEntry [blob id={}] with invalid [index={}] [fields size={}]",
+                                        file_id,
+                                        index,
+                                        field_offsets.size()),
                             ErrorCodes::LOGICAL_ERROR);
         else if (index == field_offsets.size() - 1)
             return size - field_offsets.back().first;

--- a/dbms/src/Storages/Page/V3/PageEntry.h
+++ b/dbms/src/Storages/Page/V3/PageEntry.h
@@ -43,7 +43,7 @@ public:
     size_t getFieldSize(size_t index) const
     {
         if (unlikely(index >= field_offsets.size()))
-            throw Exception(fmt::format("Try to getFieldData of PageEntry [blob id={}] with invalid [index={}] [fields size={}]",
+            throw Exception(fmt::format("Try to getFieldData of PageEntry [blob_id={}] with invalid [index={}] [fields size={}]",
                                         file_id,
                                         index,
                                         field_offsets.size()),

--- a/dbms/src/Storages/Page/V3/PageEntry.h
+++ b/dbms/src/Storages/Page/V3/PageEntry.h
@@ -40,6 +40,19 @@ public:
     PageFieldOffsetChecksums field_offsets{};
 
 public:
+    size_t getFieldSize(size_t index) const
+    {
+        // todo fmt Exception
+        if (unlikely(index >= field_offsets.size()))
+            throw Exception("Try to getFieldData of PageEntry" + DB::toString(file_id) + " with invalid index: " + DB::toString(index)
+                                + ", fields size: " + DB::toString(field_offsets.size()),
+                            ErrorCodes::LOGICAL_ERROR);
+        else if (index == field_offsets.size() - 1)
+            return size - field_offsets.back().first;
+        else
+            return field_offsets[index + 1].first - field_offsets[index].first;
+    }
+
     // Return field{index} offsets: [begin, end) of page data.
     std::pair<size_t, size_t> getFieldOffsets(size_t index) const
     {

--- a/dbms/src/Storages/Page/V3/tests/gtest_blob_store.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_blob_store.cpp
@@ -572,6 +572,70 @@ TEST_F(BlobStoreTest, testWriteRead)
     ASSERT_EQ(index, buff_nums);
 }
 
+TEST_F(BlobStoreTest, testWriteReadWithFiled)
+try
+{
+    const auto file_provider = DB::tests::TiFlashTestEnv::getContext().getFileProvider();
+
+    PageId page_id1 = 50;
+    PageId page_id2 = 51;
+    PageId page_id3 = 53;
+
+    size_t buff_size = 120;
+    WriteBatch wb;
+
+    auto blob_store = BlobStore(getCurrentTestName(), file_provider, delegator, config);
+    char c_buff[buff_size];
+
+    for (size_t j = 0; j < buff_size; ++j)
+    {
+        c_buff[j] = static_cast<char>(j & 0xff);
+    }
+
+    ReadBufferPtr buff1 = std::make_shared<ReadBufferFromMemory>(const_cast<char *>(c_buff), buff_size);
+    ReadBufferPtr buff2 = std::make_shared<ReadBufferFromMemory>(const_cast<char *>(c_buff), buff_size);
+    ReadBufferPtr buff3 = std::make_shared<ReadBufferFromMemory>(const_cast<char *>(c_buff), buff_size);
+    wb.putPage(page_id1, /* tag */ 0, buff1, buff_size, {20, 40, 40, 20});
+    wb.putPage(page_id2, /* tag */ 0, buff2, buff_size, {10, 50, 20, 20, 20});
+    wb.putPage(page_id3, /* tag */ 0, buff3, buff_size, {10, 5, 20, 20, 15, 5, 15, 30});
+    PageEntriesEdit edit = blob_store.write(wb, nullptr);
+    ASSERT_EQ(edit.size(), 3);
+
+    BlobStore::FieldReadInfo read_info1(buildV3Id(TEST_NAMESPACE_ID, page_id1), edit.getRecords()[0].entry, {0, 1, 2, 3});
+    BlobStore::FieldReadInfo read_info2(buildV3Id(TEST_NAMESPACE_ID, page_id2), edit.getRecords()[1].entry, {2, 4});
+    BlobStore::FieldReadInfo read_info3(buildV3Id(TEST_NAMESPACE_ID, page_id3), edit.getRecords()[2].entry, {1, 3});
+
+    BlobStore::FieldReadInfos read_infos = {read_info1, read_info2, read_info3};
+
+    const auto & page_map = blob_store.read(read_infos, nullptr);
+    ASSERT_EQ(page_map.size(), 3);
+
+    for (const auto & [pageid, page] : page_map)
+    {
+        if (pageid == page_id1)
+        {
+            ASSERT_EQ(page.page_id, page_id1);
+            ASSERT_EQ(page.data.size(), buff_size);
+            ASSERT_EQ(strncmp(page.data.begin(), c_buff, buff_size), 0);
+        }
+        else if (pageid == page_id2)
+        {
+            ASSERT_EQ(page.page_id, page_id2);
+            ASSERT_EQ(page.data.size(), buff_size);
+            ASSERT_EQ(strncmp(page.data.begin(), &c_buff[60], 20), 0);
+            ASSERT_EQ(strncmp(&page.data.begin()[20], &c_buff[100], 20), 0);
+        }
+        else if (pageid == page_id3)
+        {
+            ASSERT_EQ(page.page_id, page_id3);
+            ASSERT_EQ(page.data.size(), buff_size);
+            ASSERT_EQ(strncmp(page.data.begin(), &c_buff[10], 5), 0);
+            ASSERT_EQ(strncmp(&page.data.begin()[5], &c_buff[35], 20), 0);
+        }
+    }
+}
+CATCH
+
 TEST_F(BlobStoreTest, testFeildOffsetWriteRead)
 {
     const auto file_provider = DB::tests::TiFlashTestEnv::getContext().getFileProvider();

--- a/dbms/src/Storages/Page/V3/tests/gtest_blob_store.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_blob_store.cpp
@@ -610,29 +610,29 @@ try
     const auto & page_map = blob_store.read(read_infos, nullptr);
     ASSERT_EQ(page_map.size(), 3);
 
-    for (const auto & [pageid, page] : page_map)
-    {
-        if (pageid == page_id1)
-        {
-            ASSERT_EQ(page.page_id, page_id1);
-            ASSERT_EQ(page.data.size(), buff_size);
-            ASSERT_EQ(strncmp(page.data.begin(), c_buff, buff_size), 0);
-        }
-        else if (pageid == page_id2)
-        {
-            ASSERT_EQ(page.page_id, page_id2);
-            ASSERT_EQ(page.data.size(), buff_size);
-            ASSERT_EQ(strncmp(page.data.begin(), &c_buff[60], 20), 0);
-            ASSERT_EQ(strncmp(&page.data.begin()[20], &c_buff[100], 20), 0);
-        }
-        else if (pageid == page_id3)
-        {
-            ASSERT_EQ(page.page_id, page_id3);
-            ASSERT_EQ(page.data.size(), buff_size);
-            ASSERT_EQ(strncmp(page.data.begin(), &c_buff[10], 5), 0);
-            ASSERT_EQ(strncmp(&page.data.begin()[5], &c_buff[35], 20), 0);
-        }
-    }
+    // for (const auto & [pageid, page] : page_map)
+    // {
+    //     if (pageid == page_id1)
+    //     {
+    //         ASSERT_EQ(page.page_id, page_id1);
+    //         ASSERT_EQ(page.data.size(), buff_size);
+    //         ASSERT_EQ(strncmp(page.data.begin(), c_buff, buff_size), 0);
+    //     }
+    //     else if (pageid == page_id2)
+    //     {
+    //         ASSERT_EQ(page.page_id, page_id2);
+    //         ASSERT_EQ(page.data.size(), buff_size);
+    //         ASSERT_EQ(strncmp(page.data.begin(), &c_buff[60], 20), 0);
+    //         ASSERT_EQ(strncmp(&page.data.begin()[20], &c_buff[100], 20), 0);
+    //     }
+    //     else if (pageid == page_id3)
+    //     {
+    //         ASSERT_EQ(page.page_id, page_id3);
+    //         ASSERT_EQ(page.data.size(), buff_size);
+    //         ASSERT_EQ(strncmp(page.data.begin(), &c_buff[10], 5), 0);
+    //         ASSERT_EQ(strncmp(&page.data.begin()[5], &c_buff[35], 20), 0);
+    //     }
+    // }
 }
 CATCH
 

--- a/dbms/src/Storages/Page/V3/tests/gtest_blob_store.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_blob_store.cpp
@@ -610,29 +610,29 @@ try
     const auto & page_map = blob_store.read(read_infos, nullptr);
     ASSERT_EQ(page_map.size(), 3);
 
-    // for (const auto & [pageid, page] : page_map)
-    // {
-    //     if (pageid == page_id1)
-    //     {
-    //         ASSERT_EQ(page.page_id, page_id1);
-    //         ASSERT_EQ(page.data.size(), buff_size);
-    //         ASSERT_EQ(strncmp(page.data.begin(), c_buff, buff_size), 0);
-    //     }
-    //     else if (pageid == page_id2)
-    //     {
-    //         ASSERT_EQ(page.page_id, page_id2);
-    //         ASSERT_EQ(page.data.size(), buff_size);
-    //         ASSERT_EQ(strncmp(page.data.begin(), &c_buff[60], 20), 0);
-    //         ASSERT_EQ(strncmp(&page.data.begin()[20], &c_buff[100], 20), 0);
-    //     }
-    //     else if (pageid == page_id3)
-    //     {
-    //         ASSERT_EQ(page.page_id, page_id3);
-    //         ASSERT_EQ(page.data.size(), buff_size);
-    //         ASSERT_EQ(strncmp(page.data.begin(), &c_buff[10], 5), 0);
-    //         ASSERT_EQ(strncmp(&page.data.begin()[5], &c_buff[35], 20), 0);
-    //     }
-    // }
+    for (const auto & [pageid, page] : page_map)
+    {
+        if (pageid == page_id1)
+        {
+            ASSERT_EQ(page.page_id, page_id1);
+            ASSERT_EQ(page.data.size(), buff_size);
+            ASSERT_EQ(strncmp(page.data.begin(), c_buff, buff_size), 0);
+        }
+        else if (pageid == page_id2)
+        {
+            ASSERT_EQ(page.page_id, page_id2);
+            ASSERT_EQ(page.data.size(), 40);
+            ASSERT_EQ(strncmp(page.data.begin(), &c_buff[60], 20), 0);
+            ASSERT_EQ(strncmp(&page.data.begin()[20], &c_buff[100], 20), 0);
+        }
+        else if (pageid == page_id3)
+        {
+            ASSERT_EQ(page.page_id, page_id3);
+            ASSERT_EQ(page.data.size(), 25);
+            ASSERT_EQ(strncmp(page.data.begin(), &c_buff[10], 5), 0);
+            ASSERT_EQ(strncmp(&page.data.begin()[5], &c_buff[35], 20), 0);
+        }
+    }
 }
 CATCH
 

--- a/dbms/src/Storages/Page/V3/tests/gtest_blob_store.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_blob_store.cpp
@@ -715,8 +715,8 @@ try
     const size_t buff_size = 1024;
     WriteBatch wb;
     {
-        char c_buff1[buff_size];
-        char c_buff2[buff_size];
+        char c_buff1[buff_size] = {0};
+        char c_buff2[buff_size] = {0};
 
         for (size_t i = 0; i < buff_size; ++i)
         {
@@ -846,8 +846,8 @@ TEST_F(BlobStoreTest, testWriteOutOfLimitSize)
         auto blob_store = BlobStore(getCurrentTestName(), file_provider, delegator, config);
 
         WriteBatch wb;
-        char c_buff1[buf_size];
-        char c_buff2[buf_size];
+        char c_buff1[buf_size] = {0};
+        char c_buff2[buf_size] = {0};
 
         ReadBufferPtr buff1 = std::make_shared<ReadBufferFromMemory>(const_cast<char *>(c_buff1), buf_size);
         ReadBufferPtr buff2 = std::make_shared<ReadBufferFromMemory>(const_cast<char *>(c_buff2), buf_size);

--- a/dbms/src/Storages/Page/V3/tests/gtest_blob_store.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_blob_store.cpp
@@ -841,13 +841,13 @@ TEST_F(BlobStoreTest, testWriteOutOfLimitSize)
     config.file_limit_size = buff_size;
 
     size_t buffer_sizes[] = {buff_size, buff_size - 1, buff_size / 2 + 1};
-    for (auto & buf_size : buffer_sizes)
+    for (const auto & buf_size : buffer_sizes)
     {
         auto blob_store = BlobStore(getCurrentTestName(), file_provider, delegator, config);
 
         WriteBatch wb;
-        char c_buff1[buf_size] = {0};
-        char c_buff2[buf_size] = {0};
+        char c_buff1[buf_size];
+        char c_buff2[buf_size];
 
         ReadBufferPtr buff1 = std::make_shared<ReadBufferFromMemory>(const_cast<char *>(c_buff1), buf_size);
         ReadBufferPtr buff2 = std::make_shared<ReadBufferFromMemory>(const_cast<char *>(c_buff2), buf_size);

--- a/dbms/src/Storages/Page/V3/tests/gtest_blob_store.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_blob_store.cpp
@@ -621,6 +621,8 @@ try
         else if (pageid == page_id2)
         {
             ASSERT_EQ(page.page_id, page_id2);
+            // the buffer size read is equal to the fields size we read
+            // field {2, 4}
             ASSERT_EQ(page.data.size(), 40);
             ASSERT_EQ(strncmp(page.data.begin(), &c_buff[60], 20), 0);
             ASSERT_EQ(strncmp(&page.data.begin()[20], &c_buff[100], 20), 0);
@@ -628,6 +630,8 @@ try
         else if (pageid == page_id3)
         {
             ASSERT_EQ(page.page_id, page_id3);
+            // the buffer size read is equal to the fields size we read
+            // field {1, 3}
             ASSERT_EQ(page.data.size(), 25);
             ASSERT_EQ(strncmp(page.data.begin(), &c_buff[10], 5), 0);
             ASSERT_EQ(strncmp(&page.data.begin()[5], &c_buff[35], 20), 0);

--- a/dbms/src/Storages/Page/V3/tests/gtest_page_storage.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_page_storage.cpp
@@ -109,7 +109,7 @@ try
 }
 CATCH
 
-TEST_F(PageStorageTest, nullext)
+TEST_F(PageStorageTest, ReadNULL)
 try
 {
     {

--- a/dbms/src/Storages/Page/V3/tests/gtest_page_storage.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_page_storage.cpp
@@ -109,6 +109,19 @@ try
 }
 CATCH
 
+TEST_F(PageStorageTest, nullext)
+try
+{
+    {
+        WriteBatch batch;
+        batch.putExternal(0, 0);
+        page_storage->write(std::move(batch));
+    }
+    const auto & page = page_storage->read(0);
+    ASSERT_EQ(page.data.begin(), nullptr);
+}
+CATCH
+
 TEST_F(PageStorageTest, WriteMultipleBatchRead1)
 try
 {

--- a/dbms/src/Storages/Page/WriteBatch.h
+++ b/dbms/src/Storages/Page/WriteBatch.h
@@ -214,6 +214,8 @@ public:
                 str += "X" + DB::toString(w.page_id) + ",";
             else if (w.type == WriteType::UPSERT)
                 str += "U" + DB::toString(w.page_id) + ",";
+            else if (w.type == WriteType::PUT_EXTERNAL)
+                str += "E" + DB::toString(w.page_id) + ",";
         }
         if (!str.empty())
             str.erase(str.size() - 1);


### PR DESCRIPTION
Signed-off-by: jiaqizho <zhoujiaqi@pingcap.com>

### What problem does this PR solve?

Issue Number: ref #3594 

Problem Summary:
- Run `ddl test`  with enable_ps_v3 will get random `nullptr` error. 
- Also we still have some uninit errors when I run valgrind.

```
==24236== Syscall param pwrite64(buf) points to uninitialised byte(s)
==24236==    at 0xE0D8FC3: ??? (syscall-template.S:81)
==24236==    by 0x47D2EEE: DB::PosixWritableFile::pwrite(char*, unsigned long, long) const (PosixWritableFile.cpp:91)
==24236==    by 0x4B4107F: void DB::PageUtil::writeFile<std::shared_ptr<DB::WritableFile> >(std::shared_ptr<DB::WritableFile>&, unsigned long, char*, unsigned long, std::shared_ptr<DB::WriteLimiter> const&, bool) (PageUtil.h:178)
==24236==    by 0x4BB3A04: DB::PS::V3::LogWriter::flush(std::shared_ptr<DB::WriteLimiter> const&) (LogWriter.cpp:72)
==24236==    by 0x4BB3C68: DB::PS::V3::LogWriter::addRecord(DB::ReadBuffer&, unsigned long, std::shared_ptr<DB::WriteLimiter> const&) (LogWriter.cpp:143)
==24236==    by 0x4EFEF0E: DB::PS::V3::WALStore::apply(DB::PS::V3::PageEntriesEdit const&, std::shared_ptr<DB::WriteLimiter> const&) (WALStore.cpp:92)
==24236==    by 0x4EFEFF7: DB::PS::V3::WALStore::apply(DB::PS::V3::PageEntriesEdit&, DB::PS::V3::PageVersionType const&, std::shared_ptr<DB::WriteLimiter> const&) (WALStore.cpp:72)
==24236==    by 0x4EEF736: DB::PS::V3::PageDirectory::apply(DB::PS::V3::PageEntriesEdit&&, std::shared_ptr<DB::WriteLimiter> const&) (PageDirectory.cpp:964)
==24236==    by 0x4BADC49: DB::PS::V3::PageStorageImpl::writeImpl(DB::WriteBatch&&, std::shared_ptr<DB::WriteLimiter> const&) (PageStorageImpl.cpp:96)
==24236==    by 0x49A8AE1: DB::PageStorage::write(DB::WriteBatch&&, std::shared_ptr<DB::WriteLimiter> const&) (PageStorage.h:184)
==24236==    by 0x49B55DE: DB::DM::WriteBatches::rollbackWrittenLogAndData() (WriteBatches.h:154)
==24236==    by 0x49B58DA: DB::DM::WriteBatches::~WriteBatches() (WriteBatches.h:81)
==24236==  Address 0x2b2997af is 31 bytes inside a block of size 32,768 alloc'd
==24236==    at 0xA986F73: malloc (vg_replace_malloc.c:309)
==24236==    by 0x4B0528: Allocator<false>::alloc(unsigned long, unsigned long) (Allocator.cpp:94)
==24236==    by 0x4BB38C9: DB::PS::V3::LogWriter::LogWriter(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::shared_ptr<DB::FileProvider> const&, unsigned int, bool, bool) (LogWriter.cpp:48)
==24236==    by 0x4F008D4: std::_MakeUniq<DB::PS::V3::LogWriter>::__single_object std::make_unique<DB::PS::V3::LogWriter, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, std::shared_ptr<DB::FileProvider>&, unsigned int const&, bool, bool&>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, std::shared_ptr<DB::FileProvider>&, unsigned int const&, bool&&, bool&) (unique_ptr.h:825)
==24236==    by 0x4EFED15: DB::PS::V3::WALStore::createLogWriter(std::pair<unsigned int, unsigned int> const&, bool) (WALStore.cpp:134)
==24236==    by 0x4EFEEC3: DB::PS::V3::WALStore::apply(DB::PS::V3::PageEntriesEdit const&, std::shared_ptr<DB::WriteLimiter> const&) (WALStore.cpp:87)
==24236==    by 0x4EFEFF7: DB::PS::V3::WALStore::apply(DB::PS::V3::PageEntriesEdit&, DB::PS::V3::PageVersionType const&, std::shared_ptr<DB::WriteLimiter> const&) (WALStore.cpp:72)
==24236==    by 0x4EEF736: DB::PS::V3::PageDirectory::apply(DB::PS::V3::PageEntriesEdit&&, std::shared_ptr<DB::WriteLimiter> const&) (PageDirectory.cpp:964)
==24236==    by 0x4BADC49: DB::PS::V3::PageStorageImpl::writeImpl(DB::WriteBatch&&, std::shared_ptr<DB::WriteLimiter> const&) (PageStorageImpl.cpp:96)
==24236==    by 0x49A8AE1: DB::PageStorage::write(DB::WriteBatch&&, std::shared_ptr<DB::WriteLimiter> const&) (PageStorage.h:184)
==24236==    by 0x49B9788: DB::DM::WriteBatches::writeLogAndData() (WriteBatches.h:114)
==24236==    by 0x4E75B72: DB::DM::ColumnFileFlushTask::prepare(DB::DM::WriteBatches&) (ColumnFileFlushTask.cpp:58)
==24236== 



==24236== Use of uninitialised value of size 8
==24236==    at 0x527A6F2: crc64::_detail::update16(unsigned long, std::array<unsigned char, 16ul> const&) (crc64_table.h:1520)
==24236==    by 0x527A949: crc64::_detail::update_table(unsigned long, void const*, unsigned long) (crc64_table.h:1566)
==24236==    by 0x527A9F4: unsigned long crc64::_detail::update_fast<128ul, unsigned long (*)(unsigned long, void const*, unsigned long)>(unsigned long (*)(unsigned long, void const*, unsigned long), unsigned long, void const*, unsigned long) (crc64_fast.h:61)
==24236==    by 0x527AA25: crc64::Digest::Digest(crc64::Mode)::{lambda(unsigned long, void const*, unsigned long)#1}::operator()(unsigned long, void const*, unsigned long) const (crc64.cpp:54)
==24236==    by 0x527AA3E: crc64::Digest::Digest(crc64::Mode)::{lambda(unsigned long, void const*, unsigned long)#1}::_FUN(unsigned long, void const*, unsigned long) (crc64.cpp:54)
==24236==    by 0x47E06F1: crc64::Digest::update(void const*, unsigned long) (crc64.h:33)
==24236==    by 0x47E07BD: DB::Digest::CRC64::update(void const*, unsigned long) (Checksum.h:104)
==24236==    by 0x4BB36B9: DB::PS::V3::LogWriter::emitPhysicalRecord(DB::PS::V3::Format::RecordType, DB::ReadBuffer&, unsigned long) (LogWriter.cpp:191)
==24236==    by 0x4BB3B82: DB::PS::V3::LogWriter::addRecord(DB::ReadBuffer&, unsigned long, std::shared_ptr<DB::WriteLimiter> const&) (LogWriter.cpp:135)
==24236==    by 0x4EFEF0E: DB::PS::V3::WALStore::apply(DB::PS::V3::PageEntriesEdit const&, std::shared_ptr<DB::WriteLimiter> const&) (WALStore.cpp:92)
==24236==    by 0x4EFEFF7: DB::PS::V3::WALStore::apply(DB::PS::V3::PageEntriesEdit&, DB::PS::V3::PageVersionType const&, std::shared_ptr<DB::WriteLimiter> const&) (WALStore.cpp:72)
==24236==    by 0x4EEF736: DB::PS::V3::PageDirectory::apply(DB::PS::V3::PageEntriesEdit&&, std::shared_ptr<DB::WriteLimiter> const&) (PageDirectory.cpp:964)
==24236== 

```

root cause:
```
==8154== 
==8154== Thread 30 BkgPool6:
==8154== Invalid write of size 1
==8154==    at 0x10970FBA: memset (vg_replace_strmem.c:1270)
==8154==    by 0x446C07C: void DB::PODArrayBase<1ul, 4096ul, Allocator<false>, 15ul, 16ul>::alloc<>(unsigned long) (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0x446BF6B: void DB::PODArrayBase<1ul, 4096ul, Allocator<false>, 15ul, 16ul>::realloc<>(unsigned long) (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0x446BE91: void DB::PODArrayBase<1ul, 4096ul, Allocator<false>, 15ul, 16ul>::reserve<>(unsigned long) (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0xBD4BB66: DB::DataTypeString::deserializeBinaryBulk(DB::IColumn&, DB::ReadBuffer&, unsigned long, double) const (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0x46A0B97: DB::IDataType::deserializeBinaryBulkWithMultipleStreams(DB::IColumn&, std::__1::function<DB::ReadBuffer* (std::__1::vector<DB::IDataType::Substream, std::__1::allocator<DB::IDataType::Substream> > const&)> const&, unsigned long, double, bool, std::__1::vector<DB::IDataType::Substream, std::__1::allocator<DB::IDataType::Substream> >&) const (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0xBD3A4BA: DB::DataTypeNullable::deserializeBinaryBulkWithMultipleStreams(DB::IColumn&, std::__1::function<DB::ReadBuffer* (std::__1::vector<DB::IDataType::Substream, std::__1::allocator<DB::IDataType::Substream> > const&)> const&, unsigned long, double, bool, std::__1::vector<DB::IDataType::Substream, std::__1::allocator<DB::IDataType::Substream> >&) const (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0xBCD1643: DB::IDataType::deserializeBinaryBulkWithMultipleStreams(DB::IColumn&, std::__1::function<DB::ReadBuffer* (std::__1::vector<DB::IDataType::Substream, std::__1::allocator<DB::IDataType::Substream> > const&)> const&, unsigned long, double, bool, std::__1::vector<DB::IDataType::Substream, std::__1::allocator<DB::IDataType::Substream> >&&) const (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0xD708A01: DB::DM::deserializeColumn(DB::IColumn&, std::__1::shared_ptr<DB::IDataType const> const&, DB::ByteBuffer const&, unsigned long) (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0xD6FDC70: DB::DM::ColumnFileTiny::readFromDisk(DB::PageReader const&, std::__1::vector<DB::DM::ColumnDefine, std::__1::allocator<DB::DM::ColumnDefine> > const&, unsigned long, unsigned long) const (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0xD6FDEB8: DB::DM::ColumnFileTiny::fillColumns(DB::PageReader const&, std::__1::vector<DB::DM::ColumnDefine, std::__1::allocator<DB::DM::ColumnDefine> > const&, unsigned long, std::__1::vector<COWPtr<DB::IColumn>::immutable_ptr<DB::IColumn>, std::__1::allocator<COWPtr<DB::IColumn>::immutable_ptr<DB::IColumn> > >&) const (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0xD6FF132: DB::DM::ColumnFileTinyReader::readRows(std::__1::vector<COWPtr<DB::IColumn>::mutable_ptr<DB::IColumn>, std::__1::allocator<COWPtr<DB::IColumn>::mutable_ptr<DB::IColumn> > >&, unsigned long, unsigned long, DB::DM::RowKeyRange const*) (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==  Address 0x192df26f is 15 bytes after a block of size 0 alloc'd
==8154==    at 0x10966EE5: malloc (vg_replace_malloc.c:380)
==8154==    by 0x4472B4A: Allocator<false>::alloc(unsigned long, unsigned long) (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0x446C044: void DB::PODArrayBase<1ul, 4096ul, Allocator<false>, 15ul, 16ul>::alloc<>(unsigned long) (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0x446BF6B: void DB::PODArrayBase<1ul, 4096ul, Allocator<false>, 15ul, 16ul>::realloc<>(unsigned long) (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0x446BE91: void DB::PODArrayBase<1ul, 4096ul, Allocator<false>, 15ul, 16ul>::reserve<>(unsigned long) (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0xBD4BB66: DB::DataTypeString::deserializeBinaryBulk(DB::IColumn&, DB::ReadBuffer&, unsigned long, double) const (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0x46A0B97: DB::IDataType::deserializeBinaryBulkWithMultipleStreams(DB::IColumn&, std::__1::function<DB::ReadBuffer* (std::__1::vector<DB::IDataType::Substream, std::__1::allocator<DB::IDataType::Substream> > const&)> const&, unsigned long, double, bool, std::__1::vector<DB::IDataType::Substream, std::__1::allocator<DB::IDataType::Substream> >&) const (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0xBD3A4BA: DB::DataTypeNullable::deserializeBinaryBulkWithMultipleStreams(DB::IColumn&, std::__1::function<DB::ReadBuffer* (std::__1::vector<DB::IDataType::Substream, std::__1::allocator<DB::IDataType::Substream> > const&)> const&, unsigned long, double, bool, std::__1::vector<DB::IDataType::Substream, std::__1::allocator<DB::IDataType::Substream> >&) const (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0xBCD1643: DB::IDataType::deserializeBinaryBulkWithMultipleStreams(DB::IColumn&, std::__1::function<DB::ReadBuffer* (std::__1::vector<DB::IDataType::Substream, std::__1::allocator<DB::IDataType::Substream> > const&)> const&, unsigned long, double, bool, std::__1::vector<DB::IDataType::Substream, std::__1::allocator<DB::IDataType::Substream> >&&) const (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0xD708A01: DB::DM::deserializeColumn(DB::IColumn&, std::__1::shared_ptr<DB::IDataType const> const&, DB::ByteBuffer const&, unsigned long) (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0xD6FDC70: DB::DM::ColumnFileTiny::readFromDisk(DB::PageReader const&, std::__1::vector<DB::DM::ColumnDefine, std::__1::allocator<DB::DM::ColumnDefine> > const&, unsigned long, unsigned long) const (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0xD6FDEB8: DB::DM::ColumnFileTiny::fillColumns(DB::PageReader const&, std::__1::vector<DB::DM::ColumnDefine, std::__1::allocator<DB::DM::ColumnDefine> > const&, unsigned long, std::__1::vector<COWPtr<DB::IColumn>::immutable_ptr<DB::IColumn>, std::__1::allocator<COWPtr<DB::IColumn>::immutable_ptr<DB::IColumn> > >&) const (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154== 
==8154== Invalid write of size 8
==8154==    at 0xBD4BE3E: void DB::deserializeBinarySSE2<4>(DB::PODArray<unsigned char, 4096ul, Allocator<false>, 15ul, 16ul>&, DB::PODArray<unsigned long, 4096ul, Allocator<false>, 15ul, 16ul>&, DB::ReadBuffer&, unsigned long) (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0xBD4BBB3: DB::DataTypeString::deserializeBinaryBulk(DB::IColumn&, DB::ReadBuffer&, unsigned long, double) const (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0x46A0B97: DB::IDataType::deserializeBinaryBulkWithMultipleStreams(DB::IColumn&, std::__1::function<DB::ReadBuffer* (std::__1::vector<DB::IDataType::Substream, std::__1::allocator<DB::IDataType::Substream> > const&)> const&, unsigned long, double, bool, std::__1::vector<DB::IDataType::Substream, std::__1::allocator<DB::IDataType::Substream> >&) const (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0xBD3A4BA: DB::DataTypeNullable::deserializeBinaryBulkWithMultipleStreams(DB::IColumn&, std::__1::function<DB::ReadBuffer* (std::__1::vector<DB::IDataType::Substream, std::__1::allocator<DB::IDataType::Substream> > const&)> const&, unsigned long, double, bool, std::__1::vector<DB::IDataType::Substream, std::__1::allocator<DB::IDataType::Substream> >&) const (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0xBCD1643: DB::IDataType::deserializeBinaryBulkWithMultipleStreams(DB::IColumn&, std::__1::function<DB::ReadBuffer* (std::__1::vector<DB::IDataType::Substream, std::__1::allocator<DB::IDataType::Substream> > const&)> const&, unsigned long, double, bool, std::__1::vector<DB::IDataType::Substream, std::__1::allocator<DB::IDataType::Substream> >&&) const (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0xD708A01: DB::DM::deserializeColumn(DB::IColumn&, std::__1::shared_ptr<DB::IDataType const> const&, DB::ByteBuffer const&, unsigned long) (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0xD6FDC70: DB::DM::ColumnFileTiny::readFromDisk(DB::PageReader const&, std::__1::vector<DB::DM::ColumnDefine, std::__1::allocator<DB::DM::ColumnDefine> > const&, unsigned long, unsigned long) const (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0xD6FDEB8: DB::DM::ColumnFileTiny::fillColumns(DB::PageReader const&, std::__1::vector<DB::DM::ColumnDefine, std::__1::allocator<DB::DM::ColumnDefine> > const&, unsigned long, std::__1::vector<COWPtr<DB::IColumn>::immutable_ptr<DB::IColumn>, std::__1::allocator<COWPtr<DB::IColumn>::immutable_ptr<DB::IColumn> > >&) const (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0xD6FF132: DB::DM::ColumnFileTinyReader::readRows(std::__1::vector<COWPtr<DB::IColumn>::mutable_ptr<DB::IColumn>, std::__1::allocator<COWPtr<DB::IColumn>::mutable_ptr<DB::IColumn> > >&, unsigned long, unsigned long, DB::DM::RowKeyRange const*) (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0xD6F1B84: DB::DM::ColumnFileSetReader::readRows(std::__1::vector<COWPtr<DB::IColumn>::mutable_ptr<DB::IColumn>, std::__1::allocator<COWPtr<DB::IColumn>::mutable_ptr<DB::IColumn> > >&, unsigned long, unsigned long, DB::DM::RowKeyRange const*) (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0xD74B3CF: DB::DM::DeltaValueReader::readRows(std::__1::vector<COWPtr<DB::IColumn>::mutable_ptr<DB::IColumn>, std::__1::allocator<COWPtr<DB::IColumn>::mutable_ptr<DB::IColumn> > >&, unsigned long, unsigned long, DB::DM::RowKeyRange const*) (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0xD5CA55D: DB::DM::DeltaMergeBlockInputStream<DB::DM::DeltaValueReader, DB::DM::DTCompactedEntries<55ul, 20ul, 3ul>::Iterator, false>::writeInsertFromDelta(std::__1::vector<COWPtr<DB::IColumn>::mutable_ptr<DB::IColumn>, std::__1::allocator<COWPtr<DB::IColumn>::mutable_ptr<DB::IColumn> > >&, unsigned long&) (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==  Address 0x192df270 is 16 bytes after a block of size 0 alloc'd
==8154==    at 0x10966EE5: malloc (vg_replace_malloc.c:380)
==8154==    by 0x4472B4A: Allocator<false>::alloc(unsigned long, unsigned long) (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0x446C044: void DB::PODArrayBase<1ul, 4096ul, Allocator<false>, 15ul, 16ul>::alloc<>(unsigned long) (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0x446BF6B: void DB::PODArrayBase<1ul, 4096ul, Allocator<false>, 15ul, 16ul>::realloc<>(unsigned long) (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0x446BE91: void DB::PODArrayBase<1ul, 4096ul, Allocator<false>, 15ul, 16ul>::reserve<>(unsigned long) (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0xBD4BB66: DB::DataTypeString::deserializeBinaryBulk(DB::IColumn&, DB::ReadBuffer&, unsigned long, double) const (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0x46A0B97: DB::IDataType::deserializeBinaryBulkWithMultipleStreams(DB::IColumn&, std::__1::function<DB::ReadBuffer* (std::__1::vector<DB::IDataType::Substream, std::__1::allocator<DB::IDataType::Substream> > const&)> const&, unsigned long, double, bool, std::__1::vector<DB::IDataType::Substream, std::__1::allocator<DB::IDataType::Substream> >&) const (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0xBD3A4BA: DB::DataTypeNullable::deserializeBinaryBulkWithMultipleStreams(DB::IColumn&, std::__1::function<DB::ReadBuffer* (std::__1::vector<DB::IDataType::Substream, std::__1::allocator<DB::IDataType::Substream> > const&)> const&, unsigned long, double, bool, std::__1::vector<DB::IDataType::Substream, std::__1::allocator<DB::IDataType::Substream> >&) const (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0xBCD1643: DB::IDataType::deserializeBinaryBulkWithMultipleStreams(DB::IColumn&, std::__1::function<DB::ReadBuffer* (std::__1::vector<DB::IDataType::Substream, std::__1::allocator<DB::IDataType::Substream> > const&)> const&, unsigned long, double, bool, std::__1::vector<DB::IDataType::Substream, std::__1::allocator<DB::IDataType::Substream> >&&) const (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0xD708A01: DB::DM::deserializeColumn(DB::IColumn&, std::__1::shared_ptr<DB::IDataType const> const&, DB::ByteBuffer const&, unsigned long) (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0xD6FDC70: DB::DM::ColumnFileTiny::readFromDisk(DB::PageReader const&, std::__1::vector<DB::DM::ColumnDefine, std::__1::allocator<DB::DM::ColumnDefine> > const&, unsigned long, unsigned long) const (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154==    by 0xD6FDEB8: DB::DM::ColumnFileTiny::fillColumns(DB::PageReader const&, std::__1::vector<DB::DM::ColumnDefine, std::__1::allocator<DB::DM::ColumnDefine> > const&, unsigned long, std::__1::vector<COWPtr<DB::IColumn>::immutable_ptr<DB::IColumn>, std::__1::allocator<COWPtr<DB::IColumn>::immutable_ptr<DB::IColumn> > >&) const (in /data1/lidezhu/tiflash-scripts/integrated/nodes/8284/tiflash1/tiflash/tiflash)
==8154== 
```

- Diff with `read(flied)` between v2 and v3 is that v3 will direct use total `entry.size` as `buffer`.

So here is the situation:
1. In V3 we got an `entry.size` buffer when we use `read(flied)` which is shorter than V2(If we don't need to get all of `fileds`).
2. Then we call the `getFieldData` in `Page.h`. Once `index` is `size() - 1` Then the buffer will longer than `filed size`.
3. Then in `ColumnFileTiny.cpp`, we will use buffer length to deserialize the buffer. and it will cause `heap error`.

For example:
```
A filedoffsets [10,20,30,40]
Call read(filed_index) [0,2]
In V3, we got a buffer [10, 30, 60]
In V2, we got a buffer [10, 30]
And when we call `getFieldData` in `Page.h` by index 2
from  buffer [10, 30, 60] got a WriteBuferr [30,60] , length is 90
from  buffer [10, 30] got a WriteBuferr [30] , length is 30
Then in `ColumnFileTiny.cpp`,  we will use buffer length to deserialize the buffer. and it will cause `heap error`.
```


### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
