### PR TITLE
Interpreter: Mock exchange executors.

### DIFF
--- a/dbms/src/Debug/astToExecutor.cpp
+++ b/dbms/src/Debug/astToExecutor.cpp
@@ -1526,9 +1526,9 @@ ExecutorPtr compileJoin(size_t & executor_index, ExecutorPtr left, ExecutorPtr r
 }
 
 
-ExecutorPtr compileExchangeSender(ExecutorPtr input, size_t & executor_index)
+ExecutorPtr compileExchangeSender(ExecutorPtr input, size_t & executor_index, tipb::ExchangeType exchange_type)
 {
-    ExecutorPtr exchange_sender = std::make_shared<mock::ExchangeSender>(executor_index, input->output_schema, tipb::PassThrough);
+    ExecutorPtr exchange_sender = std::make_shared<mock::ExchangeSender>(executor_index, input->output_schema, exchange_type);
     exchange_sender->children.push_back(input);
     return exchange_sender;
 }

--- a/dbms/src/Debug/astToExecutor.cpp
+++ b/dbms/src/Debug/astToExecutor.cpp
@@ -808,12 +808,8 @@ bool ExchangeSender::toTiPBExecutor(tipb::Executor * tipb_executor, uint32_t col
         auto * meta_string = exchange_sender->add_encoded_task_meta();
         meta.AppendToString(meta_string);
     }
-    if (!children.empty())
-    {
-        auto * child_executor = exchange_sender->mutable_child();
-        return children[0]->toTiPBExecutor(child_executor, collator_id, mpp_info, context);
-    }
-    return true;
+    auto * child_executor = exchange_sender->mutable_child();
+    return children[0]->toTiPBExecutor(child_executor, collator_id, mpp_info, context);
 }
 
 bool ExchangeReceiver::toTiPBExecutor(tipb::Executor * tipb_executor, uint32_t collator_id, const MPPInfo & mpp_info, const Context &)

--- a/dbms/src/Debug/astToExecutor.cpp
+++ b/dbms/src/Debug/astToExecutor.cpp
@@ -1525,4 +1525,21 @@ ExecutorPtr compileJoin(size_t & executor_index, ExecutorPtr left, ExecutorPtr r
     return join;
 }
 
+
+ExecutorPtr compileExchangeSender(ExecutorPtr input, size_t & executor_index)
+{
+    ExecutorPtr exchange_sender
+        = std::make_shared<mock::ExchangeSender>(executor_index, input->output_schema, tipb::PassThrough);
+    exchange_sender->children.push_back(input);
+    return exchange_sender;
+}
+
+// ExecutorPtr compileExchangeReceiver(size_t & executor_index, DAGSchema schema)
+// {
+//     // ExecutorPtr exchange_receiver
+//     //     = std::make_shared<mock::ExchangeReceiver>(executor_index, );
+    
+//     return exchange_receiver;   
+// }
+
 } // namespace DB

--- a/dbms/src/Debug/astToExecutor.cpp
+++ b/dbms/src/Debug/astToExecutor.cpp
@@ -1528,18 +1528,15 @@ ExecutorPtr compileJoin(size_t & executor_index, ExecutorPtr left, ExecutorPtr r
 
 ExecutorPtr compileExchangeSender(ExecutorPtr input, size_t & executor_index)
 {
-    ExecutorPtr exchange_sender
-        = std::make_shared<mock::ExchangeSender>(executor_index, input->output_schema, tipb::PassThrough);
+    ExecutorPtr exchange_sender = std::make_shared<mock::ExchangeSender>(executor_index, input->output_schema, tipb::PassThrough);
     exchange_sender->children.push_back(input);
     return exchange_sender;
 }
 
-// ExecutorPtr compileExchangeReceiver(size_t & executor_index, DAGSchema schema)
-// {
-//     // ExecutorPtr exchange_receiver
-//     //     = std::make_shared<mock::ExchangeReceiver>(executor_index, );
-    
-//     return exchange_receiver;   
-// }
+ExecutorPtr compileExchangeReceiver(size_t & executor_index, DAGSchema schema)
+{
+    ExecutorPtr exchange_receiver = std::make_shared<mock::ExchangeReceiver>(executor_index, schema);
+    return exchange_receiver;
+}
 
 } // namespace DB

--- a/dbms/src/Debug/astToExecutor.cpp
+++ b/dbms/src/Debug/astToExecutor.cpp
@@ -1525,13 +1525,6 @@ ExecutorPtr compileJoin(size_t & executor_index, ExecutorPtr left, ExecutorPtr r
     return join;
 }
 
-
-ExecutorPtr compileExchangeSender(DAGSchema & schema, size_t & executor_index, tipb::ExchangeType exchange_type)
-{
-    ExecutorPtr exchange_sender = std::make_shared<mock::ExchangeSender>(executor_index, schema, exchange_type);
-    return exchange_sender;
-}
-
 ExecutorPtr compileExchangeSender(ExecutorPtr input, size_t & executor_index, tipb::ExchangeType exchange_type)
 {
     ExecutorPtr exchange_sender = std::make_shared<mock::ExchangeSender>(executor_index, input->output_schema, exchange_type);

--- a/dbms/src/Debug/astToExecutor.h
+++ b/dbms/src/Debug/astToExecutor.h
@@ -290,6 +290,7 @@ ExecutorPtr compileProject(ExecutorPtr input, size_t & executor_index, ASTPtr se
 
 ExecutorPtr compileJoin(size_t & executor_index, ExecutorPtr left, ExecutorPtr right, ASTPtr params);
 
+ExecutorPtr compileExchangeSender(DAGSchema & schema, size_t & executor_index, tipb::ExchangeType exchange_type);
 ExecutorPtr compileExchangeSender(ExecutorPtr input, size_t & executor_index, tipb::ExchangeType exchange_type);
 
 ExecutorPtr compileExchangeReceiver(size_t & executor_index, DAGSchema schema);

--- a/dbms/src/Debug/astToExecutor.h
+++ b/dbms/src/Debug/astToExecutor.h
@@ -290,7 +290,6 @@ ExecutorPtr compileProject(ExecutorPtr input, size_t & executor_index, ASTPtr se
 
 ExecutorPtr compileJoin(size_t & executor_index, ExecutorPtr left, ExecutorPtr right, ASTPtr params);
 
-ExecutorPtr compileExchangeSender(DAGSchema & schema, size_t & executor_index, tipb::ExchangeType exchange_type);
 ExecutorPtr compileExchangeSender(ExecutorPtr input, size_t & executor_index, tipb::ExchangeType exchange_type);
 
 ExecutorPtr compileExchangeReceiver(size_t & executor_index, DAGSchema schema);

--- a/dbms/src/Debug/astToExecutor.h
+++ b/dbms/src/Debug/astToExecutor.h
@@ -290,7 +290,7 @@ ExecutorPtr compileProject(ExecutorPtr input, size_t & executor_index, ASTPtr se
 
 ExecutorPtr compileJoin(size_t & executor_index, ExecutorPtr left, ExecutorPtr right, ASTPtr params);
 
-ExecutorPtr compileExchangeSender(ExecutorPtr input, size_t & executor_index);
+ExecutorPtr compileExchangeSender(ExecutorPtr input, size_t & executor_index, tipb::ExchangeType exchange_type);
 
 ExecutorPtr compileExchangeReceiver(size_t & executor_index, DAGSchema schema);
 

--- a/dbms/src/Debug/astToExecutor.h
+++ b/dbms/src/Debug/astToExecutor.h
@@ -27,7 +27,6 @@
 #include <Storages/MutableSupport.h>
 #include <Storages/Transaction/Types.h>
 #include <tipb/select.pb.h>
-#include <cstddef>
 
 namespace DB
 {

--- a/dbms/src/Debug/astToExecutor.h
+++ b/dbms/src/Debug/astToExecutor.h
@@ -27,6 +27,7 @@
 #include <Storages/MutableSupport.h>
 #include <Storages/Transaction/Types.h>
 #include <tipb/select.pb.h>
+#include <cstddef>
 
 namespace DB
 {
@@ -289,5 +290,9 @@ ExecutorPtr compileAggregation(ExecutorPtr input, size_t & executor_index, ASTPt
 ExecutorPtr compileProject(ExecutorPtr input, size_t & executor_index, ASTPtr select_list);
 
 ExecutorPtr compileJoin(size_t & executor_index, ExecutorPtr left, ExecutorPtr right, ASTPtr params);
+
+ExecutorPtr compileExchangeSender(ExecutorPtr input, size_t & executor_index);
+
+ExecutorPtr compileExchangeReceiver(size_t & executor_index, DAGSchema schema);
 
 } // namespace DB

--- a/dbms/src/TestUtils/InterpreterTestUtils.cpp
+++ b/dbms/src/TestUtils/InterpreterTestUtils.cpp
@@ -47,11 +47,10 @@ String toTreeString(const tipb::Executor & root_executor, size_t level)
     FmtBuffer buffer;
 
     auto append_str = [&buffer, &level](const tipb::Executor & executor) {
-        if (executor.has_executor_id())
-        {
-            buffer.append(String(level, ' '));
-            buffer.append(executor.executor_id()).append("\n");
-        }
+        assert(executor.has_executor_id());
+
+        buffer.append(String(level, ' '));
+        buffer.append(executor.executor_id()).append("\n");
     };
 
     traverseExecutorTree(root_executor, [&](const tipb::Executor & executor) {

--- a/dbms/src/TestUtils/InterpreterTestUtils.cpp
+++ b/dbms/src/TestUtils/InterpreterTestUtils.cpp
@@ -47,9 +47,11 @@ String toTreeString(const tipb::Executor & root_executor, size_t level)
     FmtBuffer buffer;
 
     auto append_str = [&buffer, &level](const tipb::Executor & executor) {
-        assert(executor.has_executor_id());
-        buffer.append(String(level, ' '));
-        buffer.append(executor.executor_id()).append("\n");
+        if (executor.has_executor_id())
+        {
+            buffer.append(String(level, ' '));
+            buffer.append(executor.executor_id()).append("\n");
+        }
     };
 
     traverseExecutorTree(root_executor, [&](const tipb::Executor & executor) {

--- a/dbms/src/TestUtils/InterpreterTestUtils.h
+++ b/dbms/src/TestUtils/InterpreterTestUtils.h
@@ -37,7 +37,6 @@ public:
     MockExecutorTest()
         : context(TiFlashTestEnv::getContext())
     {}
-
     static void SetUpTestCase()
     {
         try
@@ -53,8 +52,7 @@ public:
     virtual void initializeContext()
     {
         dag_context_ptr = std::make_unique<DAGContext>(1024);
-        context.setDAGContext(dag_context_ptr.get());
-        mock_dag_request_context = MockDAGRequestContext();
+        context = MockDAGRequestContext(TiFlashTestEnv::getContext());
     }
 
     DAGContext & getDAGContext()
@@ -64,8 +62,7 @@ public:
     }
 
 protected:
-    Context context;
-    MockDAGRequestContext mock_dag_request_context;
+    MockDAGRequestContext context;
     std::unique_ptr<DAGContext> dag_context_ptr;
 };
 

--- a/dbms/src/TestUtils/mockExecutor.cpp
+++ b/dbms/src/TestUtils/mockExecutor.cpp
@@ -219,19 +219,6 @@ DAGRequestBuilder & DAGRequestBuilder::exchangeSender(tipb::ExchangeType exchang
     return *this;
 }
 
-DAGRequestBuilder & DAGRequestBuilder::exchangeSender(const MockColumnInfos & columns, tipb::ExchangeType exchange_type)
-{
-    DAGSchema schema;
-    for (const auto & column_info : columns)
-    {
-        ColumnInfo ci;
-        ci.tp = column_info.second;
-        schema.emplace_back(std::make_pair(column_info.first, std::move(ci)));
-    }
-    root = compileExchangeSender(schema, getExecutorIndex(), exchange_type);
-    return *this;
-}
-
 DAGRequestBuilder & DAGRequestBuilder::join(const DAGRequestBuilder & right, ASTPtr using_expr_list)
 {
     return join(right, using_expr_list, ASTTableJoin::Kind::Inner);

--- a/dbms/src/TestUtils/mockExecutor.cpp
+++ b/dbms/src/TestUtils/mockExecutor.cpp
@@ -36,14 +36,15 @@ ASTPtr buildLiteral(const Field & field)
 
 ASTPtr buildOrderByItemList(MockOrderByItems order_by_items)
 {
-    std::vector<ASTPtr> vec;
+    std::vector<ASTPtr> vec(order_by_items.size());
+    size_t i = 0;
     for (auto item : order_by_items)
     {
-        int direction = item.second ? 1 : -1;
+        int direction = item.second ? 1 : -1; // todo
         ASTPtr locale_node;
         auto order_by_item = std::make_shared<ASTOrderByElement>(direction, direction, false, locale_node);
         order_by_item->children.push_back(std::make_shared<ASTIdentifier>(item.first));
-        vec.push_back(order_by_item);
+        vec[i++] = order_by_item;
     }
     auto exp_list = std::make_shared<ASTExpressionList>();
     exp_list->children.insert(exp_list->children.end(), vec.begin(), vec.end());
@@ -74,8 +75,8 @@ std::shared_ptr<tipb::DAGRequest> DAGRequestBuilder::build(MockDAGRequestContext
     MPPInfo mpp_info(properties.start_ts, -1, -1, {}, mock_context.receiver_source_task_ids_map);
     std::shared_ptr<tipb::DAGRequest> dag_request_ptr = std::make_shared<tipb::DAGRequest>();
     tipb::DAGRequest & dag_request = *dag_request_ptr;
-    root->toTiPBExecutor(dag_request.mutable_root_executor(), properties.collator, mpp_info, mock_context.context);
     initDAGRequest(dag_request);
+    root->toTiPBExecutor(dag_request.mutable_root_executor(), properties.collator, mpp_info, mock_context.context);
     root.reset();
     executor_index = 0;
     return dag_request_ptr;
@@ -266,10 +267,11 @@ DAGRequestBuilder & DAGRequestBuilder::buildAggregation(ASTPtr agg_funcs, ASTPtr
 
 void MockDAGRequestContext::addMockTable(const MockTableName & name, const MockColumnInfoList & columns)
 {
-    std::vector<MockColumnInfo> v_column_info;
+    std::vector<MockColumnInfo> v_column_info(columns.size());
+    size_t i = 0;
     for (const auto & info : columns)
     {
-        v_column_info.push_back(std::move(info));
+        v_column_info[i++] = std::move(info);
     }
     mock_tables[name.first + "." + name.second] = v_column_info;
 }
@@ -291,10 +293,11 @@ void MockDAGRequestContext::addExchangeRelationSchema(String name, const MockCol
 
 void MockDAGRequestContext::addExchangeRelationSchema(String name, const MockColumnInfoList & columns)
 {
-    std::vector<MockColumnInfo> v_column_info;
+    std::vector<MockColumnInfo> v_column_info(columns.size());
+    size_t i = 0;
     for (const auto & info : columns)
     {
-        v_column_info.push_back(std::move(info));
+        v_column_info[i++] = std::move(info);
     }
     exchange_schemas[name] = v_column_info;
 }

--- a/dbms/src/TestUtils/mockExecutor.cpp
+++ b/dbms/src/TestUtils/mockExecutor.cpp
@@ -283,32 +283,19 @@ void MockDAGRequestContext::addMockTable(const MockTableName & name, const MockC
     mock_tables[name.first + "." + name.second] = columns;
 }
 
-void MockDAGRequestContext::addExchangeSender(String name, const MockColumnInfos & columns, std::vector<String> receivers)
+void MockDAGRequestContext::addExchangeRelationSchema(String name, const MockColumnInfos & columns)
 {
-    exchange_sender_schemas[name] = columns;
-    sender_to_receivers_map[name] = receivers;
-    for (const auto & receiver : receivers)
-    {
-        receiver_to_sender_map[receiver] = name;
-    }
-    receiver_source_task_ids_map[name] = {};
+    exchange_schemas[name] = columns;
 }
 
-void MockDAGRequestContext::addExchangeSender(String name, const MockColumnInfoList & columns, std::initializer_list<String> receivers)
+void MockDAGRequestContext::addExchangeRelationSchema(String name, const MockColumnInfoList & columns)
 {
     std::vector<MockColumnInfo> v_column_info;
     for (const auto & info : columns)
     {
         v_column_info.push_back(std::move(info));
     }
-    exchange_sender_schemas[name] = v_column_info;
-
-    sender_to_receivers_map[name] = receivers;
-    for (const auto & receiver : receivers)
-    {
-        receiver_to_sender_map[receiver] = name;
-    }
-    receiver_source_task_ids_map[name] = {};
+    exchange_schemas[name] = v_column_info;
 }
 
 DAGRequestBuilder MockDAGRequestContext::scan(String db_name, String table_name)
@@ -318,7 +305,7 @@ DAGRequestBuilder MockDAGRequestContext::scan(String db_name, String table_name)
 
 DAGRequestBuilder MockDAGRequestContext::receive(String sender_name)
 {
-    auto builder = DAGRequestBuilder(index).exchangeReceiver(exchange_sender_schemas[sender_name]);
+    auto builder = DAGRequestBuilder(index).exchangeReceiver(exchange_schemas[sender_name]);
     receiver_source_task_ids_map[builder.getRoot()->name] = {};
     return builder;
 }

--- a/dbms/src/TestUtils/mockExecutor.cpp
+++ b/dbms/src/TestUtils/mockExecutor.cpp
@@ -323,10 +323,4 @@ DAGRequestBuilder MockDAGRequestContext::receive(String exchange_name)
     receiver_source_task_ids_map[builder.getRoot()->name] = {};
     return builder;
 }
-DAGRequestBuilder MockDAGRequestContext::send(String exchange_name, tipb::ExchangeType exchange_type)
-{
-    auto builder = DAGRequestBuilder(index).exchangeSender(exchange_schemas[exchange_name], exchange_type);
-    receiver_source_task_ids_map[builder.getRoot()->name] = {};
-    return builder;
-}
 } // namespace DB::tests

--- a/dbms/src/TestUtils/mockExecutor.cpp
+++ b/dbms/src/TestUtils/mockExecutor.cpp
@@ -20,6 +20,8 @@
 #include <Parsers/ASTOrderByElement.h>
 #include <TestUtils/TiFlashTestException.h>
 #include <TestUtils/mockExecutor.h>
+#include <cassert>
+#include "Debug/astToExecutor.h"
 namespace DB::tests
 {
 ASTPtr buildColumn(const String & column_name)
@@ -182,6 +184,13 @@ DAGRequestBuilder & DAGRequestBuilder::project(MockColumnNames col_names)
     }
 
     root = compileProject(root, getExecutorIndex(), exp_list);
+    return *this;
+}
+
+DAGRequestBuilder & DAGRequestBuilder::exchangeSender() 
+{
+    assert(root);
+    root = compileExchangeSender(root, getExecutorIndex());
     return *this;
 }
 

--- a/dbms/src/TestUtils/mockExecutor.h
+++ b/dbms/src/TestUtils/mockExecutor.h
@@ -21,6 +21,8 @@
 #include <initializer_list>
 #include <unordered_map>
 
+#include "tipb/executor.pb.h"
+
 namespace DB::tests
 {
 using MockColumnInfo = std::pair<String, TiDB::TP>;
@@ -84,6 +86,8 @@ public:
     DAGRequestBuilder & project(MockColumnNames col_names);
 
     DAGRequestBuilder & exchangeSender(tipb::ExchangeType exchange_type);
+    DAGRequestBuilder & exchangeSender(const MockColumnInfos & columns, tipb::ExchangeType exchange_type);
+
 
     // Currentlt only support inner join, left join and right join.
     // TODO support more types of join.
@@ -127,24 +131,20 @@ public:
     void addExchangeRelationSchema(String name, const MockColumnInfos & columns);
     void addExchangeRelationSchema(String name, const MockColumnInfoList & columns);
     DAGRequestBuilder scan(String db_name, String table_name);
-
-    DAGRequestBuilder receive(String sender_name);
-    Context context;
+    DAGRequestBuilder receive(String exchange_name);
+    DAGRequestBuilder send(String exchange_name, tipb::ExchangeType exchange_type = tipb::PassThrough);
 
 private:
     size_t index;
     std::unordered_map<String, MockColumnInfos> mock_tables;
     std::unordered_map<String, MockColumnInfos> exchange_schemas;
-    // ExchangeSender can specify its ExchangeReceiver
-    std::unordered_map<String, std::vector<String>> sender_to_receivers_map;
-    std::unordered_map<String, String> receiver_to_sender_map;
 
 public:
     // Currently don't support task_id, so the following to structure is useless,
     // but we need it to contruct the TaskMeta.
     // In TiFlash, we use task_id to identify an Mpp Task.
     std::unordered_map<String, std::vector<Int64>> receiver_source_task_ids_map;
-    std::vector<Int64> sender_target_task_ids; // not used
+    Context context;
 };
 
 ASTPtr buildColumn(const String & column_name);

--- a/dbms/src/TestUtils/mockExecutor.h
+++ b/dbms/src/TestUtils/mockExecutor.h
@@ -17,11 +17,10 @@
 #include <Debug/astToExecutor.h>
 #include <Interpreters/Context.h>
 #include <Parsers/ASTFunction.h>
+#include <tipb/executor.pb.h>
 
 #include <initializer_list>
 #include <unordered_map>
-
-#include "tipb/executor.pb.h"
 
 namespace DB::tests
 {
@@ -132,7 +131,6 @@ public:
     void addExchangeRelationSchema(String name, const MockColumnInfoList & columns);
     DAGRequestBuilder scan(String db_name, String table_name);
     DAGRequestBuilder receive(String exchange_name);
-    DAGRequestBuilder send(String exchange_name, tipb::ExchangeType exchange_type = tipb::PassThrough);
 
 private:
     size_t index;

--- a/dbms/src/TestUtils/mockExecutor.h
+++ b/dbms/src/TestUtils/mockExecutor.h
@@ -51,14 +51,18 @@ public:
 
     explicit DAGRequestBuilder(size_t & index)
         : executor_index(index)
-    {}
+    {
+    }
 
     std::shared_ptr<tipb::DAGRequest> build(Context & context);
 
     DAGRequestBuilder & mockTable(const String & db, const String & table, const MockColumnInfos & columns);
     DAGRequestBuilder & mockTable(const MockTableName & name, const MockColumnInfos & columns);
     DAGRequestBuilder & mockTable(const MockTableName & name, const MockColumnInfoList & columns);
-    DAGRequestBuilder & exchangeReceiver();
+
+    DAGRequestBuilder & exchangeReceiver(const MockColumnInfos & columns);
+    DAGRequestBuilder & exchangeReceiver(const MockColumnInfoList & columns);
+    DAGRequestBuilder & buildExchangeReceiver(const MockColumnInfos & columns);
 
     DAGRequestBuilder & filter(ASTPtr filter_expr);
 
@@ -90,6 +94,7 @@ private:
 
     ExecutorPtr root;
     DAGProperties properties;
+    std::unordered_map<String, std::vector<Int64>> receiver_source_task_ids_map;
 };
 
 /** Responsible for storing necessary arguments in order to Mock DAGRequest
@@ -114,6 +119,7 @@ public:
     void addMockTable(const MockTableName & name, const MockColumnInfos & columns);
 
     DAGRequestBuilder scan(String db_name, String table_name);
+    DAGRequestBuilder receive(String db_name, String table_name);
 
 private:
     size_t index;

--- a/dbms/src/TestUtils/mockExecutor.h
+++ b/dbms/src/TestUtils/mockExecutor.h
@@ -85,8 +85,6 @@ public:
     DAGRequestBuilder & project(MockColumnNames col_names);
 
     DAGRequestBuilder & exchangeSender(tipb::ExchangeType exchange_type);
-    DAGRequestBuilder & exchangeSender(const MockColumnInfos & columns, tipb::ExchangeType exchange_type);
-
 
     // Currentlt only support inner join, left join and right join.
     // TODO support more types of join.

--- a/dbms/src/TestUtils/mockExecutor.h
+++ b/dbms/src/TestUtils/mockExecutor.h
@@ -58,6 +58,7 @@ public:
     DAGRequestBuilder & mockTable(const String & db, const String & table, const MockColumnInfos & columns);
     DAGRequestBuilder & mockTable(const MockTableName & name, const MockColumnInfos & columns);
     DAGRequestBuilder & mockTable(const MockTableName & name, const MockColumnInfoList & columns);
+    DAGRequestBuilder & exchangeReceiver();
 
     DAGRequestBuilder & filter(ASTPtr filter_expr);
 
@@ -73,6 +74,7 @@ public:
     DAGRequestBuilder & project(MockAsts expr);
     DAGRequestBuilder & project(MockColumnNames col_names);
 
+    DAGRequestBuilder & exchangeSender();
     // Currentlt only support inner join, left join and right join.
     // TODO support more types of join.
     DAGRequestBuilder & join(const DAGRequestBuilder & right, ASTPtr using_expr_list);

--- a/dbms/src/TestUtils/mockExecutor.h
+++ b/dbms/src/TestUtils/mockExecutor.h
@@ -124,8 +124,8 @@ public:
     void addMockTable(const MockTableName & name, const MockColumnInfoList & columns);
     void addMockTable(const String & db, const String & table, const MockColumnInfos & columns);
     void addMockTable(const MockTableName & name, const MockColumnInfos & columns);
-    void addExchangeSender(String name, const MockColumnInfos & columns, std::vector<String> receivers);
-    void addExchangeSender(String name, const MockColumnInfoList & columns, std::initializer_list<String> receivers);
+    void addExchangeRelationSchema(String name, const MockColumnInfos & columns);
+    void addExchangeRelationSchema(String name, const MockColumnInfoList & columns);
     DAGRequestBuilder scan(String db_name, String table_name);
 
     DAGRequestBuilder receive(String sender_name);
@@ -134,7 +134,7 @@ public:
 private:
     size_t index;
     std::unordered_map<String, MockColumnInfos> mock_tables;
-    std::unordered_map<String, MockColumnInfos> exchange_sender_schemas;
+    std::unordered_map<String, MockColumnInfos> exchange_schemas;
     // ExchangeSender can specify its ExchangeReceiver
     std::unordered_map<String, std::vector<String>> sender_to_receivers_map;
     std::unordered_map<String, String> receiver_to_sender_map;
@@ -144,7 +144,7 @@ public:
     // but we need it to contruct the TaskMeta.
     // In TiFlash, we use task_id to identify an Mpp Task.
     std::unordered_map<String, std::vector<Int64>> receiver_source_task_ids_map;
-    std::vector<Int64> sender_target_task_ids;
+    std::vector<Int64> sender_target_task_ids; // not used
 };
 
 ASTPtr buildColumn(const String & column_name);

--- a/dbms/src/TestUtils/tests/gtest_mock_executors.cpp
+++ b/dbms/src/TestUtils/tests/gtest_mock_executors.cpp
@@ -172,5 +172,15 @@ try
 }
 CATCH
 
+TEST_F(MockDAGRequestTest, ExchangeReceiver)
+try
+{
+    auto request = mock_dag_request_context.receive("test_db", "test_table")
+                       .build(context);
+    String expected_string = "exchange_receiver_0\n";
+    ASSERT_DAGREQUEST_EQAUL(expected_string, request);
+}
+CATCH
+
 } // namespace tests
 } // namespace DB

--- a/dbms/src/TestUtils/tests/gtest_mock_executors.cpp
+++ b/dbms/src/TestUtils/tests/gtest_mock_executors.cpp
@@ -189,11 +189,6 @@ try
                                " project_1\n"
                                "  table_scan_0\n";
     ASSERT_DAGREQUEST_EQAUL(expected_string_3, request);
-
-    request = context.send("sender_1")
-                  .build(context);
-    String expected_string_4 = "exchange_sender_0\n";
-    ASSERT_DAGREQUEST_EQAUL(expected_string_4, request);
 }
 CATCH
 

--- a/dbms/src/TestUtils/tests/gtest_mock_executors.cpp
+++ b/dbms/src/TestUtils/tests/gtest_mock_executors.cpp
@@ -15,6 +15,7 @@
 #include <Interpreters/Context.h>
 #include <TestUtils/InterpreterTestUtils.h>
 #include <TestUtils/mockExecutor.h>
+#include <tipb/executor.pb.h>
 
 namespace DB
 {
@@ -26,23 +27,24 @@ public:
     void initializeContext() override
     {
         dag_context_ptr = std::make_unique<DAGContext>(1024);
-        context.setDAGContext(dag_context_ptr.get());
-        mock_dag_request_context = MockDAGRequestContext();
-        mock_dag_request_context.addMockTable({"test_db", "test_table"}, {{"s1", TiDB::TP::TypeString}, {"s2", TiDB::TP::TypeString}});
-        mock_dag_request_context.addMockTable({"test_db", "test_table_1"}, {{"s1", TiDB::TP::TypeLong}, {"s2", TiDB::TP::TypeString}, {"s3", TiDB::TP::TypeString}});
-        mock_dag_request_context.addMockTable({"test_db", "r_table"}, {{"r_a", TiDB::TP::TypeLong}, {"r_b", TiDB::TP::TypeString}, {"r_c", TiDB::TP::TypeString}});
-        mock_dag_request_context.addMockTable({"test_db", "l_table"}, {{"l_a", TiDB::TP::TypeLong}, {"l_b", TiDB::TP::TypeString}, {"l_c", TiDB::TP::TypeString}});
+        context = MockDAGRequestContext(TiFlashTestEnv::getContext());
+
+        context.addMockTable({"test_db", "test_table"}, {{"s1", TiDB::TP::TypeString}, {"s2", TiDB::TP::TypeString}});
+        context.addMockTable({"test_db", "test_table_1"}, {{"s1", TiDB::TP::TypeLong}, {"s2", TiDB::TP::TypeString}, {"s3", TiDB::TP::TypeString}});
+        context.addMockTable({"test_db", "r_table"}, {{"r_a", TiDB::TP::TypeLong}, {"r_b", TiDB::TP::TypeString}, {"r_c", TiDB::TP::TypeString}});
+        context.addMockTable({"test_db", "l_table"}, {{"l_a", TiDB::TP::TypeLong}, {"l_b", TiDB::TP::TypeString}, {"l_c", TiDB::TP::TypeString}});
+        context.addExchangeSender("sender_1", {{"s1", TiDB::TP::TypeString}, {"s2", TiDB::TP::TypeString}, {"s3", TiDB::TP::TypeString}}, {"receiver_1", "receiver_2"});
     }
 };
 
 TEST_F(MockDAGRequestTest, MockTable)
 try
 {
-    auto request = mock_dag_request_context.scan("test_db", "test_table").build(context);
+    auto request = context.scan("test_db", "test_table").build(context);
     String expected_string_1 = "table_scan_0\n";
     ASSERT_DAGREQUEST_EQAUL(expected_string_1, request);
 
-    request = mock_dag_request_context.scan("test_db", "test_table_1").build(context);
+    request = context.scan("test_db", "test_table_1").build(context);
     String expected_string_2 = "table_scan_0\n";
     ASSERT_DAGREQUEST_EQAUL(expected_string_2, request);
 }
@@ -51,12 +53,12 @@ CATCH
 TEST_F(MockDAGRequestTest, Filter)
 try
 {
-    auto request = mock_dag_request_context.scan("test_db", "test_table").filter(eq(col("s1"), col("s2"))).build(context);
+    auto request = context.scan("test_db", "test_table").filter(eq(col("s1"), col("s2"))).build(context);
     String expected_string = "selection_1\n"
                              " table_scan_0\n";
     ASSERT_DAGREQUEST_EQAUL(expected_string, request);
 
-    request = mock_dag_request_context.scan("test_db", "test_table_1")
+    request = context.scan("test_db", "test_table_1")
                   .filter(And(eq(col("s1"), col("s2")), lt(col("s2"), col("s3"))))
                   .build(context);
     ASSERT_DAGREQUEST_EQAUL(expected_string, request);
@@ -66,21 +68,21 @@ CATCH
 TEST_F(MockDAGRequestTest, Projection)
 try
 {
-    auto request = mock_dag_request_context.scan("test_db", "test_table")
+    auto request = context.scan("test_db", "test_table")
                        .project("s1")
                        .build(context);
     String expected_string = "project_1\n"
                              " table_scan_0\n";
     ASSERT_DAGREQUEST_EQAUL(expected_string, request);
 
-    request = mock_dag_request_context.scan("test_db", "test_table_1")
+    request = context.scan("test_db", "test_table_1")
                   .project({col("s3"), eq(col("s1"), col("s2"))})
                   .build(context);
     String expected_string_2 = "project_1\n"
                                " table_scan_0\n";
     ASSERT_DAGREQUEST_EQAUL(expected_string_2, request);
 
-    request = mock_dag_request_context.scan("test_db", "test_table_1")
+    request = context.scan("test_db", "test_table_1")
                   .project({"s1", "s2"})
                   .build(context);
     ASSERT_DAGREQUEST_EQAUL(expected_string, request);
@@ -90,14 +92,14 @@ CATCH
 TEST_F(MockDAGRequestTest, Limit)
 try
 {
-    auto request = mock_dag_request_context.scan("test_db", "test_table")
+    auto request = context.scan("test_db", "test_table")
                        .limit(10)
                        .build(context);
     String expected_string = "limit_1\n"
                              " table_scan_0\n";
     ASSERT_DAGREQUEST_EQAUL(expected_string, request);
 
-    request = mock_dag_request_context.scan("test_db", "test_table_1")
+    request = context.scan("test_db", "test_table_1")
                   .limit(lit(Field(static_cast<UInt64>(10))))
                   .build(context);
     ASSERT_DAGREQUEST_EQAUL(expected_string, request);
@@ -107,14 +109,14 @@ CATCH
 TEST_F(MockDAGRequestTest, TopN)
 try
 {
-    auto request = mock_dag_request_context.scan("test_db", "test_table")
+    auto request = context.scan("test_db", "test_table")
                        .topN({{"s1", false}}, 10)
                        .build(context);
     String expected_string = "topn_1\n"
                              " table_scan_0\n";
     ASSERT_DAGREQUEST_EQAUL(expected_string, request);
 
-    request = mock_dag_request_context.scan("test_db", "test_table")
+    request = context.scan("test_db", "test_table")
                   .topN("s1", false, 10)
                   .build(context);
     ASSERT_DAGREQUEST_EQAUL(expected_string, request);
@@ -124,7 +126,7 @@ CATCH
 TEST_F(MockDAGRequestTest, Aggregation)
 try
 {
-    auto request = mock_dag_request_context.scan("test_db", "test_table")
+    auto request = context.scan("test_db", "test_table")
                        .aggregation(Max(col("s1")), col("s2"))
                        .build(context);
     String expected_string = "aggregation_1\n"
@@ -136,13 +138,13 @@ CATCH
 TEST_F(MockDAGRequestTest, Join)
 try
 {
-    DAGRequestBuilder right_builder = mock_dag_request_context.scan("test_db", "r_table")
+    DAGRequestBuilder right_builder = context.scan("test_db", "r_table")
                                           .filter(eq(col("r_a"), col("r_b")))
                                           .project({col("r_a"), col("r_b")})
                                           .aggregation(Max(col("r_a")), col("r_b"));
 
 
-    DAGRequestBuilder left_builder = mock_dag_request_context.scan("test_db", "l_table")
+    DAGRequestBuilder left_builder = context.scan("test_db", "l_table")
                                          .topN({{"l_a", false}}, 10)
                                          .join(right_builder, col("l_a"), ASTTableJoin::Kind::Left)
                                          .limit(10);
@@ -163,33 +165,42 @@ CATCH
 TEST_F(MockDAGRequestTest, ExchangeSender)
 try
 {
-    auto request = mock_dag_request_context.scan("test_db", "test_table")
-                       .exchangeSender()
+    auto request = context.scan("test_db", "test_table")
+                       .exchangeSender(tipb::PassThrough)
                        .build(context);
     String expected_string = "exchange_sender_1\n"
                              " table_scan_0\n";
     ASSERT_DAGREQUEST_EQAUL(expected_string, request);
 
-    request = mock_dag_request_context.scan("test_db", "test_table")
+    request = context.scan("test_db", "test_table")
                   .topN("s1", false, 10)
-                  .exchangeSender()
+                  .exchangeSender(tipb::Broadcast)
                   .build(context);
     String expected_string_2 = "exchange_sender_2\n"
                                " topn_1\n"
                                "  table_scan_0\n";
     ASSERT_DAGREQUEST_EQAUL(expected_string_2, request);
+
+    request = context.scan("test_db", "test_table")
+                  .project({col("s1"), col("s2")})
+                  .exchangeSender(tipb::Hash)
+                  .build(context);
+    String expected_string_3 = "exchange_sender_2\n"
+                               " project_1\n"
+                               "  table_scan_0\n";
+    ASSERT_DAGREQUEST_EQAUL(expected_string_3, request);
 }
 CATCH
 
 TEST_F(MockDAGRequestTest, ExchangeReceiver)
 try
 {
-    auto request = mock_dag_request_context.receive("test_db", "test_table")
+    auto request = context.receive("sender_1")
                        .build(context);
     String expected_string = "exchange_receiver_0\n";
     ASSERT_DAGREQUEST_EQAUL(expected_string, request);
 
-    request = mock_dag_request_context.receive("test_db", "test_table")
+    request = context.receive("sender_1")
                   .topN("s1", false, 10)
                   .build(context);
     String expected_string_2 = "topn_1\n"

--- a/dbms/src/TestUtils/tests/gtest_mock_executors.cpp
+++ b/dbms/src/TestUtils/tests/gtest_mock_executors.cpp
@@ -33,7 +33,7 @@ public:
         context.addMockTable({"test_db", "test_table_1"}, {{"s1", TiDB::TP::TypeLong}, {"s2", TiDB::TP::TypeString}, {"s3", TiDB::TP::TypeString}});
         context.addMockTable({"test_db", "r_table"}, {{"r_a", TiDB::TP::TypeLong}, {"r_b", TiDB::TP::TypeString}, {"r_c", TiDB::TP::TypeString}});
         context.addMockTable({"test_db", "l_table"}, {{"l_a", TiDB::TP::TypeLong}, {"l_b", TiDB::TP::TypeString}, {"l_c", TiDB::TP::TypeString}});
-        context.addExchangeSender("sender_1", {{"s1", TiDB::TP::TypeString}, {"s2", TiDB::TP::TypeString}, {"s3", TiDB::TP::TypeString}}, {"receiver_1", "receiver_2"});
+        context.addExchangeRelationSchema("sender_1", {{"s1", TiDB::TP::TypeString}, {"s2", TiDB::TP::TypeString}, {"s3", TiDB::TP::TypeString}});
     }
 };
 

--- a/dbms/src/TestUtils/tests/gtest_mock_executors.cpp
+++ b/dbms/src/TestUtils/tests/gtest_mock_executors.cpp
@@ -169,6 +169,15 @@ try
     String expected_string = "exchange_sender_1\n"
                              " table_scan_0\n";
     ASSERT_DAGREQUEST_EQAUL(expected_string, request);
+
+    request = mock_dag_request_context.scan("test_db", "test_table")
+                  .topN("s1", false, 10)
+                  .exchangeSender()
+                  .build(context);
+    String expected_string_2 = "exchange_sender_2\n"
+                               " topn_1\n"
+                               "  table_scan_0\n";
+    ASSERT_DAGREQUEST_EQAUL(expected_string_2, request);
 }
 CATCH
 
@@ -179,6 +188,13 @@ try
                        .build(context);
     String expected_string = "exchange_receiver_0\n";
     ASSERT_DAGREQUEST_EQAUL(expected_string, request);
+
+    request = mock_dag_request_context.receive("test_db", "test_table")
+                  .topN("s1", false, 10)
+                  .build(context);
+    String expected_string_2 = "topn_1\n"
+                               " exchange_receiver_0\n";
+    ASSERT_DAGREQUEST_EQAUL(expected_string_2, request);
 }
 CATCH
 

--- a/dbms/src/TestUtils/tests/gtest_mock_executors.cpp
+++ b/dbms/src/TestUtils/tests/gtest_mock_executors.cpp
@@ -160,5 +160,17 @@ try
 }
 CATCH
 
+TEST_F(MockDAGRequestTest, ExchangeSender)
+try
+{
+    auto request = mock_dag_request_context.scan("test_db", "test_table")
+                       .exchangeSender()
+                       .build(context);
+    String expected_string = "exchange_sender_1\n"
+                             " table_scan_0\n";
+    ASSERT_DAGREQUEST_EQAUL(expected_string, request);
+}
+CATCH
+
 } // namespace tests
 } // namespace DB

--- a/dbms/src/TestUtils/tests/gtest_mock_executors.cpp
+++ b/dbms/src/TestUtils/tests/gtest_mock_executors.cpp
@@ -189,6 +189,11 @@ try
                                " project_1\n"
                                "  table_scan_0\n";
     ASSERT_DAGREQUEST_EQAUL(expected_string_3, request);
+
+    request = context.send("sender_1")
+                  .build(context);
+    String expected_string_4 = "exchange_sender_0\n";
+    ASSERT_DAGREQUEST_EQAUL(expected_string_4, request);
 }
 CATCH
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #4609 

Problem Summary:
I didn't support mock exchange executors function, in order to fully supprt mock dagrequest, need to implement all of them.

### What is changed and how it works?
Mock exchangeSender&Receivers.
Little refactor of Interpreter test utils in order to mock exchange executors easily.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
