### PR TITLE
reuse old index file format for empty dmfile and just ignore it's size in statistical data

### DIFF
--- a/dbms/src/Storages/DeltaMerge/File/DMFileWriter.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileWriter.h
@@ -250,7 +250,7 @@ private:
     FileProviderPtr file_provider;
     WriteLimiterPtr write_limiter;
 
-    // use to avoid write index data for empty file
+    // use to avoid count data written in index file for empty dmfile
     bool is_empty_file = true;
 };
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #4708

Problem Summary:
In this pr #4500, we avoid write data into minmax index file for emtpy dmfile. But this kind of dmfile cannot be recogonized by older version. So after degrading, tiflash fails.

### What is changed and how it works?
Reuse old index file format and just ignore the size written into minmax index file in this case.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
1. Test that `stable_siz_on_disk` is 0 for empty segments;
2. Test that after this fix the master branch can be degraded to ver6.0.0;
Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
