### PR TITLE
[DNM] enable set tiflash_mpp engine label using config

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -35,7 +35,7 @@
 [submodule "contrib/tiflash-proxy"]
 	path = contrib/tiflash-proxy
 	url = https://github.com/guo-shaoge/tikv.git
-    branch = cloud_test
+	branch = cloud_test
 [submodule "contrib/prometheus-cpp"]
 	path = contrib/prometheus-cpp
 	url = https://github.com/jupp0r/prometheus-cpp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -34,7 +34,8 @@
 	url = https://github.com/tikv/client-c.git
 [submodule "contrib/tiflash-proxy"]
 	path = contrib/tiflash-proxy
-	url = https://github.com/pingcap/tidb-engine-ext.git
+	url = https://github.com/guo-shaoge/tikv.git
+  branch = cloud_test
 [submodule "contrib/prometheus-cpp"]
 	path = contrib/prometheus-cpp
 	url = https://github.com/jupp0r/prometheus-cpp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -35,7 +35,7 @@
 [submodule "contrib/tiflash-proxy"]
 	path = contrib/tiflash-proxy
 	url = https://github.com/guo-shaoge/tikv.git
-  branch = cloud_test
+    branch = cloud_test
 [submodule "contrib/prometheus-cpp"]
 	path = contrib/prometheus-cpp
 	url = https://github.com/jupp0r/prometheus-cpp.git

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -238,7 +238,7 @@ struct TiFlashProxyConfig
     const String engine_store_advertise_address = "advertise-engine-addr";
     const String pd_endpoints = "pd-endpoints";
     const String engine_label = "engine-label";
-    // const String engine_label_value = "tiflash";
+    const String default_engine_label_value = "tiflash";
 
     explicit TiFlashProxyConfig(Poco::Util::LayeredConfiguration & config)
     {
@@ -261,7 +261,10 @@ struct TiFlashProxyConfig
                 args_map[engine_store_address] = config.getString("flash.service_addr");
             else
                 args_map[engine_store_advertise_address] = args_map[engine_store_address];
-            // args_map[engine_label] = engine_label_value;
+            if (args_map.find(engine_label) == args_map.end())
+            {
+                args_map[engine_label] = default_engine_label_value;
+            }
 
             for (auto && [k, v] : args_map)
             {

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -238,7 +238,7 @@ struct TiFlashProxyConfig
     const String engine_store_advertise_address = "advertise-engine-addr";
     const String pd_endpoints = "pd-endpoints";
     const String engine_label = "engine-label";
-    const String engine_label_value = "tiflash";
+    // const String engine_label_value = "tiflash";
 
     explicit TiFlashProxyConfig(Poco::Util::LayeredConfiguration & config)
     {
@@ -261,7 +261,7 @@ struct TiFlashProxyConfig
                 args_map[engine_store_address] = config.getString("flash.service_addr");
             else
                 args_map[engine_store_advertise_address] = args_map[engine_store_address];
-            args_map[engine_label] = engine_label_value;
+            // args_map[engine_label] = engine_label_value;
 
             for (auto && [k, v] : args_map)
             {

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -118,6 +118,7 @@
 # status-addr = "0.0.0.0:20292"
 # advertise-status-addr = "tiflash0:20292"
 # engine-addr = "tiflash0:3930"
+# engine-label = "tiflash_mpp"
 
 [logger]
 # log = "/tmp/tiflash/log/server.log"


### PR DESCRIPTION
Signed-off-by: guo-shaoge <shaoge1994@163.com>

### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:
1. Enable config **engine-label** for tiflash_proxy, check etc/config-template.toml 
2. Related tiflash_proxy change is in this [branch](https://github.com/guo-shaoge/tikv/tree/cloud_test).
### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
