### PR TITLE
Fix ingest dmfile won't rollback

### DIFF
--- a/dbms/src/Storages/DeltaMerge/WriteBatches.h
+++ b/dbms/src/Storages/DeltaMerge/WriteBatches.h
@@ -42,12 +42,13 @@ struct WriteBatches : private boost::noncopyable
     WriteLimiterPtr write_limiter;
 
     WriteBatches(StoragePool & storage_pool_, const WriteLimiterPtr & write_limiter_ = nullptr)
-        : log(storage_pool_.getNamespaceId())
-        , data(storage_pool_.getNamespaceId())
-        , meta(storage_pool_.getNamespaceId())
-        , removed_log(storage_pool_.getNamespaceId())
-        , removed_data(storage_pool_.getNamespaceId())
-        , removed_meta(storage_pool_.getNamespaceId())
+        : ns_id(storage_pool_.getNamespaceId())
+        , log(ns_id)
+        , data(ns_id)
+        , meta(ns_id)
+        , removed_log(ns_id)
+        , removed_data(ns_id)
+        , removed_meta(ns_id)
         , storage_pool(storage_pool_)
         , write_limiter(write_limiter_)
     {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #3594 

Problem Summary:

The ns_id is uninited. When ingest happened, `PageStorage` won't del the `ext_page_id` because ns_id is wrong.
```
[2022/04/27 07:21:14.499 +08:00] [TRACE] [WriteBatches.h:147] ["WriteBatches:Rollback remove from data_wb : X140630288340448.2241"] [thread_id=58]
[2022/04/27 07:21:27.138 +08:00] [TRACE] [WriteBatches.h:147] ["WriteBatches:Rollback remove from data_wb : X140630288340448.2065"] [thread_id=58]
[2022/04/27 07:21:52.968 +08:00] [TRACE] [WriteBatches.h:147] ["WriteBatches:Rollback remove from data_wb : X140630288340448.2247"] [thread_id=58]
[2022/04/27 07:22:18.728 +08:00] [TRACE] [WriteBatches.h:147] ["WriteBatches:Rollback remove from data_wb : X140630288340448.2249"] [thread_id=58]
[2022/04/27 07:22:31.249 +08:00] [TRACE] [WriteBatches.h:147] ["WriteBatches:Rollback remove from data_wb : X140630288340448.2068"] [thread_id=58]
[2022/04/27 07:22:44.229 +08:00] [TRACE] [WriteBatches.h:147] ["WriteBatches:Rollback remove from data_wb : X140630288340448.2071"] [thread_id=58]
```

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
