### PR TITLE
Fix gtest mpp tunnel local write unstable issue

### DIFF
--- a/dbms/src/Flash/Mpp/tests/gtest_mpptunnel.cpp
+++ b/dbms/src/Flash/Mpp/tests/gtest_mpptunnel.cpp
@@ -469,6 +469,7 @@ try
     data_packet_ptr->set_data("First");
     mpp_tunnel_ptr->write(*data_packet_ptr);
     mpp_tunnel_ptr->close("Cancel");
+    mpp_tunnel_ptr->getThreadManager->wait(); // Join local read thread
     GTEST_ASSERT_EQ(mpp_tunnel_ptr->getFinishFlag(), true);
     GTEST_ASSERT_EQ(local_reader_ptr->write_packet_vec.size(), 2); //Second for err msg
     GTEST_ASSERT_EQ(local_reader_ptr->write_packet_vec[0], "First");
@@ -486,6 +487,7 @@ try
     data_packet_ptr->set_data("First");
     mpp_tunnel_ptr->write(*data_packet_ptr);
     mpp_tunnel_ptr->writeDone();
+    mpp_tunnel_ptr->getThreadManager->wait(); // Join local read thread
     GTEST_ASSERT_EQ(mpp_tunnel_ptr->getFinishFlag(), true);
     GTEST_ASSERT_EQ(local_reader_ptr->write_packet_vec.size(), 1);
     GTEST_ASSERT_EQ(local_reader_ptr->write_packet_vec[0], "First");

--- a/dbms/src/Flash/Mpp/tests/gtest_mpptunnel.cpp
+++ b/dbms/src/Flash/Mpp/tests/gtest_mpptunnel.cpp
@@ -469,7 +469,7 @@ try
     data_packet_ptr->set_data("First");
     mpp_tunnel_ptr->write(*data_packet_ptr);
     mpp_tunnel_ptr->close("Cancel");
-    mpp_tunnel_ptr->getThreadManager->wait(); // Join local read thread
+    mpp_tunnel_ptr->getThreadManager()->wait(); // Join local read thread
     GTEST_ASSERT_EQ(mpp_tunnel_ptr->getFinishFlag(), true);
     GTEST_ASSERT_EQ(local_reader_ptr->write_packet_vec.size(), 2); //Second for err msg
     GTEST_ASSERT_EQ(local_reader_ptr->write_packet_vec[0], "First");
@@ -487,7 +487,7 @@ try
     data_packet_ptr->set_data("First");
     mpp_tunnel_ptr->write(*data_packet_ptr);
     mpp_tunnel_ptr->writeDone();
-    mpp_tunnel_ptr->getThreadManager->wait(); // Join local read thread
+    mpp_tunnel_ptr->getThreadManager()->wait(); // Join local read thread
     GTEST_ASSERT_EQ(mpp_tunnel_ptr->getFinishFlag(), true);
     GTEST_ASSERT_EQ(local_reader_ptr->write_packet_vec.size(), 1);
     GTEST_ASSERT_EQ(local_reader_ptr->write_packet_vec[0], "First");


### PR DESCRIPTION
Signed-off-by: yibin <huyibin@pingcap.com>

### What problem does this PR solve?

Issue Number: close #4749 

Problem Summary:

### What is changed and how it works?
In previous gtest, we use MPPTunnel's thread_manager field to create the local reader thread. However since local_reader and mpp tunnel are shared_pointer, and main_thread might finish before local read thread(low possiblity but could happen, this explains the low reproduce possibility of this issue.) Then local read thread will take responsiblity for destructing MPPTunnel object, and will lead to thread joining itself. This must be a problem. 
  Although I still can't figure out how the index out of bound error in CI happened, I believe adding thread_manager->wait() in main_thread will fix the unstable issue.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
