### PR TITLE
Fix getMaxId won't get the right max id before GC

### DIFF
--- a/dbms/src/Storages/Page/V3/PageDirectory.cpp
+++ b/dbms/src/Storages/Page/V3/PageDirectory.cpp
@@ -889,24 +889,28 @@ PageId PageDirectory::getMaxId(NamespaceId ns_id) const
         // iter is not at the beginning and mvcc_table_directory is not empty,
         // so iter-- must be a valid iterator, and it's the largest page id which is smaller than the target page id.
         iter--;
-        if (iter->first.high != ns_id)
-        {
-            return 0;
-        }
-        while (iter->second->getEntry(UINT64_MAX - 1) == std::nullopt)
+
+
+        do
         {
             if (iter->first.high != ns_id)
             {
                 return 0;
             }
 
+            if (iter->second->getEntry(UINT64_MAX - 1) != std::nullopt)
+            {
+                return iter->first.low;
+            }
+
             if (iter == mvcc_table_directory.begin())
             {
                 return 0;
             }
-            iter--;
-        }
 
+            iter--;
+
+        } while (true);
 
         return iter->first.low;
     }

--- a/dbms/src/Storages/Page/V3/PageDirectory.cpp
+++ b/dbms/src/Storages/Page/V3/PageDirectory.cpp
@@ -889,10 +889,26 @@ PageId PageDirectory::getMaxId(NamespaceId ns_id) const
         // iter is not at the beginning and mvcc_table_directory is not empty,
         // so iter-- must be a valid iterator, and it's the largest page id which is smaller than the target page id.
         iter--;
-        if (iter->first.high == ns_id)
-            return iter->first.low;
-        else
+        if (iter->first.high != ns_id)
+        {
             return 0;
+        }
+        while (iter->second->getEntry(UINT64_MAX - 1) == std::nullopt)
+        {
+            if (iter->first.high != ns_id)
+            {
+                return 0;
+            }
+
+            if (iter == mvcc_table_directory.begin())
+            {
+                return 0;
+            }
+            iter--;
+        }
+
+
+        return iter->first.low;
     }
 }
 

--- a/dbms/src/Storages/Page/V3/PageDirectory.cpp
+++ b/dbms/src/Storages/Page/V3/PageDirectory.cpp
@@ -890,29 +890,30 @@ PageId PageDirectory::getMaxId(NamespaceId ns_id) const
         // so iter-- must be a valid iterator, and it's the largest page id which is smaller than the target page id.
         iter--;
 
-
         do
         {
+            // Can't find any entries in current ns_id
             if (iter->first.high != ns_id)
             {
-                return 0;
+                break;
             }
 
+            // Find the last valid one
             if (iter->second->getEntry(UINT64_MAX - 1) != std::nullopt)
             {
                 return iter->first.low;
             }
 
+            // Current entries is deleted. There are no entries before current.
             if (iter == mvcc_table_directory.begin())
             {
-                return 0;
+                break;
             }
 
             iter--;
-
         } while (true);
 
-        return iter->first.low;
+        return 0;
     }
 }
 

--- a/dbms/src/Storages/Page/V3/PageDirectory.cpp
+++ b/dbms/src/Storages/Page/V3/PageDirectory.cpp
@@ -904,7 +904,7 @@ PageId PageDirectory::getMaxId(NamespaceId ns_id) const
                 return iter->first.low;
             }
 
-            // Current entries is deleted. There are no entries before current.
+            // Current entry is deleted and there are no entries before it.
             if (iter == mvcc_table_directory.begin())
             {
                 break;

--- a/dbms/src/Storages/Page/V3/tests/gtest_page_directory.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_page_directory.cpp
@@ -2054,10 +2054,24 @@ try
         ASSERT_EQ(dir->getMaxId(medium), 320);
         ASSERT_EQ(dir->getMaxId(large), 2);
     }
+
+    {
+        PageEntriesEdit edit;
+        edit.del(buildV3Id(medium, 320));
+        dir->apply(std::move(edit));
+        ASSERT_EQ(dir->getMaxId(medium), 300);
+    }
+
+    {
+        PageEntriesEdit edit;
+        edit.del(buildV3Id(medium, 300));
+        dir->apply(std::move(edit));
+        ASSERT_EQ(dir->getMaxId(medium), 0);
+    }
 }
 CATCH
 
-TEST_F(PageDirectoryTest, GetMaxId2)
+TEST_F(PageDirectoryTest, GetMaxIdAfterDelete)
 try
 {
     PageEntryV3 entry1{.file_id = 1, .size = 1024, .tag = 0, .offset = 0x123, .checksum = 0x4567};
@@ -2083,6 +2097,9 @@ try
         edit.del(1);
         dir->apply(std::move(edit));
     }
+    ASSERT_EQ(dir->getMaxId(TEST_NAMESPACE_ID), 0);
+
+    dir->gcInMemEntries();
     ASSERT_EQ(dir->getMaxId(TEST_NAMESPACE_ID), 0);
 }
 CATCH

--- a/dbms/src/Storages/Page/V3/tests/gtest_page_directory.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_page_directory.cpp
@@ -2057,6 +2057,36 @@ try
 }
 CATCH
 
+TEST_F(PageDirectoryTest, GetMaxId2)
+try
+{
+    PageEntryV3 entry1{.file_id = 1, .size = 1024, .tag = 0, .offset = 0x123, .checksum = 0x4567};
+    PageEntryV3 entry2{.file_id = 2, .size = 1024, .tag = 0, .offset = 0x123, .checksum = 0x4567};
+    {
+        PageEntriesEdit edit;
+        edit.put(1, entry1);
+        edit.put(2, entry2);
+        dir->apply(std::move(edit));
+    }
+
+    ASSERT_EQ(dir->getMaxId(TEST_NAMESPACE_ID), 2);
+
+    {
+        PageEntriesEdit edit;
+        edit.del(2);
+        dir->apply(std::move(edit));
+    }
+    ASSERT_EQ(dir->getMaxId(TEST_NAMESPACE_ID), 1);
+
+    {
+        PageEntriesEdit edit;
+        edit.del(1);
+        dir->apply(std::move(edit));
+    }
+    ASSERT_EQ(dir->getMaxId(TEST_NAMESPACE_ID), 0);
+}
+CATCH
+
 #undef INSERT_ENTRY_TO
 #undef INSERT_ENTRY
 #undef INSERT_ENTRY_ACQ_SNAP


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #3594 

Problem Summary:
- When we del the page id
- In getMaxId won't now current page_id have been deleted

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
