### PR TITLE
Add arg remove_invalid_files into restore

### DIFF
--- a/dbms/src/Storages/Page/PageStorage.h
+++ b/dbms/src/Storages/Page/PageStorage.h
@@ -211,7 +211,13 @@ public:
 
     virtual ~PageStorage() = default;
 
-    virtual void restore() = 0;
+    // Should not set `remove_invalid_file` to false except `KVStore`.
+    // If `remove_invalid_file` is true, It will work in V2 and will delete everything except `PageFile`.
+    // This arg won't work in V3.
+    void restore(bool remove_invalid_file = true)
+    {
+        restoreImpl(remove_invalid_file);
+    }
 
     virtual void drop() = 0;
 
@@ -291,6 +297,8 @@ public:
 #ifndef DBMS_PUBLIC_GTEST
 protected:
 #endif
+    virtual void restoreImpl(bool remove_invalid_file) = 0;
+
     virtual void writeImpl(WriteBatch && write_batch, const WriteLimiterPtr & write_limiter) = 0;
 
     virtual PageEntry getEntryImpl(NamespaceId ns_id, PageId page_id, SnapshotPtr snapshot) = 0;

--- a/dbms/src/Storages/Page/V2/PageStorage.cpp
+++ b/dbms/src/Storages/Page/V2/PageStorage.cpp
@@ -196,7 +196,7 @@ toConcreteSnapshot(const DB::PageStorage::SnapshotPtr & ptr)
     return assert_cast<PageStorage::ConcreteSnapshotRawPtr>(ptr.get());
 }
 
-void PageStorage::restore()
+void PageStorage::restoreImpl(bool remove_invalid_file)
 {
     LOG_FMT_INFO(log, "{} begin to restore data from disk. [path={}] [num_writers={}]", storage_name, delegator->defaultPath(), write_files.size());
 
@@ -208,7 +208,7 @@ void PageStorage::restore()
 #endif
     opt.ignore_legacy = false;
     opt.ignore_checkpoint = false;
-    opt.remove_invalid_files = true;
+    opt.remove_invalid_files = remove_invalid_file;
     PageFileSet page_files = PageStorage::listAllPageFiles(file_provider, delegator, page_file_log, opt);
 
     /// Restore current version from both formal and legacy page files

--- a/dbms/src/Storages/Page/V2/PageStorage.h
+++ b/dbms/src/Storages/Page/V2/PageStorage.h
@@ -91,7 +91,7 @@ public:
                 const FileProviderPtr & file_provider_);
     ~PageStorage() = default;
 
-    void restore() override;
+    void restoreImpl(bool remove_invalid_file) override;
 
     void drop() override;
 

--- a/dbms/src/Storages/Page/V3/PageStorageImpl.cpp
+++ b/dbms/src/Storages/Page/V3/PageStorageImpl.cpp
@@ -43,7 +43,7 @@ PageStorageImpl::PageStorageImpl(
 
 PageStorageImpl::~PageStorageImpl() = default;
 
-void PageStorageImpl::restore()
+void PageStorageImpl::restoreImpl(bool /*remove_invalid_file*/)
 {
     // TODO: clean up blobstore.
     // TODO: Speedup restoring

--- a/dbms/src/Storages/Page/V3/PageStorageImpl.h
+++ b/dbms/src/Storages/Page/V3/PageStorageImpl.h
@@ -60,7 +60,7 @@ public:
         return wal_config;
     }
 
-    void restore() override;
+    void restoreImpl(bool remove_invalid_file) override;
 
     void drop() override;
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #3594 

Problem Summary:
- When we use mix mode to run `PageStorage`.Then V2 and V3 will use the same `StoragePool` in `KVStore`. So they will shared path `data/kvstore/`
- So when V2 restore, it will remove invalid files(detected not PageFile) by default. If we have V3 data in disk, it will be removed.

### What is changed and how it works?
- add a arg to make sure won't remove invalid file when restore happened in KVStore

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
