### PR TITLE
Revert "Fix getMaxId won't get the right max id before GC"

### DIFF
--- a/dbms/src/Storages/Page/V3/PageDirectory.cpp
+++ b/dbms/src/Storages/Page/V3/PageDirectory.cpp
@@ -889,31 +889,10 @@ PageId PageDirectory::getMaxId(NamespaceId ns_id) const
         // iter is not at the beginning and mvcc_table_directory is not empty,
         // so iter-- must be a valid iterator, and it's the largest page id which is smaller than the target page id.
         iter--;
-
-        do
-        {
-            // Can't find any entries in current ns_id
-            if (iter->first.high != ns_id)
-            {
-                break;
-            }
-
-            // Find the last valid one
-            if (iter->second->getEntry(UINT64_MAX - 1) != std::nullopt)
-            {
-                return iter->first.low;
-            }
-
-            // Current entry is deleted and there are no entries before it.
-            if (iter == mvcc_table_directory.begin())
-            {
-                break;
-            }
-
-            iter--;
-        } while (true);
-
-        return 0;
+        if (iter->first.high == ns_id)
+            return iter->first.low;
+        else
+            return 0;
     }
 }
 

--- a/dbms/src/Storages/Page/V3/tests/gtest_page_directory.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_page_directory.cpp
@@ -2054,53 +2054,6 @@ try
         ASSERT_EQ(dir->getMaxId(medium), 320);
         ASSERT_EQ(dir->getMaxId(large), 2);
     }
-
-    {
-        PageEntriesEdit edit;
-        edit.del(buildV3Id(medium, 320));
-        dir->apply(std::move(edit));
-        ASSERT_EQ(dir->getMaxId(medium), 300);
-    }
-
-    {
-        PageEntriesEdit edit;
-        edit.del(buildV3Id(medium, 300));
-        dir->apply(std::move(edit));
-        ASSERT_EQ(dir->getMaxId(medium), 0);
-    }
-}
-CATCH
-
-TEST_F(PageDirectoryTest, GetMaxIdAfterDelete)
-try
-{
-    PageEntryV3 entry1{.file_id = 1, .size = 1024, .tag = 0, .offset = 0x123, .checksum = 0x4567};
-    PageEntryV3 entry2{.file_id = 2, .size = 1024, .tag = 0, .offset = 0x123, .checksum = 0x4567};
-    {
-        PageEntriesEdit edit;
-        edit.put(1, entry1);
-        edit.put(2, entry2);
-        dir->apply(std::move(edit));
-    }
-
-    ASSERT_EQ(dir->getMaxId(TEST_NAMESPACE_ID), 2);
-
-    {
-        PageEntriesEdit edit;
-        edit.del(2);
-        dir->apply(std::move(edit));
-    }
-    ASSERT_EQ(dir->getMaxId(TEST_NAMESPACE_ID), 1);
-
-    {
-        PageEntriesEdit edit;
-        edit.del(1);
-        dir->apply(std::move(edit));
-    }
-    ASSERT_EQ(dir->getMaxId(TEST_NAMESPACE_ID), 0);
-
-    dir->gcInMemEntries();
-    ASSERT_EQ(dir->getMaxId(TEST_NAMESPACE_ID), 0);
 }
 CATCH
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #3594 

Problem Summary: If `getMaxId` ignore the deleted entry, we will reuse the PageId after a restart, which break the assumption that we will never reuse a PageID after deleted.

### What is changed and how it works?

Reverts pingcap/tiflash#4838


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
