### PR TITLE
Fix bug for deseri type error that cause data error

### DIFF
--- a/dbms/src/Storages/Page/V3/PageDirectory.cpp
+++ b/dbms/src/Storages/Page/V3/PageDirectory.cpp
@@ -334,6 +334,11 @@ VersionedPageEntries::resolveToPageId(UInt64 seq, bool check_prev, PageEntryV3 *
             return {RESOLVE_TO_REF, ori_page_id, create_ver};
         }
     }
+    else
+    {
+        LOG_FMT_WARNING(&Poco::Logger::get("VersionedPageEntries"), "Can't reslove the EditRecordType {}", type);
+    }
+
     return {RESOLVE_FAIL, buildV3Id(0, 0), PageVersionType(0)};
 }
 

--- a/dbms/src/Storages/Page/V3/PageDirectory.cpp
+++ b/dbms/src/Storages/Page/V3/PageDirectory.cpp
@@ -721,6 +721,11 @@ PageIDAndEntryV3 PageDirectory::get(PageIdV3Internal page_id, const PageDirector
             {
                 if (throw_on_not_exist)
                 {
+                    LOG_FMT_WARNING(log, "Dump state for invalid page id [page_id={}]", page_id);
+                    for (const auto &[dump_id, dump_entry]: mvcc_table_directory)
+                    {
+                        LOG_FMT_WARNING(log, "Dumping state [page_id={}] [entry={}]", dump_id, dump_entry == nullptr ? "<null>" : dump_entry->toDebugString());
+                    }
                     throw Exception(fmt::format("Invalid page id, entry not exist [page_id={}] [resolve_id={}]", page_id, id_to_resolve), ErrorCodes::PS_ENTRY_NOT_EXISTS);
                 }
                 else

--- a/dbms/src/Storages/Page/V3/PageDirectory.cpp
+++ b/dbms/src/Storages/Page/V3/PageDirectory.cpp
@@ -722,7 +722,7 @@ PageIDAndEntryV3 PageDirectory::get(PageIdV3Internal page_id, const PageDirector
                 if (throw_on_not_exist)
                 {
                     LOG_FMT_WARNING(log, "Dump state for invalid page id [page_id={}]", page_id);
-                    for (const auto &[dump_id, dump_entry]: mvcc_table_directory)
+                    for (const auto & [dump_id, dump_entry] : mvcc_table_directory)
                     {
                         LOG_FMT_WARNING(log, "Dumping state [page_id={}] [entry={}]", dump_id, dump_entry == nullptr ? "<null>" : dump_entry->toDebugString());
                     }

--- a/dbms/src/Storages/Page/V3/WAL/serialize.cpp
+++ b/dbms/src/Storages/Page/V3/WAL/serialize.cpp
@@ -100,7 +100,6 @@ void deserializePutFrom([[maybe_unused]] const EditRecordType record_type, ReadB
     UInt32 flags = 0;
     readIntBinary(flags, buf);
 
-    // All consider as put
     PageEntriesEdit::EditRecord rec;
     rec.type = record_type;
     readIntBinary(rec.page_id, buf);

--- a/dbms/src/Storages/Page/V3/WAL/serialize.cpp
+++ b/dbms/src/Storages/Page/V3/WAL/serialize.cpp
@@ -152,7 +152,7 @@ void deserializePutExternalFrom([[maybe_unused]] const EditRecordType record_typ
     assert(record_type == EditRecordType::PUT_EXTERNAL || record_type == EditRecordType::VAR_EXTERNAL);
 
     PageEntriesEdit::EditRecord rec;
-    rec.type = EditRecordType::PUT_EXTERNAL;
+    rec.type = record_type;
     readIntBinary(rec.page_id, buf);
     deserializeVersionFrom(buf, rec.version);
     readIntBinary(rec.being_ref_count, buf);

--- a/dbms/src/Storages/Page/V3/tests/gtest_page_directory.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_page_directory.cpp
@@ -23,6 +23,7 @@
 #include <Storages/Page/V3/PageDirectoryFactory.h>
 #include <Storages/Page/V3/PageEntriesEdit.h>
 #include <Storages/Page/V3/PageEntry.h>
+#include <Storages/Page/V3/WAL/serialize.h>
 #include <Storages/Page/V3/WALStore.h>
 #include <Storages/Page/V3/tests/entries_helper.h>
 #include <Storages/tests/TiFlashStorageTestBasic.h>
@@ -1760,16 +1761,88 @@ try
 }
 CATCH
 
-TEST_F(PageDirectoryGCTest, DumpAndRestore)
+
+TEST_F(PageDirectoryGCTest, GCOnRefedExternalEntries2)
 try
 {
+    {
+        PageEntriesEdit edit; // ingest
+        edit.putExternal(352);
+        dir->apply(std::move(edit));
+    }
+    {
+        PageEntriesEdit edit;
+        edit.ref(353, 352);
+        dir->apply(std::move(edit));
+    }
+    {
+        PageEntriesEdit edit; // ingest done
+        edit.del(352);
+        dir->apply(std::move(edit));
+    }
+    {
+        PageEntriesEdit edit; // split
+        edit.ref(357, 352);
+        edit.ref(359, 352);
+        dir->apply(std::move(edit));
+    }
+    {
+        PageEntriesEdit edit; // split done
+        edit.del(353);
+        dir->apply(std::move(edit));
+    }
+    {
+        PageEntriesEdit edit; // one of segment delta-merge
+        edit.del(359);
+        dir->apply(std::move(edit));
+    }
+
+    {
+        auto snap = dir->createSnapshot();
+        auto normal_id = dir->getNormalPageId(357, snap);
+        EXPECT_EQ(normal_id.low, 352);
+    }
+    dir->gcInMemEntries();
+    {
+        auto snap = dir->createSnapshot();
+        auto normal_id = dir->getNormalPageId(357, snap);
+        EXPECT_EQ(normal_id.low, 352);
+    }
+
+    auto s0 = dir->createSnapshot();
+    auto edit = dir->dumpSnapshotToEdit(s0);
+    edit.size();
     auto restore_from_edit = [](const PageEntriesEdit & edit) {
+        auto deseri_edit = DB::PS::V3::ser::deserializeFrom(DB::PS::V3::ser::serializeTo(edit));
         auto ctx = DB::tests::TiFlashTestEnv::getContext();
         auto provider = ctx.getFileProvider();
         auto path = getTemporaryPath();
         PSDiskDelegatorPtr delegator = std::make_shared<DB::tests::MockDiskDelegatorSingle>(path);
         PageDirectoryFactory factory;
-        auto d = factory.createFromEdit(getCurrentTestName(), provider, delegator, edit);
+        auto d = factory.createFromEdit(getCurrentTestName(), provider, delegator, deseri_edit);
+        return d;
+    };
+    {
+        auto restored_dir = restore_from_edit(edit);
+        auto snap = restored_dir->createSnapshot();
+        auto normal_id = restored_dir->getNormalPageId(357, snap);
+        EXPECT_EQ(normal_id.low, 352);
+    }
+}
+CATCH
+
+
+TEST_F(PageDirectoryGCTest, DumpAndRestore)
+try
+{
+    auto restore_from_edit = [](const PageEntriesEdit & edit) {
+        auto deseri_edit = DB::PS::V3::ser::deserializeFrom(DB::PS::V3::ser::serializeTo(edit));
+        auto ctx = DB::tests::TiFlashTestEnv::getContext();
+        auto provider = ctx.getFileProvider();
+        auto path = getTemporaryPath();
+        PSDiskDelegatorPtr delegator = std::make_shared<DB::tests::MockDiskDelegatorSingle>(path);
+        PageDirectoryFactory factory;
+        auto d = factory.createFromEdit(getCurrentTestName(), provider, delegator, deseri_edit);
         return d;
     };
 

--- a/dbms/src/Storages/Page/V3/tests/gtest_wal_store.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_wal_store.cpp
@@ -132,33 +132,59 @@ TEST(WALSeriTest, Upserts)
     EXPECT_SAME_ENTRY(iter->entry, entry_p5_2);
 }
 
-TEST(WALSeriTest, RefExternal)
+TEST(WALSeriTest, RefExternalAndEntry)
 {
     PageVersionType ver1_0(/*seq=*/1, /*epoch*/ 0);
     PageVersionType ver2_0(/*seq=*/2, /*epoch*/ 0);
     PageVersionType ver3_0(/*seq=*/3, /*epoch*/ 0);
+    {
+        PageEntriesEdit edit;
+        edit.varExternal(1, ver1_0, 2);
+        edit.varDel(1, ver2_0);
+        edit.varRef(2, ver3_0, 1);
 
-    PageEntriesEdit edit;
-    edit.varExternal(1, ver1_0, 2);
-    edit.varDel(1, ver2_0);
-    edit.varRef(2, ver3_0, 1);
+        auto deseri_edit = DB::PS::V3::ser::deserializeFrom(DB::PS::V3::ser::serializeTo(edit));
+        ASSERT_EQ(deseri_edit.size(), 3);
+        auto iter = deseri_edit.getRecords().begin();
+        EXPECT_EQ(iter->type, EditRecordType::VAR_EXTERNAL);
+        EXPECT_EQ(iter->page_id.low, 1);
+        EXPECT_EQ(iter->version, ver1_0);
+        EXPECT_EQ(iter->being_ref_count, 2);
+        iter++;
+        EXPECT_EQ(iter->type, EditRecordType::VAR_DELETE);
+        EXPECT_EQ(iter->page_id.low, 1);
+        EXPECT_EQ(iter->version, ver2_0);
+        EXPECT_EQ(iter->being_ref_count, 1);
+        iter++;
+        EXPECT_EQ(iter->type, EditRecordType::VAR_REF);
+        EXPECT_EQ(iter->page_id.low, 2);
+        EXPECT_EQ(iter->version, ver3_0);
+    }
 
-    auto deseri_edit = DB::PS::V3::ser::deserializeFrom(DB::PS::V3::ser::serializeTo(edit));
-    ASSERT_EQ(deseri_edit.size(), 3);
-    auto iter = deseri_edit.getRecords().begin();
-    EXPECT_EQ(iter->type, EditRecordType::VAR_EXTERNAL);
-    EXPECT_EQ(iter->page_id.low, 1);
-    EXPECT_EQ(iter->version, ver1_0);
-    EXPECT_EQ(iter->being_ref_count, 2);
-    iter++;
-    EXPECT_EQ(iter->type, EditRecordType::VAR_DELETE);
-    EXPECT_EQ(iter->page_id.low, 1);
-    EXPECT_EQ(iter->version, ver2_0);
-    EXPECT_EQ(iter->being_ref_count, 1);
-    iter++;
-    EXPECT_EQ(iter->type, EditRecordType::VAR_REF);
-    EXPECT_EQ(iter->page_id.low, 2);
-    EXPECT_EQ(iter->version, ver3_0);
+    {
+        PageEntriesEdit edit;
+        PageEntryV3 entry_p1_2{.file_id = 2, .size = 1, .tag = 0, .offset = 0x123, .checksum = 0x4567};
+        edit.varEntry(1, ver1_0, entry_p1_2, 2);
+        edit.varDel(1, ver2_0);
+        edit.varRef(2, ver3_0, 1);
+
+        auto deseri_edit = DB::PS::V3::ser::deserializeFrom(DB::PS::V3::ser::serializeTo(edit));
+        ASSERT_EQ(deseri_edit.size(), 3);
+        auto iter = deseri_edit.getRecords().begin();
+        EXPECT_EQ(iter->type, EditRecordType::VAR_ENTRY);
+        EXPECT_EQ(iter->page_id.low, 1);
+        EXPECT_EQ(iter->version, ver1_0);
+        EXPECT_EQ(iter->being_ref_count, 2);
+        iter++;
+        EXPECT_EQ(iter->type, EditRecordType::VAR_DELETE);
+        EXPECT_EQ(iter->page_id.low, 1);
+        EXPECT_EQ(iter->version, ver2_0);
+        EXPECT_EQ(iter->being_ref_count, 1);
+        iter++;
+        EXPECT_EQ(iter->type, EditRecordType::VAR_REF);
+        EXPECT_EQ(iter->page_id.low, 2);
+        EXPECT_EQ(iter->version, ver3_0);
+    }
 }
 
 TEST(WALLognameTest, parsing)

--- a/dbms/src/Storages/Page/V3/tests/gtest_wal_store.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_wal_store.cpp
@@ -149,10 +149,12 @@ TEST(WALSeriTest, RefExternal)
     EXPECT_EQ(iter->type, EditRecordType::VAR_EXTERNAL);
     EXPECT_EQ(iter->page_id.low, 1);
     EXPECT_EQ(iter->version, ver1_0);
+    EXPECT_EQ(iter->being_ref_count, 2);
     iter++;
     EXPECT_EQ(iter->type, EditRecordType::VAR_DELETE);
     EXPECT_EQ(iter->page_id.low, 1);
     EXPECT_EQ(iter->version, ver2_0);
+    EXPECT_EQ(iter->being_ref_count, 1);
     iter++;
     EXPECT_EQ(iter->type, EditRecordType::VAR_REF);
     EXPECT_EQ(iter->page_id.low, 2);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #4851 

Problem Summary:
```
[2022/05/10 15:18:28.483 +08:00] [TRACE] [PageDirectoryFactory.cpp:131] ["PageDirectoryFactory:restoring record [type=1] [page_id=192.352] [ver=<3405,0>] [entry=PageEntry{file: 0, offset: 0x0, size: 0, checksum: 0x0}]"] [thread_id=1]
[2022/05/10 15:18:28.483 +08:00] [TRACE] [PageDirectoryFactory.cpp:131] ["PageDirectoryFactory:restoring record [type=8] [page_id=192.352] [ver=<3407,0>] [entry=PageEntry{file: 0, offset: 0x0, size: 0, checksum: 0x0}]"] [thread_id=1]
[2022/05/10 15:18:28.483 +08:00] [TRACE] [PageDirectoryFactory.cpp:131] ["PageDirectoryFactory:restoring record [type=6] [page_id=192.357] [ver=<3421,0>] [entry=PageEntry{file: 0, offset: 0x0, size: 0, checksum: 0x0}]"] [thread_id=1]
```

- The `page_id=192.352` type is `PUT_EXTERNAL(1)`, but it should be `VAR_EXTERNAL(7)`. Because this record has been dumped into `log_5_1`
- Then after restored, `PageDirectoryFactory::loadEdit` will deal this edit as `PUT_EXTERNAL(1)` following by `DEL(8)`, it will make that this page_id  `being_ref_count` be 0. MVCC will clean it in memory.

The main reason why "`page_id=192.352` type is `1`" is that we should not decode `VAR_EXTERNAL(7)`  to `PUT_EXTERNAL(1)` in `deserializePutExternalFrom`.

### What is changed and how it works?

- Changed `deserializePutExternalFrom `
- Added a log to check the similar situations.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
