### PR TITLE
feat: add a function to get number of logical cpu cores

### DIFF
--- a/dbms/src/Common/getNumberOfLogicalCPUCores.cpp
+++ b/dbms/src/Common/getNumberOfLogicalCPUCores.cpp
@@ -160,7 +160,7 @@ static unsigned getCGroupLimitedCPUCores(unsigned default_cpu_count)
                     default_cpu_count = read_cpu_count_from(fmt::format("/sys/fs/cgroup/{}/cpuset.cpus", line).c_str(), -1);
                     // read the quota and period from the cgroup file cpu.max
                     auto [cgroup_quota, cgroup_period] = read_quota_and_period_from(fmt::format("/sys/fs/cgroup/{}/cpu.max", line).c_str());
-                    // the number of cores = cpu count * quota / period
+                    
                     return calCPUCores(cgroup_quota, cgroup_period, default_cpu_count);
                 }
                 else

--- a/dbms/src/Common/getNumberOfLogicalCPUCores.cpp
+++ b/dbms/src/Common/getNumberOfLogicalCPUCores.cpp
@@ -55,7 +55,7 @@ static int read_cpu_count_from(const char * filename, int default_value)
     // 0-4,6,8-10
 
     // An empty value indicates that the cgroup is using the same setting as the nearest cgroup ancestor with a non-empty "cpuset.cpus" or all the available CPUs if none is found.
-    // The value of "cpuset.cpus" stays constant until the next update and won’t be affected by any CPU hotplug events.
+    // The value of "cpuset.cpus" stays constant until the next update and won't be affected by any CPU hotplug events.
     std::ifstream infile(filename);
     if (!infile.is_open())
     {
@@ -88,7 +88,7 @@ static std::pair<int, int> read_quota_and_period_from(const char * filename)
 {
     // cpu.max
     // A read-write two value file which exists on non-root cgroups. The default is "max 100000".
-    // The maximum bandwidth limit. It’s in the following format:
+    // The maximum bandwidth limit. It's in the following format:
 
     // $MAX $PERIOD
 

--- a/dbms/src/Common/getNumberOfLogicalCPUCores.cpp
+++ b/dbms/src/Common/getNumberOfLogicalCPUCores.cpp
@@ -3,7 +3,6 @@
 #include <common/likely.h>
 
 #include <thread>
-#include "common/logger_useful.h"
 
 #if defined(__linux__)
 #include <cmath>
@@ -182,6 +181,10 @@ static unsigned getCGroupLimitedCPUCores(unsigned default_cpu_count)
 unsigned getNumberOfLogicalCPUCores()
 {
     unsigned logical_cpu_count = std::thread::hardware_concurrency();
+    if (unlikely(logical_cpu_count == 0))
+    {
+        throw DB::Exception("Failed to get number of logical CPU cores", DB::ErrorCodes::CPUID_ERROR);
+    }
 #if defined(__linux__)
     logical_cpu_count = getCGroupLimitedCPUCores(logical_cpu_count);
 #endif // __linux__

--- a/dbms/src/Common/getNumberOfLogicalCPUCores.cpp
+++ b/dbms/src/Common/getNumberOfLogicalCPUCores.cpp
@@ -1,3 +1,18 @@
+// Copyright 2022 PingCAP, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
 #include <Common/Exception.h>
 #include <Common/getNumberOfLogicalCPUCores.h>
 #include <common/likely.h>
@@ -116,7 +131,6 @@ static std::pair<int, int> read_quota_and_period_v2(const char * filename)
     infile >> quota >> period;
     return {((quota == "max") ? period : std::stoi(quota)), period};
 }
-
 
 static unsigned getCGroupDefaultLimitedCPUCores(unsigned default_cpu_count)
 {

--- a/dbms/src/Common/getNumberOfLogicalCPUCores.cpp
+++ b/dbms/src/Common/getNumberOfLogicalCPUCores.cpp
@@ -43,6 +43,74 @@ static inline int read_int_from(const char * filename, int default_value)
         return default_value;
 }
 
+static int read_cpu_count_from(const char * filename, int default_value)
+{
+    // cpuset.cpus
+    // A read-write multiple values file which exists on non-root cpuset-enabled cgroups.
+    // It lists the requested CPUs to be used by tasks within this cgroup. The actual list of CPUs to be granted, however, is subjected to constraints imposed by its parent and can differ from the requested CPUs.
+    // The CPU numbers are comma-separated numbers or ranges. For example:
+
+    // # cat cpuset.cpus
+    // 0-4,6,8-10
+
+    // An empty value indicates that the cgroup is using the same setting as the nearest cgroup ancestor with a non-empty "cpuset.cpus" or all the available CPUs if none is found.
+    // The value of "cpuset.cpus" stays constant until the next update and won’t be affected by any CPU hotplug events.
+    std::ifstream infile(filename);
+    if (!infile.is_open())
+    {
+        return default_value;
+    }
+    std::string line;
+    std::getline(infile, line);
+    int cpu_count = 0;
+    for (std::string::size_type first = 0, i = 0; i != std::string::npos; i = line.find(','))
+    {
+        std::string cpu_set = line.substr(first, i);
+        if (cpu_set.find('-') != std::string::npos)
+        {
+            std::string start_str = cpu_set.substr(0, cpu_set.find('-'));
+            std::string end_str = cpu_set.substr(cpu_set.find('-') + 1);
+            int start = std::stoi(start_str);
+            int end = std::stoi(end_str);
+            cpu_count += end - start + 1;
+        }
+        else
+        {
+            cpu_count++;
+        }
+        first = i + 1;
+    }
+    return cpu_count;
+}
+
+static std::pair<int, int> read_quota_and_period_from(const char * filename)
+{
+    // cpu.max
+    // A read-write two value file which exists on non-root cgroups. The default is "max 100000".
+    // The maximum bandwidth limit. It’s in the following format:
+
+    // $MAX $PERIOD
+
+    // which indicates that the group may consume upto $MAX in each $PERIOD duration.
+    // "max" for $MAX indicates no limit. If only one number is written, $MAX is updated.
+    std::ifstream infile(filename);
+    if (!infile.is_open())
+    {
+        return std::make_pair(1, 1);
+    }
+    std::string quota;
+    int period;
+    infile >> quota >> period;
+    if (quota == "max")
+    {
+        return std::make_pair(period, period);
+    }
+    else
+    {
+        return std::make_pair(std::stoi(quota), period);
+    }
+}
+
 unsigned calCPUCores(int cgroup_quota, int cgroup_period, int cgroup_share, unsigned default_cpu_count)
 {
     unsigned quota_count = default_cpu_count;
@@ -80,33 +148,63 @@ unsigned getCGroupDefaultLimitedCPUCores(unsigned default_cpu_count)
 
 unsigned getCGroupLimitedCPUCores(unsigned default_cpu_count)
 {
-    std::string cpu_filter = "cpuset:";
-    std::ifstream cgroup_cpu_info("/proc/self/cgroup");
-    if (cgroup_cpu_info.is_open())
+    std::string cgroup_controllers = "/sys/fs/cgroup/cgroup.controllers";
+    std::ifstream cgroup_controllers_info(cgroup_controllers);
+    // If cgroup.controllers is open, we assume we are running on a system with cgroups v2
+    // Otherwise v1
+    bool enabled_v2 = cgroup_controllers_info.is_open();
+
+    if (enabled_v2)
     {
-        std::string line;
-        while (std::getline(cgroup_cpu_info, line))
+        std::string cpu_filter = "0::";
+        std::ifstream cgroup_cpu_info("/proc/self/cgroup");
+        if (cgroup_cpu_info.is_open())
         {
-            std::string::size_type cpu_str_idx = line.find(cpu_filter);
-            if (cpu_str_idx != std::string::npos)
+            std::string line;
+            while (std::getline(cgroup_cpu_info, line))
             {
-                line = line.substr(cpu_str_idx + cpu_filter.length(), line.length());
-                int cgroup_quota = read_int_from(fmt::format("/sys/fs/cgroup/cpu{}/cpu.cfs_quota_us", line).c_str(), -2);
-
-                // If can't read cgroup_quota here
-                // It means current process may in docker
-                if (cgroup_quota == -2)
+                std::string::size_type cpu_str_idx = line.find(cpu_filter);
+                if (cpu_str_idx != std::string::npos)
                 {
-                    return getCGroupDefaultLimitedCPUCores(default_cpu_count);
+                    line = line.substr(cpu_str_idx + cpu_filter.length(), line.length());
+                    // read the cpu count from the cgroup file cpuset.cpus
+                    int cpu_count = read_cpu_count_from(fmt::format("/sys/fs/cgroup/{}/cpuset.cpus", line).c_str(), -1);
+                    // read the quota and period from the cgroup file cpu.max
+                    auto [cgroup_quota, cgroup_period] = read_quota_and_period_from(fmt::format("/sys/fs/cgroup/{}/cpu.max", line).c_str());
+                    // the number of cores = cpu count * quota / period
+                    return ceil(static_cast<float>(cpu_count) * static_cast<float>(cgroup_quota) / static_cast<float>(cgroup_period));
                 }
-                int cgroup_period = read_int_from(fmt::format("/sys/fs/cgroup/cpu{}/cpu.cfs_quota_us", line).c_str(), -1);
-                int cgroup_share = read_int_from(fmt::format("/sys/fs/cgroup/cpu{}/cpu.shares", line).c_str(), -1);
-
-                return calCPUCores(cgroup_quota, cgroup_period, cgroup_share, default_cpu_count);
             }
         }
     }
+    else {
+        std::string cpu_filter = "cpuset:";
+        std::ifstream cgroup_cpu_info("/proc/self/cgroup");
+        if (cgroup_cpu_info.is_open())
+        {
+            std::string line;
+            while (std::getline(cgroup_cpu_info, line))
+            {
+                std::string::size_type cpu_str_idx = line.find(cpu_filter);
+                if (cpu_str_idx != std::string::npos)
+                {
+                    line = line.substr(cpu_str_idx + cpu_filter.length(), line.length());
+                    int cgroup_quota = read_int_from(fmt::format("/sys/fs/cgroup/cpu{}/cpu.cfs_quota_us", line).c_str(), -2);
 
+                    // If can't read cgroup_quota here
+                    // It means current process may in docker
+                    if (cgroup_quota == -2)
+                    {
+                        return getCGroupDefaultLimitedCPUCores(default_cpu_count);
+                    }
+                    int cgroup_period = read_int_from(fmt::format("/sys/fs/cgroup/cpu{}/cpu.cfs_quota_us", line).c_str(), -1);
+                    int cgroup_share = read_int_from(fmt::format("/sys/fs/cgroup/cpu{}/cpu.shares", line).c_str(), -1);
+
+                    return calCPUCores(cgroup_quota, cgroup_period, cgroup_share, default_cpu_count);
+                }
+            }
+        }
+    }
     return getCGroupDefaultLimitedCPUCores(default_cpu_count);
 }
 #endif // __linux__

--- a/dbms/src/Common/getNumberOfLogicalCPUCores.cpp
+++ b/dbms/src/Common/getNumberOfLogicalCPUCores.cpp
@@ -168,7 +168,6 @@ static unsigned getCGroupLimitedCPUCores(unsigned default_cpu_count)
                     {
                         return getCGroupDefaultLimitedCPUCores(default_cpu_count);
                     }
-                    // LOG_FMT_DEBUG(, message)
                     int cgroup_period = read_int_from(fmt::format("/sys/fs/cgroup{}/cpu.cfs_period_us", line).c_str(), -2);
                     default_cpu_count = read_cpuset_count_from(fmt::format("/sys/fs/cgroup/cpuset{}/cpuset.cpus", line).c_str(), default_cpu_count);
                     return calCPUCores(cgroup_quota, cgroup_period, default_cpu_count);

--- a/dbms/src/Common/getNumberOfLogicalCPUCores.cpp
+++ b/dbms/src/Common/getNumberOfLogicalCPUCores.cpp
@@ -1,0 +1,65 @@
+// Copyright 2022 PingCAP, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Common/Exception.h>
+#include <Common/getNumberOfLogicalCPUCores.h>
+
+#include <thread>
+
+#if defined(__x86_64__)
+#include <cpuid/libcpuid.h>
+#endif
+
+namespace DB
+{
+namespace ErrorCodes
+{
+extern const int CPUID_ERROR;
+}
+} // namespace DB
+
+unsigned getNumberOfLogicalCPUCores()
+{
+    unsigned res = 0;
+#if defined(__x86_64__)
+
+    cpu_raw_data_t raw_data;
+    cpu_id_t data;
+    if (0 == cpuid_get_raw_data(&raw_data) && 0 == cpu_identify(&raw_data, &data) && data.num_logical_cpus != 0)
+    {
+        res = data.num_cores * data.total_logical_cpus / data.num_logical_cpus;
+    }
+
+    /// Also, libcpuid gives strange result on Google Compute Engine VMs.
+    /// Example:
+    ///  num_cores = 12,            /// number of physical cores on current CPU socket
+    ///  total_logical_cpus = 1,    /// total number of logical cores on all sockets
+    ///  num_logical_cpus = 24.     /// number of logical cores on current CPU socket
+    /// It means two-way hyper-threading (24 / 12), but contradictory, 'total_logical_cpus' == 1.
+    if (res != 0)
+    {
+        return res;
+    }
+    // else fallback
+#endif
+
+    /// As a fallback (also for non-x86 architectures) assume there are no hyper-threading on the system.
+    /// (Actually, only Aarch64 is supported).
+    res = std::thread::hardware_concurrency();
+    if (res == 0)
+    {
+        throw DB::Exception("Cannot Identify CPU: Unsupported processor", DB::ErrorCodes::CPUID_ERROR);
+    }
+    return res;
+}

--- a/dbms/src/Common/getNumberOfLogicalCPUCores.cpp
+++ b/dbms/src/Common/getNumberOfLogicalCPUCores.cpp
@@ -154,13 +154,13 @@ static unsigned getCGroupLimitedCPUCores(unsigned default_cpu_count)
             if (cpu_str_idx != std::string::npos)
             {
                 line = line.substr(cpu_str_idx + cpu_filter.length(), line.length());
-                if (enabled_v2) 
+                if (enabled_v2)
                 {
                     // update the cpu count from the cgroup file cpuset.cpus
                     default_cpu_count = read_cpu_count_from(fmt::format("/sys/fs/cgroup/{}/cpuset.cpus", line).c_str(), -1);
                     // read the quota and period from the cgroup file cpu.max
                     auto [cgroup_quota, cgroup_period] = read_quota_and_period_from(fmt::format("/sys/fs/cgroup/{}/cpu.max", line).c_str());
-                    
+
                     return calCPUCores(cgroup_quota, cgroup_period, default_cpu_count);
                 }
                 else

--- a/dbms/src/Common/getNumberOfLogicalCPUCores.cpp
+++ b/dbms/src/Common/getNumberOfLogicalCPUCores.cpp
@@ -184,7 +184,7 @@ unsigned getCGroupLimitedCPUCores(unsigned default_cpu_count)
                     {
                         return getCGroupDefaultLimitedCPUCores(default_cpu_count);
                     }
-                    int cgroup_period = read_int_from(fmt::format("/sys/fs/cgroup/cpu{}/cpu.cfs_quota_us", line).c_str(), -1);
+                    int cgroup_period = read_int_from(fmt::format("/sys/fs/cgroup/cpu{}/cpu.cfs_period_us", line).c_str(), -1);
                     int cgroup_share = read_int_from(fmt::format("/sys/fs/cgroup/cpu{}/cpu.shares", line).c_str(), -1);
 
                     return calCPUCores(cgroup_quota, cgroup_period, cgroup_share, default_cpu_count);

--- a/dbms/src/Common/getNumberOfLogicalCPUCores.cpp
+++ b/dbms/src/Common/getNumberOfLogicalCPUCores.cpp
@@ -99,18 +99,18 @@ static std::pair<int, int> read_quota_and_period_from(const char * filename)
     std::ifstream infile(filename);
     if (!infile.is_open())
     {
-        return std::make_pair(1, 1);
+        return {1, 1};
     }
     std::string quota;
     int period;
     infile >> quota >> period;
     if (quota == "max")
     {
-        return std::make_pair(period, period);
+        return {period, period};
     }
     else
     {
-        return std::make_pair(std::stoi(quota), period);
+        return {std::stoi(quota), period};
     }
 }
 

--- a/dbms/src/Common/getNumberOfLogicalCPUCores.h
+++ b/dbms/src/Common/getNumberOfLogicalCPUCores.h
@@ -14,5 +14,5 @@
 
 #pragma once
 
-/// Get number of CPU cores without hyper-threading.
+/// Get number of logical CPU cores
 unsigned getNumberOfLogicalCPUCores();

--- a/dbms/src/Common/getNumberOfLogicalCPUCores.h
+++ b/dbms/src/Common/getNumberOfLogicalCPUCores.h
@@ -1,0 +1,18 @@
+// Copyright 2022 PingCAP, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+/// Get number of CPU cores without hyper-threading.
+unsigned getNumberOfLogicalCPUCores();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #4879 

Problem Summary:

### What is changed and how it works?
Add a function to get number of logical cpu cores:
1. Normally, `$cpu = std::thread::hardware_concurrency()`
2. With cgroup, `$cpu = min(len(cpuset), cgroup_quota / cgroup_period)`

detail doc: https://github.com/pingcap/tiflash/issues/4879#issuecomment-1131378727
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
