### PR TITLE
Fix the bug for restoring data with duplicated page id

### DIFF
--- a/dbms/src/Common/ErrorCodes.cpp
+++ b/dbms/src/Common/ErrorCodes.cpp
@@ -424,6 +424,7 @@ extern const int DEADLOCK_AVOIDED = 10013;
 extern const int PTHREAD_ERROR = 10014;
 extern const int PS_ENTRY_NOT_EXISTS = 10015;
 extern const int PS_ENTRY_NO_VALID_VERSION = 10016;
+extern const int PS_DIR_APPLY_INVALID_STATUS = 10017;
 } // namespace ErrorCodes
 
 } // namespace DB

--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -1650,8 +1650,10 @@ bool Context::initializeGlobalStoragePoolIfNeed(const PathPool & path_pool)
     auto lock = getLock();
     if (shared->global_storage_pool)
     {
-        // GlobalStoragePool may be initialized many times in some test cases for restore.
-        LOG_WARNING(shared->log, "GlobalStoragePool has already been initialized.");
+        // Can't init GlobalStoragePool twice.
+        // Because we won't remove the gc task in BackGroundPool
+        // Also won't remove it from ~GlobalStoragePool()
+        throw Exception("GlobalStoragePool has already been initialized.", ErrorCodes::LOGICAL_ERROR);
     }
     CurrentMetrics::set(CurrentMetrics::GlobalStorageRunMode, static_cast<UInt8>(shared->storage_run_mode));
     if (shared->storage_run_mode == PageStorageRunMode::MIX_MODE || shared->storage_run_mode == PageStorageRunMode::ONLY_V3)

--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -1651,8 +1651,7 @@ bool Context::initializeGlobalStoragePoolIfNeed(const PathPool & path_pool)
     if (shared->global_storage_pool)
     {
         // Can't init GlobalStoragePool twice.
-        // Because we won't remove the gc task in BackGroundPool
-        // Also won't remove it from ~GlobalStoragePool()
+        // otherwise the pagestorage instances in `StoragePool` for each table won't be updated and cause unexpected problem.
         throw Exception("GlobalStoragePool has already been initialized.", ErrorCodes::LOGICAL_ERROR);
     }
     CurrentMetrics::set(CurrentMetrics::GlobalStorageRunMode, static_cast<UInt8>(shared->storage_run_mode));

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -243,7 +243,8 @@ DeltaMergeStore::DeltaMergeStore(Context & db_context,
     try
     {
         page_storage_run_mode = storage_pool->restore(); // restore from disk
-        if (!storage_pool->maxMetaPageId())
+        if (const auto entry1 = storage_pool->metaReader()->getPageEntry(1);
+            !entry1.isValid())
         {
             // Create the first segment.
             auto segment_id = storage_pool->newMetaPageId();

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -243,8 +243,8 @@ DeltaMergeStore::DeltaMergeStore(Context & db_context,
     try
     {
         page_storage_run_mode = storage_pool->restore(); // restore from disk
-        if (const auto entry1 = storage_pool->metaReader()->getPageEntry(1);
-            !entry1.isValid())
+        if (const auto first_segment_entry = storage_pool->metaReader()->getPageEntry(DELTA_MERGE_FIRST_SEGMENT_ID);
+            !first_segment_entry.isValid())
         {
             // Create the first segment.
             auto segment_id = storage_pool->newMetaPageId();

--- a/dbms/src/Storages/DeltaMerge/StoragePool.cpp
+++ b/dbms/src/Storages/DeltaMerge/StoragePool.cpp
@@ -82,26 +82,21 @@ PageStorage::Config extractConfig(const Settings & settings, StorageType subtype
 }
 
 GlobalStoragePool::GlobalStoragePool(const PathPool & path_pool, Context & global_ctx, const Settings & settings)
-    : // The iops and bandwidth in log_storage are relatively high, use multi-disks if possible
-    log_storage(PageStorage::create("__global__.log",
-                                    path_pool.getPSDiskDelegatorGlobalMulti("log"),
-                                    extractConfig(settings, StorageType::Log),
-                                    global_ctx.getFileProvider(),
-                                    true))
-    ,
-    // The iops in data_storage is low, only use the first disk for storing data
-    data_storage(PageStorage::create("__global__.data",
-                                     path_pool.getPSDiskDelegatorGlobalSingle("data"),
-                                     extractConfig(settings, StorageType::Data),
-                                     global_ctx.getFileProvider(),
-                                     true))
-    ,
-    // The iops in meta_storage is relatively high, use multi-disks if possible
-    meta_storage(PageStorage::create("__global__.meta",
-                                     path_pool.getPSDiskDelegatorGlobalMulti("meta"),
-                                     extractConfig(settings, StorageType::Meta),
-                                     global_ctx.getFileProvider(),
-                                     true))
+    : log_storage(PageStorage::create("__global__.log",
+                                      path_pool.getPSDiskDelegatorGlobalMulti("log"),
+                                      extractConfig(settings, StorageType::Log),
+                                      global_ctx.getFileProvider(),
+                                      true))
+    , data_storage(PageStorage::create("__global__.data",
+                                       path_pool.getPSDiskDelegatorGlobalMulti("data"),
+                                       extractConfig(settings, StorageType::Data),
+                                       global_ctx.getFileProvider(),
+                                       true))
+    , meta_storage(PageStorage::create("__global__.meta",
+                                       path_pool.getPSDiskDelegatorGlobalMulti("meta"),
+                                       extractConfig(settings, StorageType::Meta),
+                                       global_ctx.getFileProvider(),
+                                       true))
     , global_context(global_ctx)
 {
 }
@@ -181,7 +176,7 @@ StoragePool::StoragePool(Context & global_ctx, NamespaceId ns_id_, StoragePathPo
                                              extractConfig(global_context.getSettingsRef(), StorageType::Log),
                                              global_context.getFileProvider());
         data_storage_v2 = PageStorage::create(name + ".data",
-                                              storage_path_pool.getPSDiskDelegatorSingle("data"),
+                                              storage_path_pool.getPSDiskDelegatorSingle("data"), // keep for behavior not changed 
                                               extractConfig(global_context.getSettingsRef(), StorageType::Data),
                                               global_ctx.getFileProvider());
         meta_storage_v2 = PageStorage::create(name + ".meta",

--- a/dbms/src/Storages/DeltaMerge/StoragePool.cpp
+++ b/dbms/src/Storages/DeltaMerge/StoragePool.cpp
@@ -118,9 +118,9 @@ GlobalStoragePool::~GlobalStoragePool()
 
 void GlobalStoragePool::restore()
 {
-    log_max_ids = log_storage->restore();
-    data_max_ids = data_storage->restore();
-    meta_max_ids = meta_storage->restore();
+    log_storage->restore();
+    data_storage->restore();
+    meta_storage->restore();
 
     gc_handle = global_context.getBackgroundPool().addTask(
         [this] {
@@ -301,35 +301,31 @@ PageStorageRunMode StoragePool::restore()
     {
     case PageStorageRunMode::ONLY_V2:
     {
-        auto log_max_ids = log_storage_v2->restore();
-        auto data_max_ids = data_storage_v2->restore();
-        auto meta_max_ids = meta_storage_v2->restore();
+        log_storage_v2->restore();
+        data_storage_v2->restore();
+        meta_storage_v2->restore();
 
-        assert(log_max_ids.size() == 1);
-        assert(data_max_ids.size() == 1);
-        assert(meta_max_ids.size() == 1);
-
-        max_log_page_id = log_max_ids[0];
-        max_data_page_id = data_max_ids[0];
-        max_meta_page_id = meta_max_ids[0];
+        max_log_page_id = log_storage_v2->getMaxId(ns_id);
+        max_data_page_id = data_storage_v2->getMaxId(ns_id);
+        max_meta_page_id = meta_storage_v2->getMaxId(ns_id);
 
         storage_pool_metrics = CurrentMetrics::Increment{CurrentMetrics::StoragePoolV2Only};
         break;
     }
     case PageStorageRunMode::ONLY_V3:
     {
-        max_log_page_id = global_storage_pool->getLogMaxId(ns_id);
-        max_data_page_id = global_storage_pool->getDataMaxId(ns_id);
-        max_meta_page_id = global_storage_pool->getMetaMaxId(ns_id);
+        max_log_page_id = global_storage_pool->log_storage->getMaxId(ns_id);
+        max_data_page_id = global_storage_pool->data_storage->getMaxId(ns_id);
+        max_meta_page_id = global_storage_pool->meta_storage->getMaxId(ns_id);
 
         storage_pool_metrics = CurrentMetrics::Increment{CurrentMetrics::StoragePoolV3Only};
         break;
     }
     case PageStorageRunMode::MIX_MODE:
     {
-        auto v2_log_max_ids = log_storage_v2->restore();
-        auto v2_data_max_ids = data_storage_v2->restore();
-        auto v2_meta_max_ids = meta_storage_v2->restore();
+        log_storage_v2->restore();
+        data_storage_v2->restore();
+        meta_storage_v2->restore();
 
         // The pages on data and log can be rewritten to V3 and the old pages on V2 are deleted by `delta merge`.
         // However, the pages on meta V2 can not be deleted. As the pages in meta are small, we perform a forceTransformMetaV2toV3 to convert pages before all.
@@ -348,10 +344,6 @@ PageStorageRunMode StoragePool::restore()
         {
             LOG_FMT_INFO(logger, "Current meta translate already done before restored.[ns_id={}] ", ns_id);
         }
-
-        assert(v2_log_max_ids.size() == 1);
-        assert(v2_data_max_ids.size() == 1);
-        assert(v2_meta_max_ids.size() == 1);
 
         // Check number of valid pages in v2
         // If V2 already have no any data in disk, Then change run_mode to ONLY_V3
@@ -375,18 +367,18 @@ PageStorageRunMode StoragePool::restore()
             data_storage_writer = std::make_shared<PageWriter>(run_mode, /*storage_v2_*/ nullptr, data_storage_v3);
             meta_storage_writer = std::make_shared<PageWriter>(run_mode, /*storage_v2_*/ nullptr, meta_storage_v3);
 
-            max_log_page_id = global_storage_pool->getLogMaxId(ns_id);
-            max_data_page_id = global_storage_pool->getDataMaxId(ns_id);
-            max_meta_page_id = global_storage_pool->getMetaMaxId(ns_id);
+            max_log_page_id = global_storage_pool->log_storage->getMaxId(ns_id);
+            max_data_page_id = global_storage_pool->data_storage->getMaxId(ns_id);
+            max_meta_page_id = global_storage_pool->meta_storage->getMaxId(ns_id);
 
             run_mode = PageStorageRunMode::ONLY_V3;
             storage_pool_metrics = CurrentMetrics::Increment{CurrentMetrics::StoragePoolV3Only};
         }
         else // Still running Mix Mode
         {
-            max_log_page_id = std::max(v2_log_max_ids[0], global_storage_pool->getLogMaxId(ns_id));
-            max_data_page_id = std::max(v2_data_max_ids[0], global_storage_pool->getDataMaxId(ns_id));
-            max_meta_page_id = std::max(v2_meta_max_ids[0], global_storage_pool->getMetaMaxId(ns_id));
+            max_log_page_id = std::max(log_storage_v2->getMaxId(ns_id), global_storage_pool->log_storage->getMaxId(ns_id));
+            max_data_page_id = std::max(data_storage_v2->getMaxId(ns_id), global_storage_pool->data_storage->getMaxId(ns_id));
+            max_meta_page_id = std::max(meta_storage_v2->getMaxId(ns_id), global_storage_pool->meta_storage->getMaxId(ns_id));
             storage_pool_metrics = CurrentMetrics::Increment{CurrentMetrics::StoragePoolMixMode};
         }
         break;

--- a/dbms/src/Storages/DeltaMerge/StoragePool.cpp
+++ b/dbms/src/Storages/DeltaMerge/StoragePool.cpp
@@ -295,8 +295,6 @@ void StoragePool::forceTransformMetaV2toV3()
 
 PageStorageRunMode StoragePool::restore()
 {
-    const auto & global_storage_pool = global_context.getGlobalStoragePool();
-
     switch (run_mode)
     {
     case PageStorageRunMode::ONLY_V2:
@@ -314,9 +312,9 @@ PageStorageRunMode StoragePool::restore()
     }
     case PageStorageRunMode::ONLY_V3:
     {
-        max_log_page_id = global_storage_pool->log_storage->getMaxId(ns_id);
-        max_data_page_id = global_storage_pool->data_storage->getMaxId(ns_id);
-        max_meta_page_id = global_storage_pool->meta_storage->getMaxId(ns_id);
+        max_log_page_id = log_storage_v3->getMaxId(ns_id);
+        max_data_page_id = data_storage_v3->getMaxId(ns_id);
+        max_meta_page_id = meta_storage_v3->getMaxId(ns_id);
 
         storage_pool_metrics = CurrentMetrics::Increment{CurrentMetrics::StoragePoolV3Only};
         break;
@@ -367,18 +365,18 @@ PageStorageRunMode StoragePool::restore()
             data_storage_writer = std::make_shared<PageWriter>(run_mode, /*storage_v2_*/ nullptr, data_storage_v3);
             meta_storage_writer = std::make_shared<PageWriter>(run_mode, /*storage_v2_*/ nullptr, meta_storage_v3);
 
-            max_log_page_id = global_storage_pool->log_storage->getMaxId(ns_id);
-            max_data_page_id = global_storage_pool->data_storage->getMaxId(ns_id);
-            max_meta_page_id = global_storage_pool->meta_storage->getMaxId(ns_id);
+            max_log_page_id = log_storage_v3->getMaxId(ns_id);
+            max_data_page_id = data_storage_v3->getMaxId(ns_id);
+            max_meta_page_id = meta_storage_v3->getMaxId(ns_id);
 
             run_mode = PageStorageRunMode::ONLY_V3;
             storage_pool_metrics = CurrentMetrics::Increment{CurrentMetrics::StoragePoolV3Only};
         }
         else // Still running Mix Mode
         {
-            max_log_page_id = std::max(log_storage_v2->getMaxId(ns_id), global_storage_pool->log_storage->getMaxId(ns_id));
-            max_data_page_id = std::max(data_storage_v2->getMaxId(ns_id), global_storage_pool->data_storage->getMaxId(ns_id));
-            max_meta_page_id = std::max(meta_storage_v2->getMaxId(ns_id), global_storage_pool->meta_storage->getMaxId(ns_id));
+            max_log_page_id = std::max(log_storage_v2->getMaxId(ns_id), log_storage_v3->getMaxId(ns_id));
+            max_data_page_id = std::max(data_storage_v2->getMaxId(ns_id), data_storage_v3->getMaxId(ns_id));
+            max_meta_page_id = std::max(meta_storage_v2->getMaxId(ns_id), meta_storage_v3->getMaxId(ns_id));
             storage_pool_metrics = CurrentMetrics::Increment{CurrentMetrics::StoragePoolMixMode};
         }
         break;

--- a/dbms/src/Storages/DeltaMerge/StoragePool.cpp
+++ b/dbms/src/Storages/DeltaMerge/StoragePool.cpp
@@ -176,7 +176,7 @@ StoragePool::StoragePool(Context & global_ctx, NamespaceId ns_id_, StoragePathPo
                                              extractConfig(global_context.getSettingsRef(), StorageType::Log),
                                              global_context.getFileProvider());
         data_storage_v2 = PageStorage::create(name + ".data",
-                                              storage_path_pool.getPSDiskDelegatorSingle("data"), // keep for behavior not changed 
+                                              storage_path_pool.getPSDiskDelegatorSingle("data"), // keep for behavior not changed
                                               extractConfig(global_context.getSettingsRef(), StorageType::Data),
                                               global_ctx.getFileProvider());
         meta_storage_v2 = PageStorage::create(name + ".meta",

--- a/dbms/src/Storages/DeltaMerge/StoragePool.h
+++ b/dbms/src/Storages/DeltaMerge/StoragePool.h
@@ -51,39 +51,6 @@ public:
 
     friend class StoragePool;
 
-    PageId getLogMaxId(NamespaceId ns_id) const
-    {
-        PageId max_log_page_id = 0;
-        if (const auto & it = log_max_ids.find(ns_id); it != log_max_ids.end())
-        {
-            max_log_page_id = it->second;
-        }
-
-        return max_log_page_id;
-    }
-
-    PageId getDataMaxId(NamespaceId ns_id) const
-    {
-        PageId max_data_page_id = 0;
-        if (const auto & it = data_max_ids.find(ns_id); it != data_max_ids.end())
-        {
-            max_data_page_id = it->second;
-        }
-
-        return max_data_page_id;
-    }
-
-    PageId getMetaMaxId(NamespaceId ns_id) const
-    {
-        PageId max_meta_page_id = 0;
-        if (const auto & it = meta_max_ids.find(ns_id); it != meta_max_ids.end())
-        {
-            max_meta_page_id = it->second;
-        }
-
-        return max_meta_page_id;
-    }
-
     // GC immediately
     // Only used on dbgFuncMisc
     bool gc();
@@ -95,10 +62,6 @@ private:
     PageStoragePtr log_storage;
     PageStoragePtr data_storage;
     PageStoragePtr meta_storage;
-
-    std::map<NamespaceId, PageId> log_max_ids;
-    std::map<NamespaceId, PageId> data_max_ids;
-    std::map<NamespaceId, PageId> meta_max_ids;
 
     std::atomic<Timepoint> last_try_gc_time = Clock::now();
 

--- a/dbms/src/Storages/Page/PageStorage.h
+++ b/dbms/src/Storages/Page/PageStorage.h
@@ -229,15 +229,11 @@ public:
 
     virtual ~PageStorage() = default;
 
-    // Return the map[ns_id, max_page_id]
-    // The caller should ensure that it only allocate new id that is larger than `max_page_id`. Reusing the
-    // same ID for different kind of write (put/ref/put_external) would make PageStorage run into unexpected error.
-    //
-    // Note that for V2, we always return a map with only one element: <ns_id=0, max_id> cause V2 have no
-    // idea about ns_id.
-    virtual std::map<NamespaceId, PageId> restore() = 0;
+    virtual void restore() = 0;
 
     virtual void drop() = 0;
+
+    virtual PageId getMaxId(NamespaceId ns_id) = 0;
 
     virtual SnapshotPtr getSnapshot(const String & tracing_id) = 0;
 

--- a/dbms/src/Storages/Page/V2/PageStorage.h
+++ b/dbms/src/Storages/Page/V2/PageStorage.h
@@ -91,9 +91,11 @@ public:
                 const FileProviderPtr & file_provider_);
     ~PageStorage() = default;
 
-    std::map<NamespaceId, PageId> restore() override;
+    void restore() override;
 
     void drop() override;
+
+    PageId getMaxId(NamespaceId ns_id) override;
 
     PageId getNormalPageIdImpl(NamespaceId ns_id, PageId page_id, SnapshotPtr snapshot, bool throw_on_not_exist) override;
 

--- a/dbms/src/Storages/Page/V2/tests/gtest_page_storage.cpp
+++ b/dbms/src/Storages/Page/V2/tests/gtest_page_storage.cpp
@@ -79,15 +79,6 @@ protected:
         return storage;
     }
 
-    std::pair<std::shared_ptr<PageStorage>, std::map<NamespaceId, PageId>> reopen()
-    {
-        auto delegator = path_pool->getPSDiskDelegatorSingle("log");
-        auto storage = std::make_shared<PageStorage>("test.t", delegator, config, file_provider);
-        auto max_ids = storage->restore();
-        return {storage, max_ids};
-    }
-
-
 protected:
     PageStorage::Config config;
     std::shared_ptr<PageStorage> storage;
@@ -733,25 +724,6 @@ try
         for (size_t i = 0; i < buf_sz; ++i)
             EXPECT_EQ(*(page1.data.begin() + i), static_cast<char>(i % 0xff));
     }
-}
-CATCH
-
-TEST_F(PageStorage_test, getMaxIdsFromRestore)
-try
-{
-    {
-        WriteBatch batch;
-        batch.putExternal(1, 0);
-        batch.putExternal(2, 0);
-        batch.delPage(1);
-        batch.delPage(2);
-        storage->write(std::move(batch));
-    }
-
-    storage = nullptr;
-    auto [page_storage, max_ids] = reopen();
-    ASSERT_EQ(max_ids.size(), 1);
-    ASSERT_EQ(max_ids[0], 2);
 }
 CATCH
 

--- a/dbms/src/Storages/Page/V3/BlobStore.h
+++ b/dbms/src/Storages/Page/V3/BlobStore.h
@@ -34,7 +34,7 @@ extern const int LOGICAL_ERROR;
 
 namespace PS::V3
 {
-using PageIdAndVersionedEntries = std::vector<std::tuple<PageIdV3Internal, PageVersionType, PageEntryV3>>;
+using PageIdAndVersionedEntries = std::vector<std::tuple<PageIdV3Internal, PageVersion, PageEntryV3>>;
 
 class BlobStore : private Allocator<false>
 {

--- a/dbms/src/Storages/Page/V3/PageDirectory.cpp
+++ b/dbms/src/Storages/Page/V3/PageDirectory.cpp
@@ -66,7 +66,7 @@ namespace PS::V3
  * VersionedPageEntries methods *
  ********************************/
 
-void VersionedPageEntries::createNewEntry(const PageVersionType & ver, const PageEntryV3 & entry)
+void VersionedPageEntries::createNewEntry(const PageVersion & ver, const PageEntryV3 & entry)
 {
     auto page_lock = acquireLock();
     if (type == EditRecordType::VAR_DELETE)
@@ -78,7 +78,7 @@ void VersionedPageEntries::createNewEntry(const PageVersionType & ver, const Pag
 
     if (type == EditRecordType::VAR_ENTRY)
     {
-        auto last_iter = MapUtils::findLess(entries, PageVersionType(ver.sequence + 1, 0));
+        auto last_iter = MapUtils::findLess(entries, PageVersion(ver.sequence + 1, 0));
         if (last_iter == entries.end())
         {
             entries.emplace(ver, EntryOrDelete::newNormalEntry(entry));
@@ -119,7 +119,7 @@ void VersionedPageEntries::createNewEntry(const PageVersionType & ver, const Pag
 // Create a new external version with version=`ver`.
 // If create success, then return a shared_ptr as a holder for page_id. The holder
 // will be release when this external version is totally removed.
-std::shared_ptr<PageIdV3Internal> VersionedPageEntries::createNewExternal(const PageVersionType & ver)
+std::shared_ptr<PageIdV3Internal> VersionedPageEntries::createNewExternal(const PageVersion & ver)
 {
     auto page_lock = acquireLock();
     if (type == EditRecordType::VAR_DELETE)
@@ -127,7 +127,7 @@ std::shared_ptr<PageIdV3Internal> VersionedPageEntries::createNewExternal(const 
         type = EditRecordType::VAR_EXTERNAL;
         is_deleted = false;
         create_ver = ver;
-        delete_ver = PageVersionType(0);
+        delete_ver = PageVersion(0);
         being_ref_count = 1;
         // return the new created holder to caller to set the page_id
         external_holder = std::make_shared<PageIdV3Internal>(0, 0);
@@ -143,7 +143,7 @@ std::shared_ptr<PageIdV3Internal> VersionedPageEntries::createNewExternal(const 
             {
                 is_deleted = false;
                 create_ver = ver;
-                delete_ver = PageVersionType(0);
+                delete_ver = PageVersion(0);
                 being_ref_count = 1;
                 // return the new created holder to caller to set the page_id
                 external_holder = std::make_shared<PageIdV3Internal>(0, 0);
@@ -172,7 +172,7 @@ std::shared_ptr<PageIdV3Internal> VersionedPageEntries::createNewExternal(const 
 }
 
 // Create a new delete version with version=`ver`.
-void VersionedPageEntries::createDelete(const PageVersionType & ver)
+void VersionedPageEntries::createDelete(const PageVersion & ver)
 {
     auto page_lock = acquireLock();
     if (type == EditRecordType::VAR_ENTRY)
@@ -207,7 +207,7 @@ void VersionedPageEntries::createDelete(const PageVersionType & ver)
 
 // Create a new reference version with version=`ver` and `ori_page_id_`.
 // If create success, then return true, otherwise return false.
-bool VersionedPageEntries::createNewRef(const PageVersionType & ver, PageIdV3Internal ori_page_id_)
+bool VersionedPageEntries::createNewRef(const PageVersion & ver, PageIdV3Internal ori_page_id_)
 {
     auto page_lock = acquireLock();
     if (type == EditRecordType::VAR_DELETE)
@@ -229,7 +229,7 @@ bool VersionedPageEntries::createNewRef(const PageVersionType & ver, PageIdV3Int
                 ori_page_id = ori_page_id_;
                 create_ver = ver;
                 is_deleted = false;
-                delete_ver = PageVersionType(0);
+                delete_ver = PageVersion(0);
                 return true;
             }
             else if (ori_page_id == ori_page_id_)
@@ -292,14 +292,14 @@ std::shared_ptr<PageIdV3Internal> VersionedPageEntries::fromRestored(const PageE
     }
 }
 
-std::tuple<VersionedPageEntries::ResolveResult, PageIdV3Internal, PageVersionType>
+std::tuple<VersionedPageEntries::ResolveResult, PageIdV3Internal, PageVersion>
 VersionedPageEntries::resolveToPageId(UInt64 seq, bool check_prev, PageEntryV3 * entry)
 {
     auto page_lock = acquireLock();
     if (type == EditRecordType::VAR_ENTRY)
     {
         // entries are sorted by <ver, epoch>, find the first one less than <ver+1, 0>
-        if (auto iter = MapUtils::findLess(entries, PageVersionType(seq + 1));
+        if (auto iter = MapUtils::findLess(entries, PageVersion(seq + 1));
             iter != entries.end())
         {
             // If we applied write batches like this: [ver=1]{put 10}, [ver=2]{ref 11->10, del 10}
@@ -309,7 +309,7 @@ VersionedPageEntries::resolveToPageId(UInt64 seq, bool check_prev, PageEntryV3 *
             {
                 if (iter == entries.begin())
                 {
-                    return {RESOLVE_FAIL, buildV3Id(0, 0), PageVersionType(0)};
+                    return {RESOLVE_FAIL, buildV3Id(0, 0), PageVersion(0)};
                 }
                 --iter;
                 // fallover the check the prev item
@@ -319,7 +319,7 @@ VersionedPageEntries::resolveToPageId(UInt64 seq, bool check_prev, PageEntryV3 *
             {
                 if (entry != nullptr)
                     *entry = iter->second.entry;
-                return {RESOLVE_TO_NORMAL, buildV3Id(0, 0), PageVersionType(0)};
+                return {RESOLVE_TO_NORMAL, buildV3Id(0, 0), PageVersion(0)};
             } // fallover to FAIL
         }
     }
@@ -329,7 +329,7 @@ VersionedPageEntries::resolveToPageId(UInt64 seq, bool check_prev, PageEntryV3 *
         bool ok = check_prev ? true : (!is_deleted || seq < delete_ver.sequence);
         if (create_ver.sequence <= seq && ok)
         {
-            return {RESOLVE_TO_NORMAL, buildV3Id(0, 0), PageVersionType(0)};
+            return {RESOLVE_TO_NORMAL, buildV3Id(0, 0), PageVersion(0)};
         }
     }
     else if (type == EditRecordType::VAR_REF)
@@ -344,7 +344,7 @@ VersionedPageEntries::resolveToPageId(UInt64 seq, bool check_prev, PageEntryV3 *
         LOG_FMT_WARNING(&Poco::Logger::get("VersionedPageEntries"), "Can't reslove the EditRecordType {}", type);
     }
 
-    return {RESOLVE_FAIL, buildV3Id(0, 0), PageVersionType(0)};
+    return {RESOLVE_FAIL, buildV3Id(0, 0), PageVersion(0)};
 }
 
 std::optional<PageEntryV3> VersionedPageEntries::getEntry(UInt64 seq) const
@@ -353,7 +353,7 @@ std::optional<PageEntryV3> VersionedPageEntries::getEntry(UInt64 seq) const
     if (type == EditRecordType::VAR_ENTRY)
     {
         // entries are sorted by <ver, epoch>, find the first one less than <ver+1, 0>
-        if (auto iter = MapUtils::findLess(entries, PageVersionType(seq + 1));
+        if (auto iter = MapUtils::findLess(entries, PageVersion(seq + 1));
             iter != entries.end())
         {
             // not deleted
@@ -393,7 +393,7 @@ bool VersionedPageEntries::isVisible(UInt64 seq) const
     else if (type == EditRecordType::VAR_ENTRY)
     {
         // entries are sorted by <ver, epoch>, find the first one less than <ver+1, 0>
-        if (auto iter = MapUtils::findLess(entries, PageVersionType(seq + 1));
+        if (auto iter = MapUtils::findLess(entries, PageVersion(seq + 1));
             iter != entries.end())
         {
             // not deleted
@@ -416,12 +416,12 @@ bool VersionedPageEntries::isVisible(UInt64 seq) const
                     ErrorCodes::LOGICAL_ERROR);
 }
 
-Int64 VersionedPageEntries::incrRefCount(const PageVersionType & ver)
+Int64 VersionedPageEntries::incrRefCount(const PageVersion & ver)
 {
     auto page_lock = acquireLock();
     if (type == EditRecordType::VAR_ENTRY)
     {
-        if (auto iter = MapUtils::findMutLess(entries, PageVersionType(ver.sequence + 1));
+        if (auto iter = MapUtils::findMutLess(entries, PageVersion(ver.sequence + 1));
             iter != entries.end())
         {
             if (iter->second.isEntry())
@@ -476,7 +476,7 @@ PageSize VersionedPageEntries::getEntriesByBlobIds(
 
 bool VersionedPageEntries::cleanOutdatedEntries(
     UInt64 lowest_seq,
-    std::map<PageIdV3Internal, std::pair<PageVersionType, Int64>> * normal_entries_to_deref,
+    std::map<PageIdV3Internal, std::pair<PageVersion, Int64>> * normal_entries_to_deref,
     PageEntriesV3 & entries_removed,
     const PageLock & /*page_lock*/)
 {
@@ -515,7 +515,7 @@ bool VersionedPageEntries::cleanOutdatedEntries(
         return true;
     }
 
-    auto iter = MapUtils::findLess(entries, PageVersionType(lowest_seq + 1));
+    auto iter = MapUtils::findLess(entries, PageVersion(lowest_seq + 1));
     // If we can't find any seq lower than `lowest_seq` then
     // all version in this list don't need gc.
     if (iter == entries.begin() || iter == entries.end())
@@ -563,7 +563,7 @@ bool VersionedPageEntries::cleanOutdatedEntries(
     return entries.empty() || (entries.size() == 1 && entries.begin()->second.isDelete());
 }
 
-bool VersionedPageEntries::derefAndClean(UInt64 lowest_seq, PageIdV3Internal page_id, const PageVersionType & deref_ver, const Int64 deref_count, PageEntriesV3 & entries_removed)
+bool VersionedPageEntries::derefAndClean(UInt64 lowest_seq, PageIdV3Internal page_id, const PageVersion & deref_ver, const Int64 deref_count, PageEntriesV3 & entries_removed)
 {
     auto page_lock = acquireLock();
     if (type == EditRecordType::VAR_EXTERNAL)
@@ -579,7 +579,7 @@ bool VersionedPageEntries::derefAndClean(UInt64 lowest_seq, PageIdV3Internal pag
     {
         // Decrease the ref-counter. The entry may be moved to a newer entry with same sequence but higher epoch,
         // so we need to find the one less than <seq+1, 0> and decrease the ref-counter of it.
-        auto iter = MapUtils::findMutLess(entries, PageVersionType(deref_ver.sequence + 1, 0));
+        auto iter = MapUtils::findMutLess(entries, PageVersion(deref_ver.sequence + 1, 0));
         if (iter == entries.end())
         {
             throw Exception(fmt::format("Can not find entry for decreasing ref count [page_id={}] [ver={}] [deref_count={}]", page_id, deref_ver, deref_count));
@@ -639,7 +639,7 @@ void VersionedPageEntries::collapseTo(const UInt64 seq, const PageIdV3Internal p
     if (type == EditRecordType::VAR_ENTRY)
     {
         // dump the latest entry if it is not a "delete"
-        auto last_iter = MapUtils::findLess(entries, PageVersionType(seq + 1));
+        auto last_iter = MapUtils::findLess(entries, PageVersion(seq + 1));
         if (last_iter == entries.end())
             return;
 
@@ -750,7 +750,7 @@ PageIDAndEntryV3 PageDirectory::get(PageIdV3Internal page_id, const PageDirector
     PageEntryV3 entry_got;
 
     PageIdV3Internal id_to_resolve = page_id;
-    PageVersionType ver_to_resolve(snap->sequence, 0);
+    PageVersion ver_to_resolve(snap->sequence, 0);
     bool ok = true;
     while (ok)
     {
@@ -803,8 +803,8 @@ std::pair<PageIDAndEntriesV3, PageIds> PageDirectory::get(const PageIdV3Internal
     PageEntryV3 entry_got;
     PageIds page_not_found = {};
 
-    const PageVersionType init_ver_to_resolve(snap->sequence, 0);
-    auto get_one = [&entry_got, init_ver_to_resolve, throw_on_not_exist, this](PageIdV3Internal page_id, PageVersionType ver_to_resolve, size_t idx) {
+    const PageVersion init_ver_to_resolve(snap->sequence, 0);
+    auto get_one = [&entry_got, init_ver_to_resolve, throw_on_not_exist, this](PageIdV3Internal page_id, PageVersion ver_to_resolve, size_t idx) {
         PageIdV3Internal id_to_resolve = page_id;
         bool ok = true;
         while (ok)
@@ -866,7 +866,7 @@ std::pair<PageIDAndEntriesV3, PageIds> PageDirectory::get(const PageIdV3Internal
 PageIdV3Internal PageDirectory::getNormalPageId(PageIdV3Internal page_id, const PageDirectorySnapshotPtr & snap, bool throw_on_not_exist) const
 {
     PageIdV3Internal id_to_resolve = page_id;
-    PageVersionType ver_to_resolve(snap->sequence, 0);
+    PageVersion ver_to_resolve(snap->sequence, 0);
     bool keep_resolve = true;
     while (keep_resolve)
     {
@@ -985,17 +985,17 @@ void PageDirectory::applyRefEditRecord(
     MVCCMapType & mvcc_table_directory,
     const VersionedPageEntriesPtr & version_list,
     const PageEntriesEdit::EditRecord & rec,
-    const PageVersionType & version)
+    const PageVersion & version)
 {
     // applying ref 3->2, existing ref 2->1, normal entry 1, then we should collapse
     // the ref to be 3->1, increase the refcounting of normale entry 1
-    auto [resolve_success, resolved_id, resolved_ver] = [&mvcc_table_directory](PageIdV3Internal id_to_resolve, PageVersionType ver_to_resolve)
-        -> std::tuple<bool, PageIdV3Internal, PageVersionType> {
+    auto [resolve_success, resolved_id, resolved_ver] = [&mvcc_table_directory](PageIdV3Internal id_to_resolve, PageVersion ver_to_resolve)
+        -> std::tuple<bool, PageIdV3Internal, PageVersion> {
         while (true)
         {
             auto resolve_ver_iter = mvcc_table_directory.find(id_to_resolve);
             if (resolve_ver_iter == mvcc_table_directory.end())
-                return {false, buildV3Id(0, 0), PageVersionType(0)};
+                return {false, buildV3Id(0, 0), PageVersion(0)};
 
             const VersionedPageEntriesPtr & resolve_version_list = resolve_ver_iter->second;
             // If we already hold the lock from `id_to_resolve`, then we should not request it again.
@@ -1061,7 +1061,7 @@ void PageDirectory::apply(PageEntriesEdit && edit, const WriteLimiterPtr & write
     // TODO: It is totally serialized, make it a pipeline
     std::unique_lock write_lock(table_rw_mutex);
     UInt64 last_sequence = sequence.load();
-    PageVersionType new_version(last_sequence + 1, 0);
+    PageVersion new_version(last_sequence + 1, 0);
 
     // stage 1, persisted the changes to WAL with version [seq=last_seq + 1, epoch=0]
     wal->apply(edit, new_version, write_limiter);
@@ -1295,7 +1295,7 @@ PageEntriesV3 PageDirectory::gcInMemEntries()
 
     // The page_id that we need to decrease ref count
     // { id_0: <version, num to decrease>, id_1: <...>, ... }
-    std::map<PageIdV3Internal, std::pair<PageVersionType, Int64>> normal_entries_to_deref;
+    std::map<PageIdV3Internal, std::pair<PageVersion, Int64>> normal_entries_to_deref;
     // Iterate all page_id and try to clean up useless var entries
     while (true)
     {

--- a/dbms/src/Storages/Page/V3/PageDirectory.cpp
+++ b/dbms/src/Storages/Page/V3/PageDirectory.cpp
@@ -380,8 +380,9 @@ std::optional<PageEntryV3> VersionedPageEntries::getLastEntry() const
     return std::nullopt;
 }
 
-// Returns true when **this id** is visible (not exist or already marked as deleted) by `seq`.
-// Note that it does not means this id can be GC.
+// Returns true when **this id** is "visible" by `seq`.
+// If this page id is marked as deleted or not created, it is "not visible".
+// Note that not visible does not means this id can be GC.
 bool VersionedPageEntries::isVisible(UInt64 seq) const
 {
     auto page_lock = acquireLock();

--- a/dbms/src/Storages/Page/V3/PageDirectory.h
+++ b/dbms/src/Storages/Page/V3/PageDirectory.h
@@ -258,7 +258,13 @@ public:
 private:
     mutable std::mutex m;
 
+    // Valid value of `type` is one of
+    // - VAR_DELETE
+    // - VAR_ENTRY
+    // - VAR_REF
+    // - VAR_EXTERNAL
     EditRecordType type;
+
     // Has been deleted, valid when type == VAR_REF/VAR_EXTERNAL
     bool is_deleted;
     // Entries sorted by version, valid when type == VAR_ENTRY

--- a/dbms/src/Storages/Page/V3/PageDirectory.h
+++ b/dbms/src/Storages/Page/V3/PageDirectory.h
@@ -174,6 +174,8 @@ public:
 
     std::optional<PageEntryV3> getLastEntry() const;
 
+    bool isVisible(UInt64 seq) const;
+
     /**
      * If there are entries point to file in `blob_ids`, take out the <page_id, ver, entry> and
      * store them into `blob_versioned_entries`.

--- a/dbms/src/Storages/Page/V3/PageDirectory.h
+++ b/dbms/src/Storages/Page/V3/PageDirectory.h
@@ -149,13 +149,13 @@ public:
         return std::lock_guard(m);
     }
 
-    void createNewEntry(const PageVersionType & ver, const PageEntryV3 & entry);
+    void createNewEntry(const PageVersion & ver, const PageEntryV3 & entry);
 
-    bool createNewRef(const PageVersionType & ver, PageIdV3Internal ori_page_id);
+    bool createNewRef(const PageVersion & ver, PageIdV3Internal ori_page_id);
 
-    std::shared_ptr<PageIdV3Internal> createNewExternal(const PageVersionType & ver);
+    std::shared_ptr<PageIdV3Internal> createNewExternal(const PageVersion & ver);
 
-    void createDelete(const PageVersionType & ver);
+    void createDelete(const PageVersion & ver);
 
     std::shared_ptr<PageIdV3Internal> fromRestored(const PageEntriesEdit::EditRecord & rec);
 
@@ -165,10 +165,10 @@ public:
         RESOLVE_TO_REF,
         RESOLVE_TO_NORMAL,
     };
-    std::tuple<ResolveResult, PageIdV3Internal, PageVersionType>
+    std::tuple<ResolveResult, PageIdV3Internal, PageVersion>
     resolveToPageId(UInt64 seq, bool check_prev, PageEntryV3 * entry);
 
-    Int64 incrRefCount(const PageVersionType & ver);
+    Int64 incrRefCount(const PageVersion & ver);
 
     std::optional<PageEntryV3> getEntry(UInt64 seq) const;
 
@@ -222,13 +222,13 @@ public:
      */
     bool cleanOutdatedEntries(
         UInt64 lowest_seq,
-        std::map<PageIdV3Internal, std::pair<PageVersionType, Int64>> * normal_entries_to_deref,
+        std::map<PageIdV3Internal, std::pair<PageVersion, Int64>> * normal_entries_to_deref,
         PageEntriesV3 & entries_removed,
         const PageLock & page_lock);
     bool derefAndClean(
         UInt64 lowest_seq,
         PageIdV3Internal page_id,
-        const PageVersionType & deref_ver,
+        const PageVersion & deref_ver,
         Int64 deref_count,
         PageEntriesV3 & entries_removed);
 
@@ -270,11 +270,11 @@ private:
     // Has been deleted, valid when type == VAR_REF/VAR_EXTERNAL
     bool is_deleted;
     // Entries sorted by version, valid when type == VAR_ENTRY
-    std::multimap<PageVersionType, EntryOrDelete> entries;
+    std::multimap<PageVersion, EntryOrDelete> entries;
     // The created version, valid when type == VAR_REF/VAR_EXTERNAL
-    PageVersionType create_ver;
+    PageVersion create_ver;
     // The deleted version, valid when type == VAR_REF/VAR_EXTERNAL && is_deleted = true
-    PageVersionType delete_ver;
+    PageVersion delete_ver;
     // Original page id, valid when type == VAR_REF
     PageIdV3Internal ori_page_id;
     // Being ref counter, valid when type == VAR_EXTERNAL
@@ -387,7 +387,7 @@ private:
         MVCCMapType & mvcc_table_directory,
         const VersionedPageEntriesPtr & version_list,
         const PageEntriesEdit::EditRecord & rec,
-        const PageVersionType & version);
+        const PageVersion & version);
 
     static inline PageDirectorySnapshotPtr
     toConcreteSnapshot(const DB::PageStorageSnapshotPtr & ptr)

--- a/dbms/src/Storages/Page/V3/PageDirectoryFactory.cpp
+++ b/dbms/src/Storages/Page/V3/PageDirectoryFactory.cpp
@@ -20,7 +20,13 @@
 
 #include <memory>
 
-namespace DB::PS::V3
+namespace DB
+{
+namespace ErrorCodes
+{
+extern const int PS_DIR_APPLY_INVALID_STATUS;
+} // namespace ErrorCodes
+namespace PS::V3
 {
 PageDirectoryPtr PageDirectoryFactory::create(String storage_name, FileProviderPtr & file_provider, PSDiskDelegatorPtr & delegator, WALStore::Config config)
 {
@@ -101,8 +107,6 @@ PageDirectoryPtr PageDirectoryFactory::createFromEdit(String storage_name, FileP
 
 void PageDirectoryFactory::loadEdit(const PageDirectoryPtr & dir, const PageEntriesEdit & edit)
 {
-    PageDirectory::MVCCMapType & mvcc_table_directory = dir->mvcc_table_directory;
-
     for (const auto & r : edit.getRecords())
     {
         if (auto it = max_apply_page_ids.find(r.page_id.high); it == max_apply_page_ids.end())
@@ -118,63 +122,88 @@ void PageDirectoryFactory::loadEdit(const PageDirectoryPtr & dir, const PageEntr
             max_applied_ver = r.version;
         max_applied_page_id = std::max(r.page_id, max_applied_page_id);
 
-        auto [iter, created] = mvcc_table_directory.insert(std::make_pair(r.page_id, nullptr));
-        if (created)
+        // We can not avoid page id from being reused under some corner situation. Try to do gcInMemEntries
+        // and apply again to resolve the error.
+        if (bool ok = applyRecord(dir, r, /*throw_on_error*/ false); unlikely(!ok))
         {
-            iter->second = std::make_shared<VersionedPageEntries>();
-        }
-
-        const auto & version_list = iter->second;
-        const auto & restored_version = r.version;
-        try
-        {
-            switch (r.type)
-            {
-            case EditRecordType::VAR_EXTERNAL:
-            case EditRecordType::VAR_REF:
-            {
-                auto holder = version_list->fromRestored(r);
-                if (holder)
-                {
-                    *holder = r.page_id;
-                    dir->external_ids.emplace_back(std::weak_ptr<PageIdV3Internal>(holder));
-                }
-                break;
-            }
-            case EditRecordType::VAR_ENTRY:
-                version_list->fromRestored(r);
-                break;
-            case EditRecordType::PUT_EXTERNAL:
-            {
-                auto holder = version_list->createNewExternal(restored_version);
-                if (holder)
-                {
-                    *holder = r.page_id;
-                    dir->external_ids.emplace_back(std::weak_ptr<PageIdV3Internal>(holder));
-                }
-                break;
-            }
-            case EditRecordType::PUT:
-                version_list->createNewEntry(restored_version, r.entry);
-                break;
-            case EditRecordType::DEL:
-            case EditRecordType::VAR_DELETE: // nothing different from `DEL`
-                version_list->createDelete(restored_version);
-                break;
-            case EditRecordType::REF:
-                PageDirectory::applyRefEditRecord(mvcc_table_directory, version_list, r, restored_version);
-                break;
-            case EditRecordType::UPSERT:
-                version_list->createNewEntry(restored_version, r.entry);
-                break;
-            }
-        }
-        catch (DB::Exception & e)
-        {
-            e.addMessage(fmt::format(" [type={}] [page_id={}] [ver={}]", r.type, r.page_id, restored_version));
-            throw e;
+            dir->gcInMemEntries();
+            applyRecord(dir, r, /*throw_on_error*/ true);
+            LOG_FMT_INFO(DB::Logger::get("PageDirectoryFactory"), "resolve from error status done, continue to restore");
         }
     }
+}
+
+bool PageDirectoryFactory::applyRecord(
+    const PageDirectoryPtr & dir,
+    const PageEntriesEdit::EditRecord & r,
+    bool throw_on_error)
+{
+    auto [iter, created] = dir->mvcc_table_directory.insert(std::make_pair(r.page_id, nullptr));
+    if (created)
+    {
+        iter->second = std::make_shared<VersionedPageEntries>();
+    }
+
+    const auto & version_list = iter->second;
+    const auto & restored_version = r.version;
+    try
+    {
+        switch (r.type)
+        {
+        case EditRecordType::VAR_EXTERNAL:
+        case EditRecordType::VAR_REF:
+        {
+            auto holder = version_list->fromRestored(r);
+            if (holder)
+            {
+                *holder = r.page_id;
+                dir->external_ids.emplace_back(std::weak_ptr<PageIdV3Internal>(holder));
+            }
+            break;
+        }
+        case EditRecordType::VAR_ENTRY:
+            version_list->fromRestored(r);
+            break;
+        case EditRecordType::PUT_EXTERNAL:
+        {
+            auto holder = version_list->createNewExternal(restored_version);
+            if (holder)
+            {
+                *holder = r.page_id;
+                dir->external_ids.emplace_back(std::weak_ptr<PageIdV3Internal>(holder));
+            }
+            break;
+        }
+        case EditRecordType::PUT:
+            version_list->createNewEntry(restored_version, r.entry);
+            break;
+        case EditRecordType::DEL:
+        case EditRecordType::VAR_DELETE: // nothing different from `DEL`
+            version_list->createDelete(restored_version);
+            break;
+        case EditRecordType::REF:
+            PageDirectory::applyRefEditRecord(
+                dir->mvcc_table_directory,
+                version_list,
+                r,
+                restored_version);
+            break;
+        case EditRecordType::UPSERT:
+            version_list->createNewEntry(restored_version, r.entry);
+            break;
+        }
+    }
+    catch (DB::Exception & e)
+    {
+        e.addMessage(fmt::format(" [type={}] [page_id={}] [ver={}]", r.type, r.page_id, restored_version));
+        if (throw_on_error || e.code() != ErrorCodes::PS_DIR_APPLY_INVALID_STATUS)
+        {
+            throw e;
+        }
+        LOG_FMT_INFO(DB::Logger::get("PageDirectoryFactory"), "try to resolve error during restore: {}", e.message());
+        return false;
+    }
+    return true;
 }
 
 void PageDirectoryFactory::loadFromDisk(const PageDirectoryPtr & dir, WALStoreReaderPtr && reader)
@@ -196,4 +225,5 @@ void PageDirectoryFactory::loadFromDisk(const PageDirectoryPtr & dir, WALStoreRe
         loadEdit(dir, edit);
     }
 }
-} // namespace DB::PS::V3
+} // namespace PS::V3
+} // namespace DB

--- a/dbms/src/Storages/Page/V3/PageDirectoryFactory.cpp
+++ b/dbms/src/Storages/Page/V3/PageDirectoryFactory.cpp
@@ -109,15 +109,6 @@ void PageDirectoryFactory::loadEdit(const PageDirectoryPtr & dir, const PageEntr
 {
     for (const auto & r : edit.getRecords())
     {
-        if (auto it = max_apply_page_ids.find(r.page_id.high); it == max_apply_page_ids.end())
-        {
-            max_apply_page_ids[r.page_id.high] = r.page_id.low;
-        }
-        else
-        {
-            it->second = std::max(it->second, r.page_id.low);
-        }
-
         if (max_applied_ver < r.version)
             max_applied_ver = r.version;
         max_applied_page_id = std::max(r.page_id, max_applied_page_id);

--- a/dbms/src/Storages/Page/V3/PageDirectoryFactory.cpp
+++ b/dbms/src/Storages/Page/V3/PageDirectoryFactory.cpp
@@ -191,7 +191,7 @@ bool PageDirectoryFactory::applyRecord(
         {
             throw e;
         }
-        LOG_FMT_INFO(DB::Logger::get("PageDirectoryFactory"), "try to resolve error during restore: {}", e.message());
+        LOG_FMT_WARNING(DB::Logger::get("PageDirectoryFactory"), "try to resolve error during restore: {}", e.message());
         return false;
     }
     return true;

--- a/dbms/src/Storages/Page/V3/PageDirectoryFactory.h
+++ b/dbms/src/Storages/Page/V3/PageDirectoryFactory.h
@@ -58,11 +58,6 @@ public:
         return *this;
     }
 
-    std::map<NamespaceId, PageId> getMaxApplyPageIds() const
-    {
-        return max_apply_page_ids;
-    }
-
 private:
     void loadFromDisk(const PageDirectoryPtr & dir, WALStoreReaderPtr && reader);
     void loadEdit(const PageDirectoryPtr & dir, const PageEntriesEdit & edit);
@@ -72,7 +67,6 @@ private:
         bool throw_on_error);
 
     BlobStore::BlobStats * blob_stats = nullptr;
-    std::map<NamespaceId, PageId> max_apply_page_ids;
 };
 
 } // namespace PS::V3

--- a/dbms/src/Storages/Page/V3/PageDirectoryFactory.h
+++ b/dbms/src/Storages/Page/V3/PageDirectoryFactory.h
@@ -37,7 +37,7 @@ using WALStoreReaderPtr = std::shared_ptr<WALStoreReader>;
 class PageDirectoryFactory
 {
 public:
-    PageVersionType max_applied_ver;
+    PageVersion max_applied_ver;
     PageIdV3Internal max_applied_page_id;
 
     PageDirectoryFactory & setBlobStore(BlobStore & blob_store)

--- a/dbms/src/Storages/Page/V3/PageDirectoryFactory.h
+++ b/dbms/src/Storages/Page/V3/PageDirectoryFactory.h
@@ -66,6 +66,10 @@ public:
 private:
     void loadFromDisk(const PageDirectoryPtr & dir, WALStoreReaderPtr && reader);
     void loadEdit(const PageDirectoryPtr & dir, const PageEntriesEdit & edit);
+    static bool applyRecord(
+        const PageDirectoryPtr & dir,
+        const PageEntriesEdit::EditRecord & r,
+        bool throw_on_error);
 
     BlobStore::BlobStats * blob_stats = nullptr;
     std::map<NamespaceId, PageId> max_apply_page_ids;

--- a/dbms/src/Storages/Page/V3/PageEntriesEdit.h
+++ b/dbms/src/Storages/Page/V3/PageEntriesEdit.h
@@ -27,45 +27,45 @@ namespace DB::PS::V3
 // `PageDirectory::apply` with create a version={directory.sequence, epoch=0}.
 // After data compaction and page entries need to be updated, will create
 // some entries with a version={old_sequence, epoch=old_epoch+1}.
-struct PageVersionType
+struct PageVersion
 {
     UInt64 sequence; // The write sequence
     UInt64 epoch; // The GC epoch
 
-    explicit PageVersionType(UInt64 seq)
+    explicit PageVersion(UInt64 seq)
         : sequence(seq)
         , epoch(0)
     {}
 
-    PageVersionType(UInt64 seq, UInt64 epoch_)
+    PageVersion(UInt64 seq, UInt64 epoch_)
         : sequence(seq)
         , epoch(epoch_)
     {}
 
-    PageVersionType()
-        : PageVersionType(0)
+    PageVersion()
+        : PageVersion(0)
     {}
 
-    bool operator<(const PageVersionType & rhs) const
+    bool operator<(const PageVersion & rhs) const
     {
         if (sequence == rhs.sequence)
             return epoch < rhs.epoch;
         return sequence < rhs.sequence;
     }
 
-    bool operator==(const PageVersionType & rhs) const
+    bool operator==(const PageVersion & rhs) const
     {
         return (sequence == rhs.sequence) && (epoch == rhs.epoch);
     }
 
-    bool operator<=(const PageVersionType & rhs) const
+    bool operator<=(const PageVersion & rhs) const
     {
         if (sequence == rhs.sequence)
             return epoch <= rhs.epoch;
         return sequence <= rhs.sequence;
     }
 };
-using VersionedEntry = std::pair<PageVersionType, PageEntryV3>;
+using VersionedEntry = std::pair<PageVersion, PageEntryV3>;
 using VersionedEntries = std::vector<VersionedEntry>;
 
 enum class EditRecordType
@@ -139,7 +139,7 @@ public:
         records.emplace_back(record);
     }
 
-    void upsertPage(PageIdV3Internal page_id, const PageVersionType & ver, const PageEntryV3 & entry)
+    void upsertPage(PageIdV3Internal page_id, const PageVersion & ver, const PageEntryV3 & entry)
     {
         EditRecord record{};
         record.type = EditRecordType::UPSERT;
@@ -166,7 +166,7 @@ public:
         records.emplace_back(record);
     }
 
-    void varRef(PageIdV3Internal ref_id, const PageVersionType & ver, PageIdV3Internal ori_page_id)
+    void varRef(PageIdV3Internal ref_id, const PageVersion & ver, PageIdV3Internal ori_page_id)
     {
         EditRecord record{};
         record.type = EditRecordType::VAR_REF;
@@ -176,7 +176,7 @@ public:
         records.emplace_back(record);
     }
 
-    void varExternal(PageIdV3Internal page_id, const PageVersionType & create_ver, Int64 being_ref_count)
+    void varExternal(PageIdV3Internal page_id, const PageVersion & create_ver, Int64 being_ref_count)
     {
         EditRecord record{};
         record.type = EditRecordType::VAR_EXTERNAL;
@@ -186,7 +186,7 @@ public:
         records.emplace_back(record);
     }
 
-    void varEntry(PageIdV3Internal page_id, const PageVersionType & ver, const PageEntryV3 & entry, Int64 being_ref_count)
+    void varEntry(PageIdV3Internal page_id, const PageVersion & ver, const PageEntryV3 & entry, Int64 being_ref_count)
     {
         EditRecord record{};
         record.type = EditRecordType::VAR_ENTRY;
@@ -197,7 +197,7 @@ public:
         records.emplace_back(record);
     }
 
-    void varDel(PageIdV3Internal page_id, const PageVersionType & delete_ver)
+    void varDel(PageIdV3Internal page_id, const PageVersion & delete_ver)
     {
         EditRecord record{};
         record.type = EditRecordType::VAR_DELETE;
@@ -217,7 +217,7 @@ public:
         EditRecordType type;
         PageIdV3Internal page_id;
         PageIdV3Internal ori_page_id;
-        PageVersionType version;
+        PageVersion version;
         PageEntryV3 entry;
         Int64 being_ref_count;
 
@@ -260,7 +260,7 @@ public:
     {
         putExternal(buildV3Id(TEST_NAMESPACE_ID, page_id));
     }
-    void upsertPage(PageId page_id, const PageVersionType & ver, const PageEntryV3 & entry)
+    void upsertPage(PageId page_id, const PageVersion & ver, const PageEntryV3 & entry)
     {
         upsertPage(buildV3Id(TEST_NAMESPACE_ID, page_id), ver, entry);
     }
@@ -272,19 +272,19 @@ public:
     {
         ref(buildV3Id(TEST_NAMESPACE_ID, ref_id), buildV3Id(TEST_NAMESPACE_ID, page_id));
     }
-    void varRef(PageId ref_id, const PageVersionType & ver, PageId ori_page_id)
+    void varRef(PageId ref_id, const PageVersion & ver, PageId ori_page_id)
     {
         varRef(buildV3Id(TEST_NAMESPACE_ID, ref_id), ver, buildV3Id(TEST_NAMESPACE_ID, ori_page_id));
     }
-    void varExternal(PageId page_id, const PageVersionType & create_ver, Int64 being_ref_count)
+    void varExternal(PageId page_id, const PageVersion & create_ver, Int64 being_ref_count)
     {
         varExternal(buildV3Id(TEST_NAMESPACE_ID, page_id), create_ver, being_ref_count);
     }
-    void varEntry(PageId page_id, const PageVersionType & ver, const PageEntryV3 & entry, Int64 being_ref_count)
+    void varEntry(PageId page_id, const PageVersion & ver, const PageEntryV3 & entry, Int64 being_ref_count)
     {
         varEntry(buildV3Id(TEST_NAMESPACE_ID, page_id), ver, entry, being_ref_count);
     }
-    void varDel(PageId page_id, const PageVersionType & delete_ver)
+    void varDel(PageId page_id, const PageVersion & delete_ver)
     {
         varDel(buildV3Id(TEST_NAMESPACE_ID, page_id), delete_ver);
     }
@@ -316,7 +316,7 @@ public:
 
 /// See https://fmt.dev/latest/api.html#formatting-user-defined-types
 template <>
-struct fmt::formatter<DB::PS::V3::PageVersionType>
+struct fmt::formatter<DB::PS::V3::PageVersion>
 {
     static constexpr auto parse(format_parse_context & ctx)
     {
@@ -331,7 +331,7 @@ struct fmt::formatter<DB::PS::V3::PageVersionType>
     }
 
     template <typename FormatContext>
-    auto format(const DB::PS::V3::PageVersionType & ver, FormatContext & ctx)
+    auto format(const DB::PS::V3::PageVersion & ver, FormatContext & ctx)
     {
         return format_to(ctx.out(), "<{},{}>", ver.sequence, ver.epoch);
     }

--- a/dbms/src/Storages/Page/V3/PageEntriesEdit.h
+++ b/dbms/src/Storages/Page/V3/PageEntriesEdit.h
@@ -76,7 +76,8 @@ enum class EditRecordType
     DEL,
     //
     UPSERT,
-    //
+    // Variant types for dumping the in-memory entries into
+    // snapshot
     VAR_ENTRY,
     VAR_REF,
     VAR_EXTERNAL,

--- a/dbms/src/Storages/Page/V3/PageStorageImpl.cpp
+++ b/dbms/src/Storages/Page/V3/PageStorageImpl.cpp
@@ -43,7 +43,7 @@ PageStorageImpl::PageStorageImpl(
 
 PageStorageImpl::~PageStorageImpl() = default;
 
-std::map<NamespaceId, PageId> PageStorageImpl::restore()
+void PageStorageImpl::restore()
 {
     // TODO: clean up blobstore.
     // TODO: Speedup restoring
@@ -53,7 +53,11 @@ std::map<NamespaceId, PageId> PageStorageImpl::restore()
     page_directory = factory
                          .setBlobStore(blob_store)
                          .create(storage_name, file_provider, delegator, parseWALConfig(config));
-    return factory.getMaxApplyPageIds();
+}
+
+PageId PageStorageImpl::getMaxId(NamespaceId ns_id)
+{
+    return page_directory->getMaxId(ns_id);
 }
 
 void PageStorageImpl::drop()

--- a/dbms/src/Storages/Page/V3/PageStorageImpl.h
+++ b/dbms/src/Storages/Page/V3/PageStorageImpl.h
@@ -60,10 +60,11 @@ public:
         return wal_config;
     }
 
-    std::map<NamespaceId, PageId> restore() override;
+    void restore() override;
 
     void drop() override;
 
+    PageId getMaxId(NamespaceId ns_id) override;
 
     PageId getNormalPageIdImpl(NamespaceId ns_id, PageId page_id, SnapshotPtr snapshot, bool throw_on_not_exist) override;
 

--- a/dbms/src/Storages/Page/V3/WAL/serialize.cpp
+++ b/dbms/src/Storages/Page/V3/WAL/serialize.cpp
@@ -23,13 +23,13 @@
 
 namespace DB::PS::V3::ser
 {
-inline void serializeVersionTo(const PageVersionType & version, WriteBuffer & buf)
+inline void serializeVersionTo(const PageVersion & version, WriteBuffer & buf)
 {
     writeIntBinary(version.sequence, buf);
     writeIntBinary(version.epoch, buf);
 }
 
-inline void deserializeVersionFrom(ReadBuffer & buf, PageVersionType & version)
+inline void deserializeVersionFrom(ReadBuffer & buf, PageVersion & version)
 {
     readIntBinary(version.sequence, buf);
     readIntBinary(version.epoch, buf);
@@ -174,7 +174,7 @@ void deserializeDelFrom([[maybe_unused]] const EditRecordType record_type, ReadB
 
     PageIdV3Internal page_id;
     readIntBinary(page_id, buf);
-    PageVersionType version;
+    PageVersion version;
     deserializeVersionFrom(buf, version);
 
     PageEntriesEdit::EditRecord rec;

--- a/dbms/src/Storages/Page/V3/WALStore.cpp
+++ b/dbms/src/Storages/Page/V3/WALStore.cpp
@@ -69,7 +69,7 @@ WALStore::WALStore(
 {
 }
 
-void WALStore::apply(PageEntriesEdit & edit, const PageVersionType & version, const WriteLimiterPtr & write_limiter)
+void WALStore::apply(PageEntriesEdit & edit, const PageVersion & version, const WriteLimiterPtr & write_limiter)
 {
     for (auto & r : edit.getMutRecords())
     {

--- a/dbms/src/Storages/Page/V3/WALStore.h
+++ b/dbms/src/Storages/Page/V3/WALStore.h
@@ -99,7 +99,7 @@ public:
         PSDiskDelegatorPtr & delegator,
         WALStore::Config config);
 
-    void apply(PageEntriesEdit & edit, const PageVersionType & version, const WriteLimiterPtr & write_limiter = nullptr);
+    void apply(PageEntriesEdit & edit, const PageVersion & version, const WriteLimiterPtr & write_limiter = nullptr);
     void apply(const PageEntriesEdit & edit, const WriteLimiterPtr & write_limiter = nullptr);
 
     struct FilesSnapshot

--- a/dbms/src/Storages/Page/V3/tests/gtest_page_directory.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_page_directory.cpp
@@ -2094,6 +2094,191 @@ try
 }
 CATCH
 
+TEST_F(PageDirectoryGCTest, RestoreWithDuplicateID)
+try
+{
+    auto restore_from_edit = [](const PageEntriesEdit & edit) {
+        auto ctx = ::DB::tests::TiFlashTestEnv::getContext();
+        auto provider = ctx.getFileProvider();
+        auto path = getTemporaryPath();
+        PSDiskDelegatorPtr delegator = std::make_shared<DB::tests::MockDiskDelegatorSingle>(path);
+        PageDirectoryFactory factory;
+        auto d = factory.createFromEdit(getCurrentTestName(), provider, delegator, edit);
+        return d;
+    };
+
+    const PageId target_id = 100;
+    // ========= 1 =======//
+    // Reuse same id: PUT_EXT/DEL/REF
+    {
+        PageEntryV3 entry_50{.file_id = 1, .size = 7890, .tag = 0, .offset = 0x123, .checksum = 0x4567};
+        PageEntriesEdit edit;
+        edit.put(50, entry_50);
+        edit.putExternal(target_id);
+        edit.del(target_id);
+        // restart and reuse id=100 as ref to replace put_ext
+        edit.ref(target_id, 50);
+
+        auto restored_dir = restore_from_edit(edit);
+        auto snap = restored_dir->createSnapshot();
+        ASSERT_EQ(restored_dir->getNormalPageId(target_id, snap).low, 50);
+    }
+    // Reuse same id: PUT_EXT/DEL/PUT
+    {
+        PageEntryV3 entry_50{.file_id = 1, .size = 7890, .tag = 0, .offset = 0x123, .checksum = 0x4567};
+        PageEntryV3 entry_100{.file_id = 100, .size = 7890, .tag = 0, .offset = 0x123, .checksum = 0x4567};
+        PageEntriesEdit edit;
+        edit.put(50, entry_50);
+        edit.putExternal(target_id);
+        edit.del(target_id);
+        // restart and reuse id=100 as put to replace put_ext
+        edit.put(target_id, entry_100);
+
+        auto restored_dir = restore_from_edit(edit);
+        auto snap = restored_dir->createSnapshot();
+        ASSERT_SAME_ENTRY(restored_dir->get(target_id, snap).second, entry_100);
+    }
+
+    // ========= 1-invalid =======//
+    // Reuse same id: PUT_EXT/BEING REF/DEL/REF
+    {
+        PageEntryV3 entry_50{.file_id = 1, .size = 7890, .tag = 0, .offset = 0x123, .checksum = 0x4567};
+        PageEntriesEdit edit;
+        edit.put(50, entry_50);
+        edit.putExternal(target_id);
+        edit.ref(101, target_id);
+        edit.del(target_id);
+        // restart and reuse id=100 as ref. Should not happen because 101 still ref to 100
+        edit.ref(target_id, 50);
+
+        ASSERT_THROW(restore_from_edit(edit);, DB::Exception);
+    }
+    // Reuse same id: PUT_EXT/BEING REF/DEL/PUT
+    {
+        PageEntryV3 entry_50{.file_id = 1, .size = 7890, .tag = 0, .offset = 0x123, .checksum = 0x4567};
+        PageEntryV3 entry_100{.file_id = 100, .size = 7890, .tag = 0, .offset = 0x123, .checksum = 0x4567};
+        PageEntriesEdit edit;
+        edit.put(50, entry_50);
+        edit.putExternal(target_id);
+        edit.ref(101, target_id);
+        edit.del(target_id);
+        // restart and reuse id=100 as put. Should not happen because 101 still ref to 100
+        edit.put(target_id, entry_100);
+
+        ASSERT_THROW(restore_from_edit(edit);, DB::Exception);
+    }
+    
+    // ========= 2 =======//
+    // Reuse same id: PUT/DEL/REF
+    {
+        PageEntryV3 entry_50{.file_id = 1, .size = 7890, .tag = 0, .offset = 0x123, .checksum = 0x4567};
+        PageEntriesEdit edit;
+        edit.put(50, entry_50);
+        edit.put(target_id, entry_50);
+        edit.del(target_id);
+        // restart and reuse id=100 as ref to replace put
+        edit.ref(target_id, 50);
+
+        auto restored_dir = restore_from_edit(edit);
+        auto snap = restored_dir->createSnapshot();
+        ASSERT_EQ(restored_dir->getNormalPageId(target_id, snap).low, 50);
+    }
+    // Reuse same id: PUT/DEL/PUT_EXT
+    {
+        PageEntryV3 entry_50{.file_id = 1, .size = 7890, .tag = 0, .offset = 0x123, .checksum = 0x4567};
+        PageEntriesEdit edit;
+        edit.put(50, entry_50);
+        edit.put(target_id, entry_50);
+        edit.del(target_id);
+        // restart and reuse id=100 as external to replace put
+        edit.putExternal(target_id);
+
+        auto restored_dir = restore_from_edit(edit);
+        auto snap = restored_dir->createSnapshot();
+        auto ext_ids = restored_dir->getAliveExternalIds(TEST_NAMESPACE_ID);
+        ASSERT_EQ(ext_ids.size(), 1);
+        ASSERT_EQ(*ext_ids.begin(), target_id);
+    }
+
+    // ========= 2-invalid =======//
+    // Reuse same id: PUT/BEING REF/DEL/REF
+    {
+        PageEntryV3 entry_50{.file_id = 1, .size = 7890, .tag = 0, .offset = 0x123, .checksum = 0x4567};
+        PageEntriesEdit edit;
+        edit.put(50, entry_50);
+        edit.put(target_id, entry_50);
+        edit.ref(101, target_id);
+        edit.del(target_id);
+        // restart and reuse id=100 as ref to replace put
+        edit.ref(target_id, 50);
+
+        ASSERT_THROW(restore_from_edit(edit);, DB::Exception);
+    }
+    // Reuse same id: PUT/BEING REF/DEL/PUT_EXT
+    {
+        PageEntryV3 entry_50{.file_id = 1, .size = 7890, .tag = 0, .offset = 0x123, .checksum = 0x4567};
+        PageEntriesEdit edit;
+        edit.put(50, entry_50);
+        edit.put(target_id, entry_50);
+        edit.ref(101, target_id);
+        edit.del(target_id);
+        // restart and reuse id=100 as external to replace put
+        edit.putExternal(target_id);
+
+        ASSERT_THROW(restore_from_edit(edit);, DB::Exception);
+    }
+
+    // ========= 3 =======//
+    // Reuse same id: REF/DEL/PUT
+    {
+        PageEntryV3 entry_50{.file_id = 1, .size = 7890, .tag = 0, .offset = 0x123, .checksum = 0x4567};
+        PageEntryV3 entry_100{.file_id = 100, .size = 7890, .tag = 0, .offset = 0x123, .checksum = 0x4567};
+        PageEntriesEdit edit;
+        edit.put(50, entry_50);
+        edit.ref(target_id, 50);
+        edit.del(target_id);
+        // restart and reuse id=100 as put to replace ref
+        edit.put(target_id, entry_100);
+
+        auto restored_dir = restore_from_edit(edit);
+        auto snap = restored_dir->createSnapshot();
+        ASSERT_SAME_ENTRY(restored_dir->get(target_id, snap).second, entry_100);
+    }
+    // Reuse same id: REF/DEL/PUT_EXT
+    {
+        PageEntryV3 entry_50{.file_id = 1, .size = 7890, .tag = 0, .offset = 0x123, .checksum = 0x4567};
+        PageEntriesEdit edit;
+        edit.put(50, entry_50);
+        edit.ref(target_id, 50);
+        edit.del(target_id);
+        // restart and reuse id=100 as external to replace ref
+        edit.putExternal(target_id);
+
+        auto restored_dir = restore_from_edit(edit);
+        auto snap = restored_dir->createSnapshot();
+        auto ext_ids = restored_dir->getAliveExternalIds(TEST_NAMESPACE_ID);
+        ASSERT_EQ(ext_ids.size(), 1);
+        ASSERT_EQ(*ext_ids.begin(), target_id);
+    }
+    // Reuse same id: REF/DEL/REF another id
+    {
+        PageEntryV3 entry_50{.file_id = 1, .size = 7890, .tag = 0, .offset = 0x123, .checksum = 0x4567};
+        PageEntryV3 entry_51{.file_id = 2, .size = 7890, .tag = 0, .offset = 0x123, .checksum = 0x4567};
+        PageEntriesEdit edit;
+        edit.put(50, entry_50);
+        edit.put(51, entry_51);
+        edit.ref(target_id, 50);
+        edit.del(target_id);
+        // restart and reuse id=target_id as external to replace put
+        edit.ref(target_id, 51);
+
+        auto restored_dir = restore_from_edit(edit);
+        auto snap = restored_dir->createSnapshot();
+        ASSERT_EQ(restored_dir->getNormalPageId(target_id, snap).low, 51);
+    }
+}
+CATCH
+
 TEST_F(PageDirectoryTest, GetMaxId)
 try
 {

--- a/dbms/src/Storages/Page/V3/tests/gtest_page_directory.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_page_directory.cpp
@@ -625,16 +625,16 @@ CATCH
 
 #define INSERT_BLOBID_ENTRY(BLOBID, VERSION)                                                                             \
     PageEntryV3 entry_v##VERSION{.file_id = (BLOBID), .size = (VERSION), .tag = 0, .offset = 0x123, .checksum = 0x4567}; \
-    entries.createNewEntry(PageVersionType(VERSION), entry_v##VERSION);
+    entries.createNewEntry(PageVersion(VERSION), entry_v##VERSION);
 #define INSERT_ENTRY(VERSION) INSERT_BLOBID_ENTRY(1, VERSION)
 #define INSERT_GC_ENTRY(VERSION, EPOCH)                                                                                                        \
     PageEntryV3 entry_gc_v##VERSION##_##EPOCH{.file_id = 2, .size = 100 * (VERSION) + (EPOCH), .tag = 0, .offset = 0x234, .checksum = 0x5678}; \
-    entries.createNewEntry(PageVersionType((VERSION), (EPOCH)), entry_gc_v##VERSION##_##EPOCH);
+    entries.createNewEntry(PageVersion((VERSION), (EPOCH)), entry_gc_v##VERSION##_##EPOCH);
 
 class VersionedEntriesTest : public ::testing::Test
 {
 public:
-    using DerefCounter = std::map<PageIdV3Internal, std::pair<PageVersionType, Int64>>;
+    using DerefCounter = std::map<PageIdV3Internal, std::pair<PageVersion, Int64>>;
     std::tuple<bool, PageEntriesV3, DerefCounter> runClean(UInt64 seq)
     {
         DerefCounter deref_counter;
@@ -643,7 +643,7 @@ public:
         return {all_removed, removed_entries, deref_counter};
     }
 
-    std::tuple<bool, PageEntriesV3> runDeref(UInt64 seq, PageVersionType ver, Int64 decrease_num)
+    std::tuple<bool, PageEntriesV3> runDeref(UInt64 seq, PageVersion ver, Int64 decrease_num)
     {
         PageEntriesV3 removed_entries;
         bool all_removed = entries.derefAndClean(seq, buildV3Id(TEST_NAMESPACE_ID, page_id), ver, decrease_num, removed_entries);
@@ -694,7 +694,7 @@ TEST_F(VersionedEntriesTest, InsertGet)
 
     // Insert delete. Can not get entry with seq >= delete_version.
     // But it won't affect reading with old seq.
-    entries.createDelete(PageVersionType(15));
+    entries.createDelete(PageVersion(15));
     ASSERT_FALSE(entries.getEntry(1).has_value());
     ASSERT_SAME_ENTRY(*entries.getEntry(2), entry_gc_v2_1);
     ASSERT_SAME_ENTRY(*entries.getEntry(3), entry_gc_v2_1);
@@ -744,7 +744,7 @@ try
     ASSERT_TRUE(entries.isVisible(6));
 
     // insert delete
-    entries.createDelete(PageVersionType(6));
+    entries.createDelete(PageVersion(6));
 
     ASSERT_FALSE(entries.isVisible(1));
     ASSERT_TRUE(entries.isVisible(2));
@@ -778,14 +778,14 @@ try
     ASSERT_FALSE(entries.isVisible(10000));
 
     // insert some entries
-    entries.createNewExternal(PageVersionType(2));
+    entries.createNewExternal(PageVersion(2));
 
     ASSERT_FALSE(entries.isVisible(1));
     ASSERT_TRUE(entries.isVisible(2));
     ASSERT_TRUE(entries.isVisible(10000));
 
     // insert delete
-    entries.createDelete(PageVersionType(6));
+    entries.createDelete(PageVersion(6));
 
     ASSERT_FALSE(entries.isVisible(1));
     ASSERT_TRUE(entries.isVisible(2));
@@ -796,7 +796,7 @@ try
     ASSERT_FALSE(entries.isVisible(10000));
 
     // insert entry after delete
-    entries.createNewExternal(PageVersionType(7));
+    entries.createNewExternal(PageVersion(7));
 
     // after re-create external page, the visible for 1~5 has changed
     ASSERT_FALSE(entries.isVisible(6));
@@ -815,14 +815,14 @@ try
     ASSERT_FALSE(entries.isVisible(10000));
 
     // insert some entries
-    entries.createNewRef(PageVersionType(2), buildV3Id(TEST_NAMESPACE_ID, 2));
+    entries.createNewRef(PageVersion(2), buildV3Id(TEST_NAMESPACE_ID, 2));
 
     ASSERT_FALSE(entries.isVisible(1));
     ASSERT_TRUE(entries.isVisible(2));
     ASSERT_TRUE(entries.isVisible(10000));
 
     // insert delete
-    entries.createDelete(PageVersionType(6));
+    entries.createDelete(PageVersion(6));
 
     ASSERT_FALSE(entries.isVisible(1));
     ASSERT_TRUE(entries.isVisible(2));
@@ -833,7 +833,7 @@ try
     ASSERT_FALSE(entries.isVisible(10000));
 
     // insert entry after delete
-    entries.createNewRef(PageVersionType(7), buildV3Id(TEST_NAMESPACE_ID, 2));
+    entries.createNewRef(PageVersion(7), buildV3Id(TEST_NAMESPACE_ID, 2));
 
     // after re-create ref page, the visible for 1~5 has changed
     ASSERT_FALSE(entries.isVisible(6));
@@ -852,7 +852,7 @@ try
     INSERT_GC_ENTRY(5, 2);
     INSERT_ENTRY(10);
     INSERT_ENTRY(11);
-    entries.createDelete(PageVersionType(15));
+    entries.createDelete(PageVersion(15));
 
     // noting to be removed
     auto [all_removed, removed_entries, deref_counter] = runClean(1);
@@ -905,15 +905,15 @@ CATCH
 TEST_F(VersionedEntriesTest, DeleteMultiTime)
 try
 {
-    entries.createDelete(PageVersionType(1));
+    entries.createDelete(PageVersion(1));
     INSERT_ENTRY(2);
     INSERT_GC_ENTRY(2, 1);
-    entries.createDelete(PageVersionType(15));
-    entries.createDelete(PageVersionType(17));
-    entries.createDelete(PageVersionType(16));
+    entries.createDelete(PageVersion(15));
+    entries.createDelete(PageVersion(17));
+    entries.createDelete(PageVersion(16));
 
     bool all_removed;
-    std::map<PageIdV3Internal, std::pair<PageVersionType, Int64>> deref_counter;
+    std::map<PageIdV3Internal, std::pair<PageVersion, Int64>> deref_counter;
     PageEntriesV3 removed_entries;
 
     // <2,0> get removed.
@@ -938,13 +938,13 @@ TEST_F(VersionedEntriesTest, DontCleanWhenBeingRef)
 try
 {
     bool all_removed;
-    std::map<PageIdV3Internal, std::pair<PageVersionType, Int64>> deref_counter;
+    std::map<PageIdV3Internal, std::pair<PageVersion, Int64>> deref_counter;
     PageEntriesV3 removed_entries;
 
     INSERT_ENTRY(2);
-    entries.incrRefCount(PageVersionType(2));
-    entries.incrRefCount(PageVersionType(2));
-    entries.createDelete(PageVersionType(5));
+    entries.incrRefCount(PageVersion(2));
+    entries.incrRefCount(PageVersion(2));
+    entries.createDelete(PageVersion(5));
 
     // <2, 0> is not available after seq=5, but not get removed
     ASSERT_SAME_ENTRY(entry_v2, *entries.getEntry(4));
@@ -958,13 +958,13 @@ try
     ASSERT_EQ(deref_counter.size(), 0);
 
     // decrease 1 ref counting
-    std::tie(all_removed, removed_entries) = runDeref(5, PageVersionType(2), 1);
+    std::tie(all_removed, removed_entries) = runDeref(5, PageVersion(2), 1);
     ASSERT_EQ(removed_entries.size(), 0);
     ASSERT_FALSE(all_removed); // should not remove this chain
     ASSERT_FALSE(entries.getEntry(5));
 
     // clear all
-    std::tie(all_removed, removed_entries) = runDeref(5, PageVersionType(2), 1);
+    std::tie(all_removed, removed_entries) = runDeref(5, PageVersion(2), 1);
     ASSERT_EQ(removed_entries.size(), 1);
     ASSERT_SAME_ENTRY(removed_entries[0], entry_v2);
     ASSERT_TRUE(all_removed); // should remove this chain
@@ -976,13 +976,13 @@ TEST_F(VersionedEntriesTest, DontCleanWhenBeingRef2)
 try
 {
     bool all_removed;
-    std::map<PageIdV3Internal, std::pair<PageVersionType, Int64>> deref_counter;
+    std::map<PageIdV3Internal, std::pair<PageVersion, Int64>> deref_counter;
     PageEntriesV3 removed_entries;
 
     INSERT_ENTRY(2);
-    entries.incrRefCount(PageVersionType(2));
-    entries.incrRefCount(PageVersionType(2));
-    entries.createDelete(PageVersionType(5));
+    entries.incrRefCount(PageVersion(2));
+    entries.incrRefCount(PageVersion(2));
+    entries.createDelete(PageVersion(5));
 
     // <2, 0> is not available after seq=5, but not get removed
     ASSERT_SAME_ENTRY(entry_v2, *entries.getEntry(4));
@@ -996,7 +996,7 @@ try
     ASSERT_EQ(deref_counter.size(), 0);
 
     // clear all
-    std::tie(all_removed, removed_entries) = runDeref(5, PageVersionType(2), 2);
+    std::tie(all_removed, removed_entries) = runDeref(5, PageVersion(2), 2);
     ASSERT_EQ(removed_entries.size(), 1);
     ASSERT_SAME_ENTRY(removed_entries[0], entry_v2);
     ASSERT_TRUE(all_removed); // should remove this chain
@@ -1008,12 +1008,12 @@ TEST_F(VersionedEntriesTest, CleanDuplicatedWhenBeingRefAndAppliedUpsert)
 try
 {
     bool all_removed;
-    std::map<PageIdV3Internal, std::pair<PageVersionType, Int64>> deref_counter;
+    std::map<PageIdV3Internal, std::pair<PageVersion, Int64>> deref_counter;
     PageEntriesV3 removed_entries;
 
     INSERT_ENTRY(2);
-    entries.incrRefCount(PageVersionType(2));
-    entries.incrRefCount(PageVersionType(2));
+    entries.incrRefCount(PageVersion(2));
+    entries.incrRefCount(PageVersion(2));
     INSERT_GC_ENTRY(2, 1);
     INSERT_GC_ENTRY(2, 2);
 
@@ -1030,7 +1030,7 @@ try
     ASSERT_EQ(deref_counter.size(), 0);
 
     // clear all
-    std::tie(all_removed, removed_entries) = runDeref(5, PageVersionType(2), 2);
+    std::tie(all_removed, removed_entries) = runDeref(5, PageVersion(2), 2);
     ASSERT_EQ(removed_entries.size(), 0);
     ASSERT_FALSE(all_removed); // should not remove this chain
     ASSERT_SAME_ENTRY(entry_gc_v2_2, *entries.getEntry(4));
@@ -1041,15 +1041,15 @@ TEST_F(VersionedEntriesTest, CleanDuplicatedWhenBeingRefAndAppliedUpsert2)
 try
 {
     bool all_removed;
-    std::map<PageIdV3Internal, std::pair<PageVersionType, Int64>> deref_counter;
+    std::map<PageIdV3Internal, std::pair<PageVersion, Int64>> deref_counter;
     PageEntriesV3 removed_entries;
 
     INSERT_ENTRY(2);
-    entries.incrRefCount(PageVersionType(2));
-    entries.incrRefCount(PageVersionType(2));
+    entries.incrRefCount(PageVersion(2));
+    entries.incrRefCount(PageVersion(2));
     INSERT_GC_ENTRY(2, 1);
     INSERT_GC_ENTRY(2, 2);
-    entries.createDelete(PageVersionType(5));
+    entries.createDelete(PageVersion(5));
 
     // <2, 2> is not available after seq=5, but not get removed
     ASSERT_SAME_ENTRY(entry_gc_v2_2, *entries.getEntry(4));
@@ -1065,7 +1065,7 @@ try
     ASSERT_EQ(deref_counter.size(), 0);
 
     // clear all
-    std::tie(all_removed, removed_entries) = runDeref(5, PageVersionType(2), 2);
+    std::tie(all_removed, removed_entries) = runDeref(5, PageVersion(2), 2);
     ASSERT_EQ(removed_entries.size(), 1);
     ASSERT_SAME_ENTRY(removed_entries[0], entry_gc_v2_2);
     ASSERT_TRUE(all_removed); // should remove this chain
@@ -1077,7 +1077,7 @@ TEST_F(VersionedEntriesTest, ReadAfterGcApplied)
 try
 {
     bool all_removed;
-    std::map<PageIdV3Internal, std::pair<PageVersionType, Int64>> deref_counter;
+    std::map<PageIdV3Internal, std::pair<PageVersion, Int64>> deref_counter;
     PageEntriesV3 removed_entries;
 
     INSERT_ENTRY(2);

--- a/dbms/src/Storages/Page/V3/tests/gtest_page_directory.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_page_directory.cpp
@@ -2167,7 +2167,7 @@ try
 
         ASSERT_THROW(restore_from_edit(edit);, DB::Exception);
     }
-    
+
     // ========= 2 =======//
     // Reuse same id: PUT/DEL/REF
     {

--- a/dbms/src/Storages/Page/V3/tests/gtest_page_storage.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_page_storage.cpp
@@ -67,15 +67,6 @@ public:
     }
 
 
-    std::pair<std::shared_ptr<PageStorageImpl>, std::map<NamespaceId, PageId>> reopen()
-    {
-        auto path = getTemporaryPath();
-        auto delegator = std::make_shared<DB::tests::MockDiskDelegatorSingle>(path);
-        auto storage = std::make_shared<PageStorageImpl>("test.t", delegator, config, file_provider);
-        auto max_ids = storage->restore();
-        return {storage, max_ids};
-    }
-
 protected:
     FileProviderPtr file_provider;
     std::unique_ptr<StoragePathPool> path_pool;
@@ -1307,42 +1298,6 @@ try
     fields.emplace_back(field);
 
     ASSERT_NO_THROW(page_storage->read(fields));
-}
-CATCH
-
-TEST_F(PageStorageTest, getMaxIdsFromRestore)
-try
-{
-    {
-        WriteBatch batch;
-        batch.putExternal(1, 0);
-        batch.putExternal(2, 0);
-        batch.delPage(1);
-        batch.delPage(2);
-        page_storage->write(std::move(batch));
-
-        WriteBatch batch2{TEST_NAMESPACE_ID + 1};
-        batch2.putExternal(1, 0);
-        batch2.putExternal(2, 0);
-        batch2.putRefPage(3, 1);
-        batch2.putRefPage(100, 2);
-        page_storage->write(std::move(batch2));
-
-        WriteBatch batch3{TEST_NAMESPACE_ID + 2};
-        batch3.putExternal(1, 0);
-        batch3.putExternal(2, 0);
-        batch3.putRefPage(3, 1);
-        batch3.putRefPage(10, 2);
-        batch3.delPage(10);
-        page_storage->write(std::move(batch3));
-    }
-
-    page_storage = nullptr;
-    auto [page_storage, max_ids] = reopen();
-    ASSERT_EQ(max_ids.size(), 3);
-    ASSERT_EQ(max_ids[TEST_NAMESPACE_ID], 2); // external page 2 is marked as deleted, but we can still restore it.
-    ASSERT_EQ(max_ids[TEST_NAMESPACE_ID + 1], 100);
-    ASSERT_EQ(max_ids[TEST_NAMESPACE_ID + 2], 10); // page 10 is marked as deleted, but we can still restore it.
 }
 CATCH
 

--- a/dbms/src/Storages/Page/V3/tests/gtest_page_storage_mix_mode.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_page_storage_mix_mode.cpp
@@ -43,16 +43,17 @@ public:
         storage_path_pool_v3 = std::make_unique<PathPool>(Strings{path}, Strings{path}, Strings{}, std::make_shared<PathCapacityMetrics>(0, paths, caps, Strings{}, caps), global_context.getFileProvider(), true);
 
         global_context.setPageStorageRunMode(PageStorageRunMode::MIX_MODE);
+        if (!global_context.getGlobalStoragePool())
+            global_context.initializeGlobalStoragePoolIfNeed(*storage_path_pool_v3);
     }
 
     void SetUp() override
     {
-        auto & global_context = DB::tests::TiFlashTestEnv::getGlobalContext();
-        global_context.setPageStorageRunMode(PageStorageRunMode::MIX_MODE);
         TiFlashStorageTestBasic::SetUp();
         const auto & path = getTemporaryPath();
         createIfNotExist(path);
 
+        auto & global_context = DB::tests::TiFlashTestEnv::getGlobalContext();
 
         std::vector<size_t> caps = {};
         Strings paths = {path};
@@ -74,7 +75,7 @@ public:
 
     PageStorageRunMode reloadMixedStoragePool()
     {
-        db_context->setPageStorageRunMode(PageStorageRunMode::MIX_MODE);
+        DB::tests::TiFlashTestEnv::getContext().setPageStorageRunMode(PageStorageRunMode::MIX_MODE);
         PageStorageRunMode run_mode = storage_pool_mix->restore();
         page_writer_mix = storage_pool_mix->logWriter();
         page_reader_mix = storage_pool_mix->logReader();
@@ -83,7 +84,7 @@ public:
 
     void reloadV2StoragePool()
     {
-        db_context->setPageStorageRunMode(PageStorageRunMode::ONLY_V2);
+        DB::tests::TiFlashTestEnv::getContext().setPageStorageRunMode(PageStorageRunMode::ONLY_V2);
         storage_pool_v2->restore();
         page_writer_v2 = storage_pool_v2->logWriter();
         page_reader_v2 = storage_pool_v2->logReader();

--- a/dbms/src/Storages/Page/V3/tests/gtest_wal_store.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_wal_store.cpp
@@ -36,7 +36,7 @@ TEST(WALSeriTest, AllPuts)
 {
     PageEntryV3 entry_p1{.file_id = 1, .size = 1, .tag = 0, .offset = 0x123, .checksum = 0x4567};
     PageEntryV3 entry_p2{.file_id = 1, .size = 2, .tag = 0, .offset = 0x123, .checksum = 0x4567};
-    PageVersionType ver20(/*seq=*/20);
+    PageVersion ver20(/*seq=*/20);
     PageEntriesEdit edit;
     edit.put(1, entry_p1);
     edit.put(2, entry_p2);
@@ -58,7 +58,7 @@ try
 {
     PageEntryV3 entry_p3{.file_id = 1, .size = 3, .tag = 0, .offset = 0x123, .checksum = 0x4567};
     PageEntryV3 entry_p5{.file_id = 1, .size = 5, .tag = 0, .offset = 0x123, .checksum = 0x4567};
-    PageVersionType ver21(/*seq=*/21);
+    PageVersion ver21(/*seq=*/21);
     PageEntriesEdit edit;
     edit.put(3, entry_p3);
     edit.ref(4, 3);
@@ -107,8 +107,8 @@ TEST(WALSeriTest, Upserts)
     PageEntryV3 entry_p1_2{.file_id = 2, .size = 1, .tag = 0, .offset = 0x123, .checksum = 0x4567};
     PageEntryV3 entry_p3_2{.file_id = 2, .size = 3, .tag = 0, .offset = 0x123, .checksum = 0x4567};
     PageEntryV3 entry_p5_2{.file_id = 2, .size = 5, .tag = 0, .offset = 0x123, .checksum = 0x4567};
-    PageVersionType ver20_1(/*seq=*/20, /*epoch*/ 1);
-    PageVersionType ver21_1(/*seq=*/21, /*epoch*/ 1);
+    PageVersion ver20_1(/*seq=*/20, /*epoch*/ 1);
+    PageVersion ver21_1(/*seq=*/21, /*epoch*/ 1);
     PageEntriesEdit edit;
     edit.upsertPage(1, ver20_1, entry_p1_2);
     edit.upsertPage(3, ver21_1, entry_p3_2);
@@ -135,9 +135,9 @@ TEST(WALSeriTest, Upserts)
 
 TEST(WALSeriTest, RefExternalAndEntry)
 {
-    PageVersionType ver1_0(/*seq=*/1, /*epoch*/ 0);
-    PageVersionType ver2_0(/*seq=*/2, /*epoch*/ 0);
-    PageVersionType ver3_0(/*seq=*/3, /*epoch*/ 0);
+    PageVersion ver1_0(/*seq=*/1, /*epoch*/ 0);
+    PageVersion ver2_0(/*seq=*/2, /*epoch*/ 0);
+    PageVersion ver3_0(/*seq=*/3, /*epoch*/ 0);
     {
         PageEntriesEdit edit;
         edit.varExternal(1, ver1_0, 2);
@@ -407,7 +407,7 @@ try
     // Stage 2. Apply with only puts
     PageEntryV3 entry_p1{.file_id = 1, .size = 1, .tag = 0, .offset = 0x123, .checksum = 0x4567};
     PageEntryV3 entry_p2{.file_id = 1, .size = 2, .tag = 0, .offset = 0x123, .checksum = 0x4567};
-    PageVersionType ver20(/*seq=*/20);
+    PageVersion ver20(/*seq=*/20);
     {
         PageEntriesEdit edit;
         edit.put(1, entry_p1);
@@ -437,7 +437,7 @@ try
     // Stage 3. Apply with puts and refs
     PageEntryV3 entry_p3{.file_id = 1, .size = 3, .tag = 0, .offset = 0x123, .checksum = 0x4567};
     PageEntryV3 entry_p5{.file_id = 1, .size = 5, .tag = 0, .offset = 0x123, .checksum = 0x4567};
-    PageVersionType ver21(/*seq=*/21);
+    PageVersion ver21(/*seq=*/21);
     {
         PageEntriesEdit edit;
         edit.put(3, entry_p3);
@@ -471,8 +471,8 @@ try
     PageEntryV3 entry_p1_2{.file_id = 2, .size = 1, .tag = 0, .offset = 0x123, .checksum = 0x4567};
     PageEntryV3 entry_p3_2{.file_id = 2, .size = 3, .tag = 0, .offset = 0x123, .checksum = 0x4567};
     PageEntryV3 entry_p5_2{.file_id = 2, .size = 5, .tag = 0, .offset = 0x123, .checksum = 0x4567};
-    PageVersionType ver20_1(/*seq=*/20, /*epoch*/ 1);
-    PageVersionType ver21_1(/*seq=*/21, /*epoch*/ 1);
+    PageVersion ver20_1(/*seq=*/20, /*epoch*/ 1);
+    PageVersion ver21_1(/*seq=*/21, /*epoch*/ 1);
     {
         PageEntriesEdit edit;
         edit.upsertPage(1, ver20_1, entry_p1_2);
@@ -516,7 +516,7 @@ try
     // Stage 1. Apply with only puts
     PageEntryV3 entry_p1{.file_id = 1, .size = 1, .tag = 0, .offset = 0x123, .checksum = 0x4567};
     PageEntryV3 entry_p2{.file_id = 1, .size = 2, .tag = 0, .offset = 0x123, .checksum = 0x4567};
-    PageVersionType ver20(/*seq=*/20);
+    PageVersion ver20(/*seq=*/20);
     {
         PageEntriesEdit edit;
         edit.put(1, entry_p1);
@@ -528,7 +528,7 @@ try
     // Stage 2. Apply with puts and refs
     PageEntryV3 entry_p3{.file_id = 1, .size = 3, .tag = 0, .offset = 0x123, .checksum = 0x4567};
     PageEntryV3 entry_p5{.file_id = 1, .size = 5, .tag = 0, .offset = 0x123, .checksum = 0x4567};
-    PageVersionType ver21(/*seq=*/21);
+    PageVersion ver21(/*seq=*/21);
     {
         PageEntriesEdit edit;
         edit.put(3, entry_p3);
@@ -543,8 +543,8 @@ try
     PageEntryV3 entry_p1_2{.file_id = 2, .size = 1, .tag = 0, .offset = 0x123, .checksum = 0x4567};
     PageEntryV3 entry_p3_2{.file_id = 2, .size = 3, .tag = 0, .offset = 0x123, .checksum = 0x4567};
     PageEntryV3 entry_p5_2{.file_id = 2, .size = 5, .tag = 0, .offset = 0x123, .checksum = 0x4567};
-    PageVersionType ver20_1(/*seq=*/20, /*epoch*/ 1);
-    PageVersionType ver21_1(/*seq=*/21, /*epoch*/ 1);
+    PageVersion ver20_1(/*seq=*/20, /*epoch*/ 1);
+    PageVersion ver21_1(/*seq=*/21, /*epoch*/ 1);
     {
         PageEntriesEdit edit;
         edit.upsertPage(1, ver20_1, entry_p1_2);
@@ -611,7 +611,7 @@ try
     PageId page_id = 0;
     std::vector<size_t> size_each_edit;
     size_each_edit.reserve(num_edits_test);
-    PageVersionType ver(/*seq*/ 32);
+    PageVersion ver(/*seq*/ 32);
     for (size_t i = 0; i < num_edits_test; ++i)
     {
         PageEntryV3 entry{.file_id = 2, .size = 1, .tag = 0, .offset = 0x123, .checksum = 0x4567};
@@ -665,7 +665,7 @@ try
     // just fill in some random entry
     for (size_t i = 0; i < 70; ++i)
     {
-        snap_edit.varEntry(d_10000(rd), PageVersionType(345, 22), entry, 1);
+        snap_edit.varEntry(d_10000(rd), PageVersion(345, 22), entry, 1);
     }
     std::tie(wal, reader) = WALStore::create(getCurrentTestName(), enc_provider, delegator, config);
     bool done = wal->saveSnapshot(std::move(file_snap), std::move(snap_edit));

--- a/dbms/src/Storages/Page/V3/tests/page_storage_ctl.cpp
+++ b/dbms/src/Storages/Page/V3/tests/page_storage_ctl.cpp
@@ -399,7 +399,7 @@ private:
         size_t index = 0;
         std::cout << fmt::format("Begin to check all of datas CRC. enable_fo_check={}", static_cast<int>(enable_fo_check)) << std::endl;
 
-        std::list<std::pair<UInt128, PageVersionType>> error_versioned_pages;
+        std::list<std::pair<UInt128, PageVersion>> error_versioned_pages;
         for (const auto & [internal_id, versioned_entries] : mvcc_table_directory)
         {
             if (index == total_pages / 10 * cut_index)

--- a/dbms/src/TestUtils/TiFlashTestEnv.cpp
+++ b/dbms/src/TestUtils/TiFlashTestEnv.cpp
@@ -95,7 +95,6 @@ Context TiFlashTestEnv::getContext(const DB::Settings & settings, Strings testda
     context.setPath(root_path);
     auto paths = getPathPool(testdata_path);
     context.setPathPool(paths.first, paths.second, Strings{}, true, context.getPathCapacity(), context.getFileProvider());
-    global_context->initializeGlobalStoragePoolIfNeed(context.getPathPool());
     context.getSettingsRef() = settings;
     return context;
 }

--- a/tests/delta-merge-test/ddl/alter.test
+++ b/tests/delta-merge-test/ddl/alter.test
@@ -73,19 +73,18 @@
 
 
 ## rename table
-# FIXME: No support rename after PR 4850 (PageStorage V3)
-# >> drop table if exists dm_test_renamed
-# >> rename table dm_test to dm_test_renamed
-# >> select * from dm_test
-# Received exception from server (version {#WORD}):
-# Code: 60. DB::Exception: Received from {#WORD} DB::Exception: Table default.dm_test doesn't exist..
+>> drop table if exists dm_test_renamed
+>> rename table dm_test to dm_test_renamed
+>> select * from dm_test
+Received exception from server (version {#WORD}):
+Code: 60. DB::Exception: Received from {#WORD} DB::Exception: Table default.dm_test doesn't exist..
 
-# >> select * from dm_test_renamed
-# ┌─a─┬────b─┬─────c─┬────d─┐
-# │ 1 │    0 │     0 │   \N │
-# │ 2 │ 1024 │ 65535 │ 4096 │
-# │ 3 │ 2048 │ 65536 │   \N │
-# └───┴──────┴───────┴──────┘
+>> select * from dm_test_renamed
+┌─a─┬────b─┬─────c─┬────d─┐
+│ 1 │    0 │     0 │   \N │
+│ 2 │ 1024 │ 65535 │ 4096 │
+│ 3 │ 2048 │ 65536 │   \N │
+└───┴──────┴───────┴──────┘
 
 
 ## Clean up

--- a/tests/delta-merge-test/raft/schema/partition_table_restart.test
+++ b/tests/delta-merge-test/raft/schema/partition_table_restart.test
@@ -31,12 +31,11 @@
 => DBGInvoke __mock_tidb_partition(default, test, 9998)
 => DBGInvoke __mock_tidb_partition(default, test, 9997)
 => DBGInvoke __refresh_schemas()
+
 => drop table default.test_9997
 # schema syncer guarantees logical table creation at last, so there won't be cases that logical table exists whereas physical table not.
 => drop table default.test
 => DBGInvoke __reset_schemas()
-# remove obsolete entry left by previous dropped table
-=> DBGInvoke __gc_global_storage_pool()
 
 => DBGInvoke __add_column_to_tidb_table(default, test, 'col_3 Nullable(Int8)')
 => DBGInvoke __rename_tidb_table(default, test, test1)

--- a/tests/delta-merge-test/raft/txn_mock/partition_table.test
+++ b/tests/delta-merge-test/raft/txn_mock/partition_table.test
@@ -94,7 +94,6 @@
 │            0 │
 └──────────────┘
 
-# FIXME: No support rename after PR 4850 (PageStorage V3)
 => DBGInvoke __rename_tidb_table(default, test, test1)
 => DBGInvoke __refresh_schemas()
 => select count(*) from default.test1_9997

--- a/tests/delta-merge-test/raft/txn_mock/partition_table.test
+++ b/tests/delta-merge-test/raft/txn_mock/partition_table.test
@@ -95,19 +95,19 @@
 └──────────────┘
 
 # FIXME: No support rename after PR 4850 (PageStorage V3)
-# => DBGInvoke __rename_tidb_table(default, test, test1)
-# => DBGInvoke __refresh_schemas()
-# => select count(*) from default.test1_9997
-# ┌─count()─┐
-# │       2 │ 
-# └─────────┘
+=> DBGInvoke __rename_tidb_table(default, test, test1)
+=> DBGInvoke __refresh_schemas()
+=> select count(*) from default.test1_9997
+┌─count()─┐
+│       2 │ 
+└─────────┘
 
-# => DBGInvoke __drop_tidb_table(default, test1)
-# => DBGInvoke __refresh_schemas()
-# => DBGInvoke is_tombstone(default, test1_9999)
-# ┌─is_tombstone(default, test_9999)─┐
-# │ true                             │
-# └──────────────────────────────────┘
+=> DBGInvoke __drop_tidb_table(default, test1)
+=> DBGInvoke __refresh_schemas()
+=> DBGInvoke is_tombstone(default, test1_9999)
+┌─is_tombstone(default, test_9999)─┐
+│ true                             │
+└──────────────────────────────────┘
 
 => drop table if exists default.test
 => drop table if exists default.test1


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/3594

Problem Summary:
https://github.com/pingcap/tiflash/issues/4872
https://github.com/pingcap/tiflash/issues/4849
We fix those two bugs with previous PRs, but those changes introduce new misbehavior for TiFlash. Find a better way to fix those bugs.

### What is changed and how it works?

Fix reusing same page_id for different kind by:
* Throw exception with error code == PS_DIR_APPLY_INVALID_STATUS when `VersionedPageEntries:: createNewEntry/createNewExternal/createNewRef/createNewExternal/createNewRef` run into invali state
* When restoring edit run into exception with error code == PS_DIR_APPLY_INVALID_STATUS, then call GC on mvcc_directory  entries and run apply edit again

Other changes:
* When restoring the storage pool for DeltaTree, get the max id for this ns_id by `PageStorage->getMaxId`
* `PageStorage->getMaxId` now ignore the invisible id
* Instead of `meta_max_id`, use `PageEntry.isValid()` to check whether page 1 is existed or not https://github.com/pingcap/tiflash/blob/3e46ac2a411560503abba977a37a5caa495e9bd2/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp#L246-L247
* Enable some tests that are disabled in the previous changes

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
