### PR TITLE
Revert "MinMax Index Supports Nullable DataType"

### DIFF
--- a/dbms/src/DataTypes/IDataType.h
+++ b/dbms/src/DataTypes/IDataType.h
@@ -471,6 +471,7 @@ public:
     virtual bool isEnum() const { return false; };
 
     virtual bool isNullable() const { return false; }
+
     /** Is this type can represent only NULL value? (It also implies isNullable)
       */
     virtual bool onlyNull() const { return false; }

--- a/dbms/src/Storages/DeltaMerge/File/DMFileWriter.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileWriter.cpp
@@ -72,9 +72,10 @@ DMFileWriter::DMFileWriter(const DMFilePtr & dmfile_,
     for (auto & cd : write_columns)
     {
         // TODO: currently we only generate index for Integers, Date, DateTime types, and this should be configurable by user.
+        // TODO: If column type is nullable, we won't generate index for it
         /// for handle column always generate index
-        auto type = removeNullable(cd.type);
-        bool do_index = cd.id == EXTRA_HANDLE_COLUMN_ID || type->isInteger() || type->isDateOrDateTime();
+        bool do_index = cd.id == EXTRA_HANDLE_COLUMN_ID || cd.type->isInteger() || cd.type->isDateOrDateTime();
+
         if (options.flags.isSingleFile())
         {
             if (do_index)

--- a/dbms/src/Storages/DeltaMerge/Index/MinMaxIndex.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/MinMaxIndex.cpp
@@ -178,14 +178,14 @@ RSResult MinMaxIndex::checkEqual(size_t pack_index, const Field & value, const D
 #undef DISPATCH
     if (typeid_cast<const DataTypeDate *>(raw_type))
     {
-        auto & minmaxes_data = toColumnVectorData<DataTypeDate::FieldType>(minmaxes);
+        const auto & minmaxes_data = toColumnVectorData<DataTypeDate::FieldType>(minmaxes);
         auto min = minmaxes_data[pack_index * 2];
         auto max = minmaxes_data[pack_index * 2 + 1];
         return RoughCheck::checkEqual<DataTypeDate::FieldType>(value, type, min, max);
     }
     if (typeid_cast<const DataTypeDateTime *>(raw_type))
     {
-        auto & minmaxes_data = toColumnVectorData<DataTypeDateTime::FieldType>(minmaxes);
+        const auto & minmaxes_data = toColumnVectorData<DataTypeDateTime::FieldType>(minmaxes);
         auto min = minmaxes_data[pack_index * 2];
         auto max = minmaxes_data[pack_index * 2 + 1];
         return RoughCheck::checkEqual<DataTypeDateTime::FieldType>(value, type, min, max);
@@ -194,16 +194,16 @@ RSResult MinMaxIndex::checkEqual(size_t pack_index, const Field & value, const D
     {
         // For DataTypeMyDateTime / DataTypeMyDate, simply compare them as comparing UInt64 is OK.
         // Check `struct MyTimeBase` for more details.
-        auto & minmaxes_data = toColumnVectorData<DataTypeMyTimeBase::FieldType>(minmaxes);
+        const auto & minmaxes_data = toColumnVectorData<DataTypeMyTimeBase::FieldType>(minmaxes);
         auto min = minmaxes_data[pack_index * 2];
         auto max = minmaxes_data[pack_index * 2 + 1];
         return RoughCheck::checkEqual<DataTypeMyTimeBase::FieldType>(value, type, min, max);
     }
     if (typeid_cast<const DataTypeString *>(raw_type))
     {
-        auto * string_column = checkAndGetColumn<ColumnString>(minmaxes.get());
-        auto & chars = string_column->getChars();
-        auto & offsets = string_column->getOffsets();
+        const auto * string_column = checkAndGetColumn<ColumnString>(minmaxes.get());
+        const auto & chars = string_column->getChars();
+        const auto & offsets = string_column->getOffsets();
         size_t pos = pack_index * 2;
         size_t prev_offset = pos == 0 ? 0 : offsets[pos - 1];
         // todo use StringRef instead of String
@@ -235,14 +235,14 @@ RSResult MinMaxIndex::checkGreater(size_t pack_index, const Field & value, const
 #undef DISPATCH
     if (typeid_cast<const DataTypeDate *>(raw_type))
     {
-        auto & minmaxes_data = toColumnVectorData<DataTypeDate::FieldType>(minmaxes);
+        const auto & minmaxes_data = toColumnVectorData<DataTypeDate::FieldType>(minmaxes);
         auto min = minmaxes_data[pack_index * 2];
         auto max = minmaxes_data[pack_index * 2 + 1];
         return RoughCheck::checkGreater<DataTypeDate::FieldType>(value, type, min, max);
     }
     if (typeid_cast<const DataTypeDateTime *>(raw_type))
     {
-        auto & minmaxes_data = toColumnVectorData<DataTypeDateTime::FieldType>(minmaxes);
+        const auto & minmaxes_data = toColumnVectorData<DataTypeDateTime::FieldType>(minmaxes);
         auto min = minmaxes_data[pack_index * 2];
         auto max = minmaxes_data[pack_index * 2 + 1];
         return RoughCheck::checkGreater<DataTypeDateTime::FieldType>(value, type, min, max);
@@ -251,16 +251,16 @@ RSResult MinMaxIndex::checkGreater(size_t pack_index, const Field & value, const
     {
         // For DataTypeMyDateTime / DataTypeMyDate, simply compare them as comparing UInt64 is OK.
         // Check `struct MyTimeBase` for more details.
-        auto & minmaxes_data = toColumnVectorData<DataTypeMyTimeBase::FieldType>(minmaxes);
+        const auto & minmaxes_data = toColumnVectorData<DataTypeMyTimeBase::FieldType>(minmaxes);
         auto min = minmaxes_data[pack_index * 2];
         auto max = minmaxes_data[pack_index * 2 + 1];
         return RoughCheck::checkGreater<DataTypeMyTimeBase::FieldType>(value, type, min, max);
     }
     if (typeid_cast<const DataTypeString *>(raw_type))
     {
-        auto * string_column = checkAndGetColumn<ColumnString>(minmaxes.get());
-        auto & chars = string_column->getChars();
-        auto & offsets = string_column->getOffsets();
+        const auto * string_column = checkAndGetColumn<ColumnString>(minmaxes.get());
+        const auto & chars = string_column->getChars();
+        const auto & offsets = string_column->getOffsets();
         size_t pos = pack_index * 2;
         size_t prev_offset = pos == 0 ? 0 : offsets[pos - 1];
         // todo use StringRef instead of String
@@ -292,14 +292,14 @@ RSResult MinMaxIndex::checkGreaterEqual(size_t pack_index, const Field & value, 
 #undef DISPATCH
     if (typeid_cast<const DataTypeDate *>(raw_type))
     {
-        auto & minmaxes_data = toColumnVectorData<DataTypeDate::FieldType>(minmaxes);
+        const auto & minmaxes_data = toColumnVectorData<DataTypeDate::FieldType>(minmaxes);
         auto min = minmaxes_data[pack_index * 2];
         auto max = minmaxes_data[pack_index * 2 + 1];
         return RoughCheck::checkGreaterEqual<DataTypeDate::FieldType>(value, type, min, max);
     }
     if (typeid_cast<const DataTypeDateTime *>(raw_type))
     {
-        auto & minmaxes_data = toColumnVectorData<DataTypeDateTime::FieldType>(minmaxes);
+        const auto & minmaxes_data = toColumnVectorData<DataTypeDateTime::FieldType>(minmaxes);
         auto min = minmaxes_data[pack_index * 2];
         auto max = minmaxes_data[pack_index * 2 + 1];
         return RoughCheck::checkGreaterEqual<DataTypeDateTime::FieldType>(value, type, min, max);
@@ -308,16 +308,16 @@ RSResult MinMaxIndex::checkGreaterEqual(size_t pack_index, const Field & value, 
     {
         // For DataTypeMyDateTime / DataTypeMyDate, simply compare them as comparing UInt64 is OK.
         // Check `struct MyTimeBase` for more details.
-        auto & minmaxes_data = toColumnVectorData<DataTypeMyTimeBase::FieldType>(minmaxes);
+        const auto & minmaxes_data = toColumnVectorData<DataTypeMyTimeBase::FieldType>(minmaxes);
         auto min = minmaxes_data[pack_index * 2];
         auto max = minmaxes_data[pack_index * 2 + 1];
         return RoughCheck::checkGreaterEqual<DataTypeMyTimeBase::FieldType>(value, type, min, max);
     }
     if (typeid_cast<const DataTypeString *>(raw_type))
     {
-        auto * string_column = checkAndGetColumn<ColumnString>(minmaxes.get());
-        auto & chars = string_column->getChars();
-        auto & offsets = string_column->getOffsets();
+        const auto * string_column = checkAndGetColumn<ColumnString>(minmaxes.get());
+        const auto & chars = string_column->getChars();
+        const auto & offsets = string_column->getOffsets();
         size_t pos = pack_index * 2;
         size_t prev_offset = pos == 0 ? 0 : offsets[pos - 1];
         // todo use StringRef instead of String
@@ -330,7 +330,7 @@ RSResult MinMaxIndex::checkGreaterEqual(size_t pack_index, const Field & value, 
     return RSResult::Some;
 }
 
-String MinMaxIndex::toString() const
+String MinMaxIndex::toString()
 {
     return "";
 }

--- a/dbms/src/Storages/DeltaMerge/Index/MinMaxIndex.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/MinMaxIndex.cpp
@@ -61,6 +61,7 @@ inline std::pair<size_t, size_t> minmax(const IColumn & column, const ColumnVect
 
 void MinMaxIndex::addPack(const IColumn & column, const ColumnVector<UInt8> * del_mark)
 {
+    const IColumn * column_ptr = &column;
     auto size = column.size();
     bool has_null = false;
     if (column.isColumnNullable())
@@ -69,6 +70,7 @@ void MinMaxIndex::addPack(const IColumn & column, const ColumnVector<UInt8> * de
 
         const auto & nullable_column = static_cast<const ColumnNullable &>(column);
         const auto & null_mark_data = nullable_column.getNullMapColumn().getData();
+        column_ptr = &nullable_column.getNestedColumn();
 
         for (size_t i = 0; i < size; ++i)
         {
@@ -80,13 +82,14 @@ void MinMaxIndex::addPack(const IColumn & column, const ColumnVector<UInt8> * de
         }
     }
 
-    auto [min_index, max_index] = details::minmax(column, del_mark, 0, column.size());
+    const IColumn & updated_column = *column_ptr;
+    auto [min_index, max_index] = details::minmax(updated_column, del_mark, 0, updated_column.size());
     if (min_index != NONE_EXIST)
     {
         has_null_marks->push_back(has_null);
         has_value_marks->push_back(1);
-        minmaxes->insertFrom(column, min_index);
-        minmaxes->insertFrom(column, max_index);
+        minmaxes->insertFrom(updated_column, min_index);
+        minmaxes->insertFrom(updated_column, max_index);
     }
     else
     {
@@ -155,64 +158,6 @@ std::pair<UInt64, UInt64> MinMaxIndex::getUInt64MinMax(size_t pack_index)
     return {minmaxes->get64(pack_index * 2), minmaxes->get64(pack_index * 2 + 1)};
 }
 
-RSResult MinMaxIndex::checkNullableEqual(size_t pack_index, const Field & value, const DataTypePtr & type)
-{
-    const ColumnNullable & column_nullable = static_cast<const ColumnNullable &>(*minmaxes);
-
-    const auto * raw_type = type.get();
-
-    // if minmaxes_data has null value, the value of minmaxes_data[i] is meaningless and maybe just some random value.
-    // But in checkEqual, we have checked the has_null_marks and ensured that there is no null value in MinMax Indexes.
-#define DISPATCH(TYPE)                                                                         \
-    if (typeid_cast<const DataType##TYPE *>(raw_type))                                         \
-    {                                                                                          \
-        auto & minmaxes_data = toColumnVectorData<TYPE>(column_nullable.getNestedColumnPtr()); \
-        auto min = minmaxes_data[pack_index * 2];                                              \
-        auto max = minmaxes_data[pack_index * 2 + 1];                                          \
-        return RoughCheck::checkEqual<TYPE>(value, type, min, max);                            \
-    }
-    FOR_NUMERIC_TYPES(DISPATCH)
-#undef DISPATCH
-    if (typeid_cast<const DataTypeDate *>(raw_type))
-    {
-        const auto & minmaxes_data = toColumnVectorData<DataTypeDate::FieldType>(column_nullable.getNestedColumnPtr());
-        auto min = minmaxes_data[pack_index * 2];
-        auto max = minmaxes_data[pack_index * 2 + 1];
-        return RoughCheck::checkEqual<DataTypeDate::FieldType>(value, type, min, max);
-    }
-    if (typeid_cast<const DataTypeDateTime *>(raw_type))
-    {
-        const auto & minmaxes_data = toColumnVectorData<DataTypeDateTime::FieldType>(column_nullable.getNestedColumnPtr());
-        auto min = minmaxes_data[pack_index * 2];
-        auto max = minmaxes_data[pack_index * 2 + 1];
-        return RoughCheck::checkEqual<DataTypeDateTime::FieldType>(value, type, min, max);
-    }
-    if (typeid_cast<const DataTypeMyDateTime *>(raw_type) || typeid_cast<const DataTypeMyDate *>(raw_type))
-    {
-        // For DataTypeMyDateTime / DataTypeMyDate, simply compare them as comparing UInt64 is OK.
-        // Check `struct MyTimeBase` for more details.
-        const auto & minmaxes_data = toColumnVectorData<DataTypeMyTimeBase::FieldType>(column_nullable.getNestedColumnPtr());
-        auto min = minmaxes_data[pack_index * 2];
-        auto max = minmaxes_data[pack_index * 2 + 1];
-        return RoughCheck::checkEqual<DataTypeMyTimeBase::FieldType>(value, type, min, max);
-    }
-    if (typeid_cast<const DataTypeString *>(raw_type))
-    {
-        const auto * string_column = checkAndGetColumn<ColumnString>(column_nullable.getNestedColumnPtr().get());
-        const auto & chars = string_column->getChars();
-        const auto & offsets = string_column->getOffsets();
-        size_t pos = pack_index * 2;
-        size_t prev_offset = pos == 0 ? 0 : offsets[pos - 1];
-        // todo use StringRef instead of String
-        auto min = String(chars[prev_offset], offsets[pos] - prev_offset - 1);
-        pos = pack_index * 2 + 1;
-        prev_offset = offsets[pos - 1];
-        auto max = String(chars[prev_offset], offsets[pos] - prev_offset - 1);
-        return RoughCheck::checkEqual<String>(value, type, min, max);
-    }
-    return RSResult::Some;
-}
-
 RSResult MinMaxIndex::checkEqual(size_t pack_index, const Field & value, const DataTypePtr & type)
 {
     if ((*has_null_marks)[pack_index] || value.isNull())
@@ -221,10 +166,6 @@ RSResult MinMaxIndex::checkEqual(size_t pack_index, const Field & value, const D
         return RSResult::None;
 
     const auto * raw_type = type.get();
-    if (typeid_cast<const DataTypeNullable *>(raw_type))
-    {
-        return checkNullableEqual(pack_index, value, removeNullable(type));
-    }
 #define DISPATCH(TYPE)                                              \
     if (typeid_cast<const DataType##TYPE *>(raw_type))              \
     {                                                               \
@@ -237,14 +178,14 @@ RSResult MinMaxIndex::checkEqual(size_t pack_index, const Field & value, const D
 #undef DISPATCH
     if (typeid_cast<const DataTypeDate *>(raw_type))
     {
-        const auto & minmaxes_data = toColumnVectorData<DataTypeDate::FieldType>(minmaxes);
+        auto & minmaxes_data = toColumnVectorData<DataTypeDate::FieldType>(minmaxes);
         auto min = minmaxes_data[pack_index * 2];
         auto max = minmaxes_data[pack_index * 2 + 1];
         return RoughCheck::checkEqual<DataTypeDate::FieldType>(value, type, min, max);
     }
     if (typeid_cast<const DataTypeDateTime *>(raw_type))
     {
-        const auto & minmaxes_data = toColumnVectorData<DataTypeDateTime::FieldType>(minmaxes);
+        auto & minmaxes_data = toColumnVectorData<DataTypeDateTime::FieldType>(minmaxes);
         auto min = minmaxes_data[pack_index * 2];
         auto max = minmaxes_data[pack_index * 2 + 1];
         return RoughCheck::checkEqual<DataTypeDateTime::FieldType>(value, type, min, max);
@@ -253,16 +194,16 @@ RSResult MinMaxIndex::checkEqual(size_t pack_index, const Field & value, const D
     {
         // For DataTypeMyDateTime / DataTypeMyDate, simply compare them as comparing UInt64 is OK.
         // Check `struct MyTimeBase` for more details.
-        const auto & minmaxes_data = toColumnVectorData<DataTypeMyTimeBase::FieldType>(minmaxes);
+        auto & minmaxes_data = toColumnVectorData<DataTypeMyTimeBase::FieldType>(minmaxes);
         auto min = minmaxes_data[pack_index * 2];
         auto max = minmaxes_data[pack_index * 2 + 1];
         return RoughCheck::checkEqual<DataTypeMyTimeBase::FieldType>(value, type, min, max);
     }
     if (typeid_cast<const DataTypeString *>(raw_type))
     {
-        const auto * string_column = checkAndGetColumn<ColumnString>(minmaxes.get());
-        const auto & chars = string_column->getChars();
-        const auto & offsets = string_column->getOffsets();
+        auto * string_column = checkAndGetColumn<ColumnString>(minmaxes.get());
+        auto & chars = string_column->getChars();
+        auto & offsets = string_column->getOffsets();
         size_t pos = pack_index * 2;
         size_t prev_offset = pos == 0 ? 0 : offsets[pos - 1];
         // todo use StringRef instead of String
@@ -274,62 +215,6 @@ RSResult MinMaxIndex::checkEqual(size_t pack_index, const Field & value, const D
     }
     return RSResult::Some;
 }
-
-RSResult MinMaxIndex::checkNullableGreater(size_t pack_index, const Field & value, const DataTypePtr & type)
-{
-    const ColumnNullable & column_nullable = static_cast<const ColumnNullable &>(*minmaxes);
-    const auto * raw_type = type.get();
-
-#define DISPATCH(TYPE)                                                                         \
-    if (typeid_cast<const DataType##TYPE *>(raw_type))                                         \
-    {                                                                                          \
-        auto & minmaxes_data = toColumnVectorData<TYPE>(column_nullable.getNestedColumnPtr()); \
-        auto min = minmaxes_data[pack_index * 2];                                              \
-        auto max = minmaxes_data[pack_index * 2 + 1];                                          \
-        return RoughCheck::checkGreater<TYPE>(value, type, min, max);                          \
-    }
-    FOR_NUMERIC_TYPES(DISPATCH)
-#undef DISPATCH
-    if (typeid_cast<const DataTypeDate *>(raw_type))
-    {
-        const auto & minmaxes_data = toColumnVectorData<DataTypeDate::FieldType>(column_nullable.getNestedColumnPtr());
-        auto min = minmaxes_data[pack_index * 2];
-        auto max = minmaxes_data[pack_index * 2 + 1];
-        return RoughCheck::checkGreater<DataTypeDate::FieldType>(value, type, min, max);
-    }
-    if (typeid_cast<const DataTypeDateTime *>(raw_type))
-    {
-        const auto & minmaxes_data = toColumnVectorData<DataTypeDateTime::FieldType>(column_nullable.getNestedColumnPtr());
-        auto min = minmaxes_data[pack_index * 2];
-        auto max = minmaxes_data[pack_index * 2 + 1];
-        return RoughCheck::checkGreater<DataTypeDateTime::FieldType>(value, type, min, max);
-    }
-    if (typeid_cast<const DataTypeMyDateTime *>(raw_type) || typeid_cast<const DataTypeMyDate *>(raw_type))
-    {
-        // For DataTypeMyDateTime / DataTypeMyDate, simply compare them as comparing UInt64 is OK.
-        // Check `struct MyTimeBase` for more details.
-        const auto & minmaxes_data = toColumnVectorData<DataTypeMyTimeBase::FieldType>(column_nullable.getNestedColumnPtr());
-        auto min = minmaxes_data[pack_index * 2];
-        auto max = minmaxes_data[pack_index * 2 + 1];
-        return RoughCheck::checkGreater<DataTypeMyTimeBase::FieldType>(value, type, min, max);
-    }
-    if (typeid_cast<const DataTypeString *>(raw_type))
-    {
-        const auto * string_column = checkAndGetColumn<ColumnString>(column_nullable.getNestedColumnPtr().get());
-        const auto & chars = string_column->getChars();
-        const auto & offsets = string_column->getOffsets();
-        size_t pos = pack_index * 2;
-        size_t prev_offset = pos == 0 ? 0 : offsets[pos - 1];
-        // todo use StringRef instead of String
-        auto min = String(chars[prev_offset], offsets[pos] - prev_offset - 1);
-        pos = pack_index * 2 + 1;
-        prev_offset = offsets[pos - 1];
-        auto max = String(chars[prev_offset], offsets[pos] - prev_offset - 1);
-        return RoughCheck::checkGreater<String>(value, type, min, max);
-    }
-    return RSResult::Some;
-}
-
 RSResult MinMaxIndex::checkGreater(size_t pack_index, const Field & value, const DataTypePtr & type, int /*nan_direction_hint*/)
 {
     if ((*has_null_marks)[pack_index] || value.isNull())
@@ -338,10 +223,6 @@ RSResult MinMaxIndex::checkGreater(size_t pack_index, const Field & value, const
         return RSResult::None;
 
     const auto * raw_type = type.get();
-    if (typeid_cast<const DataTypeNullable *>(raw_type))
-    {
-        return checkNullableGreater(pack_index, value, removeNullable(type));
-    }
 #define DISPATCH(TYPE)                                                \
     if (typeid_cast<const DataType##TYPE *>(raw_type))                \
     {                                                                 \
@@ -354,14 +235,14 @@ RSResult MinMaxIndex::checkGreater(size_t pack_index, const Field & value, const
 #undef DISPATCH
     if (typeid_cast<const DataTypeDate *>(raw_type))
     {
-        const auto & minmaxes_data = toColumnVectorData<DataTypeDate::FieldType>(minmaxes);
+        auto & minmaxes_data = toColumnVectorData<DataTypeDate::FieldType>(minmaxes);
         auto min = minmaxes_data[pack_index * 2];
         auto max = minmaxes_data[pack_index * 2 + 1];
         return RoughCheck::checkGreater<DataTypeDate::FieldType>(value, type, min, max);
     }
     if (typeid_cast<const DataTypeDateTime *>(raw_type))
     {
-        const auto & minmaxes_data = toColumnVectorData<DataTypeDateTime::FieldType>(minmaxes);
+        auto & minmaxes_data = toColumnVectorData<DataTypeDateTime::FieldType>(minmaxes);
         auto min = minmaxes_data[pack_index * 2];
         auto max = minmaxes_data[pack_index * 2 + 1];
         return RoughCheck::checkGreater<DataTypeDateTime::FieldType>(value, type, min, max);
@@ -370,16 +251,16 @@ RSResult MinMaxIndex::checkGreater(size_t pack_index, const Field & value, const
     {
         // For DataTypeMyDateTime / DataTypeMyDate, simply compare them as comparing UInt64 is OK.
         // Check `struct MyTimeBase` for more details.
-        const auto & minmaxes_data = toColumnVectorData<DataTypeMyTimeBase::FieldType>(minmaxes);
+        auto & minmaxes_data = toColumnVectorData<DataTypeMyTimeBase::FieldType>(minmaxes);
         auto min = minmaxes_data[pack_index * 2];
         auto max = minmaxes_data[pack_index * 2 + 1];
         return RoughCheck::checkGreater<DataTypeMyTimeBase::FieldType>(value, type, min, max);
     }
     if (typeid_cast<const DataTypeString *>(raw_type))
     {
-        const auto * string_column = checkAndGetColumn<ColumnString>(minmaxes.get());
-        const auto & chars = string_column->getChars();
-        const auto & offsets = string_column->getOffsets();
+        auto * string_column = checkAndGetColumn<ColumnString>(minmaxes.get());
+        auto & chars = string_column->getChars();
+        auto & offsets = string_column->getOffsets();
         size_t pos = pack_index * 2;
         size_t prev_offset = pos == 0 ? 0 : offsets[pos - 1];
         // todo use StringRef instead of String
@@ -391,62 +272,6 @@ RSResult MinMaxIndex::checkGreater(size_t pack_index, const Field & value, const
     }
     return RSResult::Some;
 }
-
-RSResult MinMaxIndex::checkNullableGreaterEqual(size_t pack_index, const Field & value, const DataTypePtr & type)
-{
-    const ColumnNullable & column_nullable = static_cast<const ColumnNullable &>(*minmaxes);
-
-    const auto * raw_type = type.get();
-#define DISPATCH(TYPE)                                                                         \
-    if (typeid_cast<const DataType##TYPE *>(raw_type))                                         \
-    {                                                                                          \
-        auto & minmaxes_data = toColumnVectorData<TYPE>(column_nullable.getNestedColumnPtr()); \
-        auto min = minmaxes_data[pack_index * 2];                                              \
-        auto max = minmaxes_data[pack_index * 2 + 1];                                          \
-        return RoughCheck::checkGreaterEqual<TYPE>(value, type, min, max);                     \
-    }
-    FOR_NUMERIC_TYPES(DISPATCH)
-#undef DISPATCH
-    if (typeid_cast<const DataTypeDate *>(raw_type))
-    {
-        const auto & minmaxes_data = toColumnVectorData<DataTypeDate::FieldType>(column_nullable.getNestedColumnPtr());
-        auto min = minmaxes_data[pack_index * 2];
-        auto max = minmaxes_data[pack_index * 2 + 1];
-        return RoughCheck::checkGreaterEqual<DataTypeDate::FieldType>(value, type, min, max);
-    }
-    if (typeid_cast<const DataTypeDateTime *>(raw_type))
-    {
-        const auto & minmaxes_data = toColumnVectorData<DataTypeDateTime::FieldType>(column_nullable.getNestedColumnPtr());
-        auto min = minmaxes_data[pack_index * 2];
-        auto max = minmaxes_data[pack_index * 2 + 1];
-        return RoughCheck::checkGreaterEqual<DataTypeDateTime::FieldType>(value, type, min, max);
-    }
-    if (typeid_cast<const DataTypeMyDateTime *>(raw_type) || typeid_cast<const DataTypeMyDate *>(raw_type))
-    {
-        // For DataTypeMyDateTime / DataTypeMyDate, simply compare them as comparing UInt64 is OK.
-        // Check `struct MyTimeBase` for more details.
-        const auto & minmaxes_data = toColumnVectorData<DataTypeMyTimeBase::FieldType>(column_nullable.getNestedColumnPtr());
-        auto min = minmaxes_data[pack_index * 2];
-        auto max = minmaxes_data[pack_index * 2 + 1];
-        return RoughCheck::checkGreaterEqual<DataTypeMyTimeBase::FieldType>(value, type, min, max);
-    }
-    if (typeid_cast<const DataTypeString *>(raw_type))
-    {
-        const auto * string_column = checkAndGetColumn<ColumnString>(column_nullable.getNestedColumnPtr().get());
-        const auto & chars = string_column->getChars();
-        const auto & offsets = string_column->getOffsets();
-        size_t pos = pack_index * 2;
-        size_t prev_offset = pos == 0 ? 0 : offsets[pos - 1];
-        // todo use StringRef instead of String
-        auto min = String(reinterpret_cast<const char *>(&chars[prev_offset]), offsets[pos] - prev_offset - 1);
-        pos = pack_index * 2 + 1;
-        prev_offset = offsets[pos - 1];
-        auto max = String(reinterpret_cast<const char *>(&chars[prev_offset]), offsets[pos] - prev_offset - 1);
-        return RoughCheck::checkGreaterEqual<String>(value, type, min, max);
-    }
-    return RSResult::Some;
-}
-
 RSResult MinMaxIndex::checkGreaterEqual(size_t pack_index, const Field & value, const DataTypePtr & type, int /*nan_direction_hint*/)
 {
     if ((*has_null_marks)[pack_index] || value.isNull())
@@ -455,10 +280,6 @@ RSResult MinMaxIndex::checkGreaterEqual(size_t pack_index, const Field & value, 
         return RSResult::None;
 
     const auto * raw_type = type.get();
-    if (typeid_cast<const DataTypeNullable *>(raw_type))
-    {
-        return checkNullableGreaterEqual(pack_index, value, removeNullable(type));
-    }
 #define DISPATCH(TYPE)                                                     \
     if (typeid_cast<const DataType##TYPE *>(raw_type))                     \
     {                                                                      \
@@ -471,14 +292,14 @@ RSResult MinMaxIndex::checkGreaterEqual(size_t pack_index, const Field & value, 
 #undef DISPATCH
     if (typeid_cast<const DataTypeDate *>(raw_type))
     {
-        const auto & minmaxes_data = toColumnVectorData<DataTypeDate::FieldType>(minmaxes);
+        auto & minmaxes_data = toColumnVectorData<DataTypeDate::FieldType>(minmaxes);
         auto min = minmaxes_data[pack_index * 2];
         auto max = minmaxes_data[pack_index * 2 + 1];
         return RoughCheck::checkGreaterEqual<DataTypeDate::FieldType>(value, type, min, max);
     }
     if (typeid_cast<const DataTypeDateTime *>(raw_type))
     {
-        const auto & minmaxes_data = toColumnVectorData<DataTypeDateTime::FieldType>(minmaxes);
+        auto & minmaxes_data = toColumnVectorData<DataTypeDateTime::FieldType>(minmaxes);
         auto min = minmaxes_data[pack_index * 2];
         auto max = minmaxes_data[pack_index * 2 + 1];
         return RoughCheck::checkGreaterEqual<DataTypeDateTime::FieldType>(value, type, min, max);
@@ -487,16 +308,16 @@ RSResult MinMaxIndex::checkGreaterEqual(size_t pack_index, const Field & value, 
     {
         // For DataTypeMyDateTime / DataTypeMyDate, simply compare them as comparing UInt64 is OK.
         // Check `struct MyTimeBase` for more details.
-        const auto & minmaxes_data = toColumnVectorData<DataTypeMyTimeBase::FieldType>(minmaxes);
+        auto & minmaxes_data = toColumnVectorData<DataTypeMyTimeBase::FieldType>(minmaxes);
         auto min = minmaxes_data[pack_index * 2];
         auto max = minmaxes_data[pack_index * 2 + 1];
         return RoughCheck::checkGreaterEqual<DataTypeMyTimeBase::FieldType>(value, type, min, max);
     }
     if (typeid_cast<const DataTypeString *>(raw_type))
     {
-        const auto * string_column = checkAndGetColumn<ColumnString>(minmaxes.get());
-        const auto & chars = string_column->getChars();
-        const auto & offsets = string_column->getOffsets();
+        auto * string_column = checkAndGetColumn<ColumnString>(minmaxes.get());
+        auto & chars = string_column->getChars();
+        auto & offsets = string_column->getOffsets();
         size_t pos = pack_index * 2;
         size_t prev_offset = pos == 0 ? 0 : offsets[pos - 1];
         // todo use StringRef instead of String
@@ -509,7 +330,7 @@ RSResult MinMaxIndex::checkGreaterEqual(size_t pack_index, const Field & value, 
     return RSResult::Some;
 }
 
-String MinMaxIndex::toString()
+String MinMaxIndex::toString() const
 {
     return "";
 }

--- a/dbms/src/Storages/DeltaMerge/Index/MinMaxIndex.h
+++ b/dbms/src/Storages/DeltaMerge/Index/MinMaxIndex.h
@@ -80,7 +80,7 @@ public:
     RSResult checkGreater(size_t pack_index, const Field & value, const DataTypePtr & type, int nan_direction);
     RSResult checkGreaterEqual(size_t pack_index, const Field & value, const DataTypePtr & type, int nan_direction);
 
-    String toString() const;
+    static String toString();
 };
 
 

--- a/dbms/src/Storages/DeltaMerge/Index/MinMaxIndex.h
+++ b/dbms/src/Storages/DeltaMerge/Index/MinMaxIndex.h
@@ -80,10 +80,7 @@ public:
     RSResult checkGreater(size_t pack_index, const Field & value, const DataTypePtr & type, int nan_direction);
     RSResult checkGreaterEqual(size_t pack_index, const Field & value, const DataTypePtr & type, int nan_direction);
 
-    static String toString();
-    RSResult checkNullableEqual(size_t pack_index, const Field & value, const DataTypePtr & type);
-    RSResult checkNullableGreater(size_t pack_index, const Field & value, const DataTypePtr & type);
-    RSResult checkNullableGreaterEqual(size_t pack_index, const Field & value, const DataTypePtr & type);
+    String toString() const;
 };
 
 

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_minmax_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_minmax_index.cpp
@@ -214,6 +214,14 @@ try
     ASSERT_EQ(true, checkMatch(case_name, *context, "MyDateTime", "2020-09-27", createLessEqual(attr("MyDateTime"), parseMyDateTime("2020-09-27"), 0)));
     ASSERT_EQ(false, checkMatch(case_name, *context, "MyDateTime", "2020-09-27", createLessEqual(attr("MyDateTime"), parseMyDateTime("2020-09-26"), 0)));
 
+    /// Currently we don't do filtering for null values. i.e. if a pack contains any null values, then the pack will pass the filter.
+    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(Int64)", {{"0", "0", "0", "100"}, {"1", "1", "0", "\\N"}}, createEqual(attr("Nullable(Int64)"), Field((Int64)101))));
+    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(Int64)", {{"0", "0", "0", "100"}, {"1", "1", "0", "\\N"}}, createIn(attr("Nullable(Int64)"), {Field((Int64)101)})));
+    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(Int64)", {{"0", "0", "0", "100"}, {"1", "1", "0", "\\N"}}, createGreater(attr("Nullable(Int64)"), Field((Int64)100), 0)));
+    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(Int64)", {{"0", "0", "0", "100"}, {"1", "1", "0", "\\N"}}, createGreaterEqual(attr("Nullable(Int64)"), Field((Int64)101), 0)));
+    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(Int64)", {{"0", "0", "0", "100"}, {"1", "1", "0", "\\N"}}, createLess(attr("Nullable(Int64)"), Field((Int64)100), 0)));
+    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(Int64)", {{"0", "0", "0", "100"}, {"1", "1", "0", "\\N"}}, createLessEqual(attr("Nullable(Int64)"), Field((Int64)99), 0)));
+
     ASSERT_EQ(false, checkDelMatch(case_name, *context, "Int64", "100", createEqual(attr("Int64"), Field((Int64)100))));
     ASSERT_EQ(true, checkPkMatch(case_name, *context, "Int64", "100", createEqual(pkAttr(), Field((Int64)100)), true));
     ASSERT_EQ(true, checkPkMatch(case_name, *context, "Int64", "100", createGreater(pkAttr(), Field((Int64)99), 0), true));
@@ -225,80 +233,6 @@ try
     ASSERT_EQ(true, checkMatch(case_name, *context, "Int64", "100", createNotIn(attr("Int64"), {Field((Int64)101), Field((Int64)102), Field((Int64)103)})));
     ASSERT_EQ(true, checkMatch(case_name, *context, "Int64", "100", createIn(attr("Int64"), {Field((Int64)100), Field((Int64)101), Field((Int64)102)})));
     // clang-format on
-}
-CATCH
-
-TEST_F(DMMinMaxIndexTest, NullableToNullable)
-try
-{
-    const auto * case_name = ::testing::UnitTest::GetInstance()->current_test_info()->name();
-    // clang-format off
-    ASSERT_EQ(false, checkMatch(case_name, *context, "Nullable(Int64)", "100", createEqual(attr("Nullable(Int64)"), Field((Int64)101))));
-    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(Int64)", "100", createEqual(attr("Nullable(Int64)"), Field((Int64)100))));
-    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(Int64)", "100", createIn(attr("Nullable(Int64)"), {Field((Int64)100)})));
-    ASSERT_EQ(false, checkMatch(case_name, *context, "Nullable(Int64)", "100", createIn(attr("Nullable(Int64)"), {Field((Int64)101)})));
-    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(Int64)", "100", createGreater(attr("Nullable(Int64)"), Field((Int64)99), 0)));
-    ASSERT_EQ(false, checkMatch(case_name, *context, "Nullable(Int64)", "100", createGreater(attr("Nullable(Int64)"), Field((Int64)100), 0)));
-    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(Int64)", "100", createGreaterEqual(attr("Nullable(Int64)"), Field((Int64)100), 0)));
-    ASSERT_EQ(false, checkMatch(case_name, *context, "Nullable(Int64)", "100", createGreaterEqual(attr("Nullable(Int64)"), Field((Int64)101), 0)));
-    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(Int64)", "100", createLess(attr("Nullable(Int64)"), Field((Int64)101), 0)));
-    ASSERT_EQ(false, checkMatch(case_name, *context, "Nullable(Int64)", "100", createLess(attr("Nullable(Int64)"), Field((Int64)100), 0)));
-    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(Int64)", "100", createLessEqual(attr("Nullable(Int64)"), Field((Int64)100), 0)));
-    ASSERT_EQ(false, checkMatch(case_name, *context, "Nullable(Int64)", "100", createLessEqual(attr("Nullable(Int64)"), Field((Int64)99), 0)));
-
-    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(Date)", "2020-09-27", createEqual(attr("Nullable(Date)"), Field((String) "2020-09-27"))));
-    ASSERT_EQ(false, checkMatch(case_name, *context, "Nullable(Date)", "2020-09-27", createEqual(attr("Nullable(Date)"), Field((String) "2020-09-28"))));
-    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(Date)", "2020-09-27", createIn(attr("Nullable(Date)"), {Field((String) "2020-09-27")})));
-    ASSERT_EQ(false, checkMatch(case_name, *context, "Nullable(Date)", "2020-09-27", createIn(attr("Nullable(Date)"), {Field((String) "2020-09-28")})));
-    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(Date)", "2020-09-27", createGreater(attr("Nullable(Date)"), Field((String) "2020-09-26"), 0)));
-    ASSERT_EQ(false, checkMatch(case_name, *context, "Nullable(Date)", "2020-09-27", createGreater(attr("Nullable(Date)"), Field((String) "2020-09-27"), 0)));
-    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(Date)", "2020-09-27", createGreaterEqual(attr("Nullable(Date)"), Field((String) "2020-09-27"), 0)));
-    ASSERT_EQ(false, checkMatch(case_name, *context, "Nullable(Date)", "2020-09-27", createGreaterEqual(attr("Nullable(Date)"), Field((String) "2020-09-28"), 0)));
-    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(Date)", "2020-09-27", createLess(attr("Nullable(Date)"), Field((String) "2020-09-28"), 0)));
-    ASSERT_EQ(false, checkMatch(case_name, *context, "Nullable(Date)", "2020-09-27", createLess(attr("Nullable(Date)"), Field((String) "2020-09-27"), 0)));
-    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(Date)", "2020-09-27", createLessEqual(attr("Nullable(Date)"), Field((String) "2020-09-27"), 0)));
-    ASSERT_EQ(false, checkMatch(case_name, *context, "Nullable(Date)", "2020-09-27", createLessEqual(attr("Nullable(Date)"), Field((String) "2020-09-26"), 0)));
-
-    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(DateTime)", "2020-01-01 05:00:01", createEqual(attr("Nullable(DateTime)"), Field((String) "2020-01-01 05:00:01"))));
-    ASSERT_EQ(false, checkMatch(case_name, *context, "Nullable(DateTime)", "2020-01-01 05:00:01", createEqual(attr("Nullable(DateTime)"), Field((String) "2020-01-01 05:00:02"))));
-    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(DateTime)", "2020-01-01 05:00:01", createIn(attr("Nullable(DateTime)"), {Field((String) "2020-01-01 05:00:01")})));
-    ASSERT_EQ(false, checkMatch(case_name, *context, "Nullable(DateTime)", "2020-01-01 05:00:01", createIn(attr("Nullable(DateTime)"), {Field((String) "2020-01-01 05:00:02")})));
-    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(DateTime)", "2020-01-01 05:00:01", createGreater(attr("Nullable(DateTime)"), Field((String) "2020-01-01 05:00:00"), 0)));
-    ASSERT_EQ(false, checkMatch(case_name, *context, "Nullable(DateTime)", "2020-01-01 05:00:01", createGreater(attr("Nullable(DateTime)"), Field((String) "2020-01-01 05:00:01"), 0)));
-    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(DateTime)", "2020-01-01 05:00:01", createGreaterEqual(attr("Nullable(DateTime)"), Field((String) "2020-01-01 05:00:01"), 0)));
-    ASSERT_EQ(false, checkMatch(case_name, *context, "Nullable(DateTime)", "2020-01-01 05:00:01", createGreaterEqual(attr("Nullable(DateTime)"), Field((String) "2020-01-01 05:00:02"), 0)));
-    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(DateTime)", "2020-01-01 05:00:01", createLess(attr("Nullable(DateTime)"), Field((String) "2020-01-01 05:00:02"), 0)));
-    ASSERT_EQ(false, checkMatch(case_name, *context, "Nullable(DateTime)", "2020-01-01 05:00:01", createLess(attr("Nullable(DateTime)"), Field((String) "2020-01-01 05:00:01"), 0)));
-    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(DateTime)", "2020-01-01 05:00:01", createLessEqual(attr("Nullable(DateTime)"), Field((String) "2020-01-01 05:00:01"), 0)));
-    ASSERT_EQ(false, checkMatch(case_name, *context, "Nullable(DateTime)", "2020-01-01 05:00:01", createLessEqual(attr("Nullable(DateTime)"), Field((String) "2020-01-01 05:00:00"), 0)));
-
-    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(MyDateTime)", "2020-09-27", createEqual(attr("Nullable(MyDateTime)"), parseMyDateTime("2020-09-27"))));
-    ASSERT_EQ(false, checkMatch(case_name, *context, "Nullable(MyDateTime)", "2020-09-27", createEqual(attr("Nullable(MyDateTime)"), parseMyDateTime("2020-09-28"))));
-    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(MyDateTime)", "2020-09-27", createIn(attr("Nullable(MyDateTime)"), {parseMyDateTime("2020-09-27")})));
-    ASSERT_EQ(false, checkMatch(case_name, *context, "Nullable(MyDateTime)", "2020-09-27", createIn(attr("Nullable(MyDateTime)"), {parseMyDateTime("2020-09-28")})));
-    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(MyDateTime)", "2020-09-27", createGreater(attr("Nullable(MyDateTime)"), parseMyDateTime("2020-09-26"), 0)));
-    ASSERT_EQ(false, checkMatch(case_name, *context, "Nullable(MyDateTime)", "2020-09-27", createGreater(attr("Nullable(MyDateTime)"), parseMyDateTime("2020-09-27"), 0)));
-    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(MyDateTime)", "2020-09-27", createGreaterEqual(attr("Nullable(MyDateTime)"), parseMyDateTime("2020-09-27"), 0)));
-    ASSERT_EQ(false, checkMatch(case_name, *context, "Nullable(MyDateTime)", "2020-09-27", createGreaterEqual(attr("Nullable(MyDateTime)"), parseMyDateTime("2020-09-28"), 0)));
-    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(MyDateTime)", "2020-09-27", createLess(attr("Nullable(MyDateTime)"), parseMyDateTime("2020-09-28"), 0)));
-    ASSERT_EQ(false, checkMatch(case_name, *context, "Nullable(MyDateTime)", "2020-09-27", createLess(attr("Nullable(MyDateTime)"), parseMyDateTime("2020-09-27"), 0)));
-    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(MyDateTime)", "2020-09-27", createLessEqual(attr("Nullable(MyDateTime)"), parseMyDateTime("2020-09-27"), 0)));
-    ASSERT_EQ(false, checkMatch(case_name, *context, "Nullable(MyDateTime)", "2020-09-27", createLessEqual(attr("Nullable(MyDateTime)"), parseMyDateTime("2020-09-26"), 0)));
-
-    // has null
-    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(Int64)", {{"0", "0", "0", "100"}, {"1", "1", "0", "\\N"}}, createEqual(attr("Nullable(Int64)"), Field((Int64)101))));
-    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(Int64)", {{"0", "0", "0", "100"}, {"1", "1", "0", "\\N"}}, createIn(attr("Nullable(Int64)"), {Field((Int64)101)})));
-    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(Int64)", {{"0", "0", "0", "100"}, {"1", "1", "0", "\\N"}}, createGreater(attr("Nullable(Int64)"), Field((Int64)100), 0)));
-    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(Int64)", {{"0", "0", "0", "100"}, {"1", "1", "0", "\\N"}}, createGreaterEqual(attr("Nullable(Int64)"), Field((Int64)101), 0)));
-    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(Int64)", {{"0", "0", "0", "100"}, {"1", "1", "0", "\\N"}}, createLess(attr("Nullable(Int64)"), Field((Int64)100), 0)));
-    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(Int64)", {{"0", "0", "0", "100"}, {"1", "1", "0", "\\N"}}, createLessEqual(attr("Nullable(Int64)"), Field((Int64)99), 0)));
-
-    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(Int64)", {{"0", "0", "0", "\\N"}}, createEqual(attr("Nullable(Int64)"), Field((Int64)101))));
-    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(Int64)", {{"0", "0", "0", "\\N"}}, createIn(attr("Nullable(Int64)"), {Field((Int64)101)})));
-    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(Int64)", {{"0", "0", "0", "\\N"}}, createGreater(attr("Nullable(Int64)"), Field((Int64)100), 0)));
-    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(Int64)", {{"0", "0", "0", "\\N"}}, createGreaterEqual(attr("Nullable(Int64)"), Field((Int64)101), 0)));
-    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(Int64)", {{"0", "0", "0", "\\N"}}, createLess(attr("Nullable(Int64)"), Field((Int64)100), 0)));
-    ASSERT_EQ(true, checkMatch(case_name, *context, "Nullable(Int64)", {{"0", "0", "0", "\\N"}}, createLessEqual(attr("Nullable(Int64)"), Field((Int64)99), 0)));
 }
 CATCH
 


### PR DESCRIPTION
Signed-off-by: hehechen <awd123456sss@gmail.com>

### What problem does this PR solve?
Reverts pingcap/tiflash#4792 to avoid the risk of TiFlash 6.1 LTS version.

Issue Number: ref #4787

### What is changed and how it works?
Reverts pingcap/tiflash#4792 to avoid the risk of TiFlash 6.1 LTS version.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
