### PR TITLE
Fix broken unit test for `--gtest_filter='*StorageDeltaMergeTest*:*RegionKVStoreTest*'`

### DIFF
--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_storage_delta_merge.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_storage_delta_merge.cpp
@@ -34,13 +34,13 @@
 #include <Storages/StorageDeltaMerge.h>
 #include <Storages/StorageDeltaMergeHelpers.h>
 #include <Storages/Transaction/RegionRangeKeys.h>
+#include <Storages/Transaction/TiDB.h>
 #include <Storages/Transaction/TiKVRange.h>
 #include <Storages/Transaction/TiKVRecordFormat.h>
 #include <TestUtils/FunctionTestUtils.h>
 
 #include <limits>
 
-#include "Storages/Transaction/TiDB.h"
 #include "dm_basic_include.h"
 
 namespace DB

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_storage_delta_merge.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_storage_delta_merge.cpp
@@ -169,6 +169,8 @@ try
     }
     EXPECT_EQ(total_segment_rows, num_rows_read);
     storage->drop();
+    // remove the storage from TiFlash context manually
+    storage->removeFromTMTContext();
 }
 CATCH
 
@@ -253,6 +255,8 @@ try
     ASSERT_EQ(storage->getDatabaseName(), new_db_name);
 
     storage->drop();
+    // remove the storage from TiFlash context manually
+    storage->removeFromTMTContext();
 }
 CATCH
 
@@ -316,6 +320,8 @@ try
     ASSERT_EQ(sort_desc.front().nulls_direction, sort_desc2.front().nulls_direction);
 
     storage->drop();
+    // remove the storage from TiFlash context manually
+    storage->removeFromTMTContext();
 }
 CATCH
 
@@ -610,7 +616,7 @@ try
     sample.insert(DB::tests::createColumn<String>(
         Strings(100, "a"),
         "col2"));
-    constexpr TiDB::TableID table_id = 1232;
+    constexpr TiDB::TableID table_id = 1;
     const String table_name = fmt::format("t_{}", table_id);
 
     Context ctx = DMTestEnv::getContext();
@@ -703,6 +709,8 @@ try
     in->readSuffix();
     ASSERT_EQ(num_rows_read, sample.rows());
     storage->drop();
+    // remove the storage from TiFlash context manually
+    storage->removeFromTMTContext();
 }
 CATCH
 
@@ -850,6 +858,8 @@ try
         ASSERT_LT(read_data(), num_rows_write);
     }
     storage->drop();
+    // remove the storage from TiFlash context manually
+    storage->removeFromTMTContext();
 }
 CATCH
 

--- a/dbms/src/Storages/Transaction/tests/gtest_kvstore.cpp
+++ b/dbms/src/Storages/Transaction/tests/gtest_kvstore.cpp
@@ -47,8 +47,7 @@ RegionPtr makeRegion(UInt64 id, const std::string start_key, const std::string e
 class RegionKVStoreTest : public ::testing::Test
 {
 public:
-    RegionKVStoreTest()
-        = default;
+    RegionKVStoreTest() = default;
 
     static void SetUpTestCase() {}
     static void testBasic();
@@ -1372,12 +1371,30 @@ void RegionKVStoreTest::testBasic()
     }
 }
 
-TEST_F(RegionKVStoreTest, run)
+TEST_F(RegionKVStoreTest, Basic)
 try
 {
     testBasic();
+}
+CATCH
+
+TEST_F(RegionKVStoreTest, KVStore)
+try
+{
     testKVStore();
+}
+CATCH
+
+TEST_F(RegionKVStoreTest, Region)
+try
+{
     testRegion();
+}
+CATCH
+
+TEST_F(RegionKVStoreTest, ReadIndex)
+try
+{
     testReadIndex();
 }
 CATCH

--- a/tests/docker/config/tics_dt.toml
+++ b/tests/docker/config/tics_dt.toml
@@ -13,25 +13,16 @@
 # limitations under the License.
 
 tmp_path = "/tmp/tiflash/data/tmp"
-display_name = "TiFlash"
-# specify paths used for store data, multiple path should be seperated by comma
 path = "/tmp/tiflash/data/db"
-capacity = "107374182400" 
-# multi-paths example
-# path = "/tmp/tiflash/data/db,/tmp/tiflash1,/tmp/tiflash2"
-# capacity = "0,0,0"
+capacity = "107374182400" # 100GB
 mark_cache_size = 5368709120
 minmax_index_cache_size = 5368709120
 tcp_port = 9000
 http_port = 8123
+
 [logger]
 count = 10
 errorlog = "/tmp/tiflash/log/error.log"
 size = "1000M"
 log = "/tmp/tiflash/log/server.log"
 level = "trace"
-[application]
-runAsDaemon = true
-[raft]
-# specify which storage engine we use. tmt or dt
-storage_engine = "dt"

--- a/tests/docker/config/tiflash_dt_async_grpc.toml
+++ b/tests/docker/config/tiflash_dt_async_grpc.toml
@@ -13,70 +13,14 @@
 # limitations under the License.
 
 tmp_path = "/tmp/tiflash/data/tmp"
-display_name = "TiFlash"
 
-## Deprecated storage path setting style. Check [storage] section for new style.
 path = "/tmp/tiflash/data/db"
 capacity = "10737418240"
-## Deprecated storage path setting style of multi-disks. Check [storage] section for new style.
-# path = "/tmp/tiflash/data/db,/tmp/tiflash1,/tmp/tiflash2"
-# capacity = "0"
 
 mark_cache_size = 5368709120
 minmax_index_cache_size = 5368709120
 tcp_port = 9000
 http_port = 8123
-
-## Storage paths settings.
-# [storage]
-## The storage format version in storage engine. Valid values: 1, 2 (experimental).
-## format_version = 1
-
-## If there are multiple SSD disks on the machine,
-## specify the path list on `storage.main.dir` can improve TiFlash performance.
-
-## If there are multiple disks with different IO metrics (e.g. one SSD and some HDDs)
-## on the machine, 
-## set `storage.latest.dir` to store the latest data on SSD (disks with higher IOPS metrics)
-## set `storage.main.dir` to store the main data on HDD (disks with lower IOPS metrics)
-## can improve TiFlash performance.
-
-# [storage.main]
-## The path to store main data.
-# e.g.
-# dir = [ "/data0/tiflash" ] 
-# or
-# dir = [ "/data0/tiflash", "/data1/tiflash" ]
-
-## Store capacity of each path, i.e. max data size allowed.
-## If it is not set, or is set to 0s, the actual disk capacity is used.
-## Note that we don't support human-readable big numbers(like "10GB") yet.
-## Please set in the specified number of bytes.
-# e.g.
-# capacity = [ 10737418240, 10737418240 ]
-
-# [storage.latest]
-## The path(s) to store latest data.
-## If not set, it will be the same with `storage.main.dir`.
-# dir = [ ]
-
-## Store capacity of each path, i.e. max data size allowed.
-## If it is not set, or is set to 0s, the actual disk capacity is used.
-# e.g.
-# capacity = [ 10737418240, 10737418240 ]
-
-# [storage.raft]
-## The path(s) to store Raft data.
-## If not set, it will be the paths in `storage.latest.dir` appended with "/kvstore".
-# dir = [ ]
-
-# [storage.io_rate_limit]
-## The max I/O bandwith. Default value is 0 and I/O rate limit is disabled.
-# max_bytes_per_sec = 268435456
-## max_read_bytes_per_sec and max_write_bytes_per_sec are the same meaning as max_bytes_per_sec,
-## but for disk that read bandwidth and write bandwith are calculated separatly, such as GCP's persistent disks.
-# max_read_bytes_per_sec = 0
-# max_write_bytes_per_sec = 0
 
 [flash]
 tidb_status_addr = "tidb0:10080"
@@ -100,22 +44,9 @@ size = "1000M"
 log = "/tmp/tiflash/log/server.log"
 level = "trace"
 
-[application]
-runAsDaemon = true
-
 [raft]
 pd_addr = "pd0:2379"
 ignore_databases = "system,default"
-# specify which storage engine we use. tmt or dt 
-storage_engine = "dt"
-# Deprecated Raft data storage path setting style. Check [storage.raft] section for new style.
-# If it is not set, it will be the first path of "path" appended with "/kvstore".
-# kvstore_path = ""
-
-[raft.snapshot]
-# The way to apply snapshot data
-# The value is one of "block" / "file1" / "file2".
-# method = "file1"
 
 [profiles]
 [profiles.default]

--- a/tests/docker/config/tiflash_dt_disable_local_tunnel.toml
+++ b/tests/docker/config/tiflash_dt_disable_local_tunnel.toml
@@ -13,70 +13,14 @@
 # limitations under the License.
 
 tmp_path = "/tmp/tiflash/data/tmp"
-display_name = "TiFlash"
 
-## Deprecated storage path setting style. Check [storage] section for new style.
 path = "/tmp/tiflash/data/db"
 capacity = "10737418240"
-## Deprecated storage path setting style of multi-disks. Check [storage] section for new style.
-# path = "/tmp/tiflash/data/db,/tmp/tiflash1,/tmp/tiflash2"
-# capacity = "0"
 
 mark_cache_size = 5368709120
 minmax_index_cache_size = 5368709120
 tcp_port = 9000
 http_port = 8123
-
-## Storage paths settings.
-# [storage]
-## The storage format version in storage engine. Valid values: 1, 2 (experimental).
-## format_version = 1
-
-## If there are multiple SSD disks on the machine,
-## specify the path list on `storage.main.dir` can improve TiFlash performance.
-
-## If there are multiple disks with different IO metrics (e.g. one SSD and some HDDs)
-## on the machine, 
-## set `storage.latest.dir` to store the latest data on SSD (disks with higher IOPS metrics)
-## set `storage.main.dir` to store the main data on HDD (disks with lower IOPS metrics)
-## can improve TiFlash performance.
-
-# [storage.main]
-## The path to store main data.
-# e.g.
-# dir = [ "/data0/tiflash" ] 
-# or
-# dir = [ "/data0/tiflash", "/data1/tiflash" ]
-
-## Store capacity of each path, i.e. max data size allowed.
-## If it is not set, or is set to 0s, the actual disk capacity is used.
-## Note that we don't support human-readable big numbers(like "10GB") yet.
-## Please set in the specified number of bytes.
-# e.g.
-# capacity = [ 10737418240, 10737418240 ]
-
-# [storage.latest]
-## The path(s) to store latest data.
-## If not set, it will be the same with `storage.main.dir`.
-# dir = [ ]
-
-## Store capacity of each path, i.e. max data size allowed.
-## If it is not set, or is set to 0s, the actual disk capacity is used.
-# e.g.
-# capacity = [ 10737418240, 10737418240 ]
-
-# [storage.raft]
-## The path(s) to store Raft data.
-## If not set, it will be the paths in `storage.latest.dir` appended with "/kvstore".
-# dir = [ ]
-
-# [storage.io_rate_limit]
-## The max I/O bandwith. Default value is 0 and I/O rate limit is disabled.
-# max_bytes_per_sec = 268435456
-## max_read_bytes_per_sec and max_write_bytes_per_sec are the same meaning as max_bytes_per_sec,
-## but for disk that read bandwidth and write bandwith are calculated separatly, such as GCP's persistent disks.
-# max_read_bytes_per_sec = 0
-# max_write_bytes_per_sec = 0
 
 [flash]
 tidb_status_addr = "tidb0:10080"
@@ -100,22 +44,9 @@ size = "1000M"
 log = "/tmp/tiflash/log/server.log"
 level = "trace"
 
-[application]
-runAsDaemon = true
-
 [raft]
 pd_addr = "pd0:2379"
 ignore_databases = "system,default"
-# specify which storage engine we use. tmt or dt 
-storage_engine = "dt"
-# Deprecated Raft data storage path setting style. Check [storage.raft] section for new style.
-# If it is not set, it will be the first path of "path" appended with "/kvstore".
-# kvstore_path = ""
-
-[raft.snapshot]
-# The way to apply snapshot data
-# The value is one of "block" / "file1" / "file2".
-# method = "file1"
 
 [profiles]
 [profiles.default]


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/4904

Problem Summary:

`RegionKVStoreTest` will try to decode data for `table id == 1`. But the schema of tests in `RegionKVStoreTest` does not match that we created in `StorageDeltaMergeTest.ReadExtraPhysicalTableID`. 

`./gtests_dbms --gtest_filter='*StorageDeltaMergeTest*:*RegionKVStoreTest*'`

```
Note: Google Test filter = *StorageDeltaMergeTest*:*RegionKVStoreTest*
[==========] Running 6 tests from 2 test cases.
[----------] Global test environment set-up.
[----------] 5 tests from StorageDeltaMergeTest
[ RUN      ] StorageDeltaMergeTest.ReadWriteCase1
...
[       OK ] StorageDeltaMergeTest.RestoreAfterClearData (624 ms)
[----------] 5 tests from StorageDeltaMergeTest (835 ms total)

[----------] 1 test from RegionKVStoreTest
[ RUN      ] RegionKVStoreTest.run
...
[2022/05/16 17:35:35.065 +08:00] [INFO] [Region.cpp:189] ["Region:[region 1] split into [region 7, index 5, table 1, ver 7, conf_ver 0, state Normal, peer ] [region 1, index 20, table 1, ver 7, conf_ver 0, state Normal, peer id: 2]"] [thread_id=1]
[2022/05/16 17:35:35.065 +08:00] [INFO] [RegionTable.cpp:44] ["RegionTable:get new table 1"] [thread_id=1]
[2022/05/16 17:35:35.065 +08:00] [TRACE] [RegionTable.cpp:122] ["RegionTable:table 1, [region 7] original 79 bytes"] [thread_id=1]
[2022/05/16 17:35:35.065 +08:00] [TRACE] [PartitionStreams.cpp:121] ["RegionTable:writeRegionDataToStorage begin to decode table 1, region 7"] [thread_id=1]
unknown file: Failure
C++ exception with description "unordered_map::at: key not found" thrown in the test body.
[  FAILED  ] RegionKVStoreTest.run (39 ms)
[----------] 1 test from RegionKVStoreTest (39 ms total)

[----------] Global test environment tear-down
[==========] 6 tests from 2 test cases ran. (874 ms total)
[  PASSED  ] 5 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] RegionKVStoreTest.run
```


### What is changed and how it works?


* Remove some useless configs for running mock tests / fullstack tests
* Calling `storage->removeFromTMTContext()` after being dropped as we do in `InterpreterDropQuery ` https://github.com/pingcap/tiflash/blob/335b124cab124828aadc318b7355f8390950f032/dbms/src/Interpreters/InterpreterDropQuery.cpp#L162-L180


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
