### PR TITLE
Fix StorageDeltaMerge constructor not match in gtest_manual_compact

### DIFF
--- a/dbms/src/Flash/Management/tests/gtest_manual_compact.cpp
+++ b/dbms/src/Flash/Management/tests/gtest_manual_compact.cpp
@@ -38,8 +38,6 @@ extern const char pause_before_server_merge_one_delta[];
 
 namespace tests
 {
-
-
 class BasicManualCompactTest
     : public DB::base::TiFlashStorageTestBasic
     , public testing::WithParamInterface<DM::tests::DMTestEnv::PkType>
@@ -83,7 +81,7 @@ public:
         storage = StorageDeltaMerge::create("TiFlash",
                                             "default" /* db_name */,
                                             "test_table" /* table_name */,
-                                            std::ref(table_info),
+                                            table_info,
                                             ColumnsDescription{columns},
                                             astptr,
                                             0,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #4949

Problem Summary:

### What is changed and how it works?
- rm `std::ref`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
