### PR TITLE
ignore delmark when add minmax for pk column (#4746)

### DIFF
--- a/dbms/src/Storages/DeltaMerge/File/DMFileWriter.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileWriter.cpp
@@ -114,17 +114,17 @@ void DMFileWriter::write(const Block & block, const BlockProperty & block_proper
 
     auto del_mark_column = tryGetByColumnId(block, TAG_COLUMN_ID).column;
 
-    const ColumnVector<UInt8> * del_mark = !del_mark_column ? nullptr : (const ColumnVector<UInt8> *)del_mark_column.get();
+    const ColumnVector<UInt8> * del_mark = !del_mark_column ? nullptr : static_cast<const ColumnVector<UInt8> *>(del_mark_column.get());
 
     for (auto & cd : write_columns)
     {
-        auto & col = getByColumnId(block, cd.id).column;
+        const auto & col = getByColumnId(block, cd.id).column;
         writeColumn(cd.id, *cd.type, *col, del_mark);
 
         if (cd.id == VERSION_COLUMN_ID)
             stat.first_version = col->get64(0);
         else if (cd.id == TAG_COLUMN_ID)
-            stat.first_tag = (UInt8)(col->get64(0));
+            stat.first_tag = static_cast<UInt8>(col->get64(0));
     }
 
     if (!options.flags.isSingleFile())

--- a/dbms/src/Storages/DeltaMerge/File/DMFileWriter.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileWriter.cpp
@@ -178,7 +178,9 @@ void DMFileWriter::writeColumn(ColId col_id, const IDataType & type, const IColu
             auto & minmax_indexs = single_file_stream->minmax_indexs;
             if (auto iter = minmax_indexs.find(stream_name); iter != minmax_indexs.end())
             {
-                iter->second->addPack(column, del_mark);
+                // For EXTRA_HANDLE_COLUMN_ID, we ignore del_mark when add minmax index.
+                // Because we need all rows which satisfy a certain range when place delta index no matter whether the row is a delete row.
+                iter->second->addPack(column, col_id == EXTRA_HANDLE_COLUMN_ID ? nullptr : del_mark);
             }
 
             auto offset_in_compressed_block = single_file_stream->original_layer.offset();
@@ -240,7 +242,11 @@ void DMFileWriter::writeColumn(ColId col_id, const IDataType & type, const IColu
                 const auto name = DMFile::getFileNameBase(col_id, substream);
                 auto & stream = column_streams.at(name);
                 if (stream->minmaxes)
-                    stream->minmaxes->addPack(column, del_mark);
+                {
+                    // For EXTRA_HANDLE_COLUMN_ID, we ignore del_mark when add minmax index.
+                    // Because we need all rows which satisfy a certain range when place delta index no matter whether the row is a delete row.
+                    stream->minmaxes->addPack(column, col_id == EXTRA_HANDLE_COLUMN_ID ? nullptr : del_mark);
+                }
 
                 /// There could already be enough data to compress into the new block.
                 if (stream->compressed_buf->offset() >= options.min_compress_block_size)

--- a/dbms/src/Storages/DeltaMerge/tests/dm_basic_include.h
+++ b/dbms/src/Storages/DeltaMerge/tests/dm_basic_include.h
@@ -227,9 +227,10 @@ public:
      * @param ts_beg    `timestamp`'s value begin
      * @param ts_end    `timestamp`'s value end (not included)
      * @param reversed  increasing/decreasing insert `timestamp`'s value
+     * @param deleted   if deleted is false, set `tag` to 0; otherwise set `tag` to 1
      * @return
      */
-    static Block prepareBlockWithTso(Int64 pk, size_t ts_beg, size_t ts_end, bool reversed = false)
+    static Block prepareBlockWithTso(Int64 pk, size_t ts_beg, size_t ts_end, bool reversed = false, bool deleted = false)
     {
         Block block;
         const size_t num_rows = (ts_end - ts_beg);
@@ -245,7 +246,7 @@ public:
             VERSION_COLUMN_ID));
         // tag_col
         block.insert(DB::tests::createColumn<UInt8>(
-            std::vector<UInt64>(num_rows, 0),
+            std::vector<UInt64>(num_rows, deleted ? 1 : 0),
             TAG_COLUMN_NAME,
             TAG_COLUMN_ID));
         return block;

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment.cpp
@@ -198,6 +198,43 @@ try
 }
 CATCH
 
+TEST_F(Segment_test, WriteRead2)
+try
+{
+    const size_t num_rows_write = dmContext().stable_pack_rows;
+    {
+        // write a block with rows all deleted
+        Block block = DMTestEnv::prepareBlockWithTso(2, 100, 100 + num_rows_write, false, true);
+        segment->write(dmContext(), block);
+        // write not deleted rows with larger pk
+        Block block2 = DMTestEnv::prepareBlockWithTso(3, 100, 100 + num_rows_write, false, false);
+        segment->write(dmContext(), block2);
+
+        // flush segment and make sure there is two packs in stable
+        segment = segment->mergeDelta(dmContext(), tableColumns());
+        ASSERT_EQ(segment->getStable()->getPacks(), 2);
+    }
+
+    {
+        Block block = DMTestEnv::prepareBlockWithTso(1, 100, 100 + num_rows_write, false, false);
+        segment->write(dmContext(), block);
+    }
+
+    {
+        auto in = segment->getInputStream(dmContext(), *tableColumns(), {RowKeyRange::newAll(false, 1)});
+        size_t num_rows_read = 0;
+        in->readPrefix();
+        while (Block block = in->read())
+        {
+            num_rows_read += block.rows();
+        }
+        in->readSuffix();
+        // only write two visible pks
+        ASSERT_EQ(num_rows_read, 2);
+    }
+}
+CATCH
+
 TEST_F(Segment_test, WriteReadMultiRange)
 try
 {

--- a/tests/docker/run.sh
+++ b/tests/docker/run.sh
@@ -50,11 +50,9 @@ function wait_env() {
 # TAG:        tiflash hash, default to `master`
 # XYZ_BRANCH: pd/tikv/tidb hash, default to `master`
 # BRANCH:     hash short cut, default to `master`
-if [ -n "$BRANCH" ]; then
-  [ -z "$PD_BRANCH" ] && export PD_BRANCH="$BRANCH"
-  [ -z "$TIKV_BRANCH" ] && export TIKV_BRANCH="$BRANCH"
-  [ -z "$TIDB_BRANCH" ] && export TIDB_BRANCH="$BRANCH"
-fi
+export PD_BRANCH="release-5.4"
+export TIKV_BRANCH="release-5.4"
+export TIDB_BRANCH="release-5.4"
 
 
 # Stop all docker instances if exist.

--- a/tests/docker/util.sh
+++ b/tests/docker/util.sh
@@ -77,12 +77,10 @@ function wait_tiflash_env() {
 function set_branch() {
   # XYZ_BRANCH: pd/tikv/tidb hash, default to `master`
   # BRANCH:     hash short cut, default to `master`
-  if [ -n "$BRANCH" ]; then
-    [ -z "$PD_BRANCH" ] && export PD_BRANCH="$BRANCH"
-    [ -z "$TIKV_BRANCH" ] && export TIKV_BRANCH="$BRANCH"
-    [ -z "$TIDB_BRANCH" ] && export TIDB_BRANCH="$BRANCH"
-  fi
-  echo "use branch \`${BRANCH-master}\` for ci test"
+  export PD_BRANCH="release-5.4"
+  export TIKV_BRANCH="release-5.4"
+  export TIDB_BRANCH="release-5.4"
+  echo "use branch \`${PD_BRANCH}\` for ci test"
 }
 
 function clean_data_log() {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #4747

Problem Summary:
If rows in a stable pack is all mark deleted, then it's minmax index for pk column is both 0.
And when dt_enable_skippable_place is enabled and try to place delta index on this segment, it will filter out all pack which is not in the pk range [start_key, +infinite). So the previous stable pack is ignored.
But for the place delta index algorithm, it's expected that all the rows in the pk range [start_key, +infinite) is placed no matter whether it's deleted. So when we try to read this segment using the placed delta index, it reports error like "DeltaMerge return wrong result"

### What is changed and how it works?
Ignore delmark when add minmax for pk column.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix potential query error when select on a table with many delete operations
```
