### PR TITLE
PageStorage: Report the file usage of BlobStore

### DIFF
--- a/dbms/src/Interpreters/AsynchronousMetrics.cpp
+++ b/dbms/src/Interpreters/AsynchronousMetrics.cpp
@@ -21,8 +21,12 @@
 #include <IO/UncompressedCache.h>
 #include <Interpreters/AsynchronousMetrics.h>
 #include <Storages/DeltaMerge/DeltaMergeStore.h>
+#include <Storages/DeltaMerge/StoragePool.h>
 #include <Storages/MarkCache.h>
+#include <Storages/Page/FileUsage.h>
 #include <Storages/StorageDeltaMerge.h>
+#include <Storages/Transaction/KVStore.h>
+#include <Storages/Transaction/TMTContext.h>
 #include <common/config_common.h>
 
 #include <chrono>
@@ -147,6 +151,7 @@ void AsynchronousMetrics::update()
     set("Uptime", context.getUptimeSeconds());
 
     {
+        // Get the snapshot status from all delta tree tables
         auto databases = context.getDatabases();
 
         double max_dt_stable_oldest_snapshot_lifetime = 0.0;
@@ -176,6 +181,34 @@ void AsynchronousMetrics::update()
         set("MaxDTMetaOldestSnapshotLifetime", max_dt_meta_oldest_snapshot_lifetime);
         set("MaxDTBackgroundTasksLength", max_dt_background_tasks_length);
     }
+
+    do
+    {
+        FileUsageStatistics usage;
+
+        // Get from RegionPersister
+        auto & tmt = context.getTMTContext();
+        auto & kvstore = tmt.getKVStore();
+        const auto kvstore_usage = kvstore->getFileUsageStatistics();
+
+        // Get the blob file status from all PS V3 instances
+        auto global_storage_pool = context.getGlobalStoragePool();
+        if (global_storage_pool == nullptr)
+            break;
+
+        const auto log_usage = global_storage_pool->log_storage->getFileUsageStatistics();
+        const auto meta_usage = global_storage_pool->meta_storage->getFileUsageStatistics();
+        const auto data_usage = global_storage_pool->data_storage->getFileUsageStatistics();
+
+        usage.total_file_num = kvstore_usage.total_file_num + log_usage.total_file_num + meta_usage.total_file_num + data_usage.total_file_num;
+        usage.total_disk_size = kvstore_usage.total_disk_size + log_usage.total_disk_size + meta_usage.total_disk_size + data_usage.total_disk_size;
+        usage.total_valid_size = kvstore_usage.total_valid_size + log_usage.total_valid_size + meta_usage.total_valid_size + data_usage.total_valid_size;
+
+        set("BlobFileNums", usage.total_file_num);
+        set("BlobDiskBytes", usage.total_disk_size);
+        set("BlobValidBytes", usage.total_valid_size);
+
+    } while (false);
 
 #if USE_TCMALLOC
     {

--- a/dbms/src/Interpreters/AsynchronousMetrics.cpp
+++ b/dbms/src/Interpreters/AsynchronousMetrics.cpp
@@ -184,14 +184,13 @@ void AsynchronousMetrics::update()
 
     do
     {
-        FileUsageStatistics usage = kvstore->getFileUsageStatistics();
 
         // Get from RegionPersister
         auto & tmt = context.getTMTContext();
         auto & kvstore = tmt.getKVStore();
+        FileUsageStatistics usage = kvstore->getFileUsageStatistics();
 
         // Get the blob file status from all PS V3 instances
-
         if (auto global_storage_pool = context.getGlobalStoragePool(); global_storage_pool != nullptr)
         {
             const auto log_usage = global_storage_pool->log_storage->getFileUsageStatistics();

--- a/dbms/src/Interpreters/AsynchronousMetrics.cpp
+++ b/dbms/src/Interpreters/AsynchronousMetrics.cpp
@@ -184,25 +184,24 @@ void AsynchronousMetrics::update()
 
     do
     {
-        FileUsageStatistics usage;
+        FileUsageStatistics usage = kvstore->getFileUsageStatistics();
 
         // Get from RegionPersister
         auto & tmt = context.getTMTContext();
         auto & kvstore = tmt.getKVStore();
-        const auto kvstore_usage = kvstore->getFileUsageStatistics();
 
         // Get the blob file status from all PS V3 instances
-        auto global_storage_pool = context.getGlobalStoragePool();
-        if (global_storage_pool == nullptr)
-            break;
 
-        const auto log_usage = global_storage_pool->log_storage->getFileUsageStatistics();
-        const auto meta_usage = global_storage_pool->meta_storage->getFileUsageStatistics();
-        const auto data_usage = global_storage_pool->data_storage->getFileUsageStatistics();
+        if (auto global_storage_pool = context.getGlobalStoragePool(); global_storage_pool != nullptr)
+        {
+            const auto log_usage = global_storage_pool->log_storage->getFileUsageStatistics();
+            const auto meta_usage = global_storage_pool->meta_storage->getFileUsageStatistics();
+            const auto data_usage = global_storage_pool->data_storage->getFileUsageStatistics();
 
-        usage.total_file_num = kvstore_usage.total_file_num + log_usage.total_file_num + meta_usage.total_file_num + data_usage.total_file_num;
-        usage.total_disk_size = kvstore_usage.total_disk_size + log_usage.total_disk_size + meta_usage.total_disk_size + data_usage.total_disk_size;
-        usage.total_valid_size = kvstore_usage.total_valid_size + log_usage.total_valid_size + meta_usage.total_valid_size + data_usage.total_valid_size;
+            usage.total_file_num += log_usage.total_file_num + meta_usage.total_file_num + data_usage.total_file_num;
+            usage.total_disk_size += log_usage.total_disk_size + meta_usage.total_disk_size + data_usage.total_disk_size;
+            usage.total_valid_size += log_usage.total_valid_size + meta_usage.total_valid_size + data_usage.total_valid_size;
+        }
 
         set("BlobFileNums", usage.total_file_num);
         set("BlobDiskBytes", usage.total_disk_size);

--- a/dbms/src/Interpreters/AsynchronousMetrics.h
+++ b/dbms/src/Interpreters/AsynchronousMetrics.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <Storages/Page/FileUsage.h>
+
 #include <condition_variable>
 #include <mutex>
 #include <string>
@@ -46,6 +48,9 @@ public:
 
     /// Returns copy of all values.
     Container getValues() const;
+
+private:
+    FileUsageStatistics getPageStorageFileUsage();
 
 private:
     Context & context;

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -464,7 +464,7 @@ private:
     }
 
     RunRaftStoreProxyParms parms;
-    pthread_t thread;
+    pthread_t thread{};
     Poco::Logger * log;
 };
 
@@ -1155,7 +1155,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
 
     /// Try to increase limit on number of open files.
     {
-        rlimit rlim;
+        rlimit rlim{};
         if (getrlimit(RLIMIT_NOFILE, &rlim))
             throw Poco::Exception("Cannot getrlimit");
 

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -1443,6 +1443,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
         }
 
         /// This object will periodically calculate some metrics.
+        /// should init after `createTMTContext` cause we collect some data from the TiFlash context object.
         AsynchronousMetrics async_metrics(*global_context);
         attachSystemTablesAsync(*global_context->getDatabase("system"), async_metrics);
 

--- a/dbms/src/Storages/DeltaMerge/StoragePool.h
+++ b/dbms/src/Storages/DeltaMerge/StoragePool.h
@@ -28,6 +28,7 @@ struct Settings;
 class Context;
 class StoragePathPool;
 class StableDiskDelegator;
+class AsynchronousMetrics;
 
 namespace DM
 {
@@ -50,6 +51,7 @@ public:
     void restore();
 
     friend class StoragePool;
+    friend class ::DB::AsynchronousMetrics;
 
     // GC immediately
     // Only used on dbgFuncMisc

--- a/dbms/src/Storages/Page/FileUsage.h
+++ b/dbms/src/Storages/Page/FileUsage.h
@@ -19,7 +19,6 @@
 
 namespace DB
 {
-
 struct FileUsageStatistics
 {
     size_t total_disk_size = 0;

--- a/dbms/src/Storages/Page/FileUsage.h
+++ b/dbms/src/Storages/Page/FileUsage.h
@@ -1,0 +1,30 @@
+// Copyright 2022 PingCAP, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <stdint.h>
+
+#include <cstddef>
+
+namespace DB
+{
+
+struct FileUsageStatistics
+{
+    size_t total_disk_size = 0;
+    size_t total_valid_size = 0;
+    size_t total_file_num = 0;
+};
+
+} // namespace DB

--- a/dbms/src/Storages/Page/PageStorage.cpp
+++ b/dbms/src/Storages/Page/PageStorage.cpp
@@ -66,6 +66,8 @@ public:
     // Get some statistics of all living snapshots and the oldest living snapshot.
     virtual SnapshotsStatistics getSnapshotsStat() const = 0;
 
+    virtual FileUsageStatistics getFileUsageStatistics() const = 0;
+
     virtual void traverse(const std::function<void(const DB::Page & page)> & acceptor, bool only_v2, bool only_v3) const = 0;
 };
 
@@ -135,6 +137,11 @@ public:
     void traverse(const std::function<void(const DB::Page & page)> & acceptor, bool /*only_v2*/, bool /*only_v3*/) const override
     {
         storage->traverse(acceptor, nullptr);
+    }
+
+    FileUsageStatistics getFileUsageStatistics() const override
+    {
+        return storage->getFileUsageStatistics();
     }
 
 private:
@@ -294,6 +301,11 @@ public:
         return statistics_total;
     }
 
+    FileUsageStatistics getFileUsageStatistics() const override
+    {
+        return storage_v3->getFileUsageStatistics();
+    }
+
     void traverse(const std::function<void(const DB::Page & page)> & acceptor, bool only_v2, bool only_v3) const override
     {
         // Used by RegionPersister::restore
@@ -422,6 +434,12 @@ PageStorage::SnapshotPtr PageReader::getSnapshot(const String & tracing_id) cons
 SnapshotsStatistics PageReader::getSnapshotsStat() const
 {
     return impl->getSnapshotsStat();
+}
+
+
+FileUsageStatistics PageReader::getFileUsageStatistics() const
+{
+    return impl->getFileUsageStatistics();
 }
 
 void PageReader::traverse(const std::function<void(const DB::Page & page)> & acceptor, bool only_v2, bool only_v3) const

--- a/dbms/src/Storages/Page/PageStorage.h
+++ b/dbms/src/Storages/Page/PageStorage.h
@@ -19,6 +19,7 @@
 #include <Interpreters/SettingsCommon.h>
 #include <Storages/FormatVersion.h>
 #include <Storages/Page/Config.h>
+#include <Storages/Page/FileUsage.h>
 #include <Storages/Page/Page.h>
 #include <Storages/Page/PageDefines.h>
 #include <Storages/Page/PageUtil.h>
@@ -251,6 +252,12 @@ public:
     // Get some statistics of all living snapshots and the oldest living snapshot.
     virtual SnapshotsStatistics getSnapshotsStat() const = 0;
 
+    virtual FileUsageStatistics getFileUsageStatistics() const
+    {
+        // return all zeros by default
+        return FileUsageStatistics{};
+    }
+
     virtual size_t getNumberOfPages() = 0;
 
     virtual std::set<PageId> getAliveExternalPageIds(NamespaceId ns_id) = 0;
@@ -379,6 +386,8 @@ public:
 
     // Get some statistics of all living snapshots and the oldest living snapshot.
     SnapshotsStatistics getSnapshotsStat() const;
+
+    FileUsageStatistics getFileUsageStatistics() const;
 
     void traverse(const std::function<void(const DB::Page & page)> & acceptor, bool only_v2 = false, bool only_v3 = false) const;
 

--- a/dbms/src/Storages/Page/Snapshot.h
+++ b/dbms/src/Storages/Page/Snapshot.h
@@ -61,7 +61,7 @@ private:
 };
 using PageStorageSnapshotMixedPtr = std::shared_ptr<PageStorageSnapshotMixed>;
 
-static inline PageStorageSnapshotMixedPtr
+inline PageStorageSnapshotMixedPtr
 toConcreteMixedSnapshot(const PageStorageSnapshotPtr & ptr)
 {
     return std::static_pointer_cast<PageStorageSnapshotMixed>(ptr);

--- a/dbms/src/Storages/Page/V3/BlobStore.cpp
+++ b/dbms/src/Storages/Page/V3/BlobStore.cpp
@@ -141,7 +141,6 @@ FileUsageStatistics BlobStore::getFileUsageStatistics() const
                 usage.total_disk_size += stat->sm_total_size;
                 usage.total_valid_size += stat->sm_valid_size;
             }
-            LOG_FMT_TRACE(log, "file usage [blob_id={}] [disk_size={}] [valid_size={}] [valid_rate={}]", stat->id, stat->sm_total_size, stat->sm_valid_size, stat->sm_valid_rate);
         }
         usage.total_file_num += stats.size();
     }

--- a/dbms/src/Storages/Page/V3/BlobStore.cpp
+++ b/dbms/src/Storages/Page/V3/BlobStore.cpp
@@ -20,6 +20,7 @@
 #include <Common/StringUtils/StringUtils.h>
 #include <Common/TiFlashMetrics.h>
 #include <Poco/File.h>
+#include <Storages/Page/FileUsage.h>
 #include <Storages/Page/PageDefines.h>
 #include <Storages/Page/V3/BlobStore.h>
 #include <Storages/Page/V3/PageDirectory.h>
@@ -66,7 +67,7 @@ using ChecksumClass = Digest::CRC64;
   * BlobStore methods *
   *********************/
 
-BlobStore::BlobStore(String storage_name, const FileProviderPtr & file_provider_, PSDiskDelegatorPtr delegator_, BlobStore::Config config_)
+BlobStore::BlobStore(String storage_name, const FileProviderPtr & file_provider_, PSDiskDelegatorPtr delegator_, const BlobStore::Config & config_)
     : delegator(std::move(delegator_))
     , file_provider(file_provider_)
     , config(config_)
@@ -113,6 +114,39 @@ void BlobStore::registerPaths()
             }
         }
     }
+}
+
+FileUsageStatistics BlobStore::getFileUsageStatistics() const
+{
+    FileUsageStatistics usage;
+
+    // Get a copy of stats map to avoid the big lock on stats map
+    const auto stats_list = blob_stats.getStats();
+
+    for (const auto & [path, stats] : stats_list)
+    {
+        (void)path;
+        for (const auto & stat : stats)
+        {
+            // We can access to these type without any locking.
+            if (stat->isReadOnly() || stat->isBigBlob())
+            {
+                usage.total_disk_size += stat->sm_total_size;
+                usage.total_valid_size += stat->sm_valid_size;
+            }
+            else
+            {
+                // Else the stat may being updated, acquire a lock to avoid data race.
+                auto lock = stat->lock();
+                usage.total_disk_size += stat->sm_total_size;
+                usage.total_valid_size += stat->sm_valid_size;
+            }
+            LOG_FMT_TRACE(log, "file usage [blob_id={}] [disk_size={}] [valid_size={}] [valid_rate={}]", stat->id, stat->sm_total_size, stat->sm_valid_size, stat->sm_valid_rate);
+        }
+        usage.total_file_num += stats.size();
+    }
+
+    return usage;
 }
 
 PageEntriesEdit BlobStore::handleLargeWrite(DB::WriteBatch & wb, const WriteLimiterPtr & write_limiter)
@@ -872,6 +906,7 @@ private:
 
 std::vector<BlobFileId> BlobStore::getGCStats()
 {
+    // Get a copy of stats map to avoid the big lock on stats map
     const auto stats_list = blob_stats.getStats();
     std::vector<BlobFileId> blob_need_gc;
     BlobStoreGCInfo blobstore_gc_info;
@@ -1196,7 +1231,7 @@ BlobStatPtr BlobStore::BlobStats::createStat(BlobFileId blob_file_id, const std:
     // New blob file id won't bigger than roll_id
     if (blob_file_id > roll_id)
     {
-        throw Exception(fmt::format("BlobStats won't create [blob_id={}], which is bigger than [RollMaxId={}]",
+        throw Exception(fmt::format("BlobStats won't create [blob_id={}], which is bigger than [roll_id={}]",
                                     blob_file_id,
                                     roll_id),
                         ErrorCodes::LOGICAL_ERROR);
@@ -1259,8 +1294,7 @@ BlobStatPtr BlobStore::BlobStats::createBigPageStatNotChecking(BlobFileId blob_f
     BlobStatPtr stat = std::make_shared<BlobStat>(
         blob_file_id,
         SpaceMap::SpaceMapType::SMAP64_BIG,
-        config.file_limit_size,
-        BlobStatType::BIG_BLOB);
+        config.file_limit_size);
 
     PageFileIdAndLevel id_lvl{blob_file_id, 0};
     stats_map[delegator->choosePath(id_lvl)].emplace_back(stat);
@@ -1438,7 +1472,7 @@ bool BlobStore::BlobStats::BlobStat::removePosFromStat(BlobFileOffset offset, si
     if (!smap->markFree(offset, buf_size))
     {
         smap->logDebugString();
-        throw Exception(fmt::format("Remove postion from BlobStat failed, [offset={} , buf_size={}, blob_id={}] is invalid.",
+        throw Exception(fmt::format("Remove postion from BlobStat failed, invalid position [offset={}] [buf_size={}] [blob_id={}]",
                                     offset,
                                     buf_size,
                                     id),
@@ -1455,7 +1489,7 @@ void BlobStore::BlobStats::BlobStat::restoreSpaceMap(BlobFileOffset offset, size
     if (!smap->markUsed(offset, buf_size))
     {
         smap->logDebugString();
-        throw Exception(fmt::format("Restore postion from BlobStat failed, [offset={}] [buf_size={}] [blob_id={}] is used or subspan is used",
+        throw Exception(fmt::format("Restore postion from BlobStat failed, the space/subspace is already being used [offset={}] [buf_size={}] [blob_id={}]",
                                     offset,
                                     buf_size,
                                     id),

--- a/dbms/src/Storages/Page/V3/BlobStore.h
+++ b/dbms/src/Storages/Page/V3/BlobStore.h
@@ -17,6 +17,7 @@
 #include <Common/Exception.h>
 #include <Common/LRUCache.h>
 #include <Interpreters/SettingsCommon.h>
+#include <Storages/Page/FileUsage.h>
 #include <Storages/Page/V3/BlobFile.h>
 #include <Storages/Page/V3/PageEntriesEdit.h>
 #include <Storages/Page/V3/PageEntry.h>
@@ -110,12 +111,17 @@ public:
             double sm_valid_rate = 1.0;
 
         public:
-            BlobStat(BlobFileId id_, SpaceMap::SpaceMapType sm_type, UInt64 sm_max_caps_, BlobStatType type_ = BlobStatType::NORMAL)
+            BlobStat(BlobFileId id_, SpaceMap::SpaceMapType sm_type, UInt64 sm_max_caps_)
                 : id(id_)
-                , type(type_)
+                , type(BlobStatType::NORMAL)
                 , smap(SpaceMap::createSpaceMap(sm_type, 0, sm_max_caps_))
                 , sm_max_caps(sm_max_caps_)
             {
+                if (sm_type == SpaceMap::SpaceMapType::SMAP64_BIG)
+                {
+                    type = BlobStatType::BIG_BLOB;
+                }
+
                 // Won't create read-only blob by default.
                 assert(type != BlobStatType::READ_ONLY);
             }
@@ -246,9 +252,11 @@ public:
         std::map<String, std::list<BlobStatPtr>> stats_map;
     };
 
-    BlobStore(String storage_name, const FileProviderPtr & file_provider_, PSDiskDelegatorPtr delegator_, BlobStore::Config config);
+    BlobStore(String storage_name, const FileProviderPtr & file_provider_, PSDiskDelegatorPtr delegator_, const BlobStore::Config & config);
 
     void registerPaths();
+
+    FileUsageStatistics getFileUsageStatistics() const;
 
     std::vector<BlobFileId> getGCStats();
 

--- a/dbms/src/Storages/Page/V3/PageStorageImpl.cpp
+++ b/dbms/src/Storages/Page/V3/PageStorageImpl.cpp
@@ -80,6 +80,11 @@ DB::PageStorage::SnapshotPtr PageStorageImpl::getSnapshot(const String & tracing
     return page_directory->createSnapshot(tracing_id);
 }
 
+FileUsageStatistics PageStorageImpl::getFileUsageStatistics() const
+{
+    return blob_store.getFileUsageStatistics();
+}
+
 SnapshotsStatistics PageStorageImpl::getSnapshotsStat() const
 {
     return page_directory->getSnapshotsStat();

--- a/dbms/src/Storages/Page/V3/PageStorageImpl.h
+++ b/dbms/src/Storages/Page/V3/PageStorageImpl.h
@@ -72,6 +72,8 @@ public:
 
     SnapshotsStatistics getSnapshotsStat() const override;
 
+    FileUsageStatistics getFileUsageStatistics() const override;
+
     size_t getNumberOfPages() override;
 
     std::set<PageId> getAliveExternalPageIds(NamespaceId ns_id) override;

--- a/dbms/src/Storages/Transaction/KVStore.h
+++ b/dbms/src/Storages/Transaction/KVStore.h
@@ -162,6 +162,11 @@ public:
 
     ~KVStore();
 
+    FileUsageStatistics getFileUsageStatistics() const
+    {
+        return region_persister.getFileUsageStatistics();
+    }
+
 private:
     friend class MockTiDB;
     friend struct MockTiDBTable;

--- a/dbms/src/Storages/Transaction/RegionPersister.cpp
+++ b/dbms/src/Storages/Transaction/RegionPersister.cpp
@@ -18,6 +18,7 @@
 #include <Interpreters/Settings.h>
 #include <Storages/DeltaMerge/StoragePool.h>
 #include <Storages/Page/ConfigSettings.h>
+#include <Storages/Page/FileUsage.h>
 #include <Storages/Page/V1/PageStorage.h>
 #include <Storages/Page/V2/PageStorage.h>
 #include <Storages/Page/V3/PageStorageImpl.h>
@@ -377,6 +378,11 @@ bool RegionPersister::gc()
     }
     else
         return stable_page_storage->gc();
+}
+
+FileUsageStatistics RegionPersister::getFileUsageStatistics() const
+{
+    return page_reader->getFileUsageStatistics();
 }
 
 } // namespace DB

--- a/dbms/src/Storages/Transaction/RegionPersister.h
+++ b/dbms/src/Storages/Transaction/RegionPersister.h
@@ -16,10 +16,10 @@
 
 #include <Common/Logger.h>
 #include <IO/MemoryReadWriteBuffer.h>
+#include <Storages/Page/FileUsage.h>
 #include <Storages/Page/PageStorage.h>
 #include <Storages/Page/WriteBatch.h>
 #include <Storages/Transaction/Types.h>
-#include <Storages/Page/FileUsage.h>
 
 namespace DB
 {

--- a/dbms/src/Storages/Transaction/RegionPersister.h
+++ b/dbms/src/Storages/Transaction/RegionPersister.h
@@ -19,6 +19,7 @@
 #include <Storages/Page/PageStorage.h>
 #include <Storages/Page/WriteBatch.h>
 #include <Storages/Transaction/Types.h>
+#include <Storages/Page/FileUsage.h>
 
 namespace DB
 {
@@ -56,6 +57,8 @@ public:
     static void computeRegionWriteBuffer(const Region & region, RegionCacheWriteElement & region_write_buffer);
 
     PageStorage::Config getPageStorageSettings() const;
+
+    FileUsageStatistics getFileUsageStatistics() const;
 
 #ifndef DBMS_PUBLIC_GTEST
 private:

--- a/metrics/grafana/tiflash_summary.json
+++ b/metrics/grafana/tiflash_summary.json
@@ -33,12 +33,6 @@
       "id": "prometheus",
       "name": "Prometheus",
       "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "timeseries",
-      "name": "Time series",
-      "version": ""
     }
   ],
   "annotations": {
@@ -58,7 +52,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1653629613474,
+  "iteration": 1653635389238,
   "links": [],
   "panels": [
     {
@@ -5508,8 +5502,6 @@
             "rightSide": true,
             "show": true,
             "sideWidth": null,
-            "sort": "current",
-            "sortDesc": true,
             "total": false,
             "values": true
           },
@@ -5620,145 +5612,112 @@
           }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "The Global StoragePool and KVStore Runmode",
+          "decimals": 1,
+          "description": "The number of files of PageStorage instances in each TiFlash node",
+          "editable": true,
+          "error": false,
           "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "axisSoftMax": 5,
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineStyle": {
-                  "fill": "solid"
-                },
-                "lineWidth": 1,
-                "pointSize": 11,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false
-              },
-              "decimals": 0,
-              "mappings": [
-                {
-                  "from": "",
-                  "id": 1,
-                  "text": "ONLY_V2",
-                  "to": "",
-                  "type": 1,
-                  "value": "1"
-                },
-                {
-                  "from": "",
-                  "id": 2,
-                  "text": "ONLY_V3",
-                  "to": "",
-                  "type": 1,
-                  "value": "2"
-                },
-                {
-                  "from": "",
-                  "id": 3,
-                  "text": "MIX_MODE",
-                  "to": "",
-                  "type": 1,
-                  "value": "3"
-                },
-                {
-                  "from": "",
-                  "id": 4,
-                  "text": " ",
-                  "to": "",
-                  "type": 1,
-                  "value": "4"
-                },
-                {
-                  "from": "",
-                  "id": 5,
-                  "text": " ",
-                  "to": "",
-                  "type": 1,
-                  "value": "5"
-                }
-              ],
-              "min": 0,
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "short"
-            },
+            "defaults": {},
             "overrides": []
           },
+          "fill": 0,
+          "fillGradient": 0,
+          "grid": {},
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
             "y": 14
           },
-          "id": 126,
-          "links": [],
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right"
-            },
-            "tooltipOptions": {
-              "mode": "multi"
-            }
+          "hiddenSeries": false,
+          "id": 129,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": true
           },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.11",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "tiflash_system_current_metric_GlobalStorageRunMode{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}",
+              "expr": "sum(tiflash_system_asynchronous_metric_BlobFileNums{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance)",
               "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "{{instance}}-Global",
-              "refId": "A",
-              "step": 10
-            },
-            {
-              "exemplar": false,
-              "expr": "tiflash_system_current_metric_RegionPersisterRunMode{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}",
               "hide": false,
               "interval": "",
-              "legendFormat": "{{instance}}-KVStore",
-              "refId": "B"
+              "intervalFactor": 2,
+              "legendFormat": "num_file-{{instance}}",
+              "refId": "A",
+              "step": 10
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
-          "title": "Global Runmode",
-          "type": "timeseries"
+          "title": "PageStorage File Num",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "percentunit",
+              "label": null,
+              "logBase": 1,
+              "max": "1.1",
+              "min": "0",
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
           "aliasColors": {},
@@ -5767,7 +5726,7 @@
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
           "decimals": 1,
-          "description": "The StoragePool Runmode in DeltaMerge Storage",
+          "description": "The number of tables running under different mode in DeltaTree",
           "editable": true,
           "error": false,
           "fieldConfig": {
@@ -6416,7 +6375,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 7
+            "y": 8
           },
           "hiddenSeries": false,
           "id": 35,
@@ -6514,7 +6473,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 7
+            "y": 8
           },
           "hiddenSeries": false,
           "id": 36,
@@ -6632,7 +6591,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 14
+            "y": 15
           },
           "hiddenSeries": false,
           "id": 37,
@@ -6766,7 +6725,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 14
+            "y": 15
           },
           "hiddenSeries": false,
           "id": 75,
@@ -6870,7 +6829,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 21
+            "y": 22
           },
           "hiddenSeries": false,
           "id": 82,
@@ -7023,7 +6982,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 28
+            "y": 29
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -7093,7 +7052,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 28
+            "y": 29
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -7163,7 +7122,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 35
+            "y": 36
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -7233,7 +7192,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 35
+            "y": 36
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -7297,7 +7256,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 42
+            "y": 43
           },
           "height": "",
           "hiddenSeries": false,
@@ -7411,7 +7370,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 49
+            "y": 50
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -7480,7 +7439,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 49
+            "y": 50
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -7550,7 +7509,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 56
+            "y": 57
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -7620,7 +7579,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 56
+            "y": 57
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -7690,7 +7649,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 63
+            "y": 64
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -7756,7 +7715,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 63
+            "y": 64
           },
           "hiddenSeries": false,
           "id": 91,

--- a/metrics/grafana/tiflash_summary.json
+++ b/metrics/grafana/tiflash_summary.json
@@ -58,7 +58,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1652861766192,
+  "iteration": 1653629613474,
   "links": [],
   "panels": [
     {
@@ -5336,14 +5336,30 @@
             "align": false,
             "alignLevel": null
           }
-        },
+        }
+      ],
+      "repeat": null,
+      "title": "Storage",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 119,
+      "panels": [
         {
           "aliasColors": {},
           "bars": false,
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "The states of BlobStore (an internal component of storage engine)",
+          "description": "The states of BlobStore (an internal component of PageStorage)",
           "fieldConfig": {
             "defaults": {},
             "overrides": []
@@ -5354,20 +5370,20 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 69
+            "y": 6
           },
           "hiddenSeries": false,
           "id": 85,
           "legend": {
-            "alignAsTable": false,
+            "alignAsTable": true,
             "avg": false,
-            "current": false,
+            "current": true,
             "max": false,
             "min": false,
-            "rightSide": false,
+            "rightSide": true,
             "show": true,
             "total": false,
-            "values": false
+            "values": true
           },
           "lines": true,
           "linewidth": 1,
@@ -5383,11 +5399,11 @@
           "renderer": "flot",
           "seriesOverrides": [
             {
-              "alias": "/^BlobAllocated/",
+              "alias": "/^allocated/",
               "yaxis": 1
             },
             {
-              "alias": "/^BlobExpandRate/",
+              "alias": "/^expand_rate/",
               "yaxis": 2
             }
           ],
@@ -5402,7 +5418,7 @@
               "hide": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "BlobAllocated-{{instance}}",
+              "legendFormat": "allocated-{{instance}}",
               "refId": "A"
             },
             {
@@ -5412,7 +5428,7 @@
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "BlobExpandRate-{{instance}}",
+              "legendFormat": "expand_rate-{{instance}}",
               "refId": "B"
             }
           ],
@@ -5420,7 +5436,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "BlobStore Status",
+          "title": "PageStorage Blob Status",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -5457,10 +5473,420 @@
             "align": false,
             "alignLevel": null
           }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "decimals": 1,
+          "description": "The disk usage of PageStorage instances in each TiFlash node",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "grid": {},
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 6
+          },
+          "hiddenSeries": false,
+          "id": 128,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.11",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "/^valid_rate/",
+              "yaxis": 2
+            },
+            {
+              "alias": "/size/",
+              "linewidth": 3
+            }
+          ],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "tiflash_system_asynchronous_metric_BlobDiskBytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "disk_size-{{instance}}",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(tiflash_system_asynchronous_metric_BlobValidBytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance)",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "valid_size-{{instance}}",
+              "refId": "B"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum((tiflash_system_asynchronous_metric_BlobValidBytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) / (tiflash_system_asynchronous_metric_BlobDiskBytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"})) by (instance)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "valid_rate-{{instance}}",
+              "refId": "C"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(tiflash_system_asynchronous_metric_BlobFileNums{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance)",
+              "format": "time_series",
+              "hide": true,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "num_file-{{instance}}",
+              "refId": "E",
+              "step": 10
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "PageStorage Disk Usage",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "bytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "percentunit",
+              "label": null,
+              "logBase": 1,
+              "max": "1.1",
+              "min": "0",
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "The Global StoragePool and KVStore Runmode",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisSoftMax": 5,
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "graph": false,
+                  "legend": false,
+                  "tooltip": false
+                },
+                "lineInterpolation": "linear",
+                "lineStyle": {
+                  "fill": "solid"
+                },
+                "lineWidth": 1,
+                "pointSize": 11,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "from": "",
+                  "id": 1,
+                  "text": "ONLY_V2",
+                  "to": "",
+                  "type": 1,
+                  "value": "1"
+                },
+                {
+                  "from": "",
+                  "id": 2,
+                  "text": "ONLY_V3",
+                  "to": "",
+                  "type": 1,
+                  "value": "2"
+                },
+                {
+                  "from": "",
+                  "id": 3,
+                  "text": "MIX_MODE",
+                  "to": "",
+                  "type": 1,
+                  "value": "3"
+                },
+                {
+                  "from": "",
+                  "id": 4,
+                  "text": " ",
+                  "to": "",
+                  "type": 1,
+                  "value": "4"
+                },
+                {
+                  "from": "",
+                  "id": 5,
+                  "text": " ",
+                  "to": "",
+                  "type": 1,
+                  "value": "5"
+                }
+              ],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 14
+          },
+          "id": 126,
+          "links": [],
+          "options": {
+            "graph": {},
+            "legend": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "right"
+            },
+            "tooltipOptions": {
+              "mode": "multi"
+            }
+          },
+          "pluginVersion": "7.5.11",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "tiflash_system_current_metric_GlobalStorageRunMode{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}}-Global",
+              "refId": "A",
+              "step": 10
+            },
+            {
+              "exemplar": false,
+              "expr": "tiflash_system_current_metric_RegionPersisterRunMode{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{instance}}-KVStore",
+              "refId": "B"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Global Runmode",
+          "type": "timeseries"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "decimals": 1,
+          "description": "The StoragePool Runmode in DeltaMerge Storage",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "grid": {},
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 14
+          },
+          "hiddenSeries": false,
+          "id": 123,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.11",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(tiflash_system_current_metric_StoragePoolV2Only{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}}-OnlyV2",
+              "refId": "A",
+              "step": 10
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(tiflash_system_current_metric_StoragePoolV3Only{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{instance}}-OnlyV3",
+              "refId": "B"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(tiflash_system_current_metric_StoragePoolMixMode{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{instance}}-MixMode",
+              "refId": "C"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "StoragePool Runmode",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         }
       ],
-      "repeat": null,
-      "title": "Storage",
+      "title": "StoragePool",
       "type": "row"
     },
     {
@@ -5470,7 +5896,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 5
+        "y": 6
       },
       "id": 64,
       "panels": [
@@ -5481,7 +5907,7 @@
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
           "decimals": 1,
-          "description": "The throughput of write and  delta's background management",
+          "description": "The throughput of write and delta's background management",
           "fieldConfig": {
             "defaults": {},
             "overrides": []
@@ -5492,7 +5918,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 6
+            "y": 71
           },
           "height": "",
           "hiddenSeries": false,
@@ -5629,7 +6055,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 15
+            "y": 80
           },
           "hiddenSeries": false,
           "id": 62,
@@ -5741,7 +6167,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 23
+            "y": 88
           },
           "height": "",
           "hiddenSeries": false,
@@ -5863,7 +6289,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 32
+            "y": 97
           },
           "hiddenSeries": false,
           "id": 90,
@@ -5970,7 +6396,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 6
+        "y": 7
       },
       "id": 34,
       "panels": [
@@ -7453,7 +7879,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 7
+        "y": 8
       },
       "id": 95,
       "panels": [
@@ -7675,290 +8101,9 @@
       ],
       "title": "Rough Set Filter Rate Histogram",
       "type": "row"
-    },
-    {
-      "collapsed": true,
-      "datasource": null,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 8
-      },
-      "id": 119,
-      "panels": [
-        {
-          "datasource": "${DS_TEST-CLUSTER}",
-          "description": "The Global StoragePool and KVStore Runmode",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "axisSoftMax": 5,
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineStyle": {
-                  "fill": "solid"
-                },
-                "lineWidth": 1,
-                "pointSize": 11,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false
-              },
-              "decimals": 0,
-              "mappings": [
-                {
-                  "from": "",
-                  "id": 1,
-                  "text": "ONLY_V2",
-                  "to": "",
-                  "type": 1,
-                  "value": "1"
-                },
-                {
-                  "from": "",
-                  "id": 2,
-                  "text": "ONLY_V3",
-                  "to": "",
-                  "type": 1,
-                  "value": "2"
-                },
-                {
-                  "from": "",
-                  "id": 3,
-                  "text": "MIX_MODE",
-                  "to": "",
-                  "type": 1,
-                  "value": "3"
-                },
-                {
-                  "from": "",
-                  "id": 4,
-                  "text": " ",
-                  "to": "",
-                  "type": 1,
-                  "value": "4"
-                },
-                {
-                  "from": "",
-                  "id": 5,
-                  "text": " ",
-                  "to": "",
-                  "type": 1,
-                  "value": "5"
-                }
-              ],
-              "min": 0,
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "short"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 9
-          },
-          "id": 126,
-          "links": [],
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right"
-            },
-            "tooltipOptions": {
-              "mode": "multi"
-            }
-          },
-          "pluginVersion": "7.5.11",
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "tiflash_system_current_metric_GlobalStorageRunMode{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "{{instance}}-GlobalRunMode",
-              "refId": "A",
-              "step": 10
-            },
-            {
-              "exemplar": false,
-              "expr": "tiflash_system_current_metric_RegionPersisterRunMode{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "{{instance}}-KVStoreRunMode",
-              "refId": "B"
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Global Runmode",
-          "type": "timeseries"
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "${DS_TEST-CLUSTER}",
-          "decimals": 1,
-          "description": "The StoragePool Runmode in DeltaMerge Storage",
-          "editable": true,
-          "error": false,
-          "fieldConfig": {
-            "defaults": {},
-            "overrides": []
-          },
-          "fill": 0,
-          "fillGradient": 0,
-          "grid": {},
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 9
-          },
-          "hiddenSeries": false,
-          "id": 123,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sideWidth": null,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null as zero",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "7.5.11",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "sum(tiflash_system_current_metric_StoragePoolV2Only{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance)",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "{{instance}}-OnlyV2",
-              "refId": "A",
-              "step": 10
-            },
-            {
-              "exemplar": true,
-              "expr": "sum(tiflash_system_current_metric_StoragePoolV3Only{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance)",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "{{instance}}-OnlyV3",
-              "refId": "B"
-            },
-            {
-              "exemplar": true,
-              "expr": "sum(tiflash_system_current_metric_StoragePoolMixMode{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance)",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "{{instance}}-MixMode",
-              "refId": "C"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "StoragePool Runmode",
-          "tooltip": {
-            "msResolution": false,
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        }
-      ],
-      "title": "StoragePool",
-      "type": "row"
     }
   ],
-  "refresh": false,
+  "refresh": "30s",
   "schemaVersion": 27,
   "style": "dark",
   "tags": [],


### PR DESCRIPTION
Signed-off-by: JaySon-Huang <tshent@qq.com>

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/4922

Problem Summary: Report the file size, valid data size, file num of all PageStorage instances in a TiFlash node

### What is changed and how it works?

- Report the file size, valid data size, file num of all PageStorage instances in `AsynchronousMetrics::update`
- Show the file size, valid data size and file num in Grafana
- Move "PageStorage Blob Status" into "StoragePool"

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] No code
- [x] Manual test (add detailed scripts or steps below)
  - Deploy and run sysbench oltp_update_index workload
  - http://172.16.5.81:21510/d/5xovuGr7k/verify-tiflash-summary?orgId=1&from=1653629400000&to=1653632700000
  - ![image](https://user-images.githubusercontent.com/4865550/170656897-22f530c7-6f34-4c3b-abd5-c4034cd86612.png)

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
