### PR TITLE
Fix v3 can not find entry in mix mode.

### DIFF
--- a/dbms/src/Storages/Page/V3/tests/gtest_page_storage_mix_mode.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_page_storage_mix_mode.cpp
@@ -568,6 +568,80 @@ try
 }
 CATCH
 
+TEST_F(PageStorageMixedTest, ReadWithSnapshotAfterMergeDelta)
+try
+{
+    UInt64 tag = 0;
+    const size_t buf_sz = 1024;
+    char c_buff[buf_sz];
+    for (size_t i = 0; i < buf_sz; ++i)
+    {
+        c_buff[i] = i % 0xff;
+    }
+    {
+        WriteBatch batch;
+        ReadBufferPtr buff = std::make_shared<ReadBufferFromMemory>(c_buff, sizeof(c_buff));
+        batch.putPage(1, tag, buff, buf_sz);
+        buff = std::make_shared<ReadBufferFromMemory>(c_buff, sizeof(c_buff));
+        batch.putPage(2, tag, buff, buf_sz, {20, 120, 400, 200, 15, 75, 170, 24});
+        page_writer_v2->write(std::move(batch), nullptr);
+    }
+    ASSERT_EQ(reloadMixedStoragePool(), PageStorageRunMode::MIX_MODE);
+    const size_t buf_sz2 = 2048;
+    char c_buff2[buf_sz2] = {0};
+    {
+        WriteBatch batch;
+        ReadBufferPtr buff2 = std::make_shared<ReadBufferFromMemory>(c_buff2, sizeof(c_buff2));
+        batch.putPage(3, tag, buff2, buf_sz2);
+        page_writer_mix->write(std::move(batch), nullptr);
+    }
+    // Thread A create snapshot for read
+    auto snapshot_mix_before_merge_delta = page_reader_mix->getSnapshot("ReadWithSnapshotAfterMergeDelta");
+    {
+        auto page_reader_mix_with_snap = storage_pool_mix->newLogReader(nullptr, snapshot_mix_before_merge_delta);
+        const auto & page1 = page_reader_mix_with_snap.read(1);
+        const auto & page2 = page_reader_mix_with_snap.read(2);
+        const auto & page3 = page_reader_mix_with_snap.read(3);
+        ASSERT_PAGE_EQ(c_buff, buf_sz, page1, 1);
+        ASSERT_PAGE_EQ(c_buff, buf_sz, page2, 2);
+        ASSERT_PAGE_EQ(c_buff2, buf_sz2, page3, 3);
+    }
+    {
+        auto page_reader_mix_with_snap = storage_pool_mix->newLogReader(nullptr, true, "ReadWithSnapshotAfterMergeDelta");
+        const auto & page1 = page_reader_mix_with_snap.read(1);
+        const auto & page2 = page_reader_mix_with_snap.read(2);
+        const auto & page3 = page_reader_mix_with_snap.read(3);
+        ASSERT_PAGE_EQ(c_buff, buf_sz, page1, 1);
+        ASSERT_PAGE_EQ(c_buff, buf_sz, page2, 2);
+        ASSERT_PAGE_EQ(c_buff2, buf_sz2, page3, 3);
+    }
+    // Thread B apply merge delta, create page 4, and delete the origin page 1, 3
+    {
+        WriteBatch batch;
+        ReadBufferPtr buff2 = std::make_shared<ReadBufferFromMemory>(c_buff2, sizeof(c_buff2));
+        batch.putPage(4, tag, buff2, buf_sz2);
+        batch.delPage(1);
+        batch.delPage(3);
+        page_writer_mix->write(std::move(batch), nullptr);
+    }
+    // Thread A continue to read 1, 3
+    {
+        auto page_reader_mix_with_snap = storage_pool_mix->newLogReader(nullptr, snapshot_mix_before_merge_delta);
+        // read 1, 3 with snapshot, should be success
+        ASSERT_NO_THROW(page_reader_mix_with_snap.read(1));
+        ASSERT_NO_THROW(page_reader_mix_with_snap.read(3));
+        ASSERT_THROW(page_reader_mix_with_snap.read(4), DB::Exception);
+    }
+    {
+        // Revert v3
+        WriteBatch batch;
+        batch.delPage(3);
+        batch.delPage(4);
+        page_writer_mix->write(std::move(batch), nullptr);
+    }
+}
+CATCH
+
 
 } // namespace PS::V3::tests
 } // namespace DB

--- a/dbms/src/Storages/Page/V3/tests/gtest_page_storage_mix_mode.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_page_storage_mix_mode.cpp
@@ -627,8 +627,10 @@ try
     {
         auto page_reader_mix_with_snap = storage_pool_mix->newLogReader(nullptr, snapshot_mix_before_merge_delta);
         // read 1, 3 with snapshot, should be success
-        ASSERT_NO_THROW(page_reader_mix_with_snap.read(1));
-        ASSERT_NO_THROW(page_reader_mix_with_snap.read(3));
+        const auto & page1 = page_reader_mix_with_snap.read(1);
+        const auto & page3 = page_reader_mix_with_snap.read(3);
+        ASSERT_PAGE_EQ(c_buff, buf_sz, page1, 1);
+        ASSERT_PAGE_EQ(c_buff, buf_sz, page3, 3);
         ASSERT_THROW(page_reader_mix_with_snap.read(4), DB::Exception);
     }
     {

--- a/dbms/src/Storages/Page/V3/tests/gtest_page_storage_mix_mode.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_page_storage_mix_mode.cpp
@@ -630,7 +630,7 @@ try
         const auto & page1 = page_reader_mix_with_snap.read(1);
         const auto & page3 = page_reader_mix_with_snap.read(3);
         ASSERT_PAGE_EQ(c_buff, buf_sz, page1, 1);
-        ASSERT_PAGE_EQ(c_buff, buf_sz, page3, 3);
+        ASSERT_PAGE_EQ(c_buff2, buf_sz2, page3, 3);
         ASSERT_THROW(page_reader_mix_with_snap.read(4), DB::Exception);
     }
     {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #5000

Problem Summary:
This is caused by concurrent reading and merge delta under mix mode

* Assume that page 1000 stored in V2
* Thread A create snapshot `s0` (contains one V2 and one V3 snapshot) under mix mode for reading, containing page 1000
* Thread B applies merge delta and delete page 1000 to V3 (and also V2, doesn't matter for this case)
* Thread A continues to read page 1000 by snapshot `s0`, when it try to get 1000 from V3, it throws exception because v3 will find a deleted entry and throw an exception.

### What is changed and how it works?
- Allow not throw, if find a deleted page in V3.
- Then if we do find a deleted page in V3, PageWriter will find the page in V2 with a V2 snapshot.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
