### PR TITLE
Add mutex to protect exchange receiver's async client

### DIFF
--- a/dbms/src/Common/MyTime.cpp
+++ b/dbms/src/Common/MyTime.cpp
@@ -998,7 +998,7 @@ UInt64 calcSeconds(int year, int month, int day, int hour, int minute, int secon
         return 0;
     Int32 current_days = calcDayNum(year, month, day);
     return current_days * MyTimeBase::SECOND_IN_ONE_DAY + hour * MyTimeBase::SECOND_IN_ONE_HOUR
-            + minute * MyTimeBase::SECOND_IN_ONE_MINUTE + second;
+        + minute * MyTimeBase::SECOND_IN_ONE_MINUTE + second;
 }
 
 size_t maxFormattedDateTimeStringLength(const String & format)

--- a/dbms/src/Common/MyTime.cpp
+++ b/dbms/src/Common/MyTime.cpp
@@ -998,7 +998,7 @@ UInt64 calcSeconds(int year, int month, int day, int hour, int minute, int secon
         return 0;
     Int32 current_days = calcDayNum(year, month, day);
     return current_days * MyTimeBase::SECOND_IN_ONE_DAY + hour * MyTimeBase::SECOND_IN_ONE_HOUR
-        + minute * MyTimeBase::SECOND_IN_ONE_MINUTE + second;
+            + minute * MyTimeBase::SECOND_IN_ONE_MINUTE + second;
 }
 
 size_t maxFormattedDateTimeStringLength(const String & format)

--- a/dbms/src/Common/MyTime.h
+++ b/dbms/src/Common/MyTime.h
@@ -200,6 +200,9 @@ void fromDayNum(MyDateTime & t, int day_num);
 // returns seconds since '0000-00-00'
 UInt64 calcSeconds(int year, int month, int day, int hour, int minute, int second);
 
+// returns seconds since '0000-00-00'
+UInt64 calcSeconds(int year, int month, int day, int hour, int minute, int second);
+
 size_t maxFormattedDateTimeStringLength(const String & format);
 
 inline time_t getEpochSecond(const MyDateTime & my_time, const DateLUTImpl & time_zone)

--- a/dbms/src/Flash/Mpp/ExchangeReceiver.cpp
+++ b/dbms/src/Flash/Mpp/ExchangeReceiver.cpp
@@ -92,10 +92,14 @@ public:
         switch (stage)
         {
         case AsyncRequestStage::WAIT_MAKE_READER:
+        {
+            // Use lock to ensure reader is created already in reactor thread
+	    std::unique_lock lock(mu);
             if (!ok)
                 reader.reset();
             notifyReactor();
             break;
+        }
         case AsyncRequestStage::WAIT_BATCH_READ:
             if (ok)
                 ++read_packet_index;
@@ -227,6 +231,8 @@ private:
     void start()
     {
         stage = AsyncRequestStage::WAIT_MAKE_READER;
+        // Use lock to ensure async reader is unreachable from grpc thread before this function returns
+        std::unique_lock lock(mu);	
         rpc_context->makeAsyncReader(*request, reader, thisAsUnaryCallback());
     }
 
@@ -283,6 +289,7 @@ private:
     size_t read_packet_index = 0;
     Status finish_status = RPCContext::getStatusOK();
     LoggerPtr log;
+    std::mutex mu;
 };
 } // namespace
 
@@ -393,10 +400,10 @@ void ExchangeReceiverBase<RPCContext>::reactor(const std::vector<Request> & asyn
     MPMCQueue<AsyncHandler *> ready_requests(alive_async_connections * 2);
     std::vector<AsyncHandler *> waiting_for_retry_requests;
 
-    std::vector<AsyncRequestHandler<RPCContext>> handlers;
+    std::vector<AsyncHandler *> handlers;
     handlers.reserve(alive_async_connections);
     for (const auto & req : async_requests)
-        handlers.emplace_back(&ready_requests, &msg_channel, rpc_context, req, exc_log->identifier());
+        handlers.emplace_back(new AsyncHandler(&ready_requests, &msg_channel, rpc_context, req, exc_log->identifier()));
 
     while (alive_async_connections > 0)
     {
@@ -437,6 +444,11 @@ void ExchangeReceiverBase<RPCContext>::reactor(const std::vector<Request> & asyn
             }
             waiting_for_retry_requests.swap(tmp);
         }
+    }
+    for (auto handler : handlers)
+    {
+        if (handler)
+            delete handler;
     }
 }
 

--- a/dbms/src/Functions/FunctionsDateTime.cpp
+++ b/dbms/src/Functions/FunctionsDateTime.cpp
@@ -254,7 +254,6 @@ void registerFunctionsDateTime(FunctionFactory & factory)
     factory.registerFunction<FunctionToTiDBToSeconds>();
     factory.registerFunction<FunctionToTiDBToDays>();
     factory.registerFunction<FunctionTiDBFromDays>();
-
     factory.registerFunction<FunctionToTimeZone>();
     factory.registerFunction<FunctionToLastDay>();
 }

--- a/dbms/src/Functions/FunctionsDateTime.h
+++ b/dbms/src/Functions/FunctionsDateTime.h
@@ -3450,7 +3450,6 @@ using FunctionToTiDBDayOfYear = FunctionMyDateOrMyDateTimeToSomething<DataTypeUI
 using FunctionToTiDBWeekOfYear = FunctionMyDateOrMyDateTimeToSomething<DataTypeUInt16, TiDBWeekOfYearTransformerImpl, return_nullable>;
 using FunctionToTiDBToSeconds = FunctionMyDateOrMyDateTimeToSomething<DataTypeUInt64, TiDBToSecondsTransformerImpl, return_nullable>;
 using FunctionToTiDBToDays = FunctionMyDateOrMyDateTimeToSomething<DataTypeUInt32, TiDBToDaysTransformerImpl, return_nullable>;
-
 using FunctionToRelativeYearNum = FunctionDateOrDateTimeToSomething<DataTypeUInt16, ToRelativeYearNumImpl>;
 using FunctionToRelativeQuarterNum = FunctionDateOrDateTimeToSomething<DataTypeUInt32, ToRelativeQuarterNumImpl>;
 using FunctionToRelativeMonthNum = FunctionDateOrDateTimeToSomething<DataTypeUInt32, ToRelativeMonthNumImpl>;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #4977

Problem Summary:

### What is changed and how it works?
For ExchangeReceiver's async client mode,  AsyncRequestHandler instance is used to handle async client request and rsp. And it is shared between grpc and reactor thread. However, when handler is creating, there is a little chance that grpc thread get the instance before the creation is completed. So there is chance that #4977 would happen. 
Now this is noticed only when makeAsyncReader failed and retried.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
