### PR TITLE
refine get type from decimal literal

### DIFF
--- a/dbms/src/Common/Decimal.h
+++ b/dbms/src/Common/Decimal.h
@@ -307,31 +307,6 @@ using Decimal128 = Decimal<Int128>;
 using Decimal256 = Decimal<Int256>;
 
 template <typename T>
-constexpr PrecType minDecimalPrecision()
-{
-    return 1;
-}
-template <>
-constexpr PrecType minDecimalPrecision<Decimal32>()
-{
-    return 1;
-}
-template <>
-constexpr PrecType minDecimalPrecision<Decimal64>()
-{
-    return 10;
-}
-template <>
-constexpr PrecType minDecimalPrecision<Decimal128>()
-{
-    return 19;
-}
-template <>
-constexpr PrecType minDecimalPrecision<Decimal256>()
-{
-    return 39;
-}
-template <typename T>
 static constexpr PrecType maxDecimalPrecision()
 {
     return 0;
@@ -355,6 +330,33 @@ template <>
 constexpr PrecType maxDecimalPrecision<Decimal256>()
 {
     return 65;
+}
+
+template <typename T>
+constexpr PrecType minDecimalPrecision()
+{
+    /// return a invalid value
+    return maxDecimalPrecision<Decimal256>() + 1;
+}
+template <>
+constexpr PrecType minDecimalPrecision<Decimal32>()
+{
+    return 1;
+}
+template <>
+constexpr PrecType minDecimalPrecision<Decimal64>()
+{
+    return maxDecimalPrecision<Decimal32>() + 1;
+}
+template <>
+constexpr PrecType minDecimalPrecision<Decimal128>()
+{
+    return maxDecimalPrecision<Decimal64>() + 1;
+}
+template <>
+constexpr PrecType minDecimalPrecision<Decimal256>()
+{
+    return maxDecimalPrecision<Decimal128>() + 1;
 }
 
 template <typename T>

--- a/dbms/src/Common/Decimal.h
+++ b/dbms/src/Common/Decimal.h
@@ -306,9 +306,30 @@ using Decimal64 = Decimal<Int64>;
 using Decimal128 = Decimal<Int128>;
 using Decimal256 = Decimal<Int256>;
 
-static constexpr PrecType minDecimalPrecision()
+template <typename T>
+constexpr PrecType minDecimalPrecision()
 {
     return 1;
+}
+template <>
+constexpr PrecType minDecimalPrecision<Decimal32>()
+{
+    return 1;
+}
+template <>
+constexpr PrecType minDecimalPrecision<Decimal64>()
+{
+    return 10;
+}
+template <>
+constexpr PrecType minDecimalPrecision<Decimal128>()
+{
+    return 19;
+}
+template <>
+constexpr PrecType minDecimalPrecision<Decimal256>()
+{
+    return 39;
 }
 template <typename T>
 static constexpr PrecType maxDecimalPrecision()

--- a/dbms/src/Core/Field.h
+++ b/dbms/src/Core/Field.h
@@ -122,7 +122,20 @@ public:
         }
         if (cnt == 0)
             cnt = 1;
-        return cnt;
+        return std::max(cnt, scale);
+    }
+
+    /// In TiFlash there are 4 subtype of decimal:
+    /// Decimal32, Decimal64, Decimal128 and Decimal256
+    /// they are not compatible with each other. So a DecimalField<Decimal32>
+    /// can not be inserted into a decimal column with DecimalType<Decimal64>
+    /// getPrecWithCurrentDecimalType will return the prec that fit
+    /// current decimal type, that is to say, current DecimalField can be
+    /// inserted into a decimal column with type `Decimal(getPrecWithCurrentDecimalType, getScale)`
+    UInt32 getPrecWithCurrentDecimalType() const
+    {
+        auto raw_prec = getPrec();
+        return std::max(raw_prec, minDecimalPrecision<T>());
     }
 
     template <typename U>

--- a/dbms/src/DataTypes/DataTypeDecimal.h
+++ b/dbms/src/DataTypes/DataTypeDecimal.h
@@ -192,7 +192,7 @@ using DataTypeDecimal256 = DataTypeDecimal<Decimal256>;
 
 inline DataTypePtr createDecimal(UInt64 prec, UInt64 scale)
 {
-    if (prec < minDecimalPrecision() || prec > maxDecimalPrecision<Decimal256>())
+    if (prec < minDecimalPrecision<Decimal32>() || prec > maxDecimalPrecision<Decimal256>())
         throw Exception("Wrong precision:" + DB::toString(prec), ErrorCodes::ARGUMENT_OUT_OF_BOUND);
 
     if (static_cast<UInt64>(scale) > prec)

--- a/dbms/src/DataTypes/FieldToDataType.h
+++ b/dbms/src/DataTypes/FieldToDataType.h
@@ -40,8 +40,7 @@ public:
     template <typename T>
     DataTypePtr operator()(const DecimalField<T> & x) const
     {
-        PrecType prec = maxDecimalPrecision<T>();
-        return std::make_shared<DataTypeDecimal<T>>(prec, x.getScale());
+        return std::make_shared<DataTypeDecimal<T>>(x.getPrecWithCurrentDecimalType(), x.getScale());
     }
 };
 

--- a/dbms/src/DataTypes/tests/gtest_decimal_literal_datatype.cpp
+++ b/dbms/src/DataTypes/tests/gtest_decimal_literal_datatype.cpp
@@ -1,0 +1,89 @@
+// Copyright 2022 PingCAP, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <DataTypes/DataTypeFactory.h>
+#include <DataTypes/FieldToDataType.h>
+#include <TestUtils/TiFlashTestBasic.h>
+
+namespace DB
+{
+namespace tests
+{
+TEST(DecimalLiteralDataTypeTest, getPrec)
+try
+{
+    ASSERT_TRUE(DecimalField<Decimal32>(0, 0).getPrec() == 1);
+    ASSERT_TRUE(DecimalField<Decimal32>(0, 1).getPrec() == 1);
+    ASSERT_TRUE(DecimalField<Decimal32>(0, 2).getPrec() == 2);
+    ASSERT_TRUE(DecimalField<Decimal32>(123, 0).getPrec() == 3);
+    ASSERT_TRUE(DecimalField<Decimal32>(123, 2).getPrec() == 3);
+    ASSERT_TRUE(DecimalField<Decimal32>(123, 4).getPrec() == 4);
+
+    ASSERT_TRUE(DecimalField<Decimal64>(0, 0).getPrec() == 1);
+    ASSERT_TRUE(DecimalField<Decimal64>(0, 1).getPrec() == 1);
+    ASSERT_TRUE(DecimalField<Decimal64>(0, 2).getPrec() == 2);
+    ASSERT_TRUE(DecimalField<Decimal64>(123, 0).getPrec() == 3);
+    ASSERT_TRUE(DecimalField<Decimal64>(123, 2).getPrec() == 3);
+    ASSERT_TRUE(DecimalField<Decimal64>(123, 4).getPrec() == 4);
+
+    ASSERT_TRUE(DecimalField<Decimal128>(0, 0).getPrec() == 1);
+    ASSERT_TRUE(DecimalField<Decimal128>(0, 1).getPrec() == 1);
+    ASSERT_TRUE(DecimalField<Decimal128>(0, 2).getPrec() == 2);
+    ASSERT_TRUE(DecimalField<Decimal128>(123, 0).getPrec() == 3);
+    ASSERT_TRUE(DecimalField<Decimal128>(123, 2).getPrec() == 3);
+    ASSERT_TRUE(DecimalField<Decimal128>(123, 4).getPrec() == 4);
+
+    ASSERT_TRUE(DecimalField<Decimal256>(Int256(0), 0).getPrec() == 1);
+    ASSERT_TRUE(DecimalField<Decimal256>(Int256(0), 1).getPrec() == 1);
+    ASSERT_TRUE(DecimalField<Decimal256>(Int256(0), 2).getPrec() == 2);
+    ASSERT_TRUE(DecimalField<Decimal256>(Int256(123), 0).getPrec() == 3);
+    ASSERT_TRUE(DecimalField<Decimal256>(Int256(123), 2).getPrec() == 3);
+    ASSERT_TRUE(DecimalField<Decimal256>(Int256(123), 4).getPrec() == 4);
+}
+CATCH
+
+TEST(DecimalLiteralDataTypeTest, fieldToDataType)
+try
+{
+    ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(1,0)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal32>(0, 0)))));
+    ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(1,1)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal32>(0, 1)))));
+    ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(2,2)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal32>(0, 2)))));
+    ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(3,0)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal32>(123, 0)))));
+    ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(3,2)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal32>(123, 2)))));
+    ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(4,4)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal32>(123, 4)))));
+
+    ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(10,0)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal64>(0, 0)))));
+    ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(10,1)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal64>(0, 1)))));
+    ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(10,2)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal64>(0, 2)))));
+    ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(10,0)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal64>(123, 0)))));
+    ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(10,2)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal64>(123, 2)))));
+    ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(13,4)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal64>(1234567891011ll, 4)))));
+
+    ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(19,0)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal128>(0, 0)))));
+    ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(19,1)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal128>(0, 1)))));
+    ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(19,2)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal128>(0, 2)))));
+    ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(19,0)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal128>(123, 0)))));
+    ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(19,2)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal128>(123, 2)))));
+    ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(21,4)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal128>(Int128(123123123123123ll) * 1000000, 4)))));
+
+    ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(39,0)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal256>(Int256(0), 0)))));
+    ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(39,1)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal256>(Int256(0), 1)))));
+    ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(39,2)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal256>(Int256(0), 2)))));
+    ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(39,0)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal256>(Int256(123), 0)))));
+    ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(39,2)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal256>(Int256(123), 2)))));
+    ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(41,4)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal256>(Int256(123123123123123123ll) * Int256(1000000000ll) * Int256(100000000000000ll), 4)))));
+}
+CATCH
+} // namespace tests
+} // namespace DB

--- a/dbms/src/DataTypes/tests/gtest_decimal_literal_datatype.cpp
+++ b/dbms/src/DataTypes/tests/gtest_decimal_literal_datatype.cpp
@@ -36,6 +36,7 @@ try
     ASSERT_TRUE(DecimalField<Decimal64>(123, 0).getPrec() == 3);
     ASSERT_TRUE(DecimalField<Decimal64>(123, 2).getPrec() == 3);
     ASSERT_TRUE(DecimalField<Decimal64>(123, 4).getPrec() == 4);
+    ASSERT_TRUE(DecimalField<Decimal64>(1234567891011ll, 4).getPrec() == 13);
 
     ASSERT_TRUE(DecimalField<Decimal128>(0, 0).getPrec() == 1);
     ASSERT_TRUE(DecimalField<Decimal128>(0, 1).getPrec() == 1);
@@ -43,6 +44,7 @@ try
     ASSERT_TRUE(DecimalField<Decimal128>(123, 0).getPrec() == 3);
     ASSERT_TRUE(DecimalField<Decimal128>(123, 2).getPrec() == 3);
     ASSERT_TRUE(DecimalField<Decimal128>(123, 4).getPrec() == 4);
+    ASSERT_TRUE(DecimalField<Decimal128>(Int128(123123123123123ll) * 1000000, 4).getPrec() == 21);
 
     ASSERT_TRUE(DecimalField<Decimal256>(Int256(0), 0).getPrec() == 1);
     ASSERT_TRUE(DecimalField<Decimal256>(Int256(0), 1).getPrec() == 1);
@@ -50,6 +52,7 @@ try
     ASSERT_TRUE(DecimalField<Decimal256>(Int256(123), 0).getPrec() == 3);
     ASSERT_TRUE(DecimalField<Decimal256>(Int256(123), 2).getPrec() == 3);
     ASSERT_TRUE(DecimalField<Decimal256>(Int256(123), 4).getPrec() == 4);
+    ASSERT_TRUE(DecimalField<Decimal256>(Int256(123123123123123123ll) * Int256(1000000000ll) * Int256(100000000000000ll), 4).getPrec() == 41);
 }
 CATCH
 

--- a/dbms/src/DataTypes/tests/gtest_decimal_literal_datatype.cpp
+++ b/dbms/src/DataTypes/tests/gtest_decimal_literal_datatype.cpp
@@ -23,6 +23,7 @@ namespace tests
 TEST(DecimalLiteralDataTypeTest, getPrec)
 try
 {
+    /// Decimal32
     ASSERT_TRUE(DecimalField<Decimal32>(0, 0).getPrec() == 1);
     ASSERT_TRUE(DecimalField<Decimal32>(0, 1).getPrec() == 1);
     ASSERT_TRUE(DecimalField<Decimal32>(0, 2).getPrec() == 2);
@@ -30,6 +31,7 @@ try
     ASSERT_TRUE(DecimalField<Decimal32>(123, 2).getPrec() == 3);
     ASSERT_TRUE(DecimalField<Decimal32>(123, 4).getPrec() == 4);
 
+    /// Decimal64
     ASSERT_TRUE(DecimalField<Decimal64>(0, 0).getPrec() == 1);
     ASSERT_TRUE(DecimalField<Decimal64>(0, 1).getPrec() == 1);
     ASSERT_TRUE(DecimalField<Decimal64>(0, 2).getPrec() == 2);
@@ -38,6 +40,7 @@ try
     ASSERT_TRUE(DecimalField<Decimal64>(123, 4).getPrec() == 4);
     ASSERT_TRUE(DecimalField<Decimal64>(1234567891011ll, 4).getPrec() == 13);
 
+    /// Decimal128
     ASSERT_TRUE(DecimalField<Decimal128>(0, 0).getPrec() == 1);
     ASSERT_TRUE(DecimalField<Decimal128>(0, 1).getPrec() == 1);
     ASSERT_TRUE(DecimalField<Decimal128>(0, 2).getPrec() == 2);
@@ -46,6 +49,7 @@ try
     ASSERT_TRUE(DecimalField<Decimal128>(123, 4).getPrec() == 4);
     ASSERT_TRUE(DecimalField<Decimal128>(Int128(123123123123123ll) * 1000000, 4).getPrec() == 21);
 
+    /// Decimal256
     ASSERT_TRUE(DecimalField<Decimal256>(Int256(0), 0).getPrec() == 1);
     ASSERT_TRUE(DecimalField<Decimal256>(Int256(0), 1).getPrec() == 1);
     ASSERT_TRUE(DecimalField<Decimal256>(Int256(0), 2).getPrec() == 2);
@@ -59,6 +63,7 @@ CATCH
 TEST(DecimalLiteralDataTypeTest, fieldToDataType)
 try
 {
+    /// Decimal32
     ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(1,0)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal32>(0, 0)))));
     ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(1,1)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal32>(0, 1)))));
     ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(2,2)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal32>(0, 2)))));
@@ -66,6 +71,7 @@ try
     ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(3,2)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal32>(123, 2)))));
     ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(4,4)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal32>(123, 4)))));
 
+    /// Decimal64
     ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(10,0)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal64>(0, 0)))));
     ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(10,1)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal64>(0, 1)))));
     ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(10,2)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal64>(0, 2)))));
@@ -73,6 +79,7 @@ try
     ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(10,2)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal64>(123, 2)))));
     ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(13,4)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal64>(1234567891011ll, 4)))));
 
+    /// Decimal128
     ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(19,0)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal128>(0, 0)))));
     ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(19,1)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal128>(0, 1)))));
     ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(19,2)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal128>(0, 2)))));
@@ -80,6 +87,7 @@ try
     ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(19,2)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal128>(123, 2)))));
     ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(21,4)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal128>(Int128(123123123123123ll) * 1000000, 4)))));
 
+    /// Decimal256
     ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(39,0)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal256>(Int256(0), 0)))));
     ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(39,1)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal256>(Int256(0), 1)))));
     ASSERT_TRUE(DataTypeFactory::instance().get("Decimal(39,2)")->equals(*applyVisitor(FieldToDataType(), Field(DecimalField<Decimal256>(Int256(0), 2)))));


### PR DESCRIPTION
Signed-off-by: xufei <xufeixw@mail.ustc.edu.cn>

### What problem does this PR solve?

Issue Number: close #5007

Problem Summary:
As the issue described.
### What is changed and how it works?
1. DecimalField::getPrec() ensures that the returned precision is not less than decimal's scale
2. `FieldToDataType` will return a more precise type for DecimalField
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
