### PR TITLE
Optimize blobstore gc when current stat total size is 0

### DIFF
--- a/dbms/src/Storages/Page/V3/BlobStore.cpp
+++ b/dbms/src/Storages/Page/V3/BlobStore.cpp
@@ -919,7 +919,7 @@ std::vector<BlobFileId> BlobStore::getGCStats()
                 // If current blob empty, the size of in disk blob may not empty
                 // So we need truncate current blob, and let it be reused.
                 auto blobfile = getBlobFile(stat->id);
-                LOG_FMT_TRACE(log, "Truncate empty blob file [blob_id={}] to 0.", stat->id, stat->sm_total_size, right_margin);
+                LOG_FMT_TRACE(log, "Truncate empty blob file [blob_id={}] to 0.", stat->id);
                 blobfile->truncate(right_margin);
                 blobstore_gc_info.appendToTruncatedBlob(stat->id, stat->sm_valid_rate);
                 continue;

--- a/dbms/src/Storages/Page/V3/BlobStore.cpp
+++ b/dbms/src/Storages/Page/V3/BlobStore.cpp
@@ -1475,7 +1475,7 @@ void BlobStore::BlobStats::BlobStat::recalculateSpaceMap()
     const auto & [total_size, valid_size] = smap->getSizes();
     sm_total_size = total_size;
     sm_valid_size = valid_size;
-    sm_valid_rate = total_size == 0 ? 0 : valid_size * 1.0 / total_size;
+    sm_valid_rate = total_size == 0 ? 0.0 : valid_size * 1.0 / total_size;
     recalculateCapacity();
 }
 

--- a/dbms/src/Storages/Page/V3/BlobStore.cpp
+++ b/dbms/src/Storages/Page/V3/BlobStore.cpp
@@ -920,7 +920,7 @@ std::vector<BlobFileId> BlobStore::getGCStats()
                 // So we need truncate current blob, and let it be reused.
                 auto blobfile = getBlobFile(stat->id);
                 LOG_FMT_TRACE(log, "Truncate empty blob file [blob_id={}] to 0.", stat->id, stat->sm_total_size, right_margin);
-                blobfile->truncate(0);
+                blobfile->truncate(right_margin);
                 blobstore_gc_info.appendToTruncatedBlob(stat->id, stat->sm_valid_rate);
                 continue;
             }

--- a/dbms/src/Storages/Page/V3/BlobStore.cpp
+++ b/dbms/src/Storages/Page/V3/BlobStore.cpp
@@ -914,8 +914,16 @@ std::vector<BlobFileId> BlobStore::getGCStats()
             // Avoid divide by zero
             if (right_margin == 0)
             {
-                assert(stat->sm_valid_rate == 0);
+                if (stat->sm_valid_rate == 0)
+                {
+                    throw Exception(fmt::format("Current blob is empty, but valid rate is not 0. [blob_id={}][valid_size={}][valid_rate={}]",
+                                                stat->id,
+                                                stat->sm_valid_size,
+                                                stat->sm_valid_rate));
+                }
+
                 LOG_FMT_TRACE(log, "Current blob is empty [blob_id={}, total size(all invalid)={}] [valid_rate={}].", stat->id, stat->sm_total_size, stat->sm_valid_rate);
+
                 // If current blob empty, the size of in disk blob may not empty
                 // So we need truncate current blob, and let it be reused.
                 auto blobfile = getBlobFile(stat->id);

--- a/dbms/src/Storages/Page/V3/BlobStore.cpp
+++ b/dbms/src/Storages/Page/V3/BlobStore.cpp
@@ -914,7 +914,7 @@ std::vector<BlobFileId> BlobStore::getGCStats()
             // Avoid divide by zero
             if (right_margin == 0)
             {
-                if (unlikely(stat->sm_valid_rate == 0))
+                if (unlikely(stat->sm_valid_rate != 0))
                 {
                     throw Exception(fmt::format("Current blob is empty, but valid rate is not 0. [blob_id={}][valid_size={}][valid_rate={}]",
                                                 stat->id,

--- a/dbms/src/Storages/Page/V3/BlobStore.cpp
+++ b/dbms/src/Storages/Page/V3/BlobStore.cpp
@@ -914,7 +914,7 @@ std::vector<BlobFileId> BlobStore::getGCStats()
             // Avoid divide by zero
             if (right_margin == 0)
             {
-                if (stat->sm_valid_rate == 0)
+                if (unlikely(stat->sm_valid_rate == 0))
                 {
                     throw Exception(fmt::format("Current blob is empty, but valid rate is not 0. [blob_id={}][valid_size={}][valid_rate={}]",
                                                 stat->id,

--- a/dbms/src/Storages/Page/V3/BlobStore.h
+++ b/dbms/src/Storages/Page/V3/BlobStore.h
@@ -107,7 +107,7 @@ public:
             UInt64 sm_max_caps = 0;
             UInt64 sm_total_size = 0;
             UInt64 sm_valid_size = 0;
-            double sm_valid_rate = 0;
+            double sm_valid_rate = 0.0;
 
         public:
             BlobStat(BlobFileId id_, SpaceMap::SpaceMapType sm_type, UInt64 sm_max_caps_, BlobStatType type_ = BlobStatType::NORMAL)

--- a/dbms/src/Storages/Page/V3/BlobStore.h
+++ b/dbms/src/Storages/Page/V3/BlobStore.h
@@ -107,7 +107,7 @@ public:
             UInt64 sm_max_caps = 0;
             UInt64 sm_total_size = 0;
             UInt64 sm_valid_size = 0;
-            double sm_valid_rate = 1.0;
+            double sm_valid_rate = 0;
 
         public:
             BlobStat(BlobFileId id_, SpaceMap::SpaceMapType sm_type, UInt64 sm_max_caps_, BlobStatType type_ = BlobStatType::NORMAL)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #5016

Problem Summary:
- After `restore`,  the size of `snapshot` will be 0, Then some of the total size from blobstat will get 0.
- But the blob file size in disk may not be 0.

### What is changed and how it works?
- Truncate the blob file size.
- Also update valid rate to 0 is total size is 0.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
