### PR TITLE
move `tunnel_map` to MPPTunnelSet

### DIFF
--- a/dbms/src/Flash/Mpp/MPPTask.cpp
+++ b/dbms/src/Flash/Mpp/MPPTask.cpp
@@ -78,18 +78,14 @@ MPPTask::~MPPTask()
 
 void MPPTask::closeAllTunnels(const String & reason)
 {
-    for (auto & it : tunnel_map)
-    {
-        it.second->close(reason);
-    }
+    if (likely(tunnel_set))
+        tunnel_set->close(reason);
 }
 
 void MPPTask::finishWrite()
 {
-    for (const auto & it : tunnel_map)
-    {
-        it.second->writeDone();
-    }
+    RUNTIME_ASSERT(tunnel_set != nullptr, log, "mpp task without tunnel set");
+    tunnel_set->finishWrite();
 }
 
 void MPPTask::run()
@@ -97,15 +93,13 @@ void MPPTask::run()
     newThreadManager()->scheduleThenDetach(true, "MPPTask", [self = shared_from_this()] { self->runImpl(); });
 }
 
-void MPPTask::registerTunnel(const MPPTaskId & id, MPPTunnelPtr tunnel)
+void MPPTask::registerTunnel(const MPPTaskId & task_id, MPPTunnelPtr tunnel)
 {
     if (status == CANCELLED)
         throw Exception("the tunnel " + tunnel->id() + " can not been registered, because the task is cancelled");
 
-    if (tunnel_map.find(id) != tunnel_map.end())
-        throw Exception("the tunnel " + tunnel->id() + " has been registered");
-
-    tunnel_map[id] = tunnel;
+    RUNTIME_ASSERT(tunnel_set != nullptr, log, "mpp task without tunnel set");
+    tunnel_set->registerTunnel(task_id, tunnel);
 }
 
 std::pair<MPPTunnelPtr, String> MPPTask::getTunnel(const ::mpp::EstablishMPPConnectionRequest * request)
@@ -120,8 +114,9 @@ std::pair<MPPTunnelPtr, String> MPPTask::getTunnel(const ::mpp::EstablishMPPConn
     }
 
     MPPTaskId receiver_id{request->receiver_meta().start_ts(), request->receiver_meta().task_id()};
-    auto it = tunnel_map.find(receiver_id);
-    if (it == tunnel_map.end())
+    RUNTIME_ASSERT(tunnel_set != nullptr, log, "mpp task without tunnel set");
+    auto tunnel_ptr = tunnel_set->getTunnelById(receiver_id);
+    if (tunnel_ptr == nullptr)
     {
         auto err_msg = fmt::format(
             "can't find tunnel ({} + {})",
@@ -129,7 +124,7 @@ std::pair<MPPTunnelPtr, String> MPPTask::getTunnel(const ::mpp::EstablishMPPConn
             request->receiver_meta().task_id());
         return {nullptr, err_msg};
     }
-    return {it->second, ""};
+    return {tunnel_ptr, ""};
 }
 
 void MPPTask::unregisterTask()
@@ -211,7 +206,7 @@ void MPPTask::prepare(const mpp::DispatchTaskRequest & task_request)
     }
 
     // register tunnels
-    tunnel_set = std::make_shared<MPPTunnelSet>();
+    tunnel_set = std::make_shared<MPPTunnelSet>(log->identifier());
     std::chrono::seconds timeout(task_request.timeout());
 
     for (int i = 0; i < exchange_sender.encoded_task_meta_size(); i++)
@@ -225,7 +220,6 @@ void MPPTask::prepare(const mpp::DispatchTaskRequest & task_request)
         MPPTunnelPtr tunnel = std::make_shared<MPPTunnel>(task_meta, task_request.meta(), timeout, context->getSettingsRef().max_threads, is_local, is_async, log->identifier());
         LOG_FMT_DEBUG(log, "begin to register the tunnel {}", tunnel->id());
         registerTunnel(MPPTaskId{task_meta.start_ts(), task_meta.task_id()}, tunnel);
-        tunnel_set->addTunnel(tunnel);
         if (!dag_context->isRootMPPTask())
         {
             FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::exception_during_mpp_register_tunnel_for_non_root_mpp_task);
@@ -369,19 +363,8 @@ void MPPTask::runImpl()
 
 void MPPTask::writeErrToAllTunnels(const String & e)
 {
-    for (auto & it : tunnel_map)
-    {
-        try
-        {
-            FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::exception_during_mpp_write_err_to_tunnel);
-            it.second->write(getPacketWithError(e), true);
-        }
-        catch (...)
-        {
-            it.second->close("Failed to write error msg to tunnel");
-            tryLogCurrentException(log, "Failed to write error " + e + " to tunnel: " + it.second->id());
-        }
-    }
+    RUNTIME_ASSERT(tunnel_set != nullptr, log, "mpp task without tunnel set");
+    tunnel_set->writeError(e);
 }
 
 void MPPTask::cancel(const String & reason)

--- a/dbms/src/Flash/Mpp/MPPTask.cpp
+++ b/dbms/src/Flash/Mpp/MPPTask.cpp
@@ -56,6 +56,7 @@ MPPTask::MPPTask(const mpp::TaskMeta & meta_, const ContextPtr & context_)
     , id(meta.start_ts(), meta.task_id())
     , log(Logger::get("MPPTask", id.toString()))
     , mpp_task_statistics(id, meta.address())
+    , needed_threads(0)
     , schedule_state(ScheduleState::WAITING)
 {}
 

--- a/dbms/src/Flash/Mpp/MPPTask.h
+++ b/dbms/src/Flash/Mpp/MPPTask.h
@@ -123,9 +123,6 @@ private:
 
     MPPTunnelSetPtr tunnel_set;
 
-    // which targeted task we should send data by which tunnel.
-    std::unordered_map<MPPTaskId, MPPTunnelPtr> tunnel_map;
-
     MPPTaskManager * manager = nullptr;
 
     const LoggerPtr log;

--- a/dbms/src/Flash/Mpp/MPPTunnelSet.cpp
+++ b/dbms/src/Flash/Mpp/MPPTunnelSet.cpp
@@ -126,9 +126,23 @@ void MPPTunnelSetBase<Tunnel>::writeError(const String & msg)
         }
         catch (...)
         {
-            tryLogCurrentException(log, "Failed to write error " + msg + " to tunnel: " + tunnel->id());
             tunnel->close("Failed to write error msg to tunnel");
+            tryLogCurrentException(log, "Failed to write error " + msg + " to tunnel: " + tunnel->id());
         }
+    }
+}
+
+template <typename Tunnel>
+void MPPTunnelSetBase<Tunnel>::registerTunnel(const MPPTaskId & id, const TunnelPtr & tunnel)
+{
+    if (id_to_index_map.find(id) != id_to_index_map.end())
+        throw Exception("the tunnel " + tunnel->id() + " has been registered");
+
+    id_to_index_map[id] = tunnels.size();
+    tunnels.push_back(tunnel);
+    if (!tunnel->isLocal())
+    {
+        remote_tunnel_cnt++;
     }
 }
 

--- a/dbms/src/Flash/Mpp/MPPTunnelSet.h
+++ b/dbms/src/Flash/Mpp/MPPTunnelSet.h
@@ -57,22 +57,11 @@ public:
     void writeError(const String & msg);
     void close(const String & reason);
     void finishWrite();
+    void registerTunnel(const MPPTaskId & id, const TunnelPtr & tunnel);
+
     TunnelPtr getTunnelById(const MPPTaskId & id);
 
     uint16_t getPartitionNum() const { return tunnels.size(); }
-
-    void registerTunnel(const MPPTaskId & id, const TunnelPtr & tunnel)
-    {
-        if (id_to_index_map.find(id) != id_to_index_map.end())
-            throw Exception("the tunnel " + tunnel->id() + " has been registered");
-
-        id_to_index_map[id] = tunnels.size();
-        tunnels.push_back(tunnel);
-        if (!tunnel->isLocal())
-        {
-            remote_tunnel_cnt++;
-        }
-    }
 
     int getRemoteTunnelCnt()
     {

--- a/dbms/src/Flash/Mpp/MPPTunnelSet.h
+++ b/dbms/src/Flash/Mpp/MPPTunnelSet.h
@@ -33,7 +33,7 @@ class MPPTunnelSetBase : private boost::noncopyable
 {
 public:
     using TunnelPtr = std::shared_ptr<Tunnel>;
-    MPPTunnelSetBase(const String & req_id)
+    explicit MPPTunnelSetBase(const String & req_id)
         : log(Logger::get("MPPTunnelSet", req_id))
     {}
 


### PR DESCRIPTION
Signed-off-by: xufei <xufeixw@mail.ustc.edu.cn>

### What problem does this PR solve?

Issue Number: ref #5095

Problem Summary:

Currently, there 2 tunnel related components in `MPPTask`
- [tunnel_set](https://github.com/pingcap/tiflash/blob/1e3207d3794d8870fc8afad895017191851e4cca/dbms/src/Flash/Mpp/MPPTask.h#L124)
- [tunnel_map](https://github.com/pingcap/tiflash/blob/1e3207d3794d8870fc8afad895017191851e4cca/dbms/src/Flash/Mpp/MPPTask.h#L127)

This pr move `tunnel_map` to MPPTunnelSet, and all the tunnel releated operate are handled in `MPPTunnelSet`
### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
