### PR TITLE
Fix blobstore truncate size may not right

### DIFF
--- a/dbms/src/Storages/Page/V3/BlobStore.cpp
+++ b/dbms/src/Storages/Page/V3/BlobStore.cpp
@@ -966,12 +966,12 @@ std::vector<BlobFileId> BlobStore::getGCStats()
                                                 stat->sm_valid_rate));
                 }
 
-                LOG_FMT_TRACE(log, "Current blob is empty [blob_id={}, total size(all invalid)={}] [valid_rate={}].", stat->id, stat->sm_total_size, stat->sm_valid_rate);
+                LOG_FMT_WARNING(log, "Current blob is empty [blob_id={}, total size(all invalid)={}] [valid_rate={}].", stat->id, stat->sm_total_size, stat->sm_valid_rate);
 
                 // If current blob empty, the size of in disk blob may not empty
                 // So we need truncate current blob, and let it be reused.
                 auto blobfile = getBlobFile(stat->id);
-                LOG_FMT_TRACE(log, "Truncate empty blob file [blob_id={}] to 0.", stat->id);
+                LOG_FMT_WARNING(log, "Truncate empty blob file [blob_id={}] to 0.", stat->id);
                 blobfile->truncate(right_margin);
                 blobstore_gc_info.appendToTruncatedBlob(stat->id, stat->sm_valid_rate);
                 continue;
@@ -1012,7 +1012,7 @@ std::vector<BlobFileId> BlobStore::getGCStats()
             if (right_margin != stat->sm_total_size)
             {
                 auto blobfile = getBlobFile(stat->id);
-                LOG_FMT_TRACE(log, "Truncate blob file [blob_id={}] [origin size={}] [truncated size={}]", stat->id, stat->sm_total_size, right_margin);
+                LOG_FMT_INFO(log, "Truncate blob file [blob_id={}] [origin size={}] [truncated size={}]", stat->id, stat->sm_total_size, right_margin);
                 blobfile->truncate(right_margin);
                 stat->sm_total_size = right_margin;
                 stat->sm_valid_rate = stat->sm_valid_size * 1.0 / stat->sm_total_size;

--- a/dbms/src/Storages/Page/V3/spacemap/SpaceMapRBTree.cpp
+++ b/dbms/src/Storages/Page/V3/spacemap/SpaceMapRBTree.cpp
@@ -743,6 +743,14 @@ UInt64 RBTreeSpaceMap::getRightMargin()
     }
 
     auto * entry = node_to_entry(node);
+
+    // If exist a node with range [xxx ,end]
+    // Then we should return end rather than last node start
+    if (entry->start + entry->count != end)
+    {
+        return end;
+    }
+
     return entry->start;
 }
 

--- a/dbms/src/Storages/Page/V3/spacemap/SpaceMapSTDMap.h
+++ b/dbms/src/Storages/Page/V3/spacemap/SpaceMapSTDMap.h
@@ -117,7 +117,17 @@ protected:
         {
             return end - start;
         }
-        return free_map.rbegin()->first;
+
+        const auto & last_node_it = free_map.rbegin();
+
+        // If exist a node with range [xxx ,end]
+        // Then we should return end rather than last node start
+        if (last_node_it->first + last_node_it->second != end)
+        {
+            return end;
+        }
+
+        return last_node_it->first;
     }
 
     bool isMarkUnused(UInt64 offset, size_t length) override

--- a/dbms/src/Storages/Page/V3/tests/gtest_free_map.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_free_map.cpp
@@ -427,6 +427,36 @@ TEST_P(SpaceMapTest, TestGetMaxCap)
     }
 }
 
+
+TEST_P(SpaceMapTest, TestGetRightMargin)
+{
+    {
+        auto smap = SpaceMap::createSpaceMap(test_type, 0, 100);
+        ASSERT_TRUE(smap->markUsed(50, 10));
+        ASSERT_EQ(smap->getRightMargin(), 60);
+        ASSERT_TRUE(smap->markUsed(80, 10));
+        ASSERT_EQ(smap->getRightMargin(), 90);
+
+        ASSERT_TRUE(smap->markUsed(90, 10));
+        ASSERT_EQ(smap->getRightMargin(), 100);
+    }
+
+    {
+        auto smap = SpaceMap::createSpaceMap(test_type, 0, 100);
+        ASSERT_TRUE(smap->markUsed(90, 10));
+        ASSERT_EQ(smap->getRightMargin(), 100);
+
+        ASSERT_TRUE(smap->markUsed(20, 10));
+        ASSERT_EQ(smap->getRightMargin(), 100);
+
+        ASSERT_TRUE(smap->markFree(90, 10));
+        ASSERT_EQ(smap->getRightMargin(), 30);
+
+        ASSERT_TRUE(smap->markUsed(90, 10));
+        ASSERT_EQ(smap->getRightMargin(), 100);
+    }
+}
+
 INSTANTIATE_TEST_CASE_P(
     Type,
     SpaceMapTest,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #5076 

Problem Summary:
- `DB::Exception: No enough data in file /data0/db/page/log/blobfile_6, read bytes: 0 , expected bytes: 43`
- In `getGcStats`, `BlobStore` will call the `getRightMargin` to get the `last free space` and truncate the file.
- But `getRightMargin` will return a invalid value if `last free space` is not align to `end`.
- For example:
  - Space limit is 100. So current space is [0, 100]
  - Insert a span [90,10]
  - Then we should get 100 when we call `getRightMargin`
  - But it return 0. Because in `getRightMargin`, we will get the last free space, and return it start.


### What is changed and how it works?
- Fix the `getRightMargin`
- Change the log level when we do truncate.


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
