### PR TITLE
upgrade prometheus-cpp to v1.0.1

### DIFF
--- a/contrib/prometheus-cpp-cmake/core/CMakeLists.txt
+++ b/contrib/prometheus-cpp-cmake/core/CMakeLists.txt
@@ -23,6 +23,12 @@ target_link_libraries(core
     $<$<AND:$<BOOL:UNIX>,$<NOT:$<BOOL:APPLE>>>:rt>
 )
 
+if(HAVE_CXX_LIBATOMIC)
+  # the exported library config must use libatomic unconditionally
+  # (the HAVE_CXX_LIBATOMIC variable should not leak into the target config)
+  target_link_libraries(core PUBLIC atomic)
+endif()
+
 target_include_directories(core
   PUBLIC
     $<BUILD_INTERFACE:${PROMETHEUS_SRC_DIR}/core/include>

--- a/contrib/prometheus-cpp-cmake/core/CMakeLists.txt
+++ b/contrib/prometheus-cpp-cmake/core/CMakeLists.txt
@@ -23,12 +23,6 @@ target_link_libraries(core
     $<$<AND:$<BOOL:UNIX>,$<NOT:$<BOOL:APPLE>>>:rt>
 )
 
-if(HAVE_CXX_LIBATOMIC)
-  # the exported library config must use libatomic unconditionally
-  # (the HAVE_CXX_LIBATOMIC variable should not leak into the target config)
-  target_link_libraries(core PUBLIC atomic)
-endif()
-
 target_include_directories(core
   PUBLIC
     $<BUILD_INTERFACE:${PROMETHEUS_SRC_DIR}/core/include>

--- a/contrib/prometheus-cpp-cmake/pull/CMakeLists.txt
+++ b/contrib/prometheus-cpp-cmake/pull/CMakeLists.txt
@@ -12,9 +12,18 @@ if(ENABLE_COMPRESSION)
 endif()
 
 add_library(pull
+  ${PROMETHEUS_SRC_DIR}/pull/src/basic_auth.cc
+  ${PROMETHEUS_SRC_DIR}/pull/src/basic_auth.h
+  ${PROMETHEUS_SRC_DIR}/pull/src/endpoint.cc
+  ${PROMETHEUS_SRC_DIR}/pull/src/endpoint.h
   ${PROMETHEUS_SRC_DIR}/pull/src/exposer.cc
   ${PROMETHEUS_SRC_DIR}/pull/src/handler.cc
   ${PROMETHEUS_SRC_DIR}/pull/src/handler.h
+  ${PROMETHEUS_SRC_DIR}/pull/src/metrics_collector.cc
+  ${PROMETHEUS_SRC_DIR}/pull/src/metrics_collector.h
+
+  ${PROMETHEUS_SRC_DIR}/pull/src/detail/base64.h
+
   $<$<BOOL:${USE_THIRDPARTY_LIBRARIES}>:$<TARGET_OBJECTS:civetweb>>
 )
 

--- a/contrib/prometheus-cpp-cmake/push/CMakeLists.txt
+++ b/contrib/prometheus-cpp-cmake/push/CMakeLists.txt
@@ -3,6 +3,8 @@ if(NOT CURL_FOUND)
 endif()
 
 add_library(push
+  ${PROMETHEUS_SRC_DIR}/push/src/curl_wrapper.cc
+  ${PROMETHEUS_SRC_DIR}/push/src/curl_wrapper.h
   ${PROMETHEUS_SRC_DIR}/push/src/gateway.cc
 )
 


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

Issue Number: close #5278 #2103

Problem Summary:

The prometheus-cpp in tiflash is out of date, and will cause compile-error in new version of libstdc++

### What is changed and how it works?

Upgrade the prometheus-cpp to v1.0.1. Modify the cmake files according to the repo.

### Check List

Tests 

- [x] No code

### Release Note

```release-note
none
```