### PR TITLE
delete copy/move ctor of MPMCQueue explicitly

### DIFF
--- a/dbms/src/Common/MPMCQueue.h
+++ b/dbms/src/Common/MPMCQueue.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <Common/SimpleIntrusiveNode.h>
+#include <Common/nocopyable.h>
 #include <common/defines.h>
 #include <common/types.h>
 
@@ -77,9 +78,7 @@ public:
     // Cannot to use copy/move constructor,
     // because MPMCQueue maybe used by different threads.
     // Copy and move it is dangerous.
-    MPMCQueue(const MPMCQueue<T> &) = delete;
-    MPMCQueue(MPMCQueue<T> &&) = delete;
-    MPMCQueue<T> & operator=(const MPMCQueue<T> &) = delete;
+    DISALLOW_COPY_AND_MOVE(MPMCQueue);
 
     /// Block until:
     /// 1. Pop succeeds with a valid T: return true.

--- a/dbms/src/Common/MPMCQueue.h
+++ b/dbms/src/Common/MPMCQueue.h
@@ -74,6 +74,13 @@ public:
             destruct(getObj(read_pos));
     }
 
+    // Cannot to use copy/move constructor,
+    // because MPMCQueue maybe used by different threads.
+    // Copy and move it is dangerous.
+    MPMCQueue(const MPMCQueue<T> &) = delete;
+    MPMCQueue(MPMCQueue<T> &&) = delete;
+    MPMCQueue<T> & operator=(const MPMCQueue<T> &) = delete;
+
     /// Block until:
     /// 1. Pop succeeds with a valid T: return true.
     /// 2. The queue is cancelled or finished: return false.


### PR DESCRIPTION
Signed-off-by: guo-shaoge <shaoge1994@163.com>

### What problem does this PR solve?

Issue Number: close #5329

Problem Summary: MPMCQueue maybe used by different threads, copy and move it is dangerous.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
