### PR TITLE
[WIP] coprocessor: separate thread for encoding data for batch cop

### DIFF
--- a/dbms/src/Flash/Coprocessor/DAGContext.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGContext.cpp
@@ -19,6 +19,7 @@
 #include <Flash/Mpp/ExchangeReceiver.h>
 #include <Flash/Statistics/traverseExecutors.h>
 #include <Storages/Transaction/TMTContext.h>
+#include <common/logger_useful.h>
 
 namespace DB
 {
@@ -86,25 +87,25 @@ void DAGContext::initExecutorIdToJoinIdMap()
 {
     // only mpp task has join executor
     // for mpp, all executor has executor id.
-    if (isMPPTask())
-    {
-        executor_id_to_join_id_map.clear();
-        traverseExecutorsReverse(dag_request, [&](const tipb::Executor & executor) {
-            std::vector<String> all_join_id;
-            // for mpp, dag_request.has_root_executor() == true, can call `getChildren` directly.
-            getChildren(executor).forEach([&](const tipb::Executor & child) {
-                assert(child.has_executor_id());
-                auto child_it = executor_id_to_join_id_map.find(child.executor_id());
-                if (child_it != executor_id_to_join_id_map.end())
-                    all_join_id.insert(all_join_id.end(), child_it->second.begin(), child_it->second.end());
-            });
-            assert(executor.has_executor_id());
-            if (executor.tp() == tipb::ExecType::TypeJoin)
-                all_join_id.push_back(executor.executor_id());
-            if (!all_join_id.empty())
-                executor_id_to_join_id_map[executor.executor_id()] = all_join_id;
+    if (!isMPPTask())
+        return;
+
+    executor_id_to_join_id_map.clear();
+    traverseExecutorsReverse(dag_request, [&](const tipb::Executor & executor) {
+        std::vector<String> all_join_id;
+        // for mpp, dag_request.has_root_executor() == true, can call `getChildren` directly.
+        getChildren(executor).forEach([&](const tipb::Executor & child) {
+            assert(child.has_executor_id());
+            auto child_it = executor_id_to_join_id_map.find(child.executor_id());
+            if (child_it != executor_id_to_join_id_map.end())
+                all_join_id.insert(all_join_id.end(), child_it->second.begin(), child_it->second.end());
         });
-    }
+        assert(executor.has_executor_id());
+        if (executor.tp() == tipb::ExecType::TypeJoin)
+            all_join_id.push_back(executor.executor_id());
+        if (!all_join_id.empty())
+            executor_id_to_join_id_map[executor.executor_id()] = all_join_id;
+    });
 }
 
 std::unordered_map<String, std::vector<String>> & DAGContext::getExecutorIdToJoinIdMap()

--- a/dbms/src/Flash/Coprocessor/DAGDriver.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGDriver.cpp
@@ -127,7 +127,8 @@ try
             writer->Write(response);
         }
 
-        auto streaming_writer = std::make_shared<StreamWriter>(writer);
+        const auto & settings = context.getSettingsRef();
+        auto streaming_writer = std::make_shared<StreamWriter>(writer, settings.max_threads);
         TiDB::TiDBCollators collators;
 
         std::unique_ptr<DAGResponseWriter> response_writer = std::make_unique<StreamingDAGResponseWriter<StreamWriterPtr, false>>(
@@ -135,8 +136,8 @@ try
             std::vector<Int64>(),
             collators,
             tipb::ExchangeType::PassThrough,
-            context.getSettingsRef().dag_records_per_chunk,
-            context.getSettingsRef().batch_send_min_limit,
+            settings.dag_records_per_chunk,
+            settings.batch_send_min_limit,
             true,
             dag_context,
             /*fine_grained_shuffle_stream_count=*/0,

--- a/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
@@ -36,6 +36,7 @@
 #include <Storages/Transaction/LockException.h>
 #include <Storages/Transaction/TMTContext.h>
 #include <TiDB/Schema/SchemaSyncer.h>
+#include <common/logger_useful.h>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"

--- a/dbms/src/Flash/Coprocessor/StreamWriter.cpp
+++ b/dbms/src/Flash/Coprocessor/StreamWriter.cpp
@@ -1,0 +1,158 @@
+// Copyright 2022 PingCAP, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Flash/Coprocessor/StreamWriter.h>
+#include <common/logger_useful.h>
+
+namespace DB
+{
+StreamWriter::StreamWriter(::grpc::ServerWriter<::coprocessor::BatchResponse> * writer_, UInt64 input_streams_num)
+    : writer(writer_)
+    , connected(true)
+    , finished(false)
+    , send_queue(std::max(5, input_streams_num * 5))
+    , thread_manager(newThreadManager())
+    , log(Logger::get("StreamWriter"))
+{
+    thread_manager->schedule(true, "StreamWriter", [this] {
+        sendJob();
+    });
+}
+
+StreamWriter::~StreamWriter()
+{
+    try
+    {
+        {
+            std::unique_lock lock(mu);
+            if (finished)
+            {
+                LOG_FMT_TRACE(log, "already finished!");
+                return;
+            }
+
+            // make sure to finish the stream writer after it is connected
+            waitUntilConnectedOrFinished(lock);
+            finishSendQueue();
+        }
+        LOG_FMT_TRACE(log, "waiting consumer finish!");
+        waitForConsumerFinish(/*allow_throw=*/false);
+        LOG_FMT_TRACE(log, "waiting child thread finished!");
+        thread_manager->wait();
+    }
+    catch (...)
+    {
+        tryLogCurrentException(log, "Error in destructor function of StreamWriter");
+    }
+}
+
+void StreamWriter::write(tipb::SelectResponse & response, [[maybe_unused]] uint16_t id)
+{
+    auto rsp = std::make_shared<::coprocessor::BatchResponse>();
+    if (!response.SerializeToString(rsp->mutable_data()))
+        throw Exception(fmt::format("Fail to serialize response, response size: {}", response.ByteSizeLong()));
+
+    {
+        std::unique_lock lock(mu);
+        waitUntilConnectedOrFinished(lock);
+        if (finished)
+            throw Exception("write to StreamWriter which is already closed, " + consumer_state.getError());
+
+        if (send_queue.push(rsp))
+        {
+            connection_profile_info.bytes += rsp->ByteSizeLong();
+            connection_profile_info.packets += 1;
+            return;
+        }
+    }
+    // push failed, wait consumer for the final state
+    waitForConsumerFinish(/*allow_throw=*/true);
+}
+
+void StreamWriter::writeDone()
+{
+    LOG_FMT_TRACE(log, "ready to finish");
+    {
+        std::unique_lock lock(mu);
+        if (finished)
+            throw Exception("write to StreamWriter which is already closed, " + consumer_state.getError());
+        waitUntilConnectedOrFinished(lock);
+        finishSendQueue();
+    }
+    waitForConsumerFinish(/*allow_throw=*/true);
+}
+
+void StreamWriter::sendJob()
+{
+    String err_msg;
+    try
+    {
+        BatchResponsePtr rsp;
+        while (send_queue.pop(rsp))
+        {
+            if (!writer->Write(*rsp))
+            {
+                err_msg = "grpc writes failed.";
+                break;
+            }
+        }
+    }
+    catch (Exception & e)
+    {
+        err_msg = e.message();
+    }
+    catch (std::exception & e)
+    {
+        err_msg = e.what();
+    }
+    catch (...)
+    {
+        err_msg = fmt::format("fatal error in {}", __PRETTY_FUNCTION__);
+    }
+    if (!err_msg.empty())
+        LOG_ERROR(log, err_msg);
+    consumerFinish(err_msg);
+}
+
+void StreamWriter::waitForConsumerFinish(bool allow_throw)
+{
+    LOG_FMT_TRACE(log, "start wait for consumer finish!");
+    String err_msg = consumer_state.getError(); // may blocking
+    if (allow_throw && !err_msg.empty())
+        throw Exception("Consumer exits unexpected, " + err_msg);
+    LOG_FMT_TRACE(log, "end wait for consumer finish!");
+}
+
+void StreamWriter::consumerFinish(const String & err_msg)
+{
+    // must finish send_queue outside of the critical area to avoid deadlock with write.
+    LOG_FMT_TRACE(log, "calling consumer finish");
+    send_queue.finish();
+    {
+        std::unique_lock lock(mu);
+        if (finished && consumer_state.errHasSet())
+            return;
+        finished = true;
+        consumer_state.setError(err_msg);
+        cv_for_finished.notify_all();
+    }
+}
+
+void StreamWriter::waitUntilConnectedOrFinished(std::unique_lock<std::mutex> & lk)
+{
+    LOG_FMT_TRACE(log, "start waitUntilConnectedOrFinished");
+    cv_for_finished.wait(lk, [&] { return connected || finished; });
+    LOG_FMT_TRACE(log, "end waitUntilConnectedOrFinished");
+}
+} // namespace DB

--- a/dbms/src/Flash/Coprocessor/StreamWriter.h
+++ b/dbms/src/Flash/Coprocessor/StreamWriter.h
@@ -15,6 +15,17 @@
 #pragma once
 
 #include <Common/Exception.h>
+#include <Common/Logger.h>
+#include <Common/MPMCQueue.h>
+#include <Common/ThreadManager.h>
+#include <Common/nocopyable.h>
+#include <Flash/Statistics/ConnectionProfileInfo.h>
+
+#include <condition_variable>
+#include <exception>
+#include <future>
+#include <mutex>
+
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -25,7 +36,6 @@
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif
-#include <mutex>
 
 namespace mpp
 {
@@ -36,31 +46,93 @@ namespace DB
 {
 struct StreamWriter
 {
-    ::grpc::ServerWriter<::coprocessor::BatchResponse> * writer;
-    std::mutex write_mutex;
+    explicit StreamWriter(::grpc::ServerWriter<::coprocessor::BatchResponse> * writer_, UInt64 input_streams_num);
 
-    explicit StreamWriter(::grpc::ServerWriter<::coprocessor::BatchResponse> * writer_)
-        : writer(writer_)
-    {}
-    void write(mpp::MPPDataPacket &)
+    ~StreamWriter();
+
+    static void write(mpp::MPPDataPacket &)
     {
         throw Exception("StreamWriter::write(mpp::MPPDataPacket &) do not support writing MPPDataPacket!");
     }
-    void write(mpp::MPPDataPacket &, [[maybe_unused]] uint16_t)
+
+    static void write(mpp::MPPDataPacket &, uint16_t)
     {
-        throw Exception("StreamWriter::write(mpp::MPPDataPacket &, [[maybe_unused]] uint16_t) do not support writing MPPDataPacket!");
+        throw Exception("StreamWriter::write(mpp::MPPDataPacket &, uint16_t) do not support writing MPPDataPacket!");
     }
-    void write(tipb::SelectResponse & response, [[maybe_unused]] uint16_t id = 0)
-    {
-        ::coprocessor::BatchResponse resp;
-        if (!response.SerializeToString(resp.mutable_data()))
-            throw Exception("Fail to serialize response, response size: " + std::to_string(response.ByteSizeLong()));
-        std::lock_guard lk(write_mutex);
-        if (!writer->Write(resp))
-            throw Exception("Failed to write resp");
-    }
+
+    void write(tipb::SelectResponse & response, uint16_t id = 0);
+
+    void writeDone();
+
     // a helper function
-    uint16_t getPartitionNum() { return 0; }
+    static uint16_t getPartitionNum() { return 0; }
+
+    DISALLOW_COPY_AND_MOVE(StreamWriter);
+
+private:
+    // work as a background task to keep sending packets until done.
+    void sendJob();
+
+    void waitForConsumerFinish(bool allow_throw);
+
+    void consumerFinish(const String & err_msg);
+
+    void finishSendQueue()
+    {
+        send_queue.finish();
+    }
+
+    void waitUntilConnectedOrFinished(std::unique_lock<std::mutex> & lk);
+
+private:
+    std::mutex mu;
+    ::grpc::ServerWriter<::coprocessor::BatchResponse> * writer;
+
+    std::condition_variable cv_for_finished;
+    bool connected;
+    bool finished;
+    using BatchResponsePtr = std::shared_ptr<::coprocessor::BatchResponse>;
+    MPMCQueue<BatchResponsePtr> send_queue;
+
+    std::shared_ptr<ThreadManager> thread_manager;
+
+    /// Consumer can be sendLoop or local receiver.
+    class ConsumerState
+    {
+    public:
+        ConsumerState()
+            : future(promise.get_future())
+        {
+        }
+
+        // before finished, must be called without protection of mu
+        String getError()
+        {
+            future.wait();
+            return future.get();
+        }
+
+        void setError(const String & err_msg)
+        {
+            promise.set_value(err_msg);
+            err_has_set = true;
+        }
+
+        bool errHasSet() const
+        {
+            return err_has_set.load();
+        }
+
+    private:
+        std::promise<String> promise;
+        std::shared_future<String> future;
+        std::atomic<bool> err_has_set{false};
+    };
+    ConsumerState consumer_state;
+
+    ConnectionProfileInfo connection_profile_info;
+
+    LoggerPtr log;
 };
 
 using StreamWriterPtr = std::shared_ptr<StreamWriter>;


### PR DESCRIPTION
Signed-off-by: JaySon-Huang <tshent@qq.com>

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/4415

Problem Summary:

### What is changed and how it works?


* * *
TPC-H sf=10

|  Time(s)| Original | Optimized |
|  ----  | ----  | ---- |
| Q1 | TBD | TBD |
| Q2  | TBD | TBD | 

```SQL
-- disable mpp, enable batch cop
set tidb_allow_mpp=0;set tidb_isolation_read_engines="tiflash"; explain analyze /*PLACEHOLDER*/ select     l_returnflag,     l_linestatus,     sum(l_quantity) as sum_qty,     sum(l_extendedprice) as sum_base_price,     sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,     sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge,     avg(l_quantity) as avg_qty,     avg(l_extendedprice) as avg_price,     avg(l_discount) as avg_disc,     count(*) as count_order from     lineitem where     l_shipdate <= date_sub('1998-12-01', interval 108 day) group by     l_returnflag,     l_linestatus order by     l_returnflag,     l_linestatus;
+--------------------------------+-------------+----------+-------------------+----------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------+---------+
| id                             | estRows     | actRows  | task              | access object  | execution info                                                                                                                                                                                                                                                                                                                                                    | operator info                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | memory   | disk    |
+--------------------------------+-------------+----------+-------------------+----------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------+---------+
| Sort_6                         | 2.98        | 4        | root              |                | time:1.98s, loops:2                                                                                                                                                                                                                                                                                                                                               | test.lineitem.l_returnflag, test.lineitem.l_linestatus                                                                                                                                                                                                                                                                                                                                                                                                                                                               | 34.3 KB  | 0 Bytes |
| └─Projection_8                 | 2.98        | 4        | root              |                | time:1.98s, loops:4, Concurrency:OFF                                                                                                                                                                                                                                                                                                                              | test.lineitem.l_returnflag, test.lineitem.l_linestatus, Column#19, Column#20, Column#21, Column#22, Column#23, Column#24, Column#25, Column#26                                                                                                                                                                                                                                                                                                                                                                       | 11.4 KB  | N/A     |
|   └─HashAgg_14                 | 2.98        | 4        | root              |                | time:1.98s, loops:4, partial_worker:{wall_time:1.98287475s, concurrency:5, task_num:1, tot_wait:9.913951777s, tot_exec:54.456µs, tot_time:9.914021331s, max:1.982838083s, p95:1.982838083s}, final_worker:{wall_time:1.982955868s, concurrency:5, task_num:3, tot_wait:9.914271152s, tot_exec:207.259µs, tot_time:9.914483773s, max:1.98293307s, p95:1.98293307s} | group by:test.lineitem.l_linestatus, test.lineitem.l_returnflag, funcs:sum(Column#27)->Column#19, funcs:sum(Column#28)->Column#20, funcs:sum(Column#29)->Column#21, funcs:sum(Column#30)->Column#22, funcs:avg(Column#31, Column#32)->Column#23, funcs:avg(Column#33, Column#34)->Column#24, funcs:avg(Column#35, Column#36)->Column#25, funcs:count(Column#37)->Column#26, funcs:firstrow(test.lineitem.l_returnflag)->test.lineitem.l_returnflag, funcs:firstrow(test.lineitem.l_linestatus)->test.lineitem.l_l... | 129.5 KB | N/A     |
|     └─TableReader_15           | 2.98        | 4        | root              |                | time:1.98s, loops:2, cop_task: {num: 1, max: 0s, proc_keys: 0, copr_cache_hit_ratio: 0.00}                                                                                                                                                                                                                                                                        | data:HashAgg_9                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | 1.54 KB  | N/A     |
|       └─HashAgg_9              | 2.98        | 4        | batchCop[tiflash] |                | tiflash_task:{time:1.97s, loops:256, threads:1}                                                                                                                                                                                                                                                                                                                   | group by:Column#50, Column#51, funcs:sum(Column#40)->Column#27, funcs:sum(Column#41)->Column#28, funcs:sum(Column#42)->Column#29, funcs:sum(Column#43)->Column#30, funcs:count(Column#44)->Column#31, funcs:sum(Column#45)->Column#32, funcs:count(Column#46)->Column#33, funcs:sum(Column#47)->Column#34, funcs:count(Column#48)->Column#35, funcs:sum(Column#49)->Column#36, funcs:count(1)->Column#37                                                                                                             | N/A      | N/A     |
|         └─Projection_20        | 59513965.06 | 58773499 | batchCop[tiflash] |                | tiflash_task:{time:1.62s, loops:943, threads:20}                                                                                                                                                                                                                                                                                                                  | test.lineitem.l_quantity, test.lineitem.l_extendedprice, mul(test.lineitem.l_extendedprice, minus(1, test.lineitem.l_discount))->Column#42, mul(mul(test.lineitem.l_extendedprice, minus(1, test.lineitem.l_discount)), plus(1, test.lineitem.l_tax))->Column#43, test.lineitem.l_quantity, test.lineitem.l_quantity, test.lineitem.l_extendedprice, test.lineitem.l_extendedprice, test.lineitem.l_discount, test.lineitem.l_discount, test.lineitem.l_returnflag, test.lineitem.l_linestatus                       | N/A      | N/A     |
|           └─Selection_13       | 59513965.06 | 58773499 | batchCop[tiflash] |                | tiflash_task:{time:797.5ms, loops:943, threads:20}                                                                                                                                                                                                                                                                                                                | le(test.lineitem.l_shipdate, 1998-08-15 00:00:00.000000)                                                                                                                                                                                                                                                                                                                                                                                                                                                             | N/A      | N/A     |
|             └─TableFullScan_12 | 60363016.00 | 60166770 | batchCop[tiflash] | table:lineitem | tiflash_task:{time:654.5ms, loops:943, threads:20}                                                                                                                                                                                                                                                                                                                | keep order:false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | N/A      | N/A     |
+--------------------------------+-------------+----------+-------------------+----------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------+---------+
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [x] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
