### PR TITLE
decrease the frequency of background gc log

### DIFF
--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -1750,7 +1750,7 @@ UInt64 DeltaMergeStore::onSyncGc(Int64 limit)
     }
 
     DB::Timestamp gc_safe_point = latest_gc_safe_point.load(std::memory_order_acquire);
-    LOG_FMT_DEBUG(log,
+    LOG_FMT_TRACE(log,
                   "GC on table {} start with key: {}, gc_safe_point: {}, max gc limit: {}",
                   table_name,
                   next_gc_check_key.toDebugString(),
@@ -1844,7 +1844,7 @@ UInt64 DeltaMergeStore::onSyncGc(Int64 limit)
                     checkSegmentUpdate(dm_context, segment, ThreadType::BG_GC);
                     gc_segments_num++;
                     finish_gc_on_segment = true;
-                    LOG_FMT_INFO(
+                    LOG_FMT_DEBUG(
                         log,
                         "GC-merge-delta done on Segment [{}] [range={}] [table={}]",
                         segment_id,
@@ -1853,7 +1853,7 @@ UInt64 DeltaMergeStore::onSyncGc(Int64 limit)
                 }
                 else
                 {
-                    LOG_FMT_INFO(
+                    LOG_FMT_DEBUG(
                         log,
                         "GC aborted on Segment [{}] [range={}] [table={}]",
                         segment_id,
@@ -1876,7 +1876,10 @@ UInt64 DeltaMergeStore::onSyncGc(Int64 limit)
         }
     }
 
-    LOG_FMT_DEBUG(log, "Finish GC on {} segments [table={}]", gc_segments_num, table_name);
+    if (gc_segments_num != 0)
+    {
+        LOG_FMT_DEBUG(log, "Finish GC on {} segments [table={}]", gc_segments_num, table_name);
+    }
     return gc_segments_num;
 }
 

--- a/dbms/src/Storages/GCManager.cpp
+++ b/dbms/src/Storages/GCManager.cpp
@@ -42,7 +42,7 @@ bool GCManager::work()
         return false;
     }
 
-    LOG_FMT_INFO(log, "Start GC with table id: {}", next_table_id);
+    LOG_FMT_DEBUG(log, "Start GC with table id: {}", next_table_id);
     // Get a storage snapshot with weak_ptrs first
     // TODO: avoid gc on storage which have no data?
     std::map<TableID, std::weak_ptr<IManageableStorage>> storages;
@@ -97,7 +97,7 @@ bool GCManager::work()
     if (iter == storages.end())
         iter = storages.begin();
     next_table_id = iter->first;
-    LOG_FMT_INFO(log, "End GC and next gc will start with table id: {}", next_table_id);
+    LOG_FMT_DEBUG(log, "End GC and next gc will start with table id: {}", next_table_id);
     gc_check_stop_watch.restart();
     // Always return false
     return false;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #5073 

Problem Summary: when the table num in the cluster is big, the gc process print too many logs which is of little use.

### What is changed and how it works?
Lower the log level of some logs and print some log when gc really happens.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
