### PR TITLE
clear obsolete v2 data for tables that totally transform to ps v3

### DIFF
--- a/dbms/src/Storages/DeltaMerge/StoragePool.cpp
+++ b/dbms/src/Storages/DeltaMerge/StoragePool.cpp
@@ -163,10 +163,11 @@ bool GlobalStoragePool::gc(const Settings & settings, bool immediately, const Se
     return done_anything;
 }
 
-StoragePool::StoragePool(Context & global_ctx, NamespaceId ns_id_, StoragePathPool & storage_path_pool, const String & name)
+StoragePool::StoragePool(Context & global_ctx, NamespaceId ns_id_, StoragePathPool & storage_path_pool_, const String & name)
     : logger(Logger::get("StoragePool", !name.empty() ? name : DB::toString(ns_id_)))
     , run_mode(global_ctx.getPageStorageRunMode())
     , ns_id(ns_id_)
+    , storage_path_pool(storage_path_pool_)
     , global_context(global_ctx)
     , storage_pool_metrics(CurrentMetrics::StoragePoolV3Only, 0)
 {
@@ -219,18 +220,42 @@ StoragePool::StoragePool(Context & global_ctx, NamespaceId ns_id_, StoragePathPo
         data_storage_v3 = global_storage_pool->data_storage;
         meta_storage_v3 = global_storage_pool->meta_storage;
 
-        log_storage_v2 = PageStorage::create(name + ".log",
-                                             storage_path_pool.getPSDiskDelegatorMulti("log"),
-                                             extractConfig(global_context.getSettingsRef(), StorageType::Log),
-                                             global_context.getFileProvider());
-        data_storage_v2 = PageStorage::create(name + ".data",
-                                              storage_path_pool.getPSDiskDelegatorMulti("data"),
-                                              extractConfig(global_context.getSettingsRef(), StorageType::Data),
-                                              global_ctx.getFileProvider());
-        meta_storage_v2 = PageStorage::create(name + ".meta",
-                                              storage_path_pool.getPSDiskDelegatorMulti("meta"),
-                                              extractConfig(global_context.getSettingsRef(), StorageType::Meta),
-                                              global_ctx.getFileProvider());
+        if (storage_path_pool.isPSV2Deleted())
+        {
+            LOG_FMT_INFO(logger, "PageStorage V2 is already mark deleted. Current pagestorage change from {} to {} [ns_id={}]", //
+                         static_cast<UInt8>(PageStorageRunMode::MIX_MODE), //
+                         static_cast<UInt8>(PageStorageRunMode::ONLY_V3), //
+                         ns_id);
+            log_storage_v2 = nullptr;
+            data_storage_v2 = nullptr;
+            meta_storage_v2 = nullptr;
+            run_mode = PageStorageRunMode::ONLY_V3;
+            storage_path_pool.clearPSV2ObsoleteData();
+        }
+        else
+        {
+            // Although there is no more write to ps v2 in mixed mode, the ps instances will keep running if there is some data in log storage when restart,
+            // so we keep its original config here.
+            // And we rely on the mechanism that writing file will be rotated if no valid pages in non writing files to reduce the disk space usage of these ps instances.
+            log_storage_v2 = PageStorage::create(name + ".log",
+                                                 storage_path_pool.getPSDiskDelegatorMulti("log"),
+                                                 extractConfig(global_context.getSettingsRef(), StorageType::Log),
+                                                 global_context.getFileProvider(),
+                                                 /* use_v3 */ false,
+                                                 /* no_more_write_to_v2 */ true);
+            data_storage_v2 = PageStorage::create(name + ".data",
+                                                  storage_path_pool.getPSDiskDelegatorMulti("data"),
+                                                  extractConfig(global_context.getSettingsRef(), StorageType::Data),
+                                                  global_ctx.getFileProvider(),
+                                                  /* use_v3 */ false,
+                                                  /* no_more_write_to_v2 */ true);
+            meta_storage_v2 = PageStorage::create(name + ".meta",
+                                                  storage_path_pool.getPSDiskDelegatorMulti("meta"),
+                                                  extractConfig(global_context.getSettingsRef(), StorageType::Meta),
+                                                  global_ctx.getFileProvider(),
+                                                  /* use_v3 */ false,
+                                                  /* no_more_write_to_v2 */ true);
+        }
 
         log_storage_reader = std::make_shared<PageReader>(run_mode, ns_id, log_storage_v2, log_storage_v3, nullptr);
         data_storage_reader = std::make_shared<PageReader>(run_mode, ns_id, data_storage_v2, data_storage_v3, nullptr);
@@ -272,7 +297,7 @@ void StoragePool::forceTransformMetaV2toV3()
         const auto & page_transform_entry = meta_transform_storage_reader->getPageEntry(page_transform.page_id);
         if (!page_transform_entry.field_offsets.empty())
         {
-            throw Exception(fmt::format("Can't transfrom meta from V2 to V3, [page_id={}] {}", //
+            throw Exception(fmt::format("Can't transform meta from V2 to V3, [page_id={}] {}", //
                                         page_transform.page_id,
                                         page_transform_entry.toDebugString()),
                             ErrorCodes::LOGICAL_ERROR);
@@ -431,18 +456,23 @@ PageStorageRunMode StoragePool::restore()
         }
         else
         {
-            LOG_FMT_INFO(logger, "Current pool.data translate already done before restored [ns_id={}] ", ns_id);
+            LOG_FMT_INFO(logger, "Current pool.data translate already done before restored [ns_id={}]", ns_id);
         }
 
         // Check number of valid pages in v2
         // If V2 already have no any data in disk, Then change run_mode to ONLY_V3
         if (log_storage_v2->getNumberOfPages() == 0 && data_storage_v2->getNumberOfPages() == 0 && meta_storage_v2->getNumberOfPages() == 0)
         {
-            // TODO: Need drop V2 in disk and check.
-            LOG_FMT_INFO(logger, "Current pagestorage change from {} to {}", //
+            LOG_FMT_INFO(logger, "Current pagestorage change from {} to {} [ns_id={}]", //
                          static_cast<UInt8>(PageStorageRunMode::MIX_MODE),
-                         static_cast<UInt8>(PageStorageRunMode::ONLY_V3));
-
+                         static_cast<UInt8>(PageStorageRunMode::ONLY_V3),
+                         ns_id);
+            if (storage_path_pool.createPSV2DeleteMarkFile())
+            {
+                log_storage_v2->drop();
+                data_storage_v2->drop();
+                meta_storage_v2->drop();
+            }
             log_storage_v2 = nullptr;
             data_storage_v2 = nullptr;
             meta_storage_v2 = nullptr;

--- a/dbms/src/Storages/DeltaMerge/StoragePool.h
+++ b/dbms/src/Storages/DeltaMerge/StoragePool.h
@@ -79,7 +79,7 @@ public:
     using Timepoint = Clock::time_point;
     using Seconds = std::chrono::seconds;
 
-    StoragePool(Context & global_ctx, NamespaceId ns_id_, StoragePathPool & path_pool, const String & name = "");
+    StoragePool(Context & global_ctx, NamespaceId ns_id_, StoragePathPool & storage_path_pool_, const String & name = "");
 
     PageStorageRunMode restore();
 
@@ -180,6 +180,8 @@ private:
 
     // whether the three storage instance is owned by this StoragePool
     const NamespaceId ns_id;
+
+    StoragePathPool & storage_path_pool;
 
     PageStoragePtr log_storage_v2;
     PageStoragePtr data_storage_v2;

--- a/dbms/src/Storages/Page/PageStorage.cpp
+++ b/dbms/src/Storages/Page/PageStorage.cpp
@@ -23,12 +23,13 @@ PageStoragePtr PageStorage::create(
     PSDiskDelegatorPtr delegator,
     const PageStorage::Config & config,
     const FileProviderPtr & file_provider,
-    bool use_v3)
+    bool use_v3,
+    bool no_more_insert_to_v2)
 {
     if (use_v3)
         return std::make_shared<PS::V3::PageStorageImpl>(name, delegator, config, file_provider);
     else
-        return std::make_shared<PS::V2::PageStorage>(name, delegator, config, file_provider);
+        return std::make_shared<PS::V2::PageStorage>(name, delegator, config, file_provider, no_more_insert_to_v2);
 }
 
 /***************************

--- a/dbms/src/Storages/Page/PageStorage.h
+++ b/dbms/src/Storages/Page/PageStorage.h
@@ -208,6 +208,14 @@ public:
     void reloadSettings(const Config & new_config) { config.reload(new_config); };
     Config getSettings() const { return config; }
 
+    // Use a more easy gc config for v2 when all of its data will be transformed to v3.
+    static Config getEasyGCConfig()
+    {
+        Config gc_config;
+        gc_config.file_roll_size = PAGE_FILE_SMALL_SIZE;
+        return gc_config;
+    }
+
 public:
     static PageStoragePtr
     create(
@@ -215,7 +223,8 @@ public:
         PSDiskDelegatorPtr delegator,
         const PageStorage::Config & config,
         const FileProviderPtr & file_provider,
-        bool use_v3 = false);
+        bool use_v3 = false,
+        bool no_more_insert_to_v2 = false);
 
     PageStorage(
         String name,

--- a/dbms/src/Storages/Page/V2/PageStorage.cpp
+++ b/dbms/src/Storages/Page/V2/PageStorage.cpp
@@ -160,12 +160,14 @@ PageFileSet PageStorage::listAllPageFiles(const FileProviderPtr & file_provider,
 PageStorage::PageStorage(String name,
                          PSDiskDelegatorPtr delegator_, //
                          const Config & config_,
-                         const FileProviderPtr & file_provider_)
+                         const FileProviderPtr & file_provider_,
+                         bool no_more_insert_)
     : DB::PageStorage(name, delegator_, config_, file_provider_)
     , write_files(std::max(1UL, config_.num_write_slots.get()))
     , page_file_log(&Poco::Logger::get("PageFile"))
     , log(&Poco::Logger::get("PageStorage"))
     , versioned_page_entries(storage_name, config.version_set_config, log)
+    , no_more_insert(no_more_insert_)
 {
     // at least 1 write slots
     config.num_write_slots = std::max(1UL, config.num_write_slots.get());
@@ -405,18 +407,20 @@ DB::PageEntry PageStorage::getEntryImpl(NamespaceId /*ns_id*/, PageId page_id, S
 // - Writable, reuse `old_writer` if it is not a nullptr, otherwise, create a new writer from `page_file`
 // - Not writable, renew the `page_file` and its belonging writer.
 //   The <id,level> of the new `page_file` is <max_id + 1, 0> of all `write_files`
+// If `force` is true, we always roll writing_file unless it is empty.
 PageStorage::WriterPtr PageStorage::checkAndRenewWriter( //
     WritingPageFile & writing_file,
     PageFileIdAndLevel max_page_file_id_lvl_hint,
     const String & parent_path_hint,
     PageStorage::WriterPtr && old_writer,
-    const String & logging_msg)
+    const String & logging_msg,
+    bool force)
 {
     WriterPtr write_file_writer;
 
     PageFile & page_file = writing_file.file;
-    bool is_writable = page_file.isValid() && page_file.getType() == PageFile::Type::Formal //
-        && isPageFileSizeFitsWritable(page_file, config);
+    bool is_writable = (!force && page_file.isValid() && page_file.getType() == PageFile::Type::Formal //
+                        && isPageFileSizeFitsWritable(page_file, config));
     if (is_writable)
     {
         if (old_writer)
@@ -451,6 +455,7 @@ PageStorage::WriterPtr PageStorage::checkAndRenewWriter( //
         PageFileIdAndLevel max_writing_id_lvl{max_page_file_id_lvl_hint};
         for (const auto & wf : write_files)
             max_writing_id_lvl = std::max(max_writing_id_lvl, wf.file.fileIdLevel());
+
         delegator->addPageFileUsedSize( //
             PageFileIdAndLevel(max_writing_id_lvl.first + 1, 0),
             0,
@@ -1086,13 +1091,55 @@ bool PageStorage::gcImpl(bool not_skip, const WriteLimiterPtr & write_limiter, c
         {
             external_pages_remover(external_pages, live_normal_pages);
         }
+
+        // This instance will accept no more write, and we check whether there is any valid page in non writing page file,
+        // If not, it's very possible that all data have been moved to v3, so we try to roll all writing files to make them can be gced
+        if (no_more_insert)
+        {
+            bool has_normal_non_writing_files = false;
+            bool has_non_empty_write_file = false;
+            for (const auto & page_file : page_files)
+            {
+                if (page_file.fileIdLevel() < min_writing_file_id_level)
+                {
+                    if (page_file.getType() == PageFile::Type::Formal)
+                    {
+                        has_normal_non_writing_files = true;
+                    }
+                }
+                else
+                {
+                    // writing files
+                    if (page_file.getDiskSize() > 0)
+                    {
+                        has_non_empty_write_file = true;
+                    }
+                }
+                if (has_normal_non_writing_files && has_non_empty_write_file)
+                    break;
+            }
+            if (!has_normal_non_writing_files && has_non_empty_write_file)
+            {
+                std::unique_lock lock(write_mutex);
+                LOG_FMT_DEBUG(log, "{} No valid pages in non writing page files and the writing page files are not all empty. Try to roll all {} writing page files", storage_name, write_files.size());
+                idle_writers.clear();
+                for (auto & write_file : write_files)
+                {
+                    auto writer = checkAndRenewWriter(write_file, {0, 0}, /*parent_path_hint=*/"", nullptr, "", /*force*/ true);
+                    idle_writers.emplace_back(std::move(writer));
+                }
+            }
+        }
     };
 
     GCType gc_type = GCType::Normal;
     // Ignore page files that maybe writing to.
     do
     {
-        if (not_skip) // For page_storage_ctl, don't skip the GC
+        // Don't skip the GC under the case:
+        //  1. For page_storage_ctl
+        //  2. After transform all data from v2 to v3
+        if (not_skip)
         {
             gc_type = GCType::Normal;
             break;
@@ -1102,6 +1149,10 @@ bool PageStorage::gcImpl(bool not_skip, const WriteLimiterPtr & write_limiter, c
         {
             // If only few page files, running gc is useless.
             gc_type = GCType::Skip;
+        }
+        else if (no_more_insert)
+        {
+            gc_type = GCType::Normal;
         }
         else if (last_gc_statistics.equals(statistics_snapshot))
         {

--- a/dbms/src/Storages/Page/V2/PageStorage.cpp
+++ b/dbms/src/Storages/Page/V2/PageStorage.cpp
@@ -407,7 +407,7 @@ DB::PageEntry PageStorage::getEntryImpl(NamespaceId /*ns_id*/, PageId page_id, S
 // - Writable, reuse `old_writer` if it is not a nullptr, otherwise, create a new writer from `page_file`
 // - Not writable, renew the `page_file` and its belonging writer.
 //   The <id,level> of the new `page_file` is <max_id + 1, 0> of all `write_files`
-// If `force` is true, we always roll writing_file unless it is empty.
+// If `force` is true, always create new page file for writing.
 PageStorage::WriterPtr PageStorage::checkAndRenewWriter( //
     WritingPageFile & writing_file,
     PageFileIdAndLevel max_page_file_id_lvl_hint,

--- a/dbms/src/Storages/Page/V2/PageStorage.h
+++ b/dbms/src/Storages/Page/V2/PageStorage.h
@@ -88,7 +88,8 @@ public:
     PageStorage(String name,
                 PSDiskDelegatorPtr delegator, //
                 const Config & config_,
-                const FileProviderPtr & file_provider_);
+                const FileProviderPtr & file_provider_,
+                bool no_more_insert_ = false);
     ~PageStorage() = default;
 
     void restore() override;
@@ -272,13 +273,17 @@ private:
 
     StatisticsInfo last_gc_statistics;
 
+    // true means this instance runs under mix mode
+    bool no_more_insert = false;
+
 private:
     WriterPtr checkAndRenewWriter(
         WritingPageFile & writing_file,
         PageFileIdAndLevel max_page_file_id_lvl_hint,
         const String & parent_path_hint,
         WriterPtr && old_writer = nullptr,
-        const String & logging_msg = "");
+        const String & logging_msg = "",
+        bool force = false);
 };
 
 } // namespace PS::V2

--- a/dbms/src/Storages/PathPool.h
+++ b/dbms/src/Storages/PathPool.h
@@ -406,6 +406,12 @@ public:
     // Those paths are generated from the first path of `latest_path_infos` and `prefix`
     PSDiskDelegatorPtr getPSDiskDelegatorSingle(const String & prefix) { return std::make_shared<PSDiskDelegatorSingle>(*this, prefix); }
 
+    bool createPSV2DeleteMarkFile();
+
+    bool isPSV2Deleted() const;
+
+    void clearPSV2ObsoleteData();
+
     void rename(const String & new_database, const String & new_table, bool clean_rename);
 
     void drop(bool recursive, bool must_success = true);
@@ -414,6 +420,8 @@ private:
     String getStorePath(const String & extra_path_root, const String & database_name, const String & table_name) const;
 
     void renamePath(const String & old_path, const String & new_path);
+
+    String getPSV2DeleteMarkFilePath() const;
 
 private:
     using DMFilePathMap = std::unordered_map<UInt64, UInt32>;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #5336 

Problem Summary: After transform from all data from ps v2 to ps v3, there are still some v2 data left which may consume unnecessary disk space.

### What is changed and how it works?
When the valid pages in ps v2 is 0, we write a mark file to indicate that ps v2 is deleted. And try to drop v2 data.
And at later restart, if we find that there is are ps v2 delete mark file, we will not restore ps v2 and may try to clear obsolete v2 data if previous drop process was interrupted.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
1. load data in ps v2 format;
2. edit config to use ps v3 format;
3. run sql `alter table ... compact tiflash replica;` to transform all data from ps v2 to ps v3;
4. restart again to check whether the ps v2 data in the table data path is deleted.

Before restart:
![image](https://user-images.githubusercontent.com/47731263/179444734-b0064e10-74df-46c8-9eb9-e1d55e0b147d.png)
After restart and run compact:
![image](https://user-images.githubusercontent.com/47731263/179444910-f0b7f287-8a96-404a-88ed-e1fda7a0e1fe.png)

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
