### PR TITLE
Fix write after unconnect finish bug

### DIFF
--- a/dbms/src/Flash/Mpp/tests/gtest_mpptunnel.cpp
+++ b/dbms/src/Flash/Mpp/tests/gtest_mpptunnel.cpp
@@ -301,6 +301,38 @@ try
 }
 CATCH
 
+TEST_F(TestMPPTunnel, WriteAfterUnconnectFinished)
+{
+    try
+    {
+        auto mpp_tunnel_ptr = constructRemoteSyncTunnel();
+        std::unique_ptr<mpp::MPPDataPacket> data_packet_ptr = std::make_unique<mpp::MPPDataPacket>();
+        setTunnelFinished(mpp_tunnel_ptr);
+        data_packet_ptr->set_data("First");
+        mpp_tunnel_ptr->write(*data_packet_ptr);
+        GTEST_FAIL();
+    }
+    catch (Exception & e)
+    {
+        GTEST_ASSERT_EQ(e.message(), "write to tunnel which is already closed,");
+    }
+}
+
+TEST_F(TestMPPTunnel, WriteDoneAfterUnconnectFinished)
+{
+    try
+    {
+        auto mpp_tunnel_ptr = constructRemoteSyncTunnel();
+        setTunnelFinished(mpp_tunnel_ptr);
+        mpp_tunnel_ptr->writeDone();
+        GTEST_FAIL();
+    }
+    catch (Exception & e)
+    {
+        GTEST_ASSERT_EQ(e.message(), "write to tunnel which is already closed,");
+    }
+}
+
 TEST_F(TestMPPTunnel, ConnectWriteCancel)
 try
 {


### PR DESCRIPTION
Signed-off-by: yibin <huyibin@pingcap.com>

### What problem does this PR solve?

Issue Number: close #5378 

Problem Summary:

### What is changed and how it works?
When MPPTunnel finished before connected, the tunnelSender won't be initialized. And in such situation, write/writeDone will to this tunnel will raise exception. However, the exception try to access tunnelSender which will lead to segment fault.
So the fix is direct, check if tunnelSender is nullptr to protect.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
