### PR TITLE
Fix background thread count in dtworkload.

### DIFF
--- a/dbms/src/Storages/DeltaMerge/workload/DTWorkload.cpp
+++ b/dbms/src/Storages/DeltaMerge/workload/DTWorkload.cpp
@@ -37,7 +37,6 @@ namespace DB::DM::tests
 DB::Settings createSettings(const WorkloadOptions & opts)
 {
     DB::Settings settings;
-    settings.set("background_pool_size", std::to_string(opts.bg_thread_count));
     if (!opts.config_file.empty())
     {
         auto table = cpptoml::parse_file(opts.config_file);

--- a/dbms/src/Storages/DeltaMerge/workload/MainEntry.cpp
+++ b/dbms/src/Storages/DeltaMerge/workload/MainEntry.cpp
@@ -269,7 +269,7 @@ int DTWorkload::mainEntry(int argc, char ** argv)
     init(opts);
 
     // For mixed mode, we need to run the test in ONLY_V2 mode first.
-    TiFlashTestEnv::initializeGlobalContext(opts.work_dirs, opts.ps_run_mode == PageStorageRunMode::ONLY_V3 ? PageStorageRunMode::ONLY_V3 : PageStorageRunMode::ONLY_V2);
+    TiFlashTestEnv::initializeGlobalContext(opts.work_dirs, opts.ps_run_mode == PageStorageRunMode::ONLY_V3 ? PageStorageRunMode::ONLY_V3 : PageStorageRunMode::ONLY_V2, opts.bg_thread_count);
     if (opts.testing_type == "daily_perf")
     {
         dailyPerformanceTest(opts);

--- a/dbms/src/TestUtils/TiFlashTestEnv.cpp
+++ b/dbms/src/TestUtils/TiFlashTestEnv.cpp
@@ -28,7 +28,7 @@ namespace DB::tests
 {
 std::unique_ptr<Context> TiFlashTestEnv::global_context = nullptr;
 
-void TiFlashTestEnv::initializeGlobalContext(Strings testdata_path, PageStorageRunMode ps_run_mode)
+void TiFlashTestEnv::initializeGlobalContext(Strings testdata_path, PageStorageRunMode ps_run_mode, uint64_t bg_thread_count)
 {
     // set itself as global context
     global_context = std::make_unique<DB::Context>(DB::Context::createGlobal());
@@ -41,8 +41,8 @@ void TiFlashTestEnv::initializeGlobalContext(Strings testdata_path, PageStorageR
 
     // initialize background & blockable background thread pool
     Settings & settings = global_context->getSettingsRef();
-    global_context->initializeBackgroundPool(settings.background_pool_size);
-    global_context->initializeBlockableBackgroundPool(settings.background_pool_size);
+    global_context->initializeBackgroundPool(bg_thread_count == 0 ? settings.background_pool_size : bg_thread_count);
+    global_context->initializeBlockableBackgroundPool(bg_thread_count == 0 ? settings.background_pool_size : bg_thread_count);
 
     // Theses global variables should be initialized by the following order
     // 1. capacity

--- a/dbms/src/TestUtils/TiFlashTestEnv.cpp
+++ b/dbms/src/TestUtils/TiFlashTestEnv.cpp
@@ -41,8 +41,8 @@ void TiFlashTestEnv::initializeGlobalContext(Strings testdata_path, PageStorageR
 
     // initialize background & blockable background thread pool
     Settings & settings = global_context->getSettingsRef();
-    global_context->initializeBackgroundPool(bg_thread_count == 0 ? settings.background_pool_size : bg_thread_count);
-    global_context->initializeBlockableBackgroundPool(bg_thread_count == 0 ? settings.background_pool_size : bg_thread_count);
+    global_context->initializeBackgroundPool(bg_thread_count == 0 ? settings.background_pool_size.get() : bg_thread_count);
+    global_context->initializeBlockableBackgroundPool(bg_thread_count == 0 ? settings.background_pool_size.get() : bg_thread_count);
 
     // Theses global variables should be initialized by the following order
     // 1. capacity

--- a/dbms/src/TestUtils/TiFlashTestEnv.h
+++ b/dbms/src/TestUtils/TiFlashTestEnv.h
@@ -89,7 +89,7 @@ public:
 
     static Context getContext(const DB::Settings & settings = DB::Settings(), Strings testdata_path = {});
 
-    static void initializeGlobalContext(Strings testdata_path = {}, PageStorageRunMode ps_run_mode = PageStorageRunMode::ONLY_V3);
+    static void initializeGlobalContext(Strings testdata_path = {}, PageStorageRunMode ps_run_mode = PageStorageRunMode::ONLY_V3, uint64_t bg_thread_count = 0);
     static Context & getGlobalContext() { return *global_context; }
     static void shutdown();
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #5348 

Problem Summary: 

- PageStorage V3 will be initialized before DeltaMerge created.
- PageStorage V3 will use default configuration to initialize background thread pools that results in background thread count is different with PageStorage V2 enabled.

### What is changed and how it works?

Initialize background thread pools in the beginning.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
