### PR TITLE
fix pagestorage v2 restore

### DIFF
--- a/dbms/src/Storages/Page/V2/PageStorage.cpp
+++ b/dbms/src/Storages/Page/V2/PageStorage.cpp
@@ -313,6 +313,7 @@ void PageStorage::restore()
     }
 
     // Fill write_files
+    PageFileIdAndLevel max_page_file_id_lvl{0, 0};
     {
         const size_t num_delta_paths = delegator->numPaths();
         std::vector<size_t> next_write_fill_idx(num_delta_paths);
@@ -320,6 +321,7 @@ void PageStorage::restore()
         // Only insert location of PageFile when it storing delta data
         for (const auto & page_file : page_files)
         {
+            max_page_file_id_lvl = std::max(max_page_file_id_lvl, page_file.fileIdLevel());
             // Checkpoint file is always stored on `delegator`'s default path, so no need to insert it's location here
             size_t idx_in_delta_paths = delegator->addPageFileUsedSize(
                 page_file.fileIdLevel(),
@@ -343,7 +345,7 @@ void PageStorage::restore()
     std::vector<String> store_paths = delegator->listPaths();
     for (size_t i = 0; i < write_files.size(); ++i)
     {
-        auto writer = checkAndRenewWriter(write_files[i], /*parent_path_hint=*/store_paths[i % store_paths.size()]);
+        auto writer = checkAndRenewWriter(write_files[i], max_page_file_id_lvl, /*parent_path_hint=*/store_paths[i % store_paths.size()]);
         idle_writers.emplace_back(std::move(writer));
     }
 #endif
@@ -405,6 +407,7 @@ DB::PageEntry PageStorage::getEntryImpl(NamespaceId /*ns_id*/, PageId page_id, S
 //   The <id,level> of the new `page_file` is <max_id + 1, 0> of all `write_files`
 PageStorage::WriterPtr PageStorage::checkAndRenewWriter( //
     WritingPageFile & writing_file,
+    PageFileIdAndLevel max_page_file_id_lvl_hint,
     const String & parent_path_hint,
     PageStorage::WriterPtr && old_writer,
     const String & logging_msg)
@@ -445,10 +448,12 @@ PageStorage::WriterPtr PageStorage::checkAndRenewWriter( //
             // Check whether caller has defined a hint path
             pf_parent_path = parent_path_hint;
         }
-
-        PageFileIdAndLevel max_writing_id_lvl{0, 0};
+        PageFileIdAndLevel max_writing_id_lvl{max_page_file_id_lvl_hint};
         for (const auto & wf : write_files)
+        {
             max_writing_id_lvl = std::max(max_writing_id_lvl, wf.file.fileIdLevel());
+        }
+
         delegator->addPageFileUsedSize( //
             PageFileIdAndLevel(max_writing_id_lvl.first + 1, 0),
             0,
@@ -459,7 +464,7 @@ PageStorage::WriterPtr PageStorage::checkAndRenewWriter( //
         writing_file.file
             = PageFile::newPageFile(max_writing_id_lvl.first + 1, 0, pf_parent_path, file_provider, PageFile::Type::Formal, page_file_log);
         writing_file.persisted.meta_offset = 0;
-
+        max_writing_id_lvl.first += 1;
         write_file_writer = writing_file.file.createWriter(config.sync_on_write, true);
     }
     return write_file_writer;
@@ -562,7 +567,7 @@ void PageStorage::writeImpl(DB::WriteBatch && wb, const WriteLimiterPtr & write_
 
         // Check whether we need to roll to new PageFile and its writer
         const auto logging_msg = " PageFile_" + DB::toString(writing_file.file.getFileId()) + "_0 is full,";
-        file_to_write = checkAndRenewWriter(writing_file, "", std::move(file_to_write), logging_msg);
+        file_to_write = checkAndRenewWriter(writing_file, {0, 0}, "", std::move(file_to_write), logging_msg);
 
         idle_writers.emplace_back(std::move(file_to_write));
 

--- a/dbms/src/Storages/Page/V2/PageStorage.cpp
+++ b/dbms/src/Storages/Page/V2/PageStorage.cpp
@@ -450,10 +450,7 @@ PageStorage::WriterPtr PageStorage::checkAndRenewWriter( //
         }
         PageFileIdAndLevel max_writing_id_lvl{max_page_file_id_lvl_hint};
         for (const auto & wf : write_files)
-        {
             max_writing_id_lvl = std::max(max_writing_id_lvl, wf.file.fileIdLevel());
-        }
-
         delegator->addPageFileUsedSize( //
             PageFileIdAndLevel(max_writing_id_lvl.first + 1, 0),
             0,
@@ -464,7 +461,6 @@ PageStorage::WriterPtr PageStorage::checkAndRenewWriter( //
         writing_file.file
             = PageFile::newPageFile(max_writing_id_lvl.first + 1, 0, pf_parent_path, file_provider, PageFile::Type::Formal, page_file_log);
         writing_file.persisted.meta_offset = 0;
-        max_writing_id_lvl.first += 1;
         write_file_writer = writing_file.file.createWriter(config.sync_on_write, true);
     }
     return write_file_writer;

--- a/dbms/src/Storages/Page/V2/PageStorage.h
+++ b/dbms/src/Storages/Page/V2/PageStorage.h
@@ -275,6 +275,7 @@ private:
 private:
     WriterPtr checkAndRenewWriter(
         WritingPageFile & writing_file,
+        PageFileIdAndLevel max_page_file_id_lvl_hint,
         const String & parent_path_hint,
         WriterPtr && old_writer = nullptr,
         const String & logging_msg = "");

--- a/dbms/src/Storages/Page/V2/tests/gtest_page_storage.cpp
+++ b/dbms/src/Storages/Page/V2/tests/gtest_page_storage.cpp
@@ -443,6 +443,38 @@ try
 }
 CATCH
 
+TEST_F(PageStorage_test, RenewWriter)
+try
+{
+    constexpr size_t buf_sz = 100;
+    char c_buff[buf_sz];
+
+    {
+        WriteBatch wb;
+        memset(c_buff, 0xf, buf_sz);
+        auto buf = std::make_shared<ReadBufferFromMemory>(c_buff, sizeof(c_buff));
+        wb.putPage(1, 0, buf, buf_sz);
+        storage->write(std::move(wb));
+    }
+
+    {
+        PageStorage::ListPageFilesOption opt;
+        auto page_files = storage->listAllPageFiles(file_provider, storage->delegator, storage->log, opt);
+        ASSERT_EQ(page_files.size(), 1UL);
+    }
+
+    PageStorage::Config config;
+    config.file_roll_size = 10; // make it easy to renew a new page file for write
+    storage = reopenWithConfig(config);
+
+    {
+        PageStorage::ListPageFilesOption opt;
+        auto page_files = storage->listAllPageFiles(file_provider, storage->delegator, storage->log, opt);
+        ASSERT_EQ(page_files.size(), 2UL);
+    }
+}
+CATCH
+
 /// Check if we can correctly do read / write after restore from disk.
 TEST_F(PageStorage_test, WriteReadRestore)
 try

--- a/dbms/src/Storages/Transaction/RegionPersister.cpp
+++ b/dbms/src/Storages/Transaction/RegionPersister.cpp
@@ -189,7 +189,7 @@ void RegionPersister::forceTransformKVStoreV2toV3()
         const auto & page_transform_entry = page_reader->getPageEntry(page.page_id);
         if (!page_transform_entry.field_offsets.empty())
         {
-            throw Exception(fmt::format("Can't transform kvstore from V2 to V3, [page_id={}] {}",
+            throw Exception(fmt::format("Can't transfrom kvstore from V2 to V3, [page_id={}] {}",
                                         page.page_id,
                                         page_transform_entry.toDebugString()),
                             ErrorCodes::LOGICAL_ERROR);

--- a/dbms/src/Storages/Transaction/RegionPersister.cpp
+++ b/dbms/src/Storages/Transaction/RegionPersister.cpp
@@ -189,7 +189,7 @@ void RegionPersister::forceTransformKVStoreV2toV3()
         const auto & page_transform_entry = page_reader->getPageEntry(page.page_id);
         if (!page_transform_entry.field_offsets.empty())
         {
-            throw Exception(fmt::format("Can't transfrom kvstore from V2 to V3, [page_id={}] {}",
+            throw Exception(fmt::format("Can't transform kvstore from V2 to V3, [page_id={}] {}",
                                         page.page_id,
                                         page_transform_entry.toDebugString()),
                             ErrorCodes::LOGICAL_ERROR);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #5385 

Problem Summary: When restart, ps v2 will try to reuse old page file for writing. But if no file can be used for writing, it will create new page file. But the file id of the new page file is determined by the max file id in writing page file set which is empty now. And it will create `PageFile_1_0` in this case for writing which may override previous data.

### What is changed and how it works?
Make sure new page file id is larger than all current page files at restart.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
