### PR TITLE
refine log in creating set for join build

### DIFF
--- a/dbms/src/DataStreams/CreatingSetsBlockInputStream.cpp
+++ b/dbms/src/DataStreams/CreatingSetsBlockInputStream.cpp
@@ -257,6 +257,8 @@ void CreatingSetsBlockInputStream::createOne(SubqueryForSet & subquery)
             if (subquery.join)
                 subquery.join->setTotals(profiling_in->getTotals());
         }
+        if (subquery.join)
+            head_rows = subquery.join->getTotalBuildInputRows();
 
         if (head_rows != 0)
         {

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -788,6 +788,7 @@ bool Join::insertFromBlock(const Block & block)
     std::unique_lock lock(rwlock);
     if (unlikely(!initialized))
         throw Exception("Logical error: Join was not initialized", ErrorCodes::LOGICAL_ERROR);
+    total_input_build_rows += block.rows();
     blocks.push_back(block);
     Block * stored_block = &blocks.back();
     return insertFromBlockInternal(stored_block, 0);
@@ -805,6 +806,7 @@ void Join::insertFromBlock(const Block & block, size_t stream_index)
     Block * stored_block = nullptr;
     {
         std::lock_guard lk(blocks_lock);
+        total_input_build_rows += block.rows();
         blocks.push_back(block);
         stored_block = &blocks.back();
         original_blocks.push_back(block);

--- a/dbms/src/Interpreters/Join.h
+++ b/dbms/src/Interpreters/Join.h
@@ -141,6 +141,8 @@ public:
     /// Sum size in bytes of all buffers, used for JOIN maps and for all memory pools.
     size_t getTotalByteCount() const;
 
+    size_t getTotalBuildInputRows() const { return total_input_build_rows; }
+
     ASTTableJoin::Kind getKind() const { return kind; }
 
     bool useNulls() const { return use_nulls; }
@@ -337,6 +339,7 @@ private:
     SizeLimits limits;
 
     Block totals;
+    std::atomic<size_t> total_input_build_rows{0};
     /** Protect state for concurrent use in insertFromBlock and joinBlock.
       * Note that these methods could be called simultaneously only while use of StorageJoin,
       *  and StorageJoin only calls these two methods.


### PR DESCRIPTION
Signed-off-by: xufei <xufeixw@mail.ustc.edu.cn>

### What problem does this PR solve?

Issue Number: close #5403

Problem Summary:

### What is changed and how it works?
1. `Join` will save the total build input rows
2. For join, `CreatingSetsBlockInputStream` get the `head_rows` from `subquery.join` directly.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
