### PR TITLE
Fix async sender nullptr bug

### DIFF
--- a/dbms/src/Flash/EstablishCall.cpp
+++ b/dbms/src/Flash/EstablishCall.cpp
@@ -118,7 +118,8 @@ void EstablishCallData::setFinishState(const String & msg)
     if (async_tunnel_sender && !async_tunnel_sender->isConsumerFinished())
     {
         async_tunnel_sender->consumerFinish(fmt::format("{}: {}",
-                                                        async_tunnel_sender->getTunnelId(), msg)); //trigger mpp tunnel finish work
+                                                        async_tunnel_sender->getTunnelId(),
+                                                        msg)); //trigger mpp tunnel finish work
     }
 }
 

--- a/dbms/src/Flash/EstablishCall.cpp
+++ b/dbms/src/Flash/EstablishCall.cpp
@@ -86,7 +86,7 @@ void EstablishCallData::initRpc()
     }
     if (eptr)
     {
-        state = FINISH;
+        setFinishStatus();
         grpc::Status status(static_cast<grpc::StatusCode>(GRPC_STATUS_UNKNOWN), getExceptionMessage(eptr, false));
         responderFinish(status);
     }
@@ -112,9 +112,19 @@ void EstablishCallData::writeErr(const mpp::MPPDataPacket & packet)
         err_status = grpc::Status(grpc::StatusCode::UNKNOWN, "Write error message failed for unknown reason.");
 }
 
-void EstablishCallData::writeDone(const ::grpc::Status & status)
+void EstablishCallData::setFinishStatus()
 {
     state = FINISH;
+    if (async_tunnel_sender && !async_tunnel_sender->isConsumerFinished())
+    {
+        async_tunnel_sender->consumerFinish(fmt::format("{}: setFinishStatus called.",
+                                                        async_tunnel_sender->getTunnelId())); //trigger mpp tunnel finish work
+    }
+}
+
+void EstablishCallData::writeDone(const ::grpc::Status & status)
+{
+    setFinishStatus();
     if (stopwatch)
     {
         LOG_FMT_INFO(async_tunnel_sender->getLogger(), "connection for {} cost {} ms.", async_tunnel_sender->getTunnelId(), stopwatch->elapsedMilliseconds());
@@ -140,12 +150,7 @@ void EstablishCallData::cancel()
 
 void EstablishCallData::finishTunnelAndResponder()
 {
-    state = FINISH;
-    if (async_tunnel_sender)
-    {
-        async_tunnel_sender->consumerFinish(fmt::format("{}: finishTunnelAndResponder called.",
-                                                        async_tunnel_sender->getTunnelId())); //trigger mpp tunnel finish work
-    }
+    setFinishStatus();
     grpc::Status status(static_cast<grpc::StatusCode>(GRPC_STATUS_UNKNOWN), "Consumer exits unexpected, grpc writes failed.");
     responder.Finish(status, this);
 }
@@ -174,7 +179,6 @@ void EstablishCallData::proceed()
     }
     else if (state == ERR_HANDLE)
     {
-        state = FINISH;
         writeDone(err_status);
     }
     else

--- a/dbms/src/Flash/EstablishCall.cpp
+++ b/dbms/src/Flash/EstablishCall.cpp
@@ -86,7 +86,7 @@ void EstablishCallData::initRpc()
     }
     if (eptr)
     {
-        setFinishStatus();
+        setFinishState();
         grpc::Status status(static_cast<grpc::StatusCode>(GRPC_STATUS_UNKNOWN), getExceptionMessage(eptr, false));
         responderFinish(status);
     }
@@ -112,19 +112,19 @@ void EstablishCallData::writeErr(const mpp::MPPDataPacket & packet)
         err_status = grpc::Status(grpc::StatusCode::UNKNOWN, "Write error message failed for unknown reason.");
 }
 
-void EstablishCallData::setFinishStatus()
+void EstablishCallData::setFinishState()
 {
     state = FINISH;
     if (async_tunnel_sender && !async_tunnel_sender->isConsumerFinished())
     {
-        async_tunnel_sender->consumerFinish(fmt::format("{}: setFinishStatus called.",
+        async_tunnel_sender->consumerFinish(fmt::format("{}: setFinishState called.",
                                                         async_tunnel_sender->getTunnelId())); //trigger mpp tunnel finish work
     }
 }
 
 void EstablishCallData::writeDone(const ::grpc::Status & status)
 {
-    setFinishStatus();
+    setFinishState();
     if (stopwatch)
     {
         LOG_FMT_INFO(async_tunnel_sender->getLogger(), "connection for {} cost {} ms.", async_tunnel_sender->getTunnelId(), stopwatch->elapsedMilliseconds());
@@ -150,7 +150,7 @@ void EstablishCallData::cancel()
 
 void EstablishCallData::finishTunnelAndResponder()
 {
-    setFinishStatus();
+    setFinishState();
     grpc::Status status(static_cast<grpc::StatusCode>(GRPC_STATUS_UNKNOWN), "Consumer exits unexpected, grpc writes failed.");
     responder.Finish(status, this);
 }

--- a/dbms/src/Flash/EstablishCall.cpp
+++ b/dbms/src/Flash/EstablishCall.cpp
@@ -86,7 +86,7 @@ void EstablishCallData::initRpc()
     }
     if (eptr)
     {
-        setFinishState();
+        setFinishState("initRpc called");
         grpc::Status status(static_cast<grpc::StatusCode>(GRPC_STATUS_UNKNOWN), getExceptionMessage(eptr, false));
         responderFinish(status);
     }
@@ -112,19 +112,19 @@ void EstablishCallData::writeErr(const mpp::MPPDataPacket & packet)
         err_status = grpc::Status(grpc::StatusCode::UNKNOWN, "Write error message failed for unknown reason.");
 }
 
-void EstablishCallData::setFinishState()
+void EstablishCallData::setFinishState(const String & msg)
 {
     state = FINISH;
     if (async_tunnel_sender && !async_tunnel_sender->isConsumerFinished())
     {
-        async_tunnel_sender->consumerFinish(fmt::format("{}: setFinishState called.",
-                                                        async_tunnel_sender->getTunnelId())); //trigger mpp tunnel finish work
+        async_tunnel_sender->consumerFinish(fmt::format("{}: {}",
+                                                        async_tunnel_sender->getTunnelId(), msg)); //trigger mpp tunnel finish work
     }
 }
 
 void EstablishCallData::writeDone(const ::grpc::Status & status)
 {
-    setFinishState();
+    setFinishState("writeDone called");
     if (stopwatch)
     {
         LOG_FMT_INFO(async_tunnel_sender->getLogger(), "connection for {} cost {} ms.", async_tunnel_sender->getTunnelId(), stopwatch->elapsedMilliseconds());
@@ -150,7 +150,7 @@ void EstablishCallData::cancel()
 
 void EstablishCallData::finishTunnelAndResponder()
 {
-    setFinishState();
+    setFinishState("finishTunnelAndResponder called");
     grpc::Status status(static_cast<grpc::StatusCode>(GRPC_STATUS_UNKNOWN), "Consumer exits unexpected, grpc writes failed.");
     responder.Finish(status, this);
 }

--- a/dbms/src/Flash/EstablishCall.h
+++ b/dbms/src/Flash/EstablishCall.h
@@ -84,6 +84,7 @@ private:
 
     void finishTunnelAndResponder();
 
+    void setFinishStatus();
     void responderFinish(const grpc::Status & status);
 
     std::mutex mu;

--- a/dbms/src/Flash/EstablishCall.h
+++ b/dbms/src/Flash/EstablishCall.h
@@ -85,7 +85,7 @@ private:
     void finishTunnelAndResponder();
 
     // will try to call async_sender's consumerFinish if needed
-    void setFinishState();
+    void setFinishState(const String & msg);
 
     void responderFinish(const grpc::Status & status);
 

--- a/dbms/src/Flash/EstablishCall.h
+++ b/dbms/src/Flash/EstablishCall.h
@@ -84,7 +84,9 @@ private:
 
     void finishTunnelAndResponder();
 
-    void setFinishStatus();
+    // will try to call async_sender's consumerFinish if needed
+    void setFinishState();
+
     void responderFinish(const grpc::Status & status);
 
     std::mutex mu;

--- a/dbms/src/Flash/Mpp/MPPTunnel.cpp
+++ b/dbms/src/Flash/Mpp/MPPTunnel.cpp
@@ -349,11 +349,18 @@ void SyncTunnelSender::startSendThread()
 
 void AsyncTunnelSender::tryFlushOne()
 {
+    // When consumer finished, sending work is done already, just return
+    if (consumer_state.msgHasSet())
+        return;
     writer->tryFlushOne();
 }
 
 void AsyncTunnelSender::sendOne()
 {
+    // When consumer finished, sending work is done already, just return
+    if (consumer_state.msgHasSet())
+        return;
+
     String err_msg;
     bool queue_empty_flag = false;
     try


### PR DESCRIPTION
Signed-off-by: yibin <huyibin@pingcap.com>

### What problem does this PR solve?

Issue Number: close #5405 

Problem Summary:

### What is changed and how it works?
In MPPTunnel refact PR, consumerFinished won't set tunnel's state to finished. So for async tunnel mode, when AsyncSender call consumerFinish and then call writer's writeDone method, writer will be deleted anytime. However, tunnel might not notice this, and call AsyncSender's tryFlushOne still, then segment fault happened.
So fix the issue by check if AsyncSender has already consumerFinished before do actually work for TryFlushOne/SendOne.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
