### PR TITLE
Fix extract fullstack test

### DIFF
--- a/tests/fullstack-test/expr/extract_datetime.test
+++ b/tests/fullstack-test/expr/extract_datetime.test
@@ -22,7 +22,7 @@ mysql> set session tidb_isolation_read_engines='tiflash'; select a from test.t w
 a
 2021-03-13 12:34:56.123456
 
-mysql> set session tidb_isolation_read_engines='tiflash'; select a from test.t where extract(day_microsecond from a) = 13123456123456 and extract(day_second from a) = 13123456 and extract(day_minute from a) = 131234 and extract(day_hour from a) = 1312 and extract(year_month from a) = 202103;
+mysql> set session tidb_isolation_read_engines='tiflash'; select a from test.t where extract(day_microsecond from a) = 123456123456 and extract(day_second from a) = 123456 and extract(day_minute from a) = 1234 and extract(day_hour from a) = 12 and extract(year_month from a) = 202103;
 a
 2021-03-13 12:34:56.123456
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #5421

Problem Summary:

After TiDB PR https://github.com/pingcap/tidb/pull/36297, `extract(day_microsecond/second/minute/hour)` behavior changed to evaluate the second argument to time, thus the day portion wouldn't be showing up in the result.

### What is changed and how it works?

Update test reference.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
