### PR TITLE
build: Fix build under intel mac machine

### DIFF
--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -159,7 +159,7 @@ SET (BENCHMARK_ENABLE_GTEST_TESTS OFF CACHE BOOL "Disable google-benchmark testi
 add_subdirectory(benchmark)
 
 set (BUILD_TESTING OFF CACHE BOOL "Disable cpu-features testing" FORCE)
-if ((NOT APPLE) AND (NOT ARCH_AARCH64))
+if (NOT (APPLE AND ARCH_AARCH64))
     add_subdirectory(cpu_features)
 endif()
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/5368

Problem Summary:
`cpu_features` is not added as a subdirectory under intel mac

### What is changed and how it works?

Due to cmake condition
```
# test CMake if condition
>  cat CMakeLists.txt
project(test)

set(ARCH_AARCH64 0)
set(ARCH_AMD64 1)
set(APPLE 1)

if ((NOT APPLE))
    message(STATUS "    not apple -- APPLE:${APPLE} ARCH_AARCH64:${ARCH_AARCH64}")
else()
    message(STATUS "        apple -- APPLE:${APPLE} ARCH_AARCH64:${ARCH_AARCH64}")
endif()

if ((NOT ARCH_AARCH64))
    message(STATUS "    not arm64 -- APPLE:${APPLE} ARCH_AARCH64:${ARCH_AARCH64}")
else()
    message(STATUS "        arm64 -- APPLE:${APPLE} ARCH_AARCH64:${ARCH_AARCH64}")
endif()

if (APPLE AND ARCH_AARCH64)
    message(STATUS "     apple and arm64  -- APPLE:${APPLE} ARCH_AARCH64:${ARCH_AARCH64}")
else()
    message(STATUS "not (apple and arm64) -- APPLE:${APPLE} ARCH_AARCH64:${ARCH_AARCH64}")
endif()

if ((NOT APPLE) AND (NOT ARCH_AARCH64))
    message(STATUS "not (apple and arm64) -- APPLE:${APPLE} ARCH_AARCH64:${ARCH_AARCH64}")
else()
    message(STATUS "     apple and arm64  -- APPLE:${APPLE} ARCH_AARCH64:${ARCH_AARCH64}")
endif()

if (NOT (APPLE AND ARCH_AARCH64))
    message(STATUS "not (apple and arm64) -- APPLE:${APPLE} ARCH_AARCH64:${ARCH_AARCH64}")
else()
    message(STATUS "     apple and arm64  -- APPLE:${APPLE} ARCH_AARCH64:${ARCH_AARCH64}")
endif()
>  cmake .
--         apple -- APPLE:1 ARCH_AARCH64:0
--     not arm64 -- APPLE:1 ARCH_AARCH64:0
-- not (apple and arm64) -- APPLE:1 ARCH_AARCH64:0
--      apple and arm64  -- APPLE:1 ARCH_AARCH64:0
-- not (apple and arm64) -- APPLE:1 ARCH_AARCH64:0
-- Configuring done
-- Generating done
-- Build files have been written to: /test
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  - build under an intel imac
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
