### PR TITLE
In scenarios where place index is not needed, there is no need to insert column cache when read stable data.

### DIFF
--- a/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.cpp
@@ -17,7 +17,7 @@
 
 namespace DB::DM
 {
-DMFileBlockInputStreamBuilder::DMFileBlockInputStreamBuilder(const Context & context)
+DMFileBlockInputStreamBuilder::DMFileBlockInputStreamBuilder(const Context & context, bool * need_column_cache)
     : file_provider(context.getFileProvider())
     , read_limiter(context.getReadLimiter())
 {
@@ -26,6 +26,10 @@ DMFileBlockInputStreamBuilder::DMFileBlockInputStreamBuilder(const Context & con
     setCaches(global_context.getMarkCache(), global_context.getMinMaxIndexCache());
     // init from settings
     setFromSettings(context.getSettingsRef());
+    if (need_column_cache)
+    {
+        need_update_column_cache = *need_column_cache;
+    }
 }
 
 DMFileBlockInputStreamPtr DMFileBlockInputStreamBuilder::build(const DMFilePtr & dmfile, const ColumnDefines & read_columns, const RowKeyRanges & rowkey_ranges)
@@ -72,7 +76,8 @@ DMFileBlockInputStreamPtr DMFileBlockInputStreamBuilder::build(const DMFilePtr &
         read_limiter,
         rows_threshold_per_read,
         read_one_pack_every_time,
-        tracing_id);
+        tracing_id,
+        need_update_column_cache);
 
     return std::make_shared<DMFileBlockInputStream>(std::move(reader));
 }

--- a/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.h
@@ -58,7 +58,7 @@ public:
     // - current settings from this context
     // - current read limiter form this context
     // - current file provider from this context
-    explicit DMFileBlockInputStreamBuilder(const Context & context);
+    explicit DMFileBlockInputStreamBuilder(const Context & context, bool * need_column_cache = nullptr);
 
     // Build the final stream ptr.
     // Should not use the builder again after `build` is called.
@@ -148,6 +148,8 @@ private:
     MinMaxIndexCachePtr index_cache;
     // column cache
     bool enable_column_cache = false;
+    // In scenarios where place index is not needed, there is no need to insert column cache when read stable data.
+    bool need_update_column_cache = true;
     ColumnCachePtr column_cache;
     ReadLimiterPtr read_limiter;
     size_t aio_threshold;

--- a/dbms/src/Storages/DeltaMerge/File/DMFileReader.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileReader.h
@@ -90,7 +90,8 @@ public:
         const ReadLimiterPtr & read_limiter,
         size_t rows_threshold_per_read_,
         bool read_one_pack_every_time_,
-        const String & tracing_id_);
+        const String & tracing_id_,
+        bool need_update_column_cache = true);
 
     Block getHeader() const { return toEmptyBlock(read_columns); }
 
@@ -143,6 +144,8 @@ private:
     FileProviderPtr file_provider;
 
     LoggerPtr log;
+    // In scenarios where place index is not needed, there is no need to insert column cache when read stable data.
+    bool need_update_column_cache = true;
 };
 
 } // namespace DM

--- a/dbms/src/Storages/DeltaMerge/Segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/Segment.cpp
@@ -1465,7 +1465,7 @@ SkippableBlockInputStreamPtr Segment::getPlacedStream(const DMContext & dm_conte
         throw Exception("rowkey ranges shouldn't be empty", ErrorCodes::LOGICAL_ERROR);
 
     SkippableBlockInputStreamPtr stable_input_stream
-        = stable_snap->getInputStream(dm_context, read_columns, rowkey_ranges, filter, max_version, expected_block_size, false);
+        = stable_snap->getInputStream(dm_context, read_columns, rowkey_ranges, filter, max_version, expected_block_size, false, true);
     RowKeyRange rowkey_range = rowkey_ranges.size() == 1 ? rowkey_ranges[0] : mergeRanges(rowkey_ranges, rowkey_ranges[0].is_common_handle, rowkey_ranges[0].rowkey_column_size);
     return std::make_shared<DeltaMergeBlockInputStream<DeltaValueReader, IndexIterator, skippable_place>>( //
         stable_input_stream,

--- a/dbms/src/Storages/DeltaMerge/StableValueSpace.cpp
+++ b/dbms/src/Storages/DeltaMerge/StableValueSpace.cpp
@@ -328,14 +328,15 @@ StableValueSpace::Snapshot::getInputStream(
     const RSOperatorPtr & filter,
     UInt64 max_data_version,
     size_t expected_block_size,
-    bool enable_clean_read)
+    bool enable_clean_read,
+    bool need_update_column_cache)
 {
     LOG_FMT_DEBUG(log, "max_data_version: {}, enable_clean_read: {}", max_data_version, enable_clean_read);
     SkippableBlockInputStreams streams;
 
     for (size_t i = 0; i < stable->files.size(); i++)
     {
-        DMFileBlockInputStreamBuilder builder(context.db_context);
+        DMFileBlockInputStreamBuilder builder(context.db_context, &need_update_column_cache);
         builder
             .enableCleanRead(enable_clean_read, max_data_version)
             .setRSOperator(filter)

--- a/dbms/src/Storages/DeltaMerge/StableValueSpace.h
+++ b/dbms/src/Storages/DeltaMerge/StableValueSpace.h
@@ -150,7 +150,8 @@ public:
                                                     const RSOperatorPtr & filter,
                                                     UInt64 max_data_version,
                                                     size_t expected_block_size,
-                                                    bool enable_clean_read);
+                                                    bool enable_clean_read,
+                                                    bool need_update_column_cache = false);
 
         RowsAndBytes getApproxRowsAndBytes(const DMContext & context, const RowKeyRange & range) const;
 


### PR DESCRIPTION
In scenarios where place index is not needed, there is no need to insert column cache when read stable data.

Signed-off-by: hehechen <awd123456sss@gmail.com>

### What problem does this PR solve?

Issue Number: close #5406

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
