### PR TITLE
feat: do del column clean read optimization for fast mode

### DIFF
--- a/dbms/src/Functions/FunctionsString.cpp
+++ b/dbms/src/Functions/FunctionsString.cpp
@@ -4752,7 +4752,7 @@ public:
 
     DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override
     {
-        auto first_argument = arguments[0];
+        const auto& first_argument = arguments[0];
         if (!first_argument->isNumber() && !first_argument->isDecimal())
             throw Exception(
                 fmt::format("Illegal type {} of first argument of function {}", first_argument->getName(), getName()),
@@ -5285,7 +5285,7 @@ private:
         {
             UInt64 number = col->getUInt(i);
 
-            int print_size = sprintf(reinterpret_cast<char *>(&res_chars[prev_res_offset]), "%lX", number);
+            int print_size = sprintf(reinterpret_cast<char *>(&res_chars[prev_res_offset]), "%llX", number);
             res_chars[prev_res_offset + print_size] = 0;
             // Add the size of printed string and a tailing zero
             prev_res_offset += print_size + 1;

--- a/dbms/src/Server/DTTool/DTToolMigrate.cpp
+++ b/dbms/src/Server/DTTool/DTToolMigrate.cpp
@@ -235,7 +235,7 @@ int migrateServiceMain(DB::Context & context, const MigrateArgs & args)
             if (!args.dry_mode)
                 output_stream.write(
                     block,
-                    {stat_iter->not_clean, properties_iter->num_rows(), properties_iter->gc_hint_version()});
+                    {stat_iter->not_clean, stat_iter->is_delete, properties_iter->num_rows(), properties_iter->gc_hint_version()});
             stat_iter++;
             properties_iter++;
         }

--- a/dbms/src/Server/tests/gtest_dttool.cpp
+++ b/dbms/src/Server/tests/gtest_dttool.cpp
@@ -180,7 +180,7 @@ TEST_F(DTToolTest, ConsecutiveMigration)
     };
 
     EXPECT_EQ(DTTool::Migrate::migrateServiceMain(*db_context, args), 0);
-    auto logger = &Poco::Logger::get("DTToolTest");
+    auto *logger = &Poco::Logger::get("DTToolTest");
     std::unordered_map<std::string, std::string> records;
     {
         Poco::File file{dmfile->path()};
@@ -281,6 +281,7 @@ TEST_F(DTToolTest, BlockwiseInvariant)
             EXPECT_EQ(prop_iter->num_rows(), new_prop_iter->num_rows());
             EXPECT_EQ(stat_iter->rows, new_stat_iter->rows);
             EXPECT_EQ(stat_iter->not_clean, new_stat_iter->not_clean);
+            EXPECT_EQ(stat_iter->is_delete, new_stat_iter->is_delete);
             EXPECT_EQ(stat_iter->first_version, new_stat_iter->first_version);
             EXPECT_EQ(stat_iter->bytes, new_stat_iter->bytes);
             EXPECT_EQ(stat_iter->first_tag, new_stat_iter->first_tag);

--- a/dbms/src/Storages/DeltaMerge/DMDecoratorStreams.h
+++ b/dbms/src/Storages/DeltaMerge/DMDecoratorStreams.h
@@ -65,6 +65,18 @@ public:
             if (block.rows() == 0)
                 continue;
 
+            /// if the pack is do clean read for del column, the del column returned is a const column, with size 1.
+            /// In this case, all the del_mark must be 0. Thus we don't need extra filter.
+            if (block.getByPosition(delete_col_pos).column->isColumnConst())
+            {
+                ++total_blocks;
+                ++complete_passed;
+                total_rows += block.rows();
+                passed_rows += block.rows();
+
+                return getNewBlockByHeader(header, block);
+            }
+
             delete_col_data = getColumnVectorDataPtr<UInt8>(block, delete_col_pos);
 
             size_t rows = block.rows();

--- a/dbms/src/Storages/DeltaMerge/DMVersionFilterBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/DMVersionFilterBlockInputStream.cpp
@@ -257,6 +257,30 @@ Block DMVersionFilterBlockInputStream<MODE>::read(FilterPtr & res_filter, bool r
                 }
             }
 
+            // Let's set is_delete.
+            is_delete.resize(rows);
+            {
+                UInt8 * is_delete_pos = is_delete.data();
+                auto * delete_pos = const_cast<UInt8 *>(delete_col_data->data());
+                for (size_t i = 0; i < batch_rows; ++i)
+                {
+                    (*is_delete_pos) = (*delete_pos);
+                    ++is_delete_pos;
+                    ++delete_pos;
+                }
+            }
+
+            {
+                UInt8 * is_delete_pos = is_delete.data();
+                UInt8 * filter_pos = filter.data();
+                for (size_t i = 0; i < batch_rows; ++i)
+                {
+                    (*is_delete_pos) &= (*filter_pos);
+                    ++is_delete_pos;
+                    ++filter_pos;
+                }
+            }
+
             // Let's calculate gc_hint_version
             gc_hint_version = std::numeric_limits<UInt64>::max();
             {
@@ -307,6 +331,7 @@ Block DMVersionFilterBlockInputStream<MODE>::read(FilterPtr & res_filter, bool r
                 {
                     filter[rows - 1] = cur_version >= version_limit || !deleted;
                     not_clean[rows - 1] = filter[rows - 1] && deleted;
+                    is_delete[rows - 1] = filter[rows - 1] && deleted;
                     effective[rows - 1] = filter[rows - 1];
                     if (filter[rows - 1])
                         gc_hint_version = std::min(
@@ -332,6 +357,7 @@ Block DMVersionFilterBlockInputStream<MODE>::read(FilterPtr & res_filter, bool r
                     filter[rows - 1] = cur_version >= version_limit
                         || ((compare(cur_handle, next_handle) != 0 || next_version > version_limit) && !deleted);
                     not_clean[rows - 1] = filter[rows - 1] && (compare(cur_handle, next_handle) == 0 || deleted);
+                    is_delete[rows - 1] = filter[rows - 1] && deleted;
                     effective[rows - 1] = filter[rows - 1] && (compare(cur_handle, next_handle) != 0);
                     if (filter[rows - 1])
                         gc_hint_version
@@ -349,6 +375,7 @@ Block DMVersionFilterBlockInputStream<MODE>::read(FilterPtr & res_filter, bool r
         if constexpr (MODE == DM_VERSION_FILTER_MODE_COMPACT)
         {
             not_clean_rows += countBytesInFilter(not_clean);
+            is_delete_rows += countBytesInFilter(is_delete);
             effective_num_rows += countBytesInFilter(effective);
         }
 

--- a/dbms/src/Storages/DeltaMerge/DMVersionFilterBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/DMVersionFilterBlockInputStream.h
@@ -68,13 +68,14 @@ public:
         LOG_FMT_DEBUG(log,
                       "Total rows: {}, pass: {:.2f}%"
                       ", complete pass: {:.2f}%, complete not pass: {:.2f}%"
-                      ", not clean: {:.2f}%, effective: {:.2f}%"
+                      ", not clean: {:.2f}%, is delete: {:.2f}%, effective: {:.2f}%"
                       ", read tso: {}",
                       total_rows,
                       passed_rows * 100.0 / total_rows,
                       complete_passed * 100.0 / total_blocks,
                       complete_not_passed * 100.0 / total_blocks,
                       not_clean_rows * 100.0 / passed_rows,
+                      is_delete_rows * 100.0 / passed_rows,
                       effective_num_rows * 100.0 / passed_rows,
                       version_limit);
     }
@@ -95,6 +96,7 @@ public:
 
     size_t getEffectiveNumRows() const { return effective_num_rows; }
     size_t getNotCleanRows() const { return not_clean_rows; }
+    size_t getIsDeleteRows() const { return is_delete_rows; }
     UInt64 getGCHintVersion() const { return gc_hint_version; }
 
 private:
@@ -114,6 +116,7 @@ private:
             filter[i]
                 = cur_version >= version_limit || ((compare(cur_handle, next_handle) != 0 || next_version > version_limit) && !deleted);
             not_clean[i] = filter[i] && (compare(cur_handle, next_handle) == 0 || deleted);
+            is_delete[i] = filter[i] && deleted;
             effective[i] = filter[i] && (compare(cur_handle, next_handle) != 0);
             if (filter[i])
                 gc_hint_version = std::min(gc_hint_version, calculateRowGcHintVersion(cur_handle, cur_version, next_handle, true, deleted));
@@ -210,6 +213,8 @@ private:
     IColumn::Filter effective{};
     // not_clean = selected & (handle equals with next || deleted)
     IColumn::Filter not_clean{};
+    // delete_rows = selected & deleted
+    IColumn::Filter is_delete{};
 
     // Calculate per block, when gc_safe_point exceed this version, there must be some data obsolete in this block
     // First calculate the gc_hint_version of every pk according to the following rules,
@@ -236,6 +241,7 @@ private:
     size_t complete_not_passed = 0;
     size_t not_clean_rows = 0;
     size_t effective_num_rows = 0;
+    size_t is_delete_rows = 0;
 
     const LoggerPtr log;
 };

--- a/dbms/src/Storages/DeltaMerge/File/DMFile.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFile.h
@@ -134,6 +134,7 @@ public:
     {
         UInt32 rows;
         UInt32 not_clean;
+        UInt32 is_delete;
         UInt64 first_version;
         UInt64 bytes;
         UInt8 first_tag;

--- a/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.cpp
@@ -40,7 +40,7 @@ DMFileBlockInputStreamPtr DMFileBlockInputStreamBuilder::build(const DMFilePtr &
     // if `rowkey_ranges` is empty, we unconditionally read all packs
     // `rowkey_ranges` and `is_common_handle`  will only be useful in clean read mode.
     // It is safe to ignore them here.
-    if (unlikely(rowkey_ranges.empty() && enable_clean_read))
+    if (unlikely(rowkey_ranges.empty() && enable_handle_clean_read))
         throw Exception("rowkey ranges shouldn't be empty with clean-read enabled", ErrorCodes::LOGICAL_ERROR);
 
     bool is_common_handle = !rowkey_ranges.empty() && rowkey_ranges[0].is_common_handle;
@@ -62,7 +62,8 @@ DMFileBlockInputStreamPtr DMFileBlockInputStreamBuilder::build(const DMFilePtr &
         dmfile,
         read_columns,
         is_common_handle,
-        enable_clean_read,
+        enable_handle_clean_read,
+        enable_del_clean_read,
         is_fast_mode,
         max_data_version,
         std::move(pack_filter),

--- a/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.h
@@ -82,17 +82,20 @@ public:
 
     // **** filters **** //
 
-    // Only set enable param to true when
+    // Only set enable_handle_clean_read_ param to true when
     // in normal mode:
     //    1. There is no delta.
     //    2. You don't need pk, version and delete_tag columns
     // in fast mode:
     //    1. You don't need pk columns
     // If you have no idea what it means, then simply set it to false.
+    // Only set is_fast_mode_ param to true when read in fast mode.
+    // Only set enable_del_clean_read_ param to true when you don't need del columns in fast mode.
     // `max_data_version_` is the MVCC filter version for reading. Used by clean read check
-    DMFileBlockInputStreamBuilder & enableCleanRead(bool enable, bool is_fast_mode_, UInt64 max_data_version_)
+    DMFileBlockInputStreamBuilder & enableCleanRead(bool enable_handle_clean_read_, bool is_fast_mode_, bool enable_del_clean_read_, UInt64 max_data_version_)
     {
-        enable_clean_read = enable;
+        enable_handle_clean_read = enable_handle_clean_read_;
+        enable_del_clean_read = enable_del_clean_read_;
         is_fast_mode = is_fast_mode_;
         max_data_version = max_data_version_;
         return *this;
@@ -156,8 +159,9 @@ private:
     FileProviderPtr file_provider;
 
     // clean read
-    bool enable_clean_read = false;
+    bool enable_handle_clean_read = false;
     bool is_fast_mode = false;
+    bool enable_del_clean_read = false;
     UInt64 max_data_version = std::numeric_limits<UInt64>::max();
     // Rough set filter
     RSOperatorPtr rs_filter;

--- a/dbms/src/Storages/DeltaMerge/File/DMFileReader.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileReader.h
@@ -76,7 +76,8 @@ public:
         // 1. There is no delta.
         // 2. You don't need pk, version and delete_tag columns
         // If you have no idea what it means, then simply set it to false.
-        bool enable_clean_read_,
+        bool enable_handle_clean_read_,
+        bool enable_del_clean_read_,
         bool is_fast_mode_,
         // The the MVCC filter version. Used by clean read check.
         UInt64 max_read_version_,
@@ -142,9 +143,11 @@ private:
     const bool single_file_mode;
 
     /// Clean read optimize
-    // In normal mode, if there is no delta for some packs in stable, we can try to do clean read.
-    // In fast mode, we always try to do clean read.
-    const bool enable_clean_read;
+    // In normal mode, if there is no delta for some packs in stable, we can try to do clean read (enable_handle_clean_read is true).
+    // In fast mode, if we don't need handle column, we will try to do clean read on handle_column(enable_handle_clean_read is true).
+    //               if we don't need del column, we will try to do clean read on del_column(enable_del_clean_read is true).
+    const bool enable_handle_clean_read;
+    const bool enable_del_clean_read;
     const bool is_fast_mode;
     const UInt64 max_read_version;
 

--- a/dbms/src/Storages/DeltaMerge/File/DMFileWriter.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileWriter.h
@@ -164,6 +164,7 @@ public:
     struct BlockProperty
     {
         size_t not_clean_rows;
+        size_t is_delete_rows;
         size_t effective_num_rows;
         size_t gc_hint_version;
     };

--- a/dbms/src/Storages/DeltaMerge/Index/MinMaxIndex.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/MinMaxIndex.cpp
@@ -46,6 +46,7 @@ inline std::pair<size_t, size_t> minmax(const IColumn & column, const ColumnVect
 
     for (size_t i = offset; i < offset + limit; ++i)
     {
+        // del_mark_data == nullptr || (del_mark_data != nullptr && (*del_mark_data)[i] != 0)
         if (!del_mark_data || !(*del_mark_data)[i])
         {
             if (batch_min_idx == NONE_EXIST || column.compareAt(i, batch_min_idx, column, -1) < 0)

--- a/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.cpp
@@ -65,7 +65,7 @@ void SSTFilesToBlockInputStream::readPrefix()
 {
     for (UInt64 i = 0; i < snaps.len; ++i)
     {
-        auto & snapshot = snaps.views[i];
+        const auto & snapshot = snaps.views[i];
         switch (snapshot.type)
         {
         case ColumnFamilyType::Default:
@@ -295,17 +295,18 @@ SSTFilesToBlockInputStream::ProcessKeys BoundedSSTFilesToBlockInputStream::getPr
     return _raw_child->process_keys;
 }
 
-const RegionPtr BoundedSSTFilesToBlockInputStream::getRegion() const
+RegionPtr BoundedSSTFilesToBlockInputStream::getRegion() const
 {
     return _raw_child->region;
 }
 
-std::tuple<size_t, size_t, UInt64> //
+std::tuple<size_t, size_t, size_t, UInt64> //
 BoundedSSTFilesToBlockInputStream::getMvccStatistics() const
 {
     return std::make_tuple(
         mvcc_compact_stream->getEffectiveNumRows(),
         mvcc_compact_stream->getNotCleanRows(),
+        mvcc_compact_stream->getIsDeleteRows(),
         mvcc_compact_stream->getGCHintVersion());
 }
 

--- a/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.h
@@ -82,7 +82,7 @@ public:
     };
 
 private:
-    void loadCFDataFromSST(ColumnFamilyType cf, const DecodedTiKVKey * rowkey_need_include);
+    void loadCFDataFromSST(ColumnFamilyType cf, const DecodedTiKVKey * rowkey_to_be_included);
 
     Block readCommitedBlock();
 
@@ -131,10 +131,10 @@ public:
 
     SSTFilesToBlockInputStream::ProcessKeys getProcessKeys() const;
 
-    const RegionPtr getRegion() const;
+    RegionPtr getRegion() const;
 
-    // Return values: (effective rows, not clean rows, gc hint version)
-    std::tuple<size_t, size_t, UInt64> getMvccStatistics() const;
+    // Return values: (effective rows, not clean rows, is delete rows, gc hint version)
+    std::tuple<size_t, size_t, size_t, UInt64> getMvccStatistics() const;
 
 private:
     const ColId pk_column_id;

--- a/dbms/src/Storages/DeltaMerge/SSTFilesToDTFilesOutputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/SSTFilesToDTFilesOutputStream.cpp
@@ -155,8 +155,10 @@ void SSTFilesToDTFilesOutputStream::write()
 {
     size_t last_effective_num_rows = 0;
     size_t last_not_clean_rows = 0;
+    size_t last_is_delete_rows = 0;
     size_t cur_effective_num_rows = 0;
     size_t cur_not_clean_rows = 0;
+    size_t cur_is_delete_rows = 0;
     while (true)
     {
         Block block = child->read();
@@ -205,15 +207,17 @@ void SSTFilesToDTFilesOutputStream::write()
 
         // Write block to the output stream
         DMFileBlockOutputStream::BlockProperty property;
-        std::tie(cur_effective_num_rows, cur_not_clean_rows, property.gc_hint_version) //
+        std::tie(cur_effective_num_rows, cur_not_clean_rows, cur_is_delete_rows, property.gc_hint_version) //
             = child->getMvccStatistics();
         property.effective_num_rows = cur_effective_num_rows - last_effective_num_rows;
         property.not_clean_rows = cur_not_clean_rows - last_not_clean_rows;
+        property.is_delete_rows = cur_is_delete_rows - last_is_delete_rows;
         dt_stream->write(block, property);
 
         commit_rows += block.rows();
         last_effective_num_rows = cur_effective_num_rows;
         last_not_clean_rows = cur_not_clean_rows;
+        last_is_delete_rows = cur_is_delete_rows;
     }
 }
 

--- a/dbms/src/Storages/DeltaMerge/StableValueSpace.cpp
+++ b/dbms/src/Storages/DeltaMerge/StableValueSpace.cpp
@@ -328,17 +328,18 @@ StableValueSpace::Snapshot::getInputStream(
     const RSOperatorPtr & filter,
     UInt64 max_data_version,
     size_t expected_block_size,
-    bool enable_clean_read,
-    bool is_fast_mode)
+    bool enable_handle_clean_read,
+    bool is_fast_mode,
+    bool enable_del_clean_read)
 {
-    LOG_FMT_DEBUG(log, "max_data_version: {}, enable_clean_read: {}", max_data_version, enable_clean_read);
+    LOG_FMT_DEBUG(log, "max_data_version: {}, enable_handle_clean_read: {}, is_fast_mode: {}, enable_del_clean_read: {}", max_data_version, enable_handle_clean_read, is_fast_mode, enable_del_clean_read);
     SkippableBlockInputStreams streams;
 
     for (size_t i = 0; i < stable->files.size(); i++)
     {
         DMFileBlockInputStreamBuilder builder(context.db_context);
         builder
-            .enableCleanRead(enable_clean_read, is_fast_mode, max_data_version)
+            .enableCleanRead(enable_handle_clean_read, is_fast_mode, enable_del_clean_read, max_data_version)
             .setRSOperator(filter)
             .setColumnCache(column_caches[i])
             .setTracingID(context.tracing_id)

--- a/dbms/src/Storages/DeltaMerge/StableValueSpace.h
+++ b/dbms/src/Storages/DeltaMerge/StableValueSpace.h
@@ -150,8 +150,9 @@ public:
                                                     const RSOperatorPtr & filter,
                                                     UInt64 max_data_version,
                                                     size_t expected_block_size,
-                                                    bool enable_clean_read,
-                                                    bool is_fast_mode = false);
+                                                    bool enable_handle_clean_read,
+                                                    bool is_fast_mode = false,
+                                                    bool enable_del_clean_read = false);
 
         RowsAndBytes getApproxRowsAndBytes(const DMContext & context, const RowKeyRange & range) const;
 

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_for_fast_mode.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_for_fast_mode.cpp
@@ -16,6 +16,8 @@
 #include <Storages/DeltaMerge/Filter/RSOperator.h>
 #include <Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_test_basic.h>
 
+#include "Storages/DeltaMerge/DeltaMergeDefines.h"
+
 /// This test file is mainly test on the correctness of read in fast mode.
 /// Because the basic functions are tested in gtest_dm_delta_merge_storage.cpp, we will not cover it here.
 
@@ -101,7 +103,7 @@ TEST_P(DeltaMergeStoreRWTest, TestFastModeWithOnlyInsertWithoutRangeFilter)
             for (auto && iter : block)
             {
                 auto c = iter.column;
-                for (Int64 i = 0; i < Int64(c->size()); ++i)
+                for (Int64 i = 0; i < static_cast<Int64>(c->size()); ++i)
                 {
                     if (iter.name == DMTestEnv::pk_name)
                     {
@@ -205,7 +207,7 @@ TEST_P(DeltaMergeStoreRWTest, TestFastModeWithOnlyInsertWithRangeFilter)
             for (auto && iter : block)
             {
                 auto c = iter.column;
-                for (Int64 i = 0; i < Int64(c->size()); ++i)
+                for (Int64 i = 0; i < static_cast<Int64>(c->size()); ++i)
                 {
                     if (iter.name == DMTestEnv::pk_name)
                     {
@@ -304,7 +306,7 @@ try
                 for (auto && iter : block)
                 {
                     auto c = iter.column;
-                    for (Int64 i = 0; i < Int64(c->size()); ++i)
+                    for (Int64 i = 0; i < static_cast<Int64>(c->size()); ++i)
                     {
                         if (iter.name == DMTestEnv::pk_name)
                         {
@@ -323,7 +325,7 @@ try
                 for (auto && iter : block)
                 {
                     auto c = iter.column;
-                    for (Int64 i = 0; i < Int64(c->size()); ++i)
+                    for (Int64 i = 0; i < static_cast<Int64>(c->size()); ++i)
                     {
                         if (iter.name == DMTestEnv::pk_name)
                         {
@@ -352,7 +354,7 @@ try
                 for (auto && iter : block)
                 {
                     auto c = iter.column;
-                    for (Int64 i = 0; i < Int64(c->size()); ++i)
+                    for (Int64 i = 0; i < static_cast<Int64>(c->size()); ++i)
                     {
                         if (iter.name == DMTestEnv::pk_name)
                         {
@@ -451,7 +453,7 @@ try
                 for (auto && iter : block)
                 {
                     auto c = iter.column;
-                    for (Int64 i = 0; i < Int64(c->size()); ++i)
+                    for (Int64 i = 0; i < static_cast<Int64>(c->size()); ++i)
                     {
                         if (iter.name == DMTestEnv::pk_name)
                         {
@@ -470,7 +472,7 @@ try
                 for (auto && iter : block)
                 {
                     auto c = iter.column;
-                    for (Int64 i = 0; i < Int64(c->size()); ++i)
+                    for (Int64 i = 0; i < static_cast<Int64>(c->size()); ++i)
                     {
                         if (iter.name == DMTestEnv::pk_name)
                         {
@@ -499,7 +501,7 @@ try
                 for (auto && iter : block)
                 {
                     auto c = iter.column;
-                    for (Int64 i = 0; i < Int64(c->size()); ++i)
+                    for (Int64 i = 0; i < static_cast<Int64>(c->size()); ++i)
                     {
                         if (iter.name == DMTestEnv::pk_name)
                         {
@@ -600,7 +602,7 @@ try
                 for (auto && iter : block)
                 {
                     auto c = iter.column;
-                    for (Int64 i = 0; i < Int64(c->size()); ++i)
+                    for (Int64 i = 0; i < static_cast<Int64>(c->size()); ++i)
                     {
                         if (iter.name == DMTestEnv::pk_name)
                         {
@@ -619,7 +621,7 @@ try
                 for (auto && iter : block)
                 {
                     auto c = iter.column;
-                    for (Int64 i = 0; i < Int64(c->size()); ++i)
+                    for (Int64 i = 0; i < static_cast<Int64>(c->size()); ++i)
                     {
                         if (iter.name == DMTestEnv::pk_name)
                         {
@@ -649,7 +651,7 @@ try
                 for (auto && iter : block)
                 {
                     auto c = iter.column;
-                    for (Int64 i = 0; i < Int64(c->size()); ++i)
+                    for (Int64 i = 0; i < static_cast<Int64>(c->size()); ++i)
                     {
                         if (iter.name == DMTestEnv::pk_name)
                         {
@@ -748,7 +750,7 @@ try
             for (auto && iter : block)
             {
                 auto c = iter.column;
-                for (Int64 i = 0; i < Int64(c->size()); ++i)
+                for (Int64 i = 0; i < static_cast<Int64>(c->size()); ++i)
                 {
                     if (iter.name == DMTestEnv::pk_name)
                     {
@@ -850,13 +852,13 @@ try
                     if (iter.name == DMTestEnv::pk_name)
                     {
                         auto c = iter.column;
-                        for (Int64 i = 0; i < Int64(c->size()); ++i)
+                        for (Int64 i = 0; i < static_cast<Int64>(c->size()); ++i)
                         {
-                            if (i < Int64(num_write_rows / 2))
+                            if (i < static_cast<Int64>(num_write_rows / 2))
                             {
                                 ASSERT_EQ(c->getInt(i), i);
                             }
-                            else if (i < Int64(2.5 * num_write_rows))
+                            else if (i < static_cast<Int64>(2.5 * num_write_rows))
                             {
                                 ASSERT_EQ(c->getInt(i), (i - num_write_rows / 2) / 2 + num_write_rows / 2);
                             }
@@ -891,7 +893,7 @@ try
                     if (iter.name == DMTestEnv::pk_name)
                     {
                         auto c = iter.column;
-                        for (Int64 i = 0; i < Int64(c->size()); ++i)
+                        for (Int64 i = 0; i < static_cast<Int64>(c->size()); ++i)
                         {
                             ASSERT_EQ(c->getInt(i), i + begin_value);
                         }
@@ -922,7 +924,7 @@ try
                     if (iter.name == DMTestEnv::pk_name)
                     {
                         auto c = iter.column;
-                        for (Int64 i = 0; i < Int64(c->size()); ++i)
+                        for (Int64 i = 0; i < static_cast<Int64>(c->size()); ++i)
                         {
                             ASSERT_EQ(c->getInt(i), i + begin_value);
                         }
@@ -1031,7 +1033,7 @@ try
             for (auto && iter : block)
             {
                 auto c = iter.column;
-                for (Int64 i = 0; i < Int64(c->size()); ++i)
+                for (Int64 i = 0; i < static_cast<Int64>(c->size()); ++i)
                 {
                     if (iter.name == DMTestEnv::pk_name)
                     {
@@ -1072,7 +1074,7 @@ try
             for (auto && iter : block)
             {
                 auto c = iter.column;
-                for (Int64 i = 0; i < Int64(c->size()); ++i)
+                for (Int64 i = 0; i < static_cast<Int64>(c->size()); ++i)
                 {
                     if (iter.name == DMTestEnv::pk_name)
                     {
@@ -1134,7 +1136,7 @@ try
             for (auto && iter : block)
             {
                 auto c = iter.column;
-                for (Int64 i = 0; i < Int64(c->size()); ++i)
+                for (Int64 i = 0; i < static_cast<Int64>(c->size()); ++i)
                 {
                     if (iter.name == DMTestEnv::pk_name)
                     {
@@ -1176,7 +1178,7 @@ try
             for (auto && iter : block)
             {
                 auto c = iter.column;
-                for (Int64 i = 0; i < Int64(c->size()); ++i)
+                for (Int64 i = 0; i < static_cast<Int64>(c->size()); ++i)
                 {
                     if (iter.name == DMTestEnv::pk_name)
                     {
@@ -1252,7 +1254,7 @@ try
             for (auto && iter : block)
             {
                 auto c = iter.column;
-                for (Int64 i = 0; i < Int64(c->size()); ++i)
+                for (Int64 i = 0; i < static_cast<Int64>(c->size()); ++i)
                 {
                     if (iter.name == DMTestEnv::pk_name)
                     {
@@ -1361,13 +1363,13 @@ try
                     if (iter.name == DMTestEnv::pk_name)
                     {
                         auto c = iter.column;
-                        for (Int64 i = 0; i < Int64(c->size()); ++i)
+                        for (Int64 i = 0; i < static_cast<Int64>(c->size()); ++i)
                         {
-                            if (i < Int64(num_write_rows / 2))
+                            if (i < static_cast<Int64>(num_write_rows / 2))
                             {
                                 ASSERT_EQ(c->getInt(i), i);
                             }
-                            else if (i < Int64(2.5 * num_write_rows))
+                            else if (i < static_cast<Int64>(2.5 * num_write_rows))
                             {
                                 ASSERT_EQ(c->getInt(i), (i - num_write_rows / 2) / 2 + num_write_rows / 2);
                             }
@@ -1401,7 +1403,7 @@ try
                     if (iter.name == DMTestEnv::pk_name)
                     {
                         auto c = iter.column;
-                        for (Int64 i = 0; i < Int64(c->size()); ++i)
+                        for (Int64 i = 0; i < static_cast<Int64>(c->size()); ++i)
                         {
                             ASSERT_EQ(c->getInt(i), i + begin_value);
                         }
@@ -1431,7 +1433,7 @@ try
                     if (iter.name == DMTestEnv::pk_name)
                     {
                         auto c = iter.column;
-                        for (Int64 i = 0; i < Int64(c->size()); ++i)
+                        for (Int64 i = 0; i < static_cast<Int64>(c->size()); ++i)
                         {
                             ASSERT_EQ(c->getInt(i), i + begin_value);
                         }
@@ -1455,7 +1457,7 @@ try
                                              columns,
                                              {RowKeyRange::newAll(store->isCommonHandle(), store->getRowKeyColumnSize())},
                                              /* num_streams= */ 1,
-                                             /* max_version= */ UInt64(1),
+                                             /* max_version= */ static_cast<UInt64>(1),
                                              EMPTY_FILTER,
                                              TRACING_NAME,
                                              /* keep_order= */ false,
@@ -1470,7 +1472,7 @@ try
             for (auto && iter : block)
             {
                 auto c = iter.column;
-                for (Int64 i = 0; i < Int64(c->size()); ++i)
+                for (Int64 i = 0; i < static_cast<Int64>(c->size()); ++i)
                 {
                     if (iter.name == DMTestEnv::pk_name)
                     {
@@ -1539,7 +1541,7 @@ try
             for (auto && iter : block)
             {
                 auto c = iter.column;
-                for (Int64 i = 0; i < Int64(c->size()); ++i)
+                for (Int64 i = 0; i < static_cast<Int64>(c->size()); ++i)
                 {
                     if (iter.name == DMTestEnv::pk_name)
                     {
@@ -1566,13 +1568,13 @@ try
 
     store->mergeDeltaAll(*db_context);
 
-    // could do clean read with handle optimization
+    // could do clean read with handle and del optimization
     {
         const auto & columns = store->getTableColumns();
         ColumnDefines real_columns;
-        for (auto & col : columns)
+        for (const auto & col : columns)
         {
-            if (col.name != EXTRA_HANDLE_COLUMN_NAME)
+            if (col.name != EXTRA_HANDLE_COLUMN_NAME && col.name != TAG_COLUMN_NAME)
             {
                 real_columns.emplace_back(col);
             }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #5252 

Problem Summary: For the query in fast mode, we always read the del_mark column, and then do filter with del_mark = 1. While for the packs that all rows' del_mark = 0, we don't need to read their del_mark column, and also don't need to do the filter with del_mark. Thus we add these optimization to cut down IO.

### What is changed and how it works?
1. fix the min-max index calculation for del column.
2. add the is_delete in PackStat to store the delete rows in a pack.
3. use is_delete to make read optimization on del column in fast mode.


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

TODO ：performance test 

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
