### PR TITLE
bugfix for coredump of GRPCCompQueue when TiFlash shutdown

### DIFF
--- a/dbms/src/Flash/Mpp/GRPCCompletionQueuePool.cpp
+++ b/dbms/src/Flash/Mpp/GRPCCompletionQueuePool.cpp
@@ -44,7 +44,10 @@ void GRPCCompletionQueuePool::thread(size_t index)
 {
     GET_METRIC(tiflash_thread_count, type_threads_of_client_cq_pool).Increment();
     SCOPE_EXIT({
-        GET_METRIC(tiflash_thread_count, type_threads_of_client_cq_pool).Decrement();
+        if (!is_shutdown)
+        {
+            GET_METRIC(tiflash_thread_count, type_threads_of_client_cq_pool).Decrement();
+        }
     });
 
     auto & q = queues[index];

--- a/dbms/src/Flash/Mpp/GRPCCompletionQueuePool.h
+++ b/dbms/src/Flash/Mpp/GRPCCompletionQueuePool.h
@@ -39,10 +39,16 @@ public:
 
     ::grpc::CompletionQueue & pickQueue();
 
+    void markShutdown()
+    {
+        is_shutdown = true;
+    }
+
 private:
     void thread(size_t index);
 
     std::atomic<size_t> next = 0;
+    std::atomic<bool> is_shutdown{false};
     std::vector<::grpc::CompletionQueue> queues;
     std::vector<std::thread> workers;
 };

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -676,6 +676,8 @@ public:
             thread_manager->wait();
             flash_grpc_server->Wait();
             flash_grpc_server.reset();
+            if (GRPCCompletionQueuePool::global_instance)
+                GRPCCompletionQueuePool::global_instance->markShutdown();
             LOG_FMT_INFO(log, "Shut down flash grpc server");
 
             /// Close flash service.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #5480

Problem Summary:

### What is changed and how it works?
notify GRPCCompQueue the shotdown event when TiFlash is shutdown.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
