### PR TITLE
Init read thread only when read thread is enabled.

### DIFF
--- a/dbms/src/TestUtils/gtests_dbms_main.cpp
+++ b/dbms/src/TestUtils/gtests_dbms_main.cpp
@@ -60,11 +60,13 @@ int main(int argc, char ** argv)
 
     DB::tests::TiFlashTestEnv::setupLogger();
     DB::tests::TiFlashTestEnv::initializeGlobalContext();
-    DB::ServerInfo server_info;
-    DB::DM::SegmentReaderPoolManager::instance().init(server_info);
-    DB::DM::SegmentReadTaskScheduler::instance();
-    DB::DM::DMFileReaderPool::instance();
-
+    if (DB::tests::TiFlashTestEnv::getGlobalContext().getSettingsRef().dt_enable_read_thread)
+    {
+        DB::ServerInfo server_info;
+        DB::DM::SegmentReaderPoolManager::instance().init(server_info);
+        DB::DM::SegmentReadTaskScheduler::instance();
+        DB::DM::DMFileReaderPool::instance();
+    }
 #ifdef FIU_ENABLE
     fiu_init(0); // init failpoint
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #5376

Problem Summary:

When `settings.dt_enable_read_thread` is false, it is unnecessary to initialize the read thread components.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
