### PR TITLE
Force to disable logical split

### DIFF
--- a/dbms/src/Storages/DeltaMerge/DMContext.h
+++ b/dbms/src/Storages/DeltaMerge/DMContext.h
@@ -114,7 +114,7 @@ public:
         , delta_small_column_file_rows(settings.dt_segment_delta_small_column_file_rows)
         , delta_small_column_file_bytes(settings.dt_segment_delta_small_column_file_size)
         , stable_pack_rows(settings.dt_segment_stable_pack_rows)
-        , enable_logical_split(settings.dt_enable_logical_split)
+        , enable_logical_split(false) // disable due to incompatible issue https://github.com/pingcap/tiflash/issues/5576
         , read_delta_only(settings.dt_read_delta_only)
         , read_stable_only(settings.dt_read_stable_only)
         , enable_relevant_place(settings.dt_enable_relevant_place)


### PR DESCRIPTION
Signed-off-by: JaySon-Huang <tshent@qq.com>

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/5576

Problem Summary:
If user deploys tiflash with explicit setting `profiles.default.dt_enable_logical_split = 1`.
After several logical split, PageStorage V3 will throw an exception for the third time logical split and make TiFlash crash.

### What is changed and how it works?

Force to disable logical split in the code path

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  - ensure the logical split settings will be forced set to false by checking the log
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
