### PR TITLE
Fix compile error under MacOS

### DIFF
--- a/dbms/src/Flash/Planner/PhysicalPlanVisitor.h
+++ b/dbms/src/Flash/Planner/PhysicalPlanVisitor.h
@@ -25,7 +25,7 @@ void visit(const PhysicalPlanNodePtr & plan, FF && f)
     {
         for (size_t i = 0; i < plan->childrenSize(); ++i)
         {
-            visit(plan->children(i), std::forward<FF>(f));
+            DB::PhysicalPlanVisitor::visit(plan->children(i), std::forward<FF>(f));
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: JaySon-Huang <tshent@qq.com>

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/5590

Problem Summary:
Compile error under MacOS after https://github.com/pingcap/tiflash/pull/5321 merged, see the issue for details.
Seems that the clang under MacOS brings `std::visit` by accident.

### What is changed and how it works?

explicitly call full name with namespace `DB::PhysicalPlanVisitor::visit` instead of `visit`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
