### PR TITLE
fix: use arguments[arg0] as argument column offset

### DIFF
--- a/dbms/src/Functions/FunctionsString.cpp
+++ b/dbms/src/Functions/FunctionsString.cpp
@@ -5566,7 +5566,7 @@ private:
         }
         else
         {
-            fillResultColumnFromOther(block.getByPosition(result).column, block.getByPosition(arg0).column);
+            fillResultColumnFromOther(block.getByPosition(result).column, block.getByPosition(arguments[arg0]).column);
         }
         return true;
     }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #5592 

Problem Summary:

Incorrectly using `arg0` as argument offsets instead of `arguments[arg0]`. 

### What is changed and how it works?

use `arguments[arg0]` as argument column offset

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
