### PR TITLE
refine: shuffle column order before execute function ut

### DIFF
--- a/dbms/src/TestUtils/FunctionTestUtils.cpp
+++ b/dbms/src/TestUtils/FunctionTestUtils.cpp
@@ -311,7 +311,7 @@ ColumnWithTypeAndName executeFunction(
         argument_column_numbers.push_back(i);
     std::shuffle(argument_column_numbers.begin(), argument_column_numbers.end(), g);
 
-    const ColumnsWithTypeAndName columns_reordered = toColumnsReordered(columns, argument_column_numbers);
+    const auto columns_reordered = toColumnsReordered(columns, argument_column_numbers);
 
     return executeFunction(context, func_name, argument_column_numbers, columns_reordered, collator, raw_function_test);
 }

--- a/dbms/src/TestUtils/FunctionTestUtils.h
+++ b/dbms/src/TestUtils/FunctionTestUtils.h
@@ -548,6 +548,7 @@ ColumnsWithTypeAndName createColumns(const ColumnsWithTypeAndName & cols);
     const ColumnsWithTypeAndName & actual,
     bool _restrict);
 
+/// Note that during execution, the offsets of each column might be reordered.
 ColumnWithTypeAndName executeFunction(
     Context & context,
     const String & func_name,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #5596 

Problem Summary:

### What is changed and how it works?

Shuffle input columns before execution in function unit tests.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
