### PR TITLE
storage: Fix race when adding background tasks

### DIFF
--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -1485,7 +1485,13 @@ void DeltaMergeStore::checkSegmentUpdate(const DMContextPtr & dm_context, const 
         if (shutdown_called.load(std::memory_order_relaxed))
             return;
 
-        auto [added, heavy] = background_tasks.tryAddTask(task, thread_type, std::max(id_to_segment.size() * 2, background_pool.getNumberOfThreads() * 3), log);
+        size_t segment_size;
+        {
+            std::shared_lock lock(read_write_mutex);
+            segment_size = id_to_segment.size();
+        }
+        
+        auto [added, heavy] = background_tasks.tryAddTask(task, thread_type, std::max(segment_size * 2, background_pool.getNumberOfThreads() * 3), log);
         // Prevent too many tasks.
         if (!added)
             return;


### PR DESCRIPTION
Signed-off-by: Wish <breezewish@outlook.com>

### What problem does this PR solve?

Issue Number: fix #5617

Problem Summary:

### What is changed and how it works?

Fix data race of accessing `id_to_segment` without a mutex.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
