### PR TITLE
Fix bug that mpp_task is not move to cancel thread due to llvm SOO

### DIFF
--- a/dbms/src/Flash/Mpp/MPPTaskManager.cpp
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.cpp
@@ -85,7 +85,7 @@ public:
         : task(other.task)
         , reason(other.reason)
     {
-        LOG_FMT_WARNING(getLogger(), "Copy constructor of MPPTaskCancelFunctor called, should not happens");
+        LOG_FMT_WARNING(getLogger(), "Copy constructor of MPPTaskCancelFunctor called, should not happen");
     }
     MPPTaskCancelFunctor(MPPTaskCancelFunctor && other) = default;
     MPPTaskCancelFunctor(MPPTaskPtr && task_, const String & reason_)

--- a/dbms/src/Flash/Mpp/MPPTaskManager.cpp
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.cpp
@@ -72,7 +72,7 @@ MPPTaskPtr MPPTaskManager::findTaskWithTimeout(const mpp::TaskMeta & meta, std::
 
 static Poco::Logger * getLogger()
 {
-    static Poco::Logger * logger = &Poco::Logger::get("MPPTaskHolder");
+    static Poco::Logger * logger = &Poco::Logger::get("MPPTaskCancelFunctor");
     return logger;
 }
 

--- a/dbms/src/Flash/Mpp/MPPTaskManager.cpp
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.cpp
@@ -70,9 +70,9 @@ MPPTaskPtr MPPTaskManager::findTaskWithTimeout(const mpp::TaskMeta & meta, std::
     return it->second;
 }
 
-static Poco::Logger * getLogger()
+static LoggerPtr getLogger()
 {
-    static Poco::Logger * logger = &Poco::Logger::get("MPPTaskCancelFunctor");
+    static LoggerPtr logger = Logger::get("MPPTaskCancelFunctor");
     return logger;
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #5095, close #5638

Problem Summary:

### What is changed and how it works?
After #5361, in `MPPTaskManager::cancelMPPQuery`, we try to move mpp task to the cancel thread so each mpp task can be destructed parallelly instead of be destructed one by one in `cancelMPPQuery` thread.
However, due to SOO in llvm(https://github.com/llvm/llvm-project/issues/32472), this move actaully failed, and there is a chance that mpp task is destructed inside the follow cancel loop:
https://github.com/pingcap/tiflash/blob/8404e6565e3ff2e47e50497550d838ea76e6e776/dbms/src/Flash/Mpp/MPPTaskManager.cpp#L102-L108

Destruct MPP inside the cancel loop means the task will be destructed before all mpp tasks are cancelled, this may cause some dead lock issues since there are some dependency between mpp tasks(especially in the case of local tunnel).


This pr fix this issue by 
- Use a Functor instead of lambda as a workaround of the SOO issues
- Save the moved Functor inside a vector to make sure mpp task never be destructed inside cancel loop, even if Functor move fails due to some unknown issues.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
run some random failpoint tests
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
