### PR TITLE
Remove `MPPTaskManager::findTaskWithTimeout`

### DIFF
--- a/dbms/src/Flash/Mpp/MPPTask.cpp
+++ b/dbms/src/Flash/Mpp/MPPTask.cpp
@@ -187,10 +187,10 @@ void MPPTask::initExchangeReceivers()
 
 std::pair<MPPTunnelPtr, String> MPPTask::getTunnel(const ::mpp::EstablishMPPConnectionRequest * request)
 {
-    if (status == CANCELLED)
+    if (status == CANCELLED || status == FAILED)
     {
         auto err_msg = fmt::format(
-            "can't find tunnel ({} + {}) because the task is cancelled",
+            "can't find tunnel ({} + {}) because the task is aborted",
             request->sender_meta().task_id(),
             request->receiver_meta().task_id());
         return {nullptr, err_msg};

--- a/dbms/src/Flash/Mpp/MPPTask.cpp
+++ b/dbms/src/Flash/Mpp/MPPTask.cpp
@@ -187,10 +187,10 @@ void MPPTask::initExchangeReceivers()
 
 std::pair<MPPTunnelPtr, String> MPPTask::getTunnel(const ::mpp::EstablishMPPConnectionRequest * request)
 {
-    if (status == CANCELLED || status == FAILED)
+    if (status == CANCELLED)
     {
         auto err_msg = fmt::format(
-            "can't find tunnel ({} + {}) because the task is aborted",
+            "can't find tunnel ({} + {}) because the task is cancelled",
             request->sender_meta().task_id(),
             request->receiver_meta().task_id());
         return {nullptr, err_msg};

--- a/dbms/src/Flash/Mpp/MPPTaskManager.h
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.h
@@ -63,10 +63,6 @@ public:
 
     ~MPPTaskManager() = default;
 
-    std::vector<UInt64> getCurrentQueries();
-
-    std::vector<MPPTaskPtr> getCurrentTasksForQuery(UInt64 query_id);
-
     MPPQueryTaskSetPtr getQueryTaskSetWithoutLock(UInt64 query_id);
 
     bool registerTask(MPPTaskPtr task);
@@ -77,9 +73,9 @@ public:
 
     bool tryToScheduleTask(const MPPTaskPtr & task);
 
-    void releaseThreadsFromScheduler(const int needed_threads);
+    void releaseThreadsFromScheduler(int needed_threads);
 
-    MPPTaskPtr findTaskWithTimeout(const mpp::TaskMeta & meta, std::chrono::seconds timeout, std::string & errMsg);
+    std::pair<MPPTunnelPtr, String> findTunnelWithTimeout(const ::mpp::EstablishMPPConnectionRequest * request, std::chrono::seconds timeout);
 
     void cancelMPPQuery(UInt64 query_id, const String & reason);
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #5095

Problem Summary:

### What is changed and how it works?
1. remove `MPPTaskManager::findTaskWithTimeout`
2. add `MPPTaskManager::findTunnleWithTImeout`
3. remove some unused code
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
