### PR TITLE
PageStorage: Log down the gc time for external pages

### DIFF
--- a/dbms/src/Storages/Page/V3/PageDirectory.h
+++ b/dbms/src/Storages/Page/V3/PageDirectory.h
@@ -32,6 +32,7 @@
 #include <mutex>
 #include <shared_mutex>
 #include <unordered_map>
+
 #include "Storages/Page/PageDefines.h"
 
 namespace CurrentMetrics

--- a/dbms/src/Storages/Page/V3/PageDirectory.h
+++ b/dbms/src/Storages/Page/V3/PageDirectory.h
@@ -20,6 +20,7 @@
 #include <Encryption/FileProvider.h>
 #include <Poco/Ext/ThreadNumber.h>
 #include <Storages/Page/Page.h>
+#include <Storages/Page/PageDefines.h>
 #include <Storages/Page/Snapshot.h>
 #include <Storages/Page/V3/BlobStore.h>
 #include <Storages/Page/V3/MapUtils.h>
@@ -32,8 +33,6 @@
 #include <mutex>
 #include <shared_mutex>
 #include <unordered_map>
-
-#include "Storages/Page/PageDefines.h"
 
 namespace CurrentMetrics
 {
@@ -350,7 +349,8 @@ public:
     // When dump snapshot, we need to keep the last valid entry. Check out `tryDumpSnapshot` for the reason.
     PageEntriesV3 gcInMemEntries(bool return_removed_entries = true, bool keep_last_valid_var_entry = false);
 
-    std::set<PageId> getAliveExternalIds(NamespaceId ns_id) const;
+    // Get the external id that is not deleted or being ref by another id over
+    // all NamespaceIds.
     std::map<NamespaceId, std::set<PageId>> getAliveExternalIds() const;
 
     PageEntriesEdit dumpSnapshotToEdit(PageDirectorySnapshotPtr snap = nullptr);

--- a/dbms/src/Storages/Page/V3/PageDirectory.h
+++ b/dbms/src/Storages/Page/V3/PageDirectory.h
@@ -32,6 +32,7 @@
 #include <mutex>
 #include <shared_mutex>
 #include <unordered_map>
+#include "Storages/Page/PageDefines.h"
 
 namespace CurrentMetrics
 {
@@ -349,6 +350,7 @@ public:
     PageEntriesV3 gcInMemEntries(bool return_removed_entries = true, bool keep_last_valid_var_entry = false);
 
     std::set<PageId> getAliveExternalIds(NamespaceId ns_id) const;
+    std::map<NamespaceId, std::set<PageId>> getAliveExternalIds() const;
 
     PageEntriesEdit dumpSnapshotToEdit(PageDirectorySnapshotPtr snap = nullptr);
 

--- a/dbms/src/Storages/Page/V3/PageStorageImpl.h
+++ b/dbms/src/Storages/Page/V3/PageStorageImpl.h
@@ -131,7 +131,7 @@ private:
         FullGCNothingMoved,
         FullGC,
     };
-    struct GCTimeConsume
+    struct GCTimeStatistics
     {
         GCStageType stage = GCStageType::Unknown;
         bool executeNextImmediately() const { return stage == GCStageType::FullGC; };
@@ -158,7 +158,8 @@ private:
         String toLogging() const;
     };
 
-    GCTimeConsume doGC(const WriteLimiterPtr & write_limiter, const ReadLimiterPtr & read_limiter);
+    GCTimeStatistics doGC(const WriteLimiterPtr & write_limiter, const ReadLimiterPtr & read_limiter);
+    void cleanExternalPage(Stopwatch & gc_watch, GCTimeStatistics & statistics);
 
     LoggerPtr log;
 

--- a/dbms/src/Storages/Page/V3/PageStorageImpl.h
+++ b/dbms/src/Storages/Page/V3/PageStorageImpl.h
@@ -108,12 +108,30 @@ public:
 
 #ifndef NDEBUG
     // Just for tests, refactor them out later
-    DB::PageStorage::SnapshotPtr getSnapshot() { return getSnapshot(""); }
-    DB::PageEntry getEntry(PageId page_id) { return getEntryImpl(TEST_NAMESPACE_ID, page_id, nullptr); }
-    DB::Page read(PageId page_id) { return readImpl(TEST_NAMESPACE_ID, page_id, nullptr, nullptr, true); }
-    PageMap read(const PageIds & page_ids) { return readImpl(TEST_NAMESPACE_ID, page_ids, nullptr, nullptr, true); }
-    PageIds read(const PageIds & page_ids, const PageHandler & handler) { return readImpl(TEST_NAMESPACE_ID, page_ids, handler, nullptr, nullptr, true); }
-    PageMap read(const std::vector<PageReadFields> & page_fields) { return readImpl(TEST_NAMESPACE_ID, page_fields, nullptr, nullptr, true); }
+    DB::PageStorage::SnapshotPtr getSnapshot()
+    {
+        return getSnapshot("");
+    }
+    DB::PageEntry getEntry(PageId page_id)
+    {
+        return getEntryImpl(TEST_NAMESPACE_ID, page_id, nullptr);
+    }
+    DB::Page read(PageId page_id)
+    {
+        return readImpl(TEST_NAMESPACE_ID, page_id, nullptr, nullptr, true);
+    }
+    PageMap read(const PageIds & page_ids)
+    {
+        return readImpl(TEST_NAMESPACE_ID, page_ids, nullptr, nullptr, true);
+    }
+    PageIds read(const PageIds & page_ids, const PageHandler & handler)
+    {
+        return readImpl(TEST_NAMESPACE_ID, page_ids, handler, nullptr, nullptr, true);
+    }
+    PageMap read(const std::vector<PageReadFields> & page_fields)
+    {
+        return readImpl(TEST_NAMESPACE_ID, page_fields, nullptr, nullptr, true);
+    }
 #endif
 
     friend class PageDirectoryFactory;
@@ -121,6 +139,41 @@ public:
 #ifndef DBMS_PUBLIC_GTEST
 private:
 #endif
+
+    enum class GCStageType
+    {
+        Unknown,
+        OnlyInMem,
+        FullGCNothingMoved,
+        FullGC,
+    };
+    struct GCTimeConsume
+    {
+        GCStageType stage = GCStageType::Unknown;
+        bool executeNextImmediately() const { return stage == GCStageType::FullGC; };
+
+        UInt64 total_cost_ms = 0;
+        UInt64 dump_snapshots_ms = 0;
+        UInt64 gc_in_mem_entries_ms = 0;
+        UInt64 blobstore_remove_entries_ms = 0;
+        UInt64 blobstore_get_gc_stats_ms = 0;
+        UInt64 gc_get_entries_ms = 0;
+        UInt64 blobstore_full_gc_ms = 0;
+        UInt64 gc_apply_ms = 0;
+
+        // GC external page
+        UInt64 clean_external_page_ms = 0;
+        UInt64 num_external_callbacks = 0;
+        // ms is usually too big for these operation, store by ns (10^-9)
+        UInt64 external_page_scan_ns = 0;
+        UInt64 external_page_get_alive_ns = 0;
+        UInt64 external_page_remove_ns = 0;
+
+        String toLogging() const;
+    };
+
+    GCTimeConsume doGC(const WriteLimiterPtr & write_limiter, const ReadLimiterPtr & read_limiter);
+
     LoggerPtr log;
 
     PageDirectoryPtr page_directory;

--- a/dbms/src/Storages/Page/V3/PageStorageImpl.h
+++ b/dbms/src/Storages/Page/V3/PageStorageImpl.h
@@ -108,30 +108,14 @@ public:
 
 #ifndef NDEBUG
     // Just for tests, refactor them out later
-    DB::PageStorage::SnapshotPtr getSnapshot()
-    {
-        return getSnapshot("");
-    }
-    DB::PageEntry getEntry(PageId page_id)
-    {
-        return getEntryImpl(TEST_NAMESPACE_ID, page_id, nullptr);
-    }
-    DB::Page read(PageId page_id)
-    {
-        return readImpl(TEST_NAMESPACE_ID, page_id, nullptr, nullptr, true);
-    }
-    PageMap read(const PageIds & page_ids)
-    {
-        return readImpl(TEST_NAMESPACE_ID, page_ids, nullptr, nullptr, true);
-    }
-    PageIds read(const PageIds & page_ids, const PageHandler & handler)
-    {
-        return readImpl(TEST_NAMESPACE_ID, page_ids, handler, nullptr, nullptr, true);
-    }
-    PageMap read(const std::vector<PageReadFields> & page_fields)
-    {
-        return readImpl(TEST_NAMESPACE_ID, page_fields, nullptr, nullptr, true);
-    }
+    // clang-format off
+    DB::PageStorage::SnapshotPtr getSnapshot() { return getSnapshot(""); }
+    DB::PageEntry getEntry(PageId page_id) { return getEntryImpl(TEST_NAMESPACE_ID, page_id, nullptr); }
+    DB::Page read(PageId page_id) { return readImpl(TEST_NAMESPACE_ID, page_id, nullptr, nullptr, true); }
+    PageMap read(const PageIds & page_ids) { return readImpl(TEST_NAMESPACE_ID, page_ids, nullptr, nullptr, true); }
+    PageIds read(const PageIds & page_ids, const PageHandler & handler) { return readImpl(TEST_NAMESPACE_ID, page_ids, handler, nullptr, nullptr, true); }
+    PageMap read(const std::vector<PageReadFields> & page_fields) { return readImpl(TEST_NAMESPACE_ID, page_fields, nullptr, nullptr, true); }
+    // clang-format on
 #endif
 
     friend class PageDirectoryFactory;
@@ -153,13 +137,15 @@ private:
         bool executeNextImmediately() const { return stage == GCStageType::FullGC; };
 
         UInt64 total_cost_ms = 0;
+
         UInt64 dump_snapshots_ms = 0;
         UInt64 gc_in_mem_entries_ms = 0;
         UInt64 blobstore_remove_entries_ms = 0;
         UInt64 blobstore_get_gc_stats_ms = 0;
-        UInt64 gc_get_entries_ms = 0;
-        UInt64 blobstore_full_gc_ms = 0;
-        UInt64 gc_apply_ms = 0;
+        // Full GC
+        UInt64 full_gc_get_entries_ms = 0;
+        UInt64 full_gc_blobstore_copy_ms = 0;
+        UInt64 full_gc_apply_ms = 0;
 
         // GC external page
         UInt64 clean_external_page_ms = 0;

--- a/dbms/src/Storages/Page/V3/tests/gtest_page_directory.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_page_directory.cpp
@@ -483,7 +483,9 @@ TEST_F(PageDirectoryTest, IdempotentNewExtPageAfterAllCleaned)
         PageEntriesEdit edit;
         edit.putExternal(10);
         dir->apply(std::move(edit));
-        auto alive_ids = dir->getAliveExternalIds(TEST_NAMESPACE_ID);
+        auto alive_ids_all = dir->getAliveExternalIds();
+        EXPECT_GT(alive_ids_all.count(TEST_NAMESPACE_ID), 0);
+        auto alive_ids = alive_ids_all[TEST_NAMESPACE_ID];
         EXPECT_EQ(alive_ids.size(), 1);
         EXPECT_GT(alive_ids.count(10), 0);
     }
@@ -492,7 +494,9 @@ TEST_F(PageDirectoryTest, IdempotentNewExtPageAfterAllCleaned)
         PageEntriesEdit edit;
         edit.putExternal(10); // should be idempotent
         dir->apply(std::move(edit));
-        auto alive_ids = dir->getAliveExternalIds(TEST_NAMESPACE_ID);
+        auto alive_ids_all = dir->getAliveExternalIds();
+        EXPECT_GT(alive_ids_all.count(TEST_NAMESPACE_ID), 0);
+        auto alive_ids = alive_ids_all[TEST_NAMESPACE_ID];
         EXPECT_EQ(alive_ids.size(), 1);
         EXPECT_GT(alive_ids.count(10), 0);
     }
@@ -502,9 +506,8 @@ TEST_F(PageDirectoryTest, IdempotentNewExtPageAfterAllCleaned)
         edit.del(10);
         dir->apply(std::move(edit));
         dir->gcInMemEntries(); // clean in memory
-        auto alive_ids = dir->getAliveExternalIds(TEST_NAMESPACE_ID);
-        EXPECT_EQ(alive_ids.size(), 0);
-        EXPECT_EQ(alive_ids.count(10), 0); // removed
+        auto alive_ids_all = dir->getAliveExternalIds();
+        EXPECT_EQ(alive_ids_all.count(TEST_NAMESPACE_ID), 0); // removed
     }
 
     {
@@ -512,7 +515,9 @@ TEST_F(PageDirectoryTest, IdempotentNewExtPageAfterAllCleaned)
         PageEntriesEdit edit;
         edit.putExternal(10);
         dir->apply(std::move(edit));
-        auto alive_ids = dir->getAliveExternalIds(TEST_NAMESPACE_ID);
+        auto alive_ids_all = dir->getAliveExternalIds();
+        EXPECT_GT(alive_ids_all.count(TEST_NAMESPACE_ID), 0);
+        auto alive_ids = alive_ids_all[TEST_NAMESPACE_ID];
         EXPECT_EQ(alive_ids.size(), 1);
         EXPECT_GT(alive_ids.count(10), 0);
     }
@@ -851,7 +856,9 @@ try
             }
         }
         auto snap = dir->createSnapshot();
-        auto alive_ids = dir->getAliveExternalIds(TEST_NAMESPACE_ID);
+        auto alive_ids_all = dir->getAliveExternalIds();
+        EXPECT_GT(alive_ids_all.count(TEST_NAMESPACE_ID), 0);
+        auto alive_ids = alive_ids_all[TEST_NAMESPACE_ID];
         EXPECT_EQ(alive_ids.size(), 1);
         EXPECT_GT(alive_ids.count(50), 0);
     }
@@ -2215,7 +2222,9 @@ try
     {
         auto outdated_entries = dir->gcInMemEntries();
         EXPECT_TRUE(outdated_entries.empty());
-        auto alive_ex_id = dir->getAliveExternalIds(TEST_NAMESPACE_ID);
+        auto alive_ids_all = dir->getAliveExternalIds();
+        EXPECT_GT(alive_ids_all.count(TEST_NAMESPACE_ID), 0);
+        auto alive_ex_id = alive_ids_all[TEST_NAMESPACE_ID];
         ASSERT_EQ(alive_ex_id.size(), 1);
         ASSERT_EQ(*alive_ex_id.begin(), 10);
     }
@@ -2230,8 +2239,8 @@ try
     {
         auto outdated_entries = dir->gcInMemEntries();
         EXPECT_EQ(0, outdated_entries.size());
-        auto alive_ex_id = dir->getAliveExternalIds(TEST_NAMESPACE_ID);
-        ASSERT_EQ(alive_ex_id.size(), 0);
+        auto alive_ids_all = dir->getAliveExternalIds();
+        EXPECT_EQ(alive_ids_all.count(TEST_NAMESPACE_ID), 0);
     }
 }
 CATCH
@@ -2372,7 +2381,9 @@ try
         EXPECT_ANY_THROW(restored_dir->get(1, temp_snap));
         EXPECT_ANY_THROW(restored_dir->get(2, temp_snap));
         EXPECT_ANY_THROW(restored_dir->get(3, temp_snap));
-        auto alive_ex = restored_dir->getAliveExternalIds(TEST_NAMESPACE_ID);
+        auto alive_ids_all = restored_dir->getAliveExternalIds();
+        EXPECT_GT(alive_ids_all.count(TEST_NAMESPACE_ID), 0);
+        auto alive_ex = alive_ids_all[TEST_NAMESPACE_ID];
         EXPECT_EQ(alive_ex.size(), 3);
         EXPECT_GT(alive_ex.count(10), 0);
         EXPECT_GT(alive_ex.count(20), 0);
@@ -2410,7 +2421,9 @@ try
         EXPECT_ANY_THROW(restored_dir->get(1, temp_snap));
         EXPECT_ANY_THROW(restored_dir->get(2, temp_snap));
         EXPECT_ANY_THROW(restored_dir->get(3, temp_snap));
-        auto alive_ex = restored_dir->getAliveExternalIds(TEST_NAMESPACE_ID);
+        auto alive_ids_all = restored_dir->getAliveExternalIds();
+        EXPECT_GT(alive_ids_all.count(TEST_NAMESPACE_ID), 0);
+        auto alive_ex = alive_ids_all[TEST_NAMESPACE_ID];
         EXPECT_EQ(alive_ex.size(), 2);
         EXPECT_GT(alive_ex.count(10), 0);
         EXPECT_EQ(restored_dir->getNormalPageId(11, temp_snap).low, 10);
@@ -2450,11 +2463,8 @@ try
         EXPECT_ANY_THROW(restored_dir->get(1, temp_snap));
         EXPECT_ANY_THROW(restored_dir->get(2, temp_snap));
         EXPECT_ANY_THROW(restored_dir->get(3, temp_snap));
-        auto alive_ex = restored_dir->getAliveExternalIds(TEST_NAMESPACE_ID);
-        EXPECT_EQ(alive_ex.size(), 0);
-        EXPECT_EQ(alive_ex.count(10), 0); // removed
-        EXPECT_EQ(alive_ex.count(20), 0); // removed
-        EXPECT_EQ(alive_ex.count(30), 0); // removed
+        auto alive_ids_all = restored_dir->getAliveExternalIds();
+        EXPECT_EQ(alive_ids_all.count(TEST_NAMESPACE_ID), 0); // removed
 
         EXPECT_ANY_THROW(restored_dir->get(50, temp_snap));
         EXPECT_SAME_ENTRY(restored_dir->get(51, temp_snap).second, entry_50);
@@ -2482,11 +2492,8 @@ try
         EXPECT_ANY_THROW(restored_dir->get(1, temp_snap));
         EXPECT_ANY_THROW(restored_dir->get(2, temp_snap));
         EXPECT_ANY_THROW(restored_dir->get(3, temp_snap));
-        auto alive_ex = restored_dir->getAliveExternalIds(TEST_NAMESPACE_ID);
-        EXPECT_EQ(alive_ex.size(), 0);
-        EXPECT_EQ(alive_ex.count(10), 0); // removed
-        EXPECT_EQ(alive_ex.count(20), 0); // removed
-        EXPECT_EQ(alive_ex.count(30), 0); // removed
+        auto alive_ids_all = restored_dir->getAliveExternalIds();
+        EXPECT_EQ(alive_ids_all.count(TEST_NAMESPACE_ID), 0); // removed
 
         EXPECT_ANY_THROW(restored_dir->get(50, temp_snap));
         EXPECT_ANY_THROW(restored_dir->get(51, temp_snap));


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/5697

Problem Summary:
The GC total time in logging does not include the time costs in `clean_external_page`.

### What is changed and how it works?

* Add a struct `GCTimeStatistics` to handle logging
* Add the time cost in `cleanExternalPage` into GC total time

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
