### PR TITLE
[DNM]For test

### DIFF
--- a/dbms/src/Common/MemoryTracker.h
+++ b/dbms/src/Common/MemoryTracker.h
@@ -25,11 +25,14 @@ namespace CurrentMetrics
 extern const Metric MemoryTracking;
 }
 
+class MemoryTracker;
+using MemoryTrackerPtr = std::shared_ptr<MemoryTracker>;
+
 /** Tracks memory consumption.
   * It throws an exception if amount of consumed memory become greater than certain limit.
   * The same memory tracker could be simultaneously used in different threads.
   */
-class MemoryTracker
+class MemoryTracker : public std::enable_shared_from_this<MemoryTracker>
 {
     std::atomic<Int64> amount{0};
     std::atomic<Int64> peak{0};
@@ -48,11 +51,25 @@ class MemoryTracker
     /// This description will be used as prefix into log messages (if isn't nullptr)
     const char * description = nullptr;
 
-public:
+    /// Make constructors private to ensure all objects of this class is created by `MemoryTracker::create`.
     MemoryTracker() = default;
     explicit MemoryTracker(Int64 limit_)
         : limit(limit_)
     {}
+
+public:
+    /// Using `std::shared_ptr` and `new` instread of `std::make_shared` is because `std::make_shared` cannot call private constructors.
+    static MemoryTrackerPtr create(Int64 limit = 0)
+    {
+        if (limit == 0)
+        {
+            return std::shared_ptr<MemoryTracker>(new MemoryTracker);
+        }
+        else
+        {
+            return std::shared_ptr<MemoryTracker>(new MemoryTracker(limit));
+        }
+    }
 
     ~MemoryTracker();
 
@@ -93,7 +110,6 @@ public:
     /// Prints info about peak memory consumption into log.
     void logPeakMemoryUsage() const;
 };
-
 
 /** The MemoryTracker object is quite difficult to pass to all places where significant amounts of memory are allocated.
   * Therefore, a thread-local pointer to used MemoryTracker is set, or nullptr if MemoryTracker does not need to be used.

--- a/dbms/src/Interpreters/ProcessList.cpp
+++ b/dbms/src/Interpreters/ProcessList.cpp
@@ -153,17 +153,17 @@ ProcessList::EntryPtr ProcessList::insert(
             ///  setting from one query effectively sets values for all other queries.
 
             /// Track memory usage for all simultaneously running queries from single user.
-            user_process_list.user_memory_tracker.setOrRaiseLimit(settings.max_memory_usage_for_user);
-            user_process_list.user_memory_tracker.setDescription("(for user)");
-            current_memory_tracker->setNext(&user_process_list.user_memory_tracker);
+            user_process_list.user_memory_tracker->setOrRaiseLimit(settings.max_memory_usage_for_user);
+            user_process_list.user_memory_tracker->setDescription("(for user)");
+            current_memory_tracker->setNext(user_process_list.user_memory_tracker.get());
 
             /// Track memory usage for all simultaneously running queries.
             /// You should specify this value in configuration for default profile,
             ///  not for specific users, sessions or queries,
             ///  because this setting is effectively global.
-            total_memory_tracker.setOrRaiseLimit(settings.max_memory_usage_for_all_queries);
-            total_memory_tracker.setDescription("(total)");
-            user_process_list.user_memory_tracker.setNext(&total_memory_tracker);
+            total_memory_tracker->setOrRaiseLimit(settings.max_memory_usage_for_all_queries);
+            total_memory_tracker->setDescription("(total)");
+            user_process_list.user_memory_tracker->setNext(total_memory_tracker.get());
         }
 
         if (!total_network_throttler && settings.max_network_bandwidth_for_all_users)
@@ -243,8 +243,8 @@ ProcessListEntry::~ProcessListEntry()
     if (parent.cur_size == 0)
     {
         /// Reset MemoryTracker, similarly (see above).
-        parent.total_memory_tracker.logPeakMemoryUsage();
-        parent.total_memory_tracker.reset();
+        parent.total_memory_tracker->logPeakMemoryUsage();
+        parent.total_memory_tracker->reset();
         parent.total_network_throttler.reset();
     }
 }

--- a/dbms/src/Interpreters/ProcessList.h
+++ b/dbms/src/Interpreters/ProcessList.h
@@ -80,7 +80,7 @@ private:
     /// Progress of output stream
     Progress progress_out;
 
-    MemoryTracker memory_tracker;
+    MemoryTrackerPtr memory_tracker;
 
     QueryPriorities::Handle priority_handle;
 
@@ -115,14 +115,14 @@ public:
         QueryPriorities::Handle && priority_handle_)
         : query(query_)
         , client_info(client_info_)
-        , memory_tracker(max_memory_usage)
+        , memory_tracker(MemoryTracker::create(max_memory_usage))
         , priority_handle(std::move(priority_handle_))
     {
-        memory_tracker.setDescription("(for query)");
-        current_memory_tracker = &memory_tracker;
+        memory_tracker->setDescription("(for query)");
+        current_memory_tracker = memory_tracker.get();
 
         if (memory_tracker_fault_probability)
-            memory_tracker.setFaultProbability(memory_tracker_fault_probability);
+            memory_tracker->setFaultProbability(memory_tracker_fault_probability);
     }
 
     ~ProcessListElement()
@@ -177,8 +177,8 @@ public:
         res.total_rows = progress_in.total_rows;
         res.written_rows = progress_out.rows;
         res.written_bytes = progress_out.bytes;
-        res.memory_usage = memory_tracker.get();
-        res.peak_memory_usage = memory_tracker.getPeak();
+        res.memory_usage = memory_tracker->get();
+        res.peak_memory_usage = memory_tracker->getPeak();
 
         return res;
     }
@@ -205,18 +205,21 @@ struct ProcessListForUser
     QueryToElement queries;
 
     /// Limit and counter for memory of all simultaneously running queries of single user.
-    MemoryTracker user_memory_tracker;
+    MemoryTrackerPtr user_memory_tracker;
 
     /// Count network usage for all simultaneously running queries of single user.
     ThrottlerPtr user_throttler;
 
+    ProcessListForUser()
+        : user_memory_tracker(MemoryTracker::create())
+    {}
     /// Clears MemoryTracker for the user.
     /// Sometimes it is important to reset the MemoryTracker, because it may accumulate skew
     ///  due to the fact that there are cases when memory can be allocated while processing the query, but released later.
     /// Clears network bandwidth Throttler, so it will not count periods of inactivity.
     void reset()
     {
-        user_memory_tracker.reset();
+        user_memory_tracker->reset();
         if (user_throttler)
             user_throttler.reset();
     }
@@ -281,7 +284,7 @@ private:
     QueryPriorities priorities;
 
     /// Limit and counter for memory of all simultaneously running queries.
-    MemoryTracker total_memory_tracker;
+    MemoryTrackerPtr total_memory_tracker;
 
     /// Limit network bandwidth for all users
     ThrottlerPtr total_network_throttler;
@@ -293,6 +296,7 @@ public:
     ProcessList(size_t max_size_ = 0)
         : cur_size(0)
         , max_size(max_size_)
+        , total_memory_tracker(MemoryTracker::create())
     {}
 
     using EntryPtr = std::shared_ptr<ProcessListEntry>;

--- a/dbms/src/Storages/BackgroundProcessingPool.cpp
+++ b/dbms/src/Storages/BackgroundProcessingPool.cpp
@@ -152,9 +152,9 @@ void BackgroundProcessingPool::threadFunction()
         addThreadId(getTid());
     }
 
-    MemoryTracker memory_tracker;
-    memory_tracker.setMetric(CurrentMetrics::MemoryTrackingInBackgroundProcessingPool);
-    current_memory_tracker = &memory_tracker;
+    auto memory_tracker = MemoryTracker::create();
+    memory_tracker->setMetric(CurrentMetrics::MemoryTrackingInBackgroundProcessingPool);
+    current_memory_tracker = memory_tracker.get();
 
     pcg64 rng(randomSeed());
     std::this_thread::sleep_for(std::chrono::duration<double>(std::uniform_real_distribution<double>(0, sleep_seconds_random_part)(rng)));

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.cpp
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.cpp
@@ -97,7 +97,7 @@ SegmentReadTasks SegmentReadTask::trySplitReadTasks(const SegmentReadTasks & tas
 
 BlockInputStreamPtr SegmentReadTaskPool::buildInputStream(SegmentReadTaskPtr & t)
 {
-    MemoryTrackerSetter setter(true, mem_tracker);
+    MemoryTrackerSetter setter(true, mem_tracker.get());
     auto seg = t->segment;
     BlockInputStreamPtr stream;
     if (is_raw)
@@ -179,7 +179,7 @@ std::unordered_map<uint64_t, std::vector<uint64_t>>::const_iterator SegmentReadT
 
 bool SegmentReadTaskPool::readOneBlock(BlockInputStreamPtr & stream, const SegmentPtr & seg)
 {
-    MemoryTrackerSetter setter(true, mem_tracker);
+    MemoryTrackerSetter setter(true, mem_tracker.get());
     auto block = stream->read();
     if (block)
     {

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.h
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.h
@@ -139,7 +139,7 @@ public:
         , log(&Poco::Logger::get("SegmentReadTaskPool"))
         , unordered_input_stream_ref_count(0)
         , exception_happened(false)
-        , mem_tracker(current_memory_tracker)
+        , mem_tracker(current_memory_tracker == nullptr ? nullptr : current_memory_tracker->shared_from_this())
     {}
 
     ~SegmentReadTaskPool()
@@ -223,7 +223,8 @@ private:
     std::atomic<bool> exception_happened;
     DB::Exception exception;
 
-    MemoryTracker * mem_tracker;
+    // The memory tracker of MPPTask.
+    MemoryTrackerPtr mem_tracker;
 
     inline static std::atomic<uint64_t> pool_id_gen{1};
     inline static BlockStat global_blk_stat;

--- a/dbms/src/Storages/Page/workload/PSBackground.cpp
+++ b/dbms/src/Storages/Page/workload/PSBackground.cpp
@@ -51,9 +51,9 @@ void PSGc::doGcOnce()
     gc_stop_watch.start();
     try
     {
-        MemoryTracker tracker;
-        tracker.setDescription("(Stress Test GC)");
-        current_memory_tracker = &tracker;
+        auto tracker = MemoryTracker::create();
+        tracker->setDescription("(Stress Test GC)");
+        current_memory_tracker = tracker.get();
         ps->gc();
         current_memory_tracker = nullptr;
     }

--- a/dbms/src/Storages/Page/workload/PSRunnable.cpp
+++ b/dbms/src/Storages/Page/workload/PSRunnable.cpp
@@ -29,9 +29,9 @@ namespace DB::PS::tests
 void PSRunnable::run()
 try
 {
-    MemoryTracker tracker;
-    tracker.setDescription(nullptr);
-    current_memory_tracker = &tracker;
+    auto tracker = MemoryTracker::create();
+    tracker->setDescription(nullptr);
+    current_memory_tracker = tracker.get();
     // If runImpl() return false, means it need break itself
     while (StressEnvStatus::getInstance().isRunning() && runImpl())
     {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:
1. Computing layer uses MemoryTracker to track memory usage of MPPTask . However, it also uses MemoryTracker to estimate the size of the data and different execution strategies, such as multi-thread or single-thread, are adopted for different data sizes.
2. The reading threads of storage will set the MemoryTracker object of the corresponding MPPTask to current_memory_tracker when reading data and avoid inaccurate data size estimates.
3. If the MPPTask exists, the corresponding MemoryTracker will be destroyed. But the reading threads of storage can still use this object and cause the process to crash.
4. For safety, reading threads should take a shared_ptr of MemoryTracker instead of a raw pointer.
### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
