### PR TITLE
[DNM] Improve performance of `avg`, `sum` aggregate functions if used without GROUP BY expression.

### DIFF
--- a/dbms/src/AggregateFunctions/AggregateFunctionSum.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionSum.h
@@ -16,8 +16,8 @@
 
 #include <AggregateFunctions/IAggregateFunction.h>
 #include <Columns/ColumnVector.h>
-#include <Common/assert_cast.h>
 #include <Common/TargetSpecific.h>
+#include <Common/assert_cast.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <IO/ReadHelpers.h>
 #include <IO/WriteHelpers.h>
@@ -60,6 +60,8 @@ struct AggregateFunctionSumData
         Impl::add(sum, value);
     }
 
+    // clang-format off
+    /// Vectorized version
     TIFLASH_MULTITARGET_FUNCTION(
     TIFLASH_MULTITARGET_FUNCTION_HEADER(
     template <typename Value>
@@ -100,8 +102,8 @@ struct AggregateFunctionSumData
         Impl::add(sum, local_sum);
     })
     )
+    // clang-format on
 
-    /// Vectorized version
     template <typename Value>
     void NO_SANITIZE_UNDEFINED NO_INLINE addMany(const Value * __restrict ptr, size_t count)
     {

--- a/dbms/src/Common/CpuId.h
+++ b/dbms/src/Common/CpuId.h
@@ -1,0 +1,321 @@
+#pragma once
+
+#include <common/types.h>
+
+#if defined(__x86_64__) || defined(__i386__)
+#include <cpuid.h>
+#endif
+
+#include <cstring>
+
+
+namespace DB::Cpu
+{
+
+#if (defined(__x86_64__) || defined(__i386__))
+/// Our version is independent of -mxsave option, because we do dynamic dispatch.
+inline UInt64 our_xgetbv(UInt32 xcr) noexcept
+{
+    UInt32 eax;
+    UInt32 edx;
+    __asm__ volatile(
+        "xgetbv"
+        : "=a"(eax), "=d"(edx)
+        : "c"(xcr));
+    return (static_cast<UInt64>(edx) << 32) | eax;
+}
+#endif
+
+inline bool cpuid(UInt32 op, UInt32 sub_op, UInt32 * res) noexcept /// NOLINT
+{
+#if defined(__x86_64__) || defined(__i386__)
+    __cpuid_count(op, sub_op, res[0], res[1], res[2], res[3]);
+    return true;
+#else
+    (void)op;
+    (void)sub_op;
+
+    memset(res, 0, 4 * sizeof(*res));
+
+    return false;
+#endif
+}
+
+inline bool cpuid(UInt32 op, UInt32 * res) noexcept /// NOLINT
+{
+#if defined(__x86_64__) || defined(__i386__)
+    __cpuid(op, res[0], res[1], res[2], res[3]);
+    return true;
+#else
+    (void)op;
+
+    memset(res, 0, 4 * sizeof(*res));
+
+    return false;
+#endif
+}
+
+#define CPU_ID_ENUMERATE(OP) \
+    OP(SSE)                  \
+    OP(SSE2)                 \
+    OP(SSE3)                 \
+    OP(SSSE3)                \
+    OP(SSE41)                \
+    OP(SSE42)                \
+    OP(F16C)                 \
+    OP(POPCNT)               \
+    OP(BMI1)                 \
+    OP(BMI2)                 \
+    OP(PCLMUL)               \
+    OP(AES)                  \
+    OP(AVX)                  \
+    OP(FMA)                  \
+    OP(AVX2)                 \
+    OP(AVX512F)              \
+    OP(AVX512DQ)             \
+    OP(AVX512IFMA)           \
+    OP(AVX512PF)             \
+    OP(AVX512ER)             \
+    OP(AVX512CD)             \
+    OP(AVX512BW)             \
+    OP(AVX512VL)             \
+    OP(AVX512VBMI)           \
+    OP(AVX512VBMI2)          \
+    OP(PREFETCHWT1)          \
+    OP(SHA)                  \
+    OP(ADX)                  \
+    OP(RDRAND)               \
+    OP(RDSEED)               \
+    OP(PCOMMIT)              \
+    OP(RDTSCP)               \
+    OP(CLFLUSHOPT)           \
+    OP(CLWB)                 \
+    OP(XSAVE)                \
+    OP(OSXSAVE)
+
+union CpuInfo
+{
+    UInt32 info[4]{};
+
+    struct Registers
+    {
+        UInt32 eax;
+        UInt32 ebx;
+        UInt32 ecx;
+        UInt32 edx;
+    } registers;
+
+    inline explicit CpuInfo(UInt32 op) noexcept { cpuid(op, info); }
+
+    inline CpuInfo(UInt32 op, UInt32 sub_op) noexcept { cpuid(op, sub_op, info); }
+};
+
+#define DEF_NAME(X) inline bool have##X() noexcept;
+    CPU_ID_ENUMERATE(DEF_NAME)
+#undef DEF_NAME
+
+bool haveRDTSCP() noexcept
+{
+    return (CpuInfo(0x80000001).registers.edx >> 27) & 1u;
+}
+
+bool haveSSE() noexcept
+{
+    return (CpuInfo(0x1).registers.edx >> 25) & 1u;
+}
+
+bool haveSSE2() noexcept
+{
+    return (CpuInfo(0x1).registers.edx >> 26) & 1u;
+}
+
+bool haveSSE3() noexcept
+{
+    return CpuInfo(0x1).registers.ecx & 1u;
+}
+
+bool havePCLMUL() noexcept
+{
+    return (CpuInfo(0x1).registers.ecx >> 1) & 1u;
+}
+
+bool haveSSSE3() noexcept
+{
+    return (CpuInfo(0x1).registers.ecx >> 9) & 1u;
+}
+
+bool haveSSE41() noexcept
+{
+    return (CpuInfo(0x1).registers.ecx >> 19) & 1u;
+}
+
+bool haveSSE42() noexcept
+{
+    return (CpuInfo(0x1).registers.ecx >> 20) & 1u;
+}
+
+bool haveF16C() noexcept
+{
+    return (CpuInfo(0x1).registers.ecx >> 29) & 1u;
+}
+
+bool havePOPCNT() noexcept
+{
+    return (CpuInfo(0x1).registers.ecx >> 23) & 1u;
+}
+
+bool haveAES() noexcept
+{
+    return (CpuInfo(0x1).registers.ecx >> 25) & 1u;
+}
+
+bool haveXSAVE() noexcept
+{
+    return (CpuInfo(0x1).registers.ecx >> 26) & 1u;
+}
+
+bool haveOSXSAVE() noexcept
+{
+    return (CpuInfo(0x1).registers.ecx >> 27) & 1u;
+}
+
+bool haveAVX() noexcept
+{
+#if defined(__x86_64__) || defined(__i386__)
+    // http://www.intel.com/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-optimization-manual.pdf
+    // https://bugs.chromium.org/p/chromium/issues/detail?id=375968
+    return haveOSXSAVE()                           // implies haveXSAVE()
+           && (our_xgetbv(0) & 6u) == 6u              // XMM state and YMM state are enabled by OS
+           && ((CpuInfo(0x1).registers.ecx >> 28) & 1u); // AVX bit
+#else
+    return false;
+#endif
+}
+
+bool haveFMA() noexcept
+{
+    return haveAVX() && ((CpuInfo(0x1).registers.ecx >> 12) & 1u);
+}
+
+bool haveAVX2() noexcept
+{
+    return haveAVX() && ((CpuInfo(0x7, 0).registers.ebx >> 5) & 1u);
+}
+
+bool haveBMI1() noexcept
+{
+    return (CpuInfo(0x7, 0).registers.ebx >> 3) & 1u;
+}
+
+bool haveBMI2() noexcept
+{
+    return (CpuInfo(0x7, 0).registers.ebx >> 8) & 1u;
+}
+
+bool haveAVX512F() noexcept
+{
+#if defined(__x86_64__) || defined(__i386__)
+    // https://software.intel.com/en-us/articles/how-to-detect-knl-instruction-support
+    return haveOSXSAVE()                           // implies haveXSAVE()
+           && (our_xgetbv(0) & 6u) == 6u              // XMM state and YMM state are enabled by OS
+           && ((our_xgetbv(0) >> 5) & 7u) == 7u       // ZMM state is enabled by OS
+           && CpuInfo(0x0).registers.eax >= 0x7          // leaf 7 is present
+           && ((CpuInfo(0x7, 0).registers.ebx >> 16) & 1u); // AVX512F bit
+#else
+    return false;
+#endif
+}
+
+bool haveAVX512DQ() noexcept
+{
+    return haveAVX512F() && ((CpuInfo(0x7, 0).registers.ebx >> 17) & 1u);
+}
+
+bool haveRDSEED() noexcept
+{
+    return CpuInfo(0x0).registers.eax >= 0x7 && ((CpuInfo(0x7, 0).registers.ebx >> 18) & 1u);
+}
+
+bool haveADX() noexcept
+{
+    return CpuInfo(0x0).registers.eax >= 0x7 && ((CpuInfo(0x7, 0).registers.ebx >> 19) & 1u);
+}
+
+bool haveAVX512IFMA() noexcept
+{
+    return haveAVX512F() && ((CpuInfo(0x7, 0).registers.ebx >> 21) & 1u);
+}
+
+bool havePCOMMIT() noexcept
+{
+    return CpuInfo(0x0).registers.eax >= 0x7 && ((CpuInfo(0x7, 0).registers.ebx >> 22) & 1u);
+}
+
+bool haveCLFLUSHOPT() noexcept
+{
+    return CpuInfo(0x0).registers.eax >= 0x7 && ((CpuInfo(0x7, 0).registers.ebx >> 23) & 1u);
+}
+
+bool haveCLWB() noexcept
+{
+    return CpuInfo(0x0).registers.eax >= 0x7 && ((CpuInfo(0x7, 0).registers.ebx >> 24) & 1u);
+}
+
+bool haveAVX512PF() noexcept
+{
+    return haveAVX512F() && ((CpuInfo(0x7, 0).registers.ebx >> 26) & 1u);
+}
+
+bool haveAVX512ER() noexcept
+{
+    return haveAVX512F() && ((CpuInfo(0x7, 0).registers.ebx >> 27) & 1u);
+}
+
+bool haveAVX512CD() noexcept
+{
+    return haveAVX512F() && ((CpuInfo(0x7, 0).registers.ebx >> 28) & 1u);
+}
+
+bool haveSHA() noexcept
+{
+    return CpuInfo(0x0).registers.eax >= 0x7 && ((CpuInfo(0x7, 0).registers.ebx >> 29) & 1u);
+}
+
+bool haveAVX512BW() noexcept
+{
+    return haveAVX512F() && ((CpuInfo(0x7, 0).registers.ebx >> 30) & 1u);
+}
+
+bool haveAVX512VL() noexcept
+{
+    return haveAVX512F() && ((CpuInfo(0x7, 0).registers.ebx >> 31) & 1u);
+}
+
+bool havePREFETCHWT1() noexcept
+{
+    return CpuInfo(0x0).registers.eax >= 0x7 && ((CpuInfo(0x7, 0).registers.ecx >> 0) & 1u);
+}
+
+bool haveAVX512VBMI() noexcept
+{
+    return haveAVX512F() && ((CpuInfo(0x7, 0).registers.ecx >> 1) & 1u);
+}
+
+bool haveAVX512VBMI2() noexcept
+{
+    return haveAVX512F() && ((CpuInfo(0x7, 0).registers.ecx >> 6) & 1u);
+}
+
+bool haveRDRAND() noexcept
+{
+    return CpuInfo(0x0).registers.eax >= 0x7 && ((CpuInfo(0x1).registers.ecx >> 30) & 1u);
+}
+
+struct CpuFlagsCache
+{
+#define DEF_NAME(X) static inline bool have_##X = have##X();
+    CPU_ID_ENUMERATE(DEF_NAME)
+#undef DEF_NAME
+};
+
+} // namespace DB::Cpu

--- a/dbms/src/Common/CpuId.h
+++ b/dbms/src/Common/CpuId.h
@@ -111,7 +111,7 @@ union CpuInfo
 };
 
 #define DEF_NAME(X) inline bool have##X() noexcept;
-    CPU_ID_ENUMERATE(DEF_NAME)
+CPU_ID_ENUMERATE(DEF_NAME)
 #undef DEF_NAME
 
 bool haveRDTSCP() noexcept
@@ -184,9 +184,9 @@ bool haveAVX() noexcept
 #if defined(__x86_64__) || defined(__i386__)
     // http://www.intel.com/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-optimization-manual.pdf
     // https://bugs.chromium.org/p/chromium/issues/detail?id=375968
-    return haveOSXSAVE()                           // implies haveXSAVE()
-           && (our_xgetbv(0) & 6u) == 6u              // XMM state and YMM state are enabled by OS
-           && ((CpuInfo(0x1).registers.ecx >> 28) & 1u); // AVX bit
+    return haveOSXSAVE() // implies haveXSAVE()
+        && (our_xgetbv(0) & 6u) == 6u // XMM state and YMM state are enabled by OS
+        && ((CpuInfo(0x1).registers.ecx >> 28) & 1u); // AVX bit
 #else
     return false;
 #endif
@@ -216,11 +216,11 @@ bool haveAVX512F() noexcept
 {
 #if defined(__x86_64__) || defined(__i386__)
     // https://software.intel.com/en-us/articles/how-to-detect-knl-instruction-support
-    return haveOSXSAVE()                           // implies haveXSAVE()
-           && (our_xgetbv(0) & 6u) == 6u              // XMM state and YMM state are enabled by OS
-           && ((our_xgetbv(0) >> 5) & 7u) == 7u       // ZMM state is enabled by OS
-           && CpuInfo(0x0).registers.eax >= 0x7          // leaf 7 is present
-           && ((CpuInfo(0x7, 0).registers.ebx >> 16) & 1u); // AVX512F bit
+    return haveOSXSAVE() // implies haveXSAVE()
+        && (our_xgetbv(0) & 6u) == 6u // XMM state and YMM state are enabled by OS
+        && ((our_xgetbv(0) >> 5) & 7u) == 7u // ZMM state is enabled by OS
+        && CpuInfo(0x0).registers.eax >= 0x7 // leaf 7 is present
+        && ((CpuInfo(0x7, 0).registers.ebx >> 16) & 1u); // AVX512F bit
 #else
     return false;
 #endif

--- a/dbms/src/Common/TargetSpecific.cpp
+++ b/dbms/src/Common/TargetSpecific.cpp
@@ -1,0 +1,51 @@
+#include <Common/TargetSpecific.h>
+
+#include <Common/CpuId.h>
+
+namespace DB
+{
+
+UInt32 getSupportedArchs()
+{
+    UInt32 result = 0;
+    if (Cpu::CpuFlagsCache::have_SSE42)
+        result |= static_cast<UInt32>(TargetArch::SSE4);
+    if (Cpu::CpuFlagsCache::have_AVX)
+        result |= static_cast<UInt32>(TargetArch::AVX);
+    if (Cpu::CpuFlagsCache::have_AVX2)
+        result |= static_cast<UInt32>(TargetArch::AVX2);
+    if (Cpu::CpuFlagsCache::have_AVX512F)
+        result |= static_cast<UInt32>(TargetArch::AVX512F);
+    if (Cpu::CpuFlagsCache::have_AVX512BW)
+        result |= static_cast<UInt32>(TargetArch::AVX512BW);
+    if (Cpu::CpuFlagsCache::have_AVX512VBMI)
+        result |= static_cast<UInt32>(TargetArch::AVX512VBMI);
+    if (Cpu::CpuFlagsCache::have_AVX512VBMI2)
+        result |= static_cast<UInt32>(TargetArch::AVX512VBMI2);
+    return result;
+}
+
+bool isArchSupported(TargetArch arch)
+{
+    static UInt32 arches = getSupportedArchs();
+    return arch == TargetArch::Default || (arches & static_cast<UInt32>(arch));
+}
+
+String toString(TargetArch arch)
+{
+    switch (arch)
+    {
+        case TargetArch::Default: return "default";
+        case TargetArch::SSE4:   return "sse4";
+        case TargetArch::AVX:     return "avx";
+        case TargetArch::AVX2:    return "avx2";
+        case TargetArch::AVX512F: return "avx512f";
+        case TargetArch::AVX512BW:    return "avx512bw";
+        case TargetArch::AVX512VBMI:  return "avx512vbmi";
+        case TargetArch::AVX512VBMI2: return "avx512vbmi";
+    }
+
+    __builtin_unreachable();
+}
+
+}

--- a/dbms/src/Common/TargetSpecific.cpp
+++ b/dbms/src/Common/TargetSpecific.cpp
@@ -1,6 +1,5 @@
-#include <Common/TargetSpecific.h>
-
 #include <Common/CpuId.h>
+#include <Common/TargetSpecific.h>
 
 namespace DB
 {
@@ -35,17 +34,25 @@ String toString(TargetArch arch)
 {
     switch (arch)
     {
-        case TargetArch::Default: return "default";
-        case TargetArch::SSE4:   return "sse4";
-        case TargetArch::AVX:     return "avx";
-        case TargetArch::AVX2:    return "avx2";
-        case TargetArch::AVX512F: return "avx512f";
-        case TargetArch::AVX512BW:    return "avx512bw";
-        case TargetArch::AVX512VBMI:  return "avx512vbmi";
-        case TargetArch::AVX512VBMI2: return "avx512vbmi";
+    case TargetArch::Default:
+        return "default";
+    case TargetArch::SSE4:
+        return "sse4";
+    case TargetArch::AVX:
+        return "avx";
+    case TargetArch::AVX2:
+        return "avx2";
+    case TargetArch::AVX512F:
+        return "avx512f";
+    case TargetArch::AVX512BW:
+        return "avx512bw";
+    case TargetArch::AVX512VBMI:
+        return "avx512vbmi";
+    case TargetArch::AVX512VBMI2:
+        return "avx512vbmi";
     }
 
     __builtin_unreachable();
 }
 
-}
+} // namespace DB

--- a/dbms/src/Common/TargetSpecific.h
+++ b/dbms/src/Common/TargetSpecific.h
@@ -46,17 +46,17 @@
  * 4. TIFLASH_IMPLEMENT_MULTITARGET_FUNCTION: implement the function body
  */
 
-namespace DB 
+namespace DB
 {
- enum class TargetArch : UInt32
+enum class TargetArch : UInt32
 {
-    Default  = 0,         /// Without any additional compiler options.
-    SSE4    = (1 << 0),  /// SSE4
-    AVX      = (1 << 1),
-    AVX2     = (1 << 2),
-    AVX512F  = (1 << 3),
-    AVX512BW    = (1 << 4),
-    AVX512VBMI  = (1 << 5),
+    Default = 0, /// Without any additional compiler options.
+    SSE4 = (1 << 0), /// SSE4
+    AVX = (1 << 1),
+    AVX2 = (1 << 2),
+    AVX512F = (1 << 3),
+    AVX512BW = (1 << 4),
+    AVX512VBMI = (1 << 5),
     AVX512VBMI2 = (1 << 6),
 };
 
@@ -727,6 +727,7 @@ TIFLASH_TARGET_SPECIFIC_NAMESPACE(
 #undef ENUM_TYPE
 #undef GET_TYPE
 
+// clang-format off
 /** Runtime Dispatch helpers for class members.
   *
   * Example of usage:
@@ -806,3 +807,4 @@ TIFLASH_TARGET_SPECIFIC_NAMESPACE(
     FUNCTION_BODY \
 
 #endif
+// clang-format on


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #5672 

Problem Summary:

### What is changed and how it works?

1. Dynamic dispatch infrastructure for class member functions 
2. speed up aggregate function sum
port from [ClickHouse/pull#37257](https://github.com/ClickHouse/ClickHouse/pull/37257/)

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
