### PR TITLE
misc: protect from calling RUNTIME_CHECK with string literals

### DIFF
--- a/dbms/src/Common/Exception.h
+++ b/dbms/src/Common/Exception.h
@@ -235,14 +235,17 @@ constexpr auto maybeStringLiteralExpr(const std::string_view sv)
 }
 } // namespace exception_details
 
-#define INTERNAL_RUNTIME_CHECK_APPEND_ARG(r, data, elem)                                                                                                             \
-    .fmtAppend(                                                                                                                                                      \
-        [] {                                                                                                                                                         \
-            static_assert(                                                                                                                                           \
-                !::DB::exception_details::maybeStringLiteralExpr(BOOST_PP_STRINGIZE(elem)),                                                                          \
-                                                                 "Seems that you may be passing a string literal to RUNTIME_CHECK. Use RUNTIME_CHECK_MSG instead."); \
-            return ", " BOOST_PP_STRINGIZE(elem) " = {}";                                                                                                            \
-        }(),                                                                                                                                                         \
+#define INTERNAL_RUNTIME_CHECK_APPEND_ARG(r, data, elem)                                                       \
+    .fmtAppend(                                                                                                \
+        [] {                                                                                                   \
+            static_assert(                                                                                     \
+                !::DB::exception_details::maybeStringLiteralExpr(                                              \
+                    BOOST_PP_STRINGIZE(elem)),                                                                 \
+                    "Unexpected " BOOST_PP_STRINGIZE(elem) ": Seems that you may be passing a string literal " \
+                                                           "to RUNTIME_CHECK? Use RUNTIME_CHECK_MSG instead. " \
+                                                           "See tiflash/pull/5777 for details.");              \
+            return ", " BOOST_PP_STRINGIZE(elem) " = {}";                                                      \
+        }(),                                                                                                   \
         elem)
 
 #define INTERNAL_RUNTIME_CHECK_APPEND_ARGS(...) \

--- a/dbms/src/Common/Exception.h
+++ b/dbms/src/Common/Exception.h
@@ -225,10 +225,25 @@ inline void log(const char * filename, int lineno, const char * condition, const
 {
     log(filename, lineno, condition, getDefaultFatalLogger(), fmt_str, std::forward<Args>(args)...);
 }
+
+/**
+ * Roughly check whether the passed in string may be a string literal expression.
+ */
+constexpr auto maybeStringLiteralExpr(const std::string_view sv)
+{
+    return sv.front() == '"' && sv.back() == '"';
+}
 } // namespace exception_details
 
-#define INTERNAL_RUNTIME_CHECK_APPEND_ARG(r, data, elem) \
-    .fmtAppend(", " BOOST_PP_STRINGIZE(elem) " = {}", elem)
+#define INTERNAL_RUNTIME_CHECK_APPEND_ARG(r, data, elem)                                                                                                             \
+    .fmtAppend(                                                                                                                                                      \
+        [] {                                                                                                                                                         \
+            static_assert(                                                                                                                                           \
+                !::DB::exception_details::maybeStringLiteralExpr(BOOST_PP_STRINGIZE(elem)),                                                                          \
+                                                                 "Seems that you may be passing a string literal to RUNTIME_CHECK. Use RUNTIME_CHECK_MSG instead."); \
+            return ", " BOOST_PP_STRINGIZE(elem) " = {}";                                                                                                            \
+        }(),                                                                                                                                                         \
+        elem)
 
 #define INTERNAL_RUNTIME_CHECK_APPEND_ARGS(...) \
     BOOST_PP_SEQ_FOR_EACH(INTERNAL_RUNTIME_CHECK_APPEND_ARG, _, BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))
@@ -264,7 +279,7 @@ inline void log(const char * filename, int lineno, const char * condition, const
         if (unlikely(!(condition)))                                         \
         {                                                                   \
             throw ::DB::Exception(                                          \
-                FmtBuffer().append("Check " #condition " failed")           \
+                ::DB::FmtBuffer().append("Check " #condition " failed")     \
                     INTERNAL_RUNTIME_CHECK_APPEND_ARGS_OR_NONE(__VA_ARGS__) \
                         .toString(),                                        \
                 ::DB::ErrorCodes::LOGICAL_ERROR);                           \
@@ -279,15 +294,15 @@ inline void log(const char * filename, int lineno, const char * condition, const
  * RUNTIME_CHECK_MSG(a != b, "invariant not meet, a = {}, b = {}", a, b);
  * ```
  */
-#define RUNTIME_CHECK_MSG(condition, fmt, ...)                                                                \
-    do                                                                                                        \
-    {                                                                                                         \
-        if (unlikely(!(condition)))                                                                           \
-        {                                                                                                     \
-            throw ::DB::Exception(                                                                            \
-                FmtBuffer().append("Check " #condition " failed: ").fmtAppend(fmt, ##__VA_ARGS__).toString(), \
-                ::DB::ErrorCodes::LOGICAL_ERROR);                                                             \
-        }                                                                                                     \
+#define RUNTIME_CHECK_MSG(condition, fmt, ...)                                                                      \
+    do                                                                                                              \
+    {                                                                                                               \
+        if (unlikely(!(condition)))                                                                                 \
+        {                                                                                                           \
+            throw ::DB::Exception(                                                                                  \
+                ::DB::FmtBuffer().append("Check " #condition " failed: ").fmtAppend(fmt, ##__VA_ARGS__).toString(), \
+                ::DB::ErrorCodes::LOGICAL_ERROR);                                                                   \
+        }                                                                                                           \
     } while (false)
 
 /**
@@ -309,7 +324,7 @@ inline void log(const char * filename, int lineno, const char * condition, const
     {                                                                  \
         if (unlikely(!(condition)))                                    \
         {                                                              \
-            exception_details::log(                                    \
+            ::DB::exception_details::log(                              \
                 &__FILE__[LogFmtDetails::getFileNameOffset(__FILE__)], \
                 __LINE__,                                              \
                 #condition,                                            \

--- a/dbms/src/DataStreams/WindowBlockInputStream.cpp
+++ b/dbms/src/DataStreams/WindowBlockInputStream.cpp
@@ -318,7 +318,7 @@ void WindowBlockInputStream::advanceFrameEndCurrentRow()
            || frame_end.block + 1 == partition_end.block);
 
     // If window only have row_number or rank/dense_rank functions, set frame_end to the next row of current_row and frame_ended to true
-    RUNTIME_CHECK(
+    RUNTIME_CHECK_MSG(
         only_have_pure_window,
         "window function only support pure window function in WindowFrame::BoundaryType::Current now.");
     frame_end = current_row;


### PR DESCRIPTION
Signed-off-by: Wish <breezewish@outlook.com>

### What problem does this PR solve?

Issue Number: close #5774

Problem Summary: 

There is [a common mistake](https://github.com/pingcap/tiflash/pull/5762#discussion_r961355060) that we may specify a string literal to `RUNTIME_CHECK` hoping it will format things. Actually it will not work.

For example,

```c++
RUNTIME_CHECK(false, "some description");
```

will just become:

```
Check false failed, "some description" = some description
```

### What is changed and how it works?

I don't have ideas how we can reliably handle this case and make it just work™. So this PR simply throw compile errors when it **seems** to be this case. 

If we have good ways to print it out nicely later then we can relax the check at that time.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

<img width="999" alt="image" src="https://user-images.githubusercontent.com/1916485/188173779-27c1955d-b61a-4276-a89e-cc5b3b82403d.png">


```
/Users/breezewish/Work/tiflash-workspace2/dbms/src/Common/tests/gtest_exception.cpp:26:5: error: static_assert failed due to requirement '!::DB::exception_details::maybeStringLiteralExpr("\"abc\"")' "Seems that you may be passing a string literal to RUNTIME_CHECK. Use RUNTIME_CHECK_MSG instead."
    RUNTIME_CHECK(a != b, "abc");
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/breezewish/Work/tiflash-workspace2/dbms/src/Common/Exception.h:283:21: note: expanded from macro 'RUNTIME_CHECK'
                    INTERNAL_RUNTIME_CHECK_APPEND_ARGS_OR_NONE(__VA_ARGS__) \
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/breezewish/Work/tiflash-workspace2/dbms/src/Common/Exception.h:255:9: note: expanded from macro 'INTERNAL_RUNTIME_CHECK_APPEND_ARGS_OR_NONE'
        INTERNAL_RUNTIME_CHECK_APPEND_ARGS)                        \
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/breezewish/Work/tiflash-workspace2/contrib/boost/boost/preprocessor/control/if.hpp:24:74: note: expanded from macro 'BOOST_PP_IF'
#    define BOOST_PP_IF(cond, t, f) BOOST_PP_IIF(BOOST_PP_BOOL(cond), t, f)
                                                                         ^
note: (skipping 11 expansions in backtrace; use -fmacro-backtrace-limit=0 to see all)
/Users/breezewish/Work/tiflash-workspace2/contrib/boost/boost/preprocessor/seq/for_each.hpp:78:76: note: expanded from macro 'BOOST_PP_SEQ_FOR_EACH_M_IM'
#    define BOOST_PP_SEQ_FOR_EACH_M_IM(r, im) BOOST_PP_SEQ_FOR_EACH_M_I(r, im)
                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
/Users/breezewish/Work/tiflash-workspace2/contrib/boost/boost/preprocessor/seq/for_each.hpp:83:61: note: expanded from macro 'BOOST_PP_SEQ_FOR_EACH_M_I'
# define BOOST_PP_SEQ_FOR_EACH_M_I(r, macro, data, seq, sz) macro(r, data, BOOST_PP_SEQ_HEAD(seq))
                                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/breezewish/Work/tiflash-workspace2/dbms/src/Common/Exception.h:241:13: note: expanded from macro 'INTERNAL_RUNTIME_CHECK_APPEND_ARG'
            static_assert(                                                                                                                                           \
            ^
1 error generated.
```

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
