### PR TITLE
Bugfix of memtracker accuracy test

### DIFF
--- a/dbms/src/Common/MemoryTracker.cpp
+++ b/dbms/src/Common/MemoryTracker.cpp
@@ -69,20 +69,6 @@ void MemoryTracker::alloc(Int64 size, bool check_memory_limit)
       *  we allow exception about memory limit exceeded to be thrown only on next allocation.
       * So, we allow over-allocations.
       */
-    Int64 current_amount = amount.load(std::memory_order_relaxed);
-    if (unlikely(!next.load(std::memory_order_relaxed) && accuracy_diff_for_test && real_rss > accuracy_diff_for_test + current_amount))
-    {
-        DB::FmtBuffer fmt_buf;
-        fmt_buf.append("Memory tracker accuracy ");
-        if (description)
-            fmt_buf.fmtAppend(" {}", description);
-
-        fmt_buf.fmtAppend(": fault injected. real_rss ({}) is much larger than tracked amount ({})",
-                          formatReadableSizeWithBinarySuffix(real_rss),
-                          formatReadableSizeWithBinarySuffix(current_amount));
-        throw DB::TiFlashException(fmt_buf.toString(), DB::Errors::Coprocessor::MemoryLimitExceeded);
-    }
-
     Int64 will_be = size + amount.fetch_add(size, std::memory_order_relaxed);
 
     if (!next.load(std::memory_order_relaxed))
@@ -91,6 +77,19 @@ void MemoryTracker::alloc(Int64 size, bool check_memory_limit)
     if (check_memory_limit)
     {
         Int64 current_limit = limit.load(std::memory_order_relaxed);
+
+        if (unlikely(!next.load(std::memory_order_relaxed) && accuracy_diff_for_test && current_limit && real_rss > accuracy_diff_for_test + current_limit))
+        {
+            DB::FmtBuffer fmt_buf;
+            fmt_buf.append("Memory tracker accuracy ");
+            if (description)
+                fmt_buf.fmtAppend(" {}", description);
+
+            fmt_buf.fmtAppend(": fault injected. real_rss ({}) is much larger than limit ({})",
+                              formatReadableSizeWithBinarySuffix(real_rss),
+                              formatReadableSizeWithBinarySuffix(current_limit));
+            throw DB::TiFlashException(fmt_buf.toString(), DB::Errors::Coprocessor::MemoryLimitExceeded);
+        }
 
         /// Using non-thread-safe random number generator. Joint distribution in different threads would not be uniform.
         /// In this case, it doesn't matter.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #5776

Problem Summary: 
Bugfix: memtracker accuracy test
When memory usage drops, it can be very inaccurate because the process itself caches memory. For example, if memory usage suddenly drops from 30G to 1G, then the ```amount``` will be 1G, but the ```real _rss``` will still be 30G.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
