### PR TITLE
storage: unify segment_id for data sharing

### DIFF
--- a/dbms/src/Debug/dbgFuncMisc.cpp
+++ b/dbms/src/Debug/dbgFuncMisc.cpp
@@ -29,7 +29,8 @@ inline size_t getReadTSOForLog(const String & line)
     {
         std::regex rx(R"((0|[1-9][0-9]*))");
         std::smatch m;
-        auto pos = line.find("read_tso=");
+        // Rely on that MPP task prefix "MPP<query:435802637197639681,task:1>"
+        auto pos = line.find("query:");
         if (pos != std::string::npos && regex_search(line.cbegin() + pos, line.cend(), m, rx))
         {
             return std::stoul(m[1]);
@@ -61,7 +62,7 @@ void dbgFuncSearchLogForKey(Context & context, const ASTs & args, DBGInvoker::Pr
         throw Exception("Args not matched, should be: key, thread_hint", ErrorCodes::BAD_ARGUMENTS);
 
     auto key = safeGet<String>(typeid_cast<const ASTLiteral &>(*args[0]).value);
-    // the candidate line must be printed by a thread which also print a line contains `thread_hint`
+    // the candidate line must be printed by a thread which also print a line contains `tso_hint`
     auto tso_hint = safeGet<String>(typeid_cast<const ASTLiteral &>(*args[1]).value);
     auto log_path = context.getConfigRef().getString("logger.log");
 

--- a/dbms/src/Storages/DeltaMerge/ReadThread/CPU.cpp
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/CPU.cpp
@@ -71,39 +71,31 @@ std::vector<std::vector<int>> getLinuxNumaNodes()
     if (!nodes.exists() || !nodes.isDirectory())
     {
         auto cpus = getCPUs(cpus_dir_name);
-        if (cpus.empty())
+        RUNTIME_CHECK_MSG(!cpus.empty(), "Not recognize CPU: {}", cpus_dir_name);
+        numa_nodes.push_back(std::move(cpus));
+        return numa_nodes;
+    }
+
+    // get the cpu id from each NUMA node
+    Poco::DirectoryIterator end;
+    for (Poco::DirectoryIterator iter(nodes); iter != end; ++iter)
+    {
+        if (!isNodeDir(iter.name()))
         {
-            throw Exception("Not recognize CPU: " + cpus_dir_name);
+            continue;
         }
+        auto dir_name = nodes_dir_name + "/" + iter.name();
+        auto cpus = getCPUs(dir_name);
+        RUNTIME_CHECK_MSG(!cpus.empty(), "Not recognize CPU: {}", nodes_dir_name);
         numa_nodes.push_back(std::move(cpus));
     }
-    else
-    {
-        Poco::DirectoryIterator end;
-        for (Poco::DirectoryIterator iter(nodes); iter != end; ++iter)
-        {
-            if (!isNodeDir(iter.name()))
-            {
-                continue;
-            }
-            auto dir_name = nodes_dir_name + "/" + iter.name();
-            auto cpus = getCPUs(dir_name);
-            if (cpus.empty())
-            {
-                throw Exception("Not recognize CPU: " + nodes_dir_name);
-            }
-            numa_nodes.push_back(std::move(cpus));
-        }
-    }
-    if (numa_nodes.empty())
-    {
-        throw Exception("Not recognize CPU");
-    }
+    RUNTIME_CHECK_MSG(!numa_nodes.empty(), "Not recognize CPU");
     return numa_nodes;
 }
 
 std::vector<std::vector<int>> getNumaNodes(Poco::Logger * log)
 {
+#ifndef __APPLE__ // Apple macbooks does not support NUMA
     try
     {
         return getLinuxNumaNodes();
@@ -120,6 +112,7 @@ std::vector<std::vector<int>> getNumaNodes(Poco::Logger * log)
     {
         LOG_FMT_WARNING(log, "Unknow Error");
     }
+#endif
     LOG_FMT_WARNING(log, "Cannot recognize the CPU NUMA infomation, use the CPU as 'one numa node'");
     std::vector<std::vector<int>> numa_nodes(1); // "One numa node"
     return numa_nodes;

--- a/dbms/src/Storages/DeltaMerge/ReadThread/ColumnSharingCache.h
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/ColumnSharingCache.h
@@ -194,7 +194,7 @@ private:
         auto add_total = add_count + add_stale;
         auto get_cached = get_hit + get_copy;
         auto get_total = get_miss + get_part + get_hit + get_copy;
-        return fmt::format("add_count {} add_stale {} add_ratio {} get_miss {} get_part {} get_hit {} get_copy {} cached_ratio {}",
+        return fmt::format("add_count={} add_stale={} add_ratio={} get_miss={} get_part={} get_hit={} get_copy={} cached_ratio={}",
                            add_count,
                            add_stale,
                            add_total > 0 ? add_count * 1.0 / add_total : 0,
@@ -218,13 +218,15 @@ class DMFileReaderPool
 {
 public:
     static DMFileReaderPool & instance();
-    DMFileReaderPool() = default;
     ~DMFileReaderPool() = default;
     DISALLOW_COPY_AND_MOVE(DMFileReaderPool);
 
     void add(DMFileReader & reader);
     void del(DMFileReader & reader);
     void set(DMFileReader & from_reader, int64_t col_id, size_t start, size_t count, ColumnPtr & col);
+
+private:
+    DMFileReaderPool() = default;
 
 private:
     std::mutex mtx;

--- a/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.cpp
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.cpp
@@ -43,7 +43,7 @@ void SegmentReadTaskScheduler::add(const SegmentReadTaskPoolPtr & pool)
         merging_segments[pool->tableId()][seg_id].push_back(pool->poolId());
         if (!seg_ids.insert(seg_id).second)
         {
-            throw DB::Exception(fmt::format("Not support split segment task. seg_ids {} => seg_id {} already exist.", seg_ids, seg_id));
+            throw DB::Exception(fmt::format("Not support split segment task. segment_ids {} => segment_id={} already exist.", seg_ids, seg_id));
         }
     }
     auto block_slots = pool->getFreeBlockSlots();
@@ -200,7 +200,7 @@ bool SegmentReadTaskScheduler::schedule()
     auto [merged_task, run_sche] = scheduleMergedTask();
     if (merged_task != nullptr)
     {
-        LOG_FMT_DEBUG(log, "scheduleMergedTask seg_id={} pool_ids={} cost={}ms", merged_task->getSegmentId(), merged_task->getPoolIds(), sw.elapsedMilliseconds());
+        LOG_FMT_DEBUG(log, "scheduleMergedTask segment_id={} pool_ids={} cost={}ms", merged_task->getSegmentId(), merged_task->getPoolIds(), sw.elapsedMilliseconds());
         SegmentReaderPoolManager::instance().addTask(std::move(merged_task));
     }
     return run_sche;

--- a/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.cpp
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.cpp
@@ -21,7 +21,7 @@ SegmentReadTaskScheduler::SegmentReadTaskScheduler()
     : stop(false)
     , log(&Poco::Logger::get("SegmentReadTaskScheduler"))
 {
-    sched_thread = std::thread(&SegmentReadTaskScheduler::schedThread, this);
+    sched_thread = std::thread(&SegmentReadTaskScheduler::schedLoop, this);
 }
 
 SegmentReadTaskScheduler::~SegmentReadTaskScheduler()
@@ -48,7 +48,7 @@ void SegmentReadTaskScheduler::add(const SegmentReadTaskPoolPtr & pool)
     }
     auto block_slots = pool->getFreeBlockSlots();
     auto [unexpired, expired] = read_pools.count(pool->tableId());
-    LOG_FMT_DEBUG(log, "add pool {} table {} block_slots {} segment count {} segments {} unexpired pool {} expired pool {}", //
+    LOG_FMT_DEBUG(log, "Added, pool_id={} table_id={} block_slots={} segment_count={} segments={} unexpired_pool={} expired_pool={}", //
                   pool->poolId(),
                   pool->tableId(),
                   block_slots,
@@ -200,13 +200,13 @@ bool SegmentReadTaskScheduler::schedule()
     auto [merged_task, run_sche] = scheduleMergedTask();
     if (merged_task != nullptr)
     {
-        LOG_FMT_DEBUG(log, "scheduleMergedTask seg_id {} pools {} => {} ms", merged_task->getSegmentId(), merged_task->getPoolIds(), sw.elapsedMilliseconds());
+        LOG_FMT_DEBUG(log, "scheduleMergedTask seg_id={} pool_ids={} cost={}ms", merged_task->getSegmentId(), merged_task->getPoolIds(), sw.elapsedMilliseconds());
         SegmentReaderPoolManager::instance().addTask(std::move(merged_task));
     }
     return run_sche;
 }
 
-void SegmentReadTaskScheduler::schedThread()
+void SegmentReadTaskScheduler::schedLoop()
 {
     while (!isStop())
     {

--- a/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.h
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.h
@@ -55,13 +55,13 @@ private:
     SegmentReadTaskScheduler();
 
     // Choose segment to read.
-    // Returns <MergedTaskPtr, run_next_schedule_immediatly>
+    // Returns <MergedTaskPtr, run_next_schedule_immediately>
     std::pair<MergedTaskPtr, bool> scheduleMergedTask();
 
     void setStop();
     bool isStop() const;
     bool schedule();
-    void schedThread();
+    void schedLoop();
 
     SegmentReadTaskPools getPoolsUnlock(const std::vector<uint64_t> & pool_ids);
     // <seg_id, pool_ids>

--- a/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReader.cpp
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReader.cpp
@@ -70,11 +70,11 @@ private:
         if (ret != 0)
         {
             // It can be failed due to some CPU core cannot access, such as CPU offline.
-            LOG_FMT_ERROR(log, "sched_setaffinity cpus {} fail: {}", cpus, std::strerror(errno));
+            LOG_FMT_ERROR(log, "sched_setaffinity fail, cpus={} errno={}", cpus, std::strerror(errno));
         }
         else
         {
-            LOG_FMT_DEBUG(log, "sched_setaffinity cpus {} succ", cpus);
+            LOG_FMT_DEBUG(log, "sched_setaffinity succ, cpus={}", cpus);
         }
 #endif
     }
@@ -114,7 +114,7 @@ private:
             }
             if (read_count <= 0)
             {
-                LOG_FMT_DEBUG(log, "pool_ids={} seg_id={} read_count={}", merged_task->getPoolIds(), merged_task->getSegmentId(), read_count);
+                LOG_FMT_DEBUG(log, "pool_ids={} segment_id={} read_count={}", merged_task->getPoolIds(), merged_task->getSegmentId(), read_count);
             }
         }
         catch (DB::Exception & e)

--- a/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReader.h
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReader.h
@@ -13,6 +13,7 @@
 // limitations under the License.
 #pragma once
 
+#include <Common/nocopyable.h>
 #include <Server/ServerInfo.h>
 #include <Storages/DeltaMerge/ReadThread/WorkQueue.h>
 #include <Storages/DeltaMerge/SegmentReadTaskPool.h>
@@ -31,10 +32,8 @@ class SegmentReaderPool
 public:
     SegmentReaderPool(int thread_count, const std::vector<int> & cpus);
     ~SegmentReaderPool();
-    SegmentReaderPool(const SegmentReaderPool &) = delete;
-    SegmentReaderPool & operator=(const SegmentReaderPool &) = delete;
-    SegmentReaderPool(SegmentReaderPool &&) = delete;
-    SegmentReaderPool & operator=(SegmentReaderPool &&) = delete;
+
+    DISALLOW_COPY_AND_MOVE(SegmentReaderPool);
 
     void addTask(MergedTaskPtr && task);
     std::vector<std::thread::id> getReaderIds() const;

--- a/dbms/src/Storages/DeltaMerge/ReadThread/UnorderedInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/UnorderedInputStream.h
@@ -45,18 +45,18 @@ public:
     {
         if (extra_table_id_index != InvalidColumnID)
         {
-            ColumnDefine extra_table_id_col_define = getExtraTableIDColumnDefine();
+            auto & extra_table_id_col_define = getExtraTableIDColumnDefine();
             ColumnWithTypeAndName col{extra_table_id_col_define.type->createColumn(), extra_table_id_col_define.type, extra_table_id_col_define.name, extra_table_id_col_define.id, extra_table_id_col_define.default_value};
             header.insert(extra_table_id_index, col);
         }
         ref_no = task_pool->increaseUnorderedInputStreamRefCount();
-        LOG_FMT_DEBUG(log, "pool {} ref {} created", task_pool->poolId(), ref_no);
+        LOG_FMT_DEBUG(log, "Created, pool_id={} ref_no={}", task_pool->poolId(), ref_no);
     }
 
     ~UnorderedInputStream()
     {
         task_pool->decreaseUnorderedInputStreamRefCount();
-        LOG_FMT_DEBUG(log, "pool {} ref {} destroy", task_pool->poolId(), ref_no);
+        LOG_FMT_DEBUG(log, "Destroy, pool_id={} ref_no={}", task_pool->poolId(), ref_no);
     }
 
     String getName() const override { return NAME; }
@@ -70,7 +70,7 @@ protected:
         return readImpl(filter_ignored, false);
     }
 
-    // Currently, res_fiter and return_filter is unused.
+    // Currently, res_filter and return_filter is unused.
     Block readImpl(FilterPtr & /*res_filter*/, bool /*return_filter*/) override
     {
         if (done)
@@ -87,7 +87,7 @@ protected:
             {
                 if (extra_table_id_index != InvalidColumnID)
                 {
-                    ColumnDefine extra_table_id_col_define = getExtraTableIDColumnDefine();
+                    auto & extra_table_id_col_define = getExtraTableIDColumnDefine();
                     ColumnWithTypeAndName col{{}, extra_table_id_col_define.type, extra_table_id_col_define.name, extra_table_id_col_define.id};
                     size_t row_number = res.rows();
                     auto col_data = col.type->createColumnConst(row_number, Field(physical_table_id));
@@ -114,7 +114,7 @@ protected:
 
     void readSuffixImpl() override
     {
-        LOG_FMT_DEBUG(log, "pool {} ref {} finish read {} rows from storage", task_pool->poolId(), ref_no, total_rows);
+        LOG_FMT_DEBUG(log, "Finish read from storage, pool_id={} ref_no={} rows={}", task_pool->poolId(), ref_no, total_rows);
     }
 
 private:

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.cpp
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.cpp
@@ -109,7 +109,7 @@ BlockInputStreamPtr SegmentReadTaskPool::buildInputStream(SegmentReadTaskPtr & t
         auto block_size = std::max(expected_block_size, static_cast<size_t>(dm_context->db_context.getSettingsRef().dt_segment_stable_pack_rows));
         stream = seg->getInputStream(*dm_context, columns_to_read, t->read_snapshot, t->ranges, filter, max_version, block_size);
     }
-    LOG_FMT_DEBUG(log, "getInputStream pool {} seg_id {} succ", pool_id, seg->segmentId());
+    LOG_FMT_DEBUG(log, "getInputStream succ, pool_id={} segment_id={}", pool_id, seg->segmentId());
     return stream;
 }
 
@@ -122,7 +122,7 @@ void SegmentReadTaskPool::finishSegment(const SegmentPtr & seg)
         active_segment_ids.erase(seg->segmentId());
         pool_finished = active_segment_ids.empty() && tasks.empty();
     }
-    LOG_FMT_DEBUG(log, "finishSegment pool {} seg_id {} pool_finished {}", pool_id, seg->segmentId(), pool_finished);
+    LOG_FMT_DEBUG(log, "finishSegment pool_id={} segment_id={} pool_finished={}", pool_id, seg->segmentId(), pool_finished);
     if (pool_finished)
     {
         q.finish();
@@ -136,7 +136,7 @@ SegmentReadTaskPtr SegmentReadTaskPool::getTask(uint64_t seg_id)
     auto itr = std::find_if(tasks.begin(), tasks.end(), [seg_id](const SegmentReadTaskPtr & task) { return task->segment->segmentId() == seg_id; });
     if (itr == tasks.end())
     {
-        throw Exception(fmt::format("pool {} seg_id {} not found", pool_id, seg_id));
+        throw Exception(fmt::format("{} pool_id={} segment_id={} not found", __PRETTY_FUNCTION__, pool_id, seg_id));
     }
     auto t = *(itr);
     tasks.erase(itr);
@@ -159,11 +159,11 @@ std::unordered_map<uint64_t, std::vector<uint64_t>>::const_iterator SegmentReadT
         auto itr = segments.find(task->segment->segmentId());
         if (itr == segments.end())
         {
-            throw DB::Exception(fmt::format("seg_id {} not found from merging segments", task->segment->segmentId()));
+            throw DB::Exception(fmt::format("segment_id {} not found from merging segments", task->segment->segmentId()));
         }
         if (std::find(itr->second.begin(), itr->second.end(), poolId()) == itr->second.end())
         {
-            throw DB::Exception(fmt::format("pool {} not found from merging segment {}=>{}", poolId(), itr->first, itr->second));
+            throw DB::Exception(fmt::format("pool_id={} not found from merging segment {}=>{}", poolId(), itr->first, itr->second));
         }
         if (target == segments.end() || itr->second.size() > target->second.size())
         {

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.h
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.h
@@ -150,7 +150,7 @@ public:
         auto total_bytes = blk_stat.totalBytes();
         auto blk_avg_bytes = total_count > 0 ? total_bytes / total_count : 0;
         auto approximate_max_pending_block_bytes = blk_avg_bytes * max_queue_size;
-        LOG_FMT_DEBUG(log, "pool {} table {} pop {} pop_empty {} pop_empty_ratio {} max_queue_size {} blk_avg_bytes {} approximate_max_pending_block_bytes {} MB total_count {} total_bytes {} MB", //
+        LOG_FMT_DEBUG(log, "pool_id={} table_id={} pop={} pop_empty={} pop_empty_ratio={} max_queue_size={} blk_avg_bytes={} approximate_max_pending_block_bytes={} MB total_count={} total_bytes={} MB", //
                       pool_id,
                       table_id,
                       pop_times,

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.h
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.h
@@ -124,7 +124,8 @@ public:
         bool is_raw_,
         bool do_range_filter_for_raw_,
         SegmentReadTasks && tasks_,
-        AfterSegmentRead after_segment_read_)
+        AfterSegmentRead after_segment_read_,
+        const String & tracing_id)
         : pool_id(nextPoolId())
         , table_id(table_id_)
         , dm_context(dm_context_)
@@ -136,7 +137,7 @@ public:
         , do_range_filter_for_raw(do_range_filter_for_raw_)
         , tasks(std::move(tasks_))
         , after_segment_read(after_segment_read_)
-        , log(&Poco::Logger::get("SegmentReadTaskPool"))
+        , log(Logger::get("SegmentReadTaskPool", tracing_id))
         , unordered_input_stream_ref_count(0)
         , exception_happened(false)
         , mem_tracker(current_memory_tracker == nullptr ? nullptr : current_memory_tracker->shared_from_this())
@@ -150,7 +151,7 @@ public:
         auto total_bytes = blk_stat.totalBytes();
         auto blk_avg_bytes = total_count > 0 ? total_bytes / total_count : 0;
         auto approximate_max_pending_block_bytes = blk_avg_bytes * max_queue_size;
-        LOG_FMT_DEBUG(log, "pool_id={} table_id={} pop={} pop_empty={} pop_empty_ratio={} max_queue_size={} blk_avg_bytes={} approximate_max_pending_block_bytes={} MB total_count={} total_bytes={} MB", //
+        LOG_FMT_DEBUG(log, "Done. pool_id={} table_id={} pop={} pop_empty={} pop_empty_ratio={} max_queue_size={} blk_avg_bytes={} approximate_max_pending_block_bytes={:.2f}MB total_count={} total_bytes={:.2f}MB", //
                       pool_id,
                       table_id,
                       pop_times,
@@ -216,7 +217,7 @@ private:
     std::unordered_set<uint64_t> active_segment_ids;
     WorkQueue<Block> q;
     BlockStat blk_stat;
-    Poco::Logger * log;
+    LoggerPtr log;
 
     std::atomic<int64_t> unordered_input_stream_ref_count;
 

--- a/dbms/src/Storages/StorageDeltaMerge.cpp
+++ b/dbms/src/Storages/StorageDeltaMerge.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Common/Exception.h>
 #include <Common/FailPoint.h>
 #include <Common/FmtUtils.h>
 #include <Common/Logger.h>
@@ -53,7 +54,6 @@
 #include <common/logger_useful.h>
 
 #include <random>
-#include "Common/Exception.h"
 
 namespace DB
 {

--- a/dbms/src/Storages/StorageDeltaMerge.cpp
+++ b/dbms/src/Storages/StorageDeltaMerge.cpp
@@ -53,6 +53,7 @@
 #include <common/logger_useful.h>
 
 #include <random>
+#include "Common/Exception.h"
 
 namespace DB
 {
@@ -638,16 +639,12 @@ BlockInputStreams StorageDeltaMerge::read(
     }
 
     // Read with MVCC filtering
-    if (unlikely(!query_info.mvcc_query_info))
-        throw Exception("mvcc query info is null", ErrorCodes::LOGICAL_ERROR);
-
     TMTContext & tmt = context.getTMTContext();
-    if (unlikely(!tmt.isInitialized()))
-        throw Exception("TMTContext is not initialized", ErrorCodes::LOGICAL_ERROR);
+    RUNTIME_CHECK(query_info.mvcc_query_info != nullptr);
+    RUNTIME_CHECK(tmt.isInitialized());
 
     const auto & mvcc_query_info = *query_info.mvcc_query_info;
-    auto req_id = fmt::format("{} read_tso={}", query_info.req_id, mvcc_query_info.read_tso);
-    auto tracing_logger = Logger::get("StorageDeltaMerge", log->identifier(), req_id);
+    auto tracing_logger = Logger::get("StorageDeltaMerge", log->identifier(), query_info.req_id);
 
     LOG_FMT_DEBUG(tracing_logger, "Read with tso: {}", mvcc_query_info.read_tso);
 
@@ -757,7 +754,7 @@ BlockInputStreams StorageDeltaMerge::read(
         num_streams,
         /*max_version=*/mvcc_query_info.read_tso,
         rs_operator,
-        req_id,
+        query_info.req_id,
         query_info.keep_order,
         /* is_fast_scan */ query_info.is_fast_scan,
         max_block_size,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/5726, ref https://github.com/pingcap/tiflash/pull/5715

Problem Summary:

### What is changed and how it works?
* Add tracing_id to SegmentReadTaskPool
* logging with `seg_id xxx` are unified to be `segment_id=xx` so that we can simply grep for it to precisely filter out all related log lines
* Skip NUMA detect on mac (previous it throw exception and make som trouble for debugging unittest under mac)
* Use the mpp query id for `DBGInvoke search_log_for_key`
  avoid the verbose logging: https://github.com/pingcap/tiflash/pull/5715#discussion_r963465875


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
