### PR TITLE
Refine error propagation in local tunnel

### DIFF
--- a/dbms/src/Flash/Mpp/ExchangeReceiver.cpp
+++ b/dbms/src/Flash/Mpp/ExchangeReceiver.cpp
@@ -633,7 +633,11 @@ void ExchangeReceiverBase<RPCContext>::readLoop(const Request & req)
                     break;
                 has_data = true;
                 if (packet->hasError())
-                    throw Exception("Exchange receiver meet error : " + packet->error().msg());
+                {
+                    meet_error = true;
+                    local_err_msg = fmt::format("Read error message from mpp packet: {}", packet->getPacket().error().msg());
+                    break;
+                }
 
                 if (!pushPacket<enable_fine_grained_shuffle, true>(
                         req.source_index,
@@ -643,15 +647,14 @@ void ExchangeReceiverBase<RPCContext>::readLoop(const Request & req)
                         log))
                 {
                     meet_error = true;
-                    auto local_state = getState();
-                    local_err_msg = "receiver's state is " + getReceiverStateStr(local_state) + ", exit from readLoop";
-                    LOG_WARNING(log, local_err_msg);
+                    local_err_msg = fmt::format("Push mpp packet failed. {}", getStatusString());
                     break;
                 }
             }
             // if meet error, such as decode packet fails, it will not retry.
             if (meet_error)
             {
+                reader->cancel(local_err_msg);
                 break;
             }
             status = reader->finish();
@@ -683,20 +686,10 @@ void ExchangeReceiverBase<RPCContext>::readLoop(const Request & req)
             local_err_msg = status.error_message();
         }
     }
-    catch (Exception & e)
-    {
-        meet_error = true;
-        local_err_msg = e.message();
-    }
-    catch (std::exception & e)
-    {
-        meet_error = true;
-        local_err_msg = e.what();
-    }
     catch (...)
     {
         meet_error = true;
-        local_err_msg = "fatal error";
+        local_err_msg = getCurrentExceptionMessage(false);
     }
     connectionDone(meet_error, local_err_msg, log);
 }
@@ -815,10 +808,12 @@ bool ExchangeReceiverBase<RPCContext>::setEndState(ExchangeReceiverState new_sta
 }
 
 template <typename RPCContext>
-ExchangeReceiverState ExchangeReceiverBase<RPCContext>::getState()
+String ExchangeReceiverBase<RPCContext>::getStatusString()
 {
     std::unique_lock lock(mu);
-    return state;
+    if (err_msg.empty())
+        return fmt::format("Receiver status is {}", getReceiverStateStr(state));
+    return fmt::format("Receiver status is {}, with error message: {}", getReceiverStateStr(state), err_msg);
 }
 
 template <typename RPCContext>

--- a/dbms/src/Flash/Mpp/ExchangeReceiver.cpp
+++ b/dbms/src/Flash/Mpp/ExchangeReceiver.cpp
@@ -53,8 +53,8 @@ String getReceiverStateStr(const ExchangeReceiverState & s)
 String constructStatusString(ExchangeReceiverState state, const String & error_message)
 {
     if (error_message.empty())
-        return fmt::format("Receiver status is {}", getReceiverStateStr(state));
-    return fmt::format("Receiver status is {}, with error message: {}", getReceiverStateStr(state), error_message);
+        return fmt::format("Receiver state: {}", getReceiverStateStr(state));
+    return fmt::format("Receiver state: {}, error message: {}", getReceiverStateStr(state), error_message);
 }
 
 // If enable_fine_grained_shuffle:

--- a/dbms/src/Flash/Mpp/ExchangeReceiver.h
+++ b/dbms/src/Flash/Mpp/ExchangeReceiver.h
@@ -177,7 +177,7 @@ private:
     void reactor(const std::vector<Request> & async_requests);
 
     bool setEndState(ExchangeReceiverState new_state);
-    ExchangeReceiverState getState();
+    String getStatusString();
 
     DecodeDetail decodeChunks(
         const std::shared_ptr<ReceivedMessage> & recv_msg,

--- a/dbms/src/Flash/Mpp/GRPCReceiverContext.cpp
+++ b/dbms/src/Flash/Mpp/GRPCReceiverContext.cpp
@@ -210,8 +210,8 @@ ExchangeRecvRequest GRPCReceiverContext::makeRequest(int index) const
     req.send_task_id = sender_task->task_id();
     req.recv_task_id = task_meta.task_id();
     req.req = std::make_shared<mpp::EstablishMPPConnectionRequest>();
-    req.req->set_allocated_receiver_meta(new mpp::TaskMeta(task_meta));
-    req.req->set_allocated_sender_meta(sender_task.release());
+    req.req->set_allocated_receiver_meta(new mpp::TaskMeta(task_meta)); // NOLINT
+    req.req->set_allocated_sender_meta(sender_task.release()); // NOLINT
     return req;
 }
 

--- a/dbms/src/Flash/Mpp/GRPCReceiverContext.h
+++ b/dbms/src/Flash/Mpp/GRPCReceiverContext.h
@@ -37,6 +37,7 @@ public:
     virtual ~ExchangePacketReader() = default;
     virtual bool read(TrackedMppDataPacketPtr & packet) = 0;
     virtual ::grpc::Status finish() = 0;
+    virtual void cancel(const String & reason) = 0;
 };
 using ExchangePacketReaderPtr = std::shared_ptr<ExchangePacketReader>;
 


### PR DESCRIPTION
Signed-off-by: xufei <xufeixw@mail.ustc.edu.cn>

### What problem does this PR solve?

Issue Number: ref #5095

Problem Summary:
When in local tunnel mode, if `ExchangeReceiver` meet some error, local tunnel will call `consumerFinish` with error message, but currently, the error message is just `Receiver Finish/Receiver closed`, it does not contain any useful information.
 
### What is changed and how it works?
This pr add a new interface `cancel` to `ExchangePacketReader`, and if exchange receiver meet error, it will call `cancel` to pass the error message to local tunnel explicitly.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
