### PR TITLE
Replace Poco::Logger by DB::Logger in MPPTaskManager and MinTSOScheduler

### DIFF
--- a/dbms/src/Flash/Mpp/MPPTaskManager.cpp
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.cpp
@@ -30,7 +30,7 @@ extern const char random_task_manager_find_task_failure_failpoint[];
 
 MPPTaskManager::MPPTaskManager(MPPTaskSchedulerPtr scheduler_)
     : scheduler(std::move(scheduler_))
-    , log(&Poco::Logger::get("TaskManager"))
+    , log(Logger::get("TaskManager"))
 {}
 
 std::pair<MPPTunnelPtr, String> MPPTaskManager::findTunnelWithTimeout(const ::mpp::EstablishMPPConnectionRequest * request, std::chrono::seconds timeout)

--- a/dbms/src/Flash/Mpp/MPPTaskManager.h
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.h
@@ -55,7 +55,7 @@ class MPPTaskManager : private boost::noncopyable
 
     MPPQueryMap mpp_query_map;
 
-    Poco::Logger * log;
+    LoggerPtr log;
 
     std::condition_variable cv;
 

--- a/dbms/src/Flash/Mpp/MinTSOScheduler.cpp
+++ b/dbms/src/Flash/Mpp/MinTSOScheduler.cpp
@@ -32,7 +32,7 @@ MinTSOScheduler::MinTSOScheduler(UInt64 soft_limit, UInt64 hard_limit)
     , thread_soft_limit(soft_limit)
     , thread_hard_limit(hard_limit)
     , estimated_thread_usage(0)
-    , log(&Poco::Logger::get("MinTSOScheduler"))
+    , log(Logger::get("MinTSOScheduler"))
 {
     auto cores = getNumberOfPhysicalCPUCores();
     active_set_soft_limit = (cores + 2) / 2; /// at least 1
@@ -128,12 +128,10 @@ void MinTSOScheduler::releaseThreadsThenSchedule(const int needed_threads, MPPTa
         return;
     }
 
-    if (static_cast<Int64>(estimated_thread_usage) < needed_threads)
-    {
-        LOG_FMT_FATAL(log, "estimated_thread_usage should not be smaller than 0, actually is {}.", static_cast<Int64>(estimated_thread_usage) - needed_threads);
-        std::terminate();
-    }
-    estimated_thread_usage -= needed_threads;
+    auto updated_estimated_threads = static_cast<Int64>(estimated_thread_usage) - needed_threads;
+    RUNTIME_ASSERT(updated_estimated_threads >= 0, log, "estimated_thread_usage should not be smaller than 0, actually is {}.", updated_estimated_threads);
+
+    estimated_thread_usage = updated_estimated_threads;
     GET_METRIC(tiflash_task_scheduler, type_estimated_thread_usage).Set(estimated_thread_usage);
     GET_METRIC(tiflash_task_scheduler, type_active_tasks_count).Decrement();
     /// as tasks release some threads, so some tasks would get scheduled.

--- a/dbms/src/Flash/Mpp/MinTSOScheduler.h
+++ b/dbms/src/Flash/Mpp/MinTSOScheduler.h
@@ -64,7 +64,7 @@ private:
     UInt64 estimated_thread_usage;
     /// to prevent from too many queries just issue a part of tasks to occupy threads, in proportion to the hardware cores.
     size_t active_set_soft_limit;
-    Poco::Logger * log;
+    LoggerPtr log;
 };
 
 } // namespace DB


### PR DESCRIPTION
Signed-off-by: xufei <xufeixw@mail.ustc.edu.cn>

### What problem does this PR solve?

Issue Number: ref #5864

Problem Summary:

### What is changed and how it works?
1. Replace `Poco::Logger` by `DB::Logger` in `MPPTaskManager` and `MinTSOScheduler`
2. Use `RUNTIME_ASSERT` to simplify code in https://github.com/pingcap/tiflash/blob/a6bc771f2b3cb1d08c628b649ff9ca796e026932/dbms/src/Flash/Mpp/MinTSOScheduler.cpp#L131-L135
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
