### PR TITLE
Use safe_ts to determine whether the peer's data synchronization progress is far behind the leader.

### DIFF
--- a/dbms/src/Storages/Transaction/ProxyFFI.cpp
+++ b/dbms/src/Storages/Transaction/ProxyFFI.cpp
@@ -564,6 +564,6 @@ void HandleSafeTSUpdate(EngineStoreServerWrap * server, uint64_t region_id, uint
     RegionTable & region_table = server->tmt->getRegionTable();
     region_table.updateSelfSafeTS(region_id, self_safe_ts);
     region_table.updateLeaderSafeTS(region_id, leader_safe_ts);
-    LOG_FMT_TRACE(&Poco::Logger::get(__FUNCTION__), "update safe ts in region_id:{}, leader_safe_ts:{}, self_safe_ts:{}", region_id, leader_safe_ts, self_safe_ts);
+    LOG_FMT_TRACE(&Poco::Logger::get(__FUNCTION__), "update safe ts in region_id={}, leader_safe_ts={}, self_safe_ts={}", region_id, leader_safe_ts, self_safe_ts);
 }
 } // namespace DB

--- a/dbms/src/Storages/Transaction/ProxyFFI.cpp
+++ b/dbms/src/Storages/Transaction/ProxyFFI.cpp
@@ -559,4 +559,11 @@ raft_serverpb::RegionLocalState TiFlashRaftProxyHelper::getRegionLocalState(uint
     return state;
 }
 
+void HandleSafeTSUpdate(EngineStoreServerWrap * server, uint64_t region_id, uint64_t self_safe_ts, uint64_t leader_safe_ts)
+{
+    RegionTable & region_table = server->tmt->getRegionTable();
+    region_table.updateSelfSafeTS(region_id, self_safe_ts);
+    region_table.updateLeaderSafeTS(region_id, leader_safe_ts);
+    LOG_FMT_TRACE(&Poco::Logger::get(__FUNCTION__), "update safe ts in region_id:{}, leader_safe_ts:{}, self_safe_ts:{}", region_id, leader_safe_ts, self_safe_ts);
+}
 } // namespace DB

--- a/dbms/src/Storages/Transaction/ProxyFFI.h
+++ b/dbms/src/Storages/Transaction/ProxyFFI.h
@@ -147,6 +147,7 @@ BaseBuffView strIntoView(const std::string * str_ptr);
 CppStrWithView GetConfig(EngineStoreServerWrap *, uint8_t full);
 void SetStore(EngineStoreServerWrap *, BaseBuffView);
 void SetPBMsByBytes(MsgPBType type, RawVoidPtr ptr, BaseBuffView view);
+void HandleSafeTSUpdate(EngineStoreServerWrap * server, uint64_t region_id, uint64_t self_safe_ts, uint64_t leader_safe_ts);
 }
 
 inline EngineStoreServerHelper GetEngineStoreServerHelper(
@@ -175,6 +176,7 @@ inline EngineStoreServerHelper GetEngineStoreServerHelper(
         .fn_get_config = GetConfig,
         .fn_set_store = SetStore,
         .fn_set_pb_msg_by_bytes = SetPBMsByBytes,
+        .fn_handle_safe_ts_update = HandleSafeTSUpdate,
     };
 }
 } // namespace DB

--- a/dbms/src/Storages/Transaction/ProxyFFIStatusService.cpp
+++ b/dbms/src/Storages/Transaction/ProxyFFIStatusService.cpp
@@ -55,11 +55,17 @@ HttpRequestRes HandleHttpRequestSyncStatus(
     // if storage is not created in ch, flash replica should not be available.
     if (tmt.getStorages().get(table_id))
     {
-        tmt.getRegionTable().handleInternalRegionsByTable(table_id, [&](const RegionTable::InternalRegions & regions) {
-            count = regions.size();
+        RegionTable & region_table = tmt.getRegionTable();
+        region_table.handleInternalRegionsByTable(table_id, [&](const RegionTable::InternalRegions & regions) {
             region_list.reserve(regions.size());
             for (const auto & region : regions)
-                region_list.push_back(region.first);
+            {
+                if (!region_table.isSafeTSDiffLarge(region.first))
+                {
+                    region_list.push_back(region.first);
+                }
+            }
+            count = region_list.size();
         });
     }
     ss << count << std::endl;

--- a/dbms/src/Storages/Transaction/ProxyFFIStatusService.cpp
+++ b/dbms/src/Storages/Transaction/ProxyFFIStatusService.cpp
@@ -60,12 +60,13 @@ HttpRequestRes HandleHttpRequestSyncStatus(
             region_list.reserve(regions.size());
             for (const auto & region : regions)
             {
-                if (!region_table.isSafeTSDiffLarge(region.first))
+                if (!region_table.isSafeTSLag(region.first))
                 {
                     region_list.push_back(region.first);
                 }
             }
             count = region_list.size();
+            LOG_FMT_DEBUG(&Poco::Logger::get(__FUNCTION__), "table_id:{}, tolal region count:{}, response region count:{}", table_id, regions.size(), count);
         });
     }
     ss << count << std::endl;

--- a/dbms/src/Storages/Transaction/ProxyFFIStatusService.cpp
+++ b/dbms/src/Storages/Transaction/ProxyFFIStatusService.cpp
@@ -66,7 +66,7 @@ HttpRequestRes HandleHttpRequestSyncStatus(
                 }
             }
             count = region_list.size();
-            LOG_FMT_DEBUG(&Poco::Logger::get(__FUNCTION__), "table_id:{}, tolal region count:{}, response region count:{}", table_id, regions.size(), count);
+            LOG_FMT_DEBUG(&Poco::Logger::get(__FUNCTION__), "table_id={}, total_region_count={}, ready_region_count={}", table_id, regions.size(), count);
         });
     }
     ss << count << std::endl;

--- a/dbms/src/Storages/Transaction/RegionTable.cpp
+++ b/dbms/src/Storages/Transaction/RegionTable.cpp
@@ -185,7 +185,11 @@ void RegionTable::removeTable(TableID table_id)
 
     // Remove from region list.
     for (const auto & region_info : table.regions)
+    {
         regions.erase(region_info.first);
+        leader_safets.erase(region_info.first);
+        self_safets.erase(region_info.first);
+    }
 
     // Remove from table map.
     tables.erase(it);
@@ -263,6 +267,8 @@ void RegionTable::removeRegion(const RegionID region_id, bool remove_data, const
         handle_range = internal_region_it->second.range_in_table;
 
         regions.erase(it);
+        leader_safets.erase(region_id);
+        self_safets.erase(region_id);
         table.regions.erase(internal_region_it);
         if (table.regions.empty())
         {

--- a/dbms/src/Storages/Transaction/RegionTable.cpp
+++ b/dbms/src/Storages/Transaction/RegionTable.cpp
@@ -187,8 +187,8 @@ void RegionTable::removeTable(TableID table_id)
     for (const auto & region_info : table.regions)
     {
         regions.erase(region_info.first);
-        leader_safets.erase(region_info.first);
-        self_safets.erase(region_info.first);
+        leader_safe_ts.erase(region_info.first);
+        self_safe_ts.erase(region_info.first);
     }
 
     // Remove from table map.
@@ -267,8 +267,8 @@ void RegionTable::removeRegion(const RegionID region_id, bool remove_data, const
         handle_range = internal_region_it->second.range_in_table;
 
         regions.erase(it);
-        leader_safets.erase(region_id);
-        self_safets.erase(region_id);
+        leader_safe_ts.erase(region_id);
+        self_safe_ts.erase(region_id);
         table.regions.erase(internal_region_it);
         if (table.regions.empty())
         {

--- a/dbms/src/Storages/Transaction/RegionTable.h
+++ b/dbms/src/Storages/Transaction/RegionTable.h
@@ -23,9 +23,11 @@
 #include <Storages/Transaction/RegionLockInfo.h>
 #include <Storages/Transaction/TiKVHandle.h>
 #include <common/logger_useful.h>
+#include <common/types.h>
 
 #include <condition_variable>
 #include <functional>
+#include <limits>
 #include <mutex>
 #include <optional>
 #include <variant>
@@ -55,6 +57,12 @@ struct RegionPtrWithSnapshotFiles;
 class RegionScanFilter;
 using RegionScanFilterPtr = std::shared_ptr<RegionScanFilter>;
 
+using SafeTS = UInt64;
+enum : SafeTS
+{
+    InvalidSafeTS = std::numeric_limits<UInt64>::max()
+};
+
 class RegionTable : private boost::noncopyable
 {
 public:
@@ -76,7 +84,7 @@ public:
 
     struct Table : boost::noncopyable
     {
-        Table(const TableID table_id_)
+        explicit Table(const TableID table_id_)
             : table_id(table_id_)
         {}
         TableID table_id;
@@ -85,6 +93,7 @@ public:
 
     using TableMap = std::unordered_map<TableID, Table>;
     using RegionInfoMap = std::unordered_map<RegionID, TableID>;
+    using SafeTsMap = std::unordered_map<RegionID, UInt64>;
 
     using DirtyRegions = std::unordered_set<RegionID>;
     using TableToOptimize = std::unordered_set<TableID>;
@@ -93,7 +102,7 @@ public:
     {
         using FlushThresholdsData = std::vector<std::pair<Int64, Seconds>>;
 
-        FlushThresholds(FlushThresholdsData && data_)
+        explicit FlushThresholds(FlushThresholdsData && data_)
             : data(std::make_shared<FlushThresholdsData>(std::move(data_)))
         {}
 
@@ -117,7 +126,7 @@ public:
         mutable std::mutex mutex;
     };
 
-    RegionTable(Context & context_);
+    explicit RegionTable(Context & context_);
     void restore();
 
     void setFlushThresholds(const FlushThresholds::FlushThresholdsData & flush_thresholds_);
@@ -127,14 +136,14 @@ public:
     /// This functional only shrink the table range of this region_id
     void shrinkRegionRange(const Region & region);
 
-    void removeRegion(const RegionID region_id, bool remove_data, const RegionTaskLock &);
+    void removeRegion(RegionID region_id, bool remove_data, const RegionTaskLock &);
 
     bool tryFlushRegions();
     RegionDataReadInfoList tryFlushRegion(RegionID region_id, bool try_persist = false);
     RegionDataReadInfoList tryFlushRegion(const RegionPtrWithBlock & region, bool try_persist);
 
-    void handleInternalRegionsByTable(const TableID table_id, std::function<void(const InternalRegions &)> && callback) const;
-    std::vector<std::pair<RegionID, RegionPtr>> getRegionsByTable(const TableID table_id) const;
+    void handleInternalRegionsByTable(TableID table_id, std::function<void(const InternalRegions &)> && callback) const;
+    std::vector<std::pair<RegionID, RegionPtr>> getRegionsByTable(TableID table_id) const;
 
     /// Write the data of the given region into the table with the given table ID, fill the data list for outer to remove.
     /// Will trigger schema sync on read error for only once,
@@ -159,17 +168,47 @@ public:
                                                                     Poco::Logger * log);
 
     /// extend range for possible InternalRegion or add one.
-    void extendRegionRange(const RegionID region_id, const RegionRangeKeys & region_range_keys);
+    void extendRegionRange(RegionID region_id, const RegionRangeKeys & region_range_keys);
+    void updateSelfSafeTS(UInt64 region_id, UInt64 self_safe_ts)
+    {
+        if (self_safe_ts == InvalidSafeTS)
+        {
+            return;
+        }
+        self_safets[region_id] = self_safe_ts;
+    }
+    void updateLeaderSafeTS(UInt64 region_id, UInt64 leader_safe_ts)
+    {
+        if (leader_safe_ts == InvalidSafeTS)
+        {
+            return;
+        }
+        leader_safets[region_id] = leader_safe_ts;
+    }
+
+    // unit: ms. If safe_ts diff is larger than 2min, we think the data synchronization progress is far behind the leader.
+    static const UInt64 SafeTsDiffThreshold = 2 * 60 * 1000;
+    bool isSafeTSDiffLarge(UInt64 region_id)
+    {
+        auto self_it = self_safets.find(region_id);
+        auto leader_it = leader_safets.find(region_id);
+        if (self_it == self_safets.end() || leader_it == leader_safets.end())
+        {
+            return false;
+        }
+        LOG_FMT_TRACE(log, "region_id:{}, table_id:{}, leader_safe_ts:{}, self_safe_ts:{}", region_id, regions[region_id], leader_it->second, self_it->second);
+        return (leader_it->second > self_it->second) && (leader_it->second - self_it->second > SafeTsDiffThreshold);
+    }
 
 private:
     friend class MockTiDB;
     friend class StorageDeltaMerge;
 
-    Table & getOrCreateTable(const TableID table_id);
+    Table & getOrCreateTable(TableID table_id);
     void removeTable(TableID table_id);
     InternalRegion & insertRegion(Table & table, const Region & region);
     InternalRegion & getOrInsertRegion(const Region & region);
-    InternalRegion & insertRegion(Table & table, const RegionRangeKeys & region_range_keys, const RegionID region_id);
+    InternalRegion & insertRegion(Table & table, const RegionRangeKeys & region_range_keys, RegionID region_id);
     InternalRegion & doGetInternalRegion(TableID table_id, RegionID region_id);
 
     RegionDataReadInfoList flushRegion(const RegionPtrWithBlock & region, bool try_persist) const;
@@ -179,6 +218,8 @@ private:
 private:
     TableMap tables;
     RegionInfoMap regions;
+    SafeTsMap leader_safets;
+    SafeTsMap self_safets;
     DirtyRegions dirty_regions;
 
     FlushThresholds flush_thresholds;

--- a/dbms/src/Storages/Transaction/RegionTable.h
+++ b/dbms/src/Storages/Transaction/RegionTable.h
@@ -175,6 +175,7 @@ public:
         {
             return;
         }
+        std::lock_guard lock(mutex);
         self_safe_ts[region_id] = safe_ts;
     }
     void updateLeaderSafeTS(UInt64 region_id, UInt64 safe_ts)
@@ -183,6 +184,7 @@ public:
         {
             return;
         }
+        std::lock_guard lock(mutex);
         leader_safe_ts[region_id] = safe_ts;
     }
 


### PR DESCRIPTION
Signed-off-by: hehechen <awd123456sss@gmail.com>

### What problem does this PR solve?

Issue Number: ref #4902

Problem Summary:

### What is changed and how it works?
Store leader and self safe_ts in `RegionTable`, use the safe_ts diff to determine whether the peer's data synchronization progress is far behind the leader.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
BR restore tables with TiFlash replica, check the log and `progress` in `information_schema.tiflash_replica`.
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
