### PR TITLE
storage: Use different names for block bg pool

### DIFF
--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -1366,7 +1366,7 @@ BackgroundProcessingPool & Context::initializeBackgroundPool(UInt16 pool_size)
 {
     auto lock = getLock();
     if (!shared->background_pool)
-        shared->background_pool = std::make_shared<BackgroundProcessingPool>(pool_size, "bg_");
+        shared->background_pool = std::make_shared<BackgroundProcessingPool>(pool_size, "bg-");
     return *shared->background_pool;
 }
 
@@ -1380,7 +1380,7 @@ BackgroundProcessingPool & Context::initializeBlockableBackgroundPool(UInt16 poo
 {
     auto lock = getLock();
     if (!shared->blockable_background_pool)
-        shared->blockable_background_pool = std::make_shared<BackgroundProcessingPool>(pool_size, "bg_block_");
+        shared->blockable_background_pool = std::make_shared<BackgroundProcessingPool>(pool_size, "bg-block-");
     return *shared->blockable_background_pool;
 }
 

--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -1366,7 +1366,7 @@ BackgroundProcessingPool & Context::initializeBackgroundPool(UInt16 pool_size)
 {
     auto lock = getLock();
     if (!shared->background_pool)
-        shared->background_pool = std::make_shared<BackgroundProcessingPool>(pool_size);
+        shared->background_pool = std::make_shared<BackgroundProcessingPool>(pool_size, "bg_");
     return *shared->background_pool;
 }
 
@@ -1380,7 +1380,7 @@ BackgroundProcessingPool & Context::initializeBlockableBackgroundPool(UInt16 poo
 {
     auto lock = getLock();
     if (!shared->blockable_background_pool)
-        shared->blockable_background_pool = std::make_shared<BackgroundProcessingPool>(pool_size);
+        shared->blockable_background_pool = std::make_shared<BackgroundProcessingPool>(pool_size, "bg_block_");
     return *shared->blockable_background_pool;
 }
 

--- a/dbms/src/Storages/BackgroundProcessingPool.cpp
+++ b/dbms/src/Storages/BackgroundProcessingPool.cpp
@@ -84,8 +84,8 @@ void BackgroundProcessingPool::TaskInfo::wake()
 
 BackgroundProcessingPool::BackgroundProcessingPool(int size_, std::string thread_prefix_)
     : size(size_)
-    , thread_ids_counter(size_)
     , thread_prefix(thread_prefix_)
+    , thread_ids_counter(size_)
 {
     LOG_FMT_INFO(&Poco::Logger::get("BackgroundProcessingPool"), "Create BackgroundProcessingPool, prefix={} n_threads={}", thread_prefix, size);
 

--- a/dbms/src/Storages/BackgroundProcessingPool.cpp
+++ b/dbms/src/Storages/BackgroundProcessingPool.cpp
@@ -87,11 +87,13 @@ BackgroundProcessingPool::BackgroundProcessingPool(int size_, std::string thread
     , thread_prefix(thread_prefix_)
     , thread_ids_counter(size_)
 {
-    LOG_FMT_INFO(&Poco::Logger::get("BackgroundProcessingPool"), "Create BackgroundProcessingPool, prefix={} n_threads={}", thread_prefix, size);
+    LOG_FMT_INFO(Logger::get("BackgroundProcessingPool"), "Create BackgroundProcessingPool, prefix={} n_threads={}", thread_prefix, size);
 
     threads.resize(size);
-    for (size_t i = 0; i < size; i++)
+    for (size_t i = 0; i < size; ++i)
+    {
         threads[i] = std::thread([this, i] { threadFunction(i); });
+    }
 }
 
 

--- a/dbms/src/Storages/BackgroundProcessingPool.cpp
+++ b/dbms/src/Storages/BackgroundProcessingPool.cpp
@@ -82,15 +82,16 @@ void BackgroundProcessingPool::TaskInfo::wake()
 }
 
 
-BackgroundProcessingPool::BackgroundProcessingPool(int size_)
+BackgroundProcessingPool::BackgroundProcessingPool(int size_, std::string thread_prefix_)
     : size(size_)
     , thread_ids_counter(size_)
+    , thread_prefix(thread_prefix_)
 {
-    LOG_FMT_INFO(&Poco::Logger::get("BackgroundProcessingPool"), "Create BackgroundProcessingPool with {} threads", size);
+    LOG_FMT_INFO(&Poco::Logger::get("BackgroundProcessingPool"), "Create BackgroundProcessingPool, prefix={} n_threads={}", thread_prefix, size);
 
     threads.resize(size);
-    for (auto & thread : threads)
-        thread = std::thread([this] { threadFunction(); });
+    for (size_t i = 0; i < size; i++)
+        threads[i] = std::thread([this, i] { threadFunction(i); });
 }
 
 
@@ -142,11 +143,10 @@ BackgroundProcessingPool::~BackgroundProcessingPool()
 }
 
 
-void BackgroundProcessingPool::threadFunction()
+void BackgroundProcessingPool::threadFunction(size_t thread_idx)
 {
     {
-        static std::atomic_uint64_t tid{0};
-        const auto name = "BkgPool" + std::to_string(tid++);
+        const auto name = thread_prefix + std::to_string(thread_idx);
         setThreadName(name.data());
         is_background_thread = true;
         addThreadId(getTid());

--- a/dbms/src/Storages/BackgroundProcessingPool.h
+++ b/dbms/src/Storages/BackgroundProcessingPool.h
@@ -109,6 +109,7 @@ private:
     using Threads = std::vector<std::thread>;
 
     const size_t size;
+    const std::string thread_prefix;
     static constexpr double sleep_seconds = 10;
     static constexpr double sleep_seconds_random_part = 1.0;
 
@@ -122,8 +123,6 @@ private:
 
     std::atomic<bool> shutdown{false};
     std::condition_variable wake_event;
-
-    std::string thread_prefix;
 
     void threadFunction(size_t thread_idx);
 };

--- a/dbms/src/Storages/BackgroundProcessingPool.h
+++ b/dbms/src/Storages/BackgroundProcessingPool.h
@@ -81,7 +81,7 @@ public:
     using TaskHandle = std::shared_ptr<TaskInfo>;
 
 
-    explicit BackgroundProcessingPool(int size_);
+    explicit BackgroundProcessingPool(int size_, std::string thread_prefix_);
 
     size_t getNumberOfThreads() const { return size; }
 
@@ -123,8 +123,9 @@ private:
     std::atomic<bool> shutdown{false};
     std::condition_variable wake_event;
 
+    std::string thread_prefix;
 
-    void threadFunction();
+    void threadFunction(size_t thread_idx);
 };
 
 using BackgroundProcessingPoolPtr = std::shared_ptr<BackgroundProcessingPool>;

--- a/metrics/grafana/tiflash_summary.json
+++ b/metrics/grafana/tiflash_summary.json
@@ -52,7 +52,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1662525920282,
+  "iteration": 1663121028653,
   "links": [],
   "panels": [
     {
@@ -1860,6 +1860,135 @@
             "y": 16
           },
           "hiddenSeries": false,
+          "id": 153,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": 250,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.11",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "Limit",
+              "color": "#F2495C",
+              "hideTooltip": true,
+              "linewidth": 2,
+              "nullPointMode": "connected"
+            }
+          ],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum by (instance) (rate(tiflash_proxy_thread_cpu_seconds_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", name=~\"snap_sender.*\"}[1m]))",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "{{name}} {{instance}}",
+              "refId": "A",
+              "step": 40
+            },
+            {
+              "exemplar": true,
+              "expr": "count by (instance) (tiflash_proxy_thread_cpu_seconds_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", name=~\"snap_sender.*\"})",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "Limit",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Snapshot Sender",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": 1,
+              "format": "percentunit",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "decimals": null,
+          "description": "",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "grid": {},
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 23
+          },
+          "hiddenSeries": false,
           "id": 151,
           "legend": {
             "alignAsTable": true,
@@ -1902,7 +2031,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum by (instance) (rate(tiflash_proxy_thread_cpu_seconds_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", name=~\"BkgPool.*\"}[1m]))",
+              "expr": "sum by (instance) (rate(tiflash_proxy_thread_cpu_seconds_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", name=~\"bg_\\\\d+\"}[1m]))",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -1914,7 +2043,7 @@
             },
             {
               "exemplar": true,
-              "expr": "count by (instance) (tiflash_proxy_thread_cpu_seconds_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", name=~\"BkgPool.*\"})",
+              "expr": "count by (instance) (tiflash_proxy_thread_cpu_seconds_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", name=~\"bg_\\\\d+\"})",
               "hide": false,
               "interval": "",
               "intervalFactor": 2,
@@ -1926,7 +2055,136 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Storage Background Tasks",
+          "title": "Storage Background (Small Tasks)",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": 1,
+              "format": "percentunit",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "decimals": null,
+          "description": "",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "grid": {},
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 23
+          },
+          "hiddenSeries": false,
+          "id": 156,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": 250,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.11",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "Limit",
+              "color": "#F2495C",
+              "hideTooltip": true,
+              "linewidth": 2,
+              "nullPointMode": "connected"
+            }
+          ],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum by (instance) (rate(tiflash_proxy_thread_cpu_seconds_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", name=~\"bg_block_\\\\d+\"}[1m]))",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "{{name}} {{instance}}",
+              "refId": "A",
+              "step": 40
+            },
+            {
+              "exemplar": true,
+              "expr": "count by (instance) (tiflash_proxy_thread_cpu_seconds_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", name=~\"bg_block_\\\\d+\"})",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "Limit",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Storage Background (Large Tasks)",
           "tooltip": {
             "msResolution": false,
             "shared": true,
@@ -1986,7 +2244,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 23
+            "y": 30
           },
           "hiddenSeries": false,
           "id": 149,
@@ -2093,135 +2351,6 @@
             "align": false,
             "alignLevel": null
           }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "${DS_TEST-CLUSTER}",
-          "decimals": null,
-          "description": "",
-          "editable": true,
-          "error": false,
-          "fieldConfig": {
-            "defaults": {},
-            "overrides": []
-          },
-          "fill": 0,
-          "fillGradient": 0,
-          "grid": {},
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 12,
-            "y": 23
-          },
-          "hiddenSeries": false,
-          "id": 153,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": true,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sideWidth": 250,
-            "sort": "max",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "7.5.11",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "Limit",
-              "color": "#F2495C",
-              "hideTooltip": true,
-              "linewidth": 2,
-              "nullPointMode": "connected"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "sum by (instance) (rate(tiflash_proxy_thread_cpu_seconds_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", name=~\"snap_sender.*\"}[1m]))",
-              "format": "time_series",
-              "hide": false,
-              "instant": false,
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "{{name}} {{instance}}",
-              "refId": "A",
-              "step": 40
-            },
-            {
-              "exemplar": true,
-              "expr": "count by (instance) (tiflash_proxy_thread_cpu_seconds_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", name=~\"snap_sender.*\"})",
-              "hide": false,
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "Limit",
-              "refId": "B"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Snapshot Sender",
-          "tooltip": {
-            "msResolution": false,
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "decimals": 1,
-              "format": "percentunit",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
         }
       ],
       "title": "Threads CPU",
@@ -2254,7 +2383,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 33
+            "y": 3
           },
           "hiddenSeries": false,
           "id": 9,
@@ -2352,7 +2481,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 33
+            "y": 3
           },
           "hiddenSeries": false,
           "id": 2,
@@ -2449,7 +2578,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 40
+            "y": 10
           },
           "hiddenSeries": false,
           "id": 11,
@@ -2567,7 +2696,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 40
+            "y": 10
           },
           "hiddenSeries": false,
           "id": 12,
@@ -2664,7 +2793,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 47
+            "y": 17
           },
           "hiddenSeries": false,
           "id": 13,
@@ -2782,7 +2911,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 47
+            "y": 17
           },
           "hiddenSeries": false,
           "id": 14,
@@ -2879,7 +3008,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 54
+            "y": 24
           },
           "hiddenSeries": false,
           "id": 63,
@@ -2995,7 +3124,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 54
+            "y": 24
           },
           "hiddenSeries": false,
           "id": 77,
@@ -3093,7 +3222,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 61
+            "y": 31
           },
           "hiddenSeries": false,
           "id": 100,
@@ -3192,7 +3321,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 61
+            "y": 31
           },
           "hiddenSeries": false,
           "id": 101,
@@ -3291,7 +3420,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 68
+            "y": 38
           },
           "hiddenSeries": false,
           "id": 102,
@@ -3390,7 +3519,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 68
+            "y": 38
           },
           "hiddenSeries": false,
           "id": 103,
@@ -3507,7 +3636,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 34
+            "y": 4
           },
           "hiddenSeries": false,
           "id": 107,
@@ -3609,7 +3738,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 34
+            "y": 4
           },
           "hiddenSeries": false,
           "id": 109,
@@ -3729,7 +3858,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 42
+            "y": 12
           },
           "hiddenSeries": false,
           "id": 111,
@@ -3840,7 +3969,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 42
+            "y": 12
           },
           "hiddenSeries": false,
           "id": 113,
@@ -3951,7 +4080,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 50
+            "y": 20
           },
           "hiddenSeries": false,
           "id": 117,
@@ -4052,7 +4181,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 50
+            "y": 20
           },
           "hiddenSeries": false,
           "id": 115,
@@ -4185,7 +4314,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 42
+            "y": 5
           },
           "hiddenSeries": false,
           "id": 17,
@@ -4284,7 +4413,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 42
+            "y": 5
           },
           "hiddenSeries": false,
           "id": 18,
@@ -4390,7 +4519,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 49
+            "y": 12
           },
           "hiddenSeries": false,
           "id": 19,
@@ -4511,7 +4640,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 49
+            "y": 12
           },
           "hiddenSeries": false,
           "id": 20,
@@ -4659,7 +4788,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 36
+            "y": 6
           },
           "hiddenSeries": false,
           "id": 41,
@@ -4772,7 +4901,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 36
+            "y": 6
           },
           "hiddenSeries": false,
           "id": 38,
@@ -4930,7 +5059,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 44
+            "y": 14
           },
           "hiddenSeries": false,
           "id": 40,
@@ -5030,7 +5159,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 52
+            "y": 22
           },
           "hiddenSeries": false,
           "id": 39,
@@ -5133,7 +5262,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 52
+            "y": 22
           },
           "hiddenSeries": false,
           "id": 42,
@@ -5237,7 +5366,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 57
+            "y": 27
           },
           "hiddenSeries": false,
           "id": 130,
@@ -5339,7 +5468,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 57
+            "y": 27
           },
           "hiddenSeries": false,
           "id": 131,
@@ -5443,7 +5572,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 62
+            "y": 32
           },
           "hiddenSeries": false,
           "id": 43,
@@ -5549,7 +5678,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 62
+            "y": 32
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -5612,7 +5741,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 70
+            "y": 40
           },
           "hiddenSeries": false,
           "id": 46,
@@ -5735,7 +5864,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 70
+            "y": 40
           },
           "hiddenSeries": false,
           "id": 47,
@@ -5859,7 +5988,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 78
+            "y": 48
           },
           "height": "",
           "hiddenSeries": false,
@@ -5989,7 +6118,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 78
+            "y": 48
           },
           "height": "",
           "hiddenSeries": false,
@@ -6117,7 +6246,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 86
+            "y": 56
           },
           "hiddenSeries": false,
           "id": 88,
@@ -6317,7 +6446,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 86
+            "y": 56
           },
           "hiddenSeries": false,
           "id": 67,
@@ -6431,7 +6560,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 94
+            "y": 64
           },
           "hiddenSeries": false,
           "id": 84,
@@ -6531,7 +6660,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 94
+            "y": 64
           },
           "hiddenSeries": false,
           "id": 86,
@@ -6663,7 +6792,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 102
+            "y": 72
           },
           "hiddenSeries": false,
           "id": 132,
@@ -6811,7 +6940,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 37
+            "y": 7
           },
           "hiddenSeries": false,
           "id": 62,
@@ -6930,7 +7059,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 45
+            "y": 15
           },
           "height": "",
           "hiddenSeries": false,
@@ -7049,7 +7178,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 45
+            "y": 15
           },
           "height": "",
           "hiddenSeries": false,
@@ -7166,7 +7295,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 53
+            "y": 23
           },
           "height": "",
           "hiddenSeries": false,
@@ -7288,7 +7417,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 62
+            "y": 32
           },
           "hiddenSeries": false,
           "id": 90,
@@ -7416,7 +7545,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 118
+            "y": 8
           },
           "hiddenSeries": false,
           "id": 85,
@@ -7541,7 +7670,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 118
+            "y": 8
           },
           "hiddenSeries": false,
           "id": 128,
@@ -7684,7 +7813,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 126
+            "y": 16
           },
           "hiddenSeries": false,
           "id": 129,
@@ -7792,7 +7921,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 126
+            "y": 16
           },
           "hiddenSeries": false,
           "id": 123,
@@ -7918,7 +8047,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 134
+            "y": 24
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -7995,7 +8124,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 39
+            "y": 9
           },
           "hiddenSeries": false,
           "id": 35,
@@ -8093,7 +8222,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 39
+            "y": 9
           },
           "hiddenSeries": false,
           "id": 36,
@@ -8211,7 +8340,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 46
+            "y": 16
           },
           "hiddenSeries": false,
           "id": 37,
@@ -8345,7 +8474,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 46
+            "y": 16
           },
           "hiddenSeries": false,
           "id": 75,
@@ -8449,7 +8578,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 53
+            "y": 23
           },
           "hiddenSeries": false,
           "id": 82,
@@ -8602,7 +8731,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 60
+            "y": 30
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -8672,7 +8801,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 60
+            "y": 30
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -8742,7 +8871,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 67
+            "y": 37
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -8812,7 +8941,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 67
+            "y": 37
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -8876,7 +9005,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 74
+            "y": 44
           },
           "height": "",
           "hiddenSeries": false,
@@ -8990,7 +9119,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 81
+            "y": 51
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -9059,7 +9188,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 81
+            "y": 51
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -9129,7 +9258,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 88
+            "y": 58
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -9199,7 +9328,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 88
+            "y": 58
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -9269,7 +9398,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 95
+            "y": 65
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -9335,7 +9464,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 95
+            "y": 65
           },
           "hiddenSeries": false,
           "id": 91,
@@ -9478,7 +9607,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 40
+            "y": 10
           },
           "hiddenSeries": false,
           "id": 99,
@@ -9631,7 +9760,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 40
+            "y": 10
           },
           "heatmap": {},
           "hideZeroBuckets": true,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #5807

Problem Summary:

### What is changed and how it works?

In https://github.com/pingcap/tiflash/pull/5808 we added metric graph for background tasks. However, due to bg pool and blockable bg pool are sharing the same name, the red-limit-line would be misleading. For example, user cannot learn the case when one of the bg pool is full and another one is idle.

This PR use different names for the two bg pool, so that we can learn whether it hits the maximum thread limit:


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

<img width="1203" alt="image" src="https://user-images.githubusercontent.com/1916485/190043541-0b82b176-09e6-4c72-9a46-951c3689b941.png">

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
