### PR TITLE
storage: Always split the pre-ingested DTFile

### DIFF
--- a/dbms/src/Storages/Transaction/ApplySnapshot.cpp
+++ b/dbms/src/Storages/Transaction/ApplySnapshot.cpp
@@ -328,6 +328,8 @@ std::vector<DM::ExternalDTFileInfo> KVStore::preHandleSSTsToDTFiles(
             }
             physical_table_id = storage->getTableInfo().id;
 
+            auto & global_settings = context.getGlobalContext().getSettingsRef();
+
             // Read from SSTs and refine the boundary of blocks output to DTFiles
             auto sst_stream = std::make_shared<DM::SSTFilesToBlockInputStream>(
                 new_region,
@@ -345,9 +347,9 @@ std::vector<DM::ExternalDTFileInfo> KVStore::preHandleSSTsToDTFiles(
                 schema_snap,
                 snapshot_apply_method,
                 job_type,
-                /* split_after_rows */ 0,
-                /* split_after_size */ 0,
-                tmt.getContext());
+                /* split_after_rows */ global_settings.dt_segment_limit_rows,
+                /* split_after_size */ global_settings.dt_segment_limit_size,
+                context);
 
             stream->writePrefix();
             stream->write();


### PR DESCRIPTION
Signed-off-by: Wish <breezewish@outlook.com>

### What problem does this PR solve?

Issue Number: ref #5237

### What is changed and how it works?

Consider that we received a 2GB-sized snapshot (which may happen when dynamic region is enabled).

- Improved: In ApplySnapshot, we use ingestBySplit. In this case, 2GB sized snapshot becomes a 2GB sized segment immediately, which causes segment split again. If we pre-split the DTFile, then the segment will be stable and don't need further operations.

- No change: In IngestSST, we use ingestByColumnFile. In this case, 2GB sized snapshots are all written to the segment delta layer. Even if we split into multiple DTFiles, they are still all written to the segment delta layer (for now). So there will be no changes.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test - There are e2e tests to cover the big region scenario.
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
