### PR TITLE
Add lld to Arch dependencies of README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain none
 source $HOME/.cargo/env
 
 # Install compilers and dependencies
-sudo pacman -S clang libc++ libc++abi compiler-rt openmp lcov cmake ninja curl openssl zlib
+sudo pacman -S clang lld libc++ libc++abi compiler-rt openmp lcov cmake ninja curl openssl zlib
 ```
 
 </details>


### PR DESCRIPTION
Signed-off-by: Jigao Luo <luojigao@outlook.com>

### What problem does this PR solve?
 
Issue Number: close #5968

Problem Summary:

### What is changed and how it works?

I have a pure Arch environment and start to install the dependencies in README.
But the build is failed as in #5968. 
The reason is easily in LLVM linker `lld` , which in not installed and **not mentioned in the Arch dependencies in README**.
`lld` is included in the MacOS brew and is mentioned in the Debian Ubuntu dependencies in README.
I guess we just forget to mention `lld` in our Arch part.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
