### PR TITLE
Support minmax index for float and double datatype

### DIFF
--- a/dbms/src/Storages/DeltaMerge/File/DMFileWriter.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileWriter.cpp
@@ -74,7 +74,7 @@ DMFileWriter::DMFileWriter(const DMFilePtr & dmfile_,
         // TODO: currently we only generate index for Integers, Date, DateTime types, and this should be configurable by user.
         /// for handle column always generate index
         auto type = removeNullable(cd.type);
-        bool do_index = cd.id == EXTRA_HANDLE_COLUMN_ID || type->isInteger() || type->isDateOrDateTime();
+        bool do_index = cd.id == EXTRA_HANDLE_COLUMN_ID || type->isNumber() || type->isDateOrDateTime();
         if (options.flags.isSingleFile())
         {
             if (do_index)

--- a/dbms/src/Storages/DeltaMerge/FilterParser/FilterParser.cpp
+++ b/dbms/src/Storages/DeltaMerge/FilterParser/FilterParser.cpp
@@ -47,6 +47,8 @@ inline bool isRoughSetFilterSupportType(const Int32 field_type)
     case TiDB::TypeLongLong:
     case TiDB::TypeInt24:
     case TiDB::TypeYear:
+    case TiDB::TypeFloat:
+    case TiDB::TypeDouble:
         return true;
     // For these date-like types, they store UTC time and ignore time_zone
     case TiDB::TypeNewDate:
@@ -68,8 +70,6 @@ inline bool isRoughSetFilterSupportType(const Int32 field_type)
     // Unknown.
     case TiDB::TypeDecimal:
     case TiDB::TypeNewDecimal:
-    case TiDB::TypeFloat:
-    case TiDB::TypeDouble:
     case TiDB::TypeNull:
     case TiDB::TypeBit:
     case TiDB::TypeEnum:

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_minmax_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_minmax_index.cpp
@@ -98,6 +98,8 @@ bool checkMatch(
 
     RowKeyRange all_range = RowKeyRange::newAll(is_common_handle, 1);
 
+    auto data_type = DataTypeFactory::instance().get(type);
+
     ColumnDefine cd(DEFAULT_COL_ID, DEFAULT_COL_NAME, DataTypeFactory::instance().get(type));
 
     ColumnDefines table_columns;
@@ -166,6 +168,10 @@ enum MinMaxTestDatatype
     Test_Nullable_DateTime,
     Test_MyDateTime,
     Test_Nullable_MyDateTime,
+    Test_Float,
+    Test_Nullable_Float,
+    Test_Double,
+    Test_Nullable_Double,
     Test_Decimal64,
     Test_Nullable_Decimal64,
     Test_Max,
@@ -180,6 +186,8 @@ bool isNullableDateType(MinMaxTestDatatype data_type)
     case Test_Nullable_DateTime:
     case Test_Nullable_MyDateTime:
     case Test_Nullable_Decimal64:
+    case Test_Nullable_Float:
+    case Test_Nullable_Double:
         return true;
     default:
         return false;
@@ -217,9 +225,17 @@ Decimal64 getDecimal64(String s)
 #define DateTime_Greater_DATA ("2022-01-01 05:00:01")
 #define DateTime_Smaller_DATA ("1997-01-01 05:00:01")
 
-#define MyDateTime_Match_DATE ("2020-09-27")
-#define MyDateTime_Greater_DATE ("2022-09-27")
-#define MyDateTime_Smaller_DATE ("1997-09-27")
+#define MyDateTime_Match_DATA ("2020-09-27")
+#define MyDateTime_Greater_DATA ("2022-09-27")
+#define MyDateTime_Smaller_DATA ("1997-09-27")
+
+#define Float_Match_DATA (100.0)
+#define Float_Greater_DATA (100.1)
+#define Float_Smaller_DATA (99.9)
+
+#define Double_Match_DATA (100.0)
+#define Double_Greater_DATA (100.1)
+#define Double_Smaller_DATA (99.9)
 
 #define Decimal_Match_DATA ("100.25566")
 #define Decimal_UnMatch_DATA ("100.25500")
@@ -266,15 +282,39 @@ std::pair<String, CSVTuples> generateTypeValue(MinMaxTestDatatype data_type, boo
     }
     case Test_MyDateTime:
     {
-        return {"MyDateTime", {{"0", "0", "0", DB::toString(MyDateTime_Match_DATE)}}};
+        return {"MyDateTime", {{"0", "0", "0", DB::toString(MyDateTime_Match_DATA)}}};
     }
     case Test_Nullable_MyDateTime:
     {
         if (has_null)
         {
-            return {"Nullable(MyDateTime)", {{"0", "0", "0", DB::toString(MyDateTime_Match_DATE)}, {"1", "1", "0", "\\N"}}};
+            return {"Nullable(MyDateTime)", {{"0", "0", "0", DB::toString(MyDateTime_Match_DATA)}, {"1", "1", "0", "\\N"}}};
         }
-        return {"Nullable(MyDateTime)", {{"0", "0", "0", DB::toString(MyDateTime_Match_DATE)}}};
+        return {"Nullable(MyDateTime)", {{"0", "0", "0", DB::toString(MyDateTime_Match_DATA)}}};
+    }
+    case Test_Float:
+    {
+        return {"Float32", {{"0", "0", "0", DB::toString(Float_Match_DATA)}}};
+    }
+    case Test_Nullable_Float:
+    {
+        if (has_null)
+        {
+            return {"Nullable(Float32)", {{"0", "0", "0", DB::toString(Float_Match_DATA)}, {"1", "1", "0", "\\N"}}};
+        }
+        return {"Nullable(Float32)", {{"0", "0", "0", DB::toString(Float_Match_DATA)}}};
+    }
+    case Test_Double:
+    {
+        return {"Float64", {{"0", "0", "0", DB::toString(Double_Match_DATA)}}};
+    }
+    case Test_Nullable_Double:
+    {
+        if (has_null)
+        {
+            return {"Nullable(Float64)", {{"0", "0", "0", DB::toString(Double_Match_DATA)}, {"1", "1", "0", "\\N"}}};
+        }
+        return {"Nullable(Float64)", {{"0", "0", "0", DB::toString(Double_Match_DATA)}}};
     }
     case Test_Decimal64:
     {
@@ -367,22 +407,66 @@ RSOperatorPtr generateEqualOperator(MinMaxTestDatatype data_type, bool is_match)
     {
         if (is_match)
         {
-            return createEqual(attr("MyDateTime"), Field(parseMyDateTime(MyDateTime_Match_DATE)));
+            return createEqual(attr("MyDateTime"), Field(parseMyDateTime(MyDateTime_Match_DATA)));
         }
         else
         {
-            return createEqual(attr("MyDateTime"), Field(parseMyDateTime(MyDateTime_Smaller_DATE)));
+            return createEqual(attr("MyDateTime"), Field(parseMyDateTime(MyDateTime_Smaller_DATA)));
         }
     }
     case Test_Nullable_MyDateTime:
     {
         if (is_match)
         {
-            return createEqual(attr("Nullable(MyDateTime)"), Field(parseMyDateTime(MyDateTime_Match_DATE)));
+            return createEqual(attr("Nullable(MyDateTime)"), Field(parseMyDateTime(MyDateTime_Match_DATA)));
         }
         else
         {
-            return createEqual(attr("Nullable(MyDateTime)"), Field(parseMyDateTime(MyDateTime_Smaller_DATE)));
+            return createEqual(attr("Nullable(MyDateTime)"), Field(parseMyDateTime(MyDateTime_Smaller_DATA)));
+        }
+    }
+    case Test_Float:
+    {
+        if (is_match)
+        {
+            return createEqual(attr("Float32"), Field(static_cast<Float64>(Float_Match_DATA)));
+        }
+        else
+        {
+            return createEqual(attr("Float32"), Field(static_cast<Float64>(Float_Smaller_DATA)));
+        }
+    }
+    case Test_Nullable_Float:
+    {
+        if (is_match)
+        {
+            return createEqual(attr("Nullable(Float32)"), Field(static_cast<Float64>(Float_Match_DATA)));
+        }
+        else
+        {
+            return createEqual(attr("Nullable(Float32)"), Field(static_cast<Float64>(Float_Smaller_DATA)));
+        }
+    }
+    case Test_Double:
+    {
+        if (is_match)
+        {
+            return createEqual(attr("Float64"), Field(static_cast<Float64>(Double_Match_DATA)));
+        }
+        else
+        {
+            return createEqual(attr("Float64"), Field(static_cast<Float64>(Double_Smaller_DATA)));
+        }
+    }
+    case Test_Nullable_Double:
+    {
+        if (is_match)
+        {
+            return createEqual(attr("Nullable(Float64)"), Field(static_cast<Float64>(Double_Match_DATA)));
+        }
+        else
+        {
+            return createEqual(attr("Nullable(Float64)"), Field(static_cast<Float64>(Double_Smaller_DATA)));
         }
     }
     case Test_Decimal64:
@@ -486,22 +570,66 @@ RSOperatorPtr generateInOperator(MinMaxTestDatatype data_type, bool is_match)
     {
         if (is_match)
         {
-            return createIn(attr("MyDateTime"), {Field(parseMyDateTime(MyDateTime_Match_DATE))});
+            return createIn(attr("MyDateTime"), {Field(parseMyDateTime(MyDateTime_Match_DATA))});
         }
         else
         {
-            return createIn(attr("MyDateTime"), {Field(parseMyDateTime(MyDateTime_Smaller_DATE))});
+            return createIn(attr("MyDateTime"), {Field(parseMyDateTime(MyDateTime_Smaller_DATA))});
         }
     }
     case Test_Nullable_MyDateTime:
     {
         if (is_match)
         {
-            return createIn(attr("Nullable(MyDateTime)"), {Field(parseMyDateTime(MyDateTime_Match_DATE))});
+            return createIn(attr("Nullable(MyDateTime)"), {Field(parseMyDateTime(MyDateTime_Match_DATA))});
         }
         else
         {
-            return createIn(attr("Nullable(MyDateTime)"), {Field(parseMyDateTime(MyDateTime_Smaller_DATE))});
+            return createIn(attr("Nullable(MyDateTime)"), {Field(parseMyDateTime(MyDateTime_Smaller_DATA))});
+        }
+    }
+    case Test_Float:
+    {
+        if (is_match)
+        {
+            return createIn(attr("Float32"), {Field(static_cast<Float64>(Float_Match_DATA))});
+        }
+        else
+        {
+            return createIn(attr("Float32"), {Field(static_cast<Float64>(Float_Smaller_DATA))});
+        }
+    }
+    case Test_Nullable_Float:
+    {
+        if (is_match)
+        {
+            return createIn(attr("Nullable(Float32)"), {Field(static_cast<Float64>(Float_Match_DATA))});
+        }
+        else
+        {
+            return createIn(attr("Nullable(Float32)"), {Field(static_cast<Float64>(Float_Smaller_DATA))});
+        }
+    }
+    case Test_Double:
+    {
+        if (is_match)
+        {
+            return createIn(attr("Float64"), {Field(static_cast<Float64>(Double_Match_DATA))});
+        }
+        else
+        {
+            return createIn(attr("Float64"), {Field(static_cast<Float64>(Double_Smaller_DATA))});
+        }
+    }
+    case Test_Nullable_Double:
+    {
+        if (is_match)
+        {
+            return createIn(attr("Nullable(Float64)"), {Field(static_cast<Float64>(Double_Match_DATA))});
+        }
+        else
+        {
+            return createIn(attr("Nullable(Float64)"), {Field(static_cast<Float64>(Double_Smaller_DATA))});
         }
     }
     case Test_Decimal64:
@@ -605,22 +733,66 @@ RSOperatorPtr generateGreaterOperator(MinMaxTestDatatype data_type, bool is_matc
     {
         if (is_match)
         {
-            return createGreater(attr("MyDateTime"), Field(parseMyDateTime(MyDateTime_Smaller_DATE)), 0);
+            return createGreater(attr("MyDateTime"), Field(parseMyDateTime(MyDateTime_Smaller_DATA)), 0);
         }
         else
         {
-            return createGreater(attr("MyDateTime"), Field(parseMyDateTime(MyDateTime_Match_DATE)), 0);
+            return createGreater(attr("MyDateTime"), Field(parseMyDateTime(MyDateTime_Match_DATA)), 0);
         }
     }
     case Test_Nullable_MyDateTime:
     {
         if (is_match)
         {
-            return createGreater(attr("Nullable(MyDateTime)"), Field(parseMyDateTime(MyDateTime_Smaller_DATE)), 0);
+            return createGreater(attr("Nullable(MyDateTime)"), Field(parseMyDateTime(MyDateTime_Smaller_DATA)), 0);
         }
         else
         {
-            return createGreater(attr("Nullable(MyDateTime)"), Field(parseMyDateTime(MyDateTime_Match_DATE)), 0);
+            return createGreater(attr("Nullable(MyDateTime)"), Field(parseMyDateTime(MyDateTime_Match_DATA)), 0);
+        }
+    }
+    case Test_Float:
+    {
+        if (is_match)
+        {
+            return createGreater(attr("Float32"), Field(static_cast<Float64>(Float_Smaller_DATA)), 0);
+        }
+        else
+        {
+            return createGreater(attr("Float32"), Field(static_cast<Float64>(Float_Match_DATA)), 0);
+        }
+    }
+    case Test_Nullable_Float:
+    {
+        if (is_match)
+        {
+            return createGreater(attr("Nullable(Float32)"), Field(static_cast<Float64>(Float_Smaller_DATA)), 0);
+        }
+        else
+        {
+            return createGreater(attr("Nullable(Float32)"), Field(static_cast<Float64>(Float_Match_DATA)), 0);
+        }
+    }
+    case Test_Double:
+    {
+        if (is_match)
+        {
+            return createGreater(attr("Float64"), Field(static_cast<Float64>(Double_Smaller_DATA)), 0);
+        }
+        else
+        {
+            return createGreater(attr("Float64"), Field(static_cast<Float64>(Double_Match_DATA)), 0);
+        }
+    }
+    case Test_Nullable_Double:
+    {
+        if (is_match)
+        {
+            return createGreater(attr("Nullable(Float64)"), Field(static_cast<Float64>(Double_Smaller_DATA)), 0);
+        }
+        else
+        {
+            return createGreater(attr("Nullable(Float64)"), Field(static_cast<Float64>(Double_Match_DATA)), 0);
         }
     }
     case Test_Decimal64:
@@ -724,22 +896,66 @@ RSOperatorPtr generateGreaterEqualOperator(MinMaxTestDatatype data_type, bool is
     {
         if (is_match)
         {
-            return createGreaterEqual(attr("MyDateTime"), Field(parseMyDateTime(MyDateTime_Smaller_DATE)), 0);
+            return createGreaterEqual(attr("MyDateTime"), Field(parseMyDateTime(MyDateTime_Smaller_DATA)), 0);
         }
         else
         {
-            return createGreaterEqual(attr("MyDateTime"), Field(parseMyDateTime(MyDateTime_Greater_DATE)), 0);
+            return createGreaterEqual(attr("MyDateTime"), Field(parseMyDateTime(MyDateTime_Greater_DATA)), 0);
         }
     }
     case Test_Nullable_MyDateTime:
     {
         if (is_match)
         {
-            return createGreaterEqual(attr("Nullable(MyDateTime)"), Field(parseMyDateTime(MyDateTime_Smaller_DATE)), 0);
+            return createGreaterEqual(attr("Nullable(MyDateTime)"), Field(parseMyDateTime(MyDateTime_Smaller_DATA)), 0);
         }
         else
         {
-            return createGreaterEqual(attr("Nullable(MyDateTime)"), Field(parseMyDateTime(MyDateTime_Greater_DATE)), 0);
+            return createGreaterEqual(attr("Nullable(MyDateTime)"), Field(parseMyDateTime(MyDateTime_Greater_DATA)), 0);
+        }
+    }
+    case Test_Float:
+    {
+        if (is_match)
+        {
+            return createGreaterEqual(attr("Float32"), Field(static_cast<Float64>(Float_Smaller_DATA)), 0);
+        }
+        else
+        {
+            return createGreaterEqual(attr("Float32"), Field(static_cast<Float64>(Float_Greater_DATA)), 0);
+        }
+    }
+    case Test_Nullable_Float:
+    {
+        if (is_match)
+        {
+            return createGreaterEqual(attr("Nullable(Float32)"), Field(static_cast<Float64>(Float_Smaller_DATA)), 0);
+        }
+        else
+        {
+            return createGreaterEqual(attr("Nullable(Float32)"), Field(static_cast<Float64>(Float_Greater_DATA)), 0);
+        }
+    }
+    case Test_Double:
+    {
+        if (is_match)
+        {
+            return createGreaterEqual(attr("Float64"), Field(static_cast<Float64>(Double_Smaller_DATA)), 0);
+        }
+        else
+        {
+            return createGreaterEqual(attr("Float64"), Field(static_cast<Float64>(Double_Greater_DATA)), 0);
+        }
+    }
+    case Test_Nullable_Double:
+    {
+        if (is_match)
+        {
+            return createGreaterEqual(attr("Nullable(Float64)"), Field(static_cast<Float64>(Double_Smaller_DATA)), 0);
+        }
+        else
+        {
+            return createGreaterEqual(attr("Nullable(Float64)"), Field(static_cast<Float64>(Double_Greater_DATA)), 0);
         }
     }
     case Test_Decimal64:
@@ -843,22 +1059,66 @@ RSOperatorPtr generateLessOperator(MinMaxTestDatatype data_type, bool is_match)
     {
         if (is_match)
         {
-            return createLess(attr("MyDateTime"), Field(parseMyDateTime(MyDateTime_Greater_DATE)), 0);
+            return createLess(attr("MyDateTime"), Field(parseMyDateTime(MyDateTime_Greater_DATA)), 0);
         }
         else
         {
-            return createLess(attr("MyDateTime"), Field(parseMyDateTime(MyDateTime_Match_DATE)), 0);
+            return createLess(attr("MyDateTime"), Field(parseMyDateTime(MyDateTime_Match_DATA)), 0);
         }
     }
     case Test_Nullable_MyDateTime:
     {
         if (is_match)
         {
-            return createLess(attr("Nullable(MyDateTime)"), Field(parseMyDateTime(MyDateTime_Greater_DATE)), 0);
+            return createLess(attr("Nullable(MyDateTime)"), Field(parseMyDateTime(MyDateTime_Greater_DATA)), 0);
         }
         else
         {
-            return createLess(attr("Nullable(MyDateTime)"), Field(parseMyDateTime(MyDateTime_Match_DATE)), 0);
+            return createLess(attr("Nullable(MyDateTime)"), Field(parseMyDateTime(MyDateTime_Match_DATA)), 0);
+        }
+    }
+    case Test_Float:
+    {
+        if (is_match)
+        {
+            return createLess(attr("Float32"), Field(static_cast<Float64>(Float_Greater_DATA)), 0);
+        }
+        else
+        {
+            return createLess(attr("Float32"), Field(static_cast<Float64>(Float_Match_DATA)), 0);
+        }
+    }
+    case Test_Nullable_Float:
+    {
+        if (is_match)
+        {
+            return createLess(attr("Nullable(Float32)"), Field(static_cast<Float64>(Float_Greater_DATA)), 0);
+        }
+        else
+        {
+            return createLess(attr("Nullable(Float32)"), Field(static_cast<Float64>(Float_Match_DATA)), 0);
+        }
+    }
+    case Test_Double:
+    {
+        if (is_match)
+        {
+            return createLess(attr("Float64"), Field(static_cast<Float64>(Double_Greater_DATA)), 0);
+        }
+        else
+        {
+            return createLess(attr("Float64"), Field(static_cast<Float64>(Double_Match_DATA)), 0);
+        }
+    }
+    case Test_Nullable_Double:
+    {
+        if (is_match)
+        {
+            return createLess(attr("Nullable(Float64)"), Field(static_cast<Float64>(Double_Greater_DATA)), 0);
+        }
+        else
+        {
+            return createLess(attr("Nullable(Float64)"), Field(static_cast<Float64>(Double_Match_DATA)), 0);
         }
     }
     case Test_Decimal64:
@@ -962,22 +1222,66 @@ RSOperatorPtr generateLessEqualOperator(MinMaxTestDatatype data_type, bool is_ma
     {
         if (is_match)
         {
-            return createLessEqual(attr("MyDateTime"), Field(parseMyDateTime(MyDateTime_Greater_DATE)), 0);
+            return createLessEqual(attr("MyDateTime"), Field(parseMyDateTime(MyDateTime_Greater_DATA)), 0);
         }
         else
         {
-            return createLessEqual(attr("MyDateTime"), Field(parseMyDateTime(MyDateTime_Smaller_DATE)), 0);
+            return createLessEqual(attr("MyDateTime"), Field(parseMyDateTime(MyDateTime_Smaller_DATA)), 0);
         }
     }
     case Test_Nullable_MyDateTime:
     {
         if (is_match)
         {
-            return createLessEqual(attr("Nullable(MyDateTime)"), Field(parseMyDateTime(MyDateTime_Greater_DATE)), 0);
+            return createLessEqual(attr("Nullable(MyDateTime)"), Field(parseMyDateTime(MyDateTime_Greater_DATA)), 0);
         }
         else
         {
-            return createLessEqual(attr("Nullable(MyDateTime)"), Field(parseMyDateTime(MyDateTime_Smaller_DATE)), 0);
+            return createLessEqual(attr("Nullable(MyDateTime)"), Field(parseMyDateTime(MyDateTime_Smaller_DATA)), 0);
+        }
+    }
+    case Test_Float:
+    {
+        if (is_match)
+        {
+            return createLessEqual(attr("Float32"), Field(static_cast<Float64>(Float_Greater_DATA)), 0);
+        }
+        else
+        {
+            return createLessEqual(attr("Float32"), Field(static_cast<Float64>(Float_Smaller_DATA)), 0);
+        }
+    }
+    case Test_Nullable_Float:
+    {
+        if (is_match)
+        {
+            return createLessEqual(attr("Nullable(Float32)"), Field(static_cast<Float64>(Float_Greater_DATA)), 0);
+        }
+        else
+        {
+            return createLessEqual(attr("Nullable(Float32)"), Field(static_cast<Float64>(Float_Smaller_DATA)), 0);
+        }
+    }
+    case Test_Double:
+    {
+        if (is_match)
+        {
+            return createLessEqual(attr("Float64"), Field(static_cast<Float64>(Double_Greater_DATA)), 0);
+        }
+        else
+        {
+            return createLessEqual(attr("Float64"), Field(static_cast<Float64>(Double_Smaller_DATA)), 0);
+        }
+    }
+    case Test_Nullable_Double:
+    {
+        if (is_match)
+        {
+            return createLessEqual(attr("Nullable(Float64)"), Field(static_cast<Float64>(Double_Greater_DATA)), 0);
+        }
+        else
+        {
+            return createLessEqual(attr("Nullable(Float64)"), Field(static_cast<Float64>(Double_Smaller_DATA)), 0);
         }
     }
     case Test_Decimal64:


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6016 

Problem Summary:

### What is changed and how it works?

1. Support establish minmax index for columns whose data type is float or double.
2. Add the UT for float and double data types.

### Check List

Tests <!-- At least one of them must be included. -->

- [ x ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
