### PR TITLE
Refine the lifecycle of memory_tracker for MPP query

### DIFF
--- a/dbms/src/Common/MemoryTracker.h
+++ b/dbms/src/Common/MemoryTracker.h
@@ -112,7 +112,9 @@ public:
     /// next should be changed only once: from nullptr to some value.
     void setNext(MemoryTracker * elem)
     {
-        next.store(elem, std::memory_order_relaxed);
+        MemoryTracker * old_val = nullptr;
+        if (!next.compare_exchange_strong(old_val, elem, std::memory_order_seq_cst, std::memory_order_relaxed))
+            return;
         next_holder = elem ? elem->shared_from_this() : nullptr;
     }
 

--- a/dbms/src/Flash/Coprocessor/DAGContext.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGContext.cpp
@@ -240,8 +240,4 @@ const SingleTableRegions & DAGContext::getTableRegionsInfoByTableID(Int64 table_
 {
     return tables_regions_info.getTableRegionInfoByTableID(table_id);
 }
-const MPPReceiverSetPtr & DAGContext::getMppReceiverSet() const
-{
-    return mpp_receiver_set;
-}
 } // namespace DB

--- a/dbms/src/Flash/Coprocessor/DAGContext.h
+++ b/dbms/src/Flash/Coprocessor/DAGContext.h
@@ -187,6 +187,7 @@ public:
         , dummy_query_string(dag_request->DebugString())
         , dummy_ast(makeDummyQuery())
         , initialize_concurrency(concurrency)
+        , is_mpp_task(true)
         , is_root_mpp_task(false)
         , log(Logger::get(log_identifier))
         , flags(dag_request->flags())
@@ -197,9 +198,6 @@ public:
     {
         assert(dag_request->has_root_executor() || dag_request->executors_size() > 0);
         return_executor_id = dag_request->root_executor().has_executor_id() || dag_request->executors(0).has_executor_id();
-        is_mpp_task = dag_request->root_executor().has_exchange_sender();
-        if (!is_mpp_task)
-            is_batch_cop = true;
 
         initOutputInfo();
     }

--- a/dbms/src/Flash/Coprocessor/DAGContext.h
+++ b/dbms/src/Flash/Coprocessor/DAGContext.h
@@ -305,13 +305,14 @@ public:
     {
         mpp_receiver_set = receiver_set;
     }
-    const MPPReceiverSetPtr & getMppReceiverSet() const;
     void addCoprocessorReader(const CoprocessorReaderPtr & coprocessor_reader);
     std::vector<CoprocessorReaderPtr> & getCoprocessorReaders();
 
     void addSubquery(const String & subquery_id, SubqueryForSet && subquery);
     bool hasSubquery() const { return !subqueries.empty(); }
     std::vector<SubqueriesForSets> && moveSubqueries() { return std::move(subqueries); }
+    void setProcessListEntry(std::shared_ptr<ProcessListEntry> entry) { process_list_entry = entry; }
+    std::shared_ptr<ProcessListEntry> getProcessListEntry() const { return process_list_entry; }
 
     const tipb::DAGRequest * dag_request;
     Int64 compile_time_ns = 0;
@@ -352,6 +353,7 @@ private:
     void initOutputInfo();
 
 private:
+    std::shared_ptr<ProcessListEntry> process_list_entry;
     /// Hold io for correcting the destruction order.
     BlockIO io;
     /// profile_streams_map is a map that maps from executor_id to profile BlockInputStreams.

--- a/dbms/src/Flash/Coprocessor/DAGContext.h
+++ b/dbms/src/Flash/Coprocessor/DAGContext.h
@@ -187,7 +187,6 @@ public:
         , dummy_query_string(dag_request->DebugString())
         , dummy_ast(makeDummyQuery())
         , initialize_concurrency(concurrency)
-        , is_mpp_task(true)
         , is_root_mpp_task(false)
         , log(Logger::get(log_identifier))
         , flags(dag_request->flags())
@@ -198,6 +197,9 @@ public:
     {
         assert(dag_request->has_root_executor() || dag_request->executors_size() > 0);
         return_executor_id = dag_request->root_executor().has_executor_id() || dag_request->executors(0).has_executor_id();
+        is_mpp_task = dag_request->root_executor().has_exchange_sender();
+        if (!is_mpp_task)
+            is_batch_cop = true;
 
         initOutputInfo();
     }

--- a/dbms/src/Flash/Coprocessor/DAGQuerySource.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGQuerySource.cpp
@@ -63,12 +63,12 @@ std::tuple<std::string, ASTPtr> DAGQuerySource::parse(size_t)
     // this is a WAR to avoid NPE when the MergeTreeDataSelectExecutor trying
     // to extract key range of the query.
     // todo find a way to enable key range extraction for dag query
-    return {getDAGContext().dag_request->DebugString(), makeDummyQuery()};
+    return {getDAGContext().dummy_query_string, getDAGContext().dummy_ast};
 }
 
 String DAGQuerySource::str(size_t)
 {
-    return getDAGContext().dag_request->DebugString();
+    return getDAGContext().dummy_query_string;
 }
 
 std::unique_ptr<IInterpreter> DAGQuerySource::interpreter(Context &, QueryProcessingStage::Enum)

--- a/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
@@ -651,7 +651,7 @@ std::unordered_map<TableID, SelectQueryInfo> DAGStorageInterpreter::generateSele
     auto create_query_info = [&](Int64 table_id) -> SelectQueryInfo {
         SelectQueryInfo query_info;
         /// to avoid null point exception
-        query_info.query = makeDummyQuery();
+        query_info.query = dagContext().dummy_ast;
         query_info.dag_query = std::make_unique<DAGQueryInfo>(
             push_down_filter.conditions,
             analyzer->getPreparedSets(),

--- a/dbms/src/Flash/EstablishCall.cpp
+++ b/dbms/src/Flash/EstablishCall.cpp
@@ -202,6 +202,11 @@ void EstablishCallData::trySendOneMsg()
     switch (async_tunnel_sender->pop(res, this))
     {
     case GRPCSendQueueRes::OK:
+        /// Note: has to switch the memory tracker before `write`
+        /// because after `write`, `async_tunnel_sender` can be destroyed at any time
+        /// so there is a risk that `res` is destructed after `aysnc_tunnel_sender`
+        /// is destructed which may cause the memory tracker in `res` become invalid
+        res->switchMemTracker(nullptr);
         write(res->packet);
         return;
     case GRPCSendQueueRes::FINISHED:

--- a/dbms/src/Flash/Mpp/ExchangeReceiver.cpp
+++ b/dbms/src/Flash/Mpp/ExchangeReceiver.cpp
@@ -246,7 +246,7 @@ public:
             if (auto error_message = getErrorFromPackets(); !error_message.empty())
                 setDone(fmt::format("Exchange receiver meet error : {}", error_message));
             else if (!sendPackets())
-                setDone("Exchange receiver meet error : push packets fail, " + err_info);
+                setDone("Exchange receiver meet error : push packets fail");
             else if (read_packet_index < batch_packet_count)
             {
                 stage = AsyncRequestStage::WAIT_FINISH;

--- a/dbms/src/Flash/Mpp/ExchangeReceiver.h
+++ b/dbms/src/Flash/Mpp/ExchangeReceiver.h
@@ -129,12 +129,9 @@ public:
         size_t max_streams_,
         const String & req_id,
         const String & executor_id,
-        uint64_t fine_grained_shuffle_stream_count,
-        bool setup_conn_manually = false);
+        uint64_t fine_grained_shuffle_stream_count);
 
     ~ExchangeReceiverBase();
-
-    void setUpConnection();
 
     void cancel();
 
@@ -175,6 +172,7 @@ private:
     void readLoop(const Request & req);
     template <bool enable_fine_grained_shuffle>
     void reactor(const std::vector<Request> & async_requests);
+    void setUpConnection();
 
     bool setEndState(ExchangeReceiverState new_state);
     String getStatusString();

--- a/dbms/src/Flash/Mpp/MPPHandler.cpp
+++ b/dbms/src/Flash/Mpp/MPPHandler.cpp
@@ -17,6 +17,8 @@
 #include <Flash/Mpp/MPPHandler.h>
 #include <Flash/Mpp/Utils.h>
 
+#include <ext/scope_guard.h>
+
 namespace DB
 {
 namespace FailPoints
@@ -44,7 +46,9 @@ void MPPHandler::handleError(const MPPTaskPtr & task, String error)
 grpc::Status MPPHandler::execute(const ContextPtr & context, mpp::DispatchTaskResponse * response)
 {
     MPPTaskPtr task = nullptr;
-    current_memory_tracker = nullptr; /// to avoid reusing threads in gRPC
+    SCOPE_EXIT({
+        current_memory_tracker = nullptr; /// to avoid reusing threads in gRPC
+    });
     try
     {
         Stopwatch stopwatch;

--- a/dbms/src/Flash/Mpp/MPPReceiverSet.cpp
+++ b/dbms/src/Flash/Mpp/MPPReceiverSet.cpp
@@ -44,15 +44,6 @@ void MPPReceiverSet::cancel()
         cop_reader->cancel();
 }
 
-
-void MPPReceiverSet::setUpConnection()
-{
-    for (auto & it : exchange_receiver_map)
-    {
-        it.second->setUpConnection();
-    }
-}
-
 void MPPReceiverSet::close()
 {
     for (auto & it : exchange_receiver_map)

--- a/dbms/src/Flash/Mpp/MPPReceiverSet.h
+++ b/dbms/src/Flash/Mpp/MPPReceiverSet.h
@@ -28,7 +28,6 @@ public:
     void addExchangeReceiver(const String & executor_id, const ExchangeReceiverPtr & exchange_receiver);
     void addCoprocessorReader(const CoprocessorReaderPtr & coprocessor_reader);
     ExchangeReceiverPtr getExchangeReceiver(const String & executor_id) const;
-    void setUpConnection();
     void cancel();
     void close();
 

--- a/dbms/src/Flash/Mpp/MPPTask.cpp
+++ b/dbms/src/Flash/Mpp/MPPTask.cpp
@@ -20,14 +20,12 @@
 #include <DataStreams/IProfilingBlockInputStream.h>
 #include <DataStreams/SquashingBlockOutputStream.h>
 #include <Flash/Coprocessor/DAGCodec.h>
-#include <Flash/Coprocessor/DAGQuerySource.h>
 #include <Flash/Coprocessor/DAGUtils.h>
 #include <Flash/Mpp/ExchangeReceiver.h>
 #include <Flash/Mpp/GRPCReceiverContext.h>
 #include <Flash/Mpp/MPPTask.h>
 #include <Flash/Mpp/MPPTunnelSet.h>
 #include <Flash/Mpp/Utils.h>
-#include <Flash/Planner/PlanQuerySource.h>
 #include <Flash/Statistics/traverseExecutors.h>
 #include <Flash/executeQuery.h>
 #include <Interpreters/ProcessList.h>

--- a/dbms/src/Flash/Mpp/MPPTask.cpp
+++ b/dbms/src/Flash/Mpp/MPPTask.cpp
@@ -69,7 +69,7 @@ MPPTask::~MPPTask()
 {
     /// MPPTask maybe destructed by different thread, set the query memory_tracker
     /// to current_memory_tracker in the destructor
-    if (current_memory_tracker != process_list_entry->get().getMemoryTrackerPtr().get())
+    if (process_list_entry != nullptr && current_memory_tracker != process_list_entry->get().getMemoryTrackerPtr().get())
         current_memory_tracker = process_list_entry->get().getMemoryTrackerPtr().get();
     abortTunnels("", true);
     if (schedule_state == ScheduleState::SCHEDULED)

--- a/dbms/src/Flash/Mpp/MPPTask.cpp
+++ b/dbms/src/Flash/Mpp/MPPTask.cpp
@@ -284,15 +284,9 @@ void MPPTask::prepare(const mpp::DispatchTaskRequest & task_request)
 
     context->setDAGContext(dag_context.get());
 
-    if (context->getSettingsRef().enable_planner)
-        query_source = std::make_unique<PlanQuerySource>(*context);
-    else
-        query_source = std::make_unique<DAGQuerySource>(*context);
-
-    auto [query, ast] = query_source->parse(context->getSettingsRef().max_query_size);
     process_list_entry = context->getProcessList().insert(
-        query,
-        ast.get(),
+        dag_context->dummy_query_string,
+        dag_context->dummy_ast.get(),
         context->getClientInfo(),
         context->getSettingsRef());
 

--- a/dbms/src/Flash/Mpp/MPPTask.cpp
+++ b/dbms/src/Flash/Mpp/MPPTask.cpp
@@ -348,7 +348,7 @@ void MPPTask::preprocess()
 void MPPTask::runImpl()
 {
     CPUAffinityManager::getInstance().bindSelfQueryThread();
-    current_memory_tracker = process_list_entry->get().getMemoryTrackerPtr().get();
+    RUNTIME_ASSERT(current_memory_tracker == process_list_entry->get().getMemoryTrackerPtr().get(), log, "The current memory tracker is not set correctly for MPPTask::runImpl");
     if (!switchStatus(INITIALIZING, RUNNING))
     {
         LOG_WARNING(log, "task not in initializing state, skip running");

--- a/dbms/src/Flash/Mpp/MPPTask.h
+++ b/dbms/src/Flash/Mpp/MPPTask.h
@@ -126,7 +126,6 @@ private:
     std::unique_ptr<DAGContext> dag_context;
 
     std::shared_ptr<ProcessListEntry> process_list_entry;
-    std::unique_ptr<IQuerySource> query_source;
 
     std::atomic<TaskStatus> status{INITIALIZING};
     String err_string;

--- a/dbms/src/Flash/Mpp/MPPTask.h
+++ b/dbms/src/Flash/Mpp/MPPTask.h
@@ -26,6 +26,7 @@
 #include <Flash/Mpp/MPPTunnelSet.h>
 #include <Flash/Mpp/TaskStatus.h>
 #include <Interpreters/Context.h>
+#include <Interpreters/IQuerySource.h>
 #include <common/logger_useful.h>
 #include <common/types.h>
 #include <kvproto/mpp.pb.h>
@@ -123,7 +124,9 @@ private:
     // `dag_context` holds inputstreams which could hold ref to `context` so it should be destructed
     // before `context`.
     std::unique_ptr<DAGContext> dag_context;
-    MemoryTracker * memory_tracker = nullptr;
+
+    std::shared_ptr<ProcessListEntry> process_list_entry;
+    std::unique_ptr<IQuerySource> query_source;
 
     std::atomic<TaskStatus> status{INITIALIZING};
     String err_string;

--- a/dbms/src/Flash/Mpp/MPPTunnel.cpp
+++ b/dbms/src/Flash/Mpp/MPPTunnel.cpp
@@ -142,7 +142,7 @@ void MPPTunnel::write(const mpp::MPPDataPacket & data)
             throw Exception(fmt::format("write to tunnel which is already closed."));
     }
 
-    if (tunnel_sender->push(std::make_shared<DB::TrackedMppDataPacket>(data, getMemTracker())))
+    if (tunnel_sender->push(data))
     {
         connection_profile_info.bytes += data.ByteSizeLong();
         connection_profile_info.packets += 1;
@@ -179,14 +179,14 @@ void MPPTunnel::connect(PacketWriter * writer)
         case TunnelSenderMode::LOCAL:
         {
             RUNTIME_ASSERT(writer == nullptr, log);
-            local_tunnel_sender = std::make_shared<LocalTunnelSender>(queue_size, log, tunnel_id);
+            local_tunnel_sender = std::make_shared<LocalTunnelSender>(queue_size, mem_tracker, log, tunnel_id);
             tunnel_sender = local_tunnel_sender;
             break;
         }
         case TunnelSenderMode::SYNC_GRPC:
         {
             RUNTIME_ASSERT(writer != nullptr, log, "Sync writer shouldn't be null");
-            sync_tunnel_sender = std::make_shared<SyncTunnelSender>(queue_size, log, tunnel_id);
+            sync_tunnel_sender = std::make_shared<SyncTunnelSender>(queue_size, mem_tracker, log, tunnel_id);
             sync_tunnel_sender->startSendThread(writer);
             tunnel_sender = sync_tunnel_sender;
             break;
@@ -214,11 +214,11 @@ void MPPTunnel::connectAsync(IAsyncCallData * call_data)
         auto kick_func_for_test = call_data->getKickFuncForTest();
         if (unlikely(kick_func_for_test.has_value()))
         {
-            async_tunnel_sender = std::make_shared<AsyncTunnelSender>(queue_size, log, tunnel_id, kick_func_for_test.value());
+            async_tunnel_sender = std::make_shared<AsyncTunnelSender>(queue_size, mem_tracker, log, tunnel_id, kick_func_for_test.value());
         }
         else
         {
-            async_tunnel_sender = std::make_shared<AsyncTunnelSender>(queue_size, log, tunnel_id, call_data->grpcCall());
+            async_tunnel_sender = std::make_shared<AsyncTunnelSender>(queue_size, mem_tracker, log, tunnel_id, call_data->grpcCall());
         }
         call_data->attachAsyncTunnelSender(async_tunnel_sender);
         tunnel_sender = async_tunnel_sender;
@@ -303,11 +303,6 @@ StringRef MPPTunnel::statusToString()
     default:
         RUNTIME_ASSERT(false, log, "Unknown TaskStatus {}", status);
     }
-}
-
-void MPPTunnel::updateMemTracker()
-{
-    mem_tracker = current_memory_tracker ? current_memory_tracker->shared_from_this() : nullptr;
 }
 
 void TunnelSender::consumerFinish(const String & msg)

--- a/dbms/src/Flash/Mpp/MPPTunnelSet.cpp
+++ b/dbms/src/Flash/Mpp/MPPTunnelSet.cpp
@@ -47,13 +47,6 @@ void MPPTunnelSetBase<Tunnel>::clearExecutionSummaries(tipb::SelectResponse & re
 }
 
 template <typename Tunnel>
-void MPPTunnelSetBase<Tunnel>::updateMemTracker()
-{
-    for (size_t i = 0; i < tunnels.size(); ++i)
-        tunnels[i]->updateMemTracker();
-}
-
-template <typename Tunnel>
 void MPPTunnelSetBase<Tunnel>::write(tipb::SelectResponse & response)
 {
     TrackedMppDataPacket tracked_packet;

--- a/dbms/src/Flash/Mpp/MPPTunnelSet.h
+++ b/dbms/src/Flash/Mpp/MPPTunnelSet.h
@@ -57,7 +57,6 @@ public:
     void close(const String & reason, bool wait_sender_finish);
     void finishWrite();
     void registerTunnel(const MPPTaskId & id, const TunnelPtr & tunnel);
-    void updateMemTracker();
 
     TunnelPtr getTunnelByReceiverTaskId(const MPPTaskId & id);
 

--- a/dbms/src/Flash/Mpp/TrackedMppDataPacket.h
+++ b/dbms/src/Flash/Mpp/TrackedMppDataPacket.h
@@ -64,7 +64,7 @@ struct MemTrackerWrapper
     {
         if (delta)
         {
-            if (memory_tracker)
+            if likely (memory_tracker)
             {
                 memory_tracker->alloc(delta);
                 size += delta;
@@ -76,7 +76,7 @@ struct MemTrackerWrapper
     {
         if (delta)
         {
-            if (memory_tracker)
+            if likely (memory_tracker)
             {
                 memory_tracker->free(delta);
                 size -= delta;

--- a/dbms/src/Flash/Mpp/TrackedMppDataPacket.h
+++ b/dbms/src/Flash/Mpp/TrackedMppDataPacket.h
@@ -46,22 +46,17 @@ inline size_t estimateAllocatedSize(const mpp::MPPDataPacket & data)
     return ret;
 }
 
-inline std::shared_ptr<MemoryTracker> getSharedPtrOfMemTracker(MemoryTracker * memory_tracker)
-{
-    return memory_tracker ? memory_tracker->shared_from_this() : nullptr;
-}
-
 struct MemTrackerWrapper
 {
-    MemTrackerWrapper(size_t _size, MemoryTracker * memory_tracker)
-        : memory_tracker(getSharedPtrOfMemTracker(memory_tracker))
+    MemTrackerWrapper(size_t _size, MemoryTracker * memory_tracker_)
+        : memory_tracker(memory_tracker_)
         , size(0)
     {
         alloc(_size);
     }
 
-    explicit MemTrackerWrapper(MemoryTracker * memory_tracker)
-        : memory_tracker(getSharedPtrOfMemTracker(memory_tracker))
+    explicit MemTrackerWrapper(MemoryTracker * memory_tracker_)
+        : memory_tracker(memory_tracker_)
         , size(0)
     {}
 
@@ -93,7 +88,7 @@ struct MemTrackerWrapper
     {
         int bak_size = size;
         freeAll();
-        memory_tracker = getSharedPtrOfMemTracker(new_memory_tracker);
+        memory_tracker = new_memory_tracker;
         alloc(bak_size);
     }
     ~MemTrackerWrapper()
@@ -106,7 +101,7 @@ struct MemTrackerWrapper
         free(size);
     }
 
-    std::shared_ptr<MemoryTracker> memory_tracker;
+    MemoryTracker * memory_tracker;
     size_t size = 0;
 };
 
@@ -154,9 +149,16 @@ struct TrackedMppDataPacket
     {
         if (need_recompute)
         {
-            mem_tracker_wrapper.freeAll();
-            mem_tracker_wrapper.alloc(estimateAllocatedSize(packet));
-            need_recompute = false;
+            try
+            {
+                mem_tracker_wrapper.freeAll();
+                mem_tracker_wrapper.alloc(estimateAllocatedSize(packet));
+                need_recompute = false;
+            }
+            catch (...)
+            {
+                error_message = getCurrentExceptionMessage(false);
+            }
         }
     }
 
@@ -175,12 +177,12 @@ struct TrackedMppDataPacket
 
     bool hasError() const
     {
-        return packet.has_error();
+        return !error_message.empty() || packet.has_error();
     }
 
-    const ::mpp::Error & error() const
+    const String & error() const
     {
-        return packet.error();
+        return error_message.empty() ? packet.error().msg() : error_message;
     }
 
     mpp::MPPDataPacket & getPacket()
@@ -191,6 +193,7 @@ struct TrackedMppDataPacket
     MemTrackerWrapper mem_tracker_wrapper;
     mpp::MPPDataPacket packet;
     bool need_recompute = false;
+    String error_message;
 };
 
 struct TrackedSelectResp

--- a/dbms/src/Flash/Planner/PlanQuerySource.cpp
+++ b/dbms/src/Flash/Planner/PlanQuerySource.cpp
@@ -27,12 +27,12 @@ std::tuple<std::string, ASTPtr> PlanQuerySource::parse(size_t)
     // this is a way to avoid NPE when the MergeTreeDataSelectExecutor trying
     // to extract key range of the query.
     // todo find a way to enable key range extraction for dag query
-    return {getDAGContext().dag_request->DebugString(), makeDummyQuery()};
+    return {getDAGContext().dummy_query_string, getDAGContext().dummy_ast};
 }
 
 String PlanQuerySource::str(size_t)
 {
-    return getDAGContext().dag_request->DebugString();
+    return getDAGContext().dummy_query_string;
 }
 
 std::unique_ptr<IInterpreter> PlanQuerySource::interpreter(Context &, QueryProcessingStage::Enum)

--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -1223,6 +1223,11 @@ DAGContext * Context::getDAGContext() const
     return dag_context;
 }
 
+bool Context::isMPPTask() const
+{
+    return dag_context != nullptr && dag_context->is_mpp_task;
+}
+
 void Context::setUncompressedCache(size_t max_size_in_bytes)
 {
     auto lock = getLock();

--- a/dbms/src/Interpreters/Context.h
+++ b/dbms/src/Interpreters/Context.h
@@ -344,6 +344,7 @@ public:
 
     void setDAGContext(DAGContext * dag_context);
     DAGContext * getDAGContext() const;
+    bool isMPPTask() const;
 
     /// List all queries.
     ProcessList & getProcessList();

--- a/dbms/src/Interpreters/ProcessList.h
+++ b/dbms/src/Interpreters/ProcessList.h
@@ -120,7 +120,6 @@ public:
     {
         memory_tracker->setDescription("(for query)");
         current_memory_tracker = memory_tracker.get();
-
         if (memory_tracker_fault_probability)
             memory_tracker->setFaultProbability(memory_tracker_fault_probability);
     }
@@ -146,6 +145,10 @@ public:
     }
 
     ThrottlerPtr getUserNetworkThrottler();
+    MemoryTrackerPtr getMemoryTrackerPtr()
+    {
+        return memory_tracker;
+    }
 
     bool updateProgressIn(const Progress & value)
     {

--- a/dbms/src/Interpreters/executeQuery.cpp
+++ b/dbms/src/Interpreters/executeQuery.cpp
@@ -233,7 +233,11 @@ std::tuple<ASTPtr, BlockIO> executeQueryImpl(
             context.setProcessListElement(&process_list_entry->get());
         }
         if (context.isMPPTask())
+        {
+            /// for MPPTask, process list entry is created in MPPTask::prepare()
+            RUNTIME_ASSERT(context.getDAGContext()->getProcessListEntry() != nullptr, "process list entry for MPP task must not be nullptr");
             process_list_entry = context.getDAGContext()->getProcessListEntry();
+        }
 
         FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::random_interpreter_failpoint);
         auto interpreter = query_src.interpreter(context, stage);


### PR DESCRIPTION
Signed-off-by: xufei <xufeixw@mail.ustc.edu.cn>

### What problem does this PR solve?

Issue Number: ref #5609

Problem Summary:
This is a refine pr for #5610
### What is changed and how it works?
1. create `processlist/memory_tracker` in `MPPTask::prepare`, so when creating `MPPTunnel/ExchangeReceiver`, there is already a memory_tracker to use.
3. save memory tracker in `TunnelSender`, so each `TrackedMPPPacket` does not need to hold the shared ptr of memory tracker
4. remove some workaround code
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  - run random failpoint tests for more than 12 hours
  - run mpp fail tests for more than 12 hours
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
