### PR TITLE
tests: Remove embed test funcs from PageEntriesEdit

### DIFF
--- a/contrib/grpc-cmake/CMakeLists.txt
+++ b/contrib/grpc-cmake/CMakeLists.txt
@@ -74,15 +74,13 @@ set(gRPC_BUILD_CSHARP_EXT OFF)
 
 add_subdirectory("${_gRPC_SOURCE_DIR}" "${_gRPC_BINARY_DIR}")
 
-# TODO: we had better update and lib to avoid warnings
-# But for now, the warnings are too annoying so we simply remote it
-
-if(TIFLASH_LLVM_TOOLCHAIN)
-  target_compile_options(grpc PRIVATE
-        -Wno-deprecated-declarations -Wno-non-c-typedef-for-linkage -Wno-implicit-const-int-float-conversion)
-  target_compile_options(grpc++ PRIVATE
-        -Wno-deprecated-declarations -Wno-non-c-typedef-for-linkage -Wno-implicit-const-int-float-conversion)
-endif()
+# clean up some clang warnings
+target_no_warning(grpc deprecated-declarations)
+target_no_warning(grpc non-c-typedef-for-linkage)
+target_no_warning(grpc implicit-const-int-float-conversion)
+target_no_warning(grpc++ deprecated-declarations)
+target_no_warning(grpc++ non-c-typedef-for-linkage)
+target_no_warning(grpc++ implicit-const-int-float-conversion)
 
 execute_process(
   COMMAND grep "//gpr_log(GPR_DEBUG, \"cannot set inq fd=%d errno=%d\", tcp->fd, errno);" "${_gRPC_SOURCE_DIR}/src/core/lib/iomgr/tcp_posix.cc"

--- a/dbms/src/Storages/Page/V3/PageEntriesEdit.h
+++ b/dbms/src/Storages/Page/V3/PageEntriesEdit.h
@@ -248,7 +248,8 @@ public:
         Int64 being_ref_count;
 
         EditRecord()
-            : page_id(0)
+            : type(EditRecordType::DEL)
+            , page_id(0)
             , ori_page_id(0)
             , version(0, 0)
             , being_ref_count(1)
@@ -275,46 +276,6 @@ public:
 
     EditRecords & getMutRecords() { return records; }
     const EditRecords & getRecords() const { return records; }
-
-#ifndef NDEBUG
-    // Just for tests, refactor them out later
-    void put(PageId page_id, const PageEntryV3 & entry)
-    {
-        put(buildV3Id(TEST_NAMESPACE_ID, page_id), entry);
-    }
-    void putExternal(PageId page_id)
-    {
-        putExternal(buildV3Id(TEST_NAMESPACE_ID, page_id));
-    }
-    void upsertPage(PageId page_id, const PageVersion & ver, const PageEntryV3 & entry)
-    {
-        upsertPage(buildV3Id(TEST_NAMESPACE_ID, page_id), ver, entry);
-    }
-    void del(PageId page_id)
-    {
-        del(buildV3Id(TEST_NAMESPACE_ID, page_id));
-    }
-    void ref(PageId ref_id, PageId page_id)
-    {
-        ref(buildV3Id(TEST_NAMESPACE_ID, ref_id), buildV3Id(TEST_NAMESPACE_ID, page_id));
-    }
-    void varRef(PageId ref_id, const PageVersion & ver, PageId ori_page_id)
-    {
-        varRef(buildV3Id(TEST_NAMESPACE_ID, ref_id), ver, buildV3Id(TEST_NAMESPACE_ID, ori_page_id));
-    }
-    void varExternal(PageId page_id, const PageVersion & create_ver, Int64 being_ref_count)
-    {
-        varExternal(buildV3Id(TEST_NAMESPACE_ID, page_id), create_ver, being_ref_count);
-    }
-    void varEntry(PageId page_id, const PageVersion & ver, const PageEntryV3 & entry, Int64 being_ref_count)
-    {
-        varEntry(buildV3Id(TEST_NAMESPACE_ID, page_id), ver, entry, being_ref_count);
-    }
-    void varDel(PageId page_id, const PageVersion & delete_ver)
-    {
-        varDel(buildV3Id(TEST_NAMESPACE_ID, page_id), delete_ver);
-    }
-#endif
 
 private:
     EditRecords records;

--- a/dbms/src/Storages/Page/V3/tests/gtest_page_directory.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_page_directory.cpp
@@ -133,7 +133,7 @@ try
     PageEntryV3 entry1{.file_id = 1, .size = 1024, .padded_size = 0, .tag = 0, .offset = 0x123, .checksum = 0x4567};
     {
         PageEntriesEdit edit;
-        edit.put(1, entry1);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 1), entry1);
         dir->apply(std::move(edit));
     }
 
@@ -143,7 +143,7 @@ try
     PageEntryV3 entry2{.file_id = 2, .size = 1024, .padded_size = 0, .tag = 0, .offset = 0x123, .checksum = 0x4567};
     {
         PageEntriesEdit edit;
-        edit.put(2, entry2);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 2), entry2);
         dir->apply(std::move(edit));
     }
 
@@ -160,8 +160,8 @@ try
     PageEntryV3 entry2_v2{.file_id = 2 + 102, .size = 1024, .padded_size = 0, .tag = 0, .offset = 0x123, .checksum = 0x4567};
     {
         PageEntriesEdit edit;
-        edit.del(2);
-        edit.put(2, entry2_v2);
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 2));
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 2), entry2_v2);
         dir->apply(std::move(edit));
     }
     auto snap3 = dir->createSnapshot();
@@ -181,7 +181,7 @@ try
     PageEntryV3 entry1{.file_id = 1, .size = 1024, .padded_size = 0, .tag = 0, .offset = 0x123, .checksum = 0x4567};
     {
         PageEntriesEdit edit;
-        edit.put(page_id, entry1);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, page_id), entry1);
         dir->apply(std::move(edit));
     }
 
@@ -191,7 +191,7 @@ try
     PageEntryV3 entry2{.file_id = 1, .size = 1024, .padded_size = 0, .tag = 0, .offset = 0x1234, .checksum = 0x4567};
     {
         PageEntriesEdit edit;
-        edit.put(page_id, entry2);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, page_id), entry2);
         dir->apply(std::move(edit));
     }
 
@@ -209,9 +209,9 @@ try
     PageEntryV3 entry3{.file_id = 1, .size = 1024, .padded_size = 0, .tag = 0, .offset = 0x12345, .checksum = 0x4567};
     {
         PageEntriesEdit edit;
-        edit.put(page_id, entry1);
-        edit.put(page_id, entry2);
-        edit.put(page_id, entry3);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, page_id), entry1);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, page_id), entry2);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, page_id), entry3);
 
         // Should not be dead-lock
         dir->apply(std::move(edit));
@@ -231,8 +231,8 @@ try
     PageEntryV3 entry2{.file_id = 2, .size = 1024, .padded_size = 0, .tag = 0, .offset = 0x123, .checksum = 0x4567};
     {
         PageEntriesEdit edit;
-        edit.put(1, entry1);
-        edit.put(2, entry2);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 1), entry1);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 2), entry2);
         dir->apply(std::move(edit));
     }
 
@@ -244,9 +244,9 @@ try
     PageEntryV3 entry4{.file_id = 4, .size = 1024, .padded_size = 0, .tag = 0, .offset = 0x123, .checksum = 0x4567};
     {
         PageEntriesEdit edit;
-        edit.del(2);
-        edit.put(3, entry3);
-        edit.put(4, entry4);
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 2));
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 3), entry3);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 4), entry4);
         dir->apply(std::move(edit));
     }
 
@@ -276,14 +276,14 @@ try
     PageEntryV3 entry2{.file_id = 2, .size = 1024, .padded_size = 0, .tag = 0, .offset = 0x123, .checksum = 0x4567};
     {
         PageEntriesEdit edit;
-        edit.put(1, entry1);
-        edit.put(2, entry2);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 1), entry1);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 2), entry2);
         dir->apply(std::move(edit));
     }
 
     { // Ref 3->2
         PageEntriesEdit edit;
-        edit.ref(3, 2);
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 3), buildV3Id(TEST_NAMESPACE_ID, 2));
         dir->apply(std::move(edit));
     }
     auto snap1 = dir->createSnapshot();
@@ -294,14 +294,14 @@ try
     PageEntryV3 entry_updated{.file_id = 999, .size = 16, .padded_size = 0, .tag = 0, .offset = 0x123, .checksum = 0x123};
     {
         PageEntriesEdit edit;
-        edit.put(3, entry_updated);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 3), entry_updated);
         ASSERT_ANY_THROW(dir->apply(std::move(edit)));
     }
 
     PageEntryV3 entry_updated2{.file_id = 777, .size = 16, .padded_size = 0, .tag = 0, .offset = 0x123, .checksum = 0x123};
     {
         PageEntriesEdit edit;
-        edit.put(2, entry_updated2);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 2), entry_updated2);
         ASSERT_ANY_THROW(dir->apply(std::move(edit)));
     }
 }
@@ -314,14 +314,14 @@ try
     PageEntryV3 entry2{.file_id = 2, .size = 1024, .padded_size = 0, .tag = 0, .offset = 0x123, .checksum = 0x4567};
     {
         PageEntriesEdit edit;
-        edit.put(1, entry1);
-        edit.put(2, entry2);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 1), entry1);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 2), entry2);
         dir->apply(std::move(edit));
     }
 
     { // Ref 3->2
         PageEntriesEdit edit;
-        edit.ref(3, 2);
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 3), buildV3Id(TEST_NAMESPACE_ID, 2));
         dir->apply(std::move(edit));
     }
     auto snap1 = dir->createSnapshot();
@@ -331,7 +331,7 @@ try
     // Delete 3, 2 won't get deleted.
     {
         PageEntriesEdit edit;
-        edit.del(3);
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 3));
         dir->apply(std::move(edit));
     }
     auto snap2 = dir->createSnapshot();
@@ -343,7 +343,7 @@ try
     // Delete 2, 3 won't get deleted.
     {
         PageEntriesEdit edit;
-        edit.del(2);
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 2));
         dir->apply(std::move(edit));
     }
     auto snap3 = dir->createSnapshot();
@@ -364,14 +364,14 @@ try
     PageEntryV3 entry2{.file_id = 2, .size = 1024, .padded_size = 0, .tag = 0, .offset = 0x123, .checksum = 0x4567};
     {
         PageEntriesEdit edit;
-        edit.put(1, entry1);
-        edit.put(2, entry2);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 1), entry1);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 2), entry2);
         dir->apply(std::move(edit));
     }
 
     { // Ref 3->2
         PageEntriesEdit edit;
-        edit.ref(3, 2);
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 3), buildV3Id(TEST_NAMESPACE_ID, 2));
         dir->apply(std::move(edit));
     }
     auto snap1 = dir->createSnapshot();
@@ -381,7 +381,7 @@ try
     // Ref 4 -> 3
     {
         PageEntriesEdit edit;
-        edit.ref(4, 3);
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 4), buildV3Id(TEST_NAMESPACE_ID, 3));
         dir->apply(std::move(edit));
     }
     auto snap2 = dir->createSnapshot();
@@ -402,14 +402,14 @@ try
     PageEntryV3 entry2{.file_id = 2, .size = 1024, .padded_size = 0, .tag = 0, .offset = 0x123, .checksum = 0x4567};
     {
         PageEntriesEdit edit;
-        edit.put(1, entry1);
-        edit.put(2, entry2);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 1), entry1);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 2), entry2);
         dir->apply(std::move(edit));
     }
 
     { // Ref 3->2
         PageEntriesEdit edit;
-        edit.ref(3, 2);
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 3), buildV3Id(TEST_NAMESPACE_ID, 2));
         dir->apply(std::move(edit));
     }
     auto snap1 = dir->createSnapshot();
@@ -419,7 +419,7 @@ try
 
     { // Ref 3 -> 2 again, should be idempotent
         PageEntriesEdit edit;
-        edit.ref(3, 2);
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 3), buildV3Id(TEST_NAMESPACE_ID, 2));
         dir->apply(std::move(edit));
     }
     auto snap2 = dir->createSnapshot();
@@ -430,8 +430,8 @@ try
 
     {
         PageEntriesEdit edit;
-        edit.del(3);
-        edit.del(2);
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 3));
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 2));
         dir->apply(std::move(edit));
     }
     auto snap3 = dir->createSnapshot();
@@ -446,7 +446,7 @@ try
         // Adding ref after deleted.
         // It will invalid snap1 and snap2
         PageEntriesEdit edit;
-        edit.ref(3, 1);
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 3), buildV3Id(TEST_NAMESPACE_ID, 1));
         dir->apply(std::move(edit));
     }
     auto snap4 = dir->createSnapshot();
@@ -469,14 +469,14 @@ try
     PageEntryV3 entry2{.file_id = 2, .size = 1024, .padded_size = 0, .tag = 0, .offset = 0x123, .checksum = 0x4567};
     {
         PageEntriesEdit edit;
-        edit.put(1, entry1);
-        edit.put(2, entry2);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 1), entry1);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 2), entry2);
         dir->apply(std::move(edit));
     }
 
     { // Ref 3->2
         PageEntriesEdit edit;
-        edit.ref(3, 2);
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 3), buildV3Id(TEST_NAMESPACE_ID, 2));
         dir->apply(std::move(edit));
     }
     auto snap1 = dir->createSnapshot();
@@ -486,7 +486,7 @@ try
 
     { // Ref 4 -> 3, collapse to 4 -> 2
         PageEntriesEdit edit;
-        edit.ref(4, 3);
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 4), buildV3Id(TEST_NAMESPACE_ID, 3));
         dir->apply(std::move(edit));
     }
     auto snap2 = dir->createSnapshot();
@@ -505,10 +505,10 @@ TEST_F(PageDirectoryTest, RefWontDeadLock)
     {
         // 1. batch.putExternal(0, 0);
         PageEntryV3 entry1;
-        edit.put(0, entry1);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 0), entry1);
 
         // 2. batch.putRefPage(1, 0);
-        edit.ref(1, 0);
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 1), buildV3Id(TEST_NAMESPACE_ID, 0));
     }
 
     dir->apply(std::move(edit));
@@ -516,10 +516,10 @@ TEST_F(PageDirectoryTest, RefWontDeadLock)
     PageEntriesEdit edit2;
     {
         // 1. batch.putRefPage(2, 1); // ref 2 -> 1 -> 0
-        edit2.ref(2, 1);
+        edit2.ref(buildV3Id(TEST_NAMESPACE_ID, 2), buildV3Id(TEST_NAMESPACE_ID, 1));
 
         // 2. batch.delPage(1); // free ref 1 -> 0
-        edit2.del(1);
+        edit2.del(buildV3Id(TEST_NAMESPACE_ID, 1));
     }
 
     dir->apply(std::move(edit2));
@@ -531,7 +531,7 @@ TEST_F(PageDirectoryTest, IdempotentNewExtPageAfterAllCleaned)
     // is idempotent
     {
         PageEntriesEdit edit;
-        edit.putExternal(10);
+        edit.putExternal(buildV3Id(TEST_NAMESPACE_ID, 10));
         dir->apply(std::move(edit));
         auto alive_ids = dir->getAliveExternalIds(TEST_NAMESPACE_ID);
         EXPECT_EQ(alive_ids.size(), 1);
@@ -540,7 +540,7 @@ TEST_F(PageDirectoryTest, IdempotentNewExtPageAfterAllCleaned)
 
     {
         PageEntriesEdit edit;
-        edit.putExternal(10); // should be idempotent
+        edit.putExternal(buildV3Id(TEST_NAMESPACE_ID, 10)); // should be idempotent
         dir->apply(std::move(edit));
         auto alive_ids = dir->getAliveExternalIds(TEST_NAMESPACE_ID);
         EXPECT_EQ(alive_ids.size(), 1);
@@ -549,7 +549,7 @@ TEST_F(PageDirectoryTest, IdempotentNewExtPageAfterAllCleaned)
 
     {
         PageEntriesEdit edit;
-        edit.del(10);
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 10));
         dir->apply(std::move(edit));
         dir->gcInMemEntries(); // clean in memory
         auto alive_ids = dir->getAliveExternalIds(TEST_NAMESPACE_ID);
@@ -560,7 +560,7 @@ TEST_F(PageDirectoryTest, IdempotentNewExtPageAfterAllCleaned)
     {
         // Add again after deleted
         PageEntriesEdit edit;
-        edit.putExternal(10);
+        edit.putExternal(buildV3Id(TEST_NAMESPACE_ID, 10));
         dir->apply(std::move(edit));
         auto alive_ids = dir->getAliveExternalIds(TEST_NAMESPACE_ID);
         EXPECT_EQ(alive_ids.size(), 1);
@@ -576,16 +576,16 @@ try
     PageEntryV3 entry3{.file_id = 3, .size = 1024, .padded_size = 0, .tag = 0, .offset = 0x123, .checksum = 0x4567};
     {
         PageEntriesEdit edit;
-        edit.put(1, entry1);
-        edit.put(2, entry2);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 1), entry1);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 2), entry2);
         dir->apply(std::move(edit));
     }
 
     // Applying ref to not exist entry is not allowed
     { // Ref 4-> 999
         PageEntriesEdit edit;
-        edit.put(3, entry3);
-        edit.ref(4, 999);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 3), entry3);
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 4), buildV3Id(TEST_NAMESPACE_ID, 999));
         ASSERT_ANY_THROW(dir->apply(std::move(edit)));
     }
 }
@@ -597,22 +597,22 @@ try
     PageEntryV3 entry1{.file_id = 1, .size = 1024, .padded_size = 0, .tag = 0, .offset = 0x123, .checksum = 0x4567};
     {
         PageEntriesEdit edit;
-        edit.put(1, entry1);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 1), entry1);
         dir->apply(std::move(edit));
     }
     {
         PageEntriesEdit edit;
-        edit.ref(2, 1);
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 2), buildV3Id(TEST_NAMESPACE_ID, 1));
         dir->apply(std::move(edit));
     }
     {
         PageEntriesEdit edit;
-        edit.del(1);
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 1));
         dir->apply(std::move(edit));
     }
     {
         PageEntriesEdit edit;
-        edit.ref(3, 1);
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 3), buildV3Id(TEST_NAMESPACE_ID, 1));
         ASSERT_ANY_THROW({ dir->apply(std::move(edit)); });
     }
 }
@@ -623,22 +623,22 @@ try
 {
     {
         PageEntriesEdit edit;
-        edit.putExternal(1);
+        edit.putExternal(buildV3Id(TEST_NAMESPACE_ID, 1));
         dir->apply(std::move(edit));
     }
     {
         PageEntriesEdit edit;
-        edit.ref(2, 1);
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 2), buildV3Id(TEST_NAMESPACE_ID, 1));
         dir->apply(std::move(edit));
     }
     {
         PageEntriesEdit edit;
-        edit.del(1);
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 1));
         dir->apply(std::move(edit));
     }
     {
         PageEntriesEdit edit;
-        edit.ref(3, 1);
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 3), buildV3Id(TEST_NAMESPACE_ID, 1));
         ASSERT_ANY_THROW({ dir->apply(std::move(edit)); });
     }
 }
@@ -651,40 +651,40 @@ try
     PageEntryV3 entry1{.file_id = 1, .size = 1024, .padded_size = 0, .tag = 0, .offset = 0x123, .checksum = 0x4567};
     {
         PageEntriesEdit edit;
-        edit.put(951, entry1);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 951), entry1);
         dir->apply(std::move(edit));
     }
 
     {
         PageEntriesEdit edit;
-        edit.ref(954, 951);
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 954), buildV3Id(TEST_NAMESPACE_ID, 951));
         dir->apply(std::move(edit));
     }
 
     {
         PageEntriesEdit edit;
-        edit.del(951);
-        edit.del(951);
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 951));
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 951));
         dir->apply(std::move(edit));
     }
 
     {
         PageEntriesEdit edit;
-        edit.ref(972, 954);
-        edit.ref(985, 954);
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 972), buildV3Id(TEST_NAMESPACE_ID, 954));
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 985), buildV3Id(TEST_NAMESPACE_ID, 954));
         dir->apply(std::move(edit));
     }
 
     {
         PageEntriesEdit edit;
-        edit.del(954);
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 954));
         dir->apply(std::move(edit));
     }
 
     {
         PageEntriesEdit edit;
-        edit.ref(998, 985);
-        edit.ref(1011, 985);
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 998), buildV3Id(TEST_NAMESPACE_ID, 985));
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 1011), buildV3Id(TEST_NAMESPACE_ID, 985));
         dir->apply(std::move(edit));
     }
 
@@ -700,7 +700,7 @@ try
     PageEntryV3 entry1{.file_id = 1, .size = 1024, .padded_size = 0, .tag = 0, .offset = 0x123, .checksum = 0x4567};
     {
         PageEntriesEdit edit;
-        edit.put(id, entry1);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, id), entry1);
         dir->apply(std::move(edit));
     }
 
@@ -763,9 +763,9 @@ try
             // create ref and del in the same write batch
             PageEntriesEdit edit;
             for (const auto & x : new_ref_page_ids)
-                edit.ref(x.first, x.second);
+                edit.ref(buildV3Id(TEST_NAMESPACE_ID, x.first), buildV3Id(TEST_NAMESPACE_ID, x.second));
             for (const auto x : delete_ref_page_ids)
-                edit.del(x);
+                edit.del(buildV3Id(TEST_NAMESPACE_ID, x));
             dir->apply(std::move(edit));
         }
         else
@@ -774,13 +774,13 @@ try
             {
                 PageEntriesEdit edit;
                 for (const auto & x : new_ref_page_ids)
-                    edit.ref(x.first, x.second);
+                    edit.ref(buildV3Id(TEST_NAMESPACE_ID, x.first), buildV3Id(TEST_NAMESPACE_ID, x.second));
                 dir->apply(std::move(edit));
             }
             {
                 PageEntriesEdit edit;
                 for (const auto x : delete_ref_page_ids)
-                    edit.del(x);
+                    edit.del(buildV3Id(TEST_NAMESPACE_ID, x));
                 dir->apply(std::move(edit));
             }
         }
@@ -807,7 +807,7 @@ try
     PageId id = 50;
     {
         PageEntriesEdit edit;
-        edit.putExternal(id);
+        edit.putExternal(buildV3Id(TEST_NAMESPACE_ID, id));
         dir->apply(std::move(edit));
     }
 
@@ -865,9 +865,9 @@ try
         {
             PageEntriesEdit edit;
             for (const auto & x : new_ref_page_ids)
-                edit.ref(x.first, x.second);
+                edit.ref(buildV3Id(TEST_NAMESPACE_ID, x.first), buildV3Id(TEST_NAMESPACE_ID, x.second));
             for (const auto x : delete_ref_page_ids)
-                edit.del(x);
+                edit.del(buildV3Id(TEST_NAMESPACE_ID, x));
             dir->apply(std::move(edit));
         }
         else
@@ -875,13 +875,13 @@ try
             {
                 PageEntriesEdit edit;
                 for (const auto & x : new_ref_page_ids)
-                    edit.ref(x.first, x.second);
+                    edit.ref(buildV3Id(TEST_NAMESPACE_ID, x.first), buildV3Id(TEST_NAMESPACE_ID, x.second));
                 dir->apply(std::move(edit));
             }
             {
                 PageEntriesEdit edit;
                 for (const auto x : delete_ref_page_ids)
-                    edit.del(x);
+                    edit.del(buildV3Id(TEST_NAMESPACE_ID, x));
                 dir->apply(std::move(edit));
             }
         }
@@ -913,8 +913,8 @@ try
 {
     {
         PageEntriesEdit edit;
-        edit.put(9, PageEntryV3{});
-        edit.putExternal(10);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 9), PageEntryV3{});
+        edit.putExternal(buildV3Id(TEST_NAMESPACE_ID, 10));
         dir->apply(std::move(edit));
     }
     auto s0 = dir->createSnapshot();
@@ -926,12 +926,12 @@ try
 
     {
         PageEntriesEdit edit;
-        edit.ref(11, 10);
-        edit.ref(12, 10);
-        edit.del(10);
-        edit.ref(13, 9);
-        edit.ref(14, 9);
-        edit.del(9);
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 11), buildV3Id(TEST_NAMESPACE_ID, 10));
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 12), buildV3Id(TEST_NAMESPACE_ID, 10));
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 10));
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 13), buildV3Id(TEST_NAMESPACE_ID, 9));
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 14), buildV3Id(TEST_NAMESPACE_ID, 9));
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 9));
         dir->apply(std::move(edit));
     }
     auto s1 = dir->createSnapshot();
@@ -944,8 +944,8 @@ try
 
     {
         PageEntriesEdit edit;
-        edit.del(11);
-        edit.del(14);
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 11));
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 14));
         dir->apply(std::move(edit));
     }
     auto s2 = dir->createSnapshot();
@@ -958,8 +958,8 @@ try
 
     {
         PageEntriesEdit edit;
-        edit.del(12);
-        edit.del(13);
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 12));
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 13));
         dir->apply(std::move(edit));
     }
     auto s3 = dir->createSnapshot();
@@ -980,7 +980,7 @@ class PageDirectoryGCTest : public PageDirectoryTest
     PageEntryV3 entry_v##VERSION{.file_id = (BLOB_FILE_ID), .size = (VERSION), .padded_size = 0, .tag = 0, .offset = 0x123, .checksum = 0x4567}; \
     {                                                                                                                                            \
         PageEntriesEdit edit;                                                                                                                    \
-        edit.put((PAGE_ID), entry_v##VERSION);                                                                                                   \
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, (PAGE_ID)), entry_v##VERSION);                                                                     \
         dir->apply(std::move(edit));                                                                                                             \
     }
 // Insert an entry into mvcc directory
@@ -989,11 +989,11 @@ class PageDirectoryGCTest : public PageDirectoryTest
 #define INSERT_ENTRY_ACQ_SNAP(PAGE_ID, VERSION) \
     INSERT_ENTRY(PAGE_ID, VERSION)              \
     auto snapshot##VERSION = dir->createSnapshot();
-#define INSERT_DELETE(PAGE_ID)       \
-    {                                \
-        PageEntriesEdit edit;        \
-        edit.del((PAGE_ID));         \
-        dir->apply(std::move(edit)); \
+#define INSERT_DELETE(PAGE_ID)                             \
+    {                                                      \
+        PageEntriesEdit edit;                              \
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, (PAGE_ID))); \
+        dir->apply(std::move(edit));                       \
     }
 
 TEST_F(PageDirectoryGCTest, ManyEditsAndDumpSnapshot)
@@ -1274,8 +1274,8 @@ try
     PageEntryV3 entry_v8{.file_id = 1, .size = 8, .padded_size = 0, .tag = 0, .offset = 0x123, .checksum = 0x4567};
     {
         PageEntriesEdit edit;
-        edit.del(page_id);
-        edit.put(another_page_id, entry_v8);
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, page_id));
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, another_page_id), entry_v8);
         dir->apply(std::move(edit));
     }
     auto snapshot8 = dir->createSnapshot();
@@ -1464,13 +1464,13 @@ try
     PageEntryV3 entry1{.file_id = 1, .size = 1024, .padded_size = 0, .tag = 0, .offset = 0x123, .checksum = 0x4567};
     {
         PageEntriesEdit edit;
-        edit.put(10, entry1);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 10), entry1);
         dir->apply(std::move(edit));
     }
     {
         PageEntriesEdit edit;
-        edit.ref(11, 10);
-        edit.del(10);
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 11), buildV3Id(TEST_NAMESPACE_ID, 10));
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 10));
         dir->apply(std::move(edit));
     }
     // entry1 should not be removed
@@ -1482,7 +1482,7 @@ try
     // del 11->entry1
     {
         PageEntriesEdit edit;
-        edit.del(11);
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 11));
         dir->apply(std::move(edit));
     }
     // entry1 get removed
@@ -1501,18 +1501,18 @@ try
     PageEntryV3 entry1{.file_id = 1, .size = 1024, .padded_size = 0, .tag = 0, .offset = 0x123, .checksum = 0x4567};
     {
         PageEntriesEdit edit;
-        edit.put(10, entry1);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 10), entry1);
         dir->apply(std::move(edit));
     }
     {
         PageEntriesEdit edit;
-        edit.ref(11, 10);
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 11), buildV3Id(TEST_NAMESPACE_ID, 10));
         dir->apply(std::move(edit));
     }
     {
         PageEntriesEdit edit;
-        edit.ref(12, 10);
-        edit.del(10);
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 12), buildV3Id(TEST_NAMESPACE_ID, 10));
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 10));
         dir->apply(std::move(edit));
     }
     // entry1 should not be removed
@@ -1524,8 +1524,8 @@ try
     // del 11->entry1
     {
         PageEntriesEdit edit;
-        edit.del(11);
-        edit.del(12);
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 11));
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 12));
         dir->apply(std::move(edit));
     }
     // entry1 get removed
@@ -1544,18 +1544,18 @@ try
     PageEntryV3 entry1{.file_id = 1, .size = 1024, .padded_size = 0, .tag = 0, .offset = 0x123, .checksum = 0x4567};
     {
         PageEntriesEdit edit;
-        edit.put(10, entry1);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 10), entry1);
         dir->apply(std::move(edit));
     }
     {
         PageEntriesEdit edit;
-        edit.ref(11, 10);
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 11), buildV3Id(TEST_NAMESPACE_ID, 10));
         dir->apply(std::move(edit));
     }
     {
         PageEntriesEdit edit;
-        edit.ref(12, 10);
-        edit.del(10);
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 12), buildV3Id(TEST_NAMESPACE_ID, 10));
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 10));
         dir->apply(std::move(edit));
     }
     // entry1 should not be removed
@@ -1588,14 +1588,14 @@ try
     // del 11->entry2
     {
         PageEntriesEdit edit;
-        edit.del(11);
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 11));
         dir->apply(std::move(edit));
         EXPECT_EQ(dir->gcInMemEntries().size(), 0);
     }
     // del 12->entry2
     {
         PageEntriesEdit edit;
-        edit.del(12);
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 12));
         dir->apply(std::move(edit));
         // entry2 get removed
         auto outdated_entries = dir->gcInMemEntries();
@@ -1611,13 +1611,13 @@ try
     // 10->ext, 11->10=>11->ext; del 10->ext
     {
         PageEntriesEdit edit;
-        edit.putExternal(10);
+        edit.putExternal(buildV3Id(TEST_NAMESPACE_ID, 10));
         dir->apply(std::move(edit));
     }
     {
         PageEntriesEdit edit;
-        edit.ref(11, 10);
-        edit.del(10);
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 11), buildV3Id(TEST_NAMESPACE_ID, 10));
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 10));
         dir->apply(std::move(edit));
     }
     // entry1 should not be removed
@@ -1632,7 +1632,7 @@ try
     // del 11->ext
     {
         PageEntriesEdit edit;
-        edit.del(11);
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 11));
         dir->apply(std::move(edit));
     }
     // entry1 get removed
@@ -1651,33 +1651,33 @@ try
 {
     {
         PageEntriesEdit edit; // ingest
-        edit.putExternal(352);
+        edit.putExternal(buildV3Id(TEST_NAMESPACE_ID, 352));
         dir->apply(std::move(edit));
     }
     {
         PageEntriesEdit edit;
-        edit.ref(353, 352);
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 353), buildV3Id(TEST_NAMESPACE_ID, 352));
         dir->apply(std::move(edit));
     }
     {
         PageEntriesEdit edit; // ingest done
-        edit.del(352);
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 352));
         dir->apply(std::move(edit));
     }
     {
         PageEntriesEdit edit; // split
-        edit.ref(357, 353);
-        edit.ref(359, 353);
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 357), buildV3Id(TEST_NAMESPACE_ID, 353));
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 359), buildV3Id(TEST_NAMESPACE_ID, 353));
         dir->apply(std::move(edit));
     }
     {
         PageEntriesEdit edit; // split done
-        edit.del(353);
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 353));
         dir->apply(std::move(edit));
     }
     {
         PageEntriesEdit edit; // one of segment delta-merge
-        edit.del(359);
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 359));
         dir->apply(std::move(edit));
     }
 
@@ -1735,15 +1735,15 @@ try
     PageEntryV3 entry_2_v2{.file_id = 2, .size = 2, .padded_size = 0, .tag = 0, .offset = 0x123, .checksum = 0x4567};
     {
         PageEntriesEdit edit;
-        edit.put(1, entry_1_v1);
-        edit.put(1, entry_1_v2);
-        edit.put(2, entry_2_v1);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 1), entry_1_v1);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 1), entry_1_v2);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 2), entry_2_v1);
         dir->apply(std::move(edit));
     }
     {
         PageEntriesEdit edit;
-        edit.put(2, entry_2_v2);
-        edit.del(3);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 2), entry_2_v2);
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 3));
         dir->apply(std::move(edit));
     }
     // dump 0
@@ -1764,13 +1764,13 @@ try
     PageEntryV3 entry_60{.file_id = 1, .size = 90, .padded_size = 0, .tag = 0, .offset = 0x123, .checksum = 0x4567};
     {
         PageEntriesEdit edit;
-        edit.del(2);
-        edit.del(1);
-        edit.putExternal(10);
-        edit.putExternal(20);
-        edit.putExternal(30);
-        edit.put(50, entry_50);
-        edit.put(60, entry_60);
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 2));
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 1));
+        edit.putExternal(buildV3Id(TEST_NAMESPACE_ID, 10));
+        edit.putExternal(buildV3Id(TEST_NAMESPACE_ID, 20));
+        edit.putExternal(buildV3Id(TEST_NAMESPACE_ID, 30));
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 50), entry_50);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 60), entry_60);
         dir->apply(std::move(edit));
     }
     auto s1 = dir->createSnapshot();
@@ -1794,21 +1794,21 @@ try
 
     {
         PageEntriesEdit edit;
-        edit.ref(11, 10);
-        edit.del(10);
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 11), buildV3Id(TEST_NAMESPACE_ID, 10));
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 10));
 
-        edit.ref(21, 20);
-        edit.ref(22, 20);
-        edit.del(20);
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 21), buildV3Id(TEST_NAMESPACE_ID, 20));
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 22), buildV3Id(TEST_NAMESPACE_ID, 20));
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 20));
 
-        edit.del(30);
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 30));
 
-        edit.ref(51, 50);
-        edit.ref(52, 51);
-        edit.del(50);
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 51), buildV3Id(TEST_NAMESPACE_ID, 50));
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 52), buildV3Id(TEST_NAMESPACE_ID, 51));
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 50));
 
-        edit.ref(61, 60);
-        edit.del(61);
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 61), buildV3Id(TEST_NAMESPACE_ID, 60));
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 61));
         dir->apply(std::move(edit));
     }
     auto s2 = dir->createSnapshot();
@@ -1844,11 +1844,11 @@ try
     {
         // only 51->50 left
         PageEntriesEdit edit;
-        edit.del(11);
-        edit.del(21);
-        edit.del(22);
-        edit.del(52);
-        edit.del(60);
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 11));
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 21));
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 22));
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 52));
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 60));
         dir->apply(std::move(edit));
     }
     auto s3 = dir->createSnapshot();
@@ -1880,7 +1880,7 @@ try
     {
         // only 51->50 left
         PageEntriesEdit edit;
-        edit.del(51);
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 51));
         dir->apply(std::move(edit));
     }
     auto s4 = dir->createSnapshot();
@@ -1928,15 +1928,15 @@ try
     PageEntryV3 entry_5_v2{.file_id = file_id2, .size = 255, .padded_size = 0, .tag = 0, .offset = 0x400, .checksum = 0x4567};
     {
         PageEntriesEdit edit;
-        edit.put(1, entry_1_v1);
-        edit.put(5, entry_5_v1);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 1), entry_1_v1);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 5), entry_5_v1);
         dir->apply(std::move(edit));
     }
     {
         PageEntriesEdit edit;
-        edit.ref(2, 1);
-        edit.del(1);
-        edit.put(5, entry_5_v2); // replaced for page 5 entry
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 2), buildV3Id(TEST_NAMESPACE_ID, 1));
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 1));
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 5), entry_5_v2); // replaced for page 5 entry
         dir->apply(std::move(edit));
     }
 
@@ -1996,11 +1996,11 @@ try
 
     {
         PageEntriesEdit edit;
-        edit.put(50, entry_50_1);
-        edit.put(50, entry_50_2);
-        edit.ref(51, 50);
-        edit.del(50);
-        edit.del(51);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 50), entry_50_1);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 50), entry_50_2);
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 51), buildV3Id(TEST_NAMESPACE_ID, 50));
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 50));
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 51));
         auto restored_dir = restore_from_edit(edit);
         auto page_ids = restored_dir->getAllPageIds();
         ASSERT_EQ(page_ids.size(), 0);

--- a/dbms/src/Storages/Page/V3/tests/gtest_wal_store.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_wal_store.cpp
@@ -14,6 +14,7 @@
 
 #include <Encryption/MockKeyManager.h>
 #include <Poco/Logger.h>
+#include <Storages/Page/PageDefines.h>
 #include <Storages/Page/V3/LogFile/LogFilename.h>
 #include <Storages/Page/V3/LogFile/LogFormat.h>
 #include <Storages/Page/V3/PageDirectory.h>
@@ -29,8 +30,6 @@
 #include <TestUtils/TiFlashTestEnv.h>
 
 #include <random>
-
-#include "Storages/Page/PageDefines.h"
 
 namespace DB::PS::V3::tests
 {

--- a/dbms/src/Storages/Page/V3/tests/gtest_wal_store.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_wal_store.cpp
@@ -30,6 +30,8 @@
 
 #include <random>
 
+#include "Storages/Page/PageDefines.h"
+
 namespace DB::PS::V3::tests
 {
 TEST(WALSeriTest, AllPuts)
@@ -38,8 +40,8 @@ TEST(WALSeriTest, AllPuts)
     PageEntryV3 entry_p2{.file_id = 1, .size = 2, .padded_size = 0, .tag = 0, .offset = 0x123, .checksum = 0x4567};
     PageVersion ver20(/*seq=*/20);
     PageEntriesEdit edit;
-    edit.put(1, entry_p1);
-    edit.put(2, entry_p2);
+    edit.put(buildV3Id(TEST_NAMESPACE_ID, 1), entry_p1);
+    edit.put(buildV3Id(TEST_NAMESPACE_ID, 2), entry_p2);
 
     for (auto & rec : edit.getMutRecords())
         rec.version = ver20;
@@ -60,12 +62,12 @@ try
     PageEntryV3 entry_p5{.file_id = 1, .size = 5, .padded_size = 0, .tag = 0, .offset = 0x123, .checksum = 0x4567};
     PageVersion ver21(/*seq=*/21);
     PageEntriesEdit edit;
-    edit.put(3, entry_p3);
-    edit.ref(4, 3);
-    edit.put(5, entry_p5);
-    edit.del(2);
-    edit.del(1);
-    edit.del(987);
+    edit.put(buildV3Id(TEST_NAMESPACE_ID, 3), entry_p3);
+    edit.ref(buildV3Id(TEST_NAMESPACE_ID, 4), buildV3Id(TEST_NAMESPACE_ID, 3));
+    edit.put(buildV3Id(TEST_NAMESPACE_ID, 5), entry_p5);
+    edit.del(buildV3Id(TEST_NAMESPACE_ID, 2));
+    edit.del(buildV3Id(TEST_NAMESPACE_ID, 1));
+    edit.del(buildV3Id(TEST_NAMESPACE_ID, 987));
 
     for (auto & rec : edit.getMutRecords())
         rec.version = ver21;
@@ -110,9 +112,9 @@ TEST(WALSeriTest, Upserts)
     PageVersion ver20_1(/*seq=*/20, /*epoch*/ 1);
     PageVersion ver21_1(/*seq=*/21, /*epoch*/ 1);
     PageEntriesEdit edit;
-    edit.upsertPage(1, ver20_1, entry_p1_2);
-    edit.upsertPage(3, ver21_1, entry_p3_2);
-    edit.upsertPage(5, ver21_1, entry_p5_2);
+    edit.upsertPage(buildV3Id(TEST_NAMESPACE_ID, 1), ver20_1, entry_p1_2);
+    edit.upsertPage(buildV3Id(TEST_NAMESPACE_ID, 3), ver21_1, entry_p3_2);
+    edit.upsertPage(buildV3Id(TEST_NAMESPACE_ID, 5), ver21_1, entry_p5_2);
 
     auto deseri_edit = DB::PS::V3::ser::deserializeFrom(DB::PS::V3::ser::serializeTo(edit));
     ASSERT_EQ(deseri_edit.size(), 3);
@@ -140,9 +142,9 @@ TEST(WALSeriTest, RefExternalAndEntry)
     PageVersion ver3_0(/*seq=*/3, /*epoch*/ 0);
     {
         PageEntriesEdit edit;
-        edit.varExternal(1, ver1_0, 2);
-        edit.varDel(1, ver2_0);
-        edit.varRef(2, ver3_0, 1);
+        edit.varExternal(buildV3Id(TEST_NAMESPACE_ID, 1), ver1_0, 2);
+        edit.varDel(buildV3Id(TEST_NAMESPACE_ID, 1), ver2_0);
+        edit.varRef(buildV3Id(TEST_NAMESPACE_ID, 2), ver3_0, buildV3Id(TEST_NAMESPACE_ID, 1));
 
         auto deseri_edit = DB::PS::V3::ser::deserializeFrom(DB::PS::V3::ser::serializeTo(edit));
         ASSERT_EQ(deseri_edit.size(), 3);
@@ -165,9 +167,9 @@ TEST(WALSeriTest, RefExternalAndEntry)
     {
         PageEntriesEdit edit;
         PageEntryV3 entry_p1_2{.file_id = 2, .size = 1, .padded_size = 0, .tag = 0, .offset = 0x123, .checksum = 0x4567};
-        edit.varEntry(1, ver1_0, entry_p1_2, 2);
-        edit.varDel(1, ver2_0);
-        edit.varRef(2, ver3_0, 1);
+        edit.varEntry(buildV3Id(TEST_NAMESPACE_ID, 1), ver1_0, entry_p1_2, 2);
+        edit.varDel(buildV3Id(TEST_NAMESPACE_ID, 1), ver2_0);
+        edit.varRef(buildV3Id(TEST_NAMESPACE_ID, 2), ver3_0, buildV3Id(TEST_NAMESPACE_ID, 1));
 
         auto deseri_edit = DB::PS::V3::ser::deserializeFrom(DB::PS::V3::ser::serializeTo(edit));
         ASSERT_EQ(deseri_edit.size(), 3);
@@ -420,8 +422,8 @@ try
     PageVersion ver20(/*seq=*/20);
     {
         PageEntriesEdit edit;
-        edit.put(1, entry_p1);
-        edit.put(2, entry_p2);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 1), entry_p1);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 2), entry_p2);
         size_each_edit.emplace_back(edit.size());
         applyWithSameVersion(wal, edit, ver20);
     }
@@ -450,10 +452,10 @@ try
     PageVersion ver21(/*seq=*/21);
     {
         PageEntriesEdit edit;
-        edit.put(3, entry_p3);
-        edit.ref(4, 3);
-        edit.put(5, entry_p5);
-        edit.del(2);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 3), entry_p3);
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 4), buildV3Id(TEST_NAMESPACE_ID, 3));
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 5), entry_p5);
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 2));
         size_each_edit.emplace_back(edit.size());
         applyWithSameVersion(wal, edit, ver21);
     }
@@ -485,9 +487,9 @@ try
     PageVersion ver21_1(/*seq=*/21, /*epoch*/ 1);
     {
         PageEntriesEdit edit;
-        edit.upsertPage(1, ver20_1, entry_p1_2);
-        edit.upsertPage(3, ver21_1, entry_p3_2);
-        edit.upsertPage(5, ver21_1, entry_p5_2);
+        edit.upsertPage(buildV3Id(TEST_NAMESPACE_ID, 1), ver20_1, entry_p1_2);
+        edit.upsertPage(buildV3Id(TEST_NAMESPACE_ID, 3), ver21_1, entry_p3_2);
+        edit.upsertPage(buildV3Id(TEST_NAMESPACE_ID, 5), ver21_1, entry_p5_2);
         size_each_edit.emplace_back(edit.size());
         wal->apply(ser::serializeTo(edit));
     }
@@ -529,8 +531,8 @@ try
     PageVersion ver20(/*seq=*/20);
     {
         PageEntriesEdit edit;
-        edit.put(1, entry_p1);
-        edit.put(2, entry_p2);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 1), entry_p1);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 2), entry_p2);
         size_each_edit.emplace_back(edit.size());
         applyWithSameVersion(wal, edit, ver20);
     }
@@ -541,10 +543,10 @@ try
     PageVersion ver21(/*seq=*/21);
     {
         PageEntriesEdit edit;
-        edit.put(3, entry_p3);
-        edit.ref(4, 3);
-        edit.put(5, entry_p5);
-        edit.del(2);
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 3), entry_p3);
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 4), buildV3Id(TEST_NAMESPACE_ID, 3));
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 5), entry_p5);
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 2));
         size_each_edit.emplace_back(edit.size());
         applyWithSameVersion(wal, edit, ver21);
     }
@@ -557,9 +559,9 @@ try
     PageVersion ver21_1(/*seq=*/21, /*epoch*/ 1);
     {
         PageEntriesEdit edit;
-        edit.upsertPage(1, ver20_1, entry_p1_2);
-        edit.upsertPage(3, ver21_1, entry_p3_2);
-        edit.upsertPage(5, ver21_1, entry_p5_2);
+        edit.upsertPage(buildV3Id(TEST_NAMESPACE_ID, 1), ver20_1, entry_p1_2);
+        edit.upsertPage(buildV3Id(TEST_NAMESPACE_ID, 3), ver21_1, entry_p3_2);
+        edit.upsertPage(buildV3Id(TEST_NAMESPACE_ID, 5), ver21_1, entry_p5_2);
         size_each_edit.emplace_back(edit.size());
         wal->apply(ser::serializeTo(edit));
     }
@@ -632,7 +634,7 @@ try
         {
             page_id += 1;
             entry.size = page_id;
-            edit.put(page_id, entry);
+            edit.put(buildV3Id(TEST_NAMESPACE_ID, page_id), entry);
         }
         applyWithSameVersion(wal, edit, ver);
 
@@ -675,7 +677,7 @@ try
     // just fill in some random entry
     for (size_t i = 0; i < 70; ++i)
     {
-        snap_edit.varEntry(d_10000(rd), PageVersion(345, 22), entry, 1);
+        snap_edit.varEntry(buildV3Id(TEST_NAMESPACE_ID, d_10000(rd)), PageVersion(345, 22), entry, 1);
     }
     std::tie(wal, reader) = WALStore::create(getCurrentTestName(), enc_provider, delegator, config);
     bool done = wal->saveSnapshot(std::move(file_snap), ser::serializeTo(snap_edit), snap_edit.size());


### PR DESCRIPTION
Signed-off-by: JaySon-Huang <tshent@qq.com>

### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/4562

Problem Summary: Remove embed test funcs from PageEntriesEdit

### What is changed and how it works?

Replace those tests functions by regex matching

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
