### PR TITLE
fix unstable tests

### DIFF
--- a/dbms/src/Flash/Mpp/tests/gtest_mpptunnel.cpp
+++ b/dbms/src/Flash/Mpp/tests/gtest_mpptunnel.cpp
@@ -424,8 +424,8 @@ TEST_F(TestMPPTunnel, WriteError)
 
 TEST_F(TestMPPTunnel, WriteAfterFinished)
 {
-    MPPTunnelPtr mpp_tunnel_ptr = nullptr;
     std::unique_ptr<PacketWriter> writer_ptr = nullptr;
+    MPPTunnelPtr mpp_tunnel_ptr = nullptr;
     try
     {
         mpp_tunnel_ptr = constructRemoteSyncTunnel();

--- a/dbms/src/Flash/Mpp/tests/gtest_mpptunnel.cpp
+++ b/dbms/src/Flash/Mpp/tests/gtest_mpptunnel.cpp
@@ -424,22 +424,25 @@ TEST_F(TestMPPTunnel, WriteError)
 
 TEST_F(TestMPPTunnel, WriteAfterFinished)
 {
+    MPPTunnelPtr mpp_tunnel_ptr = nullptr;
+    std::unique_ptr<PacketWriter> writer_ptr = nullptr;
     try
     {
-        auto mpp_tunnel_ptr = constructRemoteSyncTunnel();
-        std::unique_ptr<PacketWriter> writer_ptr = std::make_unique<MockWriter>();
+        mpp_tunnel_ptr = constructRemoteSyncTunnel();
+        writer_ptr = std::make_unique<MockWriter>();
         mpp_tunnel_ptr->connect(writer_ptr.get());
         GTEST_ASSERT_EQ(getTunnelConnectedFlag(mpp_tunnel_ptr), true);
         mpp_tunnel_ptr->close("Canceled", false);
         auto data_packet_ptr = std::make_unique<mpp::MPPDataPacket>();
         data_packet_ptr->set_data("First");
         mpp_tunnel_ptr->write(*data_packet_ptr);
-        mpp_tunnel_ptr->waitForFinish();
         GTEST_FAIL();
     }
     catch (Exception & e)
     {
         GTEST_ASSERT_EQ(e.message(), "write to tunnel which is already closed,");
+        if (mpp_tunnel_ptr != nullptr)
+            mpp_tunnel_ptr->waitForFinish();
     }
 }
 

--- a/dbms/src/Flash/Mpp/tests/gtest_mpptunnel.cpp
+++ b/dbms/src/Flash/Mpp/tests/gtest_mpptunnel.cpp
@@ -441,9 +441,9 @@ TEST_F(TestMPPTunnel, WriteAfterFinished)
     catch (Exception & e)
     {
         GTEST_ASSERT_EQ(e.message(), "write to tunnel which is already closed,");
-        if (mpp_tunnel_ptr != nullptr)
-            mpp_tunnel_ptr->waitForFinish();
     }
+    if (mpp_tunnel_ptr != nullptr)
+        mpp_tunnel_ptr->waitForFinish();
 }
 
 /// Test Local MPPTunnel


### PR DESCRIPTION
Signed-off-by: xufei <xufeixw@mail.ustc.edu.cn>

### What problem does this PR solve?

Issue Number: close #6072

Problem Summary:
TestMPPTunnel_WriteAfterFinished is unstable.
### What is changed and how it works?
The root cause is 
https://github.com/pingcap/tiflash/blob/72a21d102f4ab54800562fb07edcc7d5d5b4a05e/dbms/src/Flash/Mpp/tests/gtest_mpptunnel.cpp#L425-L444

In L433, the tunnel is closed but the sender thread is not. In L436 tunnel write throw exception, then `writer_ptr` is destructed before `mpp_tunnel_ptr` is destructed, so the sender thread use a invalid pointer.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
