### PR TITLE
suppress cmake warning 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-project (TiFlash)
 cmake_minimum_required (VERSION 3.21)
+
+cmake_policy(SET CMP0048 NEW)
+project (TiFlash)
 
 set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY true)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${TiFlash_SOURCE_DIR}/cmake/Modules/")


### PR DESCRIPTION
Signed-off-by: Lloyd-Pottiger <yan1579196623@gmail.com>

### What problem does this PR solve?

Issue Number: close #6093 

Problem Summary:

### What is changed and how it works?

```shell
# before
$ cmake .. -GNinja -DCMAKE_BUILD_TYPE=DEBUG
CMake Warning (dev) at CMakeLists.txt:15 (project):
  Policy CMP0048 is not set: project() command manages VERSION variables.
  Run "cmake --help-policy CMP0048" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  The following variable(s) would be set to empty:

    CMAKE_PROJECT_VERSION
    CMAKE_PROJECT_VERSION_MAJOR
    CMAKE_PROJECT_VERSION_MINOR
    CMAKE_PROJECT_VERSION_PATCH
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Using CXX=/data1/qiuyang/projects/tiflash-env/sysroot/bin/clang++, ver=13.0.0;CC=/data1/qiuyang/projects/tiflash-env/sysroot/bin/clang, ver=13.0.0
-- Using ccache: /data1/qiuyang/projects/tiflash-env/sysroot/bin/ccache, version 4.5.1
...

# after
$ cmake .. -GNinja -DCMAKE_BUILD_TYPE=DEBUG
-- Using CXX=/data1/qiuyang/projects/tiflash-env/sysroot/bin/clang++, ver=13.0.0;CC=/data1/qiuyang/projects/tiflash-env/sysroot/bin/clang, ver=13.0.0
-- Using ccache: /data1/qiuyang/projects/tiflash-env/sysroot/bin/ccache, version 4.5.1
...
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
