### PR TITLE
Fix unit test under clang-15

### DIFF
--- a/contrib/abseil-cpp-cmake/CMakeLists.txt
+++ b/contrib/abseil-cpp-cmake/CMakeLists.txt
@@ -5,6 +5,8 @@ if(NOT EXISTS "${ABSL_ROOT_DIR}/CMakeLists.txt")
 endif()
 set(BUILD_TESTING OFF)
 set(ABSL_PROPAGATE_CXX_STD ON)
+
+no_warning(deprecated-builtins)
 add_subdirectory("${ABSL_ROOT_DIR}" "${TiFlash_BINARY_DIR}/contrib/abseil-cpp")
 
 add_library(abseil_swiss_tables INTERFACE)

--- a/contrib/grpc-cmake/CMakeLists.txt
+++ b/contrib/grpc-cmake/CMakeLists.txt
@@ -72,15 +72,19 @@ endif()
 # We don't want to build C# extensions.
 set(gRPC_BUILD_CSHARP_EXT OFF)
 
+no_warning(deprecated-builtins)
 add_subdirectory("${_gRPC_SOURCE_DIR}" "${_gRPC_BINARY_DIR}")
 
 # clean up some clang warnings
 target_no_warning(grpc deprecated-declarations)
 target_no_warning(grpc non-c-typedef-for-linkage)
 target_no_warning(grpc implicit-const-int-float-conversion)
+target_no_warning(grpc unused-but-set-variable)
+target_no_warning(grpc unused-function)
 target_no_warning(grpc++ deprecated-declarations)
 target_no_warning(grpc++ non-c-typedef-for-linkage)
 target_no_warning(grpc++ implicit-const-int-float-conversion)
+target_no_warning(grpc++ unused-but-set-variable)
 
 execute_process(
   COMMAND grep "//gpr_log(GPR_DEBUG, \"cannot set inq fd=%d errno=%d\", tcp->fd, errno);" "${_gRPC_SOURCE_DIR}/src/core/lib/iomgr/tcp_posix.cc"

--- a/dbms/src/Common/tests/gtest_cpu_affinity_manager.cpp
+++ b/dbms/src/Common/tests/gtest_cpu_affinity_manager.cpp
@@ -25,10 +25,9 @@
 #include <Common/CPUAffinityManager.h>
 #include <Common/Config/TOMLConfiguration.h>
 #include <Poco/Util/LayeredConfiguration.h>
+#include <boost_wrapper/string.h>
 #include <gtest/gtest.h>
 #include <unistd.h>
-
-#include <boost/algorithm/string.hpp>
 
 namespace DB
 {

--- a/dbms/src/Functions/tests/gtest_strings_simd_consistency.cpp
+++ b/dbms/src/Functions/tests/gtest_strings_simd_consistency.cpp
@@ -341,9 +341,7 @@ TEST(StringsLowerUpperAscii, Random)
     std::vector<UInt8> res_new(limit + 1, 0);
     std::vector<UInt8> res_old(limit + 1, 0);
     std::default_random_engine eng(seed);
-    std::uniform_int_distribution<UInt8> dist(
-        'A',
-        'Z');
+    std::uniform_int_distribution<UInt8> dist('A', 'Z');
     for (auto & i : data)
     {
         i = dist(eng);
@@ -378,7 +376,7 @@ TEST(StringsLowerUpperUtf8, Random)
     std::vector<UInt8> res_new(limit + 1, 0);
     std::vector<UInt8> res_old(limit + 1, 0);
     std::default_random_engine eng(seed);
-    std::uniform_int_distribution dist('A', 'z');
+    std::uniform_int_distribution<UInt8> dist('A', 'z');
     size_t size = 0;
     size_t target = data.size() - 1;
     while (size < target)

--- a/dbms/src/IO/tests/gtest_dm_checksum_buffer.cpp
+++ b/dbms/src/IO/tests/gtest_dm_checksum_buffer.cpp
@@ -47,7 +47,7 @@ std::mt19937_64 eng(seed); // NOLINT(cert-err58-cpp)
 std::pair<std::vector<char>, uint64_t> randomData(size_t size)
 {
     std::vector<char> data(size);
-    std::uniform_int_distribution<char> dist{};
+    std::uniform_int_distribution<UInt8> dist{};
     for (auto & i : data)
     {
         i = dist(eng);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/5265

Problem Summary: https://github.com/pingcap/tiflash/issues/5265#issuecomment-1275698115
```
In file included from /workspace/tiflash/dbms/src/Common/tests/gtest_cpu_affinity_manager.cpp:31:
In file included from /workspace/tiflash/contrib/boost/boost/algorithm/string.hpp:23:
In file included from /workspace/tiflash/contrib/boost/boost/algorithm/string/split.hpp:16:
In file included from /workspace/tiflash/contrib/boost/boost/algorithm/string/iter_find.hpp:27:
In file included from /workspace/tiflash/contrib/boost/boost/algorithm/string/find_iterator.hpp:24:
In file included from /workspace/tiflash/contrib/boost/boost/algorithm/string/detail/find_iterator.hpp:18:
In file included from /workspace/tiflash/contrib/boost/boost/function.hpp:30:
In file included from /workspace/tiflash/contrib/boost/boost/function/detail/prologue.hpp:17:
In file included from /workspace/tiflash/contrib/boost/boost/function/function_base.hpp:22:
/workspace/tiflash/contrib/boost/boost/type_traits/has_trivial_copy.hpp:34:4: error: builtin __has_trivial_copy is deprecated; use __is_trivially_copyable instead [-Werror,-Wdeprecated-builtins]
   BOOST_HAS_TRIVIAL_COPY(T) BOOST_TT_TRIVIAL_CONSTRUCT_FIX
   ^
/workspace/tiflash/contrib/boost/boost/type_traits/intrinsics.hpp:190:41: note: expanded from macro 'BOOST_HAS_TRIVIAL_COPY'
#     define BOOST_HAS_TRIVIAL_COPY(T) (__has_trivial_copy(T) && !is_reference<T>::value)
                                        ^
In file included from /workspace/tiflash/dbms/src/Common/tests/gtest_cpu_affinity_manager.cpp:31:
In file included from /workspace/tiflash/contrib/boost/boost/algorithm/string.hpp:23:
In file included from /workspace/tiflash/contrib/boost/boost/algorithm/string/split.hpp:16:
In file included from /workspace/tiflash/contrib/boost/boost/algorithm/string/iter_find.hpp:27:
In file included from /workspace/tiflash/contrib/boost/boost/algorithm/string/find_iterator.hpp:24:
In file included from /workspace/tiflash/contrib/boost/boost/algorithm/string/detail/find_iterator.hpp:18:
In file included from /workspace/tiflash/contrib/boost/boost/function.hpp:30:
In file included from /workspace/tiflash/contrib/boost/boost/function/detail/prologue.hpp:17:
In file included from /workspace/tiflash/contrib/boost/boost/function/function_base.hpp:23:
/workspace/tiflash/contrib/boost/boost/type_traits/has_trivial_destructor.hpp:30:86: error: builtin __has_trivial_destructor is deprecated; use __is_trivially_destructible instead [-Werror,-Wdeprecated-builtins]
template <typename T> struct has_trivial_destructor : public integral_constant<bool, BOOST_HAS_TRIVIAL_DESTRUCTOR(T)>{};
                                                                                     ^
/workspace/tiflash/contrib/boost/boost/type_traits/intrinsics.hpp:196:47: note: expanded from macro 'BOOST_HAS_TRIVIAL_DESTRUCTOR'
#     define BOOST_HAS_TRIVIAL_DESTRUCTOR(T) (__has_trivial_destructor(T)  && is_destructible<T>::value)
                                              ^
2 errors generated.
[44/223] Building CXX object dbms/CMake...ests/gtest_funtions_decimal_arith.cpp.o
ninja: build stopped: subcommand failed.
make: *** [dev] Error 1
```

### What is changed and how it works?

use boost wrapper
suppress warnings when building grpc and abseil-cpp

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
