### PR TITLE
make `establishMPPConnectionAsync` non block

### DIFF
--- a/dbms/src/Common/FailPoint.cpp
+++ b/dbms/src/Common/FailPoint.cpp
@@ -101,7 +101,8 @@ std::unordered_map<String, std::shared_ptr<FailPointChannel>> FailPointHelper::f
     M(pause_before_apply_raft_cmd)             \
     M(pause_before_apply_raft_snapshot)        \
     M(pause_until_apply_raft_snapshot)         \
-    M(pause_after_copr_streams_acquired_once)
+    M(pause_after_copr_streams_acquired_once)  \
+    M(pause_before_register_non_root_mpp_task)
 
 #define APPLY_FOR_PAUSEABLE_FAILPOINTS(M) \
     M(pause_when_reading_from_dt_stream)  \
@@ -145,10 +146,20 @@ public:
     // wake up all waiting threads when destroy
     ~FailPointChannel() { notifyAll(); }
 
+    explicit FailPointChannel(UInt64 timeout_)
+        : timeout(timeout_)
+    {}
+    FailPointChannel()
+        : timeout(0)
+    {}
+
     void wait()
     {
         std::unique_lock lock(m);
-        cv.wait(lock);
+        if (timeout == 0)
+            cv.wait(lock);
+        else
+            cv.wait_for(lock, std::chrono::seconds(timeout));
     }
 
     void notifyAll()
@@ -158,9 +169,33 @@ public:
     }
 
 private:
+    UInt64 timeout;
     std::mutex m;
     std::condition_variable cv;
 };
+
+void FailPointHelper::enablePauseFailPoint(const String & fail_point_name, UInt64 time)
+{
+#define SUB_M(NAME, flags)                                                                                  \
+    if (fail_point_name == FailPoints::NAME)                                                                \
+    {                                                                                                       \
+        /* FIU_ONETIME -- Only fail once; the point of failure will be automatically disabled afterwards.*/ \
+        fiu_enable(FailPoints::NAME, 1, nullptr, flags);                                                    \
+        fail_point_wait_channels.try_emplace(FailPoints::NAME, std::make_shared<FailPointChannel>(time));   \
+        return;                                                                                             \
+    }
+
+#define M(NAME) SUB_M(NAME, FIU_ONETIME)
+    APPLY_FOR_PAUSEABLE_FAILPOINTS_ONCE(M)
+#undef M
+
+#define M(NAME) SUB_M(NAME, 0)
+    APPLY_FOR_PAUSEABLE_FAILPOINTS(M)
+#undef M
+#undef SUB_M
+
+    throw Exception(fmt::format("Cannot find fail point {}", fail_point_name), ErrorCodes::FAIL_POINT_ERROR);
+}
 
 void FailPointHelper::enableFailPoint(const String & fail_point_name)
 {
@@ -264,6 +299,8 @@ class FailPointChannel
 };
 
 void FailPointHelper::enableFailPoint(const String &) {}
+
+void FailPointHelper::enablePauseFailPoint(const String &, UInt64) {}
 
 void FailPointHelper::disableFailPoint(const String &) {}
 

--- a/dbms/src/Common/FailPoint.h
+++ b/dbms/src/Common/FailPoint.h
@@ -50,6 +50,8 @@ class FailPointHelper
 public:
     static void enableFailPoint(const String & fail_point_name);
 
+    static void enablePauseFailPoint(const String & fail_point_name, UInt64 time);
+
     static void disableFailPoint(const String & fail_point_name);
 
     static void wait(const String & fail_point_name);

--- a/dbms/src/Debug/DBGInvoker.cpp
+++ b/dbms/src/Debug/DBGInvoker.cpp
@@ -107,6 +107,7 @@ DBGInvoker::DBGInvoker()
 
     regSchemalessFunc("init_fail_point", DbgFailPointFunc::dbgInitFailPoint);
     regSchemalessFunc("enable_fail_point", DbgFailPointFunc::dbgEnableFailPoint);
+    regSchemalessFunc("enable_pause_fail_point", DbgFailPointFunc::dbgEnablePauseFailPoint);
     regSchemalessFunc("disable_fail_point", DbgFailPointFunc::dbgDisableFailPoint);
     regSchemalessFunc("wait_fail_point", DbgFailPointFunc::dbgDisableFailPoint);
 

--- a/dbms/src/Debug/dbgFuncFailPoint.cpp
+++ b/dbms/src/Debug/dbgFuncFailPoint.cpp
@@ -17,11 +17,23 @@
 #include <Debug/dbgFuncFailPoint.h>
 #include <Parsers/ASTAsterisk.h>
 #include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTLiteral.h>
 
 namespace DB
 {
+void DbgFailPointFunc::dbgInitFailPoint(Context &, const ASTs &, DBGInvoker::Printer)
+{
+    (void)fiu_init(0);
+}
 
-void DbgFailPointFunc::dbgInitFailPoint(Context &, const ASTs &, DBGInvoker::Printer) { (void)fiu_init(0); }
+void DbgFailPointFunc::dbgEnablePauseFailPoint(Context &, const ASTs & args, DBGInvoker::Printer)
+{
+    if (args.size() != 2)
+        throw Exception("Args not matched, should be: name", ErrorCodes::BAD_ARGUMENTS);
+    const String fail_name = typeid_cast<const ASTIdentifier &>(*args[0]).name;
+    auto time = safeGet<UInt64>(typeid_cast<const ASTLiteral &>(*args[1]).value);
+    FailPointHelper::enablePauseFailPoint(fail_name, time);
+}
 
 void DbgFailPointFunc::dbgEnableFailPoint(Context &, const ASTs & args, DBGInvoker::Printer)
 {

--- a/dbms/src/Debug/dbgFuncFailPoint.cpp
+++ b/dbms/src/Debug/dbgFuncFailPoint.cpp
@@ -50,9 +50,9 @@ void DbgFailPointFunc::dbgDisableFailPoint(Context &, const ASTs & args, DBGInvo
         throw Exception("Args not matched, should be: name", ErrorCodes::BAD_ARGUMENTS);
 
     String fail_name;
-    if (auto ast = typeid_cast<const ASTAsterisk *>(args[0].get()); ast != nullptr)
+    if (const auto * ast = typeid_cast<const ASTAsterisk *>(args[0].get()); ast != nullptr)
         fail_name = "*";
-    else if (auto ast = typeid_cast<const ASTIdentifier *>(args[0].get()); ast != nullptr)
+    else if (const auto * ast = typeid_cast<const ASTIdentifier *>(args[0].get()); ast != nullptr)
         fail_name = ast->name;
     else
         throw Exception("Can not parse arg[0], should be: name or *", ErrorCodes::BAD_ARGUMENTS);
@@ -68,7 +68,7 @@ void DbgFailPointFunc::dbgWaitFailPoint(Context &, const ASTs & args, DBGInvoker
     const String fail_name = typeid_cast<const ASTIdentifier &>(*args[0]).name;
     // Wait for the failpoint till it is disabled.
     // Return if it is already disabled.
-    FAIL_POINT_PAUSE(fail_name.c_str());
+    FAIL_POINT_PAUSE(fail_name.c_str()); // NOLINT
 }
 
 } // namespace DB

--- a/dbms/src/Debug/dbgFuncFailPoint.h
+++ b/dbms/src/Debug/dbgFuncFailPoint.h
@@ -18,10 +18,8 @@
 
 namespace DB
 {
-
 struct DbgFailPointFunc
 {
-
     // Init fail point. must be called if you want to enable / disable failpoints
     //    DBGInvoke init_fail_point()
     static void dbgInitFailPoint(Context & context, const ASTs & args, DBGInvoker::Printer output);
@@ -29,6 +27,11 @@ struct DbgFailPointFunc
     // Enable fail point.
     //    DBGInvoke enable_fail_point(name)
     static void dbgEnableFailPoint(Context & context, const ASTs & args, DBGInvoker::Printer output);
+
+    // Enable pause fail point
+    //    DBGInvoke enable_pause_fail_point(name, time)
+    //    time == 0 mean pause until the fail point is disabled
+    static void dbgEnablePauseFailPoint(Context & context, const ASTs & args, DBGInvoker::Printer output);
 
     // Disable fail point.
     // Usage:

--- a/dbms/src/Flash/EstablishCall.cpp
+++ b/dbms/src/Flash/EstablishCall.cpp
@@ -164,12 +164,12 @@ void EstablishCallData::tryConnectTunnel()
             tunnel->connectAsync(this);
             state = PROCESSING;
             trySendOneMsg();
-            return;
         }
         catch (...)
         {
             writeErr(getPacketWithError(getCurrentExceptionMessage(false)));
         }
+        return;
     }
     else if (tunnel != nullptr && !err_msg.empty())
     {

--- a/dbms/src/Flash/EstablishCall.h
+++ b/dbms/src/Flash/EstablishCall.h
@@ -79,6 +79,8 @@ public:
         grpc::ServerCompletionQueue * notify_cq,
         const std::shared_ptr<std::atomic<bool>> & is_shutdown);
 
+    void tryConnectTunnel();
+
 private:
     /// WARNING: Since a event from one grpc completion queue may be handled by different
     /// thread, it's EXTREMELY DANGEROUS to read/write any data after calling a grpc function
@@ -87,8 +89,6 @@ private:
     /// Keep it in mind if you want to change any logic here.
 
     void initRpc();
-
-    void tryConnectTunnel();
 
     /// The packet will be written to grpc.
     void write(const mpp::MPPDataPacket & packet);

--- a/dbms/src/Flash/EstablishCall.h
+++ b/dbms/src/Flash/EstablishCall.h
@@ -61,6 +61,14 @@ public:
     grpc_call * grpcCall() override;
 
     void attachAsyncTunnelSender(const std::shared_ptr<DB::AsyncTunnelSender> &) override;
+    void setToWaitingTunnelState()
+    {
+        state = WAITING_TUNNEL;
+    }
+    bool isWaitingTunnelState()
+    {
+        return state == WAITING_TUNNEL;
+    }
 
     // Spawn a new EstablishCallData instance to serve new clients while we process the one for this EstablishCallData.
     // The instance will deallocate itself as part of its FINISH state.
@@ -79,6 +87,9 @@ private:
     /// Keep it in mind if you want to change any logic here.
 
     void initRpc();
+
+    void tryConnectTunnel();
+
     /// The packet will be written to grpc.
     void write(const mpp::MPPDataPacket & packet);
     /// Called when an application error happens.
@@ -111,6 +122,7 @@ private:
     enum CallStatus
     {
         NEW_REQUEST,
+        WAITING_TUNNEL,
         PROCESSING,
         ERR_HANDLE,
         FINISH

--- a/dbms/src/Flash/FlashService.cpp
+++ b/dbms/src/Flash/FlashService.cpp
@@ -41,8 +41,6 @@ namespace ErrorCodes
 extern const int NOT_IMPLEMENTED;
 }
 
-const String mpp_tunnel_not_found = "MPPTunnel not found";
-
 #define CATCH_FLASHSERVICE_EXCEPTION                                                                                                        \
     catch (Exception & e)                                                                                                                   \
     {                                                                                                                                       \

--- a/dbms/src/Flash/FlashService.h
+++ b/dbms/src/Flash/FlashService.h
@@ -117,6 +117,6 @@ public:
     /// Return grpc::Status::OK when the connection is established.
     /// Return non-OK grpc::Status when the connection can not be established.
     /// Return std::string when a error happens in application and it should be sent to the client then close the connection with grpc::Status::OK.
-    std::variant<grpc::Status, std::string> establishMPPConnectionAsync(grpc::ServerContext * context, const mpp::EstablishMPPConnectionRequest * request, EstablishCallData * call_data, grpc::CompletionQueue * cq);
+    grpc::Status establishMPPConnectionAsync(grpc::ServerContext * context, const mpp::EstablishMPPConnectionRequest * request, EstablishCallData * call_data);
 };
 } // namespace DB

--- a/dbms/src/Flash/FlashService.h
+++ b/dbms/src/Flash/FlashService.h
@@ -39,8 +39,6 @@ class EstablishCallData;
 using MockStorage = tests::MockStorage;
 using MockMPPServerInfo = tests::MockMPPServerInfo;
 
-extern const String mpp_tunnel_not_found;
-
 namespace Management
 {
 class ManualCompactManager;
@@ -116,7 +114,6 @@ public:
     }
     /// Return grpc::Status::OK when the connection is established.
     /// Return non-OK grpc::Status when the connection can not be established.
-    /// Return std::string when a error happens in application and it should be sent to the client then close the connection with grpc::Status::OK.
     grpc::Status establishMPPConnectionAsync(grpc::ServerContext * context, const mpp::EstablishMPPConnectionRequest * request, EstablishCallData * call_data);
 };
 } // namespace DB

--- a/dbms/src/Flash/Mpp/MPPTaskManager.cpp
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.cpp
@@ -37,7 +37,7 @@ MPPTaskManager::MPPTaskManager(MPPTaskSchedulerPtr scheduler_)
 
 MPPQueryTaskSetPtr MPPTaskManager::addMPPQueryTaskSet(UInt64 query_id)
 {
-    auto ptr = std::make_shared<MPPQueryTaskSet>(query_id);
+    auto ptr = std::make_shared<MPPQueryTaskSet>();
     mpp_query_map.insert({query_id, ptr});
     GET_METRIC(tiflash_mpp_task_manager, type_mpp_query_count).Set(mpp_query_map.size());
     return ptr;

--- a/dbms/src/Flash/Mpp/MPPTaskManager.cpp
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.cpp
@@ -59,12 +59,20 @@ std::pair<MPPTunnelPtr, String> MPPTaskManager::findAsyncTunnel(const ::mpp::Est
 
     std::unique_lock lock(mu);
     auto query_it = mpp_query_map.find(id.start_ts);
+    if (query_it != mpp_query_map.end() && !query_it->second->isInNormalState())
+    {
+        /// if the query is aborted, return the error message
+        LOG_WARNING(log, fmt::format("Query {} is aborted, all its tasks are invalid.", id.start_ts));
+        /// meet error
+        return {nullptr, query_it->second->error_message};
+    }
+
     if (query_it == mpp_query_map.end() || query_it->second->task_map.find(id) == query_it->second->task_map.end())
     {
         /// task not found
         if (!call_data->isWaitingTunnelState())
         {
-            /// if call_data is in new_request state, then put it to waiting tunnel state
+            /// if call_data is in new_request state, put it to waiting tunnel state
             auto query_set = query_it == mpp_query_map.end() ? addMPPQueryTaskSet(id.start_ts) : query_it->second;
             auto & alarm = query_set->alarms[sender_task_id][receiver_task_id];
             call_data->setToWaitingTunnelState();
@@ -73,40 +81,31 @@ std::pair<MPPTunnelPtr, String> MPPTaskManager::findAsyncTunnel(const ::mpp::Est
         }
         else
         {
-            if (query_it != mpp_query_map.end() && query_it->second->task_map.empty())
+            /// if call_data is already in WaitingTunnelState, then remove the alarm and return tunnel not found error
+            if (query_it != mpp_query_map.end())
             {
                 auto query_set = query_it->second;
-                /// if the query task set has no mpp task, it has to be removed if there is no alarms left,
-                /// otherwise the query task set itself may be left in MPPTaskManager forever
-                auto task_alarm_it = query_set->alarms.find(sender_task_id);
-                if (task_alarm_it != query_set->alarms.end())
+                auto task_alarm_map_it = query_set->alarms.find(sender_task_id);
+                if (task_alarm_map_it != query_set->alarms.end())
                 {
-                    task_alarm_it->second.erase(receiver_task_id);
-                    if (task_alarm_it->second.empty())
-                    {
-                        query_set->alarms.erase(task_alarm_it);
-                        if (query_set->alarms.empty())
-                        {
-                            /// remove the mpp query task set if it is the last alarm
-                            removeMPPQueryTaskSet(id.start_ts, false);
-                            cv.notify_all();
-                        }
-                    }
+                    task_alarm_map_it->second.erase(receiver_task_id);
+                    if (task_alarm_map_it->second.empty())
+                        query_set->alarms.erase(task_alarm_map_it);
+                }
+                if (query_set->alarms.empty() && query_set->task_map.empty())
+                {
+                    /// if the query task set has no mpp task, it has to be removed if there is no alarms left,
+                    /// otherwise the query task set itself may be left in MPPTaskManager forever
+                    removeMPPQueryTaskSet(id.start_ts, false);
+                    cv.notify_all();
                 }
             }
             return {nullptr, fmt::format("Can't find task [{},{}] within 10 s.", id.start_ts, id.task_id)};
         }
     }
+    /// don't need to delete the alarm here because registerMPPTask will delete all the related alarm
 
-    auto query_set = query_it->second;
-    if (!query_set->isInNormalState())
-    {
-        /// if the query is aborted, return true to stop waiting timeout.
-        LOG_WARNING(log, fmt::format("Query {} is aborted, all its tasks are invalid.", id.start_ts));
-        /// meet error
-        return {nullptr, query_it->second->error_message};
-    }
-    auto it = query_set->task_map.find(id);
+    auto it = query_it->second->task_map.find(id);
     return it->second->getTunnel(request);
 }
 
@@ -261,7 +260,7 @@ std::pair<bool, String> MPPTaskManager::unregisterTask(const MPPTaskId & id)
         if (task_it != it->second->task_map.end())
         {
             it->second->task_map.erase(task_it);
-            if (it->second->task_map.empty())
+            if (it->second->task_map.empty() && it->second->alarms.empty())
                 removeMPPQueryTaskSet(id.start_ts, false);
             cv.notify_all();
             return {true, ""};

--- a/dbms/src/Flash/Mpp/MPPTaskManager.h
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.h
@@ -39,7 +39,6 @@ struct MPPQueryTaskSet
     State state = Normal;
     String error_message;
     MPPTaskMap task_map;
-    UInt64 query_id;
     std::unordered_map<Int64, std::unordered_map<Int64, grpc::Alarm>> alarms;
     /// only used in scheduler
     std::queue<MPPTaskId> waiting_tasks;
@@ -51,9 +50,6 @@ struct MPPQueryTaskSet
     {
         return state == Normal || state == Aborted;
     }
-    MPPQueryTaskSet(UInt64 query_id_)
-        : query_id(query_id_)
-    {}
 };
 
 using MPPQueryTaskSetPtr = std::shared_ptr<MPPQueryTaskSet>;

--- a/dbms/src/Flash/Mpp/MPPTaskManager.h
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.h
@@ -14,9 +14,11 @@
 
 #pragma once
 
+#include <Flash/EstablishCall.h>
 #include <Flash/Mpp/MPPTask.h>
 #include <Flash/Mpp/MinTSOScheduler.h>
 #include <common/logger_useful.h>
+#include <grpcpp/alarm.h>
 #include <kvproto/mpp.pb.h>
 
 #include <chrono>
@@ -37,6 +39,8 @@ struct MPPQueryTaskSet
     State state = Normal;
     String error_message;
     MPPTaskMap task_map;
+    UInt64 query_id;
+    std::unordered_map<Int64, std::unordered_map<Int64, grpc::Alarm>> alarms;
     /// only used in scheduler
     std::queue<MPPTaskId> waiting_tasks;
     bool isInNormalState() const
@@ -47,6 +51,9 @@ struct MPPQueryTaskSet
     {
         return state == Normal || state == Aborted;
     }
+    MPPQueryTaskSet(UInt64 query_id_)
+        : query_id(query_id_)
+    {}
 };
 
 using MPPQueryTaskSetPtr = std::shared_ptr<MPPQueryTaskSet>;
@@ -88,9 +95,15 @@ public:
 
     std::pair<MPPTunnelPtr, String> findTunnelWithTimeout(const ::mpp::EstablishMPPConnectionRequest * request, std::chrono::seconds timeout);
 
+    std::pair<MPPTunnelPtr, String> findAsyncTunnel(const ::mpp::EstablishMPPConnectionRequest * request, EstablishCallData * call_data, grpc::CompletionQueue * cq);
+
     void abortMPPQuery(UInt64 query_id, const String & reason, AbortType abort_type);
 
     String toString();
+
+private:
+    MPPQueryTaskSetPtr addMPPQueryTaskSet(UInt64 query_id);
+    void removeMPPQueryTaskSet(UInt64 query_id, bool on_abort);
 };
 
 } // namespace DB

--- a/dbms/src/Server/tests/gtest_grpc_alarm.cpp
+++ b/dbms/src/Server/tests/gtest_grpc_alarm.cpp
@@ -1,0 +1,88 @@
+// Copyright 2022 PingCAP, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Suppress gcc warning: ‘*((void*)&<anonymous> +4)’ may be used uninitialized in this function
+#if !__clang__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+#include <cpptoml.h>
+#if !__clang__
+#pragma GCC diagnostic pop
+#endif
+
+#include <Common/Config/ConfigProcessor.h>
+#include <Interpreters/Quota.h>
+#include <Poco/Logger.h>
+#include <Server/StorageConfigParser.h>
+#include <Storages/DeltaMerge/DeltaMergeStore.h>
+#include <Storages/Page/PageStorage.h>
+#include <Storages/Page/V2/PageStorage.h>
+#include <Storages/PathCapacityMetrics.h>
+#include <Storages/Transaction/Region.h>
+#include <Storages/Transaction/RegionManager.h>
+#include <Storages/Transaction/RegionPersister.h>
+#include <TestUtils/ConfigTestUtils.h>
+#include <TestUtils/TiFlashTestBasic.h>
+
+#include "grpcpp/alarm.h"
+#include "grpcpp/impl/codegen/completion_queue.h"
+
+namespace DB
+{
+namespace tests
+{
+class GRPCAlarmTest : public ::testing::Test
+{
+public:
+    GRPCAlarmTest() {}
+
+protected:
+};
+
+
+TEST_F(GRPCAlarmTest, MeetDeadline)
+try
+{
+    grpc::CompletionQueue cq;
+    void * data = reinterpret_cast<void *>(&cq);
+    grpc::Alarm alarm;
+    alarm.Set(&cq, Clock::now() + std::chrono::seconds(1), data);
+    void * output_tag;
+    bool ok;
+    const grpc::CompletionQueue::NextStatus status = cq.AsyncNext(&output_tag, &ok, Clock::now() + std::chrono::seconds(10));
+    ASSERT_TRUE(status == grpc::CompletionQueue::NextStatus::GOT_EVENT);
+    ASSERT_TRUE(ok == true);
+    ASSERT_TRUE(output_tag == data);
+}
+CATCH
+
+TEST_F(GRPCAlarmTest, Cancelled)
+try
+{
+    grpc::CompletionQueue cq;
+    void * data = reinterpret_cast<void *>(&cq);
+    grpc::Alarm alarm;
+    alarm.Set(&cq, Clock::now() + std::chrono::seconds(600), data);
+    void * output_tag;
+    bool ok;
+    alarm.Cancel();
+    const grpc::CompletionQueue::NextStatus status = cq.AsyncNext(&output_tag, &ok, Clock::now() + std::chrono::seconds(1));
+    ASSERT_TRUE(status == grpc::CompletionQueue::NextStatus::GOT_EVENT);
+    ASSERT_TRUE(ok == false);
+    ASSERT_TRUE(output_tag == data);
+}
+CATCH
+} // namespace tests
+} // namespace DB

--- a/tests/fullstack-test/mpp/async_server_alarm.test
+++ b/tests/fullstack-test/mpp/async_server_alarm.test
@@ -1,0 +1,48 @@
+# Copyright 2022 PingCAP, Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Preparation.
+=> DBGInvoke __init_fail_point()
+
+mysql> drop table if exists test.t
+mysql> create table test.t (id int, value varchar(64))
+mysql> insert into test.t values(1,'a'),(2,'b'),(3,'c')
+mysql> alter table test.t set tiflash replica 1
+
+func> wait_table test t
+mysql> analyze table test.t
+
+
+# Data.
+
+## exception before mpp register non root mpp task
+=> DBGInvoke __disable_fail_point(pause_before_register_non_root_mpp_task)
+=> DBGInvoke __enable_pause_fail_point(pause_before_register_non_root_mpp_task, 5)
+mysql> use test; set @@tidb_isolation_read_engines='tiflash'; set @@tidb_allow_mpp=1; select count(value), id from t group by id;
++--------------+------+
+| count(value) | id   |
++--------------+------+
+|            1 |    1 |
+|            1 |    2 |
+|            1 |    3 |
++--------------+------+
+=> DBGInvoke __disable_fail_point(pause_before_register_non_root_mpp_task)
+
+=> DBGInvoke __enable_pause_fail_point(pause_before_register_non_root_mpp_task, 15)
+mysql> use test; set @@tidb_isolation_read_engines='tiflash'; set @@tidb_allow_mpp=1; select count(value), id from t group by id;
+{#REGEXP}.*Can't find task*
+=> DBGInvoke __disable_fail_point(pause_before_register_non_root_mpp_task)
+
+# Clean up.
+mysql> drop table if exists test.t


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #6047, ref #5653

Problem Summary:

### What is changed and how it works?
- seperate `establishMPPConnectionAsync` and `EstablishMPPConnection` since now async establish is much different from the sync version
- use `grpc::Alarm` to make `establishMPPConnectionAsync` non block
- enhance pause failpoint so the failpoint can now be paused for a specified duration
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
