### PR TITLE
avoid init store when process query for tiflash system tables

### DIFF
--- a/dbms/src/Storages/System/StorageSystemDTSegments.cpp
+++ b/dbms/src/Storages/System/StorageSystemDTSegments.cpp
@@ -103,7 +103,10 @@ BlockInputStreams StorageSystemDTSegments::read(const Names & column_names,
             auto dm_storage = std::dynamic_pointer_cast<StorageDeltaMerge>(storage);
             const auto & table_info = dm_storage->getTableInfo();
             auto table_id = table_info.id;
-            auto segment_stats = dm_storage->getStore()->getSegmentsStats();
+            auto store = dm_storage->getStoreIfInited();
+            if (!store)
+                continue;
+            auto segment_stats = store->getSegmentsStats();
             for (auto & stat : segment_stats)
             {
                 size_t j = 0;

--- a/dbms/src/Storages/System/StorageSystemDTTables.cpp
+++ b/dbms/src/Storages/System/StorageSystemDTTables.cpp
@@ -145,8 +145,10 @@ BlockInputStreams StorageSystemDTTables::read(
             auto dm_storage = std::dynamic_pointer_cast<StorageDeltaMerge>(storage);
             const auto & table_info = dm_storage->getTableInfo();
             auto table_id = table_info.id;
-            auto stat = dm_storage->getStore()->getStoreStats();
-
+            auto store = dm_storage->getStoreIfInited();
+            if (!store)
+                continue;
+            auto stat = store->getStoreStats();
             size_t j = 0;
             res_columns[j++]->insert(database_name);
             res_columns[j++]->insert(table_name);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #5665 

Problem Summary: When process query for system tables, tiflash will initialize useless store under `mysql` database. And the data of these stores cannot be cleared manually which make test for data leak problem hard to write.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
