### PR TITLE
remove is_partial_sort

### DIFF
--- a/dbms/src/Debug/MockExecutor/SortBinder.cpp
+++ b/dbms/src/Debug/MockExecutor/SortBinder.cpp
@@ -24,7 +24,6 @@ bool SortBinder::toTiPBExecutor(tipb::Executor * tipb_executor, int32_t collator
     tipb_executor->set_executor_id(name);
     tipb_executor->set_fine_grained_shuffle_stream_count(fine_grained_shuffle_stream_count);
     tipb::Sort * sort = tipb_executor->mutable_sort();
-    sort->set_ispartialsort(is_partial_sort);
 
     for (const auto & child : by_exprs)
     {
@@ -41,7 +40,7 @@ bool SortBinder::toTiPBExecutor(tipb::Executor * tipb_executor, int32_t collator
     return children[0]->toTiPBExecutor(children_executor, collator_id, mpp_info, context);
 }
 
-ExecutorBinderPtr compileSort(ExecutorBinderPtr input, size_t & executor_index, ASTPtr order_by_expr_list, bool is_partial_sort, uint64_t fine_grained_shuffle_stream_count)
+ExecutorBinderPtr compileSort(ExecutorBinderPtr input, size_t & executor_index, ASTPtr order_by_expr_list, uint64_t fine_grained_shuffle_stream_count)
 {
     std::vector<ASTPtr> order_columns;
     if (order_by_expr_list != nullptr)
@@ -55,7 +54,7 @@ ExecutorBinderPtr compileSort(ExecutorBinderPtr input, size_t & executor_index, 
             compileExpr(input->output_schema, elem->children[0]);
         }
     }
-    ExecutorBinderPtr sort = std::make_shared<mock::SortBinder>(executor_index, input->output_schema, std::move(order_columns), is_partial_sort, fine_grained_shuffle_stream_count);
+    ExecutorBinderPtr sort = std::make_shared<mock::SortBinder>(executor_index, input->output_schema, std::move(order_columns), fine_grained_shuffle_stream_count);
     sort->children.push_back(input);
     return sort;
 }

--- a/dbms/src/Debug/MockExecutor/SortBinder.h
+++ b/dbms/src/Debug/MockExecutor/SortBinder.h
@@ -21,10 +21,9 @@ namespace DB::mock
 class SortBinder : public ExecutorBinder
 {
 public:
-    SortBinder(size_t & index_, const DAGSchema & output_schema_, ASTs && by_exprs_, bool is_partial_sort_, uint64_t fine_grained_shuffle_stream_count_ = 0)
+    SortBinder(size_t & index_, const DAGSchema & output_schema_, ASTs && by_exprs_, uint64_t fine_grained_shuffle_stream_count_ = 0)
         : ExecutorBinder(index_, "sort_" + std::to_string(index_), output_schema_)
         , by_exprs(by_exprs_)
-        , is_partial_sort(is_partial_sort_)
         , fine_grained_shuffle_stream_count(fine_grained_shuffle_stream_count_)
     {}
 
@@ -36,9 +35,8 @@ public:
 
 private:
     std::vector<ASTPtr> by_exprs;
-    bool is_partial_sort;
     uint64_t fine_grained_shuffle_stream_count;
 };
 
-ExecutorBinderPtr compileSort(ExecutorBinderPtr input, size_t & executor_index, ASTPtr order_by_expr_list, bool is_partial_sort, uint64_t fine_grained_shuffle_stream_count);
+ExecutorBinderPtr compileSort(ExecutorBinderPtr input, size_t & executor_index, ASTPtr order_by_expr_list, uint64_t fine_grained_shuffle_stream_count);
 } // namespace DB::mock

--- a/dbms/src/Flash/Coprocessor/DAGQueryBlock.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGQueryBlock.cpp
@@ -39,7 +39,7 @@ bool isSourceNode(const tipb::Executor * root)
         || root->tp() == tipb::ExecType::TypeExchangeReceiver || root->tp() == tipb::ExecType::TypeProjection
         || root->tp() == tipb::ExecType::TypePartitionTableScan
         || root->tp() == tipb::ExecType::TypeWindow
-        || (root->tp() == tipb::ExecType::TypeSort && root->sort().ispartialsort());
+        || root->tp() == tipb::ExecType::TypeSort;
 }
 
 const static String SOURCE_NAME("source");
@@ -160,7 +160,7 @@ DAGQueryBlock::DAGQueryBlock(const tipb::Executor & root_, QueryBlockIDGenerator
         children.push_back(std::make_shared<DAGQueryBlock>(source->window().child(), id_generator));
         GET_METRIC(tiflash_coprocessor_executor_count, type_window).Increment();
     }
-    else if (current->tp() == tipb::ExecType::TypeSort && current->sort().ispartialsort())
+    else if (current->tp() == tipb::ExecType::TypeSort)
     {
         children.push_back(std::make_shared<DAGQueryBlock>(source->sort().child(), id_generator));
         GET_METRIC(tiflash_coprocessor_executor_count, type_window_sort).Increment();

--- a/dbms/src/Flash/Planner/plans/PhysicalWindowSort.cpp
+++ b/dbms/src/Flash/Planner/plans/PhysicalWindowSort.cpp
@@ -34,8 +34,6 @@ PhysicalPlanNodePtr PhysicalWindowSort::build(
 {
     assert(child);
 
-    RUNTIME_ASSERT(window_sort.ispartialsort(), log, "for window sort, ispartialsort must be true");
-
     DAGExpressionAnalyzer analyzer(child->getSchema(), context);
     const auto & order_columns = analyzer.buildWindowOrderColumns(window_sort);
     const SortDescription & order_descr = getSortDescription(order_columns, window_sort.byitems());

--- a/dbms/src/TestUtils/executorSerializer.cpp
+++ b/dbms/src/TestUtils/executorSerializer.cpp
@@ -230,7 +230,7 @@ void serializeWindow(const String & executor_id, const tipb::Window & window [[m
 
 void serializeSort(const String & executor_id, const tipb::Sort & sort [[maybe_unused]], FmtBuffer & buf)
 {
-    buf.fmtAppend("{} | isPartialSort: {}, partition_by: {{", executor_id, sort.ispartialsort());
+    buf.fmtAppend("{} | partition_by: {{", executor_id);
     buf.joinStr(
         sort.byitems().begin(),
         sort.byitems().end(),

--- a/dbms/src/TestUtils/mockExecutor.cpp
+++ b/dbms/src/TestUtils/mockExecutor.cpp
@@ -333,17 +333,17 @@ DAGRequestBuilder & DAGRequestBuilder::window(MockAstVec window_funcs, MockOrder
     return *this;
 }
 
-DAGRequestBuilder & DAGRequestBuilder::sort(MockOrderByItem order_by, bool is_partial_sort, uint64_t fine_grained_shuffle_stream_count)
+DAGRequestBuilder & DAGRequestBuilder::sort(MockOrderByItem order_by, uint64_t fine_grained_shuffle_stream_count)
 {
     assert(root);
-    root = compileSort(root, getExecutorIndex(), buildOrderByItemVec({order_by}), is_partial_sort, fine_grained_shuffle_stream_count);
+    root = compileSort(root, getExecutorIndex(), buildOrderByItemVec({order_by}), fine_grained_shuffle_stream_count);
     return *this;
 }
 
-DAGRequestBuilder & DAGRequestBuilder::sort(MockOrderByItemVec order_by_vec, bool is_partial_sort, uint64_t fine_grained_shuffle_stream_count)
+DAGRequestBuilder & DAGRequestBuilder::sort(MockOrderByItemVec order_by_vec, uint64_t fine_grained_shuffle_stream_count)
 {
     assert(root);
-    root = compileSort(root, getExecutorIndex(), buildOrderByItemVec(order_by_vec), is_partial_sort, fine_grained_shuffle_stream_count);
+    root = compileSort(root, getExecutorIndex(), buildOrderByItemVec(order_by_vec), fine_grained_shuffle_stream_count);
     return *this;
 }
 

--- a/dbms/src/TestUtils/mockExecutor.h
+++ b/dbms/src/TestUtils/mockExecutor.h
@@ -136,8 +136,8 @@ public:
     DAGRequestBuilder & window(ASTPtr window_func, MockOrderByItem order_by, MockPartitionByItem partition_by, MockWindowFrame frame, uint64_t fine_grained_shuffle_stream_count = 0);
     DAGRequestBuilder & window(MockAstVec window_funcs, MockOrderByItemVec order_by_vec, MockPartitionByItemVec partition_by_vec, MockWindowFrame frame, uint64_t fine_grained_shuffle_stream_count = 0);
     DAGRequestBuilder & window(ASTPtr window_func, MockOrderByItemVec order_by_vec, MockPartitionByItemVec partition_by_vec, MockWindowFrame frame, uint64_t fine_grained_shuffle_stream_count = 0);
-    DAGRequestBuilder & sort(MockOrderByItem order_by, bool is_partial_sort, uint64_t fine_grained_shuffle_stream_count = 0);
-    DAGRequestBuilder & sort(MockOrderByItemVec order_by_vec, bool is_partial_sort, uint64_t fine_grained_shuffle_stream_count = 0);
+    DAGRequestBuilder & sort(MockOrderByItem order_by, uint64_t fine_grained_shuffle_stream_count = 0);
+    DAGRequestBuilder & sort(MockOrderByItemVec order_by_vec, uint64_t fine_grained_shuffle_stream_count = 0);
 
     void setCollation(Int32 collator_) { properties.collator = convertToTiDBCollation(collator_); }
     Int32 getCollation() const { return abs(properties.collator); }

--- a/dbms/src/TestUtils/tests/gtest_mock_executors.cpp
+++ b/dbms/src/TestUtils/tests/gtest_mock_executors.cpp
@@ -325,7 +325,7 @@ try
     auto request = context.scan("test_db", "test_table").sort({"s1", false}, true).window(RowNumber(), {"s1", true}, {"s2", false}, buildDefaultRowsFrame()).build(context);
     {
         String expected = "window_2 | partition_by: {(<1, String>, desc: false)}}, order_by: {(<0, String>, desc: true)}, func_desc: {row_number()}, frame: {start<2, false, 0>, end<2, false, 0>}\n"
-                          " sort_1 | isPartialSort: true, partition_by: {(<0, String>, desc: false)}\n"
+                          " sort_1 | partition_by: {(<0, String>, desc: false)}\n"
                           "  table_scan_0 | {<0, String>, <1, String>}\n";
         ASSERT_DAGREQUEST_EQAUL(expected, request);
     }
@@ -334,7 +334,7 @@ try
     request = context.scan("test_db", "test_table").sort({"test_table.s1", false}, true).window(RowNumber(), {"test_table.s1", true}, {"test_table.s2", false}, buildDefaultRowsFrame()).build(context);
     {
         String expected = "window_2 | partition_by: {(<1, String>, desc: false)}}, order_by: {(<0, String>, desc: true)}, func_desc: {row_number()}, frame: {start<2, false, 0>, end<2, false, 0>}\n"
-                          " sort_1 | isPartialSort: true, partition_by: {(<0, String>, desc: false)}\n"
+                          " sort_1 | partition_by: {(<0, String>, desc: false)}\n"
                           "  table_scan_0 | {<0, String>, <1, String>}\n";
         ASSERT_DAGREQUEST_EQAUL(expected, request);
     }


### PR DESCRIPTION
is_partial_sort is always true, planner removed it, so we should remove it here in TiFlash too.

### What problem does this PR solve?

Issue Number: close #6189

Problem Summary:

### What is changed and how it works?

### Check List

Tests 

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
