### PR TITLE
Fix minor compaction after restart

### DIFF
--- a/dbms/src/Storages/DeltaMerge/Delta/DeltaPack_V3.cpp
+++ b/dbms/src/Storages/DeltaMerge/Delta/DeltaPack_V3.cpp
@@ -42,6 +42,7 @@ void serializeSavedPacks_V3(WriteBuffer & buf, const DeltaPacks & packs)
                 throw Exception("A data pack without schema: " + pack->toString(), ErrorCodes::LOGICAL_ERROR);
 
             bool save_schema = cur_schema != last_schema;
+            last_schema = cur_schema;
             pack->serializeMetadata(buf, save_schema);
             break;
         }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #6159 

Problem Summary:
When do serialization for ColumnFileTiny, we can avoid serialize the schema info if it share the same schema with previous ColumnFileTiny. But actually we fail to do that, so after restart all ColumnFileTiny has its own schema object and cannot be compacted together.

### What is changed and how it works?
1. Avoid serializing the schema of ColumnFileTiny if it is already saved by previous column files.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
