### PR TITLE
update submodule lz4 to v1.9.4 and use LZ4_decompress_safe

### DIFF
--- a/dbms/src/IO/CompressedReadBufferBase.cpp
+++ b/dbms/src/IO/CompressedReadBufferBase.cpp
@@ -109,8 +109,8 @@ void CompressedReadBufferBase<has_checksum>::decompress(char * to, size_t size_d
 
     if (method == static_cast<UInt8>(CompressionMethodByte::LZ4))
     {
-        if (LZ4_decompress_fast(compressed_buffer + COMPRESSED_BLOCK_HEADER_SIZE, to, size_decompressed) < 0)
-            throw Exception("Cannot LZ4_decompress_fast", ErrorCodes::CANNOT_DECOMPRESS);
+        if (unlikely(LZ4_decompress_safe(compressed_buffer + COMPRESSED_BLOCK_HEADER_SIZE, to, size_compressed_without_checksum - COMPRESSED_BLOCK_HEADER_SIZE, size_decompressed) < 0))
+            throw Exception("Cannot LZ4_decompress_safe", ErrorCodes::CANNOT_DECOMPRESS);
     }
     else if (method == static_cast<UInt8>(CompressionMethodByte::ZSTD))
     {


### PR DESCRIPTION
Signed-off-by: Lloyd-Pottiger <yan1579196623@gmail.com>

### What problem does this PR solve?

Issue Number: close #6172

Problem Summary:

### What is changed and how it works?
1. update submodule lz4 to the latest stable version to get better performance
2. use `LZ4_decompress_safe` instead of `LZ4_decompress_fast` which is deprecated and [slower](https://github.com/lz4/lz4/blob/dev/lib/lz4.h#L815-L840)

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
