### PR TITLE
KVStore: Support new lock type 'l'

### DIFF
--- a/dbms/src/Storages/Transaction/RegionCFDataBase.cpp
+++ b/dbms/src/Storages/Transaction/RegionCFDataBase.cpp
@@ -346,6 +346,12 @@ inline void decodeLockCfValue(DecodedLockCFValue & res)
                 }
                 break;
             }
+            case LAST_CHANGE_PREFIX:
+            {
+                UInt64 _last_change_ts = readUInt64(data, len);
+                UInt64 _versions_to_last_change = readVarUInt(data, len);
+                break;
+            }
             default:
             {
                 std::string msg = std::string("invalid flag ") + flag + " in lock value " + value.toDebugString();

--- a/dbms/src/Storages/Transaction/RegionCFDataBase.cpp
+++ b/dbms/src/Storages/Transaction/RegionCFDataBase.cpp
@@ -349,10 +349,10 @@ inline void decodeLockCfValue(DecodedLockCFValue & res)
             case LAST_CHANGE_PREFIX:
             {
                 // Used to accelerate TiKV MVCC scan, useless for TiFlash.
-                UInt64 _last_change_ts = readUInt64(data, len);
-                UInt64 _versions_to_last_change = readVarUInt(data, len);
-                UNUSED(_last_change_ts);
-                UNUSED(_versions_to_last_change);
+                UInt64 last_change_ts = readUInt64(data, len);
+                UInt64 versions_to_last_change = readVarUInt(data, len);
+                UNUSED(last_change_ts);
+                UNUSED(versions_to_last_change);
                 break;
             }
             default:

--- a/dbms/src/Storages/Transaction/RegionCFDataBase.cpp
+++ b/dbms/src/Storages/Transaction/RegionCFDataBase.cpp
@@ -348,8 +348,11 @@ inline void decodeLockCfValue(DecodedLockCFValue & res)
             }
             case LAST_CHANGE_PREFIX:
             {
+                // Used to accelerate TiKV MVCC scan, useless for TiFlash.
                 UInt64 _last_change_ts = readUInt64(data, len);
                 UInt64 _versions_to_last_change = readVarUInt(data, len);
+                UNUSED(_last_change_ts);
+                UNUSED(_versions_to_last_change);
                 break;
             }
             default:

--- a/dbms/src/Storages/Transaction/RegionCFDataBase.cpp
+++ b/dbms/src/Storages/Transaction/RegionCFDataBase.cpp
@@ -235,7 +235,7 @@ size_t RegionCFDataBase<Trait>::serialize(WriteBuffer & buf) const
 template <typename Trait>
 size_t RegionCFDataBase<Trait>::deserialize(ReadBuffer & buf, RegionCFDataBase & new_region_data)
 {
-    size_t size = readBinary2<size_t>(buf);
+    auto size = readBinary2<size_t>(buf);
     size_t cf_data_size = 0;
     for (size_t i = 0; i < size; ++i)
     {

--- a/dbms/src/Storages/Transaction/TiKVRecordFormat.h
+++ b/dbms/src/Storages/Transaction/TiKVRecordFormat.h
@@ -65,6 +65,7 @@ static const char ASYNC_COMMIT_PREFIX = 'a';
 static const char ROLLBACK_TS_PREFIX = 'r';
 static const char FLAG_OVERLAPPED_ROLLBACK = 'R';
 static const char GC_FENCE_PREFIX = 'F';
+static const char LAST_CHANGE_PREFIX = 'l';
 
 static const size_t SHORT_VALUE_MAX_LEN = 64;
 

--- a/dbms/src/Storages/Transaction/tests/gtest_tikv_keyvalue.cpp
+++ b/dbms/src/Storages/Transaction/tests/gtest_tikv_keyvalue.cpp
@@ -66,6 +66,11 @@ TiKVValue encode_lock_cf_value(
             res.write(s.data(), s.size());
         }
     }
+    {
+        res.write(RecordKVFormat::LAST_CHANGE_PREFIX);
+        RecordKVFormat::encodeUInt64(12345678, res);
+        TiKV::writeVarUInt(87654321, res);
+    }
     return TiKVValue(res.releaseStr());
 }
 


### PR DESCRIPTION
Signed-off-by: Calvin Neo <calvinneo1995@gmail.com>

### What problem does this PR solve?

Issue Number: close #6238

Problem Summary:

Introduced by https://github.com/tikv/tikv/pull/13698
The new type is to boost TiKV's MVCC Read. Ignore it in TiFlash.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
