### PR TITLE
Remove gcc legacy scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,36 +59,28 @@ if (NOT MSVC)
     set (COMMON_WARNING_FLAGS "${COMMON_WARNING_FLAGS} -Wall")    # -Werror is also added inside directories with our own code.
 endif ()
 
-if (COMPILER_GCC OR COMPILER_CLANG)
-    set (CXX_WARNING_FLAGS "${CXX_WARNING_FLAGS} -Wnon-virtual-dtor")
+set (CXX_WARNING_FLAGS "${CXX_WARNING_FLAGS} -Wnon-virtual-dtor")
+
+option(ENABLE_TIME_TRACES "Enable clang feature time traces" OFF)
+if (ENABLE_TIME_TRACES)
+    set (CLANG_TIME_TRACES_FLAGS "-ftime-trace")
+    message (STATUS "Using clang time traces flag `${CLANG_TIME_TRACES_FLAGS}`. Generates JSON file based on output filename. Results can be analyzed with chrome://tracing or https://www.speedscope.app for flamegraph visualization.")
+    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CLANG_TIME_TRACES_FLAGS}")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CLANG_TIME_TRACES_FLAGS}")
 endif ()
 
-if (COMPILER_CLANG)
-    # Clang doesn't have int128 predefined macros, workaround by manually defining them
-    # Reference: https://stackoverflow.com/questions/41198673/uint128-t-not-working-with-clang-and-libstdc
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__GLIBCXX_BITSIZE_INT_N_0=128 -D__GLIBCXX_TYPE_INT_N_0=__int128")
+# https://clang.llvm.org/docs/ThinLTO.html
+# Applies to clang only.
+option(ENABLE_THINLTO "Clang-specific link time optimization" OFF)
 
-    option(ENABLE_TIME_TRACES "Enable clang feature time traces" OFF)
-    if (ENABLE_TIME_TRACES)
-        set (CLANG_TIME_TRACES_FLAGS "-ftime-trace")
-        message (STATUS "Using clang time traces flag `${CLANG_TIME_TRACES_FLAGS}`. Generates JSON file based on output filename. Results can be analyzed with chrome://tracing or https://www.speedscope.app for flamegraph visualization.")
-        set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CLANG_TIME_TRACES_FLAGS}")
-        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CLANG_TIME_TRACES_FLAGS}")
-    endif ()
-
-    # https://clang.llvm.org/docs/ThinLTO.html
-    # Applies to clang only.
-    option(ENABLE_THINLTO "Clang-specific link time optimization" OFF)
-
-    if (ENABLE_THINLTO AND NOT ENABLE_TESTS)
-        # Link time optimization
-        set (THINLTO_JOBS "0" CACHE STRING "ThinLTO compilation parallelism")
-        set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -flto=thin -fvisibility=hidden -fvisibility-inlines-hidden -fsplit-lto-unit")
-        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto=thin -fvisibility=hidden -fvisibility-inlines-hidden -fwhole-program-vtables -fsplit-lto-unit")
-        set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -flto=thin -flto-jobs=${THINLTO_JOBS} -fvisibility=hidden -fvisibility-inlines-hidden -fwhole-program-vtables -fsplit-lto-unit")
-    elseif (ENABLE_THINLTO)
-        message (WARNING "Cannot enable ThinLTO")
-    endif ()
+if (ENABLE_THINLTO AND NOT ENABLE_TESTS)
+    # Link time optimization
+    set (THINLTO_JOBS "0" CACHE STRING "ThinLTO compilation parallelism")
+    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -flto=thin -fvisibility=hidden -fvisibility-inlines-hidden -fsplit-lto-unit")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto=thin -fvisibility=hidden -fvisibility-inlines-hidden -fwhole-program-vtables -fsplit-lto-unit")
+    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -flto=thin -flto-jobs=${THINLTO_JOBS} -fvisibility=hidden -fvisibility-inlines-hidden -fwhole-program-vtables -fsplit-lto-unit")
+elseif (ENABLE_THINLTO)
+    message (WARNING "Cannot enable ThinLTO")
 endif ()
 
 option (ENABLE_LLVM_PROFILE_INSTR "Generate instrumented code to collect execution counts" OFF)
@@ -133,11 +125,9 @@ if (ENABLE_LLVM_PGO)
     endif ()
 endif ()
 
-if (COMPILER_CLANG)
-    # clang: warning: argument unused during compilation: '-stdlib=libc++'
-    # clang: warning: argument unused during compilation: '-specs=/usr/share/dpkg/no-pie-compile.specs' [-Wunused-command-line-argument]
-    set (COMMON_WARNING_FLAGS "${COMMON_WARNING_FLAGS} -Wno-unused-command-line-argument")
-endif ()
+# clang: warning: argument unused during compilation: '-stdlib=libc++'
+# clang: warning: argument unused during compilation: '-specs=/usr/share/dpkg/no-pie-compile.specs' [-Wunused-command-line-argument]
+set (COMMON_WARNING_FLAGS "${COMMON_WARNING_FLAGS} -Wno-unused-command-line-argument")
 
 option (USE_STATIC_LIBRARIES "Set to FALSE to use shared libraries" ON)
 option (MAKE_STATIC_LIBRARIES "Set to FALSE to make shared libraries" ${USE_STATIC_LIBRARIES})
@@ -172,13 +162,9 @@ endif ()
 
 include (cmake/cpu_features.cmake)
 
-if (CMAKE_VERSION VERSION_LESS "3.8.0")
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1z")
-else ()
-    set (CMAKE_CXX_STANDARD 17)
-    set (CMAKE_CXX_EXTENSIONS 1) # https://cmake.org/cmake/help/latest/prop_tgt/CXX_EXTENSIONS.html#prop_tgt:CXX_EXTENSIONS
-    set (CMAKE_CXX_STANDARD_REQUIRED ON)
-endif ()
+set (CMAKE_CXX_STANDARD 17)
+set (CMAKE_CXX_EXTENSIONS 1) # https://cmake.org/cmake/help/latest/prop_tgt/CXX_EXTENSIONS.html#prop_tgt:CXX_EXTENSIONS
+set (CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set (CMAKE_CXX_FLAGS_RELWITHDEBINFO      "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -O3")
 set (CMAKE_C_FLAGS_RELWITHDEBINFO        "${CMAKE_C_FLAGS_RELWITHDEBINFO} -O3")
@@ -202,15 +188,11 @@ set (CMAKE_C_FLAGS                       "${CMAKE_C_FLAGS} ${COMPILER_FLAGS} -fn
 set (CMAKE_C_FLAGS_RELWITHDEBINFO        "${CMAKE_C_FLAGS_RELWITHDEBINFO} ${CMAKE_C_FLAGS_ADD}")
 set (CMAKE_C_FLAGS_DEBUG                 "${CMAKE_C_FLAGS_DEBUG} ${MOST_DEBUGGABLE_LEVEL} -fverbose-asm -fno-inline ${CMAKE_C_FLAGS_ADD}")
 
-if (MAKE_STATIC_LIBRARIES AND NOT OS_DARWIN AND NOT COMPILER_CLANG)
-    set (CMAKE_EXE_LINKER_FLAGS          "${CMAKE_EXE_LINKER_FLAGS} -static-libgcc -static-libstdc++")
-endif ()
-
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 
 include (cmake/test_compiler.cmake)
 
-if (OS_LINUX AND COMPILER_CLANG)
+if (OS_LINUX)
     set (TIFLASH_LLVM_TOOLCHAIN 1)
     set (CMAKE_EXE_LINKER_FLAGS          "${CMAKE_EXE_LINKER_FLAGS} ${GLIBC_COMPATIBILITY_LINK_FLAGS}")
 
@@ -261,9 +243,6 @@ if (USE_INCLUDE_WHAT_YOU_USE)
     find_program(IWYU_PATH NAMES include-what-you-use iwyu)
     if (NOT IWYU_PATH)
         message(FATAL_ERROR "Could not find the program include-what-you-use")
-    endif()
-    if (${CMAKE_VERSION} VERSION_LESS "3.3.0")
-        message(FATAL_ERROR "include-what-you-use requires CMake version at least 3.3.")
     endif()
 endif ()
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ cmake .. -GNinja -DCMAKE_BUILD_TYPE=DEBUG
 ninja tiflash
 ```
 
-Note: In Linux, usually you need to explicitly specify to use LLVM.:
+Note: In Linux, usually you need to explicitly specify to use LLVM.
 
 ```shell
 # In cmake-build-debug directory:

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ cmake .. -GNinja -DCMAKE_BUILD_TYPE=DEBUG
 ninja tiflash
 ```
 
-Note: In Linux, usually you need to explicitly specify to use LLVM. Otherwise, the default compiler will be GCC:
+Note: In Linux, usually you need to explicitly specify to use LLVM.:
 
 ```shell
 # In cmake-build-debug directory:

--- a/cmake/test_compiler.cmake
+++ b/cmake/test_compiler.cmake
@@ -17,44 +17,23 @@ include (CMakePushCheckState)
 
 cmake_push_check_state ()
 
-if (COMPILER_CLANG)
 # clang4 : -no-pie cause error
 # clang6 : -no-pie cause warning
 
-    if (MAKE_STATIC_LIBRARIES)
-        set (TEST_FLAG "-Wl,-Bstatic -stdlib=libc++ -lc++ -lc++abi -Wl,-Bdynamic")
-    else ()
-        set (TEST_FLAG "-stdlib=libc++ -lc++ -lc++abi")
-    endif ()
-
-    set (CMAKE_REQUIRED_FLAGS "${TEST_FLAG}")
-
-    check_cxx_source_compiles("
-        #include <iostream>
-        int main() {
-            std::cerr << std::endl;
-            return 0;
-        }
-        " HAVE_LIBCXX)
-
+if (MAKE_STATIC_LIBRARIES)
+    set (TEST_FLAG "-Wl,-Bstatic -stdlib=libc++ -lc++ -lc++abi -Wl,-Bdynamic")
 else ()
-
-    cmake_push_check_state ()
-
-    set (TEST_FLAG "-no-pie")
-    set (CMAKE_REQUIRED_FLAGS "${TEST_FLAG}")
-
-    check_cxx_source_compiles("
-        int main() {
-            return 0;
-        }
-        " HAVE_NO_PIE)
-
-    if (HAVE_NO_PIE)
-        set (FLAG_NO_PIE ${TEST_FLAG})
-    endif ()
-
-
+    set (TEST_FLAG "-stdlib=libc++ -lc++ -lc++abi")
 endif ()
+
+set (CMAKE_REQUIRED_FLAGS "${TEST_FLAG}")
+
+check_cxx_source_compiles("
+    #include <iostream>
+    int main() {
+        std::cerr << std::endl;
+        return 0;
+    }
+    " HAVE_LIBCXX)
 
 cmake_pop_check_state ()

--- a/cmake/tools.cmake
+++ b/cmake/tools.cmake
@@ -35,7 +35,7 @@ message (STATUS "Using compiler:\n${COMPILER_SELF_IDENTIFICATION}")
 set (CLANG_MINIMUM_VERSION 12)
 
 if (COMPILER_GCC)
-    message (FATAL_ERROR "GCC is not officially supported, and may not work.")
+    message (FATAL_ERROR "GCC is not officially supported.")
 elseif (COMPILER_CLANG)
     if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS ${CLANG_MINIMUM_VERSION})
         message (FATAL_ERROR "Compilation with Clang version ${CMAKE_CXX_COMPILER_VERSION} is unsupported, the minimum required version is ${CLANG_MINIMUM_VERSION}.")

--- a/cmake/tools.cmake
+++ b/cmake/tools.cmake
@@ -16,7 +16,6 @@
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set (COMPILER_GCC 1)
-    set (MOST_DEBUGGABLE_LEVEL -Og)
 elseif (CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")
     set (COMPILER_APPLE_CLANG 1)
     set (COMPILER_CLANG 1) # Safe to treat AppleClang as a regular Clang, in general.
@@ -33,14 +32,10 @@ execute_process(COMMAND ${CMAKE_CXX_COMPILER} --version OUTPUT_VARIABLE COMPILER
 message (STATUS "Using compiler:\n${COMPILER_SELF_IDENTIFICATION}")
 
 # Require minimum compiler versions
-set (CLANG_MINIMUM_VERSION 5)
-set (GCC_MINIMUM_VERSION 7)
+set (CLANG_MINIMUM_VERSION 12)
 
 if (COMPILER_GCC)
-    message (WARNING "GCC is not officially supported, and may not work.")
-    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS ${GCC_MINIMUM_VERSION})
-        message (FATAL_ERROR "Compilation with GCC version ${CMAKE_CXX_COMPILER_VERSION} is not supported, minimum required version is ${GCC_MINIMUM_VERSION}")
-    endif ()
+    message (FATAL_ERROR "GCC is not officially supported, and may not work.")
 elseif (COMPILER_CLANG)
     if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS ${CLANG_MINIMUM_VERSION})
         message (FATAL_ERROR "Compilation with Clang version ${CMAKE_CXX_COMPILER_VERSION} is unsupported, the minimum required version is ${CLANG_MINIMUM_VERSION}.")
@@ -64,9 +59,7 @@ endif ()
 if (NOT LINKER_NAME)
     if (OS_DARWIN AND COMPILER_APPLE_CLANG)
         set (LINKER_NAME "ld")
-    elseif (COMPILER_CLANG AND LLD_PATH)
-        set (LINKER_NAME "lld")
-    elseif (COMPILER_GCC AND LLD_PATH)
+    elseif (LLD_PATH)
         set (LINKER_NAME "lld")
     elseif (GOLD_PATH)
         message (WARNING "Linking with gold is not recommended. Please use lld.")
@@ -83,11 +76,7 @@ endif()
 
 # Archiver
 
-if (COMPILER_GCC)
-    find_program (LLVM_AR_PATH NAMES "llvm-ar" "llvm-ar-15" "llvm-ar-14" "llvm-ar-13" "llvm-ar-12")
-else ()
-    find_program (LLVM_AR_PATH NAMES "llvm-ar-${COMPILER_VERSION_MAJOR}" "llvm-ar")
-endif ()
+find_program (LLVM_AR_PATH NAMES "llvm-ar-${COMPILER_VERSION_MAJOR}" "llvm-ar")
 
 if (LLVM_AR_PATH)
     set (CMAKE_AR "${LLVM_AR_PATH}")
@@ -101,11 +90,7 @@ endif ()
 
 # Ranlib
 
-if (COMPILER_GCC)
-    find_program (LLVM_RANLIB_PATH NAMES "llvm-ranlib" "llvm-ranlib-15" "llvm-ranlib-14" "llvm-ranlib-13" "llvm-ranlib-12")
-else ()
-    find_program (LLVM_RANLIB_PATH NAMES "llvm-ranlib-${COMPILER_VERSION_MAJOR}" "llvm-ranlib")
-endif ()
+find_program (LLVM_RANLIB_PATH NAMES "llvm-ranlib-${COMPILER_VERSION_MAJOR}" "llvm-ranlib")
 
 if (LLVM_RANLIB_PATH)
     set (CMAKE_RANLIB "${LLVM_RANLIB_PATH}")
@@ -119,11 +104,7 @@ endif ()
 
 # Objcopy
 
-if (COMPILER_GCC)
-    find_program (OBJCOPY_PATH NAMES "llvm-objcopy" "llvm-objcopy-15" "llvm-objcopy-14" "llvm-objcopy-13" "llvm-objcopy-12" "objcopy")
-else ()
-    find_program (OBJCOPY_PATH NAMES "llvm-objcopy-${COMPILER_VERSION_MAJOR}" "llvm-objcopy" "objcopy")
-endif ()
+find_program (OBJCOPY_PATH NAMES "llvm-objcopy-${COMPILER_VERSION_MAJOR}" "llvm-objcopy" "objcopy")
 
 if (OBJCOPY_PATH)
     set (CMAKE_OBJCOPY "${OBJCOPY_PATH}")


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6233, ref #6201

Problem Summary:

Since we do not support gcc any more, this PR will clean up gcc legacy scripts.

### What is changed and how it works?

- set (CLANG_MINIMUM_VERSION 12)
- remove gcc condition in cmake scripts.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
