### PR TITLE
refine PageDirectory#apply

### DIFF
--- a/dbms/src/Storages/Page/V3/PageDirectory.cpp
+++ b/dbms/src/Storages/Page/V3/PageDirectory.cpp
@@ -1240,8 +1240,7 @@ void PageDirectory::apply(PageEntriesEdit && edit, const WriteLimiterPtr & write
     // in later batch pipeline), we will increase the sequence for each record.
     for (auto & r : edit.getMutRecords())
     {
-        ++my_sequence;
-        r.version = PageVersion(my_sequence, 0);
+        r.version = PageVersion(++my_sequence, 0);
     }
 
     const auto serialized_edit_data = ser::serializeTo(edit);


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Minimize the protection area of the unique lock of `PageDirectory::apply`

### What is changed and how it works?

The serialization of `edit` and increase of `sequence` should be handled before acquiring the lock.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
