### PR TITLE
Use right-valued reference passing for `TrackedMppDataPacketPtr`

### DIFF
--- a/dbms/src/Flash/Coprocessor/tests/gtest_ti_remote_block_inputstream.cpp
+++ b/dbms/src/Flash/Coprocessor/tests/gtest_ti_remote_block_inputstream.cpp
@@ -59,13 +59,13 @@ struct MockWriter
         return summary;
     }
 
-    void partitionWrite(const TrackedMppDataPacketPtr &, uint16_t) { FAIL() << "cannot reach here."; }
-    void broadcastOrPassThroughWrite(const TrackedMppDataPacketPtr & packet)
+    void partitionWrite(TrackedMppDataPacketPtr &&, uint16_t) { FAIL() << "cannot reach here."; }
+    void broadcastOrPassThroughWrite(TrackedMppDataPacketPtr && packet)
     {
         ++total_packets;
         if (!packet->packet.chunks().empty())
             total_bytes += packet->packet.ByteSizeLong();
-        queue->push(packet);
+        queue->push(std::move(packet));
     }
     void write(tipb::SelectResponse & response)
     {

--- a/dbms/src/Flash/Mpp/BroadcastOrPassThroughWriter.cpp
+++ b/dbms/src/Flash/Mpp/BroadcastOrPassThroughWriter.cpp
@@ -92,7 +92,7 @@ void BroadcastOrPassThroughWriter<ExchangeWriterPtr>::encodeThenWriteBlocks()
     }
     assert(blocks.empty());
     rows_in_blocks = 0;
-    writer->broadcastOrPassThroughWrite(tracked_packet);
+    writer->broadcastOrPassThroughWrite(std::move(tracked_packet));
 }
 
 template class BroadcastOrPassThroughWriter<MPPTunnelSetPtr>;

--- a/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.cpp
+++ b/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.cpp
@@ -176,14 +176,14 @@ void FineGrainedShuffleWriter<ExchangeWriterPtr>::batchWriteFineGrainedShuffle()
 }
 
 template <class ExchangeWriterPtr>
-void FineGrainedShuffleWriter<ExchangeWriterPtr>::writePackets(const TrackedMppDataPacketPtrs & packets)
+void FineGrainedShuffleWriter<ExchangeWriterPtr>::writePackets(TrackedMppDataPacketPtrs & packets)
 {
     for (size_t part_id = 0; part_id < packets.size(); ++part_id)
     {
-        const auto & packet = packets[part_id];
+        auto & packet = packets[part_id];
         assert(packet);
         if (likely(packet->getPacket().chunks_size() > 0))
-            writer->partitionWrite(packet, part_id);
+            writer->partitionWrite(std::move(packet), part_id);
     }
 }
 

--- a/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.h
+++ b/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.h
@@ -42,7 +42,7 @@ public:
 private:
     void batchWriteFineGrainedShuffle();
 
-    void writePackets(const TrackedMppDataPacketPtrs & packets);
+    void writePackets(TrackedMppDataPacketPtrs & packets);
 
     void initScatterColumns();
 

--- a/dbms/src/Flash/Mpp/HashPartitionWriter.cpp
+++ b/dbms/src/Flash/Mpp/HashPartitionWriter.cpp
@@ -122,14 +122,14 @@ void HashPartitionWriter<ExchangeWriterPtr>::partitionAndEncodeThenWriteBlocks()
 }
 
 template <class ExchangeWriterPtr>
-void HashPartitionWriter<ExchangeWriterPtr>::writePackets(const TrackedMppDataPacketPtrs & packets)
+void HashPartitionWriter<ExchangeWriterPtr>::writePackets(TrackedMppDataPacketPtrs & packets)
 {
     for (size_t part_id = 0; part_id < packets.size(); ++part_id)
     {
-        const auto & packet = packets[part_id];
+        auto & packet = packets[part_id];
         assert(packet);
         if (likely(packet->getPacket().chunks_size() > 0))
-            writer->partitionWrite(packet, part_id);
+            writer->partitionWrite(std::move(packet), part_id);
     }
 }
 

--- a/dbms/src/Flash/Mpp/HashPartitionWriter.h
+++ b/dbms/src/Flash/Mpp/HashPartitionWriter.h
@@ -40,7 +40,7 @@ public:
 private:
     void partitionAndEncodeThenWriteBlocks();
 
-    void writePackets(const TrackedMppDataPacketPtrs & packets);
+    void writePackets(TrackedMppDataPacketPtrs & packets);
 
     void sendExecutionSummary();
 

--- a/dbms/src/Flash/Mpp/MPPTunnel.cpp
+++ b/dbms/src/Flash/Mpp/MPPTunnel.cpp
@@ -147,8 +147,7 @@ void MPPTunnel::close(const String & reason, bool wait_sender_finish)
         waitForSenderFinish(false);
 }
 
-// TODO: consider to hold a buffer
-void MPPTunnel::write(const TrackedMppDataPacketPtr & data)
+void MPPTunnel::write(TrackedMppDataPacketPtr && data)
 {
     LOG_TRACE(log, "ready to write");
     {
@@ -158,9 +157,9 @@ void MPPTunnel::write(const TrackedMppDataPacketPtr & data)
             throw Exception(fmt::format("write to tunnel which is already closed."));
     }
 
-    if (tunnel_sender->push(data))
+    auto pushed_data_size = data->getPacket().ByteSizeLong();
+    if (tunnel_sender->push(std::move(data)))
     {
-        auto pushed_data_size = data->getPacket().ByteSizeLong();
         updateMetric(pushed_data_size, mode);
         connection_profile_info.bytes += pushed_data_size;
         connection_profile_info.packets += 1;

--- a/dbms/src/Flash/Mpp/MPPTunnel.h
+++ b/dbms/src/Flash/Mpp/MPPTunnel.h
@@ -72,9 +72,9 @@ public:
     {
     }
 
-    virtual bool push(const TrackedMppDataPacketPtr & data)
+    virtual bool push(TrackedMppDataPacketPtr && data)
     {
-        return send_queue.push(data) == MPMCQueueResult::OK;
+        return send_queue.push(std::move(data)) == MPMCQueueResult::OK;
     }
 
     virtual void cancelWith(const String & reason)
@@ -174,9 +174,9 @@ public:
         , queue(queue_size, func)
     {}
 
-    bool push(const TrackedMppDataPacketPtr & data) override
+    bool push(TrackedMppDataPacketPtr && data) override
     {
-        return queue.push(data);
+        return queue.push(std::move(data));
     }
 
     bool finish() override
@@ -273,7 +273,7 @@ public:
     const String & id() const { return tunnel_id; }
 
     // write a single packet to the tunnel's send queue, it will block if tunnel is not ready.
-    void write(const TrackedMppDataPacketPtr & data);
+    void write(TrackedMppDataPacketPtr && data);
 
     // finish the writing, and wait until the sender finishes.
     void writeDone();

--- a/dbms/src/Flash/Mpp/MPPTunnelSet.h
+++ b/dbms/src/Flash/Mpp/MPPTunnelSet.h
@@ -48,9 +48,9 @@ public:
     // this is a root mpp writing.
     void write(tipb::SelectResponse & response);
     // this is a broadcast or pass through writing.
-    void broadcastOrPassThroughWrite(const TrackedMppDataPacketPtr & packet);
+    void broadcastOrPassThroughWrite(TrackedMppDataPacketPtr && packet);
     // this is a partition writing.
-    void partitionWrite(const TrackedMppDataPacketPtr & packet, int16_t partition_id);
+    void partitionWrite(TrackedMppDataPacketPtr && packet, int16_t partition_id);
     // this is a execution summary writing.
     void sendExecutionSummary(tipb::SelectResponse & response);
 

--- a/dbms/src/Flash/Mpp/tests/gtest_mpp_exchange_writer.cpp
+++ b/dbms/src/Flash/Mpp/tests/gtest_mpp_exchange_writer.cpp
@@ -120,8 +120,8 @@ struct MockExchangeWriter
         , part_num(part_num_)
     {}
 
-    void broadcastOrPassThroughWrite(const TrackedMppDataPacketPtr & packet) { checker(packet, 0); }
-    void partitionWrite(const TrackedMppDataPacketPtr & packet, uint16_t part_id) { checker(packet, part_id); }
+    void broadcastOrPassThroughWrite(TrackedMppDataPacketPtr && packet) { checker(packet, 0); }
+    void partitionWrite(TrackedMppDataPacketPtr && packet, uint16_t part_id) { checker(packet, part_id); }
     void write(tipb::SelectResponse &) { FAIL() << "cannot reach here, only consider CH Block format"; }
     void sendExecutionSummary(tipb::SelectResponse & response)
     {

--- a/dbms/src/Flash/Mpp/tests/gtest_mpptunnel.cpp
+++ b/dbms/src/Flash/Mpp/tests/gtest_mpptunnel.cpp
@@ -27,6 +27,16 @@ namespace DB
 {
 namespace tests
 {
+namespace
+{
+TrackedMppDataPacketPtr newDataPacket(const String & data)
+{
+    auto data_packet_ptr = std::make_shared<TrackedMppDataPacket>();
+    data_packet_ptr->getPacket().set_data(data);
+    return data_packet_ptr;
+}
+} // namespace
+
 class MockPacketWriter : public PacketWriter
 {
     bool write(const mpp::MPPDataPacket & packet) override
@@ -319,10 +329,8 @@ TEST_F(TestMPPTunnel, WriteAfterUnconnectFinished)
     try
     {
         auto mpp_tunnel_ptr = constructRemoteSyncTunnel();
-        auto data_packet_ptr = std::make_shared<TrackedMppDataPacket>();
         setTunnelFinished(mpp_tunnel_ptr);
-        data_packet_ptr->getPacket().set_data("First");
-        mpp_tunnel_ptr->write(data_packet_ptr);
+        mpp_tunnel_ptr->write(newDataPacket("First"));
         GTEST_FAIL();
     }
     catch (Exception & e)
@@ -353,9 +361,7 @@ try
     auto mpp_tunnel_ptr = constructRemoteSyncTunnel();
     mpp_tunnel_ptr->connect(writer_ptr.get());
     GTEST_ASSERT_EQ(getTunnelConnectedFlag(mpp_tunnel_ptr), true);
-    auto data_packet_ptr = std::make_shared<TrackedMppDataPacket>();
-    data_packet_ptr->getPacket().set_data("First");
-    mpp_tunnel_ptr->write(data_packet_ptr);
+    mpp_tunnel_ptr->write(newDataPacket("First"));
     mpp_tunnel_ptr->close("Cancel", true);
     GTEST_ASSERT_EQ(getTunnelFinishedFlag(mpp_tunnel_ptr), true);
     auto result_size = dynamic_cast<MockPacketWriter *>(writer_ptr.get())->write_packet_vec.size();
@@ -373,9 +379,7 @@ try
     std::unique_ptr<PacketWriter> writer_ptr = std::make_unique<MockPacketWriter>();
     mpp_tunnel_ptr->connect(writer_ptr.get());
     GTEST_ASSERT_EQ(getTunnelConnectedFlag(mpp_tunnel_ptr), true);
-    auto data_packet_ptr = std::make_shared<TrackedMppDataPacket>();
-    data_packet_ptr->getPacket().set_data("First");
-    mpp_tunnel_ptr->write(data_packet_ptr);
+    mpp_tunnel_ptr->write(newDataPacket("First"));
     mpp_tunnel_ptr->writeDone();
     GTEST_ASSERT_EQ(getTunnelFinishedFlag(mpp_tunnel_ptr), true);
     GTEST_ASSERT_EQ(dynamic_cast<MockPacketWriter *>(writer_ptr.get())->write_packet_vec.size(), 1);
@@ -390,9 +394,7 @@ try
     std::unique_ptr<PacketWriter> writer_ptr = std::make_unique<MockPacketWriter>();
     mpp_tunnel_ptr->connect(writer_ptr.get());
     GTEST_ASSERT_EQ(getTunnelConnectedFlag(mpp_tunnel_ptr), true);
-    auto data_packet_ptr = std::make_shared<TrackedMppDataPacket>();
-    data_packet_ptr->getPacket().set_data("First");
-    mpp_tunnel_ptr->write(data_packet_ptr);
+    mpp_tunnel_ptr->write(newDataPacket("First"));
     mpp_tunnel_ptr->getSyncTunnelSender()->consumerFinish("");
     waitSyncTunnelSenderThread(mpp_tunnel_ptr->getSyncTunnelSender());
 
@@ -410,9 +412,7 @@ TEST_F(TestMPPTunnel, WriteError)
         std::unique_ptr<PacketWriter> writer_ptr = std::make_unique<MockFailedWriter>();
         mpp_tunnel_ptr->connect(writer_ptr.get());
         GTEST_ASSERT_EQ(getTunnelConnectedFlag(mpp_tunnel_ptr), true);
-        auto data_packet_ptr = std::make_shared<TrackedMppDataPacket>();
-        data_packet_ptr->getPacket().set_data("First");
-        mpp_tunnel_ptr->write(data_packet_ptr);
+        mpp_tunnel_ptr->write(newDataPacket("First"));
         mpp_tunnel_ptr->waitForFinish();
         GTEST_FAIL();
     }
@@ -433,9 +433,7 @@ TEST_F(TestMPPTunnel, WriteAfterFinished)
         mpp_tunnel_ptr->connect(writer_ptr.get());
         GTEST_ASSERT_EQ(getTunnelConnectedFlag(mpp_tunnel_ptr), true);
         mpp_tunnel_ptr->close("Canceled", false);
-        auto data_packet_ptr = std::make_shared<TrackedMppDataPacket>();
-        data_packet_ptr->getPacket().set_data("First");
-        mpp_tunnel_ptr->write(data_packet_ptr);
+        mpp_tunnel_ptr->write(newDataPacket("First"));
         GTEST_FAIL();
     }
     catch (Exception & e)
@@ -504,9 +502,7 @@ try
     auto local_reader_ptr = connectLocalSyncTunnel(mpp_tunnel_ptr);
     GTEST_ASSERT_EQ(getTunnelConnectedFlag(mpp_tunnel_ptr), true);
 
-    auto data_packet_ptr = std::make_shared<TrackedMppDataPacket>();
-    data_packet_ptr->getPacket().set_data("First");
-    mpp_tunnel_ptr->write(data_packet_ptr);
+    mpp_tunnel_ptr->write(newDataPacket("First"));
     mpp_tunnel_ptr->close("Cancel", false);
     local_reader_ptr->thread_manager->wait(); // Join local read thread
     GTEST_ASSERT_EQ(getTunnelSenderConsumerFinishedFlag(mpp_tunnel_ptr->getTunnelSender()), true);
@@ -523,9 +519,7 @@ try
     auto local_reader_ptr = connectLocalSyncTunnel(mpp_tunnel_ptr);
     GTEST_ASSERT_EQ(getTunnelConnectedFlag(mpp_tunnel_ptr), true);
 
-    auto data_packet_ptr = std::make_shared<TrackedMppDataPacket>();
-    data_packet_ptr->getPacket().set_data("First");
-    mpp_tunnel_ptr->write(data_packet_ptr);
+    mpp_tunnel_ptr->write(newDataPacket("First"));
     mpp_tunnel_ptr->writeDone();
     local_reader_ptr->thread_manager->wait(); // Join local read thread
     GTEST_ASSERT_EQ(getTunnelSenderConsumerFinishedFlag(mpp_tunnel_ptr->getTunnelSender()), true);
@@ -542,9 +536,7 @@ try
     auto local_reader_ptr = connectLocalSyncTunnel(mpp_tunnel_ptr);
     GTEST_ASSERT_EQ(getTunnelConnectedFlag(mpp_tunnel_ptr), true);
 
-    auto data_packet_ptr = std::make_shared<TrackedMppDataPacket>();
-    data_packet_ptr->getPacket().set_data("First");
-    mpp_tunnel_ptr->write(data_packet_ptr);
+    mpp_tunnel_ptr->write(newDataPacket("First"));
     mpp_tunnel_ptr->getTunnelSender()->consumerFinish("");
     local_reader_ptr->thread_manager->wait(); // Join local read thread
     GTEST_ASSERT_EQ(getTunnelSenderConsumerFinishedFlag(mpp_tunnel_ptr->getTunnelSender()), true);
@@ -561,9 +553,7 @@ TEST_F(TestMPPTunnel, LocalReadTerminate)
         mpp_tunnel_ptr->connect(nullptr);
         MockTerminateLocalReaderPtr local_reader_ptr = std::make_shared<MockTerminateLocalReader>(mpp_tunnel_ptr->getLocalTunnelSender());
         GTEST_ASSERT_EQ(getTunnelConnectedFlag(mpp_tunnel_ptr), true);
-        auto data_packet_ptr = std::make_shared<TrackedMppDataPacket>();
-        data_packet_ptr->getPacket().set_data("First");
-        mpp_tunnel_ptr->write(data_packet_ptr);
+        mpp_tunnel_ptr->write(newDataPacket("First"));
         mpp_tunnel_ptr->waitForFinish();
         GTEST_FAIL();
     }
@@ -581,9 +571,7 @@ TEST_F(TestMPPTunnel, LocalWriteAfterFinished)
         auto local_reader_ptr = connectLocalSyncTunnel(mpp_tunnel_ptr);
         GTEST_ASSERT_EQ(getTunnelConnectedFlag(mpp_tunnel_ptr), true);
         mpp_tunnel_ptr->close("", false);
-        auto data_packet_ptr = std::make_shared<TrackedMppDataPacket>();
-        data_packet_ptr->getPacket().set_data("First");
-        mpp_tunnel_ptr->write(data_packet_ptr);
+        mpp_tunnel_ptr->write(newDataPacket("First"));
         mpp_tunnel_ptr->waitForFinish();
         GTEST_FAIL();
     }
@@ -605,11 +593,8 @@ try
 
     std::thread t(&MockAsyncCallData::run, call_data.get());
 
-    auto data_packet_ptr = std::make_shared<TrackedMppDataPacket>();
-    data_packet_ptr->getPacket().set_data("First");
-    mpp_tunnel_ptr->write(data_packet_ptr);
-    data_packet_ptr->getPacket().set_data("Second");
-    mpp_tunnel_ptr->write(data_packet_ptr);
+    mpp_tunnel_ptr->write(newDataPacket("First"));
+    mpp_tunnel_ptr->write(newDataPacket("Second"));
     mpp_tunnel_ptr->close("Cancel", true);
     GTEST_ASSERT_EQ(getTunnelFinishedFlag(mpp_tunnel_ptr), true);
 
@@ -631,9 +616,7 @@ try
 
     std::thread t(&MockAsyncCallData::run, call_data.get());
 
-    auto data_packet_ptr = std::make_shared<TrackedMppDataPacket>();
-    data_packet_ptr->getPacket().set_data("First");
-    mpp_tunnel_ptr->write(data_packet_ptr);
+    mpp_tunnel_ptr->write(newDataPacket("First"));
     mpp_tunnel_ptr->writeDone();
 
     GTEST_ASSERT_EQ(getTunnelFinishedFlag(mpp_tunnel_ptr), true);
@@ -654,9 +637,7 @@ try
 
     std::thread t(&MockAsyncCallData::run, call_data.get());
 
-    auto data_packet_ptr = std::make_shared<TrackedMppDataPacket>();
-    data_packet_ptr->getPacket().set_data("First");
-    mpp_tunnel_ptr->write(data_packet_ptr);
+    mpp_tunnel_ptr->write(newDataPacket("First"));
     mpp_tunnel_ptr->getTunnelSender()->consumerFinish("");
     GTEST_ASSERT_EQ(getTunnelSenderConsumerFinishedFlag(mpp_tunnel_ptr->getTunnelSender()), true);
 
@@ -679,9 +660,7 @@ TEST_F(TestMPPTunnel, AsyncWriteError)
 
         std::thread t(&MockAsyncCallData::run, call_data.get());
 
-        auto data_packet_ptr = std::make_shared<TrackedMppDataPacket>();
-        data_packet_ptr->getPacket().set_data("First");
-        mpp_tunnel_ptr->write(data_packet_ptr);
+        mpp_tunnel_ptr->write(newDataPacket("First"));
         t.join();
         mpp_tunnel_ptr->waitForFinish();
         GTEST_FAIL();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #6302

Problem Summary:

### What is changed and how it works?
-  Use right-valued reference passing for `TrackedMppDataPacketPtr`
- Copy `TrackedMppDataPacketPtr` for broadcast because `TrackedMppDataPacket::switchMemTracker` will be called by multiple threads

The reason for the crash is
- `HashPartitionWriter` pass `TrackedMppDataPacketPtr`  to local tunnel  by left-valued reference. And now the `TrackedMppDataPacketPtr` hold the memory tracker of mpp task a.
- `LocalTunnel::readForLocal` call `TrackedMppDataPacket::switchMemoryTracker` and now the `TrackedMppDataPacketPtr` hold the memory tracker of mpp task b.
- And then the memory tacker throw exception like `RSS(Resident Set Size) much larger than limit`.
- mpp task b finished, and mpp task b is destroyed, as well as mpp task b's memory tracker.
- And then `TrackedMppDataPacketPtr` destroy in `HashPartitionWriter::partitionAndEncode` of mpp task a, and call the illegal memory tracker from mpp task b
- And the tiflash node crash

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
