### PR TITLE
Remove `DAGResponseWriter::finishWrite`

### DIFF
--- a/dbms/src/DataStreams/ExchangeSenderBlockInputStream.h
+++ b/dbms/src/DataStreams/ExchangeSenderBlockInputStream.h
@@ -46,7 +46,6 @@ protected:
     }
     void readSuffixImpl() override
     {
-        writer->finishWrite();
         LOG_DEBUG(log, "finish write with {} rows", total_rows);
     }
 

--- a/dbms/src/Flash/Coprocessor/DAGBlockOutputStream.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGBlockOutputStream.cpp
@@ -35,7 +35,6 @@ void DAGBlockOutputStream::writeSuffix()
 {
     // todo error handle
     response_writer->flush();
-    response_writer->finishWrite();
 }
 
 } // namespace DB

--- a/dbms/src/Flash/Coprocessor/DAGDriver.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGDriver.cpp
@@ -110,6 +110,11 @@ try
             dag_context);
         dag_output_stream = std::make_shared<DAGBlockOutputStream>(streams.in->getHeader(), std::move(response_writer));
         copyData(*streams.in, *dag_output_stream);
+        if (dag_context.collect_execution_summaries)
+        {
+            ExecutionSummaryCollector summary_collector(dag_context);
+            summary_collector.addExecuteSummaries(*dag_response);
+        }
     }
     else
     {

--- a/dbms/src/Flash/Coprocessor/DAGResponseWriter.h
+++ b/dbms/src/Flash/Coprocessor/DAGResponseWriter.h
@@ -30,7 +30,6 @@ public:
     virtual void write(const Block & block) = 0;
     /// flush cached blocks for batch writer
     virtual void flush() = 0;
-    virtual void finishWrite() = 0;
     virtual ~DAGResponseWriter() = default;
     const DAGContext & dagContext() const { return dag_context; }
 

--- a/dbms/src/Flash/Coprocessor/StreamingDAGResponseWriter.cpp
+++ b/dbms/src/Flash/Coprocessor/StreamingDAGResponseWriter.cpp
@@ -61,12 +61,6 @@ StreamingDAGResponseWriter<StreamWriterPtr>::StreamingDAGResponseWriter(
 }
 
 template <class StreamWriterPtr>
-void StreamingDAGResponseWriter<StreamWriterPtr>::finishWrite()
-{
-    assert(0 == rows_in_blocks);
-}
-
-template <class StreamWriterPtr>
 void StreamingDAGResponseWriter<StreamWriterPtr>::flush()
 {
     if (rows_in_blocks > 0)
@@ -80,9 +74,9 @@ void StreamingDAGResponseWriter<StreamWriterPtr>::write(const Block & block)
         block.columns() == dag_context.result_field_types.size(),
         "Output column size mismatch with field type size");
     size_t rows = block.rows();
-    rows_in_blocks += rows;
     if (rows > 0)
     {
+        rows_in_blocks += rows;
         blocks.push_back(block);
     }
 

--- a/dbms/src/Flash/Coprocessor/StreamingDAGResponseWriter.h
+++ b/dbms/src/Flash/Coprocessor/StreamingDAGResponseWriter.h
@@ -37,7 +37,6 @@ public:
         DAGContext & dag_context_);
     void write(const Block & block) override;
     void flush() override;
-    void finishWrite() override;
 
 private:
     void encodeThenWriteBlocks();

--- a/dbms/src/Flash/Coprocessor/UnaryDAGResponseWriter.cpp
+++ b/dbms/src/Flash/Coprocessor/UnaryDAGResponseWriter.cpp
@@ -71,19 +71,14 @@ void UnaryDAGResponseWriter::appendWarningsToDAGResponse()
     dag_response->set_warning_count(dag_context.getWarningCount());
 }
 
-void UnaryDAGResponseWriter::finishWrite()
+void UnaryDAGResponseWriter::flush()
 {
     if (current_records_num > 0)
     {
         encodeChunkToDAGResponse();
     }
+    // TODO separate from UnaryDAGResponseWriter and support mpp/batchCop.
     appendWarningsToDAGResponse();
-
-    if (dag_context.collect_execution_summaries)
-    {
-        ExecutionSummaryCollector summary_collector(dag_context);
-        summary_collector.addExecuteSummaries(*dag_response);
-    }
 }
 
 void UnaryDAGResponseWriter::write(const Block & block)

--- a/dbms/src/Flash/Coprocessor/UnaryDAGResponseWriter.h
+++ b/dbms/src/Flash/Coprocessor/UnaryDAGResponseWriter.h
@@ -38,8 +38,7 @@ public:
         DAGContext & dag_context_);
 
     void write(const Block & block) override;
-    void flush() override {}
-    void finishWrite() override;
+    void flush() override;
     void encodeChunkToDAGResponse();
     void appendWarningsToDAGResponse();
 

--- a/dbms/src/Flash/Coprocessor/tests/gtest_streaming_writer.cpp
+++ b/dbms/src/Flash/Coprocessor/tests/gtest_streaming_writer.cpp
@@ -145,7 +145,6 @@ try
         for (const auto & block : blocks)
             dag_writer->write(block);
         dag_writer->flush();
-        dag_writer->finishWrite();
 
         // 4. Start to check write_report.
         size_t expect_rows = block_rows * block_num;

--- a/dbms/src/Flash/Coprocessor/tests/gtest_ti_remote_block_inputstream.cpp
+++ b/dbms/src/Flash/Coprocessor/tests/gtest_ti_remote_block_inputstream.cpp
@@ -306,7 +306,6 @@ public:
         for (const auto & block : source_blocks)
             dag_writer->write(block);
         dag_writer->flush();
-        dag_writer->finishWrite();
 
         // 3. send execution summary
         writer->add_summary = true;
@@ -333,7 +332,6 @@ public:
         for (const auto & block : source_blocks)
             dag_writer->write(block);
         dag_writer->flush();
-        dag_writer->finishWrite();
 
         // 3. send execution summary
         writer->add_summary = true;

--- a/dbms/src/Flash/Mpp/BroadcastOrPassThroughWriter.cpp
+++ b/dbms/src/Flash/Mpp/BroadcastOrPassThroughWriter.cpp
@@ -34,12 +34,6 @@ BroadcastOrPassThroughWriter<ExchangeWriterPtr>::BroadcastOrPassThroughWriter(
 }
 
 template <class ExchangeWriterPtr>
-void BroadcastOrPassThroughWriter<ExchangeWriterPtr>::finishWrite()
-{
-    assert(0 == rows_in_blocks);
-}
-
-template <class ExchangeWriterPtr>
 void BroadcastOrPassThroughWriter<ExchangeWriterPtr>::flush()
 {
     if (rows_in_blocks > 0)
@@ -53,9 +47,9 @@ void BroadcastOrPassThroughWriter<ExchangeWriterPtr>::write(const Block & block)
         block.columns() == dag_context.result_field_types.size(),
         "Output column size mismatch with field type size");
     size_t rows = block.rows();
-    rows_in_blocks += rows;
     if (rows > 0)
     {
+        rows_in_blocks += rows;
         blocks.push_back(block);
     }
 

--- a/dbms/src/Flash/Mpp/BroadcastOrPassThroughWriter.h
+++ b/dbms/src/Flash/Mpp/BroadcastOrPassThroughWriter.h
@@ -32,7 +32,6 @@ public:
         DAGContext & dag_context_);
     void write(const Block & block) override;
     void flush() override;
-    void finishWrite() override;
 
 private:
     void encodeThenWriteBlocks();

--- a/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.cpp
+++ b/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.cpp
@@ -45,12 +45,6 @@ FineGrainedShuffleWriter<ExchangeWriterPtr>::FineGrainedShuffleWriter(
 }
 
 template <class ExchangeWriterPtr>
-void FineGrainedShuffleWriter<ExchangeWriterPtr>::finishWrite()
-{
-    assert(0 == rows_in_blocks);
-}
-
-template <class ExchangeWriterPtr>
 void FineGrainedShuffleWriter<ExchangeWriterPtr>::prepare(const Block & sample_block)
 {
     /// Initialize header block, use column type to create new empty column to handle potential null column cases
@@ -85,9 +79,9 @@ void FineGrainedShuffleWriter<ExchangeWriterPtr>::write(const Block & block)
         "Output column size mismatch with field type size");
 
     size_t rows = block.rows();
-    rows_in_blocks += rows;
     if (rows > 0)
     {
+        rows_in_blocks += rows;
         blocks.push_back(block);
     }
 

--- a/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.h
+++ b/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.h
@@ -36,7 +36,6 @@ public:
     void prepare(const Block & sample_block) override;
     void write(const Block & block) override;
     void flush() override;
-    void finishWrite() override;
 
 private:
     void batchWriteFineGrainedShuffle();

--- a/dbms/src/Flash/Mpp/HashPartitionWriter.cpp
+++ b/dbms/src/Flash/Mpp/HashPartitionWriter.cpp
@@ -41,12 +41,6 @@ HashPartitionWriter<ExchangeWriterPtr>::HashPartitionWriter(
 }
 
 template <class ExchangeWriterPtr>
-void HashPartitionWriter<ExchangeWriterPtr>::finishWrite()
-{
-    assert(0 == rows_in_blocks);
-}
-
-template <class ExchangeWriterPtr>
 void HashPartitionWriter<ExchangeWriterPtr>::flush()
 {
     if (rows_in_blocks > 0)
@@ -60,9 +54,9 @@ void HashPartitionWriter<ExchangeWriterPtr>::write(const Block & block)
         block.columns() == dag_context.result_field_types.size(),
         "Output column size mismatch with field type size");
     size_t rows = block.rows();
-    rows_in_blocks += rows;
     if (rows > 0)
     {
+        rows_in_blocks += rows;
         blocks.push_back(block);
     }
 

--- a/dbms/src/Flash/Mpp/HashPartitionWriter.h
+++ b/dbms/src/Flash/Mpp/HashPartitionWriter.h
@@ -34,7 +34,6 @@ public:
         DAGContext & dag_context_);
     void write(const Block & block) override;
     void flush() override;
-    void finishWrite() override;
 
 private:
     void partitionAndEncodeThenWriteBlocks();

--- a/dbms/src/Flash/Mpp/tests/gtest_mpp_exchange_writer.cpp
+++ b/dbms/src/Flash/Mpp/tests/gtest_mpp_exchange_writer.cpp
@@ -172,7 +172,6 @@ try
     dag_writer->prepare(block.cloneEmpty());
     dag_writer->write(block);
     dag_writer->flush();
-    dag_writer->finishWrite();
 
     // 4. Start to check write_report.
     std::vector<Block> decoded_blocks;
@@ -233,7 +232,6 @@ try
     for (const auto & block : blocks)
         dag_writer->write(block);
     dag_writer->flush();
-    dag_writer->finishWrite();
 
     // 4. Start to check write_report.
     size_t per_part_rows = block_rows * block_num / part_num;
@@ -294,7 +292,6 @@ try
     for (const auto & block : blocks)
         dag_writer->write(block);
     dag_writer->flush();
-    dag_writer->finishWrite();
 
     // 4. Start to check write_report.
     size_t per_part_rows = block_rows * block_num / part_num;
@@ -347,7 +344,6 @@ try
     for (const auto & block : blocks)
         dag_writer->write(block);
     dag_writer->flush();
-    dag_writer->finishWrite();
 
     // 4. Start to check write_report.
     size_t expect_rows = block_rows * block_num;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #6355

Problem Summary:

### What is changed and how it works?

- remove uesless check `assert(rows_in_blocks == 0)` in ExchangeWriter and StreamingWriter
- move the almost of code in `UnaryDAGResponseWriter::finishWrite` to `UnaryDAGResponseWriter::flush`
- move filling execution summary from `UnaryDAGResponseWriter::finishWrite` to `DAGDriver::execute`

The reason for the crash is
1. One of the MPPTask occur exception and call `manager->abortMPPQuery(id.start_ts, updated_msg, AbortType::ONERROR)`
2. Other mpp task is called `MPPTask::abortDataStreams(AbortType::ONERROR)`
3. And then the final UnionBlockInputStream return an empty block in advance and finish `Stream->read`, and `StreamingWriter::flush` is not called, so `rows_in_blocks != 0`
4. the stream->readPrefix is called, and the tiflash node crash in `StreamingDAGResponseWriter::finishWrite() { assert(rows_in_blocks == 0) }`...

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
