### PR TITLE
avoid always compacting level0 under heavy write pressure

### DIFF
--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFile_V3.cpp
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFile_V3.cpp
@@ -51,6 +51,7 @@ void serializeSavedColumnFilesInV3Format(WriteBuffer & buf, const ColumnFilePers
                 throw Exception("A tiny file without schema: " + column_file->toString(), ErrorCodes::LOGICAL_ERROR);
 
             bool save_schema = cur_schema != last_schema;
+            last_schema = cur_schema;
             column_file->serializeMetadata(buf, save_schema);
             break;
         }

--- a/dbms/src/Storages/DeltaMerge/Delta/ColumnFilePersistedSet.cpp
+++ b/dbms/src/Storages/DeltaMerge/Delta/ColumnFilePersistedSet.cpp
@@ -343,6 +343,7 @@ MinorCompactionPtr ColumnFilePersistedSet::pickUpMinorCompaction(DMContext & con
 
         auto compaction = std::make_shared<MinorCompaction>(next_compaction_level, minor_compaction_version);
         auto & level = persisted_files_levels[next_compaction_level];
+        next_compaction_level++;
         if (!level.empty())
         {
             bool is_all_trivial_move = true;
@@ -384,7 +385,6 @@ MinorCompactionPtr ColumnFilePersistedSet::pickUpMinorCompaction(DMContext & con
             if (!is_all_trivial_move)
                 return compaction;
         }
-        next_compaction_level++;
     }
     return nullptr;
 }

--- a/dbms/src/Storages/DeltaMerge/Delta/DeltaValueSpace.cpp
+++ b/dbms/src/Storages/DeltaMerge/Delta/DeltaValueSpace.cpp
@@ -263,7 +263,10 @@ bool DeltaValueSpace::compact(DMContext & context)
             LOG_FMT_DEBUG(log, "{} Compact stop because structure got updated", simpleInfo());
             return false;
         }
-
+        // Reset to 0 if the minor compaction succeed,
+        // and it may trigger another minor compaction if there is still too many column files.
+        // This process will stop when there is no more minor compaction to be done.
+        last_try_compact_column_files.store(0);
         LOG_FMT_DEBUG(log, "{} {}", simpleInfo(), compaction_task->info());
     }
     wbs.writeRemoves();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #6361 

Problem Summary:
1. The minor compaction process may always select level 0 and there are two many small column files in other levels which cannot be compacted.
2. The minor compaction trigger condition is bad which will and it harder and harder to trigger it.

### What is changed and how it works?
1. Increase next compaction level before return compaction level;
2. Reset minor compaction trigger statistics if the compaction succeed;

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix too many column files under heavy write pressure.
```
