### PR TITLE
revert #6340

### DIFF
--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -1284,8 +1284,6 @@ int Server::main(const std::vector<std::string> & /*args*/)
 
             main_config_reloader.reset();
             users_config_reloader.reset();
-
-            DynamicThreadPool::global_instance.reset();
         });
 
         /// This object will periodically calculate some metrics.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #6365 

Problem Summary:
The DynamicThreadPool::global_instance->reset() is called before all query tasks done, then when task request threads from DynamicThreadPool, the global_instance points to nullptr.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
