### PR TITLE
storage: Add lock for segment abandon

### DIFF
--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -363,7 +363,7 @@ void DeltaMergeStore::dropAllSegments(bool keep_first_segment)
                 id_to_segment.emplace(new_previous_segment->segmentId(), new_previous_segment);
             }
             auto drop_lock = segment_to_drop->mustGetUpdateLock();
-            segment_to_drop->abandon(*dm_context);
+            segment_to_drop->abandon(drop_lock, *dm_context);
             segment_to_drop->drop(global_context.getFileProvider(), wbs);
         }
     }

--- a/dbms/src/Storages/DeltaMerge/Segment.h
+++ b/dbms/src/Storages/DeltaMerge/Segment.h
@@ -437,10 +437,15 @@ public:
         return std::exchange(lock_opt, std::nullopt).value();
     }
 
-    /// Marks this segment as abandoned.
-    /// Note: Segment member functions never abandon the segment itself.
-    /// The abandon state is usually triggered by the DeltaMergeStore.
-    void abandon(DMContext & context)
+    /**
+     * Marks this segment as abandoned.
+     * Note: Segment member functions never abandon the segment itself.
+     * The abandon state is usually triggered by the DeltaMergeStore.
+     *
+     * You must hold a Segment update lock in order to abandon this segment.
+     * Otherwise, the abandon operation may break an existing segment update operation.
+     */
+    void abandon(const Lock &, DMContext & context)
     {
         LOG_DEBUG(log, "Abandon segment, segment={}", simpleInfo());
         delta->abandon(context);


### PR DESCRIPTION
Signed-off-by: Wish <breezewish@outlook.com>

### What problem does this PR solve?

Issue Number: ref #5237

Problem Summary:

### What is changed and how it works?

Add explicit lock argument to abandon segment.

If someone calls abandon without a segment lock, the abandon will cause race conditions with the update operations.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
