### PR TITLE
test: merge blocks when prepare

### DIFF
--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment.cpp
@@ -53,119 +53,6 @@ bool shouldCompactStableWithTooMuchDataOutOfSegmentRange(const DMContext & conte
 }
 namespace tests
 {
-class SegmentFrameworkTest : public SegmentTestBasic
-{
-};
-
-TEST_F(SegmentFrameworkTest, PrepareWriteBlock)
-try
-{
-    reloadWithOptions(SegmentTestOptions{.is_common_handle = false});
-
-    auto s1_id = splitSegmentAt(DELTA_MERGE_FIRST_SEGMENT_ID, 10);
-    ASSERT_TRUE(s1_id.has_value());
-    auto s2_id = splitSegmentAt(*s1_id, 20);
-    ASSERT_TRUE(s2_id.has_value());
-
-    // s1 has range [10, 20)
-    {
-        auto [begin, end] = getSegmentKeyRange(*s1_id);
-        ASSERT_EQ(10, begin);
-        ASSERT_EQ(20, end);
-    }
-
-    {
-        // write_rows == segment_rows, start_key not specified
-        auto blocks = prepareWriteBlocksInSegmentRange(*s1_id, 10);
-        ASSERT_EQ(1, blocks.size());
-        auto handle_column = blocks[0].getByName(EXTRA_HANDLE_COLUMN_NAME).column;
-        const auto & handle_data = typeid_cast<const ColumnVector<Handle> &>(*handle_column).getData();
-        ASSERT_EQ(PaddedPODArray<Handle>({10, 11, 12, 13, 14, 15, 16, 17, 18, 19}), handle_data);
-    }
-    {
-        // write_rows > segment_rows, start_key not specified
-        auto blocks = prepareWriteBlocksInSegmentRange(*s1_id, 13);
-        ASSERT_EQ(2, blocks.size());
-        {
-            auto handle_column = blocks[0].getByName(EXTRA_HANDLE_COLUMN_NAME).column;
-            const auto & handle_data = typeid_cast<const ColumnVector<Handle> &>(*handle_column).getData();
-            ASSERT_EQ(PaddedPODArray<Handle>({10, 11, 12, 13, 14, 15, 16, 17, 18, 19}), handle_data);
-        }
-        {
-            auto handle_column = blocks[1].getByName(EXTRA_HANDLE_COLUMN_NAME).column;
-            const auto & handle_data = typeid_cast<const ColumnVector<Handle> &>(*handle_column).getData();
-            ASSERT_EQ(PaddedPODArray<Handle>({10, 11, 12}), handle_data);
-        }
-    }
-    {
-        // start_key specified, end_key - start_key < write_rows
-        auto blocks = prepareWriteBlocksInSegmentRange(*s1_id, 2, /* at */ 16);
-        ASSERT_EQ(1, blocks.size());
-        const auto & handle_column = blocks[0].getByName(EXTRA_HANDLE_COLUMN_NAME).column;
-        const auto & handle_data = typeid_cast<const ColumnVector<Handle> &>(*handle_column).getData();
-        ASSERT_EQ(PaddedPODArray<Handle>({16, 17}), handle_data);
-    }
-    {
-        auto blocks = prepareWriteBlocksInSegmentRange(*s1_id, 4, /* at */ 16);
-        ASSERT_EQ(1, blocks.size());
-        const auto & handle_column = blocks[0].getByName(EXTRA_HANDLE_COLUMN_NAME).column;
-        const auto & handle_data = typeid_cast<const ColumnVector<Handle> &>(*handle_column).getData();
-        ASSERT_EQ(PaddedPODArray<Handle>({16, 17, 18, 19}), handle_data);
-    }
-    {
-        auto blocks = prepareWriteBlocksInSegmentRange(*s1_id, 5, /* at */ 16);
-        ASSERT_EQ(2, blocks.size());
-        {
-            const auto & handle_column = blocks[0].getByName(EXTRA_HANDLE_COLUMN_NAME).column;
-            const auto & handle_data = typeid_cast<const ColumnVector<Handle> &>(*handle_column).getData();
-            ASSERT_EQ(PaddedPODArray<Handle>({16, 17, 18, 19}), handle_data);
-        }
-        {
-            const auto & handle_column = blocks[1].getByName(EXTRA_HANDLE_COLUMN_NAME).column;
-            const auto & handle_data = typeid_cast<const ColumnVector<Handle> &>(*handle_column).getData();
-            ASSERT_EQ(PaddedPODArray<Handle>({16}), handle_data);
-        }
-    }
-    {
-        auto blocks = prepareWriteBlocksInSegmentRange(*s1_id, 10, /* at */ 16);
-        ASSERT_EQ(3, blocks.size());
-        {
-            const auto & handle_column = blocks[0].getByName(EXTRA_HANDLE_COLUMN_NAME).column;
-            const auto & handle_data = typeid_cast<const ColumnVector<Handle> &>(*handle_column).getData();
-            ASSERT_EQ(PaddedPODArray<Handle>({16, 17, 18, 19}), handle_data);
-        }
-        {
-            const auto & handle_column = blocks[1].getByName(EXTRA_HANDLE_COLUMN_NAME).column;
-            const auto & handle_data = typeid_cast<const ColumnVector<Handle> &>(*handle_column).getData();
-            ASSERT_EQ(PaddedPODArray<Handle>({16, 17, 18, 19}), handle_data);
-        }
-        {
-            const auto & handle_column = blocks[2].getByName(EXTRA_HANDLE_COLUMN_NAME).column;
-            const auto & handle_data = typeid_cast<const ColumnVector<Handle> &>(*handle_column).getData();
-            ASSERT_EQ(PaddedPODArray<Handle>({16, 17}), handle_data);
-        }
-    }
-    {
-        // write rows < segment rows, start key not specified, should choose a random start.
-        auto blocks = prepareWriteBlocksInSegmentRange(*s1_id, 3);
-        ASSERT_EQ(1, blocks.size());
-        ASSERT_EQ(3, blocks[0].rows());
-    }
-    {
-        // Let's check whether the generated handles will be starting from 12, for at least once.
-        auto start_from_12 = 0;
-        for (size_t i = 0; i < 100; i++)
-        {
-            auto blocks = prepareWriteBlocksInSegmentRange(*s1_id, 3);
-            if (blocks[0].getByName(EXTRA_HANDLE_COLUMN_NAME).column->getInt(0) == 12)
-                start_from_12++;
-        }
-        ASSERT_TRUE(start_from_12 > 0); // We should hit at least 1 times in 100 iters.
-        ASSERT_TRUE(start_from_12 < 50); // We should not hit 50 times in 100 iters :)
-    }
-}
-CATCH
-
 
 class SegmentOperationTest : public SegmentTestBasic
 {
@@ -524,12 +411,11 @@ CATCH
 TEST_F(SegmentOperationTest, SegmentLogicalSplit)
 try
 {
-    {
-        SegmentTestOptions options;
-        options.db_settings.dt_segment_stable_pack_rows = 100;
-        options.db_settings.dt_enable_logical_split = true;
-        reloadWithOptions(options);
-    }
+    reloadWithOptions(
+        {.db_settings = {
+             .dt_segment_stable_pack_rows = 100,
+             .dt_enable_logical_split = true,
+         }});
 
     writeSegment(DELTA_MERGE_FIRST_SEGMENT_ID, 400, /* at */ 0);
     flushSegmentCache(DELTA_MERGE_FIRST_SEGMENT_ID);
@@ -560,12 +446,8 @@ CATCH
 TEST_F(SegmentOperationTest, Issue5570)
 try
 {
-    {
-        SegmentTestOptions options;
-        // a smaller pack rows for logical split
-        options.db_settings.dt_segment_stable_pack_rows = 100;
-        reloadWithOptions(options);
-    }
+    // a smaller pack rows for logical split
+    reloadWithOptions({.db_settings = {.dt_segment_stable_pack_rows = 100}});
 
     writeSegment(DELTA_MERGE_FIRST_SEGMENT_ID, 200);
     flushSegmentCache(DELTA_MERGE_FIRST_SEGMENT_ID);
@@ -622,13 +504,12 @@ CATCH
 TEST_F(SegmentOperationTest, DeltaPagesAfterDeltaMerge)
 try
 {
-    {
-        SegmentTestOptions options;
-        // a smaller pack rows for logical split
-        options.db_settings.dt_segment_stable_pack_rows = 100;
-        options.db_settings.dt_enable_logical_split = true;
-        reloadWithOptions(options);
-    }
+    // a smaller pack rows for logical split
+    reloadWithOptions(
+    {.db_settings = {
+         .dt_segment_stable_pack_rows = 100,
+         .dt_enable_logical_split = true,
+     }});
 
     writeSegment(DELTA_MERGE_FIRST_SEGMENT_ID, 100);
     writeSegment(DELTA_MERGE_FIRST_SEGMENT_ID, 100);
@@ -716,10 +597,11 @@ protected:
     void SetUp() override
     {
         SegmentOperationTest::SetUp();
-        SegmentTestOptions options;
-        options.db_settings.dt_segment_stable_pack_rows = 100;
-        options.db_settings.dt_enable_logical_split = true;
-        reloadWithOptions(options);
+        reloadWithOptions(
+            {.db_settings = {
+                 .dt_segment_stable_pack_rows = 100,
+                 .dt_enable_logical_split = true,
+             }});
         ASSERT_TRUE(dm_context->enable_logical_split);
     }
 };
@@ -792,9 +674,7 @@ class SegmentSplitTest : public SegmentTestBasic
 TEST_F(SegmentSplitTest, AutoModePhycialSplitByDefault)
 try
 {
-    SegmentTestOptions options;
-    options.db_settings.dt_segment_stable_pack_rows = 100;
-    reloadWithOptions(options);
+    reloadWithOptions({.db_settings = {.dt_segment_stable_pack_rows = 100}});
     ASSERT_FALSE(dm_context->enable_logical_split);
 
     writeSegment(DELTA_MERGE_FIRST_SEGMENT_ID, 1000);
@@ -811,11 +691,12 @@ CATCH
 TEST_F(SegmentSplitTest, PhysicalSplitMode)
 try
 {
-    SegmentTestOptions options;
-    options.db_settings.dt_segment_stable_pack_rows = 100;
     // Even if we explicitly set enable_logical_split, we will still do physical split in SplitMode::Physical.
-    options.db_settings.dt_enable_logical_split = true;
-    reloadWithOptions(options);
+    reloadWithOptions(
+        {.db_settings = {
+             .dt_segment_stable_pack_rows = 100,
+             .dt_enable_logical_split = true,
+         }});
     ASSERT_TRUE(dm_context->enable_logical_split);
 
     writeSegment(DELTA_MERGE_FIRST_SEGMENT_ID, 1000);
@@ -870,9 +751,7 @@ CATCH
 TEST_F(SegmentSplitTest, LogicalSplitModeDoesLogicalSplit)
 try
 {
-    SegmentTestOptions options;
-    options.db_settings.dt_segment_stable_pack_rows = 100;
-    reloadWithOptions(options);
+    reloadWithOptions({.db_settings = {.dt_segment_stable_pack_rows = 100}});
     // Logical split will be performed if we use logical split mode, even when enable_logical_split is false.
     ASSERT_FALSE(dm_context->enable_logical_split);
 
@@ -912,9 +791,7 @@ CATCH
 TEST_F(SegmentSplitTest, LogicalSplitModeOnePackInStable)
 try
 {
-    SegmentTestOptions options;
-    options.db_settings.dt_segment_stable_pack_rows = 100;
-    reloadWithOptions(options);
+    reloadWithOptions({.db_settings = {.dt_segment_stable_pack_rows = 100}});
 
     writeSegment(DELTA_MERGE_FIRST_SEGMENT_ID, 50);
     flushSegmentCache(DELTA_MERGE_FIRST_SEGMENT_ID);
@@ -932,9 +809,7 @@ CATCH
 TEST_F(SegmentSplitTest, LogicalSplitModeOnePackWithHoleInStable)
 try
 {
-    SegmentTestOptions options;
-    options.db_settings.dt_segment_stable_pack_rows = 100;
-    reloadWithOptions(options);
+    reloadWithOptions({.db_settings = {.dt_segment_stable_pack_rows = 100}});
 
     writeSegment(DELTA_MERGE_FIRST_SEGMENT_ID, 10, /* at */ 0);
     writeSegment(DELTA_MERGE_FIRST_SEGMENT_ID, 10, /* at */ 90);
@@ -1008,9 +883,7 @@ CATCH
 TEST_F(SegmentSplitAtTest, AutoModeEnableLogicalSplit)
 try
 {
-    SegmentTestOptions options;
-    options.db_settings.dt_enable_logical_split = true;
-    reloadWithOptions(options);
+    reloadWithOptions({.db_settings = {.dt_enable_logical_split = true}});
 
     writeSegment(DELTA_MERGE_FIRST_SEGMENT_ID, 100, /* at */ 0);
     flushSegmentCache(DELTA_MERGE_FIRST_SEGMENT_ID);
@@ -1047,9 +920,7 @@ CATCH
 TEST_F(SegmentSplitAtTest, PhysicalSplitMode)
 try
 {
-    SegmentTestOptions options;
-    options.db_settings.dt_enable_logical_split = true;
-    reloadWithOptions(options);
+    reloadWithOptions({.db_settings = {.dt_enable_logical_split = true}});
 
     writeSegment(DELTA_MERGE_FIRST_SEGMENT_ID, 100, /* at */ 0);
     flushSegmentCache(DELTA_MERGE_FIRST_SEGMENT_ID);

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment.cpp
@@ -506,10 +506,10 @@ try
 {
     // a smaller pack rows for logical split
     reloadWithOptions(
-    {.db_settings = {
-         .dt_segment_stable_pack_rows = 100,
-         .dt_enable_logical_split = true,
-     }});
+        {.db_settings = {
+             .dt_segment_stable_pack_rows = 100,
+             .dt_enable_logical_split = true,
+         }});
 
     writeSegment(DELTA_MERGE_FIRST_SEGMENT_ID, 100);
     writeSegment(DELTA_MERGE_FIRST_SEGMENT_ID, 100);

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_test_basic.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_test_basic.cpp
@@ -623,10 +623,10 @@ try
         auto block = prepareWriteBlockInSegmentRange(*s1_id, 10);
         ASSERT_COLUMN_EQ(
             block.getByName(EXTRA_HANDLE_COLUMN_NAME),
-            createColumn<Int64>({10, 11, 12, 13, 14, 15, 16, 17, 18, 19}, "col"));
+            createColumn<Int64>({10, 11, 12, 13, 14, 15, 16, 17, 18, 19}));
         ASSERT_COLUMN_EQ(
             block.getByName(VERSION_COLUMN_NAME),
-            createColumn<UInt64>({1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, "col"));
+            createColumn<UInt64>({1, 1, 1, 1, 1, 1, 1, 1, 1, 1}));
     }
     {
         // write_rows > segment_rows, start_key not specified
@@ -634,10 +634,10 @@ try
         auto block = prepareWriteBlockInSegmentRange(*s1_id, 13);
         ASSERT_COLUMN_EQ(
             block.getByName(EXTRA_HANDLE_COLUMN_NAME),
-            createColumn<Int64>({10, 10, 11, 11, 12, 12, 13, 14, 15, 16, 17, 18, 19}, "col"));
+            createColumn<Int64>({10, 10, 11, 11, 12, 12, 13, 14, 15, 16, 17, 18, 19}));
         ASSERT_COLUMN_EQ(
             block.getByName(VERSION_COLUMN_NAME),
-            createColumn<UInt64>({1, 2, 1, 2, 1, 2, 1, 1, 1, 1, 1, 1, 1}, "col"));
+            createColumn<UInt64>({1, 2, 1, 2, 1, 2, 1, 1, 1, 1, 1, 1, 1}));
     }
     {
         // start_key specified, end_key - start_key < write_rows
@@ -645,40 +645,40 @@ try
         auto block = prepareWriteBlockInSegmentRange(*s1_id, 2, /* at */ 16);
         ASSERT_COLUMN_EQ(
             block.getByName(EXTRA_HANDLE_COLUMN_NAME),
-            createColumn<Int64>({16, 17}, "col"));
+            createColumn<Int64>({16, 17}));
         ASSERT_COLUMN_EQ(
             block.getByName(VERSION_COLUMN_NAME),
-            createColumn<UInt64>({1, 1}, "col"));
+            createColumn<UInt64>({1, 1}));
     }
     {
         version = 0;
         auto block = prepareWriteBlockInSegmentRange(*s1_id, 4, /* at */ 16);
         ASSERT_COLUMN_EQ(
             block.getByName(EXTRA_HANDLE_COLUMN_NAME),
-            createColumn<Int64>({16, 17, 18, 19}, "col"));
+            createColumn<Int64>({16, 17, 18, 19}));
         ASSERT_COLUMN_EQ(
             block.getByName(VERSION_COLUMN_NAME),
-            createColumn<UInt64>({1, 1, 1, 1}, "col"));
+            createColumn<UInt64>({1, 1, 1, 1}));
     }
     {
         version = 0;
         auto block = prepareWriteBlockInSegmentRange(*s1_id, 5, /* at */ 16);
         ASSERT_COLUMN_EQ(
             block.getByName(EXTRA_HANDLE_COLUMN_NAME),
-            createColumn<Int64>({16, 16, 17, 18, 19}, "col"));
+            createColumn<Int64>({16, 16, 17, 18, 19}));
         ASSERT_COLUMN_EQ(
             block.getByName(VERSION_COLUMN_NAME),
-            createColumn<UInt64>({1, 2, 1, 1, 1}, "col"));
+            createColumn<UInt64>({1, 2, 1, 1, 1}));
     }
     {
         version = 0;
         auto block = prepareWriteBlockInSegmentRange(*s1_id, 10, /* at */ 16);
         ASSERT_COLUMN_EQ(
             block.getByName(EXTRA_HANDLE_COLUMN_NAME),
-            createColumn<Int64>({16, 16, 16, 17, 17, 17, 18, 18, 19, 19}, "col"));
+            createColumn<Int64>({16, 16, 16, 17, 17, 17, 18, 18, 19, 19}));
         ASSERT_COLUMN_EQ(
             block.getByName(VERSION_COLUMN_NAME),
-            createColumn<UInt64>({1, 2, 3, 1, 2, 3, 1, 2, 1, 2}, "col"));
+            createColumn<UInt64>({1, 2, 3, 1, 2, 3, 1, 2, 1, 2}));
     }
     {
         // write rows < segment rows, start key not specified, should choose a random start.

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_test_basic.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_test_basic.cpp
@@ -305,7 +305,7 @@ Block mergeBlocks(std::vector<Block> && blocks)
 {
     auto accumulated_block = std::move(blocks[0]);
 
-    for (size_t block_idx = 1; block_idx < blocks.size(); block_idx++)
+    for (size_t block_idx = 1; block_idx < blocks.size(); ++block_idx)
     {
         auto block = std::move(blocks[block_idx]);
 

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_test_basic.h
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_test_basic.h
@@ -74,7 +74,7 @@ public:
     void replaceSegmentData(const std::vector<PageId> & segments_id, const Block & block);
 
     Block prepareWriteBlock(Int64 start_key, Int64 end_key, bool is_deleted = false);
-    std::vector<Block> prepareWriteBlocksInSegmentRange(PageId segment_id, UInt64 total_write_rows, std::optional<Int64> write_start_key = std::nullopt, bool is_deleted = false);
+    Block prepareWriteBlockInSegmentRange(PageId segment_id, UInt64 total_write_rows, std::optional<Int64> write_start_key = std::nullopt, bool is_deleted = false);
 
     size_t getSegmentRowNumWithoutMVCC(PageId segment_id);
     size_t getSegmentRowNum(PageId segment_id);

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_test_randomized.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_test_randomized.cpp
@@ -317,9 +317,7 @@ protected:
 TEST_F(SegmentRandomizedTest, FastCommonHandle)
 try
 {
-    SegmentTestOptions options;
-    options.is_common_handle = true;
-    reloadWithOptions(options);
+    reloadWithOptions({.is_common_handle = true});
     run(/* n */ 500, /* min key */ -50000, /* max key */ 50000);
 }
 CATCH
@@ -328,9 +326,7 @@ CATCH
 TEST_F(SegmentRandomizedTest, FastIntHandle)
 try
 {
-    SegmentTestOptions options;
-    options.is_common_handle = false;
-    reloadWithOptions(options);
+    reloadWithOptions({.is_common_handle = false});
     run(/* n */ 500, /* min key */ -50000, /* max key */ 50000);
 }
 CATCH
@@ -340,9 +336,7 @@ CATCH
 TEST_F(SegmentRandomizedTest, DISABLED_ForCI)
 try
 {
-    SegmentTestOptions options;
-    options.is_common_handle = true;
-    reloadWithOptions(options);
+    reloadWithOptions({.is_common_handle = true});
     run(50000, /* min key */ -50000, /* max key */ 50000);
 }
 CATCH

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_sst_files_stream.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_sst_files_stream.cpp
@@ -111,7 +111,7 @@ try
         ASSERT_EQ(blocks.size(), 1);
         auto block = blocks[0];
         auto col = block.getByName(MutableSupport::tidb_pk_column_name);
-        ASSERT_COLUMN_EQ(col, createColumn<Int64>({-10, -9, -8, -7, -6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4}, "col"));
+        ASSERT_COLUMN_EQ(col, createColumn<Int64>({-10, -9, -8, -7, -6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4}));
     }
     {
         auto blocks = prepareBlocks(1, 14, 3);
@@ -119,27 +119,27 @@ try
         {
             auto block = blocks[0];
             auto col = block.getByName(MutableSupport::tidb_pk_column_name);
-            ASSERT_COLUMN_EQ(col, createColumn<Int64>({1, 2, 3}, "col"));
+            ASSERT_COLUMN_EQ(col, createColumn<Int64>({1, 2, 3}));
         }
         {
             auto block = blocks[1];
             auto col = block.getByName(MutableSupport::tidb_pk_column_name);
-            ASSERT_COLUMN_EQ(col, createColumn<Int64>({4, 5, 6}, "col"));
+            ASSERT_COLUMN_EQ(col, createColumn<Int64>({4, 5, 6}));
         }
         {
             auto block = blocks[2];
             auto col = block.getByName(MutableSupport::tidb_pk_column_name);
-            ASSERT_COLUMN_EQ(col, createColumn<Int64>({7, 8, 9}, "col"));
+            ASSERT_COLUMN_EQ(col, createColumn<Int64>({7, 8, 9}));
         }
         {
             auto block = blocks[3];
             auto col = block.getByName(MutableSupport::tidb_pk_column_name);
-            ASSERT_COLUMN_EQ(col, createColumn<Int64>({10, 11, 12}, "col"));
+            ASSERT_COLUMN_EQ(col, createColumn<Int64>({10, 11, 12}));
         }
         {
             auto block = blocks[4];
             auto col = block.getByName(MutableSupport::tidb_pk_column_name);
-            ASSERT_COLUMN_EQ(col, createColumn<Int64>({13}, "col"));
+            ASSERT_COLUMN_EQ(col, createColumn<Int64>({13}));
         }
     }
     {
@@ -148,17 +148,17 @@ try
         {
             auto block = blocks[0];
             auto col = block.getByName(MutableSupport::tidb_pk_column_name);
-            ASSERT_COLUMN_EQ(col, createColumn<Int64>({1}, "col"));
+            ASSERT_COLUMN_EQ(col, createColumn<Int64>({1}));
         }
         {
             auto block = blocks[1];
             auto col = block.getByName(MutableSupport::tidb_pk_column_name);
-            ASSERT_COLUMN_EQ(col, createColumn<Int64>({2}, "col"));
+            ASSERT_COLUMN_EQ(col, createColumn<Int64>({2}));
         }
         {
             auto block = blocks[2];
             auto col = block.getByName(MutableSupport::tidb_pk_column_name);
-            ASSERT_COLUMN_EQ(col, createColumn<Int64>({3}, "col"));
+            ASSERT_COLUMN_EQ(col, createColumn<Int64>({3}));
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Wish <breezewish@outlook.com>

### What problem does this PR solve?

Issue Number: ref #5237

Problem Summary:

### What is changed and how it works?

Always produce a single sorted block, instead of a list of blocks, when we need to fill rows in tests. In this way, we can produce a correct DMFile from these rows.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
