### PR TITLE
fix unstable test

### DIFF
--- a/dbms/src/Encryption/tests/gtest_rate_limiter.cpp
+++ b/dbms/src/Encryption/tests/gtest_rate_limiter.cpp
@@ -207,8 +207,8 @@ TEST(ReadLimiterTest, GetIOStatPeroid200ms)
     ASSERT_EQ(limiter.getAvailableBalance(), -31);
     request(limiter, 1);
     TimePointMS t2 = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::system_clock::now());
-    elasped = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
-    ASSERT_GE(elasped, 2 * refill_period_ms);
+    elasped = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t0).count();
+    ASSERT_GE(elasped, 3 * refill_period_ms);
     ASSERT_EQ(limiter.getAvailableBalance(), 8);
     request(limiter, 9);
     ASSERT_EQ(limiter.getAvailableBalance(), -1);


### PR DESCRIPTION
Signed-off-by: Lloyd-Pottiger <yan1579196623@gmail.com>

### What problem does this PR solve?

Issue Number: close #6261

Problem Summary:

https://ci.pingcap.net/blue/rest/organizations/jenkins/pipelines/tiflash-ghpr-unit-tests/runs/7135/nodes/75/steps/80/log/?start=0

thread may be interrupted between line 208 and line 209 which cause t1-t0 is larger than 40ms, then limiter can directly refill once without waiting.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
