### PR TITLE
Optimize search write position in BlobFile

### DIFF
--- a/dbms/src/Common/TiFlashMetrics.h
+++ b/dbms/src/Common/TiFlashMetrics.h
@@ -200,7 +200,9 @@ namespace DB
     M(tiflash_raft_process_keys, "Total number of keys processed in some types of Raft commands", Counter,                                \
         F(type_apply_snapshot, {"type", "apply_snapshot"}), F(type_ingest_sst, {"type", "ingest_sst"}))                                   \
     M(tiflash_raft_apply_write_command_duration_seconds, "Bucketed histogram of applying write command Raft logs", Histogram,             \
-        F(type_write, {{"type", "write"}}, ExpBuckets{0.0005, 2, 20}), F(type_admin, {{"type", "admin"}}, ExpBuckets{0.0005, 2, 20}))     \
+        F(type_write, {{"type", "write"}}, ExpBuckets{0.0005, 2, 20}),                                                                    \
+        F(type_admin, {{"type", "admin"}}, ExpBuckets{0.0005, 2, 20}),                                                                    \
+        F(type_flush_region, {{"type", "flush_region"}}, ExpBuckets{0.0005, 2, 20}))                                                      \
     M(tiflash_raft_upstream_latency, "The latency that tikv sends raft log to tiflash.", Histogram,                                       \
         F(type_write, {{"type", "write"}}, ExpBuckets{0.001, 2, 30}))                                                                     \
     M(tiflash_raft_write_data_to_storage_duration_seconds, "Bucketed histogram of writting region into storage layer", Histogram,         \

--- a/dbms/src/Common/TiFlashMetrics.h
+++ b/dbms/src/Common/TiFlashMetrics.h
@@ -178,10 +178,13 @@ namespace DB
     M(tiflash_storage_page_write_duration_seconds, "The duration of each write batch", Histogram,                                         \
         F(type_total, {{"type", "total"}}, ExpBuckets{0.0001, 2, 20}),                                                                    \
         F(type_blob,  {{"type", "blob"}},  ExpBuckets{0.0001, 2, 20}),                                                                    \
+        F(type_choose_stat, {{"type", "choose_stat"}}, ExpBuckets{0.0001, 2, 20}),                                                        \
         /* the bucket range for apply in memory is 50us ~ 120s */                                                                         \
-        F(type_latch,  {{"type", "latch"}},   ExpBuckets{0.00005, 1.8, 26}),                                                              \
-        F(type_wal,    {{"type", "wal"}},     ExpBuckets{0.00005, 1.8, 26}),                                                              \
-        F(type_commit, {{"type", "commmit"}}, ExpBuckets{0.00005, 1.8, 26}))                                                              \
+        F(type_search_pos, {{"type", "search_pos"}}, ExpBuckets{0.00005, 1.8, 26}),                                                       \
+        F(type_blob_write, {{"type", "blob_write"}}, ExpBuckets{0.00005, 1.8, 26}),                                                       \
+        F(type_latch,      {{"type", "latch"}},      ExpBuckets{0.00005, 1.8, 26}),                                                       \
+        F(type_wal,        {{"type", "wal"}},        ExpBuckets{0.00005, 1.8, 26}),                                                       \
+        F(type_commit,     {{"type", "commmit"}},    ExpBuckets{0.00005, 1.8, 26}))                                                       \
     M(tiflash_storage_logical_throughput_bytes, "The logical throughput of read tasks of storage in bytes", Histogram,                    \
         F(type_read, {{"type", "read"}}, EqualWidthBuckets{1 * 1024 * 1024, 60, 50 * 1024 * 1024}))                                       \
     M(tiflash_storage_io_limiter, "Storage I/O limiter metrics", Counter, F(type_fg_read_req_bytes, {"type", "fg_read_req_bytes"}),       \

--- a/dbms/src/Common/TiFlashMetrics.h
+++ b/dbms/src/Common/TiFlashMetrics.h
@@ -176,14 +176,14 @@ namespace DB
     M(tiflash_storage_page_write_batch_size, "The size of each write batch in bytes", Histogram,                                          \
         F(type_v3, {{"type", "v3"}}, ExpBuckets{4 * 1024, 4, 10}))                                                                        \
     M(tiflash_storage_page_write_duration_seconds, "The duration of each write batch", Histogram,                                         \
-        F(type_total,       {{"type", "total"}},       ExpBuckets{0.0001, 2, 20}),                                                        \
-        F(type_choose_stat, {{"type", "choose_stat"}}, ExpBuckets{0.0001, 2, 20}),                                                        \
+        F(type_total, {{"type", "total"}}, ExpBuckets{0.0001, 2, 20}),                                                                    \
         /* the bucket range for apply in memory is 50us ~ 120s */                                                                         \
-        F(type_search_pos, {{"type", "search_pos"}}, ExpBuckets{0.00005, 1.8, 26}),                                                       \
-        F(type_blob_write, {{"type", "blob_write"}}, ExpBuckets{0.00005, 1.8, 26}),                                                       \
-        F(type_latch,      {{"type", "latch"}},      ExpBuckets{0.00005, 1.8, 26}),                                                       \
-        F(type_wal,        {{"type", "wal"}},        ExpBuckets{0.00005, 1.8, 26}),                                                       \
-        F(type_commit,     {{"type", "commmit"}},    ExpBuckets{0.00005, 1.8, 26}))                                                       \
+        F(type_choose_stat, {{"type", "choose_stat"}}, ExpBuckets{0.00005, 1.8, 26}),                                                     \
+        F(type_search_pos,  {{"type", "search_pos"}},  ExpBuckets{0.00005, 1.8, 26}),                                                     \
+        F(type_blob_write,  {{"type", "blob_write"}},  ExpBuckets{0.00005, 1.8, 26}),                                                     \
+        F(type_latch,       {{"type", "latch"}},       ExpBuckets{0.00005, 1.8, 26}),                                                     \
+        F(type_wal,         {{"type", "wal"}},         ExpBuckets{0.00005, 1.8, 26}),                                                     \
+        F(type_commit,      {{"type", "commit"}},      ExpBuckets{0.00005, 1.8, 26}))                                                     \
     M(tiflash_storage_logical_throughput_bytes, "The logical throughput of read tasks of storage in bytes", Histogram,                    \
         F(type_read, {{"type", "read"}}, EqualWidthBuckets{1 * 1024 * 1024, 60, 50 * 1024 * 1024}))                                       \
     M(tiflash_storage_io_limiter, "Storage I/O limiter metrics", Counter, F(type_fg_read_req_bytes, {"type", "fg_read_req_bytes"}),       \

--- a/dbms/src/Common/TiFlashMetrics.h
+++ b/dbms/src/Common/TiFlashMetrics.h
@@ -176,8 +176,7 @@ namespace DB
     M(tiflash_storage_page_write_batch_size, "The size of each write batch in bytes", Histogram,                                          \
         F(type_v3, {{"type", "v3"}}, ExpBuckets{4 * 1024, 4, 10}))                                                                        \
     M(tiflash_storage_page_write_duration_seconds, "The duration of each write batch", Histogram,                                         \
-        F(type_total, {{"type", "total"}}, ExpBuckets{0.0001, 2, 20}),                                                                    \
-        F(type_blob,  {{"type", "blob"}},  ExpBuckets{0.0001, 2, 20}),                                                                    \
+        F(type_total,       {{"type", "total"}},       ExpBuckets{0.0001, 2, 20}),                                                        \
         F(type_choose_stat, {{"type", "choose_stat"}}, ExpBuckets{0.0001, 2, 20}),                                                        \
         /* the bucket range for apply in memory is 50us ~ 120s */                                                                         \
         F(type_search_pos, {{"type", "search_pos"}}, ExpBuckets{0.00005, 1.8, 26}),                                                       \

--- a/dbms/src/Storages/Page/V3/Blob/BlobStat.cpp
+++ b/dbms/src/Storages/Page/V3/Blob/BlobStat.cpp
@@ -268,7 +268,7 @@ BlobStats::BlobStatPtr BlobStats::blobIdToStat(BlobFileId file_id, bool ignore_n
   * BlobStat methods *
   ********************/
 
-BlobFileOffset BlobStats::BlobStat::getPosFromStat(size_t buf_size, const std::lock_guard<std::mutex> &)
+BlobFileOffset BlobStats::BlobStat::getPosFromStat(size_t buf_size, const std::unique_lock<std::mutex> &)
 {
     BlobFileOffset offset = 0;
     UInt64 max_cap = 0;
@@ -306,7 +306,7 @@ BlobFileOffset BlobStats::BlobStat::getPosFromStat(size_t buf_size, const std::l
     return offset;
 }
 
-size_t BlobStats::BlobStat::removePosFromStat(BlobFileOffset offset, size_t buf_size, const std::lock_guard<std::mutex> &)
+size_t BlobStats::BlobStat::removePosFromStat(BlobFileOffset offset, size_t buf_size, const std::unique_lock<std::mutex> &)
 {
     if (!smap->markFree(offset, buf_size))
     {

--- a/dbms/src/Storages/Page/V3/Blob/BlobStat.h
+++ b/dbms/src/Storages/Page/V3/Blob/BlobStat.h
@@ -79,9 +79,14 @@ public:
             , sm_max_caps(sm_max_caps_)
         {}
 
-        [[nodiscard]] std::lock_guard<std::mutex> lock()
+        [[nodiscard]] std::unique_lock<std::mutex> lock()
         {
-            return std::lock_guard(sm_lock);
+            return std::unique_lock(sm_lock);
+        }
+
+        [[nodiscard]] std::unique_lock<std::mutex> defer_lock()
+        {
+            return std::unique_lock(sm_lock, std::defer_lock);
         }
 
         bool isNormal() const

--- a/dbms/src/Storages/Page/V3/Blob/BlobStat.h
+++ b/dbms/src/Storages/Page/V3/Blob/BlobStat.h
@@ -104,12 +104,12 @@ public:
             type.store(BlobStatType::READ_ONLY);
         }
 
-        BlobFileOffset getPosFromStat(size_t buf_size, const std::lock_guard<std::mutex> &);
+        BlobFileOffset getPosFromStat(size_t buf_size, const std::unique_lock<std::mutex> &);
 
         /**
              * The return value is the valid data size remained in the BlobFile after the remove
              */
-        size_t removePosFromStat(BlobFileOffset offset, size_t buf_size, const std::lock_guard<std::mutex> &);
+        size_t removePosFromStat(BlobFileOffset offset, size_t buf_size, const std::unique_lock<std::mutex> &);
 
         /**
              * This method is only used when blobstore restore

--- a/dbms/src/Storages/Page/V3/PageStorageImpl.cpp
+++ b/dbms/src/Storages/Page/V3/PageStorageImpl.cpp
@@ -130,7 +130,6 @@ void PageStorageImpl::writeImpl(DB::WriteBatch && write_batch, const WriteLimite
 
     // Persist Page data to BlobStore
     auto edit = blob_store.write(write_batch, write_limiter);
-    GET_METRIC(tiflash_storage_page_write_duration_seconds, type_blob).Observe(watch.elapsedSeconds());
     page_directory->apply(std::move(edit), write_limiter);
 }
 

--- a/dbms/src/Storages/Page/V3/spacemap/SpaceMapSTDMap.h
+++ b/dbms/src/Storages/Page/V3/spacemap/SpaceMapSTDMap.h
@@ -54,9 +54,9 @@ protected:
     STDMapSpaceMap(UInt64 start, UInt64 end)
         : SpaceMap(start, end, SMAP64_STD_MAP)
     {
-        free_map.insert({start, end});
+        free_map.insert({start, end - start});
         std::set<UInt64> offsets{start};
-        free_map_invert_index.emplace(end, offsets);
+        free_map_invert_index.emplace(end - start, offsets);
     }
 
     String toDebugString() override
@@ -344,7 +344,9 @@ protected:
 private:
     inline void deleteFromInvertIndex(UInt64 length, UInt64 offset)
     {
-        auto & offsets = free_map_invert_index[length];
+        auto index_iter = free_map_invert_index.find(length);
+        RUNTIME_CHECK_MSG(index_iter != free_map_invert_index.end(), "Fail to find length {} offset {} in free_map_invert_index", length, offset);
+        auto & offsets = index_iter->second;
         offsets.erase(offset);
         if (offsets.empty())
         {

--- a/dbms/src/Storages/Page/V3/tests/gtest_blob_stat.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_blob_stat.cpp
@@ -183,38 +183,38 @@ TEST_F(BlobStoreStatsTest, testStat)
     ASSERT_EQ(blob_file_id, INVALID_BLOBFILE_ID);
     ASSERT_TRUE(stat);
 
-    auto offset = stat->getPosFromStat(10, stats.lock());
+    auto offset = stat->getPosFromStat(10, stat->lock());
     ASSERT_EQ(offset, 0);
 
-    offset = stat->getPosFromStat(100, stats.lock());
+    offset = stat->getPosFromStat(100, stat->lock());
     ASSERT_EQ(offset, 10);
 
-    offset = stat->getPosFromStat(20, stats.lock());
+    offset = stat->getPosFromStat(20, stat->lock());
     ASSERT_EQ(offset, 110);
 
     ASSERT_EQ(stat->sm_total_size, 10 + 100 + 20);
     ASSERT_EQ(stat->sm_valid_size, 10 + 100 + 20);
     ASSERT_EQ(stat->sm_valid_rate, 1);
 
-    stat->removePosFromStat(10, 100, stats.lock());
+    stat->removePosFromStat(10, 100, stat->lock());
     ASSERT_EQ(stat->sm_total_size, 10 + 100 + 20);
     ASSERT_EQ(stat->sm_valid_size, 10 + 20);
     ASSERT_LE(stat->sm_valid_rate, 1);
 
-    offset = stat->getPosFromStat(110, stats.lock());
+    offset = stat->getPosFromStat(110, stat->lock());
     ASSERT_EQ(offset, 130);
     ASSERT_EQ(stat->sm_total_size, 10 + 100 + 20 + 110);
     ASSERT_EQ(stat->sm_valid_size, 10 + 20 + 110);
     ASSERT_LE(stat->sm_valid_rate, 1);
 
-    offset = stat->getPosFromStat(90, stats.lock());
+    offset = stat->getPosFromStat(90, stat->lock());
     ASSERT_EQ(offset, 10);
     ASSERT_EQ(stat->sm_total_size, 10 + 100 + 20 + 110);
     ASSERT_EQ(stat->sm_valid_size, 10 + 20 + 110 + 90);
     ASSERT_LE(stat->sm_valid_rate, 1);
 
     // Unmark the last range
-    stat->removePosFromStat(130, 110, stats.lock());
+    stat->removePosFromStat(130, 110, stat->lock());
     ASSERT_EQ(stat->sm_total_size, 10 + 100 + 20 + 110);
     ASSERT_EQ(stat->sm_valid_size, 10 + 20 + 90);
     ASSERT_LE(stat->sm_valid_rate, 1);
@@ -227,7 +227,7 @@ TEST_F(BlobStoreStatsTest, testStat)
      * Total size should plus 10, rather than 120.
      * And the postion return should be last range freed.
      */
-    offset = stat->getPosFromStat(120, stats.lock());
+    offset = stat->getPosFromStat(120, stat->lock());
     ASSERT_EQ(offset, 130);
     ASSERT_EQ(stat->sm_total_size, 10 + 100 + 20 + 110 + 10);
     ASSERT_EQ(stat->sm_valid_size, 10 + 20 + 90 + 120);
@@ -243,11 +243,11 @@ TEST_F(BlobStoreStatsTest, testFullStats)
     BlobStats stats(logger, delegator, config);
 
     stat = stats.createStat(1, config.file_limit_size, stats.lock());
-    offset = stat->getPosFromStat(BLOBFILE_LIMIT_SIZE - 1, stats.lock());
+    offset = stat->getPosFromStat(BLOBFILE_LIMIT_SIZE - 1, stat->lock());
     ASSERT_EQ(offset, 0);
 
     // Can't get pos from a full stat
-    offset = stat->getPosFromStat(100, stats.lock());
+    offset = stat->getPosFromStat(100, stat->lock());
     ASSERT_EQ(offset, INVALID_BLOBFILE_OFFSET);
 
     // Stat internal property should not changed
@@ -262,14 +262,14 @@ TEST_F(BlobStoreStatsTest, testFullStats)
 
     // A new stat can use
     stat = stats.createStat(blob_file_id, config.file_limit_size, stats.lock());
-    offset = stat->getPosFromStat(100, stats.lock());
+    offset = stat->getPosFromStat(100, stat->lock());
     ASSERT_EQ(offset, 0);
 
     // Remove the stat which id is 0 , now remain the stat which id is 1
     stats.eraseStat(1, stats.lock());
 
     // Then full the stat which id 2
-    offset = stat->getPosFromStat(BLOBFILE_LIMIT_SIZE - 100, stats.lock());
+    offset = stat->getPosFromStat(BLOBFILE_LIMIT_SIZE - 100, stat->lock());
     ASSERT_EQ(offset, 100);
 
     // Then choose stat , it should return the stat id 3

--- a/dbms/src/Storages/Page/V3/tests/gtest_free_map.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_free_map.cpp
@@ -290,13 +290,13 @@ TEST_P(SpaceMapTest, TestSearch)
 
     std::tie(offset, max_cap, expansion) = smap->searchInsertOffset(20);
 
-    ASSERT_EQ(offset, 0);
-    ASSERT_EQ(max_cap, 40);
-    ASSERT_EQ(expansion, false);
+    ASSERT_EQ(offset, 60);
+    ASSERT_EQ(max_cap, 50);
+    ASSERT_EQ(expansion, true);
 
-    Range ranges1[] = {{.start = 20,
+    Range ranges1[] = {{.start = 0,
                         .end = 50},
-                       {.start = 60,
+                       {.start = 80,
                         .end = 100}};
     ASSERT_TRUE(smap->check(genChecker(ranges1, 2), 2));
 
@@ -307,13 +307,13 @@ TEST_P(SpaceMapTest, TestSearch)
     ASSERT_TRUE(smap->markUsed(50, 10));
 
     std::tie(offset, max_cap, expansion) = smap->searchInsertOffset(5);
-    ASSERT_EQ(offset, 0);
-    ASSERT_EQ(max_cap, 45);
-    ASSERT_EQ(expansion, false);
+    ASSERT_EQ(offset, 60);
+    ASSERT_EQ(max_cap, 50);
+    ASSERT_EQ(expansion, true);
 
-    Range ranges2[] = {{.start = 5,
+    Range ranges2[] = {{.start = 0,
                         .end = 50},
-                       {.start = 60,
+                       {.start = 65,
                         .end = 100}};
     ASSERT_TRUE(smap->check(genChecker(ranges2, 2), 2));
 
@@ -488,9 +488,9 @@ TEST(SpaceMapSTDMapTest, TestMarkFreeSearch)
     }
     {
         ASSERT_TRUE(smap->markFree(25, 25));
-        // After calling `markFree`, the `hint_biggest_offset` and `hint_biggest_cap` is not accurate.
-        ASSERT_EQ(smap_std->hint_biggest_offset, 50);
-        ASSERT_EQ(smap_std->hint_biggest_cap, 50);
+        auto iter = smap_std->free_map_invert_index.rbegin();
+        ASSERT_EQ(*(iter->second.begin()), 25);
+        ASSERT_EQ(iter->first, 75);
 
         // Allocate a space the same size as current actual `biggest_cap`
         std::tie(offset, max_cap, expansion) = smap->searchInsertOffset(75);
@@ -513,8 +513,9 @@ TEST(SpaceMapSTDMapTest, TestMarkFreeSearch)
     }
     {
         ASSERT_TRUE(smap->markFree(25, 25));
-        ASSERT_EQ(smap_std->hint_biggest_offset, 50);
-        ASSERT_EQ(smap_std->hint_biggest_cap, 50);
+        auto iter = smap_std->free_map_invert_index.rbegin();
+        ASSERT_EQ(*(iter->second.begin()), 25);
+        ASSERT_EQ(iter->first, 75);
 
         // Allocate a space smaller than current actual `biggest_cap`
         std::tie(offset, max_cap, expansion) = smap->searchInsertOffset(50);

--- a/dbms/src/Storages/Transaction/KVStore.cpp
+++ b/dbms/src/Storages/Transaction/KVStore.cpp
@@ -406,6 +406,7 @@ bool KVStore::canFlushRegionDataImpl(const RegionPtr & curr_region_ptr, UInt8 fl
 
 bool KVStore::forceFlushRegionDataImpl(Region & curr_region, bool try_until_succeed, TMTContext & tmt, const RegionTaskLock & region_task_lock, UInt64 index, UInt64 term)
 {
+    Stopwatch watch;
     if (index)
     {
         // We set actual index when handling CompactLog.
@@ -416,6 +417,7 @@ bool KVStore::forceFlushRegionDataImpl(Region & curr_region, bool try_until_succ
         persistRegion(curr_region, region_task_lock, "tryFlushRegionData");
         curr_region.markCompactLog();
         curr_region.cleanApproxMemCacheInfo();
+        GET_METRIC(tiflash_raft_apply_write_command_duration_seconds, type_flush_region).Observe(watch.elapsedSeconds());
         return true;
     }
     else


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #6404 

Problem Summary: The process to search an available space in BlobFile is an O(n) operation and introduce too much latency for the whole write process.

### What is changed and how it works?
1. Introduce a `free_map_invert_index` to eliminate the O(n) operation;
2. Skip BlobFiles which are already locked when search for an available space for write;

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
