### PR TITLE
Revert "Use `num_streams` as parallelism when read thread is enabled."

### DIFF
--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -902,11 +902,10 @@ BlockInputStreams DeltaMergeStore::readRaw(const Context & db_context,
     auto after_segment_read = [&](const DMContextPtr & dm_context_, const SegmentPtr & segment_) {
         this->checkSegmentUpdate(dm_context_, segment_, ThreadType::Read);
     };
+    size_t final_num_stream = std::min(num_streams, tasks.size());
     String req_info;
     if (db_context.getDAGContext() != nullptr && db_context.getDAGContext()->isMPPTask())
         req_info = db_context.getDAGContext()->getMPPTaskId().toString();
-    // We can use num_streams as parallelism when read thread is enabled.
-    size_t final_num_stream = enable_read_thread ? num_streams : std::min(num_streams, tasks.size());
     auto read_task_pool = std::make_shared<SegmentReadTaskPool>(
         physical_table_id,
         dm_context,
@@ -921,23 +920,21 @@ BlockInputStreams DeltaMergeStore::readRaw(const Context & db_context,
         enable_read_thread);
 
     BlockInputStreams res;
-    if (enable_read_thread)
+    for (size_t i = 0; i < final_num_stream; ++i)
     {
-        for (size_t i = 0; i < final_num_stream; ++i)
+        BlockInputStreamPtr stream;
+        if (enable_read_thread)
         {
-            res.emplace_back(std::make_shared<UnorderedInputStream>(
+            stream = std::make_shared<UnorderedInputStream>(
                 read_task_pool,
                 columns_to_read,
                 extra_table_id_index,
                 physical_table_id,
-                req_info));
+                req_info);
         }
-    }
-    else
-    {
-        for (size_t i = 0; i < final_num_stream; ++i)
+        else
         {
-            res.emplace_back(std::make_shared<DMSegmentThreadInputStream>(
+            stream = std::make_shared<DMSegmentThreadInputStream>(
                 dm_context,
                 read_task_pool,
                 after_segment_read,
@@ -948,8 +945,9 @@ BlockInputStreams DeltaMergeStore::readRaw(const Context & db_context,
                 /* read_mode */ ReadMode::Raw,
                 extra_table_id_index,
                 physical_table_id,
-                req_info));
+                req_info);
         }
+        res.push_back(stream);
     }
     return res;
 }
@@ -992,8 +990,7 @@ BlockInputStreams DeltaMergeStore::read(const Context & db_context,
     };
 
     GET_METRIC(tiflash_storage_read_tasks_count).Increment(tasks.size());
-    // We can use num_streams as parallelism when read thread is enabled.
-    size_t final_num_stream = enable_read_thread ? std::max(1, num_streams) : std::max(1, std::min(num_streams, tasks.size()));
+    size_t final_num_stream = std::max(1, std::min(num_streams, tasks.size()));
     auto read_task_pool = std::make_shared<SegmentReadTaskPool>(
         physical_table_id,
         dm_context,
@@ -1008,23 +1005,21 @@ BlockInputStreams DeltaMergeStore::read(const Context & db_context,
         enable_read_thread);
 
     BlockInputStreams res;
-    if (enable_read_thread)
+    for (size_t i = 0; i < final_num_stream; ++i)
     {
-        for (size_t i = 0; i < final_num_stream; ++i)
+        BlockInputStreamPtr stream;
+        if (enable_read_thread)
         {
-            res.emplace_back(std::make_shared<UnorderedInputStream>(
+            stream = std::make_shared<UnorderedInputStream>(
                 read_task_pool,
                 columns_to_read,
                 extra_table_id_index,
                 physical_table_id,
-                log_tracing_id));
+                log_tracing_id);
         }
-    }
-    else
-    {
-        for (size_t i = 0; i < final_num_stream; ++i)
+        else
         {
-            res.emplace_back(std::make_shared<DMSegmentThreadInputStream>(
+            stream = std::make_shared<DMSegmentThreadInputStream>(
                 dm_context,
                 read_task_pool,
                 after_segment_read,
@@ -1035,8 +1030,9 @@ BlockInputStreams DeltaMergeStore::read(const Context & db_context,
                 /* read_mode = */ is_fast_scan ? ReadMode::Fast : ReadMode::Normal,
                 extra_table_id_index,
                 physical_table_id,
-                log_tracing_id));
+                log_tracing_id);
         }
+        res.push_back(stream);
     }
     LOG_DEBUG(tracing_logger, "Read create stream done");
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #6409 

Problem Summary:

### What is changed and how it works?

Reverts pingcap/tiflash#6344

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
