### PR TITLE
storage: Allow segment to be merged close to base size

### DIFF
--- a/dbms/src/Storages/DeltaMerge/DMContext.h
+++ b/dbms/src/Storages/DeltaMerge/DMContext.h
@@ -75,10 +75,6 @@ struct DMContext : private boost::noncopyable
     const size_t delta_small_column_file_bytes;
     // The expected stable pack rows.
     const size_t stable_pack_rows;
-    // The rows of segment to be regarded as small. Small segments will be merged.
-    const size_t small_segment_rows;
-    // The bytes of segment to be regarded as small. Small segments will be merged.
-    const size_t small_segment_bytes;
 
     // The number of points to check for calculating region split.
     const size_t region_split_check_points = 128;
@@ -121,8 +117,6 @@ public:
         , delta_small_column_file_rows(settings.dt_segment_delta_small_column_file_rows)
         , delta_small_column_file_bytes(settings.dt_segment_delta_small_column_file_size)
         , stable_pack_rows(settings.dt_segment_stable_pack_rows)
-        , small_segment_rows(settings.dt_segment_limit_rows / 3)
-        , small_segment_bytes(settings.dt_segment_limit_size / 3)
         , enable_logical_split(settings.dt_enable_logical_split)
         , read_delta_only(settings.dt_read_delta_only)
         , read_stable_only(settings.dt_read_stable_only)

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalBg.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalBg.cpp
@@ -160,8 +160,8 @@ std::vector<SegmentPtr> DeltaMergeStore::getMergeableSegments(const DMContextPtr
     // Note: it is possible that there is a very small segment close to a very large segment.
     // In this case, the small segment will not get merged. It is possible that we can allow
     // segment merging for this case in future.
-    auto max_total_rows = context->small_segment_rows;
-    auto max_total_bytes = context->small_segment_bytes;
+    auto max_total_rows = context->segment_limit_rows;
+    auto max_total_bytes = context->segment_limit_bytes;
 
     std::vector<SegmentPtr> results;
     {
@@ -517,7 +517,7 @@ SegmentPtr DeltaMergeStore::gcTrySegmentMerge(const DMContextPtr & dm_context, c
 {
     auto segment_rows = segment->getEstimatedRows();
     auto segment_bytes = segment->getEstimatedBytes();
-    if (segment_rows >= dm_context->small_segment_rows || segment_bytes >= dm_context->small_segment_bytes)
+    if (segment_rows >= dm_context->segment_limit_rows || segment_bytes >= dm_context->segment_limit_bytes)
     {
         LOG_TRACE(
             log,


### PR DESCRIPTION
Signed-off-by: Wish <breezewish@outlook.com>

### What problem does this PR solve?

Issue Number: ref #6414

Problem Summary:

### What is changed and how it works?

In https://github.com/pingcap/tiflash/pull/5863 we will only merge segments when the merged size is <= 1/3 * base size. It improves performance but lead to more fragmented IO and higher memory usage.

This PR change the merge policy so that merged size could be <= 1 * base size.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
