### PR TITLE
Use `BlockIO.in->cancel` directly to avoid possible blocking of ProcessList::mutex

### DIFF
--- a/dbms/src/Flash/Mpp/MPPTask.h
+++ b/dbms/src/Flash/Mpp/MPPTask.h
@@ -107,6 +107,10 @@ private:
 
     int estimateCountOfNewThreads();
 
+    void sendCancelToQuery(bool kill);
+
+    BlockInputStreamPtr getDataStream();
+
     tipb::DAGRequest dag_req;
 
     ContextPtr context;
@@ -125,6 +129,10 @@ private:
 
     // which targeted task we should send data by which tunnel.
     std::unordered_map<MPPTaskId, MPPTunnelPtr> tunnel_map;
+
+    std::mutex stream_mu;
+    // must destroy before DAGContext.
+    BlockInputStreamPtr data_stream;
 
     MPPTaskManager * manager = nullptr;
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6418 

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Avoiding tiflash global locks with small probability of long term blocking.
```
