### PR TITLE
reduce column files num under heavy write pressure

### DIFF
--- a/dbms/src/Storages/DeltaMerge/Delta/ColumnFileFlushTask.cpp
+++ b/dbms/src/Storages/DeltaMerge/Delta/ColumnFileFlushTask.cpp
@@ -91,7 +91,7 @@ bool ColumnFileFlushTask::commit(ColumnFilePersistedSetPtr & persisted_file_set,
     }
 
     // serialize metadata and update persisted_file_set
-    if (!persisted_file_set->appendPersistedColumnFilesToLevel0(new_column_files, wbs))
+    if (!persisted_file_set->appendPersistedColumnFiles(new_column_files, wbs))
         return false;
 
     mem_table_set->removeColumnFilesInFlushTask(*this);

--- a/dbms/src/Storages/DeltaMerge/Delta/ColumnFilePersistedSet.cpp
+++ b/dbms/src/Storages/DeltaMerge/Delta/ColumnFilePersistedSet.cpp
@@ -138,7 +138,7 @@ ColumnFilePersisteds ColumnFilePersistedSet::diffColumnFiles(const ColumnFiles &
         while (it_1 != previous_column_files.end() && it_2 != persisted_files.end())
         {
             // We allow passing unflushed memtable files to `previous_column_files`, these heads will be skipped anyway.
-            if (!(*it_2)->mayBeFlushedFrom(&**it_1) && !(*it_2)->isSame(&**it_1))
+            if (!(*it_2)->mayBeFlushedFrom(&(**it_1)) && !(*it_2)->isSame(&(**it_1)))
             {
                 check_success = false;
                 break;

--- a/dbms/src/Storages/DeltaMerge/Delta/ColumnFilePersistedSet.cpp
+++ b/dbms/src/Storages/DeltaMerge/Delta/ColumnFilePersistedSet.cpp
@@ -64,17 +64,14 @@ void ColumnFilePersistedSet::checkColumnFiles(const ColumnFilePersisteds & new_c
         new_deletes += file->isDeleteRange();
     }
 
-    if (unlikely(new_rows != rows || new_deletes != deletes))
-    {
-        LOG_ERROR(log, "Rows and deletes check failed. Actual: rows[{}], deletes[{}]. Expected: rows[{}], deletes[{}]. Current column files: {}, new column files: {}.", //
-                  new_rows,
-                  new_deletes,
-                  rows.load(),
-                  deletes.load(),
-                  columnFilesToString(persisted_files),
-                  columnFilesToString(new_column_files));
-        throw Exception("Rows and deletes check failed.", ErrorCodes::LOGICAL_ERROR);
-    }
+    RUNTIME_CHECK_MSG(new_rows == rows && new_deletes == deletes,
+                      "Rows and deletes check failed. Actual: rows[{}], deletes[{}]. Expected: rows[{}], deletes[{}]. Current column files: {}, new column files: {}.", //
+                      new_rows,
+                      new_deletes,
+                      rows.load(),
+                      deletes.load(),
+                      columnFilesToString(persisted_files),
+                      columnFilesToString(new_column_files));
 }
 
 ColumnFilePersistedSet::ColumnFilePersistedSet( //

--- a/dbms/src/Storages/DeltaMerge/Delta/ColumnFilePersistedSet.cpp
+++ b/dbms/src/Storages/DeltaMerge/Delta/ColumnFilePersistedSet.cpp
@@ -27,70 +27,52 @@ namespace DB
 {
 namespace DM
 {
-inline ColumnFilePersisteds flattenColumnFileLevels(const ColumnFilePersistedSet::ColumnFilePersistedLevels & file_levels)
-{
-    ColumnFilePersisteds column_files;
-    // Last level first
-    for (auto level_it = file_levels.rbegin(); level_it != file_levels.rend(); ++level_it)
-    {
-        for (const auto & file : *level_it)
-        {
-            column_files.emplace_back(file);
-        }
-    }
-    return column_files;
-}
-
-inline void serializeColumnFilePersistedLevels(WriteBatches & wbs, PageId id, const ColumnFilePersistedSet::ColumnFilePersistedLevels & file_levels)
+inline void serializeColumnFilePersisteds(WriteBatches & wbs, PageId id, const ColumnFilePersisteds & persisted_files)
 {
     MemoryWriteBuffer buf(0, COLUMN_FILE_SERIALIZE_BUFFER_SIZE);
-    auto column_files = flattenColumnFileLevels(file_levels);
-    serializeSavedColumnFiles(buf, column_files);
+    serializeSavedColumnFiles(buf, persisted_files);
     auto data_size = buf.count();
     wbs.meta.putPage(id, 0, buf.tryGetReadBuffer(), data_size);
 }
 
 void ColumnFilePersistedSet::updateColumnFileStats()
 {
-    size_t new_persisted_files_count = 0;
     size_t new_rows = 0;
     size_t new_bytes = 0;
     size_t new_deletes = 0;
-    for (auto & file_level : persisted_files_levels)
+    for (auto & file : persisted_files)
     {
-        new_persisted_files_count += file_level.size();
-        for (auto & file : file_level)
-        {
-            new_rows += file->getRows();
-            new_bytes += file->getBytes();
-            new_deletes += file->getDeletes();
-        }
+        new_rows += file->getRows();
+        new_bytes += file->getBytes();
+        new_deletes += file->getDeletes();
     }
-    persisted_files_count = new_persisted_files_count;
-    persisted_files_level_count = persisted_files_levels.size();
+    persisted_files_count = persisted_files.size();
     rows = new_rows;
     bytes = new_bytes;
     deletes = new_deletes;
 }
 
-void ColumnFilePersistedSet::checkColumnFiles(const ColumnFilePersistedLevels & new_column_file_levels)
+void ColumnFilePersistedSet::checkColumnFiles(const ColumnFilePersisteds & new_column_files)
 {
     if constexpr (!DM_RUN_CHECK)
         return;
     size_t new_rows = 0;
     size_t new_deletes = 0;
-    for (const auto & level : new_column_file_levels)
+    for (const auto & file : new_column_files)
     {
-        for (const auto & file : level)
-        {
-            new_rows += file->getRows();
-            new_deletes += file->isDeleteRange();
-        }
+        new_rows += file->getRows();
+        new_deletes += file->isDeleteRange();
     }
 
     if (unlikely(new_rows != rows || new_deletes != deletes))
     {
-        LOG_ERROR(log, "Rows and deletes check failed. Actual: rows[{}], deletes[{}]. Expected: rows[{}], deletes[{}]. Current column files: {}, new column files: {}.", new_rows, new_deletes, rows.load(), deletes.load(), columnFilesToString(flattenColumnFileLevels(persisted_files_levels)), columnFilesToString(flattenColumnFileLevels(new_column_file_levels)));
+        LOG_ERROR(log, "Rows and deletes check failed. Actual: rows[{}], deletes[{}]. Expected: rows[{}], deletes[{}]. Current column files: {}, new column files: {}.", //
+                  new_rows,
+                  new_deletes,
+                  rows.load(),
+                  deletes.load(),
+                  columnFilesToString(persisted_files),
+                  columnFilesToString(new_column_files));
         throw Exception("Rows and deletes check failed.", ErrorCodes::LOGICAL_ERROR);
     }
 }
@@ -99,11 +81,9 @@ ColumnFilePersistedSet::ColumnFilePersistedSet( //
     PageId metadata_id_,
     const ColumnFilePersisteds & persisted_column_files)
     : metadata_id(metadata_id_)
+    , persisted_files(persisted_column_files)
     , log(Logger::get())
 {
-    // TODO: place column file to different levels, but it seems no need to do it currently because we only do minor compaction on really small files?
-    persisted_files_levels.push_back(persisted_column_files);
-
     updateColumnFileStats();
 }
 
@@ -120,27 +100,21 @@ ColumnFilePersistedSetPtr ColumnFilePersistedSet::restore( //
 
 void ColumnFilePersistedSet::saveMeta(WriteBatches & wbs) const
 {
-    serializeColumnFilePersistedLevels(wbs, metadata_id, persisted_files_levels);
+    serializeColumnFilePersisteds(wbs, metadata_id, persisted_files);
 }
 
 void ColumnFilePersistedSet::recordRemoveColumnFilesPages(WriteBatches & wbs) const
 {
-    for (const auto & level : persisted_files_levels)
-    {
-        for (const auto & file : level)
-            file->removeData(wbs);
-    }
+    for (const auto & file : persisted_files)
+        file->removeData(wbs);
 }
 
 BlockPtr ColumnFilePersistedSet::getLastSchema()
 {
-    for (const auto & level : persisted_files_levels)
+    for (auto it = persisted_files.rbegin(); it != persisted_files.rend(); ++it)
     {
-        for (auto it = level.rbegin(); it != level.rend(); ++it)
-        {
-            if (auto * t_file = (*it)->tryToTinyFile(); t_file)
-                return t_file->getSchema();
-        }
+        if (auto * t_file = (*it)->tryToTinyFile(); t_file)
+            return t_file->getSchema();
     }
     return {};
 }
@@ -156,26 +130,15 @@ ColumnFilePersisteds ColumnFilePersistedSet::diffColumnFiles(const ColumnFiles &
     //       that this function is called under a for_update snapshot context.
     RUNTIME_CHECK(previous_column_files.size() <= getColumnFileCount());
 
-    // We check in the direction from the last level to the first level.
-    // In every level, we check from the begin to the last.
     auto it_1 = previous_column_files.begin();
-    auto level_it = persisted_files_levels.rbegin();
-    auto it_2 = level_it->begin();
+    auto it_2 = persisted_files.begin();
     bool check_success = true;
     if (likely(previous_column_files.size() <= persisted_files_count.load()))
     {
-        while (it_1 != previous_column_files.end() && level_it != persisted_files_levels.rend())
+        while (it_1 != previous_column_files.end() && it_2 != persisted_files.end())
         {
-            if (it_2 == level_it->end())
-            {
-                level_it++;
-                if (unlikely(level_it == persisted_files_levels.rend()))
-                    throw Exception("Delta Check head algorithm broken", ErrorCodes::LOGICAL_ERROR);
-                it_2 = level_it->begin();
-                continue;
-            }
             // We allow passing unflushed memtable files to `previous_column_files`, these heads will be skipped anyway.
-            if (!(*it_2)->mayBeFlushedFrom(&**it_1) && !(*it_1)->isSame(&**it_1))
+            if (!(*it_2)->mayBeFlushedFrom(&**it_1) && !(*it_2)->isSame(&**it_1))
             {
                 check_success = false;
                 break;
@@ -196,21 +159,13 @@ ColumnFilePersisteds ColumnFilePersistedSet::diffColumnFiles(const ColumnFiles &
 
     if (unlikely(!check_success))
     {
-        LOG_ERROR(log, "{}, Delta Check head failed, unexpected size. head column files: {}, level details: {}", info(), columnFilesToString(previous_column_files), levelsInfo());
+        LOG_ERROR(log, "{}, Delta Check head failed, unexpected size. head column files: {}, persisted column files: {}", info(), columnFilesToString(previous_column_files), detailInfo());
         throw Exception("Check head failed, unexpected size", ErrorCodes::LOGICAL_ERROR);
     }
 
     ColumnFilePersisteds tail;
-    while (level_it != persisted_files_levels.rend())
+    while (it_2 != persisted_files.end())
     {
-        if (it_2 == level_it->end())
-        {
-            level_it++;
-            if (level_it == persisted_files_levels.rend())
-                break;
-            it_2 = level_it->begin();
-            continue;
-        }
         const auto & column_file = *it_2;
         tail.push_back(column_file);
         it_2++;
@@ -222,15 +177,12 @@ ColumnFilePersisteds ColumnFilePersistedSet::diffColumnFiles(const ColumnFiles &
 size_t ColumnFilePersistedSet::getTotalCacheRows() const
 {
     size_t cache_rows = 0;
-    for (const auto & level : persisted_files_levels)
+    for (const auto & file : persisted_files)
     {
-        for (const auto & file : level)
+        if (auto * tf = file->tryToTinyFile(); tf)
         {
-            if (auto * tf = file->tryToTinyFile(); tf)
-            {
-                if (auto && c = tf->getCache(); c)
-                    cache_rows += c->block.rows();
-            }
+            if (auto && c = tf->getCache(); c)
+                cache_rows += c->block.rows();
         }
     }
     return cache_rows;
@@ -239,15 +191,12 @@ size_t ColumnFilePersistedSet::getTotalCacheRows() const
 size_t ColumnFilePersistedSet::getTotalCacheBytes() const
 {
     size_t cache_bytes = 0;
-    for (const auto & level : persisted_files_levels)
+    for (const auto & file : persisted_files)
     {
-        for (const auto & file : level)
+        if (auto * tf = file->tryToTinyFile(); tf)
         {
-            if (auto * tf = file->tryToTinyFile(); tf)
-            {
-                if (auto && c = tf->getCache(); c)
-                    cache_bytes += c->block.allocatedBytes();
-            }
+            if (auto && c = tf->getCache(); c)
+                cache_bytes += c->block.allocatedBytes();
         }
     }
     return cache_bytes;
@@ -256,15 +205,12 @@ size_t ColumnFilePersistedSet::getTotalCacheBytes() const
 size_t ColumnFilePersistedSet::getValidCacheRows() const
 {
     size_t cache_rows = 0;
-    for (const auto & level : persisted_files_levels)
+    for (const auto & file : persisted_files)
     {
-        for (const auto & file : level)
+        if (auto * tf = file->tryToTinyFile(); tf)
         {
-            if (auto * tf = file->tryToTinyFile(); tf)
-            {
-                if (auto && c = tf->getCache(); c)
-                    cache_rows += tf->getRows();
-            }
+            if (auto && c = tf->getCache(); c)
+                cache_rows += tf->getRows();
         }
     }
     return cache_rows;
@@ -281,91 +227,76 @@ bool ColumnFilePersistedSet::checkAndIncreaseFlushVersion(size_t task_flush_vers
     return true;
 }
 
-bool ColumnFilePersistedSet::appendPersistedColumnFilesToLevel0(const ColumnFilePersisteds & column_files, WriteBatches & wbs)
+bool ColumnFilePersistedSet::appendPersistedColumnFiles(const ColumnFilePersisteds & column_files, WriteBatches & wbs)
 {
-    ColumnFilePersistedLevels new_persisted_files_levels;
-    for (auto & level : persisted_files_levels)
+    ColumnFilePersisteds new_persisted_files;
+    for (const auto & file : persisted_files)
     {
-        auto & new_level = new_persisted_files_levels.emplace_back();
-        for (auto & file : level)
-            new_level.push_back(file);
+        new_persisted_files.push_back(file);
     }
-    if (new_persisted_files_levels.empty())
-        new_persisted_files_levels.emplace_back();
-    auto & new_level_0 = new_persisted_files_levels[0];
-
-    for (const auto & f : column_files)
-        new_level_0.push_back(f);
-
+    for (const auto & file : column_files)
+    {
+        new_persisted_files.push_back(file);
+    }
     /// Save the new metadata of column files to disk.
-    serializeColumnFilePersistedLevels(wbs, metadata_id, new_persisted_files_levels);
+    serializeColumnFilePersisteds(wbs, metadata_id, new_persisted_files);
     wbs.writeMeta();
 
     /// Commit updates in memory.
-    persisted_files_levels.swap(new_persisted_files_levels);
+    persisted_files.swap(new_persisted_files);
     updateColumnFileStats();
-    LOG_DEBUG(log, "{}, after append {} column files, level info: {}", info(), column_files.size(), levelsInfo());
+    LOG_DEBUG(log, "{}, after append {} column files, persisted column files: {}", info(), column_files.size(), detailInfo());
 
     return true;
 }
 
 MinorCompactionPtr ColumnFilePersistedSet::pickUpMinorCompaction(DMContext & context)
 {
-    // Every time we try to compact all column files in a specific level.
+    // Every time we try to compact all column files.
     // For ColumnFileTiny, we will try to combine small `ColumnFileTiny`s to a bigger one.
-    // For ColumnFileDeleteRange and ColumnFileBig, we will simply move them to the next level.
-    // And only if there exists some small `ColumnFileTiny`s which can be combined together, we will actually do the compaction.
-    size_t check_level_num = 0;
-    while (check_level_num < persisted_files_levels.size())
+    // For ColumnFileDeleteRange and ColumnFileBig, we keep them intact.
+    // And only if there exists some small `ColumnFileTiny`s which can be combined, we will actually do the compaction.
+    auto compaction = std::make_shared<MinorCompaction>(minor_compaction_version);
+    if (!persisted_files.empty())
     {
-        check_level_num += 1;
-        if (next_compaction_level >= persisted_files_levels.size())
-            next_compaction_level = 0;
-
-        auto compaction = std::make_shared<MinorCompaction>(next_compaction_level, minor_compaction_version);
-        auto & level = persisted_files_levels[next_compaction_level];
-        next_compaction_level++;
-        if (!level.empty())
+        bool is_all_trivial_move = true;
+        MinorCompaction::Task cur_task;
+        for (auto & file : persisted_files)
         {
-            bool is_all_trivial_move = true;
-            MinorCompaction::Task cur_task;
-            for (auto & file : level)
+            auto pack_up_cur_task = [&]() {
+                bool is_trivial_move = compaction->packUpTask(std::move(cur_task));
+                is_all_trivial_move = is_all_trivial_move && is_trivial_move;
+                cur_task = {};
+            };
+
+            if (auto * t_file = file->tryToTinyFile(); t_file)
             {
-                auto pack_up_cur_task = [&]() {
-                    bool is_trivial_move = compaction->packUpTask(std::move(cur_task));
-                    is_all_trivial_move = is_all_trivial_move && is_trivial_move;
-                    cur_task = {};
-                };
+                bool cur_task_full = cur_task.total_rows >= context.delta_small_column_file_rows;
+                bool small_column_file = t_file->getRows() < context.delta_small_column_file_rows;
+                bool schema_ok = cur_task.to_compact.empty();
 
-                if (auto * t_file = file->tryToTinyFile(); t_file)
+                if (!schema_ok)
                 {
-                    bool cur_task_full = cur_task.total_rows >= context.delta_small_column_file_rows;
-                    bool small_column_file = t_file->getRows() < context.delta_small_column_file_rows;
-                    bool schema_ok = cur_task.to_compact.empty();
-
-                    if (!schema_ok)
-                    {
-                        if (auto * last_t_file = cur_task.to_compact.back()->tryToTinyFile(); last_t_file)
-                            schema_ok = t_file->getSchema() == last_t_file->getSchema();
-                    }
-
-                    if (cur_task_full || !small_column_file || !schema_ok)
-                        pack_up_cur_task();
-
-                    cur_task.addColumnFile(file);
+                    if (auto * last_t_file = cur_task.to_compact.back()->tryToTinyFile(); last_t_file)
+                        schema_ok = t_file->getSchema() == last_t_file->getSchema();
                 }
-                else
-                {
+
+                if (cur_task_full || !small_column_file || !schema_ok)
                     pack_up_cur_task();
-                    cur_task.addColumnFile(file);
-                }
-            }
-            bool is_trivial_move = compaction->packUpTask(std::move(cur_task));
-            is_all_trivial_move = is_all_trivial_move && is_trivial_move;
 
-            if (!is_all_trivial_move)
-                return compaction;
+                cur_task.addColumnFile(file);
+            }
+            else
+            {
+                pack_up_cur_task();
+                cur_task.addColumnFile(file);
+            }
         }
+        bool is_trivial_move = compaction->packUpTask(std::move(cur_task));
+        is_all_trivial_move = is_all_trivial_move && is_trivial_move;
+
+        if (!is_all_trivial_move)
+            return compaction;
     }
     return nullptr;
 }
@@ -378,76 +309,45 @@ bool ColumnFilePersistedSet::installCompactionResults(const MinorCompactionPtr &
         return false;
     }
     minor_compaction_version += 1;
-    LOG_DEBUG(log, "{}, before commit compaction, level info: {}", info(), levelsInfo());
-    ColumnFilePersistedLevels new_persisted_files_levels;
-    auto compaction_src_level = compaction->getCompactionSourceLevel();
-    // Copy column files in level range [0, compaction_src_level)
-    for (size_t i = 0; i < compaction_src_level; i++)
+    LOG_DEBUG(log, "{}, before commit compaction, persisted column files: {}", info(), detailInfo());
+    ColumnFilePersisteds new_persisted_files;
+    for (const auto & task : compaction->getTasks())
     {
-        auto & new_level = new_persisted_files_levels.emplace_back();
-        for (const auto & f : persisted_files_levels[i])
-            new_level.push_back(f);
+        if (task.is_trivial_move)
+            new_persisted_files.push_back(task.to_compact[0]);
+        else
+            new_persisted_files.push_back(task.result);
     }
-    // Copy the files in source level that is not in the compaction task.
-    // Actually, just level 0 may contain file that is not in the compaction task, because flush and compaction can happen concurrently.
-    // For other levels, we always compact all the files in the level.
-    // And because compaction is a single threaded process, so there will be no new files compacted to the source level at the same time.
-    const auto & old_src_level_files = persisted_files_levels[compaction_src_level];
-    auto old_src_level_files_iter = old_src_level_files.begin();
+    auto old_persisted_files_iter = persisted_files.begin();
     for (const auto & task : compaction->getTasks())
     {
         for (const auto & file : task.to_compact)
         {
-            if (unlikely(old_src_level_files_iter == old_src_level_files.end()
-                         || (file->getId() != (*old_src_level_files_iter)->getId())
-                         || (file->getRows() != (*old_src_level_files_iter)->getRows())))
+            if (unlikely(old_persisted_files_iter == persisted_files.end()
+                         || (file->getId() != (*old_persisted_files_iter)->getId())
+                         || (file->getRows() != (*old_persisted_files_iter)->getRows())))
             {
                 throw Exception("Compaction algorithm broken", ErrorCodes::LOGICAL_ERROR);
             }
-            old_src_level_files_iter++;
+            old_persisted_files_iter++;
         }
     }
-    auto & src_level_files = new_persisted_files_levels.emplace_back();
-    while (old_src_level_files_iter != old_src_level_files.end())
+    while (old_persisted_files_iter != persisted_files.end())
     {
-        src_level_files.emplace_back(*old_src_level_files_iter);
-        old_src_level_files_iter++;
-    }
-    // Add new file to the target level
-    auto target_level = compaction_src_level + 1;
-    auto & target_level_files = new_persisted_files_levels.emplace_back();
-    // Copy the old column files in the target level first if exists
-    if (persisted_files_levels.size() > target_level)
-    {
-        for (auto & column_file : persisted_files_levels[target_level])
-            target_level_files.emplace_back(column_file);
-    }
-    // Add the compaction result to new target level
-    for (const auto & task : compaction->getTasks())
-    {
-        if (task.is_trivial_move)
-            target_level_files.push_back(task.to_compact[0]);
-        else
-            target_level_files.push_back(task.result);
-    }
-    // Copy column files in level range [target_level + 1, +inf) if exists
-    for (size_t i = target_level + 1; i < persisted_files_levels.size(); i++)
-    {
-        auto & new_level = new_persisted_files_levels.emplace_back();
-        for (const auto & f : persisted_files_levels[i])
-            new_level.push_back(f);
+        new_persisted_files.emplace_back(*old_persisted_files_iter);
+        old_persisted_files_iter++;
     }
 
-    checkColumnFiles(new_persisted_files_levels);
+    checkColumnFiles(new_persisted_files);
 
     /// Save the new metadata of column files to disk.
-    serializeColumnFilePersistedLevels(wbs, metadata_id, new_persisted_files_levels);
+    serializeColumnFilePersisteds(wbs, metadata_id, new_persisted_files);
     wbs.writeMeta();
 
     /// Commit updates in memory.
-    persisted_files_levels.swap(new_persisted_files_levels);
+    persisted_files.swap(new_persisted_files);
     updateColumnFileStats();
-    LOG_DEBUG(log, "{}, after commit compaction, level info: {}", info(), levelsInfo());
+    LOG_DEBUG(log, "{}, after commit compaction, persisted column files: {}", info(), detailInfo());
 
     return true;
 }
@@ -461,25 +361,20 @@ ColumnFileSetSnapshotPtr ColumnFilePersistedSet::createSnapshot(const StorageSna
 
     size_t total_rows = 0;
     size_t total_deletes = 0;
-    // The read direction is from the last level to the first level,
-    // and in each level we read from the begin to the end.
-    for (auto level_it = persisted_files_levels.rbegin(); level_it != persisted_files_levels.rend(); level_it++)
+    for (const auto & file : persisted_files)
     {
-        for (const auto & file : *level_it)
+        if (auto * t = file->tryToTinyFile(); (t && t->getCache()))
         {
-            if (auto * t = file->tryToTinyFile(); (t && t->getCache()))
-            {
-                // Compact threads could update the value of ColumnTinyFile::cache,
-                // and since ColumnFile is not multi-threads safe, we should create a new column file object.
-                snap->column_files.push_back(std::make_shared<ColumnFileTiny>(*t));
-            }
-            else
-            {
-                snap->column_files.push_back(file);
-            }
-            total_rows += file->getRows();
-            total_deletes += file->getDeletes();
+            // Compact threads could update the value of ColumnTinyFile::cache,
+            // and since ColumnFile is not multi-threads safe, we should create a new column file object.
+            snap->column_files.push_back(std::make_shared<ColumnFileTiny>(*t));
         }
+        else
+        {
+            snap->column_files.push_back(file);
+        }
+        total_rows += file->getRows();
+        total_deletes += file->getDeletes();
     }
 
     if (unlikely(total_rows != rows || total_deletes != deletes))

--- a/dbms/src/Storages/DeltaMerge/Delta/MinorCompaction.cpp
+++ b/dbms/src/Storages/DeltaMerge/Delta/MinorCompaction.cpp
@@ -24,9 +24,8 @@ namespace DB
 {
 namespace DM
 {
-MinorCompaction::MinorCompaction(size_t compaction_src_level_, size_t current_compaction_version_)
-    : compaction_src_level{compaction_src_level_}
-    , current_compaction_version{current_compaction_version_}
+MinorCompaction::MinorCompaction(size_t current_compaction_version_)
+    : current_compaction_version{current_compaction_version_}
 {}
 
 void MinorCompaction::prepare(DMContext & context, WriteBatches & wbs, const PageReader & reader)

--- a/dbms/src/Storages/DeltaMerge/Delta/MinorCompaction.h
+++ b/dbms/src/Storages/DeltaMerge/Delta/MinorCompaction.h
@@ -54,7 +54,6 @@ public:
 private:
     Tasks tasks;
 
-    size_t compaction_src_level;
     size_t current_compaction_version;
 
     size_t total_compact_files = 0;
@@ -62,7 +61,7 @@ private:
     size_t result_compact_files = 0;
 
 public:
-    MinorCompaction(size_t compaction_src_level_, size_t current_compaction_version_);
+    explicit MinorCompaction(size_t current_compaction_version_);
 
     // Add new task and return whether this task is a trivial move
     inline bool packUpTask(Task && task)
@@ -90,7 +89,6 @@ public:
 
     const Tasks & getTasks() const { return tasks; }
 
-    size_t getCompactionSourceLevel() const { return compaction_src_level; }
     size_t getCompactionVersion() const { return current_compaction_version; }
 
     /// Create new column file by combining several small `ColumnFileTiny`s

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_value_space.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_value_space.cpp
@@ -355,7 +355,7 @@ TEST_F(DeltaValueSpaceTest, MinorCompaction)
         ASSERT_EQ(tasks[1].to_compact.size(), 1);
         ASSERT_EQ(tasks[1].is_trivial_move, true);
         ASSERT_EQ(tasks[2].to_compact.size(), 1);
-        ASSERT_EQ(tasks[3].is_trivial_move, true);
+        ASSERT_EQ(tasks[2].is_trivial_move, true);
         compaction_task->prepare(dmContext(), wbs, reader);
     }
 

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_value_space.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_value_space.cpp
@@ -334,6 +334,10 @@ TEST_F(DeltaValueSpaceTest, MinorCompaction)
         {
             delta->appendDeleteRange(dmContext(), RowKeyRange::fromHandleRange(HandleRange(0, num_rows_write_per_batch)));
         }
+        {
+            appendBlockToDeltaValueSpace(dmContext(), delta, total_rows_write, num_rows_write_per_batch);
+            total_rows_write += num_rows_write_per_batch;
+        }
         delta->flush(dmContext());
     }
     // build compaction task and finish prepare stage
@@ -341,18 +345,20 @@ TEST_F(DeltaValueSpaceTest, MinorCompaction)
     {
         PageReader reader = dmContext().storage_pool.newLogReader(dmContext().getReadLimiter(), true, "");
         compaction_task = persisted_file_set->pickUpMinorCompaction(dmContext());
-        ASSERT_EQ(compaction_task->getCompactionSourceLevel(), 0);
         // There should be two compaction sub_tasks.
         // The first task try to compact the first three column files to a larger one,
         // and the second task is just a trivial move for the last column file which is a delete range.
         const auto & tasks = compaction_task->getTasks();
-        ASSERT_EQ(tasks.size(), 2);
+        ASSERT_EQ(tasks.size(), 3);
         ASSERT_EQ(tasks[0].to_compact.size(), 3);
         ASSERT_EQ(tasks[0].is_trivial_move, false);
         ASSERT_EQ(tasks[1].to_compact.size(), 1);
         ASSERT_EQ(tasks[1].is_trivial_move, true);
+        ASSERT_EQ(tasks[2].to_compact.size(), 1);
+        ASSERT_EQ(tasks[3].is_trivial_move, true);
         compaction_task->prepare(dmContext(), wbs, reader);
     }
+
     // another thread write more data to the delta value space and flush it
     {
         appendBlockToDeltaValueSpace(dmContext(), delta, total_rows_write, num_rows_write_per_batch);
@@ -361,18 +367,27 @@ TEST_F(DeltaValueSpaceTest, MinorCompaction)
         ASSERT_EQ(delta->getUnsavedRows(), 0);
         ASSERT_EQ(persisted_file_set->getRows(), total_rows_write);
         ASSERT_EQ(persisted_file_set->getDeletes(), 1);
-        ASSERT_EQ(persisted_file_set->getColumnFileCount(), 5);
+        ASSERT_EQ(persisted_file_set->getColumnFileCount(), 6);
     }
     // commit the compaction task and check the status
     {
         ASSERT_TRUE(compaction_task->commit(persisted_file_set, wbs));
         ASSERT_EQ(persisted_file_set->getRows(), total_rows_write);
         ASSERT_EQ(persisted_file_set->getDeletes(), 1);
+        ASSERT_EQ(persisted_file_set->getColumnFileCount(), 4);
+    }
+    // now the column files in persisted_file_set should be: T_300, D_0_100, T_100, T_100
+    {
+        compaction_task = persisted_file_set->pickUpMinorCompaction(dmContext());
+        PageReader reader = dmContext().storage_pool.newLogReader(dmContext().getReadLimiter(), true, "");
+        compaction_task = persisted_file_set->pickUpMinorCompaction(dmContext());
+        compaction_task->prepare(dmContext(), wbs, reader);
+        ASSERT_TRUE(compaction_task->commit(persisted_file_set, wbs));
+        ASSERT_EQ(persisted_file_set->getRows(), total_rows_write);
+        ASSERT_EQ(persisted_file_set->getDeletes(), 1);
         ASSERT_EQ(persisted_file_set->getColumnFileCount(), 3);
     }
-    // after compaction, the column file in persisted_file_set should be like the following:
-    // level 0: T_100
-    // level 1: T_300, D_0_100
+    // now the column files in persisted_file_set should be: T_300, D_0_100, T_200
     // so there is no compaction task to do
     {
         compaction_task = persisted_file_set->pickUpMinorCompaction(dmContext());
@@ -431,7 +446,6 @@ TEST_F(DeltaValueSpaceTest, Restore)
             total_rows_write += num_rows_write_per_batch;
         }
         delta->flush(dmContext());
-        ASSERT_EQ(persisted_file_set->getColumnFileLevelCount(), 2);
         ASSERT_EQ(delta->getColumnFileCount(), 3);
         ASSERT_EQ(delta->getRows(), total_rows_write);
     }
@@ -475,9 +489,7 @@ TEST_F(DeltaValueSpaceTest, CloneNewlyAppendedColumnFiles)
     auto persisted_file_set = delta->getPersistedFileSet();
     size_t total_rows_write = 0;
     WriteBatches wbs(dmContext().storage_pool, dmContext().getWriteLimiter());
-    // create three levels in persisted_file_set
     {
-        // one column file in level 1
         {
             appendBlockToDeltaValueSpace(dmContext(), delta, total_rows_write, num_rows_write_per_batch);
             total_rows_write += num_rows_write_per_batch;
@@ -489,8 +501,6 @@ TEST_F(DeltaValueSpaceTest, CloneNewlyAppendedColumnFiles)
         delta->flush(dmContext());
         delta->compact(dmContext());
         ASSERT_EQ(delta->getColumnFileCount(), 1);
-        ASSERT_EQ(persisted_file_set->getColumnFileLevelCount(), 2);
-        // one column files in level 2
         {
             appendBlockToDeltaValueSpace(dmContext(), delta, total_rows_write, num_rows_write_per_batch);
             total_rows_write += num_rows_write_per_batch;
@@ -500,13 +510,8 @@ TEST_F(DeltaValueSpaceTest, CloneNewlyAppendedColumnFiles)
             total_rows_write += num_rows_write_per_batch;
         }
         delta->flush(dmContext());
-        // compact two level 0 files to level 1
-        delta->compact(dmContext());
-        // compact two level 1 files to level 2
         delta->compact(dmContext());
         ASSERT_EQ(delta->getColumnFileCount(), 1);
-        ASSERT_EQ(persisted_file_set->getColumnFileLevelCount(), 3);
-        // one column files in level 1 and one column files in level 2
         {
             appendBlockToDeltaValueSpace(dmContext(), delta, total_rows_write, num_rows_write_per_batch);
             total_rows_write += num_rows_write_per_batch;
@@ -517,8 +522,7 @@ TEST_F(DeltaValueSpaceTest, CloneNewlyAppendedColumnFiles)
         }
         delta->flush(dmContext());
         delta->compact(dmContext());
-        ASSERT_EQ(delta->getColumnFileCount(), 2);
-        ASSERT_EQ(persisted_file_set->getColumnFileLevelCount(), 3);
+        ASSERT_EQ(delta->getColumnFileCount(), 1);
     }
     {
         auto snapshot = delta->createSnapshot(dmContext(), true, CurrentMetrics::DT_SnapshotOfRead);

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_value_space.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_value_space.cpp
@@ -345,9 +345,10 @@ TEST_F(DeltaValueSpaceTest, MinorCompaction)
     {
         PageReader reader = dmContext().storage_pool.newLogReader(dmContext().getReadLimiter(), true, "");
         compaction_task = persisted_file_set->pickUpMinorCompaction(dmContext());
-        // There should be two compaction sub_tasks.
-        // The first task try to compact the first three column files to a larger one,
-        // and the second task is just a trivial move for the last column file which is a delete range.
+        // There should be three compaction sub_tasks.
+        // The first task try to compact the first three column files to a larger one.
+        // The second task is a trivial move for a ColumnFileDeleteRange.
+        // The third task is a trivial move for and a ColumnFileTiny.
         const auto & tasks = compaction_task->getTasks();
         ASSERT_EQ(tasks.size(), 3);
         ASSERT_EQ(tasks[0].to_compact.size(), 3);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #6431 
cherry pick of https://github.com/pingcap/tiflash/pull/6432

Problem Summary: When under heavy write pressure in some scenario, there are many small column files in `DeltaValueSpace`, and the current minor compaction algorithm cannot compact these small column files effectively which may cause large memory consumption and has the risk of out of memory.

### What is changed and how it works?
Avoid dividing different levels in `ColumnFilePersistedSet` and just keep one level in it. For every minor compaction, we will always check all column files whether they can be compacted and do the compaction at once.
Note that this may cause some write amplification, but the price should be acceptable compare to high memory usage.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
1. Compare this fix with previous binary in a cluster with heavy write pressure and with evenly write pattern;
2. Check the memory usage and write flow;
The memory usage decrease a lot:
![image](https://user-images.githubusercontent.com/47731263/205857914-aa7be668-719c-4995-bf44-16dcaeda5fdc.png)
The page write flow increase but this meets our expectation and is totally acceptable:
![image](https://user-images.githubusercontent.com/47731263/205858014-6f5219c3-f898-41a1-b2da-1b7b2b53932f.png)

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Reduce memory usage under heavy write pressure.
```
