### PR TITLE
Optimize delta compact strategy to reduce iops and write amplification

### DIFF
--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileTiny.cpp
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileTiny.cpp
@@ -165,15 +165,7 @@ Block ColumnFileTiny::readBlockForMinorCompaction(const PageReader & page_reader
     else
     {
         const auto & schema_ref = *schema;
-
-        PageStorage::PageReadFields fields;
-        fields.first = data_page_id;
-        for (size_t i = 0; i < schema_ref.columns(); ++i)
-            fields.second.push_back(i);
-
-        auto page_map = page_reader.read({fields});
-        auto page = page_map[data_page_id];
-
+        auto page = page_reader.read(data_page_id);
         auto columns = schema_ref.cloneEmptyColumns();
 
         if (unlikely(columns.size() != page.fieldSize()))

--- a/dbms/src/Storages/DeltaMerge/Delta/ColumnFilePersistedSet.cpp
+++ b/dbms/src/Storages/DeltaMerge/Delta/ColumnFilePersistedSet.cpp
@@ -263,6 +263,7 @@ MinorCompactionPtr ColumnFilePersistedSet::pickUpMinorCompaction(DMContext & con
             is_all_trivial_move = is_all_trivial_move && is_trivial_move;
             cur_task = {};
         };
+        size_t index = 0;
         for (auto & file : persisted_files)
         {
             if (auto * t_file = file->tryToTinyFile(); t_file)
@@ -280,13 +281,15 @@ MinorCompactionPtr ColumnFilePersistedSet::pickUpMinorCompaction(DMContext & con
                 if (cur_task_full || !small_column_file || !schema_ok)
                     pack_up_cur_task();
 
-                cur_task.addColumnFile(file);
+                cur_task.addColumnFile(file, index);
             }
             else
             {
                 pack_up_cur_task();
-                cur_task.addColumnFile(file);
+                cur_task.addColumnFile(file, index);
             }
+
+            ++index;
         }
         pack_up_cur_task();
 

--- a/dbms/src/Storages/DeltaMerge/Delta/DeltaValueSpace.cpp
+++ b/dbms/src/Storages/DeltaMerge/Delta/DeltaValueSpace.cpp
@@ -404,10 +404,12 @@ bool DeltaValueSpace::compact(DMContext & context)
             LOG_DEBUG(log, "Compact stop because structure got updated, delta={}", simpleInfo());
             return false;
         }
-        // Reset to 0 if the minor compaction succeed,
+        // Reset to the index of first file that can be compacted if the minor compaction succeed,
         // and it may trigger another minor compaction if there is still too many column files.
         // This process will stop when there is no more minor compaction to be done.
-        last_try_compact_column_files.store(0);
+        auto first_compact_index = compaction_task->getFirsCompactIndex();
+        RUNTIME_ASSERT(first_compact_index != std::numeric_limits<size_t>::max());
+        last_try_compact_column_files.store(first_compact_index);
         LOG_DEBUG(log, "{} delta={}", compaction_task->info(), info());
     }
     wbs.writeRemoves();

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -1179,7 +1179,7 @@ void DeltaMergeStore::checkSegmentUpdate(const DMContextPtr & dm_context, const 
         || (segment_rows >= segment_limit_rows * 3 || segment_bytes >= segment_limit_bytes * 3);
 
     // Don't do compact on starting up.
-    bool should_compact = (thread_type != ThreadType::Init) && std::max(static_cast<Int64>(column_file_count) - delta_last_try_compact_column_files, 0) >= 10;
+    bool should_compact = (thread_type != ThreadType::Init) && std::max(static_cast<Int64>(column_file_count) - delta_last_try_compact_column_files, 0) >= 15;
 
     // Don't do background place index if we limit DeltaIndex cache.
     bool should_place_delta_index = !dm_context->db_context.isDeltaIndexLimited()

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_value_space.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_value_space.cpp
@@ -26,6 +26,7 @@
 #include <gtest/gtest.h>
 
 #include <future>
+#include <limits>
 #include <memory>
 
 namespace CurrentMetrics
@@ -350,6 +351,7 @@ TEST_F(DeltaValueSpaceTest, MinorCompaction)
         // The second task is a trivial move for a ColumnFileDeleteRange.
         // The third task is a trivial move for and a ColumnFileTiny.
         const auto & tasks = compaction_task->getTasks();
+        ASSERT_EQ(compaction_task->getFirsCompactIndex(), 0);
         ASSERT_EQ(tasks.size(), 3);
         ASSERT_EQ(tasks[0].to_compact.size(), 3);
         ASSERT_EQ(tasks[0].is_trivial_move, false);
@@ -379,9 +381,13 @@ TEST_F(DeltaValueSpaceTest, MinorCompaction)
     }
     // now the column files in persisted_file_set should be: T_300, D_0_100, T_100, T_100
     {
+        // generate but not commit
         compaction_task = persisted_file_set->pickUpMinorCompaction(dmContext());
+        EXPECT_EQ(compaction_task->getFirsCompactIndex(), 2);
+        // generate and commit
         PageReader reader = dmContext().storage_pool.newLogReader(dmContext().getReadLimiter(), true, "");
         compaction_task = persisted_file_set->pickUpMinorCompaction(dmContext());
+        EXPECT_EQ(compaction_task->getFirsCompactIndex(), 2);
         compaction_task->prepare(dmContext(), wbs, reader);
         ASSERT_TRUE(compaction_task->commit(persisted_file_set, wbs));
         ASSERT_EQ(persisted_file_set->getRows(), total_rows_write);
@@ -407,6 +413,7 @@ TEST_F(DeltaValueSpaceTest, MinorCompaction)
                 auto minor_compaction_task = persisted_file_set->pickUpMinorCompaction(dmContext());
                 if (!minor_compaction_task)
                     break;
+                ASSERT_NE(minor_compaction_task->getFirsCompactIndex(), std::numeric_limits<size_t>::max());
                 minor_compaction_task->prepare(dmContext(), wbs, reader);
                 minor_compaction_task->commit(persisted_file_set, wbs);
             }

--- a/dbms/src/Storages/Page/V2/PageFile.cpp
+++ b/dbms/src/Storages/Page/V2/PageFile.cpp
@@ -922,7 +922,15 @@ PageMap PageFile::Reader::read(PageIdAndEntries & to_read, const ReadLimiterPtr 
         page.page_id = page_id;
         page.data = ByteBuffer(pos, pos + entry.size);
         page.mem_holder = mem_holder;
-        page_map.emplace(page_id, page);
+
+        // Calculate the field_offsets from page entry
+        for (size_t index = 0; index < entry.field_offsets.size(); index++)
+        {
+            const auto offset = entry.field_offsets[index].first;
+            page.field_offsets.emplace(index, offset);
+        }
+
+        page_map.emplace(page_id, std::move(page));
 
         pos += entry.size;
     }

--- a/dbms/src/Storages/Page/V2/tests/gtest_page_storage.cpp
+++ b/dbms/src/Storages/Page/V2/tests/gtest_page_storage.cpp
@@ -754,11 +754,22 @@ try
         ASSERT_EQ(page0.page_id, 0UL);
         for (size_t i = 0; i < buf_sz; ++i)
             EXPECT_EQ(*(page0.data.begin() + i), static_cast<char>(i % 0xff));
+        ASSERT_EQ(page0.fieldSize(), page0_fields.size());
+        for (const auto & [idx, sz] : page0_fields)
+        {
+            ASSERT_EQ(page0.getFieldData(idx).size(), sz);
+        }
+
         DB::Page page1 = storage->read(1);
         ASSERT_EQ(page1.data.size(), buf_sz);
         ASSERT_EQ(page1.page_id, 1UL);
         for (size_t i = 0; i < buf_sz; ++i)
             EXPECT_EQ(*(page1.data.begin() + i), static_cast<char>(i % 0xff));
+        ASSERT_EQ(page1.fieldSize(), page1_fields.size());
+        for (const auto & [idx, sz] : page1_fields)
+        {
+            ASSERT_EQ(page1.getFieldData(idx).size(), sz);
+        }
     }
 }
 CATCH

--- a/dbms/src/Storages/Page/V3/BlobStore.cpp
+++ b/dbms/src/Storages/Page/V3/BlobStore.cpp
@@ -720,7 +720,15 @@ PageMap BlobStore::read(PageIDAndEntriesV3 & entries, const ReadLimiterPtr & rea
         Page page(page_id_v3);
         page.data = ByteBuffer(pos, pos + entry.size);
         page.mem_holder = mem_holder;
-        page_map.emplace(page_id_v3.low, page);
+
+        // Calculate the field_offsets from page entry
+        for (size_t index = 0; index < entry.field_offsets.size(); index++)
+        {
+            const auto offset = entry.field_offsets[index].first;
+            page.field_offsets.emplace(index, offset);
+        }
+
+        page_map.emplace(page_id_v3.low, std::move(page));
 
         pos += entry.size;
     }
@@ -736,14 +744,14 @@ PageMap BlobStore::read(PageIDAndEntriesV3 & entries, const ReadLimiterPtr & rea
 
 Page BlobStore::read(const PageIDAndEntryV3 & id_entry, const ReadLimiterPtr & read_limiter)
 {
-    if (!id_entry.second.isValid())
+    const auto & [page_id_v3, entry] = id_entry;
+    const size_t buf_size = entry.size;
+
+    if (!entry.isValid())
     {
         Page page_not_found(buildV3Id(id_entry.first.high, INVALID_PAGE_ID));
         return page_not_found;
     }
-
-    const auto & [page_id_v3, entry] = id_entry;
-    const size_t buf_size = entry.size;
 
     // When we read `WriteBatch` which is `WriteType::PUT_EXTERNAL`.
     // The `buf_size` will be 0, we need avoid calling malloc/free with size 0.
@@ -781,6 +789,13 @@ Page BlobStore::read(const PageIDAndEntryV3 & id_entry, const ReadLimiterPtr & r
     Page page(page_id_v3);
     page.data = ByteBuffer(data_buf, data_buf + buf_size);
     page.mem_holder = mem_holder;
+
+    // Calculate the field_offsets from page entry
+    for (size_t index = 0; index < entry.field_offsets.size(); index++)
+    {
+        const auto offset = entry.field_offsets[index].first;
+        page.field_offsets.emplace(index, offset);
+    }
 
     return page;
 }

--- a/dbms/src/Storages/Page/V3/tests/gtest_page_storage.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_page_storage.cpp
@@ -426,6 +426,28 @@ try
         ASSERT_GT(page_maps.count(5), 0);
         ASSERT_EQ(page_maps[5].isValid(), false);
     }
+    {
+        // Read with id can also fetch the fieldOffsets
+        auto page_4 = page_storage->readImpl(TEST_NAMESPACE_ID, 4, nullptr, nullptr, false);
+        ASSERT_EQ(page_4.fieldSize(), 4);
+        ASSERT_EQ(page_4.getFieldData(0).size(), 20);
+        ASSERT_EQ(page_4.getFieldData(1).size(), 20);
+        ASSERT_EQ(page_4.getFieldData(2).size(), 30);
+        ASSERT_EQ(page_4.getFieldData(3).size(), 30);
+    }
+    {
+        // Read with ids can also fetch the fieldOffsets
+        PageIds page_ids{4};
+        auto pages = page_storage->readImpl(TEST_NAMESPACE_ID, page_ids, nullptr, nullptr, false);
+        ASSERT_EQ(pages.size(), 1);
+        ASSERT_GT(pages.count(4), 0);
+        auto page_4 = pages[4];
+        ASSERT_EQ(page_4.fieldSize(), 4);
+        ASSERT_EQ(page_4.getFieldData(0).size(), 20);
+        ASSERT_EQ(page_4.getFieldData(1).size(), 20);
+        ASSERT_EQ(page_4.getFieldData(2).size(), 30);
+        ASSERT_EQ(page_4.getFieldData(3).size(), 30);
+    }
 }
 CATCH
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #6460 

Problem Summary:

### What is changed and how it works?

1. Use `PageReader::read(PageId page_id)` instead of `PageReader::read(const std::vector<PageStorage::PageReadFields> & page_fields)` in `ColumnFileTiny::readBlockForMinorCompaction`. So that we only need to do 1 read for each cftiny, instead of the number of columns.
2. Use a better compact strategy: do delta compact only if the *increased* number of cftiny is larger than the limit, instead of the *total* number.

Tested on the worst update workload of TiFlash: large volume data, each transaction only update 1 rows, and the update pk is very distributed. Results:

1. Read iops reduces from 80K to 4K
2. Write amplification reduces from 75x to 25x

Before:
<img width="1427" alt="image" src="https://user-images.githubusercontent.com/2639319/206605763-30e39843-dd5b-4391-a1b9-2a6a96a74056.png">
<img width="719" alt="image" src="https://user-images.githubusercontent.com/2639319/206605589-3056c285-4d26-4948-ab9e-2776610fa4e7.png">
<img width="730" alt="image" src="https://user-images.githubusercontent.com/2639319/206605620-48411a0f-6c89-4bd1-aa3e-07e5c1d2d78a.png">
<img width="728" alt="image" src="https://user-images.githubusercontent.com/2639319/206605726-0141426b-fe33-4bda-8505-365c51afb153.png">


After:

<img width="1437" alt="image" src="https://user-images.githubusercontent.com/2639319/206606262-9abdc057-802d-4fe6-8dba-b402448659bf.png">
<img width="729" alt="image" src="https://user-images.githubusercontent.com/2639319/206606492-163a398f-c4d0-4335-bd3b-fa7222fdc732.png">
<img width="720" alt="image" src="https://user-images.githubusercontent.com/2639319/206606337-b9391b05-960d-4d10-bd9c-1a786e664e00.png">
<img width="722" alt="image" src="https://user-images.githubusercontent.com/2639319/206606379-acc878bd-d28d-46ab-bfc2-f13356cb8525.png">



### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Reduce the IOPS and write amplification of TiFlash under high update throughput workloads.
```
