### PR TITLE
Refine the storage->read in DAGStorageInterpreter

### DIFF
--- a/dbms/src/Flash/Coprocessor/DAGContext.h
+++ b/dbms/src/Flash/Coprocessor/DAGContext.h
@@ -172,7 +172,6 @@ public:
     // for test
     explicit DAGContext(UInt64 max_error_count_)
         : dag_request(nullptr)
-        , dummy_query_string("")
         , dummy_ast(makeDummyQuery())
         , collect_execution_summaries(false)
         , is_mpp_task(false)

--- a/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Common/Exception.h>
 #include <Common/FailPoint.h>
 #include <Common/FmtUtils.h>
 #include <Common/TiFlashException.h>
@@ -39,8 +40,6 @@
 #include <Storages/Transaction/LockException.h>
 #include <Storages/Transaction/TMTContext.h>
 #include <TiDB/Schema/SchemaSyncer.h>
-
-#include "Common/Exception.h"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"

--- a/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
@@ -40,6 +40,8 @@
 #include <Storages/Transaction/TMTContext.h>
 #include <TiDB/Schema/SchemaSyncer.h>
 
+#include "Common/Exception.h"
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <kvproto/coprocessor.pb.h>
@@ -631,6 +633,7 @@ std::unordered_map<TableID, SelectQueryInfo> DAGStorageInterpreter::generateSele
         query_info.is_fast_scan = table_scan.isFastScan();
         return query_info;
     };
+    RUNTIME_CHECK_MSG(mvcc_query_info->scan_context != nullptr, "Unexpected null scan_context");
     if (table_scan.isPartitionTableScan())
     {
         for (const auto physical_table_id : table_scan.getPhysicalTableIDs())

--- a/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.h
+++ b/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.h
@@ -112,12 +112,12 @@ private:
     Context & context;
     const TiDBTableScan & table_scan;
     const PushDownFilter & push_down_filter;
-    size_t max_streams;
+    const size_t max_streams;
     LoggerPtr log;
 
     /// derived from other members, doesn't change during DAGStorageInterpreter's lifetime
 
-    TableID logical_table_id;
+    const TableID logical_table_id;
     const Settings & settings;
     TMTContext & tmt;
 

--- a/dbms/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterSelectQuery.cpp
@@ -849,7 +849,6 @@ QueryProcessingStage::Enum InterpreterSelectQuery::executeFetchColumns(Pipeline 
 
             if (query_info.mvcc_query_info->regions_query_info.empty())
                 throw Exception("[InterpreterSelectQuery::executeFetchColumns] no region query", ErrorCodes::LOGICAL_ERROR);
-            query_info.mvcc_query_info->concurrent = 0.0;
         }
 
         /// PARTITION SELECT only supports MergeTree family now.
@@ -880,7 +879,7 @@ QueryProcessingStage::Enum InterpreterSelectQuery::executeFetchColumns(Pipeline 
                     if (likely(!select_query->no_kvstore))
                     {
                         auto table_info = managed_storage->getTableInfo();
-                        learner_read_snapshot = doLearnerRead(table_info.id, *query_info.mvcc_query_info, max_streams, false, context, log);
+                        learner_read_snapshot = doLearnerRead(table_info.id, *query_info.mvcc_query_info, false, context, log);
                     }
                 }
             }

--- a/dbms/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterSelectQuery.cpp
@@ -51,6 +51,7 @@
 #include <Parsers/ASTSelectQuery.h>
 #include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Parsers/ASTTablesInSelectQuery.h>
+#include <Storages/DeltaMerge/ScanContext.h>
 #include <Storages/IManageableStorage.h>
 #include <Storages/IStorage.h>
 #include <Storages/RegionQueryInfo.h>
@@ -805,7 +806,8 @@ QueryProcessingStage::Enum InterpreterSelectQuery::executeFetchColumns(Pipeline 
         SelectQueryInfo query_info;
         query_info.query = query_ptr;
         query_info.sets = query_analyzer->getPreparedSets();
-        query_info.mvcc_query_info = std::make_unique<MvccQueryInfo>(settings.resolve_locks, settings.read_tso);
+        auto scan_context = std::make_shared<DM::ScanContext>();
+        query_info.mvcc_query_info = std::make_unique<MvccQueryInfo>(settings.resolve_locks, settings.read_tso, scan_context);
 
         const String & request_str = settings.regions;
 

--- a/dbms/src/Storages/Page/V2/PageStorage.h
+++ b/dbms/src/Storages/Page/V2/PageStorage.h
@@ -92,7 +92,7 @@ public:
                 const FileProviderPtr & file_provider_,
                 BackgroundProcessingPool & ver_compact_pool_,
                 bool no_more_insert_ = false);
-    ~PageStorage() override = default;
+    ~PageStorage() override { shutdown(); }
 
     void restore() override;
 

--- a/dbms/src/Storages/RegionQueryInfo.h
+++ b/dbms/src/Storages/RegionQueryInfo.h
@@ -60,8 +60,6 @@ struct MvccQueryInfo
 
     const bool resolve_locks;
 
-    Float32 concurrent = 1.0;
-
     using RegionsQueryInfo = std::vector<RegionQueryInfo>;
     RegionsQueryInfo regions_query_info;
 

--- a/dbms/src/Storages/RegionQueryInfo.h
+++ b/dbms/src/Storages/RegionQueryInfo.h
@@ -20,6 +20,11 @@
 namespace DB
 {
 using DecodedTiKVKeyPtr = std::shared_ptr<DecodedTiKVKey>;
+namespace DM
+{
+class ScanContext;
+using ScanContextPtr = std::shared_ptr<ScanContext>;
+} // namespace DM
 
 struct RegionQueryInfo
 {
@@ -63,8 +68,10 @@ struct MvccQueryInfo
     using ReadIndexRes = std::unordered_map<RegionID, UInt64>;
     ReadIndexRes read_index_res;
 
+    DM::ScanContextPtr scan_context;
+
 public:
-    explicit MvccQueryInfo(bool resolve_locks_ = false, UInt64 read_tso_ = 0);
+    explicit MvccQueryInfo(bool resolve_locks_ = false, UInt64 read_tso_ = 0, DM::ScanContextPtr scan_ctx = nullptr);
 };
 
 } // namespace DB

--- a/dbms/src/Storages/StorageDeltaMerge.cpp
+++ b/dbms/src/Storages/StorageDeltaMerge.cpp
@@ -774,69 +774,7 @@ BlockInputStreams StorageDeltaMerge::read(
 
     auto rs_operator = parseRoughSetFilter(query_info, columns_to_read, context, tracing_logger);
 
-    auto streams = store->read(
-        context,
-        context.getSettingsRef(),
-        columns_to_read,
-        ranges,
-        num_streams,
-        /*max_version=*/mvcc_query_info.read_tso,
-        rs_operator,
-        query_info.req_id,
-        query_info.keep_order,
-        /* is_fast_scan */ query_info.is_fast_scan,
-        max_block_size,
-        parseSegmentSet(select_query.segment_expression_list),
-        extra_table_id_index);
-
-    /// Ensure read_tso info after read.
-    checkReadTso(mvcc_query_info.read_tso, context.getTMTContext(), context, global_context);
-
-    LOG_TRACE(tracing_logger, "[ranges: {}] [streams: {}]", ranges.size(), streams.size());
-
-    return streams;
-}
-
-BlockInputStreams StorageDeltaMerge::read(
-    const Names & column_names,
-    const SelectQueryInfo & query_info,
-    const Context & context,
-    QueryProcessingStage::Enum & /*processed_stage*/,
-    size_t max_block_size,
-    unsigned num_streams,
-    const ScanContextPtr & scan_context)
-{
-    auto & store = getAndMaybeInitStore();
-    // Note that `columns_to_read` should keep the same sequence as ColumnRef
-    // in `Coprocessor.TableScan.columns`, or rough set filter could be
-    // failed to parsed.
-    ColumnDefines columns_to_read;
-    size_t extra_table_id_index = InvalidColumnID;
-    setColumnsToRead(store, columns_to_read, extra_table_id_index, column_names);
-
-    const ASTSelectQuery & select_query = typeid_cast<const ASTSelectQuery &>(*query_info.query);
-    if (select_query.raw_for_mutable) // for selraw
-    {
-        // Read without MVCC filtering and del_mark = 1 filtering
-        return store->readRaw(
-            context,
-            context.getSettingsRef(),
-            columns_to_read,
-            num_streams,
-            query_info.keep_order,
-            parseSegmentSet(select_query.segment_expression_list),
-            extra_table_id_index);
-    }
-
-    auto tracing_logger = log->getChild(query_info.req_id);
-
-    // Read with MVCC filtering
-    RUNTIME_CHECK(query_info.mvcc_query_info != nullptr);
-    const auto & mvcc_query_info = *query_info.mvcc_query_info;
-
-    auto ranges = parseMvccQueryInfo(mvcc_query_info, num_streams, context, tracing_logger);
-
-    auto rs_operator = parseRoughSetFilter(query_info, columns_to_read, context, tracing_logger);
+    const auto & scan_context = mvcc_query_info.scan_context;
 
     auto streams = store->read(
         context,

--- a/dbms/src/Storages/StorageDeltaMerge.h
+++ b/dbms/src/Storages/StorageDeltaMerge.h
@@ -66,16 +66,6 @@ public:
         size_t max_block_size,
         unsigned num_streams) override;
 
-    /// use scan_context to record the performance metrics during read.
-    BlockInputStreams read(
-        const Names & column_names,
-        const SelectQueryInfo & query_info,
-        const Context & context,
-        QueryProcessingStage::Enum & processed_stage,
-        size_t max_block_size,
-        unsigned num_streams,
-        const DM::ScanContextPtr & scan_context);
-
     BlockOutputStreamPtr write(const ASTPtr & query, const Settings & settings) override;
 
     /// Write from raft layer.

--- a/dbms/src/Storages/StorageDisaggregated.cpp
+++ b/dbms/src/Storages/StorageDisaggregated.cpp
@@ -276,6 +276,7 @@ void StorageDisaggregated::pushDownFilter(DAGPipeline & pipeline)
     NamesAndTypes source_columns = genNamesAndTypesForExchangeReceiver(table_scan);
     const auto & receiver_dag_schema = exchange_receiver->getOutputSchema();
     assert(receiver_dag_schema.size() == source_columns.size());
+    UNUSED(receiver_dag_schema);
 
     analyzer = std::make_unique<DAGExpressionAnalyzer>(std::move(source_columns), context);
 

--- a/dbms/src/Storages/Transaction/LearnerRead.cpp
+++ b/dbms/src/Storages/Transaction/LearnerRead.cpp
@@ -160,7 +160,6 @@ public:
 LearnerReadSnapshot doLearnerRead(
     const TiDB::TableID logical_table_id,
     MvccQueryInfo & mvcc_query_info_,
-    size_t num_streams,
     bool for_batch_cop,
     Context & context,
     const LoggerPtr & log)
@@ -173,7 +172,7 @@ LearnerReadSnapshot doLearnerRead(
     const auto & regions_info = mvcc_query_info.getRegionsInfo();
 
     // adjust concurrency by num of regions or num of streams * mvcc_query_info.concurrent
-    size_t concurrent_num = std::max(1, std::min(static_cast<size_t>(num_streams * mvcc_query_info->concurrent), regions_info.size()));
+    size_t concurrent_num = std::max(1, regions_info.size());
 
     // use single thread to do replica read by default because there is some overhead from thread pool itself.
     concurrent_num = std::min(tmt.replicaReadMaxThread(), concurrent_num);

--- a/dbms/src/Storages/Transaction/LearnerRead.cpp
+++ b/dbms/src/Storages/Transaction/LearnerRead.cpp
@@ -17,6 +17,7 @@
 #include <Common/TiFlashMetrics.h>
 #include <Flash/Coprocessor/DAGContext.h>
 #include <Interpreters/Context.h>
+#include <Storages/DeltaMerge/ScanContext.h>
 #include <Storages/Transaction/KVStore.h>
 #include <Storages/Transaction/LearnerRead.h>
 #include <Storages/Transaction/LockException.h>
@@ -488,9 +489,10 @@ void validateQueryInfo(
     }
 }
 
-MvccQueryInfo::MvccQueryInfo(bool resolve_locks_, UInt64 read_tso_)
+MvccQueryInfo::MvccQueryInfo(bool resolve_locks_, UInt64 read_tso_, DM::ScanContextPtr scan_ctx)
     : read_tso(read_tso_)
     , resolve_locks(read_tso_ == std::numeric_limits<UInt64>::max() ? false : resolve_locks_)
+    , scan_context(std::move(scan_ctx))
 {
     // using `std::numeric_limits::max()` to resolve lock may break basic logic.
 }

--- a/dbms/src/Storages/Transaction/LearnerRead.h
+++ b/dbms/src/Storages/Transaction/LearnerRead.h
@@ -42,7 +42,6 @@ using LearnerReadSnapshot = std::unordered_map<RegionID, RegionLearnerReadSnapsh
 doLearnerRead(
     const TiDB::TableID table_id,
     MvccQueryInfo & mvcc_query_info,
-    size_t num_streams,
     bool for_batch_cop,
     Context & context,
     const LoggerPtr & log);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/6233

Problem Summary:

### What is changed and how it works?

* Put ScanContextPtr into MvccQueryInfo
* Remove the reduant DeltaMergeStore::read with explicit ScanContextPtr interface
* Remove useless `MvccQueryInfo::concurrent`
* Fix a compile error (unused var) under release mode

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
