### PR TITLE
Minor refine of `TableLock` and `MPPTask::cancel`

### DIFF
--- a/dbms/src/Flash/Coprocessor/DAGContext.h
+++ b/dbms/src/Flash/Coprocessor/DAGContext.h
@@ -380,6 +380,9 @@ private:
 
 private:
     std::shared_ptr<ProcessListEntry> process_list_entry;
+    /// Holding the table lock to make sure that the table wouldn't be dropped during the lifetime of this query,
+    /// even if there are no local regions.
+    TableLockHolders table_locks;
     /// profile_streams_map is a map that maps from executor_id to profile BlockInputStreams.
     std::unordered_map<String, BlockInputStreams> profile_streams_map;
     /// executor_id_to_join_id_map is a map that maps executor id to all the join executor id of itself and all its children.
@@ -408,10 +411,6 @@ private:
     // In disaggregated tiflash mode, table_scan in tiflash_compute node will be converted ExchangeReceiver.
     // Record here so we can add to receiver_set and cancel/close it.
     std::optional<std::pair<String, ExchangeReceiverPtr>> disaggregated_compute_exchange_receiver;
-
-    /// Holding the table lock to make sure that the table wouldn't be dropped during the lifetime of this query,
-    /// even if there are no local regions.
-    TableLockHolders table_locks;
 };
 
 } // namespace DB

--- a/dbms/src/Flash/Coprocessor/DAGContext.h
+++ b/dbms/src/Flash/Coprocessor/DAGContext.h
@@ -380,8 +380,8 @@ private:
 
 private:
     std::shared_ptr<ProcessListEntry> process_list_entry;
-    /// Holding the table lock to make sure that the table wouldn't be dropped during the lifetime of this query,
-    /// even if there are no local regions.
+    /// Holding the table lock to make sure that the table wouldn't be dropped during the lifetime of this query, even if there are no local regions.
+    /// TableLockHolders need to be released after the BlockInputStream is destroyed to prevent data read exceptions.
     TableLockHolders table_locks;
     /// profile_streams_map is a map that maps from executor_id to profile BlockInputStreams.
     std::unordered_map<String, BlockInputStreams> profile_streams_map;

--- a/dbms/src/Flash/Coprocessor/DAGContext.h
+++ b/dbms/src/Flash/Coprocessor/DAGContext.h
@@ -328,6 +328,8 @@ public:
     void setProcessListEntry(std::shared_ptr<ProcessListEntry> entry) { process_list_entry = entry; }
     std::shared_ptr<ProcessListEntry> getProcessListEntry() const { return process_list_entry; }
 
+    void addTableLock(const TableLockHolder & lock) { table_locks.push_back(lock); }
+
     const tipb::DAGRequest * dag_request;
     /// Some existing code inherited from Clickhouse assume that each query must have a valid query string and query ast,
     /// dummy_query_string and dummy_ast is used for that
@@ -406,6 +408,10 @@ private:
     // In disaggregated tiflash mode, table_scan in tiflash_compute node will be converted ExchangeReceiver.
     // Record here so we can add to receiver_set and cancel/close it.
     std::optional<std::pair<String, ExchangeReceiverPtr>> disaggregated_compute_exchange_receiver;
+
+    /// We don't want the table to be dropped during the lifetime of this query,
+    /// and sometimes if there is no local region, we will hold the table lock.
+    TableLockHolders table_locks;
 };
 
 } // namespace DB

--- a/dbms/src/Flash/Coprocessor/DAGContext.h
+++ b/dbms/src/Flash/Coprocessor/DAGContext.h
@@ -409,8 +409,8 @@ private:
     // Record here so we can add to receiver_set and cancel/close it.
     std::optional<std::pair<String, ExchangeReceiverPtr>> disaggregated_compute_exchange_receiver;
 
-    /// We don't want the table to be dropped during the lifetime of this query,
-    /// and sometimes if there is no local region, we will hold the table lock.
+    /// Holding the table lock to make sure that the table wouldn't be dropped during the lifetime of this query,
+    /// even if there are no local regions.
     TableLockHolders table_locks;
 };
 

--- a/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
@@ -360,15 +360,8 @@ void DAGStorageInterpreter::executeImpl(DAGPipeline & pipeline)
         remote_read_streams_start_index = 1;
     }
 
-    /// We don't want the table to be dropped during the lifetime of this query,
-    /// and sometimes if there is no local region, we will use the RemoteBlockInputStream
-    /// or even the null_stream to hold the lock.
-    pipeline.transform([&](auto & stream) {
-        // todo do not need to hold all locks in each stream, if the stream is reading from table a
-        //  it only needs to hold the lock of table a
-        for (const auto & lock : drop_locks)
-            stream->addTableLock(lock);
-    });
+    for (const auto & lock : drop_locks)
+        dagContext().addTableLock(lock);
 
     /// Set the limits and quota for reading data, the speed and time of the query.
     setQuotaAndLimitsOnTableScan(context, pipeline);

--- a/dbms/src/Flash/Executor/DataStreamExecutor.cpp
+++ b/dbms/src/Flash/Executor/DataStreamExecutor.cpp
@@ -42,10 +42,10 @@ ExecutionResult DataStreamExecutor::execute(ResultHandler result_handler)
     }
 }
 
-void DataStreamExecutor::cancel(bool is_kill)
+void DataStreamExecutor::cancel()
 {
     if (auto * p_stream = dynamic_cast<IProfilingBlockInputStream *>(data_stream.get()); p_stream)
-        p_stream->cancel(is_kill);
+        p_stream->cancel(/*is_kill=*/false);
 }
 
 String DataStreamExecutor::dump() const

--- a/dbms/src/Flash/Executor/DataStreamExecutor.cpp
+++ b/dbms/src/Flash/Executor/DataStreamExecutor.cpp
@@ -45,7 +45,7 @@ ExecutionResult DataStreamExecutor::execute(ResultHandler result_handler)
 void DataStreamExecutor::cancel()
 {
     if (auto * p_stream = dynamic_cast<IProfilingBlockInputStream *>(data_stream.get()); p_stream)
-        p_stream->cancel(/*is_kill=*/false);
+        p_stream->cancel(/*kill=*/false);
 }
 
 String DataStreamExecutor::dump() const

--- a/dbms/src/Flash/Executor/DataStreamExecutor.h
+++ b/dbms/src/Flash/Executor/DataStreamExecutor.h
@@ -32,7 +32,7 @@ public:
 
     String dump() const override;
 
-    void cancel(bool is_kill) override;
+    void cancel() override;
 
     int estimateNewThreadCount() override;
 

--- a/dbms/src/Flash/Executor/QueryExecutor.h
+++ b/dbms/src/Flash/Executor/QueryExecutor.h
@@ -59,7 +59,7 @@ public:
     ExecutionResult execute();
     ExecutionResult execute(ResultHandler::Handler handler);
 
-    virtual void cancel(bool is_kill) = 0;
+    virtual void cancel() = 0;
 
     virtual String dump() const = 0;
 

--- a/dbms/src/Flash/Mpp/MPPTask.cpp
+++ b/dbms/src/Flash/Mpp/MPPTask.cpp
@@ -94,7 +94,7 @@ void MPPTask::abortReceivers()
     receiver_set->cancel();
 }
 
-void MPPTask::abortDataStreams()
+void MPPTask::abortQueryExecutor()
 {
     if (auto query_executor = query_executor_holder.tryGet(); query_executor)
     {
@@ -494,7 +494,7 @@ void MPPTask::abort(const String & message, AbortType abort_type)
             /// the original error
             err_string = message;
             abortTunnels(message, false);
-            abortDataStreams();
+            abortQueryExecutor();
             abortReceivers();
             scheduleThisTask(ScheduleState::FAILED);
             /// runImpl is running, leave remaining work to runImpl

--- a/dbms/src/Flash/Mpp/MPPTask.cpp
+++ b/dbms/src/Flash/Mpp/MPPTask.cpp
@@ -94,14 +94,12 @@ void MPPTask::abortReceivers()
     receiver_set->cancel();
 }
 
-void MPPTask::abortDataStreams(AbortType abort_type)
+void MPPTask::abortDataStreams()
 {
-    /// When abort type is ONERROR, it means MPPTask already known it meet error, so let the remaining task stop silently to avoid too many useless error message
-    bool is_kill = abort_type == AbortType::ONCANCELLATION;
     if (auto query_executor = query_executor_holder.tryGet(); query_executor)
     {
         assert(query_executor.value());
-        (*query_executor)->cancel(is_kill);
+        (*query_executor)->cancel();
     }
 }
 
@@ -496,7 +494,7 @@ void MPPTask::abort(const String & message, AbortType abort_type)
             /// the original error
             err_string = message;
             abortTunnels(message, false);
-            abortDataStreams(abort_type);
+            abortDataStreams();
             abortReceivers();
             scheduleThisTask(ScheduleState::FAILED);
             /// runImpl is running, leave remaining work to runImpl

--- a/dbms/src/Flash/Mpp/MPPTask.h
+++ b/dbms/src/Flash/Mpp/MPPTask.h
@@ -92,7 +92,7 @@ private:
 
     void abortTunnels(const String & message, bool wait_sender_finish);
     void abortReceivers();
-    void abortDataStreams(AbortType abort_type);
+    void abortDataStreams();
 
     void finishWrite();
 

--- a/dbms/src/Flash/Mpp/MPPTask.h
+++ b/dbms/src/Flash/Mpp/MPPTask.h
@@ -92,7 +92,7 @@ private:
 
     void abortTunnels(const String & message, bool wait_sender_finish);
     void abortReceivers();
-    void abortDataStreams();
+    void abortQueryExecutor();
 
     void finishWrite();
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: 
ref #5095 
ref #5900

Problem Summary:

### What is changed and how it works?
- Move the table locks from `BlockInputStream` to `DAGContext`
- Always use non-kill to cancel `BlockInputStream`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
