### PR TITLE
.*: Refine `FilterBlockInputStream` and `FilterTransformAction`

### DIFF
--- a/dbms/src/DataStreams/FilterBlockInputStream.cpp
+++ b/dbms/src/DataStreams/FilterBlockInputStream.cpp
@@ -67,12 +67,13 @@ Block FilterBlockInputStream::readImpl()
     /// Until non-empty block after filtering or end of stream.
     while (true)
     {
-        res = children.back()->read();
+        FilterPtr child_filter = nullptr;
+        res = children.back()->read(child_filter, true);
 
         if (!res)
             return res;
 
-        if (filter_transform_action.transform(res))
+        if (filter_transform_action.transform(res, child_filter))
             return res;
     }
 }

--- a/dbms/src/DataStreams/FilterTransformAction.cpp
+++ b/dbms/src/DataStreams/FilterTransformAction.cpp
@@ -18,8 +18,8 @@
 #include <Columns/FilterDescription.h>
 #include <Common/typeid_cast.h>
 #include <DataStreams/FilterTransformAction.h>
+
 #include <algorithm>
-#include "Common/Exception.h"
 
 namespace DB
 {

--- a/dbms/src/DataStreams/FilterTransformAction.h
+++ b/dbms/src/DataStreams/FilterTransformAction.h
@@ -15,11 +15,13 @@
 #pragma once
 
 #include <Columns/FilterDescription.h>
-#include <DataStreams/IBlockInputStream.h>
 #include <Interpreters/ExpressionActions.h>
 
 namespace DB
 {
+
+using FilterPtr = IColumn::Filter *;
+
 struct FilterTransformAction
 {
 public:
@@ -41,4 +43,5 @@ private:
 
     ConstantFilterDescription constant_filter_description;
 };
+
 } // namespace DB

--- a/dbms/src/DataStreams/FilterTransformAction.h
+++ b/dbms/src/DataStreams/FilterTransformAction.h
@@ -16,6 +16,7 @@
 
 #include <Columns/FilterDescription.h>
 #include <Interpreters/ExpressionActions.h>
+#include <DataStreams/IBlockInputStream.h>
 
 namespace DB
 {
@@ -29,7 +30,7 @@ public:
 
     bool alwaysFalse() const;
     // return false if all filter out.
-    bool transform(Block & block);
+    bool transform(Block & block, FilterPtr child_filter);
     Block getHeader() const;
     ExpressionActionsPtr getExperssion() const;
 

--- a/dbms/src/DataStreams/FilterTransformAction.h
+++ b/dbms/src/DataStreams/FilterTransformAction.h
@@ -15,8 +15,8 @@
 #pragma once
 
 #include <Columns/FilterDescription.h>
-#include <Interpreters/ExpressionActions.h>
 #include <DataStreams/IBlockInputStream.h>
+#include <Interpreters/ExpressionActions.h>
 
 namespace DB
 {


### PR DESCRIPTION
Signed-off-by: Lloyd-Pottiger <yan1579196623@gmail.com>

### What problem does this PR solve?

Issue Number: ref #6233 

Problem Summary:

### What is changed and how it works?

In #6250 , replace `child->read(child_filter, true)` by `child->read()` in `FilterBlockInputStream`. When the child of `FilterBlockInputStream` is tablescan, we support `Block read(FilterPtr & res_filter, bool return_filter)`. By calling `Block read(FilterPtr & res_filter, bool return_filter)`, we can merge the column filter together, reducing the cost, since column filter is a heavy-cost operator.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
