### PR TITLE
Storage: support return filter in `UnorderedInputStream`

### DIFF
--- a/dbms/src/Storages/DeltaMerge/ReadThread/MergedTask.cpp
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/MergedTask.cpp
@@ -39,7 +39,7 @@ void MergedTask::initOnce()
         return;
     }
 
-    for (cur_idx = 0; cur_idx < static_cast<int>(units.size()); cur_idx++)
+    for (cur_idx = 0; cur_idx < static_cast<int>(units.size()); ++cur_idx)
     {
         auto & [pool, task, stream] = units[cur_idx];
         if (!pool->valid())

--- a/dbms/src/Storages/DeltaMerge/ReadThread/WorkQueue.h
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/WorkQueue.h
@@ -15,6 +15,7 @@
 
 #include <stdint.h>
 
+#include <cassert>
 #include <condition_variable>
 #include <mutex>
 #include <queue>

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.cpp
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.cpp
@@ -15,7 +15,7 @@
 #include <Common/CurrentMetrics.h>
 #include <Storages/DeltaMerge/Segment.h>
 #include <Storages/DeltaMerge/SegmentReadTaskPool.h>
-#include "DataStreams/IBlockInputStream.h"
+
 
 namespace CurrentMetrics
 {

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.h
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.h
@@ -32,6 +32,7 @@ using SegmentSnapshotPtr = std::shared_ptr<SegmentSnapshot>;
 using SegmentReadTaskPtr = std::shared_ptr<SegmentReadTask>;
 using SegmentReadTasks = std::list<SegmentReadTaskPtr>;
 using AfterSegmentRead = std::function<void(const DMContextPtr &, const SegmentPtr &)>;
+using BlockUnit = std::pair<Block, FilterPtr>;
 
 struct SegmentReadTask
 {
@@ -217,7 +218,7 @@ public:
     BlockInputStreamPtr buildInputStream(SegmentReadTaskPtr & t);
 
     bool readOneBlock(BlockInputStreamPtr & stream, const SegmentPtr & seg);
-    void popBlock(Block & block);
+    void popBlock(BlockUnit & block);
 
     std::unordered_map<uint64_t, std::vector<uint64_t>>::const_iterator scheduleSegment(
         const std::unordered_map<uint64_t, std::vector<uint64_t>> & segments,
@@ -243,7 +244,7 @@ private:
     int64_t getFreeActiveSegmentCountUnlock();
     bool exceptionHappened() const;
     void finishSegment(const SegmentPtr & seg);
-    void pushBlock(Block && block);
+    void pushBlock(BlockUnit && block);
 
     const uint64_t pool_id;
     const int64_t table_id;
@@ -257,7 +258,7 @@ private:
     AfterSegmentRead after_segment_read;
     std::mutex mutex;
     std::unordered_set<uint64_t> active_segment_ids;
-    WorkQueue<Block> q;
+    WorkQueue<BlockUnit> q;
     BlockStat blk_stat;
     LoggerPtr log;
 


### PR DESCRIPTION
Signed-off-by: Lloyd-Pottiger <yan1579196623@gmail.com>

### What problem does this PR solve?

Issue Number: ref #6233 

Problem Summary:

### What is changed and how it works?

Support return filter in `UnorderedInputStream`.

In #6503, we call `Block read(FilterPtr & res_filter, bool return_filter)` in `FilterBlockInputStream` instead of `Block read()` to merge the column filter together, reducing the cost, since the column filter is a heavy-cost operator. The default table scan stream is `UnorderedInputStream`, we add support for it.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
