### PR TITLE
MPP: Fix bug when building disaggregated regions info of mpp dispatch task

### DIFF
--- a/dbms/src/DataStreams/ExchangeSenderBlockInputStream.cpp
+++ b/dbms/src/DataStreams/ExchangeSenderBlockInputStream.cpp
@@ -14,6 +14,7 @@
 
 #include <Common/FailPoint.h>
 #include <DataStreams/ExchangeSenderBlockInputStream.h>
+#include <Flash/Coprocessor/DAGContext.h>
 
 namespace DB
 {

--- a/dbms/src/Debug/dbgFuncCoprocessorUtils.cpp
+++ b/dbms/src/Debug/dbgFuncCoprocessorUtils.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <Debug/dbgFuncCoprocessorUtils.h>
+#include <Flash/Coprocessor/DAGContext.h>
 
 namespace DB
 {

--- a/dbms/src/Debug/dbgFuncCoprocessorUtils.h
+++ b/dbms/src/Debug/dbgFuncCoprocessorUtils.h
@@ -20,7 +20,6 @@
 #include <Flash/Coprocessor/ArrowChunkCodec.h>
 #include <Flash/Coprocessor/CHBlockChunkCodec.h>
 #include <Flash/Coprocessor/ChunkCodec.h>
-#include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/DefaultChunkCodec.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/sortBlock.h>

--- a/dbms/src/Debug/dbgQueryExecutor.cpp
+++ b/dbms/src/Debug/dbgQueryExecutor.cpp
@@ -300,9 +300,7 @@ tipb::SelectResponse executeDAGRequest(Context & context, const tipb::DAGRequest
 
     table_regions_info.local_regions.emplace(region_id, RegionInfo(region_id, region_version, region_conf_version, std::move(key_ranges), nullptr));
 
-    DAGContext dag_context(dag_request);
-    dag_context.tables_regions_info = std::move(tables_regions_info);
-    dag_context.log = log;
+    DAGContext dag_context(dag_request, std::move(tables_regions_info), "", false, log);
     context.setDAGContext(&dag_context);
 
     DAGDriver driver(context, start_ts, DEFAULT_UNSPECIFIED_SCHEMA_VERSION, &dag_response, true);
@@ -330,9 +328,7 @@ bool runAndCompareDagReq(const coprocessor::Request & req, const coprocessor::Re
     auto & table_regions_info = tables_regions_info.getSingleTableRegions();
     table_regions_info.local_regions.emplace(region_id, RegionInfo(region_id, region->version(), region->confVer(), std::move(key_ranges), nullptr));
 
-    DAGContext dag_context(dag_request);
-    dag_context.tables_regions_info = std::move(tables_regions_info);
-    dag_context.log = log;
+    DAGContext dag_context(dag_request, std::move(tables_regions_info), "", false, log);
     context.setDAGContext(&dag_context);
     DAGDriver driver(context, properties.start_ts, DEFAULT_UNSPECIFIED_SCHEMA_VERSION, &dag_response, true);
     driver.execute();

--- a/dbms/src/Flash/BatchCoprocessorHandler.cpp
+++ b/dbms/src/Flash/BatchCoprocessorHandler.cpp
@@ -73,7 +73,7 @@ grpc::Status BatchCoprocessorHandler::execute()
                 dag_request,
                 std::move(tables_regions_info),
                 cop_context.db_context.getClientInfo().current_address.toString(),
-                true,
+                /*is_batch_cop=*/true,
                 Logger::get("BatchCoprocessorHandler"));
             cop_context.db_context.setDAGContext(&dag_context);
 

--- a/dbms/src/Flash/BatchCoprocessorHandler.cpp
+++ b/dbms/src/Flash/BatchCoprocessorHandler.cpp
@@ -69,11 +69,12 @@ grpc::Status BatchCoprocessorHandler::execute()
                 tables_regions_info.tableCount(),
                 dag_request.DebugString());
 
-            DAGContext dag_context(dag_request);
-            dag_context.is_batch_cop = true;
-            dag_context.tables_regions_info = std::move(tables_regions_info);
-            dag_context.log = Logger::get("BatchCoprocessorHandler");
-            dag_context.tidb_host = cop_context.db_context.getClientInfo().current_address.toString();
+            DAGContext dag_context(
+                dag_request,
+                std::move(tables_regions_info),
+                cop_context.db_context.getClientInfo().current_address.toString(),
+                true,
+                Logger::get("BatchCoprocessorHandler"));
             cop_context.db_context.setDAGContext(&dag_context);
 
             DAGDriver<true> driver(cop_context.db_context, cop_request->start_ts() > 0 ? cop_request->start_ts() : dag_request.start_ts_fallback(), cop_request->schema_ver(), writer);

--- a/dbms/src/Flash/BatchCoprocessorHandler.cpp
+++ b/dbms/src/Flash/BatchCoprocessorHandler.cpp
@@ -14,6 +14,7 @@
 
 #include <Common/TiFlashMetrics.h>
 #include <Flash/BatchCoprocessorHandler.h>
+#include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/DAGDriver.h>
 #include <Flash/Coprocessor/InterpreterDAG.h>
 #include <Flash/ServiceUtils.h>

--- a/dbms/src/Flash/Coprocessor/DAGContext.h
+++ b/dbms/src/Flash/Coprocessor/DAGContext.h
@@ -127,13 +127,17 @@ class DAGContext
 {
 public:
     // for non-mpp(cop/batchCop)
-    explicit DAGContext(const tipb::DAGRequest & dag_request_)
+    explicit DAGContext(const tipb::DAGRequest & dag_request_, TablesRegionsInfo && tables_regions_info_, const String & tidb_host_, bool is_batch_cop_, LoggerPtr log_)
         : dag_request(&dag_request_)
         , dummy_query_string(dag_request->DebugString())
         , dummy_ast(makeDummyQuery())
+        , tidb_host(tidb_host_)
         , collect_execution_summaries(dag_request->has_collect_execution_summaries() && dag_request->collect_execution_summaries())
         , is_mpp_task(false)
         , is_root_mpp_task(false)
+        , is_batch_cop(is_batch_cop_)
+        , tables_regions_info(std::move(tables_regions_info_))
+        , log(std::move(log_))
         , flags(dag_request->flags())
         , sql_mode(dag_request->sql_mode())
         , max_recorded_error_count(getMaxErrorCount(*dag_request))
@@ -345,9 +349,9 @@ public:
     String tidb_host = "Unknown";
     bool collect_execution_summaries{};
     bool return_executor_id{};
-    bool is_mpp_task = false;
-    bool is_root_mpp_task = false;
-    bool is_batch_cop = false;
+    /* const */ bool is_mpp_task = false;
+    /* const */ bool is_root_mpp_task = false;
+    /* const */ bool is_batch_cop = false;
     // `tunnel_set` is always set by `MPPTask` and is intended to be used for `DAGQueryBlockInterpreter`.
     MPPTunnelSetPtr tunnel_set;
     TablesRegionsInfo tables_regions_info;

--- a/dbms/src/Flash/Coprocessor/DAGDriver.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGDriver.cpp
@@ -18,6 +18,7 @@
 #include <DataStreams/IProfilingBlockInputStream.h>
 #include <DataStreams/copyData.h>
 #include <Flash/Coprocessor/DAGBlockOutputStream.h>
+#include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/DAGDriver.h>
 #include <Flash/Coprocessor/ExecutionSummaryCollector.h>
 #include <Flash/Coprocessor/StreamWriter.h>

--- a/dbms/src/Flash/Coprocessor/DAGExpressionAnalyzer.h
+++ b/dbms/src/Flash/Coprocessor/DAGExpressionAnalyzer.h
@@ -19,7 +19,6 @@
 #include <tipb/executor.pb.h>
 #pragma GCC diagnostic pop
 
-#include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/DAGQueryBlock.h>
 #include <Flash/Coprocessor/DAGSet.h>
 #include <Flash/Coprocessor/DAGUtils.h>

--- a/dbms/src/Flash/Coprocessor/DAGQueryBlock.h
+++ b/dbms/src/Flash/Coprocessor/DAGQueryBlock.h
@@ -19,7 +19,6 @@
 #include <tipb/select.pb.h>
 #pragma GCC diagnostic pop
 
-#include <Flash/Coprocessor/DAGContext.h>
 #include <Interpreters/IQuerySource.h>
 #include <Storages/Transaction/TiDB.h>
 #include <Storages/Transaction/TiKVKeyValue.h>

--- a/dbms/src/Flash/Coprocessor/DAGQuerySource.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGQuerySource.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/DAGQuerySource.h>
 #include <Flash/Coprocessor/InterpreterDAG.h>
 #include <Flash/Coprocessor/collectOutputFieldTypes.h>

--- a/dbms/src/Flash/Coprocessor/DAGQuerySource.h
+++ b/dbms/src/Flash/Coprocessor/DAGQuerySource.h
@@ -14,13 +14,14 @@
 
 #pragma once
 
-#include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/DAGQueryBlock.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/IQuerySource.h>
 
 namespace DB
 {
+class DAGContext;
+
 /// DAGQuerySource is an adaptor between DAG and CH's executeQuery.
 /// TODO: consider to directly use DAGContext instead.
 class DAGQuerySource : public IQuerySource

--- a/dbms/src/Flash/Coprocessor/DAGResponseWriter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGResponseWriter.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/DAGResponseWriter.h>
 
 namespace DB

--- a/dbms/src/Flash/Coprocessor/DAGResponseWriter.h
+++ b/dbms/src/Flash/Coprocessor/DAGResponseWriter.h
@@ -14,11 +14,13 @@
 
 #pragma once
 
-#include <Flash/Coprocessor/DAGContext.h>
+#include <common/types.h>
 #include <tipb/select.pb.h>
 
 namespace DB
 {
+class DAGContext;
+
 class DAGResponseWriter
 {
 public:

--- a/dbms/src/Flash/Coprocessor/FineGrainedShuffle.h
+++ b/dbms/src/Flash/Coprocessor/FineGrainedShuffle.h
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include <Flash/Coprocessor/DAGContext.h>
 #include <common/types.h>
 #include <tipb/executor.pb.h>
 

--- a/dbms/src/Flash/Coprocessor/InterpreterDAG.h
+++ b/dbms/src/Flash/Coprocessor/InterpreterDAG.h
@@ -21,7 +21,6 @@
 #pragma GCC diagnostic pop
 
 #include <DataStreams/BlockIO.h>
-#include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/DAGQuerySource.h>
 #include <Interpreters/IInterpreter.h>
 
@@ -30,6 +29,7 @@ namespace DB
 class Context;
 class Region;
 using RegionPtr = std::shared_ptr<Region>;
+class DAGContext;
 
 /** build ch plan from dag request: dag executors -> ch plan
   */

--- a/dbms/src/Flash/Coprocessor/MockSourceStream.h
+++ b/dbms/src/Flash/Coprocessor/MockSourceStream.h
@@ -18,7 +18,6 @@
 #include <Core/NamesAndTypes.h>
 #include <DataStreams/MockExchangeReceiverInputStream.h>
 #include <DataStreams/MockTableScanBlockInputStream.h>
-#include <Flash/Coprocessor/DAGContext.h>
 #include <Interpreters/Context.h>
 
 namespace DB

--- a/dbms/src/Flash/Coprocessor/RemoteRequest.cpp
+++ b/dbms/src/Flash/Coprocessor/RemoteRequest.cpp
@@ -14,6 +14,7 @@
 
 #include <Common/FmtUtils.h>
 #include <Flash/Coprocessor/ChunkCodec.h>
+#include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/RemoteRequest.h>
 #include <Storages/MutableSupport.h>
 #include <common/logger_useful.h>

--- a/dbms/src/Flash/Coprocessor/RemoteRequest.h
+++ b/dbms/src/Flash/Coprocessor/RemoteRequest.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <Flash/Coprocessor/PushDownFilter.h>
+#include <Flash/Coprocessor/RegionInfo.h>
 #include <Flash/Coprocessor/TiDBTableScan.h>
 #include <Storages/Transaction/TiDB.h>
 

--- a/dbms/src/Flash/Coprocessor/RequestUtils.h
+++ b/dbms/src/Flash/Coprocessor/RequestUtils.h
@@ -19,6 +19,7 @@
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#pragma clang diagnostic ignored "-Wunused-parameter"
 #endif
 #include <pingcap/coprocessor/Client.h>
 #ifdef __clang__

--- a/dbms/src/Flash/Coprocessor/RequestUtils.h
+++ b/dbms/src/Flash/Coprocessor/RequestUtils.h
@@ -1,0 +1,77 @@
+// Copyright 2022 PingCAP, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <Common/Exception.h>
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+#include <pingcap/coprocessor/Client.h>
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+namespace DB::RequestUtils
+{
+template <typename PbRegion>
+void setUpRegion(const pingcap::coprocessor::RegionInfo & region_info, PbRegion * region)
+{
+    region->set_region_id(region_info.region_id.id);
+    region->mutable_region_epoch()->set_version(region_info.region_id.ver);
+    region->mutable_region_epoch()->set_conf_ver(region_info.region_id.conf_ver);
+    for (const auto & key_range : region_info.ranges)
+    {
+        key_range.setKeyRange(region->add_ranges());
+    }
+}
+
+template <typename RequestPtr>
+std::vector<pingcap::kv::RegionVerID>
+setUpRegionInfos(const pingcap::coprocessor::BatchCopTask & batch_cop_task, const RequestPtr & req)
+{
+    RUNTIME_CHECK_MSG(batch_cop_task.region_infos.empty() != batch_cop_task.table_regions.empty(),
+                      "region_infos and table_regions should not exist at the same time, single table region info: {}, partition table region info: {}",
+                      batch_cop_task.region_infos.size(),
+                      batch_cop_task.table_regions.size());
+
+    std::vector<pingcap::kv::RegionVerID> region_ids;
+    if (!batch_cop_task.region_infos.empty())
+    {
+        // For non-partition table
+        region_ids.reserve(batch_cop_task.region_infos.size());
+        for (const auto & region_info : batch_cop_task.region_infos)
+        {
+            region_ids.push_back(region_info.region_id);
+            setUpRegion(region_info, req->add_regions());
+        }
+        return region_ids;
+    }
+    // For partition table
+    for (const auto & table_region : batch_cop_task.table_regions)
+    {
+        auto * req_table_region = req->add_table_regions();
+        req_table_region->set_physical_table_id(table_region.physical_table_id);
+        for (const auto & region_info : table_region.region_infos)
+        {
+            region_ids.push_back(region_info.region_id);
+            setUpRegion(region_info, req_table_region->add_regions());
+        }
+    }
+    return region_ids;
+}
+
+} // namespace DB::RequestUtils

--- a/dbms/src/Flash/Coprocessor/StreamingDAGResponseWriter.cpp
+++ b/dbms/src/Flash/Coprocessor/StreamingDAGResponseWriter.cpp
@@ -16,6 +16,7 @@
 #include <Common/TiFlashException.h>
 #include <Flash/Coprocessor/ArrowChunkCodec.h>
 #include <Flash/Coprocessor/CHBlockChunkCodec.h>
+#include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/DefaultChunkCodec.h>
 #include <Flash/Coprocessor/StreamWriter.h>
 #include <Flash/Coprocessor/StreamingDAGResponseWriter.h>

--- a/dbms/src/Flash/Coprocessor/StreamingDAGResponseWriter.h
+++ b/dbms/src/Flash/Coprocessor/StreamingDAGResponseWriter.h
@@ -18,13 +18,14 @@
 #include <Core/Types.h>
 #include <DataTypes/IDataType.h>
 #include <Flash/Coprocessor/ChunkCodec.h>
-#include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/DAGResponseWriter.h>
 #include <Flash/Mpp/TrackedMppDataPacket.h>
 #include <common/logger_useful.h>
 
 namespace DB
 {
+class DAGContext;
+
 /// Serializes the stream of blocks and sends them to TiDB/TiSpark with different serialization paths.
 template <class StreamWriterPtr>
 class StreamingDAGResponseWriter : public DAGResponseWriter

--- a/dbms/src/Flash/Coprocessor/TiDBTableScan.cpp
+++ b/dbms/src/Flash/Coprocessor/TiDBTableScan.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/TiDBTableScan.h>
 
 namespace DB

--- a/dbms/src/Flash/Coprocessor/TiDBTableScan.h
+++ b/dbms/src/Flash/Coprocessor/TiDBTableScan.h
@@ -14,11 +14,13 @@
 
 #pragma once
 
-#include <Flash/Coprocessor/DAGContext.h>
+#include <Storages/Transaction/TypeMapping.h>
+#include <common/types.h>
+#include <tipb/executor.pb.h>
 
 namespace DB
 {
-
+class DAGContext;
 using ColumnInfos = std::vector<TiDB::ColumnInfo>;
 
 /// TiDBTableScan is a wrap to hide the difference of `TableScan` and `PartitionTableScan`

--- a/dbms/src/Flash/Coprocessor/UnaryDAGResponseWriter.cpp
+++ b/dbms/src/Flash/Coprocessor/UnaryDAGResponseWriter.cpp
@@ -15,6 +15,7 @@
 #include <DataStreams/IProfilingBlockInputStream.h>
 #include <Flash/Coprocessor/ArrowChunkCodec.h>
 #include <Flash/Coprocessor/CHBlockChunkCodec.h>
+#include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/DefaultChunkCodec.h>
 #include <Flash/Coprocessor/ExecutionSummaryCollector.h>
 #include <Flash/Coprocessor/UnaryDAGResponseWriter.h>

--- a/dbms/src/Flash/Coprocessor/tests/gtest_req_encode.cpp
+++ b/dbms/src/Flash/Coprocessor/tests/gtest_req_encode.cpp
@@ -111,6 +111,7 @@ TEST(RequestEncodeTest, MPPPartitionRegions)
 
     {
         const auto & table0 = req.table_regions(0);
+        ASSERT_EQ(table0.regions_size(), 3);
 
         const auto & reg0 = table0.regions(0);
         ASSERT_REGION_ID_EQ(reg0, pkv::RegionVerID(111, 1, 4));
@@ -132,6 +133,7 @@ TEST(RequestEncodeTest, MPPPartitionRegions)
 
     {
         const auto & table1 = req.table_regions(1);
+        ASSERT_EQ(table1.regions_size(), 2);
 
         const auto & reg0 = table1.regions(0);
         ASSERT_REGION_ID_EQ(reg0, pkv::RegionVerID(444, 1, 4));

--- a/dbms/src/Flash/Coprocessor/tests/gtest_req_encode.cpp
+++ b/dbms/src/Flash/Coprocessor/tests/gtest_req_encode.cpp
@@ -1,0 +1,148 @@
+// Copyright 2022 PingCAP, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Flash/Coprocessor/RequestUtils.h>
+#include <gtest/gtest.h>
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+#include <kvproto/coprocessor.pb.h>
+#include <kvproto/mpp.pb.h>
+#include <pingcap/coprocessor/Client.h>
+#include <pingcap/kv/RegionCache.h>
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+namespace DB::tests
+{
+bool isSameKeyRange(const coprocessor::KeyRange & actual, const pingcap::coprocessor::KeyRange & expect)
+{
+    return (actual.start() == expect.start_key && actual.end() == expect.end_key);
+}
+#define ASSERT_RANGE_EQ(pb_keyrange, expect) ASSERT_TRUE(isSameKeyRange((pb_keyrange), (expect)))
+
+bool isSameRegionId(const coprocessor::RegionInfo & actual, const pingcap::kv::RegionVerID & expect)
+{
+    return actual.region_id() == expect.id
+        && actual.region_epoch().conf_ver() == expect.conf_ver
+        && actual.region_epoch().version() == expect.ver;
+}
+#define ASSERT_REGION_ID_EQ(pb_region, expect) ASSERT_TRUE(isSameRegionId((pb_region), (expect)))
+
+TEST(RequestEncodeTest, MPPNonPartitionRegions)
+{
+    namespace pc = pingcap::coprocessor;
+    namespace pkv = pingcap::kv;
+    pc::BatchCopTask batch_cop_task;
+    std::vector<pc::RegionInfo> regions{
+        pc::RegionInfo{.region_id = {111, 1, 4}, .ranges = {{"a", "b"}, {"b", "c"}}},
+        pc::RegionInfo{.region_id = {222, 2, 5}, .ranges = {{"dd", "e"}, {"f", "g"}}},
+        pc::RegionInfo{.region_id = {333, 3, 6}, .ranges = {{"x", "y"}}},
+    };
+    batch_cop_task.region_infos = regions;
+
+    ::mpp::DispatchTaskRequest req;
+    RequestUtils::setUpRegionInfos(batch_cop_task, &req);
+
+    ASSERT_EQ(req.regions_size(), 3);
+    ASSERT_EQ(req.table_regions_size(), 0);
+
+    auto reg0 = req.regions(0);
+    ASSERT_REGION_ID_EQ(reg0, pkv::RegionVerID(111, 1, 4));
+    ASSERT_EQ(reg0.ranges_size(), 2);
+    ASSERT_RANGE_EQ(reg0.ranges(0), pc::KeyRange("a", "b"));
+    ASSERT_RANGE_EQ(reg0.ranges(1), pc::KeyRange("b", "c"));
+
+    auto reg1 = req.regions(1);
+    ASSERT_REGION_ID_EQ(reg1, pkv::RegionVerID(222, 2, 5));
+    ASSERT_EQ(reg1.ranges_size(), 2);
+    ASSERT_RANGE_EQ(reg1.ranges(0), pc::KeyRange("dd", "e"));
+    ASSERT_RANGE_EQ(reg1.ranges(1), pc::KeyRange("f", "g"));
+
+    auto reg2 = req.regions(2);
+    ASSERT_REGION_ID_EQ(reg2, pkv::RegionVerID(333, 3, 6));
+    ASSERT_EQ(reg2.ranges_size(), 1);
+    ASSERT_RANGE_EQ(reg2.ranges(0), pc::KeyRange("x", "y"));
+}
+
+TEST(RequestEncodeTest, MPPPartitionRegions)
+{
+    namespace pc = pingcap::coprocessor;
+    namespace pkv = pingcap::kv;
+    pc::BatchCopTask batch_cop_task;
+    std::vector<pc::TableRegions> regions{
+        // clang-format off
+        pc::TableRegions{
+            .physical_table_id = 70,
+            .region_infos = {
+                pc::RegionInfo{.region_id = {111, 1, 4}, .ranges = {{"a", "b"}, {"b", "c"}}},
+                pc::RegionInfo{.region_id = {222, 2, 5}, .ranges = {{"dd", "e"}, {"f", "g"}}},
+                pc::RegionInfo{.region_id = {333, 3, 6}, .ranges = {{"x", "y"}}},
+            }},
+        pc::TableRegions{
+            .physical_table_id = 71,
+            .region_infos = {
+                pc::RegionInfo{.region_id = {444, 1, 4}, .ranges = {{"z", "z0"}, {"z2", "z3"}}},
+                pc::RegionInfo{.region_id = {555, 3, 6}, .ranges = {{"zy", "zz"}}},
+            }},
+        // clang-format on
+    };
+    batch_cop_task.table_regions = regions;
+
+    ::mpp::DispatchTaskRequest req;
+    RequestUtils::setUpRegionInfos(batch_cop_task, &req);
+
+    ASSERT_EQ(req.regions_size(), 0);
+    ASSERT_EQ(req.table_regions_size(), 2);
+
+    {
+        const auto & table0 = req.table_regions(0);
+
+        const auto & reg0 = table0.regions(0);
+        ASSERT_REGION_ID_EQ(reg0, pkv::RegionVerID(111, 1, 4));
+        ASSERT_EQ(reg0.ranges_size(), 2);
+        ASSERT_RANGE_EQ(reg0.ranges(0), pc::KeyRange("a", "b"));
+        ASSERT_RANGE_EQ(reg0.ranges(1), pc::KeyRange("b", "c"));
+
+        const auto & reg1 = table0.regions(1);
+        ASSERT_REGION_ID_EQ(reg1, pkv::RegionVerID(222, 2, 5));
+        ASSERT_EQ(reg1.ranges_size(), 2);
+        ASSERT_RANGE_EQ(reg1.ranges(0), pc::KeyRange("dd", "e"));
+        ASSERT_RANGE_EQ(reg1.ranges(1), pc::KeyRange("f", "g"));
+
+        const auto & reg2 = table0.regions(2);
+        ASSERT_REGION_ID_EQ(reg2, pkv::RegionVerID(333, 3, 6));
+        ASSERT_EQ(reg2.ranges_size(), 1);
+        ASSERT_RANGE_EQ(reg2.ranges(0), pc::KeyRange("x", "y"));
+    }
+
+    {
+        const auto & table1 = req.table_regions(1);
+
+        const auto & reg0 = table1.regions(0);
+        ASSERT_REGION_ID_EQ(reg0, pkv::RegionVerID(444, 1, 4));
+        ASSERT_EQ(reg0.ranges_size(), 2);
+        ASSERT_RANGE_EQ(reg0.ranges(0), pc::KeyRange("z", "z0"));
+        ASSERT_RANGE_EQ(reg0.ranges(1), pc::KeyRange("z2", "z3"));
+
+        const auto & reg1 = table1.regions(1);
+        ASSERT_REGION_ID_EQ(reg1, pkv::RegionVerID(555, 3, 6));
+        ASSERT_EQ(reg1.ranges_size(), 1);
+        ASSERT_RANGE_EQ(reg1.ranges(0), pc::KeyRange("zy", "zz"));
+    }
+}
+} // namespace DB::tests

--- a/dbms/src/Flash/Coprocessor/tests/gtest_streaming_writer.cpp
+++ b/dbms/src/Flash/Coprocessor/tests/gtest_streaming_writer.cpp
@@ -15,6 +15,7 @@
 #include <DataTypes/DataTypesNumber.h>
 #include <Flash/Coprocessor/ArrowChunkCodec.h>
 #include <Flash/Coprocessor/CHBlockChunkCodec.h>
+#include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/DefaultChunkCodec.h>
 #include <Interpreters/Context.h>
 #include <Storages/Transaction/TiDB.h>

--- a/dbms/src/Flash/CoprocessorHandler.cpp
+++ b/dbms/src/Flash/CoprocessorHandler.cpp
@@ -110,7 +110,7 @@ grpc::Status CoprocessorHandler::execute()
                 dag_request,
                 std::move(tables_regions_info),
                 cop_context.db_context.getClientInfo().current_address.toString(),
-                false,
+                /*is_batch_cop=*/false,
                 Logger::get("CoprocessorHandler"));
             cop_context.db_context.setDAGContext(&dag_context);
 

--- a/dbms/src/Flash/CoprocessorHandler.cpp
+++ b/dbms/src/Flash/CoprocessorHandler.cpp
@@ -106,10 +106,12 @@ grpc::Status CoprocessorHandler::execute()
                     genCopKeyRange(cop_request->ranges()),
                     &bypass_lock_ts));
 
-            DAGContext dag_context(dag_request);
-            dag_context.tables_regions_info = std::move(tables_regions_info);
-            dag_context.log = Logger::get("CoprocessorHandler");
-            dag_context.tidb_host = cop_context.db_context.getClientInfo().current_address.toString();
+            DAGContext dag_context(
+                dag_request,
+                std::move(tables_regions_info),
+                cop_context.db_context.getClientInfo().current_address.toString(),
+                false,
+                Logger::get("CoprocessorHandler"));
             cop_context.db_context.setDAGContext(&dag_context);
 
             DAGDriver driver(cop_context.db_context, cop_request->start_ts() > 0 ? cop_request->start_ts() : dag_request.start_ts_fallback(), cop_request->schema_ver(), &dag_response);

--- a/dbms/src/Flash/CoprocessorHandler.cpp
+++ b/dbms/src/Flash/CoprocessorHandler.cpp
@@ -15,6 +15,7 @@
 #include <Common/Stopwatch.h>
 #include <Common/TiFlashException.h>
 #include <Common/TiFlashMetrics.h>
+#include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/DAGDriver.h>
 #include <Flash/Coprocessor/InterpreterDAG.h>
 #include <Flash/CoprocessorHandler.h>

--- a/dbms/src/Flash/Mpp/BroadcastOrPassThroughWriter.cpp
+++ b/dbms/src/Flash/Mpp/BroadcastOrPassThroughWriter.cpp
@@ -14,6 +14,7 @@
 
 #include <Common/TiFlashException.h>
 #include <Flash/Coprocessor/CHBlockChunkCodec.h>
+#include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Mpp/BroadcastOrPassThroughWriter.h>
 #include <Flash/Mpp/MPPTunnelSet.h>
 

--- a/dbms/src/Flash/Mpp/BroadcastOrPassThroughWriter.h
+++ b/dbms/src/Flash/Mpp/BroadcastOrPassThroughWriter.h
@@ -15,13 +15,14 @@
 #pragma once
 
 #include <Flash/Coprocessor/ChunkCodec.h>
-#include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/DAGResponseWriter.h>
 #include <Flash/Mpp/TrackedMppDataPacket.h>
 #include <common/types.h>
 
 namespace DB
 {
+class DAGContext;
+
 template <class ExchangeWriterPtr>
 class BroadcastOrPassThroughWriter : public DAGResponseWriter
 {

--- a/dbms/src/Flash/Mpp/ExchangeReceiver.h
+++ b/dbms/src/Flash/Mpp/ExchangeReceiver.h
@@ -19,7 +19,6 @@
 #include <Flash/Coprocessor/CHBlockChunkCodec.h>
 #include <Flash/Coprocessor/ChunkCodec.h>
 #include <Flash/Coprocessor/ChunkDecodeAndSquash.h>
-#include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/DAGUtils.h>
 #include <Flash/Coprocessor/DecodeDetail.h>
 #include <Flash/Mpp/GRPCReceiverContext.h>

--- a/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.cpp
+++ b/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.cpp
@@ -14,6 +14,7 @@
 
 #include <Common/TiFlashException.h>
 #include <Flash/Coprocessor/CHBlockChunkCodec.h>
+#include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Mpp/FineGrainedShuffleWriter.h>
 #include <Flash/Mpp/HashBaseWriterHelper.h>
 #include <Flash/Mpp/MPPTunnelSet.h>

--- a/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.h
+++ b/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.h
@@ -15,13 +15,14 @@
 #pragma once
 
 #include <Flash/Coprocessor/ChunkCodec.h>
-#include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/DAGResponseWriter.h>
 #include <Flash/Mpp/TrackedMppDataPacket.h>
 #include <common/types.h>
 
 namespace DB
 {
+class DAGContext;
+
 template <class ExchangeWriterPtr>
 class FineGrainedShuffleWriter : public DAGResponseWriter
 {

--- a/dbms/src/Flash/Mpp/HashPartitionWriter.cpp
+++ b/dbms/src/Flash/Mpp/HashPartitionWriter.cpp
@@ -14,6 +14,7 @@
 
 #include <Common/TiFlashException.h>
 #include <Flash/Coprocessor/CHBlockChunkCodec.h>
+#include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Mpp/HashBaseWriterHelper.h>
 #include <Flash/Mpp/HashPartitionWriter.h>
 #include <Flash/Mpp/MPPTunnelSet.h>

--- a/dbms/src/Flash/Mpp/HashPartitionWriter.h
+++ b/dbms/src/Flash/Mpp/HashPartitionWriter.h
@@ -15,13 +15,14 @@
 #pragma once
 
 #include <Flash/Coprocessor/ChunkCodec.h>
-#include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/DAGResponseWriter.h>
 #include <Flash/Mpp/TrackedMppDataPacket.h>
 #include <common/types.h>
 
 namespace DB
 {
+class DAGContext;
+
 template <class ExchangeWriterPtr>
 class HashPartitionWriter : public DAGResponseWriter
 {

--- a/dbms/src/Flash/Mpp/MPPReceiverSet.h
+++ b/dbms/src/Flash/Mpp/MPPReceiverSet.h
@@ -15,7 +15,6 @@
 #pragma once
 
 #include <Flash/Coprocessor/CoprocessorReader.h>
-#include <Flash/Coprocessor/DAGContext.h>
 
 namespace DB
 {

--- a/dbms/src/Flash/Mpp/tests/gtest_mpp_exchange_writer.cpp
+++ b/dbms/src/Flash/Mpp/tests/gtest_mpp_exchange_writer.cpp
@@ -15,6 +15,7 @@
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <Flash/Coprocessor/CHBlockChunkCodec.h>
+#include <Flash/Coprocessor/DAGContext.h>
 #include <Storages/Transaction/TiDB.h>
 #include <TestUtils/ColumnGenerator.h>
 #include <TestUtils/TiFlashTestBasic.h>

--- a/dbms/src/Flash/Planner/PlanQuerySource.cpp
+++ b/dbms/src/Flash/Planner/PlanQuerySource.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Planner/PlanQuerySource.h>
 #include <Flash/Planner/Planner.h>
 #include <Parsers/makeDummyQuery.h>
@@ -38,6 +39,11 @@ String PlanQuerySource::str(size_t)
 std::unique_ptr<IInterpreter> PlanQuerySource::interpreter(Context &, QueryProcessingStage::Enum)
 {
     return std::make_unique<Planner>(context, *this);
+}
+
+const tipb::DAGRequest & PlanQuerySource::getDAGRequest() const
+{
+    return *getDAGContext().dag_request;
 }
 
 } // namespace DB

--- a/dbms/src/Flash/Planner/PlanQuerySource.h
+++ b/dbms/src/Flash/Planner/PlanQuerySource.h
@@ -14,12 +14,13 @@
 
 #pragma once
 
-#include <Flash/Coprocessor/DAGContext.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/IQuerySource.h>
 
 namespace DB
 {
+class DAGContext;
+
 class PlanQuerySource : public IQuerySource
 {
 public:
@@ -30,7 +31,7 @@ public:
     std::unique_ptr<IInterpreter> interpreter(Context & context, QueryProcessingStage::Enum stage) override;
 
     DAGContext & getDAGContext() const { return *context.getDAGContext(); }
-    const tipb::DAGRequest & getDAGRequest() const { return *getDAGContext().dag_request; }
+    const tipb::DAGRequest & getDAGRequest() const;
 
 private:
     Context & context;

--- a/dbms/src/Flash/Planner/plans/PhysicalMockExchangeReceiver.cpp
+++ b/dbms/src/Flash/Planner/plans/PhysicalMockExchangeReceiver.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <DataStreams/MockExchangeReceiverInputStream.h>
+#include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/DAGPipeline.h>
 #include <Flash/Coprocessor/MockSourceStream.h>
 #include <Flash/Planner/FinalizeHelper.h>

--- a/dbms/src/Flash/Planner/plans/PhysicalMockTableScan.cpp
+++ b/dbms/src/Flash/Planner/plans/PhysicalMockTableScan.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <DataStreams/MockTableScanBlockInputStream.h>
+#include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/DAGPipeline.h>
 #include <Flash/Coprocessor/GenSchemaAndColumn.h>
 #include <Flash/Coprocessor/MockSourceStream.h>

--- a/dbms/src/Flash/Statistics/ExchangeSenderImpl.cpp
+++ b/dbms/src/Flash/Statistics/ExchangeSenderImpl.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <Common/TiFlashException.h>
+#include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/DAGUtils.h>
 #include <Flash/Mpp/MPPTunnelSet.h>
 #include <Flash/Statistics/ExchangeSenderImpl.h>

--- a/dbms/src/Flash/Statistics/ExecutorStatistics.h
+++ b/dbms/src/Flash/Statistics/ExecutorStatistics.h
@@ -31,6 +31,8 @@
 
 namespace DB
 {
+class DAGContext;
+
 template <typename ExecutorImpl>
 class ExecutorStatistics : public ExecutorStatisticsBase
 {

--- a/dbms/src/Flash/tests/gtest_storage_disaggregated.cpp
+++ b/dbms/src/Flash/tests/gtest_storage_disaggregated.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <Core/TiFlashDisaggregatedMode.h>
+#include <Flash/Coprocessor/DAGContext.h>
 #include <Storages/StorageDisaggregated.h>
 #include <TestUtils/ExecutorTestUtils.h>
 #include <TestUtils/mockExecutor.h>

--- a/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter.h
@@ -19,7 +19,6 @@
 #include <Common/TiFlashMetrics.h>
 #include <Encryption/ReadBufferFromFileProvider.h>
 #include <Encryption/createReadBufferFromFileBaseByFileProvider.h>
-#include <Flash/Coprocessor/DAGContext.h>
 #include <Storages/DeltaMerge/DMContext.h>
 #include <Storages/DeltaMerge/File/DMFile.h>
 #include <Storages/DeltaMerge/Filter/FilterHelper.h>

--- a/dbms/src/Storages/StorageDisaggregated.cpp
+++ b/dbms/src/Storages/StorageDisaggregated.cpp
@@ -21,6 +21,19 @@ namespace DB
 {
 const String StorageDisaggregated::ExecIDPrefixForTiFlashStorageSender = "exec_id_disaggregated_tiflash_storage_sender";
 
+StorageDisaggregated::StorageDisaggregated(
+    Context & context_,
+    const TiDBTableScan & table_scan_,
+    const PushDownFilter & push_down_filter_)
+    : IStorage()
+    , context(context_)
+    , table_scan(table_scan_)
+    , log(Logger::get(context_.getDAGContext()->log ? context_.getDAGContext()->log->identifier() : ""))
+    , sender_target_mpp_task_id(context_.getDAGContext()->getMPPTaskMeta())
+    , push_down_filter(push_down_filter_)
+{
+}
+
 BlockInputStreams StorageDisaggregated::read(
     const Names &,
     const SelectQueryInfo &,

--- a/dbms/src/Storages/StorageDisaggregated.h
+++ b/dbms/src/Storages/StorageDisaggregated.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <Common/Logger.h>
+#include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/DAGExpressionAnalyzer.h>
 #include <Flash/Coprocessor/DAGPipeline.h>
 #include <Flash/Coprocessor/RemoteRequest.h>
@@ -39,14 +40,7 @@ public:
     StorageDisaggregated(
         Context & context_,
         const TiDBTableScan & table_scan_,
-        const PushDownFilter & push_down_filter_)
-        : IStorage()
-        , context(context_)
-        , table_scan(table_scan_)
-        , log(Logger::get(context_.getDAGContext()->log ? context_.getDAGContext()->log->identifier() : ""))
-        , sender_target_mpp_task_id(context_.getDAGContext()->getMPPTaskMeta())
-        , push_down_filter(push_down_filter_)
-    {}
+        const PushDownFilter & push_down_filter_);
 
     std::string getName() const override
     {

--- a/dbms/src/Storages/tests/gtest_filter_parser.cpp
+++ b/dbms/src/Storages/tests/gtest_filter_parser.cpp
@@ -83,7 +83,7 @@ DM::RSOperatorPtr FilterParserTest::generateRsOperator(const String table_info_j
         },
         getDAGProperties(""));
     auto & dag_request = *query_tasks[0].dag_request;
-    DAGContext dag_context(dag_request);
+    DAGContext dag_context(dag_request, {}, "", false, log);
     ctx.setDAGContext(&dag_context);
     // Don't care about regions information in this test
     DAGQuerySource dag(ctx);

--- a/dbms/src/TestUtils/ColumnsToTiPBExpr.h
+++ b/dbms/src/TestUtils/ColumnsToTiPBExpr.h
@@ -20,7 +20,6 @@
 #include <Core/Field.h>
 #include <Core/Types.h>
 #include <DataTypes/IDataType.h>
-#include <Flash/Coprocessor/DAGContext.h>
 
 namespace DB
 {

--- a/dbms/src/TestUtils/MPPTaskTestUtils.cpp
+++ b/dbms/src/TestUtils/MPPTaskTestUtils.cpp
@@ -104,7 +104,7 @@ ColumnsWithTypeAndName MPPTaskTestUtils::executeCoprocessorTask(std::shared_ptr<
     auto * data = req->mutable_data();
     dag_request->AppendToString(data);
 
-    DAGContext dag_context(*dag_request);
+    DAGContext dag_context(*dag_request, {}, "", false, Logger::get());
 
     TiFlashTestEnv::getGlobalContext(test_meta.context_idx).setDAGContext(&dag_context);
     TiFlashTestEnv::getGlobalContext(test_meta.context_idx).setCopTest();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/6513

Problem Summary:
Only the last region in a partition table is read from the write node, with many key ranges out of that region
https://github.com/pingcap/tiflash/blob/cadb7cd4362fa6a7a4b554f5497b2998cfb39aa8/dbms/src/Storages/StorageDisaggregated.cpp#L143-L154

### What is changed and how it works?

* Add `RequestUtils::setUpRegionInfos` to build the tables info of MPPTask/CoprocessorTask and DisaggregatedTask (in later PRs)
* Move some include DAGContext.h into .cpp files to shorten the re-compile time after DAGContext changed

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
