### PR TITLE
Fix stale read in testing scenario

### DIFF
--- a/dbms/src/Storages/Transaction/LearnerRead.cpp
+++ b/dbms/src/Storages/Transaction/LearnerRead.cpp
@@ -219,7 +219,7 @@ LearnerReadSnapshot doLearnerRead(
                 const auto & region_to_query = regions_info[region_idx];
                 const RegionID region_id = region_to_query.region_id;
                 UInt64 physical_tso = read_index_tso >> TsoPhysicalShiftBits;
-                bool can_stale_read = physical_tso < region_table.getSelfSafeTS(region_id);
+                bool can_stale_read = read_index_tso != 0 && physical_tso < region_table.getSelfSafeTS(region_id);
                 if (!can_stale_read)
                 {
                     if (auto ori_read_index = mvcc_query_info.getReadIndexRes(region_id); ori_read_index)

--- a/dbms/src/Storages/Transaction/LearnerRead.cpp
+++ b/dbms/src/Storages/Transaction/LearnerRead.cpp
@@ -219,7 +219,7 @@ LearnerReadSnapshot doLearnerRead(
                 const auto & region_to_query = regions_info[region_idx];
                 const RegionID region_id = region_to_query.region_id;
                 UInt64 physical_tso = read_index_tso >> TsoPhysicalShiftBits;
-                bool can_stale_read = read_index_tso != 0 && physical_tso < region_table.getSelfSafeTS(region_id);
+                bool can_stale_read = mvcc_query_info->read_tso != std::numeric_limits<uint64_t>::max() && physical_tso < region_table.getSelfSafeTS(region_id);
                 if (!can_stale_read)
                 {
                     if (auto ori_read_index = mvcc_query_info.getReadIndexRes(region_id); ori_read_index)


### PR DESCRIPTION
Signed-off-by: hehechen <awd123456sss@gmail.com>

### What problem does this PR solve?

Issue Number: close #6525

Problem Summary:
https://ci.pingcap.net/blue/organizations/jenkins/tiflash_scripts_ghpr_test/detail/tiflash_scripts_ghpr_test/314/pipeline
test case failed because [the read_tso is std::numeric_limits<uint64_t>::max() and became 0](https://github.com/pingcap/tiflash/blob/b99541f240c2d56c4aaadfb80de0d51f1a64c389/dbms/src/Storages/Transaction/LearnerRead.cpp#L215) so that stale read was triggered.
### What is changed and how it works?
`read_tso is 0` means that it is in testing scenario, should not trigger stale read.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
