### PR TITLE
*: Remove useless DataType widen property

### DIFF
--- a/dbms/src/DataTypes/DataTypeNullable.cpp
+++ b/dbms/src/DataTypes/DataTypeNullable.cpp
@@ -67,12 +67,12 @@ void DataTypeNullable::serializeBinaryBulkWithMultipleStreams(
     bool position_independent_encoding,
     SubstreamPath & path) const
 {
-    const ColumnNullable & col = static_cast<const ColumnNullable &>(column);
+    const auto & col = static_cast<const ColumnNullable &>(column);
     col.checkConsistency();
 
     /// First serialize null map.
     path.push_back(Substream::NullMap);
-    if (auto stream = getter(path))
+    if (auto * stream = getter(path))
         DataTypeUInt8().serializeBinaryBulk(col.getNullMapColumn(), *stream, offset, limit);
 
     /// Then serialize contents of arrays.
@@ -89,10 +89,10 @@ void DataTypeNullable::deserializeBinaryBulkWithMultipleStreams(
     bool position_independent_encoding,
     SubstreamPath & path) const
 {
-    ColumnNullable & col = static_cast<ColumnNullable &>(column);
+    auto & col = static_cast<ColumnNullable &>(column);
 
     path.push_back(Substream::NullMap);
-    if (auto stream = getter(path))
+    if (auto * stream = getter(path))
         DataTypeUInt8().deserializeBinaryBulk(col.getNullMapColumn(), *stream, limit, 0);
 
     path.back() = Substream::NullableElements;
@@ -102,7 +102,7 @@ void DataTypeNullable::deserializeBinaryBulkWithMultipleStreams(
 
 void DataTypeNullable::serializeBinary(const IColumn & column, size_t row_num, WriteBuffer & ostr) const
 {
-    const ColumnNullable & col = static_cast<const ColumnNullable &>(column);
+    const auto & col = static_cast<const ColumnNullable &>(column);
 
     bool is_null = col.isNullAt(row_num);
     writeBinary(is_null, ostr);
@@ -118,7 +118,7 @@ static void safeDeserialize(
     CheckForNull && check_for_null,
     DeserializeNested && deserialize_nested)
 {
-    ColumnNullable & col = static_cast<ColumnNullable &>(column);
+    auto & col = static_cast<ColumnNullable &>(column);
 
     if (check_for_null())
     {
@@ -145,14 +145,14 @@ void DataTypeNullable::deserializeBinary(IColumn & column, ReadBuffer & istr) co
 {
     safeDeserialize(
         column,
-        [&istr] { bool is_null = 0; readBinary(is_null, istr); return is_null; },
+        [&istr] { bool is_null = false; readBinary(is_null, istr); return is_null; },
         [this, &istr](IColumn & nested) { nested_data_type->deserializeBinary(nested, istr); });
 }
 
 
 void DataTypeNullable::serializeTextEscaped(const IColumn & column, size_t row_num, WriteBuffer & ostr) const
 {
-    const ColumnNullable & col = static_cast<const ColumnNullable &>(column);
+    const auto & col = static_cast<const ColumnNullable &>(column);
 
     if (col.isNullAt(row_num))
         writeCString("\\N", ostr);
@@ -220,7 +220,7 @@ void DataTypeNullable::deserializeTextEscaped(IColumn & column, ReadBuffer & ist
 
 void DataTypeNullable::serializeTextQuoted(const IColumn & column, size_t row_num, WriteBuffer & ostr) const
 {
-    const ColumnNullable & col = static_cast<const ColumnNullable &>(column);
+    const auto & col = static_cast<const ColumnNullable &>(column);
 
     if (col.isNullAt(row_num))
         writeCString("NULL", ostr);
@@ -239,7 +239,7 @@ void DataTypeNullable::deserializeTextQuoted(IColumn & column, ReadBuffer & istr
 
 void DataTypeNullable::serializeTextCSV(const IColumn & column, size_t row_num, WriteBuffer & ostr) const
 {
-    const ColumnNullable & col = static_cast<const ColumnNullable &>(column);
+    const auto & col = static_cast<const ColumnNullable &>(column);
 
     if (col.isNullAt(row_num))
         writeCString("\\N", ostr);
@@ -257,7 +257,7 @@ void DataTypeNullable::deserializeTextCSV(IColumn & column, ReadBuffer & istr, c
 
 void DataTypeNullable::serializeText(const IColumn & column, size_t row_num, WriteBuffer & ostr) const
 {
-    const ColumnNullable & col = static_cast<const ColumnNullable &>(column);
+    const auto & col = static_cast<const ColumnNullable &>(column);
 
     if (col.isNullAt(row_num))
         writeCString("NULL", ostr);
@@ -267,7 +267,7 @@ void DataTypeNullable::serializeText(const IColumn & column, size_t row_num, Wri
 
 void DataTypeNullable::serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettingsJSON & settings) const
 {
-    const ColumnNullable & col = static_cast<const ColumnNullable &>(column);
+    const auto & col = static_cast<const ColumnNullable &>(column);
 
     if (col.isNullAt(row_num))
         writeCString("null", ostr);
@@ -285,7 +285,7 @@ void DataTypeNullable::deserializeTextJSON(IColumn & column, ReadBuffer & istr) 
 
 void DataTypeNullable::serializeTextXML(const IColumn & column, size_t row_num, WriteBuffer & ostr) const
 {
-    const ColumnNullable & col = static_cast<const ColumnNullable &>(column);
+    const auto & col = static_cast<const ColumnNullable &>(column);
 
     if (col.isNullAt(row_num))
         writeCString("\\N", ostr);

--- a/dbms/src/DataTypes/DataTypeNullable.cpp
+++ b/dbms/src/DataTypes/DataTypeNullable.cpp
@@ -100,47 +100,6 @@ void DataTypeNullable::deserializeBinaryBulkWithMultipleStreams(
 }
 
 
-void DataTypeNullable::serializeWidenBinaryBulkWithMultipleStreams(
-    const IColumn & column,
-    const OutputStreamGetter & getter,
-    size_t offset,
-    size_t limit,
-    bool position_independent_encoding,
-    SubstreamPath & path) const
-{
-    const ColumnNullable & col = static_cast<const ColumnNullable &>(column);
-    col.checkConsistency();
-
-    /// First serialize null map.
-    path.push_back(Substream::NullMap);
-    if (auto stream = getter(path))
-        DataTypeUInt8().serializeBinaryBulk(col.getNullMapColumn(), *stream, offset, limit);
-
-    /// Then serialize contents of arrays.
-    path.back() = Substream::NullableElements;
-    nested_data_type->serializeWidenBinaryBulkWithMultipleStreams(col.getNestedColumn(), getter, offset, limit, position_independent_encoding, path);
-}
-
-
-void DataTypeNullable::deserializeWidenBinaryBulkWithMultipleStreams(
-    IColumn & column,
-    const InputStreamGetter & getter,
-    size_t limit,
-    double avg_value_size_hint,
-    bool position_independent_encoding,
-    SubstreamPath & path) const
-{
-    ColumnNullable & col = static_cast<ColumnNullable &>(column);
-
-    path.push_back(Substream::NullMap);
-    if (auto stream = getter(path))
-        DataTypeUInt8().deserializeBinaryBulk(col.getNullMapColumn(), *stream, limit, 0);
-
-    path.back() = Substream::NullableElements;
-    nested_data_type->deserializeWidenBinaryBulkWithMultipleStreams(col.getNestedColumn(), getter, limit, avg_value_size_hint, position_independent_encoding, path);
-}
-
-
 void DataTypeNullable::serializeBinary(const IColumn & column, size_t row_num, WriteBuffer & ostr) const
 {
     const ColumnNullable & col = static_cast<const ColumnNullable &>(column);

--- a/dbms/src/DataTypes/DataTypeNullable.h
+++ b/dbms/src/DataTypes/DataTypeNullable.h
@@ -50,22 +50,6 @@ public:
         bool position_independent_encoding,
         SubstreamPath & path) const override;
 
-    void serializeWidenBinaryBulkWithMultipleStreams(
-        const IColumn & column,
-        const OutputStreamGetter & getter,
-        size_t offset,
-        size_t limit,
-        bool position_independent_encoding,
-        SubstreamPath & path) const override;
-
-    void deserializeWidenBinaryBulkWithMultipleStreams(
-        IColumn & column,
-        const InputStreamGetter & getter,
-        size_t limit,
-        double avg_value_size_hint,
-        bool position_independent_encoding,
-        SubstreamPath & path) const override;
-
     void serializeBinary(const Field & field, WriteBuffer & ostr) const override { nested_data_type->serializeBinary(field, ostr); }
     void deserializeBinary(Field & field, ReadBuffer & istr) const override { nested_data_type->deserializeBinary(field, istr); }
     void serializeBinary(const IColumn & column, size_t row_num, WriteBuffer & ostr) const override;

--- a/dbms/src/DataTypes/DataTypeNumberBase.cpp
+++ b/dbms/src/DataTypes/DataTypeNumberBase.cpp
@@ -42,7 +42,7 @@ void DataTypeNumberBase<T>::serializeTextEscaped(const IColumn & column, size_t 
 template <typename T>
 static void deserializeText(IColumn & column, ReadBuffer & istr)
 {
-    T x;
+    T x{};
 
     if constexpr (std::is_integral_v<T> && std::is_arithmetic_v<T>)
         readIntTextUnsafe(x, istr);
@@ -198,7 +198,7 @@ template <typename T>
 void DataTypeNumberBase<T>::serializeBinary(const Field & field, WriteBuffer & ostr) const
 {
     /// ColumnVector<T>::value_type is a narrower type. For example, UInt8, when the Field type is UInt64
-    typename ColumnVector<T>::value_type x = get<typename NearestFieldType<FieldType>::Type>(field);
+    auto x = get<typename NearestFieldType<FieldType>::Type>(field);
     writeBinary(x, ostr);
 }
 

--- a/dbms/src/DataTypes/DataTypeNumberBase.cpp
+++ b/dbms/src/DataTypes/DataTypeNumberBase.cpp
@@ -214,15 +214,6 @@ template <typename T>
 void DataTypeNumberBase<T>::serializeBinary(const IColumn & column, size_t row_num, WriteBuffer & ostr) const
 {
     writeBinary(static_cast<const ColumnVector<T> &>(column).getData()[row_num], ostr);
-    // if (likely(widened))
-    // {
-    //     using WidestType = typename NearestFieldType<T>::Type;
-    //     writeBinary(static_cast<T>(static_cast<const ColumnVector<WidestType> &>(column).getData()[row_num]), ostr);
-    // }
-    // else
-    // {
-    //     writeBinary(static_cast<const ColumnVector<T> &>(column).getData()[row_num], ostr);
-    // }
 }
 
 template <typename T>
@@ -231,18 +222,6 @@ void DataTypeNumberBase<T>::deserializeBinary(IColumn & column, ReadBuffer & ist
     typename ColumnVector<T>::value_type x;
     readBinary(x, istr);
     static_cast<ColumnVector<T> &>(column).getData().push_back(x);
-    // if (likely(widened))
-    // {
-    //     using WidestType = typename NearestFieldType<T>::Type;
-    //     typename ColumnVector<WidestType>::value_type y;
-    //     readBinary(y, istr);
-    //     x = static_cast<T>(y);
-    // }
-    // else
-    // {
-    //     readBinary(x, istr);
-    // }
-    // static_cast<ColumnVector<T> &>(column).getData().push_back(x);
 }
 
 template <typename T>
@@ -266,51 +245,6 @@ void DataTypeNumberBase<T>::deserializeBinaryBulk(IColumn & column, ReadBuffer &
     x.resize(initial_size + limit);
     size_t size = istr.readBig(reinterpret_cast<char *>(&x[initial_size]), sizeof(typename ColumnVector<T>::value_type) * limit);
     x.resize(initial_size + size / sizeof(typename ColumnVector<T>::value_type));
-}
-
-template <typename T>
-void DataTypeNumberBase<T>::serializeWidenBinaryBulk(const IColumn & column, WriteBuffer & ostr, size_t offset, size_t limit) const
-{
-    if (!widened)
-        return serializeBinaryBulk(column, ostr, offset, limit);
-
-    const typename ColumnVector<T>::Container & x = typeid_cast<const ColumnVector<T> &>(column).getData();
-
-    size_t size = x.size();
-
-    if (limit == 0 || offset + limit > size)
-        limit = size - offset;
-
-    using WidestType = typename NearestFieldType<T>::Type;
-    typename ColumnVector<WidestType>::Container y(limit);
-    for (size_t i = 0; i < limit; i++)
-    {
-        y[i] = static_cast<WidestType>(x[offset + i]);
-    }
-
-    ostr.write(reinterpret_cast<const char *>(&y[0]), sizeof(typename ColumnVector<WidestType>::value_type) * limit);
-}
-
-template <typename T>
-void DataTypeNumberBase<T>::deserializeWidenBinaryBulk(IColumn & column, ReadBuffer & istr, size_t limit, double avg_value_size_hint) const
-{
-    if (!widened)
-        return deserializeBinaryBulk(column, istr, limit, avg_value_size_hint);
-
-    typename ColumnVector<T>::Container & x = typeid_cast<ColumnVector<T> &>(column).getData();
-    size_t initial_size = x.size();
-    x.resize(initial_size + limit);
-
-    using WidestType = typename NearestFieldType<T>::Type;
-    typename ColumnVector<WidestType>::Container y(limit);
-    size_t size = istr.readBig(reinterpret_cast<char *>(&y[0]), sizeof(typename ColumnVector<WidestType>::value_type) * limit);
-    size_t elem_size = size / sizeof(typename ColumnVector<WidestType>::value_type);
-    for (size_t i = 0; i < elem_size; i++)
-    {
-        x[initial_size + i] = static_cast<T>(y[i]);
-    }
-
-    x.resize(initial_size + elem_size);
 }
 
 template <typename T>

--- a/dbms/src/DataTypes/DataTypeNumberBase.h
+++ b/dbms/src/DataTypes/DataTypeNumberBase.h
@@ -51,8 +51,6 @@ public:
     void deserializeBinary(IColumn & column, ReadBuffer & istr) const override;
     void serializeBinaryBulk(const IColumn & column, WriteBuffer & ostr, size_t offset, size_t limit) const override;
     void deserializeBinaryBulk(IColumn & column, ReadBuffer & istr, size_t limit, double avg_value_size_hint) const override;
-    void serializeWidenBinaryBulk(const IColumn & column, WriteBuffer & ostr, size_t offset, size_t limit) const override;
-    void deserializeWidenBinaryBulk(IColumn & column, ReadBuffer & istr, size_t limit, double avg_value_size_hint) const override;
 
     MutableColumnPtr createColumn() const override;
 
@@ -67,9 +65,6 @@ public:
     bool haveMaximumSizeOfValue() const override { return true; }
     size_t getSizeOfValueInMemory() const override { return sizeof(T); }
     bool isCategorial() const override { return isValueRepresentedByInteger(); }
-
-protected:
-    bool widened = false;
 };
 
 } // namespace DB

--- a/dbms/src/DataTypes/DataTypesNumber.h
+++ b/dbms/src/DataTypes/DataTypesNumber.h
@@ -35,14 +35,6 @@ class DataTypeNumber final : public DataTypeNumberBase<T>
     bool isInteger() const override { return std::is_integral_v<T>; }
     bool isFloatingPoint() const override { return std::is_floating_point_v<T>; }
     bool canBeInsideNullable() const override { return true; }
-
-public:
-    DataTypePtr widen() const override
-    {
-        auto t = std::make_shared<DataTypeNumber<T>>();
-        t->widened = true;
-        return t;
-    }
 };
 
 using DataTypeUInt8 = DataTypeNumber<UInt8>;

--- a/dbms/src/DataTypes/IDataType.h
+++ b/dbms/src/DataTypes/IDataType.h
@@ -179,71 +179,6 @@ public:
     virtual void serializeBinaryBulk(const IColumn & column, WriteBuffer & ostr, size_t offset, size_t limit) const;
     virtual void deserializeBinaryBulk(IColumn & column, ReadBuffer & istr, size_t limit, double avg_value_size_hint) const;
 
-    /** Widen version for `serializeBinaryBulkWithMultipleStreams`.
-      */
-    virtual void serializeWidenBinaryBulkWithMultipleStreams(
-        const IColumn & column,
-        const OutputStreamGetter & getter,
-        size_t offset,
-        size_t limit,
-        bool /*position_independent_encoding*/,
-        SubstreamPath & path) const
-    {
-        if (WriteBuffer * stream = getter(path))
-            serializeWidenBinaryBulk(column, *stream, offset, limit);
-    }
-
-    void serializeWidenBinaryBulkWithMultipleStreams(
-        const IColumn & column,
-        const OutputStreamGetter & getter,
-        size_t offset,
-        size_t limit,
-        bool position_independent_encoding,
-        SubstreamPath && path) const
-    {
-        serializeWidenBinaryBulkWithMultipleStreams(column, getter, offset, limit, position_independent_encoding, path);
-    }
-
-
-    /** Widen version for `deserializeBinaryBulkWithMultipleStreams`.
-      */
-    virtual void deserializeWidenBinaryBulkWithMultipleStreams(
-        IColumn & column,
-        const InputStreamGetter & getter,
-        size_t limit,
-        double avg_value_size_hint,
-        bool /*position_independent_encoding*/,
-        SubstreamPath & path) const
-    {
-        if (ReadBuffer * stream = getter(path))
-            deserializeWidenBinaryBulk(column, *stream, limit, avg_value_size_hint);
-    }
-
-    void deserializeWidenBinaryBulkWithMultipleStreams(
-        IColumn & column,
-        const InputStreamGetter & getter,
-        size_t limit,
-        double avg_value_size_hint,
-        bool position_independent_encoding,
-        SubstreamPath && path) const
-    {
-        deserializeWidenBinaryBulkWithMultipleStreams(column, getter, limit, avg_value_size_hint, position_independent_encoding, path);
-    }
-
-    /** Widen version for `serializeBinaryBulk`.
-      */
-    virtual void serializeWidenBinaryBulk(const IColumn & column, WriteBuffer & ostr, size_t offset, size_t limit) const
-    {
-        serializeBinaryBulk(column, ostr, offset, limit);
-    }
-
-    /** Widen version for `deserializeBinaryBulk`.
-      */
-    virtual void deserializeWidenBinaryBulk(IColumn & column, ReadBuffer & istr, size_t limit, double avg_value_size_hint) const
-    {
-        deserializeBinaryBulk(column, istr, limit, avg_value_size_hint);
-    }
-
     /** Serialization/deserialization of individual values.
       *
       * These are helper methods for implementation of various formats to input/output for user (like CSV, JSON, etc.).
@@ -478,15 +413,6 @@ public:
     /** If this data type cannot be wrapped in Nullable data type.
       */
     virtual bool canBeInsideNullable() const { return false; };
-
-    /** Some specific data types are required to be widened for some specific storage for whatever reason,
-      * i.e. to avoid data rewriting upon type change,
-      * TMT will intentionally store narrow type (int8/16/32) to its widest possible type (int64) of the same family,
-      * meanwhile behaves as its original narrow type.
-      * Given that most data type objects on the fly are const (DataTypePtr), this function returns a new copy of the widened type.
-      */
-    virtual DataTypePtr widen() const { return nullptr; }
-
 
     /// Updates avg_value_size_hint for newly read column. Uses to optimize deserialization. Zero expected for first column.
     static void updateAvgValueSizeHint(const IColumn & column, double & avg_value_size_hint);

--- a/dbms/src/Storages/MutableSupport.h
+++ b/dbms/src/Storages/MutableSupport.h
@@ -52,15 +52,6 @@ public:
                 block.erase(it);
     }
 
-    bool shouldWiden(const NameAndTypePair & column)
-    {
-        DataTypePtr t
-            = column.type->isNullable() ? dynamic_cast<const DataTypeNullable *>(column.type.get())->getNestedType() : column.type;
-        return (column.name != MutableSupport::version_column_name && column.name != MutableSupport::delmark_column_name
-                && column.name != MutableSupport::tidb_pk_column_name)
-            && t->isInteger() && !(typeid_cast<const DataTypeInt64 *>(t.get()) || typeid_cast<const DataTypeUInt64 *>(t.get()));
-    }
-
     static const String mmt_storage_name;
     static const String txn_storage_name;
     static const String delta_tree_storage_name;

--- a/dbms/src/Storages/Transaction/Datum.cpp
+++ b/dbms/src/Storages/Transaction/Datum.cpp
@@ -115,7 +115,7 @@ bool DatumFlat::overflow(const ColumnInfo & column_info)
 #error "Please undefine macro M first."
 #endif
 #define M(tt, v, cf, ct) \
-    case Type##tt:          \
+    case Type##tt:       \
         return DatumOp<Type##tt>::overflow(field(), column_info);
         COLUMN_TYPES(M)
 #undef M
@@ -135,7 +135,7 @@ DatumBumpy::DatumBumpy(const DB::Field & field, TP tp)
 #ifdef M
 #error "Please undefine macro M first."
 #endif
-#define M(tt, v, cf, ct)                     \
+#define M(tt, v, cf, ct)                        \
     case Type##tt:                              \
         DatumOp<Type##tt>::flatten(orig, copy); \
         break;

--- a/dbms/src/Storages/Transaction/Datum.cpp
+++ b/dbms/src/Storages/Transaction/Datum.cpp
@@ -79,7 +79,8 @@ struct DatumOp<tp, typename std::enable_if<tp == TypeEnum>::type>
     static bool overflow(const Field &, const ColumnInfo &) { return false; }
 };
 
-DatumFlat::DatumFlat(const DB::Field & field, TP tp) : DatumBase(field, tp)
+DatumFlat::DatumFlat(const DB::Field & field, TP tp)
+    : DatumBase(field, tp)
 {
     if (orig.isNull())
         return;
@@ -89,7 +90,7 @@ DatumFlat::DatumFlat(const DB::Field & field, TP tp) : DatumBase(field, tp)
 #ifdef M
 #error "Please undefine macro M first."
 #endif
-#define M(tt, v, cf, ct, w)                       \
+#define M(tt, v, cf, ct)                          \
     case Type##tt:                                \
         DatumOp<Type##tt>::unflatten(orig, copy); \
         break;
@@ -98,7 +99,10 @@ DatumFlat::DatumFlat(const DB::Field & field, TP tp) : DatumBase(field, tp)
     }
 }
 
-bool DatumFlat::invalidNull(const ColumnInfo & column_info) { return column_info.hasNotNullFlag() && orig.isNull(); }
+bool DatumFlat::invalidNull(const ColumnInfo & column_info)
+{
+    return column_info.hasNotNullFlag() && orig.isNull();
+}
 
 bool DatumFlat::overflow(const ColumnInfo & column_info)
 {
@@ -110,7 +114,7 @@ bool DatumFlat::overflow(const ColumnInfo & column_info)
 #ifdef M
 #error "Please undefine macro M first."
 #endif
-#define M(tt, v, cf, ct, w) \
+#define M(tt, v, cf, ct) \
     case Type##tt:          \
         return DatumOp<Type##tt>::overflow(field(), column_info);
         COLUMN_TYPES(M)
@@ -120,7 +124,8 @@ bool DatumFlat::overflow(const ColumnInfo & column_info)
     throw DB::Exception("Shouldn't reach here", DB::ErrorCodes::LOGICAL_ERROR);
 }
 
-DatumBumpy::DatumBumpy(const DB::Field & field, TP tp) : DatumBase(field, tp)
+DatumBumpy::DatumBumpy(const DB::Field & field, TP tp)
+    : DatumBase(field, tp)
 {
     if (orig.isNull())
         return;
@@ -130,7 +135,7 @@ DatumBumpy::DatumBumpy(const DB::Field & field, TP tp) : DatumBase(field, tp)
 #ifdef M
 #error "Please undefine macro M first."
 #endif
-#define M(tt, v, cf, ct, w)                     \
+#define M(tt, v, cf, ct)                     \
     case Type##tt:                              \
         DatumOp<Type##tt>::flatten(orig, copy); \
         break;

--- a/dbms/src/Storages/Transaction/TiDB.cpp
+++ b/dbms/src/Storages/Transaction/TiDB.cpp
@@ -990,7 +990,7 @@ CodecFlag ColumnInfo::getCodecFlag() const
 #error "Please undefine macro M first."
 #endif
 #define M(tt, v, cf, ct) \
-    case Type##tt:          \
+    case Type##tt:       \
         return getCodecFlagBase<CodecFlag##cf>(hasUnsignedFlag());
         COLUMN_TYPES(M)
 #undef M

--- a/dbms/src/Storages/Transaction/TiDB.cpp
+++ b/dbms/src/Storages/Transaction/TiDB.cpp
@@ -989,7 +989,7 @@ CodecFlag ColumnInfo::getCodecFlag() const
 #ifdef M
 #error "Please undefine macro M first."
 #endif
-#define M(tt, v, cf, ct, w) \
+#define M(tt, v, cf, ct) \
     case Type##tt:          \
         return getCodecFlagBase<CodecFlag##cf>(hasUnsignedFlag());
         COLUMN_TYPES(M)

--- a/dbms/src/Storages/Transaction/TiDB.h
+++ b/dbms/src/Storages/Transaction/TiDB.h
@@ -53,46 +53,46 @@ using DB::Timestamp;
 
 // Column types.
 // In format:
-// TiDB type, int value, codec flag, CH type, should widen.
+// TiDB type, int value, codec flag, CH type.
 #ifdef M
 #error "Please undefine macro M first."
 #endif
-#define COLUMN_TYPES(M)                              \
-    M(Decimal, 0, Decimal, Decimal32, false)         \
-    M(Tiny, 1, VarInt, Int8, true)                   \
-    M(Short, 2, VarInt, Int16, true)                 \
-    M(Long, 3, VarInt, Int32, true)                  \
-    M(Float, 4, Float, Float32, false)               \
-    M(Double, 5, Float, Float64, false)              \
-    M(Null, 6, Nil, Nothing, false)                  \
-    M(Timestamp, 7, UInt, MyDateTime, false)         \
-    M(LongLong, 8, Int, Int64, false)                \
-    M(Int24, 9, VarInt, Int32, true)                 \
-    M(Date, 10, UInt, MyDate, false)                 \
-    M(Time, 11, Duration, Int64, false)              \
-    M(Datetime, 12, UInt, MyDateTime, false)         \
-    M(Year, 13, Int, Int16, false)                   \
-    M(NewDate, 14, Int, MyDate, false)               \
-    M(Varchar, 15, CompactBytes, String, false)      \
-    M(Bit, 16, VarInt, UInt64, false)                \
-    M(JSON, 0xf5, Json, String, false)               \
-    M(NewDecimal, 0xf6, Decimal, Decimal32, false)   \
-    M(Enum, 0xf7, VarUInt, Enum16, false)            \
-    M(Set, 0xf8, VarUInt, UInt64, false)             \
-    M(TinyBlob, 0xf9, CompactBytes, String, false)   \
-    M(MediumBlob, 0xfa, CompactBytes, String, false) \
-    M(LongBlob, 0xfb, CompactBytes, String, false)   \
-    M(Blob, 0xfc, CompactBytes, String, false)       \
-    M(VarString, 0xfd, CompactBytes, String, false)  \
-    M(String, 0xfe, CompactBytes, String, false)     \
-    M(Geometry, 0xff, CompactBytes, String, false)
+#define COLUMN_TYPES(M)                       \
+    M(Decimal, 0, Decimal, Decimal32)         \
+    M(Tiny, 1, VarInt, Int8)                  \
+    M(Short, 2, VarInt, Int16)                \
+    M(Long, 3, VarInt, Int32)                 \
+    M(Float, 4, Float, Float32)               \
+    M(Double, 5, Float, Float64)              \
+    M(Null, 6, Nil, Nothing)                  \
+    M(Timestamp, 7, UInt, MyDateTime)         \
+    M(LongLong, 8, Int, Int64)                \
+    M(Int24, 9, VarInt, Int32)                \
+    M(Date, 10, UInt, MyDate)                 \
+    M(Time, 11, Duration, Int64)              \
+    M(Datetime, 12, UInt, MyDateTime)         \
+    M(Year, 13, Int, Int16)                   \
+    M(NewDate, 14, Int, MyDate)               \
+    M(Varchar, 15, CompactBytes, String)      \
+    M(Bit, 16, VarInt, UInt64)                \
+    M(JSON, 0xf5, Json, String)               \
+    M(NewDecimal, 0xf6, Decimal, Decimal32)   \
+    M(Enum, 0xf7, VarUInt, Enum16)            \
+    M(Set, 0xf8, VarUInt, UInt64)             \
+    M(TinyBlob, 0xf9, CompactBytes, String)   \
+    M(MediumBlob, 0xfa, CompactBytes, String) \
+    M(LongBlob, 0xfb, CompactBytes, String)   \
+    M(Blob, 0xfc, CompactBytes, String)       \
+    M(VarString, 0xfd, CompactBytes, String)  \
+    M(String, 0xfe, CompactBytes, String)     \
+    M(Geometry, 0xff, CompactBytes, String)
 
 enum TP
 {
 #ifdef M
 #error "Please undefine macro M first."
 #endif
-#define M(tt, v, cf, ct, w) Type##tt = (v),
+#define M(tt, v, cf, ct) Type##tt = (v),
     COLUMN_TYPES(M)
 #undef M
 };

--- a/dbms/src/Storages/Transaction/TypeMapping.cpp
+++ b/dbms/src/Storages/Transaction/TypeMapping.cpp
@@ -336,7 +336,7 @@ ColumnInfo reverseGetColumnInfo(const NameAndTypePair & column, ColumnID id, con
     }
     else
     {
-        const auto *nullable_type = checkAndGetDataType<DataTypeNullable>(nested_type);
+        const auto * nullable_type = checkAndGetDataType<DataTypeNullable>(nested_type);
         nested_type = nullable_type->getNestedType().get();
     }
 
@@ -405,27 +405,27 @@ ColumnInfo reverseGetColumnInfo(const NameAndTypePair & column, ColumnID id, con
         column_info.setUnsignedFlag();
 
     // Fill flen and decimal for decimal.
-    if (const auto *decimal_type32 = checkAndGetDataType<DataTypeDecimal<Decimal32>>(nested_type))
+    if (const auto * decimal_type32 = checkAndGetDataType<DataTypeDecimal<Decimal32>>(nested_type))
         setDecimalPrecScale(decimal_type32, column_info);
-    else if (const auto *decimal_type64 = checkAndGetDataType<DataTypeDecimal<Decimal64>>(nested_type))
+    else if (const auto * decimal_type64 = checkAndGetDataType<DataTypeDecimal<Decimal64>>(nested_type))
         setDecimalPrecScale(decimal_type64, column_info);
-    else if (const auto *decimal_type128 = checkAndGetDataType<DataTypeDecimal<Decimal128>>(nested_type))
+    else if (const auto * decimal_type128 = checkAndGetDataType<DataTypeDecimal<Decimal128>>(nested_type))
         setDecimalPrecScale(decimal_type128, column_info);
-    else if (const auto *decimal_type256 = checkAndGetDataType<DataTypeDecimal<Decimal256>>(nested_type))
+    else if (const auto * decimal_type256 = checkAndGetDataType<DataTypeDecimal<Decimal256>>(nested_type))
         setDecimalPrecScale(decimal_type256, column_info);
 
     // Fill decimal for date time.
-    if (const auto *type = checkAndGetDataType<DataTypeMyDateTime>(nested_type))
+    if (const auto * type = checkAndGetDataType<DataTypeMyDateTime>(nested_type))
         column_info.decimal = type->getFraction();
 
     // Fill decimal for duration.
-    if (const auto *type = checkAndGetDataType<DataTypeMyDuration>(nested_type))
+    if (const auto * type = checkAndGetDataType<DataTypeMyDuration>(nested_type))
         column_info.decimal = type->getFsp();
 
     // Fill elems for enum.
     if (checkDataType<DataTypeEnum16>(nested_type))
     {
-        const auto *enum16_type = checkAndGetDataType<DataTypeEnum16>(nested_type);
+        const auto * enum16_type = checkAndGetDataType<DataTypeEnum16>(nested_type);
         for (const auto & element : enum16_type->getValues())
         {
             column_info.elems.emplace_back(element.first, element.second);

--- a/dbms/src/Storages/Transaction/tests/gtest_type_mapping.cpp
+++ b/dbms/src/Storages/Transaction/tests/gtest_type_mapping.cpp
@@ -22,12 +22,7 @@ namespace DB
 namespace tests
 {
 
-TEST(TypeMapping_test, ColumnInfoToDataType)
-{
-    // TODO fill this test
-}
-
-TEST(TypeMapping_test, DataTypeToColumnInfo)
+TEST(TypeMappingTest, DataTypeToColumnInfo)
 try
 {
     String name = "col";
@@ -67,12 +62,19 @@ try
                 {
                     ASSERT_EQ(column_info.tp, TiDB::TypeLongLong) << actual_test_type;
                 }
+
+                auto data_type = getDataTypeByColumnInfo(column_info);
+                ASSERT_EQ(data_type->getName(), actual_test_type);
             }
         }
     }
 
     column_info = reverseGetColumnInfo(NameAndTypePair{name, typeFromString("String")}, 1, default_field, true);
     ASSERT_EQ(column_info.tp, TiDB::TypeString);
+    auto data_type = getDataTypeByColumnInfo(column_info);
+    ASSERT_EQ(data_type->getName(), "String");
+
+    // TODO: test decimal, datetime, enum
 }
 CATCH
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/6233

Problem Summary:
Previously, we added "widen" property to make DDL works on TransactionMergeTree without rewriting the data on disk. https://github.com/pingcap/tiflash/pull/110
As TMT is no longer supported and DeltaTree engine support DDL by adding cast on reading, we don't need the "widen" anymore.

### What is changed and how it works?

Remove the "widen" related codes

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
