### PR TITLE
chore: fix build on mac m1

### DIFF
--- a/dbms/src/Common/OptimizedRegularExpression.inl.h
+++ b/dbms/src/Common/OptimizedRegularExpression.inl.h
@@ -617,7 +617,7 @@ void OptimizedRegularExpressionImpl<thread_safe>::replaceAllImpl(const char * su
         if (!success)
             break;
 
-        auto skipped_byte_size = reinterpret_cast<Int64>(matched_str.data() - (subject + prior_offset));
+        auto skipped_byte_size = static_cast<Int64>(matched_str.data() - (subject + prior_offset));
         res_data.resize(res_data.size() + skipped_byte_size);
         memcpy(&res_data[res_offset], subject + prior_offset, skipped_byte_size); // copy the skipped bytes
         res_offset += skipped_byte_size;
@@ -658,7 +658,7 @@ void OptimizedRegularExpressionImpl<thread_safe>::replaceOneImpl(const char * su
         --occur;
     }
 
-    auto prefix_byte_size = reinterpret_cast<Int64>(matched_str.data() - subject);
+    auto prefix_byte_size = static_cast<Int64>(matched_str.data() - subject);
     res_data.resize(res_data.size() + prefix_byte_size);
     memcpy(&res_data[res_offset], subject, prefix_byte_size); // Copy prefix string
     res_offset += prefix_byte_size;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #6559 

Problem Summary:
```
FAILED: dbms/src/Functions/CMakeFiles/clickhouse_functions.dir/FunctionsRegexp.cpp.o 
/Library/Developer/CommandLineTools/usr/bin/c++ -DBOOST_BIND_GLOBAL_PLACEHOLDERS -DBOOST_CONTEXT_EXPORT="" -DBOOST_CONTEXT_NO_LIB -DBOOST_CONTEXT_STATIC_LINK -DBOOST_FIBER_NO_LIB -DBOOST_FIBER_STATIC_LINK -DBOOST_NO_CXX98_FUNCTION_BASE -DBOOST_SYSTEM_NO_DEPRECATED -DCARES_STATICLIB -DFIU_ENABLE -DLZ4_DISABLE_DEPRECATE_WARNINGS=1 -DMULTIPLE_CONTEXT_GTEST -DPOCO_STATIC -DPOCO_UNBUNDLED_ZLIB -DTIFLASH_COMPILER_VPCLMULQDQ_SUPPORT=0 -DTIFLASH_ENABLE_ASIMD_SUPPORT=1 -DTIFLASH_SOURCE_PREFIX=\"/Users/qizhi/p/tiflash\" -I/Users/qizhi/p/tiflash/contrib/libdivide -I/Users/qizhi/p/tiflash/contrib/libmetrohash/src -I/Users/qizhi/p/tiflash/contrib/libfarmhash -I/Users/qizhi/p/tiflash/dbms/src -I/Users/qizhi/p/tiflash/contrib/tiflash-proxy/raftstore-proxy/ffi/src -I/Users/qizhi/p/tiflash/cmake-build-debug/dbms/src -I/Users/qizhi/p/tiflash/contrib/double-conversion -I/Users/qizhi/p/tiflash/contrib/boost -I/Users/qizhi/p/tiflash/contrib/xxHash -I/Users/qizhi/p/tiflash/contrib/libpcg-random/include -I/Users/qizhi/p/tiflash/contrib/libcityhash/include -I/Users/qizhi/p/tiflash/libs/libcommon/include -I/Users/qizhi/p/tiflash/cmake-build-debug/libs/libcommon/include -I/Users/qizhi/p/tiflash/libs/libpocoext/include -I/Users/qizhi/p/tiflash/contrib/poco/Data/include -I/Users/qizhi/p/tiflash/contrib/poco/Foundation/include -I/Users/qizhi/p/tiflash/contrib/zlib-ng -I/Users/qizhi/p/tiflash/cmake-build-debug/contrib/zlib-ng -I/Users/qizhi/p/tiflash/contrib/poco/Util/include -I/Users/qizhi/p/tiflash/contrib/poco/XML/include -I/Users/qizhi/p/tiflash/contrib/poco/JSON/include -I/Users/qizhi/p/tiflash/contrib/poco/Net/include -I/Users/qizhi/p/tiflash/contrib/cctz/include -I/Users/qizhi/p/tiflash/contrib/lz4/lib -I/Users/qizhi/p/tiflash/contrib/zstd/lib -I/Users/qizhi/p/tiflash/contrib/client-c/third_party/libfiu/libfiu -I/Users/qizhi/p/tiflash/contrib/prometheus-cpp/core/include -I/Users/qizhi/p/tiflash/cmake-build-debug/contrib/prometheus-cpp-cmake/core/include -I/Users/qizhi/p/tiflash/contrib/prometheus-cpp/push/include -I/Users/qizhi/p/tiflash/cmake-build-debug/contrib/prometheus-cpp-cmake/push/include -I/Users/qizhi/p/tiflash/contrib/prometheus-cpp/pull/include -I/Users/qizhi/p/tiflash/cmake-build-debug/contrib/prometheus-cpp-cmake/pull/include -I/Users/qizhi/p/tiflash/contrib/cpptoml -I/Users/qizhi/p/tiflash/contrib/magic_enum/include -I/Users/qizhi/p/tiflash/contrib/poco/NetSSL_OpenSSL/include -I/Users/qizhi/p/tiflash/contrib/poco/Crypto/include -I/Users/qizhi/p/tiflash/contrib/xxHash/cmake_unofficial/.. -I/Users/qizhi/p/tiflash/cmake-build-debug/contrib/kvproto/cpp -I/Users/qizhi/p/tiflash/cmake-build-debug/contrib/kvproto/cpp/kvproto -I/Users/qizhi/p/tiflash/contrib/grpc/include -I/Users/qizhi/p/tiflash/contrib/abseil-cpp -I/Users/qizhi/p/tiflash/contrib/client-c/include -I/Users/qizhi/p/tiflash/cmake-build-debug/contrib/grpc/third_party/cares/cares -I/Users/qizhi/p/tiflash/contrib/grpc/third_party/cares/cares -I/Users/qizhi/p/tiflash/cmake-build-debug/contrib/tipb/cpp -I/Users/qizhi/p/tiflash/cmake-build-debug/dbms/src/Storages/DeltaMerge/File/dtpb -I/Users/qizhi/p/tiflash/contrib/libbtrie/include -I/Users/qizhi/p/tiflash/cmake-build-debug/contrib/libfarmhash -isystem /Users/qizhi/p/tiflash/contrib/fmtlib-cmake/../fmtlib/include -isystem /Users/qizhi/p/tiflash/libs/libsymbolization/include -isystem /Users/qizhi/p/tiflash/contrib/boringssl/include -isystem /Users/qizhi/p/tiflash/contrib/protobuf/src -isystem /Users/qizhi/p/tiflash/contrib/re2 -isystem /Users/qizhi/p/tiflash/cmake-build-debug/contrib/re2-cmake -pipe -march=armv8+crc+simd  -fno-omit-frame-pointer  -Wall -Wno-unused-command-line-argument  -Wnon-virtual-dtor  -Wextra -Werror -g -g3 -ggdb3 -O0 -fverbose-asm -fno-inline  -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fcolor-diagnostics -fPIC -DDUMMY_BACKTRACE -std=gnu++17 -MD -MT dbms/src/Functions/CMakeFiles/clickhouse_functions.dir/FunctionsRegexp.cpp.o -MF dbms/src/Functions/CMakeFiles/clickhouse_functions.dir/FunctionsRegexp.cpp.o.d -o dbms/src/Functions/CMakeFiles/clickhouse_functions.dir/FunctionsRegexp.cpp.o -c /Users/qizhi/p/tiflash/dbms/src/Functions/FunctionsRegexp.cpp
In file included from /Users/qizhi/p/tiflash/dbms/src/Functions/FunctionsRegexp.cpp:17:
In file included from /Users/qizhi/p/tiflash/dbms/src/Functions/FunctionsRegexp.h:35:
In file included from /Users/qizhi/p/tiflash/dbms/src/Functions/Regexps.h:16:
In file included from /Users/qizhi/p/tiflash/dbms/src/Common/OptimizedRegularExpression.h:145:
/Users/qizhi/p/tiflash/dbms/src/Common/OptimizedRegularExpression.inl.h:620:34: error: reinterpret_cast from 'long' to 'Int64' (aka 'long long') is not allowed
        auto skipped_byte_size = reinterpret_cast<Int64>(matched_str.data() - (subject + prior_offset));
                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/qizhi/p/tiflash/dbms/src/Common/OptimizedRegularExpression.inl.h:683:16: note: in instantiation of member function 'OptimizedRegularExpressionImpl<false>::replaceAllImpl' requested here
        return replaceAllImpl(subject, subject_size, res_data, res_offset, repl, byte_pos);
               ^
/Users/qizhi/p/tiflash/dbms/src/Common/OptimizedRegularExpression.inl.h:739:5: note: in instantiation of member function 'OptimizedRegularExpressionImpl<false>::replaceImpl' requested here
    replaceImpl(subject, subject_size, res_data, res_offset, repl, byte_pos, occur);
```

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
