### PR TITLE
Test: Bind delta merge storage with executor ut

### DIFF
--- a/dbms/src/Debug/MockComputeServerManager.cpp
+++ b/dbms/src/Debug/MockComputeServerManager.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 #include <Common/FmtUtils.h>
 #include <Debug/MockComputeServerManager.h>
+#include <Debug/MockStorage.h>
 #include <Flash/Mpp/MPPTaskManager.h>
 #include <Storages/Transaction/TMTContext.h>
 #include <TestUtils/TiFlashTestEnv.h>
@@ -71,7 +72,7 @@ void MockComputeServerManager::startServers(const LoggerPtr & log_ptr, int start
     prepareMockMPPServerInfo();
 }
 
-void MockComputeServerManager::setMockStorage(MockStorage & mock_storage)
+void MockComputeServerManager::setMockStorage(MockStorage * mock_storage)
 {
     for (const auto & server : server_map)
     {

--- a/dbms/src/Debug/MockComputeServerManager.h
+++ b/dbms/src/Debug/MockComputeServerManager.h
@@ -14,11 +14,13 @@
 
 #pragma once
 
-#include <Debug/MockStorage.h>
 #include <Flash/Mpp/MPPTaskId.h>
 #include <Server/FlashGrpcServerHolder.h>
 
-namespace DB::tests
+namespace DB
+{
+class MockStorage;
+namespace tests
 {
 /** Hold Mock Compute Server to manage the lifetime of them.
   * Maintains Mock Compute Server info.
@@ -35,7 +37,7 @@ public:
     void startServers(const LoggerPtr & log_ptr, int start_idx);
 
     /// set MockStorage for Compute Server in order to mock input columns.
-    void setMockStorage(MockStorage & mock_storage);
+    void setMockStorage(MockStorage * mock_storage);
 
     /// stop all servers.
     void reset();
@@ -58,4 +60,5 @@ private:
     std::unordered_map<size_t, std::unique_ptr<FlashGrpcServerHolder>> server_map;
     std::unordered_map<size_t, MockServerConfig> server_config_map;
 };
-} // namespace DB::tests
+} // namespace tests
+} // namespace DB

--- a/dbms/src/Debug/MockStorage.cpp
+++ b/dbms/src/Debug/MockStorage.cpp
@@ -134,7 +134,7 @@ BlockInputStreamPtr MockStorage::getStreamFromDeltaMerge(Context & context, Int6
     SelectQueryInfo query_info;
     query_info.query = std::make_shared<ASTSelectQuery>();
     query_info.mvcc_query_info = std::make_unique<MvccQueryInfo>(context.getSettingsRef().resolve_locks, std::numeric_limits<UInt64>::max(), scan_context);
-    BlockInputStreams ins = storage->read(column_names, query_info, context, stage, 8192, 1); // Todo: Should we change the params?
+    BlockInputStreams ins = storage->read(column_names, query_info, context, stage, 8192, 1); // TODO: Support config max_block_size and num_streams
 
     BlockInputStreamPtr in = ins[0];
     return in;

--- a/dbms/src/Debug/MockStorage.cpp
+++ b/dbms/src/Debug/MockStorage.cpp
@@ -82,7 +82,6 @@ void MockStorage::addTableSchemaForDeltaMerge(const String & name, const MockCol
 
 void MockStorage::addTableDataForDeltaMerge(Context & context, const String & name, ColumnsWithTypeAndName & columns)
 {
-    // ywq todo insert into delta merge store...
     auto id = getTableIdForDeltaMerge(name);
     addNamesAndTypesForDeltaMerge(id, columns);
     if (storage_delta_merge_map.find(id) == storage_delta_merge_map.end())
@@ -90,7 +89,6 @@ void MockStorage::addTableDataForDeltaMerge(Context & context, const String & na
         // init
         ASTPtr astptr(new ASTIdentifier(name, ASTIdentifier::Kind::Table));
         NamesAndTypesList names_and_types_list;
-        // ywq todo refine
         for (const auto & column : columns)
         {
             names_and_types_list.emplace_back(column.name, column.type);
@@ -98,9 +96,9 @@ void MockStorage::addTableDataForDeltaMerge(Context & context, const String & na
         astptr->children.emplace_back(new ASTIdentifier(columns[0].name));
 
         storage_delta_merge_map[id] = StorageDeltaMerge::create("TiFlash",
-                                                                /* db_name= */ "default", // todo... don't care currently
+                                                                /* db_name= */ "default",
                                                                 name,
-                                                                std::nullopt, // todo if i need table info?
+                                                                std::nullopt,
                                                                 ColumnsDescription{names_and_types_list},
                                                                 astptr,
                                                                 0,
@@ -140,7 +138,6 @@ BlockInputStreamPtr MockStorage::getStreamFromDeltaMerge(Context & context, Int6
     return in;
 }
 
-// ywq todo refine
 void MockStorage::addTableInfoForDeltaMerge(const String & name, const MockColumnInfoVec & columns)
 {
     TableInfo table_info;

--- a/dbms/src/Debug/MockStorage.cpp
+++ b/dbms/src/Debug/MockStorage.cpp
@@ -11,11 +11,20 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#include <DataStreams/IBlockOutputStream.h>
 #include <Debug/MockStorage.h>
 #include <Flash/Coprocessor/TiDBTableScan.h>
+#include <Interpreters/Context.h>
+#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTInsertQuery.h>
+#include <Parsers/ASTSelectQuery.h>
+#include <Storages/RegionQueryInfo.h>
+#include <Storages/StorageDeltaMerge.h>
 
-namespace DB::tests
+
+namespace DB
 {
+/// for table scan
 void MockStorage::addTableSchema(const String & name, const MockColumnInfoVec & columnInfos)
 {
     name_to_id_map[name] = MockTableIdGenerator::instance().nextTableId();
@@ -63,6 +72,116 @@ MockColumnInfoVec MockStorage::getTableSchema(const String & name)
     throw Exception(fmt::format("Failed to get table schema by table name '{}'", name));
 }
 
+/// for delta merge
+void MockStorage::addTableSchemaForDeltaMerge(const String & name, const MockColumnInfoVec & columnInfos)
+{
+    name_to_id_map_for_delta_merge[name] = MockTableIdGenerator::instance().nextTableId();
+    table_schema_for_delta_merge[getTableIdForDeltaMerge(name)] = columnInfos;
+    // addTableInfoForDeltaMerge(name, columnInfos); // todo when to use it?
+}
+
+void MockStorage::addTableDataForDeltaMerge(Context & context, const String & name, ColumnsWithTypeAndName & columns)
+{
+    // ywq todo insert into delta merge store...
+    if (storage_delta_merge_map.find(name) == storage_delta_merge_map.end())
+    {
+        // init
+        ASTPtr astptr(new ASTIdentifier(name, ASTIdentifier::Kind::Table));
+        NamesAndTypesList names_and_types_list;
+        for (const auto & column : columns)
+        {
+            names_and_types_list.emplace_back(column.name, column.type);
+            std::cout << "ywq test, column name: " << column.name << ", column type: " << column.type->getName() << std::endl;
+        }
+        astptr->children.emplace_back(new ASTIdentifier(columns[0].name));
+
+        storage_delta_merge_map[name] = StorageDeltaMerge::create("TiFlash",
+                                                                  /* db_name= */ "default", // todo... don't care currently
+                                                                  name,
+                                                                  std::nullopt, // todo if i need table info?
+                                                                  ColumnsDescription{names_and_types_list},
+                                                                  astptr,
+                                                                  0,
+                                                                  context);
+
+        auto storage = storage_delta_merge_map[name];
+        storage->startup();
+
+        // write data to DeltaMergeStorage
+        ASTPtr insertptr(new ASTInsertQuery());
+        BlockOutputStreamPtr output = storage->write(insertptr, context.getSettingsRef());
+
+        Block insert_block{columns};
+
+        output->writePrefix();
+        output->write(insert_block);
+        output->writeSuffix();
+    }
+}
+
+BlockInputStreamPtr MockStorage::getStreamFromDeltaMerge(Context & context, const String & name)
+{
+    auto storage = storage_delta_merge_map[name];
+    auto column_infos = getTableSchemaForDeltaMerge(name);
+    Names column_names;
+    for (const auto & column_info : column_infos)
+        column_names.push_back(column_info.first);
+
+    auto scan_context = std::make_shared<DM::ScanContext>();
+    QueryProcessingStage::Enum stage2;
+    SelectQueryInfo query_info;
+    query_info.query = std::make_shared<ASTSelectQuery>();
+    query_info.mvcc_query_info = std::make_unique<MvccQueryInfo>(context.getSettingsRef().resolve_locks, std::numeric_limits<UInt64>::max(), scan_context);
+    BlockInputStreams ins = storage->read(column_names, query_info, context, stage2, 8192, 1);
+
+    std::cout << "ywq test: ins size:" << ins.size() << std::endl;
+    BlockInputStreamPtr in = ins[0];
+    return in;
+}
+
+// ywq todo refine it.
+void MockStorage::addTableInfoForDeltaMerge(const String & name, const MockColumnInfoVec & columns)
+{
+    TableInfo table_info;
+    table_info.name = name;
+    table_info.id = getTableId(name);
+    int i = 0;
+    for (const auto & column : columns)
+    {
+        TiDB::ColumnInfo ret;
+        std::tie(ret.name, ret.tp) = column;
+        // TODO: find a way to assign decimal field's flen.
+        if (ret.tp == TiDB::TP::TypeNewDecimal)
+            ret.flen = 65;
+        ret.id = i++;
+        table_info.columns.push_back(std::move(ret));
+    }
+    table_infos_for_delta_merge[name] = table_info;
+}
+
+Int64 MockStorage::getTableIdForDeltaMerge(const String & name)
+{
+    if (name_to_id_map_for_delta_merge.find(name) != name_to_id_map_for_delta_merge.end())
+    {
+        return name_to_id_map_for_delta_merge[name];
+    }
+    throw Exception(fmt::format("Failed to get table id by table name '{}'", name));
+}
+
+bool MockStorage::tableExistsForDeltaMerge(Int64 table_id)
+{
+    return table_schema_for_delta_merge.find(table_id) != table_schema_for_delta_merge.end();
+}
+
+MockColumnInfoVec MockStorage::getTableSchemaForDeltaMerge(const String & name)
+{
+    if (tableExistsForDeltaMerge(getTableIdForDeltaMerge(name)))
+    {
+        return table_schema_for_delta_merge[getTableIdForDeltaMerge(name)];
+    }
+    throw Exception(fmt::format("Failed to get table schema by table name '{}'", name));
+}
+
 /// for exchange receiver
 void MockStorage::addExchangeSchema(const String & exchange_name, const MockColumnInfoVec & columnInfos)
 {
@@ -105,6 +224,20 @@ MockColumnInfoVec MockStorage::getExchangeSchema(const String & exchange_name)
         return exchange_schemas[exchange_name];
     }
     throw Exception(fmt::format("Failed to get exchange schema by exchange name '{}'", exchange_name));
+}
+
+void MockStorage::clear()
+{
+    for (auto [_, storage] : storage_delta_merge_map)
+    {
+        storage->drop();
+        storage->removeFromTMTContext();
+    }
+}
+
+void MockStorage::useDeltaMerge()
+{
+    use_storage_delta_merge = true;
 }
 
 // use this function to determine where to cut the columns,
@@ -188,8 +321,9 @@ void MockStorage::addTableInfo(const String & name, const MockColumnInfoVec & co
     table_infos[name] = table_info;
 }
 
+// for dbgFuncTiDBQuery
 TableInfo MockStorage::getTableInfo(const String & name)
 {
     return table_infos[name];
 }
-} // namespace DB::tests
+} // namespace DB

--- a/dbms/src/Debug/MockStorage.cpp
+++ b/dbms/src/Debug/MockStorage.cpp
@@ -160,7 +160,7 @@ void MockStorage::addTableInfoForDeltaMerge(const String & name, const MockColum
 void MockStorage::addNamesAndTypesForDeltaMerge(Int64 table_id, const ColumnsWithTypeAndName & columns)
 {
     NamesAndTypes names_and_types;
-    for (auto column : columns)
+    for (const auto & column : columns)
     {
         names_and_types.emplace_back(column.name, column.type);
     }

--- a/dbms/src/Debug/MockStorage.cpp
+++ b/dbms/src/Debug/MockStorage.cpp
@@ -263,9 +263,9 @@ void MockStorage::clear()
     }
 }
 
-void MockStorage::setUseDeltaMerge()
+void MockStorage::setUseDeltaMerge(bool flag)
 {
-    use_storage_delta_merge = true;
+    use_storage_delta_merge = flag;
 }
 
 bool MockStorage::useDeltaMerge() const

--- a/dbms/src/Debug/MockStorage.h
+++ b/dbms/src/Debug/MockStorage.h
@@ -13,7 +13,7 @@
 // limitations under the License.
 #pragma once
 #include <Core/ColumnsWithTypeAndName.h>
-#include <DataStreams/IBlockOutputStream.h>
+#include <DataStreams/IBlockInputStream.h>
 #include <Flash/Coprocessor/TiDBTableScan.h>
 #include <Storages/Transaction/TiDB.h>
 #include <common/types.h>
@@ -21,8 +21,6 @@
 #include <atomic>
 #include <memory>
 #include <unordered_map>
-
-#include "DBGInvoker.h"
 
 namespace DB
 {

--- a/dbms/src/Debug/MockStorage.h
+++ b/dbms/src/Debug/MockStorage.h
@@ -113,11 +113,11 @@ private:
     /// for mock storage delta merge
     std::unordered_map<String, Int64> name_to_id_map_for_delta_merge; /// <table_name, table_id>
     std::unordered_map<Int64, MockColumnInfoVec> table_schema_for_delta_merge; /// <table_id, columnInfo>
-    std::unordered_map<Int64, std::shared_ptr<StorageDeltaMerge>> storage_delta_merge_map; // <table_name, StorageDeltaMerge>
+    std::unordered_map<Int64, std::shared_ptr<StorageDeltaMerge>> storage_delta_merge_map; // <table_id, StorageDeltaMerge>
     std::unordered_map<String, TableInfo> table_infos_for_delta_merge; /// <table_name, table_info>
     std::unordered_map<Int64, NamesAndTypes> names_and_types_map_for_delta_merge; /// <table_id, NamesAndTypes>
 
-    // storage delta merge can be used in
+    // storage delta merge can be used in executor ut test only.
     bool use_storage_delta_merge = false;
 
 private:

--- a/dbms/src/Debug/MockStorage.h
+++ b/dbms/src/Debug/MockStorage.h
@@ -67,11 +67,11 @@ public:
     void addTableSchemaForDeltaMerge(const String & name, const MockColumnInfoVec & columnInfos);
 
     void addTableDataForDeltaMerge(Context & context, const String & name, ColumnsWithTypeAndName & columns);
-    
+
     MockColumnInfoVec getTableSchemaForDeltaMerge(const String & name);
-    
+
     MockColumnInfoVec getTableSchemaForDeltaMerge(Int64 table_id);
-    
+
     NamesAndTypes getNameAndTypesForDeltaMerge(Int64 table_id);
 
     BlockInputStreamPtr getStreamFromDeltaMerge(Context & context, Int64 table_id);

--- a/dbms/src/Debug/MockStorage.h
+++ b/dbms/src/Debug/MockStorage.h
@@ -47,6 +47,7 @@ private:
 /** Responsible for mock data for executor tests and mpp tests.
   * 1. Use this class to add mock table schema and table column data.
   * 2. Use this class to add mock exchange schema and exchange column data.
+  * 3. Use this class to add table schema and table column data into StorageDeltaMerge.
   */
 class MockStorage
 {

--- a/dbms/src/Debug/MockStorage.h
+++ b/dbms/src/Debug/MockStorage.h
@@ -67,11 +67,16 @@ public:
     void addTableSchemaForDeltaMerge(const String & name, const MockColumnInfoVec & columnInfos);
 
     void addTableDataForDeltaMerge(Context & context, const String & name, ColumnsWithTypeAndName & columns);
+    
     MockColumnInfoVec getTableSchemaForDeltaMerge(const String & name);
+    
     MockColumnInfoVec getTableSchemaForDeltaMerge(Int64 table_id);
+    
     NamesAndTypes getNameAndTypesForDeltaMerge(Int64 table_id);
 
     BlockInputStreamPtr getStreamFromDeltaMerge(Context & context, Int64 table_id);
+
+    bool tableExistsForDeltaMerge(Int64 table_id);
 
     /// for exchange receiver
     void addExchangeSchema(const String & exchange_name, const MockColumnInfoVec & columnInfos);
@@ -95,7 +100,7 @@ public:
     /// clear for StorageDeltaMerge
     void clear();
 
-    void setUseDeltaMerge();
+    void setUseDeltaMerge(bool flag);
 
     bool useDeltaMerge() const;
 
@@ -129,8 +134,6 @@ private:
 
     // for storage delta merge table scan
     Int64 getTableIdForDeltaMerge(const String & name);
-
-    bool tableExistsForDeltaMerge(Int64 table_id);
 
     void addTableInfoForDeltaMerge(const String & name, const MockColumnInfoVec & columns);
 

--- a/dbms/src/Debug/MockStorage.h
+++ b/dbms/src/Debug/MockStorage.h
@@ -117,6 +117,7 @@ private:
     std::unordered_map<String, TableInfo> table_infos_for_delta_merge; /// <table_name, table_info>
     std::unordered_map<Int64, NamesAndTypes> names_and_types_map_for_delta_merge; /// <table_id, NamesAndTypes>
 
+    // storage delta merge can be used in
     bool use_storage_delta_merge = false;
 
 private:

--- a/dbms/src/Debug/MockStorage.h
+++ b/dbms/src/Debug/MockStorage.h
@@ -13,14 +13,22 @@
 // limitations under the License.
 #pragma once
 #include <Core/ColumnsWithTypeAndName.h>
+#include <DataStreams/IBlockOutputStream.h>
 #include <Flash/Coprocessor/TiDBTableScan.h>
 #include <Storages/Transaction/TiDB.h>
 #include <common/types.h>
 
 #include <atomic>
+#include <memory>
 #include <unordered_map>
-namespace DB::tests
+
+#include "DBGInvoker.h"
+
+namespace DB
 {
+class StorageDeltaMerge;
+class Context;
+
 using MockColumnInfo = std::pair<String, TiDB::TP>;
 using MockColumnInfoVec = std::vector<MockColumnInfo>;
 using TableInfo = TiDB::TableInfo;
@@ -50,46 +58,78 @@ public:
 
     void addTableData(const String & name, ColumnsWithTypeAndName & columns);
 
-    Int64 getTableId(const String & name);
-
-    bool tableExists(Int64 table_id);
+    MockColumnInfoVec getTableSchema(const String & name);
 
     ColumnsWithTypeAndName getColumns(Int64 table_id);
 
-    MockColumnInfoVec getTableSchema(const String & name);
+    bool tableExists(Int64 table_id);
+
+    /// for storage delta merge table scan
+    void addTableSchemaForDeltaMerge(const String & name, const MockColumnInfoVec & columnInfos);
+
+    void addTableDataForDeltaMerge(Context & context, const String & name, ColumnsWithTypeAndName & columns);
+
+    BlockInputStreamPtr getStreamFromDeltaMerge(Context & context, const String & name);
 
     /// for exchange receiver
     void addExchangeSchema(const String & exchange_name, const MockColumnInfoVec & columnInfos);
 
     void addExchangeData(const String & exchange_name, const ColumnsWithTypeAndName & columns);
 
-    bool exchangeExists(const String & executor_id);
-    bool exchangeExistsWithName(const String & name);
-
-    ColumnsWithTypeAndName getExchangeColumns(const String & executor_id);
+    MockColumnInfoVec getExchangeSchema(const String & exchange_name);
 
     void addExchangeRelation(const String & executor_id, const String & exchange_name);
 
-    MockColumnInfoVec getExchangeSchema(const String & exchange_name);
+    ColumnsWithTypeAndName getExchangeColumns(const String & executor_id);
+
+    bool exchangeExists(const String & executor_id);
 
     /// for MPP Tasks, it will split data by partition num, then each MPP service will have a subset of mock data.
     ColumnsWithTypeAndName getColumnsForMPPTableScan(const TiDBTableScan & table_scan, Int64 partition_id, Int64 partition_num);
 
     TableInfo getTableInfo(const String & name);
 
+    /// clear for StorageDeltaMerge
+    void clear();
+
+    void useDeltaMerge();
+
 private:
     /// for mock table scan
     std::unordered_map<String, Int64> name_to_id_map; /// <table_name, table_id>
     std::unordered_map<Int64, MockColumnInfoVec> table_schema; /// <table_id, columnInfo>
     std::unordered_map<Int64, ColumnsWithTypeAndName> table_columns; /// <table_id, columns>
-    std::unordered_map<String, TableInfo> table_infos;
+    std::unordered_map<String, TableInfo> table_infos; /// <table_name, table_info>
 
     /// for mock exchange receiver
     std::unordered_map<String, String> executor_id_to_name_map; /// <executor_id, exchange name>
     std::unordered_map<String, MockColumnInfoVec> exchange_schemas; /// <exchange_name, columnInfo>
     std::unordered_map<String, ColumnsWithTypeAndName> exchange_columns; /// <exchange_name, columns>
 
+    /// for mock storage delta merge
+    std::unordered_map<String, Int64> name_to_id_map_for_delta_merge; /// <table_name, table_id>
+    std::unordered_map<Int64, MockColumnInfoVec> table_schema_for_delta_merge; /// <table_id, columnInfo>
+    std::unordered_map<String, std::shared_ptr<StorageDeltaMerge>> storage_delta_merge_map; // <table_name, StorageDeltaMerge>
+    std::unordered_map<String, TableInfo> table_infos_for_delta_merge; /// <table_name, table_info>
+
+    bool use_storage_delta_merge = false;
+
 private:
+    /// for table scan
+    Int64 getTableId(const String & name);
+
     void addTableInfo(const String & name, const MockColumnInfoVec & columns);
+
+    // for storage delta merge table scan
+    Int64 getTableIdForDeltaMerge(const String & name);
+
+    bool tableExistsForDeltaMerge(Int64 table_id);
+
+    MockColumnInfoVec getTableSchemaForDeltaMerge(const String & name);
+
+    void addTableInfoForDeltaMerge(const String & name, const MockColumnInfoVec & columns);
+
+    /// for exchange receiver
+    bool exchangeExistsWithName(const String & name);
 };
-} // namespace DB::tests
+} // namespace DB

--- a/dbms/src/Debug/MockStorage.h
+++ b/dbms/src/Debug/MockStorage.h
@@ -68,8 +68,11 @@ public:
     void addTableSchemaForDeltaMerge(const String & name, const MockColumnInfoVec & columnInfos);
 
     void addTableDataForDeltaMerge(Context & context, const String & name, ColumnsWithTypeAndName & columns);
+    MockColumnInfoVec getTableSchemaForDeltaMerge(const String & name);
+    MockColumnInfoVec getTableSchemaForDeltaMerge(Int64 table_id);
+    NamesAndTypes getNameAndTypesForDeltaMerge(Int64 table_id);
 
-    BlockInputStreamPtr getStreamFromDeltaMerge(Context & context, const String & name);
+    BlockInputStreamPtr getStreamFromDeltaMerge(Context & context, Int64 table_id);
 
     /// for exchange receiver
     void addExchangeSchema(const String & exchange_name, const MockColumnInfoVec & columnInfos);
@@ -88,11 +91,14 @@ public:
     ColumnsWithTypeAndName getColumnsForMPPTableScan(const TiDBTableScan & table_scan, Int64 partition_id, Int64 partition_num);
 
     TableInfo getTableInfo(const String & name);
+    TableInfo getTableInfoForDeltaMerge(const String & name);
 
     /// clear for StorageDeltaMerge
     void clear();
 
-    void useDeltaMerge();
+    void setUseDeltaMerge();
+
+    bool useDeltaMerge() const;
 
 private:
     /// for mock table scan
@@ -109,8 +115,9 @@ private:
     /// for mock storage delta merge
     std::unordered_map<String, Int64> name_to_id_map_for_delta_merge; /// <table_name, table_id>
     std::unordered_map<Int64, MockColumnInfoVec> table_schema_for_delta_merge; /// <table_id, columnInfo>
-    std::unordered_map<String, std::shared_ptr<StorageDeltaMerge>> storage_delta_merge_map; // <table_name, StorageDeltaMerge>
+    std::unordered_map<Int64, std::shared_ptr<StorageDeltaMerge>> storage_delta_merge_map; // <table_name, StorageDeltaMerge>
     std::unordered_map<String, TableInfo> table_infos_for_delta_merge; /// <table_name, table_info>
+    std::unordered_map<Int64, NamesAndTypes> names_and_types_map_for_delta_merge; /// <table_id, NamesAndTypes>
 
     bool use_storage_delta_merge = false;
 
@@ -125,10 +132,9 @@ private:
 
     bool tableExistsForDeltaMerge(Int64 table_id);
 
-    MockColumnInfoVec getTableSchemaForDeltaMerge(const String & name);
-
     void addTableInfoForDeltaMerge(const String & name, const MockColumnInfoVec & columns);
 
+    void addNamesAndTypesForDeltaMerge(Int64 table_id, const ColumnsWithTypeAndName & columns);
     /// for exchange receiver
     bool exchangeExistsWithName(const String & name);
 };

--- a/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.cpp
@@ -32,6 +32,7 @@
 #include <DataStreams/TiRemoteBlockInputStream.h>
 #include <DataStreams/WindowBlockInputStream.h>
 #include <DataTypes/DataTypesNumber.h>
+#include <Debug/MockStorage.h>
 #include <Flash/Coprocessor/AggregationInterpreterHelper.h>
 #include <Flash/Coprocessor/DAGExpressionAnalyzer.h>
 #include <Flash/Coprocessor/DAGQueryBlockInterpreter.h>
@@ -163,7 +164,7 @@ AnalysisResult analyzeExpressions(
 // for tests, we need to mock tableScan blockInputStream as the source stream.
 void DAGQueryBlockInterpreter::handleMockTableScan(const TiDBTableScan & table_scan, DAGPipeline & pipeline)
 {
-    if (!context.mockStorage().tableExists(table_scan.getLogicalTableID()))
+    if (!context.mockStorage()->tableExists(table_scan.getLogicalTableID()))
     {
         auto names_and_types = genNamesAndTypes(table_scan, "mock_table_scan");
         auto columns_with_type_and_name = getColumnWithTypeAndName(names_and_types);
@@ -536,7 +537,7 @@ void DAGQueryBlockInterpreter::handleExchangeReceiver(DAGPipeline & pipeline)
 // for tests, we need to mock ExchangeReceiver blockInputStream as the source stream.
 void DAGQueryBlockInterpreter::handleMockExchangeReceiver(DAGPipeline & pipeline)
 {
-    if (!context.mockStorage().exchangeExists(query_block.source_name))
+    if (!context.mockStorage()->exchangeExists(query_block.source_name))
     {
         for (size_t i = 0; i < max_streams; ++i)
         {

--- a/dbms/src/Flash/Coprocessor/InterpreterUtils.cpp
+++ b/dbms/src/Flash/Coprocessor/InterpreterUtils.cpp
@@ -176,7 +176,7 @@ void executeCreatingSets(
 {
     DAGContext & dag_context = *context.getDAGContext();
     /// add union to run in parallel if needed
-    if (unlikely(context.isExecutorTest()))
+    if (unlikely(context.isExecutorTest() || context.isInterpreterTest()))
         executeUnion(pipeline, max_streams, log, /*ignore_block=*/false, "for test");
     else if (context.isMPPTest())
         executeUnion(pipeline, max_streams, log, /*ignore_block=*/true, "for mpp test");

--- a/dbms/src/Flash/Coprocessor/MockSourceStream.cpp
+++ b/dbms/src/Flash/Coprocessor/MockSourceStream.cpp
@@ -18,7 +18,7 @@ namespace DB
 {
 std::pair<NamesAndTypes, std::vector<std::shared_ptr<MockTableScanBlockInputStream>>> mockSourceStreamForMpp(Context & context, size_t max_streams, DB::LoggerPtr log, const TiDBTableScan & table_scan)
 {
-    ColumnsWithTypeAndName columns_with_type_and_name = context.mockStorage().getColumnsForMPPTableScan(table_scan, context.mockMPPServerInfo().partition_id, context.mockMPPServerInfo().partition_num);
+    ColumnsWithTypeAndName columns_with_type_and_name = context.mockStorage()->getColumnsForMPPTableScan(table_scan, context.mockMPPServerInfo().partition_id, context.mockMPPServerInfo().partition_num);
     return cutStreams<MockTableScanBlockInputStream>(context, columns_with_type_and_name, max_streams, log);
 }
 } // namespace DB

--- a/dbms/src/Flash/Coprocessor/MockSourceStream.h
+++ b/dbms/src/Flash/Coprocessor/MockSourceStream.h
@@ -18,6 +18,7 @@
 #include <Core/NamesAndTypes.h>
 #include <DataStreams/MockExchangeReceiverInputStream.h>
 #include <DataStreams/MockTableScanBlockInputStream.h>
+#include <Debug/MockStorage.h>
 #include <Flash/Coprocessor/TiDBTableScan.h>
 #include <Interpreters/Context.h>
 
@@ -70,9 +71,9 @@ std::pair<NamesAndTypes, std::vector<std::shared_ptr<SourceType>>> mockSourceStr
 {
     ColumnsWithTypeAndName columns_with_type_and_name;
     if constexpr (std::is_same_v<SourceType, MockExchangeReceiverInputStream>)
-        columns_with_type_and_name = context.mockStorage().getExchangeColumns(executor_id);
+        columns_with_type_and_name = context.mockStorage()->getExchangeColumns(executor_id);
     else
-        columns_with_type_and_name = context.mockStorage().getColumns(table_id);
+        columns_with_type_and_name = context.mockStorage()->getColumns(table_id);
 
     return cutStreams<SourceType>(context, columns_with_type_and_name, max_streams, log);
 }

--- a/dbms/src/Flash/FlashService.cpp
+++ b/dbms/src/Flash/FlashService.cpp
@@ -19,6 +19,7 @@
 #include <Common/VariantOp.h>
 #include <Common/getNumberOfCPUCores.h>
 #include <Common/setThreadName.h>
+#include <Debug/MockStorage.h>
 #include <Flash/BatchCoprocessorHandler.h>
 #include <Flash/EstablishCall.h>
 #include <Flash/FlashService.h>
@@ -490,7 +491,7 @@ grpc::Status FlashService::Compact(grpc::ServerContext * grpc_context, const kvr
     return manual_compact_manager->handleRequest(request, response);
 }
 
-void FlashService::setMockStorage(MockStorage & mock_storage_)
+void FlashService::setMockStorage(MockStorage * mock_storage_)
 {
     mock_storage = mock_storage_;
 }

--- a/dbms/src/Flash/FlashService.h
+++ b/dbms/src/Flash/FlashService.h
@@ -34,8 +34,7 @@ namespace DB
 class IServer;
 class IAsyncCallData;
 class EstablishCallData;
-
-using MockStorage = tests::MockStorage;
+class MockStorage;
 using MockMPPServerInfo = tests::MockMPPServerInfo;
 
 namespace Management
@@ -79,7 +78,7 @@ public:
 
     grpc::Status Compact(grpc::ServerContext * grpc_context, const kvrpcpb::CompactRequest * request, kvrpcpb::CompactResponse * response) override;
 
-    void setMockStorage(MockStorage & mock_storage_);
+    void setMockStorage(MockStorage * mock_storage_);
     void setMockMPPServerInfo(MockMPPServerInfo & mpp_test_info_);
     Context * getContext() { return context; }
 
@@ -97,7 +96,7 @@ protected:
     std::unique_ptr<Management::ManualCompactManager> manual_compact_manager;
 
     /// for mpp unit test.
-    MockStorage mock_storage;
+    MockStorage * mock_storage = nullptr;
     MockMPPServerInfo mpp_test_info{};
 
     // Put thread pool member(s) at the end so that ensure it will be destroyed firstly.

--- a/dbms/src/Flash/Planner/PhysicalPlan.cpp
+++ b/dbms/src/Flash/Planner/PhysicalPlan.cpp
@@ -126,7 +126,7 @@ void PhysicalPlan::build(const String & executor_id, const tipb::Executor * exec
     {
         GET_METRIC(tiflash_coprocessor_executor_count, type_exchange_sender).Increment();
         buildFinalProjection(fmt::format("{}_", executor_id), true);
-        if (unlikely(context.isExecutorTest()))
+        if (unlikely(context.isExecutorTest() || context.isInterpreterTest()))
             pushBack(PhysicalMockExchangeSender::build(executor_id, log, popBack()));
         else
         {
@@ -139,7 +139,7 @@ void PhysicalPlan::build(const String & executor_id, const tipb::Executor * exec
     case tipb::ExecType::TypeExchangeReceiver:
     {
         GET_METRIC(tiflash_coprocessor_executor_count, type_exchange_receiver).Increment();
-        if (unlikely(context.isExecutorTest()))
+        if (unlikely(context.isExecutorTest() || context.isInterpreterTest()))
             pushBack(PhysicalMockExchangeReceiver::build(context, executor_id, log, executor->exchange_receiver()));
         else
         {

--- a/dbms/src/Flash/Planner/plans/PhysicalMockExchangeReceiver.cpp
+++ b/dbms/src/Flash/Planner/plans/PhysicalMockExchangeReceiver.cpp
@@ -38,7 +38,8 @@ std::pair<NamesAndTypes, BlockInputStreams> mockSchemaAndStreams(
     size_t max_streams = dag_context.initialize_concurrency;
     assert(max_streams > 0);
 
-    if (!context.mockStorage()->exchangeExists(executor_id))
+    // Interpreter test will not use columns in MockStorage
+    if (context.isInterpreterTest() || !context.mockStorage()->exchangeExists(executor_id))
     {
         /// build with default blocks.
         for (size_t i = 0; i < max_streams; ++i)
@@ -81,8 +82,6 @@ PhysicalPlanNodePtr PhysicalMockExchangeReceiver::build(
     const LoggerPtr & log,
     const tipb::ExchangeReceiver & exchange_receiver)
 {
-    assert(context.isExecutorTest());
-
     auto [schema, mock_streams] = mockSchemaAndStreams(context, executor_id, log, exchange_receiver);
 
     auto physical_mock_exchange_receiver = std::make_shared<PhysicalMockExchangeReceiver>(

--- a/dbms/src/Flash/Planner/plans/PhysicalMockExchangeReceiver.cpp
+++ b/dbms/src/Flash/Planner/plans/PhysicalMockExchangeReceiver.cpp
@@ -38,7 +38,7 @@ std::pair<NamesAndTypes, BlockInputStreams> mockSchemaAndStreams(
     size_t max_streams = dag_context.initialize_concurrency;
     assert(max_streams > 0);
 
-    if (!context.mockStorage().exchangeExists(executor_id))
+    if (!context.mockStorage()->exchangeExists(executor_id))
     {
         /// build with default blocks.
         for (size_t i = 0; i < max_streams; ++i)

--- a/dbms/src/Flash/Planner/plans/PhysicalMockExchangeReceiver.h
+++ b/dbms/src/Flash/Planner/plans/PhysicalMockExchangeReceiver.h
@@ -23,7 +23,7 @@ namespace DB
 /**
  * A physical plan node that generates MockExchangeReceiverInputStream.
  * Used in gtest to test execution logic.
- * Only available with `context.isExecutorTest() == true`.
+ * Only available with `context.isExecutorTest() == true || context.isInterpreterTest() == true`.
  */
 class PhysicalMockExchangeReceiver : public PhysicalLeaf
 {

--- a/dbms/src/Flash/Planner/plans/PhysicalMockTableScan.cpp
+++ b/dbms/src/Flash/Planner/plans/PhysicalMockTableScan.cpp
@@ -38,8 +38,12 @@ std::pair<NamesAndTypes, BlockInputStreams> mockSchemaAndStreams(
     auto & dag_context = *context.getDAGContext();
     size_t max_streams = dag_context.initialize_concurrency;
     assert(max_streams > 0);
-
-    if (!context.mockStorage()->tableExists(table_scan.getLogicalTableID()))
+    if (context.mockStorage()->useDeltaMerge())
+    {
+        schema = context.mockStorage()->getNameAndTypesForDeltaMerge(table_scan.getLogicalTableID());
+        mock_streams.emplace_back(context.mockStorage()->getStreamFromDeltaMerge(context, table_scan.getLogicalTableID()));
+    }
+    else if (!context.mockStorage()->tableExists(table_scan.getLogicalTableID()))
     {
         /// build with default blocks.
         schema = genNamesAndTypes(table_scan, "mock_table_scan");

--- a/dbms/src/Flash/Planner/plans/PhysicalMockTableScan.cpp
+++ b/dbms/src/Flash/Planner/plans/PhysicalMockTableScan.cpp
@@ -39,7 +39,7 @@ std::pair<NamesAndTypes, BlockInputStreams> mockSchemaAndStreams(
     size_t max_streams = dag_context.initialize_concurrency;
     assert(max_streams > 0);
 
-    if (!context.mockStorage().tableExists(table_scan.getLogicalTableID()))
+    if (!context.mockStorage()->tableExists(table_scan.getLogicalTableID()))
     {
         /// build with default blocks.
         schema = genNamesAndTypes(table_scan, "mock_table_scan");

--- a/dbms/src/Flash/Planner/plans/PhysicalMockTableScan.cpp
+++ b/dbms/src/Flash/Planner/plans/PhysicalMockTableScan.cpp
@@ -22,9 +22,6 @@
 #include <Flash/Planner/plans/PhysicalMockTableScan.h>
 #include <Interpreters/Context.h>
 
-#include <cstddef>
-#include <utility>
-
 namespace DB
 {
 namespace

--- a/dbms/src/Flash/Planner/plans/PhysicalMockTableScan.cpp
+++ b/dbms/src/Flash/Planner/plans/PhysicalMockTableScan.cpp
@@ -40,10 +40,12 @@ std::pair<NamesAndTypes, BlockInputStreams> mockSchemaAndStreams(
     assert(max_streams > 0);
     if (context.mockStorage()->useDeltaMerge())
     {
+        assert(context.mockStorage()->tableExistsForDeltaMerge(table_scan.getLogicalTableID()));
         schema = context.mockStorage()->getNameAndTypesForDeltaMerge(table_scan.getLogicalTableID());
         mock_streams.emplace_back(context.mockStorage()->getStreamFromDeltaMerge(context, table_scan.getLogicalTableID()));
     }
-    else if (!context.mockStorage()->tableExists(table_scan.getLogicalTableID()))
+    // Interpreter test will not use columns in MockStorage
+    else if (context.isInterpreterTest() || !context.mockStorage()->tableExists(table_scan.getLogicalTableID()))
     {
         /// build with default blocks.
         schema = genNamesAndTypes(table_scan, "mock_table_scan");

--- a/dbms/src/Flash/Planner/plans/PhysicalMockTableScan.cpp
+++ b/dbms/src/Flash/Planner/plans/PhysicalMockTableScan.cpp
@@ -22,6 +22,9 @@
 #include <Flash/Planner/plans/PhysicalMockTableScan.h>
 #include <Interpreters/Context.h>
 
+#include <cstddef>
+#include <utility>
+
 namespace DB
 {
 namespace
@@ -34,28 +37,28 @@ std::pair<NamesAndTypes, BlockInputStreams> mockSchemaAndStreams(
 {
     NamesAndTypes schema;
     BlockInputStreams mock_streams;
-
     auto & dag_context = *context.getDAGContext();
     size_t max_streams = dag_context.initialize_concurrency;
     assert(max_streams > 0);
-    if (context.mockStorage()->useDeltaMerge())
-    {
-        assert(context.mockStorage()->tableExistsForDeltaMerge(table_scan.getLogicalTableID()));
-        schema = context.mockStorage()->getNameAndTypesForDeltaMerge(table_scan.getLogicalTableID());
-        mock_streams.emplace_back(context.mockStorage()->getStreamFromDeltaMerge(context, table_scan.getLogicalTableID()));
-    }
+
     // Interpreter test will not use columns in MockStorage
-    else if (context.isInterpreterTest() || !context.mockStorage()->tableExists(table_scan.getLogicalTableID()))
+    if (context.isInterpreterTest())
     {
-        /// build with default blocks.
         schema = genNamesAndTypes(table_scan, "mock_table_scan");
         auto columns_with_type_and_name = getColumnWithTypeAndName(schema);
         for (size_t i = 0; i < max_streams; ++i)
             mock_streams.emplace_back(std::make_shared<MockTableScanBlockInputStream>(columns_with_type_and_name, context.getSettingsRef().max_block_size));
     }
+    else if (context.mockStorage()->useDeltaMerge())
+    {
+        assert(context.mockStorage()->tableExistsForDeltaMerge(table_scan.getLogicalTableID()));
+        schema = context.mockStorage()->getNameAndTypesForDeltaMerge(table_scan.getLogicalTableID());
+        mock_streams.emplace_back(context.mockStorage()->getStreamFromDeltaMerge(context, table_scan.getLogicalTableID()));
+    }
     else
     {
         /// build from user input blocks.
+        assert(context.mockStorage()->tableExists(table_scan.getLogicalTableID()));
         NamesAndTypes names_and_types;
         std::vector<std::shared_ptr<DB::MockTableScanBlockInputStream>> mock_table_scan_streams;
         if (context.isMPPTest())

--- a/dbms/src/Flash/tests/gtest_aggregation_executor.cpp
+++ b/dbms/src/Flash/tests/gtest_aggregation_executor.cpp
@@ -33,34 +33,6 @@ namespace tests
 class AggExecutorTestRunner : public ExecutorTest
 {
 public:
-    using ColStringNullableType = std::optional<typename TypeTraits<String>::FieldType>;
-    using ColInt8NullableType = std::optional<typename TypeTraits<Int8>::FieldType>;
-    using ColInt16NullableType = std::optional<typename TypeTraits<Int16>::FieldType>;
-    using ColInt32NullableType = std::optional<typename TypeTraits<Int32>::FieldType>;
-    using ColInt64NullableType = std::optional<typename TypeTraits<Int64>::FieldType>;
-    using ColFloat32NullableType = std::optional<typename TypeTraits<Float32>::FieldType>;
-    using ColFloat64NullableType = std::optional<typename TypeTraits<Float64>::FieldType>;
-    using ColMyDateNullableType = std::optional<typename TypeTraits<MyDate>::FieldType>;
-    using ColMyDateTimeNullableType = std::optional<typename TypeTraits<MyDateTime>::FieldType>;
-    using ColDecimalNullableType = std::optional<typename TypeTraits<Decimal32>::FieldType>;
-    using ColUInt64Type = typename TypeTraits<UInt64>::FieldType;
-    using ColFloat64Type = typename TypeTraits<Float64>::FieldType;
-    using ColStringType = typename TypeTraits<String>::FieldType;
-
-    using ColumnWithNullableString = std::vector<ColStringNullableType>;
-    using ColumnWithNullableInt8 = std::vector<ColInt8NullableType>;
-    using ColumnWithNullableInt16 = std::vector<ColInt16NullableType>;
-    using ColumnWithNullableInt32 = std::vector<ColInt32NullableType>;
-    using ColumnWithNullableInt64 = std::vector<ColInt64NullableType>;
-    using ColumnWithNullableFloat32 = std::vector<ColFloat32NullableType>;
-    using ColumnWithNullableFloat64 = std::vector<ColFloat64NullableType>;
-    using ColumnWithNullableMyDate = std::vector<ColMyDateNullableType>;
-    using ColumnWithNullableMyDateTime = std::vector<ColMyDateTimeNullableType>;
-    using ColumnWithNullableDecimal = std::vector<ColDecimalNullableType>;
-    using ColumnWithUInt64 = std::vector<ColUInt64Type>;
-    using ColumnWithFloat64 = std::vector<ColFloat64Type>;
-    using ColumnWithString = std::vector<ColStringType>;
-
     ~AggExecutorTestRunner() override = default;
 
     void initializeContext() override

--- a/dbms/src/Flash/tests/gtest_executors_with_dm.cpp
+++ b/dbms/src/Flash/tests/gtest_executors_with_dm.cpp
@@ -27,7 +27,7 @@ public:
     void initializeContext() override
     {
         ExecutorTest::initializeContext();
-        context.mockStorage()->setUseDeltaMerge();
+        context.mockStorage()->setUseDeltaMerge(true);
         // note that the first column is pk.
         context.addMockDeltaMerge({"test_db", "t0"},
                                   {{"col0", TiDB::TP::TypeLongLong}},

--- a/dbms/src/Flash/tests/gtest_executors_with_dm.cpp
+++ b/dbms/src/Flash/tests/gtest_executors_with_dm.cpp
@@ -27,6 +27,7 @@ public:
     void initializeContext() override
     {
         ExecutorTest::initializeContext();
+        context.mockStorage()->setUseDeltaMerge();
         // note that the first column is pk.
         context.addMockDeltaMerge({"test_db", "t0"},
                                   {{"col0", TiDB::TP::TypeLongLong}},
@@ -59,7 +60,6 @@ public:
                                    toNullableVec<MyDate>("col7", col_mydate),
                                    toNullableVec<MyDateTime>("col8", col_mydatetime),
                                    toNullableVec<String>("col9", col_string)});
-        context.mockStorage()->setUseDeltaMerge();
     }
 
     void TearDown() override

--- a/dbms/src/Flash/tests/gtest_executors_with_dm.cpp
+++ b/dbms/src/Flash/tests/gtest_executors_with_dm.cpp
@@ -28,7 +28,9 @@ public:
     {
         ExecutorTest::initializeContext();
         context.mockStorage()->setUseDeltaMerge(true);
-        // note that the first column is pk.
+        // note that
+        // 1. the first column is pk.
+        // 2. The decimal type is not supported.
         context.addMockDeltaMerge({"test_db", "t0"},
                                   {{"col0", TiDB::TP::TypeLongLong}},
                                   {{toVec<Int64>("col0", {0, 1, 2, 3, 4, 5, 6, 7})}});

--- a/dbms/src/Flash/tests/gtest_executors_with_dm.cpp
+++ b/dbms/src/Flash/tests/gtest_executors_with_dm.cpp
@@ -24,33 +24,130 @@ namespace tests
 class ExecutorsWithDMTestRunner : public DB::tests::ExecutorTest
 {
 public:
-    using ColStringType = std::optional<typename TypeTraits<String>::FieldType>;
-    using ColInt64Type = typename TypeTraits<Int64>::FieldType;
-
-    using ColumnWithString = std::vector<ColStringType>;
-    using ColumnWithInt64 = std::vector<ColInt64Type>;
-
     void initializeContext() override
     {
         ExecutorTest::initializeContext();
+        context.addMockDeltaMerge({"test_db", "t0"},
+                                  {{"col0", TiDB::TP::TypeLongLong}},
+                                  {{toVec<Int64>("col0", {0, 1, 2, 3, 4, 5, 6, 7})}});
+
         context.addMockDeltaMerge({"test_db", "t1"},
                                   {{"col0", TiDB::TP::TypeLongLong},
                                    {"col1", TiDB::TP::TypeString}},
-                                  {{toVec<Int64>("col0", col0)},
-                                   {toNullableVec<String>("col1", col1)}});
+                                  {{toVec<Int64>("col0", {0, 1, 2, 3, 4, 5, 6, 7})},
+                                   {toNullableVec<String>("col1", {"col1-0", "col1-1", "col1-2", {}, "col1-4", {}, "col1-6", "col1-7"})}});
+
+        context.addMockDeltaMerge({"test_db", "t2"},
+                                  {{"col0", TiDB::TP::TypeLongLong},
+                                   {"col1", TiDB::TP::TypeTiny},
+                                   {"col2", TiDB::TP::TypeShort},
+                                   {"col3", TiDB::TP::TypeLong},
+                                   {"col4", TiDB::TP::TypeLongLong},
+                                   {"col5", TiDB::TP::TypeFloat},
+                                   {"col6", TiDB::TP::TypeDouble},
+                                   {"col7", TiDB::TP::TypeDate},
+                                   {"col8", TiDB::TP::TypeDatetime},
+                                   {"col9", TiDB::TP::TypeString}},
+                                  {toVec<Int64>("col0", col_id),
+                                   toNullableVec<Int8>("col1", col_tinyint),
+                                   toNullableVec<Int16>("col2", col_smallint),
+                                   toNullableVec<Int32>("col3", col_int),
+                                   toNullableVec<Int64>("col4", col_bigint),
+                                   toNullableVec<Float32>("col5", col_float),
+                                   toNullableVec<Float64>("col6", col_double),
+                                   toNullableVec<MyDate>("col7", col_mydate),
+                                   toNullableVec<MyDateTime>("col8", col_mydatetime),
+                                   toNullableVec<String>("col9", col_string)});
         context.mockStorage()->setUseDeltaMerge();
     }
-    const ColumnWithString col1{"col1-0", "col1-1", "col1-2", {}, "col1-4", {}, "col1-6", "col1-7"};
-    const ColumnWithInt64 col0{0, 1, 2, 3, 4, 5, 6, 7};
+
+    void TearDown() override
+    {
+        context.mockStorage()->clear();
+    }
+
+    ColumnWithInt64 col_id{1, 2, 3, 4, 5, 6, 7, 8, 9};
+    ColumnWithNullableInt8 col_tinyint{1, 2, 3, {}, {}, 0, 0, -1, -2};
+    ColumnWithNullableInt16 col_smallint{2, 3, {}, {}, 0, -1, -2, 4, 0};
+    ColumnWithNullableInt32 col_int{4, {}, {}, 0, 123, -1, -1, 123, 4};
+    ColumnWithNullableInt64 col_bigint{2, 2, {}, 0, -1, {}, -1, 0, 123};
+    ColumnWithNullableFloat32 col_float{3.3, {}, 0, 4.0, 3.3, 5.6, -0.1, -0.1, {}};
+    ColumnWithNullableFloat64 col_double{0.1, 0, 1.1, 1.1, 1.2, {}, {}, -1.2, -1.2};
+    ColumnWithNullableMyDate col_mydate{1000000, 2000000, {}, 300000, 1000000, {}, 0, 2000000, {}};
+    ColumnWithNullableMyDateTime col_mydatetime{2000000, 0, {}, 3000000, 1000000, {}, 0, 2000000, 1000000};
+    ColumnWithNullableString col_string{{}, "pingcap", "PingCAP", {}, "PINGCAP", "PingCAP", {}, "Shanghai", "Shanghai"};
 };
 
 TEST_F(ExecutorsWithDMTestRunner, Basic)
 try
 {
+    // table scan
     auto request = context
-                       .scan("test_db", "t1")
+                       .scan("test_db", "t0")
                        .build(context);
-    executeAndAssertColumnsEqual(request, {{toNullableVec<Int64>("col0", {0, 1, 2, 3, 4, 5, 6, 7})}, {toNullableVec<String>("col1", col1)}});
+    executeAndAssertColumnsEqual(
+        request,
+        {{toNullableVec<Int64>("col0", {0, 1, 2, 3, 4, 5, 6, 7})}});
+
+    request = context
+                  .scan("test_db", "t1")
+                  .build(context);
+    executeAndAssertColumnsEqual(
+        request,
+        {{toNullableVec<Int64>("col0", {0, 1, 2, 3, 4, 5, 6, 7})},
+         {toNullableVec<String>("col1", {"col1-0", "col1-1", "col1-2", {}, "col1-4", {}, "col1-6", "col1-7"})}});
+
+    request = context
+                  .scan("test_db", "t2")
+                  .build(context);
+
+    executeAndAssertColumnsEqual(
+        request,
+        {toNullableVec<Int64>({1, 2, 3, 4, 5, 6, 7, 8, 9}),
+         toNullableVec<Int8>(col_tinyint),
+         toNullableVec<Int16>(col_smallint),
+         toNullableVec<Int32>(col_int),
+         toNullableVec<Int64>(col_bigint),
+         toNullableVec<Float32>(col_float),
+         toNullableVec<Float64>(col_double),
+         toNullableVec<MyDate>(col_mydate),
+         toNullableVec<MyDateTime>(col_mydatetime),
+         toNullableVec<String>(col_string)});
+
+    // projection
+    request = context
+                  .scan("test_db", "t1")
+                  .project({col("col0")})
+                  .build(context);
+    executeAndAssertColumnsEqual(
+        request,
+        {{toNullableVec<Int64>("col0", {0, 1, 2, 3, 4, 5, 6, 7})}});
+
+    request = context
+                  .scan("test_db", "t1")
+                  .project({col("col1")})
+                  .build(context);
+    executeAndAssertColumnsEqual(
+        request,
+        {{toNullableVec<String>("col1", {"col1-0", "col1-1", "col1-2", {}, "col1-4", {}, "col1-6", "col1-7"})}});
+
+    // filter
+    request = context
+                  .scan("test_db", "t0")
+                  .filter(lt(col("col0"), lit(Field(static_cast<Int64>(4)))))
+                  .build(context);
+    executeAndAssertColumnsEqual(
+        request,
+        {{toNullableVec<Int64>("col0", {0, 1, 2, 3})}});
+
+    request = context
+                  .scan("test_db", "t1")
+                  .filter(lt(col("col0"), lit(Field(static_cast<Int64>(4)))))
+                  .build(context);
+    executeAndAssertColumnsEqual(
+        request,
+        {{toNullableVec<Int64>("col0", {0, 1, 2, 3})},
+         {toNullableVec<String>("col1", {"col1-0", "col1-1", "col1-2", {}})}});
 }
 CATCH
 

--- a/dbms/src/Flash/tests/gtest_executors_with_dm.cpp
+++ b/dbms/src/Flash/tests/gtest_executors_with_dm.cpp
@@ -44,7 +44,7 @@ public:
     const ColumnWithInt64 col0{0, 1, 2, 3, 4, 5, 6, 7};
 };
 
-TEST_F(ExecutorsWithDMTestRunner, DeltaMergeStorageBasic)
+TEST_F(ExecutorsWithDMTestRunner, Basic)
 try
 {
     auto request = context

--- a/dbms/src/Flash/tests/gtest_executors_with_dm.cpp
+++ b/dbms/src/Flash/tests/gtest_executors_with_dm.cpp
@@ -1,0 +1,67 @@
+// Copyright 2022 PingCAP, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Debug/MockStorage.h>
+#include <TestUtils/ExecutorTestUtils.h>
+#include <TestUtils/InputStreamTestUtils.h>
+#include <TestUtils/mockExecutor.h>
+
+namespace DB
+{
+namespace tests
+{
+
+class ExecutorsWithDMTestRunner : public DB::tests::ExecutorTest
+{
+public:
+    using ColStringType = std::optional<typename TypeTraits<String>::FieldType>;
+    using ColInt64Type = typename TypeTraits<Int64>::FieldType;
+
+    using ColumnWithString = std::vector<ColStringType>;
+    using ColumnWithInt64 = std::vector<ColInt64Type>;
+
+    void initializeContext() override
+    {
+        ExecutorTest::initializeContext();
+        context.addMockDeltaMerge({"test_db", "t1"},
+                                  {{"col0", TiDB::TP::TypeLongLong},
+                                   {"col1", TiDB::TP::TypeString}},
+                                  {{toVec<Int64>("col0", col0)},
+                                   {toNullableVec<String>("col1", col1)}});
+        context.mockStorage()->useDeltaMerge();
+    }
+    const ColumnWithString col1{"col1-0", "col1-1", "col1-2", {}, "col1-4", {}, "col1-6", "col1-7"};
+    const ColumnWithInt64 col0{0, 1, 2, 3, 4, 5, 6, 7};
+};
+
+TEST_F(ExecutorsWithDMTestRunner, DeltaMergeStorageBasic)
+try
+{
+    auto * mock_storage = context.mockStorage();
+    // ywq todo refine scan
+    ColumnsWithTypeAndName columns{toVec<Int64>("col0", col0), toNullableVec<String>("col1", col1)};
+    mock_storage->addTableSchemaForDeltaMerge("test", {{"col0", TiDB::TP::TypeLongLong}, {"col1", TiDB::TP::TypeString}});
+    mock_storage->addTableDataForDeltaMerge(context.context, "test", columns);
+    auto in = mock_storage->getStreamFromDeltaMerge(context.context, "test");
+
+    ASSERT_INPUTSTREAM_BLOCK_UR(
+        in,
+        Block(columns));
+
+    mock_storage->clear();
+}
+CATCH
+
+} // namespace tests
+} // namespace DB

--- a/dbms/src/Flash/tests/gtest_executors_with_dm.cpp
+++ b/dbms/src/Flash/tests/gtest_executors_with_dm.cpp
@@ -27,6 +27,7 @@ public:
     void initializeContext() override
     {
         ExecutorTest::initializeContext();
+        // note that the first column is pk.
         context.addMockDeltaMerge({"test_db", "t0"},
                                   {{"col0", TiDB::TP::TypeLongLong}},
                                   {{toVec<Int64>("col0", {0, 1, 2, 3, 4, 5, 6, 7})}});

--- a/dbms/src/Flash/tests/gtest_filter_executor.cpp
+++ b/dbms/src/Flash/tests/gtest_filter_executor.cpp
@@ -89,7 +89,7 @@ try
 }
 CATCH
 
-TEST_F(FilterExecutorTestRunner, and_or)
+TEST_F(FilterExecutorTestRunner, andOr)
 try
 {
     auto test_one = [&](const ASTPtr & condition, const ColumnsWithTypeAndName & expect_columns) {
@@ -197,7 +197,7 @@ try
 }
 CATCH
 
-TEST_F(FilterExecutorTestRunner, convert_bool)
+TEST_F(FilterExecutorTestRunner, convertBool)
 try
 {
     {

--- a/dbms/src/Flash/tests/gtest_limit_executor.cpp
+++ b/dbms/src/Flash/tests/gtest_limit_executor.cpp
@@ -23,9 +23,6 @@ namespace tests
 class LimitExecutorTestRunner : public DB::tests::ExecutorTest
 {
 public:
-    using ColDataType = std::optional<typename TypeTraits<String>::FieldType>;
-    using ColumnWithData = std::vector<ColDataType>;
-
     void initializeContext() override
     {
         ExecutorTest::initializeContext();
@@ -44,7 +41,7 @@ public:
     const String db_name{"test_db"};
     const String table_name{"projection_test_table"};
     const String col_name{"limit_col"};
-    const ColumnWithData col0{"col0-0", {}, "col0-2", "col0-3", {}, "col0-5", "col0-6", "col0-7"};
+    const ColumnWithNullableString col0{"col0-0", {}, "col0-2", "col0-3", {}, "col0-5", "col0-6", "col0-7"};
 };
 
 TEST_F(LimitExecutorTestRunner, Limit)
@@ -64,9 +61,9 @@ try
         if (limit_num == 0)
             expect_cols = {};
         else if (limit_num > col_data_num)
-            expect_cols = {toNullableVec<String>(col_name, ColumnWithData(col0.begin(), col0.end()))};
+            expect_cols = {toNullableVec<String>(col_name, ColumnWithNullableString(col0.begin(), col0.end()))};
         else
-            expect_cols = {toNullableVec<String>(col_name, ColumnWithData(col0.begin(), col0.begin() + limit_num))};
+            expect_cols = {toNullableVec<String>(col_name, ColumnWithNullableString(col0.begin(), col0.begin() + limit_num))};
 
         WRAP_FOR_DIS_ENABLE_PLANNER_BEGIN
         ASSERT_COLUMNS_EQ_R(executeStreams(request), expect_cols);
@@ -81,7 +78,7 @@ TEST_F(LimitExecutorTestRunner, RawQuery)
 try
 {
     String query = "select * from test_db.projection_test_table limit 1";
-    auto cols = {toNullableVec<String>(col_name, ColumnWithData(col0.begin(), col0.begin() + 1))};
+    auto cols = {toNullableVec<String>(col_name, ColumnWithNullableString(col0.begin(), col0.begin() + 1))};
     ASSERT_COLUMNS_EQ_R(executeRawQuery(query, 1), cols);
 }
 CATCH

--- a/dbms/src/Flash/tests/gtest_mock_storage.cpp
+++ b/dbms/src/Flash/tests/gtest_mock_storage.cpp
@@ -24,19 +24,13 @@ namespace tests
 class MockStorageTestRunner : public DB::tests::ExecutorTest
 {
 public:
-    using ColStringType = std::optional<typename TypeTraits<String>::FieldType>;
-    using ColInt64Type = typename TypeTraits<Int64>::FieldType;
-
-    using ColumnWithString = std::vector<ColStringType>;
-    using ColumnWithInt64 = std::vector<ColInt64Type>;
-
     void initializeContext() override
     {
         ExecutorTest::initializeContext();
     }
 
     // single column table
-    const ColumnWithString col1{"col1-0", "col1-1", "col1-2", {}, "col1-4", {}, "col1-6", "col1-7"};
+    const ColumnWithNullableString col1{"col1-0", "col1-1", "col1-2", {}, "col1-4", {}, "col1-6", "col1-7"};
     const ColumnWithInt64 col0{0, 1, 2, 3, 4, 5, 6, 7};
 
     MockStorage mock_storage;

--- a/dbms/src/Flash/tests/gtest_mock_storage.cpp
+++ b/dbms/src/Flash/tests/gtest_mock_storage.cpp
@@ -21,7 +21,6 @@ namespace DB
 {
 namespace tests
 {
-
 class MockStorageTestRunner : public DB::tests::ExecutorTest
 {
 public:

--- a/dbms/src/Flash/tests/gtest_mock_storage.cpp
+++ b/dbms/src/Flash/tests/gtest_mock_storage.cpp
@@ -49,7 +49,7 @@ try
     ColumnsWithTypeAndName columns{toVec<Int64>("col0", col0), toNullableVec<String>("col1", col1)};
     mock_storage.addTableSchemaForDeltaMerge("test", {{"col0", TiDB::TP::TypeLongLong}, {"col1", TiDB::TP::TypeString}});
     mock_storage.addTableDataForDeltaMerge(context.context, "test", columns);
-    auto in = mock_storage.getStreamFromDeltaMerge(context.context, "test");
+    auto in = mock_storage.getStreamFromDeltaMerge(context.context, 1);
 
     ASSERT_INPUTSTREAM_BLOCK_UR(
         in,

--- a/dbms/src/Flash/tests/gtest_mock_storage.cpp
+++ b/dbms/src/Flash/tests/gtest_mock_storage.cpp
@@ -1,0 +1,63 @@
+// Copyright 2022 PingCAP, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Debug/MockStorage.h>
+#include <TestUtils/ExecutorTestUtils.h>
+#include <TestUtils/InputStreamTestUtils.h>
+#include <TestUtils/mockExecutor.h>
+
+namespace DB
+{
+namespace tests
+{
+
+class MockStorageTestRunner : public DB::tests::ExecutorTest
+{
+public:
+    using ColStringType = std::optional<typename TypeTraits<String>::FieldType>;
+    using ColInt64Type = typename TypeTraits<Int64>::FieldType;
+
+    using ColumnWithString = std::vector<ColStringType>;
+    using ColumnWithInt64 = std::vector<ColInt64Type>;
+
+    void initializeContext() override
+    {
+        ExecutorTest::initializeContext();
+    }
+
+    // single column table
+    const ColumnWithString col1{"col1-0", "col1-1", "col1-2", {}, "col1-4", {}, "col1-6", "col1-7"};
+    const ColumnWithInt64 col0{0, 1, 2, 3, 4, 5, 6, 7};
+
+    MockStorage mock_storage;
+};
+
+TEST_F(MockStorageTestRunner, DeltaMergeStorageBasic)
+try
+{
+    ColumnsWithTypeAndName columns{toVec<Int64>("col0", col0), toNullableVec<String>("col1", col1)};
+    mock_storage.addTableSchemaForDeltaMerge("test", {{"col0", TiDB::TP::TypeLongLong}, {"col1", TiDB::TP::TypeString}});
+    mock_storage.addTableDataForDeltaMerge(context.context, "test", columns);
+    auto in = mock_storage.getStreamFromDeltaMerge(context.context, "test");
+
+    ASSERT_INPUTSTREAM_BLOCK_UR(
+        in,
+        Block(columns));
+
+    mock_storage.clear();
+}
+CATCH
+
+} // namespace tests
+} // namespace DB

--- a/dbms/src/Flash/tests/gtest_projection_executor.cpp
+++ b/dbms/src/Flash/tests/gtest_projection_executor.cpp
@@ -23,9 +23,6 @@ namespace tests
 class ProjectionExecutorTestRunner : public DB::tests::ExecutorTest
 {
 public:
-    using ColDataString = std::vector<std::optional<typename TypeTraits<String>::FieldType>>;
-    using ColDataInt32 = std::vector<std::optional<typename TypeTraits<Int32>::FieldType>>;
-
     void initializeContext() override
     {
         ExecutorTest::initializeContext();
@@ -70,23 +67,23 @@ public:
     };
 
     /// Prepare column data
-    const ColDataString col0{"col0-0", "col0-1", "", "col0-2", {}, "col0-3", ""};
-    const ColDataString col1{"col1-0", {}, "", "col1-1", "", "col1-2", "col1-3"};
-    const ColDataString col2{"", "col2-0", "col2-1", {}, "col2-3", {}, "col2-4"};
-    const ColDataInt32 col3{1, {}, 0, -111111, {}, 0, 9999};
+    const ColumnWithNullableString col0{"col0-0", "col0-1", "", "col0-2", {}, "col0-3", ""};
+    const ColumnWithNullableString col1{"col1-0", {}, "", "col1-1", "", "col1-2", "col1-3"};
+    const ColumnWithNullableString col2{"", "col2-0", "col2-1", {}, "col2-3", {}, "col2-4"};
+    const ColumnWithNullableInt32 col3{1, {}, 0, -111111, {}, 0, 9999};
 
     /** Each value in col4 should be different from each other so that topn 
      *  could sort the columns into an unique result, or multi-results could
      *  be right.
      */
-    const ColDataInt32 col4{0, 5, -123, -234, {}, 24353, 9999};
+    const ColumnWithNullableInt32 col4{0, 5, -123, -234, {}, 24353, 9999};
 
     /// Results after sorted by col4
-    const ColDataString col0_sorted_asc{{}, "col0-2", "", "col0-0", "col0-1", "", "col0-3"};
-    const ColDataString col1_sorted_asc{"", "col1-1", "", "col1-0", {}, "col1-3", "col1-2"};
-    const ColDataString col2_sorted_asc{"col2-3", {}, "col2-1", "", "col2-0", "col2-4", {}};
-    const ColDataInt32 col3_sorted_asc{{}, -111111, 0, 1, {}, 9999, 0};
-    const ColDataInt32 col4_sorted_asc{{}, -234, -123, 0, 5, 9999, 24353};
+    const ColumnWithNullableString col0_sorted_asc{{}, "col0-2", "", "col0-0", "col0-1", "", "col0-3"};
+    const ColumnWithNullableString col1_sorted_asc{"", "col1-1", "", "col1-0", {}, "col1-3", "col1-2"};
+    const ColumnWithNullableString col2_sorted_asc{"col2-3", {}, "col2-1", "", "col2-0", "col2-4", {}};
+    const ColumnWithNullableInt32 col3_sorted_asc{{}, -111111, 0, 1, {}, 9999, 0};
+    const ColumnWithNullableInt32 col4_sorted_asc{{}, -234, -123, 0, 5, 9999, 24353};
 
     /// Prepare some names
     std::vector<String> col_names{"col0", "col1", "col2", "col3", "col4"};

--- a/dbms/src/Flash/tests/gtest_squashing_hash_join_transform.cpp
+++ b/dbms/src/Flash/tests/gtest_squashing_hash_join_transform.cpp
@@ -33,9 +33,9 @@ public:
 
     static void check(Blocks blocks, UInt64 max_block_size)
     {
-        for (size_t i = 0; i < blocks.size(); ++i)
+        for (auto & block : blocks)
         {
-            ASSERT(blocks[i].rows() <= max_block_size);
+            ASSERT(block.rows() <= max_block_size);
         }
     }
 };

--- a/dbms/src/Flash/tests/gtest_topn_executor.cpp
+++ b/dbms/src/Flash/tests/gtest_topn_executor.cpp
@@ -23,11 +23,6 @@ namespace tests
 class TopNExecutorTestRunner : public DB::tests::ExecutorTest
 {
 public:
-    using ColStringType = std::optional<typename TypeTraits<String>::FieldType>;
-    using ColInt32Type = std::optional<typename TypeTraits<Int32>::FieldType>;
-    using ColumnWithString = std::vector<ColStringType>;
-    using ColumnWithInt32 = std::vector<ColInt32Type>;
-
     void initializeContext() override
     {
         ExecutorTest::initializeContext();
@@ -97,14 +92,14 @@ public:
 
     const String table_single_name{"topn_single_table"}; /// For single column test
     const String single_col_name{"single_col"};
-    ColumnWithString col0{"col0-0", "col0-1", "col0-2", {}, "col0-4", {}, "col0-6", "col0-7"};
+    ColumnWithNullableString col0{"col0-0", "col0-1", "col0-2", {}, "col0-4", {}, "col0-6", "col0-7"};
 
     const String table_name{"clerk"};
     const std::vector<String> col_name{"age", "gender", "country", "salary"};
-    ColumnWithInt32 col_age{{}, 27, 32, 36, {}, 34};
-    ColumnWithString col_gender{"female", "female", "male", "female", "male", "male"};
-    ColumnWithString col_country{"korea", "usa", "usa", "china", "china", "china"};
-    ColumnWithInt32 col_salary{1300, 0, {}, 900, {}, -300};
+    ColumnWithNullableInt32 col_age{{}, 27, 32, 36, {}, 34};
+    ColumnWithNullableString col_gender{"female", "female", "male", "female", "male", "male"};
+    ColumnWithNullableString col_country{"korea", "usa", "usa", "china", "china", "china"};
+    ColumnWithNullableInt32 col_salary{1300, 0, {}, 900, {}, -300};
 };
 
 TEST_F(TopNExecutorTestRunner, TopN)
@@ -121,7 +116,7 @@ try
             bool is_desc;
             is_desc = static_cast<bool>(i); /// Set descent or ascent
             if (is_desc)
-                sort(col0.begin(), col0.end(), std::greater<ColStringType>()); /// Sort col0 for the following comparison
+                sort(col0.begin(), col0.end(), std::greater<ColStringNullableType>()); /// Sort col0 for the following comparison
             else
                 sort(col0.begin(), col0.end());
 
@@ -131,9 +126,9 @@ try
 
                 expect_cols.clear();
                 if (limit_num == 0 || limit_num > col_data_num)
-                    expect_cols.push_back({toNullableVec<String>(single_col_name, ColumnWithString(col0.begin(), col0.end()))});
+                    expect_cols.push_back({toNullableVec<String>(single_col_name, ColumnWithNullableString(col0.begin(), col0.end()))});
                 else
-                    expect_cols.push_back({toNullableVec<String>(single_col_name, ColumnWithString(col0.begin(), col0.begin() + limit_num))});
+                    expect_cols.push_back({toNullableVec<String>(single_col_name, ColumnWithNullableString(col0.begin(), col0.begin() + limit_num))});
 
                 executeAndAssertColumnsEqual(request, expect_cols.back());
             }
@@ -142,18 +137,18 @@ try
 
     {
         /// Test multi-columns
-        expect_cols = {{toNullableVec<Int32>(col_name[0], ColumnWithInt32{36, 34, 32, 27, {}, {}}),
-                        toNullableVec<String>(col_name[1], ColumnWithString{"female", "male", "male", "female", "male", "female"}),
-                        toNullableVec<String>(col_name[2], ColumnWithString{"china", "china", "usa", "usa", "china", "korea"}),
-                        toNullableVec<Int32>(col_name[3], ColumnWithInt32{900, -300, {}, 0, {}, 1300})},
-                       {toNullableVec<Int32>(col_name[0], ColumnWithInt32{32, {}, 34, 27, 36, {}}),
-                        toNullableVec<String>(col_name[1], ColumnWithString{"male", "male", "male", "female", "female", "female"}),
-                        toNullableVec<String>(col_name[2], ColumnWithString{"usa", "china", "china", "usa", "china", "korea"}),
-                        toNullableVec<Int32>(col_name[3], ColumnWithInt32{{}, {}, -300, 0, 900, 1300})},
-                       {toNullableVec<Int32>(col_name[0], ColumnWithInt32{34, {}, 32, 36, {}, 27}),
-                        toNullableVec<String>(col_name[1], ColumnWithString{"male", "male", "male", "female", "female", "female"}),
-                        toNullableVec<String>(col_name[2], ColumnWithString{"china", "china", "usa", "china", "korea", "usa"}),
-                        toNullableVec<Int32>(col_name[3], ColumnWithInt32{-300, {}, {}, 900, 1300, 0})}};
+        expect_cols = {{toNullableVec<Int32>(col_name[0], ColumnWithNullableInt32{36, 34, 32, 27, {}, {}}),
+                        toNullableVec<String>(col_name[1], ColumnWithNullableString{"female", "male", "male", "female", "male", "female"}),
+                        toNullableVec<String>(col_name[2], ColumnWithNullableString{"china", "china", "usa", "usa", "china", "korea"}),
+                        toNullableVec<Int32>(col_name[3], ColumnWithNullableInt32{900, -300, {}, 0, {}, 1300})},
+                       {toNullableVec<Int32>(col_name[0], ColumnWithNullableInt32{32, {}, 34, 27, 36, {}}),
+                        toNullableVec<String>(col_name[1], ColumnWithNullableString{"male", "male", "male", "female", "female", "female"}),
+                        toNullableVec<String>(col_name[2], ColumnWithNullableString{"usa", "china", "china", "usa", "china", "korea"}),
+                        toNullableVec<Int32>(col_name[3], ColumnWithNullableInt32{{}, {}, -300, 0, 900, 1300})},
+                       {toNullableVec<Int32>(col_name[0], ColumnWithNullableInt32{34, {}, 32, 36, {}, 27}),
+                        toNullableVec<String>(col_name[1], ColumnWithNullableString{"male", "male", "male", "female", "female", "female"}),
+                        toNullableVec<String>(col_name[2], ColumnWithNullableString{"china", "china", "usa", "china", "korea", "usa"}),
+                        toNullableVec<Int32>(col_name[3], ColumnWithNullableInt32{-300, {}, {}, 900, 1300, 0})}};
 
         std::vector<MockOrderByItemVec> order_by_items{
             /// select * from clerk order by age DESC, gender DESC;
@@ -190,10 +185,10 @@ try
 
     {
         /// "and" function
-        expect_cols = {{toNullableVec<Int32>(col_name[0], ColumnWithInt32{{}, {}, 32, 27, 36, 34}),
-                        toNullableVec<String>(col_name[1], ColumnWithString{"female", "male", "male", "female", "female", "male"}),
-                        toNullableVec<String>(col_name[2], ColumnWithString{"korea", "china", "usa", "usa", "china", "china"}),
-                        toNullableVec<Int32>(col_name[3], ColumnWithInt32{1300, {}, {}, 0, 900, -300})}};
+        expect_cols = {{toNullableVec<Int32>(col_name[0], ColumnWithNullableInt32{{}, {}, 32, 27, 36, 34}),
+                        toNullableVec<String>(col_name[1], ColumnWithNullableString{"female", "male", "male", "female", "female", "male"}),
+                        toNullableVec<String>(col_name[2], ColumnWithNullableString{"korea", "china", "usa", "usa", "china", "china"}),
+                        toNullableVec<Int32>(col_name[3], ColumnWithNullableInt32{1300, {}, {}, 0, 900, -300})}};
 
         {
             /// select * from clerk order by age and salary ASC limit 100;
@@ -208,10 +203,10 @@ try
 
     {
         /// "equal" function
-        expect_cols = {{toNullableVec<Int32>(col_name[0], ColumnWithInt32{27, 36, 34, 32, {}, {}}),
-                        toNullableVec<String>(col_name[1], ColumnWithString{"female", "female", "male", "male", "female", "male"}),
-                        toNullableVec<String>(col_name[2], ColumnWithString{"usa", "china", "china", "usa", "korea", "china"}),
-                        toNullableVec<Int32>(col_name[3], ColumnWithInt32{0, 900, -300, {}, 1300, {}})}};
+        expect_cols = {{toNullableVec<Int32>(col_name[0], ColumnWithNullableInt32{27, 36, 34, 32, {}, {}}),
+                        toNullableVec<String>(col_name[1], ColumnWithNullableString{"female", "female", "male", "male", "female", "male"}),
+                        toNullableVec<String>(col_name[2], ColumnWithNullableString{"usa", "china", "china", "usa", "korea", "china"}),
+                        toNullableVec<Int32>(col_name[3], ColumnWithNullableInt32{0, 900, -300, {}, 1300, {}})}};
 
         {
             /// select age, salary from clerk order by age = salary DESC limit 100;
@@ -226,10 +221,10 @@ try
 
     {
         /// "greater" function
-        expect_cols = {{toNullableVec<Int32>(col_name[0], ColumnWithInt32{{}, 32, {}, 36, 27, 34}),
-                        toNullableVec<String>(col_name[1], ColumnWithString{"female", "male", "male", "female", "female", "male"}),
-                        toNullableVec<String>(col_name[2], ColumnWithString{"korea", "usa", "china", "china", "usa", "china"}),
-                        toNullableVec<Int32>(col_name[3], ColumnWithInt32{1300, {}, {}, 900, 0, -300})}};
+        expect_cols = {{toNullableVec<Int32>(col_name[0], ColumnWithNullableInt32{{}, 32, {}, 36, 27, 34}),
+                        toNullableVec<String>(col_name[1], ColumnWithNullableString{"female", "male", "male", "female", "female", "male"}),
+                        toNullableVec<String>(col_name[2], ColumnWithNullableString{"korea", "usa", "china", "china", "usa", "china"}),
+                        toNullableVec<Int32>(col_name[3], ColumnWithNullableInt32{1300, {}, {}, 900, 0, -300})}};
 
         {
             /// select age, gender, country, salary from clerk order by age > salary ASC limit 100;

--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -1832,7 +1832,7 @@ size_t Context::getMaxStreams() const
     bool is_cop_request = false;
     if (dag_context != nullptr)
     {
-        if (isExecutorTest())
+        if (isExecutorTest() || isInterpreterTest())
             max_streams = dag_context->initialize_concurrency;
         else if (!dag_context->isBatchCop() && !dag_context->isMPPTask())
         {
@@ -1878,6 +1878,16 @@ bool Context::isExecutorTest() const
 void Context::setExecutorTest()
 {
     test_mode = executor_test;
+}
+
+bool Context::isInterpreterTest() const
+{
+    return test_mode == interpreter_test;
+}
+
+void Context::setInterpreterTest()
+{
+    test_mode = interpreter_test;
 }
 
 bool Context::isCopTest() const

--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -27,6 +27,7 @@
 #include <DataStreams/FormatFactory.h>
 #include <Databases/IDatabase.h>
 #include <Debug/DBGInvoker.h>
+#include <Debug/MockStorage.h>
 #include <Encryption/DataKeyManager.h>
 #include <Encryption/FileProvider.h>
 #include <Encryption/RateLimiter.h>
@@ -1894,12 +1895,12 @@ bool Context::isTest() const
     return test_mode != non_test;
 }
 
-void Context::setMockStorage(MockStorage & mock_storage_)
+void Context::setMockStorage(MockStorage * mock_storage_)
 {
     mock_storage = mock_storage_;
 }
 
-MockStorage Context::mockStorage() const
+MockStorage * Context::mockStorage() const
 {
     return mock_storage;
 }

--- a/dbms/src/Interpreters/Context.h
+++ b/dbms/src/Interpreters/Context.h
@@ -18,7 +18,6 @@
 #include <Core/TiFlashDisaggregatedMode.h>
 #include <Core/Types.h>
 #include <Debug/MockServerInfo.h>
-#include <Debug/MockStorage.h>
 #include <IO/CompressionSettings.h>
 #include <Interpreters/ClientInfo.h>
 #include <Interpreters/Settings.h>
@@ -99,9 +98,9 @@ using WriteLimiterPtr = std::shared_ptr<WriteLimiter>;
 class ReadLimiter;
 using ReadLimiterPtr = std::shared_ptr<ReadLimiter>;
 using MockMPPServerInfo = DB::tests::MockMPPServerInfo;
-using MockStorage = DB::tests::MockStorage;
 class TiFlashSecurityConfig;
 using TiFlashSecurityConfigPtr = std::shared_ptr<TiFlashSecurityConfig>;
+class MockStorage;
 
 enum class PageStorageRunMode : UInt8;
 namespace DM
@@ -169,7 +168,7 @@ private:
     };
     TestMode test_mode = non_test;
 
-    MockStorage mock_storage;
+    MockStorage * mock_storage = nullptr;
     MockMPPServerInfo mpp_server_info{};
 
     TimezoneInfo timezone_info;
@@ -487,8 +486,8 @@ public:
     bool isCopTest() const;
     bool isTest() const;
 
-    void setMockStorage(MockStorage & mock_storage_);
-    MockStorage mockStorage() const;
+    void setMockStorage(MockStorage * mock_storage_);
+    MockStorage * mockStorage() const;
     MockMPPServerInfo mockMPPServerInfo() const;
     void setMockMPPServerInfo(MockMPPServerInfo & info);
 

--- a/dbms/src/Interpreters/Context.h
+++ b/dbms/src/Interpreters/Context.h
@@ -163,6 +163,7 @@ private:
         non_test,
         mpp_test,
         cop_test,
+        interpreter_test,
         executor_test,
         cancel_test
     };
@@ -482,6 +483,8 @@ public:
     void setCancelTest();
     bool isExecutorTest() const;
     void setExecutorTest();
+    bool isInterpreterTest() const;
+    void setInterpreterTest();
     void setCopTest();
     bool isCopTest() const;
     bool isTest() const;

--- a/dbms/src/Server/FlashGrpcServerHolder.cpp
+++ b/dbms/src/Server/FlashGrpcServerHolder.cpp
@@ -245,7 +245,7 @@ FlashGrpcServerHolder::~FlashGrpcServerHolder()
     }
 }
 
-void FlashGrpcServerHolder::setMockStorage(MockStorage & mock_storage)
+void FlashGrpcServerHolder::setMockStorage(MockStorage * mock_storage)
 {
     flash_service->setMockStorage(mock_storage);
 }

--- a/dbms/src/Server/FlashGrpcServerHolder.h
+++ b/dbms/src/Server/FlashGrpcServerHolder.h
@@ -27,7 +27,6 @@
 
 namespace DB
 {
-using MockStorage = tests::MockStorage;
 using MockMPPServerInfo = tests::MockMPPServerInfo;
 
 class FlashGrpcServerHolder
@@ -40,7 +39,7 @@ public:
         const LoggerPtr & log_);
     ~FlashGrpcServerHolder();
 
-    void setMockStorage(MockStorage & mock_storage);
+    void setMockStorage(MockStorage * mock_storage);
     void setMockMPPServerInfo(MockMPPServerInfo info);
 
     std::unique_ptr<FlashService> & flashService();

--- a/dbms/src/TestUtils/ExecutorTestUtils.cpp
+++ b/dbms/src/TestUtils/ExecutorTestUtils.cpp
@@ -15,6 +15,7 @@
 #include <AggregateFunctions/registerAggregateFunctions.h>
 #include <Common/FmtUtils.h>
 #include <Debug/MockComputeServerManager.h>
+#include <Debug/MockStorage.h>
 #include <Flash/Coprocessor/DAGQuerySource.h>
 #include <Flash/executeQuery.h>
 #include <TestUtils/ExecutorTestUtils.h>
@@ -62,6 +63,7 @@ void ExecutorTest::initializeContext()
 {
     dag_context_ptr = std::make_unique<DAGContext>(1024);
     context = MockDAGRequestContext(TiFlashTestEnv::getContext());
+    context.initMockStorage();
     dag_context_ptr->log = Logger::get("executorTest");
     TiFlashTestEnv::getGlobalContext().setExecutorTest();
 }
@@ -236,7 +238,7 @@ DB::ColumnsWithTypeAndName ExecutorTest::executeRawQuery(const String & query, s
         context.context,
         query,
         [&](const String & database_name, const String & table_name) {
-            return context.mockStorage().getTableInfo(database_name + "." + table_name);
+            return context.mockStorage()->getTableInfo(database_name + "." + table_name);
         },
         properties);
 

--- a/dbms/src/TestUtils/ExecutorTestUtils.cpp
+++ b/dbms/src/TestUtils/ExecutorTestUtils.cpp
@@ -98,7 +98,8 @@ void ExecutorTest::executeInterpreter(const String & expected_string, const std:
 {
     DAGContext dag_context(*request, "interpreter_test", concurrency);
     context.context.setDAGContext(&dag_context);
-    context.context.setExecutorTest();
+    context.context.setInterpreterTest();
+    context.context.setMockStorage(context.mockStorage());
     // Currently, don't care about regions information in interpreter tests.
     auto query_executor = queryExecute(context.context, /*internal=*/true);
     ASSERT_EQ(Poco::trim(expected_string), Poco::trim(query_executor->dump()));

--- a/dbms/src/TestUtils/ExecutorTestUtils.cpp
+++ b/dbms/src/TestUtils/ExecutorTestUtils.cpp
@@ -99,8 +99,7 @@ void ExecutorTest::executeInterpreter(const String & expected_string, const std:
     DAGContext dag_context(*request, "interpreter_test", concurrency);
     context.context.setDAGContext(&dag_context);
     context.context.setInterpreterTest();
-    context.context.setMockStorage(context.mockStorage());
-    // Currently, don't care about regions information in interpreter tests.
+    // Don't care regions information in interpreter tests.
     auto query_executor = queryExecute(context.context, /*internal=*/true);
     ASSERT_EQ(Poco::trim(expected_string), Poco::trim(query_executor->dump()));
 }

--- a/dbms/src/TestUtils/ExecutorTestUtils.h
+++ b/dbms/src/TestUtils/ExecutorTestUtils.h
@@ -32,7 +32,7 @@ ColumnsWithTypeAndName readBlock(BlockInputStreamPtr stream);
 ColumnsWithTypeAndName readBlocks(std::vector<BlockInputStreamPtr> streams);
 
 #define WRAP_FOR_DIS_ENABLE_PLANNER_BEGIN \
-    std::vector<bool> bools{true, false}; \
+    std::vector<bool> bools{false, true}; \
     for (auto enable_planner : bools)     \
     {                                     \
         enablePlanner(enable_planner);

--- a/dbms/src/TestUtils/ExecutorTestUtils.h
+++ b/dbms/src/TestUtils/ExecutorTestUtils.h
@@ -115,6 +115,7 @@ protected:
 #define ASSERT_DAGREQUEST_EQAUL(str, request) dagRequestEqual((str), (request));
 #define ASSERT_BLOCKINPUTSTREAM_EQAUL(str, request, concurrency) executeInterpreter((str), (request), (concurrency))
 
+// nullable type
 using ColStringNullableType = std::optional<typename TypeTraits<String>::FieldType>;
 using ColInt8NullableType = std::optional<typename TypeTraits<Int8>::FieldType>;
 using ColInt16NullableType = std::optional<typename TypeTraits<Int16>::FieldType>;
@@ -125,12 +126,14 @@ using ColFloat64NullableType = std::optional<typename TypeTraits<Float64>::Field
 using ColMyDateNullableType = std::optional<typename TypeTraits<MyDate>::FieldType>;
 using ColMyDateTimeNullableType = std::optional<typename TypeTraits<MyDateTime>::FieldType>;
 using ColDecimalNullableType = std::optional<typename TypeTraits<Decimal32>::FieldType>;
-using ColUInt64Type = typename TypeTraits<UInt64>::FieldType;
 
+// non nullable tyoe
+using ColUInt64Type = typename TypeTraits<UInt64>::FieldType;
 using ColInt64Type = typename TypeTraits<Int64>::FieldType;
 using ColFloat64Type = typename TypeTraits<Float64>::FieldType;
 using ColStringType = typename TypeTraits<String>::FieldType;
 
+// nullable column
 using ColumnWithNullableString = std::vector<ColStringNullableType>;
 using ColumnWithNullableInt8 = std::vector<ColInt8NullableType>;
 using ColumnWithNullableInt16 = std::vector<ColInt16NullableType>;
@@ -141,6 +144,8 @@ using ColumnWithNullableFloat64 = std::vector<ColFloat64NullableType>;
 using ColumnWithNullableMyDate = std::vector<ColMyDateNullableType>;
 using ColumnWithNullableMyDateTime = std::vector<ColMyDateTimeNullableType>;
 using ColumnWithNullableDecimal = std::vector<ColDecimalNullableType>;
+
+// non nullable column
 using ColumnWithInt64 = std::vector<ColInt64Type>;
 using ColumnWithUInt64 = std::vector<ColUInt64Type>;
 using ColumnWithFloat64 = std::vector<ColFloat64Type>;

--- a/dbms/src/TestUtils/ExecutorTestUtils.h
+++ b/dbms/src/TestUtils/ExecutorTestUtils.h
@@ -31,9 +31,8 @@ TiDB::TP dataTypeToTP(const DataTypePtr & type);
 ColumnsWithTypeAndName readBlock(BlockInputStreamPtr stream);
 ColumnsWithTypeAndName readBlocks(std::vector<BlockInputStreamPtr> streams);
 
-// ywq todo
 #define WRAP_FOR_DIS_ENABLE_PLANNER_BEGIN \
-    std::vector<bool> bools{true, true};  \
+    std::vector<bool> bools{true, false}; \
     for (auto enable_planner : bools)     \
     {                                     \
         enablePlanner(enable_planner);

--- a/dbms/src/TestUtils/ExecutorTestUtils.h
+++ b/dbms/src/TestUtils/ExecutorTestUtils.h
@@ -31,8 +31,9 @@ TiDB::TP dataTypeToTP(const DataTypePtr & type);
 ColumnsWithTypeAndName readBlock(BlockInputStreamPtr stream);
 ColumnsWithTypeAndName readBlocks(std::vector<BlockInputStreamPtr> streams);
 
+// ywq todo
 #define WRAP_FOR_DIS_ENABLE_PLANNER_BEGIN \
-    std::vector<bool> bools{false, true}; \
+    std::vector<bool> bools{true, true};  \
     for (auto enable_planner : bools)     \
     {                                     \
         enablePlanner(enable_planner);

--- a/dbms/src/TestUtils/ExecutorTestUtils.h
+++ b/dbms/src/TestUtils/ExecutorTestUtils.h
@@ -115,4 +115,34 @@ protected:
 #define ASSERT_DAGREQUEST_EQAUL(str, request) dagRequestEqual((str), (request));
 #define ASSERT_BLOCKINPUTSTREAM_EQAUL(str, request, concurrency) executeInterpreter((str), (request), (concurrency))
 
+using ColStringNullableType = std::optional<typename TypeTraits<String>::FieldType>;
+using ColInt8NullableType = std::optional<typename TypeTraits<Int8>::FieldType>;
+using ColInt16NullableType = std::optional<typename TypeTraits<Int16>::FieldType>;
+using ColInt32NullableType = std::optional<typename TypeTraits<Int32>::FieldType>;
+using ColInt64NullableType = std::optional<typename TypeTraits<Int64>::FieldType>;
+using ColFloat32NullableType = std::optional<typename TypeTraits<Float32>::FieldType>;
+using ColFloat64NullableType = std::optional<typename TypeTraits<Float64>::FieldType>;
+using ColMyDateNullableType = std::optional<typename TypeTraits<MyDate>::FieldType>;
+using ColMyDateTimeNullableType = std::optional<typename TypeTraits<MyDateTime>::FieldType>;
+using ColDecimalNullableType = std::optional<typename TypeTraits<Decimal32>::FieldType>;
+using ColUInt64Type = typename TypeTraits<UInt64>::FieldType;
+
+using ColInt64Type = typename TypeTraits<Int64>::FieldType;
+using ColFloat64Type = typename TypeTraits<Float64>::FieldType;
+using ColStringType = typename TypeTraits<String>::FieldType;
+
+using ColumnWithNullableString = std::vector<ColStringNullableType>;
+using ColumnWithNullableInt8 = std::vector<ColInt8NullableType>;
+using ColumnWithNullableInt16 = std::vector<ColInt16NullableType>;
+using ColumnWithNullableInt32 = std::vector<ColInt32NullableType>;
+using ColumnWithNullableInt64 = std::vector<ColInt64NullableType>;
+using ColumnWithNullableFloat32 = std::vector<ColFloat32NullableType>;
+using ColumnWithNullableFloat64 = std::vector<ColFloat64NullableType>;
+using ColumnWithNullableMyDate = std::vector<ColMyDateNullableType>;
+using ColumnWithNullableMyDateTime = std::vector<ColMyDateTimeNullableType>;
+using ColumnWithNullableDecimal = std::vector<ColDecimalNullableType>;
+using ColumnWithInt64 = std::vector<ColInt64Type>;
+using ColumnWithUInt64 = std::vector<ColUInt64Type>;
+using ColumnWithFloat64 = std::vector<ColFloat64Type>;
+using ColumnWithString = std::vector<ColStringType>;
 } // namespace DB::tests

--- a/dbms/src/TestUtils/ExecutorTestUtils.h
+++ b/dbms/src/TestUtils/ExecutorTestUtils.h
@@ -127,7 +127,7 @@ using ColMyDateNullableType = std::optional<typename TypeTraits<MyDate>::FieldTy
 using ColMyDateTimeNullableType = std::optional<typename TypeTraits<MyDateTime>::FieldType>;
 using ColDecimalNullableType = std::optional<typename TypeTraits<Decimal32>::FieldType>;
 
-// non nullable tyoe
+// non nullable type
 using ColUInt64Type = typename TypeTraits<UInt64>::FieldType;
 using ColInt64Type = typename TypeTraits<Int64>::FieldType;
 using ColFloat64Type = typename TypeTraits<Float64>::FieldType;

--- a/dbms/src/TestUtils/mockExecutor.cpp
+++ b/dbms/src/TestUtils/mockExecutor.cpp
@@ -420,6 +420,7 @@ void MockDAGRequestContext::addMockDeltaMergeSchema(const String & db, const Str
 void MockDAGRequestContext::addMockDeltaMerge(const String & db, const String & table, const MockColumnInfoVec & columnInfos, ColumnsWithTypeAndName columns)
 {
     assert(columnInfos.size() == columns.size());
+    assert(context.mockStorage()->useDeltaMerge());
     addMockDeltaMergeSchema(db, table, columnInfos);
     addMockDeltaMergeData(db, table, columns);
 }

--- a/dbms/src/TestUtils/mockExecutor.cpp
+++ b/dbms/src/TestUtils/mockExecutor.cpp
@@ -387,6 +387,9 @@ void MockDAGRequestContext::addMockTableColumnData(const MockTableName & name, C
 
 void MockDAGRequestContext::addMockDeltaMergeData(const String & db, const String & table, ColumnsWithTypeAndName columns)
 {
+    for (const auto & column : columns)
+        RUNTIME_ASSERT(!column.name.empty(), "mock column must have column name");
+
     mock_storage->addTableDataForDeltaMerge(context, db + "." + table, columns);
 }
 

--- a/dbms/src/TestUtils/mockExecutor.cpp
+++ b/dbms/src/TestUtils/mockExecutor.cpp
@@ -437,8 +437,16 @@ void MockDAGRequestContext::addExchangeReceiver(const String & name, MockColumnI
 
 DAGRequestBuilder MockDAGRequestContext::scan(const String & db_name, const String & table_name)
 {
-    auto table_info = mock_storage->getTableInfo(db_name + "." + table_name);
-    return DAGRequestBuilder(index, collation).mockTable({db_name, table_name}, table_info, mock_storage->getTableSchema(db_name + "." + table_name));
+    if (!mock_storage->useDeltaMerge())
+    {
+        auto table_info = mock_storage->getTableInfo(db_name + "." + table_name);
+        return DAGRequestBuilder(index, collation).mockTable({db_name, table_name}, table_info, mock_storage->getTableSchema(db_name + "." + table_name));
+    }
+    else
+    {
+        auto table_info = mock_storage->getTableInfoForDeltaMerge(db_name + "." + table_name);
+        return DAGRequestBuilder(index, collation).mockTable({db_name, table_name}, table_info, mock_storage->getTableSchemaForDeltaMerge(db_name + "." + table_name));
+    }
 }
 
 DAGRequestBuilder MockDAGRequestContext::receive(const String & exchange_name, uint64_t fine_grained_shuffle_stream_count)

--- a/dbms/src/TestUtils/mockExecutor.cpp
+++ b/dbms/src/TestUtils/mockExecutor.cpp
@@ -37,6 +37,7 @@
 #include <TestUtils/mockExecutor.h>
 #include <tipb/executor.pb.h>
 
+#include <memory>
 #include <unordered_set>
 
 namespace DB::tests
@@ -361,36 +362,42 @@ DAGRequestBuilder & DAGRequestBuilder::sort(MockOrderByItemVec order_by_vec, boo
 
 void MockDAGRequestContext::addMockTable(const String & db, const String & table, const MockColumnInfoVec & columnInfos)
 {
-    mock_storage.addTableSchema(db + "." + table, columnInfos);
+    mock_storage->addTableSchema(db + "." + table, columnInfos);
 }
 
 void MockDAGRequestContext::addMockTable(const MockTableName & name, const MockColumnInfoVec & columnInfos)
 {
-    mock_storage.addTableSchema(name.first + "." + name.second, columnInfos);
+    mock_storage->addTableSchema(name.first + "." + name.second, columnInfos);
 }
 
 void MockDAGRequestContext::addExchangeRelationSchema(String name, const MockColumnInfoVec & columnInfos)
 {
-    mock_storage.addExchangeSchema(name, columnInfos);
+    mock_storage->addExchangeSchema(name, columnInfos);
 }
 
 void MockDAGRequestContext::addMockTableColumnData(const String & db, const String & table, ColumnsWithTypeAndName columns)
 {
-    mock_storage.addTableData(db + "." + table, columns);
+    mock_storage->addTableData(db + "." + table, columns);
 }
 
 void MockDAGRequestContext::addMockTableColumnData(const MockTableName & name, ColumnsWithTypeAndName columns)
 {
-    mock_storage.addTableData(name.first + "." + name.second, columns);
+    mock_storage->addTableData(name.first + "." + name.second, columns);
+}
+
+void MockDAGRequestContext::addMockDeltaMergeData(const String & db, const String & table, ColumnsWithTypeAndName columns)
+{
+    mock_storage->addTableDataForDeltaMerge(context, db + "." + table, columns);
 }
 
 void MockDAGRequestContext::addExchangeReceiverColumnData(const String & name, ColumnsWithTypeAndName columns)
 {
-    mock_storage.addExchangeData(name, columns);
+    mock_storage->addExchangeData(name, columns);
 }
 
 void MockDAGRequestContext::addMockTable(const String & db, const String & table, const MockColumnInfoVec & columnInfos, ColumnsWithTypeAndName columns)
 {
+    assert(columnInfos.size() == columns.size());
     addMockTable(db, table, columnInfos);
     addMockTableColumnData(db, table, columns);
 }
@@ -402,23 +409,48 @@ void MockDAGRequestContext::addMockTable(const MockTableName & name, const MockC
     addMockTableColumnData(name, columns);
 }
 
+void MockDAGRequestContext::addMockDeltaMergeSchema(const String & db, const String & table, const MockColumnInfoVec & columnInfos)
+{
+    mock_storage->addTableSchemaForDeltaMerge(db + "." + table, columnInfos);
+}
+
+void MockDAGRequestContext::addMockDeltaMerge(const String & db, const String & table, const MockColumnInfoVec & columnInfos, ColumnsWithTypeAndName columns)
+{
+    assert(columnInfos.size() == columns.size());
+    addMockDeltaMergeSchema(db, table, columnInfos);
+    addMockDeltaMergeData(db, table, columns);
+}
+
+void MockDAGRequestContext::addMockDeltaMerge(const MockTableName & name, const MockColumnInfoVec & columnInfos, ColumnsWithTypeAndName columns)
+{
+    assert(columnInfos.size() == columns.size());
+    addMockDeltaMergeSchema(name.first, name.second, columnInfos);
+    addMockDeltaMergeData(name.first, name.second, columns);
+}
+
 void MockDAGRequestContext::addExchangeReceiver(const String & name, MockColumnInfoVec columnInfos, ColumnsWithTypeAndName columns)
 {
+    assert(columnInfos.size() == columns.size());
     addExchangeRelationSchema(name, columnInfos);
     addExchangeReceiverColumnData(name, columns);
 }
 
 DAGRequestBuilder MockDAGRequestContext::scan(const String & db_name, const String & table_name)
 {
-    auto table_info = mock_storage.getTableInfo(db_name + "." + table_name);
-    return DAGRequestBuilder(index, collation).mockTable({db_name, table_name}, table_info, mock_storage.getTableSchema(db_name + "." + table_name));
+    auto table_info = mock_storage->getTableInfo(db_name + "." + table_name);
+    return DAGRequestBuilder(index, collation).mockTable({db_name, table_name}, table_info, mock_storage->getTableSchema(db_name + "." + table_name));
 }
 
 DAGRequestBuilder MockDAGRequestContext::receive(const String & exchange_name, uint64_t fine_grained_shuffle_stream_count)
 {
-    auto builder = DAGRequestBuilder(index, collation).exchangeReceiver(mock_storage.getExchangeSchema(exchange_name), fine_grained_shuffle_stream_count);
+    auto builder = DAGRequestBuilder(index, collation).exchangeReceiver(mock_storage->getExchangeSchema(exchange_name), fine_grained_shuffle_stream_count);
     receiver_source_task_ids_map[builder.getRoot()->name] = {};
-    mock_storage.addExchangeRelation(builder.getRoot()->name, exchange_name);
+    mock_storage->addExchangeRelation(builder.getRoot()->name, exchange_name);
     return builder;
+}
+
+void MockDAGRequestContext::initMockStorage()
+{
+    mock_storage = std::make_unique<MockStorage>();
 }
 } // namespace DB::tests

--- a/dbms/src/TestUtils/mockExecutor.h
+++ b/dbms/src/TestUtils/mockExecutor.h
@@ -24,7 +24,11 @@
 #include <Storages/Transaction/Collator.h>
 #include <tipb/executor.pb.h>
 
-namespace DB::tests
+#include <memory>
+
+namespace DB
+{
+namespace tests
 {
 using MockColumnInfo = std::pair<String, TiDB::TP>;
 using MockColumnInfoVec = std::vector<MockColumnInfo>;
@@ -161,38 +165,51 @@ class MockDAGRequestContext
 {
 public:
     explicit MockDAGRequestContext(Context context_, Int32 collation_ = TiDB::ITiDBCollator::UTF8MB4_BIN)
-        : context(context_)
+        : index(0)
+        , context(context_)
         , collation(-abs(collation_))
     {
-        index = 0;
     }
 
     DAGRequestBuilder createDAGRequestBuilder()
     {
         return DAGRequestBuilder(index);
     }
-
+    /// mock column table scan
     void addMockTable(const String & db, const String & table, const MockColumnInfoVec & columnInfos);
     void addMockTable(const MockTableName & name, const MockColumnInfoVec & columnInfos);
-    void addExchangeRelationSchema(String name, const MockColumnInfoVec & columnInfos);
     void addMockTableColumnData(const String & db, const String & table, ColumnsWithTypeAndName columns);
+    void addMockTableColumnData(const MockTableName & name, ColumnsWithTypeAndName columns);
+
     void addMockTable(const String & db, const String & table, const MockColumnInfoVec & columnInfos, ColumnsWithTypeAndName columns);
     void addMockTable(const MockTableName & name, const MockColumnInfoVec & columnInfos, ColumnsWithTypeAndName columns);
-    void addMockTableColumnData(const MockTableName & name, ColumnsWithTypeAndName columns);
+
+    /// mock DeltaMerge table scan
+    // ywq todo
+    void addMockDeltaMerge(const MockTableName & name, const MockColumnInfoVec & columnInfos, ColumnsWithTypeAndName columns);
+    void addMockDeltaMerge(const String & db, const String & table, const MockColumnInfoVec & columnInfos, ColumnsWithTypeAndName columns);
+
+    void addMockDeltaMergeSchema(const String & db, const String & table, const MockColumnInfoVec & columnInfos);
+    void addMockDeltaMergeData(const String & db, const String & table, ColumnsWithTypeAndName columns);
+
+    /// mock column exchange receiver
+    void addExchangeRelationSchema(String name, const MockColumnInfoVec & columnInfos);
     void addExchangeReceiverColumnData(const String & name, ColumnsWithTypeAndName columns);
     void addExchangeReceiver(const String & name, MockColumnInfoVec columnInfos, ColumnsWithTypeAndName columns);
 
+    /// ywq todo change interface.
     DAGRequestBuilder scan(const String & db_name, const String & table_name);
     DAGRequestBuilder receive(const String & exchange_name, uint64_t fine_grained_shuffle_stream_count = 0);
 
     void setCollation(Int32 collation_) { collation = convertToTiDBCollation(collation_); }
     Int32 getCollation() const { return abs(collation); }
 
-    MockStorage & mockStorage() { return mock_storage; }
+    MockStorage * mockStorage() { return mock_storage.get(); }
+    void initMockStorage();
 
 private:
     size_t index;
-    MockStorage mock_storage;
+    std::unique_ptr<MockStorage> mock_storage = nullptr;
 
 public:
     // Currently don't support task_id, so the following to structure is useless,
@@ -212,6 +229,8 @@ MockWindowFrame buildDefaultRowsFrame();
 
 #define col(name) buildColumn((name))
 #define lit(field) buildLiteral((field))
+
+// expressions
 #define concat(expr1, expr2) makeASTFunction("concat", (expr1), (expr2))
 #define plusInt(expr1, expr2) makeASTFunction("plusint", (expr1), (expr2))
 #define minusInt(expr1, expr2) makeASTFunction("minusint", (expr1), (expr2))
@@ -239,5 +258,5 @@ MockWindowFrame buildDefaultRowsFrame();
 #define Lag1(expr) makeASTFunction("Lag", (expr))
 #define Lag2(expr1, expr2) makeASTFunction("Lag", (expr1), (expr2))
 #define Lag3(expr1, expr2, expr3) makeASTFunction("Lag", (expr1), (expr2), (expr3))
-
-} // namespace DB::tests
+} // namespace tests
+} // namespace DB

--- a/dbms/src/TestUtils/mockExecutor.h
+++ b/dbms/src/TestUtils/mockExecutor.h
@@ -185,7 +185,6 @@ public:
     void addMockTable(const MockTableName & name, const MockColumnInfoVec & columnInfos, ColumnsWithTypeAndName columns);
 
     /// mock DeltaMerge table scan
-    // ywq todo
     void addMockDeltaMerge(const MockTableName & name, const MockColumnInfoVec & columnInfos, ColumnsWithTypeAndName columns);
     void addMockDeltaMerge(const String & db, const String & table, const MockColumnInfoVec & columnInfos, ColumnsWithTypeAndName columns);
 
@@ -197,7 +196,6 @@ public:
     void addExchangeReceiverColumnData(const String & name, ColumnsWithTypeAndName columns);
     void addExchangeReceiver(const String & name, MockColumnInfoVec columnInfos, ColumnsWithTypeAndName columns);
 
-    /// ywq todo change interface.
     DAGRequestBuilder scan(const String & db_name, const String & table_name);
     DAGRequestBuilder receive(const String & exchange_name, uint64_t fine_grained_shuffle_stream_count = 0);
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #4609

Problem Summary:
We want to use `DeltaMergeStorage` to run the query in `ut framework`.
Then we can test the whole query process in single node(not including mpp with multiple nodes, we assume that data are stored in one node).
It will be helpful for features that change both `storage code` and `compute code`. Eg: late materialization and pipeline model.
Maybe RSFilter can use `ut framework` too.
Here is one simple case:
```c++
context.addMockDeltaMerge({"test_db", "t0"},
                                  {{"col0", TiDB::TP::TypeLongLong}},
                                  {{toVec<Int64>("col0", {0, 1, 2, 3, 4, 5, 6, 7})}});

auto request = context
                       .scan("test_db", "t0")
                       .build(context);
executeAndAssertColumnsEqual(
        request,
        {{toNullableVec<Int64>("col0", {0, 1, 2, 3, 4, 5, 6, 7})}});
```
### What is changed and how it works?
1. We use `MockStorage` to hold `DeltaMergeStorage`.
```c++
    std::unordered_map<String, Int64> name_to_id_map_for_delta_merge; /// <table_name, table_id>
    std::unordered_map<Int64, MockColumnInfoVec> table_schema_for_delta_merge; /// <table_id, columnInfo>
    std::unordered_map<Int64, std::shared_ptr<StorageDeltaMerge>> storage_delta_merge_map; // <table_id, StorageDeltaMerge>
    std::unordered_map<String, TableInfo> table_infos_for_delta_merge; /// <table_name, table_info>
    std::unordered_map<Int64, NamesAndTypes> names_and_types_map_for_delta_merge; /// <table_id, NamesAndTypes>
```
2. When writing the test, we must call 
```c++
MockDAGRequestContext::addMockDeltaMerge(const MockTableName & name, const MockColumnInfoVec & columnInfos, ColumnsWithTypeAndName columns);
```
to define the table schema and insert table columns.
3. `addMockDeltaMerge` will call
```c++
addMockDeltaMergeSchema(db, table, columnInfos);
addMockDeltaMergeData(db, table, columns);
```
to add schema and data into corresponding `DeltaMergeStorage`
4. When running a test query, planner will choose to use the `DeltaMergeStorage` to generate source streams.
5. BTW, I have moved a bunch of code like
```c++
using ColMyDateTimeNullableType = std::optional<typename TypeTraits<MyDateTime>::FieldType>;
using ColDecimalNullableType = std::optional<typename TypeTraits<Decimal32>::FieldType>;
```
into `dbms/src/TestUtils/ExecutorTestUtils.h` to make the test code cleaner.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
