### PR TITLE
fix tsan fail in unit test `ConfigReloaderTest.WithConfigObject`

### DIFF
--- a/dbms/src/Common/tests/gtest_config_reloader.cpp
+++ b/dbms/src/Common/tests/gtest_config_reloader.cpp
@@ -55,7 +55,7 @@ cert_allowed_cn="tidb"
                 ++call_times;
             },
             /* already_loaded = */ false);
-    
+
         auto other_config_reloader = std::make_unique<ConfigReloader>(
             path,
             [&](ConfigurationPtr config [[maybe_unused]]) {
@@ -63,7 +63,7 @@ cert_allowed_cn="tidb"
             },
             /* already_loaded = */ false,
             "otherCfgLoader");
-    
+
         main_config_reloader->start();
         other_config_reloader->start();
         std::this_thread::sleep_for(std::chrono::seconds(3));

--- a/dbms/src/Common/tests/gtest_config_reloader.cpp
+++ b/dbms/src/Common/tests/gtest_config_reloader.cpp
@@ -51,14 +51,14 @@ cert_allowed_cn="tidb"
     auto main_config_reloader = std::make_unique<ConfigReloader>(
         path,
         [&](ConfigurationPtr config [[maybe_unused]]) {
-            call_times++;
+            ++call_times;
         },
         /* already_loaded = */ false);
 
     auto other_config_reloader = std::make_unique<ConfigReloader>(
         path,
         [&](ConfigurationPtr config [[maybe_unused]]) {
-            call_times++;
+            ++call_times;
         },
         /* already_loaded = */ false,
         "otherCfgLoader");
@@ -104,7 +104,7 @@ max_memory_usage = 0
     auto main_config_reloader = std::make_unique<ConfigReloader>(
         path,
         [&](ConfigurationPtr config [[maybe_unused]]) {
-            call_times++;
+            ++call_times;
         },
         /* already_loaded = */ false);
     main_config_reloader->addConfigObject(std::make_shared<TestConfigObject>());

--- a/dbms/src/Common/tests/gtest_config_reloader.cpp
+++ b/dbms/src/Common/tests/gtest_config_reloader.cpp
@@ -48,24 +48,26 @@ cert_allowed_cn="tidb"
         )";
 
     int call_times = 0;
-    auto main_config_reloader = std::make_unique<ConfigReloader>(
-        path,
-        [&](ConfigurationPtr config [[maybe_unused]]) {
-            ++call_times;
-        },
-        /* already_loaded = */ false);
-
-    auto other_config_reloader = std::make_unique<ConfigReloader>(
-        path,
-        [&](ConfigurationPtr config [[maybe_unused]]) {
-            ++call_times;
-        },
-        /* already_loaded = */ false,
-        "otherCfgLoader");
-
-    main_config_reloader->start();
-    other_config_reloader->start();
-    std::this_thread::sleep_for(std::chrono::seconds(3));
+    {
+        auto main_config_reloader = std::make_unique<ConfigReloader>(
+            path,
+            [&](ConfigurationPtr config [[maybe_unused]]) {
+                ++call_times;
+            },
+            /* already_loaded = */ false);
+    
+        auto other_config_reloader = std::make_unique<ConfigReloader>(
+            path,
+            [&](ConfigurationPtr config [[maybe_unused]]) {
+                ++call_times;
+            },
+            /* already_loaded = */ false,
+            "otherCfgLoader");
+    
+        main_config_reloader->start();
+        other_config_reloader->start();
+        std::this_thread::sleep_for(std::chrono::seconds(3));
+    }
     ASSERT_EQ(call_times, 2);
 }
 
@@ -101,15 +103,17 @@ max_memory_usage = 0
         )";
 
     int call_times = 0;
-    auto main_config_reloader = std::make_unique<ConfigReloader>(
-        path,
-        [&](ConfigurationPtr config [[maybe_unused]]) {
-            ++call_times;
-        },
-        /* already_loaded = */ false);
-    main_config_reloader->addConfigObject(std::make_shared<TestConfigObject>());
-    main_config_reloader->start();
-    std::this_thread::sleep_for(std::chrono::seconds(3));
+    {
+        auto main_config_reloader = std::make_unique<ConfigReloader>(
+            path,
+            [&](ConfigurationPtr config [[maybe_unused]]) {
+                ++call_times;
+            },
+            /* already_loaded = */ false);
+        main_config_reloader->addConfigObject(std::make_shared<TestConfigObject>());
+        main_config_reloader->start();
+        std::this_thread::sleep_for(std::chrono::seconds(3));
+    }
     ASSERT_EQ(call_times, 2);
 }
 } // namespace tests


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #6569

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
