### PR TITLE
Test: support push down filter in ut

### DIFF
--- a/dbms/src/Debug/MockStorage.cpp
+++ b/dbms/src/Debug/MockStorage.cpp
@@ -150,6 +150,7 @@ BlockInputStreamPtr MockStorage::getStreamFromDeltaMerge(Context & context, Int6
             context.getTimezoneInfo());
         auto [before_where, filter_column_name, project_after_where] = ::DB::buildPushDownFilter(*push_down_filter, *analyzer);
         BlockInputStreams ins = storage->read(column_names, query_info, context, stage, 8192, 1); // TODO: Support config max_block_size and num_streams
+        // TODO: set num_streams, then ins.size() != 1
         BlockInputStreamPtr in = ins[0];
         in = std::make_shared<FilterBlockInputStream>(in, before_where, filter_column_name, "test");
         in->setExtraInfo("push down filter");

--- a/dbms/src/Debug/MockStorage.cpp
+++ b/dbms/src/Debug/MockStorage.cpp
@@ -124,10 +124,11 @@ void MockStorage::addTableDataForDeltaMerge(Context & context, const String & na
     }
 }
 
-BlockInputStreamPtr MockStorage::getStreamFromDeltaMerge(Context & context, Int64 id, const PushDownFilter * push_down_filter)
+BlockInputStreamPtr MockStorage::getStreamFromDeltaMerge(Context & context, Int64 table_id, const PushDownFilter * push_down_filter)
 {
-    auto storage = storage_delta_merge_map[id];
-    auto column_infos = table_schema_for_delta_merge[id];
+    assert(tableExistsForDeltaMerge(table_id));
+    auto storage = storage_delta_merge_map[table_id];
+    auto column_infos = table_schema_for_delta_merge[table_id];
     assert(storage);
     assert(!column_infos.empty());
     Names column_names;
@@ -141,7 +142,7 @@ BlockInputStreamPtr MockStorage::getStreamFromDeltaMerge(Context & context, Int6
     query_info.mvcc_query_info = std::make_unique<MvccQueryInfo>(context.getSettingsRef().resolve_locks, std::numeric_limits<UInt64>::max(), scan_context);
     if (push_down_filter && push_down_filter->hasValue())
     {
-        auto analyzer = std::make_unique<DAGExpressionAnalyzer>(names_and_types_map_for_delta_merge[id], context);
+        auto analyzer = std::make_unique<DAGExpressionAnalyzer>(names_and_types_map_for_delta_merge[table_id], context);
         query_info.dag_query = std::make_unique<DAGQueryInfo>(
             push_down_filter->conditions,
             analyzer->getPreparedSets(),

--- a/dbms/src/Debug/MockStorage.cpp
+++ b/dbms/src/Debug/MockStorage.cpp
@@ -11,8 +11,13 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#include <DataStreams/ExpressionBlockInputStream.h>
+#include <DataStreams/FilterBlockInputStream.h>
 #include <DataStreams/IBlockOutputStream.h>
 #include <Debug/MockStorage.h>
+#include <Flash/Coprocessor/DAGExpressionAnalyzer.h>
+#include <Flash/Coprocessor/DAGQueryInfo.h>
+#include <Flash/Coprocessor/InterpreterUtils.h>
 #include <Flash/Coprocessor/TiDBTableScan.h>
 #include <Interpreters/Context.h>
 #include <Parsers/ASTIdentifier.h>
@@ -119,7 +124,7 @@ void MockStorage::addTableDataForDeltaMerge(Context & context, const String & na
     }
 }
 
-BlockInputStreamPtr MockStorage::getStreamFromDeltaMerge(Context & context, Int64 id)
+BlockInputStreamPtr MockStorage::getStreamFromDeltaMerge(Context & context, Int64 id, const PushDownFilter * push_down_filter)
 {
     auto storage = storage_delta_merge_map[id];
     auto column_infos = table_schema_for_delta_merge[id];
@@ -134,10 +139,29 @@ BlockInputStreamPtr MockStorage::getStreamFromDeltaMerge(Context & context, Int6
     SelectQueryInfo query_info;
     query_info.query = std::make_shared<ASTSelectQuery>();
     query_info.mvcc_query_info = std::make_unique<MvccQueryInfo>(context.getSettingsRef().resolve_locks, std::numeric_limits<UInt64>::max(), scan_context);
-    BlockInputStreams ins = storage->read(column_names, query_info, context, stage, 8192, 1); // TODO: Support config max_block_size and num_streams
-
-    BlockInputStreamPtr in = ins[0];
-    return in;
+    if (push_down_filter && push_down_filter->hasValue())
+    {
+        auto analyzer = std::make_unique<DAGExpressionAnalyzer>(names_and_types_map_for_delta_merge[id], context);
+        query_info.dag_query = std::make_unique<DAGQueryInfo>(
+            push_down_filter->conditions,
+            analyzer->getPreparedSets(),
+            analyzer->getCurrentInputColumns(),
+            context.getTimezoneInfo());
+        auto [before_where, filter_column_name, project_after_where] = ::DB::buildPushDownFilter(*push_down_filter, *analyzer);
+        BlockInputStreams ins = storage->read(column_names, query_info, context, stage, 8192, 1); // TODO: Support config max_block_size and num_streams
+        BlockInputStreamPtr in = ins[0];
+        in = std::make_shared<FilterBlockInputStream>(in, before_where, filter_column_name, "test");
+        in->setExtraInfo("push down filter");
+        in = std::make_shared<ExpressionBlockInputStream>(in, project_after_where, "test");
+        in->setExtraInfo("projection after push down filter");
+        return in;
+    }
+    else
+    {
+        BlockInputStreams ins = storage->read(column_names, query_info, context, stage, 8192, 1);
+        BlockInputStreamPtr in = ins[0];
+        return in;
+    }
 }
 
 void MockStorage::addTableInfoForDeltaMerge(const String & name, const MockColumnInfoVec & columns)

--- a/dbms/src/Debug/MockStorage.h
+++ b/dbms/src/Debug/MockStorage.h
@@ -14,6 +14,7 @@
 #pragma once
 #include <Core/ColumnsWithTypeAndName.h>
 #include <DataStreams/IBlockInputStream.h>
+#include <Flash/Coprocessor/PushDownFilter.h>
 #include <Flash/Coprocessor/TiDBTableScan.h>
 #include <Storages/Transaction/TiDB.h>
 #include <common/types.h>
@@ -74,7 +75,7 @@ public:
 
     NamesAndTypes getNameAndTypesForDeltaMerge(Int64 table_id);
 
-    BlockInputStreamPtr getStreamFromDeltaMerge(Context & context, Int64 table_id);
+    BlockInputStreamPtr getStreamFromDeltaMerge(Context & context, Int64 table_id, const PushDownFilter * push_down_filter = nullptr);
 
     bool tableExistsForDeltaMerge(Int64 table_id);
 

--- a/dbms/src/Flash/Coprocessor/InterpreterUtils.cpp
+++ b/dbms/src/Flash/Coprocessor/InterpreterUtils.cpp
@@ -204,7 +204,13 @@ std::tuple<ExpressionActionsPtr, String, ExpressionActionsPtr> buildPushDownFilt
 
     ExpressionActionsChain chain;
     analyzer.initChain(chain, analyzer.getCurrentInputColumns());
+    std::cout << "size: " << analyzer.getCurrentInputColumns().size() << std::endl;
+    for (const auto & column : analyzer.getCurrentInputColumns())
+    {
+        std::cout << "column name: " << column.name << std::endl;
+    }
     String filter_column_name = analyzer.appendWhere(chain, push_down_filter.conditions);
+    std::cout << "ywq test filter column name: " << filter_column_name << std::endl;
     ExpressionActionsPtr before_where = chain.getLastActions();
     chain.addStep();
 

--- a/dbms/src/Flash/Coprocessor/InterpreterUtils.cpp
+++ b/dbms/src/Flash/Coprocessor/InterpreterUtils.cpp
@@ -204,13 +204,7 @@ std::tuple<ExpressionActionsPtr, String, ExpressionActionsPtr> buildPushDownFilt
 
     ExpressionActionsChain chain;
     analyzer.initChain(chain, analyzer.getCurrentInputColumns());
-    std::cout << "size: " << analyzer.getCurrentInputColumns().size() << std::endl;
-    for (const auto & column : analyzer.getCurrentInputColumns())
-    {
-        std::cout << "column name: " << column.name << std::endl;
-    }
     String filter_column_name = analyzer.appendWhere(chain, push_down_filter.conditions);
-    std::cout << "ywq test filter column name: " << filter_column_name << std::endl;
     ExpressionActionsPtr before_where = chain.getLastActions();
     chain.addStep();
 

--- a/dbms/src/Flash/Planner/PhysicalPlan.cpp
+++ b/dbms/src/Flash/Planner/PhysicalPlan.cpp
@@ -48,7 +48,7 @@ bool pushDownSelection(Context & context, const PhysicalPlanNodePtr & plan, cons
         auto physical_table_scan = std::static_pointer_cast<PhysicalTableScan>(plan);
         return physical_table_scan->pushDownFilter(executor_id, selection);
     }
-    if (plan->tp() == PlanType::MockTableScan)
+    if (plan->tp() == PlanType::MockTableScan && context.isExecutorTest())
     {
         auto physical_mock_table_scan = std::static_pointer_cast<PhysicalMockTableScan>(plan);
         if (context.mockStorage()->useDeltaMerge() && context.mockStorage()->tableExistsForDeltaMerge(physical_mock_table_scan->getLogicalTableID()))

--- a/dbms/src/Flash/Planner/PhysicalPlan.cpp
+++ b/dbms/src/Flash/Planner/PhysicalPlan.cpp
@@ -48,7 +48,7 @@ bool pushDownSelection(Context & context, const PhysicalPlanNodePtr & plan, cons
         auto physical_table_scan = std::static_pointer_cast<PhysicalTableScan>(plan);
         return physical_table_scan->pushDownFilter(executor_id, selection);
     }
-    if (plan->tp() == PlanType::MockTableScan && context.isExecutorTest())
+    if (unlikely(plan->tp() == PlanType::MockTableScan && context.isExecutorTest()))
     {
         auto physical_mock_table_scan = std::static_pointer_cast<PhysicalMockTableScan>(plan);
         if (context.mockStorage()->useDeltaMerge() && context.mockStorage()->tableExistsForDeltaMerge(physical_mock_table_scan->getLogicalTableID()))

--- a/dbms/src/Flash/Planner/PhysicalPlan.cpp
+++ b/dbms/src/Flash/Planner/PhysicalPlan.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <Common/TiFlashMetrics.h>
+#include <Debug/MockStorage.h>
 #include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/FineGrainedShuffle.h>
 #include <Flash/Planner/ExecutorIdGenerator.h>
@@ -40,12 +41,20 @@ namespace DB
 {
 namespace
 {
-bool pushDownSelection(const PhysicalPlanNodePtr & plan, const String & executor_id, const tipb::Selection & selection)
+bool pushDownSelection(Context & context, const PhysicalPlanNodePtr & plan, const String & executor_id, const tipb::Selection & selection)
 {
     if (plan->tp() == PlanType::TableScan)
     {
         auto physical_table_scan = std::static_pointer_cast<PhysicalTableScan>(plan);
         return physical_table_scan->pushDownFilter(executor_id, selection);
+    }
+    if (plan->tp() == PlanType::MockTableScan)
+    {
+        auto physical_mock_table_scan = std::static_pointer_cast<PhysicalMockTableScan>(plan);
+        if (context.mockStorage()->useDeltaMerge() && context.mockStorage()->tableExistsForDeltaMerge(physical_mock_table_scan->getLogicalTableID()))
+        {
+            return physical_mock_table_scan->pushDownFilter(context, executor_id, selection);
+        }
     }
     return false;
 }
@@ -110,7 +119,7 @@ void PhysicalPlan::build(const String & executor_id, const tipb::Executor * exec
     {
         GET_METRIC(tiflash_coprocessor_executor_count, type_sel).Increment();
         auto child = popBack();
-        if (pushDownSelection(child, executor_id, executor->selection()))
+        if (pushDownSelection(context, child, executor_id, executor->selection()))
             pushBack(child);
         else
             pushBack(PhysicalFilter::build(context, executor_id, log, executor->selection(), child));

--- a/dbms/src/Flash/Planner/plans/PhysicalMockTableScan.cpp
+++ b/dbms/src/Flash/Planner/plans/PhysicalMockTableScan.cpp
@@ -128,7 +128,6 @@ const Block & PhysicalMockTableScan::getSampleBlock() const
 
 void PhysicalMockTableScan::updateStreams(Context & context)
 {
-    std::cout << "ywq tes update streams" << std::endl;
     mock_streams.clear();
     assert(context.mockStorage()->tableExistsForDeltaMerge(table_id));
     mock_streams.emplace_back(context.mockStorage()->getStreamFromDeltaMerge(context, table_id, &push_down_filter));

--- a/dbms/src/Flash/Planner/plans/PhysicalMockTableScan.cpp
+++ b/dbms/src/Flash/Planner/plans/PhysicalMockTableScan.cpp
@@ -72,7 +72,7 @@ std::pair<NamesAndTypes, BlockInputStreams> mockSchemaAndStreams(
 
     assert(!schema.empty());
     assert(!mock_streams.empty());
-    
+
     return {std::move(schema), std::move(mock_streams)};
 }
 } // namespace

--- a/dbms/src/Flash/Planner/plans/PhysicalMockTableScan.cpp
+++ b/dbms/src/Flash/Planner/plans/PhysicalMockTableScan.cpp
@@ -50,7 +50,6 @@ std::pair<NamesAndTypes, BlockInputStreams> mockSchemaAndStreams(
     {
         assert(context.mockStorage()->tableExistsForDeltaMerge(table_scan.getLogicalTableID()));
         schema = context.mockStorage()->getNameAndTypesForDeltaMerge(table_scan.getLogicalTableID());
-        // with filter pushdown, don't init it
         mock_streams.emplace_back(context.mockStorage()->getStreamFromDeltaMerge(context, table_scan.getLogicalTableID()));
     }
     else
@@ -72,8 +71,8 @@ std::pair<NamesAndTypes, BlockInputStreams> mockSchemaAndStreams(
     }
 
     assert(!schema.empty());
-    // assert(!mock_streams.empty());
-
+    assert(!mock_streams.empty());
+    
     return {std::move(schema), std::move(mock_streams)};
 }
 } // namespace

--- a/dbms/src/Flash/Planner/plans/PhysicalMockTableScan.h
+++ b/dbms/src/Flash/Planner/plans/PhysicalMockTableScan.h
@@ -20,7 +20,6 @@
 #include <Flash/Planner/plans/PhysicalLeaf.h>
 #include <tipb/executor.pb.h>
 
-
 namespace DB
 {
 /**

--- a/dbms/src/Flash/Planner/tests/gtest_physical_plan.cpp
+++ b/dbms/src/Flash/Planner/tests/gtest_physical_plan.cpp
@@ -55,11 +55,11 @@ public:
                                      toNullableVec<Int64>("s4", {1, 1, {}})});
 
         context.addExchangeReceiver("exchange_r_table",
-                                    {{"s1", TiDB::TP::TypeString}, {"join_c", TiDB::TP::TypeString}},
+                                    {{"s", TiDB::TP::TypeString}, {"join_c", TiDB::TP::TypeString}},
                                     {toNullableVec<String>("s", {"banana", "banana"}),
                                      toNullableVec<String>("join_c", {"apple", "banana"})});
         context.addExchangeReceiver("exchange_l_table",
-                                    {{"s1", TiDB::TP::TypeString}, {"join_c", TiDB::TP::TypeString}},
+                                    {{"s", TiDB::TP::TypeString}, {"join_c", TiDB::TP::TypeString}},
                                     {toNullableVec<String>("s", {"banana", "banana"}),
                                      toNullableVec<String>("join_c", {"apple", "banana"})});
 

--- a/dbms/src/Flash/tests/gtest_collation.cpp
+++ b/dbms/src/Flash/tests/gtest_collation.cpp
@@ -56,7 +56,7 @@ public:
         /// For topn
         context.addMockTable({db_name, topn_table},
                              {{topn_col, TiDB::TP::TypeString}},
-                             {toNullableVec<String>("_col", ColumnWithString{"col0-0", "col0-1", "col0-2", {}, "col0-4", {}, "col0-6", "col0-7"})});
+                             {toNullableVec<String>(topn_col, ColumnWithString{"col0-0", "col0-1", "col0-2", {}, "col0-4", {}, "col0-6", "col0-7"})});
 
         /// For projection
         context.addMockTable({db_name, proj_table},

--- a/dbms/src/Flash/tests/gtest_filter_executor.cpp
+++ b/dbms/src/Flash/tests/gtest_filter_executor.cpp
@@ -256,8 +256,6 @@ TEST_F(FilterExecutorTestRunner, PushDownFilter)
 try
 {
     context.mockStorage()->setUseDeltaMerge(true);
-
-    // ywq todo check column name..
     context.addMockDeltaMerge({"test_db", "test_table1"},
                               {{"i1", TiDB::TP::TypeLongLong}, {"s2", TiDB::TP::TypeString}},
                               {toVec<Int64>("i1", {1, 2, 3}),
@@ -274,8 +272,8 @@ Expression: <final projection>
  Expression: <projection after push down filter>
   Filter: <push down filter>
    DeltaMergeSegmentThread)";
-        executeInterpreterWithDeltaMerge(expected, request, 10);
         // Do not support push down filter test for DAGQueryBlock
+        executeInterpreterWithDeltaMerge(expected, request, 10);
     }
     executeAndAssertColumnsEqual(
         request,

--- a/dbms/src/Flash/tests/gtest_filter_executor.cpp
+++ b/dbms/src/Flash/tests/gtest_filter_executor.cpp
@@ -267,6 +267,16 @@ try
                        .scan("test_db", "test_table1")
                        .filter(lt(col("i1"), lit(Field(static_cast<Int64>(2)))))
                        .build(context);
+
+    {
+        String expected = R"(
+Expression: <final projection>
+ Expression: <projection after push down filter>
+  Filter: <push down filter>
+   DeltaMergeSegmentThread)";
+        executeInterpreterWithDeltaMerge(expected, request, 10);
+        // Do not support push down filter test for DAGQueryBlock
+    }
     executeAndAssertColumnsEqual(
         request,
         {toNullableVec<Int64>({1}),

--- a/dbms/src/Flash/tests/gtest_filter_executor.cpp
+++ b/dbms/src/Flash/tests/gtest_filter_executor.cpp
@@ -261,6 +261,9 @@ try
                               {toVec<Int64>("i1", {1, 2, 3}),
                                toNullableVec<String>("s2", {"apple", {}, "banana"})});
 
+    // Do not support push down filter test for DAGQueryBlockInterpreter
+    enablePlanner(true);
+
     auto request = context
                        .scan("test_db", "test_table1")
                        .filter(lt(col("i1"), lit(Field(static_cast<Int64>(2)))))
@@ -272,7 +275,6 @@ Expression: <final projection>
  Expression: <projection after push down filter>
   Filter: <push down filter>
    DeltaMergeSegmentThread)";
-        // Do not support push down filter test for DAGQueryBlockInterpreter
         executeInterpreterWithDeltaMerge(expected, request, 10);
     }
     executeAndAssertColumnsEqual(

--- a/dbms/src/Flash/tests/gtest_join_executor.cpp
+++ b/dbms/src/Flash/tests/gtest_join_executor.cpp
@@ -357,7 +357,7 @@ try
     context.addMockTable("cast", "t1", {{"datetime", TiDB::TP::TypeDatetime}}, {createDateTimeColumn({{{1970, 1, 1, 0, 0, 1, 0}}}, 6)});
 
     context.addMockTable("cast", "t2", {{"datetime", TiDB::TP::TypeTimestamp}}, {createDateTimeColumn({{{1970, 1, 1, 0, 0, 1, 0}}}, 6)});
-    
+
     auto cast_request_1 = [&]() {
         return context.scan("cast", "t1")
             .join(context.scan("cast", "t2"), tipb::JoinType::TypeInnerJoin, {col("datetime")})

--- a/dbms/src/Flash/tests/gtest_join_executor.cpp
+++ b/dbms/src/Flash/tests/gtest_join_executor.cpp
@@ -48,12 +48,12 @@ public:
                               toVec<String>("join_c", {"apple", "banana"})});
 
         context.addExchangeReceiver("exchange_r_table",
-                                    {{"s1", TiDB::TP::TypeString}, {"join_c", TiDB::TP::TypeString}},
+                                    {{"s", TiDB::TP::TypeString}, {"join_c", TiDB::TP::TypeString}},
                                     {toNullableVec<String>("s", {"banana", "banana"}),
                                      toNullableVec<String>("join_c", {"apple", "banana"})});
 
         context.addExchangeReceiver("exchange_l_table",
-                                    {{"s1", TiDB::TP::TypeString}, {"join_c", TiDB::TP::TypeString}},
+                                    {{"s", TiDB::TP::TypeString}, {"join_c", TiDB::TP::TypeString}},
                                     {toNullableVec<String>("s", {"banana", "banana"}),
                                      toNullableVec<String>("join_c", {"apple", "banana"})});
     }
@@ -354,11 +354,16 @@ try
     executeAndAssertColumnsEqual(cast_request(), {createNullableColumn<Decimal256>(std::make_tuple(65, 0), {"0.12"}, {0}), createNullableColumn<Decimal256>(std::make_tuple(65, 0), {"0.12"}, {0})});
 
     /// datetime(1970-01-01 00:00:01) == timestamp(1970-01-01 00:00:01)
-    context.addMockTable("cast", "t1", {{"a", TiDB::TP::TypeDatetime}}, {createDateTimeColumn({{{1970, 1, 1, 0, 0, 1, 0}}}, 6)});
+    context.addMockTable("cast", "t1", {{"datetime", TiDB::TP::TypeDatetime}}, {createDateTimeColumn({{{1970, 1, 1, 0, 0, 1, 0}}}, 6)});
 
-    context.addMockTable("cast", "t2", {{"a", TiDB::TP::TypeTimestamp}}, {createDateTimeColumn({{{1970, 1, 1, 0, 0, 1, 0}}}, 6)});
-
-    executeAndAssertColumnsEqual(cast_request(), {createDateTimeColumn({{{1970, 1, 1, 0, 0, 1, 0}}}, 0), createDateTimeColumn({{{1970, 1, 1, 0, 0, 1, 0}}}, 0)});
+    context.addMockTable("cast", "t2", {{"datetime", TiDB::TP::TypeTimestamp}}, {createDateTimeColumn({{{1970, 1, 1, 0, 0, 1, 0}}}, 6)});
+    
+    auto cast_request_1 = [&]() {
+        return context.scan("cast", "t1")
+            .join(context.scan("cast", "t2"), tipb::JoinType::TypeInnerJoin, {col("datetime")})
+            .build(context);
+    };
+    executeAndAssertColumnsEqual(cast_request_1(), {createDateTimeColumn({{{1970, 1, 1, 0, 0, 1, 0}}}, 0), createDateTimeColumn({{{1970, 1, 1, 0, 0, 1, 0}}}, 0)});
 }
 CATCH
 

--- a/dbms/src/Flash/tests/gtest_query_expr.cpp
+++ b/dbms/src/Flash/tests/gtest_query_expr.cpp
@@ -36,9 +36,9 @@ public:
 
         context.addMockTable({"default", "test3"},
                              {{"col_1", TiDB::TP::TypeLongLong}, {"col_2", TiDB::TP::TypeLongLong}, {"col_3", TiDB::TP::TypeLongLong}},
-                             {toNullableVec<Int64>("col1", {666, 776, 777, {}, 999, {}}),
-                              toNullableVec<Int64>("col2", {666, 777, 777, 777, {}, {}}),
-                              toNullableVec<Int64>("col3", {666, 776, 777, 888, 999, 999})});
+                             {toNullableVec<Int64>("col_1", {666, 776, 777, {}, 999, {}}),
+                              toNullableVec<Int64>("col_2", {666, 777, 777, 777, {}, {}}),
+                              toNullableVec<Int64>("col_3", {666, 776, 777, 888, 999, 999})});
 
         context.addMockTable({"default", "i8"},
                              {{"a", TiDB::TP::TypeTiny}},
@@ -74,7 +74,7 @@ public:
         inputs.emplace_back(std::nullopt);
         context.addMockTable({"default", "t"},
                              {{"i", TiDB::TP::TypeLongLong}},
-                             {toNullableVec<Int64>("a", inputs)});
+                             {toNullableVec<Int64>("i", inputs)});
 
 
         context.addMockTable({"default", "logical_op_test"},

--- a/dbms/src/TestUtils/ExecutorTestUtils.cpp
+++ b/dbms/src/TestUtils/ExecutorTestUtils.cpp
@@ -99,6 +99,18 @@ void ExecutorTest::executeInterpreter(const String & expected_string, const std:
     DAGContext dag_context(*request, "interpreter_test", concurrency);
     context.context.setDAGContext(&dag_context);
     context.context.setInterpreterTest();
+
+    // Don't care regions information in interpreter tests.
+    auto query_executor = queryExecute(context.context, /*internal=*/true);
+    ASSERT_EQ(Poco::trim(expected_string), Poco::trim(query_executor->dump()));
+}
+
+void ExecutorTest::executeInterpreterWithDeltaMerge(const String & expected_string, const std::shared_ptr<tipb::DAGRequest> & request, size_t concurrency)
+{
+    DAGContext dag_context(*request, "interpreter_test_with_delta_merge", concurrency);
+    context.context.setDAGContext(&dag_context);
+    context.context.setExecutorTest();
+    context.context.setMockStorage(context.mockStorage());
     // Don't care regions information in interpreter tests.
     auto query_executor = queryExecute(context.context, /*internal=*/true);
     ASSERT_EQ(Poco::trim(expected_string), Poco::trim(query_executor->dump()));

--- a/dbms/src/TestUtils/ExecutorTestUtils.h
+++ b/dbms/src/TestUtils/ExecutorTestUtils.h
@@ -31,9 +31,8 @@ TiDB::TP dataTypeToTP(const DataTypePtr & type);
 ColumnsWithTypeAndName readBlock(BlockInputStreamPtr stream);
 ColumnsWithTypeAndName readBlocks(std::vector<BlockInputStreamPtr> streams);
 
-// ywq todo
 #define WRAP_FOR_DIS_ENABLE_PLANNER_BEGIN \
-    std::vector<bool> bools{true, true};  \
+    std::vector<bool> bools{false, true}; \
     for (auto enable_planner : bools)     \
     {                                     \
         enablePlanner(enable_planner);
@@ -67,6 +66,8 @@ public:
     static void dagRequestEqual(const String & expected_string, const std::shared_ptr<tipb::DAGRequest> & actual);
 
     void executeInterpreter(const String & expected_string, const std::shared_ptr<tipb::DAGRequest> & request, size_t concurrency);
+    void executeInterpreterWithDeltaMerge(const String & expected_string, const std::shared_ptr<tipb::DAGRequest> & request, size_t concurrency);
+
     ColumnsWithTypeAndName executeRawQuery(const String & query, size_t concurrency = 1);
     void executeAndAssertColumnsEqual(const std::shared_ptr<tipb::DAGRequest> & request, const ColumnsWithTypeAndName & expect_columns);
     void executeAndAssertRowsEqual(const std::shared_ptr<tipb::DAGRequest> & request, size_t expect_rows);

--- a/dbms/src/TestUtils/ExecutorTestUtils.h
+++ b/dbms/src/TestUtils/ExecutorTestUtils.h
@@ -31,8 +31,9 @@ TiDB::TP dataTypeToTP(const DataTypePtr & type);
 ColumnsWithTypeAndName readBlock(BlockInputStreamPtr stream);
 ColumnsWithTypeAndName readBlocks(std::vector<BlockInputStreamPtr> streams);
 
+// ywq todo
 #define WRAP_FOR_DIS_ENABLE_PLANNER_BEGIN \
-    std::vector<bool> bools{false, true}; \
+    std::vector<bool> bools{true, true};  \
     for (auto enable_planner : bools)     \
     {                                     \
         enablePlanner(enable_planner);

--- a/dbms/src/TestUtils/mockExecutor.cpp
+++ b/dbms/src/TestUtils/mockExecutor.cpp
@@ -400,14 +400,16 @@ void MockDAGRequestContext::addExchangeReceiverColumnData(const String & name, C
 
 void MockDAGRequestContext::addMockTable(const String & db, const String & table, const MockColumnInfoVec & columnInfos, ColumnsWithTypeAndName columns)
 {
-    assert(columnInfos.size() == columns.size());
+    assertMockInput(columnInfos, columns);
+
     addMockTable(db, table, columnInfos);
     addMockTableColumnData(db, table, columns);
 }
 
 void MockDAGRequestContext::addMockTable(const MockTableName & name, const MockColumnInfoVec & columnInfos, ColumnsWithTypeAndName columns)
 {
-    assert(columnInfos.size() == columns.size());
+    assertMockInput(columnInfos, columns);
+
     addMockTable(name, columnInfos);
     addMockTableColumnData(name, columns);
 }
@@ -419,22 +421,25 @@ void MockDAGRequestContext::addMockDeltaMergeSchema(const String & db, const Str
 
 void MockDAGRequestContext::addMockDeltaMerge(const String & db, const String & table, const MockColumnInfoVec & columnInfos, ColumnsWithTypeAndName columns)
 {
-    assert(columnInfos.size() == columns.size());
-    assert(context.mockStorage()->useDeltaMerge());
+    assert(mock_storage->useDeltaMerge());
+    assertMockInput(columnInfos, columns);
+
     addMockDeltaMergeSchema(db, table, columnInfos);
     addMockDeltaMergeData(db, table, columns);
 }
 
 void MockDAGRequestContext::addMockDeltaMerge(const MockTableName & name, const MockColumnInfoVec & columnInfos, ColumnsWithTypeAndName columns)
 {
-    assert(columnInfos.size() == columns.size());
+    assert(mock_storage->useDeltaMerge());
+    assertMockInput(columnInfos, columns);
+
     addMockDeltaMergeSchema(name.first, name.second, columnInfos);
     addMockDeltaMergeData(name.first, name.second, columns);
 }
 
 void MockDAGRequestContext::addExchangeReceiver(const String & name, MockColumnInfoVec columnInfos, ColumnsWithTypeAndName columns)
 {
-    assert(columnInfos.size() == columns.size());
+    assertMockInput(columnInfos, columns);
     addExchangeRelationSchema(name, columnInfos);
     addExchangeReceiverColumnData(name, columns);
 }
@@ -465,4 +470,12 @@ void MockDAGRequestContext::initMockStorage()
 {
     mock_storage = std::make_unique<MockStorage>();
 }
+
+void MockDAGRequestContext::assertMockInput(const MockColumnInfoVec & columnInfos, ColumnsWithTypeAndName columns)
+{
+    assert(columnInfos.size() == columns.size());
+    for (size_t i = 0; i < columns.size(); ++i)
+        assert(columnInfos[i].first == columns[i].name);
+}
+
 } // namespace DB::tests

--- a/dbms/src/TestUtils/mockExecutor.h
+++ b/dbms/src/TestUtils/mockExecutor.h
@@ -206,6 +206,9 @@ public:
     void initMockStorage();
 
 private:
+    static void assertMockInput(const MockColumnInfoVec & columnInfos, ColumnsWithTypeAndName columns);
+
+private:
     size_t index;
     std::unique_ptr<MockStorage> mock_storage = nullptr;
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #4609 

Problem Summary:
We don't push down filter to storage layer in current ut framework.
### What is changed and how it works?
In `getStreamFromDeltaMerge`, mock `DAGQueryInfo` with `PushDownFilter` from `tipb:Selection`
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
