### PR TITLE
move non joined block stream into HashJoinProbeBlockInputStream

### DIFF
--- a/dbms/src/Common/tests/gtest_spiller.cpp
+++ b/dbms/src/Common/tests/gtest_spiller.cpp
@@ -312,8 +312,7 @@ try
     size_t rows = 100;
     for (const auto & type_and_name : spiller_schema)
     {
-        auto column = ColumnGenerator::instance().generate({rows, type_and_name.type->getName(), RANDOM});
-        column.name = type_and_name.name;
+        auto column = ColumnGenerator::instance().generate({rows, type_and_name.type->getName(), RANDOM, type_and_name.name, 128});
         data.push_back(column);
     }
     ret.emplace_back(data);
@@ -361,8 +360,7 @@ try
     size_t rows = 100;
     for (const auto & type_and_name : spiller_schema)
     {
-        auto column = ColumnGenerator::instance().generate({rows, type_and_name.type->getName(), RANDOM});
-        column.name = type_and_name.name;
+        auto column = ColumnGenerator::instance().generate({rows, type_and_name.type->getName(), RANDOM, type_and_name.name, 128});
         data.push_back(column);
     }
     ret.emplace_back(data);
@@ -408,8 +406,7 @@ try
     size_t rows = 100;
     for (const auto & type_and_name : spiller_schema)
     {
-        auto column = ColumnGenerator::instance().generate({rows, type_and_name.type->getName(), RANDOM});
-        column.name = type_and_name.name;
+        auto column = ColumnGenerator::instance().generate({rows, type_and_name.type->getName(), RANDOM, type_and_name.name, 128});
         data.push_back(column);
     }
     ret.emplace_back(data);
@@ -451,8 +448,7 @@ try
     size_t rows = 100;
     for (const auto & type_and_name : spiller_schema)
     {
-        auto column = ColumnGenerator::instance().generate({rows, type_and_name.type->getName(), RANDOM});
-        column.name = type_and_name.name;
+        auto column = ColumnGenerator::instance().generate({rows, type_and_name.type->getName(), RANDOM, type_and_name.name, 128});
         data.push_back(column);
     }
     ret.emplace_back(data);

--- a/dbms/src/Common/tests/gtest_spiller.cpp
+++ b/dbms/src/Common/tests/gtest_spiller.cpp
@@ -312,7 +312,7 @@ try
     size_t rows = 100;
     for (const auto & type_and_name : spiller_schema)
     {
-        auto column = ColumnGenerator::instance().generate({rows, type_and_name.type->getName(), RANDOM, 128});
+        auto column = ColumnGenerator::instance().generate({rows, type_and_name.type->getName(), RANDOM});
         column.name = type_and_name.name;
         data.push_back(column);
     }
@@ -361,7 +361,7 @@ try
     size_t rows = 100;
     for (const auto & type_and_name : spiller_schema)
     {
-        auto column = ColumnGenerator::instance().generate({rows, type_and_name.type->getName(), RANDOM, 128});
+        auto column = ColumnGenerator::instance().generate({rows, type_and_name.type->getName(), RANDOM});
         column.name = type_and_name.name;
         data.push_back(column);
     }
@@ -408,7 +408,7 @@ try
     size_t rows = 100;
     for (const auto & type_and_name : spiller_schema)
     {
-        auto column = ColumnGenerator::instance().generate({rows, type_and_name.type->getName(), RANDOM, 128});
+        auto column = ColumnGenerator::instance().generate({rows, type_and_name.type->getName(), RANDOM});
         column.name = type_and_name.name;
         data.push_back(column);
     }
@@ -451,7 +451,7 @@ try
     size_t rows = 100;
     for (const auto & type_and_name : spiller_schema)
     {
-        auto column = ColumnGenerator::instance().generate({rows, type_and_name.type->getName(), RANDOM, 128});
+        auto column = ColumnGenerator::instance().generate({rows, type_and_name.type->getName(), RANDOM});
         column.name = type_and_name.name;
         data.push_back(column);
     }

--- a/dbms/src/DataStreams/HashJoinProbeBlockInputStream.cpp
+++ b/dbms/src/DataStreams/HashJoinProbeBlockInputStream.cpp
@@ -22,11 +22,10 @@ HashJoinProbeBlockInputStream::HashJoinProbeBlockInputStream(
     size_t probe_index_,
     bool has_non_joined_data_,
     const String & req_id,
-    UInt64 max_block_size_)
+    UInt64 max_block_size)
     : log(Logger::get(req_id))
     , join(join_)
     , probe_index(probe_index_)
-    , max_block_size(max_block_size_)
     , has_non_joined_data(has_non_joined_data_)
     , probe_process_info(max_block_size)
     , squashing_transform(max_block_size)
@@ -34,6 +33,7 @@ HashJoinProbeBlockInputStream::HashJoinProbeBlockInputStream(
     children.push_back(input);
 
     RUNTIME_CHECK_MSG(join != nullptr, "join ptr should not be null.");
+    RUNTIME_CHECK_MSG(join->getProbeConcurrency() > 0, "Join probe concurrency must be greater than 0");
     if (has_non_joined_data)
         non_joined_stream = join->createStreamWithNonJoinedRows(input->getHeader(), probe_index, join->getProbeConcurrency(), max_block_size);
 }

--- a/dbms/src/DataStreams/HashJoinProbeBlockInputStream.cpp
+++ b/dbms/src/DataStreams/HashJoinProbeBlockInputStream.cpp
@@ -97,13 +97,12 @@ Block HashJoinProbeBlockInputStream::readImpl()
         squashing_transform.appendBlock(result_block);
     }
     auto ret = squashing_transform.getFinalOutputBlock();
-    total_output_rows += ret.rows();
     return ret;
 }
 
 void HashJoinProbeBlockInputStream::readSuffixImpl()
 {
-    LOG_DEBUG(log, "Finish join probe, total output rows {}, joined rows {}, non joined rows {}", total_output_rows, joined_rows, non_joined_rows);
+    LOG_DEBUG(log, "Finish join probe, total output rows {}, joined rows {}, non joined rows {}", joined_rows + non_joined_rows, joined_rows, non_joined_rows);
 }
 
 Block HashJoinProbeBlockInputStream::getOutputBlock()

--- a/dbms/src/DataStreams/HashJoinProbeBlockInputStream.cpp
+++ b/dbms/src/DataStreams/HashJoinProbeBlockInputStream.cpp
@@ -143,7 +143,10 @@ Block HashJoinProbeBlockInputStream::getOutputBlock()
             auto block = non_joined_stream->read();
             non_joined_rows += block.rows();
             if (!block)
+            {
+                non_joined_stream->readSuffix();
                 status = ProbeStatus::FINISHED;
+            }
             return block;
         }
         case ProbeStatus::FINISHED:

--- a/dbms/src/DataStreams/HashJoinProbeBlockInputStream.h
+++ b/dbms/src/DataStreams/HashJoinProbeBlockInputStream.h
@@ -53,6 +53,8 @@ protected:
     Block getOutputBlock();
 
 private:
+    void readSuffixImpl() override;
+
     const LoggerPtr log;
     JoinPtr join;
     size_t probe_index;
@@ -62,6 +64,9 @@ private:
     BlockInputStreamPtr non_joined_stream;
     SquashingHashJoinBlockTransform squashing_transform;
     Block child_header;
+    size_t joined_rows = 0;
+    size_t non_joined_rows = 0;
+    size_t total_output_rows = 0;
 };
 
 } // namespace DB

--- a/dbms/src/DataStreams/HashJoinProbeBlockInputStream.h
+++ b/dbms/src/DataStreams/HashJoinProbeBlockInputStream.h
@@ -66,7 +66,6 @@ private:
     Block child_header;
     size_t joined_rows = 0;
     size_t non_joined_rows = 0;
-    size_t total_output_rows = 0;
 };
 
 } // namespace DB

--- a/dbms/src/DataStreams/HashJoinProbeBlockInputStream.h
+++ b/dbms/src/DataStreams/HashJoinProbeBlockInputStream.h
@@ -68,7 +68,6 @@ private:
     BlockInputStreamPtr non_joined_stream;
     SquashingHashJoinBlockTransform squashing_transform;
     ProbeStatus status{ProbeStatus::PROBE};
-    Block child_header;
     size_t joined_rows = 0;
     size_t non_joined_rows = 0;
 };

--- a/dbms/src/DataStreams/HashJoinProbeBlockInputStream.h
+++ b/dbms/src/DataStreams/HashJoinProbeBlockInputStream.h
@@ -39,7 +39,6 @@ public:
         const BlockInputStreamPtr & input,
         const JoinPtr & join_,
         size_t probe_index,
-        bool has_non_joined_data,
         const String & req_id,
         UInt64 max_block_size);
 
@@ -53,16 +52,22 @@ protected:
     Block getOutputBlock();
 
 private:
+    enum class ProbeStatus
+    {
+        PROBE,
+        WAIT_FOR_READ_NON_JOINED_DATA,
+        READ_NON_JOINED_DATA,
+        FINISHED,
+    };
     void readSuffixImpl() override;
 
     const LoggerPtr log;
     JoinPtr join;
     size_t probe_index;
-    bool has_non_joined_data = false;
-    bool reading_non_joined_data = false;
     ProbeProcessInfo probe_process_info;
     BlockInputStreamPtr non_joined_stream;
     SquashingHashJoinBlockTransform squashing_transform;
+    ProbeStatus status{ProbeStatus::PROBE};
     Block child_header;
     size_t joined_rows = 0;
     size_t non_joined_rows = 0;

--- a/dbms/src/DataStreams/HashJoinProbeBlockInputStream.h
+++ b/dbms/src/DataStreams/HashJoinProbeBlockInputStream.h
@@ -38,12 +38,15 @@ public:
     HashJoinProbeBlockInputStream(
         const BlockInputStreamPtr & input,
         const JoinPtr & join_,
+        size_t probe_index,
+        bool has_non_joined_data,
         const String & req_id,
         UInt64 max_block_size);
 
     String getName() const override { return name; }
     Block getTotals() override;
     Block getHeader() const override;
+    void cancel(bool kill) override;
 
 protected:
     Block readImpl() override;
@@ -52,8 +55,14 @@ protected:
 private:
     const LoggerPtr log;
     JoinPtr join;
+    size_t probe_index;
+    size_t max_block_size;
+    bool has_non_joined_data = false;
+    bool reading_non_joined_data = false;
     ProbeProcessInfo probe_process_info;
+    BlockInputStreamPtr non_joined_stream;
     SquashingHashJoinBlockTransform squashing_transform;
+    Block child_header;
 };
 
 } // namespace DB

--- a/dbms/src/DataStreams/HashJoinProbeBlockInputStream.h
+++ b/dbms/src/DataStreams/HashJoinProbeBlockInputStream.h
@@ -56,7 +56,6 @@ private:
     const LoggerPtr log;
     JoinPtr join;
     size_t probe_index;
-    size_t max_block_size;
     bool has_non_joined_data = false;
     bool reading_non_joined_data = false;
     ProbeProcessInfo probe_process_info;

--- a/dbms/src/DataStreams/MockExchangeReceiverInputStream.cpp
+++ b/dbms/src/DataStreams/MockExchangeReceiverInputStream.cpp
@@ -51,7 +51,7 @@ ColumnPtr MockExchangeReceiverInputStream::makeColumn(ColumnWithTypeAndName elem
 {
     auto column = elem.type->createColumn();
     size_t row_count = 0;
-    for (size_t i = output_index; (i < rows) & (row_count < max_block_size); ++i)
+    for (size_t i = output_index; (i < rows && i < elem.column->size()) & (row_count < max_block_size); ++i)
     {
         column->insert((*elem.column)[i]);
         ++row_count;

--- a/dbms/src/DataStreams/MockExchangeReceiverInputStream.cpp
+++ b/dbms/src/DataStreams/MockExchangeReceiverInputStream.cpp
@@ -51,7 +51,7 @@ ColumnPtr MockExchangeReceiverInputStream::makeColumn(ColumnWithTypeAndName elem
 {
     auto column = elem.type->createColumn();
     size_t row_count = 0;
-    for (size_t i = output_index; (i < rows && i < elem.column->size()) & (row_count < max_block_size); ++i)
+    for (size_t i = output_index; i < rows && i < elem.column->size() && row_count < max_block_size; ++i)
     {
         column->insert((*elem.column)[i]);
         ++row_count;

--- a/dbms/src/DataStreams/NonJoinedBlockInputStream.cpp
+++ b/dbms/src/DataStreams/NonJoinedBlockInputStream.cpp
@@ -263,7 +263,7 @@ size_t NonJoinedBlockInputStream::fillColumns(const Map & map,
                     [](void * ptr) { delete reinterpret_cast<typename Map::SegmentType::HashTable::const_iterator *>(ptr); });
                 it = reinterpret_cast<typename Map::SegmentType::HashTable::const_iterator *>(position.get());
                 end = map.getSegmentTable(current_segment).end();
-            } while (*it == end && current_segment < map.getSegmentSize() - step);
+            } while (*it == end && current_segment + step < map.getSegmentSize());
             if (*it == end)
                 break;
         }

--- a/dbms/src/DataStreams/NonJoinedBlockInputStream.cpp
+++ b/dbms/src/DataStreams/NonJoinedBlockInputStream.cpp
@@ -128,7 +128,7 @@ NonJoinedBlockInputStream::NonJoinedBlockInputStream(const Join & parent_, const
 
 Block NonJoinedBlockInputStream::readImpl()
 {
-    /// build concurrency is less than non join concurrency,
+    /// If build concurrency is less than non join concurrency,
     /// just return empty block for extra non joined block input stream read
     if (unlikely(index >= parent.getBuildConcurrency()))
         return Block();

--- a/dbms/src/DataStreams/NonJoinedBlockInputStream.cpp
+++ b/dbms/src/DataStreams/NonJoinedBlockInputStream.cpp
@@ -117,7 +117,7 @@ Block NonJoinedBlockInputStream::readImpl()
 {
     /// build concurrency is less than non join concurrency,
     /// just return empty block for extra non joined block input stream read
-    if (index > parent.getBuildConcurrency())
+    if (index >= parent.getBuildConcurrency())
         return Block();
     if (parent.blocks.empty())
         return Block();
@@ -232,7 +232,7 @@ size_t NonJoinedBlockInputStream::fillColumns(const Map & map,
     auto it = reinterpret_cast<typename Map::SegmentType::HashTable::const_iterator *>(position.get());
     auto end = map.getSegmentTable(current_segment).end();
 
-    for (; *it != end || current_segment < map.getSegmentSize() - step; ++(*it))
+    for (; *it != end || current_segment + step < map.getSegmentSize(); ++(*it))
     {
         if (*it == end)
         {

--- a/dbms/src/DataStreams/NonJoinedBlockInputStream.cpp
+++ b/dbms/src/DataStreams/NonJoinedBlockInputStream.cpp
@@ -130,7 +130,7 @@ Block NonJoinedBlockInputStream::readImpl()
 {
     /// build concurrency is less than non join concurrency,
     /// just return empty block for extra non joined block input stream read
-    if (index >= parent.getBuildConcurrency())
+    if (unlikely(index >= parent.getBuildConcurrency()))
         return Block();
     if (parent.blocks.empty())
         return Block();

--- a/dbms/src/Debug/MockStorage.cpp
+++ b/dbms/src/Debug/MockStorage.cpp
@@ -261,6 +261,11 @@ void MockStorage::addExchangeData(const String & exchange_name, const ColumnsWit
     exchange_columns[exchange_name] = columns;
 }
 
+void MockStorage::addFineGrainedExchangeData(const String & exchange_name, const std::vector<ColumnsWithTypeAndName> & columns)
+{
+    fine_grained_exchange_columns[exchange_name] = columns;
+}
+
 bool MockStorage::exchangeExists(const String & executor_id)
 {
     return exchange_schemas.find(executor_id_to_name_map[executor_id]) != exchange_schemas.end();
@@ -269,6 +274,30 @@ bool MockStorage::exchangeExists(const String & executor_id)
 bool MockStorage::exchangeExistsWithName(const String & name)
 {
     return exchange_schemas.find(name) != exchange_schemas.end();
+}
+
+std::vector<ColumnsWithTypeAndName> MockStorage::getFineGrainedExchangeColumnsVector(const String & executor_id, size_t fine_grained_stream_count)
+{
+    if (exchangeExists(executor_id))
+    {
+        auto exchange_name = executor_id_to_name_map[executor_id];
+        if (fine_grained_exchange_columns.find(exchange_name) != fine_grained_exchange_columns.end())
+        {
+            RUNTIME_CHECK_MSG(fine_grained_exchange_columns[exchange_name].size() == fine_grained_stream_count,
+                              "Fine grained exchange data does not match fine grained stream count for exchange receiver {}",
+                              executor_id);
+            return fine_grained_exchange_columns[exchange_name];
+        }
+        if (exchange_columns.find(exchange_name) != exchange_columns.end())
+        {
+            auto columns = exchange_columns[exchange_name];
+            if (columns[0].column == nullptr || columns[0].column->empty())
+                return {};
+            throw Exception(fmt::format("Failed to get fine grained exchange columns by executor_id '{}'", executor_id));
+        }
+        return {};
+    }
+    throw Exception(fmt::format("Failed to get exchange columns by executor_id '{}'", executor_id));
 }
 
 ColumnsWithTypeAndName MockStorage::getExchangeColumns(const String & executor_id)

--- a/dbms/src/Debug/MockStorage.h
+++ b/dbms/src/Debug/MockStorage.h
@@ -90,11 +90,14 @@ public:
 
     void addExchangeData(const String & exchange_name, const ColumnsWithTypeAndName & columns);
 
+    void addFineGrainedExchangeData(const String & exchange_name, const std::vector<ColumnsWithTypeAndName> & columns);
+
     MockColumnInfoVec getExchangeSchema(const String & exchange_name);
 
     void addExchangeRelation(const String & executor_id, const String & exchange_name);
 
     ColumnsWithTypeAndName getExchangeColumns(const String & executor_id);
+    std::vector<ColumnsWithTypeAndName> getFineGrainedExchangeColumnsVector(const String & executor_id, size_t fine_grained_stream_count);
 
     bool exchangeExists(const String & executor_id);
 
@@ -125,6 +128,7 @@ private:
     std::unordered_map<String, String> executor_id_to_name_map; /// <executor_id, exchange name>
     std::unordered_map<String, MockColumnInfoVec> exchange_schemas; /// <exchange_name, columnInfo>
     std::unordered_map<String, ColumnsWithTypeAndName> exchange_columns; /// <exchange_name, columns>
+    std::unordered_map<String, std::vector<ColumnsWithTypeAndName>> fine_grained_exchange_columns; /// <exchange_name, vector<columns>>
 
     /// for mock storage delta merge
     std::unordered_map<String, Int64> name_to_id_map_for_delta_merge; /// <table_name, table_id>

--- a/dbms/src/Flash/Coprocessor/DAGPipeline.h
+++ b/dbms/src/Flash/Coprocessor/DAGPipeline.h
@@ -21,11 +21,6 @@ namespace DB
 struct DAGPipeline
 {
     BlockInputStreams streams;
-    /** When executing FULL or RIGHT JOIN, there will be a data stream from which you can read "not joined" rows.
-      * It has a special meaning, since reading from it should be done after reading from the main streams.
-      * It is appended to the main streams in UnionBlockInputStream or ParallelAggregatingBlockInputStream.
-      */
-    BlockInputStreams streams_with_non_joined_data;
 
     BlockInputStreamPtr & firstStream() { return streams.at(0); }
 
@@ -34,10 +29,8 @@ struct DAGPipeline
     {
         for (auto & stream : streams)
             transform(stream);
-        for (auto & stream : streams_with_non_joined_data)
-            transform(stream);
     }
 
-    bool hasMoreThanOneStream() const { return streams.size() + streams_with_non_joined_data.size() > 1; }
+    bool hasMoreThanOneStream() const { return streams.size() > 1; }
 };
 } // namespace DB

--- a/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.cpp
@@ -516,7 +516,7 @@ void DAGQueryBlockInterpreter::handleExchangeReceiver(DAGPipeline & pipeline)
 // for tests, we need to mock ExchangeReceiver blockInputStream as the source stream.
 void DAGQueryBlockInterpreter::handleMockExchangeReceiver(DAGPipeline & pipeline)
 {
-    size_t fine_grained_stream_count = query_block.source->has_fine_grained_shuffle_stream_count() ? 0 : query_block.source->fine_grained_shuffle_stream_count();
+    size_t fine_grained_stream_count = query_block.source->has_fine_grained_shuffle_stream_count() ? query_block.source->fine_grained_shuffle_stream_count() : 0;
     auto [schema, mock_streams] = mockSchemaAndStreamsForExchangeReceiver(context, query_block.source_name, log, query_block.source->exchange_receiver(), fine_grained_stream_count);
     pipeline.streams.insert(pipeline.streams.end(), mock_streams.begin(), mock_streams.end());
     analyzer = std::make_unique<DAGExpressionAnalyzer>(std::move(schema), context);

--- a/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.cpp
@@ -328,7 +328,7 @@ void DAGQueryBlockInterpreter::handleJoin(const tipb::Join & join, DAGPipeline &
     join_ptr->setProbeConcurrency(pipeline.streams.size());
     for (auto & stream : pipeline.streams)
     {
-        stream = std::make_shared<HashJoinProbeBlockInputStream>(stream, join_ptr, probe_index++, is_tiflash_right_join, log->identifier(), settings.max_block_size);
+        stream = std::make_shared<HashJoinProbeBlockInputStream>(stream, join_ptr, probe_index++, log->identifier(), settings.max_block_size);
         stream->setExtraInfo(fmt::format("join probe, join_executor_id = {}, has_non_joined_data = {}", query_block.source_name, is_tiflash_right_join));
     }
 

--- a/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
@@ -340,8 +340,6 @@ void DAGStorageInterpreter::executeImpl(DAGPipeline & pipeline)
     // block DDL operations, keep the drop lock so that the storage not to be dropped during reading.
     const TableLockHolders drop_locks = releaseAlterLocks();
 
-    // It is impossible to have no joined stream.
-    assert(pipeline.streams_with_non_joined_data.empty());
     // after buildRemoteStreams, remote read stream will be appended in pipeline.streams.
     size_t remote_read_streams_start_index = pipeline.streams.size();
 
@@ -422,7 +420,6 @@ void DAGStorageInterpreter::executeCastAfterTableScan(
     auto [has_cast, extra_cast, project_for_cop_read] = addExtraCastsAfterTs(*analyzer, is_need_add_cast_column, table_scan);
     if (has_cast)
     {
-        assert(pipeline.streams_with_non_joined_data.empty());
         assert(remote_read_streams_start_index <= pipeline.streams.size());
         size_t i = 0;
         // local streams

--- a/dbms/src/Flash/Coprocessor/MockSourceStream.cpp
+++ b/dbms/src/Flash/Coprocessor/MockSourceStream.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/MockSourceStream.h>
 
 namespace DB
@@ -26,5 +27,64 @@ size_t getMockSourceStreamConcurrency(size_t max_streams, size_t scan_concurrenc
     if (scan_concurrency_hint == 0)
         return max_streams;
     return std::max(std::min(max_streams, scan_concurrency_hint), 1);
+}
+std::pair<NamesAndTypes, BlockInputStreams> mockSchemaAndStreamsForExchangeReceiver(
+    Context & context,
+    const String & executor_id,
+    const LoggerPtr & log,
+    const tipb::ExchangeReceiver & exchange_receiver,
+    size_t fine_grained_stream_count)
+{
+    NamesAndTypes schema;
+    BlockInputStreams mock_streams;
+
+    auto & dag_context = *context.getDAGContext();
+    size_t max_streams = dag_context.initialize_concurrency;
+    assert(max_streams > 0);
+
+    // Interpreter test will not use columns in MockStorage
+    if (context.isInterpreterTest() || !context.mockStorage()->exchangeExists(executor_id))
+    {
+        /// build with empty blocks.
+        size_t stream_count = max_streams;
+        if (fine_grained_stream_count > 0)
+            stream_count = fine_grained_stream_count;
+        for (size_t i = 0; i < stream_count; ++i)
+            mock_streams.push_back(std::make_shared<MockExchangeReceiverInputStream>(exchange_receiver, context.getSettingsRef().max_block_size, context.getSettingsRef().max_block_size / 10));
+        for (const auto & col : mock_streams.back()->getHeader())
+            schema.emplace_back(col.name, col.type);
+    }
+    else
+    {
+        /// build from user input blocks.
+        if (fine_grained_stream_count > 0)
+        {
+            std::vector<ColumnsWithTypeAndName> columns_with_type_and_name_vector;
+            columns_with_type_and_name_vector = context.mockStorage()->getFineGrainedExchangeColumnsVector(executor_id, fine_grained_stream_count);
+            if (columns_with_type_and_name_vector.empty())
+            {
+                for (size_t i = 0; i < fine_grained_stream_count; ++i)
+                    mock_streams.push_back(std::make_shared<MockExchangeReceiverInputStream>(exchange_receiver, context.getSettingsRef().max_block_size, context.getSettingsRef().max_block_size / 10));
+            }
+            else
+            {
+                for (const auto & columns : columns_with_type_and_name_vector)
+                    mock_streams.push_back(std::make_shared<MockExchangeReceiverInputStream>(columns, context.getSettingsRef().max_block_size));
+            }
+            for (const auto & col : mock_streams.back()->getHeader())
+                schema.emplace_back(col.name, col.type);
+        }
+        else
+        {
+            auto [names_and_types, mock_exchange_streams] = mockSourceStream<MockExchangeReceiverInputStream>(context, max_streams, log, executor_id);
+            schema = std::move(names_and_types);
+            mock_streams.insert(mock_streams.end(), mock_exchange_streams.begin(), mock_exchange_streams.end());
+        }
+    }
+
+    assert(!schema.empty());
+    assert(!mock_streams.empty());
+
+    return {std::move(schema), std::move(mock_streams)};
 }
 } // namespace DB

--- a/dbms/src/Flash/Coprocessor/MockSourceStream.h
+++ b/dbms/src/Flash/Coprocessor/MockSourceStream.h
@@ -79,4 +79,11 @@ std::pair<NamesAndTypes, std::vector<std::shared_ptr<SourceType>>> mockSourceStr
 
     return cutStreams<SourceType>(context, columns_with_type_and_name, max_streams, log);
 }
+
+std::pair<NamesAndTypes, BlockInputStreams> mockSchemaAndStreamsForExchangeReceiver(
+    Context & context,
+    const String & executor_id,
+    const LoggerPtr & log,
+    const tipb::ExchangeReceiver & exchange_receiver,
+    size_t fine_grained_stream_count);
 } // namespace DB

--- a/dbms/src/Flash/Planner/PhysicalPlan.cpp
+++ b/dbms/src/Flash/Planner/PhysicalPlan.cpp
@@ -149,7 +149,10 @@ void PhysicalPlan::build(const String & executor_id, const tipb::Executor * exec
     {
         GET_METRIC(tiflash_coprocessor_executor_count, type_exchange_receiver).Increment();
         if (unlikely(context.isExecutorTest() || context.isInterpreterTest()))
-            pushBack(PhysicalMockExchangeReceiver::build(context, executor_id, log, executor->exchange_receiver()));
+        {
+            size_t fine_grained_stream_count = executor->has_fine_grained_shuffle_stream_count() ? executor->fine_grained_shuffle_stream_count() : 0;
+            pushBack(PhysicalMockExchangeReceiver::build(context, executor_id, log, executor->exchange_receiver(), fine_grained_stream_count));
+        }
         else
         {
             // for MPP test, we can use real exchangeReceiver to run an query across different compute nodes

--- a/dbms/src/Flash/Planner/plans/PhysicalAggregation.cpp
+++ b/dbms/src/Flash/Planner/plans/PhysicalAggregation.cpp
@@ -107,7 +107,6 @@ void PhysicalAggregation::transformImpl(DAGPipeline & pipeline, Context & contex
     if (fine_grained_shuffle.enable())
     {
         /// For fine_grained_shuffle, just do aggregation in streams independently
-        RUNTIME_CHECK(pipeline.streams_with_non_joined_data.empty());
         pipeline.transform([&](auto & stream) {
             stream = std::make_shared<AggregatingBlockInputStream>(
                 stream,
@@ -118,13 +117,13 @@ void PhysicalAggregation::transformImpl(DAGPipeline & pipeline, Context & contex
             stream->setExtraInfo(String(enableFineGrainedShuffleExtraInfo));
         });
     }
-    else if (pipeline.streams.size() > 1 || pipeline.streams_with_non_joined_data.size() > 1)
+    else if (pipeline.streams.size() > 1)
     {
         /// If there are several sources, then we perform parallel aggregation
         const Settings & settings = context.getSettingsRef();
         BlockInputStreamPtr stream = std::make_shared<ParallelAggregatingBlockInputStream>(
             pipeline.streams,
-            pipeline.streams_with_non_joined_data,
+            BlockInputStreams{},
             params,
             context.getFileProvider(),
             true,
@@ -133,7 +132,6 @@ void PhysicalAggregation::transformImpl(DAGPipeline & pipeline, Context & contex
             log->identifier());
 
         pipeline.streams.resize(1);
-        pipeline.streams_with_non_joined_data.clear();
         pipeline.firstStream() = std::move(stream);
 
         restoreConcurrency(pipeline, context.getDAGContext()->final_concurrency, log);
@@ -144,11 +142,7 @@ void PhysicalAggregation::transformImpl(DAGPipeline & pipeline, Context & contex
         if (!pipeline.streams.empty())
             inputs.push_back(pipeline.firstStream());
 
-        if (!pipeline.streams_with_non_joined_data.empty())
-            inputs.push_back(pipeline.streams_with_non_joined_data.at(0));
-
         pipeline.streams.resize(1);
-        pipeline.streams_with_non_joined_data.clear();
 
         pipeline.firstStream() = std::make_shared<AggregatingBlockInputStream>(
             std::make_shared<ConcatBlockInputStream>(inputs, log->identifier()),

--- a/dbms/src/Flash/Planner/plans/PhysicalExchangeReceiver.cpp
+++ b/dbms/src/Flash/Planner/plans/PhysicalExchangeReceiver.cpp
@@ -60,7 +60,7 @@ PhysicalPlanNodePtr PhysicalExchangeReceiver::build(
 
 void PhysicalExchangeReceiver::transformImpl(DAGPipeline & pipeline, Context & context, size_t max_streams)
 {
-    assert(pipeline.streams.empty() && pipeline.streams_with_non_joined_data.empty());
+    assert(pipeline.streams.empty());
 
     auto & dag_context = *context.getDAGContext();
     // todo choose a more reasonable stream number

--- a/dbms/src/Flash/Planner/plans/PhysicalJoin.cpp
+++ b/dbms/src/Flash/Planner/plans/PhysicalJoin.cpp
@@ -66,17 +66,6 @@ void recordJoinExecuteInfo(
     dag_context.getJoinExecuteInfoMap()[executor_id] = std::move(join_execute_info);
 }
 
-void executeUnionForPreviousNonJoinedData(DAGPipeline & probe_pipeline, Context & context, size_t max_streams, const LoggerPtr & log)
-{
-    // If there is non-joined-streams here, we need call `executeUnion`
-    // to ensure that non-joined-streams is executed after joined-streams.
-    if (!probe_pipeline.streams_with_non_joined_data.empty())
-    {
-        executeUnion(probe_pipeline, max_streams, log, false, "final union for non_joined_data");
-        restoreConcurrency(probe_pipeline, context.getDAGContext()->final_concurrency, log);
-    }
-}
-
 } // namespace
 
 PhysicalPlanNodePtr PhysicalJoin::build(
@@ -178,35 +167,18 @@ PhysicalPlanNodePtr PhysicalJoin::build(
     return physical_join;
 }
 
-void PhysicalJoin::probeSideTransform(DAGPipeline & probe_pipeline, Context & context, size_t max_streams)
+void PhysicalJoin::probeSideTransform(DAGPipeline & probe_pipeline, Context & context)
 {
     const auto & settings = context.getSettingsRef();
-    auto & dag_context = *context.getDAGContext();
-
-    // TODO we can call `executeUnionForPreviousNonJoinedData` only when has_non_joined == true.
-    executeUnionForPreviousNonJoinedData(probe_pipeline, context, max_streams, log);
-
     /// probe side streams
-    assert(probe_pipeline.streams_with_non_joined_data.empty());
     executeExpression(probe_pipeline, probe_side_prepare_actions, log, "append join key and join filters for probe side");
     /// add join input stream
-    if (has_non_joined)
-    {
-        auto & join_execute_info = dag_context.getJoinExecuteInfoMap()[execId()];
-        size_t not_joined_concurrency = join_ptr->getNotJoinedStreamConcurrency();
-        const auto & input_header = probe_pipeline.firstStream()->getHeader();
-        for (size_t i = 0; i < not_joined_concurrency; ++i)
-        {
-            auto non_joined_stream = join_ptr->createStreamWithNonJoinedRows(input_header, i, not_joined_concurrency, settings.max_block_size);
-            non_joined_stream->setExtraInfo("add stream with non_joined_data if full_or_right_join");
-            probe_pipeline.streams_with_non_joined_data.push_back(non_joined_stream);
-            join_execute_info.non_joined_streams.push_back(non_joined_stream);
-        }
-    }
-    String join_probe_extra_info = fmt::format("join probe, join_executor_id = {}", execId());
+    String join_probe_extra_info = fmt::format("join probe, join_executor_id = {}, has_non_joined_data = {}", execId(), has_non_joined);
+    size_t probe_index = 0;
+    join_ptr->setProbeConcurrency(probe_pipeline.streams.size());
     for (auto & stream : probe_pipeline.streams)
     {
-        stream = std::make_shared<HashJoinProbeBlockInputStream>(stream, join_ptr, log->identifier(), settings.max_block_size);
+        stream = std::make_shared<HashJoinProbeBlockInputStream>(stream, join_ptr, probe_index++, has_non_joined, log->identifier(), settings.max_block_size);
         stream->setExtraInfo(join_probe_extra_info);
     }
 }
@@ -214,7 +186,7 @@ void PhysicalJoin::probeSideTransform(DAGPipeline & probe_pipeline, Context & co
 void PhysicalJoin::buildSideTransform(DAGPipeline & build_pipeline, Context & context, size_t max_streams)
 {
     auto & dag_context = *context.getDAGContext();
-    size_t join_build_concurrency = std::max(build_pipeline.streams.size(), build_pipeline.streams_with_non_joined_data.size());
+    size_t join_build_concurrency = build_pipeline.streams.size();
 
     /// build side streams
     executeExpression(build_pipeline, build_side_prepare_actions, log, "append join key and join filters for build side");
@@ -233,7 +205,6 @@ void PhysicalJoin::buildSideTransform(DAGPipeline & build_pipeline, Context & co
         }
     };
     build_streams(build_pipeline.streams);
-    build_streams(build_pipeline.streams_with_non_joined_data);
     // for test, join executor need the return blocks to output.
     executeUnion(build_pipeline, max_streams, log, /*ignore_block=*/!context.isTest(), "for join");
 
@@ -256,7 +227,7 @@ void PhysicalJoin::transformImpl(DAGPipeline & pipeline, Context & context, size
     {
         DAGPipeline & probe_pipeline = pipeline;
         probe()->transform(probe_pipeline, context, max_streams);
-        probeSideTransform(probe_pipeline, context, max_streams);
+        probeSideTransform(probe_pipeline, context);
     }
 
     doSchemaProject(pipeline, context);

--- a/dbms/src/Flash/Planner/plans/PhysicalJoin.h
+++ b/dbms/src/Flash/Planner/plans/PhysicalJoin.h
@@ -42,14 +42,12 @@ public:
         const JoinPtr & join_ptr_,
         const ExpressionActionsPtr & probe_side_prepare_actions_,
         const ExpressionActionsPtr & build_side_prepare_actions_,
-        bool has_non_joined_,
         const Block & sample_block_,
         const FineGrainedShuffle & fine_grained_shuffle_)
         : PhysicalBinary(executor_id_, PlanType::Join, schema_, req_id, probe_, build_)
         , join_ptr(join_ptr_)
         , probe_side_prepare_actions(probe_side_prepare_actions_)
         , build_side_prepare_actions(build_side_prepare_actions_)
-        , has_non_joined(has_non_joined_)
         , sample_block(sample_block_)
         , fine_grained_shuffle(fine_grained_shuffle_)
     {}
@@ -76,8 +74,6 @@ private:
 
     ExpressionActionsPtr probe_side_prepare_actions;
     ExpressionActionsPtr build_side_prepare_actions;
-
-    bool has_non_joined;
 
     Block sample_block;
     FineGrainedShuffle fine_grained_shuffle;

--- a/dbms/src/Flash/Planner/plans/PhysicalJoin.h
+++ b/dbms/src/Flash/Planner/plans/PhysicalJoin.h
@@ -59,7 +59,7 @@ public:
     const Block & getSampleBlock() const override;
 
 private:
-    void probeSideTransform(DAGPipeline & probe_pipeline, Context & context, size_t max_streams);
+    void probeSideTransform(DAGPipeline & probe_pipeline, Context & context);
 
     void buildSideTransform(DAGPipeline & build_pipeline, Context & context, size_t max_streams);
 

--- a/dbms/src/Flash/Planner/plans/PhysicalMockExchangeReceiver.cpp
+++ b/dbms/src/Flash/Planner/plans/PhysicalMockExchangeReceiver.cpp
@@ -96,7 +96,7 @@ PhysicalPlanNodePtr PhysicalMockExchangeReceiver::build(
 
 void PhysicalMockExchangeReceiver::transformImpl(DAGPipeline & pipeline, Context & /*context*/, size_t /*max_streams*/)
 {
-    assert(pipeline.streams.empty() && pipeline.streams_with_non_joined_data.empty());
+    assert(pipeline.streams.empty());
     pipeline.streams.insert(pipeline.streams.end(), mock_streams.begin(), mock_streams.end());
 }
 

--- a/dbms/src/Flash/Planner/plans/PhysicalMockExchangeReceiver.h
+++ b/dbms/src/Flash/Planner/plans/PhysicalMockExchangeReceiver.h
@@ -32,7 +32,8 @@ public:
         Context & context,
         const String & executor_id,
         const LoggerPtr & log,
-        const tipb::ExchangeReceiver & exchange_receiver);
+        const tipb::ExchangeReceiver & exchange_receiver,
+        size_t fine_grained_stream_count);
 
     PhysicalMockExchangeReceiver(
         const String & executor_id_,

--- a/dbms/src/Flash/Planner/plans/PhysicalMockTableScan.cpp
+++ b/dbms/src/Flash/Planner/plans/PhysicalMockTableScan.cpp
@@ -103,7 +103,7 @@ PhysicalPlanNodePtr PhysicalMockTableScan::build(
 
 void PhysicalMockTableScan::transformImpl(DAGPipeline & pipeline, Context & /*context*/, size_t /*max_streams*/)
 {
-    assert(pipeline.streams.empty() && pipeline.streams_with_non_joined_data.empty());
+    assert(pipeline.streams.empty());
     pipeline.streams.insert(pipeline.streams.end(), mock_streams.begin(), mock_streams.end());
 }
 

--- a/dbms/src/Flash/Planner/plans/PhysicalTableScan.cpp
+++ b/dbms/src/Flash/Planner/plans/PhysicalTableScan.cpp
@@ -53,7 +53,7 @@ PhysicalPlanNodePtr PhysicalTableScan::build(
 
 void PhysicalTableScan::transformImpl(DAGPipeline & pipeline, Context & context, size_t max_streams)
 {
-    assert(pipeline.streams.empty() && pipeline.streams_with_non_joined_data.empty());
+    assert(pipeline.streams.empty());
 
     if (context.isDisaggregatedComputeMode())
     {

--- a/dbms/src/Flash/Planner/tests/gtest_physical_plan.cpp
+++ b/dbms/src/Flash/Planner/tests/gtest_physical_plan.cpp
@@ -45,7 +45,9 @@ public:
         context.addExchangeReceiver("exchange2",
                                     {{"partition", TiDB::TP::TypeLongLong}, {"order", TiDB::TP::TypeLongLong}},
                                     {toNullableVec<Int64>("partition", {1, 1, 1, 1, 2, 2, 2, 2}),
-                                     toNullableVec<Int64>("order", {1, 1, 2, 2, 1, 1, 2, 2})});
+                                     toNullableVec<Int64>("order", {1, 1, 2, 2, 1, 1, 2, 2})},
+                                    1,
+                                    {{"partition", TiDB::TP::TypeLongLong}});
 
         context.addExchangeReceiver("exchange3",
                                     {{"s1", TiDB::TP::TypeString}, {"s2", TiDB::TP::TypeString}, {"s3", TiDB::TP::TypeLongLong}, {"s4", TiDB::TP::TypeLongLong}},

--- a/dbms/src/Flash/Planner/tests/gtest_physical_plan.cpp
+++ b/dbms/src/Flash/Planner/tests/gtest_physical_plan.cpp
@@ -434,7 +434,7 @@ CreatingSets
     MockExchangeReceiver
  Expression: <final projection>
   Expression: <remove useless column after join>
-   HashJoinProbe: <join probe, join_executor_id = Join_2>
+   HashJoinProbe: <join probe, join_executor_id = Join_2, has_non_joined_data = false>
     Expression: <append join key and join filters for probe side>
      Expression: <final projection>
       MockExchangeReceiver)",
@@ -459,16 +459,12 @@ CreatingSets
   Expression: <append join key and join filters for build side>
    Expression: <final projection>
     MockExchangeReceiver
- Union: <for test>
-  Expression: <final projection>
-   Expression: <remove useless column after join>
-    HashJoinProbe: <join probe, join_executor_id = Join_2>
-     Expression: <append join key and join filters for probe side>
-      Expression: <final projection>
-       MockExchangeReceiver
-  Expression: <final projection>
-   Expression: <remove useless column after join>
-    NonJoined: <add stream with non_joined_data if full_or_right_join>)",
+ Expression: <final projection>
+  Expression: <remove useless column after join>
+   HashJoinProbe: <join probe, join_executor_id = Join_2, has_non_joined_data = true>
+    Expression: <append join key and join filters for probe side>
+     Expression: <final projection>
+      MockExchangeReceiver)",
             {toNullableVec<String>({"banana", "banana"}),
              toNullableVec<String>({"apple", "banana"}),
              toNullableVec<String>({"banana", "banana"}),
@@ -506,33 +502,23 @@ CreatingSets
   Expression: <append join key and join filters for build side>
    Expression: <final projection>
     MockTableScan
- Union: <for join>
-  HashJoinBuild: <join build, build_side_root_executor_id = Join_5>, join_kind = Inner
-   Expression: <append join key and join filters for build side>
-    Expression: <final projection>
-     Expression: <remove useless column after join>
-      HashJoinProbe: <join probe, join_executor_id = Join_5>
-       Expression: <append join key and join filters for probe side>
-        Expression: <final projection>
-         MockTableScan
-  HashJoinBuild: <join build, build_side_root_executor_id = Join_5>, join_kind = Inner
-   Expression: <append join key and join filters for build side>
-    Expression: <final projection>
-     Expression: <remove useless column after join>
-      NonJoined: <add stream with non_joined_data if full_or_right_join>
+ HashJoinBuild: <join build, build_side_root_executor_id = Join_5>, join_kind = Inner
+  Expression: <append join key and join filters for build side>
+   Expression: <final projection>
+    Expression: <remove useless column after join>
+     HashJoinProbe: <join probe, join_executor_id = Join_5, has_non_joined_data = true>
+      Expression: <append join key and join filters for probe side>
+       Expression: <final projection>
+        MockTableScan
  Expression: <final projection>
   Expression: <remove useless column after join>
-   HashJoinProbe: <join probe, join_executor_id = Join_6>
-    Union: <final union for non_joined_data>
-     Expression: <final projection>
-      Expression: <remove useless column after join>
-       HashJoinProbe: <join probe, join_executor_id = Join_4>
-        Expression: <append join key and join filters for probe side>
-         Expression: <final projection>
-          MockTableScan
-     Expression: <final projection>
-      Expression: <remove useless column after join>
-       NonJoined: <add stream with non_joined_data if full_or_right_join>)",
+   HashJoinProbe: <join probe, join_executor_id = Join_6, has_non_joined_data = false>
+    Expression: <final projection>
+     Expression: <remove useless column after join>
+      HashJoinProbe: <join probe, join_executor_id = Join_4, has_non_joined_data = true>
+       Expression: <append join key and join filters for probe side>
+        Expression: <final projection>
+         MockTableScan)",
             {toNullableVec<Int32>({3, 3, 0}),
              toNullableVec<Int32>({2, 2, 0}),
              toNullableVec<Int32>({2, 2, 0}),
@@ -576,33 +562,23 @@ CreatingSets
   Expression: <append join key and join filters for build side>
    Expression: <final projection>
     MockTableScan
- Union: <for join>
-  HashJoinBuild: <join build, build_side_root_executor_id = Join_5>, join_kind = Left
-   Expression: <append join key and join filters for build side>
-    Expression: <final projection>
-     Expression: <remove useless column after join>
-      HashJoinProbe: <join probe, join_executor_id = Join_5>
-       Expression: <append join key and join filters for probe side>
-        Expression: <final projection>
-         MockTableScan
-  HashJoinBuild: <join build, build_side_root_executor_id = Join_5>, join_kind = Left
-   Expression: <append join key and join filters for build side>
-    Expression: <final projection>
-     Expression: <remove useless column after join>
-      NonJoined: <add stream with non_joined_data if full_or_right_join>
+ HashJoinBuild: <join build, build_side_root_executor_id = Join_5>, join_kind = Left
+  Expression: <append join key and join filters for build side>
+   Expression: <final projection>
+    Expression: <remove useless column after join>
+     HashJoinProbe: <join probe, join_executor_id = Join_5, has_non_joined_data = true>
+      Expression: <append join key and join filters for probe side>
+       Expression: <final projection>
+        MockTableScan
  Expression: <final projection>
   Expression: <remove useless column after join>
-   HashJoinProbe: <join probe, join_executor_id = Join_6>
-    Union: <final union for non_joined_data>
-     Expression: <final projection>
-      Expression: <remove useless column after join>
-       HashJoinProbe: <join probe, join_executor_id = Join_4>
-        Expression: <append join key and join filters for probe side>
-         Expression: <final projection>
-          MockTableScan
-     Expression: <final projection>
-      Expression: <remove useless column after join>
-       NonJoined: <add stream with non_joined_data if full_or_right_join>)",
+   HashJoinProbe: <join probe, join_executor_id = Join_6, has_non_joined_data = false>
+    Expression: <final projection>
+     Expression: <remove useless column after join>
+      HashJoinProbe: <join probe, join_executor_id = Join_4, has_non_joined_data = true>
+       Expression: <append join key and join filters for probe side>
+        Expression: <final projection>
+         MockTableScan)",
             {toNullableVec<Int32>({3, 3, 0}),
              toNullableVec<Int32>({2, 2, 0}),
              toNullableVec<Int32>({2, 2, 0}),

--- a/dbms/src/Flash/Planner/tests/gtest_physical_plan.cpp
+++ b/dbms/src/Flash/Planner/tests/gtest_physical_plan.cpp
@@ -405,7 +405,7 @@ CreatingSets
     MockExchangeReceiver
  Expression: <final projection>
   Expression: <remove useless column after join>
-   HashJoinProbe: <join probe, join_executor_id = Join_2>
+   HashJoinProbe: <join probe, join_executor_id = Join_2, has_non_joined_data = false>
     Expression: <append join key and join filters for probe side>
      Expression: <final projection>
       MockExchangeReceiver)",

--- a/dbms/src/Flash/tests/gtest_collation.cpp
+++ b/dbms/src/Flash/tests/gtest_collation.cpp
@@ -71,7 +71,7 @@ public:
                              {toNullableVec<String>(limit_col, ColumnWithString{"col0-0", {}, "col0-2", "col0-3", {}, "col0-5", "col0-6", "col0-7"})});
 
         /// For ExchangeSender
-        context.addExchangeRelationSchema(sender_name, {{"s1", TiDB::TP::TypeString}, {"s2", TiDB::TP::TypeString}, {"s3", TiDB::TP::TypeString}});
+        context.addExchangeReceiver(sender_name, {{"s1", TiDB::TP::TypeString}, {"s2", TiDB::TP::TypeString}, {"s3", TiDB::TP::TypeString}});
     }
 
     void setAndCheck(const String & table_name, const String & col_name, Int32 collation, const ColumnsWithTypeAndName & expect)

--- a/dbms/src/Flash/tests/gtest_interpreter.cpp
+++ b/dbms/src/Flash/tests/gtest_interpreter.cpp
@@ -419,7 +419,7 @@ CreatingSets
  Union: <for test>
   Expression x 10: <final projection>
    Expression: <remove useless column after join>
-    HashJoinProbe: <join probe, join_executor_id = Join_2>
+    HashJoinProbe: <join probe, join_executor_id = Join_2, has_non_joined_data = false>
      Expression: <final projection>
       MockExchangeReceiver)";
         ASSERT_BLOCKINPUTSTREAM_EQAUL(expected, request, 10);
@@ -446,7 +446,7 @@ CreatingSets
  Union: <for test>
   Expression x 10: <final projection>
    Expression: <remove useless column after join>
-    HashJoinProbe: <join probe, join_executor_id = Join_2>
+    HashJoinProbe: <join probe, join_executor_id = Join_2, has_non_joined_data = false>
      Expression: <final projection>
       MockExchangeReceiver)";
         ASSERT_BLOCKINPUTSTREAM_EQAUL(expected, request, 10);
@@ -523,13 +523,13 @@ CreatingSets
    Expression: <append join key and join filters for build side>
     Expression: <final projection>
      Expression: <remove useless column after join>
-      HashJoinProbe: <join probe, join_executor_id = Join_4>
+      HashJoinProbe: <join probe, join_executor_id = Join_4, has_non_joined_data = false>
        Expression: <final projection>
         MockTableScan
  Union: <for test>
   Expression x 10: <final projection>
    Expression: <remove useless column after join>
-    HashJoinProbe: <join probe, join_executor_id = Join_6>
+    HashJoinProbe: <join probe, join_executor_id = Join_6, has_non_joined_data = false>
      Expression: <final projection>
       MockTableScan)";
         ASSERT_BLOCKINPUTSTREAM_EQAUL(expected, request, 10);
@@ -565,13 +565,13 @@ CreatingSets
    Expression: <append join key and join filters for build side>
     Expression: <final projection>
      Expression: <remove useless column after join>
-      HashJoinProbe: <join probe, join_executor_id = Join_4>
+      HashJoinProbe: <join probe, join_executor_id = Join_4, has_non_joined_data = false>
        Expression: <final projection>
         MockExchangeReceiver
  Union: <for test>
   Expression x 10: <final projection>
    Expression: <remove useless column after join>
-    HashJoinProbe: <join probe, join_executor_id = Join_6>
+    HashJoinProbe: <join probe, join_executor_id = Join_6, has_non_joined_data = false>
      Expression: <final projection>
       MockExchangeReceiver)";
         ASSERT_BLOCKINPUTSTREAM_EQAUL(expected, request, 10);
@@ -608,14 +608,14 @@ CreatingSets
    Expression: <append join key and join filters for build side>
     Expression: <final projection>
      Expression: <remove useless column after join>
-      HashJoinProbe: <join probe, join_executor_id = Join_4>
+      HashJoinProbe: <join probe, join_executor_id = Join_4, has_non_joined_data = false>
        Expression: <final projection>
         MockExchangeReceiver
  Union: <for test>
   MockExchangeSender x 10
    Expression: <final projection>
     Expression: <remove useless column after join>
-     HashJoinProbe: <join probe, join_executor_id = Join_6>
+     HashJoinProbe: <join probe, join_executor_id = Join_6, has_non_joined_data = false>
       Expression: <final projection>
        MockExchangeReceiver)";
         ASSERT_BLOCKINPUTSTREAM_EQAUL(expected, request, 10);
@@ -649,7 +649,7 @@ CreatingSets
    SharedQuery: <restore concurrency>
     ParallelAggregating, max_threads: 10, final: true
      Expression x 10: <remove useless column after join>
-      HashJoinProbe: <join probe, join_executor_id = Join_2>
+      HashJoinProbe: <join probe, join_executor_id = Join_2, has_non_joined_data = false>
        Expression: <final projection>
         MockTableScan)";
         ASSERT_BLOCKINPUTSTREAM_EQAUL(expected, request, 10);
@@ -678,7 +678,7 @@ CreatingSets
    SharedQuery: <restore concurrency>
     ParallelAggregating, max_threads: 10, final: true
      Expression x 10: <remove useless column after join>
-      HashJoinProbe: <join probe, join_executor_id = Join_2>
+      HashJoinProbe: <join probe, join_executor_id = Join_2, has_non_joined_data = false>
        Expression: <append join key and join filters for probe side>
         Expression: <final projection>
          MockTableScan
@@ -718,7 +718,7 @@ CreatingSets
          SharedQuery: <restore concurrency>
           ParallelAggregating, max_threads: 20, final: true
            Expression x 20: <remove useless column after join>
-            HashJoinProbe: <join probe, join_executor_id = Join_2>
+            HashJoinProbe: <join probe, join_executor_id = Join_2, has_non_joined_data = false>
              Expression: <append join key and join filters for probe side>
               Expression: <final projection>
                MockExchangeReceiver

--- a/dbms/src/Flash/tests/gtest_interpreter.cpp
+++ b/dbms/src/Flash/tests/gtest_interpreter.cpp
@@ -678,12 +678,10 @@ CreatingSets
    SharedQuery: <restore concurrency>
     ParallelAggregating, max_threads: 10, final: true
      Expression x 10: <remove useless column after join>
-      HashJoinProbe: <join probe, join_executor_id = Join_2, has_non_joined_data = false>
+      HashJoinProbe: <join probe, join_executor_id = Join_2, has_non_joined_data = true>
        Expression: <append join key and join filters for probe side>
         Expression: <final projection>
-         MockTableScan
-     Expression x 10: <remove useless column after join>
-      NonJoined: <add stream with non_joined_data if full_or_right_join>)";
+         MockTableScan)";
         ASSERT_BLOCKINPUTSTREAM_EQAUL(expected, request, 10);
     }
 

--- a/dbms/src/Flash/tests/gtest_interpreter.cpp
+++ b/dbms/src/Flash/tests/gtest_interpreter.cpp
@@ -32,9 +32,9 @@ public:
         context.addMockTable({"test_db", "test_table_1"}, {{"s1", TiDB::TP::TypeString}, {"s2", TiDB::TP::TypeString}, {"s3", TiDB::TP::TypeString}});
         context.addMockTable({"test_db", "r_table"}, {{"r_a", TiDB::TP::TypeLong}, {"r_b", TiDB::TP::TypeString}, {"join_c", TiDB::TP::TypeString}});
         context.addMockTable({"test_db", "l_table"}, {{"l_a", TiDB::TP::TypeLong}, {"l_b", TiDB::TP::TypeString}, {"join_c", TiDB::TP::TypeString}});
-        context.addExchangeRelationSchema("sender_1", {{"s1", TiDB::TP::TypeString}, {"s2", TiDB::TP::TypeString}, {"s3", TiDB::TP::TypeString}});
-        context.addExchangeRelationSchema("sender_l", {{"l_a", TiDB::TP::TypeLong}, {"l_b", TiDB::TP::TypeString}, {"join_c", TiDB::TP::TypeString}});
-        context.addExchangeRelationSchema("sender_r", {{"r_a", TiDB::TP::TypeLong}, {"r_b", TiDB::TP::TypeString}, {"join_c", TiDB::TP::TypeString}});
+        context.addExchangeReceiver("sender_1", {{"s1", TiDB::TP::TypeString}, {"s2", TiDB::TP::TypeString}, {"s3", TiDB::TP::TypeString}});
+        context.addExchangeReceiver("sender_l", {{"l_a", TiDB::TP::TypeLong}, {"l_b", TiDB::TP::TypeString}, {"join_c", TiDB::TP::TypeString}});
+        context.addExchangeReceiver("sender_r", {{"r_a", TiDB::TP::TypeLong}, {"r_b", TiDB::TP::TypeString}, {"join_c", TiDB::TP::TypeString}});
     }
 };
 

--- a/dbms/src/Flash/tests/gtest_interpreter.cpp
+++ b/dbms/src/Flash/tests/gtest_interpreter.cpp
@@ -32,10 +32,13 @@ public:
         context.addMockTable({"test_db", "test_table_1"}, {{"s1", TiDB::TP::TypeString}, {"s2", TiDB::TP::TypeString}, {"s3", TiDB::TP::TypeString}});
         context.addMockTable({"test_db", "r_table"}, {{"r_a", TiDB::TP::TypeLong}, {"r_b", TiDB::TP::TypeString}, {"join_c", TiDB::TP::TypeString}});
         context.addMockTable({"test_db", "l_table"}, {{"l_a", TiDB::TP::TypeLong}, {"l_b", TiDB::TP::TypeString}, {"join_c", TiDB::TP::TypeString}});
-        context.addExchangeReceiver("sender_1", {{"s1", TiDB::TP::TypeString}, {"s2", TiDB::TP::TypeString}, {"s3", TiDB::TP::TypeString}});
+        context.addMockTable({"test_db", "l_table_5_concurrency"}, {{"l_a", TiDB::TP::TypeLong}, {"l_b", TiDB::TP::TypeString}, {"join_c", TiDB::TP::TypeString}}, 5);
+        context.addExchangeReceiver("sender_1", {{"s1", TiDB::TP::TypeString}, {"s2", TiDB::TP::TypeString}, {"s3", TiDB::TP::TypeString}}, enable, {{"s2", TiDB::TP::TypeString}});
         context.addExchangeReceiver("sender_l", {{"l_a", TiDB::TP::TypeLong}, {"l_b", TiDB::TP::TypeString}, {"join_c", TiDB::TP::TypeString}});
-        context.addExchangeReceiver("sender_r", {{"r_a", TiDB::TP::TypeLong}, {"r_b", TiDB::TP::TypeString}, {"join_c", TiDB::TP::TypeString}});
+        context.addExchangeReceiver("sender_r", {{"r_a", TiDB::TP::TypeLong}, {"r_b", TiDB::TP::TypeString}, {"join_c", TiDB::TP::TypeString}}, enable, {{"join_c", TiDB::TP::TypeString}});
     }
+    const size_t enable = 8;
+    const size_t disable = 0;
 };
 
 TEST_F(InterpreterExecuteTest, SingleQueryBlock)
@@ -323,8 +326,6 @@ TEST_F(InterpreterExecuteTest, FineGrainedShuffle)
 try
 {
     // fine-grained shuffle is enabled.
-    const uint64_t enable = 8;
-    const uint64_t disable = 0;
     auto request = context
                        .receive("sender_1", enable)
                        .sort({{"s1", true}, {"s2", false}}, true, enable)
@@ -333,7 +334,7 @@ try
     {
         String expected = R"(
 Union: <for test>
- Expression x 10: <final projection>
+ Expression x 8: <final projection>
   Expression: <before order and select>
    Window: <enable fine grained shuffle>, function: {row_number}, frame: {type: Rows, boundary_begin: Current, boundary_end: Current}
     Expression: <final projection>
@@ -395,8 +396,6 @@ TEST_F(InterpreterExecuteTest, FineGrainedShuffleJoin)
 try
 {
     // fine-grained shuffle is enabled.
-    const uint64_t enable = 8;
-    const uint64_t disable = 0;
     {
         // Join Source.
         DAGRequestBuilder receiver1 = context.receive("sender_l");
@@ -412,7 +411,7 @@ try
         String expected = R"(
 CreatingSets
  Union: <for join>
-  HashJoinBuild x 10: <join build, build_side_root_executor_id = exchange_receiver_1 enable fine grained shuffle>, join_kind = Left
+  HashJoinBuild x 8: <join build, build_side_root_executor_id = exchange_receiver_1 enable fine grained shuffle>, join_kind = Left
    Expression: <append join key and join filters for build side>
     Expression: <final projection>
      MockExchangeReceiver
@@ -422,6 +421,33 @@ CreatingSets
     HashJoinProbe: <join probe, join_executor_id = Join_2, has_non_joined_data = false>
      Expression: <final projection>
       MockExchangeReceiver)";
+        ASSERT_BLOCKINPUTSTREAM_EQAUL(expected, request, 10);
+    }
+    {
+        // Join Source.
+        DAGRequestBuilder scan1 = context.scan("test_db", "l_table_5_concurrency");
+        DAGRequestBuilder receiver2 = context.receive("sender_r", enable);
+
+        auto request = scan1.join(
+                                receiver2,
+                                tipb::JoinType::TypeLeftOuterJoin,
+                                {col("join_c")},
+                                enable)
+                           .build(context);
+
+        String expected = R"(
+CreatingSets
+ Union: <for join>
+  HashJoinBuild x 8: <join build, build_side_root_executor_id = exchange_receiver_1 enable fine grained shuffle>, join_kind = Left
+   Expression: <append join key and join filters for build side>
+    Expression: <final projection>
+     MockExchangeReceiver
+ Union: <for test>
+  Expression x 5: <final projection>
+   Expression: <remove useless column after join>
+    HashJoinProbe: <join probe, join_executor_id = Join_2, has_non_joined_data = false>
+     Expression: <final projection>
+      MockTableScan)";
         ASSERT_BLOCKINPUTSTREAM_EQAUL(expected, request, 10);
     }
     {
@@ -458,8 +484,6 @@ TEST_F(InterpreterExecuteTest, FineGrainedShuffleAgg)
 try
 {
     // fine-grained shuffle is enabled.
-    const uint64_t enable = 8;
-    const uint64_t disable = 0;
     {
         DAGRequestBuilder receiver1 = context.receive("sender_1", enable);
         auto request = receiver1
@@ -467,7 +491,7 @@ try
                            .build(context);
         String expected = R"(
 Union: <for test>
- Expression x 10: <final projection>
+ Expression x 8: <final projection>
   Aggregating: <enable fine grained shuffle>
    MockExchangeReceiver)";
         ASSERT_BLOCKINPUTSTREAM_EQAUL(expected, request, 10);
@@ -716,12 +740,10 @@ CreatingSets
          SharedQuery: <restore concurrency>
           ParallelAggregating, max_threads: 20, final: true
            Expression x 20: <remove useless column after join>
-            HashJoinProbe: <join probe, join_executor_id = Join_2, has_non_joined_data = false>
+            HashJoinProbe: <join probe, join_executor_id = Join_2, has_non_joined_data = true>
              Expression: <append join key and join filters for probe side>
               Expression: <final projection>
-               MockExchangeReceiver
-           Expression x 20: <remove useless column after join>
-            NonJoined: <add stream with non_joined_data if full_or_right_join>)";
+               MockExchangeReceiver)";
         ASSERT_BLOCKINPUTSTREAM_EQAUL(expected, request, 20);
     }
 }

--- a/dbms/src/Flash/tests/gtest_join_executor.cpp
+++ b/dbms/src/Flash/tests/gtest_join_executor.cpp
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <TestUtils/ColumnGenerator.h>
 #include <TestUtils/ExecutorTestUtils.h>
 
 #include <ext/enumerate.h>
 #include <tuple>
-
-#include "TestUtils/ColumnGenerator.h"
 
 namespace DB
 {
@@ -780,7 +779,7 @@ try
         right_column_data.push_back(ColumnGenerator::instance().generate(opts));
     }
 
-    for (size_t i = 0; i < common_column_data.size(); i++)
+    for (size_t i = 0; i < common_column_data.size(); ++i)
     {
         left_column_data[i].column->assumeMutable()->insertRangeFrom(*common_column_data[i].column, 0, common_rows);
         right_column_data[i].column->assumeMutable()->insertRangeFrom(*common_column_data[i].column, 0, common_rows);
@@ -847,9 +846,9 @@ try
     auto ref_blocks = getExecuteStreamsReturnBlocks(request, original_max_streams);
 
     /// case 1.1 table scan join table scan
-    for (size_t left_index = 0; left_index < left_table_names.size(); left_index++)
+    for (size_t left_index = 0; left_index < left_table_names.size(); ++left_index)
     {
-        for (size_t right_index = 0; right_index < right_table_names.size(); right_index++)
+        for (size_t right_index = 0; right_index < right_table_names.size(); ++right_index)
         {
             if (left_index == 0 && right_index == 0)
                 continue;
@@ -862,17 +861,13 @@ try
                           .topN(order_by_items, table_rows * 10)
                           .build(context);
             auto result_blocks = getExecuteStreamsReturnBlocks(request, original_max_streams);
-            ASSERT_EQ(ref_blocks.size(), result_blocks.size());
-            for (size_t i = 0; i < ref_blocks.size(); i++)
-            {
-                ASSERT_BLOCK_EQ(ref_blocks[i], result_blocks[i]);
-            }
+            ASSERT_BLOCKS_EQ(ref_blocks, result_blocks);
         }
     }
     /// case 1.2 table scan join fine grained exchange receiver
-    for (size_t left_index = 0; left_index < left_table_names.size(); left_index++)
+    for (size_t left_index = 0; left_index < left_table_names.size(); ++left_index)
     {
-        for (size_t right_index = 0; right_index < right_exchange_receiver_concurrency.size(); right_index++)
+        for (size_t right_index = 0; right_index < right_exchange_receiver_concurrency.size(); ++right_index)
         {
             order_by_items.clear();
             order_by_items.insert(order_by_items.end(), left_table_order_items[left_index].begin(), left_table_order_items[left_index].end());
@@ -884,11 +879,7 @@ try
                           .topN(order_by_items, table_rows * 10)
                           .build(context);
             auto result_blocks = getExecuteStreamsReturnBlocks(request, original_max_streams);
-            ASSERT_EQ(ref_blocks.size(), result_blocks.size());
-            for (size_t i = 0; i < ref_blocks.size(); i++)
-            {
-                ASSERT_BLOCK_EQ(ref_blocks[i], result_blocks[i]);
-            }
+            ASSERT_BLOCKS_EQ(ref_blocks, result_blocks);
         }
     }
     /// case 2, right join with right condition
@@ -904,9 +895,9 @@ try
     /// use 1 build concurrency join 1 probe concurrency as the reference
     ref_blocks = getExecuteStreamsReturnBlocks(request, original_max_streams);
     /// case 2.1 table scan join table scan
-    for (size_t left_index = 0; left_index < left_table_names.size(); left_index++)
+    for (size_t left_index = 0; left_index < left_table_names.size(); ++left_index)
     {
-        for (size_t right_index = 0; right_index < right_table_names.size(); right_index++)
+        for (size_t right_index = 0; right_index < right_table_names.size(); ++right_index)
         {
             if (left_index == 0 && right_index == 0)
                 continue;
@@ -919,17 +910,13 @@ try
                           .topN(order_by_items, table_rows * 10)
                           .build(context);
             auto result_blocks = getExecuteStreamsReturnBlocks(request, original_max_streams);
-            ASSERT_EQ(ref_blocks.size(), result_blocks.size());
-            for (size_t i = 0; i < ref_blocks.size(); i++)
-            {
-                ASSERT_BLOCK_EQ(ref_blocks[i], result_blocks[i]);
-            }
+            ASSERT_BLOCKS_EQ(ref_blocks, result_blocks);
         }
     }
     /// case 2.2 table scan join fine grained exchange receiver
-    for (size_t left_index = 0; left_index < left_table_names.size(); left_index++)
+    for (size_t left_index = 0; left_index < left_table_names.size(); ++left_index)
     {
-        for (size_t right_index = 0; right_index < right_exchange_receiver_concurrency.size(); right_index++)
+        for (size_t right_index = 0; right_index < right_exchange_receiver_concurrency.size(); ++right_index)
         {
             order_by_items.clear();
             order_by_items.insert(order_by_items.end(), left_table_order_items[left_index].begin(), left_table_order_items[left_index].end());
@@ -942,11 +929,7 @@ try
                           .topN(order_by_items, table_rows * 10)
                           .build(context);
             auto result_blocks = getExecuteStreamsReturnBlocks(request, original_max_streams);
-            ASSERT_EQ(ref_blocks.size(), result_blocks.size());
-            for (size_t i = 0; i < ref_blocks.size(); i++)
-            {
-                ASSERT_BLOCK_EQ(ref_blocks[i], result_blocks[i]);
-            }
+            ASSERT_BLOCKS_EQ(ref_blocks, result_blocks);
         }
     }
 }

--- a/dbms/src/Flash/tests/gtest_planner_interpreter.cpp
+++ b/dbms/src/Flash/tests/gtest_planner_interpreter.cpp
@@ -451,7 +451,7 @@ CreatingSets
  Union: <for test>
   Expression x 10: <final projection>
    Expression: <remove useless column after join>
-    HashJoinProbe: <join probe, join_executor_id = Join_3>
+    HashJoinProbe: <join probe, join_executor_id = Join_3, has_non_joined_data = false>
      Expression: <final projection>
       MockTableScan)";
         ASSERT_BLOCKINPUTSTREAM_EQAUL(expected, request, 10);
@@ -751,7 +751,7 @@ CreatingSets
  Union: <for test>
   Expression x 10: <final projection>
    Expression: <remove useless column after join>
-    HashJoinProbe: <join probe, join_executor_id = Join_2>
+    HashJoinProbe: <join probe, join_executor_id = Join_2, has_non_joined_data = false>
      Expression: <final projection>
       MockExchangeReceiver)";
         ASSERT_BLOCKINPUTSTREAM_EQAUL(expected, request, 10);
@@ -778,7 +778,7 @@ CreatingSets
  Union: <for test>
   Expression x 10: <final projection>
    Expression: <remove useless column after join>
-    HashJoinProbe: <join probe, join_executor_id = Join_2>
+    HashJoinProbe: <join probe, join_executor_id = Join_2, has_non_joined_data = false>
      Expression: <final projection>
       MockExchangeReceiver)";
         ASSERT_BLOCKINPUTSTREAM_EQAUL(expected, request, 10);
@@ -859,13 +859,13 @@ CreatingSets
    Expression: <append join key and join filters for build side>
     Expression: <final projection>
      Expression: <remove useless column after join>
-      HashJoinProbe: <join probe, join_executor_id = Join_4>
+      HashJoinProbe: <join probe, join_executor_id = Join_4, has_non_joined_data = false>
        Expression: <final projection>
         MockTableScan
  Union: <for test>
   Expression x 10: <final projection>
    Expression: <remove useless column after join>
-    HashJoinProbe: <join probe, join_executor_id = Join_6>
+    HashJoinProbe: <join probe, join_executor_id = Join_6, has_non_joined_data = false>
      Expression: <final projection>
       MockTableScan)";
         ASSERT_BLOCKINPUTSTREAM_EQAUL(expected, request, 10);
@@ -901,13 +901,13 @@ CreatingSets
    Expression: <append join key and join filters for build side>
     Expression: <final projection>
      Expression: <remove useless column after join>
-      HashJoinProbe: <join probe, join_executor_id = Join_4>
+      HashJoinProbe: <join probe, join_executor_id = Join_4, has_non_joined_data = false>
        Expression: <final projection>
         MockExchangeReceiver
  Union: <for test>
   Expression x 10: <final projection>
    Expression: <remove useless column after join>
-    HashJoinProbe: <join probe, join_executor_id = Join_6>
+    HashJoinProbe: <join probe, join_executor_id = Join_6, has_non_joined_data = false>
      Expression: <final projection>
       MockExchangeReceiver)";
         ASSERT_BLOCKINPUTSTREAM_EQAUL(expected, request, 10);
@@ -944,14 +944,14 @@ CreatingSets
    Expression: <append join key and join filters for build side>
     Expression: <final projection>
      Expression: <remove useless column after join>
-      HashJoinProbe: <join probe, join_executor_id = Join_4>
+      HashJoinProbe: <join probe, join_executor_id = Join_4, has_non_joined_data = false>
        Expression: <final projection>
         MockExchangeReceiver
  Union: <for test>
   MockExchangeSender x 10
    Expression: <final projection>
     Expression: <remove useless column after join>
-     HashJoinProbe: <join probe, join_executor_id = Join_6>
+     HashJoinProbe: <join probe, join_executor_id = Join_6, has_non_joined_data = false>
       Expression: <final projection>
        MockExchangeReceiver)";
         ASSERT_BLOCKINPUTSTREAM_EQAUL(expected, request, 10);
@@ -987,7 +987,7 @@ CreatingSets
      ParallelAggregating, max_threads: 10, final: true
       Expression x 10: <before aggregation>
        Expression: <remove useless column after join>
-        HashJoinProbe: <join probe, join_executor_id = Join_2>
+        HashJoinProbe: <join probe, join_executor_id = Join_2, has_non_joined_data = false>
          Expression: <final projection>
           MockTableScan)";
         ASSERT_BLOCKINPUTSTREAM_EQAUL(expected, request, 10);
@@ -1018,7 +1018,7 @@ CreatingSets
      ParallelAggregating, max_threads: 10, final: true
       Expression x 10: <before aggregation>
        Expression: <remove useless column after join>
-        HashJoinProbe: <join probe, join_executor_id = Join_2>
+        HashJoinProbe: <join probe, join_executor_id = Join_2, has_non_joined_data = false>
          Expression: <append join key and join filters for probe side>
           Expression: <final projection>
            MockTableScan
@@ -1060,7 +1060,7 @@ CreatingSets
           ParallelAggregating, max_threads: 20, final: true
            Expression x 20: <before aggregation>
             Expression: <remove useless column after join>
-             HashJoinProbe: <join probe, join_executor_id = Join_2>
+             HashJoinProbe: <join probe, join_executor_id = Join_2, has_non_joined_data = false>
               Expression: <append join key and join filters for probe side>
                Expression: <final projection>
                 MockExchangeReceiver

--- a/dbms/src/Flash/tests/gtest_planner_interpreter.cpp
+++ b/dbms/src/Flash/tests/gtest_planner_interpreter.cpp
@@ -669,7 +669,7 @@ try
     {
         String expected = R"(
 Union: <for test>
- Expression x 10: <final projection>
+ Expression x 8: <final projection>
   Expression: <expr after window>
    Window: <enable fine grained shuffle>, function: {row_number}, frame: {type: Rows, boundary_begin: Current, boundary_end: Current}
     MergeSorting: <enable fine grained shuffle>, limit = 0
@@ -744,7 +744,7 @@ try
         String expected = R"(
 CreatingSets
  Union: <for join>
-  HashJoinBuild x 10: <join build, build_side_root_executor_id = exchange_receiver_1 enable fine grained shuffle>, join_kind = Left
+  HashJoinBuild x 8: <join build, build_side_root_executor_id = exchange_receiver_1 enable fine grained shuffle>, join_kind = Left
    Expression: <append join key and join filters for build side>
     Expression: <final projection>
      MockExchangeReceiver
@@ -799,7 +799,7 @@ try
                            .build(context);
         String expected = R"(
 Union: <for test>
- Expression x 10: <final projection>
+ Expression x 8: <final projection>
   Expression: <expr after aggregation>
    Aggregating: <enable fine grained shuffle>
     Expression: <before aggregation>
@@ -1018,13 +1018,10 @@ CreatingSets
      ParallelAggregating, max_threads: 10, final: true
       Expression x 10: <before aggregation>
        Expression: <remove useless column after join>
-        HashJoinProbe: <join probe, join_executor_id = Join_2, has_non_joined_data = false>
+        HashJoinProbe: <join probe, join_executor_id = Join_2, has_non_joined_data = true>
          Expression: <append join key and join filters for probe side>
           Expression: <final projection>
-           MockTableScan
-      Expression x 10: <before aggregation>
-       Expression: <remove useless column after join>
-        NonJoined: <add stream with non_joined_data if full_or_right_join>)";
+           MockTableScan)";
         ASSERT_BLOCKINPUTSTREAM_EQAUL(expected, request, 10);
     }
 
@@ -1060,13 +1057,10 @@ CreatingSets
           ParallelAggregating, max_threads: 20, final: true
            Expression x 20: <before aggregation>
             Expression: <remove useless column after join>
-             HashJoinProbe: <join probe, join_executor_id = Join_2, has_non_joined_data = false>
+             HashJoinProbe: <join probe, join_executor_id = Join_2, has_non_joined_data = true>
               Expression: <append join key and join filters for probe side>
                Expression: <final projection>
-                MockExchangeReceiver
-           Expression x 20: <before aggregation>
-            Expression: <remove useless column after join>
-             NonJoined: <add stream with non_joined_data if full_or_right_join>)";
+                MockExchangeReceiver)";
         ASSERT_BLOCKINPUTSTREAM_EQAUL(expected, request, 20);
     }
 }

--- a/dbms/src/Flash/tests/gtest_planner_interpreter.cpp
+++ b/dbms/src/Flash/tests/gtest_planner_interpreter.cpp
@@ -32,9 +32,9 @@ public:
         context.addMockTable({"test_db", "test_table_1"}, {{"s1", TiDB::TP::TypeString}, {"s2", TiDB::TP::TypeString}, {"s3", TiDB::TP::TypeString}});
         context.addMockTable({"test_db", "r_table"}, {{"r_a", TiDB::TP::TypeLong}, {"r_b", TiDB::TP::TypeString}, {"join_c", TiDB::TP::TypeString}});
         context.addMockTable({"test_db", "l_table"}, {{"l_a", TiDB::TP::TypeLong}, {"l_b", TiDB::TP::TypeString}, {"join_c", TiDB::TP::TypeString}});
-        context.addExchangeRelationSchema("sender_1", {{"s1", TiDB::TP::TypeString}, {"s2", TiDB::TP::TypeString}, {"s3", TiDB::TP::TypeString}});
-        context.addExchangeRelationSchema("sender_l", {{"l_a", TiDB::TP::TypeLong}, {"l_b", TiDB::TP::TypeString}, {"join_c", TiDB::TP::TypeString}});
-        context.addExchangeRelationSchema("sender_r", {{"r_a", TiDB::TP::TypeLong}, {"r_b", TiDB::TP::TypeString}, {"join_c", TiDB::TP::TypeString}});
+        context.addExchangeReceiver("sender_1", {{"s1", TiDB::TP::TypeString}, {"s2", TiDB::TP::TypeString}, {"s3", TiDB::TP::TypeString}});
+        context.addExchangeReceiver("sender_l", {{"l_a", TiDB::TP::TypeLong}, {"l_b", TiDB::TP::TypeString}, {"join_c", TiDB::TP::TypeString}});
+        context.addExchangeReceiver("sender_r", {{"r_a", TiDB::TP::TypeLong}, {"r_b", TiDB::TP::TypeString}, {"join_c", TiDB::TP::TypeString}});
     }
 };
 

--- a/dbms/src/Flash/tests/gtest_split_tasks.cpp
+++ b/dbms/src/Flash/tests/gtest_split_tasks.cpp
@@ -126,7 +126,7 @@ try
         "   MergeSorting, limit = 2\n"
         "    PartialSorting: limit = 2\n"
         "     Expression: <remove useless column after join>\n"
-        "      HashJoinProbe: <join probe, join_executor_id = Join_2>\n"
+        "      HashJoinProbe: <join probe, join_executor_id = Join_2, has_non_joined_data = false>\n"
         "       Expression: <final projection>\n"
         "        MockExchangeReceiver"};
     for (size_t i = 0; i < task_size; ++i)

--- a/dbms/src/Flash/tests/gtest_window_executor.cpp
+++ b/dbms/src/Flash/tests/gtest_window_executor.cpp
@@ -69,7 +69,7 @@ public:
 
     void executeWithTableScanAndConcurrency(const std::shared_ptr<tipb::DAGRequest> & request, const String & db, const String & table_name, const ColumnsWithTypeAndName & source_columns, const ColumnsWithTypeAndName & expect_columns)
     {
-        context.addMockTableColumnData(db, table_name, source_columns);
+        context.updateMockTableColumnData(db, table_name, source_columns);
         executeAndAssertColumnsEqual(request, expect_columns);
     }
 };

--- a/dbms/src/Interpreters/ExpressionActions.cpp
+++ b/dbms/src/Interpreters/ExpressionActions.cpp
@@ -749,7 +749,7 @@ std::string ExpressionActions::dumpActions() const
 BlockInputStreamPtr ExpressionActions::createStreamWithNonJoinedDataIfFullOrRightJoin(const Block & source_header, size_t index, size_t step, size_t max_block_size) const
 {
     for (const auto & action : actions)
-        if (action.join && (action.join->getKind() == ASTTableJoin::Kind::Full || action.join->getKind() == ASTTableJoin::Kind::Right))
+        if (action.join && (action.join->needReturnNonJoinedData()))
             return action.join->createStreamWithNonJoinedRows(source_header, index, step, max_block_size);
 
     return {};

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -852,7 +852,6 @@ void Join::insertFromBlock(const Block & block, size_t stream_index)
 {
     std::shared_lock lock(rwlock);
     assert(stream_index < getBuildConcurrencyInternal());
-    assert(stream_index < getNotJoinedStreamConcurrencyInternal());
 
     if (unlikely(!initialized))
         throw Exception("Logical error: Join was not initialized", ErrorCodes::LOGICAL_ERROR);

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -472,7 +472,7 @@ void Join::setBuildConcurrencyAndInitPool(size_t build_concurrency_)
     // init for non-joined-streams.
     if (getFullness(kind))
     {
-        for (size_t i = 0; i < getNotJoinedStreamConcurrencyInternal(); ++i)
+        for (size_t i = 0; i < getBuildConcurrencyInternal(); ++i)
             rows_not_inserted_to_map.push_back(std::make_unique<RowRefList>());
     }
 }

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -137,6 +137,8 @@ Join::Join(
     , key_names_right(key_names_right_)
     , use_nulls(use_nulls_)
     , build_concurrency(0)
+    , probe_concurrency(0)
+    , active_probe_concurrency(0)
     , collators(collators_)
     , left_filter_column(left_filter_column_)
     , right_filter_column(right_filter_column_)

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -2096,6 +2096,11 @@ Block Join::joinBlock(ProbeProcessInfo & probe_process_info) const
     return block;
 }
 
+bool Join::needReturnNonJoinedData() const
+{
+    return getFullness(kind);
+}
+
 void Join::joinTotals(Block & block) const
 {
     Block totals_without_keys = totals;

--- a/dbms/src/Interpreters/Join.h
+++ b/dbms/src/Interpreters/Join.h
@@ -165,7 +165,8 @@ public:
     {
         std::unique_lock lock(probe_mutex);
         active_probe_concurrency--;
-        probe_cv.notify_all();
+        if (active_probe_concurrency == 0)
+            probe_cv.notify_all();
     }
     void waitUntilAllProbeFinished()
     {

--- a/dbms/src/Interpreters/Join.h
+++ b/dbms/src/Interpreters/Join.h
@@ -180,11 +180,6 @@ public:
         std::shared_lock lock(rwlock);
         return getBuildConcurrencyInternal();
     }
-    size_t getNotJoinedStreamConcurrency() const
-    {
-        std::shared_lock lock(rwlock);
-        return getNotJoinedStreamConcurrencyInternal();
-    }
 
     enum BuildTableState
     {

--- a/dbms/src/Interpreters/Join.h
+++ b/dbms/src/Interpreters/Join.h
@@ -389,10 +389,6 @@ private:
             throw Exception("Logical error: `setBuildConcurrencyAndInitPool` has not been called", ErrorCodes::LOGICAL_ERROR);
         return build_concurrency;
     }
-    size_t getNotJoinedStreamConcurrencyInternal() const
-    {
-        return getBuildConcurrencyInternal();
-    }
 
     /// Initialize map implementations for various join types.
     void initMapImpl(Type type_);

--- a/dbms/src/Interpreters/Join.h
+++ b/dbms/src/Interpreters/Join.h
@@ -131,6 +131,8 @@ public:
 
     void joinTotals(Block & block) const;
 
+    bool needReturnNonJoinedData() const;
+
     /** For RIGHT and FULL JOINs.
       * A stream that will contain default values from left table, joined with rows from right table, that was not joined before.
       * Use only after all calls to joinBlock was done.

--- a/dbms/src/TestUtils/ColumnGenerator.h
+++ b/dbms/src/TestUtils/ColumnGenerator.h
@@ -33,6 +33,7 @@ struct ColumnGeneratorOpts
     size_t size;
     String type_name;
     DataDistribution distribution;
+    String name = "";
     size_t string_max_size = 128;
 };
 
@@ -42,6 +43,7 @@ public:
     ColumnWithTypeAndName generate(const ColumnGeneratorOpts & opts);
 
 private:
+    ColumnWithTypeAndName generateNullMapColumn(const ColumnGeneratorOpts & opts);
     std::mt19937_64 rand_gen;
     std::uniform_int_distribution<Int64> int_rand_gen = std::uniform_int_distribution<Int64>(0, 128);
     std::uniform_real_distribution<double> real_rand_gen;

--- a/dbms/src/TestUtils/FunctionTestUtils.cpp
+++ b/dbms/src/TestUtils/FunctionTestUtils.cpp
@@ -149,6 +149,20 @@ template <typename ExpectedT, typename ActualT, typename ExpectedDisplayT, typen
     return columnEqual(expected.column, actual.column, expected.type->isFloatingPoint());
 }
 
+::testing::AssertionResult blocksEqual(
+    const Blocks & expected,
+    const Blocks & actual)
+{
+    ASSERT_EQUAL(expected.size(), actual.size(), "Blocks size mismatch");
+    for (size_t i = 0; i < expected.size(); i++)
+    {
+        auto cmp_res = blockEqual(expected[i], actual[i]);
+        if (!cmp_res)
+            return cmp_res;
+    }
+    return ::testing::AssertionSuccess();
+}
+
 ::testing::AssertionResult blockEqual(
     const Block & expected,
     const Block & actual)

--- a/dbms/src/TestUtils/FunctionTestUtils.cpp
+++ b/dbms/src/TestUtils/FunctionTestUtils.cpp
@@ -149,20 +149,6 @@ template <typename ExpectedT, typename ActualT, typename ExpectedDisplayT, typen
     return columnEqual(expected.column, actual.column, expected.type->isFloatingPoint());
 }
 
-::testing::AssertionResult blocksEqual(
-    const Blocks & expected,
-    const Blocks & actual)
-{
-    ASSERT_EQUAL(expected.size(), actual.size(), "Blocks size mismatch");
-    for (size_t i = 0; i < expected.size(); i++)
-    {
-        auto cmp_res = blockEqual(expected[i], actual[i]);
-        if (!cmp_res)
-            return cmp_res;
-    }
-    return ::testing::AssertionSuccess();
-}
-
 ::testing::AssertionResult blockEqual(
     const Block & expected,
     const Block & actual)

--- a/dbms/src/TestUtils/FunctionTestUtils.h
+++ b/dbms/src/TestUtils/FunctionTestUtils.h
@@ -597,6 +597,10 @@ ColumnsWithTypeAndName createColumns(const ColumnsWithTypeAndName & cols);
     const Block & expected,
     const Block & actual);
 
+::testing::AssertionResult blocksEqual(
+    const Blocks & expected,
+    const Blocks & actual);
+
 ::testing::AssertionResult columnsEqual(
     const ColumnsWithTypeAndName & expected,
     const ColumnsWithTypeAndName & actual,
@@ -836,6 +840,7 @@ protected:
 
 #define ASSERT_COLUMN_EQ(expected, actual) ASSERT_TRUE(DB::tests::columnEqual((expected), (actual)))
 #define ASSERT_BLOCK_EQ(expected, actual) DB::tests::blockEqual((expected), (actual))
+#define ASSERT_BLOCKS_EQ(expected, actual) DB::tests::blocksEqual((expected), (actual))
 
 /// restrictly checking columns equality, both data set and each row's offset should be the same
 #define ASSERT_COLUMNS_EQ_R(expected, actual) ASSERT_TRUE(DB::tests::columnsEqual((expected), (actual), true))

--- a/dbms/src/TestUtils/FunctionTestUtils.h
+++ b/dbms/src/TestUtils/FunctionTestUtils.h
@@ -597,10 +597,6 @@ ColumnsWithTypeAndName createColumns(const ColumnsWithTypeAndName & cols);
     const Block & expected,
     const Block & actual);
 
-::testing::AssertionResult blocksEqual(
-    const Blocks & expected,
-    const Blocks & actual);
-
 ::testing::AssertionResult columnsEqual(
     const ColumnsWithTypeAndName & expected,
     const ColumnsWithTypeAndName & actual,
@@ -840,7 +836,6 @@ protected:
 
 #define ASSERT_COLUMN_EQ(expected, actual) ASSERT_TRUE(DB::tests::columnEqual((expected), (actual)))
 #define ASSERT_BLOCK_EQ(expected, actual) DB::tests::blockEqual((expected), (actual))
-#define ASSERT_BLOCKS_EQ(expected, actual) DB::tests::blocksEqual((expected), (actual))
 
 /// restrictly checking columns equality, both data set and each row's offset should be the same
 #define ASSERT_COLUMNS_EQ_R(expected, actual) ASSERT_TRUE(DB::tests::columnsEqual((expected), (actual), true))

--- a/dbms/src/TestUtils/mockExecutor.cpp
+++ b/dbms/src/TestUtils/mockExecutor.cpp
@@ -362,10 +362,10 @@ DAGRequestBuilder & DAGRequestBuilder::sort(MockOrderByItemVec order_by_vec, boo
     return *this;
 }
 
-void MockDAGRequestContext::addMockTable(const String & db, const String & table, const MockColumnInfoVec & mock_column_infos)
+void MockDAGRequestContext::addMockTable(const String & db, const String & table, const MockColumnInfoVec & mock_column_infos, size_t concurrency_hint)
 {
     auto columns = getColumnWithTypeAndName(genNamesAndTypes(mockColumnInfosToTiDBColumnInfos(mock_column_infos), "mock_table_scan"));
-    addMockTable(db, table, mock_column_infos, columns);
+    addMockTable(db, table, mock_column_infos, columns, concurrency_hint);
 }
 
 void MockDAGRequestContext::addMockTableSchema(const String & db, const String & table, const MockColumnInfoVec & columnInfos)
@@ -377,10 +377,10 @@ void MockDAGRequestContext::addMockTableSchema(const MockTableName & name, const
     mock_storage->addTableSchema(name.first + "." + name.second, columnInfos);
 }
 
-void MockDAGRequestContext::addMockTable(const MockTableName & name, const MockColumnInfoVec & mock_column_infos)
+void MockDAGRequestContext::addMockTable(const MockTableName & name, const MockColumnInfoVec & mock_column_infos, size_t concurrency_hint)
 {
     auto columns = getColumnWithTypeAndName(genNamesAndTypes(mockColumnInfosToTiDBColumnInfos(mock_column_infos), "mock_table_scan"));
-    addMockTable(name, mock_column_infos, columns);
+    addMockTable(name, mock_column_infos, columns, concurrency_hint);
 }
 
 void MockDAGRequestContext::addMockTableConcurrencyHint(const String & db, const String & table, size_t concurrency_hint)
@@ -462,10 +462,10 @@ void MockDAGRequestContext::addMockDeltaMerge(const MockTableName & name, const 
     addMockDeltaMergeData(name.first, name.second, columns);
 }
 
-void MockDAGRequestContext::addExchangeReceiver(const String & name, const MockColumnInfoVec & columnInfos)
+void MockDAGRequestContext::addExchangeReceiver(const String & name, const MockColumnInfoVec & columnInfos, size_t fine_grained_stream_count, const MockColumnInfoVec & partition_column_infos)
 {
     auto columns = getColumnWithTypeAndName(genNamesAndTypes(mockColumnInfosToTiDBColumnInfos(columnInfos), "mock_exchange_receiver"));
-    addExchangeReceiver(name, columnInfos, columns);
+    addExchangeReceiver(name, columnInfos, columns, fine_grained_stream_count, partition_column_infos);
 }
 
 void MockDAGRequestContext::addExchangeReceiver(const String & name, const MockColumnInfoVec & columnInfos, const ColumnsWithTypeAndName & columns, size_t fine_grained_stream_count, const MockColumnInfoVec & partition_column_infos)

--- a/dbms/src/TestUtils/mockExecutor.cpp
+++ b/dbms/src/TestUtils/mockExecutor.cpp
@@ -40,6 +40,8 @@
 #include <memory>
 #include <unordered_set>
 
+#include "Flash/Mpp/HashBaseWriterHelper.h"
+
 namespace DB::tests
 {
 using TableInfo = TiDB::TableInfo;
@@ -175,12 +177,12 @@ DAGRequestBuilder & DAGRequestBuilder::mockTable(const MockTableName & name, Tab
     return mockTable(name.first, name.second, table_info, columns);
 }
 
-DAGRequestBuilder & DAGRequestBuilder::exchangeReceiver(const MockColumnInfoVec & columns, uint64_t fine_grained_shuffle_stream_count)
+DAGRequestBuilder & DAGRequestBuilder::exchangeReceiver(const String & exchange_name, const MockColumnInfoVec & columns, uint64_t fine_grained_shuffle_stream_count)
 {
-    return buildExchangeReceiver(columns, fine_grained_shuffle_stream_count);
+    return buildExchangeReceiver(exchange_name, columns, fine_grained_shuffle_stream_count);
 }
 
-DAGRequestBuilder & DAGRequestBuilder::buildExchangeReceiver(const MockColumnInfoVec & columns, uint64_t fine_grained_shuffle_stream_count)
+DAGRequestBuilder & DAGRequestBuilder::buildExchangeReceiver(const String & exchange_name, const MockColumnInfoVec & columns, uint64_t fine_grained_shuffle_stream_count)
 {
     DAGSchema schema;
     for (const auto & column : columns)
@@ -188,7 +190,7 @@ DAGRequestBuilder & DAGRequestBuilder::buildExchangeReceiver(const MockColumnInf
         TiDB::ColumnInfo info;
         info.tp = column.second;
         info.name = column.first;
-        schema.push_back({column.first, info});
+        schema.push_back({exchange_name + "." + column.first, info});
     }
 
     root = mock::compileExchangeReceiver(getExecutorIndex(), schema, fine_grained_shuffle_stream_count);
@@ -460,11 +462,70 @@ void MockDAGRequestContext::addMockDeltaMerge(const MockTableName & name, const 
     addMockDeltaMergeData(name.first, name.second, columns);
 }
 
-void MockDAGRequestContext::addExchangeReceiver(const String & name, MockColumnInfoVec columnInfos, ColumnsWithTypeAndName columns)
+void MockDAGRequestContext::addExchangeReceiver(const String & name, const MockColumnInfoVec & columnInfos)
+{
+    auto columns = getColumnWithTypeAndName(genNamesAndTypes(mockColumnInfosToTiDBColumnInfos(columnInfos), "mock_exchange_receiver"));
+    addExchangeReceiver(name, columnInfos, columns);
+}
+
+void MockDAGRequestContext::addExchangeReceiver(const String & name, const MockColumnInfoVec & columnInfos, const ColumnsWithTypeAndName & columns, size_t fine_grained_stream_count, const MockColumnInfoVec & partition_column_infos)
 {
     assertMockInput(columnInfos, columns);
     addExchangeRelationSchema(name, columnInfos);
-    addExchangeReceiverColumnData(name, columns);
+    if (fine_grained_stream_count > 0)
+    {
+        Block original_block(columns);
+        std::vector<Int64> partition_column_ids;
+        for (const auto & mock_column_info : partition_column_infos)
+        {
+            for (size_t col_index = 0; col_index < columns.size(); col_index++)
+            {
+                if (columns[col_index].name == mock_column_info.first)
+                {
+                    partition_column_ids.push_back(col_index);
+                    break;
+                }
+            }
+        }
+        RUNTIME_CHECK_MSG(partition_column_ids.size() == partition_column_infos.size(), "Could not find partition columns");
+        TiDB::TiDBCollators collators(partition_column_infos.size(), nullptr);
+        std::vector<String> partition_key_containers(partition_column_infos.size(), "");
+        auto dest_tbl_cols = HashBaseWriterHelper::createDestColumns(original_block, fine_grained_stream_count);
+        WeakHash32 hash(0);
+        HashBaseWriterHelper::computeHash(original_block, partition_column_ids, collators, partition_key_containers, hash);
+
+        IColumn::Selector selector;
+        const auto & hash_data = hash.getData();
+        selector.resize(original_block.rows());
+        for (size_t i = 0; i < original_block.rows(); ++i)
+        {
+            selector[i] = hash_data[i] % fine_grained_stream_count;
+        }
+
+        for (size_t col_id = 0; col_id < original_block.columns(); ++col_id)
+        {
+            // Scatter columns to different partitions
+            std::vector<MutableColumnPtr> part_columns = original_block.getByPosition(col_id).column->scatter(fine_grained_stream_count, selector);
+            assert(part_columns.size() == fine_grained_stream_count);
+            for (size_t bucket_idx = 0; bucket_idx < fine_grained_stream_count; ++bucket_idx)
+            {
+                dest_tbl_cols[bucket_idx][col_id] = std::move(part_columns[bucket_idx]);
+            }
+        }
+        std::vector<ColumnsWithTypeAndName> fine_grained_columns_vector;
+        for (size_t i = 0; i < fine_grained_stream_count; i++)
+        {
+            auto new_columns = columns;
+            for (size_t j = 0; j < dest_tbl_cols[i].size(); j++)
+                new_columns[j].column = std::move(dest_tbl_cols[i][j]);
+            fine_grained_columns_vector.push_back(std::move(new_columns));
+        }
+        mock_storage->addFineGrainedExchangeData(name, fine_grained_columns_vector);
+    }
+    else
+    {
+        addExchangeReceiverColumnData(name, columns);
+    }
 }
 
 DAGRequestBuilder MockDAGRequestContext::scan(const String & db_name, const String & table_name)
@@ -483,7 +544,7 @@ DAGRequestBuilder MockDAGRequestContext::scan(const String & db_name, const Stri
 
 DAGRequestBuilder MockDAGRequestContext::receive(const String & exchange_name, uint64_t fine_grained_shuffle_stream_count)
 {
-    auto builder = DAGRequestBuilder(index, collation).exchangeReceiver(mock_storage->getExchangeSchema(exchange_name), fine_grained_shuffle_stream_count);
+    auto builder = DAGRequestBuilder(index, collation).exchangeReceiver(exchange_name, mock_storage->getExchangeSchema(exchange_name), fine_grained_shuffle_stream_count);
     receiver_source_task_ids_map[builder.getRoot()->name] = {};
     mock_storage->addExchangeRelation(builder.getRoot()->name, exchange_name);
     return builder;

--- a/dbms/src/TestUtils/mockExecutor.cpp
+++ b/dbms/src/TestUtils/mockExecutor.cpp
@@ -472,6 +472,7 @@ void MockDAGRequestContext::addExchangeReceiver(const String & name, const MockC
 {
     assertMockInput(columnInfos, columns);
     addExchangeRelationSchema(name, columnInfos);
+    addExchangeReceiverColumnData(name, columns);
     if (fine_grained_stream_count > 0)
     {
         Block original_block(columns);
@@ -521,10 +522,6 @@ void MockDAGRequestContext::addExchangeReceiver(const String & name, const MockC
             fine_grained_columns_vector.push_back(std::move(new_columns));
         }
         mock_storage->addFineGrainedExchangeData(name, fine_grained_columns_vector);
-    }
-    else
-    {
-        addExchangeReceiverColumnData(name, columns);
     }
 }
 

--- a/dbms/src/TestUtils/mockExecutor.cpp
+++ b/dbms/src/TestUtils/mockExecutor.cpp
@@ -25,6 +25,7 @@
 #include <Debug/MockExecutor/TableScanBinder.h>
 #include <Debug/MockExecutor/TopNBinder.h>
 #include <Debug/dbgQueryExecutor.h>
+#include <Flash/Mpp/HashBaseWriterHelper.h>
 #include <Flash/Statistics/traverseExecutors.h>
 #include <Interpreters/Context.h>
 #include <Parsers/ASTExpressionList.h>
@@ -39,8 +40,6 @@
 
 #include <memory>
 #include <unordered_set>
-
-#include "Flash/Mpp/HashBaseWriterHelper.h"
 
 namespace DB::tests
 {

--- a/dbms/src/TestUtils/mockExecutor.h
+++ b/dbms/src/TestUtils/mockExecutor.h
@@ -88,7 +88,7 @@ public:
     DAGRequestBuilder & mockTable(const String & db, const String & table, TableInfo & table_info, const MockColumnInfoVec & columns);
     DAGRequestBuilder & mockTable(const MockTableName & name, TableInfo & table_info, const MockColumnInfoVec & columns);
 
-    DAGRequestBuilder & exchangeReceiver(const MockColumnInfoVec & columns, uint64_t fine_grained_shuffle_stream_count = 0);
+    DAGRequestBuilder & exchangeReceiver(const String & exchange_name, const MockColumnInfoVec & columns, uint64_t fine_grained_shuffle_stream_count = 0);
 
     DAGRequestBuilder & filter(ASTPtr filter_expr);
 
@@ -151,7 +151,7 @@ public:
 private:
     void initDAGRequest(tipb::DAGRequest & dag_request);
     DAGRequestBuilder & buildAggregation(ASTPtr agg_funcs, ASTPtr group_by_exprs, uint64_t fine_grained_shuffle_stream_count = 0);
-    DAGRequestBuilder & buildExchangeReceiver(const MockColumnInfoVec & columns, uint64_t fine_grained_shuffle_stream_count = 0);
+    DAGRequestBuilder & buildExchangeReceiver(const String & exchange_name, const MockColumnInfoVec & columns, uint64_t fine_grained_shuffle_stream_count = 0);
 
     mock::ExecutorBinderPtr root;
     DAGProperties properties;
@@ -178,15 +178,12 @@ public:
     /// mock column table scan
     void addMockTable(const String & db, const String & table, const MockColumnInfoVec & columnInfos);
     void addMockTable(const MockTableName & name, const MockColumnInfoVec & columnInfos);
-    void addMockTableColumnData(const String & db, const String & table, ColumnsWithTypeAndName columns);
-    void addMockTableColumnData(const MockTableName & name, ColumnsWithTypeAndName columns);
-    void addMockTableSchema(const String & db, const String & table, const MockColumnInfoVec & columnInfos);
-    void addMockTableSchema(const MockTableName & name, const MockColumnInfoVec & columnInfos);
-    void addMockTableConcurrencyHint(const String & db, const String & table, size_t concurrency_hint);
-    void addMockTableConcurrencyHint(const MockTableName & name, size_t concurrency_hint);
-
     void addMockTable(const String & db, const String & table, const MockColumnInfoVec & columnInfos, ColumnsWithTypeAndName columns, size_t concurrency_hint = 0);
     void addMockTable(const MockTableName & name, const MockColumnInfoVec & columnInfos, ColumnsWithTypeAndName columns, size_t concurrency_hint = 0);
+    void updateMockTableColumnData(const String & db, const String & table, ColumnsWithTypeAndName columns)
+    {
+        addMockTableColumnData(db, table, columns);
+    }
 
     /// mock DeltaMerge table scan
     void addMockDeltaMerge(const MockTableName & name, const MockColumnInfoVec & columnInfos, ColumnsWithTypeAndName columns);
@@ -196,9 +193,8 @@ public:
     void addMockDeltaMergeData(const String & db, const String & table, ColumnsWithTypeAndName columns);
 
     /// mock column exchange receiver
-    void addExchangeRelationSchema(String name, const MockColumnInfoVec & columnInfos);
-    void addExchangeReceiverColumnData(const String & name, ColumnsWithTypeAndName columns);
-    void addExchangeReceiver(const String & name, MockColumnInfoVec columnInfos, ColumnsWithTypeAndName columns);
+    void addExchangeReceiver(const String & name, const MockColumnInfoVec & columnInfos, const ColumnsWithTypeAndName & columns, size_t fine_grained_stream_count = 0, const MockColumnInfoVec & partition_column_infos = {});
+    void addExchangeReceiver(const String & name, const MockColumnInfoVec & columnInfos);
 
     DAGRequestBuilder scan(const String & db_name, const String & table_name);
     DAGRequestBuilder receive(const String & exchange_name, uint64_t fine_grained_shuffle_stream_count = 0);
@@ -211,6 +207,14 @@ public:
 
 private:
     static void assertMockInput(const MockColumnInfoVec & columnInfos, ColumnsWithTypeAndName columns);
+    void addExchangeReceiverColumnData(const String & name, ColumnsWithTypeAndName columns);
+    void addExchangeRelationSchema(String name, const MockColumnInfoVec & columnInfos);
+    void addMockTableSchema(const String & db, const String & table, const MockColumnInfoVec & columnInfos);
+    void addMockTableSchema(const MockTableName & name, const MockColumnInfoVec & columnInfos);
+    void addMockTableConcurrencyHint(const String & db, const String & table, size_t concurrency_hint);
+    void addMockTableConcurrencyHint(const MockTableName & name, size_t concurrency_hint);
+    void addMockTableColumnData(const String & db, const String & table, ColumnsWithTypeAndName columns);
+    void addMockTableColumnData(const MockTableName & name, ColumnsWithTypeAndName columns);
 
 private:
     size_t index;

--- a/dbms/src/TestUtils/mockExecutor.h
+++ b/dbms/src/TestUtils/mockExecutor.h
@@ -176,8 +176,8 @@ public:
         return DAGRequestBuilder(index);
     }
     /// mock column table scan
-    void addMockTable(const String & db, const String & table, const MockColumnInfoVec & columnInfos);
-    void addMockTable(const MockTableName & name, const MockColumnInfoVec & columnInfos);
+    void addMockTable(const String & db, const String & table, const MockColumnInfoVec & columnInfos, size_t concurrency_hint = 0);
+    void addMockTable(const MockTableName & name, const MockColumnInfoVec & columnInfos, size_t concurrency_hint = 0);
     void addMockTable(const String & db, const String & table, const MockColumnInfoVec & columnInfos, ColumnsWithTypeAndName columns, size_t concurrency_hint = 0);
     void addMockTable(const MockTableName & name, const MockColumnInfoVec & columnInfos, ColumnsWithTypeAndName columns, size_t concurrency_hint = 0);
     void updateMockTableColumnData(const String & db, const String & table, ColumnsWithTypeAndName columns)
@@ -194,7 +194,7 @@ public:
 
     /// mock column exchange receiver
     void addExchangeReceiver(const String & name, const MockColumnInfoVec & columnInfos, const ColumnsWithTypeAndName & columns, size_t fine_grained_stream_count = 0, const MockColumnInfoVec & partition_column_infos = {});
-    void addExchangeReceiver(const String & name, const MockColumnInfoVec & columnInfos);
+    void addExchangeReceiver(const String & name, const MockColumnInfoVec & columnInfos, size_t fine_grained_stream_count = 0, const MockColumnInfoVec & partition_column_infos = {});
 
     DAGRequestBuilder scan(const String & db_name, const String & table_name);
     DAGRequestBuilder receive(const String & exchange_name, uint64_t fine_grained_shuffle_stream_count = 0);

--- a/dbms/src/TestUtils/tests/gtest_mock_executors.cpp
+++ b/dbms/src/TestUtils/tests/gtest_mock_executors.cpp
@@ -30,7 +30,7 @@ public:
         context.addMockTable({"test_db", "test_table_1"}, {{"s1", TiDB::TP::TypeLong}, {"s2", TiDB::TP::TypeString}, {"s3", TiDB::TP::TypeString}});
         context.addMockTable({"test_db", "r_table"}, {{"r_a", TiDB::TP::TypeLong}, {"r_b", TiDB::TP::TypeString}, {"join_c", TiDB::TP::TypeString}});
         context.addMockTable({"test_db", "l_table"}, {{"l_a", TiDB::TP::TypeLong}, {"l_b", TiDB::TP::TypeString}, {"join_c", TiDB::TP::TypeString}});
-        context.addExchangeRelationSchema("sender_1", {{"s1", TiDB::TP::TypeString}, {"s2", TiDB::TP::TypeString}, {"s3", TiDB::TP::TypeString}});
+        context.addExchangeReceiver("sender_1", {{"s1", TiDB::TP::TypeString}, {"s2", TiDB::TP::TypeString}, {"s3", TiDB::TP::TypeString}});
     }
 };
 


### PR DESCRIPTION
Signed-off-by: xufei <xufei@pingcap.com>

### What problem does this PR solve?

Issue Number: ref #6528

Problem Summary:

### What is changed and how it works?
- move `NonJoinedBlockInputStream` into `HashJoinProbeBlockInputStream`
- support fine grain shuffle for mock exchange receiver
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
