### PR TITLE
save full safe_ts timestamp

### DIFF
--- a/dbms/src/Storages/Transaction/LearnerRead.cpp
+++ b/dbms/src/Storages/Transaction/LearnerRead.cpp
@@ -218,8 +218,8 @@ LearnerReadSnapshot doLearnerRead(
             {
                 const auto & region_to_query = regions_info[region_idx];
                 const RegionID region_id = region_to_query.region_id;
-                UInt64 physical_tso = read_index_tso >> TsoPhysicalShiftBits;
-                bool can_stale_read = mvcc_query_info->read_tso != std::numeric_limits<uint64_t>::max() && physical_tso < region_table.getSelfSafeTS(region_id);
+                // don't stale read in test scenarios.
+                bool can_stale_read = mvcc_query_info->read_tso != std::numeric_limits<uint64_t>::max() && read_index_tso <= region_table.getSelfSafeTS(region_id);
                 if (!can_stale_read)
                 {
                     if (auto ori_read_index = mvcc_query_info.getReadIndexRes(region_id); ori_read_index)

--- a/dbms/src/Storages/Transaction/RegionTable.cpp
+++ b/dbms/src/Storages/Transaction/RegionTable.cpp
@@ -502,7 +502,7 @@ bool RegionTable::isSafeTSLag(UInt64 region_id, UInt64 * leader_safe_ts, UInt64 
         *self_safe_ts = it->second->self_safe_ts.load(std::memory_order_relaxed);
     }
     LOG_TRACE(log, "region_id:{}, table_id:{}, leader_safe_ts:{}, self_safe_ts:{}", region_id, regions[region_id], *leader_safe_ts, *self_safe_ts);
-    return (*leader_safe_ts > *self_safe_ts) && (*leader_safe_ts - *self_safe_ts > SafeTsDiffThreshold);
+    return (*leader_safe_ts > *self_safe_ts) && ((*leader_safe_ts >> TsoPhysicalShiftBits) - (*self_safe_ts >> TsoPhysicalShiftBits) > SafeTsDiffThreshold);
 }
 
 UInt64 RegionTable::getSelfSafeTS(UInt64 region_id)

--- a/dbms/src/Storages/Transaction/tests/gtest_sync_status.cpp
+++ b/dbms/src/Storages/Transaction/tests/gtest_sync_status.cpp
@@ -195,7 +195,7 @@ void makeRegionsLag(size_t lag_num)
     auto & tmt = TiFlashTestEnv::getContext().getTMTContext();
     for (size_t i = 0; i < lag_num; i++)
     {
-        tmt.getRegionTable().updateSafeTS(i, RegionTable::SafeTsDiffThreshold + 1, 0);
+        tmt.getRegionTable().updateSafeTS(i, (RegionTable::SafeTsDiffThreshold + 1) << TsoPhysicalShiftBits, 0);
     }
 }
 


### PR DESCRIPTION
Signed-off-by: hehechen <awd123456sss@gmail.com>

### What problem does this PR solve?

Issue Number: close #6605

Problem Summary:

### What is changed and how it works?
After https://github.com/tikv/tikv/pull/13897 merged, full safe_ts timestamp will be passed to observer, so need to modify related code in TiFlash.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
