### PR TITLE
Removed redundant query id from tracingJson

### DIFF
--- a/dbms/src/Flash/Mpp/MPPTaskStatistics.cpp
+++ b/dbms/src/Flash/Mpp/MPPTaskStatistics.cpp
@@ -96,7 +96,7 @@ void MPPTaskStatistics::logTracingJson()
 {
     LOG_INFO(
         logger,
-        R"({{"query_tso":{},"task_id":{},"query_id":{},"is_root":{},"sender_executor_id":"{}","executors":{},"host":"{}")"
+        R"({{"query_tso":{},"task_id":{},"is_root":{},"sender_executor_id":"{}","executors":{},"host":"{}")"
         R"(,"task_init_timestamp":{},"task_start_timestamp":{},"task_end_timestamp":{})"
         R"(,"compile_start_timestamp":{},"compile_end_timestamp":{})"
         R"(,"read_wait_index_start_timestamp":{},"read_wait_index_end_timestamp":{})"
@@ -104,7 +104,6 @@ void MPPTaskStatistics::logTracingJson()
         R"(,"status":"{}","error_message":"{}","working_time":{},"memory_peak":{}}})",
         id.query_id.start_ts,
         id.task_id,
-        id.query_id.toString(),
         is_root,
         sender_executor_id,
         executor_statistics_collector.resToJson(),


### PR DESCRIPTION

Signed-off-by: yibin <huyibin@pingcap.com>

### What problem does this PR solve?

Issue Number: close #6587 

Problem Summary:

### What is changed and how it works?
The log is used by tracing tool, which expects the messge satisfy json format. It's ok to remove query id here, because the logger itself contains query id info already.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
   Check the changed log.
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
