### PR TITLE
Optimize `getPartitionEndRow` for window function

### DIFF
--- a/dbms/src/DataStreams/WindowBlockInputStream.cpp
+++ b/dbms/src/DataStreams/WindowBlockInputStream.cpp
@@ -240,9 +240,17 @@ Int64 WindowTransformAction::getPartitionEndRow(size_t block_rows)
     Int64 left = partition_end.row;
     Int64 right = block_rows - 1;
 
+    for (; left <= std::min(left + 9, right); ++left)
+    {
+        if (isDifferentFromPrevPartition(left))
+        {
+            return left;
+        }
+    }
+
     while (left <= right)
     {
-        Int64 middle = left + (right - left) / 2;
+        Int64 middle = (left + right) << 1;
         if (isDifferentFromPrevPartition(middle))
         {
             right = middle - 1;

--- a/dbms/src/DataStreams/WindowBlockInputStream.cpp
+++ b/dbms/src/DataStreams/WindowBlockInputStream.cpp
@@ -241,7 +241,7 @@ Int64 WindowTransformAction::getPartitionEndRow(size_t block_rows)
     Int64 right = block_rows - 1;
 
     // Compare several times first.
-    // It will benefit if the partition end is very close.
+    // It will speed up if the partition end is very close.
     for (; left <= std::min(left + 2, right); ++left)
     {
         if (isDifferentFromPrevPartition(left))
@@ -250,9 +250,9 @@ Int64 WindowTransformAction::getPartitionEndRow(size_t block_rows)
         }
     }
 
-    while (left < right)
+    while (left <= right)
     {
-        Int64 middle = (left + right) << 1;
+        Int64 middle = (left + right) >> 1;
         if (isDifferentFromPrevPartition(middle))
         {
             right = middle - 1;

--- a/dbms/src/DataStreams/WindowBlockInputStream.cpp
+++ b/dbms/src/DataStreams/WindowBlockInputStream.cpp
@@ -124,13 +124,13 @@ Block WindowBlockInputStream::readImpl()
 // Judge whether current_partition_row is end row of partition in current block
 bool WindowTransformAction::isDifferentFromPrevPartition(UInt64 current_partition_row)
 {
-    const auto reference_columns = inputAt(prev_frame_start);
-    const auto compared_columns = inputAt(partition_end);
+    const Columns & reference_columns = inputAt(prev_frame_start);
+    const Columns & compared_columns = inputAt(partition_end);
 
     for (size_t i = 0; i < partition_column_indices.size(); ++i)
     {
-        const auto reference_column = reference_columns[partition_column_indices[i]];
-        const auto * compared_column = compared_columns[partition_column_indices[i]].get();
+        const ColumnPtr & reference_column = reference_columns[partition_column_indices[i]];
+        const ColumnPtr & compared_column = compared_columns[partition_column_indices[i]];
         if (window_description.partition_by[i].collator)
         {
             if (compared_column->compareAt(current_partition_row,
@@ -240,7 +240,9 @@ Int64 WindowTransformAction::getPartitionEndRow(size_t block_rows)
     Int64 left = partition_end.row;
     Int64 right = block_rows - 1;
 
-    for (; left <= std::min(left + 9, right); ++left)
+    // Compare several times first.
+    // It will benefit if the partition end is very close.
+    for (; left <= std::min(left + 2, right); ++left)
     {
         if (isDifferentFromPrevPartition(left))
         {
@@ -248,7 +250,7 @@ Int64 WindowTransformAction::getPartitionEndRow(size_t block_rows)
         }
     }
 
-    while (left <= right)
+    while (left < right)
     {
         Int64 middle = (left + right) << 1;
         if (isDifferentFromPrevPartition(middle))


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #5900 

Problem Summary:
1. reduce some useless copy in `isDifferentFromPrevPartition`
2. compare several times first to speed up the case that the partition end is very close.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Test step
```sql
create table win(s varchar(20));
insert into 50000000 lines where `s` are all different.
explain analyze select row_number() over (partition by s) rn from win;
```

v6.5.0
```sql
mysql> explain analyze select row_number() over (partition by s) rn from win;
+------------------------------------+-------------+----------+--------------+---------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------+--------+------+
| id                                 | estRows     | actRows  | task         | access object | execution info                                                                                                                                                                                                                                                         | operator info                                                                                                  | memory | disk |
+------------------------------------+-------------+----------+--------------+---------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------+--------+------+
| TableReader_25                     | 50000000.00 | 50000000 | root         |               | time:18.7s, loops:48833, cop_task: {num: 769, max: 0s, min: 0s, avg: 0s, p95: 0s, copr_cache_hit_ratio: 0.00}                                                                                                                                                          | data:ExchangeSender_24                                                                                         | N/A    | N/A  |
| └─ExchangeSender_24                | 50000000.00 | 50000000 | mpp[tiflash] |               | tiflash_task:{time:18.7s, loops:768, threads:8}                                                                                                                                                                                                                        | ExchangeType: PassThrough                                                                                      | N/A    | N/A  |
|   └─Projection_8                   | 50000000.00 | 50000000 | mpp[tiflash] |               | tiflash_task:{time:18.5s, loops:768, threads:8}                                                                                                                                                                                                                        | Column#4, stream_count: 8                                                                                      | N/A    | N/A  |
|     └─Window_23                    | 50000000.00 | 50000000 | mpp[tiflash] |               | tiflash_task:{time:18.5s, loops:768, threads:8}                                                                                                                                                                                                                        | row_number()->Column#4 over(partition by test.win.s rows between current row and current row), stream_count: 8 | N/A    | N/A  |
|       └─Sort_14                    | 50000000.00 | 50000000 | mpp[tiflash] |               | tiflash_task:{time:7.85s, loops:768, threads:8}                                                                                                                                                                                                                        | test.win.s, stream_count: 8                                                                                    | N/A    | N/A  |
|         └─ExchangeReceiver_13      | 50000000.00 | 50000000 | mpp[tiflash] |               | tiflash_task:{time:203.9ms, loops:3992, threads:8}                                                                                                                                                                                                                     | stream_count: 8                                                                                                | N/A    | N/A  |
|           └─ExchangeSender_12      | 50000000.00 | 50000000 | mpp[tiflash] |               | tiflash_task:{time:1.62s, loops:789, threads:20}                                                                                                                                                                                                                       | ExchangeType: HashPartition, Hash Cols: [name: test.win.s, collate: utf8mb4_bin], stream_count: 8              | N/A    | N/A  |
|             └─TableFullScan_11     | 50000000.00 | 50000000 | mpp[tiflash] | table:win     | tiflash_task:{time:28.2ms, loops:789, threads:20}, tiflash_scan:{dtfile:{total_scanned_packs:6145, total_skipped_packs:0, total_scanned_rows:50000000, total_skipped_rows:0, total_rs_index_load_time: 1ms, total_read_time: 2843ms}, total_create_snapshot_time: 0ms} | keep order:false                                                                                               | N/A    | N/A  |
+------------------------------------+-------------+----------+--------------+---------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------+--------+------+
8 rows in set (18.66 sec)
```

This PR
```sql
mysql> explain analyze select row_number() over (partition by s) rn from win;
+------------------------------------+-------------+----------+--------------+---------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------+--------+------+
| id                                 | estRows     | actRows  | task         | access object | execution info                                                                                                                                                                                                                                                         | operator info                                                                                                  | memory | disk |
+------------------------------------+-------------+----------+--------------+---------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------+--------+------+
| TableReader_25                     | 50000000.00 | 50000000 | root         |               | time:8.71s, loops:48833, cop_task: {num: 769, max: 0s, min: 0s, avg: 0s, p95: 0s, copr_cache_hit_ratio: 0.00}                                                                                                                                                          | data:ExchangeSender_24                                                                                         | N/A    | N/A  |
| └─ExchangeSender_24                | 50000000.00 | 50000000 | mpp[tiflash] |               | tiflash_task:{time:8.71s, loops:768, threads:8}                                                                                                                                                                                                                        | ExchangeType: PassThrough                                                                                      | N/A    | N/A  |
|   └─Projection_8                   | 50000000.00 | 50000000 | mpp[tiflash] |               | tiflash_task:{time:8.55s, loops:768, threads:8}                                                                                                                                                                                                                        | Column#4, stream_count: 8                                                                                      | N/A    | N/A  |
|     └─Window_23                    | 50000000.00 | 50000000 | mpp[tiflash] |               | tiflash_task:{time:8.55s, loops:768, threads:8}                                                                                                                                                                                                                        | row_number()->Column#4 over(partition by test.win.s rows between current row and current row), stream_count: 8 | N/A    | N/A  |
|       └─Sort_14                    | 50000000.00 | 50000000 | mpp[tiflash] |               | tiflash_task:{time:7.88s, loops:768, threads:8}                                                                                                                                                                                                                        | test.win.s, stream_count: 8                                                                                    | N/A    | N/A  |
|         └─ExchangeReceiver_13      | 50000000.00 | 50000000 | mpp[tiflash] |               | tiflash_task:{time:263ms, loops:4016, threads:8}                                                                                                                                                                                                                       | stream_count: 8                                                                                                | N/A    | N/A  |
|           └─ExchangeSender_12      | 50000000.00 | 50000000 | mpp[tiflash] |               | tiflash_task:{time:1.73s, loops:789, threads:20}                                                                                                                                                                                                                       | ExchangeType: HashPartition, Hash Cols: [name: test.win.s, collate: utf8mb4_bin], stream_count: 8              | N/A    | N/A  |
|             └─TableFullScan_11     | 50000000.00 | 50000000 | mpp[tiflash] | table:win     | tiflash_task:{time:16.5ms, loops:789, threads:20}, tiflash_scan:{dtfile:{total_scanned_packs:6145, total_skipped_packs:0, total_scanned_rows:50000000, total_skipped_rows:0, total_rs_index_load_time: 0ms, total_read_time: 2331ms}, total_create_snapshot_time: 0ms} | keep order:false                                                                                               | N/A    | N/A  |
+------------------------------------+-------------+----------+--------------+---------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------+--------+------+
8 rows in set (8.71 sec)
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
