### PR TITLE
remove over_flow_row in aggregation

### DIFF
--- a/dbms/src/Core/BlockInfo.h
+++ b/dbms/src/Core/BlockInfo.h
@@ -26,12 +26,6 @@ class WriteBuffer;
   */
 struct BlockInfo
 {
-    /** is_overflows:
-      * After running GROUP BY ... WITH TOTALS with the max_rows_to_group_by and group_by_overflow_mode = 'any' settings,
-      *  a row is inserted in the separate block with aggregated values that have not passed max_rows_to_group_by.
-      * If it is such a block, then is_overflows is set to true for it.
-      */
-
     /** bucket_num:
       * When using the two-level aggregation method, data with different key groups are scattered across different buckets.
       * In this case, the bucket number is indicated here. It is used to optimize the merge for distributed aggregation.
@@ -39,7 +33,6 @@ struct BlockInfo
       */
 
 #define APPLY_FOR_BLOCK_INFO_FIELDS(M) \
-    M(bool, is_overflows, false, 1)    \
     M(Int32, bucket_num, -1, 2)
 
 #define DECLARE_FIELD(TYPE, NAME, DEFAULT, FIELD_NUM) \

--- a/dbms/src/DataStreams/MergingAggregatedMemoryEfficientBlockInputStream.h
+++ b/dbms/src/DataStreams/MergingAggregatedMemoryEfficientBlockInputStream.h
@@ -48,7 +48,6 @@ namespace DB
   * Each source can return one of the following block sequences:
   * 1. "unsplitted" block with bucket_num = -1;
   * 2. "splitted" (two_level) blocks with bucket_num from 0 to 255;
-  * In both cases, there may also be a block of "overflows" with bucket_num = -1 and is_overflows = true;
   *
   * We start from the convention that splitted blocks are always passed in the order of bucket_num.
   * That is, if a < b, then the bucket_num = a block goes before bucket_num = b.
@@ -56,7 +55,6 @@ namespace DB
   * - so that you do not need to read the blocks up front, but go all the way up by bucket_num.
   *
   * In this case, not all bucket_num from the range of 0..255 can be present.
-  * The overflow block can be presented in any order relative to other blocks (but it can be only one).
   *
   * It is necessary to combine these sequences of blocks and return the result as a sequence with the same properties.
   * That is, at the output, if there are "splitted" blocks in the sequence, then they should go in the order of bucket_num.
@@ -114,14 +112,12 @@ private:
     bool started = false;
     bool all_read = false;
     std::atomic<bool> has_two_level{false};
-    std::atomic<bool> has_overflows{false};
     int current_bucket_num = -1;
 
     struct Input
     {
         BlockInputStreamPtr stream;
         Block block;
-        Block overflow_block;
         std::vector<Block> splitted_blocks;
         bool is_exhausted = false;
 

--- a/dbms/src/DataStreams/MergingAndConvertingBlockInputStream.h
+++ b/dbms/src/DataStreams/MergingAndConvertingBlockInputStream.h
@@ -88,13 +88,12 @@ protected:
         {
             ++current_bucket_num;
 
-            if (first->type == AggregatedDataVariants::Type::without_key || aggregator.params.overflow_row)
+            if (first->type == AggregatedDataVariants::Type::without_key)
             {
                 aggregator.mergeWithoutKeyDataImpl(data);
                 return aggregator.prepareBlockAndFillWithoutKey(
                     *first,
-                    final,
-                    first->type != AggregatedDataVariants::Type::without_key);
+                    final);
             }
         }
 
@@ -202,8 +201,6 @@ private:
     {
         try
         {
-            /// TODO: add no_more_keys support maybe
-
             auto & merged_data = *data[0];
             auto method = merged_data.type;
             Block block;

--- a/dbms/src/DataStreams/ParallelAggregatingBlockInputStream.cpp
+++ b/dbms/src/DataStreams/ParallelAggregatingBlockInputStream.cpp
@@ -133,8 +133,7 @@ void ParallelAggregatingBlockInputStream::Handler::onBlock(Block & block, size_t
         parent.file_provider,
         parent.threads_data[thread_num].key_columns,
         parent.threads_data[thread_num].aggregate_columns,
-        parent.threads_data[thread_num].local_delta_memory,
-        parent.no_more_keys);
+        parent.threads_data[thread_num].local_delta_memory);
 
     parent.threads_data[thread_num].src_rows += block.rows();
     parent.threads_data[thread_num].src_bytes += block.bytes();
@@ -246,8 +245,7 @@ void ParallelAggregatingBlockInputStream::execute()
             file_provider,
             threads_data[0].key_columns,
             threads_data[0].aggregate_columns,
-            threads_data[0].local_delta_memory,
-            no_more_keys);
+            threads_data[0].local_delta_memory);
 }
 
 void ParallelAggregatingBlockInputStream::appendInfo(FmtBuffer & buffer) const

--- a/dbms/src/DataStreams/ParallelAggregatingBlockInputStream.h
+++ b/dbms/src/DataStreams/ParallelAggregatingBlockInputStream.h
@@ -76,13 +76,6 @@ private:
     size_t keys_size;
     size_t aggregates_size;
 
-    /** Used if there is a limit on the maximum number of rows in the aggregation,
-      *  and if group_by_overflow_mode == ANY.
-      * In this case, new keys are not added to the set, but aggregation is performed only by
-      *  keys that have already been added into the set.
-      */
-    bool no_more_keys = false;
-
     std::atomic<bool> executed{false};
 
     TemporaryFileStreams temporary_inputs;

--- a/dbms/src/DataStreams/SizeLimits.h
+++ b/dbms/src/DataStreams/SizeLimits.h
@@ -23,13 +23,8 @@ namespace DB
 /// What to do if the limit is exceeded.
 enum class OverflowMode
 {
-    THROW     = 0,    /// Throw exception.
-    BREAK     = 1,    /// Abort query execution, return what is.
-
-    /** Only for GROUP BY: do not add new rows to the set,
-      * but continue to aggregate for keys that are already in the set.
-      */
-    ANY       = 2,
+    THROW = 0, /// Throw exception.
+    BREAK = 1, /// Abort query execution, return what is.
 };
 
 
@@ -42,10 +37,13 @@ struct SizeLimits
 
     SizeLimits() {}
     SizeLimits(UInt64 max_rows, UInt64 max_bytes, OverflowMode overflow_mode)
-        : max_rows(max_rows), max_bytes(max_bytes), overflow_mode(overflow_mode) {}
+        : max_rows(max_rows)
+        , max_bytes(max_bytes)
+        , overflow_mode(overflow_mode)
+    {}
 
     /// Check limits. If exceeded, return false or throw an exception, depending on overflow_mode.
     bool check(UInt64 rows, UInt64 bytes, const char * what, int exception_code) const;
 };
 
-}
+} // namespace DB

--- a/dbms/src/DataStreams/TotalsHavingBlockInputStream.cpp
+++ b/dbms/src/DataStreams/TotalsHavingBlockInputStream.cpp
@@ -43,7 +43,7 @@ TotalsHavingBlockInputStream::TotalsHavingBlockInputStream(
     current_totals.reserve(source_header.columns());
     for (const auto & elem : source_header)
     {
-        if (const ColumnAggregateFunction * column = typeid_cast<const ColumnAggregateFunction *>(elem.column.get()))
+        if (const auto * column = typeid_cast<const ColumnAggregateFunction *>(elem.column.get()))
         {
             /// Create ColumnAggregateFunction with initial aggregate function state.
 
@@ -71,7 +71,7 @@ static void finalize(Block & block)
     for (size_t i = 0; i < block.columns(); ++i)
     {
         ColumnWithTypeAndName & current = block.getByPosition(i);
-        const DataTypeAggregateFunction * unfinalized_type = typeid_cast<const DataTypeAggregateFunction *>(current.type.get());
+        const auto * unfinalized_type = typeid_cast<const DataTypeAggregateFunction *>(current.type.get());
 
         if (unfinalized_type)
         {
@@ -113,7 +113,7 @@ Block TotalsHavingBlockInputStream::readImpl()
     Block finalized;
     Block block;
 
-    while (1)
+    while (true)
     {
         block = children[0]->read();
 
@@ -178,7 +178,7 @@ void TotalsHavingBlockInputStream::addToTotals(const Block & block, const IColum
     {
         const ColumnWithTypeAndName & current = block.getByPosition(i);
 
-        if (const ColumnAggregateFunction * column = typeid_cast<const ColumnAggregateFunction *>(current.column.get()))
+        if (const auto * column = typeid_cast<const ColumnAggregateFunction *>(current.column.get()))
         {
             auto & target = typeid_cast<ColumnAggregateFunction &>(*current_totals[i]);
             IAggregateFunction * function = target.getAggregateFunction().get();

--- a/dbms/src/DataStreams/TotalsHavingBlockInputStream.h
+++ b/dbms/src/DataStreams/TotalsHavingBlockInputStream.h
@@ -36,8 +36,9 @@ public:
     /// expression may be nullptr
     TotalsHavingBlockInputStream(
         const BlockInputStreamPtr & input_,
-        bool overflow_row_, const ExpressionActionsPtr & expression_,
-        const std::string & filter_column_, TotalsMode totals_mode_, double auto_include_threshold_);
+        const ExpressionActionsPtr & expression_,
+        const std::string & filter_column_,
+        TotalsMode totals_mode_);
 
     String getName() const override { return "TotalsHaving"; }
 
@@ -49,18 +50,11 @@ protected:
     Block readImpl() override;
 
 private:
-    bool overflow_row;
     ExpressionActionsPtr expression;
     String filter_column_name;
     TotalsMode totals_mode;
-    double auto_include_threshold;
     size_t passed_keys = 0;
     size_t total_keys = 0;
-
-    /** Here are the values that did not pass max_rows_to_group_by.
-      * They are added or not added to the current_totals, depending on the totals_mode.
-      */
-    Block overflow_aggregates;
 
     /// Here, total values are accumulated. After the work is finished, they will be placed in IProfilingBlockInputStream::totals.
     MutableColumns current_totals;
@@ -71,4 +65,4 @@ private:
     void addToTotals(const Block & block, const IColumn::Filter * filter);
 };
 
-}
+} // namespace DB

--- a/dbms/src/Flash/Coprocessor/AggregationInterpreterHelper.cpp
+++ b/dbms/src/Flash/Coprocessor/AggregationInterpreterHelper.cpp
@@ -97,7 +97,6 @@ Aggregator::Params buildParams(
         before_agg_header,
         keys,
         aggregate_descriptions,
-        false,
         settings.max_rows_to_group_by,
         settings.group_by_overflow_mode,
         allow_to_use_two_level_group_by ? settings.group_by_two_level_threshold : SettingUInt64(0),

--- a/dbms/src/Flash/tests/gtest_spill_sort.cpp
+++ b/dbms/src/Flash/tests/gtest_spill_sort.cpp
@@ -55,7 +55,7 @@ try
                        .scan("spill_sort_test", "simple_table")
                        .topN(order_by_items, limit_size)
                        .build(context);
-    context.context.setSetting("max_block_size", Field(max_block_size));
+    context.context.setSetting("max_block_size", Field(static_cast<UInt64>(max_block_size)));
     /// disable spill
     context.context.setSetting("max_bytes_before_external_sort", Field(static_cast<UInt64>(0)));
     auto ref_columns = executeStreams(request, original_max_streams);

--- a/dbms/src/Interpreters/Aggregator.cpp
+++ b/dbms/src/Interpreters/Aggregator.cpp
@@ -756,7 +756,7 @@ bool Aggregator::executeOnBlock(
 
     size_t num_rows = block.rows();
 
-    if ((result.type == AggregatedDataVariants::Type::without_key) && !result.without_key)
+    if (result.type == AggregatedDataVariants::Type::without_key && !result.without_key)
     {
         AggregateDataPtr place = result.aggregates_pool->alignedAlloc(total_size_of_aggregate_states, align_aggregate_states);
         createAggregateStates(place);
@@ -1718,68 +1718,6 @@ std::unique_ptr<IBlockInputStream> Aggregator::mergeAndConvertToBlocks(
 
     return std::make_unique<MergingAndConvertingBlockInputStream>(*this, non_empty_data, final, max_threads);
 }
-
-
-ManyAggregatedDataVariants Aggregator::prepareVariantsToMerge(ManyAggregatedDataVariants & data_variants) const
-{
-    if (data_variants.empty())
-        throw Exception("Empty data passed to Aggregator::mergeAndConvertToBlocks.", ErrorCodes::EMPTY_DATA_PASSED);
-
-    LOG_TRACE(log, "Merging aggregated data");
-
-    ManyAggregatedDataVariants non_empty_data;
-    non_empty_data.reserve(data_variants.size());
-    for (auto & data : data_variants)
-        if (!data->empty())
-            non_empty_data.push_back(data);
-
-    if (non_empty_data.empty())
-        return {};
-
-    if (non_empty_data.size() > 1)
-    {
-        /// Sort the states in descending order so that the merge is more efficient (since all states are merged into the first).
-        std::sort(non_empty_data.begin(), non_empty_data.end(), [](const AggregatedDataVariantsPtr & lhs, const AggregatedDataVariantsPtr & rhs) {
-            return lhs->size() > rhs->size();
-        });
-    }
-
-    /// If at least one of the options is two-level, then convert all the options into two-level ones, if there are not such.
-    /// Note - perhaps it would be more optimal not to convert single-level versions before the merge, but merge them separately, at the end.
-
-    bool has_at_least_one_two_level = false;
-    for (const auto & variant : non_empty_data)
-    {
-        if (variant->isTwoLevel())
-        {
-            has_at_least_one_two_level = true;
-            break;
-        }
-    }
-
-    if (has_at_least_one_two_level)
-        for (auto & variant : non_empty_data)
-            if (!variant->isTwoLevel())
-                variant->convertToTwoLevel();
-
-    AggregatedDataVariantsPtr & first = non_empty_data[0];
-
-    for (size_t i = 1, size = non_empty_data.size(); i < size; ++i)
-    {
-        if (first->type != non_empty_data[i]->type)
-            throw Exception("Cannot merge different aggregated data variants.", ErrorCodes::CANNOT_MERGE_DIFFERENT_AGGREGATED_DATA_VARIANTS);
-
-        /** Elements from the remaining sets can be moved to the first data set.
-          * Therefore, it must own all the arenas of all other sets.
-          */
-        first->aggregates_pools.insert(first->aggregates_pools.end(),
-                                       non_empty_data[i]->aggregates_pools.begin(),
-                                       non_empty_data[i]->aggregates_pools.end());
-    }
-
-    return non_empty_data;
-}
-
 
 template <typename Method, typename Table>
 void NO_INLINE Aggregator::mergeStreamsImplCase(

--- a/dbms/src/Interpreters/Aggregator.h
+++ b/dbms/src/Interpreters/Aggregator.h
@@ -728,31 +728,6 @@ struct AggregatedDataVariants : private boost::noncopyable
         }
     }
 
-    /// The size without taking into account the row in which data is written for the calculation of TOTALS.
-    size_t sizeWithoutOverflowRow() const
-    {
-        switch (type)
-        {
-        case Type::EMPTY:
-            return 0;
-        case Type::without_key:
-            return 1;
-
-#define M(NAME, IS_TWO_LEVEL)                                                                              \
-    case Type::NAME:                                                                                       \
-    {                                                                                                      \
-        const auto * ptr = reinterpret_cast<const AggregationMethodName(NAME) *>(aggregation_method_impl); \
-        return ptr->data.size();                                                                           \
-    }
-
-            APPLY_FOR_AGGREGATED_VARIANTS(M)
-#undef M
-
-        default:
-            throw Exception("Unknown aggregated data variant.", ErrorCodes::UNKNOWN_AGGREGATED_DATA_VARIANT);
-        }
-    }
-
     const char * getMethodName() const
     {
         return getMethodName(type);
@@ -882,13 +857,9 @@ using ManyAggregatedDataVariants = std::vector<AggregatedDataVariantsPtr>;
 /** How are "total" values calculated with WITH TOTALS?
   * (For more details, see TotalsHavingBlockInputStream.)
   *
-  * In the absence of group_by_overflow_mode = 'any', the data is aggregated as usual, but the states of the aggregate functions are not finalized.
+  * The data is aggregated as usual, but the states of the aggregate functions are not finalized.
   * Later, the aggregate function states for all rows (passed through HAVING) are merged into one - this will be TOTALS.
   *
-  * If there is group_by_overflow_mode = 'any', the data is aggregated as usual, except for the keys that did not fit in max_rows_to_group_by.
-  * For these keys, the data is aggregated into one additional row - see below under the names `overflow_row`, `overflows`...
-  * Later, the aggregate function states for all rows (passed through HAVING) are merged into one,
-  *  also overflow_row is added or not added (depending on the totals_mode setting) also - this will be TOTALS.
   */
 
 
@@ -912,7 +883,6 @@ public:
         Int64 local_delta_memory = 0;
 
         /// The settings of approximate calculation of GROUP BY.
-        const bool overflow_row; /// Do we need to put into AggregatedDataVariants::without_key aggregates for keys that are not in max_rows_to_group_by.
         const size_t max_rows_to_group_by;
         const OverflowMode group_by_overflow_mode;
 
@@ -938,7 +908,6 @@ public:
             const Block & src_header_,
             const ColumnNumbers & keys_,
             const AggregateDescriptions & aggregates_,
-            bool overflow_row_,
             size_t max_rows_to_group_by_,
             OverflowMode group_by_overflow_mode_,
             size_t group_by_two_level_threshold_,
@@ -952,7 +921,6 @@ public:
             , aggregates(aggregates_)
             , keys_size(keys.size())
             , aggregates_size(aggregates.size())
-            , overflow_row(overflow_row_)
             , max_rows_to_group_by(max_rows_to_group_by_)
             , group_by_overflow_mode(group_by_overflow_mode_)
             , group_by_two_level_threshold(group_by_two_level_threshold_)
@@ -968,9 +936,8 @@ public:
         Params(const Block & intermediate_header_,
                const ColumnNumbers & keys_,
                const AggregateDescriptions & aggregates_,
-               bool overflow_row_,
                const TiDB::TiDBCollators & collators_ = TiDB::dummy_collators)
-            : Params(Block(), keys_, aggregates_, overflow_row_, 0, OverflowMode::THROW, 0, 0, 0, false, "", collators_)
+            : Params(Block(), keys_, aggregates_, 0, OverflowMode::THROW, 0, 0, 0, false, "", collators_)
         {
             intermediate_header = intermediate_header_;
         }
@@ -1009,12 +976,9 @@ public:
         const FileProviderPtr & file_provider,
         ColumnRawPtrs & key_columns,
         AggregateColumns & aggregate_columns, /// Passed to not create them anew for each block
-        Int64 & local_delta_memory,
-        bool & no_more_keys);
+        Int64 & local_delta_memory);
 
     /** Convert the aggregation data structure into a block.
-      * If overflow_row = true, then aggregates for rows that are not included in max_rows_to_group_by are put in the first block.
-      *
       * If final = false, then ColumnAggregateFunction is created as the aggregation columns with the state of the calculations,
       *  which can then be combined with other states (for distributed query processing).
       * If final = true, then columns with ready values are created as aggregate columns.
@@ -1035,9 +999,6 @@ public:
     using BucketToBlocks = std::map<Int32, BlocksList>;
 
     /// Merge several partially aggregated blocks into one.
-    /// Precondition: for all blocks block.info.is_overflows flag must be the same.
-    /// (either all blocks are from overflow data or none blocks are).
-    /// The resulting block has the same value of is_overflows flag.
     Block mergeBlocks(BlocksList & blocks, bool final);
 
     /** Split block with partially-aggregated data to many blocks, as if two-level method of aggregation was used.
@@ -1151,19 +1112,15 @@ protected:
         size_t rows,
         ColumnRawPtrs & key_columns,
         TiDB::TiDBCollators & collators,
-        AggregateFunctionInstruction * aggregate_instructions,
-        bool no_more_keys,
-        AggregateDataPtr overflow_row) const;
+        AggregateFunctionInstruction * aggregate_instructions) const;
 
-    /// Specialization for a particular value no_more_keys.
-    template <bool no_more_keys, typename Method>
+    template <typename Method>
     void executeImplBatch(
         Method & method,
         typename Method::State & state,
         Arena * aggregates_pool,
         size_t rows,
-        AggregateFunctionInstruction * aggregate_instructions,
-        AggregateDataPtr overflow_row) const;
+        AggregateFunctionInstruction * aggregate_instructions) const;
 
     /// For case when there are no keys (all aggregate into one row).
     static void executeWithoutKeyImpl(
@@ -1182,21 +1139,6 @@ protected:
     /// Merge data from hash table `src` into `dst`.
     template <typename Method, typename Table>
     void mergeDataImpl(
-        Table & table_dst,
-        Table & table_src,
-        Arena * arena) const;
-
-    /// Merge data from hash table `src` into `dst`, but only for keys that already exist in dst. In other cases, merge the data into `overflows`.
-    template <typename Method, typename Table>
-    void mergeDataNoMoreKeysImpl(
-        Table & table_dst,
-        AggregatedDataWithoutKey & overflows,
-        Table & table_src,
-        Arena * arena) const;
-
-    /// Same, but ignores the rest of the keys.
-    template <typename Method, typename Table>
-    void mergeDataOnlyExistingKeysImpl(
         Table & table_dst,
         Table & table_src,
         Arena * arena) const;
@@ -1260,7 +1202,7 @@ protected:
         Columns & materialized_columns,
         AggregateFunctionInstructions & instructions);
 
-    Block prepareBlockAndFillWithoutKey(AggregatedDataVariants & data_variants, bool final, bool is_overflows) const;
+    Block prepareBlockAndFillWithoutKey(AggregatedDataVariants & data_variants, bool final) const;
     Block prepareBlockAndFillSingleLevel(AggregatedDataVariants & data_variants, bool final) const;
     BlocksList prepareBlocksAndFillTwoLevel(
         AggregatedDataVariants & data_variants,
@@ -1276,22 +1218,19 @@ protected:
         ThreadPoolManager * thread_pool,
         size_t max_threads) const;
 
-    template <bool no_more_keys, typename Method, typename Table>
+    template <typename Method, typename Table>
     void mergeStreamsImplCase(
         Block & block,
         Arena * aggregates_pool,
         Method & method,
-        Table & data,
-        AggregateDataPtr overflow_row) const;
+        Table & data) const;
 
     template <typename Method, typename Table>
     void mergeStreamsImpl(
         Block & block,
         Arena * aggregates_pool,
         Method & method,
-        Table & data,
-        AggregateDataPtr overflow_row,
-        bool no_more_keys) const;
+        Table & data) const;
 
     void mergeWithoutKeyStreamsImpl(
         Block & block,
@@ -1322,9 +1261,8 @@ protected:
       * If it is exceeded, then, depending on the group_by_overflow_mode, either
       * - throws an exception;
       * - returns false, which means that execution must be aborted;
-      * - sets the variable no_more_keys to true.
       */
-    bool checkLimits(size_t result_size, bool & no_more_keys) const;
+    bool checkLimits(size_t result_size) const;
 };
 
 /** Get the aggregation variant by its type. */

--- a/dbms/src/Interpreters/Aggregator.h
+++ b/dbms/src/Interpreters/Aggregator.h
@@ -985,8 +985,6 @@ public:
       */
     BlocksList convertToBlocks(AggregatedDataVariants & data_variants, bool final, size_t max_threads) const;
 
-    ManyAggregatedDataVariants prepareVariantsToMerge(ManyAggregatedDataVariants & data_variants) const;
-
     /** Merge several aggregation data structures and output the result as a block stream.
       */
     std::unique_ptr<IBlockInputStream> mergeAndConvertToBlocks(ManyAggregatedDataVariants & data_variants, bool final, size_t max_threads) const;

--- a/dbms/src/Interpreters/InterpreterSelectQuery.h
+++ b/dbms/src/Interpreters/InterpreterSelectQuery.h
@@ -174,9 +174,9 @@ private:
     QueryProcessingStage::Enum executeFetchColumns(Pipeline & pipeline, bool dry_run);
 
     void executeWhere(Pipeline & pipeline, const ExpressionActionsPtr & expression);
-    void executeAggregation(Pipeline & pipeline, const ExpressionActionsPtr & expression, const FileProviderPtr & file_provider, bool overflow_row, bool final);
-    void executeMergeAggregated(Pipeline & pipeline, bool overflow_row, bool final);
-    void executeTotalsAndHaving(Pipeline & pipeline, bool has_having, const ExpressionActionsPtr & expression, bool overflow_row);
+    void executeAggregation(Pipeline & pipeline, const ExpressionActionsPtr & expression, const FileProviderPtr & file_provider, bool final);
+    void executeMergeAggregated(Pipeline & pipeline, bool final);
+    void executeTotalsAndHaving(Pipeline & pipeline, bool has_having, const ExpressionActionsPtr & expression);
     void executeHaving(Pipeline & pipeline, const ExpressionActionsPtr & expression);
     void executeExpression(Pipeline & pipeline, const ExpressionActionsPtr & expression);
     void executeOrder(Pipeline & pipeline);

--- a/dbms/src/Interpreters/SettingsCommon.h
+++ b/dbms/src/Interpreters/SettingsCommon.h
@@ -711,27 +711,20 @@ public:
             return OverflowMode::THROW;
         if (s == "break")
             return OverflowMode::BREAK;
-        if (s == "any")
-            return OverflowMode::ANY;
 
         throw Exception("Unknown overflow mode: '" + s + "', must be one of 'throw', 'break', 'any'", ErrorCodes::UNKNOWN_OVERFLOW_MODE);
     }
 
     static OverflowMode getOverflowMode(const String & s)
     {
-        OverflowMode mode = getOverflowModeForGroupBy(s);
-
-        if (mode == OverflowMode::ANY && !enable_mode_any)
-            throw Exception("Illegal overflow mode: 'any' is only for 'group_by_overflow_mode'", ErrorCodes::ILLEGAL_OVERFLOW_MODE);
-
-        return mode;
+        return getOverflowModeForGroupBy(s);
     }
 
     String toString() const
     {
-        const char * strings[] = {"throw", "break", "any"};
+        const char * strings[] = {"throw", "break"};
 
-        if (value < OverflowMode::THROW || value > OverflowMode::ANY)
+        if (value < OverflowMode::THROW || value > OverflowMode::BREAK)
             throw Exception("Unknown overflow mode", ErrorCodes::UNKNOWN_OVERFLOW_MODE);
 
         return strings[static_cast<size_t>(value)];


### PR DESCRIPTION
Signed-off-by: xufei <xufei@pingcap.com>

### What problem does this PR solve?

Issue Number: ref #6528

Problem Summary:

### What is changed and how it works?
remove `over_flow_row` related logical in Aggregation, since we should never use it.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
