### PR TITLE
change the time unit of measurement in ScanContext

### DIFF
--- a/dbms/src/Flash/Coprocessor/tests/gtest_ti_remote_block_inputstream.cpp
+++ b/dbms/src/Flash/Coprocessor/tests/gtest_ti_remote_block_inputstream.cpp
@@ -75,9 +75,9 @@ struct MockWriter
         summary.scan_context->total_dmfile_skipped_packs = 2;
         summary.scan_context->total_dmfile_scanned_rows = 8000;
         summary.scan_context->total_dmfile_skipped_rows = 15000;
-        summary.scan_context->total_dmfile_rough_set_index_load_time_ms = 10;
-        summary.scan_context->total_dmfile_read_time_ms = 200;
-        summary.scan_context->total_create_snapshot_time_ms = 5;
+        summary.scan_context->total_dmfile_rough_set_index_load_time_ns = 10;
+        summary.scan_context->total_dmfile_read_time_ns = 200;
+        summary.scan_context->total_create_snapshot_time_ns = 5;
         return summary;
     }
 

--- a/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter.h
@@ -292,7 +292,7 @@ private:
         Stopwatch watch;
         loadIndex(param.indexes, dmfile, file_provider, index_cache, set_cache_if_miss, col_id, read_limiter);
 
-        scan_context->total_dmfile_rough_set_index_load_time_ms += watch.elapsedMilliseconds();
+        scan_context->total_dmfile_rough_set_index_load_time_ns += watch.elapsed();
     }
 
 private:

--- a/dbms/src/Storages/DeltaMerge/File/DMFileReader.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileReader.cpp
@@ -318,7 +318,7 @@ Block DMFileReader::read()
 {
     Stopwatch watch;
     SCOPE_EXIT(
-        scan_context->total_dmfile_read_time_ms += watch.elapsedMilliseconds(););
+        scan_context->total_dmfile_read_time_ns += watch.elapsed(););
 
     // Go to next available pack.
     size_t skip_rows;

--- a/dbms/src/Storages/DeltaMerge/ScanContext.h
+++ b/dbms/src/Storages/DeltaMerge/ScanContext.h
@@ -41,9 +41,9 @@ public:
     /// sum of skipped rows in dmfiles(both stable and ColumnFileBig) among this query
     std::atomic<uint64_t> total_dmfile_skipped_rows{0};
 
-    std::atomic<uint64_t> total_dmfile_rough_set_index_load_time_ms{0};
-    std::atomic<uint64_t> total_dmfile_read_time_ms{0};
-    std::atomic<uint64_t> total_create_snapshot_time_ms{0};
+    std::atomic<uint64_t> total_dmfile_rough_set_index_load_time_ns{0};
+    std::atomic<uint64_t> total_dmfile_read_time_ns{0};
+    std::atomic<uint64_t> total_create_snapshot_time_ns{0};
 
     ScanContext() = default;
 
@@ -53,9 +53,9 @@ public:
         total_dmfile_skipped_packs = tiflash_scan_context_pb.total_dmfile_skipped_packs();
         total_dmfile_scanned_rows = tiflash_scan_context_pb.total_dmfile_scanned_rows();
         total_dmfile_skipped_rows = tiflash_scan_context_pb.total_dmfile_skipped_rows();
-        total_dmfile_rough_set_index_load_time_ms = tiflash_scan_context_pb.total_dmfile_rough_set_index_load_time_ms();
-        total_dmfile_read_time_ms = tiflash_scan_context_pb.total_dmfile_read_time_ms();
-        total_create_snapshot_time_ms = tiflash_scan_context_pb.total_create_snapshot_time_ms();
+        total_dmfile_rough_set_index_load_time_ns = tiflash_scan_context_pb.total_dmfile_rough_set_index_load_time_ns();
+        total_dmfile_read_time_ns = tiflash_scan_context_pb.total_dmfile_read_time_ns();
+        total_create_snapshot_time_ns = tiflash_scan_context_pb.total_create_snapshot_time_ns();
     }
 
     tipb::TiFlashScanContext serialize()
@@ -65,9 +65,9 @@ public:
         tiflash_scan_context_pb.set_total_dmfile_skipped_packs(total_dmfile_skipped_packs);
         tiflash_scan_context_pb.set_total_dmfile_scanned_rows(total_dmfile_scanned_rows);
         tiflash_scan_context_pb.set_total_dmfile_skipped_rows(total_dmfile_skipped_rows);
-        tiflash_scan_context_pb.set_total_dmfile_rough_set_index_load_time_ms(total_dmfile_rough_set_index_load_time_ms);
-        tiflash_scan_context_pb.set_total_dmfile_read_time_ms(total_dmfile_read_time_ms);
-        tiflash_scan_context_pb.set_total_create_snapshot_time_ms(total_create_snapshot_time_ms);
+        tiflash_scan_context_pb.set_total_dmfile_rough_set_index_load_time_ns(total_dmfile_rough_set_index_load_time_ns);
+        tiflash_scan_context_pb.set_total_dmfile_read_time_ns(total_dmfile_read_time_ns);
+        tiflash_scan_context_pb.set_total_create_snapshot_time_ns(total_create_snapshot_time_ns);
         return tiflash_scan_context_pb;
     }
 
@@ -77,9 +77,9 @@ public:
         total_dmfile_skipped_packs += other.total_dmfile_skipped_packs;
         total_dmfile_scanned_rows += other.total_dmfile_scanned_rows;
         total_dmfile_skipped_rows += other.total_dmfile_skipped_rows;
-        total_dmfile_rough_set_index_load_time_ms += other.total_dmfile_rough_set_index_load_time_ms;
-        total_dmfile_read_time_ms += other.total_dmfile_read_time_ms;
-        total_create_snapshot_time_ms += other.total_create_snapshot_time_ms;
+        total_dmfile_rough_set_index_load_time_ns += other.total_dmfile_rough_set_index_load_time_ns;
+        total_dmfile_read_time_ns += other.total_dmfile_read_time_ns;
+        total_create_snapshot_time_ns += other.total_create_snapshot_time_ns;
     }
 
     void merge(const tipb::TiFlashScanContext & other)
@@ -88,9 +88,9 @@ public:
         total_dmfile_skipped_packs += other.total_dmfile_skipped_packs();
         total_dmfile_scanned_rows += other.total_dmfile_scanned_rows();
         total_dmfile_skipped_rows += other.total_dmfile_skipped_rows();
-        total_dmfile_rough_set_index_load_time_ms += other.total_dmfile_rough_set_index_load_time_ms();
-        total_dmfile_read_time_ms += other.total_dmfile_read_time_ms();
-        total_create_snapshot_time_ms += other.total_create_snapshot_time_ms();
+        total_dmfile_rough_set_index_load_time_ns += other.total_dmfile_rough_set_index_load_time_ns();
+        total_dmfile_read_time_ns += other.total_dmfile_read_time_ns();
+        total_create_snapshot_time_ns += other.total_create_snapshot_time_ns();
     }
 };
 

--- a/dbms/src/Storages/DeltaMerge/ScanContext.h
+++ b/dbms/src/Storages/DeltaMerge/ScanContext.h
@@ -53,9 +53,9 @@ public:
         total_dmfile_skipped_packs = tiflash_scan_context_pb.total_dmfile_skipped_packs();
         total_dmfile_scanned_rows = tiflash_scan_context_pb.total_dmfile_scanned_rows();
         total_dmfile_skipped_rows = tiflash_scan_context_pb.total_dmfile_skipped_rows();
-        total_dmfile_rough_set_index_load_time_ns = tiflash_scan_context_pb.total_dmfile_rough_set_index_load_time_ns();
-        total_dmfile_read_time_ns = tiflash_scan_context_pb.total_dmfile_read_time_ns();
-        total_create_snapshot_time_ns = tiflash_scan_context_pb.total_create_snapshot_time_ns();
+        total_dmfile_rough_set_index_load_time_ns = tiflash_scan_context_pb.total_dmfile_rough_set_index_load_time_ms() * 1000000;
+        total_dmfile_read_time_ns = tiflash_scan_context_pb.total_dmfile_read_time_ms() * 1000000;
+        total_create_snapshot_time_ns = tiflash_scan_context_pb.total_create_snapshot_time_ms() * 1000000;
     }
 
     tipb::TiFlashScanContext serialize()
@@ -65,9 +65,9 @@ public:
         tiflash_scan_context_pb.set_total_dmfile_skipped_packs(total_dmfile_skipped_packs);
         tiflash_scan_context_pb.set_total_dmfile_scanned_rows(total_dmfile_scanned_rows);
         tiflash_scan_context_pb.set_total_dmfile_skipped_rows(total_dmfile_skipped_rows);
-        tiflash_scan_context_pb.set_total_dmfile_rough_set_index_load_time_ns(total_dmfile_rough_set_index_load_time_ns);
-        tiflash_scan_context_pb.set_total_dmfile_read_time_ns(total_dmfile_read_time_ns);
-        tiflash_scan_context_pb.set_total_create_snapshot_time_ns(total_create_snapshot_time_ns);
+        tiflash_scan_context_pb.set_total_dmfile_rough_set_index_load_time_ms(total_dmfile_rough_set_index_load_time_ns / 1000000);
+        tiflash_scan_context_pb.set_total_dmfile_read_time_ms(total_dmfile_read_time_ns / 1000000);
+        tiflash_scan_context_pb.set_total_create_snapshot_time_ms(total_create_snapshot_time_ns / 1000000);
         return tiflash_scan_context_pb;
     }
 
@@ -88,9 +88,9 @@ public:
         total_dmfile_skipped_packs += other.total_dmfile_skipped_packs();
         total_dmfile_scanned_rows += other.total_dmfile_scanned_rows();
         total_dmfile_skipped_rows += other.total_dmfile_skipped_rows();
-        total_dmfile_rough_set_index_load_time_ns += other.total_dmfile_rough_set_index_load_time_ns();
-        total_dmfile_read_time_ns += other.total_dmfile_read_time_ns();
-        total_create_snapshot_time_ns += other.total_create_snapshot_time_ns();
+        total_dmfile_rough_set_index_load_time_ns += other.total_dmfile_rough_set_index_load_time_ms() * 1000000;
+        total_dmfile_read_time_ns += other.total_dmfile_read_time_ms() * 1000000;
+        total_create_snapshot_time_ns += other.total_create_snapshot_time_ms() * 1000000;
     }
 };
 

--- a/dbms/src/Storages/DeltaMerge/Segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/Segment.cpp
@@ -562,7 +562,7 @@ SegmentSnapshotPtr Segment::createSnapshot(const DMContext & dm_context, bool fo
 {
     Stopwatch watch;
     SCOPE_EXIT(
-        dm_context.scan_context->total_create_snapshot_time_ms += watch.elapsedMilliseconds(););
+        dm_context.scan_context->total_create_snapshot_time_ns += watch.elapsed(););
     auto delta_snap = delta->createSnapshot(dm_context, for_update, metric);
     auto stable_snap = stable->createSnapshot();
     if (!delta_snap || !stable_snap)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #5926

Problem Summary:

### What is changed and how it works?

Change the time unit of measurement in ScanContext.
Choose ns instead of ms as the time unit can improve the accuracy of statistics.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
