### PR TITLE
Read node support build delta index in background threads

### DIFF
--- a/dbms/src/Common/TiFlashMetrics.h
+++ b/dbms/src/Common/TiFlashMetrics.h
@@ -90,10 +90,12 @@ namespace DB
         F(type_mpp_establish_conn, {{"type", "mpp_tunnel"}}),                                                                             \
         F(type_mpp_establish_conn_local, {{"type", "mpp_tunnel_local"}}),                                                                 \
         F(type_cancel_mpp_task, {{"type", "cancel_mpp_task"}}))                                                                           \
-    M(tiflash_disaggregated_breakdown_duration_seconds, "", Histogram,                                                                      \
+    M(tiflash_disaggregated_breakdown_duration_seconds, "", Histogram,                                                                    \
         F(type_establish, {{"type", "establish"}}, ExpBuckets{0.001, 2, 20}),   \
         F(type_build_task, {{"type", "build_task"}}, ExpBuckets{0.001, 2, 20}), \
-        F(type_fetch_page, {{"type", "fetch_page"}}, ExpBuckets{0.001, 2, 20})) \
+        F(type_fetch_page, {{"type", "fetch_page"}}, ExpBuckets{0.001, 2, 20}), \
+        F(type_pop_ready_tasks, {{"type", "pop_ready_tasks"}}, ExpBuckets{0.001, 2, 20}), \
+        F(type_build_stream, {{"type", "build_stream"}}, ExpBuckets{0.001, 2, 20})) \
     M(tiflash_disaggregated_details, "", Counter,                                                                                         \
         F(type_cftiny_read, {{"type", "cftiny_read"}}),                                                                                   \
         F(type_cftiny_fetch, {{"type", "cftiny_fetch"}}))                                                                                 \

--- a/dbms/src/Flash/Disaggregated/PageDownloader.cpp
+++ b/dbms/src/Flash/Disaggregated/PageDownloader.cpp
@@ -94,7 +94,7 @@ void PageDownloader::persistLoop(size_t idx)
 
     // try to do some preparation for speed up reading
     size_t num_prepared = 0;
-    double ms_cost = 0.0;
+    double seconds_cost = 0.0;
     if (do_prepare)
     {
         while (true)
@@ -105,7 +105,7 @@ void PageDownloader::persistLoop(size_t idx)
             watch.restart();
             // do place index
             seg_task->prepare();
-            ms_cost = watch.elapsedSeconds();
+            seconds_cost = watch.elapsedSeconds();
             num_prepared += 1;
             LOG_DEBUG(log, "segment prepare done, segment_id={}", seg_task->segment_id);
             // update the state
@@ -113,7 +113,9 @@ void PageDownloader::persistLoop(size_t idx)
         }
     }
 
-    LOG_INFO(log, "Done preparation for {} segment tasks, cost={:.3f}ms", num_prepared, ms_cost);
+    remote_read_tasks->wakeAll();
+
+    LOG_INFO(log, "Done preparation for {} segment tasks, cost={:.3f}s", num_prepared, seconds_cost);
 }
 
 void PageDownloader::downloadDone(bool meet_error, const String & local_err_msg, const LoggerPtr & log)

--- a/dbms/src/Storages/DeltaMerge/Remote/RemoteSegmentThreadInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/Remote/RemoteSegmentThreadInputStream.cpp
@@ -95,7 +95,7 @@ Block RemoteSegmentThreadInputStream::readImpl(FilterPtr & res_filter, bool retu
                     throw Exception(read_tasks->getErrorMessage(), ErrorCodes::LOGICAL_ERROR);
                 }
                 LOG_DEBUG(log, "Read from remote segment done");
-                read_tasks->wakeAll();
+                // read_tasks->wakeAll();
                 return {};
             }
             cur_segment_id = task->segment_id;

--- a/dbms/src/Storages/DeltaMerge/Remote/RemoteSegmentThreadInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/RemoteSegmentThreadInputStream.h
@@ -64,6 +64,8 @@ public:
         int extra_table_id_index_,
         std::string_view req_id);
 
+    ~RemoteSegmentThreadInputStream() override;
+
     String getName() const override { return NAME; }
 
     Block getHeader() const override { return header; }
@@ -89,6 +91,10 @@ private:
     const ReadMode read_mode;
     const int extra_table_id_index;
     TableID physical_table_id;
+
+    Stopwatch watch;
+    double seconds_pop;
+    double seconds_build;
 
     size_t total_rows = 0;
     bool done = false;

--- a/dbms/src/Storages/StorageDisaggregated.cpp
+++ b/dbms/src/Storages/StorageDisaggregated.cpp
@@ -315,7 +315,6 @@ void StorageDisaggregated::buildRemoteSegmentInputStreams(
 
     auto rs_operator = buildRSOperator(db_context, column_defines);
 
-#if 1
     auto io_concurrency = std::max(50, num_streams * 10);
     auto sub_streams_size = io_concurrency / num_streams;
 
@@ -340,21 +339,6 @@ void StorageDisaggregated::buildRemoteSegmentInputStreams(
         auto union_stream = std::make_shared<UnionBlockInputStream<>>(sub_streams, BlockInputStreams{}, sub_streams_size, /*req_id=*/"");
         pipeline.streams.emplace_back(std::move(union_stream));
     }
-#else
-    auto streams = DM::RemoteSegmentThreadInputStream::buildInputStreams(
-        db_context,
-        remote_read_tasks,
-        page_downloader,
-        column_defines,
-        read_tso,
-        num_streams,
-        extra_table_id_index,
-        rs_operator,
-        extra_info,
-        /*tracing_id*/ log->identifier());
-    RUNTIME_CHECK(!streams.empty(), streams.size(), num_streams);
-    pipeline.streams.insert(pipeline.streams.end(), streams.begin(), streams.end());
-#endif
 
     auto * dag_context = db_context.getDAGContext();
     auto & table_scan_io_input_streams = dag_context->getInBoundIOInputStreamsMap()[executor_id];


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?

https://github.com/pingcap/tiflash/blob/c6b2eb5d2b9adf782cb3a84537546bc164a7700b/dbms/src/Flash/Disaggregated/PageDownloader.cpp#L98-L114

* PageDownloader do preparation (place delta index) after data downloaded
* Fix the bug that build delta index in background threads may block
* Investigate the performance issue
* `profiles.default.dis_prepare: 0` by default because it does not improve the performance now

Because we add union-stream on top of RemoteSegmentThreadInputStream to improve the io concurrency. The union stream are blocked by background tasks to build delta index. So no performance gain even if we support build delta index in background threads.

If we remove the union-stream, then we can get about 10% performance gain. However, it is still slower than increasing the io concurrency to 50.

FlameGraphs:

* [profiling_nounion_prepared.zip](https://github.com/pingcap/tiflash/files/10408401/profiling_nounion_prepared.zip)
* [profiling_nounion_raw.zip](https://github.com/pingcap/tiflash/files/10408403/profiling_nounion_raw.zip)
* [profiling_union_prepared.zip](https://github.com/pingcap/tiflash/files/10408404/profiling_union_prepared.zip)
* [profiling_union_raw.zip](https://github.com/pingcap/tiflash/files/10408405/profiling_union_raw.zip)

![image](https://user-images.githubusercontent.com/4865550/212236412-6804dc0c-bc00-4d46-855a-696fe6e929e6.png)


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
