### PR TITLE
add use_autoscaler config for AutoSaler prod rollback

### DIFF
--- a/dbms/src/Core/TiFlashDisaggregatedMode.cpp
+++ b/dbms/src/Core/TiFlashDisaggregatedMode.cpp
@@ -41,6 +41,16 @@ DisaggregatedMode getDisaggregatedMode(const Poco::Util::LayeredConfiguration & 
     return mode;
 }
 
+// todo: remove this after AutoScaler is stable.
+bool useAutoScaler(const Poco::Util::LayeredConfiguration & config)
+{
+    static const std::string autoscaler_config_key = "flash.use_autoscaler";
+    bool use_autoscaler = true;
+    if (config.has(autoscaler_config_key))
+        use_autoscaler = config.getBool(autoscaler_config_key);
+    return use_autoscaler;
+}
+
 std::string getProxyLabelByDisaggregatedMode(DisaggregatedMode mode)
 {
     switch (mode)

--- a/dbms/src/Core/TiFlashDisaggregatedMode.h
+++ b/dbms/src/Core/TiFlashDisaggregatedMode.h
@@ -33,5 +33,6 @@ enum class DisaggregatedMode
 };
 
 DisaggregatedMode getDisaggregatedMode(const Poco::Util::LayeredConfiguration & config);
+bool useAutoScaler(const Poco::Util::LayeredConfiguration & config);
 std::string getProxyLabelByDisaggregatedMode(DisaggregatedMode mode);
 } // namespace DB

--- a/dbms/src/Flash/DiagnosticsService.cpp
+++ b/dbms/src/Flash/DiagnosticsService.cpp
@@ -38,7 +38,7 @@ using diagnosticspb::SearchLogResponse;
     ::diagnosticspb::ServerInfoResponse * response)
 try
 {
-    if (context.isDisaggregatedComputeMode())
+    if (context.isDisaggregatedComputeMode() && context.useAutoScaler())
     {
         String err_msg = "tiflash compute node should be managed by AutoScaler instead of PD, this grpc should not be called be AutoScaler for now";
         LOG_ERROR(log, err_msg);

--- a/dbms/src/Interpreters/AsynchronousMetrics.cpp
+++ b/dbms/src/Interpreters/AsynchronousMetrics.cpp
@@ -121,7 +121,7 @@ static void calculateMaxAndSum(Max & max, Sum & sum, T x)
 
 FileUsageStatistics AsynchronousMetrics::getPageStorageFileUsage()
 {
-    RUNTIME_ASSERT(!context.isDisaggregatedComputeMode());
+    RUNTIME_ASSERT(!(context.isDisaggregatedComputeMode() && context.useAutoScaler()));
     // Get from RegionPersister
     auto & tmt = context.getTMTContext();
     auto & kvstore = tmt.getKVStore();
@@ -196,7 +196,7 @@ void AsynchronousMetrics::update()
         set("MaxDTBackgroundTasksLength", max_dt_background_tasks_length);
     }
 
-    if (!context.isDisaggregatedComputeMode())
+    if (!(context.isDisaggregatedComputeMode() && context.useAutoScaler()))
     {
         const FileUsageStatistics usage = getPageStorageFileUsage();
         set("BlobFileNums", usage.total_file_num);

--- a/dbms/src/Interpreters/Context.h
+++ b/dbms/src/Interpreters/Context.h
@@ -511,6 +511,16 @@ public:
         return disaggregated_mode == DisaggregatedMode::Storage;
     }
 
+    // todo: remove after AutoScaler is stable.
+    void setUseAutoScaler(bool use)
+    {
+        use_autoscaler = use;
+    }
+    bool useAutoScaler() const
+    {
+        return use_autoscaler;
+    }
+
 private:
     /** Check if the current client has access to the specified database.
       * If access is denied, throw an exception.
@@ -529,6 +539,7 @@ private:
 
     bool is_config_loaded = false; /// Is configuration loaded from toml file.
     DisaggregatedMode disaggregated_mode = DisaggregatedMode::None;
+    bool use_autoscaler = true; /// todo: remove this after AutoScaler is stable. Only meaningfule in DisaggregatedComputeMode.
 };
 
 using ContextPtr = std::shared_ptr<Context>;

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -249,11 +249,10 @@ struct TiFlashProxyConfig
     explicit TiFlashProxyConfig(Poco::Util::LayeredConfiguration & config)
     {
         auto disaggregated_mode = getDisaggregatedMode(config);
-        // todo: remove after AutoScaler is stable.
-        bool use_autoscaler = useAutoScaler(config);
 
         // tiflash_compute doesn't need proxy.
-        if (disaggregated_mode == DisaggregatedMode::Compute && use_autoscaler)
+        // todo: remove after AutoScaler is stable.
+        if (disaggregated_mode == DisaggregatedMode::Compute && useAutoScaler(config))
             return;
 
         if (!config.has(config_prefix))

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -249,9 +249,13 @@ struct TiFlashProxyConfig
     explicit TiFlashProxyConfig(Poco::Util::LayeredConfiguration & config)
     {
         auto disaggregated_mode = getDisaggregatedMode(config);
+        // todo: remove after AutoScaler is stable.
+        bool use_autoscaler = useAutoScaler(config);
+
         // tiflash_compute doesn't need proxy.
-        if (disaggregated_mode == DisaggregatedMode::Compute)
+        if (disaggregated_mode == DisaggregatedMode::Compute && use_autoscaler)
             return;
+
         if (!config.has(config_prefix))
             return;
 
@@ -909,6 +913,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
     global_context->setGlobalContext(*global_context);
     global_context->setApplicationType(Context::ApplicationType::SERVER);
     global_context->setDisaggregatedMode(getDisaggregatedMode(config()));
+    global_context->setUseAutoScaler(useAutoScaler(config()));
 
     /// Init File Provider
     if (proxy_conf.is_proxy_runnable)

--- a/dbms/src/Storages/Transaction/LearnerRead.cpp
+++ b/dbms/src/Storages/Transaction/LearnerRead.cpp
@@ -164,7 +164,7 @@ LearnerReadSnapshot doLearnerRead(
     const LoggerPtr & log)
 {
     assert(log != nullptr);
-    RUNTIME_ASSERT(!context.isDisaggregatedComputeMode());
+    RUNTIME_ASSERT(!(context.isDisaggregatedComputeMode() && context.useAutoScaler()));
 
     auto & tmt = context.getTMTContext();
 

--- a/dbms/src/Storages/Transaction/TMTContext.cpp
+++ b/dbms/src/Storages/Transaction/TMTContext.cpp
@@ -67,7 +67,7 @@ static SchemaSyncerPtr createSchemaSyncer(bool exist_pd_addr, bool for_unit_test
 
 TMTContext::TMTContext(Context & context_, const TiFlashRaftConfig & raft_config, const pingcap::ClusterConfig & cluster_config)
     : context(context_)
-    , kvstore(context_.isDisaggregatedComputeMode() ? nullptr : std::make_shared<KVStore>(context, raft_config.snapshot_apply_method))
+    , kvstore(context_.isDisaggregatedComputeMode() && context_.useAutoScaler() ? nullptr : std::make_shared<KVStore>(context, raft_config.snapshot_apply_method))
     , region_table(context)
     , background_service(nullptr)
     , gc_manager(context)
@@ -97,7 +97,7 @@ void TMTContext::updateSecurityConfig(const TiFlashRaftConfig & raft_config, con
 void TMTContext::restore(PathPool & path_pool, const TiFlashRaftProxyHelper * proxy_helper)
 {
     // For tiflash_compute mode, kvstore should be nullptr, no need to restore region_table.
-    if (context.isDisaggregatedComputeMode())
+    if (context.isDisaggregatedComputeMode() && context.useAutoScaler())
         return;
 
     kvstore->restore(path_pool, proxy_helper);
@@ -204,7 +204,7 @@ const std::unordered_set<std::string> & TMTContext::getIgnoreDatabases() const
 
 void TMTContext::reloadConfig(const Poco::Util::AbstractConfiguration & config)
 {
-    if (context.isDisaggregatedComputeMode())
+    if (context.isDisaggregatedComputeMode() && context.useAutoScaler())
         return;
 
     static constexpr const char * COMPACT_LOG_MIN_PERIOD = "flash.compact_log_min_period";

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -108,6 +108,8 @@
 ## The minimum duration to handle read-index tasks in each worker.
 # read_index_worker_tick_ms = 10
 # disaggregated_mode = "tiflash_storage" or "tiflash_compute"
+# Means whether we use AutoScaler or PD for tiflash_compute nodes. Default use AutoScaler. Will remove this after AutoScaler is stable.
+# use_autoscaler = true
 
 [flash.proxy]
 # addr = "0.0.0.0:20170"


### PR DESCRIPTION
Signed-off-by: guo-shaoge <shaoge1994@163.com>

### What problem does this PR solve?

Issue Number: close #6701

Problem Summary: 

1. https://github.com/pingcap/tiflash/pull/6588 removed proxy when node is in tiflash_compute mode, so all tilfash_compute nodes will be managed by *AutoScaler* instead of PD.
2. AutoScaler is not stable for now, we want to add switcher to help roll back.

### What is changed and how it works?
1. Check if use_autoscaler corresponding to each change in https://github.com/pingcap/tiflash/pull/6588
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
