### PR TITLE
make tiflash compatible with old version client

### DIFF
--- a/dbms/src/Core/BlockInfo.cpp
+++ b/dbms/src/Core/BlockInfo.cpp
@@ -33,6 +33,7 @@ extern const int UNKNOWN_BLOCK_INFO_FIELD;
 /// Write values in binary form. NOTE: You could use protobuf, but it would be overkill for this case.
 void BlockInfo::write(WriteBuffer & out) const
 {
+    assert(is_overflows == false);
     /// Set of pairs `FIELD_NUM`, value in binary form. Then 0.
 #define WRITE_FIELD(TYPE, NAME, DEFAULT, FIELD_NUM) \
     writeVarUInt(FIELD_NUM, out);                   \
@@ -69,6 +70,8 @@ void BlockInfo::read(ReadBuffer & in)
             throw Exception("Unknown BlockInfo field number: " + toString(field_num), ErrorCodes::UNKNOWN_BLOCK_INFO_FIELD);
         }
     }
+    if unlikely (is_overflows)
+        throw Exception("is_overflows is no longer supported" + toString(field_num), ErrorCodes::UNKNOWN_BLOCK_INFO_FIELD);
 }
 
 } // namespace DB

--- a/dbms/src/Core/BlockInfo.h
+++ b/dbms/src/Core/BlockInfo.h
@@ -30,7 +30,7 @@ struct BlockInfo
       * After running GROUP BY ... WITH TOTALS with the max_rows_to_group_by and group_by_overflow_mode = 'any' settings,
       *  a row is inserted in the separate block with aggregated values that have not passed max_rows_to_group_by.
       * If it is such a block, then is_overflows is set to true for it.
-      * Deprecated, will throw error if is_overflows is true
+      * Overflows is now deprecated, will throw error if is_overflows is true
       */
 
     /** bucket_num:

--- a/dbms/src/Core/BlockInfo.h
+++ b/dbms/src/Core/BlockInfo.h
@@ -26,6 +26,13 @@ class WriteBuffer;
   */
 struct BlockInfo
 {
+    /** is_overflows:
+      * After running GROUP BY ... WITH TOTALS with the max_rows_to_group_by and group_by_overflow_mode = 'any' settings,
+      *  a row is inserted in the separate block with aggregated values that have not passed max_rows_to_group_by.
+      * If it is such a block, then is_overflows is set to true for it.
+      * Deprecated, will throw error if is_overflows is true
+      */
+
     /** bucket_num:
       * When using the two-level aggregation method, data with different key groups are scattered across different buckets.
       * In this case, the bucket number is indicated here. It is used to optimize the merge for distributed aggregation.
@@ -33,6 +40,7 @@ struct BlockInfo
       */
 
 #define APPLY_FOR_BLOCK_INFO_FIELDS(M) \
+    M(bool, is_overflows, false, 1)    \
     M(Int32, bucket_num, -1, 2)
 
 #define DECLARE_FIELD(TYPE, NAME, DEFAULT, FIELD_NUM) \


### PR DESCRIPTION
Signed-off-by: xufei <xufeixw@mail.ustc.edu.cn>

### What problem does this PR solve?

Issue Number: ref #6696

Problem Summary:
#6633 delete `is_flowrows` in `BlockInfo`, which makes the new tiflash server not compatible with old tiflash client
### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
