### PR TITLE
fix: mitigate old docker for full stack test

### DIFF
--- a/tests/docker/cluster.yaml
+++ b/tests/docker/cluster.yaml
@@ -17,6 +17,8 @@ version: '2.3'
 services:
   pd0:
     image: hub.pingcap.net/qa/pd:${PD_BRANCH:-master}
+    security_opt:
+      - seccomp:unconfined
     volumes:
       - ./config/pd.toml:/pd.toml:ro
       - ./data/pd0:/data
@@ -34,6 +36,8 @@ services:
     restart: on-failure
   tikv0:
     image: hub.pingcap.net/qa/tikv:${TIKV_BRANCH:-master}
+    security_opt:
+      - seccomp:unconfined
     volumes:
       - ./config/tikv.toml:/tikv.toml:ro
       - ./data/tikv0:/data
@@ -50,6 +54,8 @@ services:
     restart: on-failure
   tidb0:
     image: hub.pingcap.net/qa/tidb:${TIDB_BRANCH:-master}
+    security_opt:
+      - seccomp:unconfined
     volumes:
       - ./config/tidb.toml:/tidb.toml:ro
       - ./log/tidb0:/log

--- a/tests/docker/cluster_disable_new_collation.yaml
+++ b/tests/docker/cluster_disable_new_collation.yaml
@@ -17,6 +17,8 @@ version: '2.3'
 services:
   pd0:
     image: hub.pingcap.net/qa/pd:${PD_BRANCH:-master}
+    security_opt:
+      - seccomp:unconfined
     volumes:
       - ./config/pd.toml:/pd.toml:ro
       - ./data/pd0:/data
@@ -34,6 +36,8 @@ services:
     restart: on-failure
   tikv0:
     image: hub.pingcap.net/qa/tikv:${TIKV_BRANCH:-master}
+    security_opt:
+      - seccomp:unconfined
     volumes:
       - ./config/tikv.toml:/tikv.toml:ro
       - ./data/tikv0:/data
@@ -50,6 +54,8 @@ services:
     restart: on-failure
   tidb0:
     image: hub.pingcap.net/qa/tidb:${TIDB_BRANCH:-master}
+    security_opt:
+      - seccomp:unconfined
     volumes:
       - ./config/tidb_disable_new_collation.toml:/tidb.toml:ro
       - ./log/tidb0:/log

--- a/tests/docker/cluster_new_collation.yaml
+++ b/tests/docker/cluster_new_collation.yaml
@@ -17,6 +17,8 @@ version: '2.3'
 services:
   pd0:
     image: hub.pingcap.net/qa/pd:${PD_BRANCH:-master}
+    security_opt:
+      - seccomp:unconfined
     volumes:
       - ./config/pd.toml:/pd.toml:ro
       - ./data/pd0:/data
@@ -34,6 +36,8 @@ services:
     restart: on-failure
   tikv0:
     image: hub.pingcap.net/qa/tikv:${TIKV_BRANCH:-master}
+    security_opt:
+      - seccomp:unconfined
     volumes:
       - ./config/tikv.toml:/tikv.toml:ro
       - ./data/tikv0:/data
@@ -50,6 +54,8 @@ services:
     restart: on-failure
   tidb0:
     image: hub.pingcap.net/qa/tidb:${TIDB_BRANCH:-master}
+    security_opt:
+      - seccomp:unconfined
     volumes:
       - ./config/tidb_new_collation.toml:/tidb.toml:ro
       - ./log/tidb0:/log

--- a/tests/docker/cluster_tidb_fail_point.yaml
+++ b/tests/docker/cluster_tidb_fail_point.yaml
@@ -17,6 +17,8 @@ version: '2.3'
 services:
   pd0:
     image: hub.pingcap.net/qa/pd:${PD_BRANCH:-master}
+    security_opt:
+      - seccomp:unconfined
     volumes:
       - ./config/pd.toml:/pd.toml:ro
       - ./data/pd0:/data
@@ -34,6 +36,8 @@ services:
     restart: on-failure
   tikv0:
     image: hub.pingcap.net/qa/tikv:${TIKV_BRANCH:-master}
+    security_opt:
+      - seccomp:unconfined
     volumes:
       - ./config/tikv.toml:/tikv.toml:ro
       - ./data/tikv0:/data
@@ -50,6 +54,8 @@ services:
     restart: on-failure
   tidb0:
     image: hub.pingcap.net/qa/tidb:${TIDB_BRANCH:-master}-failpoint
+    security_opt:
+      - seccomp:unconfined
     environment:
       GO_FAILPOINTS: "github.com/pingcap/tidb/server/enableTestAPI=return"
     volumes:

--- a/tests/docker/tiflash-dt.yaml
+++ b/tests/docker/tiflash-dt.yaml
@@ -19,6 +19,8 @@ services:
   # (engine DeltaTree)
   tiflash0:
     image: hub.pingcap.net/tiflash/tiflash-ci-base
+    security_opt:
+      - seccomp:unconfined
     volumes:
       - ./config/tiflash_dt.toml:/config.toml:ro
       - ./data/tiflash:/tmp/tiflash/data


### PR DESCRIPTION
Signed-off-by: lijie <lijie@pingcap.com>

### What problem does this PR solve?

Fix integration test in CI because docker is too old

Issue Number: ref #6233

Problem Summary: 

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
