### PR TITLE
Fix incorrect string value when doing int_handle.toNext

### DIFF
--- a/dbms/src/Storages/DeltaMerge/RowKeyRange.h
+++ b/dbms/src/Storages/DeltaMerge/RowKeyRange.h
@@ -173,8 +173,7 @@ struct RowKeyValue
      */
     RowKeyValue toNext() const
     {
-        // We want to always ensure that x.toNext().value > x.value.
-        // So for int value, let's build a nice next key.
+        // We want to always ensure that the IntHandle.stringValue == IntHandle.intValue.
         if (!is_common_handle)
             return toPrefixNext();
 

--- a/dbms/src/Storages/DeltaMerge/RowKeyRange.h
+++ b/dbms/src/Storages/DeltaMerge/RowKeyRange.h
@@ -130,7 +130,7 @@ struct RowKeyValue
         return std::make_shared<DecodedTiKVKey>(prefix + *value);
     }
 
-    bool operator==(const RowKeyValue & v)
+    bool operator==(const RowKeyValue & v) const
     {
         return is_common_handle == v.is_common_handle && (*value) == (*v.value) && int_value == v.int_value;
     }
@@ -173,19 +173,16 @@ struct RowKeyValue
      */
     RowKeyValue toNext() const
     {
+        // We want to always ensure that x.toNext().value > x.value.
+        // So for int value, let's build a nice next key.
+        if (!is_common_handle)
+            return toPrefixNext();
+
         HandleValuePtr next_value = std::make_shared<String>(value->begin(), value->end());
         next_value->push_back(0x0);
 
-        // This is a hack, for int handle, let's build a "next key" which is not identical to INT_MAX.
-        // In this way, it will be still < next_key.
-        if (!is_common_handle && int_value == std::numeric_limits<Int64>::max())
-            next_value->push_back(0x0);
-
-        Int64 next_int_value = int_value;
-        if (!is_common_handle && next_int_value != std::numeric_limits<Int64>::max())
-            next_int_value++;
-
-        return RowKeyValue(is_common_handle, next_value, next_int_value);
+        // For common handle, int_value will not be used in compare. Let's keep it unchanged.
+        return RowKeyValue(/* is_common_handle */ true, next_value, int_value);
     }
 
     void serialize(WriteBuffer & buf) const

--- a/dbms/src/Storages/DeltaMerge/RowKeyRange.h
+++ b/dbms/src/Storages/DeltaMerge/RowKeyRange.h
@@ -176,6 +176,11 @@ struct RowKeyValue
         HandleValuePtr next_value = std::make_shared<String>(value->begin(), value->end());
         next_value->push_back(0x0);
 
+        // This is a hack, for int handle, let's build a "next key" which is not identical to INT_MAX.
+        // In this way, it will be still < next_key.
+        if (!is_common_handle && int_value == std::numeric_limits<Int64>::max())
+            next_value->push_back(0x0);
+
         Int64 next_int_value = int_value;
         if (!is_common_handle && next_int_value != std::numeric_limits<Int64>::max())
             next_int_value++;

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_key_range.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_key_range.cpp
@@ -148,7 +148,7 @@ TEST(RowKey, ToNextKeyCommonHandle)
     EXPECT_EQ(0, compare(my_next.toRowKeyValueRef(), next.toRowKeyValueRef()));
 }
 
-TEST(RowKey, NextIntHandle)
+TEST(RowKey, NextIntHandleCompare)
 {
     auto int_max = RowKeyValue::INT_HANDLE_MAX_KEY;
     auto int_max_i64 = RowKeyValue::fromHandle(Handle(std::numeric_limits<HandleID>::max()));
@@ -156,10 +156,27 @@ TEST(RowKey, NextIntHandle)
     EXPECT_EQ(1, compare(int_max.toRowKeyValueRef(), int_max_i64.toRowKeyValueRef()));
 
     auto int_max_i64_pnext = int_max_i64.toPrefixNext();
-    EXPECT_EQ(1, compare(int_max.toRowKeyValueRef(), int_max_i64_pnext.toRowKeyValueRef()));
+    EXPECT_EQ(int_max, int_max_i64_pnext);
+    EXPECT_EQ(0, compare(int_max.toRowKeyValueRef(), int_max_i64_pnext.toRowKeyValueRef()));
+    EXPECT_EQ(0, compare(int_max_i64_pnext.toRowKeyValueRef(), int_max.toRowKeyValueRef()));
 
     auto int_max_i64_next = int_max_i64.toNext();
-    EXPECT_EQ(1, compare(int_max.toRowKeyValueRef(), int_max_i64_next.toRowKeyValueRef()));
+    EXPECT_EQ(int_max, int_max_i64_next);
+    EXPECT_EQ(0, compare(int_max.toRowKeyValueRef(), int_max_i64_next.toRowKeyValueRef()));
+    EXPECT_EQ(0, compare(int_max_i64_next.toRowKeyValueRef(), int_max.toRowKeyValueRef()));
+}
+
+TEST(RowKey, NextIntHandleMinMax)
+{
+    auto v0 = RowKeyValue::fromHandle(Handle(1178400));
+    auto v0_next = v0.toNext();
+    auto v1 = RowKeyValue::fromHandle(Handle(1178401));
+
+    EXPECT_EQ(v0, min(v0, v1));
+    EXPECT_EQ(v0, min(v0, v0_next));
+
+    EXPECT_EQ(v1, max(v0, v1));
+    EXPECT_EQ(v1, max(v0, v0_next));
 }
 
 } // namespace tests

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_key_range.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_key_range.cpp
@@ -148,6 +148,20 @@ TEST(RowKey, ToNextKeyCommonHandle)
     EXPECT_EQ(0, compare(my_next.toRowKeyValueRef(), next.toRowKeyValueRef()));
 }
 
+TEST(RowKey, NextIntHandle)
+{
+    auto int_max = RowKeyValue::INT_HANDLE_MAX_KEY;
+    auto int_max_i64 = RowKeyValue::fromHandle(Handle(std::numeric_limits<HandleID>::max()));
+
+    EXPECT_EQ(1, compare(int_max.toRowKeyValueRef(), int_max_i64.toRowKeyValueRef()));
+
+    auto int_max_i64_pnext = int_max_i64.toPrefixNext();
+    EXPECT_EQ(1, compare(int_max.toRowKeyValueRef(), int_max_i64_pnext.toRowKeyValueRef()));
+
+    auto int_max_i64_next = int_max_i64.toNext();
+    EXPECT_EQ(1, compare(int_max.toRowKeyValueRef(), int_max_i64_next.toRowKeyValueRef()));
+}
+
 } // namespace tests
 } // namespace DM
 } // namespace DB


### PR DESCRIPTION
Signed-off-by: Wish <breezewish@outlook.com>

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/6699

Problem Summary:

Consider an Int Handle in variable `foo` which is 0xCCAB. It is encoded as `{ 80 00 00 00 00 00 CC AB }` in bytes.

In #6538:

```
foo.toNext:       int_value = 0xCCAC, bytes_value = { 80 00 00 00 00 00 CC AB 00 }
foo.toPrefixNext: int_value = 0xCCAC, bytes_value = { 80 00 00 00 00 00 CC AC }
```

The implementation of `toNext()` is incorrect because it violates the rule that the int_value and bytes_value should be matching. 

Let's see what will happen when this rule is not respected:

- Consider we construct a new Int Handle in variable `bar` from int 0xCCAC. It will be built as `int_value = 0xCCAC, bytes_value = { 80 00 00 00 00 00 CC AC }`. Now `bar` and `foo`'content are not identical any more.

- The `max`, `min` and several other basic functions are implemented by comparing bytes values:

  ```c++
  inline const RowKeyValue & max(const RowKeyValue & a, const RowKeyValue & b)
  {
      return a.value->compare(*b.value) >= 0 ? a : b;
  }

  inline const RowKeyValue & min(const RowKeyValue & a, const RowKeyValue & b)
  {
      return a.value->compare(*b.value) < 0 ? a : b;
  }

  inline bool none() const
  {
      return start.value->compare(*end.value) >= 0;
  }

  inline bool intersect(const RowKeyRange & other) const
  {
      return max(other.start, start).value->compare(*min(other.end, end).value) < 0;
  }

  bool operator==(const RowKeyRange & rhs) const
  {
      return start.value->compare(*rhs.start.value) == 0 && end.value->compare(*rhs.end.value) == 0;
  }
  ```

- As a result, buggy things happen, like `foo.toNext() != bar`. Everything related with equality or orders may have wrong results.

### What is changed and how it works?

Encode Int handle using `toPrefixNext()` in `toNext()`, so that the int_value and bytes_value are still matching.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
