### PR TITLE
Fix hashJoinProb thread leak issue

### DIFF
--- a/dbms/src/DataStreams/HashJoinProbeBlockInputStream.cpp
+++ b/dbms/src/DataStreams/HashJoinProbeBlockInputStream.cpp
@@ -87,6 +87,7 @@ void HashJoinProbeBlockInputStream::cancel(bool kill)
     }
     catch (...)
     {
+        tryLogCurrentException(log, "finishOneProbe failed in cancel() ");
         join->meetError();
     }
     if (non_joined_stream != nullptr)

--- a/dbms/src/DataStreams/HashJoinProbeBlockInputStream.h
+++ b/dbms/src/DataStreams/HashJoinProbeBlockInputStream.h
@@ -60,6 +60,7 @@ private:
         FINISHED,
     };
     void readSuffixImpl() override;
+    void finishOneProbe();
 
     const LoggerPtr log;
     JoinPtr join;
@@ -69,6 +70,7 @@ private:
     ProbeStatus status{ProbeStatus::PROBE};
     size_t joined_rows = 0;
     size_t non_joined_rows = 0;
+    std::atomic<bool> probe_finished = false;
 };
 
 } // namespace DB


### PR DESCRIPTION
Signed-off-by: yibin <huyibin@pingcap.com>

### What problem does this PR solve?

Issue Number: close #6692 

Problem Summary:

### What is changed and how it works?
When one HashJoinProbStream canceled before another HashJoinProbStream entered readImpl function, the join instance's finishOneProb function wouldn't be invoked and cause HashJoinProbStream hang.
Since we can't distinguish normal finish and abort in HashJoinProbStream's cancel function now, so use atomic field to ensure join instance's finishOneProb is invoked exactly once.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
Manually run the failed randomPoint test, and check no thread leak now.
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
