### PR TITLE
Fix gtest false negative case

### DIFF
--- a/dbms/src/DataStreams/HashJoinProbeBlockInputStream.cpp
+++ b/dbms/src/DataStreams/HashJoinProbeBlockInputStream.cpp
@@ -73,7 +73,17 @@ void HashJoinProbeBlockInputStream::finishOneProbe()
 {
     bool expect = false;
     if likely (probe_finished.compare_exchange_strong(expect, true))
-        join->finishOneProbe();
+    {
+        try
+        {
+            join->finishOneProbe();
+        }
+        catch (...)
+        {
+            join->meetError();
+            throw;
+        }
+    }
 }
 
 void HashJoinProbeBlockInputStream::cancel(bool kill)

--- a/dbms/src/DataStreams/HashJoinProbeBlockInputStream.cpp
+++ b/dbms/src/DataStreams/HashJoinProbeBlockInputStream.cpp
@@ -73,17 +73,7 @@ void HashJoinProbeBlockInputStream::finishOneProbe()
 {
     bool expect = false;
     if likely (probe_finished.compare_exchange_strong(expect, true))
-    {
-        try
-        {
-            join->finishOneProbe();
-        }
-        catch (...)
-        {
-            join->meetError();
-            throw;
-        }
-    }
+        join->finishOneProbe();
 }
 
 void HashJoinProbeBlockInputStream::cancel(bool kill)

--- a/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.cpp
+++ b/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.cpp
@@ -143,17 +143,17 @@ void FineGrainedShuffleWriter<ExchangeWriterPtr>::batchWriteFineGrainedShuffleIm
         assert(fine_grained_shuffle_stream_count <= 1024);
 
         HashBaseWriterHelper::materializeBlocks(blocks);
-        while (!blocks.empty())
+        for (auto & block : blocks)
         {
-            const auto & block = blocks.back();
             if constexpr (version != MPPDataPacketV0)
             {
                 // check schema
                 assertBlockSchema(expected_types, block, FineGrainedShuffleWriterLabels[MPPDataPacketV1]);
             }
             HashBaseWriterHelper::scatterColumnsForFineGrainedShuffle(block, partition_col_ids, collators, partition_key_containers_for_reuse, partition_num, fine_grained_shuffle_stream_count, hash, selector, scattered);
-            blocks.pop_back();
+            block.clear();
         }
+        blocks.clear();
 
         // serialize each partitioned block and write it to its destination
         size_t part_id = 0;

--- a/dbms/src/Flash/Mpp/MPPTunnelSetHelper.cpp
+++ b/dbms/src/Flash/Mpp/MPPTunnelSetHelper.cpp
@@ -50,14 +50,14 @@ TrackedMppDataPacketPtr ToPacketV0(Blocks & blocks, const std::vector<tipb::Fiel
     CHBlockChunkCodec codec;
     auto codec_stream = codec.newCodecStream(field_types);
     auto tracked_packet = std::make_shared<TrackedMppDataPacket>(MPPDataPacketV0);
-    while (!blocks.empty())
+    for (auto & block : blocks)
     {
-        const auto & block = blocks.back();
         codec_stream->encode(block, 0, block.rows());
-        blocks.pop_back();
+        block.clear();
         tracked_packet->addChunk(codec_stream->getString());
         codec_stream->clear();
     }
+    blocks.clear();
     return tracked_packet;
 }
 

--- a/dbms/src/TestUtils/FunctionTestUtils.h
+++ b/dbms/src/TestUtils/FunctionTestUtils.h
@@ -835,7 +835,7 @@ protected:
 };
 
 #define ASSERT_COLUMN_EQ(expected, actual) ASSERT_TRUE(DB::tests::columnEqual((expected), (actual)))
-#define ASSERT_BLOCK_EQ(expected, actual) DB::tests::blockEqual((expected), (actual))
+#define ASSERT_BLOCK_EQ(expected, actual) ASSERT_TRUE(DB::tests::blockEqual((expected), (actual)))
 
 /// restrictly checking columns equality, both data set and each row's offset should be the same
 #define ASSERT_COLUMNS_EQ_R(expected, actual) ASSERT_TRUE(DB::tests::columnsEqual((expected), (actual), true))


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #6733 

Problem Summary:

### What is changed and how it works?
The gtest's failure is caused by the internal reorder of blocks in ExchangeSender. Fix it by writing them sequentially.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
