### PR TITLE
fix timezone test

### DIFF
--- a/dbms/src/Functions/tests/gtest_from_unixtime.cpp
+++ b/dbms/src/Functions/tests/gtest_from_unixtime.cpp
@@ -238,14 +238,14 @@ try
                      executeFunction(func_name, createColumn<Decimal128>(std::make_tuple(20, 0), decimal_20_0_data), createConstColumn<String>(5, format_data)));
 
     context.getTimezoneInfo().resetByTimezoneName("America/Santiago");
-    decimal_20_0_data = {"-1", "0", "1648951200", "1648954800", "1662263999", "1662264000", "2147483647", "2147483648"};
+    decimal_20_0_data = {"-1", "0", "1648951200", "1648954800", "1630814399", "1630814400", "2147483647", "2147483648"};
     decimal_20_0_date_time_result = {
         MyDateTime(0, 0, 0, 0, 0, 0, 0).toPackedUInt(),
         MyDateTime(1969, 12, 31, 21, 0, 0, 0).toPackedUInt(),
         MyDateTime(2022, 4, 2, 23, 0, 0, 0).toPackedUInt(),
         MyDateTime(2022, 4, 2, 23, 0, 0, 0).toPackedUInt(),
-        MyDateTime(2022, 9, 3, 23, 59, 59, 0).toPackedUInt(),
-        MyDateTime(2022, 9, 4, 1, 0, 0, 0).toPackedUInt(),
+        MyDateTime(2021, 9, 4, 23, 59, 59, 0).toPackedUInt(),
+        MyDateTime(2021, 9, 5, 1, 0, 0, 0).toPackedUInt(),
         MyDateTime(2038, 1, 19, 0, 14, 7, 0).toPackedUInt(),
         MyDateTime(2038, 1, 19, 0, 14, 8, 0).toPackedUInt(),
     };
@@ -254,8 +254,8 @@ try
         "1969-12-31 21:00:00.000000",
         "2022-04-02 23:00:00.000000",
         "2022-04-02 23:00:00.000000",
-        "2022-09-03 23:59:59.000000",
-        "2022-09-04 01:00:00.000000",
+        "2021-09-04 23:59:59.000000",
+        "2021-09-05 01:00:00.000000",
         "2038-01-19 00:14:07.000000",
         "2038-01-19 00:14:08.000000"};
 
@@ -267,8 +267,8 @@ try
     context.getTimezoneInfo().resetByTimezoneOffset(-10800);
     decimal_20_0_date_time_result[3] = MyDateTime(2022, 4, 3, 0, 0, 0, 0).toPackedUInt();
     decimal_20_0_string_result[3] = "2022-04-03 00:00:00.000000";
-    decimal_20_0_date_time_result[4] = MyDateTime(2022, 9, 4, 0, 59, 59, 0).toPackedUInt();
-    decimal_20_0_string_result[4] = "2022-09-04 00:59:59.000000";
+    decimal_20_0_date_time_result[4] = MyDateTime(2021, 9, 5, 0, 59, 59, 0).toPackedUInt();
+    decimal_20_0_string_result[4] = "2021-09-05 00:59:59.000000";
 
     ASSERT_COLUMN_EQ(createNullableColumn<MyDateTime>(std::make_tuple(0), decimal_20_0_date_time_result, null_map),
                      executeFunction(func_name, createColumn<Decimal128>(std::make_tuple(20, 0), decimal_20_0_data)));

--- a/dbms/src/Functions/tests/gtest_unix_timestamp.cpp
+++ b/dbms/src/Functions/tests/gtest_unix_timestamp.cpp
@@ -201,13 +201,13 @@ try
         MyDateTime(2022, 4, 2, 23, 59, 59, 0).toPackedUInt(),
         MyDateTime(2022, 4, 3, 0, 0, 0, 0).toPackedUInt(),
         /// When local standard time is about to reach
-        /// Sunday, 4 September 2022, 00:00:00 clocks are turned forward 1 hour to
-        /// Sunday, 4 September 2022, 01:00:00 local daylight time instead.
-        MyDateTime(2022, 9, 3, 23, 59, 59, 0).toPackedUInt(),
-        MyDateTime(2022, 9, 4, 1, 0, 0, 0).toPackedUInt(),
+        /// Sunday, 5 September 2021, 00:00:00 clocks are turned forward 1 hour to
+        /// Sunday, 5 September 2021, 01:00:00 local daylight time instead.
+        MyDateTime(2021, 9, 4, 23, 59, 59, 0).toPackedUInt(),
+        MyDateTime(2021, 9, 5, 1, 0, 0, 0).toPackedUInt(),
     };
-    date_time_int_result = {0, 1, 2147483647ull, 0, 1648951199ull, 1648954800ull, 1648958399ull, 1648958400ull, 1662263999ull, 1662264000ull};
-    date_time_decimal_result = {"0", "1", "2147483647", "0", "1648951199", "1648954800", "1648958399", "1648958400", "1662263999", "1662264000"};
+    date_time_int_result = {0, 1, 2147483647ull, 0, 1648951199ull, 1648954800ull, 1648958399ull, 1648958400ull, 1630814399ull, 1630814400ull};
+    date_time_decimal_result = {"0", "1", "2147483647", "0", "1648951199", "1648954800", "1648958399", "1648958400", "1630814399", "1630814400"};
     ASSERT_COLUMN_EQ(
         createColumn<UInt64>(date_time_int_result),
         executeFunction(func_name_int, createColumn<MyDateTime>(date_time_data)));


### PR DESCRIPTION
Signed-off-by: xufei <xufeixw@mail.ustc.edu.cn>

### What problem does this PR solve?

Issue Number: close #6756

Problem Summary:

### What is changed and how it works?
The root cause is Daylight Saving Time in Santiago in 2022 is changed from `2022-09-04 01:00:00` to `2022-09-11 01:00:00`,
this pr use the Daylight Saving Time in 2021 instead.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
