### PR TITLE
Refine spiller

### DIFF
--- a/dbms/src/Core/SpillHandler.cpp
+++ b/dbms/src/Core/SpillHandler.cpp
@@ -78,7 +78,7 @@ void SpillHandler::spillBlocks(const Blocks & blocks)
         }
         double cost = watch.elapsedSeconds();
         time_cost += cost;
-        LOG_INFO(spiller->logger, "Spilled blocks into temporary file, data size: {:.3f} MB, time cost: {:.3f} sec.", spilled_data_size / (1048576.0), cost);
+        LOG_INFO(spiller->logger, "Spilled blocks into temporary file, data size: {:.3f} MiB, time cost: {:.3f} sec.", spilled_data_size / (1048576.0), cost);
         RUNTIME_CHECK_MSG(current_spilled_file_index >= 0, "{}: spill after the spill handler is finished.", spiller->config.spill_id);
         RUNTIME_CHECK_MSG(spiller->spill_finished == false, "{}: spill after the spiller is finished.", spiller->config.spill_id);
         return;
@@ -104,7 +104,7 @@ void SpillHandler::finish()
             SpillDetails details{0, 0, 0};
             for (Int64 i = 0; i <= current_spilled_file_index; i++)
                 details.merge(spilled_files[i]->getSpillDetails());
-            return fmt::format("Commit spilled data, spill details: {} rows in {:.3f} sec,"
+            return fmt::format("Commit spilled data, details: spill {} rows in {:.3f} sec,"
                                " {:.3f} MiB uncompressed, {:.3f} MiB compressed, {:.3f} uncompressed bytes per row, {:.3f} compressed bytes per row, "
                                "compression rate: {:.3f} ({:.3f} rows/sec., {:.3f} MiB/sec. uncompressed, {:.3f} MiB/sec. compressed)",
                                details.rows,

--- a/dbms/src/Core/SpillHandler.cpp
+++ b/dbms/src/Core/SpillHandler.cpp
@@ -64,7 +64,8 @@ void SpillHandler::spillBlocks(const Blocks & blocks)
     {
         Stopwatch watch;
         RUNTIME_CHECK_MSG(spiller->spill_finished == false, "{}: spill after the spiller is finished.", spiller->config.spill_id);
-        LOG_INFO(spiller->logger, "Spilling {} blocks data into temporary file {}", blocks.size(), current_spill_file_name);
+        auto block_size = blocks.size();
+        LOG_INFO(spiller->logger, "Spilling {} blocks data into temporary file {}", block_size, current_spill_file_name);
         size_t total_rows = 0;
         if (unlikely(writer == nullptr))
         {
@@ -77,7 +78,7 @@ void SpillHandler::spillBlocks(const Blocks & blocks)
         }
         double cost = watch.elapsedSeconds();
         time_cost += cost;
-        LOG_INFO(spiller->logger, "Spilled blocks into temporary file, {} rows, time cost: {:.3f} sec.", total_rows, cost);
+        LOG_INFO(spiller->logger, "Spilled {} rows from {} blocks into temporary file, time cost: {:.3f} sec.", total_rows, block_size, cost);
         RUNTIME_CHECK_MSG(current_spilled_file_index >= 0, "{}: spill after the spill handler is finished.", spiller->config.spill_id);
         RUNTIME_CHECK_MSG(spiller->spill_finished == false, "{}: spill after the spiller is finished.", spiller->config.spill_id);
         return;

--- a/dbms/src/Core/Spiller.cpp
+++ b/dbms/src/Core/Spiller.cpp
@@ -47,13 +47,14 @@ SpilledFile::~SpilledFile()
     }
 }
 
-Spiller::Spiller(const SpillConfig & config_, bool is_input_sorted_, size_t partition_num_, const Block & input_schema_, const LoggerPtr & logger_, Int64 spill_version_)
+Spiller::Spiller(const SpillConfig & config_, bool is_input_sorted_, size_t partition_num_, const Block & input_schema_, const LoggerPtr & logger_, Int64 spill_version_, bool release_spilled_file_on_restore_)
     : config(config_)
     , is_input_sorted(is_input_sorted_)
     , partition_num(partition_num_)
     , input_schema(input_schema_)
     , logger(logger_)
     , spill_version(spill_version_)
+    , release_spilled_file_on_restore(release_spilled_file_on_restore_)
 {
     for (size_t i = 0; i < partition_num; ++i)
         spilled_files.push_back(std::make_unique<SpilledFiles>());
@@ -117,32 +118,43 @@ BlockInputStreams Spiller::restoreBlocks(size_t partition_id, size_t max_stream_
     BlockInputStreams ret;
     if (is_input_sorted)
     {
-        for (const auto & file : spilled_files[partition_id]->spilled_files)
+        for (auto & file : spilled_files[partition_id]->spilled_files)
         {
             RUNTIME_CHECK_MSG(file->exists(), "Spill file {} does not exists", file->path());
             details.merge(file->getSpillDetails());
-            std::vector<String> files{file->path()};
-            ret.push_back(std::make_shared<SpilledFilesInputStream>(files, input_schema, config.file_provider, spill_version));
+            std::vector<SpilledFileInfo> file_infos;
+            file_infos.emplace_back(file->path());
+            if (!release_spilled_file_on_restore)
+                /// if there is no need to repeated restore, move the SpilledFile to SpilledFilesInputStream so it can be delete once
+                /// all the data in this file is restored
+                file_infos.back().file = std::move(file);
+            ret.push_back(std::make_shared<SpilledFilesInputStream>(std::move(file_infos), input_schema, config.file_provider, spill_version));
         }
     }
     else
     {
         size_t return_stream_num = std::min(max_stream_size, spilled_files[partition_id]->spilled_files.size());
-        std::vector<std::vector<String>> files(return_stream_num);
+        std::vector<std::vector<SpilledFileInfo>> file_infos(return_stream_num);
         // todo balance based on SpilledRows
         for (size_t i = 0; i < spilled_files[partition_id]->spilled_files.size(); ++i)
         {
-            const auto & file = spilled_files[partition_id]->spilled_files[i];
+            auto & file = spilled_files[partition_id]->spilled_files[i];
             RUNTIME_CHECK_MSG(file->exists(), "Spill file {} does not exists", file->path());
             details.merge(file->getSpillDetails());
-            files[i % return_stream_num].push_back(file->path());
+            file_infos[i % return_stream_num].push_back(file->path());
+            if (!release_spilled_file_on_restore)
+                /// if there is no need to repeated restore, move the SpilledFile to SpilledFilesInputStream so it can be delete once
+                /// all the data in this file is restored
+                file_infos[i % return_stream_num].back().file = std::move(file);
         }
         for (size_t i = 0; i < return_stream_num; ++i)
         {
-            if (likely(!files[i].empty()))
-                ret.push_back(std::make_shared<SpilledFilesInputStream>(files[i], input_schema, config.file_provider, spill_version));
+            if (likely(!file_infos[i].empty()))
+                ret.push_back(std::make_shared<SpilledFilesInputStream>(std::move(file_infos[i]), input_schema, config.file_provider, spill_version));
         }
     }
+    if (!release_spilled_file_on_restore)
+        spilled_files[partition_id]->spilled_files.clear();
     LOG_DEBUG(logger, "Will restore {} rows from file of size {:.3f} MiB compressed, {:.3f} MiB uncompressed.", details.rows, (details.data_bytes_compressed / 1048576.0), (details.data_bytes_uncompressed / 1048576.0));
     if (ret.empty())
         ret.push_back(std::make_shared<NullBlockInputStream>(input_schema));

--- a/dbms/src/Core/tests/gtest_spiller.cpp
+++ b/dbms/src/Core/tests/gtest_spiller.cpp
@@ -262,13 +262,13 @@ try
 {
     std::vector<std::unique_ptr<Spiller>> spillers;
     spillers.push_back(std::make_unique<Spiller>(*spill_config_ptr, false, 1, spiller_test_header, logger, 1, false));
-    auto new_spill_dir = fmt::format("{}{}_{}", spill_config_ptr->spill_dir, "release_file_on_restore_test", rand());
-    SpillConfig new_spill_config(new_spill_dir, spill_config_ptr->spill_id, spill_config_ptr->max_spilled_size_per_spill, spill_config_ptr->file_provider);
-    Poco::File spiller_dir(new_spill_config.spill_dir);
+    auto new_spill_path = fmt::format("{}{}_{}", spill_config_ptr->spill_dir, "release_file_on_restore_test", rand());
+    SpillConfig new_spill_config(new_spill_path, spill_config_ptr->spill_id, spill_config_ptr->max_spilled_size_per_spill, spill_config_ptr->file_provider);
+    Poco::File new_spiller_dir(new_spill_config.spill_dir);
     /// remove spiller dir if exists
-    if (spiller_dir.exists())
-        spiller_dir.remove(true);
-    spiller_dir.createDirectories();
+    if (new_spiller_dir.exists())
+        new_spiller_dir.remove(true);
+    new_spiller_dir.createDirectories();
     spillers.push_back(std::make_unique<Spiller>(new_spill_config, false, 1, spiller_test_header, logger));
 
     Blocks blocks = generateBlocks(50);
@@ -282,7 +282,7 @@ try
         else
         {
             std::vector<String> files;
-            spiller_dir.list(files);
+            new_spiller_dir.list(files);
             GTEST_ASSERT_EQ(files.size(), 0);
         }
     }

--- a/dbms/src/Core/tests/gtest_spiller.cpp
+++ b/dbms/src/Core/tests/gtest_spiller.cpp
@@ -85,6 +85,26 @@ protected:
         }
         return ret;
     }
+    static void verifyRestoreBlocks(Spiller & spiller, size_t restore_partition_id, size_t restore_max_stream_size, size_t expected_stream_size, const Blocks & expected_blocks)
+    {
+        auto block_streams = spiller.restoreBlocks(restore_partition_id, restore_max_stream_size);
+        if (expected_stream_size > 0)
+        {
+            GTEST_ASSERT_EQ(block_streams.size(), expected_stream_size);
+        }
+        Blocks restored_blocks;
+        for (auto & block_stream : block_streams)
+        {
+            for (Block block = block_stream->read(); block; block = block_stream->read())
+                restored_blocks.push_back(block);
+        }
+        GTEST_ASSERT_EQ(expected_blocks.size(), restored_blocks.size());
+        for (size_t i = 0; i < expected_blocks.size(); ++i)
+        {
+            blockEqual(expected_blocks[i], restored_blocks[i]);
+        }
+    }
+
     static String spill_dir;
     Block spiller_test_header;
     std::shared_ptr<SpillConfig> spill_config_ptr;
@@ -194,22 +214,8 @@ try
     for (size_t partition_id = 0; partition_id < partition_num; ++partition_id)
     {
         size_t max_restore_streams = 2 + partition_id * 10;
-        auto restore_block_streams = spiller.restoreBlocks(partition_id, max_restore_streams);
         size_t expected_streams = std::min(max_restore_streams, spill_num);
-        GTEST_ASSERT_EQ(restore_block_streams.size(), expected_streams);
-        Blocks all_restored_blocks;
-        for (const auto & block_stream : restore_block_streams)
-        {
-            for (Block block = block_stream->read(); block; block = block_stream->read())
-            {
-                all_restored_blocks.push_back(block);
-            }
-        }
-        GTEST_ASSERT_EQ(all_restored_blocks.size(), all_blocks[partition_id].size());
-        for (size_t i = 0; i < all_restored_blocks.size(); ++i)
-        {
-            blockEqual(all_blocks[partition_id][i], all_restored_blocks[i]);
-        }
+        verifyRestoreBlocks(spiller, partition_id, max_restore_streams, expected_streams, all_blocks[partition_id]);
     }
 }
 CATCH
@@ -244,22 +250,40 @@ try
         for (size_t partition_id = 0; partition_id < partition_num; ++partition_id)
         {
             size_t max_restore_streams = 2 + partition_id * 10;
-            auto restore_block_streams = spiller->restoreBlocks(partition_id, max_restore_streams);
             size_t expected_streams = std::min(max_restore_streams, spill_num);
-            GTEST_ASSERT_EQ(restore_block_streams.size(), expected_streams);
-            Blocks all_restored_blocks;
-            for (const auto & block_stream : restore_block_streams)
-            {
-                for (Block block = block_stream->read(); block; block = block_stream->read())
-                {
-                    all_restored_blocks.push_back(block);
-                }
-            }
-            GTEST_ASSERT_EQ(all_restored_blocks.size(), all_blocks[partition_id].size());
-            for (size_t i = 0; i < all_restored_blocks.size(); ++i)
-            {
-                blockEqual(all_blocks[partition_id][i], all_restored_blocks[i]);
-            }
+            verifyRestoreBlocks(*spiller, partition_id, max_restore_streams, expected_streams, all_blocks[partition_id]);
+        }
+    }
+}
+CATCH
+
+TEST_F(SpillerTest, ReleaseFileOnRestore)
+try
+{
+    std::vector<std::unique_ptr<Spiller>> spillers;
+    spillers.push_back(std::make_unique<Spiller>(*spill_config_ptr, false, 1, spiller_test_header, logger, 1, false));
+    auto new_spill_dir = fmt::format("{}{}_{}", spill_config_ptr->spill_dir, "release_file_on_restore_test", rand());
+    SpillConfig new_spill_config(new_spill_dir, spill_config_ptr->spill_id, spill_config_ptr->max_spilled_size_per_spill, spill_config_ptr->file_provider);
+    Poco::File spiller_dir(new_spill_config.spill_dir);
+    /// remove spiller dir if exists
+    if (spiller_dir.exists())
+        spiller_dir.remove(true);
+    spiller_dir.createDirectories();
+    spillers.push_back(std::make_unique<Spiller>(new_spill_config, false, 1, spiller_test_header, logger, 1, true));
+
+    Blocks blocks = generateBlocks(50);
+    for (auto & spiller : spillers)
+    {
+        spiller->spillBlocks(blocks, 0);
+        spiller->finishSpill();
+        verifyRestoreBlocks(*spiller, 0, 0, 0, blocks);
+        if (spiller->releaseSpilledFileOnRestore())
+            verifyRestoreBlocks(*spiller, 0, 0, 0, blocks);
+        else
+        {
+            std::vector<String> files;
+            spiller_dir.list(files);
+            GTEST_ASSERT_EQ(files.size(), 0);
         }
     }
 }
@@ -285,23 +309,8 @@ try
     for (size_t partition_id = 0; partition_id < partition_num; ++partition_id)
     {
         size_t max_restore_streams = 2 + partition_id * 10;
-        auto restore_block_streams = spiller.restoreBlocks(partition_id, max_restore_streams);
-        /// for sorted spill, the restored stream num is always equal to the spill time
         size_t expected_streams = spill_num;
-        GTEST_ASSERT_EQ(restore_block_streams.size(), expected_streams);
-        Blocks all_restored_blocks;
-        for (const auto & block_stream : restore_block_streams)
-        {
-            for (Block block = block_stream->read(); block; block = block_stream->read())
-            {
-                all_restored_blocks.push_back(block);
-            }
-        }
-        GTEST_ASSERT_EQ(all_restored_blocks.size(), all_blocks[partition_id].size());
-        for (size_t i = 0; i < all_restored_blocks.size(); ++i)
-        {
-            blockEqual(all_blocks[partition_id][i], all_restored_blocks[i]);
-        }
+        verifyRestoreBlocks(spiller, partition_id, max_restore_streams, expected_streams, all_blocks[partition_id]);
     }
 }
 CATCH
@@ -336,23 +345,9 @@ try
         for (size_t partition_id = 0; partition_id < partition_num; ++partition_id)
         {
             size_t max_restore_streams = 2 + partition_id * 10;
-            auto restore_block_streams = spiller->restoreBlocks(partition_id, max_restore_streams);
             /// for sorted spill, the restored stream num is always equal to the spill time
             size_t expected_streams = spill_num;
-            GTEST_ASSERT_EQ(restore_block_streams.size(), expected_streams);
-            Blocks all_restored_blocks;
-            for (const auto & block_stream : restore_block_streams)
-            {
-                for (Block block = block_stream->read(); block; block = block_stream->read())
-                {
-                    all_restored_blocks.push_back(block);
-                }
-            }
-            GTEST_ASSERT_EQ(all_restored_blocks.size(), all_blocks[partition_id].size());
-            for (size_t i = 0; i < all_restored_blocks.size(); ++i)
-            {
-                blockEqual(all_blocks[partition_id][i], all_restored_blocks[i]);
-            }
+            verifyRestoreBlocks(*spiller, partition_id, max_restore_streams, expected_streams, all_blocks[partition_id]);
         }
     }
 }
@@ -449,19 +444,7 @@ try
     ret.emplace_back(data);
     spiller.spillBlocks(ret, 0);
     spiller.finishSpill();
-    auto block_streams = spiller.restoreBlocks(0, 2);
-    GTEST_ASSERT_EQ(block_streams.size(), 1);
-    Blocks restored_blocks;
-    for (auto & block_stream : block_streams)
-    {
-        for (Block block = block_stream->read(); block; block = block_stream->read())
-            restored_blocks.push_back(block);
-    }
-    GTEST_ASSERT_EQ(ret.size(), restored_blocks.size());
-    for (size_t i = 0; i < ret.size(); ++i)
-    {
-        blockEqual(ret[i], restored_blocks[i]);
-    }
+    verifyRestoreBlocks(spiller, 0, 2, 1, ret);
 }
 CATCH
 
@@ -497,19 +480,7 @@ try
     ret.emplace_back(data);
     spiller.spillBlocks(ret, 0);
     spiller.finishSpill();
-    auto block_streams = spiller.restoreBlocks(0, 2);
-    GTEST_ASSERT_EQ(block_streams.size(), 1);
-    Blocks restored_blocks;
-    for (auto & block_stream : block_streams)
-    {
-        for (Block block = block_stream->read(); block; block = block_stream->read())
-            restored_blocks.push_back(block);
-    }
-    GTEST_ASSERT_EQ(ret.size(), restored_blocks.size());
-    for (size_t i = 0; i < ret.size(); ++i)
-    {
-        blockEqual(ret[i], restored_blocks[i]);
-    }
+    verifyRestoreBlocks(spiller, 0, 2, 1, ret);
 }
 CATCH
 
@@ -543,19 +514,7 @@ try
     ret.emplace_back(data);
     spiller.spillBlocks(ret, 0);
     spiller.finishSpill();
-    auto block_streams = spiller.restoreBlocks(0, 2);
-    GTEST_ASSERT_EQ(block_streams.size(), 1);
-    Blocks restored_blocks;
-    for (auto & block_stream : block_streams)
-    {
-        for (Block block = block_stream->read(); block; block = block_stream->read())
-            restored_blocks.push_back(block);
-    }
-    GTEST_ASSERT_EQ(ret.size(), restored_blocks.size());
-    for (size_t i = 0; i < ret.size(); ++i)
-    {
-        blockEqual(ret[i], restored_blocks[i]);
-    }
+    verifyRestoreBlocks(spiller, 0, 2, 1, ret);
 }
 CATCH
 
@@ -585,19 +544,7 @@ try
     ret.emplace_back(data);
     spiller.spillBlocks(ret, 0);
     spiller.finishSpill();
-    auto block_streams = spiller.restoreBlocks(0, 2);
-    GTEST_ASSERT_EQ(block_streams.size(), 1);
-    Blocks restored_blocks;
-    for (auto & block_stream : block_streams)
-    {
-        for (Block block = block_stream->read(); block; block = block_stream->read())
-            restored_blocks.push_back(block);
-    }
-    GTEST_ASSERT_EQ(ret.size(), restored_blocks.size());
-    for (size_t i = 0; i < ret.size(); ++i)
-    {
-        blockEqual(ret[i], restored_blocks[i]);
-    }
+    verifyRestoreBlocks(spiller, 0, 2, 1, ret);
 }
 CATCH
 

--- a/dbms/src/Core/tests/gtest_spiller.cpp
+++ b/dbms/src/Core/tests/gtest_spiller.cpp
@@ -269,7 +269,7 @@ try
     if (spiller_dir.exists())
         spiller_dir.remove(true);
     spiller_dir.createDirectories();
-    spillers.push_back(std::make_unique<Spiller>(new_spill_config, false, 1, spiller_test_header, logger, 1, true));
+    spillers.push_back(std::make_unique<Spiller>(new_spill_config, false, 1, spiller_test_header, logger));
 
     Blocks blocks = generateBlocks(50);
     for (auto & spiller : spillers)
@@ -277,7 +277,7 @@ try
         spiller->spillBlocks(blocks, 0);
         spiller->finishSpill();
         verifyRestoreBlocks(*spiller, 0, 0, 0, blocks);
-        if (spiller->releaseSpilledFileOnRestore())
+        if (!spiller->releaseSpilledFileOnRestore())
             verifyRestoreBlocks(*spiller, 0, 0, 0, blocks);
         else
         {

--- a/dbms/src/DataStreams/SpilledFilesInputStream.cpp
+++ b/dbms/src/DataStreams/SpilledFilesInputStream.cpp
@@ -16,8 +16,8 @@
 
 namespace DB
 {
-SpilledFilesInputStream::SpilledFilesInputStream(std::vector<SpilledFileInfo> && spilled_files_infos_, const Block & header_, const FileProviderPtr & file_provider_, Int64 max_supported_spill_version_)
-    : spilled_file_infos(std::move(spilled_files_infos_))
+SpilledFilesInputStream::SpilledFilesInputStream(std::vector<SpilledFileInfo> && spilled_file_infos_, const Block & header_, const FileProviderPtr & file_provider_, Int64 max_supported_spill_version_)
+    : spilled_file_infos(std::move(spilled_file_infos_))
     , header(header_)
     , file_provider(file_provider_)
     , max_supported_spill_version(max_supported_spill_version_)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6528

Problem Summary:

### What is changed and how it works?
1. refine some logs in spiller
2. support `release_spilled_file_on_restore` in Spiller, which will release the spill file once all the data in that file has been restored.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
