### PR TITLE
move waitAllBuildFinish() out of JoinBlock

### DIFF
--- a/dbms/src/DataStreams/CreatingSetsBlockInputStream.cpp
+++ b/dbms/src/DataStreams/CreatingSetsBlockInputStream.cpp
@@ -114,14 +114,6 @@ void CreatingSetsBlockInputStream::createAll()
 {
     if (!created)
     {
-        for (auto & subqueries_for_sets : subqueries_for_sets_list)
-        {
-            for (auto & elem : subqueries_for_sets)
-            {
-                if (elem.second.join)
-                    elem.second.join->setInitActiveBuildConcurrency();
-            }
-        }
         Stopwatch watch;
         auto thread_manager = newThreadManager();
         try

--- a/dbms/src/DataStreams/HashJoinProbeBlockInputStream.cpp
+++ b/dbms/src/DataStreams/HashJoinProbeBlockInputStream.cpp
@@ -127,6 +127,7 @@ Block HashJoinProbeBlockInputStream::getOutputBlock()
         {
         case ProbeStatus::PROBE:
         {
+            join->waitUntilAllBuildFinished();
             if (probe_process_info.all_rows_joined_finish)
             {
                 Block block = children.back()->read();

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -471,9 +471,8 @@ void Join::setBuildConcurrencyAndInitPool(size_t build_concurrency_)
 {
     if (unlikely(build_concurrency > 0))
         throw Exception("Logical error: `setBuildConcurrencyAndInitPool` shouldn't be called more than once", ErrorCodes::LOGICAL_ERROR);
-    /// do not set active_build_concurrency because in compile stage, `joinBlock` will be called to get generate header, if active_build_concurrency
-    /// is set here, `joinBlock` will hang when used to get header
     build_concurrency = std::max(1, build_concurrency_);
+    active_build_concurrency = build_concurrency;
 
     for (size_t i = 0; i < getBuildConcurrencyInternal(); ++i)
         pools.emplace_back(std::make_shared<Arena>());
@@ -2043,8 +2042,6 @@ void Join::waitUntilAllBuildFinished() const
 
 Block Join::joinBlock(ProbeProcessInfo & probe_process_info) const
 {
-    waitUntilAllBuildFinished();
-
     std::shared_lock lock(rwlock);
 
     probe_process_info.updateStartRow();

--- a/dbms/src/Interpreters/Join.h
+++ b/dbms/src/Interpreters/Join.h
@@ -146,11 +146,6 @@ public:
 
     const Names & getLeftJoinKeys() const { return key_names_left; }
 
-    void setInitActiveBuildConcurrency()
-    {
-        std::unique_lock lock(build_probe_mutex);
-        active_build_concurrency = getBuildConcurrencyInternal();
-    }
     void finishOneBuild();
     void waitUntilAllBuildFinished() const;
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #6791 

Problem Summary:

### What is changed and how it works?
move waitAllBulidFinish() out of JoinBlock() and init active_build_concurrency in join init.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
