### PR TITLE
fix(README) : Prepare Prerequisites on Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain none
 source $HOME/.cargo/env
 
 # Install compilers and dependencies
-sudo pacman -S clang lld libc++ libc++abi compiler-rt openmp lcov cmake ninja curl openssl zlib
+sudo pacman -S clang lld libc++ libc++abi compiler-rt openmp lcov cmake ninja curl openssl zlib llvm
 ```
 
 </details>


### PR DESCRIPTION
After I install arch linux and prepare according to the prompt of README.MD. When I excute the commands follows , error occurs.
```
# In the TiFlash repository root:
mkdir cmake-build-debug  # The directory name can be customized
cd cmake-build-debug

cmake .. -GNinja -DCMAKE_BUILD_TYPE=DEBUG

ninja tiflash
```
error(cmake/tools.cmake:87):
```
Cannot find ar.
```
After excute
```
sudo pacman -S llvm
```
No error occurs again.

### What problem does this PR solve?
Issue Number: close #6800 
Problem Summary:  Prepare Prerequisites on Arch Linux is not enough. We should add ' llvm ' .

### What is changed and how it works?
Just append ' llvm ' in prepare commands on Arch Linux in ` README.md `

### Check List

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
