### PR TITLE
add support for auxiliary memory bound in mpmc_queue

### DIFF
--- a/dbms/src/Common/MPMCQueue.h
+++ b/dbms/src/Common/MPMCQueue.h
@@ -306,6 +306,7 @@ private:
             if (!wait(lock, reader_head, node, pred, deadline))
                 is_timeout = true;
         }
+        /// double check status after potential wait
         if (!isCancelled() && read_pos < write_pos)
         {
             auto & obj = getObj(read_pos);
@@ -465,8 +466,9 @@ private:
     {
         if constexpr (read)
         {
-            current_auxiliary_memory_usage -= element_auxiliary_memory[pos % capacity];
-            element_auxiliary_memory[pos % capacity] = 0;
+            auto & elem_value = element_auxiliary_memory[pos % capacity];
+            current_auxiliary_memory_usage -= elem_value;
+            elem_value = 0;
         }
         else
         {

--- a/dbms/src/Common/MPMCQueue.h
+++ b/dbms/src/Common/MPMCQueue.h
@@ -73,20 +73,20 @@ class MPMCQueue
 public:
     using Status = MPMCQueueStatus;
     using Result = MPMCQueueResult;
-    using ElementAuxiliaryMemoryUsageFunc = std::function<size_t(const T & element)>;
+    using ElementAuxiliaryMemoryUsageFunc = std::function<Int64(const T & element)>;
 
     explicit MPMCQueue(size_t capacity_)
         : capacity(capacity_)
-        , max_auxiliary_memory_usage(std::numeric_limits<size_t>::max())
+        , max_auxiliary_memory_usage(std::numeric_limits<Int64>::max())
         , get_auxiliary_memory_usage([](const T &) { return 0; })
         , data(capacity * sizeof(T))
     {
     }
 
-    /// max_auxiliary_memory_usage_ = 0 means no limit on auxiliary memory usage
-    MPMCQueue(size_t capacity_, size_t max_auxiliary_memory_usage_, ElementAuxiliaryMemoryUsageFunc && get_auxiliary_memory_usage_)
+    /// max_auxiliary_memory_usage_ <= 0 means no limit on auxiliary memory usage
+    MPMCQueue(size_t capacity_, Int64 max_auxiliary_memory_usage_, ElementAuxiliaryMemoryUsageFunc && get_auxiliary_memory_usage_)
         : capacity(capacity_)
-        , max_auxiliary_memory_usage(max_auxiliary_memory_usage_ == 0 ? std::numeric_limits<size_t>::max() : max_auxiliary_memory_usage_)
+        , max_auxiliary_memory_usage(max_auxiliary_memory_usage_ <= 0 ? std::numeric_limits<Int64>::max() : max_auxiliary_memory_usage_)
         , get_auxiliary_memory_usage(std::move(get_auxiliary_memory_usage_))
         , data(capacity * sizeof(T))
     {
@@ -463,7 +463,7 @@ private:
     /// auxiliary memory usage, then the user should provide the function to calculate the auxiliary memory usage
     /// Note: unlike capacity, max_auxiliary_memory_usage is actually a soft-limit because we need to make at least
     /// one element can be pushed to the queue even if its auxiliary memory exceeds max_auxiliary_memory_usage
-    const size_t max_auxiliary_memory_usage;
+    const Int64 max_auxiliary_memory_usage;
     const ElementAuxiliaryMemoryUsageFunc get_auxiliary_memory_usage;
 
     mutable std::mutex mu;
@@ -473,7 +473,7 @@ private:
     Int64 write_pos = 0;
     Status status = Status::NORMAL;
     String cancel_reason;
-    size_t current_auxiliary_memory_usage = 0;
+    Int64 current_auxiliary_memory_usage = 0;
 
     std::vector<UInt8> data;
 };

--- a/dbms/src/Common/MPMCQueue.h
+++ b/dbms/src/Common/MPMCQueue.h
@@ -313,8 +313,9 @@ private:
 
             /// update pos only after all operations that may throw an exception.
             ++read_pos;
+            /// assert so in debug mode, we can get notified if some bugs happens when updating current_auxiliary_memory_usage
+            assert(read_pos != write_pos || current_auxiliary_memory_usage == 0);
             if (read_pos == write_pos)
-                /// if there is no element, the current_auxiliary_memory_usage must be zero
                 current_auxiliary_memory_usage = 0;
 
             /// Notify next writer within the critical area because:

--- a/dbms/src/Common/tests/gtest_mpmc_queue.cpp
+++ b/dbms/src/Common/tests/gtest_mpmc_queue.cpp
@@ -697,7 +697,7 @@ try
 
     /// case 2: less auxiliary memory bound than the capacity bound
     size_t actual_max_size = 5;
-    size_t auxiliary_memory_bound = sizeof(Int64) * actual_max_size;
+    Int64 auxiliary_memory_bound = sizeof(Int64) * actual_max_size;
     MPMCQueue<Int64> queue_1(max_size, auxiliary_memory_bound, [](const Int64 &) { return sizeof(Int64); });
     for (size_t i = 0; i < actual_max_size; i++)
         ASSERT_TRUE(queue_1.tryPush(i) == MPMCQueueResult::OK);
@@ -714,19 +714,23 @@ try
         ASSERT_TRUE(queue_2.tryPush(i) == MPMCQueueResult::OK);
     ASSERT_TRUE(queue_2.tryPush(max_size) == MPMCQueueResult::FULL);
 
-    /// case 4, set auxiliary memory bound to 0 means unbounded for auxiliary memory usage
+    /// case 4, auxiliary memory bound <= 0 means unbounded for auxiliary memory usage
     MPMCQueue<Int64> queue_3(max_size, 0, [](const Int64 &) { return 1024 * 1024; });
     for (size_t i = 0; i < max_size; i++)
         ASSERT_TRUE(queue_3.tryPush(i) == MPMCQueueResult::OK);
     ASSERT_TRUE(queue_3.tryPush(max_size) == MPMCQueueResult::FULL);
+    MPMCQueue<Int64> queue_4(max_size, -1, [](const Int64 &) { return 1024 * 1024; });
+    for (size_t i = 0; i < max_size; i++)
+        ASSERT_TRUE(queue_4.tryPush(i) == MPMCQueueResult::OK);
+    ASSERT_TRUE(queue_4.tryPush(max_size) == MPMCQueueResult::FULL);
 
     /// case 5 even if the element's auxiliary memory is out of bound, at least one element can be pushed
-    MPMCQueue<Int64> queue_4(max_size, 1, [](const Int64 &) { return 10; });
-    ASSERT_TRUE(queue_4.tryPush(1) == MPMCQueueResult::OK);
-    ASSERT_TRUE(queue_4.tryPush(2) == MPMCQueueResult::FULL);
-    ASSERT_TRUE(queue_4.tryPop(value) == MPMCQueueResult::OK);
-    ASSERT_TRUE(queue_4.tryPop(value) == MPMCQueueResult::EMPTY);
-    ASSERT_TRUE(queue_4.tryPush(1) == MPMCQueueResult::OK);
+    MPMCQueue<Int64> queue_5(max_size, 1, [](const Int64 &) { return 10; });
+    ASSERT_TRUE(queue_5.tryPush(1) == MPMCQueueResult::OK);
+    ASSERT_TRUE(queue_5.tryPush(2) == MPMCQueueResult::FULL);
+    ASSERT_TRUE(queue_5.tryPop(value) == MPMCQueueResult::OK);
+    ASSERT_TRUE(queue_5.tryPop(value) == MPMCQueueResult::EMPTY);
+    ASSERT_TRUE(queue_5.tryPush(1) == MPMCQueueResult::OK);
 }
 CATCH
 

--- a/dbms/src/Common/tests/gtest_mpmc_queue.cpp
+++ b/dbms/src/Common/tests/gtest_mpmc_queue.cpp
@@ -685,5 +685,50 @@ try
 }
 CATCH
 
+TEST_F(MPMCQueueTest, AuxiliaryMemoryBound)
+try
+{
+    /// case 1: no auxiliary memory usage bound
+    size_t max_size = 10;
+    MPMCQueue<Int64> queue(max_size);
+    for (size_t i = 0; i < max_size; i++)
+        ASSERT_TRUE(queue.tryPush(i) == MPMCQueueResult::OK);
+    ASSERT_TRUE(queue.tryPush(max_size) == MPMCQueueResult::FULL);
+
+    /// case 2: less auxiliary memory bound than the capacity bound
+    size_t actual_max_size = 5;
+    size_t auxiliary_memory_bound = sizeof(Int64) * actual_max_size;
+    MPMCQueue<Int64> queue_1(max_size, auxiliary_memory_bound, [](const Int64 &) { return sizeof(Int64); });
+    for (size_t i = 0; i < actual_max_size; i++)
+        ASSERT_TRUE(queue_1.tryPush(i) == MPMCQueueResult::OK);
+    ASSERT_TRUE(queue_1.tryPush(actual_max_size) == MPMCQueueResult::FULL);
+    Int64 value;
+    /// after pop one element, the queue can be pushed again
+    ASSERT_TRUE(queue_1.tryPop(value) == MPMCQueueResult::OK);
+    ASSERT_TRUE(queue_1.tryPush(actual_max_size) == MPMCQueueResult::OK);
+
+    /// case 3: less capacity bound than the auxiliary memory bound
+    auxiliary_memory_bound = sizeof(Int64) * (max_size * 10);
+    MPMCQueue<Int64> queue_2(max_size, auxiliary_memory_bound, [](const Int64 &) { return sizeof(Int64); });
+    for (size_t i = 0; i < max_size; i++)
+        ASSERT_TRUE(queue_2.tryPush(i) == MPMCQueueResult::OK);
+    ASSERT_TRUE(queue_2.tryPush(max_size) == MPMCQueueResult::FULL);
+
+    /// case 4, set auxiliary memory bound to 0 means unbounded for auxiliary memory usage
+    MPMCQueue<Int64> queue_3(max_size, 0, [](const Int64 &) { return 1024 * 1024; });
+    for (size_t i = 0; i < max_size; i++)
+        ASSERT_TRUE(queue_3.tryPush(i) == MPMCQueueResult::OK);
+    ASSERT_TRUE(queue_3.tryPush(max_size) == MPMCQueueResult::FULL);
+
+    /// case 5 even if the element's auxiliary memory is out of bound, at least one element can be pushed
+    MPMCQueue<Int64> queue_4(max_size, 1, [](const Int64 &) { return 10; });
+    ASSERT_TRUE(queue_4.tryPush(1) == MPMCQueueResult::OK);
+    ASSERT_TRUE(queue_4.tryPush(2) == MPMCQueueResult::FULL);
+    ASSERT_TRUE(queue_4.tryPop(value) == MPMCQueueResult::OK);
+    ASSERT_TRUE(queue_4.tryPop(value) == MPMCQueueResult::EMPTY);
+    ASSERT_TRUE(queue_4.tryPush(1) == MPMCQueueResult::OK);
+}
+CATCH
+
 } // namespace
 } // namespace DB::tests


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6528

Problem Summary:
In TiFlash runtime, some executors(like ExchangeReceiver, MPPTunnelSender, UnionBlockInputStream) use a MPMC queue to buffer the data, but the queues are only limited by the number of elements. If the element occupies a large amount of memory, the buffer queue may occupy too much memory, this pr add `auxiliary_memory_bound` to mpmc queue, so the memory usage by the queue can be limited.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
