### PR TITLE
bump openssl version to 1.1.1t in build image

### DIFF
--- a/release-centos7-llvm/dockerfiles/misc/bake_llvm_base_aarch64.sh
+++ b/release-centos7-llvm/dockerfiles/misc/bake_llvm_base_aarch64.sh
@@ -41,7 +41,7 @@ function bake_llvm_base_aarch64() {
 
     # OpenSSL
     source $SCRIPTPATH/install_openssl.sh
-    install_openssl "1_1_1l"
+    install_openssl "1_1_1t"
     export OPENSSL_ROOT_DIR="/usr/local/opt/openssl"
 
     # Go

--- a/release-centos7-llvm/dockerfiles/misc/bake_llvm_base_amd64.sh
+++ b/release-centos7-llvm/dockerfiles/misc/bake_llvm_base_amd64.sh
@@ -40,7 +40,7 @@ function bake_llvm_base_amd64() {
 
     # OpenSSL
     source $SCRIPTPATH/install_openssl.sh
-    install_openssl "1_1_1l"
+    install_openssl "1_1_1t"
     export OPENSSL_ROOT_DIR="/usr/local/opt/openssl"
 
     # Go


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6233 

Problem Summary: The OpenSSL version in tiflash build image has some security problem recently. Although it takes no effect in tiflash release binary now because we link to BoringSSL in our release binary, just upgrade it to avoid future confusion.

### What is changed and how it works?
Update OpenSSL version in tiflash build image from `1.1.1l` to `1.1.1t`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
