### PR TITLE
*: Refine some logging level (release-6.5)

### DIFF
--- a/dbms/src/Common/Config/ConfigProcessor.h
+++ b/dbms/src/Common/Config/ConfigProcessor.h
@@ -18,6 +18,7 @@
 #include <Poco/ConsoleChannel.h>
 #include <Poco/DirectoryIterator.h>
 #include <Poco/File.h>
+#include <Poco/Logger.h>
 #include <Poco/Path.h>
 #include <Poco/Util/AbstractConfiguration.h>
 #include <common/logger_useful.h>

--- a/dbms/src/Common/TiFlashException.h
+++ b/dbms/src/Common/TiFlashException.h
@@ -251,6 +251,12 @@ public:
         , error(_error)
     {}
 
+    template <typename... Args>
+    TiFlashException(const TiFlashError & _error, const std::string & fmt, Args &&... args)
+        : Exception(FmtBuffer().fmtAppend(fmt, std::forward<Args>(args)...).toString())
+        , error(_error)
+    {}
+
     const char * name() const throw() override { return "DB::TiFlashException"; }
     const char * className() const throw() override { return "DB::TiFlashException"; }
 

--- a/dbms/src/Encryption/RateLimiter.cpp
+++ b/dbms/src/Encryption/RateLimiter.cpp
@@ -704,7 +704,7 @@ IOLimitTuner::IOLimitTuner(
     , bg_read_stat(std::move(bg_read_stat_))
     , fg_read_stat(std::move(fg_read_stat_))
     , io_config(io_config_)
-    , log(Logger::get("IOLimitTuner"))
+    , log(Logger::get())
 {}
 
 IOLimitTuner::TuneResult IOLimitTuner::tune() const
@@ -712,7 +712,7 @@ IOLimitTuner::TuneResult IOLimitTuner::tune() const
     auto msg = fmt::format("limiter {} write {} read {}", limiterCount(), writeLimiterCount(), readLimiterCount());
     if (limiterCount() < 2)
     {
-        LOG_INFO(log, "{} NOT need to tune.", msg);
+        LOG_DEBUG(log, "{} NOT need to tune.", msg);
         return {0, 0, false, 0, 0, false};
     }
     LOG_INFO(log, "{} need to tune.", msg);

--- a/dbms/src/Flash/LogSearch.h
+++ b/dbms/src/Flash/LogSearch.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <Common/Logger.h>
 #include <Poco/File.h>
 #include <common/logger_useful.h>
 #include <re2/re2.h>
@@ -37,6 +38,7 @@
 
 namespace DB
 {
+
 class LogIterator : private boost::noncopyable
 {
 public:
@@ -51,7 +53,7 @@ public:
         , levels(_levels)
         , patterns(_patterns)
         , log_input_stream(_log_input_stream)
-        , log(&Poco::Logger::get("LogIterator"))
+        , log(Logger::get())
         , cur_lineno(0)
     {
         init();
@@ -128,7 +130,7 @@ private:
     std::istream & log_input_stream;
     std::string line;
 
-    Poco::Logger * log;
+    LoggerPtr log;
 
     uint32_t cur_lineno;
     std::optional<std::pair<uint32_t, Error::Type>> err_info; // <lineno, Error::Type>

--- a/dbms/src/Storages/DeltaMerge/DeltaTree.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaTree.h
@@ -18,7 +18,6 @@
 #include <Core/Types.h>
 #include <IO/WriteHelpers.h>
 #include <Storages/DeltaMerge/Tuple.h>
-#include <common/logger_useful.h>
 
 #include <algorithm>
 #include <cstddef>
@@ -773,8 +772,6 @@ private:
     Allocator * allocator = nullptr;
     size_t bytes = 0;
 
-    Poco::Logger * log = nullptr;
-
 public:
     // For test cases only.
     ValueSpacePtr insert_value_space;
@@ -888,14 +885,10 @@ private:
     {
         allocator = new Allocator();
 
-        log = &Poco::Logger::get("DeltaTree");
-
         insert_value_space = insert_value_space_;
 
         root = createNode<Leaf>();
         left_leaf = right_leaf = as(Leaf, root);
-
-        LOG_TRACE(log, "create");
     }
 
 public:
@@ -928,8 +921,6 @@ public:
         std::swap(num_deletes, other.num_deletes);
         std::swap(num_entries, other.num_entries);
 
-        std::swap(log, other.log);
-
         std::swap(allocator, allocator);
 
         insert_value_space.swap(other.insert_value_space);
@@ -946,8 +937,6 @@ public:
         }
 
         delete allocator;
-
-        LOG_TRACE(log, "free");
     }
 
     void checkAll() const
@@ -1004,7 +993,6 @@ DT_CLASS::DeltaTree(const DT_CLASS::Self & o)
     , num_deletes(o.num_deletes)
     , num_entries(o.num_entries)
     , allocator(new Allocator())
-    , log(&Poco::Logger::get("DeltaTree"))
 {
     NodePtr my_root;
     if (isLeaf(o.root))

--- a/dbms/src/Storages/DeltaMerge/DeltaTree.ipp
+++ b/dbms/src/Storages/DeltaMerge/DeltaTree.ipp
@@ -34,8 +34,6 @@ __attribute__((noinline, flatten)) typename DT_CLASS::InternPtr DT_CLASS::TIFLAS
             as(Intern, root)->parent = nullptr;
         --height;
 
-        LOG_TRACE(log, "height {} -> {}", (height + 1), height);
-
         return {};
     }
 
@@ -57,7 +55,6 @@ __attribute__((noinline, flatten)) typename DT_CLASS::InternPtr DT_CLASS::TIFLAS
 
             ++height;
 
-            LOG_TRACE(log, "height {} -> {}", (height - 1), height);
         }
 
         auto pos = parent->searchChild(asNode(node));

--- a/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReader.cpp
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReader.cpp
@@ -42,9 +42,8 @@ public:
 
     ~SegmentReader()
     {
-        LOG_DEBUG(log, "Stop begin");
         t.join();
-        LOG_DEBUG(log, "Stop end");
+        LOG_DEBUG(log, "Stopped");
     }
 
     std::thread::id getId() const

--- a/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.cpp
@@ -87,17 +87,19 @@ void SSTFilesToBlockInputStream::readPrefix()
             break;
         }
     }
+
+    // Pass the log to SSTReader inorder to filter logs by table_id suffix
     if (!ssts_default.empty())
     {
-        default_cf_reader = std::make_unique<MultiSSTReader<MonoSSTReader, SSTView>>(proxy_helper, ColumnFamilyType::Default, make_inner_func, ssts_default);
+        default_cf_reader = std::make_unique<MultiSSTReader<MonoSSTReader, SSTView>>(proxy_helper, ColumnFamilyType::Default, make_inner_func, ssts_default, log);
     }
     if (!ssts_write.empty())
     {
-        write_cf_reader = std::make_unique<MultiSSTReader<MonoSSTReader, SSTView>>(proxy_helper, ColumnFamilyType::Write, make_inner_func, ssts_write);
+        write_cf_reader = std::make_unique<MultiSSTReader<MonoSSTReader, SSTView>>(proxy_helper, ColumnFamilyType::Write, make_inner_func, ssts_write, log);
     }
     if (!ssts_lock.empty())
     {
-        lock_cf_reader = std::make_unique<MultiSSTReader<MonoSSTReader, SSTView>>(proxy_helper, ColumnFamilyType::Lock, make_inner_func, ssts_lock);
+        lock_cf_reader = std::make_unique<MultiSSTReader<MonoSSTReader, SSTView>>(proxy_helper, ColumnFamilyType::Lock, make_inner_func, ssts_lock, log);
     }
     LOG_INFO(log, "Finish Construct MultiSSTReader, write {} lock {} default {} region {}", ssts_write.size(), ssts_lock.size(), ssts_default.size(), this->region->id());
 

--- a/dbms/src/Storages/GCManager.cpp
+++ b/dbms/src/Storages/GCManager.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Common/Logger.h>
 #include <Storages/DeltaMerge/GCOptions.h>
 #include <Storages/GCManager.h>
 #include <Storages/IManageableStorage.h>
@@ -26,7 +27,7 @@ extern const int TABLE_IS_DROPPED;
 
 GCManager::GCManager(Context & context)
     : global_context{context.getGlobalContext()}
-    , log(&Poco::Logger::get("GCManager"))
+    , log(Logger::get())
 {
 }
 

--- a/dbms/src/Storages/GCManager.h
+++ b/dbms/src/Storages/GCManager.h
@@ -17,13 +17,10 @@
 #include <Common/Stopwatch.h>
 #include <Storages/Transaction/Types.h>
 
-namespace Poco
-{
-class Logger;
-}
-
 namespace DB
 {
+class Logger;
+using LoggerPtr = std::shared_ptr<Logger>;
 class Context;
 
 class GCManager
@@ -42,6 +39,6 @@ private:
 
     AtomicStopwatch gc_check_stop_watch;
 
-    Poco::Logger * log;
+    LoggerPtr log;
 };
 } // namespace DB

--- a/dbms/src/Storages/Page/V3/Blob/GCInfo.cpp
+++ b/dbms/src/Storages/Page/V3/Blob/GCInfo.cpp
@@ -1,0 +1,99 @@
+#include <Common/FmtUtils.h>
+#include <Storages/Page/V3/Blob/GCInfo.h>
+
+#include <magic_enum.hpp>
+
+
+template <>
+struct fmt::formatter<DB::PS::V3::BlobFileGCInfo>
+{
+    static constexpr auto parse(format_parse_context & ctx) -> decltype(ctx.begin())
+    {
+        const auto * it = ctx.begin();
+        const auto * end = ctx.end();
+        if (it != end && *it != '}')
+            throw format_error("invalid format");
+        return it;
+    }
+
+    template <typename FormatContext>
+    auto format(const DB::PS::V3::BlobFileGCInfo & i, FormatContext & ctx) const -> decltype(ctx.out())
+    {
+        return format_to(ctx.out(), "<id:{} rate:{:.2f}>", i.blob_id, i.valid_rate);
+    }
+};
+template <>
+struct fmt::formatter<DB::PS::V3::BlobFileTruncateInfo>
+{
+    static constexpr auto parse(format_parse_context & ctx) -> decltype(ctx.begin())
+    {
+        const auto * it = ctx.begin();
+        const auto * end = ctx.end();
+        if (it != end && *it != '}')
+            throw format_error("invalid format");
+        return it;
+    }
+
+    template <typename FormatContext>
+    auto format(const DB::PS::V3::BlobFileTruncateInfo & i, FormatContext & ctx) const -> decltype(ctx.out())
+    {
+        return format_to(ctx.out(), "<id:{} origin:{} truncate:{} rate:{:.2f}>", i.blob_id, i.origin_size, i.truncated_size, i.valid_rate);
+    }
+};
+
+namespace DB::PS::V3
+{
+
+Poco::Message::Priority BlobStoreGCInfo::getLoggingLevel() const
+{
+    if (blob_gc_info[FullGC].empty() && blob_gc_truncate_info.empty())
+        return Poco::Message::PRIO_DEBUG;
+    return Poco::Message::PRIO_INFORMATION;
+}
+
+String BlobStoreGCInfo::toString() const
+{
+    return fmt::format("{} {} {} {}",
+                       toTypeString(ReadOnly),
+                       toTypeString(Unchanged),
+                       toTypeString(FullGC),
+                       toTypeTruncateString(Truncated));
+}
+
+String BlobStoreGCInfo::toTypeString(const Type type_index) const
+{
+    if (blob_gc_info[type_index].empty())
+        return fmt::format("{{{}: [null]}}", magic_enum::enum_name(type_index));
+
+    // e.g. {FullGC: [<id:4 rate:0.16>]}}
+    FmtBuffer fmt_buf;
+    fmt_buf.fmtAppend("{{{}: [", magic_enum::enum_name(type_index))
+        .joinStr(
+            blob_gc_info[type_index].begin(),
+            blob_gc_info[type_index].end(),
+            [](const auto & i, FmtBuffer & fb) {
+                fb.fmtAppend("{}", i);
+            },
+            ", ")
+        .append("]}}");
+    return fmt_buf.toString();
+}
+
+String BlobStoreGCInfo::toTypeTruncateString(const Type type_index) const
+{
+    if (blob_gc_truncate_info.empty())
+        return fmt::format("{{{}: [null]}}", magic_enum::enum_name(type_index));
+
+    FmtBuffer fmt_buf;
+    fmt_buf.fmtAppend("{{{}: [", type_index)
+        .joinStr(
+            blob_gc_truncate_info.begin(),
+            blob_gc_truncate_info.end(),
+            [](const auto & i, FmtBuffer & fb) {
+                fb.fmtAppend("{}", i);
+            },
+            ", ")
+        .append("]}}");
+    return fmt_buf.toString();
+}
+} // namespace DB::PS::V3

--- a/dbms/src/Storages/Page/V3/Blob/GCInfo.cpp
+++ b/dbms/src/Storages/Page/V3/Blob/GCInfo.cpp
@@ -1,3 +1,17 @@
+// Copyright 2023 PingCAP, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <Common/FmtUtils.h>
 #include <Storages/Page/V3/Blob/GCInfo.h>
 

--- a/dbms/src/Storages/Page/V3/Blob/GCInfo.h
+++ b/dbms/src/Storages/Page/V3/Blob/GCInfo.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <Poco/Message.h>
 #include <Storages/Page/V3/PageDefines.h>
 #include <common/types.h>
-#include <Poco/Message.h>
 
 namespace DB::PS::V3
 {
@@ -69,4 +69,3 @@ private:
 };
 
 } // namespace DB::PS::V3
-

--- a/dbms/src/Storages/Page/V3/Blob/GCInfo.h
+++ b/dbms/src/Storages/Page/V3/Blob/GCInfo.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <Storages/Page/V3/PageDefines.h>
+#include <common/types.h>
+#include <Poco/Message.h>
+
+namespace DB::PS::V3
+{
+
+struct BlobFileGCInfo
+{
+    BlobFileId blob_id;
+    double valid_rate;
+};
+
+struct BlobFileTruncateInfo
+{
+    BlobFileId blob_id;
+    UInt64 origin_size;
+    UInt64 truncated_size;
+    double valid_rate;
+};
+
+struct BlobStoreGCInfo
+{
+    enum Type
+    {
+        ReadOnly = 0,
+        Unchanged = 1,
+        FullGC = 2,
+        Truncated = 3,
+    };
+
+    Poco::Message::Priority getLoggingLevel() const;
+
+    String toString() const;
+
+    void appendToReadOnlyBlob(const BlobFileId blob_id, double valid_rate)
+    {
+        blob_gc_info[ReadOnly].emplace_back(BlobFileGCInfo{blob_id, valid_rate});
+    }
+
+    void appendToNoNeedGCBlob(const BlobFileId blob_id, double valid_rate)
+    {
+        blob_gc_info[Unchanged].emplace_back(BlobFileGCInfo{blob_id, valid_rate});
+    }
+
+    void appendToNeedGCBlob(const BlobFileId blob_id, double valid_rate)
+    {
+        blob_gc_info[FullGC].emplace_back(BlobFileGCInfo{blob_id, valid_rate});
+    }
+
+    void appendToTruncatedBlob(const BlobFileId blob_id, UInt64 origin_size, UInt64 truncated_size, double valid_rate)
+    {
+        blob_gc_truncate_info.emplace_back(BlobFileTruncateInfo{blob_id, origin_size, truncated_size, valid_rate});
+    }
+
+private:
+    // 1. read only blob
+    // 2. no need gc blob
+    // 3. full gc blob
+    std::vector<BlobFileGCInfo> blob_gc_info[3];
+
+    std::vector<BlobFileTruncateInfo> blob_gc_truncate_info;
+
+    String toTypeString(Type type_index) const;
+
+    String toTypeTruncateString(Type type_index) const;
+};
+
+} // namespace DB::PS::V3
+

--- a/dbms/src/Storages/Page/V3/Blob/GCInfo.h
+++ b/dbms/src/Storages/Page/V3/Blob/GCInfo.h
@@ -1,3 +1,17 @@
+// Copyright 2023 PingCAP, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <Poco/Message.h>

--- a/dbms/src/Storages/Page/V3/BlobStore.cpp
+++ b/dbms/src/Storages/Page/V3/BlobStore.cpp
@@ -720,8 +720,8 @@ PageMap BlobStore::read(PageIDAndEntriesV3 & entries, const ReadLimiterPtr & rea
         PageMap page_map;
         for (const auto & [page_id_v3, entry] : entries)
         {
-            (void)entry;
-            LOG_DEBUG(log, "Read entry [page_id={}] without entry size.", page_id_v3);
+            UNUSED(entry);
+            LOG_INFO(log, "Read entry [page_id={}] without entry size.", page_id_v3);
             Page page(page_id_v3);
             page_map.emplace(page_id_v3.low, page);
         }
@@ -808,7 +808,7 @@ Page BlobStore::read(const PageIDAndEntryV3 & id_entry, const ReadLimiterPtr & r
     // The `buf_size` will be 0, we need avoid calling malloc/free with size 0.
     if (buf_size == 0)
     {
-        LOG_DEBUG(log, "Read entry [page_id={}] without entry size.", page_id_v3);
+        LOG_INFO(log, "Read entry [page_id={}] without entry size.", page_id_v3);
         Page page(page_id_v3);
         return page;
     }

--- a/dbms/src/Storages/Page/V3/BlobStore.cpp
+++ b/dbms/src/Storages/Page/V3/BlobStore.cpp
@@ -25,6 +25,7 @@
 #include <Poco/File.h>
 #include <Storages/Page/FileUsage.h>
 #include <Storages/Page/PageDefines.h>
+#include <Storages/Page/V3/Blob/GCInfo.h>
 #include <Storages/Page/V3/BlobStore.h>
 #include <Storages/Page/V3/PageDirectory.h>
 #include <Storages/Page/V3/PageEntriesEdit.h>
@@ -36,6 +37,7 @@
 #include <boost/algorithm/string/classification.hpp>
 #include <ext/scope_guard.h>
 #include <iterator>
+#include <magic_enum.hpp>
 #include <mutex>
 #include <unordered_map>
 
@@ -720,8 +722,8 @@ PageMap BlobStore::read(PageIDAndEntriesV3 & entries, const ReadLimiterPtr & rea
         PageMap page_map;
         for (const auto & [page_id_v3, entry] : entries)
         {
-            UNUSED(entry);
-            LOG_INFO(log, "Read entry [page_id={}] without entry size.", page_id_v3);
+            // Unexpected behavior but do no harm
+            LOG_INFO(log, "Read entry without entry size, page_id={} entry={}", page_id_v3, toDebugString(entry));
             Page page(page_id_v3);
             page_map.emplace(page_id_v3.low, page);
         }
@@ -808,7 +810,8 @@ Page BlobStore::read(const PageIDAndEntryV3 & id_entry, const ReadLimiterPtr & r
     // The `buf_size` will be 0, we need avoid calling malloc/free with size 0.
     if (buf_size == 0)
     {
-        LOG_INFO(log, "Read entry [page_id={}] without entry size.", page_id_v3);
+        // Unexpected behavior but do no harm
+        LOG_INFO(log, "Read entry without entry size, page_id={} entry={}", page_id_v3, toDebugString(entry));
         Page page(page_id_v3);
         return page;
     }
@@ -868,97 +871,6 @@ BlobFilePtr BlobStore::read(const PageIdV3Internal & page_id_v3, BlobFileId blob
     return blob_file;
 }
 
-
-struct BlobStoreGCInfo
-{
-    String toString() const
-    {
-        return fmt::format("{}. {}. {}. {}.",
-                           toTypeString("Read-Only Blob", 0),
-                           toTypeString("No GC Blob", 1),
-                           toTypeString("Full GC Blob", 2),
-                           toTypeTruncateString("Truncated Blob"));
-    }
-
-    void appendToReadOnlyBlob(const BlobFileId blob_id, double valid_rate)
-    {
-        blob_gc_info[0].emplace_back(std::make_pair(blob_id, valid_rate));
-    }
-
-    void appendToNoNeedGCBlob(const BlobFileId blob_id, double valid_rate)
-    {
-        blob_gc_info[1].emplace_back(std::make_pair(blob_id, valid_rate));
-    }
-
-    void appendToNeedGCBlob(const BlobFileId blob_id, double valid_rate)
-    {
-        blob_gc_info[2].emplace_back(std::make_pair(blob_id, valid_rate));
-    }
-
-    void appendToTruncatedBlob(const BlobFileId blob_id, UInt64 origin_size, UInt64 truncated_size, double valid_rate)
-    {
-        blob_gc_truncate_info.emplace_back(std::make_tuple(blob_id, origin_size, truncated_size, valid_rate));
-    }
-
-private:
-    // 1. read only blob
-    // 2. no need gc blob
-    // 3. full gc blob
-    std::vector<std::pair<BlobFileId, double>> blob_gc_info[3];
-
-    std::vector<std::tuple<BlobFileId, UInt64, UInt64, double>> blob_gc_truncate_info;
-
-    String toTypeString(const std::string_view prefix, const size_t index) const
-    {
-        FmtBuffer fmt_buf;
-
-        if (blob_gc_info[index].empty())
-        {
-            fmt_buf.fmtAppend("{}: [null]", prefix);
-        }
-        else
-        {
-            fmt_buf.fmtAppend("{}: [", prefix);
-            fmt_buf.joinStr(
-                blob_gc_info[index].begin(),
-                blob_gc_info[index].end(),
-                [](const auto arg, FmtBuffer & fb) {
-                    fb.fmtAppend("{}/{:.2f}", arg.first, arg.second);
-                },
-                ", ");
-            fmt_buf.append("]");
-        }
-
-        return fmt_buf.toString();
-    }
-
-    String toTypeTruncateString(const std::string_view prefix) const
-    {
-        FmtBuffer fmt_buf;
-        if (blob_gc_truncate_info.empty())
-        {
-            fmt_buf.fmtAppend("{}: [null]", prefix);
-        }
-        else
-        {
-            fmt_buf.fmtAppend("{}: [", prefix);
-            fmt_buf.joinStr(
-                blob_gc_truncate_info.begin(),
-                blob_gc_truncate_info.end(),
-                [](const auto arg, FmtBuffer & fb) {
-                    fb.fmtAppend("{} origin: {} truncate: {} rate: {:.2f}", //
-                                 std::get<0>(arg), // blob id
-                                 std::get<1>(arg), // origin size
-                                 std::get<2>(arg), // truncated size
-                                 std::get<3>(arg)); // valid rate
-                },
-                ", ");
-            fmt_buf.append("]");
-        }
-        return fmt_buf.toString();
-    }
-};
-
 std::vector<BlobFileId> BlobStore::getGCStats()
 {
     // Get a copy of stats map to avoid the big lock on stats map
@@ -992,10 +904,10 @@ std::vector<BlobFileId> BlobStore::getGCStats()
             }
 
             auto lock = stat->lock();
-            auto right_margin = stat->smap->getUsedBoundary();
+            auto right_boundary = stat->smap->getUsedBoundary();
 
             // Avoid divide by zero
-            if (right_margin == 0)
+            if (right_boundary == 0)
             {
                 // Note `stat->sm_total_size` isn't strictly the same as the actual size of underlying BlobFile after restart tiflash,
                 // because some entry may be deleted but the actual disk space is not reclaimed in previous run.
@@ -1006,23 +918,23 @@ std::vector<BlobFileId> BlobStore::getGCStats()
                 // So we need truncate current blob, and let it be reused.
                 auto blobfile = getBlobFile(stat->id);
                 LOG_INFO(log, "Current blob file is empty, truncated to zero [blob_id={}] [total_size={}] [valid_rate={}]", stat->id, stat->sm_total_size, stat->sm_valid_rate);
-                blobfile->truncate(right_margin);
-                blobstore_gc_info.appendToTruncatedBlob(stat->id, stat->sm_total_size, right_margin, stat->sm_valid_rate);
-                stat->sm_total_size = right_margin;
+                blobfile->truncate(right_boundary);
+                blobstore_gc_info.appendToTruncatedBlob(stat->id, stat->sm_total_size, right_boundary, stat->sm_valid_rate);
+                stat->sm_total_size = right_boundary;
                 continue;
             }
 
-            stat->sm_valid_rate = stat->sm_valid_size * 1.0 / right_margin;
+            stat->sm_valid_rate = stat->sm_valid_size * 1.0 / right_boundary;
 
             if (stat->sm_valid_rate > 1.0)
             {
                 LOG_ERROR(
                     log,
-                    "Current blob got an invalid rate {:.2f}, total size is {}, valid size is {}, right margin is {} [blob_id={}]",
+                    "Current blob got an invalid rate {:.2f}, total size is {}, valid size is {}, right boundary is {} [blob_id={}]",
                     stat->sm_valid_rate,
                     stat->sm_total_size,
                     stat->sm_valid_size,
-                    right_margin,
+                    right_boundary,
                     stat->id);
                 assert(false);
                 continue;
@@ -1041,23 +953,23 @@ std::vector<BlobFileId> BlobStore::getGCStats()
             else
             {
                 blobstore_gc_info.appendToNoNeedGCBlob(stat->id, stat->sm_valid_rate);
-                LOG_TRACE(log, "Current [blob_id={}] valid rate is {:.2f}, no need to GC", stat->id, stat->sm_valid_rate);
+                LOG_TRACE(log, "Current [blob_id={}] valid rate is {:.2f}, unchange", stat->id, stat->sm_valid_rate);
             }
 
-            if (right_margin != stat->sm_total_size)
+            if (right_boundary != stat->sm_total_size)
             {
                 auto blobfile = getBlobFile(stat->id);
-                LOG_TRACE(log, "Truncate blob file [blob_id={}] [origin size={}] [truncated size={}]", stat->id, stat->sm_total_size, right_margin);
-                blobfile->truncate(right_margin);
-                blobstore_gc_info.appendToTruncatedBlob(stat->id, stat->sm_total_size, right_margin, stat->sm_valid_rate);
+                LOG_TRACE(log, "Truncate blob file [blob_id={}] [origin size={}] [truncated size={}]", stat->id, stat->sm_total_size, right_boundary);
+                blobfile->truncate(right_boundary);
+                blobstore_gc_info.appendToTruncatedBlob(stat->id, stat->sm_total_size, right_boundary, stat->sm_valid_rate);
 
-                stat->sm_total_size = right_margin;
+                stat->sm_total_size = right_boundary;
                 stat->sm_valid_rate = stat->sm_valid_size * 1.0 / stat->sm_total_size;
             }
         }
     }
 
-    LOG_INFO(log, "BlobStore gc get status done. gc info: {}", blobstore_gc_info.toString());
+    LOG_IMPL(log, blobstore_gc_info.getLoggingLevel(), "BlobStore gc get status done. blob_ids details {}", blobstore_gc_info.toString());
 
     return blob_need_gc;
 }

--- a/dbms/src/Storages/Page/V3/LogFile/LogWriter.cpp
+++ b/dbms/src/Storages/Page/V3/LogFile/LogWriter.cpp
@@ -150,7 +150,7 @@ void LogWriter::addRecord(ReadBuffer & payload, const size_t payload_size, const
         catch (...)
         {
             auto message = getCurrentExceptionMessage(true);
-            LOG_FATAL(&Poco::Logger::get("LogWriter"), "Write physical record failed with message: {}", message);
+            LOG_FATAL(Logger::get(), "Write physical record failed with message: {}", message);
             std::terminate();
         }
         payload.ignore(fragment_length);

--- a/dbms/src/Storages/Page/V3/PageDirectory.cpp
+++ b/dbms/src/Storages/Page/V3/PageDirectory.cpp
@@ -1474,6 +1474,8 @@ bool PageDirectory::tryDumpSnapshot(const ReadLimiterPtr & read_limiter, const W
     assert(!files_snap.persisted_log_files.empty()); // should not be empty
     auto log_num = files_snap.persisted_log_files.rbegin()->log_num;
     auto identifier = fmt::format("{}.dump_{}", wal->name(), log_num);
+
+    Stopwatch watch;
     auto snapshot_reader = wal->createReaderForFiles(identifier, files_snap.persisted_log_files, read_limiter);
     PageDirectoryFactory factory;
     // we just use the `collapsed_dir` to dump edit of the snapshot, should never call functions like `apply` that
@@ -1484,7 +1486,9 @@ bool PageDirectory::tryDumpSnapshot(const ReadLimiterPtr & read_limiter, const W
         /* wal */ nullptr);
     // The records persisted in `files_snap` is older than or equal to all records in `edit`
     auto edit_from_disk = collapsed_dir->dumpSnapshotToEdit();
-    bool done_any_io = wal->saveSnapshot(std::move(files_snap), ser::serializeTo(edit_from_disk), edit_from_disk.size(), write_limiter);
+    files_snap.num_records = edit_from_disk.size();
+    files_snap.read_elapsed_ms = watch.elapsedMilliseconds();
+    bool done_any_io = wal->saveSnapshot(std::move(files_snap), Trait::Serializer::serializeTo(edit_from_disk), write_limiter);
     return done_any_io;
 }
 
@@ -1602,22 +1606,23 @@ PageEntriesV3 PageDirectory::gcInMemEntries(bool return_removed_entries)
         }
     }
 
-    LOG_INFO(log, "After MVCC gc in memory [lowest_seq={}] "
-                  "clean [invalid_snapshot_nums={}] [invalid_page_nums={}] "
-                  "[total_deref_counter={}] [all_del_entries={}]. "
-                  "Still exist [snapshot_nums={}], [page_nums={}]. "
-                  "Longest alive snapshot: [longest_alive_snapshot_time={}] "
-                  "[longest_alive_snapshot_seq={}] [stale_snapshot_nums={}]",
-             lowest_seq,
-             invalid_snapshot_nums,
-             invalid_page_nums,
-             total_deref_counter,
-             all_del_entries.size(),
-             valid_snapshot_nums,
-             valid_page_nums,
-             longest_alive_snapshot_time,
-             longest_alive_snapshot_seq,
-             stale_snapshot_nums);
+    LOG_DEBUG(log,
+              "After MVCC gc in memory [lowest_seq={}] "
+              "clean [invalid_snapshot_nums={}] [invalid_page_nums={}] "
+              "[total_deref_counter={}] [all_del_entries={}]. "
+              "Still exist [snapshot_nums={}], [page_nums={}]. "
+              "Longest alive snapshot: [longest_alive_snapshot_time={}] "
+              "[longest_alive_snapshot_seq={}] [stale_snapshot_nums={}]",
+              lowest_seq,
+              invalid_snapshot_nums,
+              invalid_page_nums,
+              total_deref_counter,
+              all_del_entries.size(),
+              valid_snapshot_nums,
+              valid_page_nums,
+              longest_alive_snapshot_time,
+              longest_alive_snapshot_seq,
+              stale_snapshot_nums);
 
     return all_del_entries;
 }

--- a/dbms/src/Storages/Page/V3/PageStorageImpl.h
+++ b/dbms/src/Storages/Page/V3/PageStorageImpl.h
@@ -16,6 +16,7 @@
 
 #include <Common/Logger.h>
 #include <Common/Stopwatch.h>
+#include <Poco/Message.h>
 #include <Storages/Page/PageDefines.h>
 #include <Storages/Page/PageStorage.h>
 #include <Storages/Page/Snapshot.h>
@@ -110,6 +111,10 @@ private:
     {
         GCStageType stage = GCStageType::Unknown;
         bool executeNextImmediately() const { return stage == GCStageType::FullGC; };
+
+        bool compact_wal_happen = false;
+
+        Poco::Message::Priority getLoggingLevel() const;
 
         UInt64 total_cost_ms = 0;
 

--- a/dbms/src/Storages/Page/V3/WAL/WALReader.cpp
+++ b/dbms/src/Storages/Page/V3/WAL/WALReader.cpp
@@ -213,7 +213,7 @@ bool WALStoreReader::openNextFile()
         const auto log_num = next_file.log_num;
         const auto filename = next_file.filename(next_file.stage);
         const auto fullname = next_file.fullname(next_file.stage);
-        LOG_INFO(logger, "Open log file for reading [file={}]", fullname);
+        LOG_DEBUG(logger, "Open log file for reading [file={}]", fullname);
 
         auto read_buf = createReadBufferFromFileBaseByFileProvider(
             provider,

--- a/dbms/src/Storages/Page/V3/WAL/WALReader.cpp
+++ b/dbms/src/Storages/Page/V3/WAL/WALReader.cpp
@@ -213,7 +213,7 @@ bool WALStoreReader::openNextFile()
         const auto log_num = next_file.log_num;
         const auto filename = next_file.filename(next_file.stage);
         const auto fullname = next_file.fullname(next_file.stage);
-        LOG_DEBUG(logger, "Open log file for reading [file={}]", fullname);
+        LOG_INFO(logger, "Open log file for reading [file={}]", fullname);
 
         auto read_buf = createReadBufferFromFileBaseByFileProvider(
             provider,

--- a/dbms/src/Storages/Page/V3/WALStore.cpp
+++ b/dbms/src/Storages/Page/V3/WALStore.cpp
@@ -208,21 +208,21 @@ WALStore::FilesSnapshot WALStore::tryGetFilesSnapshot(size_t max_persisted_log_f
 bool WALStore::saveSnapshot(
     FilesSnapshot && files_snap,
     String && serialized_snap,
-    size_t num_records,
     const WriteLimiterPtr & write_limiter)
 {
     if (files_snap.persisted_log_files.empty())
         return false;
 
-    LOG_INFO(logger, "Saving directory snapshot [num_records={}]", num_records);
+    LOG_INFO(logger, "Saving directory snapshot [num_records={}]", files_snap.num_records);
 
     // Use {largest_log_num, 1} to save the `edit`
     const auto log_num = files_snap.persisted_log_files.rbegin()->log_num;
     // Create a temporary file for saving directory snapshot
     auto [compact_log, log_filename] = createLogWriter({log_num, 1}, /*manual_flush*/ true);
 
+    // TODO: split the snap into multiple records in LogFile so that the memory
+    //       consumption could be more smooth.
     ReadBufferFromString payload(serialized_snap);
-
     compact_log->addRecord(payload, serialized_snap.size(), write_limiter, /*background*/ true);
     compact_log->flush(write_limiter, /*background*/ true);
     compact_log.reset(); // close fd explicitly before renaming file.
@@ -231,7 +231,6 @@ bool WALStore::saveSnapshot(
     const auto temp_fullname = log_filename.fullname(LogFileStage::Temporary);
     const auto normal_fullname = log_filename.fullname(LogFileStage::Normal);
 
-    LOG_INFO(logger, "Renaming log file to be normal [fullname={}]", temp_fullname);
     // Use `renameFile` from FileProvider that take good care of encryption path
     provider->renameFile(
         temp_fullname,
@@ -239,7 +238,7 @@ bool WALStore::saveSnapshot(
         normal_fullname,
         EncryptionPath(normal_fullname, ""),
         true);
-    LOG_INFO(logger, "Rename log file to normal done [fullname={}]", normal_fullname);
+    LOG_INFO(logger, "Rename log file to normal done [tempname={}] [fullname={}]", temp_fullname, normal_fullname);
 
     // Remove compacted log files.
     for (const auto & filename : files_snap.persisted_log_files)
@@ -258,8 +257,9 @@ bool WALStore::saveSnapshot(
                 fb.append(arg.filename(arg.stage));
             },
             ", ");
-        fmt_buf.fmtAppend("] [num_records={}] [file={}] [size={}].",
-                          num_records,
+        fmt_buf.fmtAppend("] [read_cost={}] [num_records={}] [file={}] [size={}].",
+                          files_snap.read_elapsed_ms,
+                          files_snap.num_records,
                           normal_fullname,
                           serialized_snap.size());
         return fmt_buf.toString();

--- a/dbms/src/Storages/Page/V3/WALStore.h
+++ b/dbms/src/Storages/Page/V3/WALStore.h
@@ -81,6 +81,10 @@ public:
         // If the WAL log file is not inited, it is an empty set.
         LogFilenameSet persisted_log_files;
 
+        // Some stats for logging
+        UInt64 num_records = 0;
+        UInt64 read_elapsed_ms = 0;
+
         // Note that persisted_log_files should not be empty for needSave() == true,
         // cause we get the largest log num from persisted_log_files as the new
         // file name.
@@ -95,7 +99,6 @@ public:
     bool saveSnapshot(
         FilesSnapshot && files_snap,
         String && serialized_snap,
-        size_t num_records,
         const WriteLimiterPtr & write_limiter = nullptr);
 
     const String & name() { return storage_name; }

--- a/dbms/src/Storages/Page/V3/spacemap/SpaceMap.cpp
+++ b/dbms/src/Storages/Page/V3/spacemap/SpaceMap.cpp
@@ -57,7 +57,7 @@ bool SpaceMap::checkSpace(UInt64 offset, size_t size) const
 
 void SpaceMap::logDebugString()
 {
-    LOG_DEBUG(log, toDebugString());
+    LOG_DEBUG(Logger::get(), toDebugString());
 }
 
 bool SpaceMap::markFree(UInt64 offset, size_t length)
@@ -97,7 +97,6 @@ SpaceMap::SpaceMap(UInt64 start_, UInt64 end_, SpaceMapType type_)
     : type(type_)
     , start(start_)
     , end(end_)
-    , log(&Poco::Logger::get("SpaceMap"))
 {
 }
 

--- a/dbms/src/Storages/Page/V3/spacemap/SpaceMap.h
+++ b/dbms/src/Storages/Page/V3/spacemap/SpaceMap.h
@@ -168,8 +168,6 @@ public:
     /* The offset range managed by this SpaceMap. The range is [left, right). */
     UInt64 start;
     UInt64 end;
-
-    Poco::Logger * log;
 };
 
 

--- a/dbms/src/Storages/Page/V3/spacemap/SpaceMapSTDMap.h
+++ b/dbms/src/Storages/Page/V3/spacemap/SpaceMapSTDMap.h
@@ -166,7 +166,7 @@ protected:
 
         if (length > it->second || it->first + it->second < offset + length)
         {
-            LOG_WARNING(log, "Marked space used failed. [offset={}, size={}] is bigger than space [offset={},size={}]", offset, length, it->first, it->second);
+            LOG_WARNING(Logger::get(), "Marked space used failed. [offset={}, size={}] is bigger than space [offset={},size={}]", offset, length, it->first, it->second);
             return false;
         }
 
@@ -214,14 +214,14 @@ protected:
     {
         if (unlikely(free_map.empty()))
         {
-            LOG_ERROR(log, "Current space map is full");
+            LOG_ERROR(Logger::get(), "Current space map is full");
             return std::make_tuple(UINT64_MAX, 0, false);
         }
         RUNTIME_CHECK_MSG(!free_map_invert_index.empty(), "Invalid state: free_map is empty but invert index is not empty");
         auto iter = free_map_invert_index.lower_bound(size);
         if (unlikely(iter == free_map_invert_index.end()))
         {
-            LOG_ERROR(log, "Can't found any place to insert for size {}", size);
+            LOG_ERROR(Logger::get(), "Can't found any place to insert for size {}", size);
             return std::make_tuple(UINT64_MAX, free_map_invert_index.rbegin()->first, false);
         }
         auto length = iter->first;
@@ -276,7 +276,7 @@ protected:
             it_prev--;
             if (it_prev->first + it_prev->second > it->first)
             {
-                LOG_WARNING(log, "Marked space free failed. [offset={}, size={}], prev node is [offset={},size={}]", it->first, it->second, it_prev->first, it_prev->second);
+                LOG_WARNING(Logger::get(), "Marked space free failed. [offset={}, size={}], prev node is [offset={},size={}]", it->first, it->second, it_prev->first, it_prev->second);
                 free_map.erase(it);
                 deleteFromInvertIndex(length, offset);
                 return false;
@@ -288,7 +288,7 @@ protected:
         {
             if (it->first + it->second > it_next->first)
             {
-                LOG_WARNING(log, "Marked space free failed. [offset={}, size={}], next node is [offset={},size={}]", it->first, it->second, it_next->first, it_next->second);
+                LOG_WARNING(Logger::get(), "Marked space free failed. [offset={}, size={}], next node is [offset={},size={}]", it->first, it->second, it_next->first, it_next->second);
                 free_map.erase(it);
                 deleteFromInvertIndex(length, offset);
                 return false;

--- a/dbms/src/Storages/Page/V3/tests/gtest_wal_log.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_wal_log.cpp
@@ -101,7 +101,7 @@ private:
     ReportCollector report;
     std::unique_ptr<LogWriter> writer;
     std::unique_ptr<LogReader> reader;
-    Poco::Logger * log;
+    LoggerPtr log;
 
 protected:
     String path;
@@ -115,7 +115,7 @@ protected:
 
 public:
     LogFileRWTest()
-        : log(&Poco::Logger::get("LogFileRWTest"))
+        : log(Logger::get())
         , recyclable_log(std::get<0>(GetParam()))
         , allow_retry_read(std::get<1>(GetParam()))
     {

--- a/dbms/src/Storages/Page/V3/tests/gtest_wal_store.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_wal_store.cpp
@@ -699,12 +699,8 @@ try
         snap_edit.varEntry(buildV3Id(TEST_NAMESPACE_ID, d_10000(rd)), PageVersion(345, 22), entry, 1);
     }
     std::tie(wal, reader) = WALStore::create(getCurrentTestName(), enc_provider, delegator, config);
-<<<<<<< HEAD
-    bool done = wal->saveSnapshot(std::move(file_snap), ser::serializeTo(snap_edit), snap_edit.size());
-=======
     file_snap.num_records = snap_edit.size();
-    bool done = wal->saveSnapshot(std::move(file_snap), u128::Serializer::serializeTo(snap_edit));
->>>>>>> a449a4581f... Fix compile error
+    bool done = wal->saveSnapshot(std::move(file_snap), ser::serializeTo(snap_edit));
     ASSERT_TRUE(done);
     wal.reset();
     reader.reset();
@@ -786,12 +782,8 @@ TEST_P(WALStoreTest, GetFileSnapshot)
 
         // empty
         PageEntriesEdit snap_edit;
-<<<<<<< HEAD
-        bool done = wal->saveSnapshot(std::move(files), ser::serializeTo(snap_edit), snap_edit.size());
-=======
         files.num_records = snap_edit.size();
-        bool done = wal->saveSnapshot(std::move(files), u128::Serializer::serializeTo(snap_edit));
->>>>>>> a449a4581f... Fix compile error
+        bool done = wal->saveSnapshot(std::move(files), ser::serializeTo(snap_edit));
         ASSERT_TRUE(done);
         ASSERT_EQ(getNumLogFiles(), 1);
     }

--- a/dbms/src/Storages/Page/V3/tests/gtest_wal_store.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_wal_store.cpp
@@ -699,7 +699,12 @@ try
         snap_edit.varEntry(buildV3Id(TEST_NAMESPACE_ID, d_10000(rd)), PageVersion(345, 22), entry, 1);
     }
     std::tie(wal, reader) = WALStore::create(getCurrentTestName(), enc_provider, delegator, config);
+<<<<<<< HEAD
     bool done = wal->saveSnapshot(std::move(file_snap), ser::serializeTo(snap_edit), snap_edit.size());
+=======
+    file_snap.num_records = snap_edit.size();
+    bool done = wal->saveSnapshot(std::move(file_snap), u128::Serializer::serializeTo(snap_edit));
+>>>>>>> a449a4581f... Fix compile error
     ASSERT_TRUE(done);
     wal.reset();
     reader.reset();
@@ -781,7 +786,12 @@ TEST_P(WALStoreTest, GetFileSnapshot)
 
         // empty
         PageEntriesEdit snap_edit;
+<<<<<<< HEAD
         bool done = wal->saveSnapshot(std::move(files), ser::serializeTo(snap_edit), snap_edit.size());
+=======
+        files.num_records = snap_edit.size();
+        bool done = wal->saveSnapshot(std::move(files), u128::Serializer::serializeTo(snap_edit));
+>>>>>>> a449a4581f... Fix compile error
         ASSERT_TRUE(done);
         ASSERT_EQ(getNumLogFiles(), 1);
     }

--- a/dbms/src/Storages/PathCapacityMetrics.cpp
+++ b/dbms/src/Storages/PathCapacityMetrics.cpp
@@ -44,11 +44,11 @@ inline size_t safeGetQuota(const std::vector<size_t> & quotas, size_t idx)
 PathCapacityMetrics::PathCapacityMetrics(
     const size_t capacity_quota_, // will be ignored if `main_capacity_quota` is not empty
     const Strings & main_paths_,
-    const std::vector<size_t> main_capacity_quota_,
+    const std::vector<size_t> & main_capacity_quota_,
     const Strings & latest_paths_,
-    const std::vector<size_t> latest_capacity_quota_)
+    const std::vector<size_t> & latest_capacity_quota_)
     : capacity_quota(capacity_quota_)
-    , log(&Poco::Logger::get("PathCapacityMetrics"))
+    , log(Logger::get())
 {
     if (!main_capacity_quota_.empty())
     {
@@ -248,7 +248,7 @@ ssize_t PathCapacityMetrics::locatePath(std::string_view file_path) const
     return max_match_index;
 }
 
-std::tuple<FsStats, struct statvfs> PathCapacityMetrics::CapacityInfo::getStats(Poco::Logger * log) const
+std::tuple<FsStats, struct statvfs> PathCapacityMetrics::CapacityInfo::getStats(const LoggerPtr & log) const
 {
     FsStats res{};
     /// Get capacity, used, available size for one path.

--- a/dbms/src/Storages/PathCapacityMetrics.h
+++ b/dbms/src/Storages/PathCapacityMetrics.h
@@ -37,11 +37,13 @@ struct DiskCapacity
 class PathCapacityMetrics : private boost::noncopyable
 {
 public:
-    PathCapacityMetrics(const size_t capacity_quota_, // will be ignored if `main_capacity_quota` is not empty
-        const Strings & main_paths_, const std::vector<size_t> main_capacity_quota_, //
-        const Strings & latest_paths_, const std::vector<size_t> latest_capacity_quota_);
+    PathCapacityMetrics(size_t capacity_quota_, // will be ignored if `main_capacity_quota` is not empty
+                        const Strings & main_paths_,
+                        const std::vector<size_t> & main_capacity_quota_, //
+                        const Strings & latest_paths_,
+                        const std::vector<size_t> & latest_capacity_quota_);
 
-    virtual ~PathCapacityMetrics(){};
+    virtual ~PathCapacityMetrics() = default;
 
     void addUsedSize(std::string_view file_path, size_t used_bytes);
 
@@ -73,18 +75,25 @@ private:
         // Used bytes for this path
         std::atomic<uint64_t> used_bytes = 0;
 
-        std::tuple<FsStats, struct statvfs> getStats(Poco::Logger * log) const;
+        std::tuple<FsStats, struct statvfs> getStats(const LoggerPtr & log) const;
 
         CapacityInfo() = default;
-        CapacityInfo(String p, uint64_t c) : path(std::move(p)), capacity_bytes(c) {}
-        CapacityInfo(const CapacityInfo & rhs) : path(rhs.path), capacity_bytes(rhs.capacity_bytes), used_bytes(rhs.used_bytes.load()) {}
+        CapacityInfo(String p, uint64_t c)
+            : path(std::move(p))
+            , capacity_bytes(c)
+        {}
+        CapacityInfo(const CapacityInfo & rhs)
+            : path(rhs.path)
+            , capacity_bytes(rhs.capacity_bytes)
+            , used_bytes(rhs.used_bytes.load())
+        {}
     };
 
     // Max quota bytes can be use for this TiFlash instance.
     // 0 means no quota, use the whole disk.
     size_t capacity_quota;
     std::vector<CapacityInfo> path_infos;
-    Poco::Logger * log;
+    LoggerPtr log;
 };
 
 } // namespace DB

--- a/dbms/src/Storages/PathPool.cpp
+++ b/dbms/src/Storages/PathPool.cpp
@@ -66,7 +66,7 @@ PathPool::PathPool(
     , enable_raft_compatible_mode(enable_raft_compatible_mode_)
     , global_capacity(global_capacity_)
     , file_provider(file_provider_)
-    , log(Logger::get("PathPool"))
+    , log(Logger::get())
 {
     if (kvstore_paths.empty())
     {
@@ -137,7 +137,7 @@ StoragePathPool::StoragePathPool( //
     , shutdown_called(false)
     , global_capacity(std::move(global_capacity_))
     , file_provider(std::move(file_provider_))
-    , log(Logger::get("StoragePathPool"))
+    , log(Logger::get())
 {
     RUNTIME_CHECK_MSG(!database.empty() && !table.empty(), "Can NOT create StoragePathPool [database={}] [table={}]", database, table);
 

--- a/dbms/src/Storages/Transaction/BackgroundService.cpp
+++ b/dbms/src/Storages/Transaction/BackgroundService.cpp
@@ -24,7 +24,7 @@ namespace DB
 BackgroundService::BackgroundService(TMTContext & tmt_)
     : tmt(tmt_)
     , background_pool(tmt.getContext().getBackgroundPool())
-    , log(&Poco::Logger::get("BackgroundService"))
+    , log(Logger::get())
 {
     if (!tmt.isInitialized())
         throw Exception("TMTContext is not initialized", ErrorCodes::LOGICAL_ERROR);

--- a/dbms/src/Storages/Transaction/BackgroundService.h
+++ b/dbms/src/Storages/Transaction/BackgroundService.h
@@ -43,7 +43,7 @@ private:
     TMTContext & tmt;
     BackgroundProcessingPool & background_pool;
 
-    Poco::Logger * log;
+    LoggerPtr log;
 
     BackgroundProcessingPool::TaskHandle single_thread_task_handle;
     BackgroundProcessingPool::TaskHandle storage_gc_handle;

--- a/dbms/src/Storages/Transaction/LearnerRead.cpp
+++ b/dbms/src/Storages/Transaction/LearnerRead.cpp
@@ -14,9 +14,12 @@
 
 #include <Common/Logger.h>
 #include <Common/Stopwatch.h>
+#include <Common/TiFlashException.h>
 #include <Common/TiFlashMetrics.h>
 #include <Flash/Coprocessor/DAGContext.h>
 #include <Interpreters/Context.h>
+#include <Poco/Message.h>
+#include <Storages/DeltaMerge/ScanContext.h>
 #include <Storages/Transaction/KVStore.h>
 #include <Storages/Transaction/LearnerRead.h>
 #include <Storages/Transaction/LockException.h>
@@ -35,37 +38,19 @@
 
 namespace DB
 {
-class LockWrap
-{
-    mutable std::mutex mutex;
-    bool need_lock{true};
 
-protected:
-    std::unique_lock<std::mutex> genLockGuard() const
-    {
-        if (need_lock)
-            return std::unique_lock(mutex);
-        return {};
-    }
-
-public:
-    void setNoNeedLock() { need_lock = false; }
-};
-
-struct UnavailableRegions : public LockWrap
+struct UnavailableRegions
 {
     using Result = RegionException::UnavailableRegions;
 
     void add(RegionID id, RegionException::RegionReadStatus status_)
     {
         status = status_;
-        auto lock = genLockGuard();
         doAdd(id);
     }
 
     size_t size() const
     {
-        auto lock = genLockGuard();
         return ids.size();
     }
 
@@ -73,15 +58,12 @@ struct UnavailableRegions : public LockWrap
 
     void setRegionLock(RegionID region_id_, LockInfoPtr && region_lock_)
     {
-        auto lock = genLockGuard();
         region_lock = std::pair(region_id_, std::move(region_lock_));
         doAdd(region_id_);
     }
 
     void tryThrowRegionException(bool batch_cop)
     {
-        auto lock = genLockGuard();
-
         // For batch-cop request, all unavailable regions, include the ones with lock exception, should be collected and retry next round.
         // For normal cop request, which only contains one region, LockException should be thrown directly and let upper layer(like client-c, tidb, tispark) handle it.
         if (!batch_cop && region_lock)
@@ -93,7 +75,6 @@ struct UnavailableRegions : public LockWrap
 
     bool contains(RegionID region_id) const
     {
-        auto lock = genLockGuard();
         return ids.count(region_id);
     }
 
@@ -107,7 +88,6 @@ private:
 
 class MvccQueryInfoWrap
     : boost::noncopyable
-    , public LockWrap
 {
     using Base = MvccQueryInfo;
     Base & inner;
@@ -144,12 +124,10 @@ public:
     const Base::RegionsQueryInfo & getRegionsInfo() const { return *regions_info_ptr; }
     void addReadIndexRes(RegionID region_id, UInt64 read_index)
     {
-        auto lock = genLockGuard();
         inner.read_index_res[region_id] = read_index;
     }
     UInt64 getReadIndexRes(RegionID region_id) const
     {
-        auto lock = genLockGuard();
         if (auto it = inner.read_index_res.find(region_id); it != inner.read_index_res.end())
             return it->second;
         return 0;
@@ -159,7 +137,7 @@ public:
 LearnerReadSnapshot doLearnerRead(
     const TiDB::TableID logical_table_id,
     MvccQueryInfo & mvcc_query_info_,
-    size_t num_streams,
+    size_t /*num_streams*/,
     bool for_batch_cop,
     Context & context,
     const LoggerPtr & log)
@@ -170,12 +148,6 @@ LearnerReadSnapshot doLearnerRead(
 
     MvccQueryInfoWrap mvcc_query_info(mvcc_query_info_, tmt, logical_table_id);
     const auto & regions_info = mvcc_query_info.getRegionsInfo();
-
-    // adjust concurrency by num of regions or num of streams * mvcc_query_info.concurrent
-    size_t concurrent_num = std::max(1, std::min(static_cast<size_t>(num_streams * mvcc_query_info->concurrent), regions_info.size()));
-
-    // use single thread to do replica read by default because there is some overhead from thread pool itself.
-    concurrent_num = std::min(tmt.replicaReadMaxThread(), concurrent_num);
 
     KVStorePtr & kvstore = tmt.getKVStore();
     LearnerReadSnapshot regions_snapshot;
@@ -192,18 +164,21 @@ LearnerReadSnapshot doLearnerRead(
     }
     // make sure regions are not duplicated.
     if (unlikely(regions_snapshot.size() != regions_info.size()))
-        throw Exception("Duplicate region id", ErrorCodes::LOGICAL_ERROR);
+        throw TiFlashException(
+            Errors::Coprocessor::BadRequest,
+            "Duplicate region id, n_request={} n_actual={}",
+            regions_info.size(),
+            regions_snapshot.size());
 
     const size_t num_regions = regions_info.size();
 
-    const size_t batch_size = num_regions / concurrent_num;
+    // TODO: refactor this enormous lambda into smaller parts
     UnavailableRegions unavailable_regions;
     const auto batch_wait_index = [&](const size_t region_begin_idx) -> void {
         Stopwatch batch_wait_data_watch;
         Stopwatch watch;
 
-        const size_t region_end_idx = std::min(region_begin_idx + batch_size, num_regions);
-        const size_t ori_batch_region_size = region_end_idx - region_begin_idx;
+        const size_t ori_batch_region_size = num_regions - region_begin_idx;
         std::unordered_map<RegionID, kvrpcpb::ReadIndexResponse> batch_read_index_result;
 
         std::vector<kvrpcpb::ReadIndexRequest> batch_read_index_req;
@@ -213,7 +188,7 @@ LearnerReadSnapshot doLearnerRead(
             // If using `std::numeric_limits<uint64_t>::max()`, set `start-ts` 0 to get the latest index but let read-index-worker do not record as history.
             auto read_index_tso = mvcc_query_info->read_tso == std::numeric_limits<uint64_t>::max() ? 0 : mvcc_query_info->read_tso;
 
-            for (size_t region_idx = region_begin_idx; region_idx < region_end_idx; ++region_idx)
+            for (size_t region_idx = region_begin_idx; region_idx < num_regions; ++region_idx)
             {
                 const auto & region_to_query = regions_info[region_idx];
                 const RegionID region_id = region_to_query.region_id;
@@ -319,13 +294,12 @@ LearnerReadSnapshot doLearnerRead(
                 return;
             }
             // TODO: Maybe collect all the Regions that happen wait index timeout instead of just throwing one Region id
-            throw TiFlashException(fmt::format("Region {} is unavailable at {}", region_id, index), Errors::Coprocessor::RegionError);
+            throw TiFlashException(Errors::Coprocessor::RegionError, "Region {} is unavailable at {}", region_id, index);
         };
         const auto wait_index_timeout_ms = tmt.waitIndexTimeout();
-        for (size_t region_idx = region_begin_idx, read_index_res_idx = 0; region_idx < region_end_idx; ++region_idx, ++read_index_res_idx)
+        for (size_t region_idx = region_begin_idx, read_index_res_idx = 0; region_idx < num_regions; ++region_idx, ++read_index_res_idx)
         {
             const auto & region_to_query = regions_info[region_idx];
-            Int64 physical_table_id = region_to_query.physical_table_id;
 
             // if region is unavailable, skip wait index.
             if (unavailable_regions.contains(region_to_query.region_id))
@@ -365,6 +339,7 @@ LearnerReadSnapshot doLearnerRead(
             // Try to resolve locks and flush data into storage layer
             if (mvcc_query_info->resolve_locks)
             {
+                Int64 physical_table_id = region_to_query.physical_table_id;
                 auto res = RegionTable::resolveLocksAndWriteRegion(
                     tmt,
                     physical_table_id,
@@ -405,32 +380,22 @@ LearnerReadSnapshot doLearnerRead(
             unavailable_regions.size());
     };
 
-    auto start_time = Clock::now();
-    if (concurrent_num <= 1)
-    {
-        mvcc_query_info.setNoNeedLock();
-        unavailable_regions.setNoNeedLock();
-        batch_wait_index(0);
-    }
-    else
-    {
-        ::ThreadPool pool(concurrent_num);
-        for (size_t region_begin_idx = 0; region_begin_idx < num_regions; region_begin_idx += batch_size)
-        {
-            pool.schedule([&batch_wait_index, region_begin_idx] { batch_wait_index(region_begin_idx); });
-        }
-        pool.wait();
-    }
+    const auto start_time = Clock::now();
+    batch_wait_index(0);
 
     unavailable_regions.tryThrowRegionException(for_batch_cop);
 
-    auto end_time = Clock::now();
-    LOG_DEBUG(
+    const auto end_time = Clock::now();
+    const auto time_elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count();
+    // Use info level if read wait index run slow
+    const auto log_lvl = time_elapsed_ms > 1000 ? Poco::Message::PRIO_INFORMATION : Poco::Message::PRIO_DEBUG;
+    LOG_IMPL(
         log,
-        "[Learner Read] batch read index | wait index cost {} ms totally, regions_num={}, concurrency={}",
-        std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count(),
+        log_lvl,
+        "[Learner Read] batch read index | wait index cost {} totally, n_regions={} n_unavailable={}",
+        time_elapsed_ms,
         num_regions,
-        concurrent_num);
+        unavailable_regions.size());
 
     if (auto * dag_context = context.getDAGContext())
     {

--- a/dbms/src/Storages/Transaction/RegionTable.cpp
+++ b/dbms/src/Storages/Transaction/RegionTable.cpp
@@ -350,7 +350,7 @@ RegionDataReadInfoList RegionTable::tryFlushRegion(const RegionPtrWithBlock & re
         if (e.code() == ErrorCodes::ILLFORMAT_RAFT_ROW)
         {
             // br or lighting may write illegal data into tikv, skip flush.
-            LOG_WARNING(&Poco::Logger::get(__PRETTY_FUNCTION__), "Got error while reading region committed cache: {}. Skip flush region and keep original cache.", e.displayText());
+            LOG_WARNING(Logger::get(), "Got error while reading region committed cache: {}. Skip flush region and keep original cache.", e.displayText());
         }
         else
             first_exception = std::current_exception();

--- a/dbms/src/Storages/Transaction/SSTReader.h
+++ b/dbms/src/Storages/Transaction/SSTReader.h
@@ -28,7 +28,7 @@ public:
     virtual BaseBuffView valueView() const = 0;
     virtual void next() = 0;
 
-    virtual ~SSTReader(){};
+    virtual ~SSTReader() = default;
 };
 
 class MonoSSTReader : public SSTReader
@@ -81,12 +81,12 @@ public:
     {
         mono->next();
         // If there are no remained keys, we try to switch to next mono reader.
-        this->maybe_next_reader();
+        this->maybeNextReader();
     }
 
     // Switch to next mono reader if current is drained,
     // and we have a next sst file to read.
-    void maybe_next_reader() const
+    void maybeNextReader() const
     {
         if (!mono->remained())
         {
@@ -101,8 +101,8 @@ public:
         }
     }
 
-    MultiSSTReader(const TiFlashRaftProxyHelper * proxy_helper_, ColumnFamilyType type_, Initer initer_, std::vector<E> args_)
-        : log(Logger::get("MultiSSTReader"))
+    MultiSSTReader(const TiFlashRaftProxyHelper * proxy_helper_, ColumnFamilyType type_, Initer initer_, std::vector<E> args_, LoggerPtr log_)
+        : log(log_)
         , proxy_helper(proxy_helper_)
         , type(type_)
         , initer(initer_)

--- a/dbms/src/Storages/Transaction/TMTContext.cpp
+++ b/dbms/src/Storages/Transaction/TMTContext.cpp
@@ -217,7 +217,7 @@ void TMTContext::reloadConfig(const Poco::Util::AbstractConfiguration & config)
     }
     {
         LOG_INFO(
-            &Poco::Logger::root(),
+            Logger::get(),
             "read-index max thread num: {}, timeout: {}ms; wait-index timeout: {}ms; wait-region-ready timeout: {}s; read-index-worker-tick: {}ms",
             replicaReadMaxThread(),
             batchReadIndexTimeout(),

--- a/dbms/src/Storages/Transaction/tests/gtest_new_kvstore.cpp
+++ b/dbms/src/Storages/Transaction/tests/gtest_new_kvstore.cpp
@@ -128,7 +128,7 @@ TEST_F(RegionKVStoreTest, KVStoreFailRecovery)
             auto r1 = proxy_instance->getRegion(region_id);
             applied_index = r1->getLatestAppliedIndex();
             ASSERT_EQ(r1->getLatestAppliedIndex(), kvr1->appliedIndex());
-            LOG_INFO(&Poco::Logger::get("kvstore"), "applied_index {}", applied_index);
+            LOG_INFO(Logger::get(), "applied_index {}", applied_index);
             auto [index, term] = proxy_instance->normalWrite(region_id, {35}, {"v1"}, {WriteCmdType::Put}, {ColumnFamilyType::Default});
             // KVStore succeed. Proxy failed before advance.
             proxy_instance->doApply(kvs, ctx.getTMTContext(), cond, region_id, index);
@@ -235,7 +235,7 @@ TEST_F(RegionKVStoreTest, KVStoreSnapshot)
                 };
                 auto ssts = default_cf.ssts();
                 ASSERT_EQ(ssts.size(), sst_size);
-                MultiSSTReader<MonoSSTReader, SSTView> reader{proxy_helper.get(), ColumnFamilyType::Default, make_inner_func, ssts};
+                MultiSSTReader<MonoSSTReader, SSTView> reader{proxy_helper.get(), ColumnFamilyType::Default, make_inner_func, ssts, Logger::get()};
                 size_t counter = 0;
                 while (reader.remained())
                 {

--- a/dbms/src/Storages/Transaction/tests/gtest_table_info.cpp
+++ b/dbms/src/Storages/Transaction/tests/gtest_table_info.cpp
@@ -31,7 +31,7 @@ using DBInfo = TiDB::DBInfo;
 namespace DB
 {
 
-String createTableStmt(const DBInfo & db_info, const TableInfo & table_info, const SchemaNameMapper & name_mapper, Poco::Logger * log);
+String createTableStmt(const DBInfo & db_info, const TableInfo & table_info, const SchemaNameMapper & name_mapper, const LoggerPtr & log);
 
 namespace tests
 {
@@ -111,7 +111,7 @@ struct StmtCase
         // generate create statement with db_info and table_info
         auto verify_stmt = [&](TiDB::StorageEngine engine_type) {
             table_info.engine_type = engine_type;
-            String stmt = createTableStmt(db_info, table_info, MockSchemaNameMapper(), &Poco::Logger::get("TiDBTableInfo_test"));
+            String stmt = createTableStmt(db_info, table_info, MockSchemaNameMapper(), Logger::get());
             ASSERT_EQ(stmt, create_stmt_dm) << "Table info create statement (DT) mismatch:\n" + stmt + "\n" + create_stmt_dm;
 
 

--- a/dbms/src/TiDB/Schema/SchemaBuilder.cpp
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.cpp
@@ -71,7 +71,7 @@ bool isReservedDatabase(Context & context, const String & database_name)
 }
 
 
-inline void setAlterCommandColumn(Poco::Logger * log, AlterCommand & command, const ColumnInfo & column_info)
+inline void setAlterCommandColumn(const LoggerPtr & log, AlterCommand & command, const ColumnInfo & column_info)
 {
     command.column_name = column_info.name;
     command.column_id = column_info.id;
@@ -147,7 +147,7 @@ bool typeDiffers(const TiDB::ColumnInfo & a, const TiDB::ColumnInfo & b)
 /// In other words, table info and storage structure (altered by applied alter commands) are always identical,
 /// and intermediate failure won't hide the outstanding alter commands.
 inline SchemaChanges detectSchemaChanges(
-    Poco::Logger * log,
+    const LoggerPtr & log,
     const TableInfo & table_info,
     const TableInfo & orig_table_info)
 {
@@ -1004,7 +1004,7 @@ String createTableStmt(
     const DBInfo & db_info,
     const TableInfo & table_info,
     const SchemaNameMapper & name_mapper,
-    Poco::Logger * log)
+    const LoggerPtr & log)
 {
     LOG_DEBUG(log, "Analyzing table info : {}", table_info.serialize());
     auto [columns, pks] = parseColumnsFromTableInfo(table_info);

--- a/dbms/src/TiDB/Schema/SchemaBuilder.h
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.h
@@ -33,14 +33,14 @@ struct SchemaBuilder
 
     Int64 target_version;
 
-    Poco::Logger * log;
+    LoggerPtr log;
 
     SchemaBuilder(Getter & getter_, Context & context_, std::unordered_map<DB::DatabaseID, TiDB::DBInfoPtr> & dbs_, Int64 version)
         : getter(getter_)
         , context(context_)
         , databases(dbs_)
         , target_version(version)
-        , log(&Poco::Logger::get("SchemaBuilder"))
+        , log(Logger::get())
     {}
 
     void applyDiff(const SchemaDiff & diff);

--- a/dbms/src/TiDB/Schema/SchemaGetter.cpp
+++ b/dbms/src/TiDB/Schema/SchemaGetter.cpp
@@ -152,6 +152,7 @@ void AffectedOption::deserialize(Poco::JSON::Object::Ptr json)
     old_table_id = json->getValue<Int64>("old_table_id");
     old_schema_id = json->getValue<Int64>("old_schema_id");
 }
+
 void SchemaDiff::deserialize(const String & data)
 {
     Poco::JSON::Parser parser;

--- a/dbms/src/TiDB/Schema/SchemaGetter.cpp
+++ b/dbms/src/TiDB/Schema/SchemaGetter.cpp
@@ -152,7 +152,6 @@ void AffectedOption::deserialize(Poco::JSON::Object::Ptr json)
     old_table_id = json->getValue<Int64>("old_table_id");
     old_schema_id = json->getValue<Int64>("old_schema_id");
 }
-
 void SchemaDiff::deserialize(const String & data)
 {
     Poco::JSON::Parser parser;

--- a/dbms/src/TiDB/Schema/SchemaGetter.h
+++ b/dbms/src/TiDB/Schema/SchemaGetter.h
@@ -132,11 +132,11 @@ struct SchemaGetter
 {
     pingcap::kv::Snapshot snap;
 
-    Poco::Logger * log;
+    LoggerPtr log;
 
     SchemaGetter(pingcap::kv::Cluster * cluster_, UInt64 tso_)
         : snap(cluster_, tso_)
-        , log(&Poco::Logger::get("SchemaGetter"))
+        , log(Logger::get())
     {}
 
     Int64 getVersion();

--- a/dbms/src/TiDB/Schema/SchemaSyncService.cpp
+++ b/dbms/src/TiDB/Schema/SchemaSyncService.cpp
@@ -35,7 +35,7 @@ extern const int DEADLOCK_AVOIDED;
 SchemaSyncService::SchemaSyncService(DB::Context & context_)
     : context(context_)
     , background_pool(context_.getBackgroundPool())
-    , log(&Poco::Logger::get("SchemaSyncService"))
+    , log(Logger::get())
 {
     handle = background_pool.addTask(
         [&, this] {

--- a/dbms/src/TiDB/Schema/SchemaSyncService.h
+++ b/dbms/src/TiDB/Schema/SchemaSyncService.h
@@ -20,15 +20,12 @@
 #include <boost/noncopyable.hpp>
 #include <memory>
 
-namespace Poco
-{
-class Logger;
-}
-
 namespace DB
 {
 class Context;
 class BackgroundProcessingPool;
+class Logger;
+using LoggerPtr = std::shared_ptr<Logger>;
 
 class IAST;
 using ASTPtr = std::shared_ptr<IAST>;
@@ -62,7 +59,7 @@ private:
     BackgroundProcessingPool & background_pool;
     BackgroundProcessingPool::TaskHandle handle;
 
-    Poco::Logger * log;
+    LoggerPtr log;
 };
 
 using SchemaSyncServicePtr = std::shared_ptr<SchemaSyncService>;

--- a/dbms/src/TiDB/Schema/TiDBSchemaSyncer.h
+++ b/dbms/src/TiDB/Schema/TiDBSchemaSyncer.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <Common/Logger.h>
 #include <Common/Stopwatch.h>
 #include <Common/TiFlashMetrics.h>
 #include <Debug/MockSchemaGetter.h>
@@ -50,12 +51,12 @@ struct TiDBSchemaSyncer : public SchemaSyncer
 
     std::unordered_map<DB::DatabaseID, TiDB::DBInfoPtr> databases;
 
-    Poco::Logger * log;
+    LoggerPtr log;
 
     explicit TiDBSchemaSyncer(KVClusterPtr cluster_)
         : cluster(std::move(cluster_))
         , cur_version(0)
-        , log(&Poco::Logger::get("SchemaSyncer"))
+        , log(Logger::get())
     {}
 
     bool isTooOldSchema(Int64 cur_ver, Int64 new_version) { return cur_ver == 0 || new_version - cur_ver > maxNumberOfDiffs; }

--- a/libs/libcommon/include/common/logger_useful.h
+++ b/libs/libcommon/include/common/logger_useful.h
@@ -16,7 +16,6 @@
 
 /// Macros for convenient usage of Poco logger.
 
-#include <Poco/Logger.h>
 #include <common/MacroUtils.h>
 #include <fmt/compile.h>
 #include <fmt/format.h>
@@ -25,6 +24,12 @@
 #ifndef QUERY_PREVIEW_LENGTH
 #define QUERY_PREVIEW_LENGTH 160
 #endif
+
+namespace DB
+{
+class Logger;
+using LoggerPtr = std::shared_ptr<Logger>;
+} // namespace DB
 
 namespace LogFmtDetails
 {


### PR DESCRIPTION
cherry-pick of https://github.com/pingcap/tiflash/pull/6844 to release-5.0

* * *

### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/6845

Problem Summary:

With logging level "info",

<details>
<summary>Before this PR when there is no write && read on tiflash, there are more than 15 logging every 30 seconds</summary>

```
[2023/02/18 16:41:31.702 +08:00] [INFO] [RateLimiter.cpp:715] ["limiter 0 write 0 read 0 NOT need to tune."] [source=IOLimitTuner] [thread_id=47]
[2023/02/18 16:41:36.725 +08:00] [INFO] [RateLimiter.cpp:715] ["limiter 0 write 0 read 0 NOT need to tune."] [source=IOLimitTuner] [thread_id=47]
[2023/02/18 16:41:41.744 +08:00] [INFO] [RateLimiter.cpp:715] ["limiter 0 write 0 read 0 NOT need to tune."] [source=IOLimitTuner] [thread_id=47]
[2023/02/18 16:41:46.768 +08:00] [INFO] [RateLimiter.cpp:715] ["limiter 0 write 0 read 0 NOT need to tune."] [source=IOLimitTuner] [thread_id=47]
[2023/02/18 16:41:51.788 +08:00] [INFO] [RateLimiter.cpp:715] ["limiter 0 write 0 read 0 NOT need to tune."] [source=IOLimitTuner] [thread_id=47]
[2023/02/18 16:41:52.105 +08:00] [DEBUG] [GCManager.cpp:46] ["Start GC with table id: 4"] [source=GCManager] [thread_id=51]
[2023/02/18 16:41:52.106 +08:00] [DEBUG] [GCManager.cpp:101] ["End GC and next gc will start with table id: 4"] [source=GCManager] [thread_id=51]
[2023/02/18 16:41:56.808 +08:00] [INFO] [RateLimiter.cpp:715] ["limiter 0 write 0 read 0 NOT need to tune."] [source=IOLimitTuner] [thread_id=47]
[2023/02/18 16:42:01.579 +08:00] [INFO] [BlobStore.cpp:1078] ["BlobStore gc get status done. gc info: Read-Only Blob: [null]. No GC Blob: [null]. Full GC Blob: [null]. Truncated Blob: [null]."] [source=__global__.meta] [thread_id=55]
[2023/02/18 16:42:01.579 +08:00] [INFO] [GCDefines.cpp:127] ["GC finished without full gc. [total time=0ms] [compact wal=0ms] [compact directory=0ms] [compact spacemap=0ms] [gc status=0ms] [gc entries=0ms] [gc data=0ms] [gc apply=0ms]"] [source=__global__.meta] [thread_id=55]
[2023/02/18 16:42:01.579 +08:00] [INFO] [BlobStore.cpp:1078] ["BlobStore gc get status done. gc info: Read-Only Blob: [null]. No GC Blob: [null]. Full GC Blob: [null]. Truncated Blob: [null]."] [source=__global__.data] [thread_id=55]
[2023/02/18 16:42:01.579 +08:00] [INFO] [GCDefines.cpp:127] ["GC finished without full gc. [total time=0ms] [compact wal=0ms] [compact directory=0ms] [compact spacemap=0ms] [gc status=0ms] [gc entries=0ms] [gc data=0ms] [gc apply=0ms]"] [source=__global__.data] [thread_id=55]
[2023/02/18 16:42:01.579 +08:00] [INFO] [BlobStore.cpp:1078] ["BlobStore gc get status done. gc info: Read-Only Blob: [null]. No GC Blob: [null]. Full GC Blob: [null]. Truncated Blob: [null]."] [source=__global__.log] [thread_id=55]
[2023/02/18 16:42:01.579 +08:00] [INFO] [GCDefines.cpp:127] ["GC finished without full gc. [total time=0ms] [compact wal=0ms] [compact directory=0ms] [compact spacemap=0ms] [gc status=0ms] [gc entries=0ms] [gc data=0ms] [gc apply=0ms]"] [source=__global__.log] [thread_id=55]
```

</details>

<details>
<summary>After this PR, when there is no write && read, there is only 2 logging every 10 minutes</summary>

```
[2023/02/18 19:50:44.662 +08:00] [INFO] [PageDirectory.cpp:1432] ["GC apply done. [edit size=6]"] [source=__global__.meta] [thread_id=15]
[2023/02/18 19:50:44.662 +08:00] [INFO] [GCDefines.cpp:145] ["GC finished. [total time=0ms] [compact wal=0ms] [compact directory=0ms] [compact spacemap=0ms] [gc status=0ms] [gc entries=0ms] [gc data=0ms] [gc apply=0ms]"] [source=__global__.meta] [thread_id=15]
[2023/02/18 19:50:44.663 +08:00] [INFO] [DeltaMergeStore_InternalBg.cpp:164] ["GC removed useless DM file, dmfile=/data1/jaysonhuang/tiupd/data/tiflash-5010/data/t_84/stable/.del.dmf_17"] [source="table_id=84"] [thread_id=15]
[2023/02/18 19:50:44.665 +08:00] [INFO] [DeltaMergeStore_InternalBg.cpp:164] ["GC removed useless DM file, dmfile=/data1/jaysonhuang/tiupd/data/tiflash-5010/data/t_84/stable/.del.dmf_18"] [source="table_id=84"] [thread_id=15]
[2023/02/18 19:50:44.666 +08:00] [INFO] [DeltaMergeStore_InternalBg.cpp:164] ["GC removed useless DM file, dmfile=/data1/jaysonhuang/tiupd/data/tiflash-5010/data/t_84/stable/.del.dmf_24"] [source="table_id=84"] [thread_id=15]
[2023/02/18 19:51:49.747 +08:00] [INFO] [BlobStore.cpp:545] ["Removing BlobFile [blob_id=4]"] [source=__global__.meta] [thread_id=16]
[2023/02/18 19:52:19.859 +08:00] [INFO] [SchemaSyncService.cpp:100] ["Performing GC using safe point 439542201895354368"] [thread_id=17]
[2023/02/18 19:52:19.859 +08:00] [INFO] [SchemaSyncService.cpp:216] ["Performed GC using safe point 439542201895354368"] [thread_id=17]
[2023/02/18 20:02:19.764 +08:00] [INFO] [SchemaSyncService.cpp:100] ["Performing GC using safe point 439542359181754368"] [thread_id=20]
[2023/02/18 20:02:19.765 +08:00] [INFO] [SchemaSyncService.cpp:216] ["Performed GC using safe point 439542359181754368"] [thread_id=20]
[2023/02/18 20:12:19.811 +08:00] [INFO] [SchemaSyncService.cpp:100] ["Performing GC using safe point 439542516468154368"] [thread_id=22]
[2023/02/18 20:12:19.811 +08:00] [INFO] [SchemaSyncService.cpp:216] ["Performed GC using safe point 439542516468154368"] [thread_id=22]
[2023/02/18 20:22:21.692 +08:00] [INFO] [SchemaSyncService.cpp:100] ["Performing GC using safe point 439542673754554368"] [thread_id=21]
[2023/02/18 20:22:21.692 +08:00] [INFO] [SchemaSyncService.cpp:216] ["Performed GC using safe point 439542673754554368"] [thread_id=21]
[2023/02/18 20:32:21.847 +08:00] [INFO] [SchemaSyncService.cpp:100] ["Performing GC using safe point 439542831041216512"] [thread_id=19]
[2023/02/18 20:32:21.847 +08:00] [INFO] [SchemaSyncService.cpp:216] ["Performed GC using safe point 439542831041216512"] [thread_id=19]
[2023/02/18 20:42:22.364 +08:00] [INFO] [SchemaSyncService.cpp:100] ["Performing GC using safe point 439542988353568768"] [thread_id=16]
[2023/02/18 20:42:22.365 +08:00] [INFO] [SchemaSyncService.cpp:216] ["Performed GC using safe point 439542988353568768"] [thread_id=16]
[2023/02/18 20:53:18.848 +08:00] [INFO] [SchemaSyncService.cpp:100] ["Performing GC using safe point 439543161355763712"] [thread_id=25]
[2023/02/18 20:53:18.849 +08:00] [INFO] [SchemaSyncService.cpp:216] ["Performed GC using safe point 439543161355763712"] [thread_id=25]
```

</details>

### What is changed and how it works?

* Refine some logging level
  * For learner read, if time elapsed is longer than 1 seconds, use info level, else debug level
  * IOLimitTuner use debug level when there is nothing need to tune
  * For PS v3 GC, if full GC or WAL compact happen use info level, else debug level
* Replace `Poco::Logger` with `DB::Logger`
* Remove `flash.replica_read_max_thread`
  * The replica_read_max_thread is useless, especially after this improvement https://github.com/pingcap/tiflash/pull/3971
  * Simplify the logic of learner read after removing the config

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
