### PR TITLE
PageStorage: Fix unexpected dmfile removed after shutdown (cherry-pick #6558) 

### DIFF
--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -240,6 +240,13 @@ struct ContextShared
             return;
         shutdown_called = true;
 
+        if (global_storage_pool)
+        {
+            // shutdown the gc task of global storage pool before
+            // shutting down the tables.
+            global_storage_pool->shutdown();
+        }
+
         /** At this point, some tables may have threads that block our mutex.
           * To complete them correctly, we will copy the current list of tables,
           *  and ask them all to finish their work.

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -403,10 +403,11 @@ void DeltaMergeStore::shutdown()
         return;
 
     LOG_TRACE(log, "Shutdown DeltaMerge start");
-    // shutdown before unregister to avoid conflict between this thread and background gc thread on the `ExternalPagesCallbacks`
-    // because PageStorage V2 doesn't have any lock protection on the `ExternalPagesCallbacks`.(The order doesn't matter for V3)
+    // Must shutdown storage path pool to make sure the DMFile remove callbacks
+    // won't remove dmfiles unexpectly.
+    path_pool->shutdown();
+    // shutdown storage pool and clean up the local DMFile remove callbacks
     storage_pool->shutdown();
-    storage_pool->dataUnregisterExternalPagesCallbacks(storage_pool->getNamespaceId());
 
     background_pool.removeTask(background_task_handle);
     blockable_background_pool.removeTask(blockable_background_pool_handle);

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
@@ -52,6 +52,11 @@ using SegmentIdSet = std::unordered_set<UInt64>;
 struct ExternalDTFileInfo;
 struct GCOptions;
 
+namespace tests
+{
+class DeltaMergeStoreTest;
+}
+
 inline static const PageId DELTA_MERGE_FIRST_SEGMENT_ID = 1;
 
 struct SegmentStats
@@ -155,6 +160,7 @@ struct StoreStats
 class DeltaMergeStore : private boost::noncopyable
 {
 public:
+    friend class ::DB::DM::tests::DeltaMergeStoreTest;
     struct Settings
     {
         NotCompress not_compress_columns{};

--- a/dbms/src/Storages/DeltaMerge/StoragePool.cpp
+++ b/dbms/src/Storages/DeltaMerge/StoragePool.cpp
@@ -112,11 +112,7 @@ GlobalStoragePool::GlobalStoragePool(const PathPool & path_pool, Context & globa
 
 GlobalStoragePool::~GlobalStoragePool()
 {
-    if (gc_handle)
-    {
-        global_context.getBackgroundPool().removeTask(gc_handle);
-        gc_handle = nullptr;
-    }
+    shutdown();
 }
 
 void GlobalStoragePool::restore()
@@ -130,6 +126,15 @@ void GlobalStoragePool::restore()
             return this->gc(global_context.getSettingsRef());
         },
         false);
+}
+
+void GlobalStoragePool::shutdown()
+{
+    if (gc_handle)
+    {
+        global_context.getBackgroundPool().removeTask(gc_handle);
+        gc_handle = {};
+    }
 }
 
 FileUsageStatistics GlobalStoragePool::getLogFileUsage() const
@@ -535,30 +540,31 @@ StoragePool::~StoragePool()
     shutdown();
 }
 
-void StoragePool::enableGC()
-{
-    // The data in V3 will be GCed by `GlobalStoragePool::gc`, only register gc task under only v2/mix mode
-    if (run_mode == PageStorageRunMode::ONLY_V2 || run_mode == PageStorageRunMode::MIX_MODE)
-    {
-        gc_handle = global_context.getBackgroundPool().addTask([this] { return this->gc(global_context.getSettingsRef()); });
-    }
-}
-
-void StoragePool::dataRegisterExternalPagesCallbacks(const ExternalPageCallbacks & callbacks)
+void StoragePool::startup(ExternalPageCallbacks && callbacks)
 {
     switch (run_mode)
     {
     case PageStorageRunMode::ONLY_V2:
     {
+        // For V2, we need a per physical table gc handle to perform the gc of its PageStorage instances.
         data_storage_v2->registerExternalPagesCallbacks(callbacks);
+        gc_handle = global_context.getBackgroundPool().addTask([this] { return this->gc(global_context.getSettingsRef()); });
         break;
     }
     case PageStorageRunMode::ONLY_V3:
+    {
+        // For V3, the GC is handled by `GlobalStoragePool::gc`, just register callbacks is OK.
+        data_storage_v3->registerExternalPagesCallbacks(callbacks);
+        break;
+    }
     case PageStorageRunMode::MIX_MODE:
     {
-        // We have transformed all pages from V2 to V3 in `restore`, so
-        // only need to register callbacks for V3.
+        // For V3, the GC is handled by `GlobalStoragePool::gc`.
+        // Since we have transformed all external pages from V2 to V3 in `StoragePool::restore`,
+        // just register callbacks to V3 is OK
         data_storage_v3->registerExternalPagesCallbacks(callbacks);
+        // we still need a gc_handle to reclaim the V2 disk space.
+        gc_handle = global_context.getBackgroundPool().addTask([this] { return this->gc(global_context.getSettingsRef()); });
         break;
     }
     default:
@@ -566,19 +572,36 @@ void StoragePool::dataRegisterExternalPagesCallbacks(const ExternalPageCallbacks
     }
 }
 
-void StoragePool::dataUnregisterExternalPagesCallbacks(NamespaceId ns_id)
+void StoragePool::shutdown()
 {
+    // Note: Should reset the gc_handle before unregistering the pages callbacks
+    if (gc_handle)
+    {
+        global_context.getBackgroundPool().removeTask(gc_handle);
+        gc_handle = nullptr;
+    }
+
     switch (run_mode)
     {
     case PageStorageRunMode::ONLY_V2:
     {
+        meta_storage_v2->shutdown();
+        log_storage_v2->shutdown();
+        data_storage_v2->shutdown();
         data_storage_v2->unregisterExternalPagesCallbacks(ns_id);
         break;
     }
     case PageStorageRunMode::ONLY_V3:
+    {
+        data_storage_v3->unregisterExternalPagesCallbacks(ns_id);
+        break;
+    }
     case PageStorageRunMode::MIX_MODE:
     {
-        // We have transformed all pages from V2 to V3 in `restore`, so
+        meta_storage_v2->shutdown();
+        log_storage_v2->shutdown();
+        data_storage_v2->shutdown();
+        // We have transformed all external pages from V2 to V3 in `restore`, so
         // only need to unregister callbacks for V3.
         data_storage_v3->unregisterExternalPagesCallbacks(ns_id);
         break;
@@ -587,7 +610,6 @@ void StoragePool::dataUnregisterExternalPagesCallbacks(NamespaceId ns_id)
         throw Exception(fmt::format("Unknown PageStorageRunMode {}", static_cast<UInt8>(run_mode)), ErrorCodes::LOGICAL_ERROR);
     }
 }
-
 
 bool StoragePool::doV2Gc(const Settings & settings)
 {
@@ -627,21 +649,6 @@ bool StoragePool::gc(const Settings & settings, const Seconds & try_gc_period)
 
     // Only do the v2 GC
     return doV2Gc(settings);
-}
-
-void StoragePool::shutdown()
-{
-    if (gc_handle)
-    {
-        global_context.getBackgroundPool().removeTask(gc_handle);
-        gc_handle = nullptr;
-    }
-    if (run_mode != PageStorageRunMode::ONLY_V3)
-    {
-        meta_storage_v2->shutdown();
-        log_storage_v2->shutdown();
-        data_storage_v2->shutdown();
-    }
 }
 
 void StoragePool::drop()

--- a/dbms/src/Storages/DeltaMerge/StoragePool.h
+++ b/dbms/src/Storages/DeltaMerge/StoragePool.h
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include <Poco/Logger.h>
 #include <Storages/BackgroundProcessingPool.h>
 #include <Storages/Page/FileUsage.h>
 #include <Storages/Page/PageStorage.h>
@@ -36,7 +35,7 @@ namespace DM
 class StoragePool;
 using StoragePoolPtr = std::shared_ptr<StoragePool>;
 
-static const std::chrono::seconds DELTA_MERGE_GC_PERIOD(60);
+static constexpr std::chrono::seconds DELTA_MERGE_GC_PERIOD(60);
 
 class GlobalStoragePool : private boost::noncopyable
 {
@@ -50,6 +49,8 @@ public:
     ~GlobalStoragePool();
 
     void restore();
+
+    void shutdown();
 
     friend class StoragePool;
     friend class ::DB::AsynchronousMetrics;
@@ -90,7 +91,7 @@ public:
 
     NamespaceId getNamespaceId() const { return ns_id; }
 
-    PageStorageRunMode getPageStorageRunMode()
+    PageStorageRunMode getPageStorageRunMode() const
     {
         return run_mode;
     }
@@ -141,15 +142,14 @@ public:
     PageReader newMetaReader(ReadLimiterPtr read_limiter, bool snapshot_read, const String & tracing_id);
     PageReader newMetaReader(ReadLimiterPtr read_limiter, PageStorage::SnapshotPtr & snapshot);
 
-    void enableGC();
+    // Register the clean up DMFiles callbacks to PageStorage.
+    // The callbacks will be unregister when `shutdown` is called.
+    void startup(ExternalPageCallbacks && callbacks);
 
-    void dataRegisterExternalPagesCallbacks(const ExternalPageCallbacks & callbacks);
-
-    void dataUnregisterExternalPagesCallbacks(NamespaceId ns_id);
+    // Shutdown the gc handle and DMFile callbacks
+    void shutdown();
 
     bool gc(const Settings & settings, const Seconds & try_gc_period = DELTA_MERGE_GC_PERIOD);
-
-    void shutdown();
 
     // Caller must cancel gc tasks before drop
     void drop();

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_test_basic.h
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_test_basic.h
@@ -77,6 +77,12 @@ public:
         return s;
     }
 
+    Strings getAllStorePaths() const
+    {
+        auto path_delegate = store->path_pool->getStableDiskDelegator();
+        return path_delegate.listPaths();
+    }
+
 protected:
     DeltaMergeStorePtr store;
 };

--- a/dbms/src/Storages/Page/V2/PageStorage.cpp
+++ b/dbms/src/Storages/Page/V2/PageStorage.cpp
@@ -621,6 +621,7 @@ size_t PageStorage::getNumberOfPages()
     }
 }
 
+// For debugging purpose
 std::set<PageId> PageStorage::getAliveExternalPageIds(NamespaceId /*ns_id*/)
 {
     const auto & concrete_snap = getConcreteSnapshot();

--- a/dbms/src/Storages/Page/V2/PageStorage.h
+++ b/dbms/src/Storages/Page/V2/PageStorage.h
@@ -92,7 +92,7 @@ public:
                 const FileProviderPtr & file_provider_,
                 BackgroundProcessingPool & ver_compact_pool_,
                 bool no_more_insert_ = false);
-    ~PageStorage() override { shutdown(); }
+    ~PageStorage() override { shutdown(); } // NOLINT(clang-analyzer-optin.cplusplus.VirtualCall)
 
     void restore() override;
 

--- a/dbms/src/Storages/Page/V3/PageDirectory.h
+++ b/dbms/src/Storages/Page/V3/PageDirectory.h
@@ -339,7 +339,7 @@ public:
 
     // Get the external id that is not deleted or being ref by another id by
     // `ns_id`.
-    std::set<PageId> getAliveExternalIds(NamespaceId ns_id) const
+    std::optional<std::set<PageId>> getAliveExternalIds(NamespaceId ns_id) const
     {
         return external_ids_by_ns.getAliveIds(ns_id);
     }

--- a/dbms/src/Storages/Page/V3/PageDirectory/ExternalIdsByNamespace.h
+++ b/dbms/src/Storages/Page/V3/PageDirectory/ExternalIdsByNamespace.h
@@ -40,7 +40,8 @@ public:
 
     // Get all alive external ids of given `ns_id`
     // Will also cleanup the invalid external ids.
-    std::set<PageId> getAliveIds(NamespaceId ns_id) const;
+    // If the ns_id is invalid, std::nullopt will be returned.
+    std::optional<std::set<PageId>> getAliveIds(NamespaceId ns_id) const;
 
     // After table dropped, the `getAliveIds` with specified
     // `ns_id` will not be cleaned. We need this method to

--- a/dbms/src/Storages/PathPool.cpp
+++ b/dbms/src/Storages/PathPool.cpp
@@ -134,6 +134,7 @@ StoragePathPool::StoragePathPool( //
     : database(std::move(database_))
     , table(std::move(table_))
     , path_need_database_name(path_need_database_name_)
+    , shutdown_called(false)
     , global_capacity(std::move(global_capacity_))
     , file_provider(std::move(file_provider_))
     , log(Logger::get("StoragePathPool"))
@@ -161,6 +162,7 @@ StoragePathPool::StoragePathPool(StoragePathPool && rhs) noexcept
     , table(std::move(rhs.table))
     , dt_file_path_map(std::move(rhs.dt_file_path_map))
     , path_need_database_name(rhs.path_need_database_name)
+    , shutdown_called(rhs.shutdown_called.load())
     , global_capacity(std::move(rhs.global_capacity))
     , file_provider(std::move(rhs.file_provider))
     , log(std::move(rhs.log))
@@ -176,6 +178,7 @@ StoragePathPool & StoragePathPool::operator=(StoragePathPool && rhs)
         database.swap(rhs.database);
         table.swap(rhs.table);
         path_need_database_name = rhs.path_need_database_name;
+        shutdown_called = rhs.shutdown_called.load();
         global_capacity.swap(rhs.global_capacity);
         file_provider.swap(rhs.file_provider);
         log.swap(rhs.log);

--- a/dbms/src/Storages/PathPool.h
+++ b/dbms/src/Storages/PathPool.h
@@ -411,7 +411,7 @@ private:
     PathPool::PageFilePathMap page_path_map;
 };
 
-/// A class to manage paths for the specified storage.
+/// A class to manage paths for a specified physical table.
 class StoragePathPool
 {
 public:
@@ -447,6 +447,10 @@ public:
     void rename(const String & new_database, const String & new_table);
 
     void drop(bool recursive, bool must_success = true);
+
+    void shutdown() { shutdown_called.store(true); }
+
+    bool isShutdown() const { return shutdown_called.load(); }
 
     DISALLOW_COPY(StoragePathPool);
 
@@ -495,6 +499,8 @@ private:
     DMFilePathMap dt_file_path_map;
 
     bool path_need_database_name = false;
+
+    std::atomic<bool> shutdown_called;
 
     PathCapacityMetricsPtr global_capacity;
 

--- a/dbms/src/Storages/StorageDeltaMerge.cpp
+++ b/dbms/src/Storages/StorageDeltaMerge.cpp
@@ -1555,6 +1555,9 @@ void StorageDeltaMerge::startup()
     tmt.getStorages().put(std::static_pointer_cast<StorageDeltaMerge>(shared_from_this()));
 }
 
+// Avoid calling virtual function `shutdown` in destructor,
+// we should use this function instead.
+// https://stackoverflow.com/a/12093250/4412495
 void StorageDeltaMerge::shutdownImpl()
 {
     bool v = false;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #6486

Problem Summary:
From the log file, we can see that (almost all) dmfile are removed after "Release DeltaMerge Store end". This should not happen because we will check the `path_pool_weak_ref` is valid or not in the remover callback

https://github.com/pingcap/tiflash/blob/5bd0e891eef0dcaecf35198b3051f71c20939c0a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalBg.cpp#L70-L77

However, it do happen :(
Maybe there are some background tasks that is being handled and keep a shared_ptr of `path_pool` or `delta-merge-store` so the detect is false positive passed.

I can reproduce the similar problem by a unit test

https://github.com/pingcap/tiflash/blob/eac71b95263790f758f9bdf7120b692f4ad13af4/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store.cpp#L136-L149

```
[2022/12/13 21:38:02.332 +08:00] [INFO] [BaseDaemon.cpp:1300] ["Received termination signal (Terminated)"] [source=Application] [thread_id=86]
[2022/12/13 21:38:02.332 +08:00] [INFO] [Server.cpp:1342] ["Set store context status Stopping"] [thread_id=1]
[2022/12/13 21:38:02.336 +08:00] [INFO] [Server.cpp:1351] ["Set store context status Terminated"] [thread_id=1]
[2022/12/13 21:38:03.501 +08:00] [DEBUG] [Server.cpp:742] ["Received termination signal."] [thread_id=1]
...
[2022/12/13 21:38:07.398 +08:00] [INFO] [Server.cpp:1235] ["Shutting down storages."] [thread_id=1]
...
[2022/12/13 21:38:07.417 +08:00] [INFO] [RegionTable.cpp:200] ["remove table 93 in RegionTable success"] [thread_id=1]
[2022/12/13 21:38:07.417 +08:00] [INFO] [RegionTable.cpp:200] ["remove table 95 in RegionTable success"] [thread_id=1]
[2022/12/13 21:38:07.417 +08:00] [INFO] [DeltaMergeStore.cpp:289] ["Release DeltaMerge Store start"] [source="table_id=95"] [thread_id=1]
[2022/12/13 21:38:07.417 +08:00] [INFO] [DeltaMergeStore.cpp:293] ["Release DeltaMerge Store end"] [source="table_id=95"] [thread_id=1]
[2022/12/13 21:38:07.422 +08:00] [INFO] [DeltaMergeStore.cpp:289] ["Release DeltaMerge Store start"] [source="table_id=93"] [thread_id=1]
[2022/12/13 21:38:07.422 +08:00] [INFO] [DeltaMergeStore.cpp:293] ["Release DeltaMerge Store end"] [source="table_id=93"] [thread_id=1]
[2022/12/13 21:38:07.659 +08:00] [INFO] [RateLimiter.cpp:715] ["limiter 0 write 0 read 0 NOT need to tune."] [source=IOLimitTuner] [thread_id=48]
[2022/12/13 21:38:08.756 +08:00] [DEBUG] [GCManager.cpp:46] ["Start GC with table id: 4"] [source=GCManager] [thread_id=60]
[2022/12/13 21:38:08.756 +08:00] [DEBUG] [GCManager.cpp:101] ["End GC and next gc will start with table id: 1064300"] [source=GCManager] [thread_id=60]
[2022/12/13 21:38:09.314 +08:00] [INFO] [DeltaMergeStore_InternalBg.cpp:126] ["GC removed useless DM file, dmfile=/data2/hongyunyan/tiflash-41350/data/data/t_93/stable/.del.dmf_51058"] [source="table_id=93"] [thread_id=66]
[2022/12/13 21:38:09.329 +08:00] [INFO] [DeltaMergeStore_InternalBg.cpp:126] ["GC removed useless DM file, dmfile=/data2/hongyunyan/tiflash-41350/data/data/t_93/stable/.del.dmf_51172"] [source="table_id=93"] [thread_id=66]
[2022/12/13 21:38:09.342 +08:00] [INFO] [DeltaMergeStore_InternalBg.cpp:126] ["GC removed useless DM file, dmfile=/data2/hongyunyan/tiflash-41350/data/data/t_93/stable/.del.dmf_51197"] [source="table_id=93"] [thread_id=66]
[2022/12/13 21:38:09.357 +08:00] [INFO] [DeltaMergeStore_InternalBg.cpp:126] ["GC removed useless DM file, dmfile=/data2/hongyunyan/tiflash-41350/data/data/t_93/stable/.del.dmf_51385"] [source="table_id=93"] [thread_id=66]
...
[2022/12/13 21:38:23.547 +08:00] [INFO] [DeltaMergeStore_InternalBg.cpp:126] ["GC removed useless DM file, dmfile=/data2/hongyunyan/tiflash-41350/data/data/t_93/stable/.del.dmf_62619"] [source="table_id=93"] [thread_id=66]
[2022/12/13 21:38:23.564 +08:00] [INFO] [DeltaMergeStore_InternalBg.cpp:126] ["GC removed useless DM file, dmfile=/data2/hongyunyan/tiflash-41350/data/data/t_93/stable/.del.dmf_62629"] [source="table_id=93"] [thread_id=66]
[2022/12/13 21:38:23.577 +08:00] [INFO] [DeltaMergeStore_InternalBg.cpp:126] ["GC removed useless DM file, dmfile=/data2/hongyunyan/tiflash-41350/data/data/t_93/stable/.del.dmf_62634"] [source="table_id=93"] [thread_id=66]
[2022/12/13 21:38:23.586 +08:00] [DEBUG] [Server.cpp:1241] ["Shutted down storages."] [thread_id=1]
[2022/12/13 21:38:23.589 +08:00] [INFO] [DeltaMergeStore_InternalBg.cpp:126] ["GC removed useless DM file, dmfile=/data2/hongyunyan/tiflash-41350/data/data/t_93/stable/.del.dmf_62635"] [source="table_id=93"] [thread_id=66]
[2022/12/13 21:38:23.601 +08:00] [INFO] [DeltaMergeStore_InternalBg.cpp:126] ["GC removed useless DM file, dmfile=/data2/hongyunyan/tiflash-41350/data/data/t_93/stable/.del.dmf_62636"] [source="table_id=93"] [thread_id=66]
[2022/12/13 21:38:23.614 +08:00] [INFO] [DeltaMergeStore_InternalBg.cpp:126] ["GC removed useless DM file, dmfile=/data2/hongyunyan/tiflash-41350/data/data/t_93/stable/.del.dmf_62637"] [source="table_id=93"] [thread_id=66]
...
[2022/12/13 21:39:32.363 +08:00] [INFO] [DeltaMergeStore_InternalBg.cpp:126] ["GC removed useless DM file, dmfile=/data2/hongyunyan/tiflash-41350/data/data/t_93/stable/.del.dmf_95897"] [source="table_id=93"] [thread_id=66]
[2022/12/13 21:39:32.375 +08:00] [INFO] [DeltaMergeStore_InternalBg.cpp:126] ["GC removed useless DM file, dmfile=/data2/hongyunyan/tiflash-41350/data/data/t_93/stable/.del.dmf_95901"] [source="table_id=93"] [thread_id=66]
# next restart
[2022/12/13 21:39:36.453 +08:00] [INFO] [<unknown>] ["Welcome to TiFlash"] [thread_id=1]
[2022/12/13 21:39:36.453 +08:00] [INFO] [<unknown>] ["Starting daemon with revision 54381"] [thread_id=1]
[2022/12/13 21:39:36.453 +08:00] [INFO] [<unknown>] ["TiFlash build info: TiFlash\nRelease Version: v6.5.0-alpha-67-gcaef4c4-dirty\nEdition:         Community\nGit Commit Hash: caef4c48e918d02315f9d342754d5862bea0bb62\nGit Branch:      master\nUTC Build Time:  2022-12-12 09:58:30\nEnable Features: jemalloc sm4(GmSSL) avx2 avx512 unwind\nProfile:         RELEASE\n"] [thread_id=1]
```

### What is changed and how it works?

* Shutdown the global_storage_pool explicitly inside ContextShared::shutdown
* Add an atomic flag `shutdown_called` in `StoragePathPool`
* Call `StoragePathPool::shutdown` before removing the callbacks from global page storage
* Check whether the StoragePathPool is shutdown or not inside the callbacks to ensure the safety of removing dmfiles
* Use functor class `LocalDMFileGcScanner`/`LocalDMFileGcRemover` instead of lambda functions to make sure the callbacks won't contain unexpected shared_ptrs
* Make sure the `remover` callback will NOT be called if the ns_id is invalid in `PageDirectory::getAliveExternalIds`
  * Caller still need to make sure `scanner` is safe to be called


Some refactor:

* Merge `StoragePool::dataRegisterExternalPagesCallbacks, enableGC` into `StoragePool::startup`
* Merge `StoragePool::dataUnregisterExternalPagesCallbacks` into `StoragePool::shutdown` to ensure the orders inside shutdown


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix a bug that may cause data lost after restart
```
