### PR TITLE
use RepeatedPtrField<tipb::Expr> instead of vector<tipb::Expr *>

### DIFF
--- a/dbms/src/Flash/Coprocessor/DAGExpressionAnalyzer.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGExpressionAnalyzer.cpp
@@ -679,16 +679,16 @@ String DAGExpressionAnalyzer::applyFunction(
 
 String DAGExpressionAnalyzer::buildFilterColumn(
     const ExpressionActionsPtr & actions,
-    const std::vector<const tipb::Expr *> & conditions)
+    const google::protobuf::RepeatedPtrField<tipb::Expr> & conditions)
 {
     String filter_column_name;
     if (conditions.size() == 1)
     {
-        filter_column_name = getActions(*conditions[0], actions, true);
-        if (isColumnExpr(*conditions[0])
-            && (!exprHasValidFieldType(*conditions[0])
+        filter_column_name = getActions(conditions[0], actions, true);
+        if (isColumnExpr(conditions[0])
+            && (!exprHasValidFieldType(conditions[0])
                 /// if the column is not UInt8 type, we already add some convert function to convert it ot UInt8 type
-                || isUInt8Type(getDataTypeByFieldTypeForComputingLayer(conditions[0]->field_type()))))
+                || isUInt8Type(getDataTypeByFieldTypeForComputingLayer(conditions[0].field_type()))))
         {
             /// FilterBlockInputStream will CHANGE the filter column inplace, so
             /// filter column should never be a columnRef in DAG request, otherwise
@@ -700,8 +700,8 @@ String DAGExpressionAnalyzer::buildFilterColumn(
     else
     {
         Names arg_names;
-        for (const auto * condition : conditions)
-            arg_names.push_back(getActions(*condition, actions, true));
+        for (const auto & condition : conditions)
+            arg_names.push_back(getActions(condition, actions, true));
         // connect all the conditions by logical and
         filter_column_name = applyFunction("and", arg_names, actions, nullptr);
     }
@@ -710,7 +710,7 @@ String DAGExpressionAnalyzer::buildFilterColumn(
 
 String DAGExpressionAnalyzer::appendWhere(
     ExpressionActionsChain & chain,
-    const std::vector<const tipb::Expr *> & conditions)
+    const google::protobuf::RepeatedPtrField<tipb::Expr> & conditions)
 {
     auto & last_step = initAndGetLastStep(chain);
 
@@ -1054,10 +1054,7 @@ bool DAGExpressionAnalyzer::appendJoinKeyAndJoinFilters(
     if (!filters.empty())
     {
         ret = true;
-        std::vector<const tipb::Expr *> filter_vector;
-        for (const auto & c : filters)
-            filter_vector.push_back(&c);
-        filter_column_name = appendWhere(chain, filter_vector);
+        filter_column_name = appendWhere(chain, filters);
     }
     /// remove useless columns to avoid duplicate columns
     /// as when compiling the key/filter expression, the origin

--- a/dbms/src/Flash/Coprocessor/DAGExpressionAnalyzer.h
+++ b/dbms/src/Flash/Coprocessor/DAGExpressionAnalyzer.h
@@ -69,7 +69,7 @@ public:
 
     String appendWhere(
         ExpressionActionsChain & chain,
-        const std::vector<const tipb::Expr *> & conditions);
+        const google::protobuf::RepeatedPtrField<tipb::Expr> & conditions);
 
     GroupingSets buildExpandGroupingColumns(const tipb::Expand & expand, const ExpressionActionsPtr & actions);
 
@@ -175,7 +175,7 @@ public:
 
     String buildFilterColumn(
         const ExpressionActionsPtr & actions,
-        const std::vector<const tipb::Expr *> & conditions);
+        const google::protobuf::RepeatedPtrField<tipb::Expr> & conditions);
 
     void buildAggFuncs(
         const tipb::Aggregation & aggregation,

--- a/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.cpp
@@ -103,10 +103,7 @@ AnalysisResult analyzeExpressions(
     // In test mode, filter is not pushed down to table scan.
     if (query_block.selection && (!query_block.isTableScanSource() || context.isTest()))
     {
-        std::vector<const tipb::Expr *> where_conditions;
-        for (const auto & c : query_block.selection->selection().conditions())
-            where_conditions.push_back(&c);
-        res.filter_column_name = analyzer.appendWhere(chain, where_conditions);
+        res.filter_column_name = analyzer.appendWhere(chain, query_block.selection->selection().conditions());
         res.before_where = chain.getLastActions();
         chain.addStep();
     }
@@ -123,10 +120,7 @@ AnalysisResult analyzeExpressions(
 
         if (query_block.having != nullptr)
         {
-            std::vector<const tipb::Expr *> having_conditions;
-            for (const auto & c : query_block.having->selection().conditions())
-                having_conditions.push_back(&c);
-            res.having_column_name = analyzer.appendWhere(chain, having_conditions);
+            res.having_column_name = analyzer.appendWhere(chain, query_block.having->selection().conditions());
             res.before_having = chain.getLastActions();
             chain.addStep();
         }

--- a/dbms/src/Flash/Coprocessor/DAGQueryInfo.h
+++ b/dbms/src/Flash/Coprocessor/DAGQueryInfo.h
@@ -27,7 +27,7 @@ namespace DB
 struct DAGQueryInfo
 {
     DAGQueryInfo(
-        const std::vector<const tipb::Expr *> & filters_,
+        const google::protobuf::RepeatedPtrField<tipb::Expr> & filters_,
         DAGPreparedSets dag_sets_,
         const NamesAndTypes & source_columns_,
         const TimezoneInfo & timezone_info_)
@@ -36,7 +36,7 @@ struct DAGQueryInfo
         , source_columns(source_columns_)
         , timezone_info(timezone_info_){};
     // filters in dag request
-    const std::vector<const tipb::Expr *> & filters;
+    const google::protobuf::RepeatedPtrField<tipb::Expr> & filters;
     // Prepared sets extracted from dag request, which are used for indices
     // by storage engine.
     DAGPreparedSets dag_sets;

--- a/dbms/src/Flash/Coprocessor/FilterConditions.cpp
+++ b/dbms/src/Flash/Coprocessor/FilterConditions.cpp
@@ -20,7 +20,7 @@ namespace DB
 {
 FilterConditions::FilterConditions(
     const String & executor_id_,
-    const std::vector<const tipb::Expr *> & conditions_)
+    const google::protobuf::RepeatedPtrField<tipb::Expr> & conditions_)
     : executor_id(executor_id_)
     , conditions(conditions_)
 {
@@ -40,7 +40,7 @@ tipb::Executor * FilterConditions::constructSelectionForRemoteRead(tipb::Executo
         mutable_executor->set_executor_id(executor_id);
         auto * new_selection = mutable_executor->mutable_selection();
         for (const auto & condition : conditions)
-            *new_selection->add_conditions() = *condition;
+            *new_selection->add_conditions() = condition;
         return new_selection->mutable_child();
     }
     else
@@ -61,10 +61,6 @@ FilterConditions FilterConditions::filterConditionsFrom(const String & executor_
 
 FilterConditions FilterConditions::filterConditionsFrom(const String & executor_id, const tipb::Selection & selection)
 {
-    std::vector<const tipb::Expr *> conditions;
-    for (const auto & condition : selection.conditions())
-        conditions.push_back(&condition);
-
-    return {executor_id, conditions};
+    return {executor_id, selection.conditions()};
 }
 } // namespace DB

--- a/dbms/src/Flash/Coprocessor/FilterConditions.h
+++ b/dbms/src/Flash/Coprocessor/FilterConditions.h
@@ -36,14 +36,14 @@ struct FilterConditions
 
     FilterConditions(
         const String & executor_id_,
-        const std::vector<const tipb::Expr *> & conditions_);
+        const google::protobuf::RepeatedPtrField<tipb::Expr> & conditions_);
 
     bool hasValue() const { return !conditions.empty(); }
 
     tipb::Executor * constructSelectionForRemoteRead(tipb::Executor * mutable_executor) const;
 
     String executor_id;
-    std::vector<const tipb::Expr *> conditions;
+    google::protobuf::RepeatedPtrField<tipb::Expr> conditions;
 };
 
 } // namespace DB

--- a/dbms/src/Flash/Coprocessor/JoinInterpreterHelper.cpp
+++ b/dbms/src/Flash/Coprocessor/JoinInterpreterHelper.cpp
@@ -185,23 +185,13 @@ std::tuple<ExpressionActionsPtr, String, String> doGenJoinOtherConditionAction(
     String filter_column_for_other_condition;
     if (join.other_conditions_size() > 0)
     {
-        std::vector<const tipb::Expr *> condition_vector;
-        for (const auto & c : join.other_conditions())
-        {
-            condition_vector.push_back(&c);
-        }
-        filter_column_for_other_condition = dag_analyzer.appendWhere(chain, condition_vector);
+        filter_column_for_other_condition = dag_analyzer.appendWhere(chain, join.other_conditions());
     }
 
     String filter_column_for_other_eq_condition;
     if (join.other_eq_conditions_from_in_size() > 0)
     {
-        std::vector<const tipb::Expr *> condition_vector;
-        for (const auto & c : join.other_eq_conditions_from_in())
-        {
-            condition_vector.push_back(&c);
-        }
-        filter_column_for_other_eq_condition = dag_analyzer.appendWhere(chain, condition_vector);
+        filter_column_for_other_eq_condition = dag_analyzer.appendWhere(chain, join.other_eq_conditions_from_in());
     }
 
     return {chain.getLastActions(), std::move(filter_column_for_other_condition), std::move(filter_column_for_other_eq_condition)};

--- a/dbms/src/Flash/Planner/Plans/PhysicalFilter.cpp
+++ b/dbms/src/Flash/Planner/Plans/PhysicalFilter.cpp
@@ -37,10 +37,7 @@ PhysicalPlanNodePtr PhysicalFilter::build(
     DAGExpressionAnalyzer analyzer{child->getSchema(), context};
     ExpressionActionsPtr before_filter_actions = PhysicalPlanHelper::newActions(child->getSampleBlock());
 
-    std::vector<const tipb::Expr *> conditions;
-    for (const auto & c : selection.conditions())
-        conditions.push_back(&c);
-    String filter_column_name = analyzer.buildFilterColumn(before_filter_actions, conditions);
+    String filter_column_name = analyzer.buildFilterColumn(before_filter_actions, selection.conditions());
 
     auto physical_filter = std::make_shared<PhysicalFilter>(
         executor_id,

--- a/dbms/src/Storages/DeltaMerge/FilterParser/FilterParser.cpp
+++ b/dbms/src/Storages/DeltaMerge/FilterParser/FilterParser.cpp
@@ -398,15 +398,15 @@ RSOperatorPtr FilterParser::parseDAGQuery(const DAGQueryInfo & dag_info,
 
     if (dag_info.filters.size() == 1)
     {
-        op = cop::tryParse(*dag_info.filters[0], columns_to_read, creator, dag_info.timezone_info, log);
+        op = cop::tryParse(dag_info.filters[0], columns_to_read, creator, dag_info.timezone_info, log);
     }
     else
     {
         /// By default, multiple conditions with operator "and"
         RSOperators children;
-        for (size_t i = 0; i < dag_info.filters.size(); ++i)
+        for (int i = 0; i < dag_info.filters.size(); ++i)
         {
-            const auto & filter = *dag_info.filters[i];
+            const auto & filter = dag_info.filters[i];
             children.emplace_back(cop::tryParse(filter, columns_to_read, creator, dag_info.timezone_info, log));
         }
         op = createAnd(children);

--- a/dbms/src/Storages/tests/gtest_filter_parser.cpp
+++ b/dbms/src/Storages/tests/gtest_filter_parser.cpp
@@ -88,12 +88,8 @@ DM::RSOperatorPtr FilterParserTest::generateRsOperator(const String table_info_j
     // Don't care about regions information in this test
     DAGQuerySource dag(ctx);
     auto query_block = *dag.getRootQueryBlock();
-    std::vector<const tipb::Expr *> conditions;
-    if (query_block.children[0]->selection != nullptr)
-    {
-        for (const auto & condition : query_block.children[0]->selection->selection().conditions())
-            conditions.push_back(&condition);
-    }
+    google::protobuf::RepeatedPtrField<tipb::Expr> empty_condition;
+    const google::protobuf::RepeatedPtrField<tipb::Expr> & conditions = query_block.children[0]->selection != nullptr ? query_block.children[0]->selection->selection().conditions() : empty_condition;
 
     std::unique_ptr<DAGQueryInfo> dag_query;
     DM::ColumnDefines columns_to_read;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/6233

Problem Summary:
Use `RepeatedPtrField<tipb::Expr>` instead of `vector<tipb::Expr *>` to reduce useless copy and make code clear.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
