### PR TITLE
Pipeline: add random fail points

### DIFF
--- a/dbms/src/Common/FailPoint.cpp
+++ b/dbms/src/Common/FailPoint.cpp
@@ -132,7 +132,13 @@ namespace DB
     M(random_sharedquery_failpoint)                     \
     M(random_interpreter_failpoint)                     \
     M(random_task_manager_find_task_failure_failpoint)  \
-    M(random_min_tso_scheduler_failpoint)
+    M(random_min_tso_scheduler_failpoint)               \
+    M(random_pipeline_model_task_run_failpoint)         \
+    M(random_pipeline_model_task_construct_failpoint)   \
+    M(random_pipeline_model_event_schedule_failpoint)   \
+    M(random_pipeline_model_event_finish_failpoint)     \
+    M(random_pipeline_model_operator_run_failpoint)     \
+    M(random_pipeline_model_cancel_failpoint)
 
 namespace FailPoints
 {

--- a/dbms/src/Common/FailPoint.cpp
+++ b/dbms/src/Common/FailPoint.cpp
@@ -120,6 +120,7 @@ namespace DB
 
 #define APPLY_FOR_RANDOM_FAILPOINTS(M)                  \
     M(random_tunnel_wait_timeout_failpoint)             \
+    M(random_tunnel_write_failpoint)                    \
     M(random_tunnel_init_rpc_failure_failpoint)         \
     M(random_receiver_local_msg_push_failure_failpoint) \
     M(random_receiver_sync_msg_push_failure_failpoint)  \

--- a/dbms/src/Flash/Executor/PipelineExecutorStatus.cpp
+++ b/dbms/src/Flash/Executor/PipelineExecutorStatus.cpp
@@ -17,7 +17,7 @@
 
 namespace DB
 {
-ExecutionResult PipelineExecutorStatus::toExecutionResult()
+ExecutionResult PipelineExecutorStatus::toExecutionResult() noexcept
 {
     std::lock_guard lock(mu);
     return exception_ptr
@@ -25,13 +25,13 @@ ExecutionResult PipelineExecutorStatus::toExecutionResult()
         : ExecutionResult::success();
 }
 
-std::exception_ptr PipelineExecutorStatus::getExceptionPtr()
+std::exception_ptr PipelineExecutorStatus::getExceptionPtr() noexcept
 {
     std::lock_guard lock(mu);
     return exception_ptr;
 }
 
-String PipelineExecutorStatus::getExceptionMsg()
+String PipelineExecutorStatus::getExceptionMsg() noexcept
 {
     std::lock_guard lock(mu);
     try
@@ -50,13 +50,13 @@ String PipelineExecutorStatus::getExceptionMsg()
     }
 }
 
-void PipelineExecutorStatus::onErrorOccurred(const String & err_msg)
+void PipelineExecutorStatus::onErrorOccurred(const String & err_msg) noexcept
 {
     DB::Exception e(err_msg);
     onErrorOccurred(std::make_exception_ptr(e));
 }
 
-void PipelineExecutorStatus::onErrorOccurred(const std::exception_ptr & exception_ptr_)
+void PipelineExecutorStatus::onErrorOccurred(const std::exception_ptr & exception_ptr_) noexcept
 {
     assert(exception_ptr_ != nullptr);
     {
@@ -68,19 +68,19 @@ void PipelineExecutorStatus::onErrorOccurred(const std::exception_ptr & exceptio
     cancel();
 }
 
-void PipelineExecutorStatus::wait()
+void PipelineExecutorStatus::wait() noexcept
 {
     std::unique_lock lock(mu);
     cv.wait(lock, [&] { return 0 == active_event_count; });
 }
 
-void PipelineExecutorStatus::onEventSchedule()
+void PipelineExecutorStatus::onEventSchedule() noexcept
 {
     std::lock_guard lock(mu);
     ++active_event_count;
 }
 
-void PipelineExecutorStatus::onEventFinish()
+void PipelineExecutorStatus::onEventFinish() noexcept
 {
     std::lock_guard lock(mu);
     assert(active_event_count > 0);
@@ -89,7 +89,7 @@ void PipelineExecutorStatus::onEventFinish()
         cv.notify_all();
 }
 
-void PipelineExecutorStatus::cancel()
+void PipelineExecutorStatus::cancel() noexcept
 {
     is_cancelled.store(true, std::memory_order_release);
 }

--- a/dbms/src/Flash/Executor/PipelineExecutorStatus.h
+++ b/dbms/src/Flash/Executor/PipelineExecutorStatus.h
@@ -27,19 +27,19 @@ class PipelineExecutorStatus : private boost::noncopyable
 public:
     static constexpr auto timeout_err_msg = "error with timeout";
 
-    ExecutionResult toExecutionResult();
+    ExecutionResult toExecutionResult() noexcept;
 
-    std::exception_ptr getExceptionPtr();
-    String getExceptionMsg();
+    std::exception_ptr getExceptionPtr() noexcept;
+    String getExceptionMsg() noexcept;
 
-    void onEventSchedule();
+    void onEventSchedule() noexcept;
 
-    void onEventFinish();
+    void onEventFinish() noexcept;
 
-    void onErrorOccurred(const String & err_msg);
-    void onErrorOccurred(const std::exception_ptr & exception_ptr_);
+    void onErrorOccurred(const String & err_msg) noexcept;
+    void onErrorOccurred(const std::exception_ptr & exception_ptr_) noexcept;
 
-    void wait();
+    void wait() noexcept;
 
     template <typename Duration>
     void waitFor(const Duration & timeout_duration)
@@ -56,9 +56,9 @@ public:
         }
     }
 
-    void cancel();
+    void cancel() noexcept;
 
-    bool isCancelled()
+    bool isCancelled() noexcept
     {
         return is_cancelled.load(std::memory_order_acquire);
     }

--- a/dbms/src/Flash/Mpp/MPPTunnel.cpp
+++ b/dbms/src/Flash/Mpp/MPPTunnel.cpp
@@ -27,6 +27,7 @@ namespace DB
 namespace FailPoints
 {
 extern const char random_tunnel_wait_timeout_failpoint[];
+extern const char random_tunnel_write_failpoint[];
 } // namespace FailPoints
 
 namespace
@@ -85,6 +86,7 @@ MPPTunnel::MPPTunnel(
     const String & req_id)
     : status(TunnelStatus::Unconnected)
     , timeout(timeout_)
+    , timeout_nanoseconds(timeout_.count() * 1000000000ULL)
     , tunnel_id(tunnel_id_)
     , mem_tracker(current_memory_tracker ? current_memory_tracker->shared_from_this() : nullptr)
     , queue_size(std::max(5, input_steams_num_ * 5)) // MPMCQueue can benefit from a slightly larger queue size
@@ -161,6 +163,8 @@ void MPPTunnel::write(TrackedMppDataPacketPtr && data)
         RUNTIME_CHECK_MSG(tunnel_sender != nullptr, "write to tunnel {} which is already closed.", tunnel_id);
     }
 
+    FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::random_tunnel_write_failpoint);
+
     auto pushed_data_size = data->getPacket().ByteSizeLong();
     if (tunnel_sender->push(std::move(data)))
     {
@@ -174,6 +178,9 @@ void MPPTunnel::write(TrackedMppDataPacketPtr && data)
 void MPPTunnel::nonBlockingWrite(TrackedMppDataPacketPtr && data)
 {
     LOG_TRACE(log, "start non blocking writing");
+
+    FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::random_tunnel_write_failpoint);
+
     auto pushed_data_size = data->getPacket().ByteSizeLong();
     if (tunnel_sender->nonBlockingPush(std::move(data)))
     {
@@ -340,7 +347,7 @@ bool MPPTunnel::isReadyForWrite() const
             fiu_do_on(FailPoints::random_tunnel_wait_timeout_failpoint, throw Exception(tunnel_id + " is timeout"););
             if (unlikely(!timeout_stopwatch))
                 timeout_stopwatch.emplace(CLOCK_MONOTONIC_COARSE);
-            if (timeout_stopwatch->elapsedSeconds() > timeout.count())
+            if (unlikely(timeout_stopwatch->elapsed() > timeout_nanoseconds))
                 throw Exception(tunnel_id + " is timeout");
         }
         return false;

--- a/dbms/src/Flash/Mpp/MPPTunnel.h
+++ b/dbms/src/Flash/Mpp/MPPTunnel.h
@@ -560,6 +560,7 @@ private:
     TunnelStatus status;
 
     std::chrono::seconds timeout;
+    UInt64 timeout_nanoseconds{0};
     mutable std::optional<Stopwatch> timeout_stopwatch;
 
     // tunnel id is in the format like "tunnel[sender]+[receiver]"

--- a/dbms/src/Flash/Pipeline/Schedule/Events/Event.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/Events/Event.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <Common/Exception.h>
+#include <Common/FailPoint.h>
 #include <Common/MemoryTrackerSetter.h>
 #include <Flash/Executor/PipelineExecutorStatus.h>
 #include <Flash/Pipeline/Schedule/Events/Event.h>
@@ -21,6 +22,12 @@
 
 namespace DB
 {
+namespace FailPoints
+{
+extern const char random_pipeline_model_event_schedule_failpoint[];
+extern const char random_pipeline_model_event_finish_failpoint[];
+} // namespace FailPoints
+
 // if any exception throw here, we should record err msg and then cancel the query.
 #define CATCH                                                  \
     catch (...)                                                \
@@ -47,7 +54,7 @@ void Event::addOutput(const EventPtr & output)
     outputs.push_back(output);
 }
 
-void Event::onInputFinish()
+void Event::onInputFinish() noexcept
 {
     auto cur_value = unfinished_inputs.fetch_sub(1);
     assert(cur_value >= 1);
@@ -61,16 +68,22 @@ void Event::schedule() noexcept
     assert(0 == unfinished_inputs);
     exec_status.onEventSchedule();
     MemoryTrackerSetter setter{true, mem_tracker.get()};
-    // if err throw here, we should call finish directly.
-    bool direct_finish = true;
+    std::vector<TaskPtr> tasks;
     try
     {
-        // if no task is scheduled here, we can call finish directly.
-        direct_finish = scheduleImpl();
+        tasks = scheduleImpl();
+        FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::random_pipeline_model_event_schedule_failpoint);
     }
     CATCH
-    if (direct_finish)
+    if (!tasks.empty())
+    {
+        scheduleTasks(tasks);
+    }
+    else
+    {
+        // if no task is scheduled here, we can call finish directly.
         finish();
+    }
 }
 
 void Event::finish() noexcept
@@ -80,6 +93,7 @@ void Event::finish() noexcept
     try
     {
         finishImpl();
+        FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::random_pipeline_model_event_finish_failpoint);
     }
     CATCH
     // If query has already been cancelled, it will not trigger outputs.
@@ -103,7 +117,7 @@ void Event::finish() noexcept
     exec_status.onEventFinish();
 }
 
-void Event::scheduleTasks(std::vector<TaskPtr> & tasks)
+void Event::scheduleTasks(std::vector<TaskPtr> & tasks) noexcept
 {
     assert(!tasks.empty());
     assert(0 == unfinished_tasks);
@@ -121,7 +135,7 @@ void Event::onTaskFinish() noexcept
         finish();
 }
 
-void Event::switchStatus(EventStatus from, EventStatus to)
+void Event::switchStatus(EventStatus from, EventStatus to) noexcept
 {
     RUNTIME_ASSERT(status.compare_exchange_strong(from, to));
 }

--- a/dbms/src/Flash/Pipeline/Schedule/Events/Event.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/Events/Event.cpp
@@ -81,7 +81,7 @@ void Event::schedule() noexcept
     }
     else
     {
-        // if no task is scheduled here, we can call finish directly.
+        // if no task is scheduled here, we should call finish directly.
         finish();
     }
 }
@@ -123,7 +123,10 @@ void Event::scheduleTasks(std::vector<TaskPtr> & tasks) noexcept
     assert(0 == unfinished_tasks);
     unfinished_tasks = tasks.size();
     assert(status != EventStatus::FINISHED);
-    TaskScheduler::instance->submit(tasks);
+    // If query has already been cancelled, we can skip scheduling tasks.
+    // And then tasks will be destroyed and call `onTaskFinish`.
+    if (likely(!exec_status.isCancelled()))
+        TaskScheduler::instance->submit(tasks);
 }
 
 void Event::onTaskFinish() noexcept

--- a/dbms/src/Flash/Pipeline/Schedule/Events/Event.h
+++ b/dbms/src/Flash/Pipeline/Schedule/Events/Event.h
@@ -56,23 +56,23 @@ public:
     bool withoutInput();
 
 protected:
-    // Returns true meaning no task is scheduled.
-    virtual bool scheduleImpl() { return true; }
+    // Returns the tasks ready to be scheduled.
+    virtual std::vector<TaskPtr> scheduleImpl() { return {}; }
 
     // So far the ownership and the life-cycle of the resources are not very well-defined so we still rely on things like "A must be released before B".
     // And this is the explicit place to release all the resources that need to be cleaned up before event destruction, so that we can satisfy the above constraints.
     virtual void finishImpl() {}
 
-    void scheduleTasks(std::vector<TaskPtr> & tasks);
-
 private:
+    void scheduleTasks(std::vector<TaskPtr> & tasks) noexcept;
+
     void finish() noexcept;
 
     void addOutput(const EventPtr & output);
 
-    void onInputFinish();
+    void onInputFinish() noexcept;
 
-    void switchStatus(EventStatus from, EventStatus to);
+    void switchStatus(EventStatus from, EventStatus to) noexcept;
 
 protected:
     PipelineExecutorStatus & exec_status;

--- a/dbms/src/Flash/Pipeline/Schedule/Events/PlainPipelineEvent.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/Events/PlainPipelineEvent.cpp
@@ -18,7 +18,7 @@
 
 namespace DB
 {
-bool PlainPipelineEvent::scheduleImpl()
+std::vector<TaskPtr> PlainPipelineEvent::scheduleImpl()
 {
     assert(pipeline);
     auto pipeline_exec_group = pipeline->buildExecGroup(exec_status, context, concurrency);
@@ -27,7 +27,6 @@ bool PlainPipelineEvent::scheduleImpl()
     tasks.reserve(pipeline_exec_group.size());
     for (auto & pipline_exec : pipeline_exec_group)
         tasks.push_back(std::make_unique<PipelineTask>(mem_tracker, exec_status, shared_from_this(), std::move(pipline_exec)));
-    scheduleTasks(tasks);
-    return false;
+    return tasks;
 }
 } // namespace DB

--- a/dbms/src/Flash/Pipeline/Schedule/Events/PlainPipelineEvent.h
+++ b/dbms/src/Flash/Pipeline/Schedule/Events/PlainPipelineEvent.h
@@ -32,7 +32,7 @@ public:
     {}
 
 protected:
-    bool scheduleImpl() override;
+    std::vector<TaskPtr> scheduleImpl() override;
 
 private:
     size_t concurrency;

--- a/dbms/src/Flash/Pipeline/Schedule/Events/tests/gtest_event.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/Events/tests/gtest_event.cpp
@@ -59,14 +59,12 @@ public:
     static constexpr auto task_num = 10;
 
 protected:
-    // Returns true meaning no task is scheduled.
-    bool scheduleImpl() override
+    std::vector<TaskPtr> scheduleImpl() override
     {
         std::vector<TaskPtr> tasks;
         for (size_t i = 0; i < task_num; ++i)
             tasks.push_back(std::make_unique<BaseTask>(exec_status, shared_from_this(), counter));
-        scheduleTasks(tasks);
-        return false;
+        return tasks;
     }
 
     void finishImpl() override
@@ -110,17 +108,15 @@ public:
     {}
 
 protected:
-    // Returns true meaning no task is scheduled.
-    bool scheduleImpl() override
+    std::vector<TaskPtr> scheduleImpl() override
     {
         if (!with_tasks)
-            return true;
+            return {};
 
         std::vector<TaskPtr> tasks;
         for (size_t i = 0; i < 10; ++i)
             tasks.push_back(std::make_unique<RunTask>(exec_status, shared_from_this()));
-        scheduleTasks(tasks);
-        return false;
+        return tasks;
     }
 
 private:
@@ -155,21 +151,19 @@ public:
     {}
 
 protected:
-    // Returns true meaning no task is scheduled.
-    bool scheduleImpl() override
+    std::vector<TaskPtr> scheduleImpl() override
     {
         if (!with_tasks)
         {
             while (!exec_status.isCancelled())
                 std::this_thread::sleep_for(std::chrono::milliseconds(1));
-            return true;
+            return {};
         }
 
         std::vector<TaskPtr> tasks;
         for (size_t i = 0; i < 10; ++i)
             tasks.push_back(std::make_unique<DeadLoopTask>(exec_status, shared_from_this()));
-        scheduleTasks(tasks);
-        return false;
+        return tasks;
     }
 
 private:
@@ -186,11 +180,10 @@ public:
     static constexpr auto err_msg = "error from OnErrEvent";
 
 protected:
-    // Returns true meaning no task is scheduled.
-    bool scheduleImpl() override
+    std::vector<TaskPtr> scheduleImpl() override
     {
         exec_status.onErrorOccurred(err_msg);
-        return true;
+        return {};
     }
 };
 
@@ -202,11 +195,10 @@ public:
     {}
 
 protected:
-    // Returns true meaning no task is scheduled.
-    bool scheduleImpl() override
+    std::vector<TaskPtr> scheduleImpl() override
     {
         assert(mem_tracker.get() == current_memory_tracker);
-        return true;
+        return {};
     }
 
     void finishImpl() override
@@ -242,7 +234,7 @@ public:
     {}
 
 protected:
-    bool scheduleImpl() override
+    std::vector<TaskPtr> scheduleImpl() override
     {
         if (!with_task)
             throw Exception("throw exception in scheduleImpl");
@@ -250,8 +242,7 @@ protected:
         std::vector<TaskPtr> tasks;
         for (size_t i = 0; i < 10; ++i)
             tasks.push_back(std::make_unique<ThrowExceptionTask>(exec_status, shared_from_this()));
-        scheduleTasks(tasks);
-        return false;
+        return tasks;
     }
 
     void finishImpl() override
@@ -275,17 +266,15 @@ public:
     {}
 
 protected:
-    // Returns true meaning no task is scheduled.
-    bool scheduleImpl() override
+    std::vector<TaskPtr> scheduleImpl() override
     {
         if (0 == task_num)
-            return true;
+            return {};
 
         std::vector<TaskPtr> tasks;
         for (size_t i = 0; i < task_num; ++i)
             tasks.push_back(std::make_unique<RunTask>(exec_status, shared_from_this()));
-        scheduleTasks(tasks);
-        return false;
+        return tasks;
     }
 
 private:

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/FiFOTaskQueue.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/FiFOTaskQueue.cpp
@@ -18,7 +18,7 @@
 
 namespace DB
 {
-bool FIFOTaskQueue::take(TaskPtr & task)
+bool FIFOTaskQueue::take(TaskPtr & task) noexcept
 {
     assert(!task);
     {
@@ -39,7 +39,7 @@ bool FIFOTaskQueue::take(TaskPtr & task)
     return true;
 }
 
-bool FIFOTaskQueue::empty()
+bool FIFOTaskQueue::empty() noexcept
 {
     std::lock_guard lock(mu);
     return task_queue.empty();
@@ -54,7 +54,7 @@ void FIFOTaskQueue::close()
     cv.notify_all();
 }
 
-void FIFOTaskQueue::submit(TaskPtr && task)
+void FIFOTaskQueue::submit(TaskPtr && task) noexcept
 {
     assert(task);
     {
@@ -64,7 +64,7 @@ void FIFOTaskQueue::submit(TaskPtr && task)
     cv.notify_one();
 }
 
-void FIFOTaskQueue::submit(std::vector<TaskPtr> & tasks)
+void FIFOTaskQueue::submit(std::vector<TaskPtr> & tasks) noexcept
 {
     if (tasks.empty())
         return;

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/FiFOTaskQueue.h
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/FiFOTaskQueue.h
@@ -25,13 +25,13 @@ namespace DB
 class FIFOTaskQueue : public TaskQueue
 {
 public:
-    void submit(TaskPtr && task) override;
+    void submit(TaskPtr && task) noexcept override;
 
-    void submit(std::vector<TaskPtr> & tasks) override;
+    void submit(std::vector<TaskPtr> & tasks) noexcept override;
 
-    bool take(TaskPtr & task) override;
+    bool take(TaskPtr & task) noexcept override;
 
-    bool empty() override;
+    bool empty() noexcept override;
 
     void close() override;
 

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/TaskQueue.h
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/TaskQueue.h
@@ -29,14 +29,14 @@ class TaskQueue
 public:
     virtual ~TaskQueue() = default;
 
-    virtual void submit(TaskPtr && task) = 0;
+    virtual void submit(TaskPtr && task) noexcept = 0;
 
-    virtual void submit(std::vector<TaskPtr> & tasks) = 0;
+    virtual void submit(std::vector<TaskPtr> & tasks) noexcept = 0;
 
     // return false if the queue had been closed.
-    virtual bool take(TaskPtr & task) = 0;
+    virtual bool take(TaskPtr & task) noexcept = 0;
 
-    virtual bool empty() = 0;
+    virtual bool empty() noexcept = 0;
 
     virtual void close() = 0;
 };

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/tests/gtest_fifo.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/tests/gtest_fifo.cpp
@@ -31,7 +31,7 @@ public:
         , index(index_)
     {}
 
-    ExecTaskStatus executeImpl() override { return ExecTaskStatus::FINISHED; }
+    ExecTaskStatus executeImpl() noexcept override { return ExecTaskStatus::FINISHED; }
 
     size_t index;
 };

--- a/dbms/src/Flash/Pipeline/Schedule/TaskScheduler.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskScheduler.cpp
@@ -37,7 +37,7 @@ TaskScheduler::~TaskScheduler()
     wait_reactor.waitForStop();
 }
 
-void TaskScheduler::submit(std::vector<TaskPtr> & tasks)
+void TaskScheduler::submit(std::vector<TaskPtr> & tasks) noexcept
 {
     if (unlikely(tasks.empty()))
         return;

--- a/dbms/src/Flash/Pipeline/Schedule/TaskScheduler.h
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskScheduler.h
@@ -51,7 +51,7 @@ public:
 
     ~TaskScheduler();
 
-    void submit(std::vector<TaskPtr> & tasks);
+    void submit(std::vector<TaskPtr> & tasks) noexcept;
 
     static std::unique_ptr<TaskScheduler> instance;
 

--- a/dbms/src/Flash/Pipeline/Schedule/TaskThreadPool.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskThreadPool.cpp
@@ -65,7 +65,7 @@ void TaskThreadPool::loop(size_t thread_no) noexcept
     LOG_INFO(thread_logger, "loop finished");
 }
 
-void TaskThreadPool::handleTask(TaskPtr & task, const LoggerPtr & log)
+void TaskThreadPool::handleTask(TaskPtr & task, const LoggerPtr & log) noexcept
 {
     assert(task);
     TRACE_MEMORY(task);
@@ -96,12 +96,12 @@ void TaskThreadPool::handleTask(TaskPtr & task, const LoggerPtr & log)
     }
 }
 
-void TaskThreadPool::submit(TaskPtr && task)
+void TaskThreadPool::submit(TaskPtr && task) noexcept
 {
     task_queue->submit(std::move(task));
 }
 
-void TaskThreadPool::submit(std::vector<TaskPtr> & tasks)
+void TaskThreadPool::submit(std::vector<TaskPtr> & tasks) noexcept
 {
     task_queue->submit(tasks);
 }

--- a/dbms/src/Flash/Pipeline/Schedule/TaskThreadPool.h
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskThreadPool.h
@@ -34,14 +34,14 @@ public:
 
     void waitForStop();
 
-    void submit(TaskPtr && task);
+    void submit(TaskPtr && task) noexcept;
 
-    void submit(std::vector<TaskPtr> & tasks);
+    void submit(std::vector<TaskPtr> & tasks) noexcept;
 
 private:
     void loop(size_t thread_no) noexcept;
 
-    void handleTask(TaskPtr & task, const LoggerPtr & log);
+    void handleTask(TaskPtr & task, const LoggerPtr & log) noexcept;
 
 private:
     TaskQueuePtr task_queue;

--- a/dbms/src/Flash/Pipeline/Schedule/Tasks/EventTask.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/Tasks/EventTask.cpp
@@ -34,7 +34,7 @@ EventTask::~EventTask()
     event.reset();
 }
 
-void EventTask::finalize()
+void EventTask::finalize() noexcept
 {
     try
     {
@@ -49,12 +49,12 @@ void EventTask::finalize()
     }
 }
 
-ExecTaskStatus EventTask::executeImpl()
+ExecTaskStatus EventTask::executeImpl() noexcept
 {
     return doTaskAction([&] { return doExecuteImpl(); });
 }
 
-ExecTaskStatus EventTask::awaitImpl()
+ExecTaskStatus EventTask::awaitImpl() noexcept
 {
     return doTaskAction([&] { return doAwaitImpl(); });
 }

--- a/dbms/src/Flash/Pipeline/Schedule/Tasks/EventTask.h
+++ b/dbms/src/Flash/Pipeline/Schedule/Tasks/EventTask.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <Common/FailPoint.h>
 #include <Flash/Executor/PipelineExecutorStatus.h>
 #include <Flash/Pipeline/Schedule/Events/Event.h>
 #include <Flash/Pipeline/Schedule/Tasks/Task.h>
@@ -21,6 +22,11 @@
 
 namespace DB
 {
+namespace FailPoints
+{
+extern const char random_pipeline_model_task_run_failpoint[];
+} // namespace FailPoints
+
 // The base class of event related task.
 class EventTask : public Task
 {
@@ -33,19 +39,19 @@ public:
     ~EventTask();
 
 protected:
-    ExecTaskStatus executeImpl() override;
+    ExecTaskStatus executeImpl() noexcept override;
     virtual ExecTaskStatus doExecuteImpl() = 0;
 
-    ExecTaskStatus awaitImpl() override;
+    ExecTaskStatus awaitImpl() noexcept override;
     virtual ExecTaskStatus doAwaitImpl() { return ExecTaskStatus::RUNNING; };
 
     // Used to release held resources, just like `Event::finishImpl`.
-    void finalize();
+    void finalize() noexcept;
     virtual void finalizeImpl(){};
 
 private:
     template <typename Action>
-    ExecTaskStatus doTaskAction(Action && action)
+    ExecTaskStatus doTaskAction(Action && action) noexcept
     {
         if (unlikely(exec_status.isCancelled()))
         {
@@ -55,6 +61,7 @@ private:
         try
         {
             auto status = action();
+            FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::random_pipeline_model_task_run_failpoint);
             switch (status)
             {
             case FINISH_STATUS:

--- a/dbms/src/Flash/Pipeline/Schedule/Tasks/Task.h
+++ b/dbms/src/Flash/Pipeline/Schedule/Tasks/Task.h
@@ -14,11 +14,17 @@
 
 #pragma once
 
+#include <Common/FailPoint.h>
 #include <Common/MemoryTracker.h>
 #include <memory.h>
 
 namespace DB
 {
+namespace FailPoints
+{
+extern const char random_pipeline_model_task_construct_failpoint[];
+} // namespace FailPoints
+
 /**
  *    CANCELLED/ERROR/FINISHED
  *               ▲
@@ -41,7 +47,9 @@ class Task
 public:
     explicit Task(MemoryTrackerPtr mem_tracker_)
         : mem_tracker(std::move(mem_tracker_))
-    {}
+    {
+        FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::random_pipeline_model_task_construct_failpoint);
+    }
 
     virtual ~Task() = default;
 
@@ -63,8 +71,8 @@ public:
     }
 
 protected:
-    virtual ExecTaskStatus executeImpl() = 0;
-    virtual ExecTaskStatus awaitImpl() { return ExecTaskStatus::RUNNING; }
+    virtual ExecTaskStatus executeImpl() noexcept = 0;
+    virtual ExecTaskStatus awaitImpl() noexcept { return ExecTaskStatus::RUNNING; }
 
 private:
     MemoryTrackerPtr mem_tracker;

--- a/dbms/src/Flash/Pipeline/Schedule/WaitReactor.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/WaitReactor.cpp
@@ -111,12 +111,12 @@ void WaitReactor::waitForStop()
     LOG_INFO(logger, "wait reactor is stopped");
 }
 
-void WaitReactor::submit(TaskPtr && task)
+void WaitReactor::submit(TaskPtr && task) noexcept
 {
     waiting_task_list.submit(std::move(task));
 }
 
-void WaitReactor::submit(std::list<TaskPtr> & tasks)
+void WaitReactor::submit(std::list<TaskPtr> & tasks) noexcept
 {
     waiting_task_list.submit(tasks);
 }

--- a/dbms/src/Flash/Pipeline/Schedule/WaitReactor.h
+++ b/dbms/src/Flash/Pipeline/Schedule/WaitReactor.h
@@ -34,9 +34,9 @@ public:
 
     void waitForStop();
 
-    void submit(TaskPtr && task);
+    void submit(TaskPtr && task) noexcept;
 
-    void submit(std::list<TaskPtr> & tasks);
+    void submit(std::list<TaskPtr> & tasks) noexcept;
 
 private:
     void loop() noexcept;

--- a/dbms/src/Flash/Pipeline/Schedule/WaitingTaskList.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/WaitingTaskList.cpp
@@ -18,7 +18,7 @@
 
 namespace DB
 {
-bool WaitingTaskList::take(std::list<TaskPtr> & local_waiting_tasks)
+bool WaitingTaskList::take(std::list<TaskPtr> & local_waiting_tasks) noexcept
 {
     {
         std::unique_lock lock(mu);
@@ -37,7 +37,7 @@ bool WaitingTaskList::take(std::list<TaskPtr> & local_waiting_tasks)
     return true;
 }
 
-bool WaitingTaskList::tryTake(std::list<TaskPtr> & local_waiting_tasks)
+bool WaitingTaskList::tryTake(std::list<TaskPtr> & local_waiting_tasks) noexcept
 {
     std::lock_guard lock(mu);
     if (unlikely(is_closed))
@@ -55,7 +55,7 @@ void WaitingTaskList::close()
     cv.notify_all();
 }
 
-void WaitingTaskList::submit(TaskPtr && task)
+void WaitingTaskList::submit(TaskPtr && task) noexcept
 {
     assert(task);
     {
@@ -65,7 +65,7 @@ void WaitingTaskList::submit(TaskPtr && task)
     cv.notify_one();
 }
 
-void WaitingTaskList::submit(std::list<TaskPtr> & tasks)
+void WaitingTaskList::submit(std::list<TaskPtr> & tasks) noexcept
 {
     if (tasks.empty())
         return;

--- a/dbms/src/Flash/Pipeline/Schedule/WaitingTaskList.h
+++ b/dbms/src/Flash/Pipeline/Schedule/WaitingTaskList.h
@@ -26,13 +26,13 @@ class WaitingTaskList
 public:
     /// return false if the waiting task list had been closed.
     // this function will wait until `!waiting_tasks.empty()`
-    bool take(std::list<TaskPtr> & local_waiting_tasks);
+    bool take(std::list<TaskPtr> & local_waiting_tasks) noexcept;
     // this function will return immediately.
-    bool tryTake(std::list<TaskPtr> & local_waiting_tasks);
+    bool tryTake(std::list<TaskPtr> & local_waiting_tasks) noexcept;
 
-    void submit(TaskPtr && task);
+    void submit(TaskPtr && task) noexcept;
 
-    void submit(std::list<TaskPtr> & tasks);
+    void submit(std::list<TaskPtr> & tasks) noexcept;
 
     void close();
 

--- a/dbms/src/Flash/Pipeline/Schedule/tests/gtest_task_scheduler.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/tests/gtest_task_scheduler.cpp
@@ -65,7 +65,7 @@ public:
     }
 
 protected:
-    ExecTaskStatus executeImpl() override
+    ExecTaskStatus executeImpl() noexcept override
     {
         while ((--loop_count) > 0)
             return ExecTaskStatus::RUNNING;
@@ -91,7 +91,7 @@ public:
     }
 
 protected:
-    ExecTaskStatus executeImpl() override
+    ExecTaskStatus executeImpl() noexcept override
     {
         if (loop_count > 0)
         {
@@ -106,7 +106,7 @@ protected:
         return ExecTaskStatus::FINISHED;
     }
 
-    ExecTaskStatus awaitImpl() override
+    ExecTaskStatus awaitImpl() noexcept override
     {
         if (loop_count > 0)
         {
@@ -149,7 +149,7 @@ public:
     static constexpr Int64 MEMORY_TRACER_SUBMIT_THRESHOLD = 1024 * 1024; // 1 MiB
 
 protected:
-    ExecTaskStatus executeImpl() override
+    ExecTaskStatus executeImpl() noexcept override
     {
         switch (status)
         {
@@ -167,7 +167,7 @@ protected:
         }
     }
 
-    ExecTaskStatus awaitImpl() override
+    ExecTaskStatus awaitImpl() noexcept override
     {
         if (status == TraceTaskStatus::waiting)
             CurrentMemoryTracker::alloc(MEMORY_TRACER_SUBMIT_THRESHOLD - 10);
@@ -187,12 +187,12 @@ public:
     {}
 
 protected:
-    ExecTaskStatus executeImpl() override
+    ExecTaskStatus executeImpl() noexcept override
     {
         return ExecTaskStatus::WAITING;
     }
 
-    ExecTaskStatus awaitImpl() override
+    ExecTaskStatus awaitImpl() noexcept override
     {
         return ExecTaskStatus::RUNNING;
     }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6518 

Problem Summary:

### What is changed and how it works?
- Refactor `Event::scheduleImpl` to avoid potential problems.
- Add `noexcept` for some function of `Task`, `Event` and etc.
- Add random fail points:
```
    M(random_tunnel_write_failpoint)                    \
    M(random_pipeline_model_task_run_failpoint)         \
    M(random_pipeline_model_task_construct_failpoint)   \
    M(random_pipeline_model_event_schedule_failpoint)   \
    M(random_pipeline_model_event_finish_failpoint)     \
    M(random_pipeline_model_operator_run_failpoint)     \
    M(random_pipeline_model_cancel_failpoint)
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
