### PR TITLE
Fix delta index cache

### DIFF
--- a/dbms/src/Storages/DeltaMerge/Delta/DeltaValueSpace.cpp
+++ b/dbms/src/Storages/DeltaMerge/Delta/DeltaValueSpace.cpp
@@ -356,7 +356,13 @@ bool DeltaValueSpace::flush(DMContext & context)
 
         /// Update delta tree
         if (new_delta_index)
+        {
             delta_index = new_delta_index;
+
+            // Indicate that the index with old epoch should not be used anymore.
+            // This is useful in disaggregated mode which will invalidate the delta index cache in RN.
+            delta_index_epoch += 1;
+        }
 
         LOG_DEBUG(log, "Flush end, flush_tasks={} flush_rows={} flush_deletes={} delta={}", flush_task->getTaskNum(), flush_task->getFlushRows(), flush_task->getFlushDeletes(), info());
     }

--- a/dbms/src/Storages/DeltaMerge/Delta/DeltaValueSpace.h
+++ b/dbms/src/Storages/DeltaMerge/Delta/DeltaValueSpace.h
@@ -98,6 +98,7 @@ private:
     std::atomic<size_t> last_try_place_delta_index_rows = 0;
 
     DeltaIndexPtr delta_index;
+    UInt64 delta_index_epoch = 0;
 
     // Protects the operations in this instance.
     // It is a recursive_mutex because the lock may be also used by the parent segment as its update lock.
@@ -327,6 +328,7 @@ private:
 public:
     // The delta index of cached.
     DeltaIndexPtr shared_delta_index;
+    UInt64 delta_index_epoch;
 
     ColumnFileSetSnapshotPtr mem_table_snap;
     ColumnFileSetSnapshotPtr persisted_files_snap;
@@ -338,6 +340,7 @@ public:
 
         auto c = std::make_shared<DeltaValueSnapshot>(type, is_update, _delta);
         c->shared_delta_index = shared_delta_index;
+        c->delta_index_epoch = delta_index_epoch;
         c->mem_table_snap = mem_table_snap->clone();
         c->persisted_files_snap = persisted_files_snap->clone();
 

--- a/dbms/src/Storages/DeltaMerge/Delta/Snapshot.cpp
+++ b/dbms/src/Storages/DeltaMerge/Delta/Snapshot.cpp
@@ -109,6 +109,7 @@ DeltaSnapshotPtr DeltaValueSpace::createSnapshot(const DMContext & context, bool
     snap->mem_table_snap = mem_table_set->createSnapshot(storage_reader, for_update);
     snap->persisted_files_snap = persisted_file_set->createSnapshot(storage_reader);
     snap->shared_delta_index = delta_index;
+    snap->delta_index_epoch = delta_index_epoch;
 
     return snap;
 }

--- a/dbms/src/Storages/DeltaMerge/File/dtpb/column_file.proto
+++ b/dbms/src/Storages/DeltaMerge/File/dtpb/column_file.proto
@@ -74,7 +74,9 @@ message ColumnFileRemote {
 message DisaggregatedSegment {
     uint64 segment_id = 1;
     uint64 segment_epoch = 2;
-    bytes key_range = 3;
+    uint64 delta_index_epoch = 3;
+
+    bytes key_range = 4;
 
     repeated ColumnFileBig stable_pages = 10;
     // serialized array of ColumnFileRemote

--- a/dbms/src/Storages/DeltaMerge/Remote/DeltaIndexCache.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/DeltaIndexCache.h
@@ -37,14 +37,18 @@ public:
     struct CacheKey
     {
         UInt64 write_node_id;
+        Int64 table_id;
         UInt64 segment_id;
         UInt64 segment_epoch;
+        UInt64 delta_index_epoch;
 
         bool operator==(const CacheKey & other) const
         {
             return write_node_id == other.write_node_id
+                && table_id == other.table_id
                 && segment_id == other.segment_id
-                && segment_epoch == other.segment_epoch;
+                && segment_epoch == other.segment_epoch
+                && delta_index_epoch == other.delta_index_epoch;
         }
     };
 
@@ -54,7 +58,7 @@ public:
         {
             using std::hash;
 
-            return hash<UInt64>()(k.write_node_id) ^ hash<UInt64>()(k.segment_id) ^ hash<UInt64>()(k.segment_epoch);
+            return hash<UInt64>()(k.write_node_id) ^ hash<Int64>()(k.write_node_id) ^ hash<UInt64>()(k.segment_id) ^ hash<UInt64>()(k.segment_epoch) ^ hash<UInt64>()(k.delta_index_epoch);
         }
     };
 
@@ -67,16 +71,10 @@ public:
             auto index = std::make_shared<DeltaIndex>();
             return index;
         });
-
         return index_ptr;
     }
 
 private:
-    struct WeakIndex
-    {
-        std::weak_ptr<DeltaIndex> index;
-    };
-
     LRUCache<CacheKey, DeltaIndex, CacheKeyHasher> cache;
 };
 

--- a/dbms/src/Storages/DeltaMerge/Remote/DeltaIndexCache.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/DeltaIndexCache.h
@@ -58,7 +58,11 @@ public:
         {
             using std::hash;
 
-            return hash<UInt64>()(k.write_node_id) ^ hash<Int64>()(k.write_node_id) ^ hash<UInt64>()(k.segment_id) ^ hash<UInt64>()(k.segment_epoch) ^ hash<UInt64>()(k.delta_index_epoch);
+            return hash<UInt64>()(k.write_node_id) ^ //
+                hash<Int64>()(k.table_id) ^ //
+                hash<UInt64>()(k.segment_id) ^ //
+                hash<UInt64>()(k.segment_epoch) ^ //
+                hash<UInt64>()(k.delta_index_epoch);
         }
     };
 

--- a/dbms/src/Storages/DeltaMerge/Segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/Segment.cpp
@@ -121,6 +121,7 @@ dtpb::DisaggregatedSegment SegmentSnapshot::serializeToRemoteProtocol(
     dtpb::DisaggregatedSegment remote;
     remote.set_segment_id(segment_id);
     remote.set_segment_epoch(segment_epoch);
+    remote.set_delta_index_epoch(delta->delta_index_epoch);
 
     WriteBufferFromOwnString wb;
     {
@@ -177,11 +178,15 @@ SegmentSnapshotPtr SegmentSnapshot::deserializeFromRemoteProtocol(
         write_node_id,
         table_id,
         segment_range);
+
     delta_snap->shared_delta_index = remote_manager->getDeltaIndexCache()->getDeltaIndex({
         .write_node_id = write_node_id,
+        .table_id = table_id,
         .segment_id = proto.segment_id(),
         .segment_epoch = proto.segment_epoch(),
+        .delta_index_epoch = proto.delta_index_epoch(),
     });
+    delta_snap->delta_index_epoch = proto.delta_index_epoch();
 
     auto data_store = remote_manager->getDataStore();
     auto new_stable = std::make_shared<StableValueSpace>(/* id */ 0);


### PR DESCRIPTION
When there are flush, the delta index is changed. This PR adds a delta index epoch for it, so that read node can know delta index cache is invalidated.