### PR TITLE
Support read S3 authentication information from configuration.

### DIFF
--- a/dbms/src/Server/StorageConfigParser.cpp
+++ b/dbms/src/Server/StorageConfigParser.cpp
@@ -538,8 +538,22 @@ void StorageS3Config::parse(const String & content, const LoggerPtr & log)
     readConfig(table, "cache_dir", cache_dir);
     readConfig(table, "cache_capacity", cache_capacity);
 
-    access_key_id = Poco::Environment::get("AWS_ACCESS_KEY_ID", /*default*/ "");
-    secret_access_key = Poco::Environment::get("AWS_SECRET_ACCESS_KEY", /*default*/ "");
+    auto read_s3_auth_info_from_env = [&]() {
+        access_key_id = Poco::Environment::get("ACCESS_KEY_ID", /*default*/ "");
+        secret_access_key = Poco::Environment::get("SECRET_ACCESS_KEY", /*default*/ "");
+        return !access_key_id.empty() && !secret_access_key.empty();
+    };
+    auto read_s3_auth_info_from_config = [&]() {
+        readConfig(table, "access_key_id", access_key_id);
+        readConfig(table, "secret_access_key", secret_access_key);
+    };
+    if (!read_s3_auth_info_from_env())
+    {
+        // Reset and read from config.
+        access_key_id.clear();
+        secret_access_key.clear();
+        read_s3_auth_info_from_config();
+    }
 
     LOG_INFO(
         log,

--- a/dbms/src/Server/tests/gtest_storage_config.cpp
+++ b/dbms/src/Server/tests/gtest_storage_config.cpp
@@ -720,14 +720,14 @@ CATCH
 
 std::pair<String, String> getS3Env()
 {
-    return {Poco::Environment::get("AWS_ACCESS_KEY_ID", /*default*/ ""),
-            Poco::Environment::get("AWS_SECRET_ACCESS_KEY", /*default*/ "")};
+    return {Poco::Environment::get("ACCESS_KEY_ID", /*default*/ ""),
+            Poco::Environment::get("SECRET_ACCESS_KEY", /*default*/ "")};
 }
 
 void setS3Env(const String & id, const String & key)
 {
-    Poco::Environment::set("AWS_ACCESS_KEY_ID", id);
-    Poco::Environment::set("AWS_SECRET_ACCESS_KEY", key);
+    Poco::Environment::set("ACCESS_KEY_ID", id);
+    Poco::Environment::set("SECRET_ACCESS_KEY", key);
 }
 
 TEST_F(StorageConfigTest, S3Config)
@@ -739,6 +739,8 @@ try
 [storage.main]
 dir = ["123"]
 [storage.s3]
+access_key_id = "11111111"
+secret_access_key = "22222222"
         )",
         R"(
 [storage]
@@ -747,25 +749,31 @@ dir = ["123"]
 [storage.s3]
 endpoint = "127.0.0.1:8080"
 bucket = "s3_bucket"
+access_key_id = "33333333"
+secret_access_key = "44444444"
         )",
     };
 
+    // Save env variables and restore when exit.
     auto id_key = getS3Env();
     SCOPE_EXIT({
         setS3Env(id_key.first, id_key.second);
     });
+
+
+    const String env_access_key_id{"abcdefgh"};
+    const String env_secret_access_key{"1234567890"};
+    setS3Env(env_access_key_id, env_secret_access_key);
+    // Env variables have been set, we except to use environment variables first.
     for (size_t i = 0; i < tests.size(); ++i)
     {
         const auto & test_case = tests[i];
         auto config = loadConfigFromString(test_case);
         LOG_INFO(log, "parsing [index={}] [content={}]", i, test_case);
-        const String test_id{"abcdefgh"};
-        const String test_key{"1234567890"};
-        setS3Env(test_id, test_key);
         auto [global_capacity_quota, storage] = TiFlashStorageConfig::parseSettings(*config, log);
         const auto & s3_config = storage.s3_config;
-        ASSERT_EQ(s3_config.access_key_id, test_id);
-        ASSERT_EQ(s3_config.secret_access_key, test_key);
+        ASSERT_EQ(s3_config.access_key_id, env_access_key_id);
+        ASSERT_EQ(s3_config.secret_access_key, env_secret_access_key);
         if (i == 0)
         {
             ASSERT_TRUE(s3_config.endpoint.empty());
@@ -777,6 +785,37 @@ bucket = "s3_bucket"
             ASSERT_EQ(s3_config.endpoint, "127.0.0.1:8080");
             ASSERT_EQ(s3_config.bucket, "s3_bucket");
             ASSERT_TRUE(s3_config.isS3Enabled());
+        }
+        else
+        {
+            throw Exception("Not support");
+        }
+    }
+
+    setS3Env("", "");
+    // Env variables have been cleared, we except to use configuration.
+    for (size_t i = 0; i < tests.size(); ++i)
+    {
+        const auto & test_case = tests[i];
+        auto config = loadConfigFromString(test_case);
+        LOG_INFO(log, "parsing [index={}] [content={}]", i, test_case);
+        auto [global_capacity_quota, storage] = TiFlashStorageConfig::parseSettings(*config, log);
+        const auto & s3_config = storage.s3_config;
+        if (i == 0)
+        {
+            ASSERT_TRUE(s3_config.endpoint.empty());
+            ASSERT_TRUE(s3_config.bucket.empty());
+            ASSERT_FALSE(s3_config.isS3Enabled());
+            ASSERT_EQ(s3_config.access_key_id, "11111111");
+            ASSERT_EQ(s3_config.secret_access_key, "22222222");
+        }
+        else if (i == 1)
+        {
+            ASSERT_EQ(s3_config.endpoint, "127.0.0.1:8080");
+            ASSERT_EQ(s3_config.bucket, "s3_bucket");
+            ASSERT_TRUE(s3_config.isS3Enabled());
+            ASSERT_EQ(s3_config.access_key_id, "33333333");
+            ASSERT_EQ(s3_config.secret_access_key, "44444444");
         }
         else
         {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #6827

### What is changed and how it works?
1. Currently, TiFlash reads access_key_id and secret_access_key from envionment variables.
2. This PR supports reading access_key_id and secret_access_key from configuration, too.
3. In conclusion, after this PR, TiFlash will first read from the environment variables. If access_key_id or secret_access_key is empty, it will read from configuration.
4. Change envionment variables' name:
    1. `AWS_ACCESS_KEY_ID` to `ACCESS_KEY_ID`
    2. `AWS_SECRET_ACCESS_KEY` to `SECRET_ACCESS_KEY`

Add new configuration:
1. `storage.s3.access_key_id`
3. `storage.s3.secret_access_key`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
