### PR TITLE
Rename env variables of S3 authentication.

### DIFF
--- a/dbms/src/Server/StorageConfigParser.cpp
+++ b/dbms/src/Server/StorageConfigParser.cpp
@@ -539,8 +539,8 @@ void StorageS3Config::parse(const String & content, const LoggerPtr & log)
     readConfig(table, "cache_capacity", cache_capacity);
 
     auto read_s3_auth_info_from_env = [&]() {
-        access_key_id = Poco::Environment::get("ACCESS_KEY_ID", /*default*/ "");
-        secret_access_key = Poco::Environment::get("SECRET_ACCESS_KEY", /*default*/ "");
+        access_key_id = Poco::Environment::get(S3_ACCESS_KEY_ID, /*default*/ "");
+        secret_access_key = Poco::Environment::get(S3_SECRET_ACCESS_KEY, /*default*/ "");
         return !access_key_id.empty() && !secret_access_key.empty();
     };
     auto read_s3_auth_info_from_config = [&]() {

--- a/dbms/src/Server/StorageConfigParser.h
+++ b/dbms/src/Server/StorageConfigParser.h
@@ -105,6 +105,9 @@ struct StorageS3Config
     String cache_dir;
     UInt64 cache_capacity = 0;
 
+    inline static String S3_ACCESS_KEY_ID = "S3_ACCESS_KEY_ID";
+    inline static String S3_SECRET_ACCESS_KEY = "S3_SECRET_ACCESS_KEY";
+
     void parse(const String & content, const LoggerPtr & log);
     bool isS3Enabled() const;
     bool isFileCacheEnabled() const;

--- a/dbms/src/Server/tests/gtest_storage_config.cpp
+++ b/dbms/src/Server/tests/gtest_storage_config.cpp
@@ -720,14 +720,14 @@ CATCH
 
 std::pair<String, String> getS3Env()
 {
-    return {Poco::Environment::get("ACCESS_KEY_ID", /*default*/ ""),
-            Poco::Environment::get("SECRET_ACCESS_KEY", /*default*/ "")};
+    return {Poco::Environment::get(StorageS3Config::S3_ACCESS_KEY_ID, /*default*/ ""),
+            Poco::Environment::get(StorageS3Config::S3_SECRET_ACCESS_KEY, /*default*/ "")};
 }
 
 void setS3Env(const String & id, const String & key)
 {
-    Poco::Environment::set("ACCESS_KEY_ID", id);
-    Poco::Environment::set("SECRET_ACCESS_KEY", key);
+    Poco::Environment::set(StorageS3Config::S3_ACCESS_KEY_ID, id);
+    Poco::Environment::set(StorageS3Config::S3_SECRET_ACCESS_KEY, key);
 }
 
 TEST_F(StorageConfigTest, S3Config)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6827

Problem Summary:

1. Envionment variables' name `ACCESS_KEY_ID` and `SECRET_ACCESS_KEY` that are intruduced by  #6933, **looks very general. It can easily conflict with others**.
2. So, rename both `ACCESS_KEY_ID` and `SECRET_ACCESS_KEY` to `S3_ACCESS_KEY_ID` and `S3_SECRET_ACCESS_KEY`. 

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
