### PR TITLE
Remove ByteBuffer

### DIFF
--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFilePersisted.cpp
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFilePersisted.cpp
@@ -76,9 +76,9 @@ void serializeColumn(WriteBuffer & buf, const IColumn & column, const DataTypePt
     compressed.next();
 }
 
-void deserializeColumn(IColumn & column, const DataTypePtr & type, const ConstByteBuffer & data_buf, size_t rows)
+void deserializeColumn(IColumn & column, const DataTypePtr & type, std::string_view data_buf, size_t rows)
 {
-    ReadBufferFromMemory buf(data_buf.begin(), data_buf.size());
+    ReadBufferFromString buf(data_buf);
     CompressedReadBuffer compressed(buf);
     type->deserializeBinaryBulkWithMultipleStreams(
         column,

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFilePersisted.h
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFilePersisted.h
@@ -41,7 +41,7 @@ void serializeSchema(WriteBuffer & buf, const Block & schema);
 BlockPtr deserializeSchema(ReadBuffer & buf);
 
 void serializeColumn(WriteBuffer & buf, const IColumn & column, const DataTypePtr & type, size_t offset, size_t limit, CompressionMethod compression_method, Int64 compression_level);
-void deserializeColumn(IColumn & column, const DataTypePtr & type, const ConstByteBuffer & data_buf, size_t rows);
+void deserializeColumn(IColumn & column, const DataTypePtr & type, std::string_view data_buf, size_t rows);
 
 /// Serialize those column files' metadata into buf.
 void serializeSavedColumnFiles(WriteBuffer & buf, const ColumnFilePersisteds & column_files);

--- a/dbms/src/Storages/Page/Page.h
+++ b/dbms/src/Storages/Page/Page.h
@@ -65,7 +65,7 @@ public:
     {}
 
     PageIdU64 page_id;
-    ByteBuffer data;
+    std::string_view data;
     MemHolder mem_holder;
     // Field offsets inside this page.
     std::set<FieldOffsetInsidePage> field_offsets;
@@ -76,7 +76,7 @@ private:
 public:
     inline bool isValid() const { return is_valid; }
 
-    ConstByteBuffer getFieldData(size_t index) const
+    std::string_view getFieldData(size_t index) const
     {
         auto iter = field_offsets.find(FieldOffsetInsidePage(index));
         if (unlikely(iter == field_offsets.end()))
@@ -88,7 +88,8 @@ public:
         PageFieldOffset end = (iter == field_offsets.end() ? data.size() : iter->offset);
         assert(beg <= data.size());
         assert(end <= data.size());
-        return ConstByteBuffer(data.begin() + beg, data.begin() + end);
+        assert(end >= beg);
+        return std::string_view(data.begin() + beg, end - beg);
     }
 
     inline static PageFieldSizes fieldOffsetsToSizes(const PageFieldOffsetChecksums & field_offsets, size_t data_size)

--- a/dbms/src/Storages/Page/PageDefinesBase.h
+++ b/dbms/src/Storages/Page/PageDefinesBase.h
@@ -94,42 +94,6 @@ using PageFileIdAndLevels = std::vector<PageFileIdAndLevel>;
 
 using PageSize = UInt64;
 
-template <class Pos>
-struct ByteBufferInternal
-{
-    ByteBufferInternal()
-        : begin_pos(nullptr)
-        , end_pos(nullptr)
-    {}
-
-    ByteBufferInternal(Pos begin_pos_, Pos end_pos_)
-        : begin_pos(begin_pos_)
-        , end_pos(end_pos_)
-    {}
-
-    inline Pos begin() const { return begin_pos; }
-    inline Pos end() const { return end_pos; }
-    inline size_t size() const { return end_pos - begin_pos; }
-
-private:
-    Pos begin_pos;
-    Pos end_pos; /// 1 byte after the end of the buffer
-};
-
-struct ByteBuffer : public ByteBufferInternal<char *>
-{
-    using ByteBufferInternal<char *>::ByteBufferInternal;
-};
-
-struct ConstByteBuffer : public ByteBufferInternal<const char *>
-{
-    using ByteBufferInternal<const char *>::ByteBufferInternal;
-
-    explicit ConstByteBuffer(const ByteBuffer & buf)
-        : ConstByteBuffer(buf.begin(), buf.end())
-    {}
-};
-
 /// https://stackoverflow.com/a/13938417
 inline size_t alignPage(size_t n)
 {

--- a/dbms/src/Storages/Page/V1/Page.h
+++ b/dbms/src/Storages/Page/V1/Page.h
@@ -25,8 +25,7 @@ using PageIdSet = PS::V2::PageIdSet;
 struct Page
 {
     PageId page_id;
-    ByteBuffer data;
-
+    std::string_view data;
     MemHolder mem_holder;
 };
 using Pages = std::vector<Page>;

--- a/dbms/src/Storages/Page/V1/PageFile.cpp
+++ b/dbms/src/Storages/Page/V1/PageFile.cpp
@@ -21,6 +21,7 @@
 #include <common/logger_useful.h>
 
 #include <boost/algorithm/string/classification.hpp>
+#include <span>
 
 #ifndef __APPLE__
 #include <fcntl.h>
@@ -58,7 +59,7 @@ using Checksum = UInt64;
 static const size_t PAGE_META_SIZE = sizeof(PageId) + sizeof(PageTag) + sizeof(PageOffset) + sizeof(PageSize) + sizeof(Checksum);
 
 /// Return <data to write into meta file, data to write into data file>.
-std::pair<ByteBuffer, ByteBuffer> genWriteData( //
+std::pair<std::span<char>, std::span<char>> genWriteData( //
     const WriteBatch & wb,
     PageFile & page_file,
     PageEntriesEdit & edit)
@@ -284,14 +285,14 @@ void PageFile::Writer::write(const WriteBatch & wb, PageEntriesEdit & edit)
     ProfileEvents::increment(ProfileEvents::PSMWritePages, wb.putWriteCount());
 
     // TODO: investigate if not copy data into heap, write big pages can be faster?
-    ByteBuffer meta_buf, data_buf;
+    std::span<char> meta_buf, data_buf;
     std::tie(meta_buf, data_buf) = PageMetaFormat::genWriteData(wb, page_file, edit);
 
-    SCOPE_EXIT({ page_file.free(meta_buf.begin(), meta_buf.size()); });
-    SCOPE_EXIT({ page_file.free(data_buf.begin(), data_buf.size()); });
+    SCOPE_EXIT({ page_file.free(meta_buf.data(), meta_buf.size()); });
+    SCOPE_EXIT({ page_file.free(data_buf.data(), data_buf.size()); });
 
-    auto write_buf = [&](WritableFilePtr & file, UInt64 offset, ByteBuffer buf) {
-        PageUtil::writeFile(file, offset, buf.begin(), buf.size());
+    auto write_buf = [&](WritableFilePtr & file, UInt64 offset, std::span<char> buf) {
+        PageUtil::writeFile(file, offset, buf.data(), buf.size());
         if (sync_on_write)
             PageUtil::syncFile(file);
     };
@@ -359,7 +360,7 @@ PageMap PageFile::Reader::read(PageIdAndEntries & to_read)
 
         Page page;
         page.page_id = page_id;
-        page.data = ByteBuffer(pos, pos + page_cache.size);
+        page.data = std::string_view(pos, page_cache.size);
         page.mem_holder = mem_holder;
         page_map.emplace(page_id, page);
 
@@ -408,7 +409,7 @@ void PageFile::Reader::read(PageIdAndEntries & to_read, const PageHandler & hand
 
         Page page;
         page.page_id = page_id;
-        page.data = ByteBuffer(data_buf, data_buf + page_cache.size);
+        page.data = std::string_view(data_buf, page_cache.size);
         page.mem_holder = mem_holder;
 
         ++it;

--- a/dbms/src/Storages/Page/V2/PageFile.cpp
+++ b/dbms/src/Storages/Page/V2/PageFile.cpp
@@ -29,6 +29,7 @@
 #include <boost/algorithm/string/classification.hpp>
 #include <ext/scope_guard.h>
 #include <magic_enum.hpp>
+#include <span>
 
 #ifndef __APPLE__
 #include <fcntl.h>
@@ -85,7 +86,7 @@ static const size_t PAGE_META_SIZE = sizeof(PageId) + sizeof(PageFileId) + sizeo
     + sizeof(PageOffset) + sizeof(PageSize) + sizeof(Checksum);
 
 /// Return <data to write into meta file, data to write into data file>.
-std::pair<ByteBuffer, ByteBuffer> genWriteData( //
+std::pair<std::span<char>, std::span<char>> genWriteData( //
     DB::WriteBatch & wb,
     PageFile & page_file,
     PageEntriesEdit & edit)
@@ -798,17 +799,17 @@ size_t PageFile::Writer::write(DB::WriteBatch & wb, PageEntriesEdit & edit, cons
     }
 
     // TODO: investigate if not copy data into heap, write big pages can be faster?
-    ByteBuffer meta_buf, data_buf;
+    std::span<char> meta_buf, data_buf;
     std::tie(meta_buf, data_buf) = PageMetaFormat::genWriteData(wb, page_file, edit);
 
-    SCOPE_EXIT({ page_file.free(meta_buf.begin(), meta_buf.size()); });
-    SCOPE_EXIT({ page_file.free(data_buf.begin(), data_buf.size()); });
+    SCOPE_EXIT({ page_file.free(meta_buf.data(), meta_buf.size()); });
+    SCOPE_EXIT({ page_file.free(data_buf.data(), data_buf.size()); });
 
-    auto write_buf = [&](WritableFilePtr & file, UInt64 offset, ByteBuffer buf, bool enable_failpoint) {
+    auto write_buf = [&](WritableFilePtr & file, UInt64 offset, std::span<char> buf, bool enable_failpoint) {
         PageUtil::writeFile(
             file,
             offset,
-            buf.begin(),
+            buf.data(),
             buf.size(),
             write_limiter,
             background,
@@ -932,7 +933,7 @@ PageMap PageFile::Reader::read(PageIdAndEntries & to_read, const ReadLimiterPtr 
         }
 
         Page page(page_id);
-        page.data = ByteBuffer(pos, pos + entry.size);
+        page.data = std::string_view(pos, entry.size);
         page.mem_holder = mem_holder;
 
         // Calculate the field_offsets from page entry
@@ -1021,7 +1022,7 @@ PageMap PageFile::Reader::read(PageFile::Reader::FieldReadInfos & to_read, const
         }
 
         Page page(page_id);
-        page.data = ByteBuffer(pos, write_offset);
+        page.data = std::string_view(pos, write_offset - pos);
         page.mem_holder = mem_holder;
         page.field_offsets.swap(fields_offset_in_page);
         fields_offset_in_page.clear();
@@ -1091,7 +1092,7 @@ Page PageFile::Reader::read(FieldReadInfo & to_read, const ReadLimiterPtr & read
     }
 
     Page page(to_read.page_id);
-    page.data = ByteBuffer(data_buf, write_offset);
+    page.data = std::string_view(data_buf, write_offset - data_buf);
     page.mem_holder = mem_holder;
     page.field_offsets.swap(fields_offset_in_page);
 

--- a/dbms/src/Storages/Page/V2/tests/gtest_page_file.cpp
+++ b/dbms/src/Storages/Page/V2/tests/gtest_page_file.cpp
@@ -87,7 +87,7 @@ TEST(Page_test, GetField)
         c_buff[i] = i % 0xff;
 
     Page page{1};
-    page.data = ByteBuffer(c_buff, c_buff + buf_sz);
+    page.data = std::string_view(c_buff, buf_sz);
     std::set<FieldOffsetInsidePage> fields{// {field_index, data_offset}
                                            {2, 0},
                                            {3, 20},

--- a/dbms/src/Storages/Page/V2/tests/gtest_page_storage_multi_writers.cpp
+++ b/dbms/src/Storages/Page/V2/tests/gtest_page_storage_multi_writers.cpp
@@ -406,7 +406,7 @@ try
         ASSERT_EQ(old_entry.checksum, entry.checksum) << "of Page[" << page_id << "]";
 
         auto old_page = old_storage->read(page_id, nullptr, old_snapshot);
-        char * buf = old_page.data.begin();
+        const char * buf = old_page.data.begin();
         for (size_t i = 0; i < old_page.data.size(); ++i)
             ASSERT_EQ(((size_t) * (buf + i)) % 0xFF, page_id % 0xFF);
 

--- a/dbms/src/Storages/Page/V3/BlobStore.cpp
+++ b/dbms/src/Storages/Page/V3/BlobStore.cpp
@@ -686,7 +686,7 @@ BlobStore<Trait>::read(FieldReadInfos & to_read, const ReadLimiterPtr & read_lim
         {
             UNUSED(entry, fields);
             Page page(Trait::PageIdTrait::getU64ID(page_id));
-            page.data = ByteBuffer(nullptr, nullptr);
+            page.data = std::string_view(nullptr, 0);
             page_map.emplace(Trait::PageIdTrait::getPageMapKey(page_id), std::move(page));
         }
         return page_map;
@@ -743,7 +743,8 @@ BlobStore<Trait>::read(FieldReadInfos & to_read, const ReadLimiterPtr & read_lim
         }
 
         Page page(Trait::PageIdTrait::getU64ID(page_id_v3));
-        page.data = ByteBuffer(pos, write_offset);
+        RUNTIME_CHECK(write_offset >= pos);
+        page.data = std::string_view(pos, write_offset - pos);
         page.mem_holder = shared_mem_holder;
         page.field_offsets.swap(fields_offset_in_page);
         fields_offset_in_page.clear();
@@ -839,7 +840,7 @@ BlobStore<Trait>::read(PageIdAndEntries & entries, const ReadLimiterPtr & read_l
         }
 
         Page page(Trait::PageIdTrait::getU64ID(page_id_v3));
-        page.data = ByteBuffer(pos, pos + entry.size);
+        page.data = std::string_view(pos, entry.size);
         page.mem_holder = mem_holder;
 
         // Calculate the field_offsets from page entry
@@ -920,7 +921,7 @@ Page BlobStore<Trait>::read(const PageIdAndEntry & id_entry, const ReadLimiterPt
     }
 
     Page page(Trait::PageIdTrait::getU64ID(page_id_v3));
-    page.data = ByteBuffer(data_buf, data_buf + buf_size);
+    page.data = std::string_view(data_buf, buf_size);
     page.mem_holder = mem_holder;
 
     // Calculate the field_offsets from page entry

--- a/dbms/src/Storages/Page/V3/CheckpointFile/CPWriteDataSource.cpp
+++ b/dbms/src/Storages/Page/V3/CheckpointFile/CPWriteDataSource.cpp
@@ -32,7 +32,7 @@ Page CPWriteDataSourceFixture::read(const BlobStore<universal::BlobStoreTrait>::
 
     Page page(1);
     page.mem_holder = nullptr;
-    page.data = ByteBuffer(value.data(), value.data() + value.size());
+    page.data = std::string_view(value);
     return page;
 }
 

--- a/dbms/src/Storages/Page/V3/Universal/S3PageReader.cpp
+++ b/dbms/src/Storages/Page/V3/Universal/S3PageReader.cpp
@@ -39,7 +39,7 @@ Page S3PageReader::read(const UniversalPageIdAndEntry & page_id_and_entry)
         pos += n;
     }
     Page page{UniversalPageIdFormat::getU64ID(page_id_and_entry.first)};
-    page.data = ByteBuffer(data_buf, data_buf + buf_size);
+    page.data = std::string_view(data_buf, buf_size);
     page.mem_holder = mem_holder;
     // Calculate the field_offsets from page entry
     for (size_t index = 0; index < page_entry.field_offsets.size(); index++)
@@ -96,7 +96,7 @@ std::pair<UniversalPageMap, UniversalPageMap> S3PageReader::read(const FieldRead
             data_pos += size_to_read;
         }
         Page page{UniversalPageIdFormat::getU64ID(read_info.page_id)};
-        page.data = ByteBuffer(read_fields_buf + page_begin, read_fields_buf + data_pos);
+        page.data = std::string_view(read_fields_buf + page_begin, data_pos - page_begin);
         page.mem_holder = read_fields_mem_holder;
         page.field_offsets.swap(fields_offset_in_page);
         read_fields_page_map.emplace(read_info.page_id, page);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/6233

Problem Summary:

ByteBuffer is:

- Not immutable, where actually it should be immutable
- The name is misleading, does not indicate it has no ownership
- Does not implement standard compare operators, hard to use
- Is not printable by default in google test
- Hard to construct easily

### What is changed and how it works?

`ByteBuffer` is replaced by `std::string_view`, which is an immutable view to a buffer and does not own the memory of the buffer.

Note: In some places we need a mutable `char *` in order to free the memory later. For such cases, `std::span<char>` is used instead.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
