### PR TITLE
support upload ps checkpoint to S3

### DIFF
--- a/dbms/src/Encryption/PosixRandomAccessFile.cpp
+++ b/dbms/src/Encryption/PosixRandomAccessFile.cpp
@@ -38,6 +38,11 @@ extern const int CANNOT_SEEK_THROUGH_FILE;
 extern const int CANNOT_SELECT;
 } // namespace ErrorCodes
 
+RandomAccessFilePtr PosixRandomAccessFile::create(const String & file_name_)
+{
+    return std::make_shared<PosixRandomAccessFile>(file_name_, /*flags*/ -1, /*read_limiter_*/ nullptr);
+}
+
 PosixRandomAccessFile::PosixRandomAccessFile(const std::string & file_name_, int flags, const ReadLimiterPtr & read_limiter_)
     : file_name{file_name_}
     , read_limiter(read_limiter_)

--- a/dbms/src/Encryption/PosixRandomAccessFile.h
+++ b/dbms/src/Encryption/PosixRandomAccessFile.h
@@ -32,6 +32,8 @@ using ReadLimiterPtr = std::shared_ptr<ReadLimiter>;
 class PosixRandomAccessFile : public RandomAccessFile
 {
 public:
+    static RandomAccessFilePtr create(const String & file_name_);
+
     PosixRandomAccessFile(const std::string & file_name_, int flags, const ReadLimiterPtr & read_limiter_ = nullptr);
 
     ~PosixRandomAccessFile() override;

--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -1708,6 +1708,7 @@ void Context::initializeWriteNodePageStorageIfNeed(const PathPool & path_pool)
                 *this,
                 "write",
                 path_pool.getPSDiskDelegatorGlobalMulti(PathPool::write_uni_path_prefix),
+                getTemporaryPath(),
                 config);
             LOG_INFO(shared->log, "initialized GlobalUniversalPageStorage(WriteNode)");
         }

--- a/dbms/src/Storages/Page/V3/CheckpointFile/CPManifestFileReader.h
+++ b/dbms/src/Storages/Page/V3/CheckpointFile/CPManifestFileReader.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include <IO/CompressedReadBuffer.h>
-#include <IO/ReadBufferFromFile.h>
+#include <IO/ReadBufferFromRandomAccessFile.h>
 #include <Storages/Page/V3/CheckpointFile/Proto/manifest_file.pb.h>
 #include <Storages/Page/V3/CheckpointFile/fwd.h>
 #include <Storages/Page/V3/PageEntriesEdit.h>
@@ -30,7 +30,7 @@ class CPManifestFileReader : private boost::noncopyable
 public:
     struct Options
     {
-        const std::string & file_path;
+        RandomAccessFilePtr plain_file;
     };
 
     static CPManifestFileReaderPtr create(Options options)
@@ -39,7 +39,7 @@ public:
     }
 
     explicit CPManifestFileReader(Options options)
-        : file_reader(std::make_unique<ReadBufferFromFile>(options.file_path))
+        : file_reader(std::make_unique<ReadBufferFromRandomAccessFile>(options.plain_file))
         , compressed_reader(std::make_unique<CompressedReadBuffer<true>>(*file_reader))
     {}
 
@@ -62,7 +62,7 @@ private:
     };
 
     // compressed<plain_file>
-    const std::unique_ptr<ReadBufferFromFile> file_reader;
+    const std::unique_ptr<ReadBufferFromRandomAccessFile> file_reader;
     const ReadBufferPtr compressed_reader;
 
     ReadStage read_stage = ReadStage::ReadingPrefix;

--- a/dbms/src/Storages/Page/V3/CheckpointFile/tests/gtest_file_read_write.cpp
+++ b/dbms/src/Storages/Page/V3/CheckpointFile/tests/gtest_file_read_write.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Encryption/PosixRandomAccessFile.h>
+#include <IO/ReadBufferFromRandomAccessFile.h>
 #include <Storages/Page/V3/CheckpointFile/CPFilesWriter.h>
 #include <Storages/Page/V3/CheckpointFile/CPManifestFileReader.h>
 #include <Storages/Page/V3/CheckpointFile/CPWriteDataSource.h>
@@ -41,7 +43,8 @@ public:
         std::string ret;
         ret.resize(location.size_in_file);
 
-        auto buf = ReadBufferFromFile(dir + "/" + *location.data_file_id);
+        auto data_file = PosixRandomAccessFile::create(dir + "/" + *location.data_file_id);
+        ReadBufferFromRandomAccessFile buf(data_file);
         buf.seek(location.offset_in_file);
         auto n = buf.readBig(ret.data(), location.size_in_file);
         RUNTIME_CHECK(n == location.size_in_file);
@@ -75,8 +78,9 @@ try
     ASSERT_TRUE(Poco::File(dir + "/data_1").exists());
     ASSERT_TRUE(Poco::File(dir + "/manifest_foo").exists());
 
+    auto manifest_file = PosixRandomAccessFile::create(dir + "/manifest_foo");
     auto manifest_reader = CPManifestFileReader::create({
-        .file_path = dir + "/manifest_foo",
+        .plain_file = manifest_file,
     });
     auto prefix = manifest_reader->readPrefix();
     ASSERT_EQ(5, prefix.local_sequence());
@@ -129,8 +133,9 @@ try
     writer->writeSuffix();
     writer.reset();
 
+    auto manifest_file = PosixRandomAccessFile::create(dir + "/manifest_foo");
     auto manifest_reader = CPManifestFileReader::create({
-        .file_path = dir + "/manifest_foo",
+        .plain_file = manifest_file,
     });
     auto prefix = manifest_reader->readPrefix();
     CheckpointProto::StringsInternMap im;
@@ -193,8 +198,9 @@ try
     writer->writeSuffix();
     writer.reset();
 
+    auto manifest_file = PosixRandomAccessFile::create(dir + "/manifest_foo");
     auto manifest_reader = CPManifestFileReader::create({
-        .file_path = dir + "/manifest_foo",
+        .plain_file = manifest_file,
     });
     manifest_reader->readPrefix();
     CheckpointProto::StringsInternMap im;
@@ -295,8 +301,9 @@ try
     writer->writeSuffix();
     writer.reset();
 
+    auto manifest_file = PosixRandomAccessFile::create(dir + "/manifest_foo");
     auto manifest_reader = CPManifestFileReader::create({
-        .file_path = dir + "/manifest_foo",
+        .plain_file = manifest_file,
     });
     manifest_reader->readPrefix();
     CheckpointProto::StringsInternMap im;
@@ -383,8 +390,9 @@ try
     writer->writeSuffix();
     writer.reset();
 
+    auto manifest_file = PosixRandomAccessFile::create(dir + "/manifest_foo");
     auto manifest_reader = CPManifestFileReader::create({
-        .file_path = dir + "/manifest_foo",
+        .plain_file = manifest_file,
     });
     manifest_reader->readPrefix();
     CheckpointProto::StringsInternMap im;
@@ -471,8 +479,9 @@ try
     writer->writeSuffix();
     writer.reset();
 
+    auto manifest_file = PosixRandomAccessFile::create(dir + "/manifest_foo");
     auto manifest_reader = CPManifestFileReader::create({
-        .file_path = dir + "/manifest_foo",
+        .plain_file = manifest_file,
     });
     manifest_reader->readPrefix();
     CheckpointProto::StringsInternMap im;
@@ -513,8 +522,9 @@ try
     writer->writeSuffix();
     writer.reset();
 
+    auto manifest_file = PosixRandomAccessFile::create(dir + "/manifest_foo");
     auto manifest_reader = CPManifestFileReader::create({
-        .file_path = dir + "/manifest_foo",
+        .plain_file = manifest_file,
     });
     manifest_reader->readPrefix();
     CheckpointProto::StringsInternMap im;
@@ -567,8 +577,9 @@ try
     writer->writeSuffix();
     writer.reset();
 
+    auto manifest_file = PosixRandomAccessFile::create(dir + "/manifest_foo");
     auto manifest_reader = CPManifestFileReader::create({
-        .file_path = dir + "/manifest_foo",
+        .plain_file = manifest_file,
     });
     manifest_reader->readPrefix();
     CheckpointProto::StringsInternMap im;
@@ -626,8 +637,9 @@ try
     writer->writeSuffix();
     writer.reset();
 
+    auto manifest_file = PosixRandomAccessFile::create(dir + "/manifest_foo");
     auto manifest_reader = CPManifestFileReader::create({
-        .file_path = dir + "/manifest_1",
+        .plain_file = manifest_file,
     });
     manifest_reader->readPrefix();
     CheckpointProto::StringsInternMap im;

--- a/dbms/src/Storages/Page/V3/Universal/UniversalPageStorage.cpp
+++ b/dbms/src/Storages/Page/V3/Universal/UniversalPageStorage.cpp
@@ -319,26 +319,30 @@ UniversalPageStorage::dumpIncrementalCheckpoint(const UniversalPageStorage::Dump
     // As a checkpoint, we write both entries (in manifest) and its data.
     // Some entries' data may be already written by a previous checkpoint. These data will not be written again.
 
+    // TODO: the following format is highly coupled with the detail format in S3Filename.cpp, find an elegant way to remove the couple.
     auto data_file_id = fmt::format(
         fmt::runtime(options.data_file_id_pattern),
-        fmt::arg("sequence", snap->sequence),
-        fmt::arg("sub_file_index", 0));
+        fmt::arg("seq", snap->sequence),
+        fmt::arg("index", 0));
     auto data_file_path = fmt::format(
         fmt::runtime(options.data_file_path_pattern),
-        fmt::arg("sequence", snap->sequence),
-        fmt::arg("sub_file_index", 0));
+        fmt::arg("seq", snap->sequence),
+        fmt::arg("index", 0));
 
     auto manifest_file_id = fmt::format(
         fmt::runtime(options.manifest_file_id_pattern),
-        fmt::arg("sequence", snap->sequence));
+        fmt::arg("seq", snap->sequence));
     auto manifest_file_path = fmt::format(
         fmt::runtime(options.manifest_file_path_pattern),
-        fmt::arg("sequence", snap->sequence));
+        fmt::arg("seq", snap->sequence));
 
     RUNTIME_CHECK(
         data_file_path != manifest_file_path,
         data_file_path,
         manifest_file_path);
+
+    Poco::File(Poco::Path(data_file_path).parent().toString()).createDirectories();
+    Poco::File(Poco::Path(manifest_file_path).parent().toString()).createDirectories();
 
     auto writer = PS::V3::CPFilesWriter::create({
         .data_file_path = data_file_path,

--- a/dbms/src/Storages/Page/V3/Universal/UniversalPageStorageService.cpp
+++ b/dbms/src/Storages/Page/V3/Universal/UniversalPageStorageService.cpp
@@ -12,8 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Encryption/createWriteBufferFromFileBaseByFileProvider.h>
+#include <IO/ReadBufferFromFile.h>
+#include <IO/WriteBufferFromWritableFile.h>
+#include <IO/copyData.h>
 #include <Interpreters/Context.h>
+#include <Poco/TemporaryFile.h>
 #include <Storages/Page/V3/Universal/UniversalPageStorageService.h>
+#include <Storages/S3/S3Common.h>
+#include <Storages/S3/S3Filename.h>
+#include <Storages/S3/S3WritableFile.h>
+#include <Storages/Transaction/KVStore.h>
+#include <Storages/Transaction/TMTContext.h>
 
 namespace DB
 {
@@ -21,9 +31,10 @@ UniversalPageStorageServicePtr UniversalPageStorageService::create(
     Context & context,
     const String & name,
     PSDiskDelegatorPtr delegator,
+    String && temp_path,
     const PageStorageConfig & config)
 {
-    auto service = UniversalPageStorageServicePtr(new UniversalPageStorageService(context));
+    auto service = UniversalPageStorageServicePtr(new UniversalPageStorageService(context, std::move(temp_path)));
     service->uni_page_storage = UniversalPageStorage::create(name, delegator, config, context.getFileProvider());
     service->uni_page_storage->restore();
     service->gc_handle = context.getBackgroundPool().addTask(
@@ -32,6 +43,13 @@ UniversalPageStorageServicePtr UniversalPageStorageService::create(
         },
         false,
         /*interval_ms*/ 60 * 1000);
+    service->checkpoint_handle = context.getBackgroundPool().addTask(
+        [service] {
+            service->doCheckpoint();
+            return false;
+        },
+        false,
+        /*interval_ms*/ 10 * 1000);
     return service;
 }
 
@@ -47,6 +65,79 @@ bool UniversalPageStorageService::gc()
     return this->uni_page_storage->gc();
 }
 
+void UniversalPageStorageService::doCheckpoint(bool force)
+{
+    Timepoint now = Clock::now();
+    if (!force && now < (last_checkpoint_time.load() + Seconds(10)))
+        return;
+
+    last_checkpoint_time = now;
+
+    auto store_info = global_context.getTMTContext().getKVStore()->getStoreMeta();
+    if (store_info.id() == 0)
+    {
+        LOG_INFO(Logger::get(), "Skip checkpoint because store meta is not initialized");
+        return;
+    }
+
+    try
+    {
+        Stopwatch watch;
+        PS::V3::CheckpointProto::WriterInfo writer_info;
+        writer_info.set_store_id(store_info.id());
+        writer_info.set_version(store_info.version());
+        writer_info.set_version_git(store_info.git_hash());
+        writer_info.set_start_at_ms(store_info.start_timestamp() * 1000);
+        auto remote_info = writer_info.mutable_remote_info();
+        remote_info->set_type_name("S3");
+
+        Poco::TemporaryFile temp_checkpoint_dir{temp_path};
+        Poco::File(temp_checkpoint_dir).createDirectories();
+
+        auto data_file_id_pattern = S3::S3Filename::newCheckpointDataNameTemplate(store_info.id());
+        auto manifest_file_id_pattern = S3::S3Filename::newCheckpointManifestNameTemplate(store_info.id());
+        UniversalPageStorage::DumpCheckpointOptions options{
+            .data_file_id_pattern = data_file_id_pattern,
+            .data_file_path_pattern = temp_checkpoint_dir.path() + "/" + data_file_id_pattern,
+            .manifest_file_id_pattern = manifest_file_id_pattern,
+            .manifest_file_path_pattern = temp_checkpoint_dir.path() + "/" + manifest_file_id_pattern,
+            .writer_info = writer_info,
+        };
+        auto result = uni_page_storage->dumpIncrementalCheckpoint(options);
+
+        auto file_provider = global_context.getFileProvider();
+        // TODO: create related S3 lock
+        // Note we must upload data file before manifest file
+        for (const auto & data_file_info : result.new_data_files)
+        {
+            ReadBufferFromFile buf(data_file_info.path);
+            WritableFilePtr s3_file = std::make_shared<S3::S3WritableFile>(S3::ClientFactory::instance().sharedClient(),
+                                                                           S3::ClientFactory::instance().bucket(),
+                                                                           data_file_info.id,
+                                                                           S3::WriteSettings{});
+            WriteBufferFromWritableFile s3_write_buf(s3_file);
+            copyData(buf, s3_write_buf);
+            s3_write_buf.sync();
+        }
+        for (const auto & manifest_file_info : result.new_manifest_files)
+        {
+            ReadBufferFromFile buf(manifest_file_info.path);
+            WritableFilePtr s3_file = std::make_shared<S3::S3WritableFile>(S3::ClientFactory::instance().sharedClient(),
+                                                                           S3::ClientFactory::instance().bucket(),
+                                                                           manifest_file_info.id,
+                                                                           S3::WriteSettings{});
+            WriteBufferFromWritableFile s3_write_buf(s3_file);
+            copyData(buf, s3_write_buf);
+            s3_write_buf.sync();
+        }
+        LOG_INFO(Logger::get(), "Dump checkpoint finished in {} milliseconds.", watch.elapsedMilliseconds());
+    }
+    catch (...)
+    {
+        tryLogCurrentException(__PRETTY_FUNCTION__);
+    }
+}
+
 UniversalPageStorageService::~UniversalPageStorageService()
 {
     shutdown();
@@ -58,6 +149,11 @@ void UniversalPageStorageService::shutdown()
     {
         global_context.getBackgroundPool().removeTask(gc_handle);
         gc_handle = nullptr;
+    }
+    if (checkpoint_handle)
+    {
+        global_context.getBackgroundPool().removeTask(gc_handle);
+        checkpoint_handle = nullptr;
     }
 }
 } // namespace DB

--- a/dbms/src/Storages/Page/V3/Universal/UniversalPageStorageService.cpp
+++ b/dbms/src/Storages/Page/V3/Universal/UniversalPageStorageService.cpp
@@ -105,7 +105,6 @@ void UniversalPageStorageService::doCheckpoint(bool force)
         };
         auto result = uni_page_storage->dumpIncrementalCheckpoint(options);
 
-        auto file_provider = global_context.getFileProvider();
         // TODO: create related S3 lock
         // Note we must upload data file before manifest file
         for (const auto & data_file_info : result.new_data_files)

--- a/dbms/src/Storages/Page/V3/Universal/UniversalPageStorageService.cpp
+++ b/dbms/src/Storages/Page/V3/Universal/UniversalPageStorageService.cpp
@@ -88,7 +88,7 @@ void UniversalPageStorageService::doCheckpoint(bool force)
         writer_info.set_version(store_info.version());
         writer_info.set_version_git(store_info.git_hash());
         writer_info.set_start_at_ms(store_info.start_timestamp() * 1000);
-        auto remote_info = writer_info.mutable_remote_info();
+        auto * remote_info = writer_info.mutable_remote_info();
         remote_info->set_type_name("S3");
 
         Poco::TemporaryFile temp_checkpoint_dir{temp_path};

--- a/dbms/src/Storages/Page/V3/Universal/UniversalPageStorageService.h
+++ b/dbms/src/Storages/Page/V3/Universal/UniversalPageStorageService.h
@@ -33,25 +33,33 @@ public:
         Context & context,
         const String & name,
         PSDiskDelegatorPtr delegator,
+        String && temp_path,
         const PageStorageConfig & config);
 
     bool gc();
+    // `force` is just used in test.
+    void doCheckpoint(bool force = false);
     UniversalPageStoragePtr getUniversalPageStorage() const { return uni_page_storage; }
     ~UniversalPageStorageService();
     void shutdown();
 
 private:
-    explicit UniversalPageStorageService(Context & global_context_)
+    explicit UniversalPageStorageService(Context & global_context_, String && temp_path_)
         : global_context(global_context_)
         , uni_page_storage(nullptr)
+        , temp_path(std::move(temp_path_))
     {
     }
 
 private:
     Context & global_context;
     UniversalPageStoragePtr uni_page_storage;
+    String temp_path;
+
     BackgroundProcessingPool::TaskHandle gc_handle;
+    BackgroundProcessingPool::TaskHandle checkpoint_handle;
 
     std::atomic<Timepoint> last_try_gc_time = Clock::now();
+    std::atomic<Timepoint> last_checkpoint_time = Clock::now();
 };
 } // namespace DB

--- a/dbms/src/Storages/Page/V3/Universal/tests/gtest_remote_read.cpp
+++ b/dbms/src/Storages/Page/V3/Universal/tests/gtest_remote_read.cpp
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Encryption/PosixRandomAccessFile.h>
+#include <IO/ReadBufferFromFile.h>
+#include <IO/ReadBufferFromRandomAccessFile.h>
 #include <IO/WriteBufferFromWritableFile.h>
 #include <IO/copyData.h>
 #include <Storages/Page/V3/BlobStore.h>
@@ -146,8 +149,9 @@ try
     uploadFile(remote_dir, "data_1");
     uploadFile(remote_dir, "manifest_foo");
 
+    auto manifest_file = PosixRandomAccessFile::create(remote_dir + "/manifest_foo");
     auto manifest_reader = PS::V3::CPManifestFileReader::create({
-        .file_path = remote_dir + "/manifest_foo",
+        .plain_file = manifest_file,
     });
     manifest_reader->readPrefix();
     PS::V3::CheckpointProto::StringsInternMap im;
@@ -205,8 +209,9 @@ try
     uploadFile(remote_dir, "data_1");
     uploadFile(remote_dir, "manifest_foo");
 
+    auto manifest_file = PosixRandomAccessFile::create(remote_dir + "/manifest_foo");
     auto manifest_reader = PS::V3::CPManifestFileReader::create({
-        .file_path = remote_dir + "/manifest_foo",
+        .plain_file = manifest_file,
     });
     manifest_reader->readPrefix();
     PS::V3::CheckpointProto::StringsInternMap im;
@@ -272,8 +277,9 @@ try
     uploadFile(remote_dir, "data_1");
     uploadFile(remote_dir, "manifest_foo");
 
+    auto manifest_file = PosixRandomAccessFile::create(remote_dir + "/manifest_foo");
     auto manifest_reader = PS::V3::CPManifestFileReader::create({
-        .file_path = remote_dir + "/manifest_foo",
+        .plain_file = manifest_file,
     });
     manifest_reader->readPrefix();
     PS::V3::CheckpointProto::StringsInternMap im;
@@ -344,8 +350,9 @@ try
     uploadFile(remote_dir, "data_1");
     uploadFile(remote_dir, "manifest_foo");
 
+    auto manifest_file = PosixRandomAccessFile::create(remote_dir + "/manifest_foo");
     auto manifest_reader = PS::V3::CPManifestFileReader::create({
-        .file_path = remote_dir + "/manifest_foo",
+        .plain_file = manifest_file,
     });
     manifest_reader->readPrefix();
     PS::V3::CheckpointProto::StringsInternMap im;

--- a/dbms/src/Storages/S3/S3Filename.cpp
+++ b/dbms/src/Storages/S3/S3Filename.cpp
@@ -357,4 +357,14 @@ S3Filename S3Filename::newCheckpointManifest(StoreID store_id, UInt64 upload_seq
     };
 }
 
+String S3Filename::newCheckpointDataNameTemplate(StoreID store_id)
+{
+    return fmt::format(details::fmt_data_file, fmt::arg("store_id", store_id), fmt::arg("subpath", details::fmt_subpath_checkpoint_data));
+}
+
+String S3Filename::newCheckpointManifestNameTemplate(StoreID store_id)
+{
+    return fmt::format(details::fmt_manifest, fmt::arg("store_id", store_id), fmt::arg("subpath", details::fmt_subpath_manifest));
+}
+
 } // namespace DB::S3

--- a/dbms/src/Storages/S3/S3Filename.h
+++ b/dbms/src/Storages/S3/S3Filename.h
@@ -135,6 +135,9 @@ struct S3Filename
     static S3Filename newCheckpointData(StoreID store_id, UInt64 upload_seq, UInt64 file_idx);
     static S3Filename newCheckpointManifest(StoreID store_id, UInt64 upload_seq);
 
+    static String newCheckpointDataNameTemplate(StoreID store_id);
+    static String newCheckpointManifestNameTemplate(StoreID store_id);
+
     String toFullKey() const;
 
     // `toFullKeyWithPrefix` will as a `s3:://` prefix in full key.

--- a/dbms/src/Storages/S3/S3GCManager.cpp
+++ b/dbms/src/Storages/S3/S3GCManager.cpp
@@ -15,6 +15,7 @@
 #include <Common/Exception.h>
 #include <Common/Logger.h>
 #include <Core/Types.h>
+#include <Encryption/PosixRandomAccessFile.h>
 #include <Flash/Disaggregated/S3LockClient.h>
 #include <Interpreters/Context.h>
 #include <Storages/Page/V3/CheckpointFile/CPManifestFileReader.h>
@@ -396,7 +397,8 @@ std::unordered_set<String> S3GCManager::getValidLocksFromManifest(const String &
     // parse lock from manifest
     PS::V3::CheckpointProto::StringsInternMap strings_cache;
     using ManifestReader = DB::PS::V3::CPManifestFileReader;
-    auto reader = ManifestReader::create(ManifestReader::Options{.file_path = local_manifest_path});
+    auto manifest_file = PosixRandomAccessFile::create(local_manifest_path);
+    auto reader = ManifestReader::create(ManifestReader::Options{.plain_file = manifest_file});
     auto mf_prefix = reader->readPrefix();
 
     while (true)

--- a/dbms/src/Storages/Transaction/KVStore.cpp
+++ b/dbms/src/Storages/Transaction/KVStore.cpp
@@ -833,6 +833,11 @@ StoreID KVStore::getStoreID(std::memory_order memory_order) const
     return getStore().store_id.load(memory_order);
 }
 
+metapb::Store KVStore::getStoreMeta() const
+{
+    return getStore().getMeta();
+}
+
 KVStore::StoreMeta & KVStore::getStore()
 {
     return this->store;
@@ -845,8 +850,15 @@ const KVStore::StoreMeta & KVStore::getStore() const
 
 void KVStore::StoreMeta::update(Base && base_)
 {
+    std::lock_guard lock(mu);
     base = std::move(base_);
     store_id = base.id();
+}
+
+KVStore::StoreMeta::Base KVStore::StoreMeta::getMeta() const
+{
+    std::lock_guard lock(mu);
+    return base;
 }
 
 KVStore::~KVStore()

--- a/dbms/src/Storages/Transaction/KVStore.h
+++ b/dbms/src/Storages/Transaction/KVStore.h
@@ -143,6 +143,8 @@ public:
     // May return 0 if uninitialized
     StoreID getStoreID(std::memory_order = std::memory_order_relaxed) const;
 
+    metapb::Store getStoreMeta() const;
+
     BatchReadIndexRes batchReadIndex(const std::vector<kvrpcpb::ReadIndexRequest> & req, uint64_t timeout_ms) const;
 
     /// Initialize read-index worker context. It only can be invoked once.
@@ -184,10 +186,13 @@ private:
     friend class ReadIndexStressTest;
     struct StoreMeta
     {
+        mutable std::mutex mu;
+
         using Base = metapb::Store;
         Base base;
         std::atomic_uint64_t store_id{0};
         void update(Base &&);
+        Base getMeta() const;
         friend class KVStore;
     };
     StoreMeta & getStore();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6827 

Problem Summary: Support upload uni ps checkpoint files to S3.
Duplicate with https://github.com/pingcap/tiflash/pull/6984

### What is changed and how it works?
1. Add a background task in `UniversalPageStorageService` to upload uni ps checkpoint data to S3 periodically;
2. Pass a `RandomAccessFilePtr` instead of file path to `CPManifestFileReader`;

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
