### PR TITLE
Reduce import Context.h in non test code

### DIFF
--- a/dbms/src/DataStreams/AddingDefaultBlockOutputStream.h
+++ b/dbms/src/DataStreams/AddingDefaultBlockOutputStream.h
@@ -14,11 +14,11 @@
 
 #pragma once
 
-#include <DataStreams/IBlockOutputStream.h>
 #include <Columns/ColumnConst.h>
-#include <Storages/ColumnDefault.h>
-#include <Interpreters/Context.h>
+#include <DataStreams/IBlockOutputStream.h>
+#include <Interpreters/Context_fwd.h>
 #include <Interpreters/evaluateMissingDefaults.h>
+#include <Storages/ColumnDefault.h>
 
 
 namespace DB
@@ -37,8 +37,11 @@ public:
         NamesAndTypesList required_columns_,
         const ColumnDefaults & column_defaults_,
         const Context & context_)
-        : output(output_), header(header_), required_columns(required_columns_),
-          column_defaults(column_defaults_), context(context_)
+        : output(output_)
+        , header(header_)
+        , required_columns(required_columns_)
+        , column_defaults(column_defaults_)
+        , context(context_)
     {
     }
 
@@ -59,4 +62,4 @@ private:
 };
 
 
-}
+} // namespace DB

--- a/dbms/src/DataStreams/CreatingSetsBlockInputStream.cpp
+++ b/dbms/src/DataStreams/CreatingSetsBlockInputStream.cpp
@@ -20,6 +20,7 @@
 #include <DataStreams/materializeBlock.h>
 #include <Interpreters/Join.h>
 #include <Interpreters/Set.h>
+#include <Interpreters/Settings.h>
 #include <Storages/IStorage.h>
 
 #include <iomanip>

--- a/dbms/src/DataStreams/PushingToViewsBlockOutputStream.cpp
+++ b/dbms/src/DataStreams/PushingToViewsBlockOutputStream.cpp
@@ -15,6 +15,7 @@
 #include <Common/Exception.h>
 #include <DataStreams/PushingToViewsBlockOutputStream.h>
 #include <DataStreams/SquashingBlockInputStream.h>
+#include <Interpreters/Context.h>
 #include <Interpreters/InterpreterSelectQuery.h>
 #include <Storages/IStorage.h>
 

--- a/dbms/src/DataStreams/TiRemoteBlockInputStream.h
+++ b/dbms/src/DataStreams/TiRemoteBlockInputStream.h
@@ -23,7 +23,6 @@
 #include <Flash/Coprocessor/RemoteExecutionSummary.h>
 #include <Flash/Mpp/ExchangeReceiver.h>
 #include <Flash/Statistics/ConnectionProfileInfo.h>
-#include <Interpreters/Context.h>
 #include <Storages/DeltaMerge/ScanContext.h>
 #include <common/logger_useful.h>
 

--- a/dbms/src/Debug/MockExecutor/ExchangeReceiverBinder.cpp
+++ b/dbms/src/Debug/MockExecutor/ExchangeReceiverBinder.cpp
@@ -18,6 +18,7 @@
 #include <Debug/MockExecutor/ExchangeReceiverBinder.h>
 #include <Debug/MockExecutor/ExchangeSenderBinder.h>
 #include <Debug/MockExecutor/ExecutorBinder.h>
+#include <Interpreters/Context.h>
 #include <Storages/Transaction/TiDB.h>
 #include <kvproto/mpp.pb.h>
 

--- a/dbms/src/Debug/dbgQueryCompiler.cpp
+++ b/dbms/src/Debug/dbgQueryCompiler.cpp
@@ -28,6 +28,7 @@
 #include <Debug/MockExecutor/TopNBinder.h>
 #include <Debug/MockExecutor/WindowBinder.h>
 #include <Debug/dbgQueryCompiler.h>
+#include <Interpreters/Context.h>
 #include <Parsers/ASTAsterisk.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>

--- a/dbms/src/Flash/Coprocessor/CoprocessorReader.h
+++ b/dbms/src/Flash/Coprocessor/CoprocessorReader.h
@@ -20,7 +20,6 @@
 #include <Flash/Coprocessor/ChunkDecodeAndSquash.h>
 #include <Flash/Coprocessor/DecodeDetail.h>
 #include <Flash/Coprocessor/DefaultChunkCodec.h>
-#include <Interpreters/Context.h>
 #include <common/logger_useful.h>
 
 #include <chrono>

--- a/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.cpp
@@ -44,6 +44,7 @@
 #include <Flash/Coprocessor/StorageDisaggregatedInterpreter.h>
 #include <Flash/Mpp/newMPPExchangeWriter.h>
 #include <Interpreters/Aggregator.h>
+#include <Interpreters/Context.h>
 #include <Interpreters/Expand.h>
 #include <Interpreters/Join.h>
 #include <Parsers/ASTSelectQuery.h>
@@ -816,5 +817,9 @@ BlockInputStreams DAGQueryBlockInterpreter::execute()
     DAGPipeline pipeline;
     executeImpl(pipeline);
     return pipeline.streams;
+}
+DAGContext & DAGQueryBlockInterpreter::dagContext() const
+{
+    return *context.getDAGContext();
 }
 } // namespace DB

--- a/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.h
+++ b/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.h
@@ -20,7 +20,7 @@
 #include <Flash/Coprocessor/DAGStorageInterpreter.h>
 #include <Flash/Coprocessor/TiDBTableScan.h>
 #include <Interpreters/AggregateDescription.h>
-#include <Interpreters/Context.h>
+#include <Interpreters/Context_fwd.h>
 #include <Interpreters/ExpressionActions.h>
 #include <Storages/TableLockHolder.h>
 #include <Storages/Transaction/TiDB.h>
@@ -92,10 +92,7 @@ private:
 
     void restorePipelineConcurrency(DAGPipeline & pipeline);
 
-    DAGContext & dagContext() const
-    {
-        return *context.getDAGContext();
-    }
+    DAGContext & dagContext() const;
 
     Context & context;
     std::vector<BlockInputStreams> input_streams_vec;

--- a/dbms/src/Flash/Coprocessor/DAGQuerySource.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGQuerySource.cpp
@@ -16,6 +16,7 @@
 #include <Flash/Coprocessor/DAGQuerySource.h>
 #include <Flash/Coprocessor/InterpreterDAG.h>
 #include <Flash/Coprocessor/collectOutputFieldTypes.h>
+#include <Interpreters/Context.h>
 #include <Parsers/makeDummyQuery.h>
 #include <fmt/core.h>
 
@@ -75,6 +76,11 @@ String DAGQuerySource::str(size_t)
 std::unique_ptr<IInterpreter> DAGQuerySource::interpreter(Context &, QueryProcessingStage::Enum)
 {
     return std::make_unique<InterpreterDAG>(context, *this);
+}
+
+DAGContext & DAGQuerySource::getDAGContext() const
+{
+    return *context.getDAGContext();
 }
 
 } // namespace DB

--- a/dbms/src/Flash/Coprocessor/DAGQuerySource.h
+++ b/dbms/src/Flash/Coprocessor/DAGQuerySource.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include <Flash/Coprocessor/DAGQueryBlock.h>
-#include <Interpreters/Context.h>
+#include <Interpreters/Context_fwd.h>
 #include <Interpreters/IQuerySource.h>
 
 namespace DB
@@ -35,7 +35,7 @@ public:
 
     std::shared_ptr<DAGQueryBlock> getRootQueryBlock() const { return root_query_block; }
 
-    DAGContext & getDAGContext() const { return *context.getDAGContext(); }
+    DAGContext & getDAGContext() const;
 
 private:
     Context & context;

--- a/dbms/src/Flash/Coprocessor/StorageDisaggregatedInterpreter.h
+++ b/dbms/src/Flash/Coprocessor/StorageDisaggregatedInterpreter.h
@@ -17,7 +17,7 @@
 #include <Flash/Coprocessor/DAGExpressionAnalyzer.h>
 #include <Flash/Coprocessor/DAGPipeline.h>
 #include <Flash/Coprocessor/FilterConditions.h>
-#include <Interpreters/Context.h>
+#include <Interpreters/Context_fwd.h>
 #include <Storages/StorageDisaggregated.h>
 
 namespace DB

--- a/dbms/src/Flash/Management/ManualCompact.h
+++ b/dbms/src/Flash/Management/ManualCompact.h
@@ -13,7 +13,7 @@
 // limitations under the License.
 #pragma once
 
-#include <Interpreters/Context.h>
+#include <Interpreters/Context_fwd.h>
 #include <Interpreters/Settings.h>
 #include <common/ThreadPool.h>
 #include <common/logger_useful.h>

--- a/dbms/src/Flash/Mpp/ExchangeReceiver.h
+++ b/dbms/src/Flash/Mpp/ExchangeReceiver.h
@@ -18,7 +18,6 @@
 #include <Flash/Coprocessor/ChunkDecodeAndSquash.h>
 #include <Flash/Coprocessor/DAGUtils.h>
 #include <Flash/Mpp/GRPCReceiverContext.h>
-#include <Interpreters/Context.h>
 
 #include <future>
 #include <mutex>

--- a/dbms/src/Flash/Mpp/MPPHandler.cpp
+++ b/dbms/src/Flash/Mpp/MPPHandler.cpp
@@ -16,6 +16,7 @@
 #include <Common/Stopwatch.h>
 #include <Flash/Mpp/MPPHandler.h>
 #include <Flash/Mpp/Utils.h>
+#include <Interpreters/Context.h>
 
 #include <ext/scope_guard.h>
 

--- a/dbms/src/Flash/Mpp/MPPTask.h
+++ b/dbms/src/Flash/Mpp/MPPTask.h
@@ -25,7 +25,7 @@
 #include <Flash/Mpp/MPPTunnel.h>
 #include <Flash/Mpp/MPPTunnelSet.h>
 #include <Flash/Mpp/TaskStatus.h>
-#include <Interpreters/Context.h>
+#include <Interpreters/Context_fwd.h>
 #include <common/logger_useful.h>
 #include <common/types.h>
 #include <kvproto/mpp.pb.h>

--- a/dbms/src/Flash/Planner/PlanQuerySource.cpp
+++ b/dbms/src/Flash/Planner/PlanQuerySource.cpp
@@ -15,6 +15,7 @@
 #include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Planner/PlanQuerySource.h>
 #include <Flash/Planner/Planner.h>
+#include <Interpreters/Context.h>
 #include <Parsers/makeDummyQuery.h>
 
 namespace DB
@@ -44,6 +45,11 @@ std::unique_ptr<IInterpreter> PlanQuerySource::interpreter(Context &, QueryProce
 const tipb::DAGRequest & PlanQuerySource::getDAGRequest() const
 {
     return *getDAGContext().dag_request;
+}
+
+DAGContext & PlanQuerySource::getDAGContext() const
+{
+    return *context.getDAGContext();
 }
 
 } // namespace DB

--- a/dbms/src/Flash/Planner/PlanQuerySource.h
+++ b/dbms/src/Flash/Planner/PlanQuerySource.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include <Interpreters/Context.h>
+#include <Interpreters/Context_fwd.h>
 #include <Interpreters/IQuerySource.h>
 
 namespace DB
@@ -30,7 +30,7 @@ public:
     String str(size_t max_query_size) override;
     std::unique_ptr<IInterpreter> interpreter(Context & context, QueryProcessingStage::Enum stage) override;
 
-    DAGContext & getDAGContext() const { return *context.getDAGContext(); }
+    DAGContext & getDAGContext() const;
     const tipb::DAGRequest & getDAGRequest() const;
 
 private:

--- a/dbms/src/Flash/Planner/Plans/PhysicalAggregationBuild.cpp
+++ b/dbms/src/Flash/Planner/Plans/PhysicalAggregationBuild.cpp
@@ -14,6 +14,7 @@
 
 #include <Flash/Coprocessor/AggregationInterpreterHelper.h>
 #include <Flash/Planner/Plans/PhysicalAggregationBuild.h>
+#include <Interpreters/Context.h>
 #include <Operators/AggregateSinkOp.h>
 #include <Operators/ExpressionTransformOp.h>
 

--- a/dbms/src/Flash/Planner/Plans/PhysicalAggregationBuild.h
+++ b/dbms/src/Flash/Planner/Plans/PhysicalAggregationBuild.h
@@ -18,7 +18,7 @@
 #include <Flash/Planner/Plans/PhysicalUnary.h>
 #include <Flash/Planner/Plans/PipelineBreakerHelper.h>
 #include <Interpreters/AggregateDescription.h>
-#include <Interpreters/Context.h>
+#include <Interpreters/Context_fwd.h>
 #include <Interpreters/ExpressionActions.h>
 #include <Operators/AggregateContext.h>
 

--- a/dbms/src/Functions/FunctionsTiDBConversion.h
+++ b/dbms/src/Functions/FunctionsTiDBConversion.h
@@ -51,7 +51,7 @@
 #include <IO/ReadBufferFromMemory.h>
 #include <IO/WriteBufferFromVector.h>
 #include <IO/parseDateTimeBestEffort.h>
-#include <Interpreters/Context.h>
+#include <Interpreters/Context_fwd.h>
 #include <Interpreters/ExpressionActions.h>
 #include <Storages/Transaction/Collator.h>
 

--- a/dbms/src/Functions/LeastGreatest.h
+++ b/dbms/src/Functions/LeastGreatest.h
@@ -32,7 +32,7 @@
 #include <Functions/IFunction.h>
 #include <Functions/StringUtil.h>
 #include <Functions/castTypeToEither.h>
-#include <Interpreters/Context.h>
+#include <Interpreters/Context_fwd.h>
 #include <common/types.h>
 #include <fmt/core.h>
 

--- a/dbms/src/Interpreters/Context.h
+++ b/dbms/src/Interpreters/Context.h
@@ -20,6 +20,7 @@
 #include <Debug/MockServerInfo.h>
 #include <IO/CompressionSettings.h>
 #include <Interpreters/ClientInfo.h>
+#include <Interpreters/Context_fwd.h>
 #include <Interpreters/Settings.h>
 #include <Interpreters/TimezoneInfo.h>
 #include <Server/ServerInfo.h>
@@ -550,8 +551,6 @@ private:
     DisaggregatedMode disaggregated_mode = DisaggregatedMode::None;
     bool use_autoscaler = true; /// todo: remove this after AutoScaler is stable. Only meaningful in DisaggregatedComputeMode.
 };
-
-using ContextPtr = std::shared_ptr<Context>;
 
 
 /// Puts an element into the map, erases it in the destructor.

--- a/dbms/src/Interpreters/Context_fwd.h
+++ b/dbms/src/Interpreters/Context_fwd.h
@@ -14,12 +14,12 @@
 
 #pragma once
 
-#include <Core/ColumnWithTypeAndName.h>
-#include <Interpreters/Context_fwd.h>
-
+#include <memory>
 
 namespace DB
 {
-ColumnPtr castColumn(const ColumnWithTypeAndName & arg, const DataTypePtr & type, const Context & context);
-ColumnPtr tiDBCastColumn(const ColumnWithTypeAndName & arg, const DataTypePtr & type, const Context & context);
+
+class Context;
+using ContextPtr = std::shared_ptr<Context>;
+
 } // namespace DB

--- a/dbms/src/Interpreters/ExpressionAnalyzer.cpp
+++ b/dbms/src/Interpreters/ExpressionAnalyzer.cpp
@@ -32,6 +32,7 @@
 #include <Functions/FunctionHelpers.h>
 #include <Functions/FunctionsMiscellaneous.h>
 #include <Functions/IFunction.h>
+#include <Interpreters/Context.h>
 #include <Interpreters/ExpressionActions.h>
 #include <Interpreters/ExpressionAnalyzer.h>
 #include <Interpreters/InterpreterSelectWithUnionQuery.h>

--- a/dbms/src/Interpreters/InterpreterAlterQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterAlterQuery.cpp
@@ -16,6 +16,7 @@
 #include <DataTypes/DataTypeFactory.h>
 #include <IO/ReadBufferFromFile.h>
 #include <IO/copyData.h>
+#include <Interpreters/Context.h>
 #include <Interpreters/InterpreterAlterQuery.h>
 #include <Parsers/ASTAlterQuery.h>
 #include <Parsers/ASTCreateQuery.h>

--- a/dbms/src/Interpreters/InterpreterAlterQuery.h
+++ b/dbms/src/Interpreters/InterpreterAlterQuery.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include <Interpreters/Context.h>
+#include <Interpreters/Context_fwd.h>
 #include <Interpreters/IInterpreter.h>
 #include <Parsers/ASTAlterQuery.h>
 #include <Storages/AlterCommands.h>

--- a/dbms/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterInsertQuery.cpp
@@ -21,6 +21,7 @@
 #include <DataStreams/SquashingBlockOutputStream.h>
 #include <DataStreams/copyData.h>
 #include <IO/ConcatReadBuffer.h>
+#include <Interpreters/Context.h>
 #include <Interpreters/InterpreterInsertQuery.h>
 #include <Interpreters/InterpreterSelectWithUnionQuery.h>
 #include <Parsers/ASTFunction.h>

--- a/dbms/src/Interpreters/InterpreterInsertQuery.h
+++ b/dbms/src/Interpreters/InterpreterInsertQuery.h
@@ -16,7 +16,7 @@
 
 #include <DataStreams/BlockIO.h>
 #include <DataStreams/IBlockOutputStream.h>
-#include <Interpreters/Context.h>
+#include <Interpreters/Context_fwd.h>
 #include <Interpreters/IInterpreter.h>
 #include <Parsers/ASTInsertQuery.h>
 

--- a/dbms/src/Interpreters/Set.h
+++ b/dbms/src/Interpreters/Set.h
@@ -22,7 +22,7 @@
 #include <Core/Block.h>
 #include <DataStreams/SizeLimits.h>
 #include <DataTypes/IDataType.h>
-#include <Interpreters/Context.h>
+#include <Interpreters/Context_fwd.h>
 #include <Interpreters/SetVariants.h>
 #include <Parsers/IAST.h>
 #include <Storages/Transaction/Collator.h>

--- a/dbms/src/Server/CLIService.h
+++ b/dbms/src/Server/CLIService.h
@@ -13,10 +13,12 @@
 // limitations under the License.
 
 #pragma once
+
 #include <Common/TiFlashBuildInfo.h>
 #include <Common/UnifiedLogFormatter.h>
 #include <Encryption/DataKeyManager.h>
 #include <Encryption/MockKeyManager.h>
+#include <Interpreters/Context.h>
 #include <Poco/ConsoleChannel.h>
 #include <Poco/File.h>
 #include <Poco/FormattingChannel.h>

--- a/dbms/src/Server/CertificateReloader.cpp
+++ b/dbms/src/Server/CertificateReloader.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <Common/TiFlashSecurity.h>
+#include <Interpreters/Context.h>
 #include <Server/CertificateReloader.h>
 
 #if Poco_NetSSL_FOUND

--- a/dbms/src/Server/CertificateReloader.h
+++ b/dbms/src/Server/CertificateReloader.h
@@ -19,7 +19,7 @@
 #if Poco_NetSSL_FOUND
 
 #include <Common/Logger.h>
-#include <Interpreters/Context.h>
+#include <Interpreters/Context_fwd.h>
 #include <Poco/Crypto/X509Certificate.h>
 #include <Poco/Net/Context.h>
 #include <openssl/ssl.h>

--- a/dbms/src/Server/DTTool/DTTool.h
+++ b/dbms/src/Server/DTTool/DTTool.h
@@ -13,10 +13,12 @@
 // limitations under the License.
 
 #pragma once
+
 #include <Common/TiFlashBuildInfo.h>
 #include <Common/UnifiedLogFormatter.h>
 #include <Encryption/DataKeyManager.h>
 #include <Encryption/MockKeyManager.h>
+#include <Interpreters/Context.h>
 #include <Poco/ConsoleChannel.h>
 #include <Poco/File.h>
 #include <Poco/FormattingChannel.h>

--- a/dbms/src/Server/FlashGrpcServerHolder.cpp
+++ b/dbms/src/Server/FlashGrpcServerHolder.cpp
@@ -11,8 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #include <Debug/MockExecutor/AstToPBUtils.h>
 #include <Flash/EstablishCall.h>
+#include <Interpreters/Context.h>
 #include <Server/FlashGrpcServerHolder.h>
 
 // In order to include grpc::SecureServerCredentials which used in

--- a/dbms/src/Server/HTTPHandler.cpp
+++ b/dbms/src/Server/HTTPHandler.cpp
@@ -34,6 +34,7 @@
 #include <IO/WriteHelpers.h>
 #include <IO/ZlibInflatingReadBuffer.h>
 #include <IO/copyData.h>
+#include <Interpreters/Context.h>
 #include <Interpreters/Quota.h>
 #include <Interpreters/executeQuery.h>
 #include <Poco/File.h>

--- a/dbms/src/Server/IServer.h
+++ b/dbms/src/Server/IServer.h
@@ -15,10 +15,9 @@
 #pragma once
 
 #include <Common/TiFlashSecurity.h>
-#include <Interpreters/Context.h>
+#include <Interpreters/Context_fwd.h>
 #include <Poco/Logger.h>
 #include <Poco/Util/LayeredConfiguration.h>
-
 
 namespace DB
 {

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -1136,7 +1136,11 @@ int Server::main(const std::vector<std::string> & /*args*/)
     global_context->initializeGlobalStoragePoolIfNeed(global_context->getPathPool());
     LOG_INFO(log, "Global PageStorage run mode is {}", static_cast<UInt8>(global_context->getPageStorageRunMode()));
 
-    global_context->initializeWriteNodePageStorageIfNeed(global_context->getPathPool());
+    if (global_context->isDisaggregatedStorageMode())
+        global_context->initializeWriteNodePageStorageIfNeed(global_context->getPathPool());
+
+    if (global_context->isDisaggregatedComputeMode())
+        global_context->initializeReadNodePageStorageForCacheIfNeed(global_context->getPathPool());
 
     /// Initialize RateLimiter.
     global_context->initializeRateLimiter(config(), bg_pool, blockable_bg_pool);

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -1136,11 +1136,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
     global_context->initializeGlobalStoragePoolIfNeed(global_context->getPathPool());
     LOG_INFO(log, "Global PageStorage run mode is {}", static_cast<UInt8>(global_context->getPageStorageRunMode()));
 
-    if (global_context->isDisaggregatedStorageMode())
-        global_context->initializeWriteNodePageStorageIfNeed(global_context->getPathPool());
-
-    if (global_context->isDisaggregatedComputeMode())
-        global_context->initializeReadNodePageStorageForCacheIfNeed(global_context->getPathPool());
+    global_context->initializeWriteNodePageStorageIfNeed(global_context->getPathPool());
 
     /// Initialize RateLimiter.
     global_context->initializeRateLimiter(config(), bg_pool, blockable_bg_pool);

--- a/dbms/src/Server/TCPHandler.cpp
+++ b/dbms/src/Server/TCPHandler.cpp
@@ -30,6 +30,7 @@
 #include <IO/ReadBufferFromPocoSocket.h>
 #include <IO/WriteBufferFromPocoSocket.h>
 #include <IO/copyData.h>
+#include <Interpreters/Context.h>
 #include <Interpreters/Quota.h>
 #include <Interpreters/SharedQueries.h>
 #include <Interpreters/TablesStatus.h>

--- a/dbms/src/Server/TCPHandler.h
+++ b/dbms/src/Server/TCPHandler.h
@@ -24,6 +24,7 @@
 #include <IO/Progress.h>
 #include <IO/ReadHelpers.h>
 #include <IO/WriteHelpers.h>
+#include <Interpreters/Context.h>
 #include <Poco/Net/TCPServerConnection.h>
 #include <Storages/Transaction/RegionLockInfo.h>
 

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSchema.h
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSchema.h
@@ -15,7 +15,7 @@
 #pragma once
 #include <Common/nocopyable.h>
 #include <Core/Block.h>
-#include <Interpreters/Context.h>
+#include <Interpreters/Context_fwd.h>
 #include <Storages/BackgroundProcessingPool.h>
 #include <Storages/DeltaMerge/DeltaMergeDefines.h>
 #include <Storages/DeltaMerge/DeltaMergeHelpers.h>

--- a/dbms/src/Storages/DeltaMerge/DMContext.h
+++ b/dbms/src/Storages/DeltaMerge/DMContext.h
@@ -16,7 +16,7 @@
 
 #include <Common/Logger.h>
 #include <Core/Types.h>
-#include <Interpreters/Context.h>
+#include <Interpreters/Context_fwd.h>
 #include <Interpreters/Settings.h>
 #include <Storages/DeltaMerge/DMChecksumConfig.h>
 #include <Storages/DeltaMerge/DeltaMergeDefines.h>

--- a/dbms/src/Storages/DeltaMerge/DMSegmentThreadInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/DMSegmentThreadInputStream.h
@@ -17,7 +17,7 @@
 #include <Common/FailPoint.h>
 #include <DataStreams/IProfilingBlockInputStream.h>
 #include <DataStreams/SegmentReadTransformAction.h>
-#include <Interpreters/Context.h>
+#include <Interpreters/Context_fwd.h>
 #include <Storages/DeltaMerge/DMContext.h>
 #include <Storages/DeltaMerge/Segment.h>
 #include <Storages/DeltaMerge/SegmentReadTaskPool.h>

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
@@ -17,7 +17,7 @@
 #include <Core/Block.h>
 #include <Core/SortDescription.h>
 #include <DataStreams/IBlockInputStream.h>
-#include <Interpreters/Context.h>
+#include <Interpreters/Context_fwd.h>
 #include <Operators/Operator.h>
 #include <Storages/AlterCommands.h>
 #include <Storages/BackgroundProcessingPool.h>
@@ -34,6 +34,7 @@
 
 namespace DB
 {
+
 class Logger;
 using LoggerPtr = std::shared_ptr<Logger>;
 

--- a/dbms/src/Storages/DeltaMerge/File/DMFileBlockOutputStream.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileBlockOutputStream.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include <Core/Block.h>
-#include <Interpreters/Context.h>
+#include <Interpreters/Context_fwd.h>
 #include <Storages/DeltaMerge/File/DMFileWriter.h>
 
 namespace DB

--- a/dbms/src/Storages/DeltaMerge/tests/DMTestEnv.h
+++ b/dbms/src/Storages/DeltaMerge/tests/DMTestEnv.h
@@ -20,7 +20,7 @@
 #include <DataTypes/DataTypesNumber.h>
 #include <IO/Operators.h>
 #include <IO/WriteBufferFromString.h>
-#include <Interpreters/Context.h>
+#include <Interpreters/Context_fwd.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Storages/DeltaMerge/DeltaMergeDefines.h>
 #include <Storages/DeltaMerge/Range.h>

--- a/dbms/src/Storages/DeltaMerge/tests/MultiSegmentTestUtil.h
+++ b/dbms/src/Storages/DeltaMerge/tests/MultiSegmentTestUtil.h
@@ -16,7 +16,7 @@
 #pragma once
 
 #include <Common/FailPoint.h>
-#include <Interpreters/Context.h>
+#include <Interpreters/Context_fwd.h>
 #include <Storages/DeltaMerge/DMContext.h>
 #include <Storages/DeltaMerge/DeltaMergeDefines.h>
 #include <Storages/DeltaMerge/DeltaMergeStore.h>

--- a/dbms/src/Storages/IManageableStorage.h
+++ b/dbms/src/Storages/IManageableStorage.h
@@ -16,13 +16,14 @@
 
 #include <DataStreams/IBlockInputStream.h>
 #include <DataTypes/DataTypesNumber.h>
-#include <Interpreters/Context.h>
+#include <Interpreters/Context_fwd.h>
 #include <Operators/Operator.h>
 #include <Storages/IStorage.h>
 #include <Storages/Transaction/DecodingStorageSchemaSnapshot.h>
 #include <Storages/Transaction/StorageEngineType.h>
 #include <Storages/Transaction/TiKVHandle.h>
 #include <Storages/Transaction/Types.h>
+
 
 namespace TiDB
 {

--- a/dbms/src/Storages/Page/V2/gc/LegacyCompactor.h
+++ b/dbms/src/Storages/Page/V2/gc/LegacyCompactor.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include <Core/Types.h>
-#include <Interpreters/Context.h>
+#include <Interpreters/Context_fwd.h>
 #include <Poco/Logger.h>
 #include <Storages/Page/PageDefinesBase.h>
 #include <Storages/Page/V2/PageFile.h>

--- a/dbms/src/Storages/StorageDisaggregated.h
+++ b/dbms/src/Storages/StorageDisaggregated.h
@@ -19,7 +19,7 @@
 #include <Flash/Coprocessor/DAGExpressionAnalyzer.h>
 #include <Flash/Coprocessor/DAGPipeline.h>
 #include <Flash/Coprocessor/RemoteRequest.h>
-#include <Interpreters/Context.h>
+#include <Interpreters/Context_fwd.h>
 #include <Storages/IStorage.h>
 
 #pragma GCC diagnostic push
@@ -30,6 +30,7 @@
 
 namespace DB
 {
+
 // Naive implementation of StorageDisaggregated, all region data will be transferred by GRPC,
 // rewrite this when local cache is supported.
 // Naive StorageDisaggregated will convert TableScan to ExchangeReceiver(executed in tiflash_compute node),

--- a/dbms/src/Storages/StorageNull.cpp
+++ b/dbms/src/Storages/StorageNull.cpp
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <Storages/StorageNull.h>
-#include <Storages/StorageFactory.h>
-
-#include <Interpreters/InterpreterAlterQuery.h>
 #include <Databases/IDatabase.h>
-
 #include <IO/WriteHelpers.h>
+#include <Interpreters/Context.h>
+#include <Interpreters/InterpreterAlterQuery.h>
+#include <Storages/StorageFactory.h>
+#include <Storages/StorageNull.h>
 
 
 namespace DB
@@ -26,14 +25,13 @@ namespace DB
 
 namespace ErrorCodes
 {
-    extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
+extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
 }
 
 
 void registerStorageNull(StorageFactory & factory)
 {
-    factory.registerStorage("Null", [](const StorageFactory::Arguments & args)
-    {
+    factory.registerStorage("Null", [](const StorageFactory::Arguments & args) {
         if (!args.engine_args.empty())
             throw Exception(
                 "Engine " + args.engine_name + " doesn't support any arguments (" + toString(args.engine_args.size()) + " given)",
@@ -44,7 +42,11 @@ void registerStorageNull(StorageFactory & factory)
 }
 
 void StorageNull::alter(
-    const TableLockHolder &, const AlterCommands & params, const String & database_name, const String & table_name, const Context & context)
+    const TableLockHolder &,
+    const AlterCommands & params,
+    const String & database_name,
+    const String & table_name,
+    const Context & context)
 {
     ColumnsDescription new_columns = getColumns();
     params.apply(new_columns);
@@ -52,4 +54,4 @@ void StorageNull::alter(
     setColumns(std::move(new_columns));
 }
 
-}
+} // namespace DB

--- a/dbms/src/TiDB/Schema/SchemaBuilder.h
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include <Interpreters/Context.h>
+#include <Interpreters/Context_fwd.h>
 #include <Storages/Transaction/TMTStorages.h>
 #include <TiDB/Schema/SchemaGetter.h>
 

--- a/dbms/src/WindowFunctions/WindowFunctionFactory.h
+++ b/dbms/src/WindowFunctions/WindowFunctionFactory.h
@@ -27,7 +27,6 @@
 
 namespace DB
 {
-class Context;
 class IDataType;
 
 using DataTypePtr = std::shared_ptr<const IDataType>;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/6233

Problem Summary:

### What is changed and how it works?

This PR reduces the direct import of `Context.h`, so that when we change it less code need to be re-compiled.

Note: Currently most of the unit tests are still importing `Context.h`. This is harder to resolve and will be done later.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
