### PR TITLE
Make DMContext adapt to remote data provider

### DIFF
--- a/dbms/src/Server/DTTool/DTToolBench.cpp
+++ b/dbms/src/Server/DTTool/DTToolBench.cpp
@@ -346,7 +346,7 @@ int benchEntry(const std::vector<std::string> & opts)
             path_pool,
             storage_pool,
             /*min_version_*/ 0,
-            dm_settings.not_compress_columns,
+            /*physical_table_id*/ 1,
             false,
             1,
             db_context->getSettingsRef());

--- a/dbms/src/Server/DTTool/DTToolBench.cpp
+++ b/dbms/src/Server/DTTool/DTToolBench.cpp
@@ -338,13 +338,13 @@ int benchEntry(const std::vector<std::string> & opts)
         size_t write_records = 0;
         auto settings = DB::Settings();
         auto db_context = env.getContext();
-        auto path_pool = std::make_unique<DB::StoragePathPool>(db_context->getPathPool().withTable("test", "t1", false));
-        auto storage_pool = std::make_unique<DB::DM::StoragePool>(*db_context, /*ns_id*/ 1, *path_pool, "test.t1");
+        auto path_pool = std::make_shared<DB::StoragePathPool>(db_context->getPathPool().withTable("test", "t1", false));
+        auto storage_pool = std::make_shared<DB::DM::StoragePool>(*db_context, /*ns_id*/ 1, *path_pool, "test.t1");
         auto dm_settings = DB::DM::DeltaMergeStore::Settings{};
         auto dm_context = std::make_unique<DB::DM::DMContext>( //
             *db_context,
-            *path_pool,
-            *storage_pool,
+            path_pool,
+            storage_pool,
             /*min_version_*/ 0,
             dm_settings.not_compress_columns,
             false,

--- a/dbms/src/Server/tests/gtest_dttool.cpp
+++ b/dbms/src/Server/tests/gtest_dttool.cpp
@@ -80,7 +80,7 @@ struct DTToolTest : public DB::base::TiFlashStorageTestBasic
             path_pool,
             storage_pool,
             /*min_version_*/ 0,
-            dm_settings.not_compress_columns,
+            /*physical_table_id*/ 1,
             false,
             1,
             db_context->getSettingsRef());

--- a/dbms/src/Server/tests/gtest_dttool.cpp
+++ b/dbms/src/Server/tests/gtest_dttool.cpp
@@ -72,13 +72,13 @@ struct DTToolTest : public DB::base::TiFlashStorageTestBasic
             property.effective_num_rows = block_size;
             properties.push_back(property);
         }
-        auto path_pool = std::make_unique<DB::StoragePathPool>(db_context->getPathPool().withTable("test", "t1", false));
-        auto storage_pool = std::make_unique<DB::DM::StoragePool>(*db_context, /*ns_id*/ 1, *path_pool, "test.t1");
+        auto path_pool = std::make_shared<DB::StoragePathPool>(db_context->getPathPool().withTable("test", "t1", false));
+        auto storage_pool = std::make_shared<DB::DM::StoragePool>(*db_context, /*ns_id*/ 1, *path_pool, "test.t1");
         auto dm_settings = DB::DM::DeltaMergeStore::Settings{};
         auto dm_context = std::make_unique<DB::DM::DMContext>( //
             *db_context,
-            *path_pool,
-            *storage_pool,
+            path_pool,
+            storage_pool,
             /*min_version_*/ 0,
             dm_settings.not_compress_columns,
             false,

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileBig.cpp
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileBig.cpp
@@ -84,8 +84,8 @@ ColumnFilePersistedPtr ColumnFileBig::deserializeMetadata(const DMContext & cont
     readIntBinary(valid_rows, buf);
     readIntBinary(valid_bytes, buf);
 
-    auto file_id = context.storage_pool.dataReader()->getNormalPageId(file_page_id);
-    auto file_parent_path = context.path_pool.getStableDiskDelegator().getDTFilePath(file_id);
+    auto file_id = context.storage_pool->dataReader()->getNormalPageId(file_page_id);
+    auto file_parent_path = context.path_pool->getStableDiskDelegator().getDTFilePath(file_id);
 
     auto dmfile = DMFile::restore(context.db_context.getFileProvider(), file_id, file_page_id, file_parent_path, DMFile::ReadMetaMode::all());
 

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileTiny.cpp
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileTiny.cpp
@@ -218,7 +218,7 @@ ColumnFileTinyPtr ColumnFileTiny::writeColumnFile(const DMContext & context, con
 
 PageIdU64 ColumnFileTiny::writeColumnFileData(const DMContext & context, const Block & block, size_t offset, size_t limit, WriteBatches & wbs)
 {
-    auto page_id = context.storage_pool.newLogPageId();
+    auto page_id = context.storage_pool->newLogPageId();
 
     MemoryWriteBuffer write_buf;
     PageFieldSizes col_data_sizes;

--- a/dbms/src/Storages/DeltaMerge/DMContext.h
+++ b/dbms/src/Storages/DeltaMerge/DMContext.h
@@ -27,11 +27,13 @@
 namespace DB
 {
 class StoragePathPool;
+using StoragePathPoolPtr = std::shared_ptr<StoragePathPool>;
 
 
 namespace DM
 {
 class StoragePool;
+using StoragePoolPtr = std::shared_ptr<StoragePool>;
 using NotCompress = std::unordered_set<ColId>;
 struct DMContext;
 using DMContextPtr = std::shared_ptr<DMContext>;
@@ -43,8 +45,8 @@ struct DMContext : private boost::noncopyable
 {
     const Context & db_context;
 
-    StoragePathPool & path_pool;
-    StoragePool & storage_pool;
+    StoragePathPoolPtr path_pool;
+    StoragePoolPtr storage_pool;
 
     // gc safe-point, maybe update.
     DB::Timestamp min_version;
@@ -91,8 +93,8 @@ struct DMContext : private boost::noncopyable
 
 public:
     DMContext(const Context & db_context_,
-              StoragePathPool & path_pool_,
-              StoragePool & storage_pool_,
+              const StoragePathPoolPtr & path_pool_,
+              const StoragePoolPtr & storage_pool_,
               const DB::Timestamp min_version_,
               const NotCompress & not_compress_,
               bool is_common_handle_,

--- a/dbms/src/Storages/DeltaMerge/DMContext.h
+++ b/dbms/src/Storages/DeltaMerge/DMContext.h
@@ -45,6 +45,7 @@ struct DMContext : private boost::noncopyable
 {
     const Context & db_context;
 
+    // leaving these pointers possible to be nullptr is dangerous for only reading from/writing to local storage. Find a better way to handle it later
     StoragePathPoolPtr path_pool;
     StoragePoolPtr storage_pool;
 

--- a/dbms/src/Storages/DeltaMerge/DMContext.h
+++ b/dbms/src/Storages/DeltaMerge/DMContext.h
@@ -51,10 +51,9 @@ struct DMContext : private boost::noncopyable
     // gc safe-point, maybe update.
     DB::Timestamp min_version;
 
-    const NotCompress & not_compress; // Not used currently.
+    const TableID physical_table_id;
 
     bool is_common_handle;
-
     // The number of columns in primary key if is_common_handle = true, otherwise, should always be 1.
     size_t rowkey_column_size;
     // The base rows of segment.
@@ -96,7 +95,7 @@ public:
               const StoragePathPoolPtr & path_pool_,
               const StoragePoolPtr & storage_pool_,
               const DB::Timestamp min_version_,
-              const NotCompress & not_compress_,
+              TableID physical_table_id_,
               bool is_common_handle_,
               size_t rowkey_column_size_,
               const DB::Settings & settings,
@@ -106,7 +105,7 @@ public:
         , path_pool(path_pool_)
         , storage_pool(storage_pool_)
         , min_version(min_version_)
-        , not_compress(not_compress_)
+        , physical_table_id(physical_table_id_)
         , is_common_handle(is_common_handle_)
         , rowkey_column_size(rowkey_column_size_)
         , segment_limit_rows(settings.dt_segment_limit_rows)

--- a/dbms/src/Storages/DeltaMerge/Delta/ColumnFilePersistedSet.cpp
+++ b/dbms/src/Storages/DeltaMerge/Delta/ColumnFilePersistedSet.cpp
@@ -90,7 +90,7 @@ ColumnFilePersistedSetPtr ColumnFilePersistedSet::restore( //
     const RowKeyRange & segment_range,
     PageIdU64 id)
 {
-    Page page = context.storage_pool.metaReader()->read(id);
+    Page page = context.storage_pool->metaReader()->read(id);
     ReadBufferFromMemory buf(page.data.begin(), page.data.size());
     auto column_files = deserializeSavedColumnFiles(context, segment_range, buf);
     return std::make_shared<ColumnFilePersistedSet>(id, column_files);

--- a/dbms/src/Storages/DeltaMerge/Delta/DeltaValueSpace.cpp
+++ b/dbms/src/Storages/DeltaMerge/Delta/DeltaValueSpace.cpp
@@ -114,15 +114,15 @@ std::vector<ColumnFilePtrT> CloneColumnFilesHelper<ColumnFilePtrT>::clone(
         else if (auto * t = column_file->tryToTinyFile(); t)
         {
             // Use a newly created page_id to reference the data page_id of current column file.
-            PageIdU64 new_data_page_id = context.storage_pool.newLogPageId();
+            PageIdU64 new_data_page_id = context.storage_pool->newLogPageId();
             wbs.log.putRefPage(new_data_page_id, t->getDataPageId());
             auto new_column_file = t->cloneWith(new_data_page_id);
             cloned.push_back(new_column_file);
         }
         else if (auto * f = column_file->tryToBigFile(); f)
         {
-            auto delegator = context.path_pool.getStableDiskDelegator();
-            auto new_page_id = context.storage_pool.newDataPageIdForDTFile(delegator, __PRETTY_FUNCTION__);
+            auto delegator = context.path_pool->getStableDiskDelegator();
+            auto new_page_id = context.storage_pool->newDataPageIdForDTFile(delegator, __PRETTY_FUNCTION__);
             // Note that the file id may has already been mark as deleted. We must
             // create a reference to the page id itself instead of create a reference
             // to the file id.
@@ -290,7 +290,7 @@ bool DeltaValueSpace::flush(DMContext & context)
     ///  2. The serialized metadata of column files in DeltaValueSpace
 
     ColumnFileFlushTaskPtr flush_task;
-    WriteBatches wbs(context.storage_pool, context.getWriteLimiter());
+    WriteBatches wbs(*context.storage_pool, context.getWriteLimiter());
     DeltaIndexPtr cur_delta_index;
     {
         /// Prepare data which will be written to disk.
@@ -376,13 +376,13 @@ bool DeltaValueSpace::compact(DMContext & context)
             LOG_DEBUG(log, "Compact cancel because nothing to compact, delta={}", simpleInfo());
             return true;
         }
-        log_storage_snap = context.storage_pool.logReader()->getSnapshot(/*tracing_id*/ fmt::format("minor_compact_{}", simpleInfo()));
+        log_storage_snap = context.storage_pool->logReader()->getSnapshot(/*tracing_id*/ fmt::format("minor_compact_{}", simpleInfo()));
     }
 
-    WriteBatches wbs(context.storage_pool, context.getWriteLimiter());
+    WriteBatches wbs(*context.storage_pool, context.getWriteLimiter());
     {
         // do compaction task
-        const auto & reader = context.storage_pool.newLogReader(context.getReadLimiter(), log_storage_snap);
+        const auto & reader = context.storage_pool->newLogReader(context.getReadLimiter(), log_storage_snap);
         compaction_task->prepare(context, wbs, *reader);
         log_storage_snap.reset(); // release the snapshot ASAP
     }

--- a/dbms/src/Storages/DeltaMerge/Delta/Snapshot.cpp
+++ b/dbms/src/Storages/DeltaMerge/Delta/Snapshot.cpp
@@ -39,7 +39,7 @@ DeltaSnapshotPtr DeltaValueSpace::createSnapshot(const DMContext & context, bool
     snap->is_update = for_update;
     snap->delta = this->shared_from_this();
 
-    auto storage_snap = std::make_shared<StorageSnapshot>(context.storage_pool, context.getReadLimiter(), context.tracing_id, /*snapshot_read*/ true);
+    auto storage_snap = std::make_shared<StorageSnapshot>(*context.storage_pool, context.getReadLimiter(), context.tracing_id, /*snapshot_read*/ true);
     auto data_from_storage_snap = ColumnFileDataProviderLocalStoragePool::create(storage_snap);
     snap->persisted_files_snap = persisted_file_set->createSnapshot(data_from_storage_snap);
     snap->mem_table_snap = mem_table_set->createSnapshot(data_from_storage_snap, for_update);

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -426,8 +426,8 @@ DMContextPtr DeltaMergeStore::newDMContext(const Context & db_context, const DB:
     // Because db_context could be a temporary object and won't last long enough during the query process.
     // Like the context created by InterpreterSelectWithUnionQuery.
     auto * ctx = new DMContext(db_context.getGlobalContext(),
-                               *path_pool,
-                               *storage_pool,
+                               path_pool,
+                               storage_pool,
                                latest_gc_safe_point.load(std::memory_order_acquire),
                                settings.not_compress_columns,
                                is_common_handle,

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -429,7 +429,7 @@ DMContextPtr DeltaMergeStore::newDMContext(const Context & db_context, const DB:
                                path_pool,
                                storage_pool,
                                latest_gc_safe_point.load(std::memory_order_acquire),
-                               settings.not_compress_columns,
+                               physical_table_id,
                                is_common_handle,
                                rowkey_column_size,
                                db_settings,

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_Ingest.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore_Ingest.cpp
@@ -75,7 +75,7 @@ Segments DeltaMergeStore::ingestDTFilesUsingColumnFile(
     const std::vector<DMFilePtr> & files,
     bool clear_data_in_range)
 {
-    auto delegate = dm_context->path_pool.getStableDiskDelegator();
+    auto delegate = dm_context->path_pool->getStableDiskDelegator();
     auto file_provider = dm_context->db_context.getFileProvider();
 
     Segments updated_segments;
@@ -398,7 +398,7 @@ bool DeltaMergeStore::ingestDTFileIntoSegmentUsingSplit(
          *    │-------- Ingest Range --------│
          */
 
-        auto delegate = dm_context.path_pool.getStableDiskDelegator();
+        auto delegate = dm_context.path_pool->getStableDiskDelegator();
         auto file_provider = dm_context.db_context.getFileProvider();
 
         WriteBatches wbs(*storage_pool, dm_context.getWriteLimiter());
@@ -554,7 +554,7 @@ void DeltaMergeStore::ingestFiles(
 
     EventRecorder write_block_recorder(ProfileEvents::DMWriteFile, ProfileEvents::DMWriteFileNS);
 
-    auto delegate = dm_context->path_pool.getStableDiskDelegator();
+    auto delegate = dm_context->path_pool->getStableDiskDelegator();
     auto file_provider = dm_context->db_context.getFileProvider();
 
     size_t rows = 0;

--- a/dbms/src/Storages/DeltaMerge/Segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/Segment.cpp
@@ -170,10 +170,10 @@ StableValueSpacePtr createNewStable( //
     PageIdU64 stable_id,
     WriteBatches & wbs)
 {
-    auto delegator = context.path_pool.getStableDiskDelegator();
+    auto delegator = context.path_pool->getStableDiskDelegator();
     auto store_path = delegator.choosePath();
 
-    PageIdU64 dtfile_id = context.storage_pool.newDataPageIdForDTFile(delegator, __PRETTY_FUNCTION__);
+    PageIdU64 dtfile_id = context.storage_pool->newDataPageIdForDTFile(delegator, __PRETTY_FUNCTION__);
     auto dtfile = writeIntoNewDMFile(context, schema_snap, input_stream, dtfile_id, store_path);
 
     auto stable = std::make_shared<StableValueSpace>(stable_id);
@@ -224,7 +224,7 @@ SegmentPtr Segment::newSegment( //
     PageIdU64 delta_id,
     PageIdU64 stable_id)
 {
-    WriteBatches wbs(context.storage_pool, context.getWriteLimiter());
+    WriteBatches wbs(*context.storage_pool, context.getWriteLimiter());
 
     auto delta = std::make_shared<DeltaValueSpace>(delta_id);
     auto stable = createNewStable(context, schema, std::make_shared<EmptySkippableBlockInputStream>(*schema), stable_id, wbs);
@@ -257,8 +257,8 @@ SegmentPtr Segment::newSegment( //
         rowkey_range,
         segment_id,
         next_segment_id,
-        context.storage_pool.newMetaPageId(),
-        context.storage_pool.newMetaPageId());
+        context.storage_pool->newMetaPageId(),
+        context.storage_pool->newMetaPageId());
 }
 
 SegmentPtr Segment::restoreSegment( //
@@ -266,7 +266,7 @@ SegmentPtr Segment::restoreSegment( //
     DMContext & context,
     PageIdU64 segment_id)
 {
-    Page page = context.storage_pool.metaReader()->read(segment_id); // not limit restore
+    Page page = context.storage_pool->metaReader()->read(segment_id); // not limit restore
 
     ReadBufferFromMemory buf(page.data.begin(), page.data.size());
     SegmentFormat::Version version;
@@ -339,7 +339,7 @@ bool Segment::writeToCache(DMContext & dm_context, const Block & block, size_t o
 bool Segment::write(DMContext & dm_context, const Block & block, bool flush_cache)
 {
     LOG_TRACE(log, "Segment write to disk, rows={}", block.rows());
-    WriteBatches wbs(dm_context.storage_pool, dm_context.getWriteLimiter());
+    WriteBatches wbs(*dm_context.storage_pool, dm_context.getWriteLimiter());
 
     auto column_file = ColumnFileTiny::writeColumnFile(dm_context, block, 0, block.rows(), wbs);
     wbs.writeAll();
@@ -888,7 +888,7 @@ BlockInputStreamPtr Segment::getInputStreamModeRaw(const DMContext & dm_context,
 
 SegmentPtr Segment::mergeDelta(DMContext & dm_context, const ColumnDefinesPtr & schema_snap) const
 {
-    WriteBatches wbs(dm_context.storage_pool, dm_context.getWriteLimiter());
+    WriteBatches wbs(*dm_context.storage_pool, dm_context.getWriteLimiter());
     auto segment_snap = createSnapshot(dm_context, true, CurrentMetrics::DT_SnapshotOfDeltaMerge);
     if (!segment_snap)
         return {};
@@ -993,7 +993,7 @@ SegmentPtr Segment::replaceData(const Segment::Lock & lock, //
     ColumnFiles in_memory_files{};
     ColumnFilePersisteds persisted_files{};
 
-    WriteBatches wbs(context.storage_pool, context.getWriteLimiter());
+    WriteBatches wbs(*context.storage_pool, context.getWriteLimiter());
 
     // If a snapshot is specified, we retain newly written data since the snapshot.
     // Otherwise, we just discard everything in the delta layer.
@@ -1039,7 +1039,7 @@ SegmentPtr Segment::replaceData(const Segment::Lock & lock, //
 
 SegmentPair Segment::split(DMContext & dm_context, const ColumnDefinesPtr & schema_snap, std::optional<RowKeyValue> opt_split_at, SplitMode opt_split_mode) const
 {
-    WriteBatches wbs(dm_context.storage_pool, dm_context.getWriteLimiter());
+    WriteBatches wbs(*dm_context.storage_pool, dm_context.getWriteLimiter());
     auto segment_snap = createSnapshot(dm_context, true, CurrentMetrics::DT_SnapshotOfSegmentSplit);
     if (!segment_snap)
         return {};
@@ -1355,21 +1355,21 @@ Segment::prepareSplitLogical( //
     }
 
     GenPageId log_gen_page_id = [&]() {
-        return storage_pool.newLogPageId();
+        return storage_pool->newLogPageId();
     };
 
     DMFiles my_stable_files;
     DMFiles other_stable_files;
 
-    auto delegate = dm_context.path_pool.getStableDiskDelegator();
+    auto delegate = dm_context.path_pool->getStableDiskDelegator();
     for (const auto & dmfile : segment_snap->stable->getDMFiles())
     {
         auto ori_page_id = dmfile->pageId();
         auto file_id = dmfile->fileId();
         auto file_parent_path = delegate.getDTFilePath(file_id);
 
-        auto my_dmfile_page_id = storage_pool.newDataPageIdForDTFile(delegate, __PRETTY_FUNCTION__);
-        auto other_dmfile_page_id = storage_pool.newDataPageIdForDTFile(delegate, __PRETTY_FUNCTION__);
+        auto my_dmfile_page_id = storage_pool->newDataPageIdForDTFile(delegate, __PRETTY_FUNCTION__);
+        auto other_dmfile_page_id = storage_pool->newDataPageIdForDTFile(delegate, __PRETTY_FUNCTION__);
 
         // Note that the file id may has already been mark as deleted. We must
         // create a reference to the page id itself instead of create a reference
@@ -1395,7 +1395,7 @@ Segment::prepareSplitLogical( //
         other_stable_files.push_back(other_dmfile);
     }
 
-    auto other_stable_id = storage_pool.newMetaPageId();
+    auto other_stable_id = storage_pool->newMetaPageId();
 
     auto my_stable = std::make_shared<StableValueSpace>(segment_snap->stable->getId());
     auto other_stable = std::make_shared<StableValueSpace>(other_stable_id);
@@ -1500,7 +1500,7 @@ std::optional<Segment::SplitInfo> Segment::prepareSplitPhysical( //
             *read_info.read_columns,
             dm_context.min_version,
             is_common_handle);
-        auto other_stable_id = dm_context.storage_pool.newMetaPageId();
+        auto other_stable_id = dm_context.storage_pool->newMetaPageId();
         other_stable = createNewStable(dm_context, schema_snap, other_data, other_stable_id, wbs);
     }
 
@@ -1548,8 +1548,8 @@ SegmentPair Segment::applySplit( //
     // Created references to tail pages' pages in "log" storage, we need to write them down.
     wbs.writeLogAndData();
 
-    auto other_segment_id = dm_context.storage_pool.newMetaPageId();
-    auto other_delta_id = dm_context.storage_pool.newMetaPageId();
+    auto other_segment_id = dm_context.storage_pool->newMetaPageId();
+    auto other_delta_id = dm_context.storage_pool->newMetaPageId();
 
     auto my_delta = std::make_shared<DeltaValueSpace>( //
         delta->getId(),
@@ -1597,7 +1597,7 @@ SegmentPair Segment::applySplit( //
 
 SegmentPtr Segment::merge(DMContext & dm_context, const ColumnDefinesPtr & schema_snap, const std::vector<SegmentPtr> & ordered_segments)
 {
-    WriteBatches wbs(dm_context.storage_pool, dm_context.getWriteLimiter());
+    WriteBatches wbs(*dm_context.storage_pool, dm_context.getWriteLimiter());
 
     std::vector<SegmentSnapshotPtr> ordered_snapshots;
     for (const auto & seg : ordered_segments)

--- a/dbms/src/Storages/DeltaMerge/StableValueSpace.cpp
+++ b/dbms/src/Storages/DeltaMerge/StableValueSpace.cpp
@@ -91,7 +91,7 @@ StableValueSpacePtr StableValueSpace::restore(DMContext & context, PageIdU64 id)
 {
     auto stable = std::make_shared<StableValueSpace>(id);
 
-    Page page = context.storage_pool.metaReader()->read(id); // not limit restore
+    Page page = context.storage_pool->metaReader()->read(id); // not limit restore
     ReadBufferFromMemory buf(page.data.begin(), page.data.size());
     UInt64 version, valid_rows, valid_bytes, size;
     readIntBinary(version, buf);
@@ -106,8 +106,8 @@ StableValueSpacePtr StableValueSpace::restore(DMContext & context, PageIdU64 id)
     {
         readIntBinary(page_id, buf);
 
-        auto file_id = context.storage_pool.dataReader()->getNormalPageId(page_id);
-        auto file_parent_path = context.path_pool.getStableDiskDelegator().getDTFilePath(file_id);
+        auto file_id = context.storage_pool->dataReader()->getNormalPageId(page_id);
+        auto file_parent_path = context.path_pool->getStableDiskDelegator().getDTFilePath(file_id);
 
         auto dmfile = DMFile::restore(context.db_context.getFileProvider(), file_id, page_id, file_parent_path, DMFile::ReadMetaMode::all());
         stable->files.push_back(dmfile);

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_column_file.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_column_file.cpp
@@ -64,7 +64,7 @@ public:
             path_pool,
             storage_pool,
             /*min_version_*/ 0,
-            settings.not_compress_columns,
+            /*physical_table_id*/ 100,
             false,
             1,
             db_context->getSettingsRef());

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_value_space.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_value_space.cpp
@@ -103,7 +103,7 @@ protected:
                                                  storage_path_pool,
                                                  storage_pool,
                                                  /*min_version_*/ 0,
-                                                 settings.not_compress_columns,
+                                                 /*physical_table_id*/ 100,
                                                  false,
                                                  1,
                                                  db_context->getSettingsRef());

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_file.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_file.cpp
@@ -98,8 +98,8 @@ public:
         auto mode = GetParam();
         auto configuration = createConfiguration(mode);
         parent_path = TiFlashStorageTestBasic::getTemporaryPath();
-        path_pool = std::make_unique<StoragePathPool>(db_context->getPathPool().withTable("test", "DMFileTest", false));
-        storage_pool = std::make_unique<StoragePool>(*db_context, /*ns_id*/ 100, *path_pool, "test.t1");
+        path_pool = std::make_shared<StoragePathPool>(db_context->getPathPool().withTable("test", "DMFileTest", false));
+        storage_pool = std::make_shared<StoragePool>(*db_context, /*ns_id*/ 100, *path_pool, "test.t1");
         dm_file = DMFile::create(1, parent_path, std::move(configuration), modeToVersion(mode));
         table_columns = std::make_shared<ColumnDefines>();
         column_cache = std::make_shared<ColumnCache>();
@@ -116,8 +116,8 @@ public:
         *path_pool = db_context->getPathPool().withTable("test", "t1", false);
         dm_context = std::make_unique<DMContext>( //
             *db_context,
-            *path_pool,
-            *storage_pool,
+            path_pool,
+            storage_pool,
             /*min_version_*/ 0,
             settings.not_compress_columns,
             false,
@@ -142,8 +142,8 @@ public:
 private:
     std::unique_ptr<DMContext> dm_context{};
     /// all these var live as ref in dm_context
-    std::unique_ptr<StoragePathPool> path_pool{};
-    std::unique_ptr<StoragePool> storage_pool{};
+    std::shared_ptr<StoragePathPool> path_pool{};
+    std::shared_ptr<StoragePool> storage_pool{};
     ColumnDefinesPtr table_columns;
     DeltaMergeStore::Settings settings;
 
@@ -1079,8 +1079,8 @@ public:
         auto mode = GetParam();
         auto configuration = createConfiguration(mode);
 
-        path_pool = std::make_unique<StoragePathPool>(db_context->getPathPool().withTable("test", "t", false));
-        storage_pool = std::make_unique<StoragePool>(*db_context, table_id, *path_pool, "test.t1");
+        path_pool = std::make_shared<StoragePathPool>(db_context->getPathPool().withTable("test", "t", false));
+        storage_pool = std::make_shared<StoragePool>(*db_context, table_id, *path_pool, "test.t1");
         dm_file = DMFile::create(0, path, std::move(configuration), modeToVersion(mode));
         table_columns = std::make_shared<ColumnDefines>();
         column_cache = std::make_shared<ColumnCache>();
@@ -1099,8 +1099,8 @@ public:
 
         dm_context = std::make_unique<DMContext>( //
             *db_context,
-            *path_pool,
-            *storage_pool,
+            path_pool,
+            storage_pool,
             /*min_version_*/ 0,
             settings.not_compress_columns,
             is_common_handle,
@@ -1117,8 +1117,8 @@ private:
     String path;
     std::unique_ptr<DMContext> dm_context{};
     /// all these var live as ref in dm_context
-    std::unique_ptr<StoragePathPool> path_pool{};
-    std::unique_ptr<StoragePool> storage_pool{};
+    std::shared_ptr<StoragePathPool> path_pool{};
+    std::shared_ptr<StoragePool> storage_pool{};
     ColumnDefinesPtr table_columns;
     DeltaMergeStore::Settings settings;
 

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_file.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_file.cpp
@@ -119,7 +119,7 @@ public:
             path_pool,
             storage_pool,
             /*min_version_*/ 0,
-            settings.not_compress_columns,
+            /*physical_table_id*/ 100,
             false,
             1,
             db_context->getSettingsRef());
@@ -1102,7 +1102,7 @@ public:
             path_pool,
             storage_pool,
             /*min_version_*/ 0,
-            settings.not_compress_columns,
+            /*physical_table_id*/ 100,
             is_common_handle,
             rowkey_column_size,
             db_context->getSettingsRef());

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment.cpp
@@ -95,7 +95,7 @@ protected:
                                                  storage_path_pool,
                                                  storage_pool,
                                                  /*min_version_*/ 0,
-                                                 settings.not_compress_columns,
+                                                 /*physical_table_id*/ 100,
                                                  false,
                                                  1,
                                                  db_context->getSettingsRef());

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment.cpp
@@ -77,8 +77,8 @@ protected:
     SegmentPtr reload(const ColumnDefinesPtr & pre_define_columns = {}, DB::Settings && db_settings = DB::Settings())
     {
         TiFlashStorageTestBasic::reload(std::move(db_settings));
-        storage_path_pool = std::make_unique<StoragePathPool>(db_context->getPathPool().withTable("test", "t1", false));
-        storage_pool = std::make_unique<StoragePool>(*db_context, /*ns_id*/ 100, *storage_path_pool, "test.t1");
+        storage_path_pool = std::make_shared<StoragePathPool>(db_context->getPathPool().withTable("test", "t1", false));
+        storage_pool = std::make_shared<StoragePool>(*db_context, /*ns_id*/ 100, *storage_path_pool, "test.t1");
         storage_pool->restore();
         ColumnDefinesPtr cols = (!pre_define_columns) ? DMTestEnv::getDefaultColumns() : pre_define_columns;
         setColumns(cols);
@@ -92,8 +92,8 @@ protected:
         *table_columns = *columns;
 
         dm_context = std::make_unique<DMContext>(*db_context,
-                                                 *storage_path_pool,
-                                                 *storage_pool,
+                                                 storage_path_pool,
+                                                 storage_pool,
                                                  /*min_version_*/ 0,
                                                  settings.not_compress_columns,
                                                  false,
@@ -107,8 +107,8 @@ protected:
 
 protected:
     /// all these var lives as ref in dm_context
-    std::unique_ptr<StoragePathPool> storage_path_pool;
-    std::unique_ptr<StoragePool> storage_pool;
+    std::shared_ptr<StoragePathPool> storage_path_pool;
+    std::shared_ptr<StoragePool> storage_pool;
     ColumnDefinesPtr table_columns;
     DM::DeltaMergeStore::Settings settings;
     /// dm_context
@@ -1040,8 +1040,8 @@ public:
 
     std::pair<RowKeyRange, PageIdU64s> genDMFile(DMContext & context, const Block & block)
     {
-        auto delegator = context.path_pool.getStableDiskDelegator();
-        auto file_id = context.storage_pool.newDataPageIdForDTFile(delegator, __PRETTY_FUNCTION__);
+        auto delegator = context.path_pool->getStableDiskDelegator();
+        auto file_id = context.storage_pool->newDataPageIdForDTFile(delegator, __PRETTY_FUNCTION__);
         auto input_stream = std::make_shared<OneBlockInputStream>(block);
         auto store_path = delegator.choosePath();
 
@@ -1078,7 +1078,7 @@ try
                 break;
             case SegmentTestMode::V2_FileOnly:
             {
-                auto delegate = dmContext().path_pool.getStableDiskDelegator();
+                auto delegate = dmContext().path_pool->getStableDiskDelegator();
                 auto file_provider = dmContext().db_context.getFileProvider();
                 auto [range, file_ids] = genDMFile(dmContext(), block);
                 auto file_id = file_ids[0];
@@ -1109,7 +1109,7 @@ try
     // Test split
     SegmentPtr other_segment;
     {
-        WriteBatches wbs(dmContext().storage_pool);
+        WriteBatches wbs(*dmContext().storage_pool);
         auto segment_snap = segment->createSnapshot(dmContext(), true, CurrentMetrics::DT_SnapshotOfSegmentSplit);
         ASSERT_FALSE(!segment_snap);
 
@@ -1137,7 +1137,7 @@ try
 
     // Test merge
     {
-        WriteBatches wbs(dmContext().storage_pool);
+        WriteBatches wbs(*dmContext().storage_pool);
 
         auto left_snap = segment->createSnapshot(dmContext(), true, CurrentMetrics::DT_SnapshotOfSegmentMerge);
         auto right_snap = other_segment->createSnapshot(dmContext(), true, CurrentMetrics::DT_SnapshotOfSegmentMerge);

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment_common_handle.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment_common_handle.cpp
@@ -73,7 +73,7 @@ protected:
                                                   path_pool,
                                                   storage_pool,
                                                   /*min_version_*/ 0,
-                                                  settings.not_compress_columns,
+                                                  /*physical_table_id*/ 100,
                                                   is_common_handle,
                                                   rowkey_column_size,
                                                   db_context->getSettingsRef());

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment_common_handle.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment_common_handle.cpp
@@ -35,7 +35,7 @@ namespace tests
 class SegmentCommonHandleTest : public DB::base::TiFlashStorageTestBasic
 {
 public:
-    SegmentCommonHandleTest() {}
+    SegmentCommonHandleTest() = default;
 
 public:
     static void SetUpTestCase() {}
@@ -53,8 +53,8 @@ protected:
     SegmentPtr reload(ColumnDefinesPtr cols = {}, DB::Settings && db_settings = DB::Settings())
     {
         TiFlashStorageTestBasic::reload(std::move(db_settings));
-        path_pool = std::make_unique<StoragePathPool>(db_context->getPathPool().withTable("test", "t", false));
-        storage_pool = std::make_unique<StoragePool>(*db_context, /*table_id*/ 100, *path_pool, "test.t1");
+        path_pool = std::make_shared<StoragePathPool>(db_context->getPathPool().withTable("test", "t", false));
+        storage_pool = std::make_shared<StoragePool>(*db_context, /*table_id*/ 100, *path_pool, "test.t1");
         storage_pool->restore();
         if (!cols)
             cols = DMTestEnv::getDefaultColumns(is_common_handle ? DMTestEnv::PkType::CommonHandle : DMTestEnv::PkType::HiddenTiDBRowID);
@@ -70,8 +70,8 @@ protected:
         *table_columns_ = *columns;
 
         dm_context_ = std::make_unique<DMContext>(*db_context,
-                                                  *path_pool,
-                                                  *storage_pool,
+                                                  path_pool,
+                                                  storage_pool,
                                                   /*min_version_*/ 0,
                                                   settings.not_compress_columns,
                                                   is_common_handle,
@@ -85,8 +85,8 @@ protected:
 
 private:
     /// all these var lives as ref in dm_context
-    std::unique_ptr<StoragePathPool> path_pool;
-    std::unique_ptr<StoragePool> storage_pool;
+    std::shared_ptr<StoragePathPool> path_pool;
+    std::shared_ptr<StoragePool> storage_pool;
     ColumnDefinesPtr table_columns_;
     DM::DeltaMergeStore::Settings settings;
     /// dm_context
@@ -281,8 +281,7 @@ try
 CATCH
 
 class SegmentDeletion_Common_Handle_test : public SegmentCommonHandleTest
-    , //
-                                           public testing::WithParamInterface<std::tuple<bool, bool>>
+    , public testing::WithParamInterface<std::tuple<bool, bool>>
 {
 };
 

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment.cpp
@@ -349,7 +349,7 @@ try
         auto segment = segments[DELTA_MERGE_FIRST_SEGMENT_ID];
         auto delta = segment->getDelta();
         auto mem_table_set = delta->getMemTableSet();
-        WriteBatches wbs(dm_context->storage_pool);
+        WriteBatches wbs(*dm_context->storage_pool);
         auto lock = segment->mustGetUpdateLock();
         auto [memory_cf, persisted_cf] = delta->cloneAllColumnFiles(lock, *dm_context, segment->getRowKeyRange(), wbs);
         ASSERT_FALSE(memory_cf.empty());

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_replace_data.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_replace_data.cpp
@@ -161,7 +161,7 @@ class SegmentReplaceDataSimpleTest : public SegmentTestBasic
 TEST_F(SegmentReplaceDataSimpleTest, DMFileGCIsUnchanged)
 try
 {
-    WriteBatches ingest_wbs(dm_context->storage_pool, dm_context->getWriteLimiter());
+    WriteBatches ingest_wbs(*dm_context->storage_pool, dm_context->getWriteLimiter());
 
     auto delegator = storage_path_pool->getStableDiskDelegator();
     auto file_id = storage_pool->newDataPageIdForDTFile(delegator, __PRETTY_FUNCTION__);

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_test_basic.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_test_basic.cpp
@@ -706,7 +706,7 @@ void SegmentTestBasic::reloadDMContext()
                                              storage_path_pool,
                                              storage_pool,
                                              /*min_version_*/ 0,
-                                             settings.not_compress_columns,
+                                             /*physical_table_id*/ 100,
                                              options.is_common_handle,
                                              1,
                                              db_context->getSettingsRef());

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_test_basic.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_test_basic.cpp
@@ -417,7 +417,7 @@ void SegmentTestBasic::ingestDTFileIntoDelta(PageIdU64 segment_id, UInt64 write_
 
     {
         auto block = prepareWriteBlockInSegmentRange(segment_id, write_rows, start_at, /* is_deleted */ false);
-        WriteBatches ingest_wbs(dm_context->storage_pool, dm_context->getWriteLimiter());
+        WriteBatches ingest_wbs(*dm_context->storage_pool, dm_context->getWriteLimiter());
         auto delegator = storage_path_pool->getStableDiskDelegator();
         auto parent_path = delegator.choosePath();
         auto file_id = storage_pool->newDataPageIdForDTFile(delegator, __PRETTY_FUNCTION__);
@@ -428,7 +428,7 @@ void SegmentTestBasic::ingestDTFileIntoDelta(PageIdU64 segment_id, UInt64 write_
         ingest_wbs.writeLogAndData();
         delegator.addDTFile(file_id, dm_file->getBytesOnDisk(), parent_path);
 
-        WriteBatches wbs(dm_context->storage_pool, dm_context->getWriteLimiter());
+        WriteBatches wbs(*dm_context->storage_pool, dm_context->getWriteLimiter());
         auto ref_id = storage_pool->newDataPageIdForDTFile(delegator, __PRETTY_FUNCTION__);
         wbs.data.putRefPage(ref_id, dm_file->pageId());
         auto ref_file = DMFile::restore(dm_context->db_context.getFileProvider(), file_id, ref_id, parent_path, DMFile::ReadMetaMode::all());
@@ -458,7 +458,7 @@ void SegmentTestBasic::ingestDTFileByReplace(PageIdU64 segment_id, UInt64 write_
 
     {
         auto block = prepareWriteBlockInSegmentRange(segment_id, write_rows, start_at, /* is_deleted */ false);
-        WriteBatches ingest_wbs(dm_context->storage_pool, dm_context->getWriteLimiter());
+        WriteBatches ingest_wbs(*dm_context->storage_pool, dm_context->getWriteLimiter());
         auto delegator = storage_path_pool->getStableDiskDelegator();
         auto parent_path = delegator.choosePath();
         auto file_id = storage_pool->newDataPageIdForDTFile(delegator, __PRETTY_FUNCTION__);
@@ -468,7 +468,7 @@ void SegmentTestBasic::ingestDTFileByReplace(PageIdU64 segment_id, UInt64 write_
         ingest_wbs.writeLogAndData();
         delegator.addDTFile(file_id, dm_file->getBytesOnDisk(), parent_path);
 
-        WriteBatches wbs(dm_context->storage_pool, dm_context->getWriteLimiter());
+        WriteBatches wbs(*dm_context->storage_pool, dm_context->getWriteLimiter());
         auto ref_id = storage_pool->newDataPageIdForDTFile(delegator, __PRETTY_FUNCTION__);
         wbs.data.putRefPage(ref_id, dm_file->pageId());
         auto ref_file = DMFile::restore(dm_context->db_context.getFileProvider(), file_id, ref_id, parent_path, DMFile::ReadMetaMode::all());
@@ -540,7 +540,7 @@ void SegmentTestBasic::replaceSegmentData(PageIdU64 segment_id, const Block & bl
     auto parent_path = delegator.choosePath();
     auto file_provider = db_context->getFileProvider();
 
-    WriteBatches ingest_wbs(dm_context->storage_pool, dm_context->getWriteLimiter());
+    WriteBatches ingest_wbs(*dm_context->storage_pool, dm_context->getWriteLimiter());
 
     auto file_id = storage_pool->newDataPageIdForDTFile(delegator, __PRETTY_FUNCTION__);
     auto input_stream = std::make_shared<OneBlockInputStream>(block);
@@ -691,8 +691,8 @@ std::set<PageIdU64> SegmentTestBasic::getAliveExternalPageIdsAfterGC(NamespaceId
 SegmentPtr SegmentTestBasic::reload(bool is_common_handle, const ColumnDefinesPtr & pre_define_columns, DB::Settings && db_settings)
 {
     TiFlashStorageTestBasic::reload(std::move(db_settings));
-    storage_path_pool = std::make_unique<StoragePathPool>(db_context->getPathPool().withTable("test", "t1", false));
-    storage_pool = std::make_unique<StoragePool>(*db_context, NAMESPACE_ID, *storage_path_pool, "test.t1");
+    storage_path_pool = std::make_shared<StoragePathPool>(db_context->getPathPool().withTable("test", "t1", false));
+    storage_pool = std::make_shared<StoragePool>(*db_context, NAMESPACE_ID, *storage_path_pool, "test.t1");
     storage_pool->restore();
     ColumnDefinesPtr cols = (!pre_define_columns) ? DMTestEnv::getDefaultColumns(is_common_handle ? DMTestEnv::PkType::CommonHandle : DMTestEnv::PkType::HiddenTiDBRowID) : pre_define_columns;
     setColumns(cols);
@@ -703,8 +703,8 @@ SegmentPtr SegmentTestBasic::reload(bool is_common_handle, const ColumnDefinesPt
 void SegmentTestBasic::reloadDMContext()
 {
     dm_context = std::make_unique<DMContext>(*db_context,
-                                             *storage_path_pool,
-                                             *storage_pool,
+                                             storage_path_pool,
+                                             storage_pool,
                                              /*min_version_*/ 0,
                                              settings.not_compress_columns,
                                              options.is_common_handle,

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_test_basic.h
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_test_basic.h
@@ -135,8 +135,8 @@ protected:
     inline static constexpr PageIdU64 NAMESPACE_ID = 100;
 
     /// all these var lives as ref in dm_context
-    std::unique_ptr<StoragePathPool> storage_path_pool;
-    std::unique_ptr<StoragePool> storage_pool;
+    std::shared_ptr<StoragePathPool> storage_path_pool;
+    std::shared_ptr<StoragePool> storage_pool;
     /// dm_context
     std::unique_ptr<DMContext> dm_context;
     ColumnDefinesPtr table_columns;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/6233

Problem Summary:

The PathPool, StoragePool in DMContext may not need when reading from S3.
Meanwhile, when uploading files to S3, physical table id is needed.

### What is changed and how it works?

Make PathPool, StoragePool an optional pointer in DMContext
Add physical_table_id in DMContext
Remove useless `not_compress`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
