### PR TITLE
fix(expr): round decimal divide result when return type is Int512

### DIFF
--- a/dbms/src/Functions/divide.cpp
+++ b/dbms/src/Functions/divide.cpp
@@ -65,7 +65,7 @@ struct TiDBDivideFloatingImpl<A, B, false>
         /// ref https://github.com/pingcap/tiflash/issues/6462
         /// For division of Decimal/Decimal or Int/Decimal or Decimal/Int, we should round the result to make compatible with TiDB.
         /// basically refer to https://stackoverflow.com/a/71634489
-        if constexpr (std::is_integral_v<Result> || std::is_same_v<Result, Int256>)
+        if constexpr (std::is_integral_v<Result> || std::is_same_v<Result, Int256> || std::is_same_v<Result, Int512>)
         {
             /// 1. do division first, get the quotient and mod, todo:(perf) find a unified `divmod` function to speed up this.
             Result quotient = x / d;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/7022

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
