### PR TITLE
Fix thread pool blocks when program exit

### DIFF
--- a/dbms/src/Common/ThreadManager.cpp
+++ b/dbms/src/Common/ThreadManager.cpp
@@ -126,7 +126,7 @@ public:
     }
 
 protected:
-    ThreadPool pool;
+    legacy::ThreadPool pool;
 };
 } // namespace
 

--- a/dbms/src/Common/UniThreadPool.cpp
+++ b/dbms/src/Common/UniThreadPool.cpp
@@ -16,6 +16,7 @@
 #include <Common/Exception.h>
 #include <Common/UniThreadPool.h>
 #include <Common/setThreadName.h>
+#include <IO/IOThreadPool.h>
 #include <Poco/Util/Application.h>
 #include <Poco/Util/LayeredConfiguration.h>
 
@@ -365,4 +366,12 @@ GlobalThreadPool & GlobalThreadPool::instance()
 
     return *the_instance;
 }
+
+GlobalThreadPool::~GlobalThreadPool() noexcept
+{
+    // We must make sure IOThread is released before GlobalThreadPool runs
+    // `finalize`. Or the threads in GlobalThreadPool never ends.
+    IOThreadPool::shutdown();
+}
+
 } // namespace DB

--- a/dbms/src/Common/UniThreadPool.h
+++ b/dbms/src/Common/UniThreadPool.h
@@ -164,6 +164,7 @@ class GlobalThreadPool : public FreeThreadPool
 public:
     static void initialize(size_t max_threads = 10000, size_t max_free_threads = 1000, size_t queue_size = 10000);
     static GlobalThreadPool & instance();
+    ~GlobalThreadPool() noexcept;
 };
 
 

--- a/dbms/src/Common/tests/gtest_concurrent_hashmap.cpp
+++ b/dbms/src/Common/tests/gtest_concurrent_hashmap.cpp
@@ -47,7 +47,7 @@ TEST(TestConcurrentHashMap, ConcurrentInsert)
         ThreadPool insert_pool(test_concurrency);
         for (size_t i = 0; i < test_concurrency; i++)
         {
-            insert_pool.schedule([&] {
+            insert_pool.scheduleOrThrowOnError([&] {
                 for (size_t insert_value = 0; insert_value < 10000; insert_value++)
                 {
                     typename ConcurrentMap::SegmentType::IteratorWithLock it;
@@ -77,7 +77,7 @@ TEST(TestConcurrentHashMap, ConcurrentInsertWithExplicitLock)
         ThreadPool insert_pool(test_concurrency);
         for (size_t i = 0; i < test_concurrency; i++)
         {
-            insert_pool.schedule([&] {
+            insert_pool.scheduleOrThrowOnError([&] {
                 for (size_t insert_value = 0; insert_value < 10000; insert_value++)
                 {
                     size_t segment_index = 0;
@@ -124,7 +124,7 @@ TEST(TestConcurrentHashMap, ConcurrentRandomInsert)
         ThreadPool insert_pool(test_concurrency);
         for (size_t i = 0; i < test_concurrency; i++)
         {
-            insert_pool.schedule([&, i] {
+            insert_pool.scheduleOrThrowOnError([&, i] {
                 std::default_random_engine e;
                 e.seed(std::chrono::system_clock::now().time_since_epoch().count());
                 std::uniform_int_distribution<unsigned> u(0, 100);
@@ -152,15 +152,15 @@ TEST(TestConcurrentHashMap, ConcurrentRandomInsert)
         for (size_t i = 1; i < test_concurrency; i++)
         {
             Map current_map = maps[i];
-            for (auto it = current_map.begin(); it != current_map.end(); it++)
+            for (auto & it : current_map)
             {
-                if (final_map.count(it->first))
+                if (final_map.count(it.first))
                 {
-                    final_map[it->first] = final_map[it->first] + it->second;
+                    final_map[it.first] = final_map[it.first] + it.second;
                 }
                 else
                 {
-                    final_map.insert({it->first, it->second});
+                    final_map.insert({it.first, it.second});
                 }
             }
         }
@@ -187,7 +187,7 @@ TEST(TestConcurrentHashMap, ConcurrentRandomInsertWithExplicitLock)
         ThreadPool insert_pool(test_concurrency);
         for (size_t i = 0; i < test_concurrency; i++)
         {
-            insert_pool.schedule([&, i] {
+            insert_pool.scheduleOrThrowOnError([&, i] {
                 std::default_random_engine e;
                 e.seed(std::chrono::system_clock::now().time_since_epoch().count());
                 std::uniform_int_distribution<unsigned> u(0, 100);
@@ -224,15 +224,15 @@ TEST(TestConcurrentHashMap, ConcurrentRandomInsertWithExplicitLock)
         for (size_t i = 1; i < test_concurrency; i++)
         {
             Map current_map = maps[i];
-            for (auto it = current_map.begin(); it != current_map.end(); it++)
+            for (auto & it : current_map)
             {
-                if (final_map.count(it->first))
+                if (final_map.count(it.first))
                 {
-                    final_map[it->first] += it->second;
+                    final_map[it.first] += it.second;
                 }
                 else
                 {
-                    final_map.insert({it->first, it->second});
+                    final_map.insert({it.first, it.second});
                 }
             }
         }

--- a/dbms/src/Common/tests/gtest_concurrent_hashmap.cpp
+++ b/dbms/src/Common/tests/gtest_concurrent_hashmap.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include <Common/HashTable/HashMap.h>
-#include <common/ThreadPool.h>
+#include <Common/UniThreadPool.h>
 #include <gtest/gtest.h>
 
 #include <ext/singleton.h>

--- a/dbms/src/DataStreams/AsynchronousBlockInputStream.h
+++ b/dbms/src/DataStreams/AsynchronousBlockInputStream.h
@@ -90,7 +90,7 @@ public:
     }
 
 protected:
-    ThreadPool pool{1};
+    legacy::ThreadPool pool{1};
     Poco::Event ready;
     bool started = false;
     bool first = true;

--- a/dbms/src/DataStreams/MergingAggregatedMemoryEfficientBlockInputStream.cpp
+++ b/dbms/src/DataStreams/MergingAggregatedMemoryEfficientBlockInputStream.cpp
@@ -94,7 +94,7 @@ MergingAggregatedMemoryEfficientBlockInputStream::MergingAggregatedMemoryEfficie
     /** Create threads that will request and read data from remote servers.
       */
     if (reading_threads > 1)
-        reading_pool = std::make_unique<ThreadPool>(reading_threads);
+        reading_pool = std::make_unique<legacy::ThreadPool>(reading_threads);
 
     /** Create threads. Each of them will pull next set of blocks to merge in a loop,
       *  then merge them and place result in a queue (in fact, ordered map), from where we will read ready result blocks.

--- a/dbms/src/DataStreams/MergingAggregatedMemoryEfficientBlockInputStream.h
+++ b/dbms/src/DataStreams/MergingAggregatedMemoryEfficientBlockInputStream.h
@@ -136,7 +136,7 @@ private:
     /// Get blocks that you can merge. This allows you to merge them in parallel in separate threads.
     BlocksToMerge getNextBlocksToMerge();
 
-    std::unique_ptr<ThreadPool> reading_pool;
+    std::unique_ptr<legacy::ThreadPool> reading_pool;
 
     /// For a parallel merge.
 

--- a/dbms/src/Databases/DatabaseMemory.cpp
+++ b/dbms/src/Databases/DatabaseMemory.cpp
@@ -31,7 +31,7 @@ DatabaseMemory::DatabaseMemory(String name_)
 
 void DatabaseMemory::loadTables(
     Context & /*context*/,
-    ThreadPool * /*thread_pool*/,
+    legacy::ThreadPool * /*thread_pool*/,
     bool /*has_force_restore_data_flag*/)
 {
     /// Nothing to load.

--- a/dbms/src/Databases/DatabaseMemory.h
+++ b/dbms/src/Databases/DatabaseMemory.h
@@ -17,7 +17,10 @@
 #include <Databases/DatabasesCommon.h>
 
 
-namespace Poco { class Logger; }
+namespace Poco
+{
+class Logger;
+}
 
 
 namespace DB
@@ -31,13 +34,13 @@ namespace DB
 class DatabaseMemory : public DatabaseWithOwnTablesBase
 {
 public:
-    DatabaseMemory(String name_);
+    explicit DatabaseMemory(String name_);
 
     String getEngineName() const override { return "Memory"; }
 
     void loadTables(
         Context & context,
-        ThreadPool * thread_pool,
+        legacy::ThreadPool * thread_pool,
         bool has_force_restore_data_flag) override;
 
     void createTable(
@@ -77,4 +80,4 @@ private:
     Poco::Logger * log;
 };
 
-}
+} // namespace DB

--- a/dbms/src/Databases/DatabaseOrdinary.cpp
+++ b/dbms/src/Databases/DatabaseOrdinary.cpp
@@ -83,7 +83,7 @@ DatabaseOrdinary::DatabaseOrdinary(String name_, const String & metadata_path_, 
 }
 
 
-void DatabaseOrdinary::loadTables(Context & context, ThreadPool * thread_pool, bool has_force_restore_data_flag)
+void DatabaseOrdinary::loadTables(Context & context, legacy::ThreadPool * thread_pool, bool has_force_restore_data_flag)
 {
     using FileNames = std::vector<std::string>;
     FileNames file_names = DatabaseLoading::listSQLFilenames(metadata_path, log);

--- a/dbms/src/Databases/DatabaseOrdinary.h
+++ b/dbms/src/Databases/DatabaseOrdinary.h
@@ -32,7 +32,7 @@ public:
 
     void loadTables(
         Context & context,
-        ThreadPool * thread_pool,
+        legacy::ThreadPool * thread_pool,
         bool has_force_restore_data_flag) override;
 
     void createTable(

--- a/dbms/src/Databases/DatabaseTiFlash.cpp
+++ b/dbms/src/Databases/DatabaseTiFlash.cpp
@@ -105,7 +105,7 @@ static constexpr size_t PRINT_MESSAGE_EACH_N_TABLES = 256;
 static constexpr size_t PRINT_MESSAGE_EACH_N_SECONDS = 5;
 static constexpr size_t TABLES_PARALLEL_LOAD_BUNCH_SIZE = 100;
 
-void DatabaseTiFlash::loadTables(Context & context, ThreadPool * thread_pool, bool has_force_restore_data_flag)
+void DatabaseTiFlash::loadTables(Context & context, legacy::ThreadPool * thread_pool, bool has_force_restore_data_flag)
 {
     using FileNames = std::vector<std::string>;
     FileNames table_files = DatabaseLoading::listSQLFilenames(getMetadataPath(), log);

--- a/dbms/src/Databases/DatabaseTiFlash.h
+++ b/dbms/src/Databases/DatabaseTiFlash.h
@@ -37,7 +37,7 @@ public:
     String getEngineName() const override { return "TiFlash"; }
 
 
-    void loadTables(Context & context, ThreadPool * thread_pool, bool has_force_restore_data_flag) override;
+    void loadTables(Context & context, legacy::ThreadPool * thread_pool, bool has_force_restore_data_flag) override;
 
     void createTable(const Context & context, const String & table_name, const StoragePtr & table, const ASTPtr & query) override;
 

--- a/dbms/src/Databases/DatabasesCommon.cpp
+++ b/dbms/src/Databases/DatabasesCommon.cpp
@@ -362,7 +362,7 @@ void cleanupTables(IDatabase & database, const String & db_name, const Tables & 
     }
 }
 
-void startupTables(IDatabase & database, const String & db_name, Tables & tables, ThreadPool * thread_pool, Poco::Logger * log)
+void startupTables(IDatabase & database, const String & db_name, Tables & tables, legacy::ThreadPool * thread_pool, Poco::Logger * log)
 {
     LOG_INFO(log, "Starting up {} tables.", tables.size());
 

--- a/dbms/src/Databases/DatabasesCommon.h
+++ b/dbms/src/Databases/DatabasesCommon.h
@@ -65,7 +65,7 @@ std::vector<String> listSQLFilenames(const String & meta_dir, Poco::Logger * log
 
 // Startup tables with thread_pool. If exception with code TIDB_TABLE_ALREADY_EXISTS thrown in startup,
 // those tables' meta will be removed and deatch from database.
-void startupTables(IDatabase & database, const String & db_name, Tables & tables, ThreadPool * thread_pool, Poco::Logger * log);
+void startupTables(IDatabase & database, const String & db_name, Tables & tables, legacy::ThreadPool * thread_pool, Poco::Logger * log);
 
 void loadTable(Context & context,
                IDatabase & database,

--- a/dbms/src/Databases/IDatabase.h
+++ b/dbms/src/Databases/IDatabase.h
@@ -18,13 +18,11 @@
 #include <Core/Types.h>
 #include <Storages/ColumnsDescription.h>
 #include <Storages/Transaction/Types.h>
+#include <common/ThreadPool.h>
 
 #include <ctime>
 #include <functional>
 #include <memory>
-
-
-class ThreadPool;
 
 
 namespace DB
@@ -74,7 +72,7 @@ public:
 
     /// Load a set of existing tables. If thread_pool is specified, use it.
     /// You can call only once, right after the object is created.
-    virtual void loadTables(Context & context, ThreadPool * thread_pool, bool has_force_restore_data_flag) = 0;
+    virtual void loadTables(Context & context, legacy::ThreadPool * thread_pool, bool has_force_restore_data_flag) = 0;
 
     /// Check the existence of the table.
     virtual bool isTableExist(const Context & context, const String & name) const = 0;

--- a/dbms/src/Databases/test/gtest_database.cpp
+++ b/dbms/src/Databases/test/gtest_database.cpp
@@ -515,7 +515,7 @@ try
 
     {
         // If we loadTable for db2, new table meta should be removed.
-        ThreadPool thread_pool(2);
+        legacy::ThreadPool thread_pool(2);
         db2->loadTables(*ctx, &thread_pool, true);
 
         Poco::File new_meta_file(db2->getTableMetadataPath(tbl_name));

--- a/dbms/src/Flash/FlashService.cpp
+++ b/dbms/src/Flash/FlashService.cpp
@@ -94,18 +94,18 @@ void FlashService::init(Context & context_)
     auto cop_pool_size = static_cast<size_t>(settings.cop_pool_size);
     cop_pool_size = cop_pool_size ? cop_pool_size : default_size;
     LOG_INFO(log, "Use a thread pool with {} threads to handle cop requests.", cop_pool_size);
-    cop_pool = std::make_unique<ThreadPool>(cop_pool_size, [] { setThreadName("cop-pool"); });
+    cop_pool = std::make_unique<legacy::ThreadPool>(cop_pool_size, [] { setThreadName("cop-pool"); });
 
     auto batch_cop_pool_size = static_cast<size_t>(settings.batch_cop_pool_size);
     batch_cop_pool_size = batch_cop_pool_size ? batch_cop_pool_size : default_size;
     LOG_INFO(log, "Use a thread pool with {} threads to handle batch cop requests.", batch_cop_pool_size);
-    batch_cop_pool = std::make_unique<ThreadPool>(batch_cop_pool_size, [] { setThreadName("batch-cop-pool"); });
+    batch_cop_pool = std::make_unique<legacy::ThreadPool>(batch_cop_pool_size, [] { setThreadName("batch-cop-pool"); });
 }
 
 FlashService::~FlashService() = default;
 
 // Use executeInThreadPool to submit job to thread pool which return grpc::Status.
-grpc::Status executeInThreadPool(ThreadPool & pool, std::function<grpc::Status()> job)
+grpc::Status executeInThreadPool(legacy::ThreadPool & pool, std::function<grpc::Status()> job)
 {
     std::packaged_task<grpc::Status()> task(job);
     std::future<grpc::Status> future = task.get_future();

--- a/dbms/src/Flash/FlashService.h
+++ b/dbms/src/Flash/FlashService.h
@@ -120,7 +120,7 @@ protected:
     MockMPPServerInfo mpp_test_info{};
 
     // Put thread pool member(s) at the end so that ensure it will be destroyed firstly.
-    std::unique_ptr<ThreadPool> cop_pool, batch_cop_pool;
+    std::unique_ptr<legacy::ThreadPool> cop_pool, batch_cop_pool;
 };
 
 class AsyncFlashService final : public tikvpb::Tikv::WithAsyncMethod_EstablishMPPConnection<FlashService>

--- a/dbms/src/Flash/Management/ManualCompact.cpp
+++ b/dbms/src/Flash/Management/ManualCompact.cpp
@@ -34,7 +34,7 @@ ManualCompactManager::ManualCompactManager(const Context & global_context_, cons
     , settings(settings_)
     , log(&Poco::Logger::get("ManualCompactManager"))
 {
-    worker_pool = std::make_unique<ThreadPool>(static_cast<size_t>(settings.manual_compact_pool_size), [] { setThreadName("m-compact-pool"); });
+    worker_pool = std::make_unique<legacy::ThreadPool>(static_cast<size_t>(settings.manual_compact_pool_size), [] { setThreadName("m-compact-pool"); });
 }
 
 grpc::Status ManualCompactManager::handleRequest(const ::kvrpcpb::CompactRequest * request, ::kvrpcpb::CompactResponse * response)

--- a/dbms/src/Flash/Management/ManualCompact.h
+++ b/dbms/src/Flash/Management/ManualCompact.h
@@ -92,7 +92,7 @@ private:
     Poco::Logger * log;
 
     /// Placed last to be destroyed first.
-    std::unique_ptr<ThreadPool> worker_pool;
+    std::unique_ptr<legacy::ThreadPool> worker_pool;
 };
 
 } // namespace Management

--- a/dbms/src/IO/AsynchronousWriteBuffer.h
+++ b/dbms/src/IO/AsynchronousWriteBuffer.h
@@ -30,7 +30,7 @@ class AsynchronousWriteBuffer : public WriteBuffer
 private:
     WriteBuffer & out; /// The main buffer, responsible for writing data.
     std::vector<char> memory; /// A piece of memory for duplicating the buffer.
-    ThreadPool pool; /// For asynchronous data writing.
+    legacy::ThreadPool pool; /// For asynchronous data writing.
     bool started; /// Has an asynchronous data write started?
 
     /// Swap the main and duplicate buffers.

--- a/dbms/src/IO/IOThreadPool.h
+++ b/dbms/src/IO/IOThreadPool.h
@@ -18,12 +18,15 @@
 
 namespace DB
 {
+struct Settings;
 
 /*
  * ThreadPool used for the IO.
  */
 class IOThreadPool
 {
+    friend void adjustThreadPoolSize(const Settings & settings, size_t logical_cores);
+
     static std::unique_ptr<ThreadPool> instance;
 
 public:

--- a/dbms/src/IO/IOThreadPool.h
+++ b/dbms/src/IO/IOThreadPool.h
@@ -29,6 +29,8 @@ class IOThreadPool
 public:
     static void initialize(size_t max_threads, size_t max_free_threads, size_t queue_size);
     static ThreadPool & get();
+
+    static void shutdown() noexcept { instance.reset(); }
 };
 
 } // namespace DB

--- a/dbms/src/Interpreters/InterpreterCreateQuery.h
+++ b/dbms/src/Interpreters/InterpreterCreateQuery.h
@@ -16,9 +16,8 @@
 
 #include <Interpreters/IInterpreter.h>
 #include <Storages/ColumnsDescription.h>
+#include <common/ThreadPool.h>
 
-
-class ThreadPool;
 
 namespace DB
 {
@@ -43,7 +42,7 @@ public:
     static ASTPtr formatColumns(const NamesAndTypesList & columns);
     static ASTPtr formatColumns(const ColumnsDescription & columns);
 
-    void setDatabaseLoadingThreadpool(ThreadPool & thread_pool_)
+    void setDatabaseLoadingThreadpool(legacy::ThreadPool & thread_pool_)
     {
         thread_pool = &thread_pool_;
     }
@@ -74,7 +73,7 @@ private:
     Context & context;
 
     /// Using while loading database.
-    ThreadPool * thread_pool = nullptr;
+    legacy::ThreadPool * thread_pool = nullptr;
 
     /// Skip safety threshold when loading tables.
     bool has_force_restore_data_flag = false;

--- a/dbms/src/Interpreters/loadMetadata.cpp
+++ b/dbms/src/Interpreters/loadMetadata.cpp
@@ -42,7 +42,7 @@ static void executeCreateQuery(const String & query,
                                Context & context,
                                const String & database,
                                const String & file_name,
-                               ThreadPool * pool,
+                               legacy::ThreadPool * pool,
                                bool has_force_restore_data_flag)
 {
     ParserCreateQuery parser;
@@ -67,7 +67,7 @@ static void loadDatabase(
     Context & context,
     const String & database,
     const String & database_metadata_file,
-    ThreadPool * thread_pool,
+    legacy::ThreadPool * thread_pool,
     bool force_restore_data)
 {
     /// There may exist .sql file with database creation statement.
@@ -103,7 +103,7 @@ void loadMetadata(Context & context)
     bool has_force_restore_data_flag = force_restore_data_flag_file.exists();
 
     /// For parallel tables loading.
-    ThreadPool thread_pool(SettingMaxThreads().getAutoValue());
+    legacy::ThreadPool thread_pool(SettingMaxThreads().getAutoValue());
     Poco::Logger * log = &Poco::Logger::get("loadMetadata");
 
     /// Loop over databases sql files. This ensure filename ends with ".sql".

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -892,7 +892,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
 
     // Later we may create thread pool from GlobalThreadPool
     // init it before other components
-    initThreadPool(); 
+    initThreadPool();
 
     TiFlashErrorRegistry::instance(); // This invocation is for initializing
 

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -831,7 +831,7 @@ private:
 // Later we will adjust it by `adjustThreadPoolSize`
 void initThreadPool()
 {
-    size_t default_num_threads = 2 * std::min(4UL, std::thread::hardware_concurrency());
+    size_t default_num_threads = std::max(4UL, 2 * std::thread::hardware_concurrency());
     GlobalThreadPool::initialize(
         /*max_threads*/ default_num_threads,
         /*max_free_threads*/ default_num_threads / 2,

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_ingest.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_ingest.cpp
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 #include <Common/FailPoint.h>
+#include <Common/UniThreadPool.h>
 #include <Interpreters/Context.h>
 #include <Storages/DeltaMerge/GCOptions.h>
 #include <Storages/DeltaMerge/tests/gtest_dm_simple_pk_test_basic.h>
 #include <TestUtils/InputStreamTestUtils.h>
-#include <common/ThreadPool.h>
 
 #include <future>
 #include <random>

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_ingest.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_ingest.cpp
@@ -234,7 +234,7 @@ try
     auto pool = std::make_shared<ThreadPool>(4);
     for (const auto & op : ops)
     {
-        pool->schedule([=, &log] {
+        pool->scheduleOrThrowOnError([=, &log] {
             try
             {
                 LOG_INFO(

--- a/dbms/src/Storages/Page/V2/tests/gtest_page_storage_multi_paths.cpp
+++ b/dbms/src/Storages/Page/V2/tests/gtest_page_storage_multi_paths.cpp
@@ -20,7 +20,6 @@
 #include <Poco/Logger.h>
 #include <Poco/Path.h>
 #include <Poco/Runnable.h>
-#include <Poco/ThreadPool.h>
 #include <Poco/Timer.h>
 #include <Storages/Page/Page.h>
 #include <Storages/Page/V2/PageDefines.h>

--- a/dbms/src/Storages/Page/V2/tests/test_page_storage_write_disk_full.cpp
+++ b/dbms/src/Storages/Page/V2/tests/test_page_storage_write_disk_full.cpp
@@ -18,7 +18,6 @@
 #include <Poco/FormattingChannel.h>
 #include <Poco/PatternFormatter.h>
 #include <Poco/Runnable.h>
-#include <Poco/ThreadPool.h>
 #include <Poco/Timer.h>
 #include <Storages/Page/V2/PageStorage.h>
 #include <common/logger_useful.h>

--- a/dbms/src/Storages/Page/tools/PageCtl/PageStorageCtlV2.cpp
+++ b/dbms/src/Storages/Page/tools/PageCtl/PageStorageCtlV2.cpp
@@ -19,7 +19,6 @@
 #include <Poco/Logger.h>
 #include <Poco/PatternFormatter.h>
 #include <Poco/Runnable.h>
-#include <Poco/ThreadPool.h>
 #include <Poco/Timer.h>
 #include <Storages/BackgroundProcessingPool.h>
 #include <Storages/Page/V2/PageStorage.h>

--- a/libs/libcommon/include/common/ThreadPool.h
+++ b/libs/libcommon/include/common/ThreadPool.h
@@ -23,6 +23,8 @@
 #include <vector>
 
 
+namespace legacy
+{
 /** Very simple thread pool similar to boost::threadpool.
   * Advantages:
   * - catches exceptions and rethrows on wait.
@@ -75,3 +77,4 @@ private:
     void worker();
     void finalize();
 };
+} // namespace legacy

--- a/libs/libcommon/src/ThreadPool.cpp
+++ b/libs/libcommon/src/ThreadPool.cpp
@@ -25,6 +25,9 @@ static Poco::Logger * getLogger()
     return logger;
 }
 
+namespace legacy
+{
+
 ThreadPool::ThreadPool(size_t m_size, Job pre_worker)
     : m_size(m_size)
 {
@@ -151,3 +154,5 @@ void ThreadPool::worker()
         has_free_thread.notify_all();
     }
 }
+
+} // namespace legacy


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/6827

Problem Summary:

The order of calling destructors for different static instances is decided by the compiler. When `GlobalThreadPool::the_instance` dctor called before `IOThreadPool::instance`, then the threads blocks forever.

### What is changed and how it works?

* Ensure IOThreadPool is released before GlobalThreadPool try to end all its threads
* Init the thread pool at the program beginning
* Add namespace `legacy` for the thread pool defined in `<common/ThreadPool.h>`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Test by running `./dbms/gtests_dbms --gtest_filter='*S3*'` with changes in this PR: https://github.com/pingcap/tiflash/pull/7034
Before this fix, the program hangs when exit. After this fix, the program can exit normally

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
