### PR TITLE
Rename tiflash_storage to tiflash_write

### DIFF
--- a/dbms/src/Core/TiFlashDisaggregatedMode.cpp
+++ b/dbms/src/Core/TiFlashDisaggregatedMode.cpp
@@ -24,9 +24,9 @@ DisaggregatedMode getDisaggregatedMode(const Poco::Util::LayeredConfiguration & 
     if (config.has(config_key))
     {
         std::string mode_str = config.getString(config_key);
-        RUNTIME_ASSERT(mode_str == DISAGGREGATED_MODE_STORAGE || mode_str == DISAGGREGATED_MODE_COMPUTE,
+        RUNTIME_ASSERT(mode_str == DISAGGREGATED_MODE_WRITE || mode_str == DISAGGREGATED_MODE_COMPUTE,
                        "Expect disaggregated_mode is {} or {}, got: {}",
-                       DISAGGREGATED_MODE_STORAGE,
+                       DISAGGREGATED_MODE_WRITE,
                        DISAGGREGATED_MODE_COMPUTE,
                        mode_str);
         if (mode_str == DISAGGREGATED_MODE_COMPUTE)

--- a/dbms/src/Core/TiFlashDisaggregatedMode.h
+++ b/dbms/src/Core/TiFlashDisaggregatedMode.h
@@ -20,10 +20,12 @@
 
 #define DEF_PROXY_LABEL "tiflash"
 #define DISAGGREGATED_MODE_COMPUTE_PROXY_LABEL DISAGGREGATED_MODE_COMPUTE
-#define DISAGGREGATED_MODE_STORAGE "tiflash_storage"
+// Note that TiFlash Write Node is also named as TiFlash Storage Node in many places.
+// To make sure it is consistent to our documents, we better stick with "tiflash_write" in the configurations.
+#define DISAGGREGATED_MODE_WRITE "tiflash_write"
 #define DISAGGREGATED_MODE_COMPUTE "tiflash_compute"
 // engine_role determine whether TiFlash use S3 to write.
-#define DISAGGREGATED_MODE_STORAGE_ENGINE_ROLE "write"
+#define DISAGGREGATED_MODE_WRITE_ENGINE_ROLE "write"
 
 namespace DB
 {

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -294,7 +294,7 @@ struct TiFlashProxyConfig
             args_map[engine_label] = getProxyLabelByDisaggregatedMode(disaggregated_mode);
             if (disaggregated_mode != DisaggregatedMode::Compute && has_s3_config)
             {
-                args_map[engine_role_label] = DISAGGREGATED_MODE_STORAGE_ENGINE_ROLE;
+                args_map[engine_role_label] = DISAGGREGATED_MODE_WRITE_ENGINE_ROLE;
             }
 
             for (auto && [k, v] : args_map)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6882

Problem Summary:

### What is changed and how it works?

Rename "tiflash_storage" to "tiflash_write" in configuration, to make sure naming is consistent to documents.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
