### PR TITLE
Storage: File size of DMFile's subfiles can be zero.

### DIFF
--- a/dbms/src/Storages/S3/FileCache.cpp
+++ b/dbms/src/Storages/S3/FileCache.cpp
@@ -392,7 +392,7 @@ void FileCache::downloadImpl(const String & s3_key, FileSegmentPtr & file_seg)
     }
     auto & result = outcome.GetResult();
     auto content_length = result.GetContentLength();
-    RUNTIME_CHECK_MSG(content_length > 0, "s3_key={}, content_length={}", s3_key, content_length);
+    RUNTIME_CHECK_MSG(content_length >= 0, "s3_key={}, content_length={}", s3_key, content_length);
     ProfileEvents::increment(ProfileEvents::S3ReadBytes, content_length);
     GET_METRIC(tiflash_storage_s3_request_seconds, type_get_object).Observe(sw.elapsedSeconds());
     if (!finalizeReservedSize(file_seg->getFileType(), file_seg->getSize(), content_length))

--- a/dbms/src/Storages/S3/FileCache.cpp
+++ b/dbms/src/Storages/S3/FileCache.cpp
@@ -392,7 +392,7 @@ void FileCache::downloadImpl(const String & s3_key, FileSegmentPtr & file_seg)
     }
     auto & result = outcome.GetResult();
     auto content_length = result.GetContentLength();
-    RUNTIME_CHECK_MSG(content_length >= 0, "s3_key={}, content_length={}", s3_key, content_length);
+    RUNTIME_CHECK(content_length >= 0, s3_key, content_length);
     ProfileEvents::increment(ProfileEvents::S3ReadBytes, content_length);
     GET_METRIC(tiflash_storage_s3_request_seconds, type_get_object).Observe(sw.elapsedSeconds());
     if (!finalizeReservedSize(file_seg->getFileType(), file_seg->getSize(), content_length))
@@ -405,11 +405,13 @@ void FileCache::downloadImpl(const String & s3_key, FileSegmentPtr & file_seg)
     const auto & local_fname = file_seg->getLocalFileName();
     prepareParentDir(local_fname);
     auto temp_fname = toTemporaryFilename(local_fname);
+    if (content_length > 0)
     {
         Aws::OFStream ostr(temp_fname, std::ios_base::out | std::ios_base::binary);
         RUNTIME_CHECK_MSG(ostr.is_open(), "Open {} failed: {}", temp_fname, strerror(errno));
         ostr << result.GetBody().rdbuf();
-        RUNTIME_CHECK_MSG(ostr.good(), "Write {} failed: {}", temp_fname, strerror(errno));
+        // If content_length == 0, ostr.good() is false. Does not know the reason.
+        RUNTIME_CHECK_MSG(ostr.good(), "Write {} content_length {} failed: {}", temp_fname, content_length, strerror(errno));
         ostr.flush();
     }
     std::filesystem::rename(temp_fname, local_fname);

--- a/dbms/src/Storages/S3/FileCache.cpp
+++ b/dbms/src/Storages/S3/FileCache.cpp
@@ -405,14 +405,16 @@ void FileCache::downloadImpl(const String & s3_key, FileSegmentPtr & file_seg)
     const auto & local_fname = file_seg->getLocalFileName();
     prepareParentDir(local_fname);
     auto temp_fname = toTemporaryFilename(local_fname);
-    if (content_length > 0)
     {
         Aws::OFStream ostr(temp_fname, std::ios_base::out | std::ios_base::binary);
         RUNTIME_CHECK_MSG(ostr.is_open(), "Open {} failed: {}", temp_fname, strerror(errno));
-        ostr << result.GetBody().rdbuf();
-        // If content_length == 0, ostr.good() is false. Does not know the reason.
-        RUNTIME_CHECK_MSG(ostr.good(), "Write {} content_length {} failed: {}", temp_fname, content_length, strerror(errno));
-        ostr.flush();
+        if (content_length > 0)
+        {
+            ostr << result.GetBody().rdbuf();
+            // If content_length == 0, ostr.good() is false. Does not know the reason.
+            RUNTIME_CHECK_MSG(ostr.good(), "Write {} content_length {} failed: {}", temp_fname, content_length, strerror(errno));
+            ostr.flush();
+        }
     }
     std::filesystem::rename(temp_fname, local_fname);
     auto fsize = std::filesystem::file_size(local_fname);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6827

Problem Summary:

When a segment is initialized, it will create an empty DMFile that contains some empty files.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
