### PR TITLE
Add more spill tests and fix bug

### DIFF
--- a/dbms/src/Columns/ColumnString.h
+++ b/dbms/src/Columns/ColumnString.h
@@ -249,20 +249,11 @@ public:
     {
         const size_t string_size = *reinterpret_cast<const size_t *>(pos);
         pos += sizeof(string_size);
-
-        if (likely(collator))
-        {
-            // https://github.com/pingcap/tiflash/pull/6135
-            // - Generate empty string column
-            // - Make size of `offsets` as previous way for func `ColumnString::size()`
-            offsets.push_back(0);
-            return pos + string_size;
-        }
+        if (likely(collator != nullptr))
+            insertData(pos, string_size);
         else
-        {
             insertDataWithTerminatingZero(pos, string_size);
-            return pos + string_size;
-        }
+        return pos + string_size;
     }
 
     void updateHashWithValue(size_t n, SipHash & hash, const TiDB::TiDBCollatorPtr & collator, String & sort_key_container) const override

--- a/dbms/src/Columns/IColumn.h
+++ b/dbms/src/Columns/IColumn.h
@@ -202,7 +202,7 @@ public:
       *     but it is only used by TiDB , which does not support complex columns, so just ignore
       *     the complex column will be ok.
       * 3. Even if the restored column will be discarded, deserializeAndInsertFromArena still need to
-      *     insert the data because when spill happens, this column will be used as the original key column.
+      *     insert the data because when spill happens, this column will be used during the merge agg stage.
       */
     virtual const char * deserializeAndInsertFromArena(const char * pos, const TiDB::TiDBCollatorPtr & collator) = 0;
     const char * deserializeAndInsertFromArena(const char * pos) { return deserializeAndInsertFromArena(pos, nullptr); }

--- a/dbms/src/Columns/IColumn.h
+++ b/dbms/src/Columns/IColumn.h
@@ -201,6 +201,8 @@ public:
       * 2. The input parameter `collator` does not work well for complex columns(column tuple),
       *     but it is only used by TiDB , which does not support complex columns, so just ignore
       *     the complex column will be ok.
+      * 3. Even if the restored column will be discarded, deserializeAndInsertFromArena still need to
+      *     insert the data because when spill happens, this column will be used as the original key column.
       */
     virtual const char * deserializeAndInsertFromArena(const char * pos, const TiDB::TiDBCollatorPtr & collator) = 0;
     const char * deserializeAndInsertFromArena(const char * pos) { return deserializeAndInsertFromArena(pos, nullptr); }

--- a/dbms/src/Flash/tests/gtest_spill_aggregation.cpp
+++ b/dbms/src/Flash/tests/gtest_spill_aggregation.cpp
@@ -21,7 +21,6 @@ namespace DB
 {
 namespace tests
 {
-
 class SpillAggregationTestRunner : public DB::tests::ExecutorTest
 {
 public:
@@ -94,6 +93,12 @@ try
         ASSERT_EQ(block.rows() <= small_max_block_size, true);
     }
     ASSERT_COLUMNS_EQ_UR(ref_columns, vstackBlocks(std::move(blocks)).getColumnsWithTypeAndName());
+}
+CATCH
+
+TEST_F(SpillAggregationTestRunner, AggWithSpeicalGroupKey)
+try
+{
 }
 CATCH
 } // namespace tests

--- a/dbms/src/Flash/tests/gtest_spill_aggregation.cpp
+++ b/dbms/src/Flash/tests/gtest_spill_aggregation.cpp
@@ -134,16 +134,16 @@ try
     std::vector<size_t> concurrences{1, 8};
     std::vector<Int64> collators{TiDB::ITiDBCollator::UTF8MB4_BIN, TiDB::ITiDBCollator::UTF8MB4_GENERAL_CI};
     std::vector<std::vector<String>> group_by_keys{
-        /// fast path with one int and one string
+        /// fast path with one int and one string in bin collation
         {"key_64", "key_string_1"},
-        /// fast path with two string
+        /// fast path with two string in bin collation
         {"key_string_1", "key_string_2"},
-        /// fast path with one string
+        /// fast path with one string in bin collation
         {"key_string_1"},
         /// keys need to be shuffled
         {"key_8", "key_16", "key_32", "key_64"},
     };
-    std::vector<ASTPtr> agg_funcs{Max(col("value")), CountDistinct(col("value"))};
+    std::vector<std::vector<ASTPtr>> agg_funcs{{Max(col("value"))}, {Max(col("value")), Min(col("value"))}};
     for (auto collator_id : collators)
     {
         for (const auto & keys : group_by_keys)
@@ -160,7 +160,143 @@ try
                     key_vec.push_back(col(key));
                 auto request = context
                                    .scan("test_db", "agg_table_with_special_key")
-                                   .aggregation({agg_func}, key_vec)
+                                   .aggregation(agg_func, key_vec)
+                                   .build(context);
+                /// use one level, no block split, no spill as the reference
+                context.context->setSetting("group_by_two_level_threshold_bytes", Field(static_cast<UInt64>(0)));
+                context.context->setSetting("max_bytes_before_external_group_by", Field(static_cast<UInt64>(0)));
+                context.context->setSetting("max_block_size", Field(static_cast<UInt64>(unique_rows * 2)));
+                /// here has to enable memory tracker otherwise the processList in the context is the last query's processList
+                /// and may cause segment fault, maybe a bug but should not happens in TiDB because all the tasks from tidb
+                /// enable memory tracker
+                auto reference = executeStreams(request, 1, true);
+                if (current_collator->isCI())
+                {
+                    /// for ci collation, need to sort and compare the result manually
+                    for (const auto & result_col : reference)
+                    {
+                        if (!removeNullable(result_col.type)->isString())
+                        {
+                            sd.push_back(SortColumnDescription(result_col.name, 1, 1, nullptr));
+                        }
+                        else
+                        {
+                            sd.push_back(SortColumnDescription(result_col.name, 1, 1, current_collator));
+                            has_string_key = true;
+                        }
+                    }
+                    /// don't run ci test if there is no string key
+                    if (!has_string_key)
+                        continue;
+                    Block tmp_block(reference);
+                    sortBlock(tmp_block, sd);
+                    reference = tmp_block.getColumnsWithTypeAndName();
+                }
+                for (auto concurrency : concurrences)
+                {
+                    context.context->setSetting("group_by_two_level_threshold", Field(static_cast<UInt64>(1)));
+                    context.context->setSetting("group_by_two_level_threshold_bytes", Field(static_cast<UInt64>(1)));
+                    context.context->setSetting("max_bytes_before_external_group_by", Field(static_cast<UInt64>(max_bytes_before_external_agg)));
+                    context.context->setSetting("max_block_size", Field(static_cast<UInt64>(max_block_size)));
+                    auto blocks = getExecuteStreamsReturnBlocks(request, concurrency, true);
+                    for (auto & block : blocks)
+                    {
+                        block.checkNumberOfRows();
+                        ASSERT(block.rows() <= max_block_size);
+                    }
+                    if (current_collator->isCI())
+                    {
+                        auto merged_block = vstackBlocks(std::move(blocks));
+                        sortBlock(merged_block, sd);
+                        auto merged_columns = merged_block.getColumnsWithTypeAndName();
+                        for (size_t col_index = 0; col_index < reference.size(); col_index++)
+                            ASSERT_TRUE(columnEqual(reference[col_index].column, merged_columns[col_index].column, sd[col_index].collator));
+                    }
+                    else
+                    {
+                        ASSERT_TRUE(columnsEqual(reference, vstackBlocks(std::move(blocks)).getColumnsWithTypeAndName(), false));
+                    }
+                }
+            }
+        }
+    }
+}
+CATCH
+
+TEST_F(SpillAggregationTestRunner, AggWithDistinctAggFunc)
+try
+{
+    /// prepare data
+    size_t unique_rows = 3000;
+    DB::MockColumnInfoVec table_column_infos{
+        {"key_8", TiDB::TP::TypeTiny, false},
+        {"key_16", TiDB::TP::TypeShort, false},
+        {"key_32", TiDB::TP::TypeLong, false},
+        {"key_64", TiDB::TP::TypeLongLong, false},
+        {"key_string_1", TiDB::TP::TypeString, false},
+        {"key_string_2", TiDB::TP::TypeString, false},
+        {"value_1", TiDB::TP::TypeString, false},
+        {"value_2", TiDB::TP::TypeLong, false},
+    };
+    size_t key_column = 6;
+    ColumnsWithTypeAndName table_column_data;
+    for (const auto & column_info : mockColumnInfosToTiDBColumnInfos(table_column_infos))
+    {
+        ColumnGeneratorOpts opts{unique_rows, getDataTypeByColumnInfoForComputingLayer(column_info)->getName(), RANDOM, column_info.name};
+        table_column_data.push_back(ColumnGenerator::instance().generate(opts));
+    }
+    for (size_t i = 0; i < key_column; i++)
+        table_column_data[i].column->assumeMutable()->insertRangeFrom(*table_column_data[i].column, 0, unique_rows / 2);
+    for (size_t i = key_column; i < table_column_data.size(); i++)
+    {
+        auto & table_column = table_column_data[i];
+        ColumnGeneratorOpts opts{unique_rows / 2, table_column.type->getName(), RANDOM, table_column.name};
+        auto column = ColumnGenerator::instance().generate(opts);
+        table_column.column->assumeMutable()->insertRangeFrom(*column.column, 0, unique_rows / 2);
+    }
+
+    ColumnWithTypeAndName shuffle_column = ColumnGenerator::instance().generate({unique_rows + unique_rows / 2, "UInt64", RANDOM});
+    IColumn::Permutation perm;
+    shuffle_column.column->getPermutation(false, 0, -1, perm);
+    for (auto & column : table_column_data)
+    {
+        column.column = column.column->permute(perm, 0);
+    }
+
+    context.addMockTable("test_db", "agg_table_with_special_key", table_column_infos, table_column_data);
+
+    size_t max_block_size = 800;
+    size_t max_bytes_before_external_agg = 100;
+    std::vector<size_t> concurrences{1, 8};
+    std::vector<Int64> collators{TiDB::ITiDBCollator::UTF8MB4_BIN, TiDB::ITiDBCollator::UTF8MB4_GENERAL_CI};
+    std::vector<std::vector<String>> group_by_keys{
+        /// fast path with one int and one string
+        {"key_64", "key_string_1"},
+        /// fast path with two string
+        {"key_string_1", "key_string_2"},
+        /// fast path with one string
+        {"key_string_1"},
+        /// keys need to be shuffled
+        {"key_8", "key_16", "key_32", "key_64"},
+    };
+    std::vector<std::vector<ASTPtr>> agg_funcs{{Max(col("value_1")), CountDistinct(col("value_2"))}, {CountDistinct(col("value_1")), CountDistinct(col("value_2"))}, {CountDistinct(col("value_1"))}};
+    for (auto collator_id : collators)
+    {
+        for (const auto & keys : group_by_keys)
+        {
+            for (const auto & agg_func : agg_funcs)
+            {
+                context.setCollation(collator_id);
+                const auto * current_collator = TiDB::ITiDBCollator::getCollator(collator_id);
+                ASSERT_TRUE(current_collator != nullptr);
+                SortDescription sd;
+                bool has_string_key = false;
+                MockAstVec key_vec;
+                for (const auto & key : keys)
+                    key_vec.push_back(col(key));
+                auto request = context
+                                   .scan("test_db", "agg_table_with_special_key")
+                                   .aggregation(agg_func, key_vec)
                                    .build(context);
                 /// use one level, no block split, no spill as the reference
                 context.context->setSetting("group_by_two_level_threshold_bytes", Field(static_cast<UInt64>(0)));

--- a/dbms/src/Flash/tests/gtest_spill_aggregation.cpp
+++ b/dbms/src/Flash/tests/gtest_spill_aggregation.cpp
@@ -96,9 +96,130 @@ try
 }
 CATCH
 
-TEST_F(SpillAggregationTestRunner, AggWithSpeicalGroupKey)
+TEST_F(SpillAggregationTestRunner, AggWithSpecialGroupKey)
 try
 {
+    /// prepare data
+    size_t unique_rows = 3000;
+    DB::MockColumnInfoVec table_column_infos{{"key_8", TiDB::TP::TypeTiny, false}, {"key_16", TiDB::TP::TypeShort, false}, {"key_32", TiDB::TP::TypeLong, false}, {"key_64", TiDB::TP::TypeLongLong, false}, {"key_string_1", TiDB::TP::TypeString, false}, {"key_string_2", TiDB::TP::TypeString, false}, {"value", TiDB::TP::TypeLong, false}};
+    ColumnsWithTypeAndName table_column_data;
+    for (const auto & column_info : mockColumnInfosToTiDBColumnInfos(table_column_infos))
+    {
+        ColumnGeneratorOpts opts{unique_rows, getDataTypeByColumnInfoForComputingLayer(column_info)->getName(), RANDOM, column_info.name};
+        table_column_data.push_back(ColumnGenerator::instance().generate(opts));
+    }
+    for (auto & table_column : table_column_data)
+    {
+        if (table_column.name != "value")
+            table_column.column->assumeMutable()->insertRangeFrom(*table_column.column, 0, unique_rows / 2);
+        else
+        {
+            ColumnGeneratorOpts opts{unique_rows / 2, table_column.type->getName(), RANDOM, table_column.name};
+            auto column = ColumnGenerator::instance().generate(opts);
+            table_column.column->assumeMutable()->insertRangeFrom(*column.column, 0, unique_rows / 2);
+        }
+    }
+    ColumnWithTypeAndName shuffle_column = ColumnGenerator::instance().generate({unique_rows + unique_rows / 2, "UInt64", RANDOM});
+    IColumn::Permutation perm;
+    shuffle_column.column->getPermutation(false, 0, -1, perm);
+    for (auto & column : table_column_data)
+    {
+        column.column = column.column->permute(perm, 0);
+    }
+
+    context.addMockTable("test_db", "agg_table_with_special_key", table_column_infos, table_column_data);
+
+    size_t max_block_size = 800;
+    size_t max_bytes_before_external_agg = 100;
+    std::vector<size_t> concurrences{1, 8};
+    std::vector<Int64> collators{TiDB::ITiDBCollator::UTF8MB4_BIN, TiDB::ITiDBCollator::UTF8MB4_GENERAL_CI};
+    std::vector<std::vector<String>> group_by_keys{
+        /// fast path with one int and one string
+        {"key_64", "key_string_1"},
+        /// fast path with two string
+        {"key_string_1", "key_string_2"},
+        /// fast path with one string
+        {"key_string_1"},
+        /// keys need to be shuffled
+        {"key_8", "key_16", "key_32", "key_64"},
+    };
+    std::vector<ASTPtr> agg_funcs{Max(col("value")), CountDistinct(col("value"))};
+    for (auto collator_id : collators)
+    {
+        for (const auto & keys : group_by_keys)
+        {
+            for (const auto & agg_func : agg_funcs)
+            {
+                context.setCollation(collator_id);
+                const auto * current_collator = TiDB::ITiDBCollator::getCollator(collator_id);
+                ASSERT_TRUE(current_collator != nullptr);
+                SortDescription sd;
+                bool has_string_key = false;
+                MockAstVec key_vec;
+                for (const auto & key : keys)
+                    key_vec.push_back(col(key));
+                auto request = context
+                                   .scan("test_db", "agg_table_with_special_key")
+                                   .aggregation({agg_func}, key_vec)
+                                   .build(context);
+                /// use one level, no block split, no spill as the reference
+                context.context->setSetting("group_by_two_level_threshold_bytes", Field(static_cast<UInt64>(0)));
+                context.context->setSetting("max_bytes_before_external_group_by", Field(static_cast<UInt64>(0)));
+                context.context->setSetting("max_block_size", Field(static_cast<UInt64>(unique_rows * 2)));
+                /// here has to enable memory tracker otherwise the processList in the context is the last query's processList
+                /// and may cause segment fault, maybe a bug but should not happens in TiDB because all the tasks from tidb
+                /// enable memory tracker
+                auto reference = executeStreams(request, 1, true);
+                if (current_collator->isCI())
+                {
+                    /// for ci collation, need to sort and compare the result manually
+                    for (const auto & result_col : reference)
+                    {
+                        if (!removeNullable(result_col.type)->isString())
+                        {
+                            sd.push_back(SortColumnDescription(result_col.name, 1, 1, nullptr));
+                        }
+                        else
+                        {
+                            sd.push_back(SortColumnDescription(result_col.name, 1, 1, current_collator));
+                            has_string_key = true;
+                        }
+                    }
+                    /// don't run ci test if there is no string key
+                    if (!has_string_key)
+                        continue;
+                    Block tmp_block(reference);
+                    sortBlock(tmp_block, sd);
+                    reference = tmp_block.getColumnsWithTypeAndName();
+                }
+                for (auto concurrency : concurrences)
+                {
+                    context.context->setSetting("group_by_two_level_threshold", Field(static_cast<UInt64>(1)));
+                    context.context->setSetting("group_by_two_level_threshold_bytes", Field(static_cast<UInt64>(1)));
+                    context.context->setSetting("max_bytes_before_external_group_by", Field(static_cast<UInt64>(max_bytes_before_external_agg)));
+                    context.context->setSetting("max_block_size", Field(static_cast<UInt64>(max_block_size)));
+                    auto blocks = getExecuteStreamsReturnBlocks(request, concurrency, true);
+                    for (auto & block : blocks)
+                    {
+                        block.checkNumberOfRows();
+                        ASSERT(block.rows() <= max_block_size);
+                    }
+                    if (current_collator->isCI())
+                    {
+                        auto merged_block = vstackBlocks(std::move(blocks));
+                        sortBlock(merged_block, sd);
+                        auto merged_columns = merged_block.getColumnsWithTypeAndName();
+                        for (size_t col_index = 0; col_index < reference.size(); col_index++)
+                            ASSERT_TRUE(columnEqual(reference[col_index].column, merged_columns[col_index].column, sd[col_index].collator));
+                    }
+                    else
+                    {
+                        ASSERT_TRUE(columnsEqual(reference, vstackBlocks(std::move(blocks)).getColumnsWithTypeAndName(), false));
+                    }
+                }
+            }
+        }
+    }
 }
 CATCH
 } // namespace tests

--- a/dbms/src/Flash/tests/gtest_spill_sort.cpp
+++ b/dbms/src/Flash/tests/gtest_spill_sort.cpp
@@ -21,7 +21,6 @@ namespace DB
 {
 namespace tests
 {
-
 class SpillSortTestRunner : public DB::tests::ExecutorTest
 {
 public:
@@ -90,7 +89,7 @@ try
     context.addMockTable("spill_sort_test", "collation_table", column_infos, column_data, 8);
 
     MockOrderByItemVec order_by_items{std::make_pair("a", true), std::make_pair("b", true), std::make_pair("c", true), std::make_pair("d", true), std::make_pair("e", true)};
-    std::vector<Int64> collators{TiDB::ITiDBCollator::UTF8MB4_BIN, TiDB::ITiDBCollator::UTF8MB4_GENERAL_CI};
+    std::vector<Int64> collators{TiDB::ITiDBCollator::UTF8MB4_BIN, TiDB::ITiDBCollator::UTF8MB4_GENERAL_CI, TiDB::ITiDBCollator::UTF8MB4_UNICODE_CI};
     for (const auto & collator_id : collators)
     {
         context.setCollation(collator_id);

--- a/dbms/src/Flash/tests/gtest_spill_sort.cpp
+++ b/dbms/src/Flash/tests/gtest_spill_sort.cpp
@@ -70,5 +70,48 @@ try
     ASSERT_COLUMNS_EQ_UR(ref_columns, executeStreams(request, original_max_streams));
 }
 CATCH
+
+TEST_F(SpillSortTestRunner, CollatorTest)
+try
+{
+    DB::MockColumnInfoVec column_infos{{"a", TiDB::TP::TypeString, false}, {"b", TiDB::TP::TypeString, false}, {"c", TiDB::TP::TypeString, false}, {"d", TiDB::TP::TypeString, false}, {"e", TiDB::TP::TypeString, false}};
+    ColumnsWithTypeAndName column_data;
+    size_t table_rows = 102400;
+    UInt64 max_block_size = 500;
+    size_t original_max_streams = 20;
+    size_t total_data_size = 0;
+    size_t limit_size = table_rows / 10 * 8;
+    for (const auto & column_info : mockColumnInfosToTiDBColumnInfos(column_infos))
+    {
+        ColumnGeneratorOpts opts{table_rows, getDataTypeByColumnInfoForComputingLayer(column_info)->getName(), RANDOM, column_info.name, 5};
+        column_data.push_back(ColumnGenerator::instance().generate(opts));
+        total_data_size += column_data.back().column->byteSize();
+    }
+    context.addMockTable("spill_sort_test", "collation_table", column_infos, column_data, 8);
+
+    MockOrderByItemVec order_by_items{std::make_pair("a", true), std::make_pair("b", true), std::make_pair("c", true), std::make_pair("d", true), std::make_pair("e", true)};
+    std::vector<Int64> collators{TiDB::ITiDBCollator::UTF8MB4_BIN, TiDB::ITiDBCollator::UTF8MB4_GENERAL_CI};
+    for (const auto & collator_id : collators)
+    {
+        context.setCollation(collator_id);
+        auto request = context
+                           .scan("spill_sort_test", "collation_table")
+                           .topN(order_by_items, limit_size)
+                           .build(context);
+        context.context->setSetting("max_block_size", Field(static_cast<UInt64>(max_block_size)));
+        /// disable spill
+        context.context->setSetting("max_bytes_before_external_sort", Field(static_cast<UInt64>(0)));
+        auto ref_columns = executeStreams(request, original_max_streams);
+        /// enable spill
+        context.context->setSetting("max_bytes_before_external_sort", Field(static_cast<UInt64>(total_data_size / 10)));
+        // don't use `executeAndAssertColumnsEqual` since it takes too long to run
+        /// todo use ASSERT_COLUMNS_EQ_R once TiFlash support final TopN
+        ASSERT_COLUMNS_EQ_UR(ref_columns, executeStreams(request, original_max_streams));
+        /// enable spill and use small max_cached_data_bytes_in_spiller
+        context.context->setSetting("max_cached_data_bytes_in_spiller", Field(static_cast<UInt64>(total_data_size / 100)));
+        ASSERT_COLUMNS_EQ_UR(ref_columns, executeStreams(request, original_max_streams));
+    }
+}
+CATCH
 } // namespace tests
 } // namespace DB

--- a/dbms/src/Interpreters/Aggregator.cpp
+++ b/dbms/src/Interpreters/Aggregator.cpp
@@ -1766,7 +1766,8 @@ void NO_INLINE Aggregator::mergeStreamsImplCase(
     std::vector<std::string> sort_key_containers;
     sort_key_containers.resize(params.keys_size, "");
 
-    typename Method::State state(key_columns, key_sizes, params.collators);
+    /// in merge stage, don't need to care about the collator because the key is already the sort_key of original string
+    typename Method::State state(key_columns, key_sizes, {});
 
     /// For all rows.
     size_t rows = block.rows();

--- a/dbms/src/Interpreters/Aggregator.h
+++ b/dbms/src/Interpreters/Aggregator.h
@@ -225,10 +225,7 @@ struct AggregationMethodOneKeyStringNoCache
         /// still need to insert data to key because spill may will use this
         static_cast<ColumnString *>(key_columns[0])->insertData(key.data, key.size);
     }
-    // resize offsets for column string
-    ALWAYS_INLINE static inline void initAggKeys(size_t, IColumn *)
-    {
-    }
+    ALWAYS_INLINE static inline void initAggKeys(size_t, IColumn *) {}
 };
 
 /*
@@ -289,18 +286,15 @@ struct AggregationMethodFastPathTwoKeysNoCache
         column->getData().resize_fill(rows, 0);
     }
 
-    // Only update offsets but DO NOT insert string data.
-    // Because of https://github.com/pingcap/tiflash/blob/84c2650bc4320919b954babeceb5aeaadb845770/dbms/src/Columns/IColumn.h#L160-L173, such column will be discarded.
     ALWAYS_INLINE static inline const char * insertAggKeyIntoColumnString(const char * pos, IColumn * key_column)
     {
+        /// still need to insert data to key because spill may will use this
         const size_t string_size = *reinterpret_cast<const size_t *>(pos);
         pos += sizeof(string_size);
         static_cast<ColumnString *>(key_column)->insertData(pos, string_size);
         return pos + string_size;
     }
-    ALWAYS_INLINE static inline void initAggKeyString(size_t, IColumn *)
-    {
-    }
+    ALWAYS_INLINE static inline void initAggKeyString(size_t, IColumn *) {}
 
     template <>
     ALWAYS_INLINE static inline void initAggKeys<ColumnsHashing::KeyDescStringBin>(size_t rows, IColumn * key_column)

--- a/dbms/src/TestUtils/mockExecutor.h
+++ b/dbms/src/TestUtils/mockExecutor.h
@@ -261,6 +261,7 @@ MockWindowFrame buildDefaultRowsFrame();
 #define Min(expr) makeASTFunction("min", (expr))
 #define Count(expr) makeASTFunction("count", (expr))
 #define Sum(expr) makeASTFunction("sum", (expr))
+#define CountDistinct(expr) makeASTFunction("countDistinct", (expr))
 
 /// Window functions
 #define RowNumber() makeASTFunction("RowNumber")


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6528

Problem Summary:

### What is changed and how it works?
1. For aggregation key of a string with not null collator, still fill the string column in `insertKeyIntoColumns`, since it will be used during the restore stage
2. For merge aggregation stage, clear the collator info because the input column is already the `sort_key` of the original column, so don't need to get the sort_key again
3. Add more spill tests on spill agg and spill sort
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
