### PR TITLE
Support disagg read after data ingest by FAP

### DIFF
--- a/dbms/src/Interpreters/Settings.h
+++ b/dbms/src/Interpreters/Settings.h
@@ -238,7 +238,7 @@ struct Settings
     M(SettingCompressionMethod, dt_compression_method, CompressionMethod::LZ4, "The method of data compression when writing.")                                                                                                          \
     M(SettingInt64, dt_compression_level, 1, "The compression level.")                                                                                                                                                                  \
     \
-    M(SettingInt64, remote_checkpoint_interval_seconds, 60, "The interval of uploading checkpoint to the remote store. Unit is second.")                                                                                                \
+    M(SettingInt64, remote_checkpoint_interval_seconds, 30, "The interval of uploading checkpoint to the remote store. Unit is second.")                                                                                                \
     M(SettingInt64, remote_gc_interval_seconds, 3600, "The interval of running GC task on the remote store. Unit is second.")                                                                                                           \
     \
     M(SettingUInt64, max_rows_in_set, 0, "Maximum size of the set (in number of elements) resulting from the execution of the IN section.")                                                                                             \

--- a/dbms/src/Server/StorageConfigParser.cpp
+++ b/dbms/src/Server/StorageConfigParser.cpp
@@ -550,7 +550,7 @@ void StorageS3Config::parse(const String & content, const LoggerPtr & log)
     readConfig(table, "request_timeout_ms", request_timeout_ms);
     RUNTIME_CHECK(request_timeout_ms > 0);
     readConfig(table, "root", root);
-    RUNTIME_CHECK_MSG(root == "/", "Only support using '/' as the S3 key root now"); // working on in another PR
+    RUNTIME_CHECK(!root.empty());
 
     auto read_s3_auth_info_from_env = [&]() {
         access_key_id = Poco::Environment::get(S3_ACCESS_KEY_ID, /*default*/ "");

--- a/dbms/src/Server/StorageConfigParser.cpp
+++ b/dbms/src/Server/StorageConfigParser.cpp
@@ -550,7 +550,7 @@ void StorageS3Config::parse(const String & content, const LoggerPtr & log)
     readConfig(table, "request_timeout_ms", request_timeout_ms);
     RUNTIME_CHECK(request_timeout_ms > 0);
     readConfig(table, "root", root);
-    RUNTIME_CHECK(!root.empty());
+    RUNTIME_CHECK_MSG(root == "/", "Only support using '/' as the S3 key root now"); // working on in another PR
 
     auto read_s3_auth_info_from_env = [&]() {
         access_key_id = Poco::Environment::get(S3_ACCESS_KEY_ID, /*default*/ "");

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSetSnapshot.h
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSetSnapshot.h
@@ -103,7 +103,7 @@ public:
 
     RowKeyRange getSquashDeleteRange() const;
 
-    const auto & getDataProvider() { return data_provider; }
+    const auto & getDataProvider() const { return data_provider; }
 };
 
 } // namespace DM

--- a/dbms/src/Storages/DeltaMerge/Remote/DataStore/DataStore.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/DataStore/DataStore.h
@@ -69,6 +69,8 @@ public:
      */
     virtual IPreparedDMFileTokenPtr prepareDMFile(const S3::DMFileOID & oid, UInt64 page_id = 0) = 0;
 
+    virtual IPreparedDMFileTokenPtr prepareDMFileByKey(const String & remote_key) = 0;
+
     /**
      * Blocks until all checkpoint files are successfully put in the remote data store.
      * Returns true if all files are successfully uploaded.

--- a/dbms/src/Storages/DeltaMerge/Remote/DataStore/DataStoreS3.cpp
+++ b/dbms/src/Storages/DeltaMerge/Remote/DataStore/DataStoreS3.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Common/Exception.h>
 #include <Common/Stopwatch.h>
 #include <IO/IOThreadPools.h>
 #include <Poco/File.h>
@@ -137,6 +138,14 @@ void DataStoreS3::copyToLocal(const S3::DMFileOID & remote_oid, const std::vecto
 IPreparedDMFileTokenPtr DataStoreS3::prepareDMFile(const S3::DMFileOID & oid, UInt64 page_id)
 {
     return std::make_shared<S3PreparedDMFileToken>(file_provider, oid, page_id);
+}
+
+IPreparedDMFileTokenPtr DataStoreS3::prepareDMFileByKey(const String & remote_key)
+{
+    const auto view = S3::S3FilenameView::fromKeyWithPrefix(remote_key);
+    RUNTIME_CHECK(view.isDMFile(), magic_enum::enum_name(view.type), remote_key);
+    auto oid = view.getDMFileOID();
+    return prepareDMFile(oid, 0);
 }
 
 DMFilePtr S3PreparedDMFileToken::restore(DMFile::ReadMetaMode read_mode)

--- a/dbms/src/Storages/DeltaMerge/Remote/DataStore/DataStoreS3.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/DataStore/DataStoreS3.h
@@ -47,6 +47,8 @@ public:
      */
     IPreparedDMFileTokenPtr prepareDMFile(const S3::DMFileOID & oid, UInt64 page_id) override;
 
+    IPreparedDMFileTokenPtr prepareDMFileByKey(const String & remote_key) override;
+
     bool putCheckpointFiles(const PS::V3::LocalCheckpointFiles & local_files, StoreID store_id, UInt64 upload_seq) override;
 
 #ifndef DBMS_PUBLIC_GTEST

--- a/dbms/src/Storages/DeltaMerge/Remote/Proto/remote.proto
+++ b/dbms/src/Storages/DeltaMerge/Remote/Proto/remote.proto
@@ -72,6 +72,7 @@ message ColumnFileInMemory {
 message ColumnFileTiny {
     uint64 page_id = 1;
     uint64 page_size = 2;
+    CheckpointInfo checkpoint_info = 3;
 
     // serialized schema
     bytes schema = 5;
@@ -82,7 +83,7 @@ message ColumnFileTiny {
 
 message ColumnFileBig {
     uint64 page_id = 1;
-    uint64 file_id = 2;
+    CheckpointInfo checkpoint_info = 2;
 
     // TODO: We should better recalculate these fields from local DTFile.
     uint64 valid_rows = 10;
@@ -91,6 +92,14 @@ message ColumnFileBig {
 
 message ColumnFileDeleteRange {
     bytes key_range = 1;
+}
+
+message CheckpointInfo {
+    bytes data_file_id = 1;
+    uint64 offset = 2;
+    uint64 size = 3;
+    // whether the data reclaimed on the write node or not
+    bool is_local_data_reclaimed = 4;
 }
 
 message TiFlashColumnInfo {

--- a/dbms/src/Storages/DeltaMerge/Remote/Serializer.cpp
+++ b/dbms/src/Storages/DeltaMerge/Remote/Serializer.cpp
@@ -124,14 +124,10 @@ SegmentSnapshotPtr Serializer::deserializeSegmentSnapshotFrom(
     delta_snap->mem_table_snap = deserializeColumnFileSet(
         proto.column_files_memtable(),
         data_store,
-        remote_store_id,
-        table_id,
         segment_range);
     delta_snap->persisted_files_snap = deserializeColumnFileSet(
         proto.column_files_persisted(),
         data_store,
-        remote_store_id,
-        table_id,
         segment_range);
 
     // Note: At this moment, we still cannot read from `delta_snap->mem_table_snap` and `delta_snap->persisted_files_snap`,
@@ -207,8 +203,6 @@ Serializer::serializeTo(const ColumnFileSetSnapshotPtr & snap)
 ColumnFileSetSnapshotPtr Serializer::deserializeColumnFileSet(
     const RepeatedPtrField<RemotePb::ColumnFileRemote> & proto,
     const Remote::IDataStorePtr & data_store,
-    StoreID remote_store_id,
-    TableID table_id,
     const RowKeyRange & segment_range)
 {
     auto empty_data_provider = std::make_shared<ColumnFileDataProviderNop>();
@@ -228,7 +222,6 @@ ColumnFileSetSnapshotPtr Serializer::deserializeColumnFileSet(
         }
         else if (remote_column_file.has_big())
         {
-            UNUSED(remote_store_id, table_id);
             const auto & big_file = remote_column_file.big();
             ret->column_files.push_back(deserializeCFBig(
                 big_file,

--- a/dbms/src/Storages/DeltaMerge/Remote/Serializer.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/Serializer.h
@@ -102,7 +102,6 @@ struct Serializer
     static RemotePb::ColumnFileRemote serializeTo(const ColumnFileBig & cf_big);
     static ColumnFileBigPtr deserializeCFBig(
         const RemotePb::ColumnFileBig & proto,
-        const Remote::DMFileOID & oid,
         const Remote::IDataStorePtr & data_store,
         const RowKeyRange & segment_range);
 };

--- a/dbms/src/Storages/DeltaMerge/Remote/Serializer.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/Serializer.h
@@ -84,8 +84,6 @@ struct Serializer
     static ColumnFileSetSnapshotPtr deserializeColumnFileSet(
         const google::protobuf::RepeatedPtrField<RemotePb::ColumnFileRemote> & proto,
         const Remote::IDataStorePtr & data_store,
-        StoreID remote_store_id,
-        TableID table_id,
         const RowKeyRange & segment_range);
 
     /// column file ///

--- a/dbms/src/Storages/StorageDisaggregatedRemote.cpp
+++ b/dbms/src/Storages/StorageDisaggregatedRemote.cpp
@@ -227,7 +227,7 @@ DM::RNRemoteReadTaskPtr StorageDisaggregated::buildDisaggregatedTask(
 
                     LOG_DEBUG(
                         log,
-                        "Build RNRemoteTableReadTask finished, elapsed={}s store={} addr={} segments={} task_id={}",
+                        "Build RNRemoteTableReadTask finished, elapsed={:.3f}s store={} addr={} segments={} task_id={}",
                         watch_table.elapsedSeconds(),
                         resp->store_id(),
                         batch_cop_task.store_addr,

--- a/dbms/src/TiDB/Etcd/Client.cpp
+++ b/dbms/src/TiDB/Etcd/Client.cpp
@@ -189,7 +189,8 @@ Client::campaign(const String & name, const String & value, LeaseID lease_id)
     req.set_lease(lease_id);
 
     grpc::ClientContext context;
-    context.set_deadline(std::chrono::system_clock::now() + timeout);
+    // usually use `campaign` blocks until become leader or error happens,
+    // don't set timeout.
 
     v3electionpb::CampaignResponse resp;
     auto status = leaderClient()->election_stub->Campaign(&context, req, &resp);

--- a/dbms/src/TiDB/OwnerManager.cpp
+++ b/dbms/src/TiDB/OwnerManager.cpp
@@ -247,6 +247,7 @@ void EtcdOwnerManager::camaignLoop(Etcd::SessionPtr session)
 
             const auto lease_id = session->leaseID();
             LOG_DEBUG(log, "new campaign loop with lease_id={:x}", lease_id);
+            // Let this thread blocks until becone owner or error occurs
             auto && [new_leader, status] = client->campaign(campaign_name, id, lease_id);
             if (!status.ok())
             {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/6827

Problem Summary: After FastAddPeer (https://github.com/pingcap/tiflash/pull/6987), the data of one TiFlash write node could ingest some data (ColumnFileTiny/DMFile) that is generated by another TiFlash write node. This break the previous consumption. WNs should return the real remote location to the RN so that RN can fetch the data from remote store (e.g. S3) directly.

### What is changed and how it works?

* Change the checkpoint interval from 60 seconds to 30 seconds
* Serialize the remote key (S3 path) for DMFile to `RemotePb::ColumnFileBig` so that RN can get the correct S3 key for reading
* Note that if a ColumnFileTiny is ingested by FAP and later read by RN,
  * Now it is still read by WN at the first time, then written back to WN's UniPS
  * When RN receives the page data, it will put it into its LocalPageCache

> Now it is still read by WN at the first time, then written back to WN's UniPS
> This might increase some latency at the first time reading data after FAP, but we can optimize it later

Other
* Q: Why not let the RN parse the WN's manifest on S3 to get the location info of given PageIDs on that store_id?
* A: The latest segment info could be not in the manifest on S3 yet.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

* Deploy a cluster with 1 disagg WN and 1 disagg RN
* Load some data to WN
* Scale-out another WN and read data through RN
* Scale-in the origin WN totally and read data through RN

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
