### PR TITLE
Support sharing the same S3 bucket for multiple clusters

### DIFF
--- a/dbms/src/Flash/Disaggregated/MockS3LockClient.h
+++ b/dbms/src/Flash/Disaggregated/MockS3LockClient.h
@@ -30,13 +30,7 @@ class MockS3LockClient : public IS3LockClient
 {
 public:
     explicit MockS3LockClient(std::shared_ptr<TiFlashS3Client> c)
-        : MockS3LockClient(c, c->bucket())
-    {
-    }
-
-    MockS3LockClient(std::shared_ptr<Aws::S3::S3Client> c, const String & bucket_)
         : s3_client(std::move(c))
-        , bucket(bucket_)
     {
     }
 
@@ -45,16 +39,16 @@ public:
     {
         // If the data file exist and no delmark exist, then create a lock file on `data_file_key`
         auto view = S3FilenameView::fromKey(data_file_key);
-        if (!objectExists(*s3_client, bucket, data_file_key))
+        if (!objectExists(*s3_client, data_file_key))
         {
             return {false, ""};
         }
         auto delmark_key = view.getDelMarkKey();
-        if (objectExists(*s3_client, bucket, delmark_key))
+        if (objectExists(*s3_client, delmark_key))
         {
             return {false, ""};
         }
-        uploadEmptyFile(*s3_client, bucket, view.getLockKey(lock_store_id, lock_seq));
+        uploadEmptyFile(*s3_client, view.getLockKey(lock_store_id, lock_seq));
         return {true, ""};
     }
 
@@ -65,22 +59,25 @@ public:
         auto view = S3FilenameView::fromKey(data_file_key);
         auto lock_prefix = view.getLockPrefix();
         bool any_lock_exist = false;
-        listPrefix(*s3_client, bucket, lock_prefix, [&any_lock_exist](const Aws::S3::Model::ListObjectsV2Result & result) -> S3::PageResult {
-            if (!result.GetContents().empty())
-                any_lock_exist = true;
-            return S3::PageResult{.num_keys = result.GetContents().size(), .more = false};
-        });
+        listPrefix(
+            *s3_client,
+            lock_prefix,
+            [&any_lock_exist](const Aws::S3::Model::ListObjectsV2Result & result, const String & root) -> S3::PageResult {
+                UNUSED(root);
+                if (!result.GetContents().empty())
+                    any_lock_exist = true;
+                return S3::PageResult{.num_keys = result.GetContents().size(), .more = false};
+            });
         if (any_lock_exist)
         {
             return {false, ""};
         }
-        uploadEmptyFile(*s3_client, bucket, view.getDelMarkKey());
+        uploadEmptyFile(*s3_client, view.getDelMarkKey());
         return {true, ""};
     }
 
 private:
-    std::shared_ptr<Aws::S3::S3Client> s3_client;
-    String bucket;
+    std::shared_ptr<TiFlashS3Client> s3_client;
 };
 
 } // namespace DB::S3

--- a/dbms/src/Flash/Disaggregated/MockS3LockClient.h
+++ b/dbms/src/Flash/Disaggregated/MockS3LockClient.h
@@ -59,7 +59,7 @@ public:
         auto view = S3FilenameView::fromKey(data_file_key);
         auto lock_prefix = view.getLockPrefix();
         auto lock_key_opt = S3::anyKeyExistWithPrefix(*s3_client, lock_prefix);
-        bool any_lock_exist = !lock_key_opt.has_value();
+        bool any_lock_exist = lock_key_opt.has_value();
         if (any_lock_exist)
         {
             return {false, ""};

--- a/dbms/src/Flash/Disaggregated/S3LockService.cpp
+++ b/dbms/src/Flash/Disaggregated/S3LockService.cpp
@@ -228,7 +228,7 @@ bool S3LockService::tryAddLockImpl(
     }
     const auto lock_key = key_view.getLockKey(lock_store_id, lock_seq);
     // upload lock file
-    DB::S3::uploadEmptyFile(*s3_client, s3_client->bucket(), lock_key);
+    DB::S3::uploadEmptyFile(*s3_client, lock_key);
     if (!gc_owner->isOwner())
     {
         // although the owner is changed after lock file is uploaded, but
@@ -250,9 +250,9 @@ std::optional<String> S3LockService::anyLockExist(const String & lock_prefix)
     auto s3_client = S3::ClientFactory::instance().sharedTiFlashClient();
     DB::S3::listPrefix(
         *s3_client,
-        s3_client->bucket(),
         lock_prefix,
-        [&lock_key](const Aws::S3::Model::ListObjectsV2Result & result) -> S3::PageResult {
+        [&lock_key](const Aws::S3::Model::ListObjectsV2Result & result, const String & root) -> S3::PageResult {
+            UNUSED(root);
             const auto & contents = result.GetContents();
             if (!contents.empty())
             {
@@ -319,7 +319,7 @@ bool S3LockService::tryMarkDeleteImpl(const String & data_file_key, disaggregate
         tagging = TaggingObjectIsDeleted;
     }
     auto s3_client = S3::ClientFactory::instance().sharedTiFlashClient();
-    DB::S3::uploadEmptyFile(*s3_client, s3_client->bucket(), delmark_key, tagging);
+    DB::S3::uploadEmptyFile(*s3_client, delmark_key, tagging);
     if (!gc_owner->isOwner())
     {
         // owner changed happens when delmark is uploading, can not

--- a/dbms/src/Flash/Disaggregated/S3LockService.cpp
+++ b/dbms/src/Flash/Disaggregated/S3LockService.cpp
@@ -200,7 +200,7 @@ bool S3LockService::tryAddLockImpl(
     auto s3_client = S3::ClientFactory::instance().sharedTiFlashClient();
     // make sure data file exists
     auto object_key = key_view.isDMFile() ? fmt::format("{}/{}", data_file_key, DM::DMFile::metav2FileName()) : data_file_key;
-    if (!DB::S3::objectExists(*s3_client, s3_client->bucket(), object_key))
+    if (!DB::S3::objectExists(*s3_client, object_key))
     {
         auto * e = response->mutable_result()->mutable_conflict();
         e->set_reason(fmt::format("data file not exist, key={}", data_file_key));
@@ -210,7 +210,7 @@ bool S3LockService::tryAddLockImpl(
 
     // make sure data file is not mark as deleted
     const auto delmark_key = key_view.getDelMarkKey();
-    if (DB::S3::objectExists(*s3_client, s3_client->bucket(), delmark_key))
+    if (DB::S3::objectExists(*s3_client, delmark_key))
     {
         auto * e = response->mutable_result()->mutable_conflict();
         e->set_reason(fmt::format("data file is mark deleted, key={} delmark={}", data_file_key, delmark_key));

--- a/dbms/src/Flash/Disaggregated/S3LockService.h
+++ b/dbms/src/Flash/Disaggregated/S3LockService.h
@@ -100,8 +100,6 @@ private:
 
     DataFileMutexPtr getDataFileLatch(const String & data_file_key);
 
-    static std::optional<String> anyLockExist(const String & lock_prefix);
-
 private:
     std::unordered_map<String, DataFileMutexPtr> file_latch_map;
     std::mutex file_latch_map_mutex;

--- a/dbms/src/Flash/Disaggregated/tests/gtest_s3_lock_service.cpp
+++ b/dbms/src/Flash/Disaggregated/tests/gtest_s3_lock_service.cpp
@@ -132,7 +132,7 @@ try
 
     ASSERT_TRUE(status_code.ok()) << status_code.error_message();
     ASSERT_TRUE(response.result().has_success()) << response.ShortDebugString();
-    ASSERT_TRUE(DB::S3::objectExists(*s3_client, s3_client->bucket(), lock_key));
+    ASSERT_TRUE(DB::S3::objectExists(*s3_client, lock_key));
 
     DB::S3::deleteObject(*s3_client, lock_key);
 }
@@ -153,7 +153,7 @@ try
 
     ASSERT_TRUE(status_code.ok()) << status_code.error_message();
     ASSERT_TRUE(response.result().has_success()) << response.ShortDebugString();
-    ASSERT_TRUE(DB::S3::objectExists(*s3_client, s3_client->bucket(), delmark_key));
+    ASSERT_TRUE(DB::S3::objectExists(*s3_client, delmark_key));
 
     DB::S3::deleteObject(*s3_client, delmark_key);
 }
@@ -175,7 +175,7 @@ try
         auto status_code = s3_lock_service->tryMarkDelete(&request, &response);
 
         ASSERT_TRUE(status_code.ok()) << status_code.error_message();
-        ASSERT_TRUE(DB::S3::objectExists(*s3_client, s3_client->bucket(), delmark_key));
+        ASSERT_TRUE(DB::S3::objectExists(*s3_client, delmark_key));
     }
 
     // Try add lock file, should fail
@@ -190,7 +190,7 @@ try
         ASSERT_TRUE(status_code.ok());
         ASSERT_TRUE(!response.result().has_success()) << response.ShortDebugString();
         ASSERT_TRUE(response.result().has_conflict()) << response.ShortDebugString();
-        ASSERT_TRUE(!DB::S3::objectExists(*s3_client, s3_client->bucket(), lock_key));
+        ASSERT_TRUE(!DB::S3::objectExists(*s3_client, lock_key));
     }
 
     DB::S3::deleteObject(*s3_client, delmark_key);
@@ -216,7 +216,7 @@ try
         auto status_code = s3_lock_service->tryAddLock(&request, &response);
 
         ASSERT_TRUE(status_code.ok());
-        ASSERT_TRUE(DB::S3::objectExists(*s3_client, s3_client->bucket(), lock_key));
+        ASSERT_TRUE(DB::S3::objectExists(*s3_client, lock_key));
     }
 
     // Try add delete mark, should fail
@@ -230,7 +230,7 @@ try
         ASSERT_TRUE(status_code.ok());
         ASSERT_TRUE(!response.result().has_success()) << response.ShortDebugString();
         ASSERT_TRUE(response.result().has_conflict()) << response.ShortDebugString();
-        ASSERT_TRUE(!DB::S3::objectExists(*s3_client, s3_client->bucket(), delmark_key));
+        ASSERT_TRUE(!DB::S3::objectExists(*s3_client, delmark_key));
     }
 
     DB::S3::deleteObject(*s3_client, lock_key);
@@ -257,7 +257,7 @@ try
         ASSERT_TRUE(status_code.ok());
         ASSERT_TRUE(!response.result().has_success()) << response.ShortDebugString();
         ASSERT_TRUE(response.result().has_conflict()) << response.ShortDebugString();
-        ASSERT_TRUE(!DB::S3::objectExists(*s3_client, s3_client->bucket(), lock_key));
+        ASSERT_TRUE(!DB::S3::objectExists(*s3_client, lock_key));
     }
 }
 CATCH
@@ -282,7 +282,7 @@ try
 
             ASSERT_TRUE(status_code.ok());
             ASSERT_TRUE(response.result().has_success()) << response.ShortDebugString();
-            ASSERT_TRUE(DB::S3::objectExists(*s3_client, s3_client->bucket(), lock_key));
+            ASSERT_TRUE(DB::S3::objectExists(*s3_client, lock_key));
 
             DB::S3::deleteObject(*s3_client, lock_key);
         }
@@ -316,7 +316,7 @@ try
         auto status_code = s3_lock_service->tryMarkDelete(&request, &response);
 
         ASSERT_TRUE(status_code.ok());
-        ASSERT_TRUE(DB::S3::objectExists(*s3_client, s3_client->bucket(), delmark_key));
+        ASSERT_TRUE(DB::S3::objectExists(*s3_client, delmark_key));
     };
 
     std::vector<std::thread> threads;

--- a/dbms/src/Flash/Disaggregated/tests/gtest_s3_lock_service.cpp
+++ b/dbms/src/Flash/Disaggregated/tests/gtest_s3_lock_service.cpp
@@ -55,7 +55,7 @@ public:
 
         s3_client = client_factory.sharedTiFlashClient();
         s3_lock_service = std::make_unique<DB::S3::S3LockService>(owner_manager);
-        ::DB::tests::TiFlashTestEnv::createBucketIfNotExist(*s3_client, s3_client->bucket());
+        ::DB::tests::TiFlashTestEnv::createBucketIfNotExist(*s3_client);
         createS3DataFiles();
     }
     CATCH
@@ -66,7 +66,7 @@ public:
         for (size_t i = 1; i <= 5; ++i)
         {
             auto data_filename = S3Filename::fromDMFileOID(DMFileOID{.store_id = store_id, .table_id = physical_table_id, .file_id = dm_file_id});
-            DB::S3::uploadEmptyFile(*s3_client, s3_client->bucket(), fmt::format("{}/{}", data_filename.toFullKey(), DM::DMFile::metav2FileName()));
+            DB::S3::uploadEmptyFile(*s3_client, fmt::format("{}/{}", data_filename.toFullKey(), DM::DMFile::metav2FileName()));
             ++dm_file_id;
         }
     }
@@ -78,7 +78,7 @@ public:
         {
             --dm_file_id;
             auto data_filename = S3Filename::fromDMFileOID(DMFileOID{.store_id = store_id, .table_id = physical_table_id, .file_id = dm_file_id});
-            DB::S3::deleteObject(*s3_client, s3_client->bucket(), data_filename.toFullKey());
+            DB::S3::deleteObject(*s3_client, data_filename.toFullKey());
         }
     }
 
@@ -134,7 +134,7 @@ try
     ASSERT_TRUE(response.result().has_success()) << response.ShortDebugString();
     ASSERT_TRUE(DB::S3::objectExists(*s3_client, s3_client->bucket(), lock_key));
 
-    DB::S3::deleteObject(*s3_client, s3_client->bucket(), lock_key);
+    DB::S3::deleteObject(*s3_client, lock_key);
 }
 CATCH
 
@@ -155,7 +155,7 @@ try
     ASSERT_TRUE(response.result().has_success()) << response.ShortDebugString();
     ASSERT_TRUE(DB::S3::objectExists(*s3_client, s3_client->bucket(), delmark_key));
 
-    DB::S3::deleteObject(*s3_client, s3_client->bucket(), delmark_key);
+    DB::S3::deleteObject(*s3_client, delmark_key);
 }
 CATCH
 
@@ -193,7 +193,7 @@ try
         ASSERT_TRUE(!DB::S3::objectExists(*s3_client, s3_client->bucket(), lock_key));
     }
 
-    DB::S3::deleteObject(*s3_client, s3_client->bucket(), delmark_key);
+    DB::S3::deleteObject(*s3_client, delmark_key);
 }
 CATCH
 
@@ -233,7 +233,7 @@ try
         ASSERT_TRUE(!DB::S3::objectExists(*s3_client, s3_client->bucket(), delmark_key));
     }
 
-    DB::S3::deleteObject(*s3_client, s3_client->bucket(), lock_key);
+    DB::S3::deleteObject(*s3_client, lock_key);
 }
 CATCH
 
@@ -284,7 +284,7 @@ try
             ASSERT_TRUE(response.result().has_success()) << response.ShortDebugString();
             ASSERT_TRUE(DB::S3::objectExists(*s3_client, s3_client->bucket(), lock_key));
 
-            DB::S3::deleteObject(*s3_client, s3_client->bucket(), lock_key);
+            DB::S3::deleteObject(*s3_client, lock_key);
         }
     };
 
@@ -331,7 +331,7 @@ try
         thread.join();
     }
 
-    DB::S3::deleteObject(*s3_client, s3_client->bucket(), delmark_key);
+    DB::S3::deleteObject(*s3_client, delmark_key);
 }
 CATCH
 
@@ -390,13 +390,13 @@ try
         auto delmark_key = data_filename.toView().getDelMarkKey();
 
         // Either lock or delete file should exist
-        if (DB::S3::objectExists(*s3_client, s3_client->bucket(), delmark_key))
+        if (DB::S3::objectExists(*s3_client, delmark_key))
         {
-            DB::S3::deleteObject(*s3_client, s3_client->bucket(), delmark_key);
+            DB::S3::deleteObject(*s3_client, delmark_key);
         }
-        else if (DB::S3::objectExists(*s3_client, s3_client->bucket(), lock_key))
+        else if (DB::S3::objectExists(*s3_client, lock_key))
         {
-            DB::S3::deleteObject(*s3_client, s3_client->bucket(), lock_key);
+            DB::S3::deleteObject(*s3_client, lock_key);
         }
         else
         {

--- a/dbms/src/Storages/DeltaMerge/File/DMFile.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFile.cpp
@@ -28,6 +28,7 @@
 #include <Storages/Page/PageUtil.h>
 #include <Storages/S3/S3Common.h>
 #include <Storages/S3/S3Filename.h>
+#include <aws/s3/model/CommonPrefix.h>
 #include <boost_wrapper/string_split.h>
 #include <common/logger_useful.h>
 #include <fmt/format.h>
@@ -649,20 +650,15 @@ std::vector<String> DMFile::listS3(const String & parent_path)
     std::vector<String> filenames;
     auto client = S3::ClientFactory::instance().sharedTiFlashClient();
     auto list_prefix = parent_path + "/";
-    S3::listPrefix(
+    S3::listPrefixWithDelimiter(
         *client,
         list_prefix,
         /*delimiter*/ "/",
-        [&filenames, &list_prefix](const Aws::S3::Model::ListObjectsV2Result & result, const String & root) {
-            const Aws::Vector<Aws::S3::Model::CommonPrefix> & prefixes = result.GetCommonPrefixes();
-            filenames.reserve(filenames.size() + prefixes.size());
-            for (const auto & prefix : prefixes)
-            {
-                RUNTIME_CHECK(prefix.GetPrefix().size() > root.size() + list_prefix.size(), prefix.GetPrefix(), root.size(), list_prefix);
-                auto short_name_size = prefix.GetPrefix().size() - root.size() - list_prefix.size() - 1; // `1` for the delimiter in last.
-                filenames.push_back(prefix.GetPrefix().substr(root.size() + list_prefix.size(), short_name_size)); // Cut prefix and last delimiter.
-            }
-            return S3::PageResult{.num_keys = prefixes.size(), .more = true};
+        [&filenames, &list_prefix](const Aws::S3::Model::CommonPrefix & prefix) {
+            RUNTIME_CHECK(prefix.GetPrefix().size() > list_prefix.size(), prefix.GetPrefix(), list_prefix);
+            auto short_name_size = prefix.GetPrefix().size() - list_prefix.size() - 1; // `1` for the delimiter in last.
+            filenames.push_back(prefix.GetPrefix().substr(list_prefix.size(), short_name_size)); // Cut prefix and last delimiter.
+            return S3::PageResult{.num_keys = 1, .more = true};
         });
     return filenames;
 }

--- a/dbms/src/Storages/DeltaMerge/Remote/DataStore/DataStoreS3.cpp
+++ b/dbms/src/Storages/DeltaMerge/Remote/DataStore/DataStoreS3.cpp
@@ -36,8 +36,7 @@ void DataStoreS3::putDMFile(DMFilePtr local_dmfile, const S3::DMFileOID & oid, b
     const auto remote_dir = S3::S3Filename::fromDMFileOID(oid).toFullKey();
     LOG_DEBUG(log, "Start upload DMFile, local_dir={} remote_dir={} local_files={}", local_dir, remote_dir, local_files);
 
-    auto s3_client = S3::ClientFactory::instance().sharedClient();
-    const auto & bucket = S3::ClientFactory::instance().bucket();
+    auto s3_client = S3::ClientFactory::instance().sharedTiFlashClient();
 
     std::vector<std::future<void>> upload_results;
     for (const auto & fname : local_files)
@@ -51,7 +50,7 @@ void DataStoreS3::putDMFile(DMFilePtr local_dmfile, const S3::DMFileOID & oid, b
         auto remote_fname = fmt::format("{}/{}", remote_dir, fname);
         auto task = std::make_shared<std::packaged_task<void()>>(
             [&, local_fname = std::move(local_fname), remote_fname = std::move(remote_fname)]() {
-                S3::uploadFile(*s3_client, bucket, local_fname, remote_fname);
+                S3::uploadFile(*s3_client, local_fname, remote_fname);
             });
         upload_results.push_back(task->get_future());
         IOThreadPool::get().scheduleOrThrowOnError([task]() { (*task)(); });
@@ -64,7 +63,7 @@ void DataStoreS3::putDMFile(DMFilePtr local_dmfile, const S3::DMFileOID & oid, b
     // Only when the meta upload is successful, the dmfile upload can be considered successful.
     auto local_meta_fname = fmt::format("{}/{}", local_dir, DMFile::metav2FileName());
     auto remote_meta_fname = fmt::format("{}/{}", remote_dir, DMFile::metav2FileName());
-    S3::uploadFile(*s3_client, bucket, local_meta_fname, remote_meta_fname);
+    S3::uploadFile(*s3_client, local_meta_fname, remote_meta_fname);
 
     if (remove_local)
     {
@@ -75,8 +74,7 @@ void DataStoreS3::putDMFile(DMFilePtr local_dmfile, const S3::DMFileOID & oid, b
 
 bool DataStoreS3::putCheckpointFiles(const PS::V3::LocalCheckpointFiles & local_files, StoreID store_id, UInt64 upload_seq)
 {
-    auto s3_client = S3::ClientFactory::instance().sharedClient();
-    const auto & bucket = S3::ClientFactory::instance().bucket();
+    auto s3_client = S3::ClientFactory::instance().sharedTiFlashClient();
 
     /// First upload all CheckpointData files and their locks,
     /// then upload the CheckpointManifest to make the files within
@@ -90,8 +88,8 @@ bool DataStoreS3::putCheckpointFiles(const PS::V3::LocalCheckpointFiles & local_
             const auto & local_datafile = local_files.data_files[idx];
             auto s3key = S3::S3Filename::newCheckpointData(store_id, upload_seq, idx);
             auto lock_key = s3key.toView().getLockKey(store_id, upload_seq);
-            S3::uploadFile(*s3_client, bucket, local_datafile, s3key.toFullKey());
-            S3::uploadEmptyFile(*s3_client, bucket, lock_key);
+            S3::uploadFile(*s3_client, local_datafile, s3key.toFullKey());
+            S3::uploadEmptyFile(*s3_client, lock_key);
         });
         upload_results.push_back(task->get_future());
         IOThreadPool::get().scheduleOrThrowOnError([task] { (*task)(); });
@@ -103,15 +101,14 @@ bool DataStoreS3::putCheckpointFiles(const PS::V3::LocalCheckpointFiles & local_
 
     // upload manifest after all CheckpointData uploaded
     auto s3key = S3::S3Filename::newCheckpointManifest(store_id, upload_seq);
-    S3::uploadFile(*s3_client, bucket, local_files.manifest_file, s3key.toFullKey());
+    S3::uploadFile(*s3_client, local_files.manifest_file, s3key.toFullKey());
 
     return true; // upload success
 }
 
 void DataStoreS3::copyToLocal(const S3::DMFileOID & remote_oid, const std::vector<String> & target_short_fnames, const String & local_dir)
 {
-    auto s3_client = S3::ClientFactory::instance().sharedClient();
-    const auto & bucket = S3::ClientFactory::instance().bucket();
+    auto s3_client = S3::ClientFactory::instance().sharedTiFlashClient();
     const auto remote_dir = S3::S3Filename::fromDMFileOID(remote_oid).toFullKey();
     std::vector<std::future<void>> results;
     for (const auto & fname : target_short_fnames)
@@ -121,7 +118,7 @@ void DataStoreS3::copyToLocal(const S3::DMFileOID & remote_oid, const std::vecto
         auto task = std::make_shared<std::packaged_task<void()>>(
             [&, local_fname = std::move(local_fname), remote_fname = std::move(remote_fname)]() {
                 auto tmp_fname = fmt::format("{}.tmp", local_fname);
-                S3::downloadFile(*s3_client, bucket, tmp_fname, remote_fname);
+                S3::downloadFile(*s3_client, tmp_fname, remote_fname);
                 Poco::File(tmp_fname).renameTo(local_fname);
             });
         results.push_back(task->get_future());

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_fast_add_peer.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_fast_add_peer.cpp
@@ -36,6 +36,7 @@
 #include <aws/s3/model/CreateBucketRequest.h>
 
 #include "DataStreams/OneBlockInputStream.h"
+#include "TestUtils/TiFlashTestEnv.h"
 
 
 namespace DB
@@ -60,7 +61,8 @@ public:
     void SetUp() override
     {
         FailPointHelper::enableFailPoint(FailPoints::force_use_dmfile_format_v3);
-        ASSERT_TRUE(createBucketIfNotExist());
+        auto s3_client = S3::ClientFactory::instance().sharedTiFlashClient();
+        ASSERT_TRUE(::DB::tests::TiFlashTestEnv::createBucketIfNotExist(*s3_client));
         TiFlashStorageTestBasic::SetUp();
         auto & global_context = TiFlashTestEnv::getGlobalContext();
         if (global_context.getSharedContextDisagg()->remote_data_store == nullptr)
@@ -161,29 +163,6 @@ protected:
         auto handle_range = RowKeyRange::fromHandleRange(range);
         auto external_file = ExternalDTFileInfo{.id = file_id, .range = handle_range};
         return {handle_range, {external_file}}; // There are some duplicated info. This is to minimize the change to our test code.
-    }
-
-    bool createBucketIfNotExist()
-    {
-        auto s3_client = S3::ClientFactory::instance().sharedClient();
-        auto bucket = S3::ClientFactory::instance().bucket();
-        Aws::S3::Model::CreateBucketRequest request;
-        request.SetBucket(bucket);
-        auto outcome = s3_client->CreateBucket(request);
-        if (outcome.IsSuccess())
-        {
-            LOG_DEBUG(Logger::get(), "Created bucket {}", bucket);
-        }
-        else if (outcome.GetError().GetExceptionName() == "BucketAlreadyOwnedByYou")
-        {
-            LOG_DEBUG(Logger::get(), "Bucket {} already exist", bucket);
-        }
-        else
-        {
-            const auto & err = outcome.GetError();
-            LOG_ERROR(Logger::get(), "CreateBucket: {}:{}", err.GetExceptionName(), err.GetMessage());
-        }
-        return outcome.IsSuccess() || outcome.GetError().GetExceptionName() == "BucketAlreadyOwnedByYou";
     }
 
     void dumpCheckpoint()

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_fast_add_peer.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_fast_add_peer.cpp
@@ -15,6 +15,7 @@
 #include <Common/Exception.h>
 #include <Common/FailPoint.h>
 #include <DataStreams/BlocksListBlockInputStream.h>
+#include <DataStreams/OneBlockInputStream.h>
 #include <Flash/Disaggregated/MockS3LockClient.h>
 #include <Interpreters/SharedContexts/Disagg.h>
 #include <Storages/DeltaMerge/DMContext.h>
@@ -33,10 +34,8 @@
 #include <Storages/Transaction/TMTContext.h>
 #include <TestUtils/InputStreamTestUtils.h>
 #include <TestUtils/TiFlashTestBasic.h>
+#include <TestUtils/TiFlashTestEnv.h>
 #include <aws/s3/model/CreateBucketRequest.h>
-
-#include "DataStreams/OneBlockInputStream.h"
-#include "TestUtils/TiFlashTestEnv.h"
 
 
 namespace DB

--- a/dbms/src/Storages/Page/V3/CheckpointFile/Proto/common.proto
+++ b/dbms/src/Storages/Page/V3/CheckpointFile/Proto/common.proto
@@ -27,4 +27,5 @@ message WriterInfo {
 message RemoteInfo {
     string type_name = 1; // e.g. "S3" / "LocalFS"
     string name = 2; // Remote-type specific name for description purpose.
+    string root = 3; // Identifier for the cluster. It is the `storage.s3.root` when using S3
 }

--- a/dbms/src/Storages/Page/V3/Universal/S3LockLocalManager.cpp
+++ b/dbms/src/Storages/Page/V3/Universal/S3LockLocalManager.cpp
@@ -53,7 +53,7 @@ void S3LockLocalManager::initStoreInfo(StoreID actual_store_id, DB::S3::S3LockCl
 
         // we need to restore the last_upload_sequence from S3
         auto s3_client = S3::ClientFactory::instance().sharedTiFlashClient();
-        const auto manifests = S3::CheckpointManifestS3Set::getFromS3(*s3_client, s3_client->bucket(), actual_store_id);
+        const auto manifests = S3::CheckpointManifestS3Set::getFromS3(*s3_client, actual_store_id);
         if (!manifests.empty())
         {
             last_upload_sequence = manifests.latestUploadSequence();
@@ -171,7 +171,7 @@ String S3LockLocalManager::createS3Lock(const String & datafile_key, const S3::S
         // directly create lock through S3 client
         // TODO: handle s3 network error and retry?
         auto s3_client = S3::ClientFactory::instance().sharedTiFlashClient();
-        S3::uploadEmptyFile(*s3_client, s3_client->bucket(), lockkey);
+        S3::uploadEmptyFile(*s3_client, lockkey);
         LOG_DEBUG(log, "S3 lock created for local datafile, lockkey={}", lockkey);
     }
     else

--- a/dbms/src/Storages/Page/V3/Universal/S3PageReader.cpp
+++ b/dbms/src/Storages/Page/V3/Universal/S3PageReader.cpp
@@ -34,13 +34,13 @@ Page S3PageReader::read(const UniversalPageIdAndEntry & page_id_and_entry)
     if (remote_name_view.isLockFile())
     {
 #endif
-        remote_file = std::make_shared<S3::S3RandomAccessFile>(s3_client, s3_client->bucket(), remote_name_view.asDataFile().toFullKey());
+        remote_file = std::make_shared<S3::S3RandomAccessFile>(s3_client, remote_name_view.asDataFile().toFullKey());
 #ifdef DBMS_PUBLIC_GTEST
     }
     else
     {
         // Just used in unit test which want to just focus on read write logic
-        remote_file = std::make_shared<S3::S3RandomAccessFile>(s3_client, s3_client->bucket(), *location.data_file_id);
+        remote_file = std::make_shared<S3::S3RandomAccessFile>(s3_client, *location.data_file_id);
     }
 #endif
     ReadBufferFromRandomAccessFile buf(remote_file);

--- a/dbms/src/Storages/Page/V3/Universal/UniversalPageStorageService.cpp
+++ b/dbms/src/Storages/Page/V3/Universal/UniversalPageStorageService.cpp
@@ -126,7 +126,10 @@ bool UniversalPageStorageService::uploadCheckpoint()
     return uploadCheckpointImpl(store_info, s3lock_client, remote_store);
 }
 
-bool UniversalPageStorageService::uploadCheckpointImpl(const metapb::Store & store_info, const S3::S3LockClientPtr & s3lock_client, const DM::Remote::IDataStorePtr & remote_store)
+bool UniversalPageStorageService::uploadCheckpointImpl(
+    const metapb::Store & store_info,
+    const S3::S3LockClientPtr & s3lock_client,
+    const DM::Remote::IDataStorePtr & remote_store)
 {
     uni_page_storage->initLocksLocalManager(store_info.id(), s3lock_client);
     const auto upload_info = uni_page_storage->allocateNewUploadLocksInfo();
@@ -140,7 +143,10 @@ bool UniversalPageStorageService::uploadCheckpointImpl(const metapb::Store & sto
         auto * ri = wi.mutable_remote_info();
         ri->set_type_name("S3");
         // ri->set_name(); this field is not used currently
+        auto client = S3::ClientFactory::instance().sharedTiFlashClient();
+        ri->set_root(client->root());
     }
+   
 
     auto local_dir = Poco::Path(global_context.getTemporaryPath() + fmt::format("/checkpoint_upload_{}", upload_info.upload_sequence)).absolute();
     Poco::File(local_dir).createDirectories();

--- a/dbms/src/Storages/Page/V3/Universal/UniversalPageStorageService.cpp
+++ b/dbms/src/Storages/Page/V3/Universal/UniversalPageStorageService.cpp
@@ -146,7 +146,7 @@ bool UniversalPageStorageService::uploadCheckpointImpl(
         auto client = S3::ClientFactory::instance().sharedTiFlashClient();
         ri->set_root(client->root());
     }
-   
+
 
     auto local_dir = Poco::Path(global_context.getTemporaryPath() + fmt::format("/checkpoint_upload_{}", upload_info.upload_sequence)).absolute();
     Poco::File(local_dir).createDirectories();

--- a/dbms/src/Storages/Page/V3/Universal/tests/gtest_lock_local_mgr.cpp
+++ b/dbms/src/Storages/Page/V3/Universal/tests/gtest_lock_local_mgr.cpp
@@ -39,24 +39,22 @@ class S3LockLocalManagerTest : public testing::Test
 {
 public:
     S3LockLocalManagerTest()
-        : s3_client(S3::ClientFactory::instance().sharedClient())
-        , bucket(S3::ClientFactory::instance().bucket())
+        : s3_client(S3::ClientFactory::instance().sharedTiFlashClient())
         , log(Logger::get())
     {}
 
     void SetUp() override
     {
-        ::DB::tests::TiFlashTestEnv::createBucketIfNotExist(*s3_client, bucket);
+        ::DB::tests::TiFlashTestEnv::createBucketIfNotExist(*s3_client);
     }
 
     void TearDown() override
     {
-        ::DB::tests::TiFlashTestEnv::deleteBucket(*s3_client, bucket);
+        ::DB::tests::TiFlashTestEnv::deleteBucket(*s3_client);
     }
 
 protected:
-    std::shared_ptr<Aws::S3::S3Client> s3_client;
-    String bucket;
+    std::shared_ptr<S3::TiFlashS3Client> s3_client;
     LoggerPtr log;
 };
 
@@ -65,7 +63,7 @@ try
 {
     StoreID this_store_id = 100;
     PS::V3::S3LockLocalManager mgr;
-    auto mock_s3lock_client = std::make_shared<S3::MockS3LockClient>(s3_client, bucket);
+    auto mock_s3lock_client = std::make_shared<S3::MockS3LockClient>(s3_client);
     mgr.initStoreInfo(this_store_id, mock_s3lock_client);
 
     auto info = mgr.allocateNewUploadLocksInfo();
@@ -81,7 +79,7 @@ try
     auto s3name_dtfile = S3::S3Filename::fromDMFileOID(S3::DMFileOID{.store_id = old_store_id, .table_id = 10, .file_id = 5});
     auto s3name_datafile = S3::S3Filename::newCheckpointData(old_store_id, old_store_seq, 1);
     {
-        S3::uploadEmptyFile(*s3_client, bucket, s3name_dtfile.toFullKey());
+        S3::uploadEmptyFile(*s3_client, s3name_dtfile.toFullKey());
         PS::V3::CheckpointLocation loc{
             .data_file_id = std::make_shared<String>(s3name_dtfile.toFullKey()),
             .offset_in_file = 0,
@@ -91,7 +89,7 @@ try
     }
     {
         auto key = std::make_shared<String>(s3name_datafile.toFullKey());
-        S3::uploadEmptyFile(*s3_client, bucket, *key);
+        S3::uploadEmptyFile(*s3_client, *key);
         PS::V3::CheckpointLocation loc2{
             .data_file_id = key,
             .offset_in_file = 0,
@@ -117,8 +115,8 @@ try
     ASSERT_GT(info.pre_lock_keys.count(expected_lockkey1), 0) << fmt::format("{}", lock_by_seq);
     const String expected_lockkey2 = s3name_dtfile.toView().getLockKey(this_store_id, info.upload_sequence);
     ASSERT_GT(info.pre_lock_keys.count(expected_lockkey2), 0) << fmt::format("{}", info.pre_lock_keys);
-    EXPECT_TRUE(S3::objectExists(*s3_client, bucket, expected_lockkey1));
-    EXPECT_TRUE(S3::objectExists(*s3_client, bucket, expected_lockkey2));
+    EXPECT_TRUE(S3::objectExists(*s3_client, expected_lockkey1));
+    EXPECT_TRUE(S3::objectExists(*s3_client, expected_lockkey2));
 
     // pre_lock_keys won't be cleaned after `allocateNewUploadLocksInfo`
     info = mgr.allocateNewUploadLocksInfo();
@@ -140,7 +138,7 @@ try
 {
     StoreID this_store_id = 100;
     PS::V3::S3LockLocalManager mgr;
-    auto mock_s3lock_client = std::make_shared<S3::MockS3LockClient>(s3_client, bucket);
+    auto mock_s3lock_client = std::make_shared<S3::MockS3LockClient>(s3_client);
     mgr.initStoreInfo(this_store_id, mock_s3lock_client);
 
     // Mock FAP ingest following pages from another store
@@ -152,7 +150,7 @@ try
     auto s3name_dtfile = S3::S3Filename::fromDMFileOID(S3::DMFileOID{.store_id = old_store_id, .table_id = 10, .file_id = 5});
     auto s3name_datafile = S3::S3Filename::newCheckpointData(old_store_id, old_store_seq, 1);
     {
-        S3::uploadEmptyFile(*s3_client, bucket, s3name_dtfile.toFullKey());
+        S3::uploadEmptyFile(*s3_client, s3name_dtfile.toFullKey());
         PS::V3::CheckpointLocation loc{
             .data_file_id = std::make_shared<String>(s3name_dtfile.toFullKey()),
             .offset_in_file = 0,
@@ -162,7 +160,7 @@ try
     }
     {
         auto key = std::make_shared<String>(s3name_datafile.toFullKey());
-        S3::uploadEmptyFile(*s3_client, bucket, *key);
+        S3::uploadEmptyFile(*s3_client, *key);
         PS::V3::CheckpointLocation loc2{
             .data_file_id = key,
             .offset_in_file = 0,

--- a/dbms/src/Storages/Page/V3/Universal/tests/gtest_remote_read.cpp
+++ b/dbms/src/Storages/Page/V3/Universal/tests/gtest_remote_read.cpp
@@ -56,10 +56,9 @@ public:
         createIfNotExist(path);
         file_provider = DB::tests::TiFlashTestEnv::getDefaultFileProvider();
         delegator = std::make_shared<DB::tests::MockDiskDelegatorSingle>(path);
-        s3_client = S3::ClientFactory::instance().sharedClient();
-        bucket = S3::ClientFactory::instance().bucket();
+        s3_client = S3::ClientFactory::instance().sharedTiFlashClient();
 
-        ASSERT_TRUE(::DB::tests::TiFlashTestEnv::createBucketIfNotExist(*s3_client, bucket));
+        ASSERT_TRUE(::DB::tests::TiFlashTestEnv::createBucketIfNotExist(*s3_client));
 
         page_storage = UniversalPageStorage::create("write", delegator, config, file_provider);
         page_storage->restore();
@@ -76,7 +75,7 @@ public:
         delegator = std::make_shared<DB::tests::MockDiskDelegatorSingle>(path);
         auto storage = UniversalPageStorage::create("test.t", delegator, config_, file_provider);
         storage->restore();
-        auto mock_s3lock_client = std::make_shared<S3::MockS3LockClient>(s3_client, bucket);
+        auto mock_s3lock_client = std::make_shared<S3::MockS3LockClient>(s3_client);
         storage->initLocksLocalManager(100, mock_s3lock_client);
         return storage;
     }
@@ -86,7 +85,7 @@ public:
         const String & full_path = dir + "/" + f_name;
         ReadBufferPtr src_buf = std::make_shared<ReadBufferFromFile>(full_path);
         S3::WriteSettings write_setting;
-        WritableFilePtr dst_file = std::make_shared<S3::S3WritableFile>(s3_client, bucket, f_name, write_setting);
+        WritableFilePtr dst_file = std::make_shared<S3::S3WritableFile>(s3_client, f_name, write_setting);
         WriteBufferPtr dst_buf = std::make_shared<WriteBufferFromWritableFile>(dst_file);
         copyData(*src_buf, *dst_buf);
         dst_buf->next();
@@ -97,7 +96,7 @@ public:
 protected:
     void deleteBucket()
     {
-        ::DB::tests::TiFlashTestEnv::deleteBucket(*s3_client, bucket);
+        ::DB::tests::TiFlashTestEnv::deleteBucket(*s3_client);
     }
 
 protected:
@@ -105,8 +104,7 @@ protected:
     String remote_dir;
     FileProviderPtr file_provider;
     PSDiskDelegatorPtr delegator;
-    std::shared_ptr<Aws::S3::S3Client> s3_client;
-    String bucket;
+    std::shared_ptr<S3::TiFlashS3Client> s3_client;
     PageStorageConfig config;
     std::shared_ptr<UniversalPageStorage> page_storage;
 
@@ -321,7 +319,7 @@ try
     }
 
     // create an empty bucket because reload will try to read from S3
-    ASSERT_TRUE(::DB::tests::TiFlashTestEnv::createBucketIfNotExist(*s3_client, bucket));
+    ASSERT_TRUE(::DB::tests::TiFlashTestEnv::createBucketIfNotExist(*s3_client));
     reload();
 
     {

--- a/dbms/src/Storages/S3/CheckpointManifestS3Set.cpp
+++ b/dbms/src/Storages/S3/CheckpointManifestS3Set.cpp
@@ -27,18 +27,12 @@ CheckpointManifestS3Set::getFromS3(const S3::TiFlashS3Client & client, StoreID s
 
     std::vector<CheckpointManifestS3Object> manifests;
 
-    listPrefix(client, manifest_prefix, [&](const Aws::S3::Model::ListObjectsV2Result & result, const String & root) {
-        UNUSED(root);
-        const auto & objects = result.GetContents();
-        manifests.reserve(manifests.size() + objects.size());
-        for (const auto & object : objects)
-        {
-            const auto & mf_key = object.GetKey();
-            // also store the object.GetLastModified() for removing
-            // outdated manifest objects
-            manifests.emplace_back(CheckpointManifestS3Object{mf_key, object.GetLastModified()});
-        }
-        return DB::S3::PageResult{.num_keys = objects.size(), .more = true};
+    S3::listPrefix(client, manifest_prefix, [&](const Aws::S3::Model::Object & object) {
+        const auto & mf_key = object.GetKey();
+        // also store the object.GetLastModified() for removing
+        // outdated manifest objects
+        manifests.emplace_back(CheckpointManifestS3Object{mf_key, object.GetLastModified()});
+        return DB::S3::PageResult{.num_keys = 1, .more = true};
     });
     return CheckpointManifestS3Set::create(manifests);
 }

--- a/dbms/src/Storages/S3/CheckpointManifestS3Set.cpp
+++ b/dbms/src/Storages/S3/CheckpointManifestS3Set.cpp
@@ -23,17 +23,12 @@ namespace DB::S3
 CheckpointManifestS3Set
 CheckpointManifestS3Set::getFromS3(const S3::TiFlashS3Client & client, StoreID store_id)
 {
-    return CheckpointManifestS3Set::getFromS3(client, client.bucket(), store_id);
-}
-
-CheckpointManifestS3Set
-CheckpointManifestS3Set::getFromS3(const Aws::S3::S3Client & client, const String & bucket, StoreID store_id)
-{
     const auto manifest_prefix = S3::S3Filename::fromStoreId(store_id).toManifestPrefix();
 
     std::vector<CheckpointManifestS3Object> manifests;
 
-    listPrefix(client, bucket, manifest_prefix, [&](const Aws::S3::Model::ListObjectsV2Result & result) {
+    listPrefix(client, manifest_prefix, [&](const Aws::S3::Model::ListObjectsV2Result & result, const String & root) {
+        UNUSED(root);
         const auto & objects = result.GetContents();
         manifests.reserve(manifests.size() + objects.size());
         for (const auto & object : objects)

--- a/dbms/src/Storages/S3/CheckpointManifestS3Set.h
+++ b/dbms/src/Storages/S3/CheckpointManifestS3Set.h
@@ -38,8 +38,6 @@ class CheckpointManifestS3Set
 public:
     static CheckpointManifestS3Set getFromS3(const S3::TiFlashS3Client & client, StoreID store_id);
 
-    static CheckpointManifestS3Set getFromS3(const Aws::S3::S3Client & client, const String & bucket, StoreID store_id);
-
     static CheckpointManifestS3Set create(const std::vector<CheckpointManifestS3Object> & manifest_keys);
 
     ALWAYS_INLINE bool empty() const { return manifests.empty(); }

--- a/dbms/src/Storages/S3/FileCache.cpp
+++ b/dbms/src/Storages/S3/FileCache.cpp
@@ -380,7 +380,7 @@ void FileCache::downloadImpl(const String & s3_key, FileSegmentPtr & file_seg)
     Stopwatch sw;
     auto client = S3::ClientFactory::instance().sharedTiFlashClient();
     Aws::S3::Model::GetObjectRequest req;
-    client->setBucketAndKey(req, s3_key);
+    client->setBucketAndKeyWithRoot(req, s3_key);
     ProfileEvents::increment(ProfileEvents::S3GetObject);
     auto outcome = client->GetObject(req);
     if (!outcome.IsSuccess())

--- a/dbms/src/Storages/S3/FileCache.cpp
+++ b/dbms/src/Storages/S3/FileCache.cpp
@@ -378,10 +378,9 @@ bool FileCache::finalizeReservedSize(FileType reserve_for, UInt64 reserved_size,
 void FileCache::downloadImpl(const String & s3_key, FileSegmentPtr & file_seg)
 {
     Stopwatch sw;
-    auto client = S3::ClientFactory::instance().sharedClient();
-    const auto & bucket = S3::ClientFactory::instance().bucket();
+    auto client = S3::ClientFactory::instance().sharedTiFlashClient();
     Aws::S3::Model::GetObjectRequest req;
-    req.SetBucket(bucket);
+    req.SetBucket(client->bucket());
     req.SetKey(s3_key);
     ProfileEvents::increment(ProfileEvents::S3GetObject);
     auto outcome = client->GetObject(req);

--- a/dbms/src/Storages/S3/FileCache.cpp
+++ b/dbms/src/Storages/S3/FileCache.cpp
@@ -380,8 +380,7 @@ void FileCache::downloadImpl(const String & s3_key, FileSegmentPtr & file_seg)
     Stopwatch sw;
     auto client = S3::ClientFactory::instance().sharedTiFlashClient();
     Aws::S3::Model::GetObjectRequest req;
-    req.SetBucket(client->bucket());
-    req.SetKey(s3_key);
+    client->setBucketAndKey(req, s3_key);
     ProfileEvents::increment(ProfileEvents::S3GetObject);
     auto outcome = client->GetObject(req);
     if (!outcome.IsSuccess())

--- a/dbms/src/Storages/S3/MockS3Client.cpp
+++ b/dbms/src/Storages/S3/MockS3Client.cpp
@@ -24,6 +24,7 @@
 #include <aws/s3/S3Client.h>
 #include <aws/s3/S3Errors.h>
 #include <aws/s3/S3ServiceClientModel.h>
+#include <aws/s3/model/CommonPrefix.h>
 #include <aws/s3/model/CompleteMultipartUploadRequest.h>
 #include <aws/s3/model/CopyObjectRequest.h>
 #include <aws/s3/model/CreateBucketRequest.h>
@@ -54,6 +55,13 @@ namespace DB::S3::tests
 {
 using namespace Aws::S3;
 
+String MockS3Client::normalizedKey(String ori_key)
+{
+    if (ori_key.starts_with('/'))
+        return ori_key.substr(1, ori_key.size());
+    return ori_key;
+}
+
 Model::GetObjectOutcome MockS3Client::GetObject(const Model::GetObjectRequest & request) const
 {
     std::lock_guard lock(mtx);
@@ -63,7 +71,7 @@ Model::GetObjectOutcome MockS3Client::GetObject(const Model::GetObjectRequest & 
         return Aws::S3::S3ErrorMapper::GetErrorForName("NoSuchBucket");
     }
     const auto & bucket_storage = itr->second;
-    auto itr_obj = bucket_storage.find(request.GetKey());
+    auto itr_obj = bucket_storage.find(normalizedKey(request.GetKey()));
     if (itr_obj == bucket_storage.end())
     {
         return Aws::S3::S3ErrorMapper::GetErrorForName("NoSuchKey");
@@ -84,7 +92,7 @@ Model::PutObjectOutcome MockS3Client::PutObject(const Model::PutObjectRequest & 
         return Aws::S3::S3ErrorMapper::GetErrorForName("NoSuchBucket");
     }
     auto & bucket_storage = itr->second;
-    bucket_storage[request.GetKey()] = String{std::istreambuf_iterator<char>(*request.GetBody()), {}};
+    bucket_storage[normalizedKey(request.GetKey())] = String{std::istreambuf_iterator<char>(*request.GetBody()), {}};
     return Model::PutObjectResult{};
 }
 
@@ -111,8 +119,8 @@ Model::CopyObjectOutcome MockS3Client::CopyObject(const Model::CopyObjectRequest
     auto src_bucket_storage = src_itr->second;
     auto dst_bucket_storage = dst_itr->second;
     RUNTIME_CHECK(src_bucket_storage.contains(src_key), src_bucket, src_key);
-    dst_bucket_storage[request.GetKey()] = src_bucket_storage[src_key];
-    storage_tagging[request.GetBucket()][request.GetKey()] = request.GetTagging();
+    dst_bucket_storage[normalizedKey(request.GetKey())] = src_bucket_storage[src_key];
+    storage_tagging[request.GetBucket()][normalizedKey(request.GetKey())] = request.GetTagging();
     return Model::CopyObjectResult{};
 }
 
@@ -124,7 +132,7 @@ Model::GetObjectTaggingOutcome MockS3Client::GetObjectTagging(const Model::GetOb
     {
         return Aws::S3::S3ErrorMapper::GetErrorForName("NoSuckBucket");
     }
-    auto taggings = storage_tagging[request.GetBucket()][request.GetKey()];
+    auto taggings = storage_tagging[request.GetBucket()][normalizedKey(request.GetKey())];
     auto pos = taggings.find('=');
     RUNTIME_CHECK(pos != String::npos, pos, taggings.size());
     Aws::S3::Model::Tag tag;
@@ -144,7 +152,7 @@ Model::DeleteObjectOutcome MockS3Client::DeleteObject(const Model::DeleteObjectR
         return Aws::S3::S3ErrorMapper::GetErrorForName("NoSuchBucket");
     }
     auto & bucket_storage = itr->second;
-    bucket_storage.erase(request.GetKey());
+    bucket_storage.erase(normalizedKey(request.GetKey()));
     return Model::DeleteObjectResult{};
 }
 
@@ -158,18 +166,43 @@ Model::ListObjectsV2Outcome MockS3Client::ListObjectsV2(const Model::ListObjects
     }
     const auto & bucket_storage = itr->second;
     Model::ListObjectsV2Result result;
-    for (auto itr_obj = bucket_storage.lower_bound(request.GetPrefix()); itr_obj != bucket_storage.end(); ++itr_obj)
+    RUNTIME_CHECK(!request.DelimiterHasBeenSet() || request.GetDelimiter() == "/", request.GetDelimiter());
+
+    auto normalized_prefix = normalizedKey(request.GetPrefix());
+    if (!request.DelimiterHasBeenSet())
     {
-        if (startsWith(itr_obj->first, request.GetPrefix()))
+        for (auto itr_obj = bucket_storage.lower_bound(normalized_prefix); itr_obj != bucket_storage.end(); ++itr_obj)
         {
-            Model::Object obj;
-            obj.SetKey(itr_obj->first);
-            obj.SetSize(itr_obj->second.size());
-            result.AddContents(std::move(obj));
+            if (startsWith(itr_obj->first, normalized_prefix))
+            {
+                Model::Object obj;
+                obj.SetKey(itr_obj->first);
+                obj.SetSize(itr_obj->second.size());
+                result.AddContents(std::move(obj));
+            }
+            else
+            {
+                break;
+            }
         }
-        else
+    }
+    else
+    {
+        std::set<String> common_prefix;
+        const auto & delimiter = request.GetDelimiter();
+        for (auto itr_obj = bucket_storage.lower_bound(normalized_prefix); itr_obj != bucket_storage.end(); ++itr_obj)
         {
-            break;
+            if (!startsWith(itr_obj->first, normalized_prefix))
+                break;
+            const auto & key = itr_obj->first;
+            auto pos = key.find(delimiter, normalized_prefix.size());
+            if (pos == String::npos)
+                continue;
+            common_prefix.insert(key.substr(0, pos + delimiter.size()));
+        }
+        for (const auto & p : common_prefix)
+        {
+            result.AddCommonPrefixes(Model::CommonPrefix().WithPrefix(p));
         }
     }
     return result;
@@ -184,7 +217,7 @@ Model::HeadObjectOutcome MockS3Client::HeadObject(const Model::HeadObjectRequest
         return Aws::S3::S3ErrorMapper::GetErrorForName("NoSuchBucket");
     }
     const auto & bucket_storage = itr->second;
-    auto itr_obj = bucket_storage.find(request.GetKey());
+    auto itr_obj = bucket_storage.find(normalizedKey(request.GetKey()));
     if (itr_obj != bucket_storage.end())
     {
         auto r = Model::HeadObjectResult{};
@@ -192,7 +225,7 @@ Model::HeadObjectOutcome MockS3Client::HeadObject(const Model::HeadObjectRequest
             if (auto v = FailPointHelper::getFailPointVal(FailPoints::force_set_mocked_s3_object_mtime); v)
             {
                 auto m = std::any_cast<std::map<String, Aws::Utils::DateTime>>(v.value());
-                if (auto iter_m = m.find(request.GetKey()); iter_m != m.end())
+                if (auto iter_m = m.find(normalizedKey(request.GetKey())); iter_m != m.end())
                 {
                     r.SetLastModified(iter_m->second);
                 }
@@ -237,7 +270,7 @@ Model::CompleteMultipartUploadOutcome MockS3Client::CompleteMultipartUpload(cons
         return Aws::S3::S3ErrorMapper::GetErrorForName("NoSuchBucket");
     }
     auto & bucket_storage = itr->second;
-    bucket_storage[request.GetKey()] = s;
+    bucket_storage[normalizedKey(request.GetKey())] = s;
     return Model::CompleteMultipartUploadResult{};
 }
 

--- a/dbms/src/Storages/S3/MockS3Client.cpp
+++ b/dbms/src/Storages/S3/MockS3Client.cpp
@@ -134,7 +134,7 @@ Model::GetObjectTaggingOutcome MockS3Client::GetObjectTagging(const Model::GetOb
     }
     auto taggings = storage_tagging[request.GetBucket()][normalizedKey(request.GetKey())];
     auto pos = taggings.find('=');
-    RUNTIME_CHECK(pos != String::npos, pos, taggings.size());
+    RUNTIME_CHECK(pos != String::npos, taggings, pos, taggings.size());
     Aws::S3::Model::Tag tag;
     tag.WithKey(taggings.substr(0, pos))
         .WithValue(taggings.substr(pos + 1, taggings.size()));

--- a/dbms/src/Storages/S3/MockS3Client.h
+++ b/dbms/src/Storages/S3/MockS3Client.h
@@ -25,8 +25,8 @@ using namespace Aws::S3;
 class MockS3Client final : public S3::TiFlashS3Client
 {
 public:
-    explicit MockS3Client(const String & bucket = "")
-        : TiFlashS3Client(bucket, "/")
+    explicit MockS3Client(const String & bucket, const String & root)
+        : TiFlashS3Client(bucket, root)
     {}
 
     ~MockS3Client() override = default;

--- a/dbms/src/Storages/S3/MockS3Client.h
+++ b/dbms/src/Storages/S3/MockS3Client.h
@@ -45,6 +45,8 @@ public:
     Model::GetObjectTaggingOutcome GetObjectTagging(const Model::GetObjectTaggingRequest & request) const override;
 
 private:
+    static String normalizedKey(String ori_key);
+
     // Object key -> Object data
     using BucketStorage = std::map<String, String>;
     // Object key -> Object tagging

--- a/dbms/src/Storages/S3/MockS3Client.h
+++ b/dbms/src/Storages/S3/MockS3Client.h
@@ -26,7 +26,7 @@ class MockS3Client final : public S3::TiFlashS3Client
 {
 public:
     explicit MockS3Client(const String & bucket = "")
-        : TiFlashS3Client(bucket)
+        : TiFlashS3Client(bucket, "/")
     {}
 
     ~MockS3Client() override = default;

--- a/dbms/src/Storages/S3/S3Common.h
+++ b/dbms/src/Storages/S3/S3Common.h
@@ -68,7 +68,7 @@ public:
     const String & root() const { return key_root; }
 
     template <typename Request>
-    void setBucketAndKey(Request & req, const String & key) const
+    void setBucketAndKeyWithRoot(Request & req, const String & key) const
     {
         req.WithBucket(bucket_name).WithKey(key_root + key);
     }

--- a/dbms/src/Storages/S3/S3Common.h
+++ b/dbms/src/Storages/S3/S3Common.h
@@ -47,10 +47,11 @@ public:
     // Usually one tiflash instance only need access one bucket.
     // Store the bucket name to simpilfy some param passing.
 
-    explicit TiFlashS3Client(const String & bucket_name_);
+    explicit TiFlashS3Client(const String & bucket_name_, const String & root_);
 
     TiFlashS3Client(
         const String & bucket_name_,
+        const String & root_,
         const Aws::Auth::AWSCredentials & credentials,
         const Aws::Client::ClientConfiguration & clientConfiguration,
         Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy signPayloads,
@@ -60,8 +61,11 @@ public:
 
     const String & bucket() const { return bucket_name; }
 
+    const String & root() const { return key_root; }
+
 private:
     const String bucket_name;
+    const String key_root;
 };
 
 enum class S3GCMethod
@@ -83,8 +87,7 @@ public:
 
     void shutdown();
 
-    const String & bucket() const;
-    std::shared_ptr<Aws::S3::S3Client> sharedClient() const;
+    const String & bucket() const { return config.bucket; }
 
     std::shared_ptr<TiFlashS3Client> sharedTiFlashClient() const;
 
@@ -112,28 +115,28 @@ struct ObjectInfo
 
 bool isNotFoundError(Aws::S3::S3Errors error);
 
-Aws::S3::Model::HeadObjectOutcome headObject(const Aws::S3::S3Client & client, const String & bucket, const String & key, const String & version_id = "");
+Aws::S3::Model::HeadObjectOutcome headObject(const TiFlashS3Client & client, const String & key, const String & version_id = "");
 
-S3::ObjectInfo getObjectInfo(const Aws::S3::S3Client & client, const String & bucket, const String & key, const String & version_id, bool throw_on_error);
+S3::ObjectInfo getObjectInfo(const TiFlashS3Client & client, const String & key, const String & version_id, bool throw_on_error);
 
-size_t getObjectSize(const Aws::S3::S3Client & client, const String & bucket, const String & key, const String & version_id, bool throw_on_error);
+size_t getObjectSize(const TiFlashS3Client & client, const String & key, const String & version_id, bool throw_on_error);
 
-bool objectExists(const Aws::S3::S3Client & client, const String & bucket, const String & key, const String & version_id = "");
+bool objectExists(const TiFlashS3Client & client, const String & key, const String & version_id = "");
 
-void uploadFile(const Aws::S3::S3Client & client, const String & bucket, const String & local_fname, const String & remote_fname);
+void uploadFile(const TiFlashS3Client & client, const String & local_fname, const String & remote_fname);
 
 constexpr std::string_view TaggingObjectIsDeleted = "tiflash_deleted=true";
-void ensureLifecycleRuleExist(const Aws::S3::S3Client & client, const String & bucket, Int32 expire_days);
+void ensureLifecycleRuleExist(const TiFlashS3Client & client, Int32 expire_days);
 
 /**
  * tagging is the tag-set for the object. The tag-set must be encoded as URL Query
  * parameters. (For example, "Key1=Value1")
  */
-void uploadEmptyFile(const Aws::S3::S3Client & client, const String & bucket, const String & key, const String & tagging = "");
+void uploadEmptyFile(const TiFlashS3Client & client, const String & key, const String & tagging = "");
 
-void downloadFile(const Aws::S3::S3Client & client, const String & bucket, const String & local_fname, const String & remote_fname);
+void downloadFile(const TiFlashS3Client & client, const String & local_fname, const String & remote_fname);
 
-void rewriteObjectWithTagging(const Aws::S3::S3Client & client, const String & bucket, const String & key, const String & tagging);
+void rewriteObjectWithTagging(const TiFlashS3Client & client, const String & key, const String & tagging);
 
 struct PageResult
 {
@@ -143,25 +146,22 @@ struct PageResult
     bool more;
 };
 void listPrefix(
-    const Aws::S3::S3Client & client,
-    const String & bucket,
+    const TiFlashS3Client & client,
     const String & prefix,
-    std::function<PageResult(const Aws::S3::Model::ListObjectsV2Result & result)> pager);
+    std::function<PageResult(const Aws::S3::Model::ListObjectsV2Result & result, const String & root)> pager);
 void listPrefix(
-    const Aws::S3::S3Client & client,
-    const String & bucket,
+    const TiFlashS3Client & client,
     const String & prefix,
     std::string_view delimiter,
-    std::function<PageResult(const Aws::S3::Model::ListObjectsV2Result & result)> pager);
+    std::function<PageResult(const Aws::S3::Model::ListObjectsV2Result & result, const String & root)> pager);
 
-std::unordered_map<String, size_t> listPrefixWithSize(const Aws::S3::S3Client & client, const String & bucket, const String & prefix);
+std::unordered_map<String, size_t> listPrefixWithSize(const TiFlashS3Client & client, const String & prefix);
 
 
 std::pair<bool, Aws::Utils::DateTime> tryGetObjectModifiedTime(
-    const Aws::S3::S3Client & client,
-    const String & bucket,
+    const TiFlashS3Client & client,
     const String & key);
 
-void deleteObject(const Aws::S3::S3Client & client, const String & bucket, const String & key);
+void deleteObject(const TiFlashS3Client & client, const String & key);
 
 } // namespace DB::S3

--- a/dbms/src/Storages/S3/S3Common.h
+++ b/dbms/src/Storages/S3/S3Common.h
@@ -121,9 +121,9 @@ private:
 
 bool isNotFoundError(Aws::S3::S3Errors error);
 
-Aws::S3::Model::HeadObjectOutcome headObject(const TiFlashS3Client & client, const String & key, const String & version_id = "");
+Aws::S3::Model::HeadObjectOutcome headObject(const TiFlashS3Client & client, const String & key);
 
-bool objectExists(const TiFlashS3Client & client, const String & key, const String & version_id = "");
+bool objectExists(const TiFlashS3Client & client, const String & key);
 
 void uploadFile(const TiFlashS3Client & client, const String & local_fname, const String & remote_fname);
 
@@ -167,5 +167,14 @@ std::pair<bool, Aws::Utils::DateTime> tryGetObjectModifiedTime(
     const String & key);
 
 void deleteObject(const TiFlashS3Client & client, const String & key);
+
+// Unlike `listPrefix` or other methods above, this does not handle
+// the TiFlashS3Client `root`.
+void rawListPrefix(
+    const Aws::S3::S3Client & client,
+    const String & bucket,
+    const String & prefix,
+    std::string_view delimiter,
+    std::function<PageResult(const Aws::S3::Model::ListObjectsV2Result & result)> pager);
 
 } // namespace DB::S3

--- a/dbms/src/Storages/S3/S3Common.h
+++ b/dbms/src/Storages/S3/S3Common.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <Common/Exception.h>
+#include <Common/Logger.h>
 #include <Common/nocopyable.h>
 #include <Server/StorageConfigParser.h>
 #include <aws/core/Aws.h>
@@ -24,8 +25,6 @@
 #include <common/types.h>
 
 #include <magic_enum.hpp>
-
-#include "Common/Logger.h"
 
 namespace DB::ErrorCodes
 {
@@ -151,12 +150,14 @@ struct PageResult
 void listPrefix(
     const TiFlashS3Client & client,
     const String & prefix,
-    std::function<PageResult(const Aws::S3::Model::ListObjectsV2Result & result, const String & root)> pager);
-void listPrefix(
+    std::function<PageResult(const Aws::S3::Model::Object & object)> pager);
+void listPrefixWithDelimiter(
     const TiFlashS3Client & client,
     const String & prefix,
     std::string_view delimiter,
-    std::function<PageResult(const Aws::S3::Model::ListObjectsV2Result & result, const String & root)> pager);
+    std::function<PageResult(const Aws::S3::Model::CommonPrefix & common_prefix)> pager);
+
+std::optional<String> anyKeyExistWithPrefix(const TiFlashS3Client & client, const String & prefix);
 
 std::unordered_map<String, size_t> listPrefixWithSize(const TiFlashS3Client & client, const String & prefix);
 

--- a/dbms/src/Storages/S3/S3RandomAccessFile.cpp
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.cpp
@@ -46,7 +46,7 @@ ssize_t S3RandomAccessFile::read(char * buf, size_t size)
     size_t gcount = istr.gcount();
     if (gcount == 0 && !istr.eof())
     {
-        LOG_ERROR(log, "Cannot read from istream. bucket={} key={}", client_ptr->bucket(), remote_fname);
+        LOG_ERROR(log, "Cannot read from istream. bucket={} root={} key={}", client_ptr->bucket(), client_ptr->root(), remote_fname);
         return -1;
     }
     ProfileEvents::increment(ProfileEvents::S3ReadBytes, gcount);
@@ -79,7 +79,7 @@ void S3RandomAccessFile::initialize()
     auto outcome = client_ptr->GetObject(req);
     if (!outcome.IsSuccess())
     {
-        throw S3::fromS3Error(outcome.GetError(), "bucket={} key={}", client_ptr->bucket(), remote_fname);
+        throw S3::fromS3Error(outcome.GetError(), "S3 GetObject failed, bucket={} root={} key={}", client_ptr->bucket(), client_ptr->root(), remote_fname);
     }
     ProfileEvents::increment(ProfileEvents::S3ReadBytes, outcome.GetResult().GetContentLength());
     GET_METRIC(tiflash_storage_s3_request_seconds, type_get_object).Observe(sw.elapsedSeconds());

--- a/dbms/src/Storages/S3/S3RandomAccessFile.cpp
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.cpp
@@ -74,7 +74,7 @@ void S3RandomAccessFile::initialize()
 {
     Stopwatch sw;
     Aws::S3::Model::GetObjectRequest req;
-    client_ptr->setBucketAndKey(req, remote_fname);
+    client_ptr->setBucketAndKeyWithRoot(req, remote_fname);
     ProfileEvents::increment(ProfileEvents::S3GetObject);
     auto outcome = client_ptr->GetObject(req);
     if (!outcome.IsSuccess())

--- a/dbms/src/Storages/S3/S3RandomAccessFile.cpp
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.cpp
@@ -30,11 +30,9 @@ extern const Event S3ReadBytes;
 namespace DB::S3
 {
 S3RandomAccessFile::S3RandomAccessFile(
-    std::shared_ptr<Aws::S3::S3Client> client_ptr_,
-    const String & bucket_,
+    std::shared_ptr<TiFlashS3Client> client_ptr_,
     const String & remote_fname_)
     : client_ptr(std::move(client_ptr_))
-    , bucket(bucket_)
     , remote_fname(remote_fname_)
     , log(Logger::get("S3RandomAccessFile"))
 {
@@ -48,7 +46,7 @@ ssize_t S3RandomAccessFile::read(char * buf, size_t size)
     size_t gcount = istr.gcount();
     if (gcount == 0 && !istr.eof())
     {
-        LOG_ERROR(log, "Cannot read from istream. bucket={} key={}", bucket, remote_fname);
+        LOG_ERROR(log, "Cannot read from istream. bucket={} key={}", client_ptr->bucket(), remote_fname);
         return -1;
     }
     ProfileEvents::increment(ProfileEvents::S3ReadBytes, gcount);
@@ -76,13 +74,13 @@ void S3RandomAccessFile::initialize()
 {
     Stopwatch sw;
     Aws::S3::Model::GetObjectRequest req;
-    req.SetBucket(bucket);
+    req.SetBucket(client_ptr->bucket());
     req.SetKey(remote_fname);
     ProfileEvents::increment(ProfileEvents::S3GetObject);
     auto outcome = client_ptr->GetObject(req);
     if (!outcome.IsSuccess())
     {
-        throw S3::fromS3Error(outcome.GetError(), "bucket={} key={}", bucket, remote_fname);
+        throw S3::fromS3Error(outcome.GetError(), "bucket={} key={}", client_ptr->bucket(), remote_fname);
     }
     ProfileEvents::increment(ProfileEvents::S3ReadBytes, outcome.GetResult().GetContentLength());
     GET_METRIC(tiflash_storage_s3_request_seconds, type_get_object).Observe(sw.elapsedSeconds());
@@ -111,6 +109,6 @@ RandomAccessFilePtr S3RandomAccessFile::create(const String & remote_fname)
         return file;
     }
     auto & ins = S3::ClientFactory::instance();
-    return std::make_shared<S3RandomAccessFile>(ins.sharedClient(), ins.bucket(), remote_fname);
+    return std::make_shared<S3RandomAccessFile>(ins.sharedTiFlashClient(), remote_fname);
 }
 } // namespace DB::S3

--- a/dbms/src/Storages/S3/S3RandomAccessFile.cpp
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.cpp
@@ -74,8 +74,7 @@ void S3RandomAccessFile::initialize()
 {
     Stopwatch sw;
     Aws::S3::Model::GetObjectRequest req;
-    req.SetBucket(client_ptr->bucket());
-    req.SetKey(remote_fname);
+    client_ptr->setBucketAndKey(req, remote_fname);
     ProfileEvents::increment(ProfileEvents::S3GetObject);
     auto outcome = client_ptr->GetObject(req);
     if (!outcome.IsSuccess())

--- a/dbms/src/Storages/S3/S3RandomAccessFile.h
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.h
@@ -17,6 +17,7 @@
 #include <Common/Exception.h>
 #include <Common/Logger.h>
 #include <Encryption/RandomAccessFile.h>
+#include <Storages/S3/S3Common.h>
 #include <aws/s3/model/GetObjectResult.h>
 #include <common/types.h>
 
@@ -38,8 +39,7 @@ public:
     static RandomAccessFilePtr create(const String & remote_fname);
 
     S3RandomAccessFile(
-        std::shared_ptr<Aws::S3::S3Client> client_ptr_,
-        const String & bucket_,
+        std::shared_ptr<TiFlashS3Client> client_ptr_,
         const String & remote_fname_);
 
     off_t seek(off_t offset, int whence) override;
@@ -48,7 +48,7 @@ public:
 
     std::string getFileName() const override
     {
-        return fmt::format("{}/{}", bucket, remote_fname);
+        return fmt::format("{}/{}", client_ptr->bucket(), remote_fname);
     }
 
     ssize_t pread(char * /*buf*/, size_t /*size*/, off_t /*offset*/) const override
@@ -74,8 +74,7 @@ public:
 private:
     void initialize();
 
-    std::shared_ptr<Aws::S3::S3Client> client_ptr;
-    String bucket;
+    std::shared_ptr<TiFlashS3Client> client_ptr;
     String remote_fname;
 
     Aws::S3::Model::GetObjectResult read_result;

--- a/dbms/src/Storages/S3/S3WritableFile.cpp
+++ b/dbms/src/Storages/S3/S3WritableFile.cpp
@@ -24,6 +24,8 @@
 #include <ext/scope_guard.h>
 #include <magic_enum.hpp>
 
+#include "Storages/S3/S3Common.h"
+
 namespace ProfileEvents
 {
 extern const Event S3WriteBytes;
@@ -56,12 +58,10 @@ struct S3WritableFile::PutObjectTask
 };
 
 S3WritableFile::S3WritableFile(
-    std::shared_ptr<Aws::S3::S3Client> client_ptr_,
-    const String & bucket_,
+    std::shared_ptr<TiFlashS3Client> client_ptr_,
     const String & remote_fname_,
     const WriteSettings & write_settings_)
-    : bucket(bucket_)
-    , remote_fname(remote_fname_)
+    : remote_fname(remote_fname_)
     , client_ptr(std::move(client_ptr_))
     , write_settings(write_settings_)
     , log(Logger::get("S3WritableFile"))
@@ -76,7 +76,7 @@ ssize_t S3WritableFile::write(char * buf, size_t size)
     temporary_buffer->write(buf, size);
     if (!temporary_buffer->good())
     {
-        LOG_ERROR(log, "write size={} failed: bucket={} key={}", size, bucket, remote_fname);
+        LOG_ERROR(log, "write size={} failed: bucket={} key={}", size, client_ptr->bucket(), remote_fname);
         return -1;
     }
     ProfileEvents::increment(ProfileEvents::S3WriteBytes, size);
@@ -127,7 +127,7 @@ void S3WritableFile::finalize()
     if (write_settings.check_objects_after_upload)
     {
         // TODO(jinhe): check checksums.
-        auto resp = S3::headObject(*client_ptr, bucket, remote_fname);
+        auto resp = S3::headObject(*client_ptr, remote_fname);
         checkS3Outcome(resp);
     }
 }
@@ -139,7 +139,7 @@ void S3WritableFile::createMultipartUpload()
         GET_METRIC(tiflash_storage_s3_request_seconds, type_create_multi_part_upload).Observe(sw.elapsedSeconds());
     });
     Aws::S3::Model::CreateMultipartUploadRequest req;
-    req.SetBucket(bucket);
+    req.SetBucket(client_ptr->bucket());
     req.SetKey(remote_fname);
     req.SetContentType("binary/octet-stream");
     ProfileEvents::increment(ProfileEvents::S3CreateMultipartUpload);
@@ -153,7 +153,7 @@ void S3WritableFile::writePart()
     auto size = temporary_buffer->tellp();
     if (size < 0)
     {
-        throw Exception(ErrorCodes::CORRUPTED_DATA, "Buffer is in bad state. bucket={}, key={}", bucket, remote_fname);
+        throw Exception(ErrorCodes::CORRUPTED_DATA, "Buffer is in bad state. bucket={}, key={}", client_ptr->bucket(), remote_fname);
     }
     if (size == 0)
     {
@@ -172,7 +172,7 @@ void S3WritableFile::fillUploadRequest(Aws::S3::Model::UploadPartRequest & req)
     // Increase part number.
     ++part_number;
     // Setup request.
-    req.SetBucket(bucket);
+    req.SetBucket(client_ptr->bucket());
     req.SetKey(remote_fname);
     req.SetPartNumber(static_cast<int>(part_number));
     req.SetUploadId(multipart_upload_id);
@@ -195,10 +195,10 @@ void S3WritableFile::processUploadRequest(UploadPartTask & task)
 
 void S3WritableFile::completeMultipartUpload()
 {
-    RUNTIME_CHECK_MSG(!part_tags.empty(), "Failed to complete multipart upload. No parts have uploaded. bucket={}, key={}", bucket, remote_fname);
+    RUNTIME_CHECK_MSG(!part_tags.empty(), "Failed to complete multipart upload. No parts have uploaded. bucket={}, key={}", client_ptr->bucket(), remote_fname);
 
     Aws::S3::Model::CompleteMultipartUploadRequest req;
-    req.SetBucket(bucket);
+    req.SetBucket(client_ptr->bucket());
     req.SetKey(remote_fname);
     req.SetUploadId(multipart_upload_id);
     Aws::S3::Model::CompletedMultipartUpload multipart_upload;
@@ -220,17 +220,17 @@ void S3WritableFile::completeMultipartUpload()
         auto outcome = client_ptr->CompleteMultipartUpload(req);
         if (outcome.IsSuccess())
         {
-            LOG_DEBUG(log, "Multipart upload has completed. bucket={} key={} upload_id={} parts={}", bucket, remote_fname, multipart_upload_id, part_tags.size());
+            LOG_DEBUG(log, "Multipart upload has completed. bucket={} key={} upload_id={} parts={}", client_ptr->bucket(), remote_fname, multipart_upload_id, part_tags.size());
             break;
         }
         if (i + 1 < max_retry)
         {
             const auto & e = outcome.GetError();
-            LOG_INFO(log, "Multipart upload failed and need retry: bucket={} key={} upload_id={} parts={} error={} message={}", bucket, remote_fname, multipart_upload_id, part_tags.size(), magic_enum::enum_name(e.GetErrorType()), e.GetMessage());
+            LOG_INFO(log, "Multipart upload failed and need retry: bucket={} key={} upload_id={} parts={} error={} message={}", client_ptr->bucket(), remote_fname, multipart_upload_id, part_tags.size(), magic_enum::enum_name(e.GetErrorType()), e.GetMessage());
         }
         else
         {
-            throw fromS3Error(outcome.GetError(), "bucket={} key={} upload_id={} parts={}", bucket, remote_fname, multipart_upload_id, part_tags.size());
+            throw fromS3Error(outcome.GetError(), "bucket={} key={} upload_id={} parts={}", client_ptr->bucket(), remote_fname, multipart_upload_id, part_tags.size());
         }
     }
 }
@@ -240,7 +240,7 @@ void S3WritableFile::makeSinglepartUpload()
     auto size = temporary_buffer->tellp();
     if (size < 0)
     {
-        throw Exception(ErrorCodes::CORRUPTED_DATA, "Buffer is in bad state. bucket={}, key={}", bucket, remote_fname);
+        throw Exception(ErrorCodes::CORRUPTED_DATA, "Buffer is in bad state. bucket={}, key={}", client_ptr->bucket(), remote_fname);
     }
     PutObjectTask task;
     fillPutRequest(task.req);
@@ -249,7 +249,7 @@ void S3WritableFile::makeSinglepartUpload()
 
 void S3WritableFile::fillPutRequest(Aws::S3::Model::PutObjectRequest & req)
 {
-    req.SetBucket(bucket);
+    req.SetBucket(client_ptr->bucket());
     req.SetKey(remote_fname);
     req.SetContentLength(temporary_buffer->tellp());
     req.SetBody(temporary_buffer);
@@ -269,17 +269,17 @@ void S3WritableFile::processPutRequest(const PutObjectTask & task)
         auto outcome = client_ptr->PutObject(task.req);
         if (outcome.IsSuccess())
         {
-            LOG_DEBUG(log, "Single part upload has completed. bucket={}, key={}, size={}", bucket, remote_fname, task.req.GetContentLength());
+            LOG_DEBUG(log, "Single part upload has completed. bucket={}, key={}, size={}", client_ptr->bucket(), remote_fname, task.req.GetContentLength());
             break;
         }
         if (i + 1 < max_retry)
         {
             const auto & e = outcome.GetError();
-            LOG_INFO(log, "Single part upload failed: bucket={} key={} error={} message={}", bucket, remote_fname, magic_enum::enum_name(e.GetErrorType()), e.GetMessage());
+            LOG_INFO(log, "Single part upload failed: bucket={} key={} error={} message={}", client_ptr->bucket(), remote_fname, magic_enum::enum_name(e.GetErrorType()), e.GetMessage());
         }
         else
         {
-            throw fromS3Error(outcome.GetError(), "bucket={} key={}", bucket, remote_fname);
+            throw fromS3Error(outcome.GetError(), "bucket={} key={}", client_ptr->bucket(), remote_fname);
         }
     }
 }
@@ -287,8 +287,7 @@ void S3WritableFile::processPutRequest(const PutObjectTask & task)
 std::shared_ptr<S3WritableFile> S3WritableFile::create(const String & remote_fname_)
 {
     return std::make_shared<S3WritableFile>(
-        S3::ClientFactory::instance().sharedClient(),
-        S3::ClientFactory::instance().bucket(),
+        S3::ClientFactory::instance().sharedTiFlashClient(),
         remote_fname_,
         WriteSettings{});
 }

--- a/dbms/src/Storages/S3/S3WritableFile.cpp
+++ b/dbms/src/Storages/S3/S3WritableFile.cpp
@@ -15,6 +15,7 @@
 #include <Common/ProfileEvents.h>
 #include <Common/Stopwatch.h>
 #include <Common/TiFlashMetrics.h>
+#include <Storages/S3/S3Common.h>
 #include <Storages/S3/S3WritableFile.h>
 #include <aws/s3/model/CompleteMultipartUploadRequest.h>
 #include <aws/s3/model/CreateMultipartUploadRequest.h>
@@ -23,8 +24,6 @@
 
 #include <ext/scope_guard.h>
 #include <magic_enum.hpp>
-
-#include "Storages/S3/S3Common.h"
 
 namespace ProfileEvents
 {

--- a/dbms/src/Storages/S3/S3WritableFile.cpp
+++ b/dbms/src/Storages/S3/S3WritableFile.cpp
@@ -138,7 +138,7 @@ void S3WritableFile::createMultipartUpload()
         GET_METRIC(tiflash_storage_s3_request_seconds, type_create_multi_part_upload).Observe(sw.elapsedSeconds());
     });
     Aws::S3::Model::CreateMultipartUploadRequest req;
-    client_ptr->setBucketAndKey(req, remote_fname);
+    client_ptr->setBucketAndKeyWithRoot(req, remote_fname);
     req.SetContentType("binary/octet-stream");
     ProfileEvents::increment(ProfileEvents::S3CreateMultipartUpload);
     auto outcome = client_ptr->CreateMultipartUpload(req);
@@ -170,7 +170,7 @@ void S3WritableFile::fillUploadRequest(Aws::S3::Model::UploadPartRequest & req)
     // Increase part number.
     ++part_number;
     // Setup request.
-    client_ptr->setBucketAndKey(req, remote_fname);
+    client_ptr->setBucketAndKeyWithRoot(req, remote_fname);
     req.SetPartNumber(static_cast<int>(part_number));
     req.SetUploadId(multipart_upload_id);
     req.SetContentLength(temporary_buffer->tellp());
@@ -195,7 +195,7 @@ void S3WritableFile::completeMultipartUpload()
     RUNTIME_CHECK_MSG(!part_tags.empty(), "Failed to complete multipart upload. No parts have uploaded. bucket={}, key={}", client_ptr->bucket(), remote_fname);
 
     Aws::S3::Model::CompleteMultipartUploadRequest req;
-    client_ptr->setBucketAndKey(req, remote_fname);
+    client_ptr->setBucketAndKeyWithRoot(req, remote_fname);
     req.SetUploadId(multipart_upload_id);
     Aws::S3::Model::CompletedMultipartUpload multipart_upload;
     for (size_t i = 0; i < part_tags.size(); ++i)
@@ -245,7 +245,7 @@ void S3WritableFile::makeSinglepartUpload()
 
 void S3WritableFile::fillPutRequest(Aws::S3::Model::PutObjectRequest & req)
 {
-    client_ptr->setBucketAndKey(req, remote_fname);
+    client_ptr->setBucketAndKeyWithRoot(req, remote_fname);
     req.SetContentLength(temporary_buffer->tellp());
     req.SetBody(temporary_buffer);
     req.SetContentType("binary/octet-stream");

--- a/dbms/src/Storages/S3/S3WritableFile.cpp
+++ b/dbms/src/Storages/S3/S3WritableFile.cpp
@@ -139,8 +139,7 @@ void S3WritableFile::createMultipartUpload()
         GET_METRIC(tiflash_storage_s3_request_seconds, type_create_multi_part_upload).Observe(sw.elapsedSeconds());
     });
     Aws::S3::Model::CreateMultipartUploadRequest req;
-    req.SetBucket(client_ptr->bucket());
-    req.SetKey(remote_fname);
+    client_ptr->setBucketAndKey(req, remote_fname);
     req.SetContentType("binary/octet-stream");
     ProfileEvents::increment(ProfileEvents::S3CreateMultipartUpload);
     auto outcome = client_ptr->CreateMultipartUpload(req);
@@ -172,8 +171,7 @@ void S3WritableFile::fillUploadRequest(Aws::S3::Model::UploadPartRequest & req)
     // Increase part number.
     ++part_number;
     // Setup request.
-    req.SetBucket(client_ptr->bucket());
-    req.SetKey(remote_fname);
+    client_ptr->setBucketAndKey(req, remote_fname);
     req.SetPartNumber(static_cast<int>(part_number));
     req.SetUploadId(multipart_upload_id);
     req.SetContentLength(temporary_buffer->tellp());
@@ -198,8 +196,7 @@ void S3WritableFile::completeMultipartUpload()
     RUNTIME_CHECK_MSG(!part_tags.empty(), "Failed to complete multipart upload. No parts have uploaded. bucket={}, key={}", client_ptr->bucket(), remote_fname);
 
     Aws::S3::Model::CompleteMultipartUploadRequest req;
-    req.SetBucket(client_ptr->bucket());
-    req.SetKey(remote_fname);
+    client_ptr->setBucketAndKey(req, remote_fname);
     req.SetUploadId(multipart_upload_id);
     Aws::S3::Model::CompletedMultipartUpload multipart_upload;
     for (size_t i = 0; i < part_tags.size(); ++i)
@@ -249,8 +246,7 @@ void S3WritableFile::makeSinglepartUpload()
 
 void S3WritableFile::fillPutRequest(Aws::S3::Model::PutObjectRequest & req)
 {
-    req.SetBucket(client_ptr->bucket());
-    req.SetKey(remote_fname);
+    client_ptr->setBucketAndKey(req, remote_fname);
     req.SetContentLength(temporary_buffer->tellp());
     req.SetBody(temporary_buffer);
     req.SetContentType("binary/octet-stream");

--- a/dbms/src/Storages/S3/S3WritableFile.h
+++ b/dbms/src/Storages/S3/S3WritableFile.h
@@ -51,8 +51,7 @@ public:
     static std::shared_ptr<S3WritableFile> create(const String & remote_fname_);
 
     S3WritableFile(
-        std::shared_ptr<Aws::S3::S3Client> client_ptr_,
-        const String & bucket_,
+        std::shared_ptr<TiFlashS3Client> client_ptr_,
         const String & remote_fname_,
         const WriteSettings & write_settings_);
 
@@ -65,7 +64,7 @@ public:
 
     std::string getFileName() const override
     {
-        return fmt::format("{}/{}", bucket, remote_fname);
+        return fmt::format("{}/{}", client_ptr->bucket(), remote_fname);
     }
 
     void close() override
@@ -145,13 +144,12 @@ private:
     {
         if (!outcome.IsSuccess())
         {
-            throw S3::fromS3Error(outcome.GetError(), "bucket={} key={}", bucket, remote_fname);
+            throw S3::fromS3Error(outcome.GetError(), "bucket={} key={}", client_ptr->bucket(), remote_fname);
         }
     }
 
-    const String bucket;
     const String remote_fname;
-    const std::shared_ptr<Aws::S3::S3Client> client_ptr;
+    const std::shared_ptr<TiFlashS3Client> client_ptr;
     const WriteSettings write_settings;
 
     std::shared_ptr<Aws::StringStream> temporary_buffer; // Buffer to accumulate data.

--- a/dbms/src/Storages/S3/S3WritableFile.h
+++ b/dbms/src/Storages/S3/S3WritableFile.h
@@ -144,7 +144,7 @@ private:
     {
         if (!outcome.IsSuccess())
         {
-            throw S3::fromS3Error(outcome.GetError(), "bucket={} key={}", client_ptr->bucket(), remote_fname);
+            throw S3::fromS3Error(outcome.GetError(), "bucket={} root={} key={}", client_ptr->bucket(), client_ptr->root(), remote_fname);
         }
     }
 

--- a/dbms/src/Storages/S3/tests/gtest_s3client.cpp
+++ b/dbms/src/Storages/S3/tests/gtest_s3client.cpp
@@ -1,0 +1,46 @@
+// Copyright 2022 PingCAP, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Storages/S3/S3Common.h>
+#include <TestUtils/TiFlashTestBasic.h>
+#include <TestUtils/TiFlashTestEnv.h>
+#include <gtest/gtest.h>
+
+namespace DB::S3::tests
+{
+
+class S3ClientTest : public ::testing::Test
+{
+public:
+    void SetUp() override
+    {
+        client = ClientFactory::instance().sharedTiFlashClient();
+        ::DB::tests::TiFlashTestEnv::deleteBucket(*client);
+        ::DB::tests::TiFlashTestEnv::createBucketIfNotExist(*client);
+    }
+
+    std::shared_ptr<TiFlashS3Client> client;
+};
+
+TEST_F(S3ClientTest, UploadRead)
+try
+{
+    ASSERT_FALSE(objectExists(*client, "s999/manifest/mf_1"));
+    uploadEmptyFile(*client, "s999/manifest/mf_1");
+    ASSERT_TRUE(objectExists(*client, "s999/manifest/mf_1"));
+
+}
+CATCH
+
+} // namespace DB::S3::tests

--- a/dbms/src/Storages/S3/tests/gtest_s3client.cpp
+++ b/dbms/src/Storages/S3/tests/gtest_s3client.cpp
@@ -15,6 +15,7 @@
 #include <Storages/S3/S3Common.h>
 #include <TestUtils/TiFlashTestBasic.h>
 #include <TestUtils/TiFlashTestEnv.h>
+#include <aws/s3/model/ListObjectsV2Request.h>
 #include <gtest/gtest.h>
 
 namespace DB::S3::tests
@@ -36,10 +37,33 @@ public:
 TEST_F(S3ClientTest, UploadRead)
 try
 {
+    deleteObject(*client, "s999/manifest/mf_1");
     ASSERT_FALSE(objectExists(*client, "s999/manifest/mf_1"));
     uploadEmptyFile(*client, "s999/manifest/mf_1");
     ASSERT_TRUE(objectExists(*client, "s999/manifest/mf_1"));
 
+    uploadEmptyFile(*client, "s999/manifest/mf_2");
+    uploadEmptyFile(*client, "s999/manifest/mf_789");
+
+    uploadEmptyFile(*client, "s999/data/dat_789_0");
+    uploadEmptyFile(*client, "s999/data/dat_790_0");
+
+    Strings prefixes;
+    listPrefixWithDelimiter(*client, "s999/", "/", [&](const Aws::S3::Model::CommonPrefix & p) {
+        prefixes.emplace_back(p.GetPrefix());
+        return PageResult{.num_keys = 1, .more = true};
+    });
+    EXPECT_FALSE(true) << fmt::format("{}", prefixes);
+
+    prefixes.clear();
+    listPrefix(*client, "s999/", "/", [&](const Aws::S3::Model::ListObjectsV2Result & result, const String &) {
+        for (const auto & prefix : result.GetCommonPrefixes())
+        {
+            prefixes.emplace_back(prefix.GetPrefix());
+        }
+        return PageResult{.num_keys = result.GetCommonPrefixes().size(), .more = true};
+    });
+    EXPECT_FALSE(true) << fmt::format("{}", prefixes);
 }
 CATCH
 

--- a/dbms/src/Storages/S3/tests/gtest_s3client.cpp
+++ b/dbms/src/Storages/S3/tests/gtest_s3client.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 PingCAP, Ltd.
+// Copyright 2023 PingCAP, Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -48,22 +48,16 @@ try
     uploadEmptyFile(*client, "s999/data/dat_789_0");
     uploadEmptyFile(*client, "s999/data/dat_790_0");
 
+    uploadEmptyFile(*client, "s999/abcd");
+
     Strings prefixes;
     listPrefixWithDelimiter(*client, "s999/", "/", [&](const Aws::S3::Model::CommonPrefix & p) {
         prefixes.emplace_back(p.GetPrefix());
         return PageResult{.num_keys = 1, .more = true};
     });
-    EXPECT_FALSE(true) << fmt::format("{}", prefixes);
-
-    prefixes.clear();
-    listPrefix(*client, "s999/", "/", [&](const Aws::S3::Model::ListObjectsV2Result & result, const String &) {
-        for (const auto & prefix : result.GetCommonPrefixes())
-        {
-            prefixes.emplace_back(prefix.GetPrefix());
-        }
-        return PageResult{.num_keys = result.GetCommonPrefixes().size(), .more = true};
-    });
-    EXPECT_FALSE(true) << fmt::format("{}", prefixes);
+    ASSERT_EQ(prefixes.size(), 2) << fmt::format("{}", prefixes);
+    EXPECT_EQ(prefixes[0], "s999/data/");
+    EXPECT_EQ(prefixes[1], "s999/manifest/");
 }
 CATCH
 

--- a/dbms/src/Storages/S3/tests/gtest_s3gcmanager.cpp
+++ b/dbms/src/Storages/S3/tests/gtest_s3gcmanager.cpp
@@ -71,7 +71,7 @@ public:
         auto mock_pd_client = std::make_shared<pingcap::pd::MockPDClient>();
         gc_mgr = std::make_unique<S3GCManager>(mock_pd_client, mock_gc_owner, mock_lock_client, config);
 
-        ::DB::tests::TiFlashTestEnv::createBucketIfNotExist(*mock_s3_client, mock_s3_client->bucket());
+        ::DB::tests::TiFlashTestEnv::createBucketIfNotExist(*mock_s3_client);
 
         dir = getTemporaryPath();
         dropDataOnDisk(dir);
@@ -80,7 +80,7 @@ public:
 
     void TearDown() override
     {
-        ::DB::tests::TiFlashTestEnv::deleteBucket(*mock_s3_client, mock_s3_client->bucket());
+        ::DB::tests::TiFlashTestEnv::deleteBucket(*mock_s3_client);
     }
 
 protected:
@@ -123,7 +123,7 @@ try
         for (const auto & [seq, diff_sec] : mfs)
         {
             auto key = S3Filename::newCheckpointManifest(store_id, seq).toFullKey();
-            uploadEmptyFile(*mock_s3_client, mock_s3_client->bucket(), key);
+            uploadEmptyFile(*mock_s3_client, key);
             objs.emplace_back(CheckpointManifestS3Object{
                 .key = key,
                 .last_modification = timepoint + std::chrono::milliseconds(diff_sec * 1000),
@@ -174,11 +174,11 @@ try
         if (seq == 4 || seq == 5)
         {
             // deleted
-            ASSERT_FALSE(S3::objectExists(*mock_s3_client, mock_s3_client->bucket(), obj.key));
+            ASSERT_FALSE(S3::objectExists(*mock_s3_client, obj.key));
         }
         else
         {
-            ASSERT_TRUE(S3::objectExists(*mock_s3_client, mock_s3_client->bucket(), obj.key));
+            ASSERT_TRUE(S3::objectExists(*mock_s3_client, obj.key));
         }
     }
 }
@@ -190,28 +190,28 @@ try
 {
     auto timepoint = Aws::Utils::DateTime("2023-02-01T08:00:00Z", Aws::Utils::DateFormat::ISO_8601);
     {
-        uploadEmptyFile(*mock_s3_client, mock_s3_client->bucket(), "datafile_key");
-        uploadEmptyFile(*mock_s3_client, mock_s3_client->bucket(), "datafile_key.del");
+        uploadEmptyFile(*mock_s3_client, "datafile_key");
+        uploadEmptyFile(*mock_s3_client, "datafile_key.del");
 
         // delmark expired
         auto delmark_mtime = timepoint - std::chrono::milliseconds(3601 * 1000);
         gc_mgr->removeDataFileIfDelmarkExpired("datafile_key", "datafile_key.del", timepoint, delmark_mtime);
 
         // removed
-        ASSERT_FALSE(S3::objectExists(*mock_s3_client, mock_s3_client->bucket(), "datafile_key"));
-        ASSERT_FALSE(S3::objectExists(*mock_s3_client, mock_s3_client->bucket(), "datafile_key.del"));
+        ASSERT_FALSE(S3::objectExists(*mock_s3_client, "datafile_key"));
+        ASSERT_FALSE(S3::objectExists(*mock_s3_client, "datafile_key.del"));
     }
     {
-        uploadEmptyFile(*mock_s3_client, mock_s3_client->bucket(), "datafile_key");
-        uploadEmptyFile(*mock_s3_client, mock_s3_client->bucket(), "datafile_key.del");
+        uploadEmptyFile(*mock_s3_client, "datafile_key");
+        uploadEmptyFile(*mock_s3_client, "datafile_key.del");
 
         // delmark not expired
         auto delmark_mtime = timepoint - std::chrono::milliseconds(3599 * 1000);
         gc_mgr->removeDataFileIfDelmarkExpired("datafile_key", "datafile_key.del", timepoint, delmark_mtime);
 
         // removed
-        ASSERT_TRUE(S3::objectExists(*mock_s3_client, mock_s3_client->bucket(), "datafile_key"));
-        ASSERT_TRUE(S3::objectExists(*mock_s3_client, mock_s3_client->bucket(), "datafile_key.del"));
+        ASSERT_TRUE(S3::objectExists(*mock_s3_client, "datafile_key"));
+        ASSERT_TRUE(S3::objectExists(*mock_s3_client, "datafile_key.del"));
     }
 }
 CATCH
@@ -229,69 +229,69 @@ try
 
     auto timepoint = Aws::Utils::DateTime("2023-02-01T08:00:00Z", Aws::Utils::DateFormat::ISO_8601);
     auto clear_bucket = [&] {
-        DB::tests::TiFlashTestEnv::deleteBucket(*mock_s3_client, mock_s3_client->bucket());
-        DB::tests::TiFlashTestEnv::createBucketIfNotExist(*mock_s3_client, mock_s3_client->bucket());
+        DB::tests::TiFlashTestEnv::deleteBucket(*mock_s3_client);
+        DB::tests::TiFlashTestEnv::createBucketIfNotExist(*mock_s3_client);
     };
 
     {
         clear_bucket();
         // delmark not exist, and no more lockfile
-        S3::uploadEmptyFile(*mock_s3_client, mock_s3_client->bucket(), df.toFullKey());
-        S3::uploadEmptyFile(*mock_s3_client, mock_s3_client->bucket(), lock_key);
+        S3::uploadEmptyFile(*mock_s3_client, df.toFullKey());
+        S3::uploadEmptyFile(*mock_s3_client, lock_key);
 
-        ASSERT_FALSE(S3::objectExists(*mock_s3_client, mock_s3_client->bucket(), delmark_key));
+        ASSERT_FALSE(S3::objectExists(*mock_s3_client, delmark_key));
 
         gc_mgr->cleanOneLock(lock_key, lock_view, timepoint);
 
         // lock is deleted and delmark is created
-        ASSERT_FALSE(S3::objectExists(*mock_s3_client, mock_s3_client->bucket(), lock_key));
-        ASSERT_TRUE(S3::objectExists(*mock_s3_client, mock_s3_client->bucket(), delmark_key));
-        ASSERT_TRUE(S3::objectExists(*mock_s3_client, mock_s3_client->bucket(), df.toFullKey()));
+        ASSERT_FALSE(S3::objectExists(*mock_s3_client, lock_key));
+        ASSERT_TRUE(S3::objectExists(*mock_s3_client, delmark_key));
+        ASSERT_TRUE(S3::objectExists(*mock_s3_client, df.toFullKey()));
     }
     {
         clear_bucket();
         // delmark not exist, but still locked by another lockfile
-        S3::uploadEmptyFile(*mock_s3_client, mock_s3_client->bucket(), df.toFullKey());
-        S3::uploadEmptyFile(*mock_s3_client, mock_s3_client->bucket(), lock_key);
+        S3::uploadEmptyFile(*mock_s3_client, df.toFullKey());
+        S3::uploadEmptyFile(*mock_s3_client, lock_key);
         // another lock
         auto another_lock_key = df.toView().getLockKey(store_id + 1, 450);
-        S3::uploadEmptyFile(*mock_s3_client, mock_s3_client->bucket(), another_lock_key);
+        S3::uploadEmptyFile(*mock_s3_client, another_lock_key);
         gc_mgr->cleanOneLock(lock_key, lock_view, timepoint);
 
         // lock is deleted but delmark is not created
-        ASSERT_FALSE(S3::objectExists(*mock_s3_client, mock_s3_client->bucket(), lock_key));
-        ASSERT_FALSE(S3::objectExists(*mock_s3_client, mock_s3_client->bucket(), delmark_key));
-        ASSERT_TRUE(S3::objectExists(*mock_s3_client, mock_s3_client->bucket(), another_lock_key));
-        ASSERT_TRUE(S3::objectExists(*mock_s3_client, mock_s3_client->bucket(), df.toFullKey()));
+        ASSERT_FALSE(S3::objectExists(*mock_s3_client, lock_key));
+        ASSERT_FALSE(S3::objectExists(*mock_s3_client, delmark_key));
+        ASSERT_TRUE(S3::objectExists(*mock_s3_client, another_lock_key));
+        ASSERT_TRUE(S3::objectExists(*mock_s3_client, df.toFullKey()));
     }
     {
         clear_bucket();
         // delmark exist, not expired
-        S3::uploadEmptyFile(*mock_s3_client, mock_s3_client->bucket(), df.toFullKey());
-        S3::uploadEmptyFile(*mock_s3_client, mock_s3_client->bucket(), delmark_key);
+        S3::uploadEmptyFile(*mock_s3_client, df.toFullKey());
+        S3::uploadEmptyFile(*mock_s3_client, delmark_key);
         auto delmark_mtime = timepoint - std::chrono::milliseconds(3599 * 1000);
         FailPointHelper::enableFailPoint(FailPoints::force_set_mocked_s3_object_mtime, std::map<String, Aws::Utils::DateTime>{{delmark_key, delmark_mtime}});
         // mock_s3_client->head_result_mtime = delmark_mtime;
         gc_mgr->cleanOneLock(lock_key, lock_view, timepoint);
 
         // lock is deleted, datafile and delmark remain
-        ASSERT_FALSE(S3::objectExists(*mock_s3_client, mock_s3_client->bucket(), lock_key));
-        ASSERT_TRUE(S3::objectExists(*mock_s3_client, mock_s3_client->bucket(), delmark_key));
-        ASSERT_TRUE(S3::objectExists(*mock_s3_client, mock_s3_client->bucket(), df.toFullKey()));
+        ASSERT_FALSE(S3::objectExists(*mock_s3_client, lock_key));
+        ASSERT_TRUE(S3::objectExists(*mock_s3_client, delmark_key));
+        ASSERT_TRUE(S3::objectExists(*mock_s3_client, df.toFullKey()));
     }
     {
         clear_bucket();
         // delmark exist, expired
-        S3::uploadEmptyFile(*mock_s3_client, mock_s3_client->bucket(), df.toFullKey());
-        S3::uploadEmptyFile(*mock_s3_client, mock_s3_client->bucket(), delmark_key);
+        S3::uploadEmptyFile(*mock_s3_client, df.toFullKey());
+        S3::uploadEmptyFile(*mock_s3_client, delmark_key);
         auto delmark_mtime = timepoint - std::chrono::milliseconds(3601 * 1000);
         FailPointHelper::enableFailPoint(FailPoints::force_set_mocked_s3_object_mtime, std::map<String, Aws::Utils::DateTime>{{delmark_key, delmark_mtime}});
         gc_mgr->cleanOneLock(lock_key, lock_view, timepoint);
 
         // lock datafile and delmark are deleted
-        ASSERT_FALSE(S3::objectExists(*mock_s3_client, mock_s3_client->bucket(), lock_key));
-        ASSERT_FALSE(S3::objectExists(*mock_s3_client, mock_s3_client->bucket(), delmark_key));
-        ASSERT_FALSE(S3::objectExists(*mock_s3_client, mock_s3_client->bucket(), df.toFullKey()));
+        ASSERT_FALSE(S3::objectExists(*mock_s3_client, lock_key));
+        ASSERT_FALSE(S3::objectExists(*mock_s3_client, delmark_key));
+        ASSERT_FALSE(S3::objectExists(*mock_s3_client, df.toFullKey()));
     }
 }
 CATCH
@@ -310,24 +310,24 @@ try
 
     auto timepoint = Aws::Utils::DateTime("2023-02-01T08:00:00Z", Aws::Utils::DateFormat::ISO_8601);
     auto clear_bucket = [&] {
-        DB::tests::TiFlashTestEnv::deleteBucket(*mock_s3_client, mock_s3_client->bucket());
-        DB::tests::TiFlashTestEnv::createBucketIfNotExist(*mock_s3_client, mock_s3_client->bucket());
+        DB::tests::TiFlashTestEnv::deleteBucket(*mock_s3_client);
+        DB::tests::TiFlashTestEnv::createBucketIfNotExist(*mock_s3_client);
     };
 
     {
         clear_bucket();
         // delmark not exist, and no more lockfile
-        S3::uploadEmptyFile(*mock_s3_client, mock_s3_client->bucket(), df.toFullKey());
-        S3::uploadEmptyFile(*mock_s3_client, mock_s3_client->bucket(), lock_key);
+        S3::uploadEmptyFile(*mock_s3_client, df.toFullKey());
+        S3::uploadEmptyFile(*mock_s3_client, lock_key);
 
-        ASSERT_FALSE(S3::objectExists(*mock_s3_client, mock_s3_client->bucket(), delmark_key));
+        ASSERT_FALSE(S3::objectExists(*mock_s3_client, delmark_key));
 
         gc_mgr->cleanOneLock(lock_key, lock_view, timepoint);
 
         // lock is deleted and delmark is created, object is rewrite with tagging
-        ASSERT_FALSE(S3::objectExists(*mock_s3_client, mock_s3_client->bucket(), lock_key));
-        ASSERT_TRUE(S3::objectExists(*mock_s3_client, mock_s3_client->bucket(), delmark_key));
-        ASSERT_TRUE(S3::objectExists(*mock_s3_client, mock_s3_client->bucket(), df.toFullKey()));
+        ASSERT_FALSE(S3::objectExists(*mock_s3_client, lock_key));
+        ASSERT_TRUE(S3::objectExists(*mock_s3_client, delmark_key));
+        ASSERT_TRUE(S3::objectExists(*mock_s3_client, df.toFullKey()));
         const auto res = static_cast<MockS3Client *>(mock_s3_client.get())->GetObjectTagging( //
             Aws::S3::Model::GetObjectTaggingRequest() //
                 .WithBucket(mock_s3_client->bucket())
@@ -340,18 +340,18 @@ try
     {
         clear_bucket();
         // delmark not exist, but still locked by another lockfile
-        S3::uploadEmptyFile(*mock_s3_client, mock_s3_client->bucket(), df.toFullKey());
-        S3::uploadEmptyFile(*mock_s3_client, mock_s3_client->bucket(), lock_key);
+        S3::uploadEmptyFile(*mock_s3_client, df.toFullKey());
+        S3::uploadEmptyFile(*mock_s3_client, lock_key);
         // another lock
         auto another_lock_key = df.toView().getLockKey(store_id + 1, 450);
-        S3::uploadEmptyFile(*mock_s3_client, mock_s3_client->bucket(), another_lock_key);
+        S3::uploadEmptyFile(*mock_s3_client, another_lock_key);
         gc_mgr->cleanOneLock(lock_key, lock_view, timepoint);
 
         // lock is deleted but delmark is not created
-        ASSERT_FALSE(S3::objectExists(*mock_s3_client, mock_s3_client->bucket(), lock_key));
-        ASSERT_FALSE(S3::objectExists(*mock_s3_client, mock_s3_client->bucket(), delmark_key));
-        ASSERT_TRUE(S3::objectExists(*mock_s3_client, mock_s3_client->bucket(), another_lock_key));
-        ASSERT_TRUE(S3::objectExists(*mock_s3_client, mock_s3_client->bucket(), df.toFullKey()));
+        ASSERT_FALSE(S3::objectExists(*mock_s3_client, lock_key));
+        ASSERT_FALSE(S3::objectExists(*mock_s3_client, delmark_key));
+        ASSERT_TRUE(S3::objectExists(*mock_s3_client, another_lock_key));
+        ASSERT_TRUE(S3::objectExists(*mock_s3_client, df.toFullKey()));
     }
 }
 CATCH
@@ -401,7 +401,7 @@ try
         // prepare for `LIST`
         for (const auto & k : keys)
         {
-            uploadEmptyFile(*mock_s3_client, mock_s3_client->bucket(), k);
+            uploadEmptyFile(*mock_s3_client, k);
         }
     }
 
@@ -410,8 +410,8 @@ try
         gc_mgr->cleanUnusedLocks(lock_store_id, S3Filename::getLockPrefix(), safe_sequence, valid_lock_files, timepoint);
 
         // lock is deleted and delmark is created
-        ASSERT_FALSE(S3::objectExists(*mock_s3_client, mock_s3_client->bucket(), expected_deleted_lock_key));
-        ASSERT_TRUE(S3::objectExists(*mock_s3_client, mock_s3_client->bucket(), expected_created_delmark));
+        ASSERT_FALSE(S3::objectExists(*mock_s3_client, expected_deleted_lock_key));
+        ASSERT_TRUE(S3::objectExists(*mock_s3_client, expected_created_delmark));
     }
 }
 CATCH
@@ -475,7 +475,7 @@ try
         writer->writeSuffix();
         writer.reset();
 
-        S3::uploadFile(*mock_s3_client, mock_s3_client->bucket(), dir + "/" + mf_key, mf_key);
+        S3::uploadFile(*mock_s3_client, dir + "/" + mf_key, mf_key);
     }
     { // prepare the second manifest on S3
         const String entry_data = "cherry_value";
@@ -507,7 +507,7 @@ try
         writer->writeSuffix();
         writer.reset();
 
-        S3::uploadFile(*mock_s3_client, mock_s3_client->bucket(), dir + "/" + mf_key2, mf_key2);
+        S3::uploadFile(*mock_s3_client, dir + "/" + mf_key2, mf_key2);
     }
 
     // read from S3 key

--- a/dbms/src/Storages/Transaction/FastAddPeer.cpp
+++ b/dbms/src/Storages/Transaction/FastAddPeer.cpp
@@ -286,13 +286,12 @@ CheckpointInfoPtr selectCheckpointInfo(Context & context, uint64_t region_id, ui
     auto & tmt_context = context.getTMTContext();
     std::vector<UInt64> all_store_ids = getAllStoreIDsFromPD(tmt_context);
     auto current_store_id = tmt_context.getKVStore()->getStoreMeta().id();
-    auto s3_client = S3::ClientFactory::instance().sharedClient();
-    auto bucket = S3::ClientFactory::instance().bucket();
+    auto s3_client = S3::ClientFactory::instance().sharedTiFlashClient();
     for (const auto & store_id : all_store_ids)
     {
         if (store_id == current_store_id)
             continue;
-        const auto manifests = S3::CheckpointManifestS3Set::getFromS3(*s3_client, bucket, store_id);
+        const auto manifests = S3::CheckpointManifestS3Set::getFromS3(*s3_client, store_id);
         if (manifests.empty())
         {
             LOG_DEBUG(log, "no manifest on this store, skip store_id={}", store_id);

--- a/dbms/src/Storages/Transaction/tests/gtest_kvstore_fast_add_peer.cpp
+++ b/dbms/src/Storages/Transaction/tests/gtest_kvstore_fast_add_peer.cpp
@@ -74,29 +74,6 @@ public:
     }
 
 protected:
-    bool createBucketIfNotExist()
-    {
-        auto s3_client = S3::ClientFactory::instance().sharedClient();
-        auto bucket = S3::ClientFactory::instance().bucket();
-        Aws::S3::Model::CreateBucketRequest request;
-        request.SetBucket(bucket);
-        auto outcome = s3_client->CreateBucket(request);
-        if (outcome.IsSuccess())
-        {
-            LOG_DEBUG(Logger::get(), "Created bucket {}", bucket);
-        }
-        else if (outcome.GetError().GetExceptionName() == "BucketAlreadyOwnedByYou")
-        {
-            LOG_DEBUG(Logger::get(), "Bucket {} already exist", bucket);
-        }
-        else
-        {
-            const auto & err = outcome.GetError();
-            LOG_ERROR(Logger::get(), "CreateBucket: {}:{}", err.GetExceptionName(), err.GetMessage());
-        }
-        return outcome.IsSuccess() || outcome.GetError().GetExceptionName() == "BucketAlreadyOwnedByYou";
-    }
-
     void dumpCheckpoint()
     {
         auto & global_context = TiFlashTestEnv::getGlobalContext();
@@ -221,13 +198,12 @@ try
     auto [index, term] = proxy_instance->normalWrite(region_id, {34}, {"v2"}, {WriteCmdType::Put}, {ColumnFamilyType::Default});
     persistAfterWrite(global_context, kvs, proxy_instance, page_storage, region_id, index);
 
-    ASSERT_TRUE(createBucketIfNotExist());
+    auto s3_client = S3::ClientFactory::instance().sharedTiFlashClient();
+    ASSERT_TRUE(::DB::tests::TiFlashTestEnv::createBucketIfNotExist(*s3_client));
     dumpCheckpoint();
 
     std::optional<CheckpointInfoPtr> checkpoint_info;
-    auto s3_client = S3::ClientFactory::instance().sharedClient();
-    auto bucket = S3::ClientFactory::instance().bucket();
-    const auto manifests = S3::CheckpointManifestS3Set::getFromS3(*s3_client, bucket, store_id);
+    const auto manifests = S3::CheckpointManifestS3Set::getFromS3(*s3_client, store_id);
     ASSERT_TRUE(!manifests.empty());
     const auto & latest_manifest_key = manifests.latestManifestKey();
     auto temp_ps_wrapper = reuseOrCreateTempPageStorage(global_context, latest_manifest_key);

--- a/dbms/src/TestUtils/TiFlashTestEnv.cpp
+++ b/dbms/src/TestUtils/TiFlashTestEnv.cpp
@@ -24,6 +24,7 @@
 #include <Server/RaftConfigParser.h>
 #include <Storages/DeltaMerge/ColumnFile/ColumnFileSchema.h>
 #include <Storages/DeltaMerge/StoragePool.h>
+#include <Storages/S3/S3Common.h>
 #include <Storages/Transaction/TMTContext.h>
 #include <TestUtils/TiFlashTestEnv.h>
 #include <aws/s3/S3Client.h>
@@ -238,19 +239,19 @@ FileProviderPtr TiFlashTestEnv::getMockFileProvider()
     return std::make_shared<FileProvider>(std::make_shared<MockKeyManager>(encryption_enabled), encryption_enabled);
 }
 
-bool TiFlashTestEnv::createBucketIfNotExist(Aws::S3::S3Client & s3_client, const String & bucket)
+bool TiFlashTestEnv::createBucketIfNotExist(::DB::S3::TiFlashS3Client & s3_client)
 {
     auto log = Logger::get();
     Aws::S3::Model::CreateBucketRequest request;
-    request.SetBucket(bucket);
+    request.SetBucket(s3_client.bucket());
     auto outcome = s3_client.CreateBucket(request);
     if (outcome.IsSuccess())
     {
-        LOG_DEBUG(log, "Created bucket {}", bucket);
+        LOG_DEBUG(log, "Created bucket {}", s3_client.bucket());
     }
     else if (outcome.GetError().GetExceptionName() == "BucketAlreadyOwnedByYou")
     {
-        LOG_DEBUG(log, "Bucket {} already exist", bucket);
+        LOG_DEBUG(log, "Bucket {} already exist", s3_client.bucket());
     }
     else
     {
@@ -260,10 +261,10 @@ bool TiFlashTestEnv::createBucketIfNotExist(Aws::S3::S3Client & s3_client, const
     return outcome.IsSuccess() || outcome.GetError().GetExceptionName() == "BucketAlreadyOwnedByYou";
 }
 
-void TiFlashTestEnv::deleteBucket(Aws::S3::S3Client & s3_client, const String & bucket)
+void TiFlashTestEnv::deleteBucket(::DB::S3::TiFlashS3Client & s3_client)
 {
     Aws::S3::Model::DeleteBucketRequest request;
-    request.SetBucket(bucket);
+    request.SetBucket(s3_client.bucket());
     s3_client.DeleteBucket(request);
 }
 

--- a/dbms/src/TestUtils/TiFlashTestEnv.cpp
+++ b/dbms/src/TestUtils/TiFlashTestEnv.cpp
@@ -241,22 +241,21 @@ FileProviderPtr TiFlashTestEnv::getMockFileProvider()
 
 bool TiFlashTestEnv::createBucketIfNotExist(::DB::S3::TiFlashS3Client & s3_client)
 {
-    auto log = Logger::get();
     Aws::S3::Model::CreateBucketRequest request;
     request.SetBucket(s3_client.bucket());
     auto outcome = s3_client.CreateBucket(request);
     if (outcome.IsSuccess())
     {
-        LOG_DEBUG(log, "Created bucket {}", s3_client.bucket());
+        LOG_DEBUG(s3_client.log, "Created bucket {}", s3_client.bucket());
     }
     else if (outcome.GetError().GetExceptionName() == "BucketAlreadyOwnedByYou")
     {
-        LOG_DEBUG(log, "Bucket {} already exist", s3_client.bucket());
+        LOG_DEBUG(s3_client.log, "Bucket {} already exist", s3_client.bucket());
     }
     else
     {
         const auto & err = outcome.GetError();
-        LOG_ERROR(log, "CreateBucket: {}:{}", err.GetExceptionName(), err.GetMessage());
+        LOG_ERROR(s3_client.log, "CreateBucket: {}:{}", err.GetExceptionName(), err.GetMessage());
     }
     return outcome.IsSuccess() || outcome.GetError().GetExceptionName() == "BucketAlreadyOwnedByYou";
 }

--- a/dbms/src/TestUtils/TiFlashTestEnv.h
+++ b/dbms/src/TestUtils/TiFlashTestEnv.h
@@ -24,16 +24,16 @@
 #include <TestUtils/TiFlashTestException.h>
 #include <fmt/core.h>
 
-namespace Aws::S3
-{
-class S3Client;
-}
 
 namespace DB
 {
 struct Settings;
 class DAGContext;
 class MockStorage;
+namespace S3
+{
+class TiFlashS3Client;
+}
 } // namespace DB
 
 namespace DB::tests
@@ -105,9 +105,9 @@ public:
 
     static FileProviderPtr getMockFileProvider();
 
-    static bool createBucketIfNotExist(Aws::S3::S3Client & s3_client, const String & bucket);
+    static bool createBucketIfNotExist(::DB::S3::TiFlashS3Client & s3_client);
 
-    static void deleteBucket(Aws::S3::S3Client & s3_client, const String & bucket);
+    static void deleteBucket(::DB::S3::TiFlashS3Client & s3_client);
 
     TiFlashTestEnv() = delete;
 

--- a/dbms/src/TestUtils/gtests_dbms_main.cpp
+++ b/dbms/src/TestUtils/gtests_dbms_main.cpp
@@ -81,11 +81,7 @@ int main(int argc, char ** argv)
     DB::IOThreadPool::initialize(/*max_threads*/ 20, /*max_free_threds*/ 10, /*queue_size*/ 1000);
     const auto s3_endpoint = Poco::Environment::get("S3_ENDPOINT", "");
     const auto s3_bucket = Poco::Environment::get("S3_BUCKET", "mockbucket");
-    auto s3_root = Poco::Environment::get("S3_ROOT", "jayson/test/");
-    if (!endsWith(s3_root, "/"))
-    {
-        s3_root += "/";
-    }
+    const auto s3_root = Poco::Environment::get("S3_ROOT", "/");
     const auto access_key_id = Poco::Environment::get("AWS_ACCESS_KEY_ID", "");
     const auto secret_access_key = Poco::Environment::get("AWS_SECRET_ACCESS_KEY", "");
     const auto mock_s3 = Poco::Environment::get("MOCK_S3", "true"); // In unit-tests, use MockS3Client by default.

--- a/dbms/src/TestUtils/gtests_dbms_main.cpp
+++ b/dbms/src/TestUtils/gtests_dbms_main.cpp
@@ -80,8 +80,8 @@ int main(int argc, char ** argv)
     DB::GlobalThreadPool::initialize(/*max_threads*/ 20, /*max_free_threds*/ 10, /*queue_size*/ 1000);
     DB::IOThreadPool::initialize(/*max_threads*/ 20, /*max_free_threds*/ 10, /*queue_size*/ 1000);
     const auto s3_endpoint = Poco::Environment::get("S3_ENDPOINT", "");
-    const auto s3_bucket = Poco::Environment::get("S3_BUCKET", "mock_bucket");
-    auto s3_root = Poco::Environment::get("S3_ROOT", "/");
+    const auto s3_bucket = Poco::Environment::get("S3_BUCKET", "mockbucket");
+    auto s3_root = Poco::Environment::get("S3_ROOT", "jayson/test/");
     if (!endsWith(s3_root, "/"))
     {
         s3_root += "/";

--- a/dbms/src/TestUtils/gtests_dbms_main.cpp
+++ b/dbms/src/TestUtils/gtests_dbms_main.cpp
@@ -81,6 +81,11 @@ int main(int argc, char ** argv)
     DB::IOThreadPool::initialize(/*max_threads*/ 20, /*max_free_threds*/ 10, /*queue_size*/ 1000);
     const auto s3_endpoint = Poco::Environment::get("S3_ENDPOINT", "");
     const auto s3_bucket = Poco::Environment::get("S3_BUCKET", "mock_bucket");
+    auto s3_root = Poco::Environment::get("S3_ROOT", "/");
+    if (!endsWith(s3_root, "/"))
+    {
+        s3_root += "/";
+    }
     const auto access_key_id = Poco::Environment::get("AWS_ACCESS_KEY_ID", "");
     const auto secret_access_key = Poco::Environment::get("AWS_SECRET_ACCESS_KEY", "");
     const auto mock_s3 = Poco::Environment::get("MOCK_S3", "true"); // In unit-tests, use MockS3Client by default.
@@ -89,6 +94,7 @@ int main(int argc, char ** argv)
         .bucket = s3_bucket,
         .access_key_id = access_key_id,
         .secret_access_key = secret_access_key,
+        .root = s3_root,
     };
     Poco::Environment::set("AWS_EC2_METADATA_DISABLED", "true"); // disable to speedup testing
     DB::S3::ClientFactory::instance().init(s3config, mock_s3 == "true");

--- a/dbms/src/TestUtils/gtests_dbms_main.cpp
+++ b/dbms/src/TestUtils/gtests_dbms_main.cpp
@@ -81,7 +81,7 @@ int main(int argc, char ** argv)
     DB::IOThreadPool::initialize(/*max_threads*/ 20, /*max_free_threds*/ 10, /*queue_size*/ 1000);
     const auto s3_endpoint = Poco::Environment::get("S3_ENDPOINT", "");
     const auto s3_bucket = Poco::Environment::get("S3_BUCKET", "mockbucket");
-    const auto s3_root = Poco::Environment::get("S3_ROOT", "/");
+    const auto s3_root = Poco::Environment::get("S3_ROOT", "tiflash_ut/");
     const auto access_key_id = Poco::Environment::get("AWS_ACCESS_KEY_ID", "");
     const auto secret_access_key = Poco::Environment::get("AWS_SECRET_ACCESS_KEY", "");
     const auto mock_s3 = Poco::Environment::get("MOCK_S3", "true"); // In unit-tests, use MockS3Client by default.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/6827

Problem Summary:

The number of buckets in Amazon S3 is limited, we need to share the same bucket for different TiDB clusters on Cloud. https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingBucket.html

> You can store any number of objects in a bucket and can have up to 100 buckets in your account.

In order to share the same bucket among different TiDB clusters, we should setup different `storage.s3.root`. The `storage.s3.root` will be prepended to each S3 key. This PR makes the `storage.s3.root` effective.

### What is changed and how it works?

When sending a request to S3, we use `TiFlashS3Client::setBucketAndKeyWithRoot` to prepend the `root` to the S3 key.
And when getting an object key like using `LIST`, we copy the object struct with `root` cut from the key properly.

Another way to do this is to prepend each S3 key to where we need to store a S3 key. This could waste many disk/memory and make `S3Filename` coupled with the S3Config. Only add it when sending requests/receiving responses from S3 could be better.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
