### PR TITLE
Default enable Delta Index cache for disaggregated read

### DIFF
--- a/dbms/src/Interpreters/Settings.h
+++ b/dbms/src/Interpreters/Settings.h
@@ -240,6 +240,7 @@ struct Settings
     \
     M(SettingInt64, remote_checkpoint_interval_seconds, 30, "The interval of uploading checkpoint to the remote store. Unit is second.")                                                                                                \
     M(SettingInt64, remote_gc_interval_seconds, 3600, "The interval of running GC task on the remote store. Unit is second.")                                                                                                           \
+    M(SettingDouble, disagg_read_concurrency_scale, 20.0, "Scale * logical cpu cores = disaggregated read IO concurrency.")                                                                                                             \
     \
     M(SettingUInt64, max_rows_in_set, 0, "Maximum size of the set (in number of elements) resulting from the execution of the IN section.")                                                                                             \
     M(SettingUInt64, max_bytes_in_set, 0, "Maximum size of the set (in bytes in memory) resulting from the execution of the IN section.")                                                                                               \

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -1326,13 +1326,13 @@ int Server::main(const std::vector<std::string> & /*args*/)
     /// This setting is currently a bit tricky:
     /// - In non-disaggregated mode, its default value is 0, means unlimited, and it
     //    controls the number of total bytes keep in the memory.
-    /// - In disaggregated mode, its default value is 0. 0 means cache is disabled, and it
+    /// - In disaggregated mode, its default value is 2000. 0 means cache is disabled, and it
     ///   controls the **number** of trees keep in the memory. <-- Will be fixed.
     ///   We cannot support unlimited delta index cache in disaggregated mode for now,
     ///   because cache items will be never explicitly removed.
-    size_t delta_index_cache_size = config().getUInt64("delta_index_cache_size", 0);
     if (global_context->getSharedContextDisagg()->isDisaggregatedComputeMode())
     {
+        size_t delta_index_cache_size = config().getUInt64("delta_index_cache_size", 2000);
         // In disaggregate compute node, we will not use DeltaIndexManager to cache the delta index.
         // Instead, we use RNDeltaIndexCache.
 
@@ -1346,6 +1346,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
     }
     else
     {
+        size_t delta_index_cache_size = config().getUInt64("delta_index_cache_size", 0);
         global_context->setDeltaIndexManager(delta_index_cache_size);
     }
 

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -1332,22 +1332,19 @@ int Server::main(const std::vector<std::string> & /*args*/)
     ///   because cache items will be never explicitly removed.
     if (global_context->getSharedContextDisagg()->isDisaggregatedComputeMode())
     {
-        size_t delta_index_cache_size = config().getUInt64("delta_index_cache_size", 2000);
+        size_t n = config().getUInt64("delta_index_cache_count", 2000);
         // In disaggregate compute node, we will not use DeltaIndexManager to cache the delta index.
         // Instead, we use RNDeltaIndexCache.
 
         // TODO: Currently RNDeltaIndexCache caches by number of entities, instead of
         // number of bytes!
 
-        if (delta_index_cache_size > 100000)
-            delta_index_cache_size = 100000; // In case of someone incorrectly uses byte size.
-
-        global_context->getSharedContextDisagg()->initReadNodeDeltaIndexCache(delta_index_cache_size);
+        global_context->getSharedContextDisagg()->initReadNodeDeltaIndexCache(n);
     }
     else
     {
-        size_t delta_index_cache_size = config().getUInt64("delta_index_cache_size", 0);
-        global_context->setDeltaIndexManager(delta_index_cache_size);
+        size_t n = config().getUInt64("delta_index_cache_size", 0);
+        global_context->setDeltaIndexManager(n);
     }
 
     /// Set path for format schema files

--- a/dbms/src/Storages/DeltaMerge/Remote/DisaggSnapshot.cpp
+++ b/dbms/src/Storages/DeltaMerge/Remote/DisaggSnapshot.cpp
@@ -75,7 +75,9 @@ SegmentReadTaskPtr DisaggPhysicalTableReadSnapshot::popTask(const UInt64 segment
     std::unique_lock lock(mtx);
     if (auto iter = tasks.find(segment_id); iter != tasks.end())
     {
-        return iter->second;
+        auto task = iter->second;
+        tasks.erase(iter);
+        return task;
     }
     return nullptr;
 }

--- a/dbms/src/Storages/DeltaMerge/Remote/RNRemoteSegmentThreadInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/Remote/RNRemoteSegmentThreadInputStream.cpp
@@ -97,7 +97,7 @@ RNRemoteSegmentThreadInputStream::RNRemoteSegmentThreadInputStream(
 
 RNRemoteSegmentThreadInputStream::~RNRemoteSegmentThreadInputStream()
 {
-    LOG_INFO(log, "RNRemoteSegmentThreadInputStream done, time blocked in pop task: {:.3f}sec, build task: {:.3f}sec", seconds_pop, seconds_build);
+    LOG_DEBUG(log, "RNRemoteSegmentThreadInputStream done, time blocked in pop task: {:.3f}sec, build task: {:.3f}sec", seconds_pop, seconds_build);
     GET_METRIC(tiflash_disaggregated_breakdown_duration_seconds, type_pop_ready_tasks).Observe(seconds_pop);
     GET_METRIC(tiflash_disaggregated_breakdown_duration_seconds, type_build_stream).Observe(seconds_build);
 }

--- a/dbms/src/Storages/StorageDisaggregatedRemote.cpp
+++ b/dbms/src/Storages/StorageDisaggregatedRemote.cpp
@@ -265,7 +265,7 @@ DM::RNRemoteReadTaskPtr StorageDisaggregated::buildDisaggregatedTask(
 
     const auto avg_establish_rpc_ms = std::accumulate(summaries.begin(), summaries.end(), 0.0, [](double lhs, const DisaggregatedExecutionSummary & rhs) -> double { return lhs + rhs.establish_rpc_ms; }) / summaries.size();
     const auto avg_build_remote_task_ms = std::accumulate(summaries.begin(), summaries.end(), 0.0, [](double lhs, const DisaggregatedExecutionSummary & rhs) -> double { return lhs + rhs.build_remote_task_ms; }) / summaries.size();
-    LOG_INFO(log, "establish disaggregated task rpc cost {:.2f}ms, build remote tasks cost {:.2f}ms", avg_establish_rpc_ms, avg_build_remote_task_ms);
+    LOG_INFO(log, "Establish disaggregated task finished, avg_rpc_elapsed={:.2f}ms, avg_build_task_elapsed={:.2f}ms", avg_establish_rpc_ms, avg_build_remote_task_ms);
 
     return read_task;
 }

--- a/dbms/src/Storages/StorageDisaggregatedRemote.cpp
+++ b/dbms/src/Storages/StorageDisaggregatedRemote.cpp
@@ -370,6 +370,7 @@ void StorageDisaggregated::buildRemoteSegmentInputStreams(
 {
     auto io_concurrency = static_cast<size_t>(static_cast<double>(num_streams) * db_context.getSettingsRef().disagg_read_concurrency_scale);
     LOG_DEBUG(log, "Build disagg streams with {} segment tasks, num_streams={} io_concurrency={}", remote_read_tasks->numSegments(), num_streams, io_concurrency);
+    // TODO: We can reduce max io_concurrency to numSegments.
 
     const auto & executor_id = table_scan.getTableScanExecutorID();
     // Build a RNPageReceiver to fetch the pages from all write nodes


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/6827

Problem Summary:

### What is changed and how it works?

- [x] Enable Delta Index cache by default.
- [x] Use 20\*Cores (instead of 10\*Cores) as a higher RN read concurrency.
- [x] Fix the bug that WN snapshots are never released.  TODO: We need to add metrics!

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
