### PR TITLE
Speedup ingest when S3 is enabled && fix bug caused by store_id not inited

### DIFF
--- a/dbms/src/Common/TiFlashMetrics.h
+++ b/dbms/src/Common/TiFlashMetrics.h
@@ -231,8 +231,11 @@ namespace DB
     M(tiflash_raft_command_duration_seconds, "Bucketed histogram of some raft command: apply snapshot",                                             \
         Histogram, /* these command usually cost several seconds, increase the start bucket to 50ms */                                              \
         F(type_ingest_sst, {{"type", "ingest_sst"}}, ExpBuckets{0.05, 2, 10}),                                                                      \
+        F(type_ingest_sst_sst2dt, {{"type", "ingest_sst_sst2dt"}}, ExpBuckets{0.05, 2, 10}),                                                        \
+        F(type_ingest_sst_upload, {{"type", "ingest_sst_upload"}}, ExpBuckets{0.05, 2, 10}),                                                        \
         F(type_apply_snapshot_predecode, {{"type", "snapshot_predecode"}}, ExpBuckets{0.05, 2, 10}),                                                \
         F(type_apply_snapshot_predecode_sst2dt, {{"type", "snapshot_predecode_sst2dt"}}, ExpBuckets{0.05, 2, 10}),                                  \
+        F(type_apply_snapshot_predecode_upload, {{"type", "snapshot_predecode_upload"}}, ExpBuckets{0.05, 2, 10}),                                  \
         F(type_apply_snapshot_flush, {{"type", "snapshot_flush"}}, ExpBuckets{0.05, 2, 10}))                                                        \
     M(tiflash_raft_process_keys, "Total number of keys processed in some types of Raft commands", Counter,                                          \
         F(type_apply_snapshot, {"type", "apply_snapshot"}), F(type_ingest_sst, {"type", "ingest_sst"}))                                             \

--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -1756,6 +1756,14 @@ UniversalPageStoragePtr Context::getWriteNodePageStorage() const
     }
 }
 
+UniversalPageStoragePtr Context::tryGetWriteNodePageStorage() const
+{
+    auto lock = getLock();
+    if (shared->ps_write)
+        return shared->ps_write->getUniversalPageStorage();
+    return nullptr;
+}
+
 // In some unit tests, we may want to reinitialize WriteNodePageStorage multiple times to mock restart.
 // And we need to release old one before creating new one.
 // And we must do it explicitly. Because if we do it implicitly in `initializeWriteNodePageStorageIfNeed`, there is a potential deadlock here.

--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -1316,14 +1316,6 @@ DBGInvoker & Context::getDBGInvoker() const
     return shared->dbg_invoker;
 }
 
-TMTContext & Context::getTMTContext() const
-{
-    auto lock = getLock();
-    if (!shared->tmt_context)
-        throw Exception("no tmt context");
-    return *(shared->tmt_context);
-}
-
 void Context::setMarkCache(size_t cache_size_in_bytes)
 {
     auto lock = getLock();
@@ -1452,6 +1444,20 @@ void Context::createTMTContext(const TiFlashRaftConfig & raft_config, pingcap::C
     if (shared->tmt_context)
         throw Exception("TMTContext has already existed", ErrorCodes::LOGICAL_ERROR);
     shared->tmt_context = std::make_shared<TMTContext>(*this, raft_config, cluster_config);
+}
+
+bool Context::isTMTContextInited() const
+{
+    auto lock = getLock();
+    return shared->tmt_context != nullptr;
+}
+
+TMTContext & Context::getTMTContext() const
+{
+    auto lock = getLock();
+    if (!shared->tmt_context)
+        throw Exception("no tmt context");
+    return *(shared->tmt_context);
 }
 
 void Context::initializePathCapacityMetric( //

--- a/dbms/src/Interpreters/Context.h
+++ b/dbms/src/Interpreters/Context.h
@@ -367,8 +367,6 @@ public:
     /// Execute inner functions, debug only.
     DBGInvoker & getDBGInvoker() const;
 
-    TMTContext & getTMTContext() const;
-
     /// Create a cache of marks of specified size. This can be done only once.
     void setMarkCache(size_t cache_size_in_bytes);
     std::shared_ptr<MarkCache> getMarkCache() const;
@@ -397,6 +395,8 @@ public:
     BackgroundProcessingPool & getPSBackgroundPool();
 
     void createTMTContext(const TiFlashRaftConfig & raft_config, pingcap::ClusterConfig && cluster_config);
+    bool isTMTContextInited() const;
+    TMTContext & getTMTContext() const;
 
     void initializeSchemaSyncService();
     SchemaSyncServicePtr & getSchemaSyncService();

--- a/dbms/src/Interpreters/Context.h
+++ b/dbms/src/Interpreters/Context.h
@@ -429,6 +429,7 @@ public:
 
     void initializeWriteNodePageStorageIfNeed(const PathPool & path_pool);
     UniversalPageStoragePtr getWriteNodePageStorage() const;
+    UniversalPageStoragePtr tryGetWriteNodePageStorage() const;
     void tryReleaseWriteNodePageStorageForTest();
 
     SharedContextDisaggPtr getSharedContextDisagg() const;

--- a/dbms/src/Server/Bootstrap.cpp
+++ b/dbms/src/Server/Bootstrap.cpp
@@ -1,0 +1,42 @@
+// Copyright 2023 PingCAP, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Common/Exception.h>
+#include <Common/RedactHelpers.h>
+#include <Storages/Page/V3/Universal/UniversalPageIdFormatImpl.h>
+#include <Storages/Page/V3/Universal/UniversalPageStorage.h>
+#include <raft_serverpb.pb.h>
+
+namespace DB
+{
+
+std::optional<raft_serverpb::StoreIdent>
+tryGetStoreIdent(const UniversalPageStoragePtr & wn_ps)
+{
+    auto page = wn_ps->read(
+        UniversalPageIdFormat::getStoreIdentId(),
+        nullptr,
+        {},
+        /*throw_on_not_exist*/ false);
+    if (!page.isValid())
+    {
+        return std::nullopt;
+    }
+    raft_serverpb::StoreIdent store_ident;
+    bool ok = store_ident.ParseFromString(String(page.data));
+    RUNTIME_ASSERT(ok, "Failed to parse store ident, data={}", Redact::keyToHexString(page.data.data(), page.data.size()));
+    return store_ident;
+}
+
+} // namespace DB

--- a/dbms/src/Server/Bootstrap.cpp
+++ b/dbms/src/Server/Bootstrap.cpp
@@ -16,6 +16,7 @@
 #include <Common/RedactHelpers.h>
 #include <Storages/Page/V3/Universal/UniversalPageIdFormatImpl.h>
 #include <Storages/Page/V3/Universal/UniversalPageStorage.h>
+#include <Storages/Transaction/Types.h>
 #include <raft_serverpb.pb.h>
 
 namespace DB
@@ -36,6 +37,11 @@ tryGetStoreIdentFromKey(const UniversalPageStoragePtr & wn_ps, const String & ke
         "Failed to parse store ident, key={} data={}",
         Redact::keyToHexString(key.data(), key.size()),
         Redact::keyToHexString(page.data.data(), page.data.size()));
+    RUNTIME_ASSERT(
+        store_ident.store_id() != InvalidStoreID,
+        "Get invalid store_id from store ident, key={} store_ident={{{}}}",
+        Redact::keyToDebugString(key.data(), key.size()),
+        store_ident.ShortDebugString());
     return store_ident;
 }
 

--- a/dbms/src/Server/Bootstrap.h
+++ b/dbms/src/Server/Bootstrap.h
@@ -12,35 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#pragma once
-
-#include <Common/Logger.h>
-#include <Common/nocopyable.h>
-#include <Interpreters/Context_fwd.h>
-
-#include <memory>
+#include <kvproto/raft_serverpb.pb.h>
 
 namespace DB
 {
-struct BgStorageInitHolder
-{
-    bool need_join = false;
-    std::unique_ptr<std::thread> init_thread;
 
-    void start(Context & global_context, const LoggerPtr & log, bool lazily_init_store, bool is_s3_enabled);
+class UniversalPageStorage;
+using UniversalPageStoragePtr = std::shared_ptr<UniversalPageStorage>;
 
-    // wait until finish if need
-    void waitUntilFinish();
-
-    BgStorageInitHolder() = default;
-
-    // Exception safe for joining the init_thread
-    ~BgStorageInitHolder()
-    {
-        waitUntilFinish();
-    }
-
-    DISALLOW_COPY_AND_MOVE(BgStorageInitHolder);
-};
+std::optional<raft_serverpb::StoreIdent>
+tryGetStoreIdent(const UniversalPageStoragePtr & wn_ps);
 
 } // namespace DB

--- a/dbms/src/Server/CMakeLists.txt
+++ b/dbms/src/Server/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library (tiflash-server-lib
     StatusFile.cpp
     TCPHandler.cpp
     BgStorageInit.cpp
+    Bootstrap.cpp
     StorageConfigParser.cpp
     UserConfigParser.cpp
     RaftConfigParser.cpp)

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -1296,16 +1296,17 @@ int Server::main(const std::vector<std::string> & /*args*/)
           && global_context->getSharedContextDisagg()->use_autoscaler))
     {
         global_context->initializeWriteNodePageStorageIfNeed(global_context->getPathPool());
-        auto wn_ps = global_context->getWriteNodePageStorage();
-        RUNTIME_ASSERT(wn_ps != nullptr);
-        store_ident = tryGetStoreIdent(wn_ps);
-        if (!store_ident)
+        if (auto wn_ps = global_context->tryGetWriteNodePageStorage(); wn_ps != nullptr)
         {
-            LOG_INFO(log, "StoreIdent not exist, new tiflash node");
-        }
-        else
-        {
-            LOG_INFO(log, "StoreIdent restored, {{{}}}", store_ident->ShortDebugString());
+            store_ident = tryGetStoreIdent(wn_ps);
+            if (!store_ident)
+            {
+                LOG_INFO(log, "StoreIdent not exist, new tiflash node");
+            }
+            else
+            {
+                LOG_INFO(log, "StoreIdent restored, {{{}}}", store_ident->ShortDebugString());
+            }
         }
     }
 

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -1303,7 +1303,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
         }
         else
         {
-            LOG_INFO(log, "StoreIdent restored, {}", store_ident->ShortDebugString());
+            LOG_INFO(log, "StoreIdent restored, {{{}}}", store_ident->ShortDebugString());
         }
     }
 

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -245,15 +245,18 @@ DeltaMergeStore::DeltaMergeStore(Context & db_context,
             auto segment_id = storage_pool->newMetaPageId();
             if (segment_id != DELTA_MERGE_FIRST_SEGMENT_ID)
             {
-                if (page_storage_run_mode == PageStorageRunMode::ONLY_V2)
-                {
-                    throw Exception(fmt::format("The first segment id should be {}", DELTA_MERGE_FIRST_SEGMENT_ID), ErrorCodes::LOGICAL_ERROR);
-                }
+                RUNTIME_CHECK_MSG(
+                    page_storage_run_mode != PageStorageRunMode::ONLY_V2,
+                    "The first segment id should be {}, but get {}, run_mode={}",
+                    DELTA_MERGE_FIRST_SEGMENT_ID,
+                    segment_id,
+                    magic_enum::enum_name(page_storage_run_mode));
 
                 // In ONLY_V3 or MIX_MODE, If create a new DeltaMergeStore
                 // Should used fixed DELTA_MERGE_FIRST_SEGMENT_ID to create first segment
                 segment_id = DELTA_MERGE_FIRST_SEGMENT_ID;
             }
+            LOG_INFO(log, "creating the first segment with segment_id={}", segment_id);
 
             auto first_segment = Segment::newSegment( //
                 log,
@@ -286,7 +289,7 @@ DeltaMergeStore::DeltaMergeStore(Context & db_context,
 
     setUpBackgroundTask(dm_context);
 
-    LOG_INFO(log, "Restore DeltaMerge Store end, ps_run_mode={}", static_cast<UInt8>(page_storage_run_mode));
+    LOG_INFO(log, "Restore DeltaMerge Store end, ps_run_mode={}", magic_enum::enum_name(page_storage_run_mode));
 }
 
 DeltaMergeStore::~DeltaMergeStore()

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_Ingest.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore_Ingest.cpp
@@ -570,7 +570,7 @@ void DeltaMergeStore::ingestFiles(
     size_t bytes_on_disk = 0;
 
     auto remote_data_store = dm_context->db_context.getSharedContextDisagg()->remote_data_store;
-    StoreID store_id = 0;
+    StoreID store_id = InvalidStoreID;
     if (remote_data_store)
     {
         store_id = dm_context->db_context.getTMTContext().getKVStore()->getStoreID();

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_Ingest.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore_Ingest.cpp
@@ -569,13 +569,34 @@ void DeltaMergeStore::ingestFiles(
     size_t bytes = 0;
     size_t bytes_on_disk = 0;
 
+    auto remote_data_store = dm_context->db_context.getSharedContextDisagg()->remote_data_store;
+    StoreID store_id = 0;
+    if (remote_data_store)
+    {
+        store_id = dm_context->db_context.getTMTContext().getKVStore()->getStoreID();
+    }
+
     DMFiles files;
     for (const auto & external_file : external_files)
     {
         auto file_parent_path = delegate.getDTFilePath(external_file.id);
 
         // we always create a ref file to this DMFile with all meta info restored later, so here we just restore meta info to calculate its' memory and disk size
-        auto file = DMFile::restore(file_provider, external_file.id, external_file.id, file_parent_path, DMFile::ReadMetaMode::memoryAndDiskSize());
+        DMFilePtr file;
+        if (!remote_data_store)
+        {
+            file = DMFile::restore(
+                file_provider,
+                external_file.id,
+                external_file.id,
+                file_parent_path,
+                DMFile::ReadMetaMode::memoryAndDiskSize());
+        }
+        else
+        {
+            Remote::DMFileOID oid{.store_id = store_id, .table_id = dm_context->physical_table_id, .file_id = external_file.id};
+            file = remote_data_store->prepareDMFile(oid, external_file.id)->restore(DMFile::ReadMetaMode::memoryAndDiskSize());
+        }
         rows += file->getRows();
         bytes += file->getBytes();
         bytes_on_disk += file->getBytesOnDisk();
@@ -629,7 +650,6 @@ void DeltaMergeStore::ingestFiles(
     WriteBatches ingest_wbs(*storage_pool, dm_context->getWriteLimiter());
     if (!files.empty())
     {
-        auto remote_data_store = dm_context->db_context.getSharedContextDisagg()->remote_data_store;
         for (const auto & file : files)
         {
             if (!remote_data_store)
@@ -638,9 +658,7 @@ void DeltaMergeStore::ingestFiles(
             }
             else
             {
-                auto store_id = dm_context->db_context.getTMTContext().getKVStore()->getStoreID();
                 Remote::DMFileOID oid{.store_id = store_id, .table_id = dm_context->physical_table_id, .file_id = file->fileId()};
-                remote_data_store->putDMFile(file, oid, /*remove_local*/ true);
                 PS::V3::CheckpointLocation loc{
                     .data_file_id = std::make_shared<String>(S3::S3Filename::fromDMFileOID(oid).toFullKey()),
                     .offset_in_file = 0,

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_Ingest.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore_Ingest.cpp
@@ -579,12 +579,11 @@ void DeltaMergeStore::ingestFiles(
     DMFiles files;
     for (const auto & external_file : external_files)
     {
-        auto file_parent_path = delegate.getDTFilePath(external_file.id);
-
         // we always create a ref file to this DMFile with all meta info restored later, so here we just restore meta info to calculate its' memory and disk size
         DMFilePtr file;
         if (!remote_data_store)
         {
+            auto file_parent_path = delegate.getDTFilePath(external_file.id);
             file = DMFile::restore(
                 file_provider,
                 external_file.id,

--- a/dbms/src/Storages/DeltaMerge/File/DMFile.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFile.cpp
@@ -751,12 +751,12 @@ std::set<UInt64> DMFile::listAllInPath(
     return file_ids;
 }
 
-bool DMFile::canGC()
+bool DMFile::canGC() const
 {
     return !Poco::File(ngcPath()).exists();
 }
 
-void DMFile::enableGC()
+void DMFile::enableGC() const
 {
     Poco::File ngc_file(ngcPath());
     if (ngc_file.exists())

--- a/dbms/src/Storages/DeltaMerge/File/DMFile.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFile.h
@@ -252,8 +252,8 @@ public:
     static String getPathByStatus(const String & parent_path, UInt64 file_id, DMFile::Status status);
     static String getNGCPath(const String & parent_path, UInt64 file_id, DMFile::Status status);
 
-    bool canGC();
-    void enableGC();
+    bool canGC() const;
+    void enableGC() const;
     void remove(const FileProviderPtr & file_provider);
 
     // The ID for locating DTFile on disk
@@ -371,8 +371,8 @@ public:
     String mergedPath(UInt32 number) const { return subFilePath(mergedFilename(number)); }
 
     using FileNameBase = String;
-    size_t colIndexSizeByName(const FileNameBase & file_name_base) { return Poco::File(colIndexPath(file_name_base)).getSize(); }
-    size_t colDataSizeByName(const FileNameBase & file_name_base) { return Poco::File(colDataPath(file_name_base)).getSize(); }
+    size_t colIndexSizeByName(const FileNameBase & file_name_base) const { return Poco::File(colIndexPath(file_name_base)).getSize(); }
+    size_t colDataSizeByName(const FileNameBase & file_name_base) const { return Poco::File(colDataPath(file_name_base)).getSize(); }
     size_t colIndexSize(ColId id);
     size_t colDataSize(ColId id, bool is_null_map);
 

--- a/dbms/src/Storages/DeltaMerge/Remote/DataStore/DataStore.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/DataStore/DataStore.h
@@ -63,6 +63,11 @@ public:
     /**
      * Blocks until a local DMFile is successfully put in the remote data store.
      * Should be used by a write node.
+     *
+     *
+     * `remove_local` When it is true, pfter put is success, the `local_dm_file`
+     * will turn to an instance pointing to remote location
+     * (`DMFile::switchToRemote`).
      */
     virtual void putDMFile(DMFilePtr local_dm_file, const S3::DMFileOID & oid, bool remove_local) = 0;
 

--- a/dbms/src/Storages/DeltaMerge/Remote/DataStore/DataStore.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/DataStore/DataStore.h
@@ -65,7 +65,7 @@ public:
      * Should be used by a write node.
      *
      *
-     * `remove_local` When it is true, pfter put is success, the `local_dm_file`
+     * `remove_local` When it is true, after put is success, the `local_dm_file`
      * will turn to an instance pointing to remote location
      * (`DMFile::switchToRemote`).
      */

--- a/dbms/src/Storages/DeltaMerge/Remote/DataStore/DataStoreS3.cpp
+++ b/dbms/src/Storages/DeltaMerge/Remote/DataStore/DataStoreS3.cpp
@@ -19,6 +19,7 @@
 #include <Storages/DeltaMerge/Remote/DataStore/DataStoreS3.h>
 #include <Storages/S3/S3Common.h>
 #include <Storages/S3/S3Filename.h>
+#include <Storages/Transaction/Types.h>
 
 #include <future>
 #include <unordered_map>
@@ -29,6 +30,7 @@ void DataStoreS3::putDMFile(DMFilePtr local_dmfile, const S3::DMFileOID & oid, b
 {
     Stopwatch sw;
     RUNTIME_CHECK(local_dmfile->fileId() == oid.file_id);
+    RUNTIME_CHECK_MSG(oid.store_id != InvalidStoreID, "try to upload a DMFile with invalid StoreID, oid={} path={}", oid, local_dmfile->path());
 
     const auto local_dir = local_dmfile->path();
     const auto local_files = local_dmfile->listFilesForUpload();

--- a/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.h
@@ -50,6 +50,7 @@ using SSTFilesToBlockInputStreamPtr = std::shared_ptr<SSTFilesToBlockInputStream
 class BoundedSSTFilesToBlockInputStream;
 using BoundedSSTFilesToBlockInputStreamPtr = std::shared_ptr<BoundedSSTFilesToBlockInputStream>;
 
+// Read blocks from TiKV's SSTFiles
 class SSTFilesToBlockInputStream final : public IBlockInputStream
 {
 public:
@@ -120,10 +121,10 @@ class BoundedSSTFilesToBlockInputStream final
 {
 public:
     BoundedSSTFilesToBlockInputStream(SSTFilesToBlockInputStreamPtr child,
-                                      const ColId pk_column_id_,
+                                      ColId pk_column_id_,
                                       const DecodingStorageSchemaSnapshotConstPtr & schema_snap);
 
-    String getName() const { return "BoundedSSTFilesToBlockInputStream"; }
+    static String getName()  { return "BoundedSSTFilesToBlockInputStream"; }
 
     void readPrefix();
 

--- a/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.h
@@ -124,7 +124,7 @@ public:
                                       ColId pk_column_id_,
                                       const DecodingStorageSchemaSnapshotConstPtr & schema_snap);
 
-    static String getName()  { return "BoundedSSTFilesToBlockInputStream"; }
+    static String getName() { return "BoundedSSTFilesToBlockInputStream"; }
 
     void readPrefix();
 

--- a/dbms/src/Storages/DeltaMerge/SSTFilesToDTFilesOutputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/SSTFilesToDTFilesOutputStream.cpp
@@ -140,7 +140,7 @@ void SSTFilesToDTFilesOutputStream<ChildStream>::writeSuffix()
             GET_METRIC(tiflash_raft_command_duration_seconds, type_apply_snapshot_predecode_upload).Observe(elapsed_seconds);
             break;
         case FileConvertJobType::IngestSST:
-            GET_METRIC(tiflash_raft_command_duration_seconds, type_apply_snapshot_predecode_upload).Observe(elapsed_seconds);
+            GET_METRIC(tiflash_raft_command_duration_seconds, type_ingest_sst_upload).Observe(elapsed_seconds);
             break;
         }
     }

--- a/dbms/src/Storages/DeltaMerge/SSTFilesToDTFilesOutputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/SSTFilesToDTFilesOutputStream.cpp
@@ -118,6 +118,8 @@ void SSTFilesToDTFilesOutputStream<ChildStream>::writeSuffix()
             return fmt_buf.toString();
         }());
 
+    // We could create an async task once a DMFile is generated in `finalizeDTFileStream`
+    // to take more resources to shorten the time of IngestSST/ApplySnapshot.
     auto remote_data_store = context.getSharedContextDisagg()->remote_data_store;
     if (remote_data_store)
     {

--- a/dbms/src/Storages/DeltaMerge/SSTFilesToDTFilesOutputStream.h
+++ b/dbms/src/Storages/DeltaMerge/SSTFilesToDTFilesOutputStream.h
@@ -165,12 +165,12 @@ public:
         return mock_data->read();
     }
 
-    std::tuple<size_t, size_t, size_t, UInt64> getMvccStatistics() const
+    static std::tuple<size_t, size_t, size_t, UInt64> getMvccStatistics() 
     {
         return {};
     }
 
-    SSTFilesToBlockInputStream::ProcessKeys getProcessKeys() const
+    static SSTFilesToBlockInputStream::ProcessKeys getProcessKeys() 
     {
         return {};
     }

--- a/dbms/src/Storages/DeltaMerge/SSTFilesToDTFilesOutputStream.h
+++ b/dbms/src/Storages/DeltaMerge/SSTFilesToDTFilesOutputStream.h
@@ -165,12 +165,12 @@ public:
         return mock_data->read();
     }
 
-    static std::tuple<size_t, size_t, size_t, UInt64> getMvccStatistics() 
+    static std::tuple<size_t, size_t, size_t, UInt64> getMvccStatistics()
     {
         return {};
     }
 
-    static SSTFilesToBlockInputStream::ProcessKeys getProcessKeys() 
+    static SSTFilesToBlockInputStream::ProcessKeys getProcessKeys()
     {
         return {};
     }

--- a/dbms/src/Storages/GCManager.cpp
+++ b/dbms/src/Storages/GCManager.cpp
@@ -46,7 +46,7 @@ bool GCManager::work()
         gc_check_stop_watch.restart();
         return false;
     }
-    if (global_context.getSharedContextDisagg()->isDisaggregatedStorageMode())
+    if (global_context.getSharedContextDisagg()->isDisaggregatedComputeMode())
     {
         // We have disabled the background service for running this, just add a sanitize check
         assert(false);

--- a/dbms/src/Storages/GCManager.cpp
+++ b/dbms/src/Storages/GCManager.cpp
@@ -45,7 +45,7 @@ bool GCManager::work()
         return false;
     }
 
-    LOG_DEBUG(log, "Start GC with keyspace id: {}, table id: {}", next_keyspace_table_id.first, next_keyspace_table_id.second);
+    LOG_DEBUG(log, "Start GC with keyspace={}, table_id={}", next_keyspace_table_id.first, next_keyspace_table_id.second);
     // Get a storage snapshot with weak_ptrs first
     // TODO: avoid gc on storage which have no data?
     std::map<KeyspaceTableID, std::weak_ptr<IManageableStorage>> storages;
@@ -83,7 +83,7 @@ bool GCManager::work()
             // do not acquire structure lock on the storage.
             auto gc_segments_num = storage->onSyncGc(gc_segments_limit, DM::GCOptions::newAll());
             gc_segments_limit = gc_segments_limit - gc_segments_num;
-            LOG_TRACE(ks_log, "GCManager gc {} segments of table {}", gc_segments_num, storage->getTableInfo().id);
+            LOG_TRACE(ks_log, "GCManager gc {} segments of table_id={}", gc_segments_num, storage->getTableInfo().id);
             // Reach the limit on the number of segments to be gc, stop here
             if (gc_segments_limit <= 0)
                 break;
@@ -104,7 +104,7 @@ bool GCManager::work()
 
     if (iter != storages.end())
         next_keyspace_table_id = iter->first;
-    LOG_DEBUG(log, "End GC and next gc will start with keyspace {}, table id: {}", next_keyspace_table_id.first, next_keyspace_table_id.second);
+    LOG_DEBUG(log, "End GC and next gc will start with keyspace={}, table_id={}", next_keyspace_table_id.first, next_keyspace_table_id.second);
     gc_check_stop_watch.restart();
     // Always return false
     return false;

--- a/dbms/src/Storages/Page/V3/CheckpointFile/CPDataFileStat.cpp
+++ b/dbms/src/Storages/Page/V3/CheckpointFile/CPDataFileStat.cpp
@@ -77,7 +77,7 @@ std::unordered_set<String> getRemoteFileIdsNeedCompact(
 {
     {
         std::unordered_set<String> file_ids;
-        // If the total_size is 0, try to get the actual size from S3
+        // If the total_size less than 0, try to get the actual size from S3
         for (const auto & [file_id, stat] : stats)
         {
             if (stat.total_size < 0)
@@ -119,7 +119,7 @@ std::unordered_set<String> getRemoteFileIdsNeedCompact(
     LOG_IMPL(
         log,
         (rewrite_files_info.empty() ? Poco::Message::PRIO_DEBUG : Poco::Message::PRIO_INFORMATION),
-        "CheckpointData pick for compaction={} unchange={}",
+        "CheckpointData pick for compaction={} unchanged={}",
         rewrite_files_info,
         remain_files_info);
     return rewrite_files;

--- a/dbms/src/Storages/Page/V3/Universal/UniversalPageIdFormatImpl.h
+++ b/dbms/src/Storages/Page/V3/Universal/UniversalPageIdFormatImpl.h
@@ -16,6 +16,8 @@
 
 #include <IO/Endian.h>
 #include <IO/WriteBuffer.h>
+#include <IO/WriteBufferFromString.h>
+#include <IO/WriteHelpers.h>
 #include <Storages/Page/V3/Universal/UniversalPageId.h>
 #include <fmt/format.h>
 
@@ -36,7 +38,7 @@ namespace DB
 //  And because some key will be migrated from kv engine to raft engine,
 //  kv engine and raft engine may write and delete the same key.
 //  So to distinguish data written by kv engine and raft engine,
-//  we prepend an `0x01` to the key written by raft engine, andprepend an `0x02` to the key written by kv engine.
+//  we prepend an `0x01` to the key written by raft engine, and prepend an `0x02` to the key written by kv engine.
 //  For example, suppose a key in tikv to be {0x01, 0x02, 0x03}.
 //  If it is written by raft engine, then actual key uni ps see will be {0x01, 0x01, 0x02, 0x03}.
 //  But if it is written by kv engine, the actual key uni ps see will be {0x02, 0x01, 0x02, 0x03}.
@@ -143,6 +145,16 @@ public:
         writeChar(0x02, buff);
         encodeUInt64(region_id, buff);
         writeChar(0x02, buff);
+        return buff.releaseStr();
+    }
+
+    // RAFT_PREFIX LOCAL_PREFIX STORE_IDENT_KEY
+    static String getStoreIdentId()
+    {
+        WriteBufferFromOwnString buff;
+        writeChar(0x01, buff);
+        writeChar(0x01, buff);
+        writeChar(0x01, buff);
         return buff.releaseStr();
     }
 

--- a/dbms/src/Storages/Page/V3/Universal/UniversalPageIdFormatImpl.h
+++ b/dbms/src/Storages/Page/V3/Universal/UniversalPageIdFormatImpl.h
@@ -148,6 +148,18 @@ public:
         return buff.releaseStr();
     }
 
+    // Store ident //
+
+    // KV_PREFIX LOCAL_PREFIX STORE_IDENT_KEY
+    static String getStoreIdentIdInKVEngine()
+    {
+        WriteBufferFromOwnString buff;
+        writeChar(0x02, buff);
+        writeChar(0x01, buff);
+        writeChar(0x01, buff);
+        return buff.releaseStr();
+    }
+
     // RAFT_PREFIX LOCAL_PREFIX STORE_IDENT_KEY
     static String getStoreIdentId()
     {

--- a/dbms/src/Storages/Page/V3/Universal/UniversalPageStorageService.cpp
+++ b/dbms/src/Storages/Page/V3/Universal/UniversalPageStorageService.cpp
@@ -108,6 +108,12 @@ bool UniversalPageStorageService::uploadCheckpoint()
         is_checkpoint_uploading.compare_exchange_strong(is_running, false);
     });
 
+    if (!global_context.isTMTContextInited())
+    {
+        LOG_INFO(log, "Skip checkpoint because context is not initialized");
+        return false;
+    }
+
     auto & tmt = global_context.getTMTContext();
 
     auto store_info = tmt.getKVStore()->getStoreMeta();

--- a/dbms/src/Storages/S3/S3RandomAccessFile.h
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.h
@@ -24,6 +24,11 @@
 
 #include <ext/scope_guard.h>
 
+/// Remove the population of thread_local from Poco
+#ifdef thread_local
+#undef thread_local
+#endif
+
 namespace Aws::S3
 {
 class S3Client;

--- a/dbms/src/Storages/Transaction/ApplySnapshot.cpp
+++ b/dbms/src/Storages/Transaction/ApplySnapshot.cpp
@@ -288,7 +288,7 @@ std::vector<DM::ExternalDTFileInfo> KVStore::preHandleSnapshotToFiles(
 }
 
 /// `preHandleSSTsToDTFiles` read data from SSTFiles and generate DTFile(s) for commited data
-/// return the ids of DTFile(s), the uncommited data will be inserted to `new_region`
+/// return the ids of DTFile(s), the uncommitted data will be inserted to `new_region`
 std::vector<DM::ExternalDTFileInfo> KVStore::preHandleSSTsToDTFiles(
     RegionPtr new_region,
     const SSTViewVec snaps,
@@ -318,7 +318,7 @@ std::vector<DM::ExternalDTFileInfo> KVStore::preHandleSSTsToDTFiles(
         try
         {
             // Get storage schema atomically, will do schema sync if the storage does not exists.
-            // Will return the storage even if it is tombstoned.
+            // Will return the storage even if it is tombstone.
             const auto [table_drop_lock, storage, schema_snap] = AtomicGetStorageSchema(new_region, tmt);
             if (unlikely(storage == nullptr))
             {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/6827

Problem Summary:

* In the previous PR, when handling ingesting SST/apply snapshot, we put the DMFile to S3 in the `DeltaMergeStore::ingestFiles`, which could be slow because the apply threads is quite limited compared to the predecode threads. This greatly slow down the speed of ingesting snapshot from TiKV/restoring from BR
* Some background services that cause Segment creation could be failed when `store_id` is not inited
  * GCManager - background delta-merge and segment-merge
  * SchemaSyncService - create a new DeltaMergeStore and its very first segment
  * If these services create segment before `store_id` is inited, they will try put some data to S3 with `store_id==0`, which will be deleted by S3GCManager

### What is changed and how it works?

* Move upload to S3 to `SSTFilesToDTFilesOutputStream::writeSuffix`, so that different DMFiles could be upload parallel by pre-decode threads
* For the `store_id` problem
  * Try to read the `StoreIdent` from UniPS when disagg is enabled
  * If `StoreIdent` can be restored from UniPS, it means the node has been bootstrapped. Then we setup the `store_id` to KVStore right after TMTContext is created
  * If `StoreIdent` can not be restored from UniPS, it means the node is not bootstrapped. Then we postpone the schema sync with TiDB after proxy bootstrap and setup the `store_id`
  * Add more checks for `store_id` when the background service involve segment rewrite

#### Further improvements
* [ ] We could create an async task once a DMFile is generated in `SSTFilesToDTFilesOutputStream::finalizeDTFileStream` to take more resources to speed up ingestSST/applySnapshot later
* [ ] We need to categorize the dependencies between all global instances and tiflash-proxy, try to bootstrap the node more eailier

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
