### PR TITLE
Fix deprecated warnings of clang-15

### DIFF
--- a/dbms/src/Storages/S3/MockS3Client.cpp
+++ b/dbms/src/Storages/S3/MockS3Client.cpp
@@ -42,11 +42,11 @@
 #include <aws/s3/model/Object.h>
 #include <aws/s3/model/PutObjectRequest.h>
 #include <aws/s3/model/UploadPartRequest.h>
+#include <boost_wrapper/string_split.h>
 #include <common/types.h>
 #include <fiu.h>
 
 #include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/split.hpp>
 #include <mutex>
 #include <string_view>
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6827

Problem Summary:

clang-15 has deprecated some built-in functions that used by boost string split.

### What is changed and how it works?

Ignored these warnning in `boost/algorithm/string/split.hpp`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
