### PR TITLE
Fix race condition for DisaggSnapshot

### DIFF
--- a/dbms/src/Flash/Disaggregated/WNEstablishDisaggTaskHandler.cpp
+++ b/dbms/src/Flash/Disaggregated/WNEstablishDisaggTaskHandler.cpp
@@ -101,10 +101,9 @@ void WNEstablishDisaggTaskHandler::execute(disaggregated::EstablishDisaggTaskRes
     }
 
     using DM::Remote::Serializer;
-    for (const auto & [table_id, table_tasks] : snap->tableSnapshots())
-    {
-        response->add_tables(Serializer::serializeTo(table_tasks, task_id).SerializeAsString());
-    }
+    snap->iterateTableSnapshots([&](const DM::Remote::DisaggPhysicalTableReadSnapshotPtr & snap) {
+        response->add_tables(Serializer::serializeTo(snap, task_id).SerializeAsString());
+    });
 }
 
 } // namespace DB

--- a/dbms/src/Storages/DeltaMerge/Remote/DisaggSnapshot.cpp
+++ b/dbms/src/Storages/DeltaMerge/Remote/DisaggSnapshot.cpp
@@ -51,8 +51,16 @@ SegmentPagesFetchTask DisaggReadSnapshot::popSegTask(TableID physical_table_id, 
     return task;
 }
 
+void DisaggReadSnapshot::iterateTableSnapshots(std::function<void(const DisaggPhysicalTableReadSnapshotPtr &)> fn) const
+{
+    std::shared_lock read_lock(mtx);
+    for (const auto & [_, table_snapshot] : table_snapshots)
+        fn(table_snapshot);
+}
+
 bool DisaggReadSnapshot::empty() const
 {
+    std::shared_lock read_lock(mtx);
     for (const auto & tbl : table_snapshots)
     {
         if (!tbl.second->empty())

--- a/dbms/src/Storages/DeltaMerge/Remote/DisaggSnapshot.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/DisaggSnapshot.h
@@ -74,24 +74,25 @@ public:
     DisaggReadSnapshot() = default;
 
     // Add read tasks for a physical table.
-    // This function is not thread safe
     void addTask(TableID physical_table_id, DisaggPhysicalTableReadSnapshotPtr && task)
     {
         if (!task)
             return;
+        std::unique_lock lock(mtx);
         table_snapshots.emplace(physical_table_id, std::move(task));
     }
 
     // Pop one segment task for reading
     SegmentPagesFetchTask popSegTask(TableID physical_table_id, UInt64 segment_id);
 
+    void iterateTableSnapshots(std::function<void(const DisaggPhysicalTableReadSnapshotPtr &)>) const;
+
     bool empty() const;
-    const TableSnapshotMap & tableSnapshots() const { return table_snapshots; }
 
     DISALLOW_COPY(DisaggReadSnapshot);
 
 private:
-    mutable std::mutex mtx;
+    mutable std::shared_mutex mtx;
     TableSnapshotMap table_snapshots;
 };
 
@@ -105,7 +106,11 @@ public:
 
     SegmentReadTaskPtr popTask(UInt64 segment_id);
 
-    ALWAYS_INLINE bool empty() const { return tasks.empty(); }
+    ALWAYS_INLINE bool empty() const
+    {
+        std::shared_lock read_lock(mtx);
+        return tasks.empty();
+    }
 
     DISALLOW_COPY(DisaggPhysicalTableReadSnapshot);
 
@@ -118,7 +123,7 @@ public:
     std::shared_ptr<std::vector<tipb::FieldType>> output_field_types;
 
 private:
-    mutable std::mutex mtx;
+    mutable std::shared_mutex mtx;
     // segment_id -> SegmentReadTaskPtr
     std::unordered_map<UInt64, SegmentReadTaskPtr> tasks;
 };

--- a/dbms/src/Storages/DeltaMerge/Remote/Serializer.cpp
+++ b/dbms/src/Storages/DeltaMerge/Remote/Serializer.cpp
@@ -46,6 +46,7 @@ namespace DB::DM::Remote
 RemotePb::RemotePhysicalTable
 Serializer::serializeTo(const DisaggPhysicalTableReadSnapshotPtr & snap, const DisaggTaskId & task_id)
 {
+    std::shared_lock read_lock(snap->mtx);
     RemotePb::RemotePhysicalTable remote_table;
     remote_table.set_snapshot_id(task_id.toMeta().SerializeAsString());
     remote_table.set_table_id(snap->physical_table_id);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/6827

Problem Summary:

Meet following fault in test environment:

```
       0x72f0621	faultSignalHandler(int, siginfo_t*, void*) [tiflash+120522273]
                	libs/libdaemon/src/BaseDaemon.cpp:220
  0x7fb576f13420	<unknown symbol> [libpthread.so.0+82976]
       0x72ca124	DB::DM::Remote::DisaggReadSnapshot::empty() const [tiflash+120365348]
                	dbms/src/Storages/DeltaMerge/Remote/DisaggSnapshot.cpp:58
       0x7b9fdc5	DB::DM::Remote::WNDisaggSnapshotManager::unregisterSnapshotIfEmpty(DB::DM::DisaggTaskId const&) [tiflash+129629637]
                	dbms/src/Storages/DeltaMerge/Remote/WNDisaggSnapshotManager.cpp:45
       0x7f3f036	DB::FlashService::FetchDisaggPages(grpc::ServerContext*, disaggregated::FetchDisaggPagesRequest const*, grpc::ServerWriter<disaggregated::PagesPacket>*) [tiflash+133427254]
                	dbms/src/Flash/FlashService.cpp:796
       0x8fede1e	std::__1::__function::__func<tikvpb::Tikv::Service::Service()::$_61, std::__1::allocator<tikvpb::Tikv::Service::Service()::$_61>, grpc::Status (tikvpb::Tikv::Service*, grpc::ServerContext*, disaggregated::FetchDisaggPagesRequest const*, grpc::ServerWriter<disaggregated::PagesPacket>*)>::operator()(tikvpb::Tikv::Service*&&, grpc::ServerContext*&&, disaggregated::FetchDisaggPagesRequest const*&&, grpc::ServerWriter<disaggregated::PagesPacket>*&&) [tiflash+150920734]
                	/data3/jaysonhuang/tiflash-env-13/sysroot/bin/../include/c++/v1/__functional/function.h:345
       0x9036925	grpc::Status grpc::internal::CatchingFunctionHandler<grpc::internal::ServerStreamingHandler<tikvpb::Tikv::Service, disaggregated::FetchDisaggPagesRequest, disaggregated::PagesPacket>::RunHandler(grpc::internal::MethodHandler::HandlerParameter const&)::'lambda'()>(grpc::internal::ServerStreamingHandler<tikvpb::Tikv::Service, disaggregated::FetchDisaggPagesRequest, disaggregated::PagesPacket>::RunHandler(grpc::internal::MethodHandler::HandlerParameter const&)::'lambda'()&&) [tiflash+151218469]
                	contrib/grpc/include/grpcpp/impl/codegen/method_handler.h:44
       0x903623a	grpc::internal::ServerStreamingHandler<tikvpb::Tikv::Service, disaggregated::FetchDisaggPagesRequest, disaggregated::PagesPacket>::RunHandler(grpc::internal::MethodHandler::HandlerParameter const&) [tiflash+151216698]
                	contrib/grpc/include/grpcpp/impl/codegen/method_handler.h:206
       0x8a30d89	grpc::Server::SyncRequest::ContinueRunAfterInterception() [tiflash+144903561]
                	contrib/grpc/src/cpp/server/server_cc.cc:433
       0x8a30b98	grpc::Server::SyncRequest::Run(std::__1::shared_ptr<grpc::Server::GlobalCallbacks> const&, bool) [tiflash+144903064]
                	contrib/grpc/src/cpp/server/server_cc.cc:421
       0x8a40737	grpc::ThreadManager::MainWorkLoop() [tiflash+144967479]
                	contrib/grpc/src/cpp/thread_manager/thread_manager.cc:211
       0x8a41001	grpc::ThreadManager::WorkerThread::WorkerThread(grpc::ThreadManager*)::$_0::__invoke(void*) [tiflash+144969729]
                	contrib/grpc/src/cpp/thread_manager/thread_manager.cc:36
       0x8dd517c	grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::'lambda'(void*)::__invoke(void*) [tiflash+148722044]
                	contrib/grpc/src/core/lib/gprpp/thd_posix.cc:110
  0x7fb576f07609	start_thread [libpthread.so.0+34313]
                	/build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:477
```

### What is changed and how it works?

Add locks for missing paths.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below): WIP
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
