### PR TITLE
support keyspace with S3 disagg read

### DIFF
--- a/dbms/src/Flash/Coprocessor/DAGContext.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGContext.cpp
@@ -22,6 +22,7 @@
 #include <Flash/Statistics/traverseExecutors.h>
 #include <Storages/Transaction/TMTContext.h>
 #include <tipb/executor.pb.h>
+#include <kvproto/disaggregated.pb.h>
 
 namespace DB
 {
@@ -94,7 +95,8 @@ DAGContext::DAGContext(tipb::DAGRequest & dag_request_, const mpp::TaskMeta & me
     initListBasedExecutors();
 }
 
-DAGContext::DAGContext(tipb::DAGRequest & dag_request_, const DM::DisaggTaskId & task_id_, TablesRegionsInfo && tables_regions_info_, const String & compute_node_host_, LoggerPtr log_)
+// for disaggregated task on write node
+DAGContext::DAGContext(tipb::DAGRequest & dag_request_, const disaggregated::DisaggTaskMeta & task_meta_, TablesRegionsInfo && tables_regions_info_, const String & compute_node_host_, LoggerPtr log_)
     : dag_request(&dag_request_)
     , dummy_query_string(dag_request->DebugString())
     , dummy_ast(makeDummyQuery())
@@ -108,10 +110,11 @@ DAGContext::DAGContext(tipb::DAGRequest & dag_request_, const DM::DisaggTaskId &
     , log(std::move(log_))
     , flags(dag_request->flags())
     , sql_mode(dag_request->sql_mode())
-    , disaggregated_id(std::make_unique<DM::DisaggTaskId>(task_id_))
+    , disaggregated_id(std::make_unique<DM::DisaggTaskId>(task_meta_))
     , max_recorded_error_count(getMaxErrorCount(*dag_request))
     , warnings(max_recorded_error_count)
     , warning_count(0)
+    , keyspace_id(RequestUtils::deriveKeyspaceID(task_meta_))
 {
     RUNTIME_CHECK(isTreeBasedExecutors() && dag_request->root_executor().has_executor_id());
     return_executor_id = dag_request->root_executor().has_executor_id() || dag_request->executors(0).has_executor_id();

--- a/dbms/src/Flash/Coprocessor/DAGContext.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGContext.cpp
@@ -21,7 +21,6 @@
 #include <Flash/Planner/ExecutorIdGenerator.h>
 #include <Flash/Statistics/traverseExecutors.h>
 #include <Storages/Transaction/TMTContext.h>
-#include <tipb/executor.pb.h>
 #include <kvproto/disaggregated.pb.h>
 #include <tipb/executor.pb.h>
 

--- a/dbms/src/Flash/Coprocessor/DAGContext.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGContext.cpp
@@ -23,6 +23,7 @@
 #include <Storages/Transaction/TMTContext.h>
 #include <tipb/executor.pb.h>
 #include <kvproto/disaggregated.pb.h>
+#include <tipb/executor.pb.h>
 
 namespace DB
 {

--- a/dbms/src/Flash/Coprocessor/DAGContext.h
+++ b/dbms/src/Flash/Coprocessor/DAGContext.h
@@ -134,7 +134,7 @@ public:
     DAGContext(tipb::DAGRequest & dag_request_, const mpp::TaskMeta & meta_, bool is_root_mpp_task_);
 
     // for disaggregated task on write node
-    DAGContext(tipb::DAGRequest & dag_request_, const DM::DisaggTaskId & task_id_, TablesRegionsInfo && tables_regions_info_, const String & compute_node_host_, LoggerPtr log_);
+    DAGContext(tipb::DAGRequest & dag_request_, const disaggregated::DisaggTaskMeta & task_meta_, TablesRegionsInfo && tables_regions_info_, const String & compute_node_host_, LoggerPtr log_);
 
     // for test
     explicit DAGContext(UInt64 max_error_count_);

--- a/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
@@ -819,7 +819,7 @@ void DAGStorageInterpreter::buildLocalStreams(DAGPipeline & pipeline, size_t max
 
 std::unordered_map<TableID, DAGStorageInterpreter::StorageWithStructureLock> DAGStorageInterpreter::getAndLockStorages(Int64 query_schema_version)
 {
-    auto keyspace_id = context.getDAGContext()->getKeyspaceID();
+    const auto keyspace_id = context.getDAGContext()->getKeyspaceID();
     std::unordered_map<TableID, DAGStorageInterpreter::StorageWithStructureLock> storages_with_lock;
     if (unlikely(query_schema_version == DEFAULT_UNSPECIFIED_SCHEMA_VERSION))
     {

--- a/dbms/src/Flash/Disaggregated/RNPageReceiverContext.cpp
+++ b/dbms/src/Flash/Disaggregated/RNPageReceiverContext.cpp
@@ -21,14 +21,13 @@
 #include <Storages/DeltaMerge/Remote/RNLocalPageCache.h>
 #include <Storages/DeltaMerge/Remote/RNRemoteReadTask.h>
 #include <Storages/Transaction/TMTContext.h>
+#include <Storages/Transaction/Types.h>
 #include <grpcpp/completion_queue.h>
 #include <kvproto/disaggregated.pb.h>
+#include <kvproto/kvrpcpb.pb.h>
 
 #include <cassert>
 #include <tuple>
-
-#include "Storages/Transaction/Types.h"
-#include "kvrpcpb.pb.h"
 
 namespace pingcap::kv
 {

--- a/dbms/src/Flash/Disaggregated/RNPageReceiverContext.cpp
+++ b/dbms/src/Flash/Disaggregated/RNPageReceiverContext.cpp
@@ -27,6 +27,9 @@
 #include <cassert>
 #include <tuple>
 
+#include "Storages/Transaction/Types.h"
+#include "kvrpcpb.pb.h"
+
 namespace pingcap::kv
 {
 template <>
@@ -99,8 +102,14 @@ FetchPagesRequest::FetchPagesRequest(DM::RNRemoteSegmentReadTaskPtr seg_task_)
     if (!seg_task)
         return;
 
-    *req->mutable_snapshot_id() = seg_task->snapshot_id.toMeta();
-    req->set_table_id(seg_task->table_id);
+    auto meta = seg_task->snapshot_id.toMeta();
+    // The keyspace_id here is not vital, as we locate the table and segment by given
+    // snapshot_id. But it could be helpful for debugging.
+    auto keyspace_id = seg_task->ks_table_id.first;
+    meta.set_keyspace_id(keyspace_id);
+    meta.set_api_version(keyspace_id == NullspaceID ? kvrpcpb::APIVersion::V1 : kvrpcpb::APIVersion::V2);
+    *req->mutable_snapshot_id() = meta;
+    req->set_table_id(seg_task->ks_table_id.second);
     req->set_segment_id(seg_task->segment_id);
 
     {
@@ -110,7 +119,7 @@ FetchPagesRequest::FetchPagesRequest(DM::RNRemoteSegmentReadTaskPtr seg_task_)
         {
             auto page_oid = DM::Remote::PageOID{
                 .store_id = seg_task->store_id,
-                .table_id = seg_task->table_id,
+                .ks_table_id = seg_task_->ks_table_id,
                 .page_id = page_id,
             };
             cf_tiny_oids.emplace_back(page_oid);

--- a/dbms/src/Flash/Disaggregated/RNPageReceiverContext.cpp
+++ b/dbms/src/Flash/Disaggregated/RNPageReceiverContext.cpp
@@ -118,7 +118,7 @@ FetchPagesRequest::FetchPagesRequest(DM::RNRemoteSegmentReadTaskPtr seg_task_)
         {
             auto page_oid = DM::Remote::PageOID{
                 .store_id = seg_task->store_id,
-                .ks_table_id = seg_task_->ks_table_id,
+                .ks_table_id = seg_task->ks_table_id,
                 .page_id = page_id,
             };
             cf_tiny_oids.emplace_back(page_oid);

--- a/dbms/src/Flash/Disaggregated/RNPageReceiverContext.h
+++ b/dbms/src/Flash/Disaggregated/RNPageReceiverContext.h
@@ -54,7 +54,7 @@ struct FetchPagesRequest
     String identifier() const
     {
         assert(isValid());
-        return fmt::format("{}+{}+{}", seg_task->store_id, seg_task->table_id, seg_task->segment_id);
+        return fmt::format("{}+{}+{}+{}", seg_task->store_id, seg_task->ks_table_id.first, seg_task->ks_table_id.second, seg_task->segment_id);
     }
 
     String debugString() const;

--- a/dbms/src/Flash/Disaggregated/WNEstablishDisaggTaskHandler.cpp
+++ b/dbms/src/Flash/Disaggregated/WNEstablishDisaggTaskHandler.cpp
@@ -16,7 +16,6 @@
 #include <Common/TiFlashException.h>
 #include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/DAGUtils.h>
-#include <Flash/Coprocessor/RequestUtils.h>
 #include <Flash/Disaggregated/WNEstablishDisaggTaskHandler.h>
 #include <Flash/Executor/QueryExecutorHolder.h>
 #include <Flash/executeQuery.h>

--- a/dbms/src/Flash/Disaggregated/WNEstablishDisaggTaskHandler.cpp
+++ b/dbms/src/Flash/Disaggregated/WNEstablishDisaggTaskHandler.cpp
@@ -16,6 +16,7 @@
 #include <Common/TiFlashException.h>
 #include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/DAGUtils.h>
+#include <Flash/Coprocessor/RequestUtils.h>
 #include <Flash/Disaggregated/WNEstablishDisaggTaskHandler.h>
 #include <Flash/Executor/QueryExecutorHolder.h>
 #include <Flash/executeQuery.h>
@@ -44,7 +45,6 @@ WNEstablishDisaggTaskHandler::WNEstablishDisaggTaskHandler(ContextPtr context_, 
 void WNEstablishDisaggTaskHandler::prepare(const disaggregated::EstablishDisaggTaskRequest * request)
 {
     const auto & meta = request->meta();
-    DM::DisaggTaskId task_id(meta);
 
     auto & tmt_context = context->getTMTContext();
     TablesRegionsInfo tables_regions_info = TablesRegionsInfo::create(request->regions(), request->table_regions(), tmt_context);
@@ -73,7 +73,7 @@ void WNEstablishDisaggTaskHandler::prepare(const disaggregated::EstablishDisaggT
 
     dag_context = std::make_unique<DAGContext>(
         dag_req,
-        task_id,
+        meta,
         std::move(tables_regions_info),
         context->getClientInfo().current_address.toString(),
         log);

--- a/dbms/src/Flash/FlashService.cpp
+++ b/dbms/src/Flash/FlashService.cpp
@@ -50,6 +50,8 @@
 
 #include <ext/scope_guard.h>
 
+#include "Flash/Coprocessor/RequestUtils.h"
+
 namespace DB
 {
 namespace ErrorCodes
@@ -743,9 +745,10 @@ grpc::Status FlashService::FetchDisaggPages(
 
     auto snaps = context->getSharedContextDisagg()->wn_snapshot_manager;
     const DM::DisaggTaskId task_id(request->snapshot_id());
+    const auto keyspace_id = RequestUtils::deriveKeyspaceID(request->snapshot_id());
     auto logger = Logger::get(task_id);
 
-    LOG_DEBUG(logger, "Fetching pages, table_id={} segment_id={}", task_id, request->table_id(), request->segment_id());
+    LOG_DEBUG(logger, "Fetching pages, keyspace_id={} table_id={} segment_id={}", keyspace_id, request->table_id(), request->segment_id());
 
     SCOPE_EXIT({
         // The snapshot is created in the 1st request (Establish), and will be destroyed when all FetchPages are finished.

--- a/dbms/src/Flash/FlashService.cpp
+++ b/dbms/src/Flash/FlashService.cpp
@@ -23,7 +23,6 @@
 #include <Flash/BatchCoprocessorHandler.h>
 #include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/RequestUtils.h>
-#include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Disaggregated/S3LockService.h>
 #include <Flash/Disaggregated/WNEstablishDisaggTaskHandler.h>
 #include <Flash/Disaggregated/WNFetchPagesStreamWriter.h>

--- a/dbms/src/Flash/FlashService.cpp
+++ b/dbms/src/Flash/FlashService.cpp
@@ -22,6 +22,7 @@
 #include <Debug/MockStorage.h>
 #include <Flash/BatchCoprocessorHandler.h>
 #include <Flash/Coprocessor/DAGContext.h>
+#include <Flash/Coprocessor/RequestUtils.h>
 #include <Flash/Disaggregated/S3LockService.h>
 #include <Flash/Disaggregated/WNEstablishDisaggTaskHandler.h>
 #include <Flash/Disaggregated/WNFetchPagesStreamWriter.h>
@@ -49,8 +50,6 @@
 #include <kvproto/disaggregated.pb.h>
 
 #include <ext/scope_guard.h>
-
-#include "Flash/Coprocessor/RequestUtils.h"
 
 namespace DB
 {

--- a/dbms/src/Flash/FlashService.cpp
+++ b/dbms/src/Flash/FlashService.cpp
@@ -745,6 +745,7 @@ grpc::Status FlashService::FetchDisaggPages(
 
     auto snaps = context->getSharedContextDisagg()->wn_snapshot_manager;
     const DM::DisaggTaskId task_id(request->snapshot_id());
+    // get the keyspace from meta, it is now used for debugging
     const auto keyspace_id = RequestUtils::deriveKeyspaceID(request->snapshot_id());
     auto logger = Logger::get(task_id);
 

--- a/dbms/src/Flash/FlashService.cpp
+++ b/dbms/src/Flash/FlashService.cpp
@@ -23,6 +23,7 @@
 #include <Flash/BatchCoprocessorHandler.h>
 #include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/RequestUtils.h>
+#include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Disaggregated/S3LockService.h>
 #include <Flash/Disaggregated/WNEstablishDisaggTaskHandler.h>
 #include <Flash/Disaggregated/WNFetchPagesStreamWriter.h>

--- a/dbms/src/Flash/Mpp/MPPTunnelSetHelper.cpp
+++ b/dbms/src/Flash/Mpp/MPPTunnelSetHelper.cpp
@@ -175,7 +175,7 @@ TrackedMppDataPacketPtr ToCompressedPacket(
     assert(uncompressed_source);
     for ([[maybe_unused]] const auto & chunk : uncompressed_source->getPacket().chunks())
     {
-        assert(chunk.empty());
+        assert(!chunk.empty());
         assert(static_cast<CompressionMethodByte>(chunk[0]) == CompressionMethodByte::NONE);
     }
 

--- a/dbms/src/Server/StorageConfigParser.cpp
+++ b/dbms/src/Server/StorageConfigParser.cpp
@@ -223,6 +223,7 @@ void TiFlashStorageConfig::parseMisc(const String & storage_section, const Logge
     readConfig(table, "format_version", format_version);
 
     readConfig(table, "api_version", api_version);
+    readConfig(table, "api-version", api_version);
 
     auto get_bool_config_or_default = [&](const String & name, bool default_value) {
 #ifndef NDEBUG

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileInMemory.h
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileInMemory.h
@@ -55,7 +55,10 @@ public:
     explicit ColumnFileInMemory(const ColumnFileSchemaPtr & schema_, const CachePtr & cache_ = nullptr)
         : schema(schema_)
         , cache(cache_ ? cache_ : std::make_shared<Cache>(schema_->getSchema()))
-    {}
+    {
+        rows = cache->block.rows();
+        bytes = cache->block.bytes();
+    }
 
     Type getType() const override { return Type::INMEMORY_FILE; }
 

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -45,6 +45,7 @@
 #include <Storages/Page/V2/VersionSet/PageEntriesVersionSetWithDelta.h>
 #include <Storages/PathPool.h>
 #include <Storages/Transaction/TMTContext.h>
+#include <Storages/Transaction/Types.h>
 #include <common/logger_useful.h>
 
 #include <atomic>
@@ -1178,7 +1179,7 @@ DeltaMergeStore::writeNodeBuildRemoteReadSnapshot(
     GET_METRIC(tiflash_disaggregated_read_tasks_count).Increment(tasks.size());
     LOG_DEBUG(tracing_logger, "Read create segment snapshot done");
 
-    return std::make_unique<Remote::DisaggPhysicalTableReadSnapshot>(physical_table_id, std::move(tasks));
+    return std::make_unique<Remote::DisaggPhysicalTableReadSnapshot>(KeyspaceTableID{keyspace_id, physical_table_id}, std::move(tasks));
 }
 
 size_t forceMergeDeltaRows(const DMContextPtr & dm_context)

--- a/dbms/src/Storages/DeltaMerge/Remote/DisaggSnapshot.cpp
+++ b/dbms/src/Storages/DeltaMerge/Remote/DisaggSnapshot.cpp
@@ -32,7 +32,7 @@ SegmentPagesFetchTask DisaggReadSnapshot::popSegTask(TableID physical_table_id, 
         return SegmentPagesFetchTask::error(fmt::format("Segment task not found by table_id, table_id={}, segment_id={}", physical_table_id, segment_id));
     }
 
-    assert(table_iter->second->physical_table_id == physical_table_id);
+    assert(table_iter->second->ks_physical_table_id.second == physical_table_id);
     auto seg_task = table_iter->second->popTask(segment_id);
     if (!seg_task)
     {
@@ -69,8 +69,8 @@ bool DisaggReadSnapshot::empty() const
     return true;
 }
 
-DisaggPhysicalTableReadSnapshot::DisaggPhysicalTableReadSnapshot(TableID table_id_, SegmentReadTasks && tasks_)
-    : physical_table_id(table_id_)
+DisaggPhysicalTableReadSnapshot::DisaggPhysicalTableReadSnapshot(KeyspaceTableID ks_table_id_, SegmentReadTasks && tasks_)
+    : ks_physical_table_id(ks_table_id_)
 {
     for (auto && t : tasks_)
     {

--- a/dbms/src/Storages/DeltaMerge/Remote/DisaggSnapshot.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/DisaggSnapshot.h
@@ -102,7 +102,7 @@ class DisaggPhysicalTableReadSnapshot
     friend struct Serializer;
 
 public:
-    DisaggPhysicalTableReadSnapshot(TableID table_id_, SegmentReadTasks && tasks_);
+    DisaggPhysicalTableReadSnapshot(KeyspaceTableID ks_table_id_, SegmentReadTasks && tasks_);
 
     SegmentReadTaskPtr popTask(UInt64 segment_id);
 
@@ -115,7 +115,7 @@ public:
     DISALLOW_COPY(DisaggPhysicalTableReadSnapshot);
 
 public:
-    const TableID physical_table_id;
+    const KeyspaceTableID ks_physical_table_id;
 
     // TODO: these members are the same in the logical table level,
     //       maybe we can reuse them to reduce memory consumption.

--- a/dbms/src/Storages/DeltaMerge/Remote/DisaggTaskId.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/DisaggTaskId.h
@@ -40,7 +40,7 @@ public:
 
     disaggregated::DisaggTaskMeta toMeta() const;
 
-    // There could be more thatn one TableScan in one MPPTask (in the future).
+    // There could be more than one TableScan in one MPPTask (in the future).
     // We use `MPPTaskId` and `ExecutorID` to represent the ID of one DisaggTask.
     const MPPTaskId mpp_task_id;
     const String executor_id;

--- a/dbms/src/Storages/DeltaMerge/Remote/ObjectId.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/ObjectId.h
@@ -14,11 +14,10 @@
 
 #pragma once
 
+#include <Core/Types.h>
 #include <Storages/Transaction/Types.h>
 #include <common/types.h>
 #include <fmt/format.h>
-
-#include "Core/Types.h"
 
 namespace DB::DM::Remote
 {

--- a/dbms/src/Storages/DeltaMerge/Remote/ObjectId.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/ObjectId.h
@@ -18,6 +18,8 @@
 #include <common/types.h>
 #include <fmt/format.h>
 
+#include "Core/Types.h"
+
 namespace DB::DM::Remote
 {
 
@@ -38,7 +40,7 @@ struct DMFileOID
 struct PageOID
 {
     StoreID store_id = 0;
-    TableID table_id = 0;
+    KeyspaceTableID ks_table_id;
     UInt64 page_id = 0;
 };
 
@@ -71,6 +73,13 @@ struct fmt::formatter<DB::DM::Remote::PageOID>
     template <typename FormatContext>
     auto format(const DB::DM::Remote::PageOID & value, FormatContext & ctx) const -> decltype(ctx.out())
     {
-        return format_to(ctx.out(), "{}_{}_{}", value.store_id, value.table_id, value.page_id);
+        if (value.ks_table_id.first == DB::NullspaceID)
+        {
+            return format_to(ctx.out(), "{}_{}_{}", value.store_id, value.ks_table_id.second, value.page_id);
+        }
+        else
+        {
+            return format_to(ctx.out(), "{}_{}_{}_{}", value.store_id, value.ks_table_id.first, value.ks_table_id.second, value.page_id);
+        }
     }
 };

--- a/dbms/src/Storages/DeltaMerge/Remote/Proto/remote.proto
+++ b/dbms/src/Storages/DeltaMerge/Remote/Proto/remote.proto
@@ -19,6 +19,7 @@ package DB.DM.RemotePb;
 message RemotePhysicalTable {
     bytes snapshot_id = 1; // disaggregated.DisaggTaskMeta
     uint64 table_id = 2;
+    uint32 keyspace_id = 4;
     repeated RemoteSegment segments = 3;
 }
 

--- a/dbms/src/Storages/DeltaMerge/Remote/Proto/remote.proto
+++ b/dbms/src/Storages/DeltaMerge/Remote/Proto/remote.proto
@@ -67,7 +67,6 @@ message ColumnFileInMemory {
     repeated bytes block_columns = 2;
 
     uint64 rows = 3;
-    // uint64 bytes = 4;
 }
 
 message ColumnFileTiny {

--- a/dbms/src/Storages/DeltaMerge/Remote/RNDataProvider.cpp
+++ b/dbms/src/Storages/DeltaMerge/Remote/RNDataProvider.cpp
@@ -28,7 +28,7 @@ Page ColumnFileDataProviderRNLocalPageCache::readTinyData(
 
     auto oid = Remote::PageOID{
         .store_id = store_id,
-        .table_id = table_id,
+        .ks_table_id = ks_table_id,
         .page_id = page_id,
     };
     return page_cache->getPage(oid, *fields);

--- a/dbms/src/Storages/DeltaMerge/Remote/RNDataProvider.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/RNDataProvider.h
@@ -17,6 +17,7 @@
 #include <Storages/DeltaMerge/ColumnFile/ColumnFileDataProvider.h>
 #include <Storages/DeltaMerge/Remote/RNDataProvider_fwd.h>
 #include <Storages/DeltaMerge/Remote/RNLocalPageCache_fwd.h>
+#include <Storages/Transaction/Types.h>
 
 namespace DB::DM::Remote
 {
@@ -27,19 +28,19 @@ private:
     RNLocalPageCachePtr page_cache;
     RNLocalPageCacheGuardPtr pages_guard; // Only keep for maintaining lifetime for related keys
 
-    UInt64 store_id;
-    Int64 table_id;
+    StoreID store_id;
+    KeyspaceTableID ks_table_id;
 
 public:
     explicit ColumnFileDataProviderRNLocalPageCache(
         RNLocalPageCachePtr page_cache_,
         RNLocalPageCacheGuardPtr pages_guard_,
-        UInt64 store_id_,
-        Int64 table_id_)
+        StoreID store_id_,
+        KeyspaceTableID ks_table_id_)
         : page_cache(page_cache_)
         , pages_guard(pages_guard_)
         , store_id(store_id_)
-        , table_id(table_id_)
+        , ks_table_id(ks_table_id_)
     {}
 
     Page readTinyData(

--- a/dbms/src/Storages/DeltaMerge/Remote/RNLocalPageCache.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/RNLocalPageCache.h
@@ -21,10 +21,9 @@
 #include <Storages/Page/Page.h>
 #include <Storages/Page/PageStorage_fwd.h>
 #include <Storages/Page/V3/Universal/UniversalPageId.h>
+#include <Storages/Transaction/Types.h>
 
 #include <boost/noncopyable.hpp>
-
-#include "Storages/Transaction/Types.h"
 
 namespace DB
 {

--- a/dbms/src/Storages/DeltaMerge/Remote/RNLocalPageCache.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/RNLocalPageCache.h
@@ -24,6 +24,8 @@
 
 #include <boost/noncopyable.hpp>
 
+#include "Storages/Transaction/Types.h"
+
 namespace DB
 {
 class ReadBuffer;
@@ -213,7 +215,14 @@ public:
 private:
     static UniversalPageId buildCacheId(const PageOID & oid)
     {
-        return fmt::format("{}_{}_{}", oid.store_id, oid.table_id, oid.page_id);
+        if (oid.ks_table_id.first == NullspaceID)
+        {
+            return fmt::format("{}_{}_{}", oid.store_id, oid.ks_table_id.second, oid.page_id);
+        }
+        else
+        {
+            return fmt::format("{}_{}_{}_{}", oid.store_id, oid.ks_table_id.first, oid.ks_table_id.second, oid.page_id);
+        }
     }
 
 #ifndef DBMS_PUBLIC_GTEST

--- a/dbms/src/Storages/DeltaMerge/Remote/RNRemoteReadTask.cpp
+++ b/dbms/src/Storages/DeltaMerge/Remote/RNRemoteReadTask.cpp
@@ -128,7 +128,7 @@ void RNRemoteReadTask::updateTaskState(const RNRemoteSegmentReadTaskPtr & seg_ta
         {
             auto & task = *task_iter;
             if (task->store_id != seg_task->store_id
-                || task->table_id != seg_task->table_id
+                || task->ks_table_id != seg_task->ks_table_id
                 || task->segment_id != seg_task->segment_id)
             {
                 continue;
@@ -312,7 +312,7 @@ RNRemoteTableReadTaskPtr RNRemoteTableReadTask::buildFrom(
     // ensure the local cache pages.
     auto table_task = std::make_shared<RNRemoteTableReadTask>(
         store_id,
-        remote_table.table_id(),
+        KeyspaceTableID{remote_table.keyspace_id(), remote_table.table_id()},
         snapshot_id,
         address);
 
@@ -334,7 +334,7 @@ RNRemoteTableReadTaskPtr RNRemoteTableReadTask::buildFrom(
                 remote_seg,
                 snapshot_id,
                 table_task->store_id,
-                table_task->table_id,
+                table_task->ks_table_id,
                 table_task->address,
                 log);
         });
@@ -357,14 +357,14 @@ Allocator<false> RNRemoteSegmentReadTask::allocator;
 
 RNRemoteSegmentReadTask::RNRemoteSegmentReadTask(
     DisaggTaskId snapshot_id_,
-    UInt64 store_id_,
-    TableID table_id_,
+    StoreID store_id_,
+    KeyspaceTableID ks_table_id_,
     UInt64 segment_id_,
     String address_,
     LoggerPtr log_)
     : snapshot_id(std::move(snapshot_id_))
     , store_id(store_id_)
-    , table_id(table_id_)
+    , ks_table_id(ks_table_id_)
     , segment_id(segment_id_)
     , address(std::move(address_))
     , log(std::move(log_))
@@ -375,8 +375,8 @@ RNRemoteSegmentReadTaskPtr RNRemoteSegmentReadTask::buildFrom(
     const Context & db_context,
     const RemotePb::RemoteSegment & proto,
     const DisaggTaskId & snapshot_id,
-    UInt64 store_id,
-    TableID table_id,
+    StoreID store_id,
+    KeyspaceTableID ks_table_id,
     const String & address,
     const LoggerPtr & log)
 {
@@ -395,7 +395,7 @@ RNRemoteSegmentReadTaskPtr RNRemoteSegmentReadTask::buildFrom(
     auto task = std::make_shared<RNRemoteSegmentReadTask>(
         snapshot_id,
         store_id,
-        table_id,
+        ks_table_id,
         proto.segment_id(),
         address,
         log);
@@ -405,8 +405,8 @@ RNRemoteSegmentReadTaskPtr RNRemoteSegmentReadTask::buildFrom(
         /* path_pool */ nullptr,
         /* storage_pool */ nullptr,
         /* min_version */ 0,
-        NullspaceID, // FIXME: pass right keyspace id
-        table_id,
+        ks_table_id.first,
+        ks_table_id.second,
         /* is_common_handle */ segment_range.is_common_handle,
         /* rowkey_column_size */ segment_range.rowkey_column_size,
         db_context.getSettingsRef(),
@@ -426,7 +426,7 @@ RNRemoteSegmentReadTaskPtr RNRemoteSegmentReadTask::buildFrom(
     task->segment_snap = Remote::Serializer::deserializeSegmentSnapshotFrom(
         *(task->dm_context),
         store_id,
-        table_id,
+        ks_table_id.second,
         proto);
 
     // Note: At this moment, we still cannot read from `task->segment_snap`,
@@ -451,9 +451,10 @@ RNRemoteSegmentReadTaskPtr RNRemoteSegmentReadTask::buildFrom(
         task->delta_tinycf_page_sizes = persisted_sizes;
 
         LOG_INFO(log,
-                 "Build RemoteSegmentReadTask, store_id={} table_id={} memtable_cfs={} persisted_cfs={}",
+                 "Build RemoteSegmentReadTask, store_id={} keyspace_id={} table_id={} memtable_cfs={} persisted_cfs={}",
                  task->store_id,
-                 task->table_id,
+                 task->ks_table_id.first,
+                 task->ks_table_id.second,
                  task->segment_snap->delta->getMemTableSetSnapshot()->getColumnFileCount(),
                  task->segment_snap->delta->getPersistedFileSetSnapshot()->getColumnFileCount());
     }
@@ -471,7 +472,7 @@ void RNRemoteSegmentReadTask::initColumnFileDataProvider(Remote::RNLocalPageCach
         page_cache,
         pages_guard,
         store_id,
-        table_id);
+        ks_table_id);
 }
 
 void RNRemoteSegmentReadTask::receivePage(RemotePb::RemotePage && remote_page)
@@ -482,8 +483,9 @@ void RNRemoteSegmentReadTask::receivePage(RemotePb::RemotePage && remote_page)
     // Use LocalPageCache
     auto oid = Remote::PageOID{
         .store_id = store_id,
-        .table_id = table_id,
-        .page_id = remote_page.page_id()};
+        .ks_table_id = ks_table_id,
+        .page_id = remote_page.page_id(),
+    };
     auto read_buffer = std::make_shared<ReadBufferFromMemory>(remote_page.data().data(), buf_size);
     PageFieldSizes field_sizes;
     field_sizes.reserve(remote_page.field_sizes_size());

--- a/dbms/src/Storages/DeltaMerge/Remote/RNRemoteReadTask.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/RNRemoteReadTask.h
@@ -133,19 +133,19 @@ class RNRemoteTableReadTask
 {
 public:
     RNRemoteTableReadTask(
-        UInt64 store_id_,
-        TableID table_id_,
+        StoreID store_id_,
+        KeyspaceTableID ks_table_id_,
         DisaggTaskId snap_id_,
         const String & address_)
         : store_id(store_id_)
-        , table_id(table_id_)
+        , ks_table_id(ks_table_id_)
         , snapshot_id(std::move(snap_id_))
         , address(address_)
     {}
 
     StoreID storeID() const { return store_id; }
 
-    TableID tableID() const { return table_id; }
+    KeyspaceTableID ksTableID() const { return ks_table_id; }
 
     static RNRemoteTableReadTaskPtr buildFrom(
         const Context & db_context,
@@ -180,7 +180,7 @@ public:
 
 private:
     const StoreID store_id;
-    const TableID table_id;
+    const KeyspaceTableID ks_table_id;
     const DisaggTaskId snapshot_id;
     const String address;
 
@@ -197,7 +197,7 @@ public:
         const RemotePb::RemoteSegment & proto,
         const DisaggTaskId & snapshot_id,
         StoreID store_id,
-        TableID table_id,
+        KeyspaceTableID ks_table_id,
         const String & address,
         const LoggerPtr & log);
 
@@ -243,7 +243,7 @@ public:
     RNRemoteSegmentReadTask(
         DisaggTaskId snapshot_id_,
         StoreID store_id_,
-        TableID table_id_,
+        KeyspaceTableID ks_table_id_,
         UInt64 segment_id_,
         String address_,
         LoggerPtr log_);
@@ -252,7 +252,7 @@ public:
     SegmentReadTaskState state = SegmentReadTaskState::Init;
     const DisaggTaskId snapshot_id;
     const StoreID store_id;
-    const TableID table_id;
+    const KeyspaceTableID ks_table_id;
     const UInt64 segment_id;
     const String address;
 

--- a/dbms/src/Storages/DeltaMerge/Remote/RNRemoteSegmentThreadInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/RNRemoteSegmentThreadInputStream.h
@@ -92,6 +92,7 @@ private:
     const size_t expected_block_size;
     const ReadMode read_mode;
     const int extra_table_id_index;
+    KeyspaceID keyspace_id;
     TableID physical_table_id;
 
     Stopwatch watch;

--- a/dbms/src/Storages/DeltaMerge/Remote/Serializer.cpp
+++ b/dbms/src/Storages/DeltaMerge/Remote/Serializer.cpp
@@ -49,7 +49,8 @@ Serializer::serializeTo(const DisaggPhysicalTableReadSnapshotPtr & snap, const D
     std::shared_lock read_lock(snap->mtx);
     RemotePb::RemotePhysicalTable remote_table;
     remote_table.set_snapshot_id(task_id.toMeta().SerializeAsString());
-    remote_table.set_table_id(snap->physical_table_id);
+    remote_table.set_keyspace_id(snap->ks_physical_table_id.first);
+    remote_table.set_table_id(snap->ks_physical_table_id.second);
     for (const auto & [seg_id, seg_task] : snap->tasks)
     {
         auto remote_seg = Serializer::serializeTo(

--- a/dbms/src/Storages/StorageDisaggregated.cpp
+++ b/dbms/src/Storages/StorageDisaggregated.cpp
@@ -136,7 +136,6 @@ RequestAndRegionIDs StorageDisaggregated::buildDispatchMPPTaskRequest(
 {
     auto dispatch_req = std::make_shared<::mpp::DispatchTaskRequest>();
     ::mpp::TaskMeta * dispatch_req_meta = dispatch_req->mutable_meta();
-    // TODO(iosmanthus): support S3 remote read in keyspace mode.
     auto keyspace_id = context.getDAGContext()->getKeyspaceID();
     dispatch_req_meta->set_keyspace_id(keyspace_id);
     dispatch_req_meta->set_api_version(keyspace_id == NullspaceID ? kvrpcpb::APIVersion::V1 : kvrpcpb::APIVersion::V2);

--- a/dbms/src/Storages/StorageDisaggregatedRemote.cpp
+++ b/dbms/src/Storages/StorageDisaggregatedRemote.cpp
@@ -45,6 +45,7 @@
 #include <Storages/Transaction/TiDB.h>
 #include <Storages/Transaction/Types.h>
 #include <kvproto/disaggregated.pb.h>
+#include <kvproto/kvrpcpb.pb.h>
 #include <pingcap/coprocessor/Client.h>
 #include <pingcap/kv/Cluster.h>
 #include <pingcap/kv/RegionCache.h>
@@ -53,8 +54,6 @@
 
 #include <atomic>
 #include <numeric>
-
-#include "kvrpcpb.pb.h"
 
 namespace pingcap::kv
 {

--- a/dbms/src/Storages/StorageDisaggregatedRemote.cpp
+++ b/dbms/src/Storages/StorageDisaggregatedRemote.cpp
@@ -54,6 +54,8 @@
 #include <atomic>
 #include <numeric>
 
+#include "kvrpcpb.pb.h"
+
 namespace pingcap::kv
 {
 // The rpc trait
@@ -286,7 +288,7 @@ StorageDisaggregated::buildDisaggregatedTaskForNode(
     const auto & settings = db_context.getSettingsRef();
     auto establish_req = std::make_shared<disaggregated::EstablishDisaggTaskRequest>();
     {
-        auto * meta = establish_req->mutable_meta();
+        disaggregated::DisaggTaskMeta * meta = establish_req->mutable_meta();
         meta->set_start_ts(sender_target_mpp_task_id.query_id.start_ts);
         meta->set_query_ts(sender_target_mpp_task_id.query_id.query_ts);
         meta->set_server_id(sender_target_mpp_task_id.query_id.server_id);
@@ -294,6 +296,9 @@ StorageDisaggregated::buildDisaggregatedTaskForNode(
         auto * dag_context = db_context.getDAGContext();
         meta->set_task_id(dag_context->getMPPTaskId().task_id);
         meta->set_executor_id(table_scan.getTableScanExecutorID());
+        const auto keyspace_id = dag_context->getKeyspaceID();
+        meta->set_keyspace_id(keyspace_id);
+        meta->set_api_version(keyspace_id == NullspaceID ? kvrpcpb::APIVersion::V1 : kvrpcpb::APIVersion::V2);
     }
     // how long the task is valid on the write node
     establish_req->set_timeout_s(DEFAULT_DISAGG_TASK_TIMEOUT_SEC);

--- a/dbms/src/Storages/Transaction/KeyspaceSnapshot.cpp
+++ b/dbms/src/Storages/Transaction/KeyspaceSnapshot.cpp
@@ -14,6 +14,7 @@
 
 #include <IO/Endian.h>
 #include <Storages/Transaction/KeyspaceSnapshot.h>
+#include <Storages/Transaction/TiKVKeyspaceIDImpl.h>
 
 namespace DB
 {

--- a/dbms/src/Storages/Transaction/TiKVKeyValue.cpp
+++ b/dbms/src/Storages/Transaction/TiKVKeyValue.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <Storages/Transaction/TiKVKeyValue.h>
+#include <Storages/Transaction/TiKVKeyspaceIDImpl.h>
 
 namespace DB
 {

--- a/dbms/src/Storages/Transaction/TiKVKeyValue.h
+++ b/dbms/src/Storages/Transaction/TiKVKeyValue.h
@@ -17,7 +17,6 @@
 #include <Common/RedactHelpers.h>
 #include <Common/nocopyable.h>
 #include <Storages/Transaction/SerializationHelper.h>
-#include <Storages/Transaction/TiKVKeyspaceIDImpl.h>
 #include <Storages/Transaction/Types.h>
 
 namespace DB

--- a/dbms/src/Storages/Transaction/TiKVKeyspaceIDImpl.h
+++ b/dbms/src/Storages/Transaction/TiKVKeyspaceIDImpl.h
@@ -16,6 +16,7 @@
 
 #include <IO/Endian.h>
 #include <Storages/Transaction/Types.h>
+#include <common/defines.h>
 
 namespace DB
 {

--- a/tests/tidb-ci/run.sh
+++ b/tests/tidb-ci/run.sh
@@ -33,10 +33,9 @@ docker-compose -f cluster.yaml -f tiflash-dt.yaml exec -T tiflash0 bash -c 'cd /
 docker-compose -f cluster.yaml -f tiflash-dt.yaml down
 clean_data_log
 
-#TODO: Fix it https://github.com/pingcap/tiflash/issues/7120
-#docker-compose -f cluster.yaml -f tiflash-dt-async-grpc.yaml up -d
-#wait_env
-#docker-compose -f cluster.yaml -f tiflash-dt-async-grpc.yaml exec -T tiflash0 bash -c 'cd /tests ; ./run-test.sh tidb-ci/async_grpc'
+docker-compose -f cluster.yaml -f tiflash-dt-async-grpc.yaml up -d
+wait_env
+docker-compose -f cluster.yaml -f tiflash-dt-async-grpc.yaml exec -T tiflash0 bash -c 'cd /tests ; ./run-test.sh tidb-ci/async_grpc'
 
 docker-compose -f cluster.yaml -f tiflash-dt-async-grpc.yaml down
 clean_data_log

--- a/tests/tidb-ci/run.sh
+++ b/tests/tidb-ci/run.sh
@@ -33,9 +33,10 @@ docker-compose -f cluster.yaml -f tiflash-dt.yaml exec -T tiflash0 bash -c 'cd /
 docker-compose -f cluster.yaml -f tiflash-dt.yaml down
 clean_data_log
 
-docker-compose -f cluster.yaml -f tiflash-dt-async-grpc.yaml up -d
-wait_env
-docker-compose -f cluster.yaml -f tiflash-dt-async-grpc.yaml exec -T tiflash0 bash -c 'cd /tests ; ./run-test.sh tidb-ci/async_grpc'
+#TODO: Fix it https://github.com/pingcap/tiflash/issues/7120
+#docker-compose -f cluster.yaml -f tiflash-dt-async-grpc.yaml up -d
+#wait_env
+#docker-compose -f cluster.yaml -f tiflash-dt-async-grpc.yaml exec -T tiflash0 bash -c 'cd /tests ; ./run-test.sh tidb-ci/async_grpc'
 
 docker-compose -f cluster.yaml -f tiflash-dt-async-grpc.yaml down
 clean_data_log


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/6827

Problem Summary: We need to support keyspace for S3 disagg read. A following PR of https://github.com/pingcap/tiflash/pull/7113

### What is changed and how it works?

Also fix the bug that in disagg mode, data in memtable is not read out.

Depends on:
* https://github.com/pingcap/kvproto/pull/1085

Requests:

* RN: Disagg read task handled in `StorageDisaggregatedRemote`, setup the keyspace_id and api_version
* WN: Receive request by `WNEstablishDisaggTaskHandler`, parse the keyspace_id from meta and set it to `DAGContext:: keyspace_id`
* WN: Run into `DAGStorageInterpreter` and get the `DeltaMergeStorage` by `keyspace_id, table_id` (reuse existing logic)
* WN: `DeltaMergeStore::writeNodeBuildRemoteReadSnapshot` setup the keyspace_id, table_id along with the snapshot
* WN: `WNEstablishDisaggTaskHandler::execute` serialize `RemotePb::RemotePhysicalTable`
* RN: `StorageDisaggregated::buildDisaggregatedTask` parse the keyspace_id, table_id from `RemotePb::RemotePhysicalTable` and calls `RNRemoteTableReadTask::buildFrom`
* RN: The keyspace_id is added into each `RNRemoteSegmentReadTask`

Local cache:
* RN: fetch the page data from WN
* RN: persist the page with ID{store_id, keyspace_id, table_id, page_id} in local cache

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
