### PR TITLE
Fix bug for dmfile is remove unexpectly (release-7.0)

### DIFF
--- a/dbms/src/Common/FailPoint.cpp
+++ b/dbms/src/Common/FailPoint.cpp
@@ -97,8 +97,8 @@ namespace DB
     M(invalid_mpp_version)                                   \
     M(force_fail_in_flush_region_data)                       \
     M(force_use_dmfile_format_v3)                            \
-    M(force_set_mocked_s3_object_mtime)
-
+    M(force_set_mocked_s3_object_mtime)                      \
+    M(force_stop_background_checkpoint_upload)
 
 #define APPLY_FOR_PAUSEABLE_FAILPOINTS_ONCE(M) \
     M(pause_with_alter_locks_acquired)         \

--- a/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
@@ -378,7 +378,7 @@ void DAGStorageInterpreter::prepare()
 
     // Do learner read
     const DAGContext & dag_context = *context.getDAGContext();
-    if (dag_context.isBatchCop() || dag_context.isMPPTask())
+    if (dag_context.isBatchCop() || dag_context.isMPPTask() || dag_context.is_disaggregated_task)
         learner_read_snapshot = doBatchCopLearnerRead();
     else
         learner_read_snapshot = doCopLearnerRead();

--- a/dbms/src/Flash/Disaggregated/WNEstablishDisaggTaskHandler.cpp
+++ b/dbms/src/Flash/Disaggregated/WNEstablishDisaggTaskHandler.cpp
@@ -101,10 +101,9 @@ void WNEstablishDisaggTaskHandler::execute(disaggregated::EstablishDisaggTaskRes
     }
 
     using DM::Remote::Serializer;
-    for (const auto & [table_id, table_tasks] : snap->tableSnapshots())
-    {
-        response->add_tables(Serializer::serializeTo(table_tasks, task_id).SerializeAsString());
-    }
+    snap->iterateTableSnapshots([&](const DM::Remote::DisaggPhysicalTableReadSnapshotPtr & snap) {
+        response->add_tables(Serializer::serializeTo(snap, task_id).SerializeAsString());
+    });
 }
 
 } // namespace DB

--- a/dbms/src/Flash/Mpp/MPPTunnelSetHelper.cpp
+++ b/dbms/src/Flash/Mpp/MPPTunnelSetHelper.cpp
@@ -175,7 +175,7 @@ TrackedMppDataPacketPtr ToCompressedPacket(
     assert(uncompressed_source);
     for ([[maybe_unused]] const auto & chunk : uncompressed_source->getPacket().chunks())
     {
-        assert(chunk.empty());
+        assert(!chunk.empty());
         assert(static_cast<CompressionMethodByte>(chunk[0]) == CompressionMethodByte::NONE);
     }
 

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -1495,11 +1495,11 @@ int Server::main(const std::vector<std::string> & /*args*/)
         // So, stop threads explicitly before `TiFlashTestEnv::shutdown()`.
         DB::DM::SegmentReaderPoolManager::instance().stop();
         FileCache::shutdown();
+        global_context->shutdown();
         if (storage_config.s3_config.isS3Enabled())
         {
             S3::ClientFactory::instance().shutdown();
         }
-        global_context->shutdown();
         LOG_DEBUG(log, "Shutted down storages.");
     });
 

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileInMemory.h
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileInMemory.h
@@ -55,7 +55,10 @@ public:
     explicit ColumnFileInMemory(const ColumnFileSchemaPtr & schema_, const CachePtr & cache_ = nullptr)
         : schema(schema_)
         , cache(cache_ ? cache_ : std::make_shared<Cache>(schema_->getSchema()))
-    {}
+    {
+        rows = cache->block.rows();
+        bytes = cache->block.bytes();
+    }
 
     Type getType() const override { return Type::INMEMORY_FILE; }
 

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
@@ -310,6 +310,7 @@ public:
     bool ingestSegmentDataIntoSegmentUsingSplit(
         DMContext & dm_context,
         const SegmentPtr & segment,
+        const RowKeyRange & ingest_range,
         const SegmentPtr & segment_to_ingest);
 
     void ingestSegmentsFromCheckpointInfo(const DMContextPtr & dm_context,

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_Ingest.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore_Ingest.cpp
@@ -875,7 +875,7 @@ std::vector<SegmentPtr> DeltaMergeStore::ingestSegmentsUsingSplit(
                 segment->simpleInfo(),
                 segment_ingest_range.toDebugString());
 
-            const bool succeeded = ingestSegmentDataIntoSegmentUsingSplit(*dm_context, segment, target_segments[segment_idx]);
+            const bool succeeded = ingestSegmentDataIntoSegmentUsingSplit(*dm_context, segment, segment_ingest_range, target_segments[segment_idx]);
             if (succeeded)
             {
                 updated_segments.insert(segment);
@@ -904,10 +904,10 @@ std::vector<SegmentPtr> DeltaMergeStore::ingestSegmentsUsingSplit(
 bool DeltaMergeStore::ingestSegmentDataIntoSegmentUsingSplit(
     DMContext & dm_context,
     const SegmentPtr & segment,
+    const RowKeyRange & ingest_range,
     const SegmentPtr & segment_to_ingest)
 {
     const auto & segment_range = segment->getRowKeyRange();
-    const auto & ingest_range = segment_to_ingest->getRowKeyRange();
 
     // The ingest_range must fall in segment's range.
     RUNTIME_CHECK(

--- a/dbms/src/Storages/DeltaMerge/Remote/DisaggSnapshot.cpp
+++ b/dbms/src/Storages/DeltaMerge/Remote/DisaggSnapshot.cpp
@@ -51,8 +51,16 @@ SegmentPagesFetchTask DisaggReadSnapshot::popSegTask(TableID physical_table_id, 
     return task;
 }
 
+void DisaggReadSnapshot::iterateTableSnapshots(std::function<void(const DisaggPhysicalTableReadSnapshotPtr &)> fn) const
+{
+    std::shared_lock read_lock(mtx);
+    for (const auto & [_, table_snapshot] : table_snapshots)
+        fn(table_snapshot);
+}
+
 bool DisaggReadSnapshot::empty() const
 {
+    std::shared_lock read_lock(mtx);
     for (const auto & tbl : table_snapshots)
     {
         if (!tbl.second->empty())

--- a/dbms/src/Storages/DeltaMerge/Remote/DisaggSnapshot.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/DisaggSnapshot.h
@@ -74,24 +74,25 @@ public:
     DisaggReadSnapshot() = default;
 
     // Add read tasks for a physical table.
-    // This function is not thread safe
     void addTask(TableID physical_table_id, DisaggPhysicalTableReadSnapshotPtr && task)
     {
         if (!task)
             return;
+        std::unique_lock lock(mtx);
         table_snapshots.emplace(physical_table_id, std::move(task));
     }
 
     // Pop one segment task for reading
     SegmentPagesFetchTask popSegTask(TableID physical_table_id, UInt64 segment_id);
 
+    void iterateTableSnapshots(std::function<void(const DisaggPhysicalTableReadSnapshotPtr &)>) const;
+
     bool empty() const;
-    const TableSnapshotMap & tableSnapshots() const { return table_snapshots; }
 
     DISALLOW_COPY(DisaggReadSnapshot);
 
 private:
-    mutable std::mutex mtx;
+    mutable std::shared_mutex mtx;
     TableSnapshotMap table_snapshots;
 };
 
@@ -105,7 +106,11 @@ public:
 
     SegmentReadTaskPtr popTask(UInt64 segment_id);
 
-    ALWAYS_INLINE bool empty() const { return tasks.empty(); }
+    ALWAYS_INLINE bool empty() const
+    {
+        std::shared_lock read_lock(mtx);
+        return tasks.empty();
+    }
 
     DISALLOW_COPY(DisaggPhysicalTableReadSnapshot);
 
@@ -118,7 +123,7 @@ public:
     std::shared_ptr<std::vector<tipb::FieldType>> output_field_types;
 
 private:
-    mutable std::mutex mtx;
+    mutable std::shared_mutex mtx;
     // segment_id -> SegmentReadTaskPtr
     std::unordered_map<UInt64, SegmentReadTaskPtr> tasks;
 };

--- a/dbms/src/Storages/DeltaMerge/Remote/Proto/remote.proto
+++ b/dbms/src/Storages/DeltaMerge/Remote/Proto/remote.proto
@@ -66,7 +66,6 @@ message ColumnFileInMemory {
     repeated bytes block_columns = 2;
 
     uint64 rows = 3;
-    // uint64 bytes = 4;
 }
 
 message ColumnFileTiny {

--- a/dbms/src/Storages/DeltaMerge/Remote/RNRemoteSegmentThreadInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/RNRemoteSegmentThreadInputStream.h
@@ -102,6 +102,8 @@ private:
     bool done = false;
 
     BlockInputStreamPtr cur_stream;
+    RNRemoteSegmentReadTaskPtr cur_read_task; // When reading from cur_stream we need cur_read_task is alive.
+
     UInt64 cur_segment_id;
 
     LoggerPtr log;

--- a/dbms/src/Storages/DeltaMerge/Remote/Serializer.cpp
+++ b/dbms/src/Storages/DeltaMerge/Remote/Serializer.cpp
@@ -46,6 +46,7 @@ namespace DB::DM::Remote
 RemotePb::RemotePhysicalTable
 Serializer::serializeTo(const DisaggPhysicalTableReadSnapshotPtr & snap, const DisaggTaskId & task_id)
 {
+    std::shared_lock read_lock(snap->mtx);
     RemotePb::RemotePhysicalTable remote_table;
     remote_table.set_snapshot_id(task_id.toMeta().SerializeAsString());
     remote_table.set_table_id(snap->physical_table_id);

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_fast_add_peer.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_fast_add_peer.cpp
@@ -45,6 +45,7 @@ namespace DB
 namespace FailPoints
 {
 extern const char force_use_dmfile_format_v3[];
+extern const char force_stop_background_checkpoint_upload[];
 } // namespace FailPoints
 namespace DM
 {
@@ -62,6 +63,7 @@ public:
     void SetUp() override
     {
         FailPointHelper::enableFailPoint(FailPoints::force_use_dmfile_format_v3);
+        FailPointHelper::enableFailPoint(FailPoints::force_stop_background_checkpoint_upload);
         auto s3_client = S3::ClientFactory::instance().sharedTiFlashClient();
         ASSERT_TRUE(::DB::tests::TiFlashTestEnv::createBucketIfNotExist(*s3_client));
         TiFlashStorageTestBasic::SetUp();
@@ -95,6 +97,7 @@ public:
     void TearDown() override
     {
         FailPointHelper::disableFailPoint(FailPoints::force_use_dmfile_format_v3);
+        FailPointHelper::disableFailPoint(FailPoints::force_stop_background_checkpoint_upload);
         auto & global_context = TiFlashTestEnv::getGlobalContext();
         if (!already_initialize_data_store)
         {

--- a/dbms/src/Storages/S3/S3Common.cpp
+++ b/dbms/src/Storages/S3/S3Common.cpp
@@ -182,6 +182,7 @@ bool ClientFactory::isEnabled() const
 void ClientFactory::init(const StorageS3Config & config_, bool mock_s3_)
 {
     config = config_;
+    RUNTIME_CHECK(!config.root.starts_with("//"), config.root);
     config.root = normalizedRoot(config.root);
     Aws::InitAPI(aws_options);
     Aws::Utils::Logging::InitializeAWSLogging(std::make_shared<AWSLogger>());
@@ -477,11 +478,13 @@ void listPrefix(
 {
     Stopwatch sw;
     Aws::S3::Model::ListObjectsV2Request req;
-    req.WithBucket(client.bucket()).WithPrefix(client.root() + prefix);
+    bool is_root_single_slash = client.root() == "/";
+    // If the `root == '/'`, don't prepend the root to the prefix, otherwise S3 list doesn't work.
+    req.WithBucket(client.bucket()).WithPrefix(is_root_single_slash ? prefix : client.root() + prefix);
 
     // If the `root == '/'`, then the return result will cut it off
     // else we need to cut the root in the following codes
-    bool need_cut = client.root() != "/";
+    bool need_cut = !is_root_single_slash;
     size_t cut_size = client.root().size();
 
     bool done = false;
@@ -540,7 +543,9 @@ void listPrefixWithDelimiter(
 {
     Stopwatch sw;
     Aws::S3::Model::ListObjectsV2Request req;
-    req.WithBucket(client.bucket()).WithPrefix(client.root() + prefix);
+    bool is_root_single_slash = client.root() == "/";
+    // If the `root == '/'`, don't prepend the root to the prefix, otherwise S3 list doesn't work.
+    req.WithBucket(client.bucket()).WithPrefix(is_root_single_slash ? prefix : client.root() + prefix);
     if (!delimiter.empty())
     {
         req.SetDelimiter(String(delimiter));
@@ -548,7 +553,7 @@ void listPrefixWithDelimiter(
 
     // If the `root == '/'`, then the return result will cut it off
     // else we need to cut the root in the following codes
-    bool need_cut = client.root() != "/";
+    bool need_cut = !is_root_single_slash;
     size_t cut_size = client.root().size();
 
     bool done = false;

--- a/dbms/src/Storages/S3/S3Common.h
+++ b/dbms/src/Storages/S3/S3Common.h
@@ -70,7 +70,9 @@ public:
     template <typename Request>
     void setBucketAndKeyWithRoot(Request & req, const String & key) const
     {
-        req.WithBucket(bucket_name).WithKey(key_root + key);
+        bool is_root_single_slash = key_root == "/";
+        // If the `root == '/'`, don't prepend the root to the prefix, otherwise S3 list doesn't work.
+        req.WithBucket(bucket_name).WithKey(is_root_single_slash ? key : key_root + key);
     }
 
 private:


### PR DESCRIPTION
cherry-pick of https://github.com/pingcap/tiflash/pull/7129

New commit since release-7.0: https://github.com/pingcap/tiflash/compare/release-7.0...master. pick some essential crash fixes and correctness fixes

* * *

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/7128

Problem Summary:

When S3GCManager remove a DMFile stored in S3, it try to scan all sub files of that dmfile and mark them as "tiflash_deleted=true". But we must append a "/" after the key or it will remove unexpect S3 objects of other dmfile.

Removing dmfile with key "s108/data/t_104/dmf_2/meta", "s108/data/t_104/dmf_2/1.mrk", ... should never remove "s108/data/t_104/dmf_27/meta" etc...

```
[2023/03/20 21:34:57.126 +08:00] [DEBUG] [S3LockClient.cpp:114] ["request, address=127.0.0.1:3930 req=data_file_key: \"s108/data/t_104/dmf_2\""] [source="<key=s108/data/t_104/dmf_2,type=MarkDelete>"] [thread_id=15]
[2023/03/20 21:34:57.171 +08:00] [DEBUG] [S3Common.cpp:524] ["listPrefix prefix=lock/s108/t_104/dmf_2.lock_, total_keys=0, cost=0.04s"] [source="bucket=flow root=cluster1/"] [thread_id=11]
[2023/03/20 21:34:57.287 +08:00] [DEBUG] [S3Common.cpp:312] ["uploadEmptyFile key=s108/data/t_104/dmf_2.del, cost=0.12s"] [source="bucket=flow root=cluster1/"] [thread_id=11]
[2023/03/20 21:34:57.287 +08:00] [INFO] [S3LockService.cpp:309] ["data file is mark deleted, key=s108/data/t_104/dmf_2 delmark=s108/data/t_104/dmf_2.del"] [thread_id=11]
[2023/03/20 21:34:57.287 +08:00] [INFO] [S3GCManager.cpp:309] ["delmark created, key=s108/data/t_104/dmf_2"] [thread_id=15]
[2023/03/20 21:34:58.478 +08:00] [DEBUG] [S3Common.cpp:375] ["rewrite object key=s108/data/t_104/dmf_2.del cost=0.09s"] [source="bucket=flow root=cluster1/"] [thread_id=15]
[2023/03/20 21:34:58.478 +08:00] [INFO] [S3GCManager.cpp:442] ["datafile deleted by lifecycle tagging, key=s108/data/t_104/dmf_2 sub_key=s108/data/t_104/dmf_2.del"] [thread_id=15]
...
[2023/03/20 21:34:59.882 +08:00] [DEBUG] [S3Common.cpp:375] ["rewrite object key=s108/data/t_104/dmf_22.del cost=0.07s"] [source="bucket=flow root=cluster1/"] [thread_id=15]
[2023/03/20 21:34:59.882 +08:00] [INFO] [S3GCManager.cpp:442] ["datafile deleted by lifecycle tagging, key=s108/data/t_104/dmf_2 sub_key=s108/data/t_104/dmf_22.del"] [thread_id=15]
[2023/03/20 21:35:00.043 +08:00] [DEBUG] [S3Common.cpp:375] ["rewrite object key=s108/data/t_104/dmf_22/%2D1.dat cost=0.16s"] [source="bucket=flow root=cluster1/"] [thread_id=15]
...
[2023/03/20 21:35:02.518 +08:00] [DEBUG] [S3Common.cpp:375] ["rewrite object key=s108/data/t_104/dmf_27/meta cost=0.08s"] [source="bucket=flow root=cluster1/"] [thread_id=15]
[2023/03/20 21:35:02.518 +08:00] [INFO] [S3GCManager.cpp:442] ["datafile deleted by lifecycle tagging, key=s108/data/t_104/dmf_2 sub_key=s108/data/t_104/dmf_27/meta"] [thread_id=15]
...
[2023/03/20 21:35:04.989 +08:00] [DEBUG] [S3Common.cpp:524] ["listPrefix prefix=s108/data/t_104/dmf_2, total_keys=42, cost=7.70s"] [source="bucket=flow root=cluster1/"] [thread_id=15]
[2023/03/20 21:35:04.989 +08:00] [INFO] [S3GCManager.cpp:445] ["datafile deleted by lifecycle tagging, all sub keys are deleted, key=s108/data/t_104/dmf_2"] [thread_id=15]
```

### What is changed and how it works?

Add a suffix "/" to the key when scanning the sub objects of a dmfile on S3

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
