### PR TITLE
Move maps to join partition

### DIFF
--- a/dbms/src/DataStreams/NonJoinedBlockInputStream.cpp
+++ b/dbms/src/DataStreams/NonJoinedBlockInputStream.cpp
@@ -158,7 +158,7 @@ Block NonJoinedBlockInputStream::readImpl()
         const auto & src_col = result_sample_block.safeGetByPosition(column_indices_right[i]);
         columns_right[i] = src_col.type->createColumn();
         if (row_counter_column == nullptr)
-            row_counter_column = columns_left[i].get();
+            row_counter_column = columns_right[i].get();
     }
     assert(row_counter_column != nullptr);
 

--- a/dbms/src/DataStreams/NonJoinedBlockInputStream.cpp
+++ b/dbms/src/DataStreams/NonJoinedBlockInputStream.cpp
@@ -78,7 +78,6 @@ NonJoinedBlockInputStream::NonJoinedBlockInputStream(const Join & parent_, const
     , index(index_)
     , step(step_)
     , max_block_size(max_block_size_)
-    , add_not_mapped_rows(true)
 {
     size_t build_concurrency = parent.getBuildConcurrency();
     if (unlikely(step > build_concurrency || index >= build_concurrency))
@@ -123,7 +122,7 @@ NonJoinedBlockInputStream::NonJoinedBlockInputStream(const Join & parent_, const
 
     columns_left.resize(num_columns_left);
     columns_right.resize(num_columns_right);
-    next_index = index;
+    current_partition_index = index;
 }
 
 Block NonJoinedBlockInputStream::readImpl()
@@ -142,64 +141,33 @@ Block NonJoinedBlockInputStream::readImpl()
         /// no build data in memory, the non joined result must be empty
         return {};
 
-    /// todo read data based on JoinPartition
-    if (add_not_mapped_rows)
-    {
-        setNextCurrentNotMappedRow();
-        add_not_mapped_rows = false;
-    }
-
-    if (parent.strictness == ASTTableJoin::Strictness::Any)
-        return createBlock<ASTTableJoin::Strictness::Any>(parent.maps_any_full);
-    else if (parent.strictness == ASTTableJoin::Strictness::All)
-        return createBlock<ASTTableJoin::Strictness::All>(parent.maps_all_full);
-    else
-        throw Exception("Logical error: unknown JOIN strictness (must be ANY or ALL)", ErrorCodes::LOGICAL_ERROR);
-}
-
-void NonJoinedBlockInputStream::setNextCurrentNotMappedRow()
-{
-    while (current_not_mapped_row == nullptr && next_index < parent.rows_not_inserted_to_map.size())
-    {
-        current_not_mapped_row = parent.rows_not_inserted_to_map[next_index].head.next;
-        next_index += step;
-    }
-}
-
-template <ASTTableJoin::Strictness STRICTNESS, typename Maps>
-Block NonJoinedBlockInputStream::createBlock(const Maps & maps)
-{
     size_t num_columns_left = column_indices_left.size();
     size_t num_columns_right = column_indices_right.size();
+    IColumn * row_counter_column = nullptr;
 
     for (size_t i = 0; i < num_columns_left; ++i)
     {
         const auto & src_col = result_sample_block.safeGetByPosition(column_indices_left[i]);
         columns_left[i] = src_col.type->createColumn();
+        if (row_counter_column == nullptr)
+            row_counter_column = columns_left[i].get();
     }
 
     for (size_t i = 0; i < num_columns_right; ++i)
     {
         const auto & src_col = result_sample_block.safeGetByPosition(column_indices_right[i]);
         columns_right[i] = src_col.type->createColumn();
+        if (row_counter_column == nullptr)
+            row_counter_column = columns_left[i].get();
     }
+    assert(row_counter_column != nullptr);
 
-    size_t rows_added = 0;
-
-    switch (parent.type)
+    while (current_partition_index < parent.getBuildConcurrency() && row_counter_column->size() < max_block_size)
     {
-#define M(TYPE)                                                                                                             \
-    case Join::Type::TYPE:                                                                                                  \
-        rows_added = fillColumns<STRICTNESS>(*maps.TYPE, num_columns_left, columns_left, num_columns_right, columns_right); \
-        break;
-        APPLY_FOR_JOIN_VARIANTS(M)
-#undef M
-
-    default:
-        throw Exception("Unknown JOIN keys variant.", ErrorCodes::UNKNOWN_SET_DATA_VARIANT);
+        fillColumnsUsingCurrentPartition(num_columns_left, columns_left, num_columns_right, columns_right, row_counter_column);
     }
 
-    if (!rows_added)
+    if (row_counter_column->empty())
         return {};
 
     Block res = result_sample_block.cloneEmpty();
@@ -211,28 +179,115 @@ Block NonJoinedBlockInputStream::createBlock(const Maps & maps)
     return res;
 }
 
+void NonJoinedBlockInputStream::fillColumnsUsingCurrentPartition(
+    size_t num_columns_left,
+    MutableColumns & mutable_columns_left,
+    size_t num_columns_right,
+    MutableColumns & mutable_columns_right,
+    IColumn * row_counter_column)
+{
+    const auto & partition = parent.partitions[current_partition_index];
+    if (parent.isSpilled() && partition->isSpill())
+    {
+        /// if the partition is spilled, just skip it
+        advancedToNextPartition();
+        return;
+    }
+    if (!not_mapped_row_pos_inited)
+    {
+        not_mapped_row_pos = partition->getRowsNotInsertedToMap()->head.next;
+        not_mapped_row_pos_inited = true;
+    }
+    if (parent.strictness == ASTTableJoin::Strictness::Any)
+    {
+        switch (parent.type)
+        {
+#define M(TYPE)                                     \
+    case JoinType::TYPE:                            \
+        fillColumns<ASTTableJoin::Strictness::Any>( \
+            *partition->maps_any_full.TYPE,         \
+            num_columns_left,                       \
+            mutable_columns_left,                   \
+            num_columns_right,                      \
+            mutable_columns_right,                  \
+            row_counter_column);                    \
+        break;
+            APPLY_FOR_JOIN_VARIANTS(M)
+#undef M
+
+        default:
+            throw Exception("Unknown JOIN keys variant.", ErrorCodes::UNKNOWN_SET_DATA_VARIANT);
+        }
+    }
+    else if (parent.strictness == ASTTableJoin::Strictness::All)
+    {
+        switch (parent.type)
+        {
+#define M(TYPE)                                     \
+    case JoinType::TYPE:                            \
+        fillColumns<ASTTableJoin::Strictness::All>( \
+            *partition->maps_all_full.TYPE,         \
+            num_columns_left,                       \
+            mutable_columns_left,                   \
+            num_columns_right,                      \
+            mutable_columns_right,                  \
+            row_counter_column);                    \
+        break;
+            APPLY_FOR_JOIN_VARIANTS(M)
+#undef M
+
+        default:
+            throw Exception("Unknown JOIN keys variant.", ErrorCodes::UNKNOWN_SET_DATA_VARIANT);
+        }
+    }
+    else
+        throw Exception("Logical error: unknown JOIN strictness (must be ANY or ALL)", ErrorCodes::LOGICAL_ERROR);
+}
+
+struct RowCountInfo
+{
+    RowCountInfo(size_t current_rows_, size_t max_rows_)
+        : current_rows(current_rows_)
+        , added_rows(0)
+        , max_rows(max_rows_)
+    {}
+    inline size_t getAddedRows() const { return added_rows; }
+    inline size_t getCurrentRows() const { return current_rows; }
+    inline bool reachMaxRows() const { return current_rows == max_rows; }
+    inline void inc(size_t rows)
+    {
+        added_rows += rows;
+        current_rows += rows;
+    }
+    inline size_t availableRowCount() const { return max_rows - current_rows; }
+
+private:
+    size_t current_rows;
+    size_t added_rows;
+    size_t max_rows;
+};
 
 template <ASTTableJoin::Strictness STRICTNESS, typename Map>
-size_t NonJoinedBlockInputStream::fillColumns(const Map & map,
-                                              size_t num_columns_left,
-                                              MutableColumns & mutable_columns_left,
-                                              size_t num_columns_right,
-                                              MutableColumns & mutable_columns_right)
+void NonJoinedBlockInputStream::fillColumns(const Map & map,
+                                            size_t num_columns_left,
+                                            MutableColumns & mutable_columns_left,
+                                            size_t num_columns_right,
+                                            MutableColumns & mutable_columns_right,
+                                            IColumn * row_counter_column)
 {
-    size_t rows_added = 0;
     size_t key_num = parent.key_names_right.size();
     /// first add rows that is not in the hash table
-    while (current_not_mapped_row != nullptr)
+    RowCountInfo row_count_info(row_counter_column->size(), max_block_size);
+    while (not_mapped_row_pos != nullptr)
     {
-        ++rows_added;
+        row_count_info.inc(1);
         /// handle left columns later to utilize insertManyDefaults
         for (size_t j = 0; j < num_columns_right; ++j)
-            mutable_columns_right[j]->insertFrom(*current_not_mapped_row->block->getByPosition(key_num + j).column.get(),
-                                                 current_not_mapped_row->row_num);
+            mutable_columns_right[j]->insertFrom(*not_mapped_row_pos->block->getByPosition(key_num + j).column.get(),
+                                                 not_mapped_row_pos->row_num);
 
-        current_not_mapped_row = current_not_mapped_row->next;
-        setNextCurrentNotMappedRow();
-        if (rows_added == max_block_size)
+        not_mapped_row_pos = not_mapped_row_pos->next;
+        if (row_count_info.reachMaxRows())
             break;
     }
     /// Fill left columns with defaults
@@ -241,68 +296,42 @@ size_t NonJoinedBlockInputStream::fillColumns(const Map & map,
         /// but we don't care about the key column now so just insert a default value is ok.
         /// refer to https://github.com/pingcap/tiflash/blob/v6.5.0/dbms/src/Flash/Coprocessor/DAGExpressionAnalyzer.cpp#L953
         /// for detailed explanation
-        mutable_columns_left[j]->insertManyDefaults(rows_added);
+        mutable_columns_left[j]->insertManyDefaults(row_count_info.getAddedRows());
 
-    if (rows_added == max_block_size)
-        return rows_added;
+    if (row_count_info.reachMaxRows())
+        return;
 
     /// then add rows that in hash table, but not joined
-    if (!position)
+    if (!pos_in_hashmap_inited)
     {
-        current_segment = index;
-
-        while (parent.partitions[current_segment]->isSpill())
-        {
-            current_segment += step;
-            if (current_segment >= map.getSegmentSize())
-            {
-                return rows_added;
-            }
-        }
-
-        position = decltype(position)(
-            static_cast<void *>(new typename Map::SegmentType::HashTable::const_iterator(map.getSegmentTable(current_segment).begin())),
-            [](void * ptr) { delete reinterpret_cast<typename Map::SegmentType::HashTable::const_iterator *>(ptr); });
+        pos_in_hashmap = decltype(pos_in_hashmap)(
+            static_cast<void *>(new typename Map::const_iterator(map.begin())),
+            [](void * ptr) { delete reinterpret_cast<typename Map::const_iterator *>(ptr); });
+        pos_in_hashmap_inited = true;
     }
 
-    if (current_segment >= map.getSegmentSize())
-    {
-        return rows_added;
-    }
     /// use pointer instead of reference because `it` need to be re-assigned latter
-    auto it = reinterpret_cast<typename Map::SegmentType::HashTable::const_iterator *>(position.get());
-    auto end = map.getSegmentTable(current_segment).end();
+    auto it = reinterpret_cast<typename Map::const_iterator *>(pos_in_hashmap.get());
+    auto end = map.end();
 
-    for (; *it != end || current_segment + step < map.getSegmentSize();)
+    for (; *it != end;)
     {
-        if (*it == end || parent.partitions[current_segment]->isSpill())
-        {
-            current_segment += step;
-            while (parent.partitions[current_segment]->isSpill())
-            {
-                current_segment += step;
-                if (current_segment >= map.getSegmentSize())
-                {
-                    return rows_added;
-                }
-            }
-            position = decltype(position)(
-                static_cast<void *>(new typename Map::SegmentType::HashTable::const_iterator(
-                    map.getSegmentTable(current_segment).begin())),
-                [](void * ptr) { delete reinterpret_cast<typename Map::SegmentType::HashTable::const_iterator *>(ptr); });
-            it = reinterpret_cast<typename Map::SegmentType::HashTable::const_iterator *>(position.get());
-            end = map.getSegmentTable(current_segment).end();
-            continue;
-        }
-
         if ((*it)->getMapped().getUsed())
         {
             ++(*it);
             continue;
         }
 
-        rows_added += AdderNonJoined<STRICTNESS, typename Map::mapped_type>::add((*it)->getMapped(), key_num, num_columns_left, mutable_columns_left, num_columns_right, mutable_columns_right, next_element_in_row_list, max_block_size - rows_added);
-        assert(rows_added <= max_block_size);
+        row_count_info.inc(AdderNonJoined<STRICTNESS, typename Map::mapped_type>::add(
+            (*it)->getMapped(),
+            key_num,
+            num_columns_left,
+            mutable_columns_left,
+            num_columns_right,
+            mutable_columns_right,
+            next_element_in_row_list,
+            row_count_info.availableRowCount()));
+        assert(row_count_info.getCurrentRows() <= max_block_size);
         if constexpr (STRICTNESS == ASTTableJoin::Strictness::Any)
         {
             ++(*it);
@@ -313,9 +342,11 @@ size_t NonJoinedBlockInputStream::fillColumns(const Map & map,
             ++(*it);
         }
 
-        if (rows_added == max_block_size)
+        if (row_count_info.reachMaxRows())
             break;
     }
-    return rows_added;
+
+    if (*it == end)
+        advancedToNextPartition();
 }
 } // namespace DB

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -21,26 +21,20 @@
 #include <Common/typeid_cast.h>
 #include <Core/ColumnNumbers.h>
 #include <DataStreams/HashJoinBuildBlockInputStream.h>
-#include <DataStreams/IProfilingBlockInputStream.h>
 #include <DataStreams/NonJoinedBlockInputStream.h>
 #include <DataStreams/materializeBlock.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypesNumber.h>
-#include <Flash/Mpp/HashBaseWriterHelper.h>
 #include <Functions/FunctionHelpers.h>
 #include <Interpreters/Join.h>
 #include <Interpreters/NullAwareSemiJoinHelper.h>
 #include <Interpreters/NullableUtils.h>
 #include <common/logger_useful.h>
 
-#include <ext/scope_guard.h>
-
-
 namespace DB
 {
 namespace FailPoints
 {
-extern const char random_join_build_failpoint[];
 extern const char random_join_prob_failpoint[];
 extern const char exception_mpp_hash_build[];
 extern const char exception_mpp_hash_probe[];
@@ -48,11 +42,8 @@ extern const char exception_mpp_hash_probe[];
 
 namespace ErrorCodes
 {
-extern const int UNKNOWN_SET_DATA_VARIANT;
 extern const int LOGICAL_ERROR;
-extern const int SET_SIZE_LIMIT_EXCEEDED;
 extern const int TYPE_MISMATCH;
-extern const int ILLEGAL_COLUMN;
 } // namespace ErrorCodes
 
 namespace
@@ -100,32 +91,6 @@ size_t getRestoreJoinBuildConcurrency(size_t total_partitions, size_t spilled_pa
         return std::max(2, restore_build_concurrency);
     }
 }
-UInt64 inline updateHashValue(size_t restore_round, UInt64 x)
-{
-    static std::vector<UInt64> hash_constants{0xff51afd7ed558ccdULL, 0xc4ceb9fe1a85ec53ULL, 0xde43a68e4d184aa3ULL, 0x86f1fda459fa47c7ULL, 0xd91419add64f471fULL, 0xc18eea9cbe12489eULL, 0x2cb94f36b9fe4c38ULL, 0xef0f50cc5f0c4cbaULL};
-    static size_t hash_constants_size = hash_constants.size();
-    assert(hash_constants_size > 0 && (hash_constants_size & (hash_constants_size - 1)) == 0);
-    assert(restore_round != 0);
-    x ^= x >> 33;
-    x *= hash_constants[restore_round & (hash_constants_size - 1)];
-    x ^= x >> 33;
-    x *= hash_constants[(restore_round + 1) & (hash_constants_size - 1)];
-    x ^= x >> 33;
-    return x;
-}
-struct JoinBuildInfo
-{
-    bool enable_fine_grained_shuffle;
-    size_t fine_grained_shuffle_count;
-    bool enable_spill;
-    bool is_spilled;
-    size_t build_concurrency;
-    size_t restore_round;
-    bool needVirtualDispatchForProbeBlock() const
-    {
-        return enable_fine_grained_shuffle || (enable_spill && !is_spilled);
-    }
-};
 ColumnRawPtrs extractAndMaterializeKeyColumns(const Block & block, Columns & materialized_columns, const Strings & key_columns_names)
 {
     ColumnRawPtrs key_columns(key_columns_names.size());
@@ -140,22 +105,6 @@ ColumnRawPtrs extractAndMaterializeKeyColumns(const Block & block, Columns & mat
         }
     }
     return key_columns;
-}
-
-void computeDispatchHash(size_t rows,
-                         const ColumnRawPtrs & key_columns,
-                         const TiDB::TiDBCollators & collators,
-                         std::vector<String> & partition_key_containers,
-                         size_t join_restore_round,
-                         WeakHash32 & hash)
-{
-    HashBaseWriterHelper::computeHash(rows, key_columns, collators, partition_key_containers, hash);
-    if (join_restore_round != 0)
-    {
-        auto & data = hash.getData();
-        for (size_t i = 0; i < rows; ++i)
-            data[i] = updateHashValue(join_restore_round, data[i]);
-    }
 }
 } // namespace
 
@@ -248,12 +197,12 @@ bool CanAsColumnString(const IColumn * column)
         || (column->isColumnConst() && typeid_cast<const ColumnString *>(&static_cast<const ColumnConst *>(column)->getDataColumn()));
 }
 
-Join::Type Join::chooseMethod(const ColumnRawPtrs & key_columns, Sizes & key_sizes_) const
+JoinType Join::chooseMethod(const ColumnRawPtrs & key_columns, Sizes & key_sizes_) const
 {
     const size_t keys_size = key_columns.size();
 
     if (keys_size == 0)
-        return Type::CROSS;
+        return JoinType::CROSS;
 
     bool all_fixed = true;
     size_t keys_bytes = 0;
@@ -274,29 +223,29 @@ Join::Type Join::chooseMethod(const ColumnRawPtrs & key_columns, Sizes & key_siz
     {
         size_t size_of_field = key_columns[0]->sizeOfValueIfFixed();
         if (size_of_field == 1)
-            return Type::key8;
+            return JoinType::key8;
         if (size_of_field == 2)
-            return Type::key16;
+            return JoinType::key16;
         if (size_of_field == 4)
-            return Type::key32;
+            return JoinType::key32;
         if (size_of_field == 8)
-            return Type::key64;
+            return JoinType::key64;
         if (size_of_field == 16)
-            return Type::keys128;
+            return JoinType::keys128;
         throw Exception("Logical error: numeric column has sizeOfField not in 1, 2, 4, 8, 16.", ErrorCodes::LOGICAL_ERROR);
     }
 
     /// If the keys fit in N bits, we will use a hash table for N-bit-packed keys
     if (all_fixed && keys_bytes <= 16)
-        return Type::keys128;
+        return JoinType::keys128;
     if (all_fixed && keys_bytes <= 32)
-        return Type::keys256;
+        return JoinType::keys256;
 
     /// If there is single string key, use hash table of it's values.
     if (keys_size == 1 && CanAsColumnString(key_columns[0]))
     {
         if (collators.empty() || !collators[0])
-            return Type::key_strbin;
+            return JoinType::key_strbin;
         else
         {
             switch (collators[0]->getCollatorType())
@@ -306,263 +255,43 @@ Join::Type Join::chooseMethod(const ColumnRawPtrs & key_columns, Sizes & key_siz
             case TiDB::ITiDBCollator::CollatorType::LATIN1_BIN:
             case TiDB::ITiDBCollator::CollatorType::ASCII_BIN:
             {
-                return Type::key_strbinpadding;
+                return JoinType::key_strbinpadding;
             }
             case TiDB::ITiDBCollator::CollatorType::BINARY:
             {
-                return Type::key_strbin;
+                return JoinType::key_strbin;
             }
             default:
             {
                 // for CI COLLATION, use original way
-                return Type::key_string;
+                return JoinType::key_string;
             }
             }
         }
     }
 
     if (keys_size == 1 && typeid_cast<const ColumnFixedString *>(key_columns[0]))
-        return Type::key_fixed_string;
+        return JoinType::key_fixed_string;
 
     /// Otherwise, use serialized values as the key.
-    return Type::serialized;
-}
-
-
-template <typename Maps>
-static void initImpl(Maps & maps, Join::Type type, size_t build_concurrency)
-{
-    switch (type)
-    {
-    case Join::Type::EMPTY:
-        break;
-    case Join::Type::CROSS:
-        break;
-
-#define M(TYPE)                                                                                      \
-    case Join::Type::TYPE:                                                                           \
-        maps.TYPE = std::make_unique<typename decltype(maps.TYPE)::element_type>(build_concurrency); \
-        break;
-        APPLY_FOR_JOIN_VARIANTS(M)
-#undef M
-
-    default:
-        throw Exception("Unknown JOIN keys variant.", ErrorCodes::UNKNOWN_SET_DATA_VARIANT);
-    }
-}
-
-template <typename Maps>
-static size_t getTotalRowCountImpl(const Maps & maps, Join::Type type)
-{
-    switch (type)
-    {
-    case Join::Type::EMPTY:
-        return 0;
-    case Join::Type::CROSS:
-        return 0;
-
-#define M(NAME)            \
-    case Join::Type::NAME: \
-        return maps.NAME ? maps.NAME->rowCount() : 0;
-        APPLY_FOR_JOIN_VARIANTS(M)
-#undef M
-
-    default:
-        throw Exception("Unknown JOIN keys variant.", ErrorCodes::UNKNOWN_SET_DATA_VARIANT);
-    }
-}
-
-template <typename Maps>
-static size_t getTotalByteCountImpl(const Maps & maps, Join::Type type)
-{
-    switch (type)
-    {
-    case Join::Type::EMPTY:
-        return 0;
-    case Join::Type::CROSS:
-        return 0;
-
-#define M(NAME)            \
-    case Join::Type::NAME: \
-        return maps.NAME ? maps.NAME->getBufferSizeInBytes() : 0;
-        APPLY_FOR_JOIN_VARIANTS(M)
-#undef M
-
-    default:
-        throw Exception("Unknown JOIN keys variant.", ErrorCodes::UNKNOWN_SET_DATA_VARIANT);
-    }
-}
-
-template <typename Maps>
-static size_t getPartitionByteCountImpl(const Maps & maps, Join::Type type, size_t partition_index)
-{
-    switch (type)
-    {
-    case Join::Type::EMPTY:
-        return 0;
-    case Join::Type::CROSS:
-        return 0;
-
-#define M(NAME)            \
-    case Join::Type::NAME: \
-        return maps.NAME ? maps.NAME->getSegmentBufferSizeInBytes(partition_index) : 0;
-        APPLY_FOR_JOIN_VARIANTS(M)
-#undef M
-
-    default:
-        throw Exception("Unknown JOIN keys variant.", ErrorCodes::UNKNOWN_SET_DATA_VARIANT);
-    }
-}
-
-template <typename Maps>
-static size_t clearMapPartition(const Maps & maps, Join::Type type, size_t partition_index)
-{
-    size_t ret = 0;
-    switch (type)
-    {
-    case Join::Type::EMPTY:
-        ret = 0;
-        break;
-    case Join::Type::CROSS:
-        ret = 0;
-        break;
-
-#define M(NAME)                                                  \
-    case Join::Type::NAME:                                       \
-        if (maps.NAME)                                           \
-        {                                                        \
-            ret = maps.NAME->resetSegmentTable(partition_index); \
-        }                                                        \
-        break;
-        APPLY_FOR_JOIN_VARIANTS(M)
-#undef M
-
-    default:
-        throw Exception("Unknown JOIN keys variant.", ErrorCodes::UNKNOWN_SET_DATA_VARIANT);
-    }
-    return ret;
-}
-
-
-template <Join::Type type, typename Value, typename Mapped>
-struct KeyGetterForTypeImpl;
-
-template <typename Value, typename Mapped>
-struct KeyGetterForTypeImpl<Join::Type::key8, Value, Mapped>
-{
-    using Type = ColumnsHashing::HashMethodOneNumber<Value, Mapped, UInt8, false>;
-};
-template <typename Value, typename Mapped>
-struct KeyGetterForTypeImpl<Join::Type::key16, Value, Mapped>
-{
-    using Type = ColumnsHashing::HashMethodOneNumber<Value, Mapped, UInt16, false>;
-};
-template <typename Value, typename Mapped>
-struct KeyGetterForTypeImpl<Join::Type::key32, Value, Mapped>
-{
-    using Type = ColumnsHashing::HashMethodOneNumber<Value, Mapped, UInt32, false>;
-};
-template <typename Value, typename Mapped>
-struct KeyGetterForTypeImpl<Join::Type::key64, Value, Mapped>
-{
-    using Type = ColumnsHashing::HashMethodOneNumber<Value, Mapped, UInt64, false>;
-};
-template <typename Value, typename Mapped>
-struct KeyGetterForTypeImpl<Join::Type::key_string, Value, Mapped>
-{
-    using Type = ColumnsHashing::HashMethodString<Value, Mapped, true, false>;
-};
-template <typename Value, typename Mapped>
-struct KeyGetterForTypeImpl<Join::Type::key_strbinpadding, Value, Mapped>
-{
-    using Type = ColumnsHashing::HashMethodStringBin<Value, Mapped, true>;
-};
-template <typename Value, typename Mapped>
-struct KeyGetterForTypeImpl<Join::Type::key_strbin, Value, Mapped>
-{
-    using Type = ColumnsHashing::HashMethodStringBin<Value, Mapped, false>;
-};
-template <typename Value, typename Mapped>
-struct KeyGetterForTypeImpl<Join::Type::key_fixed_string, Value, Mapped>
-{
-    using Type = ColumnsHashing::HashMethodFixedString<Value, Mapped, true, false>;
-};
-template <typename Value, typename Mapped>
-struct KeyGetterForTypeImpl<Join::Type::keys128, Value, Mapped>
-{
-    using Type = ColumnsHashing::HashMethodKeysFixed<Value, UInt128, Mapped, false, false>;
-};
-template <typename Value, typename Mapped>
-struct KeyGetterForTypeImpl<Join::Type::keys256, Value, Mapped>
-{
-    using Type = ColumnsHashing::HashMethodKeysFixed<Value, UInt256, Mapped, false, false>;
-};
-template <typename Value, typename Mapped>
-struct KeyGetterForTypeImpl<Join::Type::serialized, Value, Mapped>
-{
-    using Type = ColumnsHashing::HashMethodSerialized<Value, Mapped>;
-};
-
-
-template <Join::Type type, typename Data>
-struct KeyGetterForType
-{
-    using Value = typename Data::value_type;
-    using Mapped_t = typename Data::mapped_type;
-    using Mapped = std::conditional_t<std::is_const_v<Data>, const Mapped_t, Mapped_t>;
-    using Type = typename KeyGetterForTypeImpl<type, Value, Mapped>::Type;
-};
-
-void Join::initMapImpl(Type type_)
-{
-    type = type_;
-
-    if (isCrossJoin(kind))
-        return;
-
-    if (!getFullness(kind))
-    {
-        if (strictness == ASTTableJoin::Strictness::Any)
-            initImpl(maps_any, type, getBuildConcurrency());
-        else
-            initImpl(maps_all, type, getBuildConcurrency());
-    }
-    else
-    {
-        if (strictness == ASTTableJoin::Strictness::Any)
-            initImpl(maps_any_full, type, getBuildConcurrency());
-        else
-            initImpl(maps_all_full, type, getBuildConcurrency());
-    }
+    return JoinType::serialized;
 }
 
 size_t Join::getTotalRowCount() const
 {
     size_t res = 0;
 
-    if (type == Type::CROSS)
+    if (type == JoinType::CROSS)
     {
         res = total_input_build_rows;
     }
     else
     {
-        res += getTotalRowCountImpl(maps_any, type);
-        res += getTotalRowCountImpl(maps_all, type);
-        res += getTotalRowCountImpl(maps_any_full, type);
-        res += getTotalRowCountImpl(maps_all_full, type);
+        for (const auto & partition : partitions)
+            res += partition->getRowCount();
     }
 
     return res;
-}
-
-size_t Join::getPartitionByteCount(size_t partition_index) const
-{
-    size_t ret = 0;
-    ret += getPartitionByteCountImpl(maps_any, type, partition_index);
-    ret += getPartitionByteCountImpl(maps_all, type, partition_index);
-    ret += getPartitionByteCountImpl(maps_any_full, type, partition_index);
-    ret += getPartitionByteCountImpl(maps_all_full, type, partition_index);
-    return ret;
 }
 
 size_t Join::getTotalByteCount()
@@ -575,7 +304,7 @@ size_t Join::getTotalByteCount()
     }
     else
     {
-        if (type == Type::CROSS)
+        if (type == JoinType::CROSS)
         {
             for (const auto & block : blocks)
                 res += block.bytes();
@@ -584,15 +313,10 @@ size_t Join::getTotalByteCount()
         {
             for (const auto & block : original_blocks)
                 res += block.bytes();
-            res += getTotalByteCountImpl(maps_any, type);
-            res += getTotalByteCountImpl(maps_all, type);
-            res += getTotalByteCountImpl(maps_any_full, type);
-            res += getTotalByteCountImpl(maps_all_full, type);
-
             for (const auto & partition : partitions)
             {
                 /// note the return value might not be accurate since it does not use lock, but should be enough for current usage
-                res += partition->getPartitionPoolSize();
+                res += partition->getHashMapAndPoolByteCount();
             }
         }
     }
@@ -620,15 +344,7 @@ void Join::setBuildConcurrencyAndInitJoinPartition(size_t build_concurrency_)
     partitions.reserve(build_concurrency);
     for (size_t i = 0; i < getBuildConcurrency(); ++i)
     {
-        partitions.push_back(std::make_unique<JoinPartition>(log));
-    }
-
-    // init for non-joined-streams.
-    if (getFullness(kind) || isNullAwareSemiFamily(kind))
-    {
-        rows_not_inserted_to_map.reserve(getBuildConcurrency());
-        for (size_t i = 0; i < getBuildConcurrency(); ++i)
-            rows_not_inserted_to_map.emplace_back(max_block_size);
+        partitions.push_back(std::make_unique<JoinPartition>(type, kind, strictness, max_block_size, log));
     }
 }
 
@@ -696,28 +412,25 @@ void Join::initBuild(const Block & sample_block, size_t build_concurrency_)
     if (unlikely(initialized))
         throw Exception("Logical error: Join has been initialized", ErrorCodes::LOGICAL_ERROR);
     initialized = true;
+    type = chooseMethod(getKeyColumns(key_names_right, sample_block), key_sizes);
     setBuildConcurrencyAndInitJoinPartition(build_concurrency_);
     build_sample_block = sample_block;
     build_spiller = std::make_unique<Spiller>(build_spill_config, false, build_concurrency_, build_sample_block, log);
-    /// Choose data structure to use for JOIN.
-    initMapImpl(chooseMethod(getKeyColumns(key_names_right, sample_block), key_sizes));
-    if (type == Type::CROSS)
+    if (max_bytes_before_external_join > 0)
     {
-        /// todo support spill for cross join
-        max_bytes_before_external_join = 0;
-        LOG_WARNING(log, "Cross join does not support spilling, so set max_bytes_before_external_join = 0");
-    }
-    if (isNullAwareSemiFamily(kind))
-    {
-        max_bytes_before_external_join = 0;
-        LOG_WARNING(log, "null aware join does not support spilling, so set max_bytes_before_external_join = 0");
+        if (type == JoinType::CROSS)
+        {
+            /// todo support spill for cross join
+            max_bytes_before_external_join = 0;
+            LOG_WARNING(log, "Cross join does not support spilling, so set max_bytes_before_external_join = 0");
+        }
+        if (isNullAwareSemiFamily(kind))
+        {
+            max_bytes_before_external_join = 0;
+            LOG_WARNING(log, "null aware join does not support spilling, so set max_bytes_before_external_join = 0");
+        }
     }
     setSampleBlock(sample_block);
-    for (size_t i = 0; i < build_concurrency; i++)
-    {
-        partitions[i]->addMemoryUsage(partitions[i]->getPartitionPoolSize());
-        partitions[i]->addMemoryUsage(getPartitionByteCount(i));
-    }
 }
 
 void Join::initProbe(const Block & sample_block, size_t probe_concurrency_)
@@ -727,291 +440,6 @@ void Join::initProbe(const Block & sample_block, size_t probe_concurrency_)
     probe_sample_block = sample_block;
     probe_spiller = std::make_unique<Spiller>(probe_spill_config, false, build_concurrency, probe_sample_block, log);
 }
-
-namespace
-{
-void insertRowToList(Join::RowRefList * list, Join::RowRefList * elem, Block * stored_block, size_t index)
-{
-    elem->next = list->next; // NOLINT(clang-analyzer-core.NullDereference)
-    list->next = elem;
-    elem->block = stored_block;
-    elem->row_num = index;
-}
-
-/// Inserting an element into a hash table of the form `key -> reference to a string`, which will then be used by JOIN.
-template <ASTTableJoin::Strictness STRICTNESS, typename Map, typename KeyGetter>
-struct Inserter
-{
-    static void insert(Map & map, const typename Map::key_type & key, Block * stored_block, size_t i, Arena & pool, std::vector<String> & sort_key_containers);
-};
-
-template <typename Map, typename KeyGetter>
-struct Inserter<ASTTableJoin::Strictness::Any, Map, KeyGetter>
-{
-    static void insert(Map & map, KeyGetter & key_getter, Block * stored_block, size_t i, Arena & pool, std::vector<String> & sort_key_container)
-    {
-        auto emplace_result = key_getter.emplaceKey(map, i, pool, sort_key_container);
-
-        if (emplace_result.isInserted())
-            new (&emplace_result.getMapped()) typename Map::mapped_type(stored_block, i);
-    }
-};
-
-template <typename Map, typename KeyGetter>
-struct Inserter<ASTTableJoin::Strictness::All, Map, KeyGetter>
-{
-    using MappedType = typename Map::mapped_type;
-    static void insert(Map & map, KeyGetter & key_getter, Block * stored_block, size_t i, Arena & pool, std::vector<String> & sort_key_container)
-    {
-        auto emplace_result = key_getter.emplaceKey(map, i, pool, sort_key_container);
-
-        if (emplace_result.isInserted())
-            new (&emplace_result.getMapped()) typename Map::mapped_type(stored_block, i);
-        else
-        {
-            /** The first element of the list is stored in the value of the hash table, the rest in the pool.
-                 * We will insert each time the element into the second place.
-                 * That is, the former second element, if it was, will be the third, and so on.
-                 */
-            auto elem = reinterpret_cast<MappedType *>(pool.alloc(sizeof(MappedType)));
-            insertRowToList(&emplace_result.getMapped(), elem, stored_block, i);
-        }
-    }
-};
-
-
-template <ASTTableJoin::Strictness STRICTNESS, typename KeyGetter, typename Map, bool has_null_map>
-void NO_INLINE insertFromBlockImplTypeCase(
-    ASTTableJoin::Kind kind,
-    Map & map,
-    size_t rows,
-    const ColumnRawPtrs & key_columns,
-    const Sizes & key_sizes,
-    const TiDB::TiDBCollators & collators,
-    Block * stored_block,
-    ConstNullMapPtr null_map,
-    Join::RowsNotInsertToMap * rows_not_inserted_to_map,
-    size_t stream_index,
-    Arena & pool)
-{
-    KeyGetter key_getter(key_columns, key_sizes, collators);
-    std::vector<std::string> sort_key_containers;
-    sort_key_containers.resize(key_columns.size());
-
-    bool null_need_materialize = isNullAwareSemiFamily(kind);
-    for (size_t i = 0; i < rows; ++i)
-    {
-        if (has_null_map && (*null_map)[i])
-        {
-            if (rows_not_inserted_to_map)
-            {
-                /// for right/full out join or null-aware semi join, need to insert into rows_not_inserted_to_map
-                rows_not_inserted_to_map->insertRow(stored_block, i, null_need_materialize, pool);
-            }
-            continue;
-        }
-
-        size_t segment_index = stream_index;
-        Inserter<STRICTNESS, typename Map::SegmentType::HashTable, KeyGetter>::insert(
-            map.getSegmentTable(segment_index),
-            key_getter,
-            stored_block,
-            i,
-            pool,
-            sort_key_containers);
-    }
-}
-
-template <ASTTableJoin::Strictness STRICTNESS, typename KeyGetter, typename Map, bool has_null_map>
-void NO_INLINE insertFromBlockImplTypeCaseWithLock(
-    ASTTableJoin::Kind kind,
-    Map & map,
-    size_t rows,
-    const ColumnRawPtrs & key_columns,
-    const Sizes & key_sizes,
-    const TiDB::TiDBCollators & collators,
-    Block * stored_block,
-    ConstNullMapPtr null_map,
-    Join::RowsNotInsertToMap * rows_not_inserted_to_map,
-    size_t stream_index,
-    Arena & pool)
-{
-    KeyGetter key_getter(key_columns, key_sizes, collators);
-    std::vector<std::string> sort_key_containers(key_columns.size());
-    size_t segment_size = map.getSegmentSize();
-    /// when inserting with lock, first calculate and save the segment index for each row, then
-    /// insert the rows segment by segment to avoid too much conflict. This will introduce some overheads:
-    /// 1. key_getter.getKey will be called twice, here we do not cache key because it can not be cached
-    /// with relatively low cost(if key is stringRef, just cache a stringRef is meaningless, we need to cache the whole `sort_key_containers`)
-    /// 2. hash value is calculated twice, maybe we can refine the code to cache the hash value
-    /// 3. extra memory to store the segment index info
-    std::vector<std::vector<size_t>> segment_index_info;
-    if (has_null_map && rows_not_inserted_to_map)
-    {
-        segment_index_info.resize(segment_size + 1);
-    }
-    else
-    {
-        segment_index_info.resize(segment_size);
-    }
-    size_t rows_per_seg = rows / segment_index_info.size();
-    for (auto & segment_index : segment_index_info)
-    {
-        segment_index.reserve(rows_per_seg);
-    }
-    for (size_t i = 0; i < rows; ++i)
-    {
-        if (has_null_map && (*null_map)[i])
-        {
-            if (rows_not_inserted_to_map)
-                segment_index_info[segment_index_info.size() - 1].push_back(i);
-            continue;
-        }
-        auto key_holder = key_getter.getKeyHolder(i, &pool, sort_key_containers);
-        SCOPE_EXIT(keyHolderDiscardKey(key_holder));
-        auto key = keyHolderGetKey(key_holder);
-
-        size_t segment_index = 0;
-        size_t hash_value = 0;
-        if (!ZeroTraits::check(key))
-        {
-            hash_value = map.hash(key);
-            segment_index = hash_value % segment_size;
-        }
-        segment_index_info[segment_index].push_back(i);
-    }
-
-    bool null_need_materialize = isNullAwareSemiFamily(kind);
-    for (size_t insert_index = 0; insert_index < segment_index_info.size(); insert_index++)
-    {
-        FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::random_join_build_failpoint);
-        size_t segment_index = (insert_index + stream_index) % segment_index_info.size();
-        if (segment_index == segment_size)
-        {
-            /// null value
-            /// here ignore mutex because rows_not_inserted_to_map is privately owned by each stream thread
-            for (auto index : segment_index_info[segment_index])
-            {
-                /// for right/full out join or null-aware semi join, need to insert into rows_not_inserted_to_map
-                RUNTIME_ASSERT(rows_not_inserted_to_map != nullptr);
-                rows_not_inserted_to_map->insertRow(stored_block, index, null_need_materialize, pool);
-            }
-        }
-        else
-        {
-            std::lock_guard lk(map.getSegmentMutex(segment_index));
-            for (size_t i = 0; i < segment_index_info[segment_index].size(); ++i)
-            {
-                Inserter<STRICTNESS, typename Map::SegmentType::HashTable, KeyGetter>::insert(map.getSegmentTable(segment_index), key_getter, stored_block, segment_index_info[segment_index][i], pool, sort_key_containers);
-            }
-        }
-    }
-}
-
-template <ASTTableJoin::Strictness STRICTNESS, typename KeyGetter, typename Map>
-void insertFromBlockImplType(
-    ASTTableJoin::Kind kind,
-    Map & map,
-    size_t rows,
-    const ColumnRawPtrs & key_columns,
-    const Sizes & key_sizes,
-    const TiDB::TiDBCollators & collators,
-    Block * stored_block,
-    ConstNullMapPtr null_map,
-    Join::RowsNotInsertToMap * rows_not_inserted_to_map,
-    size_t stream_index,
-    size_t insert_concurrency,
-    Arena & pool,
-    bool enable_fine_grained_shuffle,
-    bool enable_join_spill)
-{
-    if (enable_join_spill)
-    {
-        /// case 1, join with spill support, the partition level lock is acquired in `insertFromBlock`
-        if (null_map)
-            insertFromBlockImplTypeCase<STRICTNESS, KeyGetter, Map, true>(kind, map, rows, key_columns, key_sizes, collators, stored_block, null_map, rows_not_inserted_to_map, stream_index, pool);
-        else
-            insertFromBlockImplTypeCase<STRICTNESS, KeyGetter, Map, false>(kind, map, rows, key_columns, key_sizes, collators, stored_block, null_map, rows_not_inserted_to_map, stream_index, pool);
-        return;
-    }
-    else if (enable_fine_grained_shuffle)
-    {
-        /// case 2, join with fine_grained_shuffle, no need to acquire any lock
-        if (null_map)
-            insertFromBlockImplTypeCase<STRICTNESS, KeyGetter, Map, true>(kind, map, rows, key_columns, key_sizes, collators, stored_block, null_map, rows_not_inserted_to_map, stream_index, pool);
-        else
-            insertFromBlockImplTypeCase<STRICTNESS, KeyGetter, Map, false>(kind, map, rows, key_columns, key_sizes, collators, stored_block, null_map, rows_not_inserted_to_map, stream_index, pool);
-    }
-    else if (insert_concurrency > 1)
-    {
-        /// case 3, normal join with concurrency > 1, will acquire lock in `insertFromBlockImplTypeCaseWithLock`
-        if (null_map)
-            insertFromBlockImplTypeCaseWithLock<STRICTNESS, KeyGetter, Map, true>(kind, map, rows, key_columns, key_sizes, collators, stored_block, null_map, rows_not_inserted_to_map, stream_index, pool);
-        else
-            insertFromBlockImplTypeCaseWithLock<STRICTNESS, KeyGetter, Map, false>(kind, map, rows, key_columns, key_sizes, collators, stored_block, null_map, rows_not_inserted_to_map, stream_index, pool);
-    }
-    else
-    {
-        /// case 4, normal join with concurrency == 1, no need to acquire any lock
-        RUNTIME_CHECK(stream_index == 0);
-        if (null_map)
-            insertFromBlockImplTypeCase<STRICTNESS, KeyGetter, Map, true>(kind, map, rows, key_columns, key_sizes, collators, stored_block, null_map, rows_not_inserted_to_map, stream_index, pool);
-        else
-            insertFromBlockImplTypeCase<STRICTNESS, KeyGetter, Map, false>(kind, map, rows, key_columns, key_sizes, collators, stored_block, null_map, rows_not_inserted_to_map, stream_index, pool);
-    }
-}
-
-template <ASTTableJoin::Strictness STRICTNESS, typename Maps>
-void insertFromBlockImpl(
-    ASTTableJoin::Kind kind,
-    Join::Type type,
-    Maps & maps,
-    size_t rows,
-    const ColumnRawPtrs & key_columns,
-    const Sizes & key_sizes,
-    const TiDB::TiDBCollators & collators,
-    Block * stored_block,
-    ConstNullMapPtr null_map,
-    Join::RowsNotInsertToMap * rows_not_inserted_to_map,
-    size_t stream_index,
-    size_t insert_concurrency,
-    Arena & pool,
-    bool enable_fine_grained_shuffle,
-    bool enable_join_spill)
-{
-    switch (type)
-    {
-    case Join::Type::EMPTY:
-        break;
-    case Join::Type::CROSS:
-        break; /// Do nothing. We have already saved block, and it is enough.
-
-#define M(TYPE)                                                                                                                                \
-    case Join::Type::TYPE:                                                                                                                     \
-        insertFromBlockImplType<STRICTNESS, typename KeyGetterForType<Join::Type::TYPE, std::remove_reference_t<decltype(*maps.TYPE)>>::Type>( \
-            kind,                                                                                                                              \
-            *maps.TYPE,                                                                                                                        \
-            rows,                                                                                                                              \
-            key_columns,                                                                                                                       \
-            key_sizes,                                                                                                                         \
-            collators,                                                                                                                         \
-            stored_block,                                                                                                                      \
-            null_map,                                                                                                                          \
-            rows_not_inserted_to_map,                                                                                                          \
-            stream_index,                                                                                                                      \
-            insert_concurrency,                                                                                                                \
-            pool,                                                                                                                              \
-            enable_fine_grained_shuffle,                                                                                                       \
-            enable_join_spill);                                                                                                                \
-        break;
-        APPLY_FOR_JOIN_VARIANTS(M)
-#undef M
-
-    default:
-        throw Exception("Unknown JOIN keys variant.", ErrorCodes::UNKNOWN_SET_DATA_VARIANT);
-    }
-}
-} // namespace
 
 void recordFilteredRows(const Block & block, const String & filter_column, ColumnPtr & null_map_holder, ConstNullMapPtr & null_map)
 {
@@ -1132,18 +560,12 @@ void Join::insertFromBlock(const Block & block, size_t stream_index)
                     stored_block = join_partition->getLastBuildBlock();
                 if (stored_block != nullptr)
                 {
-                    size_t pool_size_before_insert = join_partition->getPartitionPoolSize();
-                    size_t map_size_before_insert = getPartitionByteCount(i);
+                    size_t byte_before_insert = join_partition->getHashMapAndPoolByteCount();
                     insertFromBlockInternal(stored_block, i);
-                    size_t pool_size_after_insert = join_partition->getPartitionPoolSize();
-                    size_t map_size_after_insert = getPartitionByteCount(i);
-                    if likely (pool_size_after_insert > pool_size_before_insert)
+                    size_t byte_after_insert = join_partition->getHashMapAndPoolByteCount();
+                    if likely (byte_after_insert > byte_before_insert)
                     {
-                        join_partition->addMemoryUsage(pool_size_after_insert - pool_size_before_insert);
-                    }
-                    if likely (map_size_after_insert > map_size_before_insert)
-                    {
-                        join_partition->addMemoryUsage(map_size_after_insert - map_size_before_insert);
+                        join_partition->addMemoryUsage(byte_after_insert - byte_before_insert);
                     }
                     continue;
                 }
@@ -1265,393 +687,13 @@ void Join::insertFromBlockInternal(Block * stored_block, size_t stream_index)
 
     if (!isCrossJoin(kind))
     {
-        assert(partitions[stream_index]->getPartitionPool() != nullptr);
+        if (enable_join_spill)
+            assert(partitions[stream_index]->getPartitionPool() != nullptr);
         /// Fill the hash table.
-        if (isNullAwareSemiFamily(kind))
-        {
-            if (strictness == ASTTableJoin::Strictness::Any)
-                insertFromBlockImpl<ASTTableJoin::Strictness::Any>(kind, type, maps_any, rows, key_columns, key_sizes, collators, stored_block, null_map, &rows_not_inserted_to_map[stream_index], stream_index, getBuildConcurrency(), *partitions[stream_index]->getPartitionPool(), enable_fine_grained_shuffle, enable_join_spill);
-            else
-                insertFromBlockImpl<ASTTableJoin::Strictness::All>(kind, type, maps_all, rows, key_columns, key_sizes, collators, stored_block, null_map, &rows_not_inserted_to_map[stream_index], stream_index, getBuildConcurrency(), *partitions[stream_index]->getPartitionPool(), enable_fine_grained_shuffle, enable_join_spill);
-        }
-        else if (getFullness(kind))
-        {
-            if (strictness == ASTTableJoin::Strictness::Any)
-                insertFromBlockImpl<ASTTableJoin::Strictness::Any>(kind, type, maps_any_full, rows, key_columns, key_sizes, collators, stored_block, null_map, &rows_not_inserted_to_map[stream_index], stream_index, getBuildConcurrency(), *partitions[stream_index]->getPartitionPool(), enable_fine_grained_shuffle, enable_join_spill);
-            else
-                insertFromBlockImpl<ASTTableJoin::Strictness::All>(kind, type, maps_all_full, rows, key_columns, key_sizes, collators, stored_block, null_map, &rows_not_inserted_to_map[stream_index], stream_index, getBuildConcurrency(), *partitions[stream_index]->getPartitionPool(), enable_fine_grained_shuffle, enable_join_spill);
-        }
-        else
-        {
-            if (strictness == ASTTableJoin::Strictness::Any)
-                insertFromBlockImpl<ASTTableJoin::Strictness::Any>(kind, type, maps_any, rows, key_columns, key_sizes, collators, stored_block, null_map, nullptr, stream_index, getBuildConcurrency(), *partitions[stream_index]->getPartitionPool(), enable_fine_grained_shuffle, enable_join_spill);
-            else
-                insertFromBlockImpl<ASTTableJoin::Strictness::All>(kind, type, maps_all, rows, key_columns, key_sizes, collators, stored_block, null_map, nullptr, stream_index, getBuildConcurrency(), *partitions[stream_index]->getPartitionPool(), enable_fine_grained_shuffle, enable_join_spill);
-        }
+        JoinPartition::insertBlockIntoMaps(partitions, rows, key_columns, key_sizes, collators, stored_block, null_map, stream_index, getBuildConcurrency(), enable_fine_grained_shuffle, enable_join_spill);
     }
 }
 
-
-namespace
-{
-template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS, typename Map>
-struct Adder;
-
-template <typename Map>
-struct Adder<ASTTableJoin::Kind::Left, ASTTableJoin::Strictness::Any, Map>
-{
-    static bool addFound(const typename Map::SegmentType::HashTable::ConstLookupResult & it, size_t num_columns_to_add, MutableColumns & added_columns, size_t /*i*/, IColumn::Filter * /*filter*/, IColumn::Offset & /*current_offset*/, IColumn::Offsets * /*offsets*/, const std::vector<size_t> & right_indexes, ProbeProcessInfo & /*probe_process_info*/)
-    {
-        for (size_t j = 0; j < num_columns_to_add; ++j)
-            added_columns[j]->insertFrom(*it->getMapped().block->getByPosition(right_indexes[j]).column.get(), it->getMapped().row_num);
-        return false;
-    }
-
-    static bool addNotFound(size_t num_columns_to_add, MutableColumns & added_columns, size_t /*i*/, IColumn::Filter * /*filter*/, IColumn::Offset & /*current_offset*/, IColumn::Offsets * /*offsets*/, ProbeProcessInfo & /*probe_process_info*/)
-    {
-        for (size_t j = 0; j < num_columns_to_add; ++j)
-            added_columns[j]->insertDefault();
-        return false;
-    }
-};
-
-template <typename Map>
-struct Adder<ASTTableJoin::Kind::Inner, ASTTableJoin::Strictness::Any, Map>
-{
-    static bool addFound(const typename Map::SegmentType::HashTable::ConstLookupResult & it, size_t num_columns_to_add, MutableColumns & added_columns, size_t i, IColumn::Filter * filter, IColumn::Offset & /*current_offset*/, IColumn::Offsets * /*offsets*/, const std::vector<size_t> & right_indexes, ProbeProcessInfo & /*probe_process_info*/)
-    {
-        (*filter)[i] = 1;
-
-        for (size_t j = 0; j < num_columns_to_add; ++j)
-            added_columns[j]->insertFrom(*it->getMapped().block->getByPosition(right_indexes[j]).column.get(), it->getMapped().row_num);
-
-        return false;
-    }
-
-    static bool addNotFound(size_t /*num_columns_to_add*/, MutableColumns & /*added_columns*/, size_t i, IColumn::Filter * filter, IColumn::Offset & /*current_offset*/, IColumn::Offsets * /*offsets*/, ProbeProcessInfo & /*probe_process_info*/)
-    {
-        (*filter)[i] = 0;
-        return false;
-    }
-};
-
-template <typename Map>
-struct Adder<ASTTableJoin::Kind::Anti, ASTTableJoin::Strictness::Any, Map>
-{
-    static bool addFound(const typename Map::SegmentType::HashTable::ConstLookupResult & /*it*/, size_t /*num_columns_to_add*/, MutableColumns & /*added_columns*/, size_t i, IColumn::Filter * filter, IColumn::Offset & /*current_offset*/, IColumn::Offsets * /*offsets*/, const std::vector<size_t> & /*right_indexes*/, ProbeProcessInfo & /*probe_process_info*/)
-    {
-        (*filter)[i] = 0;
-        return false;
-    }
-
-    static bool addNotFound(size_t num_columns_to_add, MutableColumns & added_columns, size_t i, IColumn::Filter * filter, IColumn::Offset & /*current_offset*/, IColumn::Offsets * /*offsets*/, ProbeProcessInfo & /*probe_process_info*/)
-    {
-        (*filter)[i] = 1;
-        for (size_t j = 0; j < num_columns_to_add; ++j)
-            added_columns[j]->insertDefault();
-        return false;
-    }
-};
-
-template <typename Map>
-struct Adder<ASTTableJoin::Kind::LeftSemi, ASTTableJoin::Strictness::Any, Map>
-{
-    static bool addFound(const typename Map::SegmentType::HashTable::ConstLookupResult & /*it*/, size_t num_columns_to_add, MutableColumns & added_columns, size_t /*i*/, IColumn::Filter * /*filter*/, IColumn::Offset & /*current_offset*/, IColumn::Offsets * /*offsets*/, const std::vector<size_t> & /*right_indexes*/, ProbeProcessInfo & /*probe_process_info*/)
-    {
-        for (size_t j = 0; j < num_columns_to_add - 1; ++j)
-            added_columns[j]->insertDefault();
-        added_columns[num_columns_to_add - 1]->insert(FIELD_INT8_1);
-        return false;
-    }
-
-    static bool addNotFound(size_t num_columns_to_add, MutableColumns & added_columns, size_t /*i*/, IColumn::Filter * /*filter*/, IColumn::Offset & /*current_offset*/, IColumn::Offsets * /*offsets*/, ProbeProcessInfo & /*probe_process_info*/)
-    {
-        for (size_t j = 0; j < num_columns_to_add - 1; ++j)
-            added_columns[j]->insertDefault();
-        added_columns[num_columns_to_add - 1]->insert(FIELD_INT8_0);
-        return false;
-    }
-};
-
-template <typename Map>
-struct Adder<ASTTableJoin::Kind::LeftSemi, ASTTableJoin::Strictness::All, Map>
-{
-    static bool addFound(const typename Map::SegmentType::HashTable::ConstLookupResult & it, size_t num_columns_to_add, MutableColumns & added_columns, size_t i, IColumn::Filter * /*filter*/, IColumn::Offset & current_offset, IColumn::Offsets * offsets, const std::vector<size_t> & right_indexes, ProbeProcessInfo & /*probe_process_info*/)
-    {
-        for (auto current = &static_cast<const typename Map::mapped_type::Base_t &>(it->getMapped()); current != nullptr; current = current->next)
-        {
-            for (size_t j = 0; j < num_columns_to_add - 1; ++j)
-                added_columns[j]->insertFrom(*current->block->getByPosition(right_indexes[j]).column.get(), current->row_num);
-            ++current_offset;
-        }
-        (*offsets)[i] = current_offset;
-        /// we insert only one row to `match-helper` for each row of left block
-        /// so before the execution of `HandleOtherConditions`, column sizes of temporary block may be different.
-        added_columns[num_columns_to_add - 1]->insert(FIELD_INT8_1);
-        return false;
-    }
-
-    static bool addNotFound(size_t num_columns_to_add, MutableColumns & added_columns, size_t i, IColumn::Filter * /*filter*/, IColumn::Offset & current_offset, IColumn::Offsets * offsets, ProbeProcessInfo & /*probe_process_info*/)
-    {
-        ++current_offset;
-        (*offsets)[i] = current_offset;
-
-        for (size_t j = 0; j < num_columns_to_add - 1; ++j)
-            added_columns[j]->insertDefault();
-        added_columns[num_columns_to_add - 1]->insert(FIELD_INT8_0);
-        return false;
-    }
-};
-
-template <ASTTableJoin::Kind KIND, typename Map>
-struct Adder<KIND, ASTTableJoin::Strictness::All, Map>
-{
-    static bool addFound(const typename Map::SegmentType::HashTable::ConstLookupResult & it, size_t num_columns_to_add, MutableColumns & added_columns, size_t i, IColumn::Filter * filter, IColumn::Offset & current_offset, IColumn::Offsets * offsets, const std::vector<size_t> & right_indexes, ProbeProcessInfo & probe_process_info)
-    {
-        size_t rows_joined = 0;
-        // If there are too many rows in the column to split, record the number of rows that have been expanded for next read.
-        // and it means the rows in this block are not joined finish.
-
-        for (auto current = &static_cast<const typename Map::mapped_type::Base_t &>(it->getMapped()); current != nullptr; current = current->next)
-            ++rows_joined;
-
-        if (current_offset && current_offset + rows_joined > probe_process_info.max_block_size)
-        {
-            return true;
-        }
-
-        for (auto current = &static_cast<const typename Map::mapped_type::Base_t &>(it->getMapped()); current != nullptr; current = current->next)
-        {
-            for (size_t j = 0; j < num_columns_to_add; ++j)
-                added_columns[j]->insertFrom(*current->block->getByPosition(right_indexes[j]).column.get(), current->row_num);
-        }
-
-        current_offset += rows_joined;
-        (*offsets)[i] = current_offset;
-        if constexpr (KIND == ASTTableJoin::Kind::Anti)
-            /// anti join with other condition is very special: if the row is matched during probe stage, we can not throw it
-            /// away because it might failed in other condition, so we add the matched rows to the result, but set (*filter)[i] = 0
-            /// to indicate that the row is matched during probe stage, this will be used in handleOtherConditions
-            (*filter)[i] = 0;
-
-        return false;
-    }
-
-    static bool addNotFound(size_t num_columns_to_add, MutableColumns & added_columns, size_t i, IColumn::Filter * filter, IColumn::Offset & current_offset, IColumn::Offsets * offsets, ProbeProcessInfo & probe_process_info)
-    {
-        if constexpr (KIND == ASTTableJoin::Kind::Inner)
-        {
-            (*offsets)[i] = current_offset;
-        }
-        else
-        {
-            if (current_offset && current_offset + 1 > probe_process_info.max_block_size)
-            {
-                return true;
-            }
-            if (KIND == ASTTableJoin::Kind::Anti)
-                (*filter)[i] = 1;
-            ++current_offset;
-            (*offsets)[i] = current_offset;
-
-            for (size_t j = 0; j < num_columns_to_add; ++j)
-                added_columns[j]->insertDefault();
-        }
-        return false;
-    }
-};
-
-template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS, typename KeyGetter, typename Map, bool has_null_map>
-void NO_INLINE joinBlockImplTypeCase(
-    const Map & map,
-    size_t rows,
-    const ColumnRawPtrs & key_columns,
-    const Sizes & key_sizes,
-    MutableColumns & added_columns,
-    ConstNullMapPtr null_map,
-    std::unique_ptr<IColumn::Filter> & filter,
-    IColumn::Offset & current_offset,
-    std::unique_ptr<IColumn::Offsets> & offsets_to_replicate,
-    const std::vector<size_t> & right_indexes,
-    const TiDB::TiDBCollators & collators,
-    const JoinBuildInfo & join_build_info,
-    ProbeProcessInfo & probe_process_info)
-{
-    if (rows == 0)
-    {
-        probe_process_info.all_rows_joined_finish = true;
-        return;
-    }
-
-    assert(probe_process_info.start_row < rows);
-
-    size_t num_columns_to_add = right_indexes.size();
-
-    KeyGetter key_getter(key_columns, key_sizes, collators);
-    std::vector<std::string> sort_key_containers;
-    sort_key_containers.resize(key_columns.size());
-    Arena pool;
-    WeakHash32 build_hash(0); /// reproduce hash values according to build stage
-    if (join_build_info.needVirtualDispatchForProbeBlock())
-    {
-        assert(!(join_build_info.restore_round > 0 && join_build_info.enable_fine_grained_shuffle));
-        /// TODO: consider adding a virtual column in Sender side to avoid computing cost and potential inconsistency by heterogeneous envs(AMD64, ARM64)
-        /// Note: 1. Not sure, if inconsistency will do happen in heterogeneous envs
-        ///       2. Virtual column would take up a little more network bandwidth, might lead to poor performance if network was bottleneck
-        /// Currently, the computation cost is tolerable, since it's a very simple crc32 hash algorithm, and heterogeneous envs support is not considered
-        computeDispatchHash(rows, key_columns, collators, sort_key_containers, join_build_info.restore_round, build_hash);
-    }
-
-    size_t segment_size = map.getSegmentSize();
-    const auto & build_hash_data = build_hash.getData();
-    assert(probe_process_info.start_row < rows);
-    size_t i;
-    bool block_full = false;
-    for (i = probe_process_info.start_row; i < rows; ++i)
-    {
-        if (has_null_map && (*null_map)[i])
-        {
-            block_full = Adder<KIND, STRICTNESS, Map>::addNotFound(
-                num_columns_to_add,
-                added_columns,
-                i,
-                filter.get(),
-                current_offset,
-                offsets_to_replicate.get(),
-                probe_process_info);
-        }
-        else
-        {
-            auto key_holder = key_getter.getKeyHolder(i, &pool, sort_key_containers);
-            SCOPE_EXIT(keyHolderDiscardKey(key_holder));
-            auto key = keyHolderGetKey(key_holder);
-
-            size_t hash_value = 0;
-            bool zero_flag = ZeroTraits::check(key);
-            if (!zero_flag)
-            {
-                hash_value = map.hash(key);
-            }
-
-            size_t segment_index = 0;
-            if (join_build_info.is_spilled)
-            {
-                segment_index = probe_process_info.partition_index;
-            }
-            else if (join_build_info.needVirtualDispatchForProbeBlock())
-            {
-                /// Need to calculate the correct segment_index so that rows with same key will map to the same segment_index both in Build and Prob
-                /// The "reproduce" of segment_index generated in Build phase relies on the facts that:
-                /// Possible pipelines(FineGrainedShuffleWriter => ExchangeReceiver => HashBuild)
-                /// 1. In FineGrainedShuffleWriter, selector value finally maps to packet_stream_id by '% fine_grained_shuffle_count'
-                /// 2. In ExchangeReceiver, build_stream_id = packet_stream_id % build_stream_count;
-                /// 3. In HashBuild, build_concurrency decides map's segment size, and build_steam_id decides the segment index
-                if (join_build_info.enable_fine_grained_shuffle)
-                {
-                    auto packet_stream_id = build_hash_data[i] % join_build_info.fine_grained_shuffle_count;
-                    if likely (join_build_info.fine_grained_shuffle_count == segment_size)
-                        segment_index = packet_stream_id;
-                    else
-                        segment_index = packet_stream_id % segment_size;
-                }
-                else
-                {
-                    segment_index = build_hash_data[i] % join_build_info.build_concurrency;
-                }
-            }
-            else
-            {
-                segment_index = hash_value % segment_size;
-            }
-
-            auto & internal_map = map.getSegmentTable(segment_index);
-            /// do not require segment lock because in join, the hash table can not be changed in probe stage.
-            auto it = internal_map.find(key, hash_value);
-            if (it != internal_map.end())
-            {
-                it->getMapped().setUsed();
-                block_full = Adder<KIND, STRICTNESS, Map>::addFound(
-                    it,
-                    num_columns_to_add,
-                    added_columns,
-                    i,
-                    filter.get(),
-                    current_offset,
-                    offsets_to_replicate.get(),
-                    right_indexes,
-                    probe_process_info);
-            }
-            else
-                block_full = Adder<KIND, STRICTNESS, Map>::addNotFound(
-                    num_columns_to_add,
-                    added_columns,
-                    i,
-                    filter.get(),
-                    current_offset,
-                    offsets_to_replicate.get(),
-                    probe_process_info);
-        }
-
-        // if block_full is true means that the current offset is greater than max_block_size, we need break the loop.
-        if (block_full)
-        {
-            break;
-        }
-    }
-
-    probe_process_info.end_row = i;
-    // if i == rows, it means that all probe rows have been joined finish.
-    probe_process_info.all_rows_joined_finish = (i == rows);
-}
-
-template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS, typename KeyGetter, typename Map>
-void joinBlockImplType(
-    const Map & map,
-    size_t rows,
-    const ColumnRawPtrs & key_columns,
-    const Sizes & key_sizes,
-    MutableColumns & added_columns,
-    ConstNullMapPtr null_map,
-    std::unique_ptr<IColumn::Filter> & filter,
-    IColumn::Offset & current_offset,
-    std::unique_ptr<IColumn::Offsets> & offsets_to_replicate,
-    const std::vector<size_t> & right_indexes,
-    const TiDB::TiDBCollators & collators,
-    const JoinBuildInfo & join_build_info,
-    ProbeProcessInfo & probe_process_info)
-{
-    if (null_map)
-        joinBlockImplTypeCase<KIND, STRICTNESS, KeyGetter, Map, true>(
-            map,
-            rows,
-            key_columns,
-            key_sizes,
-            added_columns,
-            null_map,
-            filter,
-            current_offset,
-            offsets_to_replicate,
-            right_indexes,
-            collators,
-            join_build_info,
-            probe_process_info);
-    else
-        joinBlockImplTypeCase<KIND, STRICTNESS, KeyGetter, Map, false>(
-            map,
-            rows,
-            key_columns,
-            key_sizes,
-            added_columns,
-            null_map,
-            filter,
-            current_offset,
-            offsets_to_replicate,
-            right_indexes,
-            collators,
-            join_build_info,
-            probe_process_info);
-}
-} // namespace
 
 void mergeNullAndFilterResult(Block & block, ColumnVector<UInt8>::Container & filter_column, const String & filter_column_name, bool null_as_true)
 {
@@ -1875,9 +917,9 @@ void Join::handleOtherConditions(Block & block, std::unique_ptr<IColumn::Filter>
     throw Exception("Logical error: unknown combination of JOIN", ErrorCodes::LOGICAL_ERROR);
 }
 
-template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS, typename Maps>
-void Join::joinBlockImpl(Block & block, const Maps & maps, ProbeProcessInfo & probe_process_info) const
+Block Join::joinBlockHash(ProbeProcessInfo & probe_process_info) const
 {
+    Block block = probe_process_info.block;
     size_t keys_size = key_names_left.size();
 
     /// Rare case, when keys are constant. To avoid code bloat, simply materialize them.
@@ -1967,31 +1009,7 @@ void Join::joinBlockImpl(Block & block, const Maps & maps, ProbeProcessInfo & pr
 
     bool enable_spill_join = isEnableSpill();
     JoinBuildInfo join_build_info{enable_fine_grained_shuffle, fine_grained_shuffle_count, enable_spill_join, is_spilled, build_concurrency, restore_round};
-    switch (type)
-    {
-#define M(TYPE)                                                                                                                                \
-    case Join::Type::TYPE:                                                                                                                     \
-        joinBlockImplType<KIND, STRICTNESS, typename KeyGetterForType<Join::Type::TYPE, std::remove_reference_t<decltype(*maps.TYPE)>>::Type>( \
-            *maps.TYPE,                                                                                                                        \
-            rows,                                                                                                                              \
-            key_columns,                                                                                                                       \
-            key_sizes,                                                                                                                         \
-            added_columns,                                                                                                                     \
-            null_map,                                                                                                                          \
-            filter,                                                                                                                            \
-            current_offset,                                                                                                                    \
-            offsets_to_replicate,                                                                                                              \
-            right_indexes,                                                                                                                     \
-            collators,                                                                                                                         \
-            join_build_info,                                                                                                                   \
-            probe_process_info);                                                                                                               \
-        break;
-        APPLY_FOR_JOIN_VARIANTS(M)
-#undef M
-
-    default:
-        throw Exception("Unknown JOIN keys variant.", ErrorCodes::UNKNOWN_SET_DATA_VARIANT);
-    }
+    JoinPartition::probeBlock(partitions, rows, key_columns, key_sizes, added_columns, null_map, filter, current_offset, offsets_to_replicate, right_indexes, collators, join_build_info, probe_process_info);
     FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::random_join_prob_failpoint);
     for (size_t i = 0; i < num_columns_to_add; ++i)
     {
@@ -2040,6 +1058,8 @@ void Join::joinBlockImpl(Block & block, const Maps & maps, ProbeProcessInfo & pr
             throw Exception("Should not reach here, the strictness of join with other condition must be ALL");
         handleOtherConditions(block, filter, offsets_to_replicate, right_table_column_indexes);
     }
+
+    return block;
 }
 
 namespace
@@ -2180,7 +1200,7 @@ struct CrossJoinAdder<ASTTableJoin::Kind::Cross_LeftSemi, STRICTNESS>
 } // namespace
 
 template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS, bool has_null_map>
-void Join::joinBlockImplCrossInternal(Block & block, ConstNullMapPtr null_map [[maybe_unused]]) const
+void Join::joinBlockCrossImpl(Block & block, ConstNullMapPtr null_map [[maybe_unused]]) const
 {
     /// Add new columns to the block.
     size_t num_existing_columns = block.columns();
@@ -2274,9 +1294,9 @@ void Join::joinBlockImplCrossInternal(Block & block, ConstNullMapPtr null_map [[
     }
 }
 
-template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS>
-void Join::joinBlockImplCross(Block & block) const
+Block Join::joinBlockCross(ProbeProcessInfo & probe_process_info) const
 {
+    Block block = probe_process_info.block;
     size_t rows_left = block.rows();
     ColumnPtr null_map_holder;
     ConstNullMapPtr null_map{};
@@ -2285,10 +1305,43 @@ void Join::joinBlockImplCross(Block & block) const
     std::unique_ptr<IColumn::Filter> filter = std::make_unique<IColumn::Filter>(rows_left);
     std::unique_ptr<IColumn::Offsets> offsets_to_replicate = std::make_unique<IColumn::Offsets>(rows_left);
 
+    using enum ASTTableJoin::Strictness;
+    using enum ASTTableJoin::Kind;
+
+#define DISPATCH(HAS_NULL_MAP)                                                  \
+    if (kind == Cross && strictness == All)                                     \
+        joinBlockCrossImpl<Cross, All, HAS_NULL_MAP>(block, null_map);          \
+    else if (kind == Cross && strictness == Any)                                \
+        joinBlockCrossImpl<Cross, Any, HAS_NULL_MAP>(block, null_map);          \
+    else if (kind == Cross_Left && strictness == All)                           \
+        joinBlockCrossImpl<Cross_Left, All, HAS_NULL_MAP>(block, null_map);     \
+    else if (kind == Cross_Left && strictness == Any)                           \
+        joinBlockCrossImpl<Cross_Left, Any, HAS_NULL_MAP>(block, null_map);     \
+    else if (kind == Cross_Anti && strictness == All)                           \
+        joinBlockCrossImpl<Cross_Anti, All, HAS_NULL_MAP>(block, null_map);     \
+    else if (kind == Cross_Anti && strictness == Any)                           \
+        joinBlockCrossImpl<Cross_Anti, Any, HAS_NULL_MAP>(block, null_map);     \
+    else if (kind == Cross_LeftSemi && strictness == All)                       \
+        joinBlockCrossImpl<Cross_LeftSemi, All, HAS_NULL_MAP>(block, null_map); \
+    else if (kind == Cross_LeftSemi && strictness == Any)                       \
+        joinBlockCrossImpl<Cross_LeftSemi, Any, HAS_NULL_MAP>(block, null_map); \
+    else if (kind == Cross_LeftAnti && strictness == All)                       \
+        joinBlockCrossImpl<Cross_LeftSemi, All, HAS_NULL_MAP>(block, null_map); \
+    else if (kind == Cross_LeftAnti && strictness == Any)                       \
+        joinBlockCrossImpl<Cross_LeftSemi, Any, HAS_NULL_MAP>(block, null_map); \
+    else                                                                        \
+        throw Exception("Logical error: unknown combination of JOIN", ErrorCodes::LOGICAL_ERROR);
+
     if (null_map)
-        joinBlockImplCrossInternal<KIND, STRICTNESS, true>(block, null_map);
+    {
+        DISPATCH(true)
+    }
     else
-        joinBlockImplCrossInternal<KIND, STRICTNESS, false>(block, nullptr);
+    {
+        DISPATCH(false)
+    }
+#undef DISPATCH
+    return block;
 }
 
 void Join::checkTypes(const Block & block) const
@@ -2296,187 +1349,113 @@ void Join::checkTypes(const Block & block) const
     checkTypesOfKeys(block, sample_block_with_keys);
 }
 
-void Join::RowsNotInsertToMap::insertRow(Block * stored_block, size_t index, bool need_materialize, Arena & pool)
+Block Join::joinBlockNullAware(ProbeProcessInfo & probe_process_info) const
 {
-    if (need_materialize)
-    {
-        if (materialized_columns_vec.empty() || total_size % max_block_size == 0)
-            materialized_columns_vec.emplace_back(stored_block->cloneEmptyColumns());
+    Block block = probe_process_info.block;
 
-        auto & last_one = materialized_columns_vec.back();
-        size_t columns = stored_block->columns();
-        RUNTIME_ASSERT(last_one.size() == columns);
-        for (size_t i = 0; i < columns; ++i)
-            last_one[i]->insertFrom(*stored_block->getByPosition(i).column.get(), index);
-    }
-    else
+    size_t keys_size = key_names_left.size();
+    ColumnRawPtrs key_columns(keys_size);
+
+    /// Rare case, when keys are constant. To avoid code bloat, simply materialize them.
+    /// Note: this variable can't be removed because it will take smart pointers' lifecycle to the end of this function.
+    Columns materialized_columns;
+
+    /// Memoize key columns to work with.
+    for (size_t i = 0; i < keys_size; ++i)
     {
-        auto * elem = reinterpret_cast<Join::RowRefList *>(pool.alloc(sizeof(Join::RowRefList)));
-        insertRowToList(&head, elem, stored_block, index);
+        key_columns[i] = block.getByName(key_names_left[i]).column.get();
+
+        if (ColumnPtr converted = key_columns[i]->convertToFullColumnIfConst())
+        {
+            materialized_columns.emplace_back(converted);
+            key_columns[i] = materialized_columns.back().get();
+        }
     }
-    ++total_size;
+
+    /// Note that `extractAllKeyNullMap` must be done before `extractNestedColumnsAndNullMap`
+    /// because `extractNestedColumnsAndNullMap` will change the nullable column to its nested column.
+    ColumnPtr all_key_null_map_holder;
+    ConstNullMapPtr all_key_null_map{};
+    extractAllKeyNullMap(key_columns, all_key_null_map_holder, all_key_null_map);
+
+    ColumnPtr null_map_holder;
+    ConstNullMapPtr null_map{};
+    extractNestedColumnsAndNullMap(key_columns, null_map_holder, null_map);
+
+    ColumnPtr filter_map_holder;
+    ConstNullMapPtr filter_map{};
+    recordFilteredRows(block, non_equal_conditions.left_filter_column, filter_map_holder, filter_map);
+
+    size_t existing_columns = block.columns();
+
+    /// Add new columns to the block.
+    size_t num_columns_to_add = sample_block_with_columns_to_add.columns();
+
+    for (size_t i = 0; i < num_columns_to_add; ++i)
+    {
+        const ColumnWithTypeAndName & src_column = sample_block_with_columns_to_add.getByPosition(i);
+        RUNTIME_CHECK_MSG(!block.has(src_column.name), "block from probe side has a column with the same name: {} as a column in sample_block_with_columns_to_add", src_column.name);
+        block.insert(src_column);
+    }
+
+    using enum ASTTableJoin::Strictness;
+    using enum ASTTableJoin::Kind;
+    if (kind == NullAware_Anti && strictness == All)
+        joinBlockNullAwareImpl<NullAware_Anti, All, MapsAll>(block, existing_columns, key_columns, null_map, filter_map, all_key_null_map);
+    else if (kind == NullAware_Anti && strictness == Any)
+        joinBlockNullAwareImpl<NullAware_Anti, Any, MapsAny>(block, existing_columns, key_columns, null_map, filter_map, all_key_null_map);
+    else if (kind == NullAware_LeftSemi && strictness == All)
+        joinBlockNullAwareImpl<NullAware_LeftSemi, All, MapsAll>(block, existing_columns, key_columns, null_map, filter_map, all_key_null_map);
+    else if (kind == NullAware_LeftSemi && strictness == Any)
+        joinBlockNullAwareImpl<NullAware_LeftSemi, Any, MapsAny>(block, existing_columns, key_columns, null_map, filter_map, all_key_null_map);
+    else if (kind == NullAware_LeftAnti && strictness == All)
+        joinBlockNullAwareImpl<NullAware_LeftAnti, All, MapsAll>(block, existing_columns, key_columns, null_map, filter_map, all_key_null_map);
+    else if (kind == NullAware_LeftAnti && strictness == Any)
+        joinBlockNullAwareImpl<NullAware_LeftAnti, Any, MapsAny>(block, existing_columns, key_columns, null_map, filter_map, all_key_null_map);
+    else
+        throw Exception("Logical error: unknown combination of JOIN", ErrorCodes::LOGICAL_ERROR);
+
+    FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::random_join_prob_failpoint);
+
+    return block;
 }
 
-template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS, typename KeyGetter, typename Map, bool has_null_map, bool has_filter_map>
-void NO_INLINE joinBlockImplNullAwareInternal(
-    const Map & map,
+template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS, typename Maps>
+void Join::joinBlockNullAwareImpl(
     Block & block,
     size_t left_columns,
-    const BlocksList & right_blocks,
-    const std::vector<Join::RowsNotInsertToMap> & null_rows,
-    size_t max_block_size,
-    const JoinNonEqualConditions & non_equal_conditions,
     const ColumnRawPtrs & key_columns,
-    const Sizes & key_sizes,
     const ConstNullMapPtr & null_map,
     const ConstNullMapPtr & filter_map,
-    const ConstNullMapPtr & all_key_null_map,
-    const TiDB::TiDBCollators & collators,
-    bool null_key_check_all_blocks_directly,
-    bool right_has_all_key_null_row,
-    bool right_table_is_empty)
+    const ConstNullMapPtr all_key_null_map) const
 {
-    static_assert(KIND == ASTTableJoin::Kind::NullAware_Anti || KIND == ASTTableJoin::Kind::NullAware_LeftAnti
-                  || KIND == ASTTableJoin::Kind::NullAware_LeftSemi);
-    static_assert(STRICTNESS == ASTTableJoin::Strictness::Any || STRICTNESS == ASTTableJoin::Strictness::All);
-
     size_t rows = block.rows();
-    KeyGetter key_getter(key_columns, key_sizes, collators);
-    std::vector<std::string> sort_key_containers;
-    sort_key_containers.resize(key_columns.size());
+    std::vector<RowsNotInsertToMap *> null_rows(partitions.size(), nullptr);
+    for (size_t i = 0; i < partitions.size(); ++i)
+        null_rows[i] = partitions[i]->getRowsNotInsertedToMap();
 
-    Arena pool;
-    size_t segment_size = map.getSegmentSize();
+    NALeftSideInfo left_side_info(null_map, filter_map, all_key_null_map);
+    NARightSideInfo right_side_info(right_has_all_key_null_row.load(std::memory_order_relaxed), right_table_is_empty.load(std::memory_order_relaxed), null_key_check_all_blocks_directly, null_rows);
+    auto [res, res_list] = JoinPartition::probeBlockNullAware<KIND, STRICTNESS, Maps>(
+        partitions,
+        block,
+        key_columns,
+        key_sizes,
+        collators,
+        left_side_info,
+        right_side_info);
 
-    PaddedPODArray<NASemiJoinResult<KIND, STRICTNESS>> res;
-    res.reserve(rows);
-    std::list<NASemiJoinResult<KIND, STRICTNESS> *> res_list;
-    /// We can just consider the result of left semi join because `NASemiJoinResult::setResult` will correct
-    /// the result if it's not left semi join.
-    for (size_t i = 0; i < rows; ++i)
-    {
-        if constexpr (has_filter_map)
-        {
-            if ((*filter_map)[i])
-            {
-                /// Filter out by left_conditions so the result set is empty.
-                res.emplace_back(i, NASemiJoinStep::DONE, nullptr);
-                res.back().template setResult<NASemiJoinResultType::FALSE_VALUE>();
-                continue;
-            }
-        }
-        if (right_table_is_empty)
-        {
-            /// If right table is empty, the result is false.
-            /// E.g. (1,2) in ().
-            res.emplace_back(i, NASemiJoinStep::DONE, nullptr);
-            res.back().template setResult<NASemiJoinResultType::FALSE_VALUE>();
-            continue;
-        }
-        if constexpr (has_null_map)
-        {
-            if ((*null_map)[i])
-            {
-                if constexpr (STRICTNESS == ASTTableJoin::Strictness::Any)
-                {
-                    if (key_columns.size() == 1 || right_has_all_key_null_row || (all_key_null_map && (*all_key_null_map)[i]))
-                    {
-                        /// Note that right_table_is_empty must be false here so the right table is not empty.
-                        /// The result is NULL if
-                        ///   1. key column size is 1. E.g. (null) in (1,2).
-                        ///   2. right table has a all-key-null row. E.g. (1,null) in ((2,2),(null,null)).
-                        ///   3. this row is all-key-null. E.g. (null,null) in ((1,1),(2,2)).
-                        res.emplace_back(i, NASemiJoinStep::DONE, nullptr);
-                        res.back().template setResult<NASemiJoinResultType::NULL_VALUE>();
-                        continue;
-                    }
-                }
-                /// In the worse case, all rows in the right table will be checked.
-                /// E.g. (1,null) in ((2,1),(2,3),(2,null),(3,null)) => false.
-                if (null_key_check_all_blocks_directly)
-                    res.emplace_back(i, NASemiJoinStep::NULL_KEY_CHECK_ALL_BLOCKS, nullptr);
-                else
-                    res.emplace_back(i, NASemiJoinStep::NULL_KEY_CHECK_NULL_ROWS, nullptr);
-                res_list.push_back(&res.back());
-                continue;
-            }
-        }
-
-        auto key_holder = key_getter.getKeyHolder(i, &pool, sort_key_containers);
-        SCOPE_EXIT(keyHolderDiscardKey(key_holder));
-        auto key = keyHolderGetKey(key_holder);
-
-        size_t segment_index = 0;
-        size_t hash_value = 0;
-        if (!ZeroTraits::check(key))
-        {
-            hash_value = map.hash(key);
-            segment_index = hash_value % segment_size;
-        }
-
-        auto & internal_map = map.getSegmentTable(segment_index);
-        /// do not require segment lock because in join, the hash table can not be changed in probe stage.
-        auto it = internal_map.find(key, hash_value);
-        if (it != internal_map.end())
-        {
-            /// Find the matched row(s).
-            if (STRICTNESS == ASTTableJoin::Strictness::Any)
-            {
-                /// If strictness is any, the result is true.
-                /// E.g. (1,2) in ((1,2),(1,3),(null,3))
-                res.emplace_back(i, NASemiJoinStep::DONE, nullptr);
-                res.back().template setResult<NASemiJoinResultType::TRUE_VALUE>();
-            }
-            else
-            {
-                /// Else the other condition must be checked for these matched right row(s).
-                auto map_it = &static_cast<const typename Map::mapped_type::Base_t &>(it->getMapped());
-                res.emplace_back(i, NASemiJoinStep::NOT_NULL_KEY_CHECK_MATCHED_ROWS, static_cast<const void *>(map_it));
-                res_list.push_back(&res.back());
-            }
-            continue;
-        }
-
-        /// Not find the matched row.
-        if constexpr (STRICTNESS == ASTTableJoin::Strictness::Any)
-        {
-            if (right_has_all_key_null_row)
-            {
-                /// If right table has a all-key-null row, the result is NULL.
-                /// E.g. (1) in (null) or (1,2) in ((1,3),(null,null)).
-                res.emplace_back(i, NASemiJoinStep::DONE, nullptr);
-                res.back().template setResult<NASemiJoinResultType::NULL_VALUE>();
-                continue;
-            }
-            else if (key_columns.size() == 1)
-            {
-                /// If key size is 1 and all key in right table row is not NULL(right_has_all_key_null_row is false),
-                /// the result is false.
-                /// E.g. (1) in (2,3,4,5).
-                res.emplace_back(i, NASemiJoinStep::DONE, nullptr);
-                res.back().template setResult<NASemiJoinResultType::FALSE_VALUE>();
-                continue;
-            }
-            /// Then key size is greater than 1 and right table does not have a all-key-null row.
-            /// E.g. (1,2) in ((1,3),(1,null)) => NULL, (1,2) in ((1,3),(2,null)) => false.
-        }
-        /// We have to compare them to the null rows one by one.
-        /// In the worse case, all null rows in the right table will be checked.
-        /// E.g. (1,2) in ((2,null),(3,null),(null,1),(null,3)) => false.
-        res.emplace_back(i, NASemiJoinStep::NOT_NULL_KEY_CHECK_NULL_ROWS, nullptr);
-        res_list.push_back(&res.back());
-    }
     RUNTIME_ASSERT(res.size() == rows, "NASemiJoinResult size {} must be equal to block size {}", res.size(), rows);
 
     size_t right_columns = block.columns() - left_columns;
 
     if (!res_list.empty())
     {
-        NASemiJoinHelper<KIND, STRICTNESS, typename Map::mapped_type::Base_t> helper(
+        NASemiJoinHelper<KIND, STRICTNESS, typename Maps::MappedType::Base_t> helper(
             block,
             left_columns,
             right_columns,
-            right_blocks,
+            blocks,
             null_rows,
             max_block_size,
             non_equal_conditions);
@@ -2565,147 +1544,6 @@ void NO_INLINE joinBlockImplNullAwareInternal(
     }
 }
 
-template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS, typename KeyGetter, typename Map>
-void NO_INLINE joinBlockImplNullAwareCast(
-    const Map & map,
-    Block & block,
-    size_t left_columns,
-    const BlocksList & right_blocks,
-    const std::vector<Join::RowsNotInsertToMap> & null_rows,
-    size_t max_block_size,
-    const JoinNonEqualConditions & non_equal_conditions,
-    const ColumnRawPtrs & key_columns,
-    const Sizes & key_sizes,
-    const ConstNullMapPtr & null_map,
-    const ConstNullMapPtr & filter_map,
-    const ConstNullMapPtr & all_key_null_map,
-    const TiDB::TiDBCollators & collators,
-    bool null_key_check_all_blocks_directly,
-    bool right_has_all_key_null_row,
-    bool right_table_is_empty)
-{
-#define impl(has_null_map, has_filter_map)                                                          \
-    joinBlockImplNullAwareInternal<KIND, STRICTNESS, KeyGetter, Map, has_null_map, has_filter_map>( \
-        map,                                                                                        \
-        block,                                                                                      \
-        left_columns,                                                                               \
-        right_blocks,                                                                               \
-        null_rows,                                                                                  \
-        max_block_size,                                                                             \
-        non_equal_conditions,                                                                       \
-        key_columns,                                                                                \
-        key_sizes,                                                                                  \
-        null_map,                                                                                   \
-        filter_map,                                                                                 \
-        all_key_null_map,                                                                           \
-        collators,                                                                                  \
-        null_key_check_all_blocks_directly,                                                         \
-        right_has_all_key_null_row,                                                                 \
-        right_table_is_empty);
-
-    if (null_map)
-    {
-        if (filter_map)
-        {
-            impl(true, true);
-        }
-        else
-        {
-            impl(true, false);
-        }
-    }
-    else
-    {
-        if (filter_map)
-        {
-            impl(false, true);
-        }
-        else
-        {
-            impl(false, false);
-        }
-    }
-}
-
-template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS, typename Maps>
-void Join::joinBlockImplNullAware(Block & block, const Maps & maps) const
-{
-    size_t keys_size = key_names_left.size();
-    ColumnRawPtrs key_columns(keys_size);
-
-    /// Rare case, when keys are constant. To avoid code bloat, simply materialize them.
-    /// Note: this variable can't be removed because it will take smart pointers' lifecycle to the end of this function.
-    Columns materialized_columns;
-
-    /// Memoize key columns to work with.
-    for (size_t i = 0; i < keys_size; ++i)
-    {
-        key_columns[i] = block.getByName(key_names_left[i]).column.get();
-
-        if (ColumnPtr converted = key_columns[i]->convertToFullColumnIfConst())
-        {
-            materialized_columns.emplace_back(converted);
-            key_columns[i] = materialized_columns.back().get();
-        }
-    }
-
-    /// Note that `extractAllKeyNullMap` must be done before `extractNestedColumnsAndNullMap`
-    /// because `extractNestedColumnsAndNullMap` will change the nullable column to its nested column.
-    ColumnPtr all_key_null_map_holder;
-    ConstNullMapPtr all_key_null_map{};
-    extractAllKeyNullMap(key_columns, all_key_null_map_holder, all_key_null_map);
-
-    ColumnPtr null_map_holder;
-    ConstNullMapPtr null_map{};
-    extractNestedColumnsAndNullMap(key_columns, null_map_holder, null_map);
-
-    ColumnPtr filter_map_holder;
-    ConstNullMapPtr filter_map{};
-    recordFilteredRows(block, non_equal_conditions.left_filter_column, filter_map_holder, filter_map);
-
-    size_t existing_columns = block.columns();
-
-    /// Add new columns to the block.
-    size_t num_columns_to_add = sample_block_with_columns_to_add.columns();
-
-    for (size_t i = 0; i < num_columns_to_add; ++i)
-    {
-        const ColumnWithTypeAndName & src_column = sample_block_with_columns_to_add.getByPosition(i);
-        RUNTIME_CHECK_MSG(!block.has(src_column.name), "block from probe side has a column with the same name: {} as a column in sample_block_with_columns_to_add", src_column.name);
-        block.insert(src_column);
-    }
-
-    switch (type)
-    {
-#define M(TYPE)                                                                                                                                         \
-    case Join::Type::TYPE:                                                                                                                              \
-        joinBlockImplNullAwareCast<KIND, STRICTNESS, typename KeyGetterForType<Join::Type::TYPE, std::remove_reference_t<decltype(*maps.TYPE)>>::Type>( \
-            *maps.TYPE,                                                                                                                                 \
-            block,                                                                                                                                      \
-            existing_columns,                                                                                                                           \
-            blocks,                                                                                                                                     \
-            rows_not_inserted_to_map,                                                                                                                   \
-            max_block_size,                                                                                                                             \
-            non_equal_conditions,                                                                                                                       \
-            key_columns,                                                                                                                                \
-            key_sizes,                                                                                                                                  \
-            null_map,                                                                                                                                   \
-            filter_map,                                                                                                                                 \
-            all_key_null_map,                                                                                                                           \
-            collators,                                                                                                                                  \
-            null_key_check_all_blocks_directly,                                                                                                         \
-            right_has_all_key_null_row.load(std::memory_order_relaxed),                                                                                 \
-            right_table_is_empty.load(std::memory_order_relaxed));                                                                                      \
-        break;
-        APPLY_FOR_JOIN_VARIANTS(M)
-#undef M
-
-    default:
-        throw Exception("Unknown JOIN keys variant.", ErrorCodes::UNKNOWN_SET_DATA_VARIANT);
-    }
-    FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::random_join_prob_failpoint);
-}
-
 void Join::checkTypesOfKeys(const Block & block_left, const Block & block_right) const
 {
     size_t keys_size = key_names_left.size();
@@ -2745,8 +1583,10 @@ void Join::workAfterBuildFinish()
     if (isNullAwareSemiFamily(kind))
     {
         size_t null_rows_size = 0;
-        for (const auto & i : rows_not_inserted_to_map)
-            null_rows_size += i.total_size;
+        for (const auto & partition : partitions)
+        {
+            null_rows_size += partition->getRowsNotInsertedToMap()->total_size;
+        }
         /// Considering the rows with null key in left table, in the worse case, it may need to check all rows in right table.
         /// Null rows are used for speeding up the check process. If the result of null-aware equal expression is NULL, the
         /// check process can be finished.
@@ -2772,8 +1612,8 @@ void Join::workAfterBuildFinish()
     {
         if (hasPartitionSpilled())
         {
-            trySpillBuildPartitions(true);
-            tryMarkBuildSpillFinish();
+            spillAllBuildPartitions();
+            build_spiller->finishSpill();
         }
         for (const auto & partition : partitions)
         {
@@ -2793,8 +1633,8 @@ void Join::workAfterProbeFinish()
     {
         if (hasPartitionSpilled())
         {
-            trySpillProbePartitions(true);
-            tryMarkProbeSpillFinish();
+            spillAllProbePartitions();
+            probe_spiller->finishSpill();
             if (!needReturnNonJoinedData())
             {
                 releaseAllPartitions();
@@ -2846,13 +1686,7 @@ void Join::finishOneNonJoin(size_t partition_index)
         /// only clear hash table if not active build/probe threads
         while (partition_index < build_concurrency)
         {
-            std::unique_lock partition_lock = partitions[partition_index]->lockPartition();
-            partitions[partition_index]->releaseBuildPartitionBlocks(partition_lock);
-            partitions[partition_index]->releaseProbePartitionBlocks(partition_lock);
-            if (!partitions[partition_index]->isSpill())
-            {
-                releaseBuildPartitionHashTable(partition_index, partition_lock);
-            }
+            partitions[partition_index]->releasePartition();
             partition_index += build_concurrency;
         }
     }
@@ -2877,73 +1711,17 @@ Block Join::joinBlock(ProbeProcessInfo & probe_process_info, bool dry_run) const
 
     probe_process_info.updateStartRow();
 
-    Block block = probe_process_info.block;
+    Block block{};
 
     using enum ASTTableJoin::Strictness;
     using enum ASTTableJoin::Kind;
 
-    if (kind == Left && strictness == Any)
-        joinBlockImpl<Left, Any>(block, maps_any, probe_process_info);
-    else if (kind == Inner && strictness == Any)
-        joinBlockImpl<Inner, Any>(block, maps_any, probe_process_info);
-    else if (kind == Left && strictness == All)
-        joinBlockImpl<Left, All>(block, maps_all, probe_process_info);
-    else if (kind == Inner && strictness == All)
-        joinBlockImpl<Inner, All>(block, maps_all, probe_process_info);
-    else if (kind == Full && strictness == Any)
-        joinBlockImpl<Left, Any>(block, maps_any_full, probe_process_info);
-    else if (kind == Right && strictness == Any)
-        joinBlockImpl<Inner, Any>(block, maps_any_full, probe_process_info);
-    else if (kind == Full && strictness == All)
-        joinBlockImpl<Left, All>(block, maps_all_full, probe_process_info);
-    else if (kind == Right && strictness == All)
-        joinBlockImpl<Inner, All>(block, maps_all_full, probe_process_info);
-    else if (kind == Anti && strictness == Any)
-        joinBlockImpl<Anti, Any>(block, maps_any, probe_process_info);
-    else if (kind == Anti && strictness == All)
-        joinBlockImpl<Anti, All>(block, maps_all, probe_process_info);
-    else if (kind == LeftSemi && strictness == Any)
-        joinBlockImpl<LeftSemi, Any>(block, maps_any, probe_process_info);
-    else if (kind == LeftSemi && strictness == All)
-        joinBlockImpl<LeftSemi, All>(block, maps_all, probe_process_info);
-    else if (kind == LeftAnti && strictness == Any)
-        joinBlockImpl<LeftSemi, Any>(block, maps_any, probe_process_info);
-    else if (kind == LeftAnti && strictness == All)
-        joinBlockImpl<LeftSemi, All>(block, maps_all, probe_process_info);
-    else if (kind == Cross && strictness == All)
-        joinBlockImplCross<Cross, All>(block);
-    else if (kind == Cross && strictness == Any)
-        joinBlockImplCross<Cross, Any>(block);
-    else if (kind == Cross_Left && strictness == All)
-        joinBlockImplCross<Cross_Left, All>(block);
-    else if (kind == Cross_Left && strictness == Any)
-        joinBlockImplCross<Cross_Left, Any>(block);
-    else if (kind == Cross_Anti && strictness == All)
-        joinBlockImplCross<Cross_Anti, All>(block);
-    else if (kind == Cross_Anti && strictness == Any)
-        joinBlockImplCross<Cross_Anti, Any>(block);
-    else if (kind == Cross_LeftSemi && strictness == All)
-        joinBlockImplCross<Cross_LeftSemi, All>(block);
-    else if (kind == Cross_LeftSemi && strictness == Any)
-        joinBlockImplCross<Cross_LeftSemi, Any>(block);
-    else if (kind == Cross_LeftAnti && strictness == All)
-        joinBlockImplCross<Cross_LeftSemi, All>(block);
-    else if (kind == Cross_LeftAnti && strictness == Any)
-        joinBlockImplCross<Cross_LeftSemi, Any>(block);
-    else if (kind == NullAware_Anti && strictness == All)
-        joinBlockImplNullAware<NullAware_Anti, All>(block, maps_all);
-    else if (kind == NullAware_Anti && strictness == Any)
-        joinBlockImplNullAware<NullAware_Anti, Any>(block, maps_any);
-    else if (kind == NullAware_LeftSemi && strictness == All)
-        joinBlockImplNullAware<NullAware_LeftSemi, All>(block, maps_all);
-    else if (kind == NullAware_LeftSemi && strictness == Any)
-        joinBlockImplNullAware<NullAware_LeftSemi, Any>(block, maps_any);
-    else if (kind == NullAware_LeftAnti && strictness == All)
-        joinBlockImplNullAware<NullAware_LeftAnti, All>(block, maps_all);
-    else if (kind == NullAware_LeftAnti && strictness == Any)
-        joinBlockImplNullAware<NullAware_LeftAnti, Any>(block, maps_any);
+    if (isCrossJoin(kind))
+        block = joinBlockCross(probe_process_info);
+    else if (!isNullAwareSemiFamily(kind))
+        block = joinBlockHash(probe_process_info);
     else
-        throw Exception("Logical error: unknown combination of JOIN", ErrorCodes::LOGICAL_ERROR);
+        block = joinBlockNullAware(probe_process_info);
 
     /// for (cartesian)antiLeftSemi join, the meaning of "match-helper" is `non-matched` instead of `matched`.
     if (kind == LeftAnti || kind == Cross_LeftAnti)
@@ -3102,28 +1880,12 @@ void Join::spillMostMemoryUsedPartitionIfNeed()
 
         std::unique_lock partition_lock = partitions[target_partition_index]->lockPartition();
         partitions[target_partition_index]->markSpill();
-        releaseBuildPartitionHashTable(target_partition_index, partition_lock);
-        spilled_partition_indexes.push_back(target_partition_index);
+        partitions[target_partition_index]->releasePartitionPoolAndHashMap(partition_lock);
         blocks_to_spill = partitions[target_partition_index]->trySpillBuildPartition(true, build_spill_config.max_cached_data_bytes_in_spiller, partition_lock);
+        spilled_partition_indexes.push_back(target_partition_index);
     }
     build_spiller->spillBlocks(std::move(blocks_to_spill), target_partition_index);
     LOG_DEBUG(log, fmt::format("all bytes used after spill : {}", getTotalByteCount()));
-}
-
-void Join::tryMarkBuildSpillFinish()
-{
-    if (!spilled_partition_indexes.empty())
-    {
-        build_spiller->finishSpill();
-    }
-}
-
-void Join::tryMarkProbeSpillFinish()
-{
-    if (!spilled_partition_indexes.empty())
-    {
-        probe_spiller->finishSpill();
-    }
 }
 
 bool Join::getPartitionSpilled(size_t partition_index)
@@ -3244,65 +2006,28 @@ void Join::dispatchProbeBlock(Block & block, std::list<std::tuple<size_t, Block>
     }
 }
 
-void Join::trySpillBuildPartitions(bool force)
+void Join::spillAllBuildPartitions()
 {
     for (size_t i = 0; i < partitions.size(); ++i)
     {
-        build_spiller->spillBlocks(partitions[i]->trySpillBuildPartition(force, build_spill_config.max_cached_data_bytes_in_spiller), i);
+        build_spiller->spillBlocks(partitions[i]->trySpillBuildPartition(true, build_spill_config.max_cached_data_bytes_in_spiller), i);
     }
 }
 
-void Join::trySpillProbePartitions(bool force)
+void Join::spillAllProbePartitions()
 {
     for (size_t i = 0; i < partitions.size(); ++i)
     {
-        probe_spiller->spillBlocks(partitions[i]->trySpillProbePartition(force, probe_spill_config.max_cached_data_bytes_in_spiller), i);
+        probe_spiller->spillBlocks(partitions[i]->trySpillProbePartition(true, probe_spill_config.max_cached_data_bytes_in_spiller), i);
     }
-}
-
-void Join::releaseBuildPartitionHashTable(size_t partition_index, std::unique_lock<std::mutex> & partition_lock)
-{
-    size_t map_bytes = clearMapPartition(maps_any, type, partition_index);
-    map_bytes += clearMapPartition(maps_all, type, partition_index);
-    map_bytes += clearMapPartition(maps_any_full, type, partition_index);
-    map_bytes += clearMapPartition(maps_all_full, type, partition_index);
-    const auto & join_partition = partitions[partition_index];
-    if (getFullness(kind))
-    {
-        rows_not_inserted_to_map[partition_index] = RowsNotInsertToMap(max_block_size);
-    }
-    join_partition->subMemoryUsage(map_bytes);
-    join_partition->releasePartitionPool(partition_lock);
 }
 
 void Join::releaseAllPartitions()
 {
-    for (size_t i = 0; i < partitions.size(); ++i)
+    for (auto & partition : partitions)
     {
-        std::unique_lock partition_lock = partitions[i]->lockPartition();
-        partitions[i]->releaseBuildPartitionBlocks(partition_lock);
-        partitions[i]->releaseProbePartitionBlocks(partition_lock);
-        if (!partitions[i]->isSpill())
-        {
-            releaseBuildPartitionHashTable(i, partition_lock);
-        }
+        partition->releasePartition();
     }
 }
 
-void ProbeProcessInfo::resetBlock(Block && block_, size_t partition_index_)
-{
-    block = std::move(block_);
-    partition_index = partition_index_;
-    start_row = 0;
-    end_row = 0;
-    all_rows_joined_finish = false;
-    // If the probe block size is greater than max_block_size, we will set max_block_size to the probe block size to avoid some unnecessary split.
-    max_block_size = std::max(max_block_size, block.rows());
-}
-
-void ProbeProcessInfo::updateStartRow()
-{
-    assert(start_row <= end_row);
-    start_row = end_row;
-}
 } // namespace DB

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -1427,7 +1427,7 @@ void Join::joinBlockNullAwareImpl(
     const ColumnRawPtrs & key_columns,
     const ConstNullMapPtr & null_map,
     const ConstNullMapPtr & filter_map,
-    const ConstNullMapPtr all_key_null_map) const
+    const ConstNullMapPtr & all_key_null_map) const
 {
     size_t rows = block.rows();
     std::vector<RowsNotInsertToMap *> null_rows(partitions.size(), nullptr);
@@ -1718,10 +1718,10 @@ Block Join::joinBlock(ProbeProcessInfo & probe_process_info, bool dry_run) const
 
     if (isCrossJoin(kind))
         block = joinBlockCross(probe_process_info);
-    else if (!isNullAwareSemiFamily(kind))
-        block = joinBlockHash(probe_process_info);
-    else
+    else if (isNullAwareSemiFamily(kind))
         block = joinBlockNullAware(probe_process_info);
+    else
+        block = joinBlockHash(probe_process_info);
 
     /// for (cartesian)antiLeftSemi join, the meaning of "match-helper" is `non-matched` instead of `matched`.
     if (kind == LeftAnti || kind == Cross_LeftAnti)

--- a/dbms/src/Interpreters/Join.h
+++ b/dbms/src/Interpreters/Join.h
@@ -362,7 +362,7 @@ private:
         const ColumnRawPtrs & key_columns,
         const ConstNullMapPtr & null_map,
         const ConstNullMapPtr & filter_map,
-        const ConstNullMapPtr all_key_null_map) const;
+        const ConstNullMapPtr & all_key_null_map) const;
 
     IColumn::Selector hashToSelector(const WeakHash32 & hash) const;
     IColumn::Selector selectDispatchBlock(const Strings & key_columns_names, const Block & from_block);

--- a/dbms/src/Interpreters/Join.h
+++ b/dbms/src/Interpreters/Join.h
@@ -18,17 +18,14 @@
 #include <Columns/ColumnNullable.h>
 #include <Columns/ColumnString.h>
 #include <Common/Arena.h>
-#include <Common/HashTable/HashMap.h>
 #include <Common/Logger.h>
 #include <Core/Spiller.h>
 #include <DataStreams/IBlockInputStream.h>
 #include <Flash/Coprocessor/JoinInterpreterHelper.h>
-#include <Interpreters/AggregationCommon.h>
 #include <Interpreters/ExpressionActions.h>
+#include <Interpreters/JoinHashTable.h>
 #include <Interpreters/JoinPartition.h>
 #include <Interpreters/SettingsCommon.h>
-#include <Parsers/ASTTablesInSelectQuery.h>
-#include <absl/base/optimization.h>
 
 #include <shared_mutex>
 
@@ -116,7 +113,7 @@ public:
 
     size_t restore_round;
 
-    /** Call `setBuildConcurrencyAndInitJoinPartition`, `initMapImpl` and `setSampleBlock`.
+    /** Call `setBuildConcurrencyAndInitJoinPartition` and `setSampleBlock`.
       * You must call this method before subsequent calls to insertFromBlock.
       */
     void initBuild(const Block & sample_block, size_t build_concurrency_ = 1);
@@ -144,10 +141,6 @@ public:
 
     bool isRestoreJoin() const;
 
-    void tryMarkBuildSpillFinish();
-
-    void tryMarkProbeSpillFinish();
-
     bool getPartitionSpilled(size_t partition_index);
 
     bool hasPartitionSpilledWithLock();
@@ -168,8 +161,6 @@ public:
     size_t getTotalByteCount();
     /// The peak build bytes usage, if spill is not enabled, the same as getTotalByteCount
     size_t getPeakBuildBytesUsage();
-    /// size in bytes for partition hash map
-    size_t getPartitionByteCount(size_t partition_index) const;
 
     size_t getTotalBuildInputRows() const { return total_input_build_rows; }
 
@@ -221,105 +212,6 @@ public:
     void meetError(const String & error_message);
     void meetErrorImpl(const String & error_message, std::unique_lock<std::mutex> & lock);
 
-    /// Reference to the row in block.
-    struct RowRef
-    {
-        const Block * block;
-        size_t row_num;
-
-        RowRef() = default;
-        RowRef(const Block * block_, size_t row_num_)
-            : block(block_)
-            , row_num(row_num_)
-        {}
-    };
-
-    /// Single linked list of references to rows. Used for ALL JOINs (non-unique JOINs)
-    struct RowRefList : RowRef
-    {
-        RowRefList * next = nullptr;
-
-        RowRefList() = default;
-        RowRefList(const Block * block_, size_t row_num_)
-            : RowRef(block_, row_num_)
-        {}
-    };
-
-    /** Depending on template parameter, adds or doesn't add a flag, that element was used (row was joined).
-      * For implementation of RIGHT and FULL JOINs.
-      * NOTE: It is possible to store the flag in one bit of pointer to block or row_num. It seems not reasonable, because memory saving is minimal.
-      */
-    template <bool enable, typename Base>
-    struct WithUsedFlag;
-
-    template <typename Base>
-    struct WithUsedFlag<true, Base> : Base
-    {
-        mutable std::atomic<bool> used{};
-        using Base::Base;
-        using Base_t = Base;
-        void setUsed() const { used.store(true, std::memory_order_relaxed); } /// Could be set simultaneously from different threads.
-        bool getUsed() const { return used.load(std::memory_order_relaxed); }
-    };
-
-    template <typename Base>
-    struct WithUsedFlag<false, Base> : Base
-    {
-        using Base::Base;
-        using Base_t = Base;
-        void setUsed() const {}
-        bool getUsed() const { return true; }
-    };
-
-
-/// Different types of keys for maps.
-#define APPLY_FOR_JOIN_VARIANTS(M) \
-    M(key8)                        \
-    M(key16)                       \
-    M(key32)                       \
-    M(key64)                       \
-    M(key_string)                  \
-    M(key_strbinpadding)           \
-    M(key_strbin)                  \
-    M(key_fixed_string)            \
-    M(keys128)                     \
-    M(keys256)                     \
-    M(serialized)
-
-    enum class Type
-    {
-        EMPTY,
-        CROSS,
-#define M(NAME) NAME,
-        APPLY_FOR_JOIN_VARIANTS(M)
-#undef M
-    };
-
-
-    /** Different data structures, that are used to perform JOIN.
-      */
-    template <typename Mapped>
-    struct MapsTemplate
-    {
-        std::unique_ptr<ConcurrentHashMap<UInt8, Mapped, TrivialHash, HashTableFixedGrower<8>>> key8;
-        std::unique_ptr<ConcurrentHashMap<UInt16, Mapped, TrivialHash, HashTableFixedGrower<16>>> key16;
-        std::unique_ptr<ConcurrentHashMap<UInt32, Mapped, HashCRC32<UInt32>>> key32;
-        std::unique_ptr<ConcurrentHashMap<UInt64, Mapped, HashCRC32<UInt64>>> key64;
-        std::unique_ptr<ConcurrentHashMapWithSavedHash<StringRef, Mapped>> key_string;
-        std::unique_ptr<ConcurrentHashMapWithSavedHash<StringRef, Mapped>> key_strbinpadding;
-        std::unique_ptr<ConcurrentHashMapWithSavedHash<StringRef, Mapped>> key_strbin;
-        std::unique_ptr<ConcurrentHashMapWithSavedHash<StringRef, Mapped>> key_fixed_string;
-        std::unique_ptr<ConcurrentHashMap<UInt128, Mapped, HashCRC32<UInt128>>> keys128;
-        std::unique_ptr<ConcurrentHashMap<UInt256, Mapped, HashCRC32<UInt256>>> keys256;
-        std::unique_ptr<ConcurrentHashMapWithSavedHash<StringRef, Mapped>> serialized;
-        // TODO: add more cases like Aggregator
-    };
-
-    using MapsAny = MapsTemplate<WithUsedFlag<false, RowRef>>;
-    using MapsAll = MapsTemplate<WithUsedFlag<false, RowRefList>>;
-    using MapsAnyFull = MapsTemplate<WithUsedFlag<true, RowRef>>;
-    using MapsAllFull = MapsTemplate<WithUsedFlag<true, RowRefList>>;
-
     static const String match_helper_prefix;
     static const DataTypePtr match_helper_type;
 
@@ -328,28 +220,6 @@ public:
 
     SpillerPtr build_spiller;
     SpillerPtr probe_spiller;
-
-    struct alignas(ABSL_CACHELINE_SIZE) RowsNotInsertToMap
-    {
-        explicit RowsNotInsertToMap(size_t max_block_size_)
-            : max_block_size(max_block_size_)
-        {
-            RUNTIME_ASSERT(max_block_size > 0);
-        }
-
-        /// Row list
-        RowRefList head;
-        /// Materialized rows
-        std::vector<MutableColumns> materialized_columns_vec;
-        size_t max_block_size;
-
-        size_t total_size = 0;
-
-        /// Insert row to this structure.
-        /// If need_materialize is true, row will be inserted into materialized_columns_vec.
-        /// Else it will be inserted into row list.
-        void insertRow(Block * stored_block, size_t index, bool need_materialize, Arena & pool);
-    };
 
 private:
     friend class NonJoinedBlockInputStream;
@@ -409,18 +279,6 @@ private:
 
     JoinPtr restore_join;
 
-    // todo refine NonJoinedBlockInputStream and move both `maps` and `rows_not_inserted_to_map` to JoinPartitions
-    //  and each JoinPartition use a non-concurrent map is enough
-    MapsAny maps_any; /// For ANY LEFT|INNER JOIN
-    MapsAll maps_all; /// For ALL LEFT|INNER JOIN
-    MapsAnyFull maps_any_full; /// For ANY RIGHT|FULL JOIN
-    MapsAllFull maps_all_full; /// For ALL RIGHT|FULL JOIN
-
-    /// For right/full join, including
-    /// 1. Rows with NULL join keys
-    /// 2. Rows that are filtered by right join conditions
-    /// For null-aware semi join family, including rows with NULL join keys.
-    std::vector<RowsNotInsertToMap> rows_not_inserted_to_map;
     /// Whether to directly check all blocks for row with null key.
     bool null_key_check_all_blocks_directly = false;
 
@@ -433,9 +291,9 @@ private:
     bool has_build_data_in_memory = false;
 
 private:
-    Type type = Type::EMPTY;
+    JoinType type = JoinType::EMPTY;
 
-    Type chooseMethod(const ColumnRawPtrs & key_columns, Sizes & key_sizes) const;
+    JoinType chooseMethod(const ColumnRawPtrs & key_columns, Sizes & key_sizes) const;
 
     Sizes key_sizes;
 
@@ -464,9 +322,6 @@ private:
     bool enable_fine_grained_shuffle = false;
     size_t fine_grained_shuffle_count = 0;
 
-    /// Initialize map implementations for various join types.
-    void initMapImpl(Type type_);
-
     /** Set information about structure of right hand of JOIN (joined data).
       * You must call this method before subsequent calls to insertFromBlock.
       */
@@ -485,8 +340,11 @@ private:
       */
     void insertFromBlockInternal(Block * stored_block, size_t stream_index);
 
-    template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS, typename Maps>
-    void joinBlockImpl(Block & block, const Maps & maps, ProbeProcessInfo & probe_process_info) const;
+    Block joinBlockHash(ProbeProcessInfo & probe_process_info) const;
+
+    Block joinBlockNullAware(ProbeProcessInfo & probe_process_info) const;
+
+    Block joinBlockCross(ProbeProcessInfo & probe_process_info) const;
 
     /** Handle non-equal join conditions
       *
@@ -494,20 +352,24 @@ private:
       */
     void handleOtherConditions(Block & block, std::unique_ptr<IColumn::Filter> & filter, std::unique_ptr<IColumn::Offsets> & offsets_to_replicate, const std::vector<size_t> & right_table_column) const;
 
-
-    template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS>
-    void joinBlockImplCross(Block & block) const;
-
     template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS, bool has_null_map>
-    void joinBlockImplCrossInternal(Block & block, ConstNullMapPtr null_map) const;
+    void joinBlockCrossImpl(Block & block, ConstNullMapPtr null_map) const;
+
+    template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS, typename Maps>
+    void joinBlockNullAwareImpl(
+        Block & block,
+        size_t left_columns,
+        const ColumnRawPtrs & key_columns,
+        const ConstNullMapPtr & null_map,
+        const ConstNullMapPtr & filter_map,
+        const ConstNullMapPtr all_key_null_map) const;
 
     IColumn::Selector hashToSelector(const WeakHash32 & hash) const;
     IColumn::Selector selectDispatchBlock(const Strings & key_columns_names, const Block & from_block);
 
-    void trySpillBuildPartitions(bool force);
-    void trySpillProbePartitions(bool force);
+    void spillAllBuildPartitions();
+    void spillAllProbePartitions();
     /// use lock as the argument to force the caller acquire the lock before call them
-    void releaseBuildPartitionHashTable(size_t partition_index, std::unique_lock<std::mutex> & partition_lock);
     void releaseAllPartitions();
 
 
@@ -516,9 +378,6 @@ private:
 
     void workAfterBuildFinish();
     void workAfterProbeFinish();
-
-    template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS, typename Maps>
-    void joinBlockImplNullAware(Block & block, const Maps & maps) const;
 };
 
 struct RestoreInfo
@@ -534,23 +393,6 @@ struct RestoreInfo
         , non_joined_stream(non_joined_data_stream_)
         , build_stream(build_stream_)
         , probe_stream(probe_stream_){};
-};
-
-struct ProbeProcessInfo
-{
-    Block block;
-    size_t partition_index;
-    UInt64 max_block_size;
-    size_t start_row;
-    size_t end_row;
-    bool all_rows_joined_finish;
-
-    explicit ProbeProcessInfo(UInt64 max_block_size_)
-        : max_block_size(max_block_size_)
-        , all_rows_joined_finish(true){};
-
-    void resetBlock(Block && block_, size_t partition_index_ = 0);
-    void updateStartRow();
 };
 
 void convertColumnToNullable(ColumnWithTypeAndName & column);

--- a/dbms/src/Interpreters/JoinHashTable.h
+++ b/dbms/src/Interpreters/JoinHashTable.h
@@ -118,26 +118,27 @@ struct MapsTemplate
 {
     using MappedType = Mapped;
     using key8Type = HashMap<UInt8, Mapped, TrivialHash, HashTableFixedGrower<8>>;
-    std::unique_ptr<key8Type> key8;
     using key16Type = HashMap<UInt16, Mapped, TrivialHash, HashTableFixedGrower<16>>;
-    std::unique_ptr<key16Type> key16;
     using key32Type = HashMap<UInt32, Mapped, HashCRC32<UInt32>>;
-    std::unique_ptr<key32Type> key32;
     using key64Type = HashMap<UInt64, Mapped, HashCRC32<UInt64>>;
-    std::unique_ptr<key64Type> key64;
     using key_stringType = HashMapWithSavedHash<StringRef, Mapped>;
-    std::unique_ptr<key_stringType> key_string;
     using key_strbinpaddingType = HashMapWithSavedHash<StringRef, Mapped>;
-    std::unique_ptr<key_strbinpaddingType> key_strbinpadding;
     using key_strbinType = HashMapWithSavedHash<StringRef, Mapped>;
-    std::unique_ptr<key_strbinType> key_strbin;
     using key_fixed_stringType = HashMapWithSavedHash<StringRef, Mapped>;
-    std::unique_ptr<key_fixed_stringType> key_fixed_string;
     using keys128Type = HashMap<UInt128, Mapped, HashCRC32<UInt128>>;
-    std::unique_ptr<keys128Type> keys128;
     using keys256Type = HashMap<UInt256, Mapped, HashCRC32<UInt256>>;
-    std::unique_ptr<keys256Type> keys256;
     using serializedType = HashMapWithSavedHash<StringRef, Mapped>;
+
+    std::unique_ptr<key8Type> key8;
+    std::unique_ptr<key16Type> key16;
+    std::unique_ptr<key32Type> key32;
+    std::unique_ptr<key64Type> key64;
+    std::unique_ptr<key_stringType> key_string;
+    std::unique_ptr<key_strbinpaddingType> key_strbinpadding;
+    std::unique_ptr<key_strbinType> key_strbin;
+    std::unique_ptr<key_fixed_stringType> key_fixed_string;
+    std::unique_ptr<keys128Type> keys128;
+    std::unique_ptr<keys256Type> keys256;
     std::unique_ptr<serializedType> serialized;
     // TODO: add more cases like Aggregator
 };

--- a/dbms/src/Interpreters/JoinHashTable.h
+++ b/dbms/src/Interpreters/JoinHashTable.h
@@ -99,17 +99,30 @@ enum class JoinType
 template <typename Mapped>
 struct ConcurrentMapsTemplate
 {
-    std::unique_ptr<ConcurrentHashMap<UInt8, Mapped, TrivialHash, HashTableFixedGrower<8>>> key8;
-    std::unique_ptr<ConcurrentHashMap<UInt16, Mapped, TrivialHash, HashTableFixedGrower<16>>> key16;
-    std::unique_ptr<ConcurrentHashMap<UInt32, Mapped, HashCRC32<UInt32>>> key32;
-    std::unique_ptr<ConcurrentHashMap<UInt64, Mapped, HashCRC32<UInt64>>> key64;
-    std::unique_ptr<ConcurrentHashMapWithSavedHash<StringRef, Mapped>> key_string;
-    std::unique_ptr<ConcurrentHashMapWithSavedHash<StringRef, Mapped>> key_strbinpadding;
-    std::unique_ptr<ConcurrentHashMapWithSavedHash<StringRef, Mapped>> key_strbin;
-    std::unique_ptr<ConcurrentHashMapWithSavedHash<StringRef, Mapped>> key_fixed_string;
-    std::unique_ptr<ConcurrentHashMap<UInt128, Mapped, HashCRC32<UInt128>>> keys128;
-    std::unique_ptr<ConcurrentHashMap<UInt256, Mapped, HashCRC32<UInt256>>> keys256;
-    std::unique_ptr<ConcurrentHashMapWithSavedHash<StringRef, Mapped>> serialized;
+    using MappedType = Mapped;
+    using key8Type = ConcurrentHashMap<UInt8, Mapped, TrivialHash, HashTableFixedGrower<8>>;
+    using key16Type = ConcurrentHashMap<UInt16, Mapped, TrivialHash, HashTableFixedGrower<16>>;
+    using key32Type = ConcurrentHashMap<UInt32, Mapped, HashCRC32<UInt32>>;
+    using key64Type = ConcurrentHashMap<UInt64, Mapped, HashCRC32<UInt64>>;
+    using key_stringType = ConcurrentHashMapWithSavedHash<StringRef, Mapped>;
+    using key_strbinpaddingType = ConcurrentHashMapWithSavedHash<StringRef, Mapped>;
+    using key_strbinType = ConcurrentHashMapWithSavedHash<StringRef, Mapped>;
+    using key_fixed_stringType = ConcurrentHashMapWithSavedHash<StringRef, Mapped>;
+    using keys128Type = ConcurrentHashMap<UInt128, Mapped, HashCRC32<UInt128>>;
+    using keys256Type = ConcurrentHashMap<UInt256, Mapped, HashCRC32<UInt256>>;
+    using serializedType = ConcurrentHashMapWithSavedHash<StringRef, Mapped>;
+
+    std::unique_ptr<key8Type> key8;
+    std::unique_ptr<key16Type> key16;
+    std::unique_ptr<key32Type> key32;
+    std::unique_ptr<key64Type> key64;
+    std::unique_ptr<key_stringType> key_string;
+    std::unique_ptr<key_strbinpaddingType> key_strbinpadding;
+    std::unique_ptr<key_strbinType> key_strbin;
+    std::unique_ptr<key_fixed_stringType> key_fixed_string;
+    std::unique_ptr<keys128Type> keys128;
+    std::unique_ptr<keys256Type> keys256;
+    std::unique_ptr<serializedType> serialized;
     // TODO: add more cases like Aggregator
 };
 

--- a/dbms/src/Interpreters/JoinHashTable.h
+++ b/dbms/src/Interpreters/JoinHashTable.h
@@ -1,0 +1,154 @@
+// Copyright 2023 PingCAP, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <Common/HashTable/HashMap.h>
+#include <Core/Block.h>
+
+namespace DB
+{
+/// Reference to the row in block.
+struct RowRef
+{
+    const Block * block;
+    size_t row_num;
+
+    RowRef() = default;
+    RowRef(const Block * block_, size_t row_num_)
+        : block(block_)
+        , row_num(row_num_)
+    {}
+};
+
+/// Single linked list of references to rows. Used for ALL JOINs (non-unique JOINs)
+struct RowRefList : RowRef
+{
+    RowRefList * next = nullptr;
+
+    RowRefList() = default;
+    RowRefList(const Block * block_, size_t row_num_)
+        : RowRef(block_, row_num_)
+    {}
+};
+
+/** Depending on template parameter, adds or doesn't add a flag, that element was used (row was joined).
+      * For implementation of RIGHT and FULL JOINs.
+      * NOTE: It is possible to store the flag in one bit of pointer to block or row_num. It seems not reasonable, because memory saving is minimal.
+      */
+template <bool enable, typename Base>
+struct WithUsedFlag;
+
+template <typename Base>
+struct WithUsedFlag<true, Base> : Base
+{
+    mutable std::atomic<bool> used{};
+    using Base::Base;
+    using Base_t = Base;
+    void setUsed() const { used.store(true, std::memory_order_relaxed); } /// Could be set simultaneously from different threads.
+    bool getUsed() const { return used.load(std::memory_order_relaxed); }
+};
+
+template <typename Base>
+struct WithUsedFlag<false, Base> : Base
+{
+    using Base::Base;
+    using Base_t = Base;
+    void setUsed() const {}
+    bool getUsed() const { return true; }
+};
+
+
+/// Different types of keys for maps.
+#define APPLY_FOR_JOIN_VARIANTS(M) \
+    M(key8)                        \
+    M(key16)                       \
+    M(key32)                       \
+    M(key64)                       \
+    M(key_string)                  \
+    M(key_strbinpadding)           \
+    M(key_strbin)                  \
+    M(key_fixed_string)            \
+    M(keys128)                     \
+    M(keys256)                     \
+    M(serialized)
+
+enum class JoinType
+{
+    EMPTY,
+    CROSS,
+#define M(NAME) NAME,
+    APPLY_FOR_JOIN_VARIANTS(M)
+#undef M
+};
+
+
+/** Different data structures, that are used to perform JOIN.
+      */
+template <typename Mapped>
+struct ConcurrentMapsTemplate
+{
+    std::unique_ptr<ConcurrentHashMap<UInt8, Mapped, TrivialHash, HashTableFixedGrower<8>>> key8;
+    std::unique_ptr<ConcurrentHashMap<UInt16, Mapped, TrivialHash, HashTableFixedGrower<16>>> key16;
+    std::unique_ptr<ConcurrentHashMap<UInt32, Mapped, HashCRC32<UInt32>>> key32;
+    std::unique_ptr<ConcurrentHashMap<UInt64, Mapped, HashCRC32<UInt64>>> key64;
+    std::unique_ptr<ConcurrentHashMapWithSavedHash<StringRef, Mapped>> key_string;
+    std::unique_ptr<ConcurrentHashMapWithSavedHash<StringRef, Mapped>> key_strbinpadding;
+    std::unique_ptr<ConcurrentHashMapWithSavedHash<StringRef, Mapped>> key_strbin;
+    std::unique_ptr<ConcurrentHashMapWithSavedHash<StringRef, Mapped>> key_fixed_string;
+    std::unique_ptr<ConcurrentHashMap<UInt128, Mapped, HashCRC32<UInt128>>> keys128;
+    std::unique_ptr<ConcurrentHashMap<UInt256, Mapped, HashCRC32<UInt256>>> keys256;
+    std::unique_ptr<ConcurrentHashMapWithSavedHash<StringRef, Mapped>> serialized;
+    // TODO: add more cases like Aggregator
+};
+
+template <typename Mapped>
+struct MapsTemplate
+{
+    using MappedType = Mapped;
+    using key8Type = HashMap<UInt8, Mapped, TrivialHash, HashTableFixedGrower<8>>;
+    std::unique_ptr<key8Type> key8;
+    using key16Type = HashMap<UInt16, Mapped, TrivialHash, HashTableFixedGrower<16>>;
+    std::unique_ptr<key16Type> key16;
+    using key32Type = HashMap<UInt32, Mapped, HashCRC32<UInt32>>;
+    std::unique_ptr<key32Type> key32;
+    using key64Type = HashMap<UInt64, Mapped, HashCRC32<UInt64>>;
+    std::unique_ptr<key64Type> key64;
+    using key_stringType = HashMapWithSavedHash<StringRef, Mapped>;
+    std::unique_ptr<key_stringType> key_string;
+    using key_strbinpaddingType = HashMapWithSavedHash<StringRef, Mapped>;
+    std::unique_ptr<key_strbinpaddingType> key_strbinpadding;
+    using key_strbinType = HashMapWithSavedHash<StringRef, Mapped>;
+    std::unique_ptr<key_strbinType> key_strbin;
+    using key_fixed_stringType = HashMapWithSavedHash<StringRef, Mapped>;
+    std::unique_ptr<key_fixed_stringType> key_fixed_string;
+    using keys128Type = HashMap<UInt128, Mapped, HashCRC32<UInt128>>;
+    std::unique_ptr<keys128Type> keys128;
+    using keys256Type = HashMap<UInt256, Mapped, HashCRC32<UInt256>>;
+    std::unique_ptr<keys256Type> keys256;
+    using serializedType = HashMapWithSavedHash<StringRef, Mapped>;
+    std::unique_ptr<serializedType> serialized;
+    // TODO: add more cases like Aggregator
+};
+
+using ConcurrentMapsAny = ConcurrentMapsTemplate<WithUsedFlag<false, RowRef>>;
+using ConcurrentMapsAll = ConcurrentMapsTemplate<WithUsedFlag<false, RowRefList>>;
+using ConcurrentMapsAnyFull = ConcurrentMapsTemplate<WithUsedFlag<true, RowRef>>;
+using ConcurrentMapsAllFull = ConcurrentMapsTemplate<WithUsedFlag<true, RowRefList>>;
+
+using MapsAny = MapsTemplate<WithUsedFlag<false, RowRef>>;
+using MapsAll = MapsTemplate<WithUsedFlag<false, RowRefList>>;
+using MapsAnyFull = MapsTemplate<WithUsedFlag<true, RowRef>>;
+using MapsAllFull = MapsTemplate<WithUsedFlag<true, RowRefList>>;
+} // namespace DB

--- a/dbms/src/Interpreters/JoinPartition.cpp
+++ b/dbms/src/Interpreters/JoinPartition.cpp
@@ -13,10 +13,211 @@
 // limitations under the License.
 
 #include <Common/Arena.h>
+#include <Common/ColumnsHashing.h>
+#include <Common/FailPoint.h>
 #include <Interpreters/JoinPartition.h>
+#include <Interpreters/NullAwareSemiJoinHelper.h>
+
+#include <ext/scope_guard.h>
 
 namespace DB
 {
+namespace ErrorCodes
+{
+extern const int UNKNOWN_SET_DATA_VARIANT;
+extern const int LOGICAL_ERROR;
+} // namespace ErrorCodes
+
+namespace FailPoints
+{
+extern const char random_join_build_failpoint[];
+} // namespace FailPoints
+
+void RowsNotInsertToMap::insertRow(Block * stored_block, size_t index, bool need_materialize, Arena & pool)
+{
+    if (need_materialize)
+    {
+        if (materialized_columns_vec.empty() || total_size % max_block_size == 0)
+            materialized_columns_vec.emplace_back(stored_block->cloneEmptyColumns());
+
+        auto & last_one = materialized_columns_vec.back();
+        size_t columns = stored_block->columns();
+        RUNTIME_ASSERT(last_one.size() == columns);
+        for (size_t i = 0; i < columns; ++i)
+            last_one[i]->insertFrom(*stored_block->getByPosition(i).column.get(), index);
+    }
+    else
+    {
+        auto * elem = reinterpret_cast<RowRefList *>(pool.alloc(sizeof(RowRefList)));
+        insertRowToList(&head, elem, stored_block, index);
+    }
+    ++total_size;
+}
+
+void insertRowToList(RowRefList * list, RowRefList * elem, Block * stored_block, size_t index)
+{
+    elem->next = list->next; // NOLINT(clang-analyzer-core.NullDereference)
+    list->next = elem;
+    elem->block = stored_block;
+    elem->row_num = index;
+}
+
+template <typename Maps>
+static void initImpl(Maps & maps, JoinType type)
+{
+    switch (type)
+    {
+    case JoinType::EMPTY:
+        break;
+    case JoinType::CROSS:
+        break;
+
+#define M(TYPE)                                                                     \
+    case JoinType::TYPE:                                                            \
+        maps.TYPE = std::make_unique<typename decltype(maps.TYPE)::element_type>(); \
+        break;
+        APPLY_FOR_JOIN_VARIANTS(M)
+#undef M
+
+    default:
+        throw Exception("Unknown JOIN keys variant.", ErrorCodes::UNKNOWN_SET_DATA_VARIANT);
+    }
+}
+
+template <typename Map, typename Maps>
+static Map & getMapImpl(Maps & maps, JoinType type)
+{
+    void * ret = nullptr;
+    switch (type)
+    {
+    case JoinType::EMPTY:
+    case JoinType::CROSS:
+        throw Exception("Should not reach here");
+
+#define M(TYPE)                \
+    case JoinType::TYPE:       \
+        ret = maps.TYPE.get(); \
+        break;
+        APPLY_FOR_JOIN_VARIANTS(M)
+#undef M
+
+    default:
+        throw Exception("Unknown JOIN keys variant.", ErrorCodes::UNKNOWN_SET_DATA_VARIANT);
+    }
+    return *reinterpret_cast<Map *>(ret);
+}
+
+template <typename Maps>
+static size_t getRowCountImpl(const Maps & maps, JoinType type)
+{
+    switch (type)
+    {
+    case JoinType::EMPTY:
+        return 0;
+    case JoinType::CROSS:
+        return 0;
+
+#define M(NAME)          \
+    case JoinType::NAME: \
+        return maps.NAME ? maps.NAME->size() : 0;
+        APPLY_FOR_JOIN_VARIANTS(M)
+#undef M
+
+    default:
+        throw Exception("Unknown JOIN keys variant.", ErrorCodes::UNKNOWN_SET_DATA_VARIANT);
+    }
+}
+
+template <typename Maps>
+static size_t getByteCountImpl(const Maps & maps, JoinType type)
+{
+    switch (type)
+    {
+    case JoinType::EMPTY:
+        return 0;
+    case JoinType::CROSS:
+        return 0;
+
+#define M(NAME)          \
+    case JoinType::NAME: \
+        return maps.NAME ? maps.NAME->getBufferSizeInBytes() : 0;
+        APPLY_FOR_JOIN_VARIANTS(M)
+#undef M
+
+    default:
+        throw Exception("Unknown JOIN keys variant.", ErrorCodes::UNKNOWN_SET_DATA_VARIANT);
+    }
+}
+
+template <typename Maps>
+static size_t clearMaps(Maps & maps, JoinType type)
+{
+    size_t ret = 0;
+    switch (type)
+    {
+    case JoinType::EMPTY:
+    case JoinType::CROSS:
+        ret = 0;
+        break;
+#define M(NAME)                                      \
+    case JoinType::NAME:                             \
+        if (maps.NAME)                               \
+        {                                            \
+            ret = maps.NAME->getBufferSizeInBytes(); \
+            maps.NAME.reset();                       \
+        }                                            \
+        break;
+        APPLY_FOR_JOIN_VARIANTS(M)
+#undef M
+
+    default:
+        throw Exception("Unknown JOIN keys variant.", ErrorCodes::UNKNOWN_SET_DATA_VARIANT);
+    }
+    return ret;
+}
+
+size_t JoinPartition::getRowCount()
+{
+    size_t ret = 0;
+    ret += getRowCountImpl(maps_any, join_type);
+    ret += getRowCountImpl(maps_all, join_type);
+    ret += getRowCountImpl(maps_any_full, join_type);
+    ret += getRowCountImpl(maps_all_full, join_type);
+    return ret;
+}
+
+size_t JoinPartition::getHashMapAndPoolByteCount()
+{
+    size_t ret = 0;
+    ret += getByteCountImpl(maps_any, join_type);
+    ret += getByteCountImpl(maps_all, join_type);
+    ret += getByteCountImpl(maps_any_full, join_type);
+    ret += getByteCountImpl(maps_all_full, join_type);
+    ret += pool->size();
+    return ret;
+}
+
+void JoinPartition::initMap()
+{
+    if (isCrossJoin(kind))
+        return;
+
+    if (!getFullness(kind))
+    {
+        if (strictness == ASTTableJoin::Strictness::Any)
+            initImpl(maps_any, join_type);
+        else
+            initImpl(maps_all, join_type);
+    }
+    else
+    {
+        if (strictness == ASTTableJoin::Strictness::Any)
+            initImpl(maps_any_full, join_type);
+        else
+            initImpl(maps_all_full, join_type);
+    }
+}
+
 void JoinPartition::insertBlockForBuild(Block && block)
 {
     size_t rows = block.rows();
@@ -43,25 +244,33 @@ std::unique_lock<std::mutex> JoinPartition::lockPartition()
 }
 void JoinPartition::releaseBuildPartitionBlocks(std::unique_lock<std::mutex> &)
 {
-    subMemoryUsage(build_partition.bytes);
+    auto released_bytes = build_partition.bytes;
     build_partition.bytes = 0;
     build_partition.rows = 0;
     build_partition.blocks.clear();
     build_partition.original_blocks.clear();
+    subMemoryUsage(released_bytes);
 }
 void JoinPartition::releaseProbePartitionBlocks(std::unique_lock<std::mutex> &)
 {
-    subMemoryUsage(probe_partition.bytes);
+    auto released_bytes = probe_partition.bytes;
     probe_partition.bytes = 0;
     probe_partition.rows = 0;
     probe_partition.blocks.clear();
+    subMemoryUsage(released_bytes);
 }
-void JoinPartition::releasePartitionPool(std::unique_lock<std::mutex> &)
+
+void JoinPartition::releasePartitionPoolAndHashMap(std::unique_lock<std::mutex> &)
 {
-    size_t pool_bytes = pool->size();
+    size_t released_bytes = pool->size();
     pool.reset();
-    subMemoryUsage(pool_bytes);
+    released_bytes += clearMaps(maps_any, join_type);
+    released_bytes += clearMaps(maps_all, join_type);
+    released_bytes += clearMaps(maps_any_full, join_type);
+    released_bytes += clearMaps(maps_all_full, join_type);
+    subMemoryUsage(released_bytes);
 }
+
 Blocks JoinPartition::trySpillBuildPartition(bool force, size_t max_cached_data_bytes, std::unique_lock<std::mutex> & partition_lock)
 {
     if (spill && ((force && build_partition.bytes) || build_partition.bytes >= max_cached_data_bytes))
@@ -96,4 +305,1137 @@ Blocks JoinPartition::trySpillProbePartition(bool force, size_t max_cached_data_
     else
         return {};
 }
+namespace
+{
+/// code for hash map insertion
+template <JoinType type, typename Value, typename Mapped>
+struct KeyGetterForTypeImpl;
+
+template <typename Value, typename Mapped>
+struct KeyGetterForTypeImpl<JoinType::key8, Value, Mapped>
+{
+    using Type = ColumnsHashing::HashMethodOneNumber<Value, Mapped, UInt8, false>;
+};
+template <typename Value, typename Mapped>
+struct KeyGetterForTypeImpl<JoinType::key16, Value, Mapped>
+{
+    using Type = ColumnsHashing::HashMethodOneNumber<Value, Mapped, UInt16, false>;
+};
+template <typename Value, typename Mapped>
+struct KeyGetterForTypeImpl<JoinType::key32, Value, Mapped>
+{
+    using Type = ColumnsHashing::HashMethodOneNumber<Value, Mapped, UInt32, false>;
+};
+template <typename Value, typename Mapped>
+struct KeyGetterForTypeImpl<JoinType::key64, Value, Mapped>
+{
+    using Type = ColumnsHashing::HashMethodOneNumber<Value, Mapped, UInt64, false>;
+};
+template <typename Value, typename Mapped>
+struct KeyGetterForTypeImpl<JoinType::key_string, Value, Mapped>
+{
+    using Type = ColumnsHashing::HashMethodString<Value, Mapped, true, false>;
+};
+template <typename Value, typename Mapped>
+struct KeyGetterForTypeImpl<JoinType::key_strbinpadding, Value, Mapped>
+{
+    using Type = ColumnsHashing::HashMethodStringBin<Value, Mapped, true>;
+};
+template <typename Value, typename Mapped>
+struct KeyGetterForTypeImpl<JoinType::key_strbin, Value, Mapped>
+{
+    using Type = ColumnsHashing::HashMethodStringBin<Value, Mapped, false>;
+};
+template <typename Value, typename Mapped>
+struct KeyGetterForTypeImpl<JoinType::key_fixed_string, Value, Mapped>
+{
+    using Type = ColumnsHashing::HashMethodFixedString<Value, Mapped, true, false>;
+};
+template <typename Value, typename Mapped>
+struct KeyGetterForTypeImpl<JoinType::keys128, Value, Mapped>
+{
+    using Type = ColumnsHashing::HashMethodKeysFixed<Value, UInt128, Mapped, false, false>;
+};
+template <typename Value, typename Mapped>
+struct KeyGetterForTypeImpl<JoinType::keys256, Value, Mapped>
+{
+    using Type = ColumnsHashing::HashMethodKeysFixed<Value, UInt256, Mapped, false, false>;
+};
+template <typename Value, typename Mapped>
+struct KeyGetterForTypeImpl<JoinType::serialized, Value, Mapped>
+{
+    using Type = ColumnsHashing::HashMethodSerialized<Value, Mapped>;
+};
+
+
+template <JoinType type, typename Data>
+struct KeyGetterForType
+{
+    using Value = typename Data::value_type;
+    using Mapped_t = typename Data::mapped_type;
+    using Mapped = std::conditional_t<std::is_const_v<Data>, const Mapped_t, Mapped_t>;
+    using Type = typename KeyGetterForTypeImpl<type, Value, Mapped>::Type;
+};
+
+/// Inserting an element into a hash table of the form `key -> reference to a string`, which will then be used by JOIN.
+template <ASTTableJoin::Strictness STRICTNESS, typename Map, typename KeyGetter>
+struct Inserter
+{
+    static void insert(Map & map, const typename Map::key_type & key, Block * stored_block, size_t i, Arena & pool, std::vector<String> & sort_key_containers);
+};
+
+template <typename Map, typename KeyGetter>
+struct Inserter<ASTTableJoin::Strictness::Any, Map, KeyGetter>
+{
+    static void insert(Map & map, KeyGetter & key_getter, Block * stored_block, size_t i, Arena & pool, std::vector<String> & sort_key_container)
+    {
+        auto emplace_result = key_getter.emplaceKey(map, i, pool, sort_key_container);
+
+        if (emplace_result.isInserted())
+            new (&emplace_result.getMapped()) typename Map::mapped_type(stored_block, i);
+    }
+};
+
+template <typename Map, typename KeyGetter>
+struct Inserter<ASTTableJoin::Strictness::All, Map, KeyGetter>
+{
+    using MappedType = typename Map::mapped_type;
+    static void insert(Map & map, KeyGetter & key_getter, Block * stored_block, size_t i, Arena & pool, std::vector<String> & sort_key_container)
+    {
+        auto emplace_result = key_getter.emplaceKey(map, i, pool, sort_key_container);
+
+        if (emplace_result.isInserted())
+            new (&emplace_result.getMapped()) typename Map::mapped_type(stored_block, i);
+        else
+        {
+            /** The first element of the list is stored in the value of the hash table, the rest in the pool.
+                 * We will insert each time the element into the second place.
+                 * That is, the former second element, if it was, will be the third, and so on.
+                 */
+            auto elem = reinterpret_cast<MappedType *>(pool.alloc(sizeof(MappedType)));
+            insertRowToList(&emplace_result.getMapped(), elem, stored_block, i);
+        }
+    }
+};
+
+/// insert Block into one map, don't need acquire lock inside this function
+template <ASTTableJoin::Strictness STRICTNESS, typename KeyGetter, typename Map, bool has_null_map>
+void NO_INLINE insertBlockIntoMapTypeCase(
+    JoinPartition & join_partition,
+    size_t rows,
+    const ColumnRawPtrs & key_columns,
+    const Sizes & key_sizes,
+    const TiDB::TiDBCollators & collators,
+    Block * stored_block,
+    ConstNullMapPtr null_map)
+{
+    auto * rows_not_inserted_to_map = join_partition.getRowsNotInsertedToMap();
+    auto & pool = *join_partition.getPartitionPool();
+
+    Map & map = join_partition.template getHashMap<Map>();
+    KeyGetter key_getter(key_columns, key_sizes, collators);
+    std::vector<std::string> sort_key_containers;
+    sort_key_containers.resize(key_columns.size());
+
+    bool null_need_materialize = isNullAwareSemiFamily(join_partition.getJoinKind());
+    for (size_t i = 0; i < rows; ++i)
+    {
+        if (has_null_map && (*null_map)[i])
+        {
+            if (rows_not_inserted_to_map)
+            {
+                /// for right/full out join or null-aware semi join, need to insert into rows_not_inserted_to_map
+                rows_not_inserted_to_map->insertRow(stored_block, i, null_need_materialize, pool);
+            }
+            continue;
+        }
+
+        Inserter<STRICTNESS, Map, KeyGetter>::insert(
+            map,
+            key_getter,
+            stored_block,
+            i,
+            pool,
+            sort_key_containers);
+    }
+}
+
+/// insert Block into maps, for each map, need to acquire lock before insert
+template <ASTTableJoin::Strictness STRICTNESS, typename KeyGetter, typename Map, bool has_null_map>
+void NO_INLINE insertBlockIntoMapsTypeCase(
+    JoinPartitions & join_partitions,
+    size_t rows,
+    const ColumnRawPtrs & key_columns,
+    const Sizes & key_sizes,
+    const TiDB::TiDBCollators & collators,
+    Block * stored_block,
+    ConstNullMapPtr null_map,
+    size_t stream_index)
+{
+    auto & current_join_partition = join_partitions[stream_index];
+    auto * rows_not_inserted_to_map = current_join_partition->getRowsNotInsertedToMap();
+    auto & pool = *current_join_partition->getPartitionPool();
+
+    /// use this map to calculate key hash
+    auto & map = current_join_partition->getHashMap<Map>();
+    KeyGetter key_getter(key_columns, key_sizes, collators);
+    std::vector<std::string> sort_key_containers(key_columns.size());
+    /// note this implicitly assume that each join partition has only one hash table
+    size_t segment_size = join_partitions.size();
+    /// when inserting with lock, first calculate and save the segment index for each row, then
+    /// insert the rows segment by segment to avoid too much conflict. This will introduce some overheads:
+    /// 1. key_getter.getKey will be called twice, here we do not cache key because it can not be cached
+    /// with relatively low cost(if key is stringRef, just cache a stringRef is meaningless, we need to cache the whole `sort_key_containers`)
+    /// 2. hash value is calculated twice, maybe we can refine the code to cache the hash value
+    /// 3. extra memory to store the segment index info
+    std::vector<std::vector<size_t>> segment_index_info;
+    if (has_null_map && rows_not_inserted_to_map)
+    {
+        segment_index_info.resize(segment_size + 1);
+    }
+    else
+    {
+        segment_index_info.resize(segment_size);
+    }
+    size_t rows_per_seg = rows / segment_index_info.size();
+    for (auto & segment_index : segment_index_info)
+    {
+        segment_index.reserve(rows_per_seg);
+    }
+    for (size_t i = 0; i < rows; ++i)
+    {
+        if (has_null_map && (*null_map)[i])
+        {
+            if (rows_not_inserted_to_map)
+                segment_index_info[segment_index_info.size() - 1].push_back(i);
+            continue;
+        }
+        auto key_holder = key_getter.getKeyHolder(i, &pool, sort_key_containers);
+        SCOPE_EXIT(keyHolderDiscardKey(key_holder));
+        auto key = keyHolderGetKey(key_holder);
+
+        size_t segment_index = 0;
+        if (!ZeroTraits::check(key))
+        {
+            size_t hash_value = map.hash(key);
+            segment_index = hash_value % segment_size;
+        }
+        segment_index_info[segment_index].push_back(i);
+    }
+
+    bool null_need_materialize = isNullAwareSemiFamily(current_join_partition->getJoinKind());
+    for (size_t insert_index = 0; insert_index < segment_index_info.size(); insert_index++)
+    {
+        FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::random_join_build_failpoint);
+        size_t segment_index = (insert_index + stream_index) % segment_index_info.size();
+        if (segment_index == segment_size)
+        {
+            /// null value
+            /// here ignore mutex because rows_not_inserted_to_map is privately owned by each stream thread
+            for (auto index : segment_index_info[segment_index])
+            {
+                /// for right/full out join or null-aware semi join, need to insert into rows_not_inserted_to_map
+                RUNTIME_ASSERT(rows_not_inserted_to_map != nullptr);
+                rows_not_inserted_to_map->insertRow(stored_block, index, null_need_materialize, pool);
+            }
+        }
+        else
+        {
+            auto lock = join_partitions[segment_index]->lockPartition();
+            auto & current_map = join_partitions[segment_index]->getHashMap<Map>();
+            for (auto & i : segment_index_info[segment_index])
+            {
+                Inserter<STRICTNESS, Map, KeyGetter>::insert(current_map, key_getter, stored_block, i, pool, sort_key_containers);
+            }
+        }
+    }
+}
+
+template <ASTTableJoin::Strictness STRICTNESS, typename KeyGetter, typename Map>
+void insertBlockIntoMapsImplType(
+    JoinPartitions & join_partitions,
+    size_t rows,
+    const ColumnRawPtrs & key_columns,
+    const Sizes & key_sizes,
+    const TiDB::TiDBCollators & collators,
+    Block * stored_block,
+    ConstNullMapPtr null_map,
+    size_t stream_index,
+    size_t insert_concurrency,
+    bool enable_fine_grained_shuffle,
+    bool enable_join_spill)
+{
+    auto & current_join_partition = join_partitions[stream_index];
+    if (enable_join_spill)
+    {
+        /// case 1, join with spill support, the partition level lock is acquired in `Join::insertFromBlock`
+        if (null_map)
+            insertBlockIntoMapTypeCase<STRICTNESS, KeyGetter, Map, true>(*current_join_partition, rows, key_columns, key_sizes, collators, stored_block, null_map);
+        else
+            insertBlockIntoMapTypeCase<STRICTNESS, KeyGetter, Map, false>(*current_join_partition, rows, key_columns, key_sizes, collators, stored_block, null_map);
+        return;
+    }
+    else if (enable_fine_grained_shuffle)
+    {
+        /// case 2, join with fine_grained_shuffle, no need to acquire any lock
+        if (null_map)
+            insertBlockIntoMapTypeCase<STRICTNESS, KeyGetter, Map, true>(*current_join_partition, rows, key_columns, key_sizes, collators, stored_block, null_map);
+        else
+            insertBlockIntoMapTypeCase<STRICTNESS, KeyGetter, Map, false>(*current_join_partition, rows, key_columns, key_sizes, collators, stored_block, null_map);
+    }
+    else if (insert_concurrency > 1)
+    {
+        /// case 3, normal join with concurrency > 1, will acquire lock in `insertBlockIntoMapsTypeCase`
+        if (null_map)
+            insertBlockIntoMapsTypeCase<STRICTNESS, KeyGetter, Map, true>(join_partitions, rows, key_columns, key_sizes, collators, stored_block, null_map, stream_index);
+        else
+            insertBlockIntoMapsTypeCase<STRICTNESS, KeyGetter, Map, false>(join_partitions, rows, key_columns, key_sizes, collators, stored_block, null_map, stream_index);
+    }
+    else
+    {
+        /// case 4, normal join with concurrency == 1, no need to acquire any lock
+        RUNTIME_CHECK(stream_index == 0);
+        if (null_map)
+            insertBlockIntoMapTypeCase<STRICTNESS, KeyGetter, Map, true>(*current_join_partition, rows, key_columns, key_sizes, collators, stored_block, null_map);
+        else
+            insertBlockIntoMapTypeCase<STRICTNESS, KeyGetter, Map, false>(*current_join_partition, rows, key_columns, key_sizes, collators, stored_block, null_map);
+    }
+}
+
+template <ASTTableJoin::Strictness STRICTNESS, typename Maps>
+void insertBlockIntoMapsImpl(
+    JoinPartitions & join_partitions,
+    size_t rows,
+    const ColumnRawPtrs & key_columns,
+    const Sizes & key_sizes,
+    const TiDB::TiDBCollators & collators,
+    Block * stored_block,
+    ConstNullMapPtr null_map,
+    size_t stream_index,
+    size_t insert_concurrency,
+    bool enable_fine_grained_shuffle,
+    bool enable_join_spill)
+{
+    switch (join_partitions[stream_index]->getJoinType())
+    {
+    case JoinType::EMPTY:
+        break;
+    case JoinType::CROSS:
+        break; /// Do nothing. We have already saved block, and it is enough.
+
+#define M(TYPE)                                                                                                                                         \
+    case JoinType::TYPE:                                                                                                                                \
+        insertBlockIntoMapsImplType<STRICTNESS, typename KeyGetterForType<JoinType::TYPE, typename Maps::TYPE##Type>::Type, typename Maps::TYPE##Type>( \
+            join_partitions,                                                                                                                            \
+            rows,                                                                                                                                       \
+            key_columns,                                                                                                                                \
+            key_sizes,                                                                                                                                  \
+            collators,                                                                                                                                  \
+            stored_block,                                                                                                                               \
+            null_map,                                                                                                                                   \
+            stream_index,                                                                                                                               \
+            insert_concurrency,                                                                                                                         \
+            enable_fine_grained_shuffle,                                                                                                                \
+            enable_join_spill);                                                                                                                         \
+        break;
+        APPLY_FOR_JOIN_VARIANTS(M)
+#undef M
+
+    default:
+        throw Exception("Unknown JOIN keys variant.", ErrorCodes::UNKNOWN_SET_DATA_VARIANT);
+    }
+}
+} // namespace
+
+template <typename Map>
+Map & JoinPartition::getHashMap()
+{
+    assert(!spill);
+    if (getFullness(kind))
+    {
+        if (strictness == ASTTableJoin::Strictness::Any)
+            return getMapImpl<Map>(maps_any_full, join_type);
+        else
+            return getMapImpl<Map>(maps_all_full, join_type);
+    }
+    else
+    {
+        if (strictness == ASTTableJoin::Strictness::Any)
+            return getMapImpl<Map>(maps_any, join_type);
+        else
+            return getMapImpl<Map>(maps_all, join_type);
+    }
+}
+
+void JoinPartition::insertBlockIntoMaps(
+    JoinPartitions & join_partitions,
+    size_t rows,
+    const ColumnRawPtrs & key_columns,
+    const std::vector<size_t> & key_sizes,
+    const TiDB::TiDBCollators & collators,
+    Block * stored_block,
+    ConstNullMapPtr & null_map,
+    size_t stream_index,
+    size_t insert_concurrency,
+    bool enable_fine_grained_shuffle,
+    bool enable_join_spill)
+{
+    auto & current_join_partition = join_partitions[stream_index];
+    assert(!current_join_partition->spill);
+    if (isNullAwareSemiFamily(current_join_partition->kind))
+    {
+        if (current_join_partition->strictness == ASTTableJoin::Strictness::Any)
+            insertBlockIntoMapsImpl<ASTTableJoin::Strictness::Any, MapsAny>(join_partitions, rows, key_columns, key_sizes, collators, stored_block, null_map, stream_index, insert_concurrency, enable_fine_grained_shuffle, enable_join_spill);
+        else
+            insertBlockIntoMapsImpl<ASTTableJoin::Strictness::All, MapsAll>(join_partitions, rows, key_columns, key_sizes, collators, stored_block, null_map, stream_index, insert_concurrency, enable_fine_grained_shuffle, enable_join_spill);
+    }
+    else if (getFullness(current_join_partition->kind))
+    {
+        if (current_join_partition->strictness == ASTTableJoin::Strictness::Any)
+            insertBlockIntoMapsImpl<ASTTableJoin::Strictness::Any, MapsAnyFull>(join_partitions, rows, key_columns, key_sizes, collators, stored_block, null_map, stream_index, insert_concurrency, enable_fine_grained_shuffle, enable_join_spill);
+        else
+            insertBlockIntoMapsImpl<ASTTableJoin::Strictness::All, MapsAllFull>(join_partitions, rows, key_columns, key_sizes, collators, stored_block, null_map, stream_index, insert_concurrency, enable_fine_grained_shuffle, enable_join_spill);
+    }
+    else
+    {
+        if (current_join_partition->strictness == ASTTableJoin::Strictness::Any)
+            insertBlockIntoMapsImpl<ASTTableJoin::Strictness::Any, MapsAny>(join_partitions, rows, key_columns, key_sizes, collators, stored_block, null_map, stream_index, insert_concurrency, enable_fine_grained_shuffle, enable_join_spill);
+        else
+            insertBlockIntoMapsImpl<ASTTableJoin::Strictness::All, MapsAll>(join_partitions, rows, key_columns, key_sizes, collators, stored_block, null_map, stream_index, insert_concurrency, enable_fine_grained_shuffle, enable_join_spill);
+    }
+}
+namespace
+{
+/// code for hash map probe
+template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS, typename Map>
+struct Adder;
+
+template <typename Map>
+struct Adder<ASTTableJoin::Kind::Left, ASTTableJoin::Strictness::Any, Map>
+{
+    static bool addFound(const typename Map::ConstLookupResult & it, size_t num_columns_to_add, MutableColumns & added_columns, size_t /*i*/, IColumn::Filter * /*filter*/, IColumn::Offset & /*current_offset*/, IColumn::Offsets * /*offsets*/, const std::vector<size_t> & right_indexes, ProbeProcessInfo & /*probe_process_info*/)
+    {
+        for (size_t j = 0; j < num_columns_to_add; ++j)
+            added_columns[j]->insertFrom(*it->getMapped().block->getByPosition(right_indexes[j]).column.get(), it->getMapped().row_num);
+        return false;
+    }
+
+    static bool addNotFound(size_t num_columns_to_add, MutableColumns & added_columns, size_t /*i*/, IColumn::Filter * /*filter*/, IColumn::Offset & /*current_offset*/, IColumn::Offsets * /*offsets*/, ProbeProcessInfo & /*probe_process_info*/)
+    {
+        for (size_t j = 0; j < num_columns_to_add; ++j)
+            added_columns[j]->insertDefault();
+        return false;
+    }
+};
+
+template <typename Map>
+struct Adder<ASTTableJoin::Kind::Inner, ASTTableJoin::Strictness::Any, Map>
+{
+    static bool addFound(const typename Map::ConstLookupResult & it, size_t num_columns_to_add, MutableColumns & added_columns, size_t i, IColumn::Filter * filter, IColumn::Offset & /*current_offset*/, IColumn::Offsets * /*offsets*/, const std::vector<size_t> & right_indexes, ProbeProcessInfo & /*probe_process_info*/)
+    {
+        (*filter)[i] = 1;
+
+        for (size_t j = 0; j < num_columns_to_add; ++j)
+            added_columns[j]->insertFrom(*it->getMapped().block->getByPosition(right_indexes[j]).column.get(), it->getMapped().row_num);
+
+        return false;
+    }
+
+    static bool addNotFound(size_t /*num_columns_to_add*/, MutableColumns & /*added_columns*/, size_t i, IColumn::Filter * filter, IColumn::Offset & /*current_offset*/, IColumn::Offsets * /*offsets*/, ProbeProcessInfo & /*probe_process_info*/)
+    {
+        (*filter)[i] = 0;
+        return false;
+    }
+};
+
+template <typename Map>
+struct Adder<ASTTableJoin::Kind::Anti, ASTTableJoin::Strictness::Any, Map>
+{
+    static bool addFound(const typename Map::ConstLookupResult & /*it*/, size_t /*num_columns_to_add*/, MutableColumns & /*added_columns*/, size_t i, IColumn::Filter * filter, IColumn::Offset & /*current_offset*/, IColumn::Offsets * /*offsets*/, const std::vector<size_t> & /*right_indexes*/, ProbeProcessInfo & /*probe_process_info*/)
+    {
+        (*filter)[i] = 0;
+        return false;
+    }
+
+    static bool addNotFound(size_t num_columns_to_add, MutableColumns & added_columns, size_t i, IColumn::Filter * filter, IColumn::Offset & /*current_offset*/, IColumn::Offsets * /*offsets*/, ProbeProcessInfo & /*probe_process_info*/)
+    {
+        (*filter)[i] = 1;
+        for (size_t j = 0; j < num_columns_to_add; ++j)
+            added_columns[j]->insertDefault();
+        return false;
+    }
+};
+
+template <typename Map>
+struct Adder<ASTTableJoin::Kind::LeftSemi, ASTTableJoin::Strictness::Any, Map>
+{
+    static bool addFound(const typename Map::ConstLookupResult & /*it*/, size_t num_columns_to_add, MutableColumns & added_columns, size_t /*i*/, IColumn::Filter * /*filter*/, IColumn::Offset & /*current_offset*/, IColumn::Offsets * /*offsets*/, const std::vector<size_t> & /*right_indexes*/, ProbeProcessInfo & /*probe_process_info*/)
+    {
+        for (size_t j = 0; j < num_columns_to_add - 1; ++j)
+            added_columns[j]->insertDefault();
+        added_columns[num_columns_to_add - 1]->insert(FIELD_INT8_1);
+        return false;
+    }
+
+    static bool addNotFound(size_t num_columns_to_add, MutableColumns & added_columns, size_t /*i*/, IColumn::Filter * /*filter*/, IColumn::Offset & /*current_offset*/, IColumn::Offsets * /*offsets*/, ProbeProcessInfo & /*probe_process_info*/)
+    {
+        for (size_t j = 0; j < num_columns_to_add - 1; ++j)
+            added_columns[j]->insertDefault();
+        added_columns[num_columns_to_add - 1]->insert(FIELD_INT8_0);
+        return false;
+    }
+};
+
+template <typename Map>
+struct Adder<ASTTableJoin::Kind::LeftSemi, ASTTableJoin::Strictness::All, Map>
+{
+    static bool addFound(const typename Map::ConstLookupResult & it, size_t num_columns_to_add, MutableColumns & added_columns, size_t i, IColumn::Filter * /*filter*/, IColumn::Offset & current_offset, IColumn::Offsets * offsets, const std::vector<size_t> & right_indexes, ProbeProcessInfo & /*probe_process_info*/)
+    {
+        for (auto current = &static_cast<const typename Map::mapped_type::Base_t &>(it->getMapped()); current != nullptr; current = current->next)
+        {
+            for (size_t j = 0; j < num_columns_to_add - 1; ++j)
+                added_columns[j]->insertFrom(*current->block->getByPosition(right_indexes[j]).column.get(), current->row_num);
+            ++current_offset;
+        }
+        (*offsets)[i] = current_offset;
+        /// we insert only one row to `match-helper` for each row of left block
+        /// so before the execution of `HandleOtherConditions`, column sizes of temporary block may be different.
+        added_columns[num_columns_to_add - 1]->insert(FIELD_INT8_1);
+        return false;
+    }
+
+    static bool addNotFound(size_t num_columns_to_add, MutableColumns & added_columns, size_t i, IColumn::Filter * /*filter*/, IColumn::Offset & current_offset, IColumn::Offsets * offsets, ProbeProcessInfo & /*probe_process_info*/)
+    {
+        ++current_offset;
+        (*offsets)[i] = current_offset;
+
+        for (size_t j = 0; j < num_columns_to_add - 1; ++j)
+            added_columns[j]->insertDefault();
+        added_columns[num_columns_to_add - 1]->insert(FIELD_INT8_0);
+        return false;
+    }
+};
+
+template <ASTTableJoin::Kind KIND, typename Map>
+struct Adder<KIND, ASTTableJoin::Strictness::All, Map>
+{
+    static bool addFound(const typename Map::ConstLookupResult & it, size_t num_columns_to_add, MutableColumns & added_columns, size_t i, IColumn::Filter * filter, IColumn::Offset & current_offset, IColumn::Offsets * offsets, const std::vector<size_t> & right_indexes, ProbeProcessInfo & probe_process_info)
+    {
+        size_t rows_joined = 0;
+        // If there are too many rows in the column to split, record the number of rows that have been expanded for next read.
+        // and it means the rows in this block are not joined finish.
+
+        for (auto current = &static_cast<const typename Map::mapped_type::Base_t &>(it->getMapped()); current != nullptr; current = current->next)
+            ++rows_joined;
+
+        if (current_offset && current_offset + rows_joined > probe_process_info.max_block_size)
+        {
+            return true;
+        }
+
+        for (auto current = &static_cast<const typename Map::mapped_type::Base_t &>(it->getMapped()); current != nullptr; current = current->next)
+        {
+            for (size_t j = 0; j < num_columns_to_add; ++j)
+                added_columns[j]->insertFrom(*current->block->getByPosition(right_indexes[j]).column.get(), current->row_num);
+        }
+
+        current_offset += rows_joined;
+        (*offsets)[i] = current_offset;
+        if constexpr (KIND == ASTTableJoin::Kind::Anti)
+            /// anti join with other condition is very special: if the row is matched during probe stage, we can not throw it
+            /// away because it might failed in other condition, so we add the matched rows to the result, but set (*filter)[i] = 0
+            /// to indicate that the row is matched during probe stage, this will be used in handleOtherConditions
+            (*filter)[i] = 0;
+
+        return false;
+    }
+
+    static bool addNotFound(size_t num_columns_to_add, MutableColumns & added_columns, size_t i, IColumn::Filter * filter, IColumn::Offset & current_offset, IColumn::Offsets * offsets, ProbeProcessInfo & probe_process_info)
+    {
+        if constexpr (KIND == ASTTableJoin::Kind::Inner)
+        {
+            (*offsets)[i] = current_offset;
+        }
+        else
+        {
+            if (current_offset && current_offset + 1 > probe_process_info.max_block_size)
+            {
+                return true;
+            }
+            if (KIND == ASTTableJoin::Kind::Anti)
+                (*filter)[i] = 1;
+            ++current_offset;
+            (*offsets)[i] = current_offset;
+
+            for (size_t j = 0; j < num_columns_to_add; ++j)
+                added_columns[j]->insertDefault();
+        }
+        return false;
+    }
+};
+template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS, typename KeyGetter, typename Map, bool has_null_map>
+void NO_INLINE probeBlockImplTypeCase(
+    const JoinPartitions & join_partitions,
+    size_t rows,
+    const ColumnRawPtrs & key_columns,
+    const Sizes & key_sizes,
+    MutableColumns & added_columns,
+    ConstNullMapPtr null_map,
+    std::unique_ptr<IColumn::Filter> & filter,
+    IColumn::Offset & current_offset,
+    std::unique_ptr<IColumn::Offsets> & offsets_to_replicate,
+    const std::vector<size_t> & right_indexes,
+    const TiDB::TiDBCollators & collators,
+    const JoinBuildInfo & join_build_info,
+    ProbeProcessInfo & probe_process_info)
+{
+    if (rows == 0)
+    {
+        probe_process_info.all_rows_joined_finish = true;
+        return;
+    }
+
+    assert(probe_process_info.start_row < rows);
+    size_t segment_size = join_partitions.size();
+    assert(segment_size > 0);
+    std::vector<Map *> all_maps(segment_size, nullptr);
+    for (size_t i = 0; i < segment_size; ++i)
+    {
+        if (join_partitions[i]->isSpill())
+        {
+            assert(i != probe_process_info.partition_index);
+            all_maps[i] = nullptr;
+        }
+        else
+        {
+            all_maps[i] = &join_partitions[i]->template getHashMap<Map>();
+        }
+    }
+
+    size_t num_columns_to_add = right_indexes.size();
+
+    KeyGetter key_getter(key_columns, key_sizes, collators);
+    std::vector<std::string> sort_key_containers;
+    sort_key_containers.resize(key_columns.size());
+    Arena pool;
+    WeakHash32 build_hash(0); /// reproduce hash values according to build stage
+    if (join_build_info.needVirtualDispatchForProbeBlock())
+    {
+        assert(!(join_build_info.restore_round > 0 && join_build_info.enable_fine_grained_shuffle));
+        /// TODO: consider adding a virtual column in Sender side to avoid computing cost and potential inconsistency by heterogeneous envs(AMD64, ARM64)
+        /// Note: 1. Not sure, if inconsistency will do happen in heterogeneous envs
+        ///       2. Virtual column would take up a little more network bandwidth, might lead to poor performance if network was bottleneck
+        /// Currently, the computation cost is tolerable, since it's a very simple crc32 hash algorithm, and heterogeneous envs support is not considered
+        computeDispatchHash(rows, key_columns, collators, sort_key_containers, join_build_info.restore_round, build_hash);
+    }
+
+    const auto & build_hash_data = build_hash.getData();
+    assert(probe_process_info.start_row < rows);
+    size_t i;
+    bool block_full = false;
+    for (i = probe_process_info.start_row; i < rows; ++i)
+    {
+        if (has_null_map && (*null_map)[i])
+        {
+            block_full = Adder<KIND, STRICTNESS, Map>::addNotFound(
+                num_columns_to_add,
+                added_columns,
+                i,
+                filter.get(),
+                current_offset,
+                offsets_to_replicate.get(),
+                probe_process_info);
+        }
+        else
+        {
+            auto key_holder = key_getter.getKeyHolder(i, &pool, sort_key_containers);
+            SCOPE_EXIT(keyHolderDiscardKey(key_holder));
+            auto key = keyHolderGetKey(key_holder);
+
+            size_t hash_value = 0;
+            bool zero_flag = ZeroTraits::check(key);
+            if (!zero_flag)
+            {
+                hash_value = all_maps[probe_process_info.partition_index]->hash(key);
+            }
+
+            size_t segment_index = 0;
+            if (join_build_info.is_spilled)
+            {
+                segment_index = probe_process_info.partition_index;
+            }
+            else if (join_build_info.needVirtualDispatchForProbeBlock())
+            {
+                /// Need to calculate the correct segment_index so that rows with same key will map to the same segment_index both in Build and Prob
+                /// The "reproduce" of segment_index generated in Build phase relies on the facts that:
+                /// Possible pipelines(FineGrainedShuffleWriter => ExchangeReceiver => HashBuild)
+                /// 1. In FineGrainedShuffleWriter, selector value finally maps to packet_stream_id by '% fine_grained_shuffle_count'
+                /// 2. In ExchangeReceiver, build_stream_id = packet_stream_id % build_stream_count;
+                /// 3. In HashBuild, build_concurrency decides map's segment size, and build_steam_id decides the segment index
+                if (join_build_info.enable_fine_grained_shuffle)
+                {
+                    auto packet_stream_id = build_hash_data[i] % join_build_info.fine_grained_shuffle_count;
+                    if likely (join_build_info.fine_grained_shuffle_count == segment_size)
+                        segment_index = packet_stream_id;
+                    else
+                        segment_index = packet_stream_id % segment_size;
+                }
+                else
+                {
+                    segment_index = build_hash_data[i] % join_build_info.build_concurrency;
+                }
+            }
+            else
+            {
+                segment_index = hash_value % segment_size;
+            }
+
+            auto & internal_map = *all_maps[segment_index];
+            /// do not require segment lock because in join, the hash table can not be changed in probe stage.
+            auto it = internal_map.find(key, hash_value);
+            if (it != internal_map.end())
+            {
+                it->getMapped().setUsed();
+                block_full = Adder<KIND, STRICTNESS, Map>::addFound(
+                    it,
+                    num_columns_to_add,
+                    added_columns,
+                    i,
+                    filter.get(),
+                    current_offset,
+                    offsets_to_replicate.get(),
+                    right_indexes,
+                    probe_process_info);
+            }
+            else
+                block_full = Adder<KIND, STRICTNESS, Map>::addNotFound(
+                    num_columns_to_add,
+                    added_columns,
+                    i,
+                    filter.get(),
+                    current_offset,
+                    offsets_to_replicate.get(),
+                    probe_process_info);
+        }
+
+        // if block_full is true means that the current offset is greater than max_block_size, we need break the loop.
+        if (block_full)
+        {
+            break;
+        }
+    }
+
+    probe_process_info.end_row = i;
+    // if i == rows, it means that all probe rows have been joined finish.
+    probe_process_info.all_rows_joined_finish = (i == rows);
+}
+
+template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS, typename KeyGetter, typename Map>
+void probeBlockImplType(
+    const JoinPartitions & join_partitions,
+    size_t rows,
+    const ColumnRawPtrs & key_columns,
+    const Sizes & key_sizes,
+    MutableColumns & added_columns,
+    ConstNullMapPtr null_map,
+    std::unique_ptr<IColumn::Filter> & filter,
+    IColumn::Offset & current_offset,
+    std::unique_ptr<IColumn::Offsets> & offsets_to_replicate,
+    const std::vector<size_t> & right_indexes,
+    const TiDB::TiDBCollators & collators,
+    const JoinBuildInfo & join_build_info,
+    ProbeProcessInfo & probe_process_info)
+{
+    if (null_map)
+        probeBlockImplTypeCase<KIND, STRICTNESS, KeyGetter, Map, true>(
+            join_partitions,
+            rows,
+            key_columns,
+            key_sizes,
+            added_columns,
+            null_map,
+            filter,
+            current_offset,
+            offsets_to_replicate,
+            right_indexes,
+            collators,
+            join_build_info,
+            probe_process_info);
+    else
+        probeBlockImplTypeCase<KIND, STRICTNESS, KeyGetter, Map, false>(
+            join_partitions,
+            rows,
+            key_columns,
+            key_sizes,
+            added_columns,
+            null_map,
+            filter,
+            current_offset,
+            offsets_to_replicate,
+            right_indexes,
+            collators,
+            join_build_info,
+            probe_process_info);
+}
+template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS, typename KeyGetter, typename Map, bool has_null_map, bool has_filter_map>
+std::pair<PaddedPODArray<NASemiJoinResult<KIND, STRICTNESS>>, std::list<NASemiJoinResult<KIND, STRICTNESS> *>> NO_INLINE probeBlockNullAwareInternal(
+    const JoinPartitions & join_partitions,
+    Block & block,
+    const ColumnRawPtrs & key_columns,
+    const Sizes & key_sizes,
+    const TiDB::TiDBCollators & collators,
+    const NALeftSideInfo & left_side_info,
+    const NARightSideInfo & right_side_info)
+{
+    static_assert(KIND == ASTTableJoin::Kind::NullAware_Anti || KIND == ASTTableJoin::Kind::NullAware_LeftAnti
+                  || KIND == ASTTableJoin::Kind::NullAware_LeftSemi);
+    static_assert(STRICTNESS == ASTTableJoin::Strictness::Any || STRICTNESS == ASTTableJoin::Strictness::All);
+
+    size_t rows = block.rows();
+    KeyGetter key_getter(key_columns, key_sizes, collators);
+    std::vector<std::string> sort_key_containers;
+    sort_key_containers.resize(key_columns.size());
+
+    Arena pool;
+    size_t segment_size = join_partitions.size();
+
+    PaddedPODArray<NASemiJoinResult<KIND, STRICTNESS>> res;
+    res.reserve(rows);
+    std::list<NASemiJoinResult<KIND, STRICTNESS> *> res_list;
+    /// We can just consider the result of left semi join because `NASemiJoinResult::setResult` will correct
+    /// the result if it's not left semi join.
+    for (size_t i = 0; i < rows; ++i)
+    {
+        if constexpr (has_filter_map)
+        {
+            if ((*left_side_info.filter_map)[i])
+            {
+                /// Filter out by left_conditions so the result set is empty.
+                res.emplace_back(i, NASemiJoinStep::DONE, nullptr);
+                res.back().template setResult<NASemiJoinResultType::FALSE_VALUE>();
+                continue;
+            }
+        }
+        if (right_side_info.is_empty)
+        {
+            /// If right table is empty, the result is false.
+            /// E.g. (1,2) in ().
+            res.emplace_back(i, NASemiJoinStep::DONE, nullptr);
+            res.back().template setResult<NASemiJoinResultType::FALSE_VALUE>();
+            continue;
+        }
+        if constexpr (has_null_map)
+        {
+            if ((*left_side_info.null_map)[i])
+            {
+                if constexpr (STRICTNESS == ASTTableJoin::Strictness::Any)
+                {
+                    if (key_columns.size() == 1 || right_side_info.has_all_key_null_row || (left_side_info.all_key_null_map && (*left_side_info.all_key_null_map)[i]))
+                    {
+                        /// Note that right_table_is_empty must be false here so the right table is not empty.
+                        /// The result is NULL if
+                        ///   1. key column size is 1. E.g. (null) in (1,2).
+                        ///   2. right table has a all-key-null row. E.g. (1,null) in ((2,2),(null,null)).
+                        ///   3. this row is all-key-null. E.g. (null,null) in ((1,1),(2,2)).
+                        res.emplace_back(i, NASemiJoinStep::DONE, nullptr);
+                        res.back().template setResult<NASemiJoinResultType::NULL_VALUE>();
+                        continue;
+                    }
+                }
+                /// In the worse case, all rows in the right table will be checked.
+                /// E.g. (1,null) in ((2,1),(2,3),(2,null),(3,null)) => false.
+                if (right_side_info.null_key_check_all_blocks_directly)
+                    res.emplace_back(i, NASemiJoinStep::NULL_KEY_CHECK_ALL_BLOCKS, nullptr);
+                else
+                    res.emplace_back(i, NASemiJoinStep::NULL_KEY_CHECK_NULL_ROWS, nullptr);
+                res_list.push_back(&res.back());
+                continue;
+            }
+        }
+
+        auto key_holder = key_getter.getKeyHolder(i, &pool, sort_key_containers);
+        SCOPE_EXIT(keyHolderDiscardKey(key_holder));
+        auto key = keyHolderGetKey(key_holder);
+        /// used to calculate key hash
+        Map & map = join_partitions[0]->template getHashMap<Map>();
+
+        size_t segment_index = 0;
+        size_t hash_value = 0;
+        if (!ZeroTraits::check(key))
+        {
+            hash_value = map.hash(key);
+            segment_index = hash_value % segment_size;
+        }
+
+        auto & internal_map = join_partitions[segment_index]->template getHashMap<Map>();
+        /// do not require segment lock because in join, the hash table can not be changed in probe stage.
+        auto it = internal_map.find(key, hash_value);
+        if (it != internal_map.end())
+        {
+            /// Find the matched row(s).
+            if (STRICTNESS == ASTTableJoin::Strictness::Any)
+            {
+                /// If strictness is any, the result is true.
+                /// E.g. (1,2) in ((1,2),(1,3),(null,3))
+                res.emplace_back(i, NASemiJoinStep::DONE, nullptr);
+                res.back().template setResult<NASemiJoinResultType::TRUE_VALUE>();
+            }
+            else
+            {
+                /// Else the other condition must be checked for these matched right row(s).
+                auto map_it = &static_cast<const typename Map::mapped_type::Base_t &>(it->getMapped());
+                res.emplace_back(i, NASemiJoinStep::NOT_NULL_KEY_CHECK_MATCHED_ROWS, static_cast<const void *>(map_it));
+                res_list.push_back(&res.back());
+            }
+            continue;
+        }
+
+        /// Not find the matched row.
+        if constexpr (STRICTNESS == ASTTableJoin::Strictness::Any)
+        {
+            if (right_side_info.has_all_key_null_row)
+            {
+                /// If right table has a all-key-null row, the result is NULL.
+                /// E.g. (1) in (null) or (1,2) in ((1,3),(null,null)).
+                res.emplace_back(i, NASemiJoinStep::DONE, nullptr);
+                res.back().template setResult<NASemiJoinResultType::NULL_VALUE>();
+                continue;
+            }
+            else if (key_columns.size() == 1)
+            {
+                /// If key size is 1 and all key in right table row is not NULL(right_has_all_key_null_row is false),
+                /// the result is false.
+                /// E.g. (1) in (2,3,4,5).
+                res.emplace_back(i, NASemiJoinStep::DONE, nullptr);
+                res.back().template setResult<NASemiJoinResultType::FALSE_VALUE>();
+                continue;
+            }
+            /// Then key size is greater than 1 and right table does not have a all-key-null row.
+            /// E.g. (1,2) in ((1,3),(1,null)) => NULL, (1,2) in ((1,3),(2,null)) => false.
+        }
+        /// We have to compare them to the null rows one by one.
+        /// In the worse case, all null rows in the right table will be checked.
+        /// E.g. (1,2) in ((2,null),(3,null),(null,1),(null,3)) => false.
+        res.emplace_back(i, NASemiJoinStep::NOT_NULL_KEY_CHECK_NULL_ROWS, nullptr);
+        res_list.push_back(&res.back());
+    }
+    return std::make_pair(std::move(res), std::move(res_list));
+}
+
+template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS, typename KeyGetter, typename Map>
+std::pair<PaddedPODArray<NASemiJoinResult<KIND, STRICTNESS>>, std::list<NASemiJoinResult<KIND, STRICTNESS> *>> probeBlockNullAwareType(
+    const JoinPartitions & join_partitions,
+    Block & block,
+    const ColumnRawPtrs & key_columns,
+    const Sizes & key_sizes,
+    const TiDB::TiDBCollators & collators,
+    const NALeftSideInfo & left_side_info,
+    const NARightSideInfo & right_side_info)
+{
+#define impl(has_null_map, has_filter_map)                                                              \
+    return probeBlockNullAwareInternal<KIND, STRICTNESS, KeyGetter, Map, has_null_map, has_filter_map>( \
+        join_partitions,                                                                                \
+        block,                                                                                          \
+        key_columns,                                                                                    \
+        key_sizes,                                                                                      \
+        collators,                                                                                      \
+        left_side_info,                                                                                 \
+        right_side_info);
+
+    if (left_side_info.null_map)
+    {
+        if (left_side_info.filter_map)
+        {
+            impl(true, true);
+        }
+        else
+        {
+            impl(true, false);
+        }
+    }
+    else
+    {
+        if (left_side_info.filter_map)
+        {
+            impl(false, true);
+        }
+        else
+        {
+            impl(false, false);
+        }
+    }
+}
+} // namespace
+void JoinPartition::probeBlock(
+    const JoinPartitions & join_partitions,
+    size_t rows,
+    const ColumnRawPtrs & key_columns,
+    const std::vector<size_t> & key_sizes,
+    MutableColumns & added_columns,
+    ConstNullMapPtr null_map,
+    std::unique_ptr<IColumn::Filter> & filter,
+    IColumn::Offset & current_offset,
+    std::unique_ptr<IColumn::Offsets> & offsets_to_replicate,
+    const std::vector<size_t> & right_indexes,
+    const TiDB::TiDBCollators & collators,
+    const JoinBuildInfo & join_build_info,
+    ProbeProcessInfo & probe_process_info)
+{
+    using enum ASTTableJoin::Strictness;
+    using enum ASTTableJoin::Kind;
+    const auto & current_partition = join_partitions[probe_process_info.partition_index];
+    auto kind = current_partition->kind;
+    auto strictness = current_partition->strictness;
+    assert(rows == 0 || !current_partition->spill);
+
+#define CALL(KIND, STRICTNESS, MAP)        \
+    probeBlockImpl<KIND, STRICTNESS, MAP>( \
+        join_partitions,                   \
+        rows,                              \
+        key_columns,                       \
+        key_sizes,                         \
+        added_columns,                     \
+        null_map,                          \
+        filter,                            \
+        current_offset,                    \
+        offsets_to_replicate,              \
+        right_indexes,                     \
+        collators,                         \
+        join_build_info,                   \
+        probe_process_info);
+
+    if (kind == Left && strictness == Any)
+        CALL(Left, Any, MapsAny)
+    else if (kind == Inner && strictness == Any)
+        CALL(Inner, Any, MapsAny)
+    else if (kind == Left && strictness == All)
+        CALL(Left, All, MapsAll)
+    else if (kind == Inner && strictness == All)
+        CALL(Inner, All, MapsAll)
+    else if (kind == Full && strictness == Any)
+        CALL(Left, Any, MapsAnyFull)
+    else if (kind == Right && strictness == Any)
+        CALL(Inner, Any, MapsAnyFull)
+    else if (kind == Full && strictness == All)
+        CALL(Left, All, MapsAllFull)
+    else if (kind == Right && strictness == All)
+        CALL(Inner, All, MapsAllFull)
+    else if (kind == Anti && strictness == Any)
+        CALL(Anti, Any, MapsAny)
+    else if (kind == Anti && strictness == All)
+        CALL(Anti, All, MapsAll)
+    else if (kind == LeftSemi && strictness == Any)
+        CALL(LeftSemi, Any, MapsAny)
+    else if (kind == LeftSemi && strictness == All)
+        CALL(LeftSemi, All, MapsAll)
+    else if (kind == LeftAnti && strictness == Any)
+        CALL(LeftSemi, Any, MapsAny)
+    else if (kind == LeftAnti && strictness == All)
+        CALL(LeftSemi, All, MapsAll)
+    else
+        throw Exception("Logical error: unknown combination of JOIN", ErrorCodes::LOGICAL_ERROR);
+#undef CALL
+}
+
+template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS, typename Maps>
+void JoinPartition::probeBlockImpl(
+    const JoinPartitions & join_partitions,
+    size_t rows,
+    const ColumnRawPtrs & key_columns,
+    const std::vector<size_t> & key_sizes,
+    MutableColumns & added_columns,
+    ConstNullMapPtr null_map,
+    std::unique_ptr<IColumn::Filter> & filter,
+    IColumn::Offset & current_offset,
+    std::unique_ptr<IColumn::Offsets> & offsets_to_replicate,
+    const std::vector<size_t> & right_indexes,
+    const TiDB::TiDBCollators & collators,
+    const JoinBuildInfo & join_build_info,
+    ProbeProcessInfo & probe_process_info)
+{
+    const auto & current_join_partition = join_partitions[probe_process_info.partition_index];
+    auto type = current_join_partition->join_type;
+    switch (type)
+    {
+#define M(TYPE)                                                                                                                                      \
+    case JoinType::TYPE:                                                                                                                             \
+        probeBlockImplType<KIND, STRICTNESS, typename KeyGetterForType<JoinType::TYPE, typename Maps::TYPE##Type>::Type, typename Maps::TYPE##Type>( \
+            join_partitions,                                                                                                                         \
+            rows,                                                                                                                                    \
+            key_columns,                                                                                                                             \
+            key_sizes,                                                                                                                               \
+            added_columns,                                                                                                                           \
+            null_map,                                                                                                                                \
+            filter,                                                                                                                                  \
+            current_offset,                                                                                                                          \
+            offsets_to_replicate,                                                                                                                    \
+            right_indexes,                                                                                                                           \
+            collators,                                                                                                                               \
+            join_build_info,                                                                                                                         \
+            probe_process_info);                                                                                                                     \
+        break;
+        APPLY_FOR_JOIN_VARIANTS(M)
+#undef M
+
+    default:
+        throw Exception("Unknown JOIN keys variant.", ErrorCodes::UNKNOWN_SET_DATA_VARIANT);
+    }
+}
+
+template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS, typename Maps>
+std::pair<PaddedPODArray<NASemiJoinResult<KIND, STRICTNESS>>, std::list<NASemiJoinResult<KIND, STRICTNESS> *>> JoinPartition::probeBlockNullAware(
+    const JoinPartitions & join_partitions,
+    Block & block,
+    const ColumnRawPtrs & key_columns,
+    const Sizes & key_sizes,
+    const TiDB::TiDBCollators & collators,
+    const NALeftSideInfo & left_side_info,
+    const NARightSideInfo & right_side_info)
+{
+    auto type = join_partitions[0]->join_type;
+    switch (type)
+    {
+#define M(TYPE)                                                                                                                                                  \
+    case JoinType::TYPE:                                                                                                                                         \
+        return probeBlockNullAwareType<KIND, STRICTNESS, typename KeyGetterForType<JoinType::TYPE, typename Maps::TYPE##Type>::Type, typename Maps::TYPE##Type>( \
+            join_partitions,                                                                                                                                     \
+            block,                                                                                                                                               \
+            key_columns,                                                                                                                                         \
+            key_sizes,                                                                                                                                           \
+            collators,                                                                                                                                           \
+            left_side_info,                                                                                                                                      \
+            right_side_info);
+        APPLY_FOR_JOIN_VARIANTS(M)
+#undef M
+
+    default:
+        throw Exception("Unknown JOIN keys variant.", ErrorCodes::UNKNOWN_SET_DATA_VARIANT);
+    }
+}
+
+void JoinPartition::releasePartition()
+{
+    std::unique_lock partition_lock = lockPartition();
+    releaseBuildPartitionBlocks(partition_lock);
+    releaseProbePartitionBlocks(partition_lock);
+    if (!spill)
+    {
+        releasePartitionPoolAndHashMap(partition_lock);
+    }
+}
+
+#define M(KIND, STRICTNESS, MAPTYPE)                                                                                          \
+    template std::pair<PaddedPODArray<NASemiJoinResult<KIND, (STRICTNESS)>>, std::list<NASemiJoinResult<KIND, STRICTNESS> *>> \
+    JoinPartition::probeBlockNullAware<KIND, STRICTNESS, MAPTYPE>(                                                            \
+        const JoinPartitions & join_partitions,                                                                               \
+        Block & block,                                                                                                        \
+        const ColumnRawPtrs & key_columns,                                                                                    \
+        const Sizes & key_sizes,                                                                                              \
+        const TiDB::TiDBCollators & collators,                                                                                \
+        const NALeftSideInfo & left_side_info,                                                                                \
+        const NARightSideInfo & right_side_info);
+
+APPLY_FOR_NULL_AWARE_JOIN(M)
+#undef M
+
 } // namespace DB

--- a/dbms/src/Interpreters/JoinPartition.h
+++ b/dbms/src/Interpreters/JoinPartition.h
@@ -14,12 +14,21 @@
 
 #pragma once
 
+#include <Columns/ColumnNullable.h>
 #include <Core/Block.h>
+#include <Flash/Coprocessor/JoinInterpreterHelper.h>
+#include <Interpreters/JoinHashTable.h>
+#include <Interpreters/JoinUtils.h>
+#include <Interpreters/NullAwareSemiJoinHelper.h>
+#include <Parsers/ASTTablesInSelectQuery.h>
+#include <absl/base/optimization.h>
 
 namespace DB
 {
 class Arena;
 using ArenaPtr = std::shared_ptr<Arena>;
+using Sizes = std::vector<size_t>;
+
 struct BuildPartition
 {
     BlocksList blocks;
@@ -34,16 +43,63 @@ struct ProbePartition
     size_t bytes{0};
 };
 
+class Join;
+struct alignas(ABSL_CACHELINE_SIZE) RowsNotInsertToMap
+{
+    explicit RowsNotInsertToMap(size_t max_block_size_)
+        : max_block_size(max_block_size_)
+    {
+        RUNTIME_ASSERT(max_block_size > 0);
+    }
+
+    /// Row list
+    RowRefList head;
+    /// Materialized rows
+    std::vector<MutableColumns> materialized_columns_vec;
+    size_t max_block_size;
+
+    size_t total_size = 0;
+
+    /// Insert row to this structure.
+    /// If need_materialize is true, row will be inserted into materialized_columns_vec.
+    /// Else it will be inserted into row list.
+    void insertRow(Block * stored_block, size_t index, bool need_materialize, Arena & pool);
+};
+
+void insertRowToList(RowRefList * list, RowRefList * elem, Block * stored_block, size_t index);
+
+class JoinPartition;
+using JoinPartitions = std::vector<std::unique_ptr<JoinPartition>>;
 class JoinPartition
 {
 public:
-    JoinPartition(const LoggerPtr & log_)
-        : pool(std::make_shared<Arena>())
+    JoinPartition(JoinType join_type_, ASTTableJoin::Kind kind_, ASTTableJoin::Strictness strictness_, size_t max_block_size, const LoggerPtr & log_)
+        : kind(kind_)
+        , strictness(strictness_)
+        , join_type(join_type_)
+        , pool(std::make_shared<Arena>())
         , spill(false)
         , log(log_)
-    {}
+    {
+        /// Choose data structure to use for JOIN.
+        initMap();
+        if (getFullness(kind) || isNullAwareSemiFamily(kind))
+            rows_not_inserted_to_map = std::make_unique<RowsNotInsertToMap>(max_block_size);
+        memory_usage = getHashMapAndPoolByteCount();
+    }
     void insertBlockForBuild(Block && block);
     void insertBlockForProbe(Block && block);
+    size_t getRowCount();
+    size_t getHashMapAndPoolByteCount();
+    RowsNotInsertToMap * getRowsNotInsertedToMap()
+    {
+        if (getFullness(kind) || isNullAwareSemiFamily(kind))
+        {
+            assert(rows_not_inserted_to_map != nullptr);
+            return rows_not_inserted_to_map.get();
+        }
+        return nullptr;
+    };
     Blocks trySpillProbePartition(bool force, size_t max_cached_data_bytes)
     {
         std::unique_lock lock(partition_mutex);
@@ -58,7 +114,7 @@ public:
     /// use lock as the argument to force the caller acquire the lock before call them
     void releaseBuildPartitionBlocks(std::unique_lock<std::mutex> &);
     void releaseProbePartitionBlocks(std::unique_lock<std::mutex> &);
-    void releasePartitionPool(std::unique_lock<std::mutex> &);
+    void releasePartitionPoolAndHashMap(std::unique_lock<std::mutex> &);
     Blocks trySpillBuildPartition(bool force, size_t max_cached_data_bytes, std::unique_lock<std::mutex> & partition_lock);
     Blocks trySpillProbePartition(bool force, size_t max_cached_data_bytes, std::unique_lock<std::mutex> & partition_lock);
     bool hasBuildData() const { return !build_partition.original_blocks.empty(); }
@@ -75,25 +131,101 @@ public:
     }
     bool isSpill() const { return spill; }
     void markSpill() { spill = true; }
+    JoinType getJoinType() const { return join_type; }
+    ASTTableJoin::Kind getJoinKind() const { return kind; }
     Block * getLastBuildBlock() { return &build_partition.blocks.back(); }
-    /// after move hash table to `JoinPartition`, we can rename it to getPartitionHashMapSize
-    /// and return the bytes used by both hash map and the pool
-    size_t getPartitionPoolSize() const { return pool->size(); }
-    ArenaPtr & getPartitionPool() { return pool; }
+    ArenaPtr & getPartitionPool()
+    {
+        assert(pool != nullptr);
+        return pool;
+    }
     size_t getMemoryUsage() const { return memory_usage; }
+    template <typename Map>
+    Map & getHashMap();
+
+    /// insert block to hash maps in `JoinPartitions`
+    static void insertBlockIntoMaps(
+        JoinPartitions & join_partitions,
+        size_t rows,
+        const ColumnRawPtrs & key_columns,
+        const std::vector<size_t> & key_sizes,
+        const TiDB::TiDBCollators & collators,
+        Block * stored_block,
+        ConstNullMapPtr & null_map,
+        size_t stream_index,
+        size_t insert_concurrency,
+        bool enable_fine_grained_shuffle,
+        bool enable_join_spill);
+
+    /// probe the block using hash maps in `JoinPartitions`
+    static void probeBlock(
+        const JoinPartitions & join_partitions,
+        size_t rows,
+        const ColumnRawPtrs & key_columns,
+        const std::vector<size_t> & key_sizes,
+        MutableColumns & added_columns,
+        ConstNullMapPtr null_map,
+        std::unique_ptr<IColumn::Filter> & filter,
+        IColumn::Offset & current_offset,
+        std::unique_ptr<IColumn::Offsets> & offsets_to_replicate,
+        const std::vector<size_t> & right_indexes,
+        const TiDB::TiDBCollators & collators,
+        const JoinBuildInfo & join_build_info,
+        ProbeProcessInfo & probe_process_info);
+    template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS, typename Maps>
+    static void probeBlockImpl(
+        const JoinPartitions & join_partitions,
+        size_t rows,
+        const ColumnRawPtrs & key_columns,
+        const std::vector<size_t> & key_sizes,
+        MutableColumns & added_columns,
+        ConstNullMapPtr null_map,
+        std::unique_ptr<IColumn::Filter> & filter,
+        IColumn::Offset & current_offset,
+        std::unique_ptr<IColumn::Offsets> & offsets_to_replicate,
+        const std::vector<size_t> & right_indexes,
+        const TiDB::TiDBCollators & collators,
+        const JoinBuildInfo & join_build_info,
+        ProbeProcessInfo & probe_process_info);
+
+    template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS, typename Maps>
+    static std::pair<PaddedPODArray<NASemiJoinResult<KIND, STRICTNESS>>, std::list<NASemiJoinResult<KIND, STRICTNESS> *>> probeBlockNullAware(
+        const JoinPartitions & join_partitions,
+        Block & block,
+        const ColumnRawPtrs & key_columns,
+        const Sizes & key_sizes,
+        const TiDB::TiDBCollators & collators,
+        const NALeftSideInfo & left_side_info,
+        const NARightSideInfo & right_side_info);
+
+    void releasePartition();
 
 private:
+    friend class NonJoinedBlockInputStream;
+    void initMap();
     /// mutex to protect concurrent modify partition
     /// note if you wants to acquire both build_probe_mutex and partition_mutex,
     /// please lock build_probe_mutex first
     std::mutex partition_mutex;
     BuildPartition build_partition;
     ProbePartition probe_partition;
+
+    ASTTableJoin::Kind kind;
+    ASTTableJoin::Strictness strictness;
+    JoinType join_type;
+    MapsAny maps_any; /// For ANY LEFT|INNER JOIN
+    MapsAll maps_all; /// For ALL LEFT|INNER JOIN
+    MapsAnyFull maps_any_full; /// For ANY RIGHT|FULL JOIN
+    MapsAllFull maps_all_full; /// For ALL RIGHT|FULL JOIN
+    /// For right/full join, including
+    /// 1. Rows with NULL join keys
+    /// 2. Rows that are filtered by right join conditions
+    /// For null-aware semi join family, including rows with NULL join keys.
+    std::unique_ptr<RowsNotInsertToMap> rows_not_inserted_to_map;
     ArenaPtr pool;
     bool spill;
     /// only update this field when spill is enabled. todo support this field in non-spill mode
     std::atomic<size_t> memory_usage{0};
     const LoggerPtr log;
 };
-using JoinPartitions = std::vector<std::unique_ptr<JoinPartition>>;
 } // namespace DB

--- a/dbms/src/Interpreters/JoinUtils.cpp
+++ b/dbms/src/Interpreters/JoinUtils.cpp
@@ -1,0 +1,67 @@
+// Copyright 2023 PingCAP, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Flash/Mpp/HashBaseWriterHelper.h>
+#include <Interpreters/JoinUtils.h>
+
+namespace DB
+{
+void ProbeProcessInfo::resetBlock(Block && block_, size_t partition_index_)
+{
+    block = std::move(block_);
+    partition_index = partition_index_;
+    start_row = 0;
+    end_row = 0;
+    all_rows_joined_finish = false;
+    // If the probe block size is greater than max_block_size, we will set max_block_size to the probe block size to avoid some unnecessary split.
+    max_block_size = std::max(max_block_size, block.rows());
+}
+
+void ProbeProcessInfo::updateStartRow()
+{
+    assert(start_row <= end_row);
+    start_row = end_row;
+}
+namespace
+{
+UInt64 inline updateHashValue(size_t restore_round, UInt64 x)
+{
+    static std::vector<UInt64> hash_constants{0xff51afd7ed558ccdULL, 0xc4ceb9fe1a85ec53ULL, 0xde43a68e4d184aa3ULL, 0x86f1fda459fa47c7ULL, 0xd91419add64f471fULL, 0xc18eea9cbe12489eULL, 0x2cb94f36b9fe4c38ULL, 0xef0f50cc5f0c4cbaULL};
+    static size_t hash_constants_size = hash_constants.size();
+    assert(hash_constants_size > 0 && (hash_constants_size & (hash_constants_size - 1)) == 0);
+    assert(restore_round != 0);
+    x ^= x >> 33;
+    x *= hash_constants[restore_round & (hash_constants_size - 1)];
+    x ^= x >> 33;
+    x *= hash_constants[(restore_round + 1) & (hash_constants_size - 1)];
+    x ^= x >> 33;
+    return x;
+}
+} // namespace
+void computeDispatchHash(size_t rows,
+                         const ColumnRawPtrs & key_columns,
+                         const TiDB::TiDBCollators & collators,
+                         std::vector<String> & partition_key_containers,
+                         size_t join_restore_round,
+                         WeakHash32 & hash)
+{
+    HashBaseWriterHelper::computeHash(rows, key_columns, collators, partition_key_containers, hash);
+    if (join_restore_round != 0)
+    {
+        auto & data = hash.getData();
+        for (size_t i = 0; i < rows; ++i)
+            data[i] = updateHashValue(join_restore_round, data[i]);
+    }
+}
+} // namespace DB


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6233

Problem Summary:

### What is changed and how it works?
1. move hash map to `JoinPartition`
2. move all the insert/probe hash table code to `JoinPartition`
3. refine `NonJoinedBlockInputStream` so it now read non joined data based on `JoinPartition`

blocked by #7127
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
