### PR TITLE
Storage: should seek before read

### DIFF
--- a/dbms/src/Flash/Coprocessor/TiDBTableScan.cpp
+++ b/dbms/src/Flash/Coprocessor/TiDBTableScan.cpp
@@ -70,6 +70,8 @@ void TiDBTableScan::constructTableScanForRemoteRead(tipb::TableScan * tipb_table
         tipb_table_scan->set_table_id(table_id);
         for (const auto & column : partition_table_scan.columns())
             *tipb_table_scan->add_columns() = column;
+        for (const auto & filter : partition_table_scan.pushed_down_filter_conditions())
+            *tipb_table_scan->add_pushed_down_filter_conditions() = filter;
         tipb_table_scan->set_desc(partition_table_scan.desc());
         for (auto id : partition_table_scan.primary_column_ids())
             tipb_table_scan->add_primary_column_ids(id);

--- a/dbms/src/Storages/DeltaMerge/File/DMFileReader.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileReader.h
@@ -180,6 +180,9 @@ private:
 
     std::unique_ptr<ColumnSharingCacheMap> col_data_cache{};
     std::unordered_map<ColId, bool> last_read_from_cache{};
+
+    /// call skipNextBlock() before read()
+    bool last_read_skipped{false};
 };
 
 } // namespace DM


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/42555

Problem Summary:

### What is changed and how it works?

1. set `partition_table_scan.pushed_down_filter_conditions`
2. seek before read when skip last time
3. `&` with bitmap when filter condition is always true

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
