### PR TITLE
Show CallerIdentity when connect to S3 client

### DIFF
--- a/contrib/aws-cmake/CMakeLists.txt
+++ b/contrib/aws-cmake/CMakeLists.txt
@@ -32,6 +32,7 @@ endif()
 SET(AWS_SDK_DIR "${TiFlash_SOURCE_DIR}/contrib/aws")
 SET(AWS_SDK_CORE_DIR "${AWS_SDK_DIR}/src/aws-cpp-sdk-core")
 SET(AWS_SDK_S3_DIR "${AWS_SDK_DIR}/generated/src/aws-cpp-sdk-s3")
+SET(AWS_SDK_STS_DIR "${AWS_SDK_DIR}/generated/src/aws-cpp-sdk-sts")
 
 SET(AWS_AUTH_DIR "${TiFlash_SOURCE_DIR}/contrib/aws-c-auth")
 SET(AWS_CAL_DIR "${TiFlash_SOURCE_DIR}/contrib/aws-c-cal")
@@ -115,6 +116,14 @@ file(GLOB AWS_SDK_S3_SRC
 list(APPEND AWS_SOURCES ${AWS_SDK_S3_SRC})
 list(APPEND AWS_PUBLIC_INCLUDES "${AWS_SDK_S3_DIR}/include/")
 
+# aws-cpp-sdk-sts
+file(GLOB AWS_SDK_STS_SRC
+    "${AWS_SDK_STS_DIR}/source/*.cpp"
+    "${AWS_SDK_STS_DIR}/source/model/*.cpp"
+)
+
+list(APPEND AWS_SOURCES ${AWS_SDK_STS_SRC})
+list(APPEND AWS_PUBLIC_INCLUDES "${AWS_SDK_STS_DIR}/include/")
 
 # aws-c-auth
 file(GLOB AWS_AUTH_SRC

--- a/dbms/src/Storages/S3/S3Common.cpp
+++ b/dbms/src/Storages/S3/S3Common.cpp
@@ -365,7 +365,9 @@ std::unique_ptr<Aws::S3::S3Client> ClientFactory::create(const StorageS3Config &
     }
     if (config_.access_key_id.empty() && config_.secret_access_key.empty())
     {
-        Aws::STS::STSClient sts_client(cfg);
+        Aws::Client::ClientConfiguration sts_cfg;
+        sts_cfg.verifySSL = false;
+        Aws::STS::STSClient sts_client(sts_cfg);
         Aws::STS::Model::GetCallerIdentityRequest req;
         auto get_identity_outcome = sts_client.GetCallerIdentity(req);
         if (!get_identity_outcome.IsSuccess())

--- a/dbms/src/Storages/S3/S3Common.h
+++ b/dbms/src/Storages/S3/S3Common.h
@@ -129,7 +129,7 @@ private:
     DISALLOW_COPY_AND_MOVE(ClientFactory);
     std::unique_ptr<Aws::S3::S3Client> create() const;
 
-    static std::unique_ptr<Aws::S3::S3Client> create(const StorageS3Config & config_);
+    static std::unique_ptr<Aws::S3::S3Client> create(const StorageS3Config & config_, const LoggerPtr & log);
     static Aws::Http::Scheme parseScheme(std::string_view endpoint);
 
     std::shared_ptr<TiFlashS3Client> initClientFromWriteNode();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/7157, ref https://github.com/pingcap/tiflash/issues/6827

Problem Summary:
S3 disagg CN failed to access to S3. But the aws client can access to S3.

### What is changed and how it works?

Use STSClient to show the `CallerIdentity` when connecting to AWS. It will show some logging as below.
```
[2023/03/25 11:31:35.774 +00:00] [INFO] [S3Common.cpp:381] ["CallerIdentity{UserId:xxx:i-xxx, Account:xxx, Arn:arn:aws:sts::xxx:assumed-role/xxx/i-xxx}"] [thread_id=1]
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
