### PR TITLE
Fix S3GC is broken on AWS

### DIFF
--- a/dbms/src/Common/TiFlashMetrics.h
+++ b/dbms/src/Common/TiFlashMetrics.h
@@ -230,7 +230,7 @@ namespace DB
     M(tiflash_disaggregated_details, "", Counter,                                                                                                   \
         F(type_cftiny_read, {{"type", "cftiny_read"}}),                                                                                             \
         F(type_cftiny_fetch, {{"type", "cftiny_fetch"}}))                                                                                           \
-    M(tiflash_raft_command_duration_seconds, "Bucketed histogram of some raft command: apply snapshot",                                             \
+    M(tiflash_raft_command_duration_seconds, "Bucketed histogram of some raft command: apply snapshot and ingest SST",                              \
         Histogram, /* these command usually cost several seconds, increase the start bucket to 50ms */                                              \
         F(type_ingest_sst, {{"type", "ingest_sst"}}, ExpBuckets{0.05, 2, 10}),                                                                      \
         F(type_ingest_sst_sst2dt, {{"type", "ingest_sst_sst2dt"}}, ExpBuckets{0.05, 2, 10}),                                                        \
@@ -328,6 +328,15 @@ namespace DB
         F(type_list_objects, {{"type", "list_objects"}}, ExpBuckets{0.001, 2, 20}),                                                                 \
         F(type_delete_object, {{"type", "delete_object"}}, ExpBuckets{0.001, 2, 20}),                                                               \
         F(type_head_object, {{"type", "head_object"}}, ExpBuckets{0.001, 2, 20}))                                                                   \
+    M(tiflash_storage_s3_gc_seconds, "S3 GC subprocess duration in seconds",                                                                        \
+        Histogram,  /* these command usually cost several seconds, increase the start bucket to 500ms */                                            \
+        F(type_total, {{"type", "total"}}, ExpBuckets{0.5, 2, 20}),                                                                                 \
+        F(type_one_store, {{"type", "one_store"}}, ExpBuckets{0.5, 2, 20}),                                                                         \
+        F(type_read_locks, {{"type", "read_locks"}}, ExpBuckets{0.5, 2, 20}),                                                                       \
+        F(type_clean_locks, {{"type", "clean_locks"}}, ExpBuckets{0.5, 2, 20}),                                                                     \
+        F(type_clean_manifests, {{"type", "clean_manifests"}}, ExpBuckets{0.5, 2, 20}),                                                             \
+        F(type_scan_then_clean_data_files, {{"type", "scan_then_clean_data_files"}}, ExpBuckets{0.5, 2, 20}),                                       \
+        F(type_clean_one_lock, {{"type", "clean_one_lock"}}, ExpBuckets{0.5, 2, 20}))                                                               \
     M(tiflash_storage_checkpoint_seconds, "PageStorage checkpoint elapsed time", Histogram,                                                         \
         F(type_dump_checkpoint_snapshot, {{"type", "dump_checkpoint_snapshot"}}, ExpBuckets{0.001, 2, 20}),                                         \
         F(type_dump_checkpoint_data, {{"type", "dump_checkpoint_data"}}, ExpBuckets{0.001, 2, 20}),                                                 \

--- a/dbms/src/Interpreters/Settings.h
+++ b/dbms/src/Interpreters/Settings.h
@@ -244,8 +244,9 @@ struct Settings
     M(SettingInt64, dt_compression_level, 1, "The compression level.")                                                                                                                                                                  \
     \
     M(SettingInt64, remote_checkpoint_interval_seconds, 30, "The interval of uploading checkpoint to the remote store. Unit is second.")                                                                                                \
+    M(SettingInt64, remote_gc_method, 1, "The method of running GC task on the remote store. 1 - lifecycle, 2 - scan.")                                                                                                                 \
     M(SettingInt64, remote_gc_interval_seconds, 3600, "The interval of running GC task on the remote store. Unit is second.")                                                                                                           \
-    M(SettingInt64, remote_gc_min_age_seconds, 3600, "The file will NOT be compacted when the time difference between the last modification is less than this threshold")                                                              \
+    M(SettingInt64, remote_gc_min_age_seconds, 3600, "The file will NOT be compacted when the time difference between the last modification is less than this threshold")                                                               \
     M(SettingDouble, remote_gc_ratio, 0.5, "The files with valid rate less than this threshold will be compacted")                                                                                                                      \
     M(SettingInt64, remote_gc_small_size, 128 * 1024, "The files with total size less than this threshold will be compacted")                                                                                                           \
     M(SettingDouble, disagg_read_concurrency_scale, 20.0, "Scale * logical cpu cores = disaggregated read IO concurrency.")                                                                                                             \

--- a/dbms/src/Server/StorageConfigParser.h
+++ b/dbms/src/Server/StorageConfigParser.h
@@ -103,7 +103,7 @@ struct StorageS3Config
     String secret_access_key;
     UInt64 max_connections = 1024;
     UInt64 connection_timeout_ms = 1000;
-    UInt64 request_timeout_ms = 3000;
+    UInt64 request_timeout_ms = 7000;
     String root;
 
     inline static String S3_ACCESS_KEY_ID = "S3_ACCESS_KEY_ID";

--- a/dbms/src/Server/StorageConfigParser.h
+++ b/dbms/src/Server/StorageConfigParser.h
@@ -101,7 +101,7 @@ struct StorageS3Config
     String bucket;
     String access_key_id;
     String secret_access_key;
-    UInt64 max_connections = 1024;
+    UInt64 max_connections = 4096;
     UInt64 connection_timeout_ms = 1000;
     UInt64 request_timeout_ms = 7000;
     String root;

--- a/dbms/src/Storages/DeltaMerge/Remote/DataStore/DataStore.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/DataStore/DataStore.h
@@ -103,6 +103,9 @@ public:
         std::chrono::system_clock::time_point mtime; // last_modification_time
     };
     virtual std::unordered_map<String, DataFileInfo> getDataFilesInfo(const std::unordered_set<String> & lock_keys) = 0;
+
+    // Attach tagging to the keys on remote store
+    virtual void setTaggingsForKeys(const std::vector<String> & keys, std::string_view tagging) = 0;
 };
 
 

--- a/dbms/src/Storages/DeltaMerge/Remote/DataStore/DataStoreS3.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/DataStore/DataStoreS3.h
@@ -53,6 +53,7 @@ public:
 
     std::unordered_map<String, DataFileInfo> getDataFilesInfo(const std::unordered_set<String> & lock_keys) override;
 
+    void setTaggingsForKeys(const std::vector<String> & keys, std::string_view tagging) override;
 #ifndef DBMS_PUBLIC_GTEST
 private:
 #else

--- a/dbms/src/Storages/S3/S3Common.cpp
+++ b/dbms/src/Storages/S3/S3Common.cpp
@@ -41,6 +41,7 @@
 #include <aws/s3/model/ListObjectsRequest.h>
 #include <aws/s3/model/ListObjectsV2Request.h>
 #include <aws/s3/model/ListObjectsV2Result.h>
+#include <aws/s3/model/MetadataDirective.h>
 #include <aws/s3/model/PutBucketLifecycleConfigurationRequest.h>
 #include <aws/s3/model/PutObjectRequest.h>
 #include <aws/s3/model/TaggingDirective.h>
@@ -531,7 +532,9 @@ void rewriteObjectWithTagging(const TiFlashS3Client & client, const String & key
     // The copy_source format is "${source_bucket}/${source_key}"
     auto copy_source = client.bucket() + "/" + (client.root() == "/" ? "" : client.root()) + key;
     client.setBucketAndKeyWithRoot(req, key);
+    // metadata directive and tagging directive must be set to `REPLACE`
     req.WithCopySource(copy_source) //
+        .WithMetadataDirective(Aws::S3::Model::MetadataDirective::REPLACE)
         .WithTagging(tagging)
         .WithTaggingDirective(Aws::S3::Model::TaggingDirective::REPLACE);
     ProfileEvents::increment(ProfileEvents::S3CopyObject);

--- a/dbms/src/Storages/S3/S3Common.h
+++ b/dbms/src/Storages/S3/S3Common.h
@@ -91,7 +91,7 @@ public:
 
 enum class S3GCMethod
 {
-    Lifecycle,
+    Lifecycle = 1,
     ScanThenDelete,
 };
 

--- a/dbms/src/Storages/S3/S3GCManager.cpp
+++ b/dbms/src/Storages/S3/S3GCManager.cpp
@@ -493,7 +493,7 @@ void S3GCManager::lifecycleMarkDataFileDeleted(const String & datafile_key)
     {
         // CheckpointDataFile is a single object, add tagging for it and update its mtime
         rewriteObjectWithTagging(*client, datafile_key, String(TaggingObjectIsDeleted));
-        LOG_INFO(sub_logger, "datafile deleted by lifecycle tagging", datafile_key);
+        LOG_INFO(sub_logger, "datafile deleted by lifecycle tagging");
     }
     else
     {
@@ -511,12 +511,11 @@ void S3GCManager::lifecycleMarkDataFileDeleted(const String & datafile_key)
         remote_data_store->setTaggingsForKeys(sub_keys, TaggingObjectIsDeleted);
         for (const auto & sub_key : sub_keys)
         {
-            LOG_INFO(sub_logger, "datafile deleted by lifecycle tagging, sub_key={}", datafile_key, sub_key);
+            LOG_INFO(sub_logger, "datafile deleted by lifecycle tagging, sub_key={}", sub_key);
         }
         LOG_INFO(
             sub_logger,
             "datafile deleted by lifecycle tagging, all sub keys are deleted, n_sub_keys={}",
-            datafile_key,
             sub_keys.size());
     }
 }

--- a/dbms/src/Storages/S3/S3GCManager.cpp
+++ b/dbms/src/Storages/S3/S3GCManager.cpp
@@ -532,7 +532,7 @@ void S3GCManager::physicalRemoveDataFile(const String & datafile_key)
     {
         // CheckpointDataFile is a single object, remove it.
         deleteObject(*client, datafile_key);
-        LOG_INFO(sub_logger, "datafile deleted, key={}", datafile_key);
+        LOG_INFO(sub_logger, "datafile deleted");
     }
     else
     {
@@ -541,13 +541,14 @@ void S3GCManager::physicalRemoveDataFile(const String & datafile_key)
         // only the sub objects of given key of this DMFile.
         // TODO: If GCManager unexpectedly exit in the middle, it will leave some broken
         //       sub file for DMFile, try clean them later.
-        S3::listPrefix(*client, datafile_key + "/", [&client, &datafile_key, &sub_logger](const Aws::S3::Model::Object & object) {
+        std::vector<String> sub_keys;
+        S3::listPrefix(*client, datafile_key + "/", [&client, &sub_logger](const Aws::S3::Model::Object & object) {
             const auto & sub_key = object.GetKey();
             deleteObject(*client, sub_key);
-            LOG_INFO(sub_logger, "datafile deleted, sub_key={}", datafile_key, sub_key);
+            LOG_INFO(sub_logger, "datafile deleted, sub_key={}", sub_key);
             return PageResult{.num_keys = 1, .more = true};
         });
-        LOG_INFO(sub_logger, "datafile deleted, all sub keys are deleted", datafile_key);
+        LOG_INFO(sub_logger, "datafile deleted, all sub keys are deleted");
     }
 }
 

--- a/dbms/src/Storages/S3/S3GCManager.h
+++ b/dbms/src/Storages/S3/S3GCManager.h
@@ -16,6 +16,7 @@
 
 #include <Core/Types.h>
 #include <Storages/BackgroundProcessingPool.h>
+#include <Storages/DeltaMerge/Remote/DataStore/DataStore_fwd.h>
 #include <Storages/S3/CheckpointManifestS3Set.h>
 #include <Storages/S3/S3Common.h>
 #include <common/types.h>
@@ -87,6 +88,7 @@ public:
         pingcap::pd::ClientPtr pd_client_,
         OwnerManagerPtr gc_owner_manager_,
         S3LockClientPtr lock_client_,
+        DM::Remote::IDataStorePtr remote_data_store_,
         S3GCConfig config_);
 
     ~S3GCManager() = default;
@@ -131,6 +133,8 @@ private:
 
     const OwnerManagerPtr gc_owner_manager;
     const S3LockClientPtr lock_client;
+
+    DM::Remote::IDataStorePtr remote_data_store;
 
     std::atomic<bool> shutdown_called;
 

--- a/dbms/src/Storages/Transaction/TMTContext.cpp
+++ b/dbms/src/Storages/Transaction/TMTContext.cpp
@@ -100,27 +100,27 @@ TMTContext::TMTContext(Context & context_, const TiFlashRaftConfig & raft_config
         s3gc_owner->campaignOwner(); // start campaign
         s3lock_client = std::make_shared<S3::S3LockClient>(cluster.get(), s3gc_owner);
 
-        S3::S3GCConfig gc_config;
+        S3::S3GCConfig remote_gc_config;
         {
             Int64 gc_method_int = context.getSettingsRef().remote_gc_method;
             if (gc_method_int == 1)
             {
-                gc_config.method = S3::S3GCMethod::Lifecycle;
-                LOG_INFO(Logger::get(), "using s3_gc_method={}", magic_enum::enum_name(gc_config.method));
+                remote_gc_config.method = S3::S3GCMethod::Lifecycle;
+                LOG_INFO(Logger::get(), "Using remote_gc_method={}", magic_enum::enum_name(remote_gc_config.method));
             }
             else if (gc_method_int == 2)
             {
-                gc_config.method = S3::S3GCMethod::ScanThenDelete;
-                LOG_INFO(Logger::get(), "using s3_gc_method={}", magic_enum::enum_name(gc_config.method));
+                remote_gc_config.method = S3::S3GCMethod::ScanThenDelete;
+                LOG_INFO(Logger::get(), "Using remote_gc_method={}", magic_enum::enum_name(remote_gc_config.method));
             }
             else
             {
-                LOG_WARNING(Logger::get(), "Unknown gc method from settings, using default method, value={} s3_gc_method={}", gc_method_int, magic_enum::enum_name(gc_config.method));
+                LOG_WARNING(Logger::get(), "Unknown remote gc method from settings, using default method, value={} remote_gc_method={}", gc_method_int, magic_enum::enum_name(remote_gc_config.method));
             }
         }
-        gc_config.interval_seconds = context.getSettingsRef().remote_gc_interval_seconds; // TODO: make it reloadable
-        gc_config.method = S3::ClientFactory::instance().gc_method;
-        s3gc_manager = std::make_unique<S3::S3GCManagerService>(context, cluster->pd_client, s3gc_owner, s3lock_client, gc_config);
+        remote_gc_config.interval_seconds = context.getSettingsRef().remote_gc_interval_seconds; // TODO: make it reloadable
+        remote_gc_config.method = S3::ClientFactory::instance().gc_method;
+        s3gc_manager = std::make_unique<S3::S3GCManagerService>(context, cluster->pd_client, s3gc_owner, s3lock_client, remote_gc_config);
     }
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/7158

Problem Summary: As issue described. And find `CopyObject` request time out after fixing that problem.

### What is changed and how it works?

* Add `MetadataDirective::REPLACE` to `CopyObject`
* Delete subkeys of DMFile in parallel to shorten the GC time
* Changed `storage.s3.request_timeout_ms` default to 7 seconds, `storage.s3.max_connections` default to 4096
  * S3 GC rewriting CheckpointDataFile cause about 3~4 seconds
* Add some metrics and loggings about S3 GC time comsume
* Add a settings `remote_gc_method` to allow using scan instead of lifecycle for running GC on S3

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
