### PR TITLE
Split edits record of checkpoint manifest into multi-parts.

### DIFF
--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -1159,7 +1159,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
         storage_config.kvstore_data_path, //
         global_context->getPathCapacity(),
         global_context->getFileProvider());
-    if (const auto & config = storage_config.remote_cache_config; config.isCacheEnabled())
+    if (const auto & config = storage_config.remote_cache_config; config.isCacheEnabled() && global_context->getSharedContextDisagg()->isDisaggregatedComputeMode())
     {
         config.initCacheDir();
         FileCache::initialize(global_context->getPathCapacity(), config);

--- a/dbms/src/Storages/Page/V3/CheckpointFile/CPFilesWriter.cpp
+++ b/dbms/src/Storages/Page/V3/CheckpointFile/CPFilesWriter.cpp
@@ -29,6 +29,7 @@ CPFilesWriter::CPFilesWriter(CPFilesWriter::Options options)
     , max_data_file_size(options.max_data_file_size)
     , manifest_writer(CPManifestFileWriter::create({
           .file_path = options.manifest_file_path,
+          .max_edit_records_per_part = options.max_edit_records_per_part,
       }))
     , data_source(options.data_source)
     , locked_files(options.must_locked_files)

--- a/dbms/src/Storages/Page/V3/CheckpointFile/CPFilesWriter.h
+++ b/dbms/src/Storages/Page/V3/CheckpointFile/CPFilesWriter.h
@@ -47,8 +47,8 @@ public:
          */
         const std::unordered_set<String> & must_locked_files = {};
         UInt64 sequence;
-        UInt64 max_data_file_size;
-        UInt64 max_edit_records_per_part;
+        UInt64 max_data_file_size = 256 * 1024 * 1024;
+        UInt64 max_edit_records_per_part = 100000;
     };
 
     static CPFilesWriterPtr create(Options options)

--- a/dbms/src/Storages/Page/V3/CheckpointFile/CPFilesWriter.h
+++ b/dbms/src/Storages/Page/V3/CheckpointFile/CPFilesWriter.h
@@ -48,6 +48,7 @@ public:
         const std::unordered_set<String> & must_locked_files = {};
         UInt64 sequence;
         UInt64 max_data_file_size;
+        UInt64 max_edit_records_per_part;
     };
 
     static CPFilesWriterPtr create(Options options)

--- a/dbms/src/Storages/Page/V3/CheckpointFile/CPManifestFileWriter.h
+++ b/dbms/src/Storages/Page/V3/CheckpointFile/CPManifestFileWriter.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <Common/Exception.h>
 #include <IO/CompressedWriteBuffer.h>
 #include <IO/WriteBufferFromFile.h>
 #include <Storages/Page/V3/CheckpointFile/Proto/manifest_file.pb.h>
@@ -31,6 +32,7 @@ public:
     struct Options
     {
         const std::string & file_path;
+        UInt64 max_edit_records_per_part = 0;
     };
 
     static CPManifestFileWriterPtr create(Options options)
@@ -41,7 +43,10 @@ public:
     explicit CPManifestFileWriter(Options options)
         : file_writer(std::make_unique<WriteBufferFromFile>(options.file_path))
         , compressed_writer(std::make_unique<CompressedWriteBuffer<true>>(*file_writer, CompressionSettings()))
-    {}
+        , max_edit_records_per_part(options.max_edit_records_per_part)
+    {
+        RUNTIME_CHECK(max_edit_records_per_part > 0, max_edit_records_per_part);
+    }
 
     ~CPManifestFileWriter()
     {
@@ -64,6 +69,8 @@ public:
     void flush();
 
 private:
+    void writeEditsPart(const universal::PageEntriesEdit & edit, UInt64 start, UInt64 limit);
+
     enum class WriteStage
     {
         WritingPrefix = 0,
@@ -77,6 +84,7 @@ private:
     // compressed<plain_file>
     const std::unique_ptr<WriteBufferFromFile> file_writer;
     const WriteBufferPtr compressed_writer;
+    const UInt64 max_edit_records_per_part;
 
     WriteStage write_stage = WriteStage::WritingPrefix;
 };

--- a/dbms/src/Storages/Page/V3/CheckpointFile/CPManifestFileWriter.h
+++ b/dbms/src/Storages/Page/V3/CheckpointFile/CPManifestFileWriter.h
@@ -32,7 +32,7 @@ public:
     struct Options
     {
         const std::string & file_path;
-        UInt64 max_edit_records_per_part = 0;
+        UInt64 max_edit_records_per_part = 100000;
     };
 
     static CPManifestFileWriterPtr create(Options options)

--- a/dbms/src/Storages/Page/V3/Universal/UniversalPageStorage.cpp
+++ b/dbms/src/Storages/Page/V3/Universal/UniversalPageStorage.cpp
@@ -455,6 +455,7 @@ PS::V3::CPDataWriteStats UniversalPageStorage::dumpIncrementalCheckpoint(const U
         .must_locked_files = options.must_locked_files,
         .sequence = sequence,
         .max_data_file_size = options.max_data_file_size,
+        .max_edit_records_per_part = options.max_edit_records_per_part,
     });
 
     writer->writePrefix({

--- a/dbms/src/Storages/Page/V3/Universal/UniversalPageStorage.h
+++ b/dbms/src/Storages/Page/V3/Universal/UniversalPageStorage.h
@@ -195,6 +195,7 @@ public:
         const std::function<std::unordered_set<String>()> compact_getter = nullptr;
 
         UInt64 max_data_file_size = 256 * 1024 * 1024; // 256MB
+        UInt64 max_edit_records_per_part = 100000;
     };
 
     PS::V3::CPDataWriteStats dumpIncrementalCheckpoint(const DumpCheckpointOptions & options);

--- a/metrics/grafana/tiflash_summary.json
+++ b/metrics/grafana/tiflash_summary.json
@@ -9108,6 +9108,133 @@
             "align": false,
             "alignLevel": null
           }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "PageStorage Checkpoint Duration",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 40
+          },
+          "hiddenSeries": false,
+          "id": 177,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.11",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "histogram_quantile(1.00, sum(rate(tiflash_storage_checkpoint_seconds_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (le, type))",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{type}}-max",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "histogram_quantile(0.99, sum(rate(tiflash_storage_checkpoint_seconds_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (le, type))",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{type}}-99",
+              "refId": "C"
+            },
+            {
+              "exemplar": true,
+              "expr": "histogram_quantile(0.90, sum(rate(tiflash_storage_checkpoint_seconds_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (le, type))",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{type}}-90",
+              "refId": "D"
+            },
+            {
+              "exemplar": true,
+              "expr": "histogram_quantile(0.80, sum(rate(tiflash_storage_checkpoint_seconds_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (le, type))",
+              "hide": true,
+              "interval": "",
+              "legendFormat": "{{type}}-80",
+              "refId": "E"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "PageStorage Checkpoint Duration",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         }
       ],
       "title": "PageStorage",


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6827

Problem Summary:

```
[2023/03/24 08:49:10.532 +00:00] [INFO] [S3GCManager.cpp:149] ["latest manifest, gc_store_id=172 upload_seq=486 key=s172/manifest/mf_486"] [thread_id=14]
[2023/03/24 08:49:10.532 +00:00] [INFO] [S3GCManager.cpp:512] ["Reading manifest, key=s172/manifest/mf_486"] [thread_id=14]
[2023/03/24 08:49:16.765 +00:00] [ERROR] [Exception.cpp:90] ["Code: 49, e.displayText() = DB::Exception: Check prefix_size < MAX_SIZE failed: Expect total message to be < 1GiB, size=1401166563, e.what() = DB::Exception......
```

### What is changed and how it works?

- Split edits record of checkpoint manifest into multi-parts, 100000 records per part by default.

- By the way, only enable FileCache in compute nodes.


- Also add metrics in of checkpoint durations.
![image](https://user-images.githubusercontent.com/6143402/227939106-879b68df-fa56-490a-bbb8-e402d457b559.png)


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
