### PR TITLE
Add metrics to MPMCQueue and UniThreadPool

### DIFF
--- a/dbms/src/Common/TiFlashMetrics.h
+++ b/dbms/src/Common/TiFlashMetrics.h
@@ -258,6 +258,30 @@ namespace DB
     M(tiflash_object_count, "Number of objects", Gauge,                                                                                             \
         F(type_count_of_establish_calldata, {"type", "count_of_establish_calldata"}),                                                               \
         F(type_count_of_mpptunnel, {"type", "count_of_mpptunnel"}))                                                                                 \
+    M(tiflash_queue_push_duration_seconds, "Duration of push to queue", Histogram,                                                                  \
+        F(type_disagg_page_receiver, {{"type", "disagg_page_receiver"}}, ExpBuckets{0.01, 2, 20}))                                                 \
+    M(tiflash_queue_active, "In-queue elements", Gauge,                                                                                             \
+        F(type_disagg_page_receiver, {"type", "disagg_page_receiver"}))                                                                             \
+    M(tiflash_queue_capacity, "Queue capacity", Gauge,                                                                                              \
+        F(type_disagg_page_receiver, {"type", "disagg_page_receiver"}))                                                                             \
+    M(tiflash_queue_pending_push, "Pending elements to push to queue", Gauge,                                                                       \
+        F(type_disagg_page_receiver, {"type", "disagg_page_receiver"}))                                                                             \
+    M(tiflash_uni_thread_queue_duration_seconds, "Duration of queuing in the uni thread pool", Histogram,                                           \
+        F(type_global, {{"type", "global"}}, ExpBuckets{0.01, 2, 20}),                                                                             \
+        F(type_disagg_page_preparer, {{"type", "disagg_page_preparer"}}, ExpBuckets{0.01, 2, 20}),                                                 \
+        F(type_disagg_read_task, {{"type", "disagg_read_task"}}, ExpBuckets{0.01, 2, 20}))                                                         \
+    M(tiflash_uni_thread_queued, "In-queue tasks in the uni thread pool", Gauge,                                                                    \
+        F(type_global, {"type", "global"}),                                                                                                         \
+        F(type_disagg_page_preparer, {"type", "disagg_page_preparer"}),                                                                             \
+        F(type_disagg_read_task, {"type", "disagg_read_task"}))                                                                                     \
+    M(tiflash_uni_thread_capacity, "Max threads of the uni thread pool", Gauge,                                                                     \
+        F(type_global, {"type", "global"}),                                                                                                         \
+        F(type_disagg_page_preparer, {"type", "disagg_page_preparer"}),                                                                             \
+        F(type_disagg_read_task, {"type", "disagg_read_task"}))                                                                                     \
+    M(tiflash_uni_thread_pending, "Pending tasks to push to queue in the uni thread pool", Gauge,                                                   \
+        F(type_global, {"type", "global"}),                                                                                                         \
+        F(type_disagg_page_preparer, {"type", "disagg_page_preparer"}),                                                                             \
+        F(type_disagg_read_task, {"type", "disagg_read_task"}))                                                                                     \
     M(tiflash_thread_count, "Number of threads", Gauge,                                                                                             \
         F(type_max_threads_of_thdpool, {"type", "thread_pool_total_max"}),                                                                          \
         F(type_active_threads_of_thdpool, {"type", "thread_pool_active"}),                                                                          \

--- a/dbms/src/Flash/Disaggregated/RNPageReceiver.cpp
+++ b/dbms/src/Flash/Disaggregated/RNPageReceiver.cpp
@@ -94,6 +94,12 @@ RNPageReceiverBase<RPCContext>::RNPageReceiverBase(
     try
     {
         msg_channel = std::make_unique<MPMCQueue<PageReceivedMessagePtr>>(max_buffer_size);
+        msg_channel->setMetrics({
+            .push_duration = &GET_METRIC(tiflash_queue_push_duration_seconds, type_disagg_page_receiver),
+            .n_active = &GET_METRIC(tiflash_queue_active, type_disagg_page_receiver),
+            .n_capacity = &GET_METRIC(tiflash_queue_capacity, type_disagg_page_receiver),
+            .n_pending_push = &GET_METRIC(tiflash_queue_pending_push, type_disagg_page_receiver),
+        });
         // setup fetch threads to fetch pages/blocks from write nodes
         setUpConnection();
     }

--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -1504,12 +1504,6 @@ SchemaSyncServicePtr & Context::getSchemaSyncService()
     return shared->schema_sync_service;
 }
 
-void Context::initializeTiFlashMetrics() const
-{
-    auto lock = getLock();
-    (void)TiFlashMetrics::instance();
-}
-
 void Context::initializeFileProvider(KeyManagerPtr key_manager, bool enable_encryption)
 {
     auto lock = getLock();

--- a/dbms/src/Interpreters/Context.h
+++ b/dbms/src/Interpreters/Context.h
@@ -411,8 +411,6 @@ public:
         size_t remote_cache_capacity = 0);
     PathCapacityMetricsPtr getPathCapacity() const;
 
-    void initializeTiFlashMetrics() const;
-
     void initializeFileProvider(KeyManagerPtr key_manager, bool enable_encryption);
     FileProviderPtr getFileProvider() const;
 

--- a/dbms/src/Server/DTTool/DTTool.h
+++ b/dbms/src/Server/DTTool/DTTool.h
@@ -91,7 +91,6 @@ class ImitativeEnv
         global_context = DB::Context::createGlobal();
         global_context->setApplicationType(DB::Context::ApplicationType::LOCAL);
 
-        global_context->initializeTiFlashMetrics();
         KeyManagerPtr key_manager = std::make_shared<MockKeyManager>(encryption);
         global_context->initializeFileProvider(key_manager, encryption);
 

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -1293,9 +1293,6 @@ int Server::main(const std::vector<std::string> & /*args*/)
     if (config().has("macros"))
         global_context->setMacros(std::make_unique<Macros>(config(), "macros"));
 
-    /// Init TiFlash metrics.
-    global_context->initializeTiFlashMetrics();
-
     /// Initialize users config reloader.
     auto users_config_reloader = UserConfig::parseSettings(config(), config_path, global_context, log);
 

--- a/dbms/src/TestUtils/TiFlashTestEnv.cpp
+++ b/dbms/src/TestUtils/TiFlashTestEnv.cpp
@@ -104,7 +104,6 @@ void TiFlashTestEnv::addGlobalContext(const DB::Settings & settings_, Strings te
     global_context->setApplicationType(DB::Context::ApplicationType::LOCAL);
     global_context->setTemporaryPath(getTemporaryPath());
 
-    global_context->initializeTiFlashMetrics();
     KeyManagerPtr key_manager = std::make_shared<MockKeyManager>(false);
     global_context->initializeFileProvider(key_manager, false);
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/6827

Problem Summary:

### What is changed and how it works?

Add metrics to observe the time paid in MPMCQueue and UniThreadPool, and how full (saturation) they are.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below): WIP
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
