### PR TITLE
Fix exception thrown when reading from multiple partitions under S3 disagg

### DIFF
--- a/dbms/src/Common/FailPoint.cpp
+++ b/dbms/src/Common/FailPoint.cpp
@@ -70,7 +70,8 @@ namespace DB
     M(force_ps_wal_compact)                                       \
     M(pause_before_full_gc_prepare)                               \
     M(force_owner_mgr_state)                                      \
-    M(exception_during_spill)
+    M(exception_during_spill)                                     \
+    M(force_fail_to_create_etcd_session)
 
 #define APPLY_FOR_FAILPOINTS(M)                              \
     M(skip_check_segment_update)                             \

--- a/dbms/src/Server/StorageConfigParser.cpp
+++ b/dbms/src/Server/StorageConfigParser.cpp
@@ -585,7 +585,7 @@ void StorageS3Config::parse(const String & content)
 String StorageS3Config::toString() const
 {
     return fmt::format(
-        "StroageS3Config{{"
+        "StorageS3Config{{"
         "endpoint={} bucket={} root={} "
         "max_connections={} connection_timeout_ms={} "
         "request_timeout_ms={} access_key_id_size={} secret_access_key_size={}"

--- a/dbms/src/Storages/DeltaMerge/Remote/RNRemoteReadTask.cpp
+++ b/dbms/src/Storages/DeltaMerge/Remote/RNRemoteReadTask.cpp
@@ -52,30 +52,33 @@
 namespace DB::DM
 {
 
-RNRemoteReadTask::RNRemoteReadTask(std::vector<RNRemoteTableReadTaskPtr> && tasks_)
+RNRemoteReadTask::RNRemoteReadTask(std::vector<RNRemoteStoreReadTaskPtr> && input_tasks_)
     : num_segments(0)
     , log(Logger::get())
 {
-    for (const auto & table_task : tasks_)
+    for (const auto & store_task : input_tasks_)
     {
-        if (!table_task)
+        if (!store_task)
             continue;
-        auto res = tasks.emplace(table_task->storeID(), table_task);
-        RUNTIME_CHECK_MSG(res.second, "Duplicated task from store_id={}", table_task->storeID());
-        num_segments += table_task->size();
+        auto res = store_tasks.emplace(store_task->store_id, store_task);
+        RUNTIME_CHECK_MSG(res.second, "Duplicated task from store_id={}", store_task->store_id);
+        num_segments += store_task->numRemainTasks();
 
         // Push all inited tasks to ready queue
-        for (const auto & task : table_task->allTasks())
+        for (const auto & table_task : store_task->table_read_tasks)
         {
-            // TODO: If all pages are ready in local
-            // cache, and the segment does not contains any
-            // blocks on write node's mem-table, then we
-            // can simply skip the fetch page pharse and
-            // push it into ready queue
-            ready_segment_tasks[task->state].push_back(task);
+            for (const auto & seg_task : table_task->tasks)
+            {
+                // TODO: If all pages are ready in local
+                // cache, and the segment does not contains any
+                // blocks on write node's mem-table, then we
+                // can simply skip the fetch page pharse and
+                // push it into ready queue
+                ready_segment_tasks[seg_task->state].push_back(seg_task);
+            }
         }
     }
-    curr_store = tasks.begin();
+    curr_store = store_tasks.begin();
 }
 
 RNRemoteReadTask::~RNRemoteReadTask()
@@ -95,22 +98,22 @@ RNRemoteSegmentReadTaskPtr RNRemoteReadTask::nextFetchTask()
     std::lock_guard gurad(mtx_tasks);
     while (true)
     {
-        if (tasks.empty())
+        if (store_tasks.empty())
             return nullptr;
 
-        if (curr_store->second->size() > 0)
+        if (curr_store->second->numRemainTasks() > 0)
         {
             auto task = curr_store->second->nextTask();
             // Move to next store
             curr_store++;
-            if (curr_store == tasks.end())
-                curr_store = tasks.begin();
+            if (curr_store == store_tasks.end())
+                curr_store = store_tasks.begin();
             return task;
         }
         // No tasks left in this store, erase and try to pop task from the next store
-        curr_store = tasks.erase(curr_store);
-        if (curr_store == tasks.end())
-            curr_store = tasks.begin();
+        curr_store = store_tasks.erase(curr_store);
+        if (curr_store == store_tasks.end())
+            curr_store = store_tasks.begin();
     }
 }
 
@@ -300,7 +303,43 @@ bool RNRemoteReadTask::doneOrErrorHappen() const
     return false;
 }
 
-RNRemoteTableReadTaskPtr RNRemoteTableReadTask::buildFrom(
+/// RNRemoteStoreReadTask ///
+
+RNRemoteStoreReadTask::RNRemoteStoreReadTask(
+    StoreID store_id_,
+    std::vector<RNRemotePhysicalTableReadTaskPtr> table_read_tasks_)
+    : store_id(store_id_)
+    , table_read_tasks(std::move(table_read_tasks_))
+{
+    cur_table_task = table_read_tasks.begin();
+}
+
+size_t RNRemoteStoreReadTask::numRemainTasks() const
+{
+    std::lock_guard guard(mtx_tasks);
+    size_t num_segments = 0;
+    for (const auto & table_task : table_read_tasks)
+    {
+        num_segments += table_task->numRemainTasks();
+    }
+    return num_segments;
+}
+
+RNRemoteSegmentReadTaskPtr RNRemoteStoreReadTask::nextTask()
+{
+    std::lock_guard guard(mtx_tasks);
+    while (cur_table_task != table_read_tasks.end())
+    {
+        if (auto seg_task = (*cur_table_task)->nextTask(); seg_task != nullptr)
+            return seg_task;
+        ++cur_table_task;
+    }
+    return {};
+}
+
+/// RNRemotePhysicalTableReadTask ///
+
+RNRemotePhysicalTableReadTaskPtr RNRemotePhysicalTableReadTask::buildFrom(
     const Context & db_context,
     const StoreID store_id,
     const String & address,
@@ -310,7 +349,7 @@ RNRemoteTableReadTaskPtr RNRemoteTableReadTask::buildFrom(
 {
     // Deserialize from `DisaggregatedPhysicalTable`, this should also
     // ensure the local cache pages.
-    auto table_task = std::make_shared<RNRemoteTableReadTask>(
+    auto table_task = std::make_shared<RNRemotePhysicalTableReadTask>(
         store_id,
         KeyspaceTableID{remote_table.keyspace_id(), remote_table.table_id()},
         snapshot_id,
@@ -347,6 +386,16 @@ RNRemoteTableReadTaskPtr RNRemoteTableReadTask::buildFrom(
         table_task->tasks.push_back(f.get());
 
     return table_task;
+}
+
+RNRemoteSegmentReadTaskPtr RNRemotePhysicalTableReadTask::nextTask()
+{
+    std::lock_guard gurad(mtx_tasks);
+    if (tasks.empty())
+        return nullptr;
+    auto task = tasks.front();
+    tasks.pop_front();
+    return task;
 }
 
 /**

--- a/dbms/src/Storages/DeltaMerge/Remote/RNRemoteReadTask.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/RNRemoteReadTask.h
@@ -20,6 +20,7 @@
 #include <Storages/DeltaMerge/Remote/DisaggTaskId.h>
 #include <Storages/DeltaMerge/Remote/Proto/remote.pb.h>
 #include <Storages/DeltaMerge/Remote/RNLocalPageCache_fwd.h>
+#include <Storages/DeltaMerge/Remote/RNRemoteReadTask_fwd.h>
 #include <Storages/DeltaMerge/RowKeyRange.h>
 #include <Storages/DeltaMerge/SegmentReadTaskPool.h>
 #include <Storages/Page/PageDefinesBase.h>
@@ -39,15 +40,8 @@ namespace DM
 {
 namespace tests
 {
-class RemoteReadTaskTest;
+class RNRemoteReadTaskTest;
 }
-
-class RNRemoteReadTask;
-using RNRemoteReadTaskPtr = std::shared_ptr<RNRemoteReadTask>;
-class RNRemoteTableReadTask;
-using RNRemoteTableReadTaskPtr = std::shared_ptr<RNRemoteTableReadTask>;
-class RNRemoteSegmentReadTask;
-using RNRemoteSegmentReadTaskPtr = std::shared_ptr<RNRemoteSegmentReadTask>;
 
 enum class SegmentReadTaskState
 {
@@ -68,7 +62,7 @@ enum class SegmentReadTaskState
 class RNRemoteReadTask
 {
 public:
-    explicit RNRemoteReadTask(std::vector<RNRemoteTableReadTaskPtr> && tasks_);
+    explicit RNRemoteReadTask(std::vector<RNRemoteStoreReadTaskPtr> && input_tasks_);
 
     ~RNRemoteReadTask();
 
@@ -100,7 +94,7 @@ public:
 
     const String & getErrorMessage() const;
 
-    friend class tests::RemoteReadTaskTest;
+    friend class tests::RNRemoteReadTaskTest;
     friend struct DB::FetchPagesRequest;
 
 private:
@@ -115,8 +109,8 @@ private:
 
     // A task pool for fetching data from write nodes
     mutable std::mutex mtx_tasks;
-    std::unordered_map<UInt64, RNRemoteTableReadTaskPtr> tasks;
-    std::unordered_map<UInt64, RNRemoteTableReadTaskPtr>::iterator curr_store;
+    std::unordered_map<StoreID, RNRemoteStoreReadTaskPtr> store_tasks;
+    std::unordered_map<StoreID, RNRemoteStoreReadTaskPtr>::iterator curr_store;
 
     // A task pool for segment tasks
     // The tasks are sorted by the ready state of segment tasks
@@ -129,10 +123,29 @@ private:
 };
 
 // Represent a read tasks from one write node
-class RNRemoteTableReadTask
+class RNRemoteStoreReadTask
 {
 public:
-    RNRemoteTableReadTask(
+    RNRemoteStoreReadTask(
+        StoreID store_id_,
+        std::vector<RNRemotePhysicalTableReadTaskPtr> table_read_tasks_);
+
+    size_t numRemainTasks() const;
+    RNRemoteSegmentReadTaskPtr nextTask();
+
+    friend class RNRemoteReadTask;
+
+private:
+    const StoreID store_id;
+    mutable std::mutex mtx_tasks;
+    const std::vector<RNRemotePhysicalTableReadTaskPtr> table_read_tasks;
+    std::vector<RNRemotePhysicalTableReadTaskPtr>::const_iterator cur_table_task;
+};
+
+class RNRemotePhysicalTableReadTask
+{
+public:
+    RNRemotePhysicalTableReadTask(
         StoreID store_id_,
         KeyspaceTableID ks_table_id_,
         DisaggTaskId snap_id_,
@@ -143,11 +156,7 @@ public:
         , address(address_)
     {}
 
-    StoreID storeID() const { return store_id; }
-
-    KeyspaceTableID ksTableID() const { return ks_table_id; }
-
-    static RNRemoteTableReadTaskPtr buildFrom(
+    static RNRemotePhysicalTableReadTaskPtr buildFrom(
         const Context & db_context,
         StoreID store_id,
         const String & address,
@@ -155,28 +164,16 @@ public:
         const RemotePb::RemotePhysicalTable & table,
         const LoggerPtr & log);
 
-    size_t size() const
+    size_t numRemainTasks() const
     {
         std::lock_guard guard(mtx_tasks);
         return tasks.size();
     }
 
-    RNRemoteSegmentReadTaskPtr nextTask()
-    {
-        std::lock_guard gurad(mtx_tasks);
-        if (tasks.empty())
-            return nullptr;
-        auto task = tasks.front();
-        tasks.pop_front();
-        return task;
-    }
+    RNRemoteSegmentReadTaskPtr nextTask();
 
-    const std::list<RNRemoteSegmentReadTaskPtr> & allTasks() const
-    {
-        return tasks;
-    }
-
-    friend class tests::RemoteReadTaskTest;
+    friend class tests::RNRemoteReadTaskTest;
+    friend class RNRemoteReadTask;
 
 private:
     const StoreID store_id;
@@ -235,7 +232,7 @@ public:
 
     void prepare();
 
-    friend class tests::RemoteReadTaskTest;
+    friend class tests::RNRemoteReadTaskTest;
     friend struct DB::FetchPagesRequest;
     friend class RNRemoteReadTask;
 

--- a/dbms/src/Storages/DeltaMerge/Remote/RNRemoteReadTask_fwd.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/RNRemoteReadTask_fwd.h
@@ -1,0 +1,31 @@
+// Copyright 2023 PingCAP, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+
+namespace DB::DM
+{
+
+class RNRemoteReadTask;
+using RNRemoteReadTaskPtr = std::shared_ptr<RNRemoteReadTask>;
+class RNRemoteStoreReadTask;
+using RNRemoteStoreReadTaskPtr = std::shared_ptr<RNRemoteStoreReadTask>;
+class RNRemotePhysicalTableReadTask;
+using RNRemotePhysicalTableReadTaskPtr = std::shared_ptr<RNRemotePhysicalTableReadTask>;
+class RNRemoteSegmentReadTask;
+using RNRemoteSegmentReadTaskPtr = std::shared_ptr<RNRemoteSegmentReadTask>;
+
+} // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/Remote/tests/gtest_rn_remote_read_task.cpp
+++ b/dbms/src/Storages/DeltaMerge/Remote/tests/gtest_rn_remote_read_task.cpp
@@ -1,0 +1,234 @@
+// Copyright 2023 PingCAP, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Common/Logger.h>
+#include <Storages/DeltaMerge/Remote/Proto/remote.pb.h>
+#include <Storages/DeltaMerge/Remote/RNRemoteReadTask.h>
+#include <Storages/DeltaMerge/Remote/RNRemoteReadTask_fwd.h>
+#include <Storages/DeltaMerge/RowKeyRange.h>
+#include <Storages/Transaction/Types.h>
+#include <TestUtils/TiFlashTestBasic.h>
+#include <TestUtils/TiFlashTestEnv.h>
+#include <common/types.h>
+
+#include <magic_enum.hpp>
+#include <memory>
+
+namespace DB::DM::tests
+{
+using namespace DB::tests;
+
+class RNRemoteReadTaskTest : public ::testing::Test
+{
+public:
+    void SetUp() override
+    {
+        log = Logger::get();
+    }
+
+    RNRemotePhysicalTableReadTaskPtr buildTableTestTask(
+        StoreID store_id,
+        KeyspaceTableID ks_table_id,
+        const std::vector<UInt64> & seg_ids)
+    {
+        DisaggTaskId snapshot_id;
+        String address;
+        auto physical_table_task = std::make_shared<RNRemotePhysicalTableReadTask>(store_id, ks_table_id, snapshot_id, address);
+        for (const auto & seg_id : seg_ids)
+        {
+            auto seg_task = std::make_shared<RNRemoteSegmentReadTask>(snapshot_id, store_id, ks_table_id, seg_id, address, log);
+            physical_table_task->tasks.emplace_back(std::move(seg_task));
+        }
+        return physical_table_task;
+    }
+
+    RNRemoteReadTaskPtr buildTestTask()
+    {
+        std::vector<RNRemoteStoreReadTaskPtr> store_tasks{
+            std::make_shared<RNRemoteStoreReadTask>(
+                111,
+                std::vector<RNRemotePhysicalTableReadTaskPtr>{
+                    // partition 0
+                    buildTableTestTask(111, TEST_KS_TABLE_PART0_ID, {2, 5, 100}),
+                    // partition 1
+                    buildTableTestTask(111, TEST_KS_TABLE_PART1_ID, {1}),
+                }),
+            std::make_shared<RNRemoteStoreReadTask>(
+                222,
+                std::vector<RNRemotePhysicalTableReadTaskPtr>{
+                    // partition 0
+                    buildTableTestTask(222, TEST_KS_TABLE_PART0_ID, {202, 205, 300}),
+                }),
+            std::make_shared<RNRemoteStoreReadTask>(
+                333,
+                std::vector<RNRemotePhysicalTableReadTaskPtr>{
+                    // partition 0
+                    buildTableTestTask(333, TEST_KS_TABLE_PART0_ID, {400, 401, 402, 403}),
+                }),
+        };
+        return std::make_shared<RNRemoteReadTask>(std::move(store_tasks));
+    }
+
+protected:
+    static constexpr KeyspaceTableID TEST_KS_TABLE_PART0_ID = {NullspaceID, 100};
+    static constexpr KeyspaceTableID TEST_KS_TABLE_PART1_ID = {NullspaceID, 101};
+    LoggerPtr log;
+};
+
+TEST_F(RNRemoteReadTaskTest, popTasksWithoutPreparation)
+{
+    auto read_task = buildTestTask();
+    const auto num_segments = read_task->numSegments();
+    ASSERT_EQ(num_segments, 3 + 1 + 3 + 4);
+
+    for (size_t i = 0; i < num_segments; ++i)
+    {
+        auto seg_task = read_task->nextFetchTask();
+
+        read_task->updateTaskState(seg_task, SegmentReadTaskState::DataReady, false); // mock fetch done
+        auto ready_seg_task = read_task->nextReadyTask();
+        ASSERT_EQ(ready_seg_task->state, SegmentReadTaskState::DataReady) << magic_enum::enum_name(ready_seg_task->state);
+        ASSERT_EQ(seg_task->segment_id, ready_seg_task->segment_id);
+        ASSERT_EQ(seg_task->store_id, ready_seg_task->store_id);
+        ASSERT_EQ(seg_task->ks_table_id, ready_seg_task->ks_table_id);
+    }
+
+    ASSERT_EQ(read_task->nextFetchTask(), nullptr);
+    ASSERT_EQ(read_task->nextReadyTask(), nullptr);
+}
+
+TEST_F(RNRemoteReadTaskTest, popPrepareTasks)
+{
+    auto read_task = buildTestTask();
+    const auto num_segments = read_task->numSegments();
+    ASSERT_EQ(num_segments, 3 + 1 + 3 + 4);
+
+    for (size_t i = 0; i < num_segments; ++i)
+    {
+        auto seg_task = read_task->nextFetchTask();
+
+        read_task->updateTaskState(seg_task, SegmentReadTaskState::DataReady, false); // mock fetch done
+        auto prepare_seg_task = read_task->nextTaskForPrepare();
+        ASSERT_EQ(prepare_seg_task->state, SegmentReadTaskState::DataReadyAndPrepraring) << magic_enum::enum_name(prepare_seg_task->state);
+        ASSERT_EQ(seg_task->segment_id, prepare_seg_task->segment_id);
+        ASSERT_EQ(seg_task->store_id, prepare_seg_task->store_id);
+        ASSERT_EQ(seg_task->ks_table_id, prepare_seg_task->ks_table_id);
+        read_task->updateTaskState(prepare_seg_task, SegmentReadTaskState::DataReadyAndPrepared, false);
+    }
+
+    // there is no more task for prepare, return nullptr quickly
+    ASSERT_EQ(read_task->nextTaskForPrepare(), nullptr);
+    ASSERT_EQ(read_task->nextFetchTask(), nullptr);
+
+    for (size_t i = 0; i < num_segments; ++i)
+    {
+        auto ready_task = read_task->nextReadyTask();
+        ASSERT_EQ(ready_task->state, SegmentReadTaskState::DataReadyAndPrepared) << magic_enum::enum_name(ready_task->state);
+    }
+    ASSERT_EQ(read_task->nextReadyTask(), nullptr);
+}
+
+TEST_F(RNRemoteReadTaskTest, popTasksWithAllPrepared)
+{
+    auto read_task = buildTestTask();
+    const auto num_segments = read_task->numSegments();
+    ASSERT_EQ(num_segments, 3 + 1 + 3 + 4);
+
+    for (size_t i = 0; i < num_segments; ++i)
+    {
+        auto seg_task = read_task->nextFetchTask();
+        read_task->updateTaskState(seg_task, SegmentReadTaskState::DataReady, false); // mock fetch done
+        {
+            auto prepare_seg_task = read_task->nextTaskForPrepare();
+            ASSERT_EQ(prepare_seg_task->state, SegmentReadTaskState::DataReadyAndPrepraring) << magic_enum::enum_name(prepare_seg_task->state);
+            ASSERT_EQ(seg_task->segment_id, prepare_seg_task->segment_id);
+            ASSERT_EQ(seg_task->store_id, prepare_seg_task->store_id);
+            ASSERT_EQ(seg_task->ks_table_id, prepare_seg_task->ks_table_id);
+            read_task->updateTaskState(seg_task, SegmentReadTaskState::DataReadyAndPrepared, false); // mock prepare done
+        }
+        {
+            auto ready_seg_task = read_task->nextReadyTask();
+            ASSERT_EQ(ready_seg_task->state, SegmentReadTaskState::DataReadyAndPrepared) << magic_enum::enum_name(ready_seg_task->state);
+            ASSERT_EQ(seg_task->segment_id, ready_seg_task->segment_id);
+            ASSERT_EQ(seg_task->store_id, ready_seg_task->store_id);
+            ASSERT_EQ(seg_task->ks_table_id, ready_seg_task->ks_table_id);
+        }
+    }
+
+    ASSERT_EQ(read_task->nextFetchTask(), nullptr);
+    ASSERT_EQ(read_task->nextTaskForPrepare(), nullptr);
+    ASSERT_EQ(read_task->nextReadyTask(), nullptr);
+}
+
+TEST_F(RNRemoteReadTaskTest, popTasksWithSomePrepared)
+{
+    auto read_task = buildTestTask();
+    const auto num_segments = read_task->numSegments();
+    ASSERT_EQ(num_segments, 3 + 1 + 3 + 4);
+
+    for (size_t i = 0; i < num_segments; ++i)
+    {
+        auto seg_task = read_task->nextFetchTask();
+        read_task->updateTaskState(seg_task, SegmentReadTaskState::DataReady, false); // mock fetch done
+        bool do_prepare = i % 2 == 0;
+        if (do_prepare)
+        {
+            auto prepare_seg_task = read_task->nextTaskForPrepare();
+            ASSERT_EQ(prepare_seg_task->state, SegmentReadTaskState::DataReadyAndPrepraring) << magic_enum::enum_name(prepare_seg_task->state);
+            ASSERT_EQ(seg_task->segment_id, prepare_seg_task->segment_id);
+            ASSERT_EQ(seg_task->store_id, prepare_seg_task->store_id);
+            ASSERT_EQ(seg_task->ks_table_id, prepare_seg_task->ks_table_id);
+            read_task->updateTaskState(seg_task, SegmentReadTaskState::DataReadyAndPrepared, false); // mock prepare done
+        }
+        {
+            auto ready_seg_task = read_task->nextReadyTask();
+            ASSERT_EQ(ready_seg_task->state, do_prepare ? SegmentReadTaskState::DataReadyAndPrepared : SegmentReadTaskState::DataReady) << magic_enum::enum_name(ready_seg_task->state);
+            ASSERT_EQ(seg_task->segment_id, ready_seg_task->segment_id);
+            ASSERT_EQ(seg_task->store_id, ready_seg_task->store_id);
+            ASSERT_EQ(seg_task->ks_table_id, ready_seg_task->ks_table_id);
+        }
+    }
+
+    ASSERT_EQ(read_task->nextFetchTask(), nullptr);
+    ASSERT_EQ(read_task->nextTaskForPrepare(), nullptr);
+    ASSERT_EQ(read_task->nextReadyTask(), nullptr);
+}
+
+TEST_F(RNRemoteReadTaskTest, failTask)
+{
+    auto read_task = buildTestTask();
+    const auto num_segments = read_task->numSegments();
+    ASSERT_EQ(num_segments, 3 + 1 + 3 + 4);
+
+    assert(num_segments >= 4);
+    for (size_t i = 0; i < 3; ++i)
+    {
+        auto seg_task = read_task->nextFetchTask();
+        read_task->updateTaskState(seg_task, SegmentReadTaskState::DataReady, false);
+        auto ready_seg_task = read_task->nextReadyTask();
+        ASSERT_EQ(ready_seg_task->state, SegmentReadTaskState::DataReady) << magic_enum::enum_name(ready_seg_task->state);
+        ASSERT_EQ(seg_task->segment_id, ready_seg_task->segment_id);
+        ASSERT_EQ(seg_task->store_id, ready_seg_task->store_id);
+        ASSERT_EQ(seg_task->ks_table_id, ready_seg_task->ks_table_id);
+    }
+    // mock meet error for this segment task
+    auto seg_task = read_task->nextFetchTask();
+    read_task->updateTaskState(seg_task, SegmentReadTaskState::DataReady, /*meet_error*/ true);
+    // cancel all
+    ASSERT_EQ(read_task->nextReadyTask(), nullptr);
+    ASSERT_EQ(read_task->nextTaskForPrepare(), nullptr);
+}
+
+
+} // namespace DB::DM::tests

--- a/dbms/src/Storages/S3/S3Common.cpp
+++ b/dbms/src/Storages/S3/S3Common.cpp
@@ -60,6 +60,7 @@
 #include <filesystem>
 #include <fstream>
 #include <ios>
+#include <magic_enum.hpp>
 #include <memory>
 #include <mutex>
 #include <thread>
@@ -374,7 +375,7 @@ std::unique_ptr<Aws::S3::S3Client> ClientFactory::create(const StorageS3Config &
         if (!get_identity_outcome.IsSuccess())
         {
             const auto & error = get_identity_outcome.GetError();
-            LOG_WARNING(log, "get CallerIdentity failed, exception={} message={}", error.GetExceptionName(), error.GetMessage());
+            LOG_WARNING(log, "get CallerIdentity failed, exception={} message={} request_id={}", error.GetExceptionName(), error.GetMessage(), error.GetRequestId());
         }
         else
         {
@@ -431,7 +432,7 @@ bool objectExists(const TiFlashS3Client & client, const String & key)
     {
         return false;
     }
-    throw fromS3Error(outcome.GetError(), "S3 HeadObject failed, bucket={} root={} key={}", client.bucket(), client.root(), key);
+    throw fromS3Error(error, "S3 HeadObject failed, bucket={} root={} key={}", client.bucket(), client.root(), key);
 }
 
 static bool doUploadEmptyFile(const TiFlashS3Client & client, const String & key, const String & tagging, Int32 max_retry_times, Int32 current_retry)
@@ -454,7 +455,15 @@ static bool doUploadEmptyFile(const TiFlashS3Client & client, const String & key
         }
         else
         {
-            LOG_ERROR(client.log, "S3 PutEmptyObject failed, bucket={} root={} key={}", client.bucket(), client.root(), key);
+            const auto & e = result.GetError();
+            LOG_ERROR(
+                client.log,
+                "S3 PutEmptyObject failed: {}, request_id={} bucket={} root={} key={}",
+                e.GetMessage(),
+                e.GetRequestId(),
+                client.bucket(),
+                client.root(),
+                key);
             return false;
         }
     }
@@ -489,7 +498,16 @@ static bool doUploadFile(const TiFlashS3Client & client, const String & local_fn
         }
         else
         {
-            LOG_ERROR(client.log, "S3 PutObject failed: {}, local_fname={} bucket={} root={} key={}", result.GetError().GetMessage(), local_fname, client.bucket(), client.root(), remote_fname);
+            const auto & e = result.GetError();
+            LOG_ERROR(
+                client.log,
+                "S3 PutObject failed: {}, request_id={} local_fname={} bucket={} root={} key={}",
+                e.GetMessage(),
+                e.GetRequestId(),
+                local_fname,
+                client.bucket(),
+                client.root(),
+                remote_fname);
             return false;
         }
     }
@@ -810,7 +828,7 @@ ObjectInfo tryGetObjectInfo(
         {
             return ObjectInfo{.exist = false, .size = 0, .last_modification_time = {}};
         }
-        throw fromS3Error(o.GetError(), "Failed to check existence of object, bucket={} root={} key={}", client.bucket(), client.root(), key);
+        throw fromS3Error(o.GetError(), "S3 HeadObject failed, bucket={} root={} key={}", client.bucket(), client.root(), key);
     }
     // Else the object still exist
     const auto & res = o.GetResult();
@@ -826,7 +844,10 @@ void deleteObject(const TiFlashS3Client & client, const String & key)
     client.setBucketAndKeyWithRoot(req, key);
     ProfileEvents::increment(ProfileEvents::S3DeleteObject);
     auto o = client.DeleteObject(req);
-    RUNTIME_CHECK(o.IsSuccess(), o.GetError().GetMessage());
+    if (!o.IsSuccess())
+    {
+        throw fromS3Error(o.GetError(), "S3 DeleteObject failed, bucket={} root={} key={}", client.bucket(), client.root(), key);
+    }
     const auto & res = o.GetResult();
     UNUSED(res);
     GET_METRIC(tiflash_storage_s3_request_seconds, type_delete_object).Observe(sw.elapsedSeconds());

--- a/dbms/src/Storages/S3/S3Common.h
+++ b/dbms/src/Storages/S3/S3Common.h
@@ -44,7 +44,7 @@ Exception fromS3Error(const Aws::S3::S3Error & e, const std::string & fmt, Args 
 {
     return DB::Exception(
         ErrorCodes::S3_ERROR,
-        fmt + fmt::format(" s3error={} s3msg={}", magic_enum::enum_name(e.GetErrorType()), e.GetMessage()),
+        fmt + fmt::format(" s3error={} s3msg={} request_id={}", magic_enum::enum_name(e.GetErrorType()), e.GetMessage(), e.GetRequestId()),
         args...);
 }
 

--- a/dbms/src/Storages/S3/S3WritableFile.cpp
+++ b/dbms/src/Storages/S3/S3WritableFile.cpp
@@ -224,14 +224,15 @@ void S3WritableFile::completeMultipartUpload()
             const auto & e = outcome.GetError();
             LOG_INFO(
                 log,
-                "Multipart upload failed and need retry: bucket={} root={} key={} upload_id={} parts={} error={} message={}",
+                "Multipart upload failed and need retry: bucket={} root={} key={} upload_id={} parts={} error={} message={} request_id={}",
                 client_ptr->bucket(),
                 client_ptr->root(),
                 remote_fname,
                 multipart_upload_id,
                 part_tags.size(),
                 magic_enum::enum_name(e.GetErrorType()),
-                e.GetMessage());
+                e.GetMessage(),
+                e.GetRequestId());
         }
         else
         {
@@ -286,7 +287,15 @@ void S3WritableFile::processPutRequest(const PutObjectTask & task)
         if (i + 1 < max_retry)
         {
             const auto & e = outcome.GetError();
-            LOG_INFO(log, "Single part upload failed: bucket={} root={} key={} error={} message={}", client_ptr->bucket(), client_ptr->root(), remote_fname, magic_enum::enum_name(e.GetErrorType()), e.GetMessage());
+            LOG_INFO(
+                log,
+                "Single part upload failed: bucket={} root={} key={} error={} message={} request_id={}",
+                client_ptr->bucket(),
+                client_ptr->root(),
+                remote_fname,
+                magic_enum::enum_name(e.GetErrorType()),
+                e.GetMessage(),
+                e.GetRequestId());
         }
         else
         {

--- a/dbms/src/Storages/StorageDisaggregated.h
+++ b/dbms/src/Storages/StorageDisaggregated.h
@@ -20,6 +20,7 @@
 #include <Flash/Coprocessor/RemoteRequest.h>
 #include <Flash/Mpp/MPPTaskId.h>
 #include <Interpreters/Context_fwd.h>
+#include <Storages/DeltaMerge/Remote/RNRemoteReadTask_fwd.h>
 #include <Storages/IStorage.h>
 
 #pragma GCC diagnostic push
@@ -40,10 +41,6 @@ using ColumnDefines = std::vector<ColumnDefine>;
 using ColumnDefinesPtr = std::shared_ptr<ColumnDefines>;
 class RSOperator;
 using RSOperatorPtr = std::shared_ptr<RSOperator>;
-class RNRemoteReadTask;
-using RNRemoteReadTaskPtr = std::shared_ptr<RNRemoteReadTask>;
-class RNRemoteTableReadTask;
-using RNRemoteTableReadTaskPtr = std::shared_ptr<RNRemoteTableReadTask>;
 } // namespace DM
 
 using RequestAndRegionIDs = std::tuple<std::shared_ptr<::mpp::DispatchTaskRequest>, std::vector<::pingcap::kv::RegionVerID>, uint64_t>;
@@ -96,8 +93,8 @@ private:
     void buildDisaggTask(
         const Context & db_context,
         const pingcap::coprocessor::BatchCopTask & batch_cop_task,
-        std::vector<DM::RNRemoteTableReadTaskPtr> & build_results,
-        std::mutex & build_results_lock);
+        std::vector<DM::RNRemoteStoreReadTaskPtr> & store_read_tasks,
+        std::mutex & store_read_tasks_lock);
     std::shared_ptr<disaggregated::EstablishDisaggTaskRequest>
     buildDisaggTaskForNode(
         const Context & db_context,

--- a/dbms/src/Storages/StorageDisaggregatedRemote.cpp
+++ b/dbms/src/Storages/StorageDisaggregatedRemote.cpp
@@ -148,9 +148,9 @@ DM::RNRemoteReadTaskPtr StorageDisaggregated::buildDisaggTasks(
 {
     size_t tasks_n = batch_cop_tasks.size();
 
-    std::mutex build_results_lock;
-    std::vector<DM::RNRemoteTableReadTaskPtr> build_results;
-    build_results.reserve(tasks_n);
+    std::mutex store_read_tasks_lock;
+    std::vector<DM::RNRemoteStoreReadTaskPtr> store_read_tasks;
+    store_read_tasks.reserve(tasks_n);
 
     auto thread_manager = newThreadManager();
     const auto & executor_id = table_scan.getTableScanExecutorID();
@@ -162,22 +162,22 @@ DM::RNRemoteReadTaskPtr StorageDisaggregated::buildDisaggTasks(
             true,
             "BuildDisaggTask",
             [&] {
-                buildDisaggTask(db_context, cop_task, build_results, build_results_lock);
+                buildDisaggTask(db_context, cop_task, store_read_tasks, store_read_tasks_lock);
             });
     }
 
     // The first exception will be thrown out.
     thread_manager->wait();
 
-    return std::make_shared<DM::RNRemoteReadTask>(std::move(build_results));
+    return std::make_shared<DM::RNRemoteReadTask>(std::move(store_read_tasks));
 }
 
 /// Note: This function runs concurrently when there are multiple Write Nodes.
 void StorageDisaggregated::buildDisaggTask(
     const Context & db_context,
     const pingcap::coprocessor::BatchCopTask & batch_cop_task,
-    std::vector<DM::RNRemoteTableReadTaskPtr> & build_results,
-    std::mutex & build_results_lock)
+    std::vector<DM::RNRemoteStoreReadTaskPtr> & store_read_tasks,
+    std::mutex & store_read_tasks_lock)
 {
     Stopwatch watch;
 
@@ -287,7 +287,8 @@ void StorageDisaggregated::buildDisaggTask(
     }
 
     // Parse the resp and gen tasks on read node
-    // The number of tasks is equal to number of write nodes
+    std::vector<DM::RNRemotePhysicalTableReadTaskPtr> remote_seg_tasks;
+    remote_seg_tasks.reserve(resp->tables_size());
     for (const auto & physical_table : resp->tables())
     {
         DB::DM::RemotePb::RemotePhysicalTable table;
@@ -296,26 +297,25 @@ void StorageDisaggregated::buildDisaggTask(
 
         Stopwatch w_build_table_task;
 
-        const auto task = DM::RNRemoteTableReadTask::buildFrom(
+        const auto task = DM::RNRemotePhysicalTableReadTask::buildFrom(
             db_context,
             resp->store_id(),
             batch_cop_task.store_addr,
             snapshot_id,
             table,
             log);
-        {
-            std::unique_lock lock(build_results_lock);
-            build_results.push_back(task);
-        }
+        remote_seg_tasks.emplace_back(task);
 
         LOG_DEBUG(
             log,
-            "Build RNRemoteTableReadTask finished, elapsed={:.3f}s store={} addr={} segments={}",
+            "Build RNRemotePhysicalTableReadTask finished, elapsed={:.3f}s store={} addr={} segments={}",
             w_build_table_task.elapsedSeconds(),
             resp->store_id(),
             batch_cop_task.store_addr,
             table.segments().size());
     }
+    std::unique_lock lock(store_read_tasks_lock);
+    store_read_tasks.emplace_back(std::make_shared<DM::RNRemoteStoreReadTask>(resp->store_id(), remote_seg_tasks));
 
     GET_METRIC(tiflash_disaggregated_breakdown_duration_seconds, type_build_read_task).Observe(watch.elapsedSeconds());
 }

--- a/dbms/src/TiDB/Etcd/Client.cpp
+++ b/dbms/src/TiDB/Etcd/Client.cpp
@@ -165,7 +165,7 @@ SessionPtr Client::createSession(grpc::ClientContext * grpc_context, Int64 ttl)
     {
         return session;
     }
-    return nullptr;
+    return {};
 }
 
 grpc::Status Client::leaseRevoke(LeaseID lease_id)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/7187, ref https://github.com/pingcap/tiflash/issues/6827

Problem Summary:

<details>
    <summary> build a partition table and analyze it </summary>

```
# insert some rows to 
SET @@sql_mode = '';

CREATE TABLE employees  (
    id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
    fname VARCHAR(25) NOT NULL,
    lname VARCHAR(25) NOT NULL,
    store_id INT NOT NULL,
    department_id INT NOT NULL
)

PARTITION BY RANGE(id)  (
    PARTITION p0 VALUES LESS THAN (5),
    PARTITION p1 VALUES LESS THAN (10),
    PARTITION p2 VALUES LESS THAN (15),
    PARTITION p3 VALUES LESS THAN MAXVALUE
);

INSERT INTO employees VALUES
    ('', 'Bob', 'Taylor', 3, 2), ('', 'Frank', 'Williams', 1, 2),
    ('', 'Ellen', 'Johnson', 3, 4), ('', 'Jim', 'Smith', 2, 4),
    ('', 'Mary', 'Jones', 1, 1), ('', 'Linda', 'Black', 2, 3),
    ('', 'Ed', 'Jones', 2, 1), ('', 'June', 'Wilson', 3, 1),
    ('', 'Andy', 'Smith', 1, 3), ('', 'Lou', 'Waters', 2, 4),
    ('', 'Jill', 'Stone', 1, 4), ('', 'Roger', 'White', 3, 2),
    ('', 'Howard', 'Andrews', 1, 2), ('', 'Fred', 'Goldberg', 3, 3),
    ('', 'Barbara', 'Brown', 2, 3), ('', 'Alice', 'Rogers', 2, 2),
    ('', 'Mark', 'Morgan', 3, 3), ('', 'Karen', 'Cole', 3, 2);

analyze table employees;

explain select * from employees;
+---------------------+---------+--------------+-----------------+-------------------------------------------+
| id                  | estRows | task         | access object   | operator info                             |
+---------------------+---------+--------------+-----------------+-------------------------------------------+
| TableReader_10      | 18.00   | root         | partition:all   | MppVersion: 1, data:ExchangeSender_9      |
| └─ExchangeSender_9  | 18.00   | mpp[tiflash] |                 | ExchangeType: PassThrough                 |
|   └─TableFullScan_8 | 18.00   | mpp[tiflash] | table:employees | keep order:false, PartitionTableScan:true |
+---------------------+---------+--------------+-----------------+-------------------------------------------+
```

</details>

* When reading rows from multiple partitions, and [`dynamic puring`](https://docs.pingcap.com/tidb/dev/partitioned-table#dynamic-pruning-mode) is enabled, building disagg tasks with throw error like `DB::Exception: Check res.second failed: Duplicated task from store_id=xxx`
* Lack of `request_id` for locating the problem of S3

### What is changed and how it works?

* Add a new class `RNRemoteStoreReadTask` to represent the store layer read tasks
* Add request_id to the error message generated from S3
* Fix a crash issue when create etcd session failed

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code


Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
