### PR TITLE
Propogate disagg fetch page errors

### DIFF
--- a/dbms/src/Flash/Disaggregated/RNPagePreparer.h
+++ b/dbms/src/Flash/Disaggregated/RNPagePreparer.h
@@ -65,7 +65,6 @@ private:
     std::mutex mu;
     Int32 live_persisters;
     PageReceiverState state;
-    String err_msg;
 
     std::atomic<size_t> total_rows;
     std::atomic<size_t> total_pages;

--- a/dbms/src/Storages/DeltaMerge/Remote/RNRemoteReadTask.cpp
+++ b/dbms/src/Storages/DeltaMerge/Remote/RNRemoteReadTask.cpp
@@ -149,14 +149,20 @@ void RNRemoteReadTask::updateTaskState(const RNRemoteSegmentReadTaskPtr & seg_ta
     cv_ready_tasks.notify_one();
 }
 
-void RNRemoteReadTask::allDataReceive(const String & end_err_msg)
+void RNRemoteReadTask::setError(const String & msg)
+{
+    if (msg.empty())
+        return;
+    std::unique_lock ready_lock(mtx_ready_tasks);
+    if (!err_msg.empty())
+        return;
+    err_msg = msg;
+}
+
+void RNRemoteReadTask::allDataReceive()
 {
     {
         std::unique_lock ready_lock(mtx_ready_tasks);
-        // set up the error message
-        if (err_msg.empty() && !end_err_msg.empty())
-            err_msg = end_err_msg;
-
         for (auto iter = ready_segment_tasks.begin(); iter != ready_segment_tasks.end(); /* empty */)
         {
             const auto state = iter->first;

--- a/dbms/src/Storages/DeltaMerge/Remote/RNRemoteReadTask.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/RNRemoteReadTask.h
@@ -87,7 +87,9 @@ public:
         SegmentReadTaskState target_state,
         bool meet_error);
 
-    void allDataReceive(const String & end_err_msg);
+    void allDataReceive();
+
+    void setError(const String & msg);
 
     // Return a segment read task that is ready for some preparation
     // to speed up later reading

--- a/dbms/src/Storages/DeltaMerge/Remote/RNRemoteSegmentThreadInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/Remote/RNRemoteSegmentThreadInputStream.cpp
@@ -116,14 +116,17 @@ Block RNRemoteSegmentThreadInputStream::readImpl(FilterPtr & res_filter, bool re
             cur_read_task = read_tasks->nextReadyTask();
             seconds_next_task += watch.elapsedSeconds();
             watch.restart();
+
+            if (!read_tasks->getErrorMessage().empty())
+            {
+                done = true;
+                throw Exception(read_tasks->getErrorMessage(), ErrorCodes::LOGICAL_ERROR);
+            }
             if (!cur_read_task)
             {
                 // There is no task left or error happen
                 done = true;
-                if (!read_tasks->getErrorMessage().empty())
-                {
-                    throw Exception(read_tasks->getErrorMessage(), ErrorCodes::LOGICAL_ERROR);
-                }
+
                 LOG_DEBUG(log, "Read from remote segment done");
                 return {};
             }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/6827

Problem Summary:

### What is changed and how it works?

When there are errors the channel may close beforehand, thus losing errors.

This is a small hack that will record error in time.

I will soon refactor the PagePrepare / PageReceive part and this hack will improved.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
