### PR TITLE
Compatible new field in write/lock cf with TiKV

### DIFF
--- a/dbms/src/Storages/Transaction/RegionCFDataBase.cpp
+++ b/dbms/src/Storages/Transaction/RegionCFDataBase.cpp
@@ -16,6 +16,7 @@
 #include <Storages/Transaction/RegionCFDataTrait.h>
 #include <Storages/Transaction/RegionData.h>
 #include <Storages/Transaction/RegionRangeKeys.h>
+#include "Storages/Transaction/TiKVRecordFormat.h"
 
 namespace DB
 {
@@ -355,7 +356,7 @@ inline void decodeLockCfValue(DecodedLockCFValue & res)
                 UNUSED(versions_to_last_change);
                 break;
             }
-            case TXN_SOURCE_PREFIX:
+            case TXN_SOURCE_PREFIX_FOR_LOCK:
             {
                 // Used for CDC, useless for TiFlash.
                 UInt64 txn_source_prefic = readUInt64(data, len);

--- a/dbms/src/Storages/Transaction/RegionCFDataBase.cpp
+++ b/dbms/src/Storages/Transaction/RegionCFDataBase.cpp
@@ -17,8 +17,6 @@
 #include <Storages/Transaction/RegionData.h>
 #include <Storages/Transaction/RegionRangeKeys.h>
 
-#include "Storages/Transaction/TiKVRecordFormat.h"
-
 namespace DB
 {
 using CFModifyFlag = RecordKVFormat::CFModifyFlag;

--- a/dbms/src/Storages/Transaction/RegionCFDataBase.cpp
+++ b/dbms/src/Storages/Transaction/RegionCFDataBase.cpp
@@ -17,6 +17,8 @@
 #include <Storages/Transaction/RegionData.h>
 #include <Storages/Transaction/RegionRangeKeys.h>
 
+#include "Storages/Transaction/TiKVRecordFormat.h"
+
 namespace DB
 {
 using CFModifyFlag = RecordKVFormat::CFModifyFlag;
@@ -353,6 +355,13 @@ inline void decodeLockCfValue(DecodedLockCFValue & res)
                 UInt64 versions_to_last_change = readVarUInt(data, len);
                 UNUSED(last_change_ts);
                 UNUSED(versions_to_last_change);
+                break;
+            }
+            case TXN_SOURCE_PREFIX:
+            {
+                // Used for CDC, useless for TiFlash.
+                UInt64 txn_source_prefic = readUInt64(data, len);
+                UNUSED(txn_source_prefic);
                 break;
             }
             default:

--- a/dbms/src/Storages/Transaction/RegionCFDataBase.cpp
+++ b/dbms/src/Storages/Transaction/RegionCFDataBase.cpp
@@ -359,7 +359,7 @@ inline void decodeLockCfValue(DecodedLockCFValue & res)
             case TXN_SOURCE_PREFIX_FOR_LOCK:
             {
                 // Used for CDC, useless for TiFlash.
-                UInt64 txn_source_prefic = readUInt64(data, len);
+                UInt64 txn_source_prefic = readVarUInt(data, len);
                 UNUSED(txn_source_prefic);
                 break;
             }

--- a/dbms/src/Storages/Transaction/RegionCFDataBase.cpp
+++ b/dbms/src/Storages/Transaction/RegionCFDataBase.cpp
@@ -16,7 +16,6 @@
 #include <Storages/Transaction/RegionCFDataTrait.h>
 #include <Storages/Transaction/RegionData.h>
 #include <Storages/Transaction/RegionRangeKeys.h>
-#include "Storages/Transaction/TiKVRecordFormat.h"
 
 namespace DB
 {

--- a/dbms/src/Storages/Transaction/TiKVRecordFormat.h
+++ b/dbms/src/Storages/Transaction/TiKVRecordFormat.h
@@ -66,7 +66,8 @@ static const char ROLLBACK_TS_PREFIX = 'r';
 static const char FLAG_OVERLAPPED_ROLLBACK = 'R';
 static const char GC_FENCE_PREFIX = 'F';
 static const char LAST_CHANGE_PREFIX = 'l';
-static const char TXN_SOURCE_PREFIX = 'S';
+static const char TXN_SOURCE_PREFIX_FOR_WRITE = 'S';
+static const char TXN_SOURCE_PREFIX_FOR_LOCK = 's';
 
 static const size_t SHORT_VALUE_MAX_LEN = 64;
 
@@ -437,7 +438,7 @@ inline DecodedWriteCFValue decodeWriteCfValue(const TiKVValue & value)
             UNUSED(versions_to_last_change);
             break;
         }
-        case RecordKVFormat::TXN_SOURCE_PREFIX:
+        case RecordKVFormat::TXN_SOURCE_PREFIX_FOR_WRITE:
         {
             // Used for CDC, useless for TiFlash.
             UInt64 txn_source_prefic = readUInt64(data, len);

--- a/dbms/src/Storages/Transaction/TiKVRecordFormat.h
+++ b/dbms/src/Storages/Transaction/TiKVRecordFormat.h
@@ -66,6 +66,7 @@ static const char ROLLBACK_TS_PREFIX = 'r';
 static const char FLAG_OVERLAPPED_ROLLBACK = 'R';
 static const char GC_FENCE_PREFIX = 'F';
 static const char LAST_CHANGE_PREFIX = 'l';
+static const char TXN_SOURCE_PREFIX = 'S';
 
 static const size_t SHORT_VALUE_MAX_LEN = 64;
 
@@ -427,6 +428,22 @@ inline DecodedWriteCFValue decodeWriteCfValue(const TiKVValue & value)
                  * rewriting record and there must be a complete row written to tikv, just ignore it in tiflash.
                  */
             return std::nullopt;
+        case RecordKVFormat::LAST_CHANGE_PREFIX:
+        {
+            // Used to accelerate TiKV MVCC scan, useless for TiFlash.
+            UInt64 last_change_ts = readUInt64(data, len);
+            UInt64 versions_to_last_change = readVarUInt(data, len);
+            UNUSED(last_change_ts);
+            UNUSED(versions_to_last_change);
+            break;
+        }
+        case RecordKVFormat::TXN_SOURCE_PREFIX:
+        {
+            // Used for CDC, useless for TiFlash.
+            UInt64 txn_source_prefic = readUInt64(data, len);
+            UNUSED(txn_source_prefic);
+            break;
+        }
         default:
             throw Exception("invalid flag " + std::to_string(flag) + " in write cf", ErrorCodes::LOGICAL_ERROR);
         }

--- a/dbms/src/Storages/Transaction/TiKVRecordFormat.h
+++ b/dbms/src/Storages/Transaction/TiKVRecordFormat.h
@@ -441,7 +441,7 @@ inline DecodedWriteCFValue decodeWriteCfValue(const TiKVValue & value)
         case RecordKVFormat::TXN_SOURCE_PREFIX_FOR_WRITE:
         {
             // Used for CDC, useless for TiFlash.
-            UInt64 txn_source_prefic = readUInt64(data, len);
+            UInt64 txn_source_prefic = readVarUInt(data, len);
             UNUSED(txn_source_prefic);
             break;
         }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #7212

Problem Summary:

Compatible new field(TXN_SOURCE_PREFIX,LAST_CHANGE_PREFIX)  in write/lock cf with TiKV.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
