### PR TITLE
fix potential deadlock in `CreatingSetBlockInputStream`

### DIFF
--- a/dbms/src/DataStreams/CreatingSetsBlockInputStream.cpp
+++ b/dbms/src/DataStreams/CreatingSetsBlockInputStream.cpp
@@ -270,12 +270,18 @@ void CreatingSetsBlockInputStream::createOne(SubqueryForSet & subquery)
     }
     catch (...)
     {
-        std::unique_lock lock(exception_mutex);
-        exception_from_workers.push_back(std::current_exception());
+        {
+            std::unique_lock lock(exception_mutex);
+            exception_from_workers.push_back(std::current_exception());
+        }
         auto error_message = getCurrentExceptionMessage(false, true);
         if (subquery.join)
             subquery.join->meetError(error_message);
         LOG_ERROR(log, "{} throw exception: {} In {} sec. ", gen_log_msg(), error_message, watch.elapsedSeconds());
+        /// createOne is concurrently running in multiple threads, call cancel here to stop other threads
+        /// need to use cancel(true) here because the other threads may be blocked in `ExchangeReceiver::nextResult`,
+        /// cancel(true) will wake up these threads
+        cancel(true);
     }
 }
 

--- a/dbms/src/DataStreams/ParallelAggregatingBlockInputStream.cpp
+++ b/dbms/src/DataStreams/ParallelAggregatingBlockInputStream.cpp
@@ -112,6 +112,7 @@ Block ParallelAggregatingBlockInputStream::readImpl()
                 */
 
             aggregator.finishSpill();
+            LOG_INFO(log, "Begin restore data from disk for aggregation.");
             BlockInputStreams input_streams = aggregator.restoreSpilledData();
             impl = std::make_unique<MergingAggregatedMemoryEfficientBlockInputStream>(
                 input_streams,

--- a/dbms/src/Flash/Executor/PipelineExecutor.cpp
+++ b/dbms/src/Flash/Executor/PipelineExecutor.cpp
@@ -49,8 +49,8 @@ void PipelineExecutor::wait()
 {
     if (unlikely(context.isTest()))
     {
-        // In test mode, a single query should take no more than 15 seconds to execute.
-        static std::chrono::seconds timeout(15);
+        // In test mode, a single query should take no more than 5 minutes to execute.
+        static std::chrono::minutes timeout(5);
         status.waitFor(timeout);
     }
     else
@@ -64,8 +64,8 @@ void PipelineExecutor::consume(const ResultQueuePtr & result_queue, ResultHandle
     Block ret;
     if (unlikely(context.isTest()))
     {
-        // In test mode, a single query should take no more than 15 seconds to execute.
-        static std::chrono::seconds timeout(15);
+        // In test mode, a single query should take no more than 5 minutes to execute.
+        static std::chrono::minutes timeout(5);
         while (result_queue->popTimeout(ret, timeout) == MPMCQueueResult::OK)
             result_handler(ret);
     }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #7221

Problem Summary:

### What is changed and how it works?
Cancel current running when one of the hash build meet error
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
   Add random failpoint tests
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
