### PR TITLE
Make poco client can detect stream end correctly

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -94,7 +94,7 @@
 	url = https://github.com/guanzhi/GmSSL.git
 [submodule "contrib/aws"]
 	path = contrib/aws
-	url = https://github.com/aws/aws-sdk-cpp.git
+	url = https://github.com/JaySon-Huang/aws-sdk-cpp.git
 [submodule "contrib/aws-c-auth"]
 	path = contrib/aws-c-auth
 	url = https://github.com/awslabs/aws-c-auth.git

--- a/dbms/src/Server/StorageConfigParser.h
+++ b/dbms/src/Server/StorageConfigParser.h
@@ -106,7 +106,7 @@ struct StorageS3Config
     String secret_access_key;
     UInt64 max_connections = 4096;
     UInt64 connection_timeout_ms = 1000;
-    UInt64 request_timeout_ms = 7000;
+    UInt64 request_timeout_ms = 30000;
     UInt64 max_redirections = 10;
     String root;
 

--- a/dbms/src/Storages/DeltaMerge/File/DMFileWriter.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileWriter.cpp
@@ -15,6 +15,7 @@
 #include <Common/TiFlashException.h>
 #include <Storages/DeltaMerge/DeltaMergeHelpers.h>
 #include <Storages/DeltaMerge/File/DMFileWriter.h>
+#include <Storages/S3/S3Common.h>
 
 #ifndef NDEBUG
 #include <sys/stat.h>

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_file.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_file.cpp
@@ -28,6 +28,7 @@
 #include <Storages/DeltaMerge/tests/DMTestEnv.h>
 #include <Storages/FormatVersion.h>
 #include <Storages/PathPool.h>
+#include <Storages/S3/S3Common.h>
 #include <TestUtils/FunctionTestUtils.h>
 #include <TestUtils/InputStreamTestUtils.h>
 #include <TestUtils/TiFlashStorageTestBasic.h>

--- a/dbms/src/Storages/Page/V3/Universal/tests/gtest_lock_local_mgr.cpp
+++ b/dbms/src/Storages/Page/V3/Universal/tests/gtest_lock_local_mgr.cpp
@@ -21,9 +21,7 @@
 #include <Storages/S3/S3Common.h>
 #include <Storages/S3/S3Filename.h>
 #include <TestUtils/TiFlashTestBasic.h>
-#include <aws/s3/S3Client.h>
-#include <aws/s3/model/CreateBucketRequest.h>
-#include <aws/s3/model/DeleteBucketRequest.h>
+#include <TestUtils/TiFlashTestEnv.h>
 #include <common/logger_useful.h>
 #include <gtest/gtest.h>
 
@@ -45,6 +43,7 @@ public:
 
     void SetUp() override
     {
+        ::DB::tests::TiFlashTestEnv::deleteBucket(*s3_client);
         ::DB::tests::TiFlashTestEnv::createBucketIfNotExist(*s3_client);
     }
 

--- a/dbms/src/Storages/Page/V3/Universal/tests/gtest_lock_local_mgr.cpp
+++ b/dbms/src/Storages/Page/V3/Universal/tests/gtest_lock_local_mgr.cpp
@@ -47,11 +47,6 @@ public:
         ::DB::tests::TiFlashTestEnv::createBucketIfNotExist(*s3_client);
     }
 
-    void TearDown() override
-    {
-        ::DB::tests::TiFlashTestEnv::deleteBucket(*s3_client);
-    }
-
 protected:
     std::shared_ptr<S3::TiFlashS3Client> s3_client;
     LoggerPtr log;

--- a/dbms/src/Storages/S3/MockS3Client.cpp
+++ b/dbms/src/Storages/S3/MockS3Client.cpp
@@ -86,7 +86,10 @@ Model::GetObjectOutcome MockS3Client::GetObject(const Model::GetObjectRequest & 
         boost::algorithm::split(v, request.GetRange().substr(prefix.size()), boost::algorithm::is_any_of("-"));
         RUNTIME_CHECK(v.size() == 2, request.GetRange());
         left = std::stoul(v[0]);
-        right = std::stoul(v[1]);
+        if (!v[1].empty())
+        {
+            right = std::stoul(v[1]);
+        }
     }
     auto size = right - left + 1;
     Model::GetObjectResult result;

--- a/dbms/src/Storages/S3/MockS3Client.cpp
+++ b/dbms/src/Storages/S3/MockS3Client.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <Common/Exception.h>
-#include <Common/FailPoint.h>
 #include <Common/Logger.h>
 #include <Common/StringUtils/StringUtils.h>
 #include <Storages/S3/MockS3Client.h>
@@ -53,10 +52,6 @@
 #include <mutex>
 #include <string_view>
 
-namespace DB::FailPoints
-{
-extern const char force_set_mocked_s3_object_mtime[];
-} // namespace DB::FailPoints
 namespace DB::S3::tests
 {
 using namespace Aws::S3;
@@ -253,24 +248,6 @@ Model::HeadObjectOutcome MockS3Client::HeadObject(const Model::HeadObjectRequest
     if (itr_obj != bucket_storage.end())
     {
         auto r = Model::HeadObjectResult{};
-        auto try_set_mtime = [&] {
-            if (auto v = FailPointHelper::getFailPointVal(FailPoints::force_set_mocked_s3_object_mtime); v)
-            {
-                auto m = std::any_cast<std::map<String, Aws::Utils::DateTime>>(v.value());
-                const auto req_key = normalizedKey(request.GetKey());
-                if (auto iter_m = m.find(req_key); iter_m != m.end())
-                {
-                    r.SetLastModified(iter_m->second);
-                    LOG_WARNING(Logger::get(), "failpoint set mtime, key={} mtime={}", req_key, iter_m->second.ToGmtString(Aws::Utils::DateFormat::ISO_8601));
-                }
-                else
-                {
-                    LOG_WARNING(Logger::get(), "failpoint set mtime failed, key={}", req_key);
-                }
-            }
-        };
-        UNUSED(try_set_mtime);
-        fiu_do_on(FailPoints::force_set_mocked_s3_object_mtime, { try_set_mtime(); });
         r.SetContentLength(itr_obj->second.size());
         return r;
     }

--- a/dbms/src/Storages/S3/PocoHTTPClient.cpp
+++ b/dbms/src/Storages/S3/PocoHTTPClient.cpp
@@ -77,8 +77,8 @@ namespace DB::S3
 {
 
 PocoHTTPClientConfiguration::PocoHTTPClientConfiguration(
-    const RemoteHostFilter & remote_host_filter_,
-    unsigned int s3_max_redirects_,
+    const std::shared_ptr<RemoteHostFilter> & remote_host_filter_,
+    UInt32 s3_max_redirects_,
     bool enable_s3_requests_logging_)
     : remote_host_filter(remote_host_filter_)
     , s3_max_redirects(s3_max_redirects_)
@@ -317,7 +317,7 @@ void PocoHTTPClient::makeRequestInternal(
             if (poco_response.getStatus() == Poco::Net::HTTPResponse::HTTP_TEMPORARY_REDIRECT)
             {
                 auto location = poco_response.get("location");
-                remote_host_filter.checkURL(Poco::URI(location));
+                remote_host_filter->checkURL(Poco::URI(location));
                 uri = location;
                 if (enable_s3_requests_logging)
                     LOG_DEBUG(log, "Redirecting request to new location: {}", location);

--- a/dbms/src/Storages/S3/PocoHTTPClient.h
+++ b/dbms/src/Storages/S3/PocoHTTPClient.h
@@ -55,16 +55,16 @@ struct PocoHTTPClientConfiguration
     std::function<ClientConfigurationPerRequest(const Aws::Http::HttpRequest &)> per_request_configuration = [](const Aws::Http::HttpRequest &) {
         return ClientConfigurationPerRequest();
     };
-    const RemoteHostFilter & remote_host_filter;
-    unsigned int s3_max_redirects;
+    std::shared_ptr<RemoteHostFilter> remote_host_filter;
+    UInt32 s3_max_redirects;
     bool enable_s3_requests_logging;
     HTTPHeaderEntries extra_headers;
 
     std::function<void(const ClientConfigurationPerRequest &)> error_report;
 
     PocoHTTPClientConfiguration(
-        const RemoteHostFilter & remote_host_filter_,
-        unsigned int s3_max_redirects_,
+        const std::shared_ptr<RemoteHostFilter> & remote_host_filter_,
+        UInt32 s3_max_redirects_,
         bool enable_s3_requests_logging_);
 
     /// Constructor of Aws::Client::ClientConfiguration must be called after AWS SDK initialization.
@@ -154,7 +154,7 @@ private:
     std::function<ClientConfigurationPerRequest(const Aws::Http::HttpRequest &)> per_request_configuration;
     std::function<void(const ClientConfigurationPerRequest &)> error_report;
     ConnectionTimeouts timeouts;
-    const RemoteHostFilter & remote_host_filter;
+    const std::shared_ptr<RemoteHostFilter> remote_host_filter;
     const HTTPHeaderEntries extra_headers;
     UInt32 s3_max_redirects;
     bool enable_s3_requests_logging;

--- a/dbms/src/Storages/S3/PocoHTTPClientFactory.cpp
+++ b/dbms/src/Storages/S3/PocoHTTPClientFactory.cpp
@@ -23,7 +23,7 @@
 
 namespace DB::S3
 {
-PocoHTTPClientFactory::PocoHTTPClientFactory(PocoHTTPClientConfiguration & http_cfg)
+PocoHTTPClientFactory::PocoHTTPClientFactory(const PocoHTTPClientConfiguration & http_cfg)
     : poco_cfg(http_cfg)
 {
 }

--- a/dbms/src/Storages/S3/PocoHTTPClientFactory.h
+++ b/dbms/src/Storages/S3/PocoHTTPClientFactory.h
@@ -28,7 +28,7 @@ namespace DB::S3
 class PocoHTTPClientFactory : public Aws::Http::HttpClientFactory
 {
 public:
-    explicit PocoHTTPClientFactory(PocoHTTPClientConfiguration & http_cfg);
+    explicit PocoHTTPClientFactory(const PocoHTTPClientConfiguration & http_cfg);
 
     ~PocoHTTPClientFactory() override = default;
     [[nodiscard]] std::shared_ptr<Aws::Http::HttpClient>

--- a/dbms/src/Storages/S3/S3Common.cpp
+++ b/dbms/src/Storages/S3/S3Common.cpp
@@ -282,7 +282,10 @@ void ClientFactory::init(const StorageS3Config & config_, bool mock_s3_)
     // Override the HTTP client, use PocoHTTPClient instead
     aws_options.httpOptions.httpClientFactory_create_fn = [&config_] {
         // TODO: do we need the remote host filter?
-        PocoHTTPClientConfiguration poco_cfg(RemoteHostFilter(), config_.max_redirections, /*enable_s3_requests_logging_*/ config_.verbose);
+        PocoHTTPClientConfiguration poco_cfg(
+            std::make_shared<RemoteHostFilter>(),
+            config_.max_redirections,
+            /*enable_s3_requests_logging_*/ config_.verbose);
         return std::make_shared<PocoHTTPClientFactory>(poco_cfg);
     };
     Aws::InitAPI(aws_options);

--- a/dbms/src/Storages/S3/S3Common.cpp
+++ b/dbms/src/Storages/S3/S3Common.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <Common/Exception.h>
+#include <Common/FailPoint.h>
 #include <Common/Logger.h>
 #include <Common/ProfileEvents.h>
 #include <Common/RemoteHostFilter.h>
@@ -64,6 +65,7 @@
 #include <pingcap/kv/internal/type_traits.h>
 #include <re2/re2.h>
 
+#include <any>
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <filesystem>
@@ -153,6 +155,10 @@ namespace pingcap::kv
 PINGCAP_DEFINE_TRAITS(disaggregated, GetDisaggConfig, GetDisaggConfig);
 }
 
+namespace DB::FailPoints
+{
+extern const char force_set_mocked_s3_object_mtime[];
+} // namespace DB::FailPoints
 namespace DB::S3
 {
 
@@ -886,7 +892,30 @@ ObjectInfo tryGetObjectInfo(
         throw fromS3Error(o.GetError(), "S3 HeadObject failed, bucket={} root={} key={}", client.bucket(), client.root(), key);
     }
     // Else the object still exist
+#ifndef FIU_ENABLE
     const auto & res = o.GetResult();
+#else
+    // handle the failpoint for hijacking the last modified time of returned object
+    auto & res = o.GetResult();
+    auto try_set_mtime = [&] {
+        if (auto v = FailPointHelper::getFailPointVal(FailPoints::force_set_mocked_s3_object_mtime); v)
+        {
+            auto m = std::any_cast<std::map<String, Aws::Utils::DateTime>>(v.value());
+            const auto & req_key = key;
+            if (auto iter_m = m.find(req_key); iter_m != m.end())
+            {
+                res.SetLastModified(iter_m->second);
+                LOG_WARNING(Logger::get(), "failpoint set mtime, key={} mtime={}", req_key, iter_m->second.ToGmtString(Aws::Utils::DateFormat::ISO_8601));
+            }
+            else
+            {
+                LOG_WARNING(Logger::get(), "failpoint set mtime failed, key={}", req_key);
+            }
+        }
+    };
+    UNUSED(try_set_mtime);
+    fiu_do_on(FailPoints::force_set_mocked_s3_object_mtime, { try_set_mtime(); });
+#endif
     // "DeleteMark" of S3 service, don't know what will lead to this
     RUNTIME_CHECK(!res.GetDeleteMarker(), client.bucket(), key);
     return ObjectInfo{.exist = true, .size = res.GetContentLength(), .last_modification_time = res.GetLastModified()};
@@ -952,6 +981,22 @@ void rawListPrefix(
         }
     }
     LOG_DEBUG(log, "rawListPrefix bucket={} prefix={} delimiter={} total_keys={} cost={:.2f}s", bucket, prefix, delimiter, num_keys, sw.elapsedSeconds());
+}
+
+void rawDeleteObject(const Aws::S3::S3Client & client, const String & bucket, const String & key)
+{
+    Stopwatch sw;
+    Aws::S3::Model::DeleteObjectRequest req;
+    req.WithBucket(bucket).WithKey(key);
+    ProfileEvents::increment(ProfileEvents::S3DeleteObject);
+    auto o = client.DeleteObject(req);
+    if (!o.IsSuccess())
+    {
+        throw fromS3Error(o.GetError(), "S3 DeleteObject failed, bucket={} key={}", bucket, key);
+    }
+    const auto & res = o.GetResult();
+    UNUSED(res);
+    GET_METRIC(tiflash_storage_s3_request_seconds, type_delete_object).Observe(sw.elapsedSeconds());
 }
 
 } // namespace DB::S3

--- a/dbms/src/Storages/S3/S3Common.h
+++ b/dbms/src/Storages/S3/S3Common.h
@@ -210,6 +210,10 @@ void rawListPrefix(
     std::string_view delimiter,
     std::function<PageResult(const Aws::S3::Model::ListObjectsV2Result & result)> pager);
 
+// Unlike `deleteObject` or other method above, this does not handle
+// the TiFlashS3Client `root`.
+void rawDeleteObject(const Aws::S3::S3Client & client, const String & bucket, const String & key);
+
 template <typename F, typename... T>
 void retryWrapper(F f, const T &... args)
 {

--- a/dbms/src/Storages/S3/S3RandomAccessFile.cpp
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.cpp
@@ -66,7 +66,6 @@ ssize_t S3RandomAccessFile::read(char * buf, size_t size)
         LOG_ERROR(log, "Cannot read from istream. bucket={} root={} key={} errmsg={}", client_ptr->bucket(), client_ptr->root(), remote_fname, strerror(errno));
         return -1;
     }
-    LOG_DEBUG(log, "Read file={} content_length={} cur_offset={} => gcount={}", remote_fname, content_length, cur_offset, gcount);
     cur_offset += gcount;
     ProfileEvents::increment(ProfileEvents::S3ReadBytes, gcount);
     return gcount;
@@ -92,7 +91,6 @@ off_t S3RandomAccessFile::seek(off_t offset_, int whence)
     auto & istr = read_result.GetBody();
     istr.ignore(offset_ - cur_offset);
     RUNTIME_CHECK(istr, remote_fname, strerror(errno));
-    LOG_DEBUG(log, "Seek file={} content_length={} cur_offset={} => offset={}", remote_fname, content_length, cur_offset, offset_);
     cur_offset = offset_;
     return cur_offset;
 }
@@ -149,8 +147,7 @@ inline static RandomAccessFilePtr createFromNormalFile(const String & remote_fna
         return file;
     }
     auto & ins = S3::ClientFactory::instance();
-    auto ptr = std::make_shared<S3RandomAccessFile>(ins.sharedTiFlashClient(), remote_fname);
-    return ptr;
+    return std::make_shared<S3RandomAccessFile>(ins.sharedTiFlashClient(), remote_fname);
 }
 
 inline static String readMergedSubFilesFromS3(const S3RandomAccessFile::ReadFileInfo & read_file_info_)

--- a/dbms/src/Storages/S3/S3RandomAccessFile.h
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.h
@@ -18,6 +18,7 @@
 #include <Common/Logger.h>
 #include <Encryption/RandomAccessFile.h>
 #include <Storages/DeltaMerge/File/MergedFile.h>
+#include <Storages/S3/S3Common.h>
 #include <aws/s3/model/GetObjectResult.h>
 #include <common/types.h>
 

--- a/dbms/src/Storages/S3/S3RandomAccessFile.h
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.h
@@ -1,4 +1,4 @@
-// Copyright 2022 PingCAP, Ltd.
+// Copyright 2023 PingCAP, Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,9 +28,9 @@
 #undef thread_local
 #endif
 
-namespace DB::S3
+namespace Aws::S3
 {
-class TiFlashS3Client;
+class S3Client;
 }
 
 namespace DB::ErrorCodes
@@ -50,12 +50,14 @@ public:
         const String & remote_fname_,
         std::optional<std::pair<UInt64, UInt64>> offset_and_size_ = std::nullopt);
 
-    // Can only seek forward.
     off_t seek(off_t offset, int whence) override;
 
     ssize_t read(char * buf, size_t size) override;
 
-    std::string getFileName() const override;
+    std::string getFileName() const override
+    {
+        return fmt::format("{}/{}", client_ptr->bucket(), remote_fname);
+    }
 
     ssize_t pread(char * /*buf*/, size_t /*size*/, off_t /*offset*/) const override
     {
@@ -104,13 +106,11 @@ private:
     std::shared_ptr<TiFlashS3Client> client_ptr;
     String remote_fname;
     std::optional<std::pair<UInt64, UInt64>> offset_and_size;
-    off_t cur_offset;
+
     Aws::S3::Model::GetObjectResult read_result;
-    Int64 content_length;
 
     DB::LoggerPtr log;
     bool is_close = false;
-    bool is_inited = false;
 };
 
 } // namespace DB::S3

--- a/dbms/src/Storages/S3/tests/gtest_s3file.cpp
+++ b/dbms/src/Storages/S3/tests/gtest_s3file.cpp
@@ -64,14 +64,10 @@ using DMFileBlockInputStreamPtr = std::shared_ptr<DMFileBlockInputStream>;
 class S3FileTest : public DB::base::TiFlashStorageTestBasic
 {
 public:
-    static void SetUpTestCase()
-    {
-    }
+    static void SetUpTestCase() {}
 
     void SetUp() override
     {
-        is_mocked_s3_client = ::DB::tests::TiFlashTestEnv::isMockedS3Client();
-
         TiFlashStorageTestBasic::SetUp();
 
         reload();
@@ -187,7 +183,6 @@ protected:
         return data_store->prepareDMFile(oid)->restore(DMFile::ReadMetaMode::all());
     }
 
-    bool is_mocked_s3_client = false;
     LoggerPtr log;
     std::vector<char> buf_unit;
     std::shared_ptr<TiFlashS3Client> s3_client;

--- a/dbms/src/Storages/S3/tests/gtest_s3gcmanager.cpp
+++ b/dbms/src/Storages/S3/tests/gtest_s3gcmanager.cpp
@@ -355,11 +355,10 @@ try
         S3::uploadEmptyFile(*mock_s3_client, df.toFullKey());
         S3::uploadEmptyFile(*mock_s3_client, delmark_key);
         auto delmark_mtime = timepoint - std::chrono::milliseconds(3599 * 1000);
-        FailPointHelper::enableFailPoint(FailPoints::force_set_mocked_s3_object_mtime, std::map<String, Aws::Utils::DateTime>{{mock_s3_client->root() + delmark_key, delmark_mtime}});
+        FailPointHelper::enableFailPoint(FailPoints::force_set_mocked_s3_object_mtime, std::map<String, Aws::Utils::DateTime>{{delmark_key, delmark_mtime}});
         SCOPE_EXIT({
             FailPointHelper::disableFailPoint(FailPoints::force_set_mocked_s3_object_mtime);
         });
-        // mock_s3_client->head_result_mtime = delmark_mtime;
         gc_mgr->cleanOneLock(lock_key, lock_view, timepoint);
 
         // lock is deleted, datafile and delmark remain
@@ -373,7 +372,7 @@ try
         S3::uploadEmptyFile(*mock_s3_client, df.toFullKey());
         S3::uploadEmptyFile(*mock_s3_client, delmark_key);
         auto delmark_mtime = timepoint - std::chrono::milliseconds(3601 * 1000);
-        FailPointHelper::enableFailPoint(FailPoints::force_set_mocked_s3_object_mtime, std::map<String, Aws::Utils::DateTime>{{mock_s3_client->root() + delmark_key, delmark_mtime}});
+        FailPointHelper::enableFailPoint(FailPoints::force_set_mocked_s3_object_mtime, std::map<String, Aws::Utils::DateTime>{{delmark_key, delmark_mtime}});
         SCOPE_EXIT({
             FailPointHelper::disableFailPoint(FailPoints::force_set_mocked_s3_object_mtime);
         });

--- a/dbms/src/Storages/Transaction/TMTContext.cpp
+++ b/dbms/src/Storages/Transaction/TMTContext.cpp
@@ -132,8 +132,11 @@ void TMTContext::updateSecurityConfig(const TiFlashRaftConfig & raft_config, con
     {
         // update the client config including pd_client
         cluster->update(raft_config.pd_addrs, cluster_config);
-        // update the etcd_client after pd_client get updated
-        etcd_client->update(cluster_config);
+        if (etcd_client)
+        {
+            // update the etcd_client after pd_client get updated
+            etcd_client->update(cluster_config);
+        }
     }
 }
 

--- a/dbms/src/TestUtils/TiFlashTestEnv.cpp
+++ b/dbms/src/TestUtils/TiFlashTestEnv.cpp
@@ -30,12 +30,14 @@
 #include <aws/s3/S3Client.h>
 #include <aws/s3/model/CreateBucketRequest.h>
 #include <aws/s3/model/DeleteBucketRequest.h>
+#include <common/logger_useful.h>
 
 #include <memory>
 
 namespace DB::tests
 {
 std::vector<ContextPtr> TiFlashTestEnv::global_contexts = {};
+bool TiFlashTestEnv::is_mocked_s3_client = true;
 
 String TiFlashTestEnv::getTemporaryPath(const std::string_view test_case, bool get_abs)
 {
@@ -262,9 +264,32 @@ bool TiFlashTestEnv::createBucketIfNotExist(::DB::S3::TiFlashS3Client & s3_clien
 
 void TiFlashTestEnv::deleteBucket(::DB::S3::TiFlashS3Client & s3_client)
 {
+    TiFlashTestEnv::createBucketIfNotExist(s3_client);
+    if (!is_mocked_s3_client)
+    {
+        // All objects (including all object versions and delete markers)
+        // in the bucket must be deleted before the bucket itself can be
+        // deleted.
+        LOG_INFO(s3_client.log, "DeleteBucket, clean all existing objects begin");
+        S3::rawListPrefix(s3_client, s3_client.bucket(), s3_client.root(), "", [&](const Aws::S3::Model::ListObjectsV2Result & r) -> S3::PageResult {
+            for (const auto & obj : r.GetContents())
+            {
+                const auto & key = obj.GetKey();
+                LOG_INFO(s3_client.log, "DeleteBucket, clean existing object, key={}", key);
+                S3::rawDeleteObject(s3_client, s3_client.bucket(), key);
+            }
+            return S3::PageResult{.num_keys = r.GetContents().size(), .more = true};
+        });
+        LOG_INFO(s3_client.log, "DeleteBucket, clean all existing objects done");
+    }
     Aws::S3::Model::DeleteBucketRequest request;
     request.SetBucket(s3_client.bucket());
-    s3_client.DeleteBucket(request);
+    auto outcome = s3_client.DeleteBucket(request);
+    if (!outcome.IsSuccess())
+    {
+        const auto & err = outcome.GetError();
+        LOG_WARNING(s3_client.log, "DeleteBucket: {}:{}", err.GetExceptionName(), err.GetMessage());
+    }
 }
 
 } // namespace DB::tests

--- a/dbms/src/TestUtils/TiFlashTestEnv.h
+++ b/dbms/src/TestUtils/TiFlashTestEnv.h
@@ -76,7 +76,7 @@ public:
         const static std::vector<String> SEARCH_PATH = {"../tests/testdata/", "/tests/testdata/"};
         for (const auto & prefix : SEARCH_PATH)
         {
-            String path = prefix + name;
+            String path = Poco::Path{prefix + name}.absolute().toString();
             if (auto f = Poco::File(path); f.exists() && f.isDirectory())
             {
                 Strings paths;
@@ -105,13 +105,15 @@ public:
 
     static FileProviderPtr getMockFileProvider();
 
+    static void setIsMockedS3Client(bool mock) { is_mocked_s3_client = mock; }
+    static bool isMockedS3Client() { return is_mocked_s3_client; }
     static bool createBucketIfNotExist(::DB::S3::TiFlashS3Client & s3_client);
-
     static void deleteBucket(::DB::S3::TiFlashS3Client & s3_client);
 
-    TiFlashTestEnv() = delete;
+    TiFlashTestEnv() = delete; // no instance allow
 
 private:
     static std::vector<ContextPtr> global_contexts;
+    static bool is_mocked_s3_client;
 };
 } // namespace DB::tests

--- a/dbms/src/TestUtils/gtests_dbms_main.cpp
+++ b/dbms/src/TestUtils/gtests_dbms_main.cpp
@@ -23,6 +23,7 @@
 #include <Storages/DeltaMerge/ReadThread/SegmentReader.h>
 #include <Storages/S3/S3Common.h>
 #include <TestUtils/TiFlashTestBasic.h>
+#include <TestUtils/TiFlashTestEnv.h>
 #include <gtest/gtest.h>
 #include <signal.h>
 
@@ -97,6 +98,7 @@ int main(int argc, char ** argv)
     };
     s3config.enable(/*check_requirements*/ false, DB::Logger::get());
     Poco::Environment::set("AWS_EC2_METADATA_DISABLED", "true"); // disable to speedup testing
+    DB::tests::TiFlashTestEnv::setIsMockedS3Client(mock_s3 == "true");
     DB::S3::ClientFactory::instance().init(s3config, mock_s3 == "true");
 
 #ifdef FIU_ENABLE


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/7176

Problem Summary:

The S3::listObjects always return an empty result after https://github.com/pingcap/tiflash/pull/7209. So does some other S3 APIs

### What is changed and how it works?

* pick https://github.com/ClickHouse/aws-sdk-cpp/commit/41a52d906db0401de841b5985825282f7ad621dc for poco HTTP client stream ends
* pick a part of https://github.com/pingcap/tiflash/pull/7247 to fix the seek operation on S3 file
* fix some issue when testing with local deployed MinIO
* increase the default storage.s3.request_timeout_ms to 30 seconds
* fix a crash cause by `RemoteHostFilter`
* fix a crash cause by cert update when deployed without disagg

```
[2023/04/06 11:32:09.521 +00:00] [ERROR] [BaseDaemon.cpp:376] [########################################] [source=BaseDaemon] [thread_id=35]
[2023/04/06 11:32:09.521 +00:00] [ERROR] [BaseDaemon.cpp:377] ["(from thread 34) Received signal Segmentation fault(11)."] [source=BaseDaemon] [thread_id=35]
[2023/04/06 11:32:09.521 +00:00] [ERROR] [BaseDaemon.cpp:407] ["Address: 0x8"] [source=BaseDaemon] [thread_id=35]
[2023/04/06 11:32:09.521 +00:00] [ERROR] [BaseDaemon.cpp:413] ["Access: read."] [source=BaseDaemon] [thread_id=35]
[2023/04/06 11:32:09.521 +00:00] [ERROR] [BaseDaemon.cpp:422] ["Address not mapped to object."] [source=BaseDaemon] [thread_id=35]
[2023/04/06 11:32:09.723 +00:00] [ERROR] [BaseDaemon.cpp:569] ["
       0x7366571\tfaultSignalHandler(int, siginfo_t*, void*) [tiflash+121005425]
                \tlibs/libdaemon/src/BaseDaemon.cpp:220
  0x7f79e6a62420\t<unknown symbol> [libpthread.so.0+82976]
       0x1c548d6\tstd::__1::__hash_const_iterator<std::__1::__hash_node<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, void*>*> std::__1::__hash_table<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > >::find<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) const [tiflash+29706454]
                \t/data3/jaysonhuang/tiflash-env-13/sysroot/bin/../include/c++/v1/__hash_table:2425
       0x7e0e0c0\tDB::RemoteHostFilter::checkForDirectEntry(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) const [tiflash+132178112]
                \tdbms/src/Common/RemoteHostFilter.cpp:86
       0x7e0dde3\tDB::RemoteHostFilter::checkURL(Poco::URI const&) const [tiflash+132177379]
                \tdbms/src/Common/RemoteHostFilter.cpp:33
       0x7e08894\tDB::S3::PocoHTTPClient::makeRequestInternal(Aws::Http::HttpRequest&, std::__1::shared_ptr<DB::S3::PocoHTTPResponse>&, Aws::Utils::RateLimits::RateLimiterInterface*, Aws::Utils::RateLimits::RateLimiterInterface*) const [tiflash+132155540]
                \tdbms/src/Storages/S3/PocoHTTPClient.cpp:318
       0x7e074b7\tDB::S3::PocoHTTPClient::MakeRequest(std::__1::shared_ptr<Aws::Http::HttpRequest> const&, Aws::Utils::RateLimits::RateLimiterInterface*, Aws::Utils::RateLimits::RateLimiterInterface*) const [tiflash+132150455]
                \tdbms/src/Storages/S3/PocoHTTPClient.cpp:113
       0x82dcca5\tAws::Client::AWSClient::AttemptOneRequest(std::__1::shared_ptr<Aws::Http::HttpRequest> const&, Aws::AmazonWebServiceRequest const&, char const*, char const*, char const*) const [tiflash+137219237]
                \tcontrib/aws/src/aws-cpp-sdk-core/source/client/AWSClient.cpp:506
       0x82dabfb\tAws::Client::AWSClient::AttemptExhaustively(Aws::Http::URI const&, Aws::AmazonWebServiceRequest const&, Aws::Http::HttpMethod, char const*, char const*, char const*) const [tiflash+137210875]
                \tcontrib/aws/src/aws-cpp-sdk-core/source/client/AWSClient.cpp:272
       0x82f6d8b\tAws::Client::AWSXMLClient::MakeRequest(Aws::Http::URI const&, Aws::AmazonWebServiceRequest const&, Aws::Http::HttpMethod, char const*, char const*, char const*) const [tiflash+137325963]
                \tcontrib/aws/src/aws-cpp-sdk-core/source/client/AWSXmlClient.cpp:99
       0x82f6d40\tAws::Client::AWSXMLClient::MakeRequest(Aws::AmazonWebServiceRequest const&, Aws::Endpoint::AWSEndpoint const&, Aws::Http::HttpMethod, char const*, char const*, char const*) const [tiflash+137325888]
                \tcontrib/aws/src/aws-cpp-sdk-core/source/client/AWSXmlClient.cpp:66
       0x83a3ae3\tAws::S3::S3Client::ListObjectsV2(Aws::S3::Model::ListObjectsV2Request const&) const [tiflash+138033891]
                \tcontrib/aws/generated/src/aws-cpp-sdk-s3/source/S3Client.cpp:1380
       0x7de97c7\tDB::S3::listPrefix(DB::S3::TiFlashS3Client const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::function<DB::S3::PageResult (Aws::S3::Model::Object const&)>) [tiflash+132028359]
                \tdbms/src/Storages/S3/S3Common.cpp:771
       0x7dd169b\tDB::S3::CheckpointManifestS3Set::getFromS3(DB::S3::TiFlashS3Client const&, unsigned long) [tiflash+131929755]
                \tdbms/src/Storages/S3/CheckpointManifestS3Set.cpp:30
       0x745fd41\tDB::PS::V3::S3LockLocalManager::initStoreInfo(unsigned long, std::__1::shared_ptr<DB::S3::IS3LockClient>) [tiflash+122027329]
                \tdbms/src/Storages/Page/V3/Universal/S3LockLocalManager.cpp:61
       0x7458a22\tDB::UniversalPageStorage::initLocksLocalManager(unsigned long, std::__1::shared_ptr<DB::S3::IS3LockClient>) [tiflash+121997858]
                \tdbms/src/Storages/Page/V3/Universal/UniversalPageStorage.cpp:400
       0x75bfd01\tDB::UniversalPageStorageService::uploadCheckpointImpl(metapb::Store const&, std::__1::shared_ptr<DB::S3::IS3LockClient> const&, std::__1::shared_ptr<DB::DM::Remote::IDataStore> const&) [tiflash+123469057]
                \tdbms/src/Storages/Page/V3/Universal/UniversalPageStorageService.cpp:173
       0x75bf790\tDB::UniversalPageStorageService::uploadCheckpoint() [tiflash+123467664]
                \tdbms/src/Storages/Page/V3/Universal/UniversalPageStorageService.cpp:144
       0x75c0fed\tstd::__1::__function::__func<DB::UniversalPageStorageService::create(DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::shared_ptr<DB::PSDiskDelegator>, DB::PageStorageConfig const&)::$_3, std::__1::allocator<DB::UniversalPageStorageService::create(DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::shared_ptr<DB::PSDiskDelegator>, DB::PageStorageConfig const&)::$_3>, bool ()>::operator()() [tiflash+123473901]
                \t/data3/jaysonhuang/tiflash-env-13/sysroot/bin/../include/c++/v1/__functional/function.h:345
       0x7d3d60b\tDB::BackgroundProcessingPool::threadFunction(unsigned long) [tiflash+131323403]
                \tdbms/src/Storages/BackgroundProcessingPool.cpp:234
       0x7d3e155\tvoid* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, DB::BackgroundProcessingPool::BackgroundProcessingPool(int, std::__1::basic_string<char, std::__1::char_traits<char>, std::_
_1::allocator<char> >)::$_1> >(void*) [tiflash+131326293]
                \t/data3/jaysonhuang/tiflash-env-13/sysroot/bin/../include/c++/v1/thread:291
  0x7f79e6a56609\tstart_thread [libpthread.so.0+34313]
                \t/build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:477"] [source=BaseDaemon] [thread_id=35]
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
