### PR TITLE
Fix S3 file's seek operation and retry when connection reset by peer

### DIFF
--- a/dbms/src/Common/ProfileEvents.cpp
+++ b/dbms/src/Common/ProfileEvents.cpp
@@ -137,6 +137,7 @@
     M(S3ListObjects)                           \
     M(S3DeleteObject)                          \
     M(S3CopyObject)                            \
+    M(S3GetObjectRerty)                        \
     M(FileCacheHit)                            \
     M(FileCacheMiss)                           \
     M(FileCacheEvict)

--- a/dbms/src/Common/ProfileEvents.cpp
+++ b/dbms/src/Common/ProfileEvents.cpp
@@ -137,7 +137,7 @@
     M(S3ListObjects)                           \
     M(S3DeleteObject)                          \
     M(S3CopyObject)                            \
-    M(S3GetObjectRerty)                        \
+    M(S3GetObjectRetry)                        \
     M(FileCacheHit)                            \
     M(FileCacheMiss)                           \
     M(FileCacheEvict)

--- a/dbms/src/Storages/DeltaMerge/File/DMFileWriter.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileWriter.cpp
@@ -15,6 +15,7 @@
 #include <Common/TiFlashException.h>
 #include <Storages/DeltaMerge/DeltaMergeHelpers.h>
 #include <Storages/DeltaMerge/File/DMFileWriter.h>
+#include <Storages/S3/S3Common.h>
 
 #ifndef NDEBUG
 #include <sys/stat.h>

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_file.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_file.cpp
@@ -28,6 +28,7 @@
 #include <Storages/DeltaMerge/tests/DMTestEnv.h>
 #include <Storages/FormatVersion.h>
 #include <Storages/PathPool.h>
+#include <Storages/S3/S3Common.h>
 #include <TestUtils/FunctionTestUtils.h>
 #include <TestUtils/InputStreamTestUtils.h>
 #include <TestUtils/TiFlashStorageTestBasic.h>

--- a/dbms/src/Storages/DeltaMerge/workload/MainEntry.cpp
+++ b/dbms/src/Storages/DeltaMerge/workload/MainEntry.cpp
@@ -484,7 +484,7 @@ void getRandomObject(const DB::DM::tests::WorkloadOptions & opts)
     auto local_fname = fmt::format("{}/{}/{}", opts.s3_temp_dir, tid, index++);
     auto client = getS3Client(opts);
     Stopwatch sw;
-    S3::downloadFile(*client, local_fname, remote_fname);
+    S3::downloadFileByS3RandomAccessFile(client, local_fname, remote_fname);
     s3_stat.addGetStat(remote_fname, sw.elapsedSeconds());
     auto download_size = std::filesystem::file_size(local_fname);
     std::cout << fmt::format("GetObject {} bytes={} cost={:.3f}s", remote_fname, download_size, sw.elapsedSeconds()) << std::endl;

--- a/dbms/src/Storages/S3/MockS3Client.cpp
+++ b/dbms/src/Storages/S3/MockS3Client.cpp
@@ -91,7 +91,10 @@ Model::GetObjectOutcome MockS3Client::GetObject(const Model::GetObjectRequest & 
         boost::algorithm::split(v, request.GetRange().substr(prefix.size()), boost::algorithm::is_any_of("-"));
         RUNTIME_CHECK(v.size() == 2, request.GetRange());
         left = std::stoul(v[0]);
-        right = std::stoul(v[1]);
+        if (!v[1].empty())
+        {
+            right = std::stoul(v[1]);
+        }
     }
     auto size = right - left + 1;
     Model::GetObjectResult result;

--- a/dbms/src/Storages/S3/PocoHTTPClient.cpp
+++ b/dbms/src/Storages/S3/PocoHTTPClient.cpp
@@ -206,11 +206,9 @@ void PocoHTTPClient::makeRequestInternal(
         for (unsigned int attempt = 0; attempt <= s3_max_redirects; ++attempt)
         {
             Poco::URI target_uri(uri);
-            HTTPSessionPtr session;
             auto request_configuration = per_request_configuration(request);
-
             RUNTIME_CHECK(request_configuration.proxy_host.empty());
-            session = makeHTTPSession(target_uri, timeouts, /* resolve_host = */ true);
+            auto session = makeHTTPSession(target_uri, timeouts, /* resolve_host = */ true);
 
             /// In case of error this address will be written to logs
             request.SetResolvedRemoteHost(session->getResolvedAddress());
@@ -281,7 +279,7 @@ void PocoHTTPClient::makeRequestInternal(
             if (request.GetContentBody())
             {
                 if (enable_s3_requests_logging)
-                    LOG_DEBUG(log, "Writing request body.");
+                    LOG_DEBUG(log, "URI={}, Writing request body.", uri);
 
                 /// Rewind content body buffer.
                 /// NOTE: we should do that always (even if `attempt == 0`) because the same request can be retried also by AWS,
@@ -291,11 +289,11 @@ void PocoHTTPClient::makeRequestInternal(
 
                 auto size = Poco::StreamCopier::copyStream(*request.GetContentBody(), request_body_stream);
                 if (enable_s3_requests_logging)
-                    LOG_DEBUG(log, "Written {} bytes to request body", size);
+                    LOG_DEBUG(log, "URI={}, Written {} bytes to request body", uri, size);
             }
 
             if (enable_s3_requests_logging)
-                LOG_DEBUG(log, "Receiving response...");
+                LOG_DEBUG(log, "URI={}, Receiving response...", uri);
             auto & response_body_stream = session->receiveResponse(poco_response);
 
             watch.stop();
@@ -306,21 +304,21 @@ void PocoHTTPClient::makeRequestInternal(
             if (status_code >= SUCCESS_RESPONSE_MIN && status_code <= SUCCESS_RESPONSE_MAX)
             {
                 if (enable_s3_requests_logging)
-                    LOG_DEBUG(log, "Response status: {}, {}", status_code, poco_response.getReason());
+                    LOG_DEBUG(log, "URI={}, Response status: {}, {}", uri, status_code, poco_response.getReason());
             }
             else
             {
                 /// Error statuses are more important so we show them even if `enable_s3_requests_logging == false`.
-                LOG_INFO(log, "Response status: {}, {}", status_code, poco_response.getReason());
+                LOG_INFO(log, "URI={}, Response status: {}, {}", uri, status_code, poco_response.getReason());
             }
 
-            if (poco_response.getStatus() == Poco::Net::HTTPResponse::HTTP_TEMPORARY_REDIRECT)
+            if (poco_response.getStatus() == Poco::Net::HTTPResponse::HTTP_TEMPORARY_REDIRECT || status_code == 302)
             {
                 auto location = poco_response.get("location");
                 remote_host_filter.checkURL(Poco::URI(location));
                 uri = location;
                 if (enable_s3_requests_logging)
-                    LOG_DEBUG(log, "Redirecting request to new location: {}", location);
+                    LOG_DEBUG(log, "URI={}, Redirecting request to new location: {}", uri, location);
 
                 addMetric(request, S3MetricType::Redirects);
 
@@ -338,7 +336,7 @@ void PocoHTTPClient::makeRequestInternal(
                     response->AddHeader(header_name, header_value);
                     headers_ss << header_name << ": " << header_value << "; ";
                 }
-                LOG_DEBUG(log, "Received headers: {}", headers_ss.str());
+                LOG_DEBUG(log, "URI={}, Received headers: {}", uri, headers_ss.str());
             }
             else
             {

--- a/dbms/src/Storages/S3/PocoHTTPClient.cpp
+++ b/dbms/src/Storages/S3/PocoHTTPClient.cpp
@@ -312,7 +312,7 @@ void PocoHTTPClient::makeRequestInternal(
                 LOG_INFO(log, "URI={}, Response status: {}, {}", uri, status_code, poco_response.getReason());
             }
 
-            if (poco_response.getStatus() == Poco::Net::HTTPResponse::HTTP_TEMPORARY_REDIRECT || status_code == 302)
+            if (poco_response.getStatus() == Poco::Net::HTTPResponse::HTTP_TEMPORARY_REDIRECT || poco_response.getStatus() == Poco::Net::HTTPResponse::HTTP_FOUND)
             {
                 auto location = poco_response.get("location");
                 remote_host_filter.checkURL(Poco::URI(location));

--- a/dbms/src/Storages/S3/S3Common.cpp
+++ b/dbms/src/Storages/S3/S3Common.cpp
@@ -597,6 +597,29 @@ void downloadFile(const TiFlashS3Client & client, const String & local_fname, co
     RUNTIME_CHECK_MSG(ostr.good(), "Write {} fail: {}", local_fname, strerror(errno));
 }
 
+
+void downloadFileByS3RandomAccessFile(std::shared_ptr<TiFlashS3Client> client, const String & local_fname, const String & remote_fname)
+{
+    Stopwatch sw;
+    S3RandomAccessFile file(client, remote_fname);
+    Aws::OFStream ostr(local_fname, std::ios_base::out | std::ios_base::binary);
+    RUNTIME_CHECK_MSG(ostr.is_open(), "Open {} fail: {}", local_fname, strerror(errno));
+
+    char buf[8192];
+    while (true)
+    {
+        auto n = file.read(buf, sizeof(buf));
+        RUNTIME_CHECK(n >= 0, remote_fname);
+        if (n == 0)
+        {
+            break;
+        }
+
+        ostr.write(buf, n);
+        RUNTIME_CHECK_MSG(ostr.good(), "Write {} fail: {}", local_fname, strerror(errno));
+    }
+}
+
 void rewriteObjectWithTagging(const TiFlashS3Client & client, const String & key, const String & tagging)
 {
     Stopwatch sw;

--- a/dbms/src/Storages/S3/S3Common.h
+++ b/dbms/src/Storages/S3/S3Common.h
@@ -19,6 +19,7 @@
 #include <Common/nocopyable.h>
 #include <Interpreters/Context_fwd.h>
 #include <Server/StorageConfigParser.h>
+#include <Storages/S3/S3RandomAccessFile.h>
 #include <aws/core/Aws.h>
 #include <aws/core/http/Scheme.h>
 #include <aws/s3/S3Client.h>
@@ -39,13 +40,16 @@ extern const int S3_ERROR;
 
 namespace DB::S3
 {
+
+inline String S3ErrorMessage(const Aws::S3::S3Error & e)
+{
+    return fmt::format(" s3error={} s3msg={} request_id={}", magic_enum::enum_name(e.GetErrorType()), e.GetMessage(), e.GetRequestId());
+}
+
 template <typename... Args>
 Exception fromS3Error(const Aws::S3::S3Error & e, const std::string & fmt, Args &&... args)
 {
-    return DB::Exception(
-        ErrorCodes::S3_ERROR,
-        fmt + fmt::format(" s3error={} s3msg={} request_id={}", magic_enum::enum_name(e.GetErrorType()), e.GetMessage(), e.GetRequestId()),
-        args...);
+    return DB::Exception(ErrorCodes::S3_ERROR, fmt + S3ErrorMessage(e), args...);
 }
 
 class TiFlashS3Client : public Aws::S3::S3Client
@@ -164,6 +168,7 @@ void ensureLifecycleRuleExist(const TiFlashS3Client & client, Int32 expire_days)
 void uploadEmptyFile(const TiFlashS3Client & client, const String & key, const String & tagging = "", int max_retry_times = 3);
 
 void downloadFile(const TiFlashS3Client & client, const String & local_fname, const String & remote_fname);
+void downloadFileByS3RandomAccessFile(std::shared_ptr<TiFlashS3Client> client, const String & local_fname, const String & remote_fname);
 
 void rewriteObjectWithTagging(const TiFlashS3Client & client, const String & key, const String & tagging);
 

--- a/dbms/src/Storages/S3/S3RandomAccessFile.cpp
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.cpp
@@ -61,11 +61,13 @@ ssize_t S3RandomAccessFile::read(char * buf, size_t size)
     while (true)
     {
         auto n = readImpl(buf, size);
-        if (unlikely(n < 0 && errno == 104))
+        if (unlikely(n < 0 && errno == ECONNRESET))
         {
             // If it is a "Connection reset by peer" error, then initialize again
             if (initialize())
+            {
                 continue;
+            }
         }
         return n;
     }
@@ -91,9 +93,13 @@ off_t S3RandomAccessFile::seek(off_t offset_, int whence)
     while (true)
     {
         auto off = seekImpl(offset_, whence);
-        if (unlikely(off < 0 && errno == 104 && initialize())) // Connection reset by peer and re-initialize succ.
+        if (unlikely(off < 0 && errno == ECONNRESET))
         {
-            continue;
+            // If it is a "Connection reset by peer" error, then initialize again
+            if (initialize())
+            {
+                continue;
+            }
         }
         return off;
     }

--- a/dbms/src/Storages/S3/S3RandomAccessFile.cpp
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.cpp
@@ -33,7 +33,7 @@ namespace ProfileEvents
 {
 extern const Event S3GetObject;
 extern const Event S3ReadBytes;
-extern const Event S3GetObjectRerty;
+extern const Event S3GetObjectRetry;
 } // namespace ProfileEvents
 
 namespace DB::S3

--- a/dbms/src/Storages/S3/S3RandomAccessFile.cpp
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.cpp
@@ -150,7 +150,7 @@ bool S3RandomAccessFile::initialize()
         ProfileEvents::increment(ProfileEvents::S3GetObject);
         if (cur_retry > 1)
         {
-            ProfileEvents::increment(ProfileEvents::S3GetObjectRerty);
+            ProfileEvents::increment(ProfileEvents::S3GetObjectRetry);
         }
         auto outcome = client_ptr->GetObject(req);
         if (!outcome.IsSuccess())

--- a/dbms/src/Storages/S3/S3RandomAccessFile.cpp
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.cpp
@@ -25,12 +25,15 @@
 #include <Storages/S3/S3RandomAccessFile.h>
 #include <aws/s3/model/GetObjectRequest.h>
 
+#include <chrono>
 #include <optional>
+#include <thread>
 
 namespace ProfileEvents
 {
 extern const Event S3GetObject;
 extern const Event S3ReadBytes;
+extern const Event S3GetObjectRerty;
 } // namespace ProfileEvents
 
 namespace DB::S3
@@ -38,66 +41,135 @@ namespace DB::S3
 S3RandomAccessFile::S3RandomAccessFile(
     std::shared_ptr<TiFlashS3Client> client_ptr_,
     const String & remote_fname_,
-    std::optional<std::pair<UInt64, UInt64>> offset_and_size_)
+    std::optional<std::pair<UInt64, UInt64>> offset_and_size_in_object_)
     : client_ptr(std::move(client_ptr_))
     , remote_fname(remote_fname_)
-    , offset_and_size(offset_and_size_)
-    , log(Logger::get("S3RandomAccessFile"))
+    , offset_and_size_in_object(offset_and_size_in_object_)
+    , cur_offset(0)
+    , log(Logger::get(remote_fname))
 {
-    initialize();
+    RUNTIME_CHECK(initialize(), remote_fname);
+}
+
+std::string S3RandomAccessFile::getFileName() const
+{
+    return fmt::format("{}/{}", client_ptr->bucket(), remote_fname);
 }
 
 ssize_t S3RandomAccessFile::read(char * buf, size_t size)
+{
+    while (true)
+    {
+        auto n = readImpl(buf, size);
+        if (unlikely(n < 0 && errno == 104 && initialize())) // Connection reset by peer and re-initialize succ.
+        {
+            continue;
+        }
+        return n;
+    }
+}
+
+ssize_t S3RandomAccessFile::readImpl(char * buf, size_t size)
 {
     auto & istr = read_result.GetBody();
     istr.read(buf, size);
     size_t gcount = istr.gcount();
     if (gcount == 0 && !istr.eof())
     {
-        LOG_ERROR(log, "Cannot read from istream. bucket={} root={} key={}", client_ptr->bucket(), client_ptr->root(), remote_fname);
+        LOG_ERROR(log, "Cannot read from istream, errmsg={}", strerror(errno));
         return -1;
     }
+    cur_offset += gcount;
     ProfileEvents::increment(ProfileEvents::S3ReadBytes, gcount);
     return gcount;
 }
 
 off_t S3RandomAccessFile::seek(off_t offset_, int whence)
 {
-    if (unlikely(whence != SEEK_SET))
+    while (true)
     {
-        LOG_ERROR(log, "Only SEEK_SET mode is allowed, but {} is received", whence);
-        return -1;
+        auto off = seekImpl(offset_, whence);
+        if (unlikely(off < 0 && errno == 104 && initialize())) // Connection reset by peer and re-initialize succ.
+        {
+            continue;
+        }
+        return off;
     }
-    if (unlikely(offset_ < 0))
-    {
-        LOG_ERROR(log, "Seek position is out of bounds. Offset: {}", offset_);
-        return -1;
-    }
-    auto & istr = read_result.GetBody();
-    istr.seekg(offset_);
-    return istr.tellg();
 }
 
-void S3RandomAccessFile::initialize()
+off_t S3RandomAccessFile::seekImpl(off_t offset_, int whence)
+{
+    RUNTIME_CHECK_MSG(whence == SEEK_SET, "Only SEEK_SET mode is allowed, but {} is received", whence);
+    RUNTIME_CHECK_MSG(
+        offset_ >= cur_offset && offset_ <= content_length,
+        "Seek position is out of bounds: offset={}, cur_offset={}, content_length={}",
+        offset_,
+        cur_offset,
+        content_length);
+
+    if (offset_ == cur_offset)
+    {
+        return cur_offset;
+    }
+    auto & istr = read_result.GetBody();
+    istr.ignore(offset_ - cur_offset);
+    if (!istr)
+    {
+        LOG_ERROR(log, "Cannot ignore from istream, errmsg={}", strerror(errno));
+        return -1;
+    }
+    ProfileEvents::increment(ProfileEvents::S3ReadBytes, offset_ - cur_offset);
+    cur_offset = offset_;
+    return cur_offset;
+}
+
+String S3RandomAccessFile::readRangeOfObject()
+{
+    if (offset_and_size_in_object)
+    {
+        auto start = offset_and_size_in_object->first + cur_offset;
+        auto end = offset_and_size_in_object->first + offset_and_size_in_object->second - 1;
+        return fmt::format("bytes={}-{}", start, end);
+    }
+    else
+    {
+        return fmt::format("bytes={}-", cur_offset);
+    }
+}
+
+bool S3RandomAccessFile::initialize()
 {
     Stopwatch sw;
+    bool request_succ = false;
     Aws::S3::Model::GetObjectRequest req;
-    if (offset_and_size)
-    {
-        auto left = offset_and_size->first;
-        auto right = offset_and_size->first + offset_and_size->second - 1;
-        req.SetRange(fmt::format("bytes={}-{}", left, right));
-    }
+    req.SetRange(readRangeOfObject());
     client_ptr->setBucketAndKeyWithRoot(req, remote_fname);
-    ProfileEvents::increment(ProfileEvents::S3GetObject);
-    auto outcome = client_ptr->GetObject(req);
-    if (!outcome.IsSuccess())
+    while (cur_retry < max_retry)
     {
-        throw S3::fromS3Error(outcome.GetError(), "S3 GetObject failed, bucket={} root={} key={}", client_ptr->bucket(), client_ptr->root(), remote_fname);
+        cur_retry += 1;
+        ProfileEvents::increment(ProfileEvents::S3GetObject);
+        if (cur_retry > 1)
+        {
+            ProfileEvents::increment(ProfileEvents::S3GetObjectRerty);
+        }
+        auto outcome = client_ptr->GetObject(req);
+        if (!outcome.IsSuccess())
+        {
+            LOG_ERROR(log, "S3 GetObject failed: {}, cur_retry={}", S3::S3ErrorMessage(outcome.GetError()), cur_retry);
+            continue;
+        }
+
+        request_succ = true;
+        if (content_length == 0)
+        {
+            content_length = outcome.GetResult().GetContentLength();
+        }
+        read_result = outcome.GetResultWithOwnership();
+        RUNTIME_CHECK(read_result.GetBody(), remote_fname, strerror(errno));
+        GET_METRIC(tiflash_storage_s3_request_seconds, type_get_object).Observe(sw.elapsedSeconds());
+        break;
     }
-    ProfileEvents::increment(ProfileEvents::S3ReadBytes, outcome.GetResult().GetContentLength());
-    GET_METRIC(tiflash_storage_s3_request_seconds, type_get_object).Observe(sw.elapsedSeconds());
-    read_result = outcome.GetResultWithOwnership();
+    return request_succ;
 }
 
 inline static RandomAccessFilePtr tryOpenCachedFile(const String & remote_fname, std::optional<UInt64> filesize)

--- a/dbms/src/Storages/S3/S3RandomAccessFile.cpp
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.cpp
@@ -120,8 +120,7 @@ off_t S3RandomAccessFile::seekImpl(off_t offset_, int whence)
         return cur_offset;
     }
     auto & istr = read_result.GetBody();
-    istr.ignore(offset_ - cur_offset);
-    if (!istr)
+    if (!istr.ignore(offset_ - cur_offset))
     {
         LOG_ERROR(log, "Cannot ignore from istream, errmsg={}", strerror(errno));
         return -1;

--- a/dbms/src/Storages/S3/S3RandomAccessFile.cpp
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.cpp
@@ -61,9 +61,11 @@ ssize_t S3RandomAccessFile::read(char * buf, size_t size)
     while (true)
     {
         auto n = readImpl(buf, size);
-        if (unlikely(n < 0 && errno == 104 && initialize())) // Connection reset by peer and re-initialize succ.
+        if (unlikely(n < 0 && errno == 104))
         {
-            continue;
+            // If it is a "Connection reset by peer" error, then initialize again
+            if (initialize())
+                continue;
         }
         return n;
     }

--- a/dbms/src/Storages/S3/S3RandomAccessFile.h
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.h
@@ -108,6 +108,7 @@ private:
     String remote_fname;
     // We may merge several small files into a S3 object.
     // `offset_and_size_in_object` is the offset and size of current file in S3 Object.
+    // And `cur_offset` is the offset in the current file.
     std::optional<std::pair<UInt64, UInt64>> offset_and_size_in_object;
     off_t cur_offset;
     Aws::S3::Model::GetObjectResult read_result;

--- a/dbms/src/Storages/S3/S3RandomAccessFile.h
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.h
@@ -18,7 +18,6 @@
 #include <Common/Logger.h>
 #include <Encryption/RandomAccessFile.h>
 #include <Storages/DeltaMerge/File/MergedFile.h>
-#include <Storages/S3/S3Common.h>
 #include <aws/s3/model/GetObjectResult.h>
 #include <common/types.h>
 
@@ -29,9 +28,9 @@
 #undef thread_local
 #endif
 
-namespace Aws::S3
+namespace DB::S3
 {
-class S3Client;
+class TiFlashS3Client;
 }
 
 namespace DB::ErrorCodes
@@ -51,14 +50,12 @@ public:
         const String & remote_fname_,
         std::optional<std::pair<UInt64, UInt64>> offset_and_size_ = std::nullopt);
 
+    // Can only seek forward.
     off_t seek(off_t offset, int whence) override;
 
     ssize_t read(char * buf, size_t size) override;
 
-    std::string getFileName() const override
-    {
-        return fmt::format("{}/{}", client_ptr->bucket(), remote_fname);
-    }
+    std::string getFileName() const override;
 
     ssize_t pread(char * /*buf*/, size_t /*size*/, off_t /*offset*/) const override
     {
@@ -97,7 +94,10 @@ public:
     }
 
 private:
-    void initialize();
+    bool initialize();
+    off_t seekImpl(off_t offset, int whence);
+    ssize_t readImpl(char * buf, size_t size);
+    String readRangeOfObject();
 
     // When reading, it is necessary to pass the extra information of file, such file size, the merged file information to S3RandomAccessFile::create.
     // It is troublesome to pass parameters layer by layer. So currently, use thread_local global variable to pass parameters.
@@ -106,12 +106,18 @@ private:
 
     std::shared_ptr<TiFlashS3Client> client_ptr;
     String remote_fname;
-    std::optional<std::pair<UInt64, UInt64>> offset_and_size;
-
+    // We may merge several small files into a S3 object.
+    // `offset_and_size_in_object` is the offset and size of current file in S3 Object.
+    std::optional<std::pair<UInt64, UInt64>> offset_and_size_in_object;
+    off_t cur_offset;
     Aws::S3::Model::GetObjectResult read_result;
+    Int64 content_length = 0;
 
     DB::LoggerPtr log;
     bool is_close = false;
+
+    Int32 cur_retry = 0;
+    static constexpr Int32 max_retry = 3;
 };
 
 } // namespace DB::S3


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6827

Problem Summary:
After using `PocoHTTPClient`:
1. `S3RandomAccessFile::seek` is failed.
2. Occasionally a connection reset by peer occurs.

### What is changed and how it works?

1. Use `ignore` to replace `seek`.
2. Retry when connection reset by peer occurs.


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  - Run chbenchmark in AWS EC2 and S3.
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
