### PR TITLE
Fix metrics of FileCache used size.

### DIFF
--- a/dbms/src/Storages/S3/FileCache.cpp
+++ b/dbms/src/Storages/S3/FileCache.cpp
@@ -583,6 +583,7 @@ void FileCache::restoreDMFile(const std::filesystem::directory_entry & dmfile_en
             if (canCache(file_type) && cache_capacity - cache_used >= size)
             {
                 table.set(toS3Key(fname), std::make_shared<FileSegment>(fname, FileSegment::Status::Complete, size, file_type));
+                capacity_metrics->addUsedSize(fname, size);
                 cache_used += size;
             }
             else


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6827

### What is changed and how it works?

Add file size to metrics when tiflash restart.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  - Restart TiFlash and check the metrics.
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
