### PR TITLE
Region retry for partitioned table in disaggrgated read

### DIFF
--- a/dbms/src/Storages/StorageDisaggregatedRemote.cpp
+++ b/dbms/src/Storages/StorageDisaggregatedRemote.cpp
@@ -251,7 +251,9 @@ void StorageDisaggregated::buildDisaggTask(
                 }
             };
 
+            // non-partition table
             retry_from_region_infos(req->regions());
+            // partition table
             for (const auto & table_region : req->table_regions())
             {
                 if (retry_regions.empty())

--- a/dbms/src/Storages/StorageDisaggregatedRemote.cpp
+++ b/dbms/src/Storages/StorageDisaggregatedRemote.cpp
@@ -250,6 +250,9 @@ void StorageDisaggregated::buildDisaggTask(
             }
             for (const auto & table_region : req->table_regions())
             {
+                if (retry_regions.empty())
+                    break;
+
                 for (const auto & region : table_region.regions())
                 {
                     auto region_ver_id = pingcap::kv::RegionVerID(
@@ -261,8 +264,6 @@ void StorageDisaggregated::buildDisaggTask(
                     if (retry_regions.empty())
                         break;
                 }
-                if (retry_regions.empty())
-                    break;
             }
 
             RUNTIME_CHECK_MSG(retry_regions.empty(), "Failed to drop regions {} from the cache", retry_regions);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/6827

Problem Summary:

### What is changed and how it works?

Drop regions when retry for partitioned table scan.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

```sql
create table t1(id int, age int, key(id)) partition by range(id) (
  partition p0 values less than (100),
  partition p1 values less than (200),
  partition p2 values less than (300),
  partition p3 values less than (400));

insert into t1 values (1, 10);
insert into t1 values (10, 10);

alter table t1 set tiflash replica 1;

set @@session.tidb_isolation_read_engines='tiflash';
set @@session.tidb_partition_prune_mode = 'dynamic';

analyze table t1;

select * from information_schema.tiflash_replica;

select count(*) from t1 where id < 150;

-- Trigger a region ver change manually

split table t1 by (4), (7);

select count(*) from t1 where id < 150;
```

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
