### PR TITLE
refine code to avoid redundant calculation when join probe split happens

### DIFF
--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -88,21 +88,6 @@ size_t getRestoreJoinBuildConcurrency(size_t total_partitions, size_t spilled_pa
         return std::max(2, restore_build_concurrency);
     }
 }
-ColumnRawPtrs extractAndMaterializeKeyColumns(const Block & block, Columns & materialized_columns, const Strings & key_columns_names)
-{
-    ColumnRawPtrs key_columns(key_columns_names.size());
-    for (size_t i = 0; i < key_columns_names.size(); ++i)
-    {
-        key_columns[i] = block.getByName(key_columns_names[i]).column.get();
-
-        if (ColumnPtr converted = key_columns[i]->convertToFullColumnIfConst())
-        {
-            materialized_columns.emplace_back(converted);
-            key_columns[i] = materialized_columns.back().get();
-        }
-    }
-    return key_columns;
-}
 } // namespace
 
 const std::string Join::match_helper_prefix = "__left-semi-join-match-helper";
@@ -344,54 +329,6 @@ void Join::initProbe(const Block & sample_block, size_t probe_concurrency_)
     setProbeConcurrency(probe_concurrency_);
     probe_sample_block = sample_block;
     probe_spiller = std::make_unique<Spiller>(probe_spill_config, false, build_concurrency, probe_sample_block, log);
-}
-
-void recordFilteredRows(const Block & block, const String & filter_column, ColumnPtr & null_map_holder, ConstNullMapPtr & null_map)
-{
-    if (filter_column.empty())
-        return;
-    auto column = block.getByName(filter_column).column;
-    if (column->isColumnConst())
-        column = column->convertToFullColumnIfConst();
-    const PaddedPODArray<UInt8> * column_data;
-    if (column->isColumnNullable())
-    {
-        const auto & column_nullable = static_cast<const ColumnNullable &>(*column);
-        if (!null_map_holder)
-        {
-            null_map_holder = column_nullable.getNullMapColumnPtr();
-        }
-        else
-        {
-            MutableColumnPtr mutable_null_map_holder = (*std::move(null_map_holder)).mutate();
-
-            PaddedPODArray<UInt8> & mutable_null_map = static_cast<ColumnUInt8 &>(*mutable_null_map_holder).getData();
-            const PaddedPODArray<UInt8> & other_null_map = column_nullable.getNullMapData();
-            for (size_t i = 0, size = mutable_null_map.size(); i < size; ++i)
-                mutable_null_map[i] |= other_null_map[i];
-
-            null_map_holder = std::move(mutable_null_map_holder);
-        }
-        column_data = &static_cast<const ColumnVector<UInt8> *>(column_nullable.getNestedColumnPtr().get())->getData();
-    }
-    else
-    {
-        if (!null_map_holder)
-        {
-            null_map_holder = ColumnVector<UInt8>::create(column->size(), 0);
-        }
-        column_data = &static_cast<const ColumnVector<UInt8> *>(column.get())->getData();
-    }
-
-    MutableColumnPtr mutable_null_map_holder = (*std::move(null_map_holder)).mutate();
-    PaddedPODArray<UInt8> & mutable_null_map = static_cast<ColumnUInt8 &>(*mutable_null_map_holder).getData();
-
-    for (size_t i = 0, size = column_data->size(); i < size; ++i)
-        mutable_null_map[i] |= !(*column_data)[i];
-
-    null_map_holder = std::move(mutable_null_map_holder);
-
-    null_map = &static_cast<const ColumnUInt8 &>(*null_map_holder).getData();
 }
 
 /// the block should be valid.
@@ -824,44 +761,12 @@ void Join::handleOtherConditions(Block & block, std::unique_ptr<IColumn::Filter>
 
 Block Join::doJoinBlockHash(ProbeProcessInfo & probe_process_info) const
 {
+    assert(probe_process_info.prepare_for_probe_done);
     probe_process_info.updateStartRow();
     /// this makes a copy of `probe_process_info.block`
     Block block = probe_process_info.block;
     size_t keys_size = key_names_left.size();
-
-    /// Rare case, when keys are constant. To avoid code bloat, simply materialize them.
-    /// Note: this variable can't be removed because it will take smart pointers' lifecycle to the end of this function.
-    Columns materialized_columns;
-    ColumnRawPtrs key_columns = extractAndMaterializeKeyColumns(block, materialized_columns, key_names_left);
-
-    /// Keys with NULL value in any column won't join to anything.
-    ColumnPtr null_map_holder;
-    ConstNullMapPtr null_map{};
-    extractNestedColumnsAndNullMap(key_columns, null_map_holder, null_map);
-    /// reuse null_map to record the filtered rows, the rows contains NULL or does not
-    /// match the join filter won't join to anything
-    recordFilteredRows(block, non_equal_conditions.left_filter_column, null_map_holder, null_map);
-
     size_t existing_columns = block.columns();
-
-    /** If you use FULL or RIGHT JOIN, then the columns from the "left" table must be materialized.
-      * Because if they are constants, then in the "not joined" rows, they may have different values
-      *  - default values, which can differ from the values of these constants.
-      */
-    if (getFullness(kind))
-    {
-        for (size_t i = 0; i < existing_columns; ++i)
-        {
-            auto & col = block.getByPosition(i).column;
-
-            if (ColumnPtr converted = col->convertToFullColumnIfConst())
-                col = converted;
-
-            /// convert left columns (except keys) to Nullable
-            if (std::end(key_names_left) == std::find(key_names_left.begin(), key_names_left.end(), block.getByPosition(i).name))
-                convertColumnToNullable(block.getByPosition(i));
-        }
-    }
 
     /** For LEFT/INNER JOIN, the saved blocks do not contain keys.
       * For FULL/RIGHT JOIN, the saved blocks contain keys;
@@ -899,24 +804,13 @@ Block Join::doJoinBlockHash(ProbeProcessInfo & probe_process_info) const
     }
 
     size_t rows = block.rows();
-
-    /// Used with ANY INNER JOIN
-    std::unique_ptr<IColumn::Filter> filter;
-
-    if (((kind == ASTTableJoin::Kind::Inner || kind == ASTTableJoin::Kind::Right) && strictness == ASTTableJoin::Strictness::Any)
-        || kind == ASTTableJoin::Kind::Anti)
-        filter = std::make_unique<IColumn::Filter>(rows);
-
-    /// Used with ALL ... JOIN
     IColumn::Offset current_offset = 0;
-    std::unique_ptr<IColumn::Offsets> offsets_to_replicate;
-
-    if (strictness == ASTTableJoin::Strictness::All)
-        offsets_to_replicate = std::make_unique<IColumn::Offsets>(rows);
+    auto & filter = probe_process_info.filter;
+    auto & offsets_to_replicate = probe_process_info.offsets_to_replicate;
 
     bool enable_spill_join = isEnableSpill();
     JoinBuildInfo join_build_info{enable_fine_grained_shuffle, fine_grained_shuffle_count, enable_spill_join, is_spilled, build_concurrency, restore_round};
-    JoinPartition::probeBlock(partitions, rows, key_columns, key_sizes, added_columns, null_map, filter, current_offset, offsets_to_replicate, right_indexes, collators, join_build_info, probe_process_info);
+    JoinPartition::probeBlock(partitions, rows, probe_process_info.key_columns, key_sizes, added_columns, probe_process_info.null_map, filter, current_offset, offsets_to_replicate, right_indexes, collators, join_build_info, probe_process_info);
     FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::random_join_prob_failpoint);
     for (size_t i = 0; i < num_columns_to_add; ++i)
     {
@@ -973,6 +867,7 @@ Block Join::joinBlockHash(ProbeProcessInfo & probe_process_info) const
 {
     std::vector<Block> result_blocks;
     size_t result_rows = 0;
+    probe_process_info.prepareForProbe(key_names_left, non_equal_conditions.left_filter_column, kind, strictness);
     while (true)
     {
         auto block = doJoinBlockHash(probe_process_info);

--- a/dbms/src/Interpreters/JoinUtils.cpp
+++ b/dbms/src/Interpreters/JoinUtils.cpp
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Columns/ColumnUtils.h>
 #include <Flash/Mpp/HashBaseWriterHelper.h>
 #include <Interpreters/JoinUtils.h>
+#include <Interpreters/NullableUtils.h>
 
 namespace DB
 {
@@ -26,15 +28,131 @@ void ProbeProcessInfo::resetBlock(Block && block_, size_t partition_index_)
     all_rows_joined_finish = false;
     // If the probe block size is greater than max_block_size, we will set max_block_size to the probe block size to avoid some unnecessary split.
     max_block_size = std::max(max_block_size, block.rows());
-    // min_result_block_size is use to avoid generating too many small block, use 50% of the block size as the default value
+    // min_result_block_size is used to avoid generating too many small block, use 50% of the block size as the default value
     min_result_block_size = std::max(1, (std::min(block.rows(), max_block_size) + 1) / 2);
+    prepare_for_probe_done = false;
+    null_map = nullptr;
+    null_map_holder = nullptr;
+    key_columns.clear();
+    materialized_columns.clear();
+    filter.reset();
+    offsets_to_replicate.reset();
 }
 
 void ProbeProcessInfo::updateStartRow()
 {
     assert(start_row <= end_row);
     start_row = end_row;
+    if (filter != nullptr)
+        filter->resize(block.rows());
+    if (offsets_to_replicate != nullptr)
+        offsets_to_replicate->resize(block.rows());
 }
+
+ColumnRawPtrs extractAndMaterializeKeyColumns(const Block & block, Columns & materialized_columns, const Strings & key_columns_names)
+{
+    ColumnRawPtrs key_columns(key_columns_names.size());
+    for (size_t i = 0; i < key_columns_names.size(); ++i)
+    {
+        key_columns[i] = block.getByName(key_columns_names[i]).column.get();
+
+        if (ColumnPtr converted = key_columns[i]->convertToFullColumnIfConst())
+        {
+            materialized_columns.emplace_back(converted);
+            key_columns[i] = materialized_columns.back().get();
+        }
+    }
+    return key_columns;
+}
+
+void recordFilteredRows(const Block & block, const String & filter_column, ColumnPtr & null_map_holder, ConstNullMapPtr & null_map)
+{
+    if (filter_column.empty())
+        return;
+    auto column = block.getByName(filter_column).column;
+    if (column->isColumnConst())
+        column = column->convertToFullColumnIfConst();
+    const PaddedPODArray<UInt8> * column_data;
+    if (column->isColumnNullable())
+    {
+        const auto & column_nullable = static_cast<const ColumnNullable &>(*column);
+        if (!null_map_holder)
+        {
+            null_map_holder = column_nullable.getNullMapColumnPtr();
+        }
+        else
+        {
+            MutableColumnPtr mutable_null_map_holder = (*std::move(null_map_holder)).mutate();
+
+            PaddedPODArray<UInt8> & mutable_null_map = static_cast<ColumnUInt8 &>(*mutable_null_map_holder).getData();
+            const PaddedPODArray<UInt8> & other_null_map = column_nullable.getNullMapData();
+            for (size_t i = 0, size = mutable_null_map.size(); i < size; ++i)
+                mutable_null_map[i] |= other_null_map[i];
+
+            null_map_holder = std::move(mutable_null_map_holder);
+        }
+        column_data = &static_cast<const ColumnVector<UInt8> *>(column_nullable.getNestedColumnPtr().get())->getData();
+    }
+    else
+    {
+        if (!null_map_holder)
+        {
+            null_map_holder = ColumnVector<UInt8>::create(column->size(), 0);
+        }
+        column_data = &static_cast<const ColumnVector<UInt8> *>(column.get())->getData();
+    }
+
+    MutableColumnPtr mutable_null_map_holder = (*std::move(null_map_holder)).mutate();
+    PaddedPODArray<UInt8> & mutable_null_map = static_cast<ColumnUInt8 &>(*mutable_null_map_holder).getData();
+
+    for (size_t i = 0, size = column_data->size(); i < size; ++i)
+        mutable_null_map[i] |= !(*column_data)[i];
+
+    null_map_holder = std::move(mutable_null_map_holder);
+
+    null_map = &static_cast<const ColumnUInt8 &>(*null_map_holder).getData();
+}
+
+void ProbeProcessInfo::prepareForProbe(const Names & key_names, const String & filter_column, ASTTableJoin::Kind kind, ASTTableJoin::Strictness strictness)
+{
+    if (prepare_for_probe_done)
+        return;
+    /// Rare case, when keys are constant. To avoid code bloat, simply materialize them.
+    /// Note: this variable can't be removed because it will take smart pointers' lifecycle to the end of this function.
+    key_columns = extractAndMaterializeKeyColumns(block, materialized_columns, key_names);
+    /// Keys with NULL value in any column won't join to anything.
+    extractNestedColumnsAndNullMap(key_columns, null_map_holder, null_map);
+    /// reuse null_map to record the filtered rows, the rows contains NULL or does not
+    /// match the join filter won't join to anything
+    recordFilteredRows(block, filter_column, null_map_holder, null_map);
+    size_t existing_columns = block.columns();
+
+    /** If you use FULL or RIGHT JOIN, then the columns from the "left" table must be materialized.
+      * Because if they are constants, then in the "not joined" rows, they may have different values
+      *  - default values, which can differ from the values of these constants.
+      */
+    if (getFullness(kind))
+    {
+        for (size_t i = 0; i < existing_columns; ++i)
+        {
+            auto & col = block.getByPosition(i).column;
+
+            if (ColumnPtr converted = col->convertToFullColumnIfConst())
+                col = converted;
+
+            /// convert left columns (except keys) to Nullable
+            if (std::end(key_names) == std::find(key_names.begin(), key_names.end(), block.getByPosition(i).name))
+                convertColumnToNullable(block.getByPosition(i));
+        }
+    }
+    if (((kind == ASTTableJoin::Kind::Inner || kind == ASTTableJoin::Kind::Right) && strictness == ASTTableJoin::Strictness::Any)
+        || kind == ASTTableJoin::Kind::Anti)
+        filter = std::make_unique<IColumn::Filter>(block.rows());
+    if (strictness == ASTTableJoin::Strictness::All)
+        offsets_to_replicate = std::make_unique<IColumn::Offsets>(block.rows());
+    prepare_for_probe_done = true;
+}
+
 namespace
 {
 UInt64 inline updateHashValue(size_t restore_round, UInt64 x)

--- a/dbms/src/Interpreters/JoinUtils.h
+++ b/dbms/src/Interpreters/JoinUtils.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <Columns/ColumnNullable.h>
 #include <Core/Block.h>
 #include <Parsers/ASTTablesInSelectQuery.h>
 
@@ -71,6 +72,17 @@ struct ProbeProcessInfo
     size_t end_row;
     bool all_rows_joined_finish;
 
+    /// these are used for probe
+    bool prepare_for_probe_done = false;
+    Columns materialized_columns;
+    ColumnRawPtrs key_columns;
+    ColumnPtr null_map_holder = nullptr;
+    ConstNullMapPtr null_map = nullptr;
+    /// Used with ANY INNER JOIN
+    std::unique_ptr<IColumn::Filter> filter = nullptr;
+    /// Used with ALL ... JOIN
+    std::unique_ptr<IColumn::Offsets> offsets_to_replicate = nullptr;
+
     explicit ProbeProcessInfo(UInt64 max_block_size_)
         : max_block_size(max_block_size_)
         , min_result_block_size((max_block_size + 1) / 2)
@@ -78,6 +90,7 @@ struct ProbeProcessInfo
 
     void resetBlock(Block && block_, size_t partition_index_ = 0);
     void updateStartRow();
+    void prepareForProbe(const Names & key_names, const String & filter_column, ASTTableJoin::Kind kind, ASTTableJoin::Strictness strictness);
 };
 struct JoinBuildInfo
 {
@@ -98,4 +111,6 @@ void computeDispatchHash(size_t rows,
                          std::vector<String> & partition_key_containers,
                          size_t join_restore_round,
                          WeakHash32 & hash);
+ColumnRawPtrs extractAndMaterializeKeyColumns(const Block & block, Columns & materialized_columns, const Strings & key_columns_names);
+void recordFilteredRows(const Block & block, const String & filter_column, ColumnPtr & null_map_holder, ConstNullMapPtr & null_map);
 } // namespace DB


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6233

Problem Summary:
Currently, for each `Join::doJoinBlockHash`, it will do some preparations before call `JoinPartition::probeBlock`, if split happens, these preparations are redundant if the input block is unchanged.
### What is changed and how it works?
Refine code to avoid redundant calculation when join probe split happens
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
