### PR TITLE
Refine establish log

### DIFF
--- a/dbms/src/Flash/EstablishCall.cpp
+++ b/dbms/src/Flash/EstablishCall.cpp
@@ -122,6 +122,8 @@ void EstablishCallData::attachAsyncTunnelSender(const std::shared_ptr<DB::AsyncT
 
 void EstablishCallData::startEstablishConnection()
 {
+    connection_id = fmt::format("tunnel{}+{}", request.sender_meta().task_id(), request.receiver_meta().task_id());
+    query_id = MPPQueryId(request.sender_meta()).toString();
     stopwatch = std::make_unique<Stopwatch>();
 }
 
@@ -137,7 +139,7 @@ void EstablishCallData::initRpc()
     {
         FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::random_tunnel_init_rpc_failure_failpoint);
 
-        auto res = service->establishMPPConnectionAsync(&ctx, &request, this);
+        auto res = service->establishMPPConnectionAsync(this);
 
         if (!res.ok())
             writeDone("initRpc called with no-ok status", res);
@@ -201,13 +203,19 @@ void EstablishCallData::writeErr(const mpp::MPPDataPacket & packet)
     write(packet);
 }
 
+static LoggerPtr & getLogger()
+{
+    static auto logger = Logger::get("EstablishCallData");
+    return logger;
+}
+
 void EstablishCallData::writeDone(String msg, const grpc::Status & status)
 {
     state = FINISH;
 
     if (async_tunnel_sender)
     {
-        LOG_INFO(async_tunnel_sender->getLogger(), "connection for {} cost {} ms, including {} ms to waiting task.", async_tunnel_sender->getTunnelId(), stopwatch->elapsedMilliseconds(), waiting_task_time_ms);
+        LOG_INFO(async_tunnel_sender->getLogger(), "connection for {} cost {}ms, including {}ms to waiting task.", async_tunnel_sender->getTunnelId(), stopwatch->elapsedMilliseconds(), waiting_task_time_ms);
 
         RUNTIME_ASSERT(!async_tunnel_sender->isConsumerFinished(), async_tunnel_sender->getLogger(), "tunnel {} consumer finished in advance", async_tunnel_sender->getTunnelId());
 
@@ -217,6 +225,10 @@ void EstablishCallData::writeDone(String msg, const grpc::Status & status)
         }
         // Trigger mpp tunnel finish work.
         async_tunnel_sender->consumerFinish(msg);
+    }
+    else if (stopwatch != nullptr)
+    {
+        LOG_WARNING(getLogger(), "EstablishCallData finishes without connected, time cost {}ms, query id: {}, connection id: {}", stopwatch->elapsedMilliseconds(), query_id, connection_id);
     }
 
     responder.Finish(status, this);

--- a/dbms/src/Flash/EstablishCall.h
+++ b/dbms/src/Flash/EstablishCall.h
@@ -18,9 +18,8 @@
 #include <Common/Stopwatch.h>
 #include <Flash/FlashService.h>
 #include <Flash/Mpp/GRPCSendQueue.h>
+#include <Flash/Mpp/MPPTaskId.h>
 #include <kvproto/tikvpb.grpc.pb.h>
-
-#include "Flash/Mpp/MPPTaskId.h"
 
 namespace DB
 {

--- a/dbms/src/Flash/EstablishCall.h
+++ b/dbms/src/Flash/EstablishCall.h
@@ -20,6 +20,8 @@
 #include <Flash/Mpp/GRPCSendQueue.h>
 #include <kvproto/tikvpb.grpc.pb.h>
 
+#include "Flash/Mpp/MPPTaskId.h"
+
 namespace DB
 {
 class AsyncTunnelSender;
@@ -82,6 +84,9 @@ public:
 
     void tryConnectTunnel();
 
+    const mpp::EstablishMPPConnectionRequest & getRequest() const { return request; }
+    grpc::ServerContext * getGrpcContext() { return &ctx; }
+
 private:
     /// WARNING: Since a event from one grpc completion queue may be handled by different
     /// thread, it's EXTREMELY DANGEROUS to read/write any data after calling a grpc function
@@ -133,6 +138,8 @@ private:
 
     std::shared_ptr<DB::AsyncTunnelSender> async_tunnel_sender;
     std::unique_ptr<Stopwatch> stopwatch;
+    String query_id;
+    String connection_id;
     double waiting_task_time_ms = 0;
 };
 } // namespace DB

--- a/dbms/src/Flash/FlashService.cpp
+++ b/dbms/src/Flash/FlashService.cpp
@@ -357,20 +357,19 @@ static grpc::Status CheckMppVersionForEstablishMPPConnection(const mpp::Establis
     return grpc::Status::OK;
 }
 
-grpc::Status AsyncFlashService::establishMPPConnectionAsync(grpc::ServerContext * grpc_context,
-                                                            const mpp::EstablishMPPConnectionRequest * request,
-                                                            EstablishCallData * call_data)
+grpc::Status AsyncFlashService::establishMPPConnectionAsync(EstablishCallData * call_data)
 {
     CPUAffinityManager::getInstance().bindSelfGrpcThread();
     // Establish a pipe for data transferring. The pipes have registered by the task in advance.
     // We need to find it out and bind the grpc stream with it.
-    LOG_INFO(log, "Handling establish mpp connection request: {}", request->DebugString());
+    auto & request = call_data->getRequest();
+    LOG_INFO(log, "Handling establish mpp connection request: {}", request.DebugString());
 
-    auto check_result = checkGrpcContext(grpc_context);
+    auto check_result = checkGrpcContext(call_data->getGrpcContext());
     if (!check_result.ok())
         return check_result;
 
-    if (auto res = CheckMppVersionForEstablishMPPConnection(request); !res.ok())
+    if (auto res = CheckMppVersionForEstablishMPPConnection(&request); !res.ok())
     {
         LOG_WARNING(log, res.error_message());
         return res;

--- a/dbms/src/Flash/FlashService.cpp
+++ b/dbms/src/Flash/FlashService.cpp
@@ -362,7 +362,7 @@ grpc::Status AsyncFlashService::establishMPPConnectionAsync(EstablishCallData * 
     CPUAffinityManager::getInstance().bindSelfGrpcThread();
     // Establish a pipe for data transferring. The pipes have registered by the task in advance.
     // We need to find it out and bind the grpc stream with it.
-    auto & request = call_data->getRequest();
+    const auto & request = call_data->getRequest();
     LOG_INFO(log, "Handling establish mpp connection request: {}", request.DebugString());
 
     auto check_result = checkGrpcContext(call_data->getGrpcContext());

--- a/dbms/src/Flash/FlashService.h
+++ b/dbms/src/Flash/FlashService.h
@@ -135,6 +135,6 @@ public:
     }
     /// Return grpc::Status::OK when the connection is established.
     /// Return non-OK grpc::Status when the connection can not be established.
-    grpc::Status establishMPPConnectionAsync(grpc::ServerContext * context, const mpp::EstablishMPPConnectionRequest * request, EstablishCallData * call_data);
+    grpc::Status establishMPPConnectionAsync(EstablishCallData * call_data);
 };
 } // namespace DB


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6233

Problem Summary:
When try to find the root cause of #7294, I found if `EstablishCallData::writeDone` is called, it will be more convenient to log it's query/connection info even if the current connection is not connected.
### What is changed and how it works?
- Try to log information in `EstablishCallData::writeDone` even if the EstablishCallData is not connected.
- Log tunnel info when `FindTunnel` failed.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
