### PR TITLE
Support using podman to replace docker in some build scripts

### DIFF
--- a/release-centos7-llvm/Makefile
+++ b/release-centos7-llvm/Makefile
@@ -12,37 +12,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+DOCKER ?= docker
+
 # base docker files
 image_tiflash_llvm_base_amd64:
-	docker build dockerfiles -f dockerfiles/tiflash-llvm-base-amd64 -t hub.pingcap.net/tiflash/tiflash-llvm-base:amd64
+	$(DOCKER) build dockerfiles -f dockerfiles/tiflash-llvm-base-amd64 -t hub.pingcap.net/tiflash/tiflash-llvm-base:amd64
 
 image_tiflash_llvm_base_aarch64:
-	docker build dockerfiles -f dockerfiles/tiflash-llvm-base-aarch64 -t hub.pingcap.net/tiflash/tiflash-llvm-base:aarch64
+	$(DOCKER) build dockerfiles -f dockerfiles/tiflash-llvm-base-aarch64 -t hub.pingcap.net/tiflash/tiflash-llvm-base:aarch64
 
 # build tiflash
 build_tiflash_release_amd64:
-	docker run --rm -v $(realpath ..):/build/tics hub.pingcap.net/tiflash/tiflash-llvm-base:amd64 /build/tics/release-centos7-llvm/scripts/build-release.sh
+	$(DOCKER) run --rm -v $(realpath ..):/build/tics hub.pingcap.net/tiflash/tiflash-llvm-base:amd64 /build/tics/release-centos7-llvm/scripts/build-release.sh
 
 # Add build_tiflash_debug_amd64 target to enable FailPoints on x86. Since outputs are the same as release version, no new package targets added. 
 build_tiflash_debug_amd64:
-	docker run --rm -v $(realpath ..):/build/tics hub.pingcap.net/tiflash/tiflash-llvm-base:amd64 /build/tics/release-centos7-llvm/scripts/build-debug.sh
+	$(DOCKER) run --rm -v $(realpath ..):/build/tics hub.pingcap.net/tiflash/tiflash-llvm-base:amd64 /build/tics/release-centos7-llvm/scripts/build-debug.sh
 
 build_tiflash_ci_amd64:
-	docker run --rm -v $(realpath ..):/build/tics hub.pingcap.net/tiflash/tiflash-llvm-base:amd64 /build/tics/release-centos7-llvm/scripts/build-tiflash-ci.sh
+	$(DOCKER) run --rm -v $(realpath ..):/build/tics hub.pingcap.net/tiflash/tiflash-llvm-base:amd64 /build/tics/release-centos7-llvm/scripts/build-tiflash-ci.sh
 
 build_tiflash_release_aarch64:
-	docker run --rm -v $(realpath ..):/build/tics hub.pingcap.net/tiflash/tiflash-llvm-base:aarch64 /build/tics/release-centos7-llvm/scripts/build-release.sh
+	$(DOCKER) run --rm -v $(realpath ..):/build/tics hub.pingcap.net/tiflash/tiflash-llvm-base:aarch64 /build/tics/release-centos7-llvm/scripts/build-release.sh
 
 build_tiflash_ci_aarch64:
-	docker run --rm -v $(realpath ..):/build/tics hub.pingcap.net/tiflash/tiflash-llvm-base:aarch64 /build/tics/release-centos7-llvm/scripts/build-tiflash-ci.sh
+	$(DOCKER) run --rm -v $(realpath ..):/build/tics hub.pingcap.net/tiflash/tiflash-llvm-base:aarch64 /build/tics/release-centos7-llvm/scripts/build-tiflash-ci.sh
 
 # package tiflash
 image_tiflash_release:
-	docker build -f dockerfiles/Dockerfile-tiflash-centos7 -t hub.pingcap.net/tiflash/tiflash-server-centos7 .
+	$(DOCKER) build -f dockerfiles/Dockerfile-tiflash-centos7 -t hub.pingcap.net/tiflash/tiflash-server-centos7 .
 
 image_tiflash_ci:
-	docker build -f dockerfiles/Dockerfile-tiflash-ci -t hub.pingcap.net/tiflash/tiflash-ci-centos7 .
+	$(DOCKER) build -f dockerfiles/Dockerfile-tiflash-ci -t hub.pingcap.net/tiflash/tiflash-ci-centos7 .
 
 image_tiflash_ci_base:
-	docker build -f dockerfiles/Dockerfile-tiflash-ci-base -t hub.pingcap.net/tiflash/tiflash-ci-base .
+	$(DOCKER) build -f dockerfiles/Dockerfile-tiflash-ci-base -t hub.pingcap.net/tiflash/tiflash-ci-base .
 

--- a/release-centos7-llvm/env/Makefile
+++ b/release-centos7-llvm/env/Makefile
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+DOCKER ?= docker
 ARCH=$(shell uname -m)
 MOUNT=$(shell realpath tiflash-env)
 DOCKER_TAG=$(shell [[ "$(ARCH)" == "aarch64" ]] && echo "aarch64" || echo "amd64" )
+
 tiflash-env:
 	mkdir -p tiflash-env
 
@@ -30,7 +32,7 @@ tiflash-env/tiflash-linker: tiflash-env
 tiflash-env-$(ARCH).tar.xz: tiflash-env/prepare-sysroot.sh tiflash-env/loader tiflash-env/tiflash-linker
 	# Add the z to modify the selinux label of the host file or directory being mounted into the container.
 	# Reference: https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label
-	docker run --rm -v $(MOUNT):/tiflash-env:z hub.pingcap.net/tiflash/tiflash-llvm-base:$(DOCKER_TAG) /tiflash-env/prepare-sysroot.sh
+	$(DOCKER) run --rm -v $(MOUNT):/tiflash-env:z hub.pingcap.net/tiflash/tiflash-llvm-base:$(DOCKER_TAG) /tiflash-env/prepare-sysroot.sh
 	tar -cvaf tiflash-env-$(ARCH).tar.xz tiflash-env
 
 clean:


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/6233

Problem Summary:

`podman` is a default placement for `docker` under rocky linux 9.

### What is changed and how it works?

Define the docker binary by `DOCKER ?= docker` in some Makefiles, so that we can run by `DOCKER=podman make build_tiflash_release_amd64`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
