### PR TITLE
Add more cross join tests, refine `CrossJoinAdder`

### DIFF
--- a/dbms/src/Debug/MockExecutor/JoinBinder.h
+++ b/dbms/src/Debug/MockExecutor/JoinBinder.h
@@ -35,8 +35,6 @@ public:
         , is_null_aware_semi_join(is_null_aware_semi_join)
         , inner_index(inner_index_)
     {
-        if (!(join_cols.size() + left_conds.size() + right_conds.size() + other_conds.size() + other_eq_conds_from_in.size()))
-            throw Exception("No join condition found.");
     }
 
     void columnPrune(std::unordered_set<String> & used_columns) override;

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -154,6 +154,8 @@ Join::Join(
         has_other_condition = false;
     }
 
+    if (unlikely(kind == ASTTableJoin::Kind::Cross_RightOuter))
+        throw Exception("Cross right outer join should be converted to cross Left outer join during compile");
     String err = non_equal_conditions.validate(kind);
     if (unlikely(!err.empty()))
         throw Exception("Validate join conditions error: {}" + err);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6233

Problem Summary:
1. add more tests for cross join
2. refine `CrossJoinAdder`, so only `Cross_Anti` join will use `is_row_matched` and only `strictness == All` will use `expanded_row_size_after_join`
### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
