### PR TITLE
Check read content length of S3 file.

### DIFF
--- a/dbms/src/Storages/S3/S3RandomAccessFile.cpp
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.cpp
@@ -78,6 +78,8 @@ ssize_t S3RandomAccessFile::readImpl(char * buf, size_t size)
     auto & istr = read_result.GetBody();
     istr.read(buf, size);
     size_t gcount = istr.gcount();
+    // Theoretically, `istr.eof()` is equivalent to `cur_offset + gcount != static_cast<size_t>(content_length)`.
+    // It's just a double check for more safty.
     if (gcount < size && (!istr.eof() || cur_offset + gcount != static_cast<size_t>(content_length)))
     {
         LOG_ERROR(

--- a/dbms/src/Storages/S3/S3RandomAccessFile.cpp
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.cpp
@@ -78,9 +78,16 @@ ssize_t S3RandomAccessFile::readImpl(char * buf, size_t size)
     auto & istr = read_result.GetBody();
     istr.read(buf, size);
     size_t gcount = istr.gcount();
-    if (gcount == 0 && !istr.eof())
+    if (gcount < size && (!istr.eof() || cur_offset + gcount != static_cast<size_t>(content_length)))
     {
-        LOG_ERROR(log, "Cannot read from istream, errmsg={}", strerror(errno));
+        LOG_ERROR(
+            log,
+            "Cannot read from istream, gcount={}, eof={}, cur_offset={}, content_length={} errmsg={}",
+            gcount,
+            istr.eof(),
+            cur_offset,
+            content_length,
+            strerror(errno));
         return -1;
     }
     cur_offset += gcount;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #7312 

### What is changed and how it works?

Check read content length of S3 file.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  - Run chbenchmark.
    - TP workload: `tiup bench ch --warehouses 1500 -T 20 -t 0 --time 100h --ignore-error -H 127.0.0.1 -P 4000 -D chbenchmark run`
    - AP workload: `tiup bench ch --warehouses 1500 -T 0 -t 2 --time 100h  -H 127.0.0.1 -P 4000 -D chbenchmark --ignore-error  run`
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
