### PR TITLE
Fix large write cause tiflash crash

### DIFF
--- a/dbms/src/Common/FailPoint.cpp
+++ b/dbms/src/Common/FailPoint.cpp
@@ -100,7 +100,8 @@ namespace DB
     M(force_use_dmfile_format_v3)                            \
     M(force_set_mocked_s3_object_mtime)                      \
     M(force_stop_background_checkpoint_upload)               \
-    M(skip_seek_before_read_dmfile)
+    M(skip_seek_before_read_dmfile)                          \
+    M(exception_after_large_write_exceed)
 
 #define APPLY_FOR_PAUSEABLE_FAILPOINTS_ONCE(M) \
     M(pause_with_alter_locks_acquired)         \

--- a/dbms/src/IO/MemoryReadWriteBuffer.cpp
+++ b/dbms/src/IO/MemoryReadWriteBuffer.cpp
@@ -49,7 +49,7 @@ public:
         return setChunk();
     }
 
-    ~ReadBufferFromMemoryWriteBuffer()
+    ~ReadBufferFromMemoryWriteBuffer() override
     {
         for (const auto & range : chunk_list)
             free(range.begin(), range.size());
@@ -138,7 +138,7 @@ void MemoryWriteBuffer::addChunk()
         }
     }
 
-    Position begin = reinterpret_cast<Position>(alloc(next_chunk_size));
+    auto * begin = reinterpret_cast<Position>(alloc(next_chunk_size));
     chunk_tail = chunk_list.emplace_after(chunk_tail, begin, begin + next_chunk_size);
     total_chunks_size += next_chunk_size;
 

--- a/dbms/src/Storages/Page/V3/Blob/BlobStat.h
+++ b/dbms/src/Storages/Page/V3/Blob/BlobStat.h
@@ -37,18 +37,6 @@ public:
         READ_ONLY = 2
     };
 
-    static String blobTypeToString(BlobStatType type)
-    {
-        switch (type)
-        {
-        case BlobStatType::NORMAL:
-            return "normal";
-        case BlobStatType::READ_ONLY:
-            return "read only";
-        }
-        return "Invalid";
-    }
-
     struct BlobStat
     {
         const BlobFileId id;

--- a/dbms/src/Storages/Page/V3/BlobStore.cpp
+++ b/dbms/src/Storages/Page/V3/BlobStore.cpp
@@ -69,6 +69,7 @@ static constexpr bool BLOBSTORE_CHECKSUM_ON_READ = true;
 using BlobStatPtr = BlobStats::BlobStatPtr;
 using ChecksumClass = Digest::CRC64;
 static_assert(!std::is_same_v<ChecksumClass, Digest::XXH3>, "The checksum must support streaming checksum");
+static_assert(!std::is_same_v<ChecksumClass, Digest::City128>, "The checksum must support streaming checksum");
 
 /**********************
   * BlobStore methods *
@@ -573,7 +574,7 @@ BlobStore<Trait>::write(typename Trait::WriteBatch && wb, const WriteLimiterPtr 
     catch (DB::Exception & e)
     {
         removePosFromStats(blob_id, offset_in_file, actually_allocated_size);
-        LOG_ERROR(log, "[blob_id={}] [offset_in_file={}] [size={}] [actually_allocated_size={}] write failed [error={}]", blob_id, offset_in_file, all_page_data_size, actually_allocated_size, e.message());
+        LOG_ERROR(log, "write failed, blob_id={} offset_in_file={} size={} actually_allocated_size={} msg={}", blob_id, offset_in_file, all_page_data_size, actually_allocated_size, e.message());
         throw e;
     }
 

--- a/dbms/src/Storages/Page/V3/BlobStore.cpp
+++ b/dbms/src/Storages/Page/V3/BlobStore.cpp
@@ -424,6 +424,7 @@ BlobStore<Trait>::write(typename Trait::WriteBatch && wb, const WriteLimiterPtr 
     // This can avoid allocating a big buffer for writing data and can smooth memory usage.
     if (all_page_data_size > config.file_limit_size)
     {
+        LOG_INFO(log, "handling large write, all_page_data_size={}", all_page_data_size);
         return handleLargeWrite(std::move(wb), write_limiter);
     }
 

--- a/dbms/src/Storages/Page/V3/BlobStore.h
+++ b/dbms/src/Storages/Page/V3/BlobStore.h
@@ -98,7 +98,7 @@ public:
 private:
 #endif
 
-    PageEntriesEdit handleLargeWrite(typename Trait::WriteBatch & wb, const WriteLimiterPtr & write_limiter = nullptr);
+    PageEntriesEdit handleLargeWrite(typename Trait::WriteBatch && wb, const WriteLimiterPtr & write_limiter = nullptr);
 
     BlobFilePtr read(const PageId & page_id_v3, BlobFileId blob_id, BlobFileOffset offset, char * buffers, size_t size, const ReadLimiterPtr & read_limiter = nullptr, bool background = false);
 

--- a/dbms/src/Storages/Page/V3/tests/gtest_blob_store.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_blob_store.cpp
@@ -12,10 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Common/FailPoint.h>
 #include <Common/Logger.h>
 #include <Encryption/RateLimiter.h>
 #include <IO/ReadBufferFromMemory.h>
 #include <Poco/Logger.h>
+#include <Storages/Page/PageConstants.h>
+#include <Storages/Page/PageDefinesBase.h>
 #include <Storages/Page/V3/BlobStore.h>
 #include <Storages/Page/V3/PageDefines.h>
 #include <Storages/Page/V3/PageDirectory.h>
@@ -27,6 +30,11 @@
 #include <TestUtils/MockReadLimiter.h>
 #include <TestUtils/TiFlashStorageTestBasic.h>
 #include <TestUtils/TiFlashTestBasic.h>
+
+namespace DB::FailPoints
+{
+extern const char exception_after_large_write_exceed[];
+} // namespace DB::FailPoints
 
 namespace DB::PS::V3::tests
 {
@@ -1135,7 +1143,7 @@ try
 }
 CATCH
 
-TEST_F(BlobStoreTest, TestBigBlob)
+TEST_F(BlobStoreTest, LargeWrite)
 try
 {
     const auto file_provider = DB::tests::TiFlashTestEnv::getDefaultFileProvider();
@@ -1146,16 +1154,11 @@ try
     test_config.file_limit_size = 4 * MB;
     auto blob_store = BlobStore(getCurrentTestName(), file_provider, delegator, test_config);
 
-    // PUT page_id 50 into blob 1
-
+    // PUT page_id 50 into blob 1 (normal write)
     {
         MemoryWriteBuffer buffer;
-        size_t serialized_size = 0;
-        while (buffer.count() < test_config.file_limit_size)
-        {
-            buffer.write(fixed_buffer, fixed_buffer_size);
-            serialized_size += fixed_buffer_size;
-        }
+        size_t serialized_size = 200;
+        buffer.write(fixed_buffer, serialized_size);
 
         WriteBatch wb;
         ReadBufferPtr read_buff = buffer.tryGetReadBuffer();
@@ -1170,15 +1173,20 @@ try
 
         const auto & stat = blob_store.blob_stats.blobIdToStat(1);
         ASSERT_TRUE(stat->isNormal());
-        ASSERT_EQ(stat->sm_max_caps, serialized_size);
+        ASSERT_EQ(stat->sm_max_caps, test_config.file_limit_size - serialized_size);
         ASSERT_DOUBLE_EQ(stat->sm_valid_rate, 1.0);
         ASSERT_EQ(stat->sm_valid_size, serialized_size);
         ASSERT_EQ(stat->sm_total_size, serialized_size);
 
+        // Verify read
+        Page page = blob_store.read(std::make_pair(buildV3Id(TEST_NAMESPACE_ID, page_id), records[0].entry), nullptr);
+        ASSERT_TRUE(page.isValid());
+        ASSERT_EQ(page.data.size(), serialized_size);
+
         page_id++;
     }
 
-    // PUT page_id 51 into blob 2
+    // PUT page_id 51 into blob 2 (large write)
     {
         MemoryWriteBuffer buffer;
         size_t serialized_size = 0;
@@ -1201,6 +1209,7 @@ try
 
         // verify blobstat
         const auto & stat = blob_store.blob_stats.blobIdToStat(2);
+        ASSERT_TRUE(stat->isReadOnly()); // large write, this stat is read only
         ASSERT_EQ(stat->sm_max_caps, 0);
         ASSERT_DOUBLE_EQ(stat->sm_valid_rate, 1.0);
         ASSERT_EQ(stat->sm_valid_size, serialized_size);
@@ -1212,17 +1221,17 @@ try
         ASSERT_EQ(page.data.size(), serialized_size);
 
         page_id++;
-        wb.clear();
     }
-#if 0
-    // PUT page_id 52 into blob 1
+
+    // PUT page_id 52 into blob 1 (normal write)
     {
-        size_t size_100 = 100;
-        char c_buff[size_100];
+        MemoryWriteBuffer buffer;
+        size_t serialized_size = 100;
+        buffer.write(fixed_buffer, serialized_size);
 
         WriteBatch wb;
-        ReadBufferPtr buff = std::make_shared<ReadBufferFromMemory>(const_cast<char *>(c_buff), size_100);
-        wb.putPage(page_id, /* tag */ 0, buff, size_100);
+        ReadBufferPtr read_buff = buffer.tryGetReadBuffer();
+        wb.putPage(page_id, /* tag */ 0, read_buff, serialized_size);
         PageEntriesEdit edit = blob_store.write(std::move(wb), nullptr);
 
         const auto & records = edit.getRecords();
@@ -1233,86 +1242,260 @@ try
 
         const auto & stat = blob_store.blob_stats.blobIdToStat(1);
         ASSERT_TRUE(stat->isNormal());
-        ASSERT_EQ(stat->sm_max_caps, 100);
+        ASSERT_EQ(stat->sm_max_caps, test_config.file_limit_size - 200 - 100);
         ASSERT_DOUBLE_EQ(stat->sm_valid_rate, 1.0);
         ASSERT_EQ(stat->sm_valid_size, 300);
         ASSERT_EQ(stat->sm_total_size, 300);
 
+        // Verify read
+        Page page = blob_store.read(std::make_pair(buildV3Id(TEST_NAMESPACE_ID, page_id), records[0].entry), nullptr);
+        ASSERT_TRUE(page.isValid());
+        ASSERT_EQ(page.data.size(), serialized_size);
+
         page_id++;
-        wb.clear();
     }
 
     // PUT page_id 53 into blob 3 range [0,300]
     {
-        size_t size_300 = 300;
-        char c_buff[size_300];
+        MemoryWriteBuffer buffer;
+        size_t serialized_size = 0;
+        while (buffer.count() < test_config.file_limit_size * 1.5)
+        {
+            buffer.write(fixed_buffer, fixed_buffer_size);
+            serialized_size += fixed_buffer_size;
+        }
 
         WriteBatch wb;
-        ReadBufferPtr buff = std::make_shared<ReadBufferFromMemory>(const_cast<char *>(c_buff), size_300);
-        wb.putPage(page_id, /* tag */ 0, buff, size_300);
+        ReadBufferPtr read_buff = buffer.tryGetReadBuffer();
+        wb.putPage(page_id, /* tag */ 0, read_buff, serialized_size);
         PageEntriesEdit edit = blob_store.write(std::move(wb), nullptr);
 
         const auto & records = edit.getRecords();
         ASSERT_EQ(records.size(), 1);
         ASSERT_EQ(records[0].entry.file_id, 3);
         ASSERT_EQ(records[0].entry.offset, 0);
-        ASSERT_EQ(records[0].entry.size, 300);
+        ASSERT_EQ(records[0].entry.size, serialized_size);
 
         const auto & stat = blob_store.blob_stats.blobIdToStat(3);
-        ASSERT_TRUE(stat->isNormal());
-        ASSERT_EQ(stat->sm_max_caps, 100);
+        ASSERT_TRUE(stat->isReadOnly()); // large write, this stat is read only
+        ASSERT_EQ(stat->sm_max_caps, 0);
         ASSERT_DOUBLE_EQ(stat->sm_valid_rate, 1.0);
-        ASSERT_EQ(stat->sm_valid_size, 300);
-        ASSERT_EQ(stat->sm_total_size, 300);
+        ASSERT_EQ(stat->sm_valid_size, serialized_size);
+        ASSERT_EQ(stat->sm_total_size, serialized_size);
+
+        // Verify read
+        Page page = blob_store.read(std::make_pair(buildV3Id(TEST_NAMESPACE_ID, page_id), records[0].entry), nullptr);
+        ASSERT_TRUE(page.isValid());
+        ASSERT_EQ(page.data.size(), serialized_size);
 
         page_id++;
     }
 
-    // Test mix BigBlob
+    // Large write compose by multiple puts
     {
-        char c_buff1[600];
-        char c_buff2[10];
-        char c_buff3[500];
-        char c_buff4[200];
+        std::vector<double> test_scales = {1.5, 0.2, 0.4, 1.1};
+        std::vector<size_t> actual_size;
 
         WriteBatch wb;
-        wb.putPage(page_id++, /* tag */ 0, std::make_shared<ReadBufferFromMemory>(const_cast<char *>(c_buff1), sizeof(c_buff1)), sizeof(c_buff1));
-        wb.putPage(page_id++, /* tag */ 0, std::make_shared<ReadBufferFromMemory>(const_cast<char *>(c_buff2), sizeof(c_buff2)), sizeof(c_buff2));
-        wb.putPage(page_id++, /* tag */ 0, std::make_shared<ReadBufferFromMemory>(const_cast<char *>(c_buff3), sizeof(c_buff3)), sizeof(c_buff3));
-        wb.putPage(page_id++, /* tag */ 0, std::make_shared<ReadBufferFromMemory>(const_cast<char *>(c_buff4), sizeof(c_buff4)), sizeof(c_buff4));
+        for (const auto & scale : test_scales)
+        {
+            size_t serialized_size = 0;
+            MemoryWriteBuffer buffer;
+            while (buffer.count() < test_config.file_limit_size * scale)
+            {
+                buffer.write(fixed_buffer, fixed_buffer_size);
+                serialized_size += fixed_buffer_size;
+            }
+            wb.putPage(page_id++, /* tag */ 0, buffer.tryGetReadBuffer(), serialized_size);
+            actual_size.emplace_back(serialized_size);
+        }
+        ASSERT_EQ(test_scales.size(), actual_size.size());
 
         PageEntriesEdit edit = blob_store.write(std::move(wb), nullptr);
 
         const auto & records = edit.getRecords();
         ASSERT_EQ(records.size(), 4);
 
-        // PUT page_id 54 into blob 4 range [0,600]
+        // PUT page_id 54 into blob 4 (large write)
         ASSERT_EQ(records[0].page_id.low, 54);
         ASSERT_EQ(records[0].entry.file_id, 4);
         ASSERT_EQ(records[0].entry.offset, 0);
-        ASSERT_EQ(records[0].entry.size, 600);
+        ASSERT_EQ(records[0].entry.size, actual_size[0]);
 
         // PUT page_id 55 into blob 1 or 3
         ASSERT_EQ(records[1].page_id.low, 55);
         ASSERT_TRUE(records[1].entry.file_id == 1 || records[1].entry.file_id == 3);
+        ASSERT_EQ(records[1].entry.size, actual_size[1]);
 
-        // PUT page_id 56 into blob 5 range [0,600]
+        // PUT page_id 56 into blob 5
         ASSERT_EQ(records[2].page_id.low, 56);
-        ASSERT_EQ(records[2].entry.file_id, 5);
-        ASSERT_EQ(records[2].entry.offset, 0);
-        ASSERT_EQ(records[2].entry.size, 500);
+        ASSERT_TRUE(records[2].entry.file_id == 1 || records[2].entry.file_id == 3);
+        ASSERT_EQ(records[2].entry.size, actual_size[2]);
 
-        // PUT page_id 57 into blob 6 range [0,200]
+        // PUT page_id 57 into blob 6 (large write)
         ASSERT_EQ(records[3].page_id.low, 57);
-        ASSERT_EQ(records[3].entry.file_id, 6);
+        ASSERT_EQ(records[3].entry.file_id, 5);
         ASSERT_EQ(records[3].entry.offset, 0);
-        ASSERT_EQ(records[3].entry.size, 200);
+        ASSERT_EQ(records[3].entry.size, actual_size[3]);
     }
-#endif
 }
 CATCH
 
-TEST_F(BlobStoreTest, TestBigBlobRemove)
+TEST_F(BlobStoreTest, LargeWriteWithFields)
+try
+{
+    const auto file_provider = DB::tests::TiFlashTestEnv::getDefaultFileProvider();
+    PageIdU64 fixed_page_id = 50;
+    PageIdU64 page_id = fixed_page_id;
+
+    BlobConfig test_config;
+    test_config.file_limit_size = 4 * MB;
+    auto blob_store = BlobStore(getCurrentTestName(), file_provider, delegator, test_config);
+
+    // PUT page_id 50 into blob 1 (large write)
+    {
+        MemoryWriteBuffer buffer;
+        size_t serialized_size = 0;
+        while (buffer.count() < test_config.file_limit_size * 2)
+        {
+            buffer.write(fixed_buffer, fixed_buffer_size);
+            serialized_size += fixed_buffer_size;
+        }
+
+        WriteBatch wb;
+        ReadBufferPtr read_buff = buffer.tryGetReadBuffer();
+        PageFieldSizes field_sizes = [&]() {
+            PageFieldSizes sizes{1035, 1 * MB + 24, 30, 50, 70, 67, 89, 97};
+            auto sum_of_sizes = std::accumulate(field_sizes.begin(), field_sizes.end(), 0UL);
+            field_sizes.emplace_back(serialized_size - sum_of_sizes);
+            return sizes;
+        }();
+        wb.putPage(page_id, /* tag */ 0, read_buff, serialized_size, field_sizes);
+        PageEntriesEdit edit = blob_store.write(std::move(wb), nullptr);
+
+        const auto & records = edit.getRecords();
+        ASSERT_EQ(records.size(), 1);
+        ASSERT_EQ(records[0].entry.file_id, 1);
+        ASSERT_EQ(records[0].entry.offset, 0);
+        ASSERT_EQ(records[0].entry.size, serialized_size);
+
+        // verify blobstat
+        const auto & stat = blob_store.blob_stats.blobIdToStat(1);
+        ASSERT_TRUE(stat->isReadOnly()); // large write, this stat is read only
+        ASSERT_EQ(stat->sm_max_caps, 0);
+        ASSERT_DOUBLE_EQ(stat->sm_valid_rate, 1.0);
+        ASSERT_EQ(stat->sm_valid_size, serialized_size);
+        ASSERT_EQ(stat->sm_total_size, serialized_size);
+
+        // Verify read
+        {
+            Page page = blob_store.read(std::make_pair(buildV3Id(TEST_NAMESPACE_ID, page_id), records[0].entry), nullptr);
+            ASSERT_TRUE(page.isValid());
+            ASSERT_EQ(page.data.size(), serialized_size);
+        }
+
+        // Verify read with fields
+        {
+            BlobStore::FieldReadInfos to_read{
+                BlobStore::FieldReadInfo(buildV3Id(TEST_NAMESPACE_ID, page_id), records[0].entry, {0, 1, 2, 3, 4, 5, 6, 7, 8}),
+            };
+            BlobStore::PageMap page = blob_store.read(to_read, nullptr);
+        }
+
+        // Verify read with fields
+        {
+            BlobStore::FieldReadInfos to_read{
+                BlobStore::FieldReadInfo(buildV3Id(TEST_NAMESPACE_ID, page_id), records[0].entry, {0, 1, 2, 3, 4, 5, 6}),
+            };
+            BlobStore::PageMap page = blob_store.read(to_read, nullptr);
+        }
+
+        page_id++;
+    }
+}
+CATCH
+
+
+TEST_F(BlobStoreTest, LargeWriteWithFailed)
+try
+{
+    const auto file_provider = DB::tests::TiFlashTestEnv::getDefaultFileProvider();
+    PageIdU64 fixed_page_id = 50;
+    PageIdU64 page_id = fixed_page_id;
+
+    BlobConfig test_config;
+    test_config.file_limit_size = 4 * MB;
+    auto blob_store = BlobStore(getCurrentTestName(), file_provider, delegator, test_config);
+
+    // PUT page_id 50 into blob 1 (normal write)
+    {
+        MemoryWriteBuffer buffer;
+        size_t serialized_size = 200;
+        buffer.write(fixed_buffer, serialized_size);
+
+        WriteBatch wb;
+        ReadBufferPtr read_buff = buffer.tryGetReadBuffer();
+        wb.putPage(page_id, /* tag */ 0, read_buff, serialized_size);
+        PageEntriesEdit edit = blob_store.write(std::move(wb), nullptr);
+
+        const auto & records = edit.getRecords();
+        ASSERT_EQ(records.size(), 1);
+        ASSERT_EQ(records[0].entry.file_id, 1);
+        ASSERT_EQ(records[0].entry.offset, 0);
+        ASSERT_EQ(records[0].entry.size, serialized_size);
+
+        const auto & stat = blob_store.blob_stats.blobIdToStat(1);
+        ASSERT_TRUE(stat->isNormal());
+        ASSERT_EQ(stat->sm_max_caps, test_config.file_limit_size - serialized_size);
+        ASSERT_DOUBLE_EQ(stat->sm_valid_rate, 1.0);
+        ASSERT_EQ(stat->sm_valid_size, serialized_size);
+        ASSERT_EQ(stat->sm_total_size, serialized_size);
+
+        // Verify read
+        Page page = blob_store.read(std::make_pair(buildV3Id(TEST_NAMESPACE_ID, page_id), records[0].entry), nullptr);
+        ASSERT_TRUE(page.isValid());
+        ASSERT_EQ(page.data.size(), serialized_size);
+
+        page_id++;
+    }
+
+    // PUT page_id 51 into blob 2 (large write, fail happen)
+    {
+        MemoryWriteBuffer buffer;
+        size_t serialized_size = 0;
+        while (buffer.count() < test_config.file_limit_size * 2)
+        {
+            buffer.write(fixed_buffer, fixed_buffer_size);
+            serialized_size += fixed_buffer_size;
+        }
+
+        const auto num_stats = blob_store.blob_stats.getStats().size();
+        ASSERT_EQ(num_stats, 1);
+
+        WriteBatch wb;
+        ReadBufferPtr read_buff = buffer.tryGetReadBuffer();
+        wb.putPage(page_id, /* tag */ 0, read_buff, serialized_size);
+
+        // throw an exception after write exceed `test_config.file_limit_size`
+        FailPointHelper::enableFailPoint(FailPoints::exception_after_large_write_exceed, static_cast<size_t>(test_config.file_limit_size));
+        try
+        {
+            blob_store.write(std::move(wb), nullptr);
+        }
+        catch (DB::Exception & e)
+        {
+            ASSERT_EQ(e.code(), ErrorCodes::FAIL_POINT_ERROR);
+        }
+
+        // no new-added stat
+        ASSERT_EQ(blob_store.blob_stats.blobIdToStat(2, /*ignore_not_exist*/ true), nullptr);
+
+        page_id++;
+    }
+}
+CATCH
+
+TEST_F(BlobStoreTest, LargeWriteRemove)
 try
 {
     const auto file_provider = DB::tests::TiFlashTestEnv::getDefaultFileProvider();
@@ -1344,7 +1527,7 @@ try
 }
 CATCH
 
-TEST_F(BlobStoreTest, TestBigBlobRegisterPath)
+TEST_F(BlobStoreTest, LargeWriteRegisterPath)
 try
 {
     const auto file_provider = DB::tests::TiFlashTestEnv::getDefaultFileProvider();
@@ -1454,7 +1637,7 @@ try
 }
 CATCH
 
-TEST_F(BlobStoreTest, TestBigBlobGC)
+TEST_F(BlobStoreTest, LargeWriteGC)
 try
 {
     const auto file_provider = DB::tests::TiFlashTestEnv::getDefaultFileProvider();

--- a/dbms/src/Storages/Page/V3/tests/gtest_blob_store.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_blob_store.cpp
@@ -1146,7 +1146,7 @@ CATCH
 TEST_F(BlobStoreTest, LargeWrite)
 try
 {
-    const auto file_provider = DB::tests::TiFlashTestEnv::getDefaultFileProvider();
+    const auto file_provider = DB::tests::TiFlashTestEnv::getMockFileProvider();
     PageIdU64 fixed_page_id = 50;
     PageIdU64 page_id = fixed_page_id;
 
@@ -1344,7 +1344,7 @@ CATCH
 TEST_F(BlobStoreTest, LargeWriteWithFields)
 try
 {
-    const auto file_provider = DB::tests::TiFlashTestEnv::getDefaultFileProvider();
+    const auto file_provider = DB::tests::TiFlashTestEnv::getMockFileProvider();
     PageIdU64 fixed_page_id = 50;
     PageIdU64 page_id = fixed_page_id;
 
@@ -1399,7 +1399,9 @@ try
             BlobStore::FieldReadInfos to_read{
                 BlobStore::FieldReadInfo(buildV3Id(TEST_NAMESPACE_ID, page_id), records[0].entry, {0, 1, 2, 3, 4, 5, 6, 7, 8}),
             };
-            BlobStore::PageMap page = blob_store.read(to_read, nullptr);
+            BlobStore::PageMap page_map = blob_store.read(to_read, nullptr);
+            ASSERT_NE(page_map.find(page_id), page_map.end());
+            ASSERT_EQ(page_map.at(page_id).fieldSize(), to_read[0].fields.size());
         }
 
         // Verify read with fields
@@ -1407,7 +1409,19 @@ try
             BlobStore::FieldReadInfos to_read{
                 BlobStore::FieldReadInfo(buildV3Id(TEST_NAMESPACE_ID, page_id), records[0].entry, {0, 1, 2, 3, 4, 5, 6}),
             };
-            BlobStore::PageMap page = blob_store.read(to_read, nullptr);
+            BlobStore::PageMap page_map = blob_store.read(to_read, nullptr);
+            ASSERT_NE(page_map.find(page_id), page_map.end());
+            ASSERT_EQ(page_map.at(page_id).fieldSize(), to_read[0].fields.size());
+        }
+
+        // Verify read with fields
+        {
+            BlobStore::FieldReadInfos to_read{
+                BlobStore::FieldReadInfo(buildV3Id(TEST_NAMESPACE_ID, page_id), records[0].entry, {1, 2, 3, 5, 6, 8}),
+            };
+            BlobStore::PageMap page_map = blob_store.read(to_read, nullptr);
+            ASSERT_NE(page_map.find(page_id), page_map.end());
+            ASSERT_EQ(page_map.at(page_id).fieldSize(), to_read[0].fields.size());
         }
 
         page_id++;
@@ -1419,7 +1433,7 @@ CATCH
 TEST_F(BlobStoreTest, LargeWriteWithFailed)
 try
 {
-    const auto file_provider = DB::tests::TiFlashTestEnv::getDefaultFileProvider();
+    const auto file_provider = DB::tests::TiFlashTestEnv::getMockFileProvider();
     PageIdU64 fixed_page_id = 50;
     PageIdU64 page_id = fixed_page_id;
 
@@ -1498,7 +1512,7 @@ CATCH
 TEST_F(BlobStoreTest, LargeWriteRemove)
 try
 {
-    const auto file_provider = DB::tests::TiFlashTestEnv::getDefaultFileProvider();
+    const auto file_provider = DB::tests::TiFlashTestEnv::getMockFileProvider();
     PageIdU64 fixed_page_id = 50;
     PageIdU64 page_id = fixed_page_id;
 
@@ -1530,7 +1544,7 @@ CATCH
 TEST_F(BlobStoreTest, LargeWriteRegisterPath)
 try
 {
-    const auto file_provider = DB::tests::TiFlashTestEnv::getDefaultFileProvider();
+    const auto file_provider = DB::tests::TiFlashTestEnv::getMockFileProvider();
     PageIdU64 fixed_page_id = 50;
     PageIdU64 page_id = fixed_page_id;
 
@@ -1570,7 +1584,7 @@ CATCH
 TEST_F(BlobStoreTest, TestRestartWithSmallerFileLimitSize)
 try
 {
-    const auto file_provider = DB::tests::TiFlashTestEnv::getDefaultFileProvider();
+    const auto file_provider = DB::tests::TiFlashTestEnv::getMockFileProvider();
     PageIdU64 page_id = 50;
 
     BlobConfig config_with_small_file_limit_size;
@@ -1640,7 +1654,7 @@ CATCH
 TEST_F(BlobStoreTest, LargeWriteGC)
 try
 {
-    const auto file_provider = DB::tests::TiFlashTestEnv::getDefaultFileProvider();
+    const auto file_provider = DB::tests::TiFlashTestEnv::getMockFileProvider();
     PageIdU64 page_id1 = 50;
     PageIdU64 page_id2 = 51;
     PageIdU64 page_id3 = 52;

--- a/dbms/src/Storages/Transaction/RegionPersister.cpp
+++ b/dbms/src/Storages/Transaction/RegionPersister.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Common/Exception.h>
 #include <Common/FailPoint.h>
 #include <IO/MemoryReadWriteBuffer.h>
 #include <Interpreters/Context.h>
@@ -27,6 +28,7 @@
 #include <Storages/Transaction/Region.h>
 #include <Storages/Transaction/RegionManager.h>
 #include <Storages/Transaction/RegionPersister.h>
+#include <common/logger_useful.h>
 
 #include <magic_enum.hpp>
 #include <memory>
@@ -106,6 +108,7 @@ void RegionPersister::doPersist(RegionCacheWriteElement & region_write_buffer, c
     }
 
     auto read_buf = buffer.tryGetReadBuffer();
+    RUNTIME_CHECK_MSG(read_buf != nullptr, "failed to gen buffer for {}", region.toString(true));
     DB::WriteBatchWrapper wb{run_mode, getWriteBatchPrefix()};
     wb.putPage(region_id, applied_index, read_buf, region_size);
     page_writer->write(std::move(wb), global_context.getWriteLimiter());

--- a/dbms/src/Storages/Transaction/tests/gtest_region_persister.cpp
+++ b/dbms/src/Storages/Transaction/tests/gtest_region_persister.cpp
@@ -386,17 +386,19 @@ try
             persister.persist(*region);
             regions.emplace(region->id(), region);
         }
+        ASSERT_EQ(regions.size(), test_scales.size());
     }
 
-    RegionMap new_regions;
+    RegionMap restored_regions;
     {
         RegionPersister persister(ctx, region_manager);
-        new_regions = persister.restore(*mocked_path_pool, nullptr, config);
+        restored_regions = persister.restore(*mocked_path_pool, nullptr, config);
     }
+    ASSERT_EQ(restored_regions.size(), regions.size());
     for (const auto & [region_id, region] : regions)
     {
-        ASSERT_NE(new_regions.find(region_id), new_regions.end()) << region_id;
-        auto & new_region = new_regions.at(region_id);
+        ASSERT_NE(restored_regions.find(region_id), restored_regions.end()) << region_id;
+        auto & new_region = restored_regions.at(region_id);
         ASSERT_EQ(new_region->id(), region_id);
         ASSERT_EQ(new_region->confVer(), region->confVer()) << region_id;
         ASSERT_EQ(new_region->dataSize(), region->dataSize()) << region_id;

--- a/dbms/src/Storages/Transaction/tests/gtest_region_persister.cpp
+++ b/dbms/src/Storages/Transaction/tests/gtest_region_persister.cpp
@@ -13,10 +13,12 @@
 // limitations under the License.
 
 #include <Common/FailPoint.h>
+#include <Common/Logger.h>
 #include <Common/Stopwatch.h>
 #include <IO/ReadBufferFromFile.h>
 #include <IO/WriteBufferFromFile.h>
 #include <Interpreters/Context.h>
+#include <RaftStoreProxyFFI/ColumnFamily.h>
 #include <Storages/Page/PageStorage.h>
 #include <Storages/PathPool.h>
 #include <Storages/Transaction/Region.h>
@@ -27,6 +29,7 @@
 #include <TestUtils/TiFlashTestBasic.h>
 #include <TestUtils/TiFlashTestEnv.h>
 #include <common/logger_useful.h>
+#include <common/types.h>
 
 #include <ext/scope_guard.h>
 
@@ -204,6 +207,7 @@ class RegionPersisterTest
 public:
     RegionPersisterTest()
         : dir_path(TiFlashTestEnv::getTemporaryPath("/region_persister_test"))
+        , log(Logger::get())
     {
         test_run_mode = GetParam();
         old_run_mode = test_run_mode;
@@ -250,6 +254,7 @@ protected:
     PageStorageRunMode old_run_mode;
 
     std::unique_ptr<PathPool> mocked_path_pool;
+    LoggerPtr log;
 };
 
 TEST_P(RegionPersisterTest, persister)
@@ -275,9 +280,9 @@ try
         {
             auto region = std::make_shared<Region>(createRegionMeta(i, table_id));
             TiKVKey key = RecordKVFormat::genKey(table_id, i, diff++);
-            region->insert("default", TiKVKey::copyFrom(key), TiKVValue("value1"));
-            region->insert("write", TiKVKey::copyFrom(key), RecordKVFormat::encodeWriteCfValue('P', 0));
-            region->insert("lock", TiKVKey::copyFrom(key), RecordKVFormat::encodeLockCfValue('P', "", 0, 0));
+            region->insert(ColumnFamilyType::Default, TiKVKey::copyFrom(key), TiKVValue("value1"));
+            region->insert(ColumnFamilyType::Write, TiKVKey::copyFrom(key), RecordKVFormat::encodeWriteCfValue('P', 0));
+            region->insert(ColumnFamilyType::Lock, TiKVKey::copyFrom(key), RecordKVFormat::encodeLockCfValue('P', "", 0, 0));
 
             persister.persist(*region);
 
@@ -330,6 +335,71 @@ try
             }
         }
         ASSERT_EQ(num_regions_missed, 1);
+    }
+}
+CATCH
+
+TEST_P(RegionPersisterTest, LargeRegion)
+try
+{
+    RegionManager region_manager;
+
+    auto ctx = TiFlashTestEnv::getGlobalContext();
+
+    const TableID table_id = 100;
+    const RegionID region_id_base = 20;
+    const String large_value(1024 * 512, 'v');
+
+    PageStorageConfig config;
+    config.blob_file_limit_size = 32 * MB;
+    RegionMap regions;
+    {
+        UInt64 tso = 0;
+        RegionPersister persister(ctx, region_manager);
+        persister.restore(*mocked_path_pool, nullptr, config);
+
+        // Persist region
+        auto gen_region_data = [&](RegionID region_id, UInt64 expect_size) {
+            auto region = std::make_shared<Region>(createRegionMeta(region_id, table_id));
+            UInt64 handle_id = 0;
+            while (true)
+            {
+                if (auto data_size = region->dataSize(); data_size > expect_size)
+                {
+                    LOG_INFO(log, "will persist region_id={} size={}", region_id, data_size);
+                    break;
+                }
+                TiKVKey key = RecordKVFormat::genKey(table_id, handle_id, tso++);
+                region->insert(ColumnFamilyType::Default, TiKVKey::copyFrom(key), TiKVValue(large_value.data()));
+                region->insert(ColumnFamilyType::Write, TiKVKey::copyFrom(key), RecordKVFormat::encodeWriteCfValue('P', 0));
+                region->insert(ColumnFamilyType::Lock, TiKVKey::copyFrom(key), RecordKVFormat::encodeLockCfValue('P', "", 0, 0));
+                handle_id += 1;
+            }
+            return region;
+        };
+
+        std::vector<double> test_scales{0.5, 1.0, 1.5, 2.5};
+        for (size_t idx = 0; idx < test_scales.size(); ++idx)
+        {
+            auto scale = test_scales[idx];
+            auto region = gen_region_data(region_id_base + idx, config.blob_file_limit_size * scale);
+            persister.persist(*region);
+            regions.emplace(region->id(), region);
+        }
+    }
+
+    RegionMap new_regions;
+    {
+        RegionPersister persister(ctx, region_manager);
+        new_regions = persister.restore(*mocked_path_pool, nullptr, config);
+    }
+    for (const auto & [region_id, region] : regions)
+    {
+        ASSERT_NE(new_regions.find(region_id), new_regions.end()) << region_id;
+        auto & new_region = new_regions.at(region_id);
+        ASSERT_EQ(new_region->id(), region_id);
+        ASSERT_EQ(new_region->confVer(), region->confVer()) << region_id;
+        ASSERT_EQ(new_region->dataSize(), region->dataSize()) << region_id;
     }
 }
 CATCH


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/7316

Problem Summary:

The root cause is `BlobStore<Trait>::handleLargeWrite` get a buffer from `MemoryWriteBuffer` and access the memory by `write.size`, which exceed the memory bound. `MemoryWriteBuffer` actually is composed by a list of `chunk`s

https://github.com/pingcap/tiflash/blob/b2b976edbe33b4bb130d9abff44948877d86cda5/dbms/src/Storages/Page/V3/BlobStore.cpp#L190-L216

### What is changed and how it works?

The write batch data size is large, we do NOT copy the data into a temporary buffer in order to make the memory usage of tiflash more smooth. Instead, we process the data in ReadBuffer in a streaming manner.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix a crash issue when tiflash persists the data of a large Region
```
