### PR TITLE
Fix build under release mode

### DIFF
--- a/dbms/src/Functions/FunctionsGrouping.h
+++ b/dbms/src/Functions/FunctionsGrouping.h
@@ -36,7 +36,7 @@ extern const int TOO_LESS_ARGUMENTS_FOR_FUNCTION;
 extern const int TOO_MANY_ARGUMENTS_FOR_FUNCTION;
 } // namespace ErrorCodes
 
-static bool isPowerOf2(uint64_t num)
+[[maybe_unused]] static bool isPowerOf2(uint64_t num)
 {
     return (num & (num - 1)) == 0;
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/7134

Problem Summary: release build is broken caused by https://github.com/pingcap/tiflash/pull/7135

```
[2023-04-21T14:30:11.625Z] In file included from /home/jenkins/agent/workspace/build-common/go/src/github.com/pingcap/tics/dbms/src/Functions/FunctionsGrouping.cpp:16:
[2023-04-21T14:30:11.625Z] /home/jenkins/agent/workspace/build-common/go/src/github.com/pingcap/tics/dbms/src/Functions/FunctionsGrouping.h:39:13: error: unused function 'isPowerOf2' [-Werror,-Wunused-function]
[2023-04-21T14:30:11.625Z] static bool isPowerOf2(uint64_t num)
[2023-04-21T14:30:11.625Z]             ^
[2023-04-21T14:30:11.625Z] 1 error generated.
```

### What is changed and how it works?
Add `[[maybe_unused]]`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
