### PR TITLE
WIP: optimize sort with cutoff value

### DIFF
--- a/dbms/src/Columns/ColumnAggregateFunction.h
+++ b/dbms/src/Columns/ColumnAggregateFunction.h
@@ -202,6 +202,11 @@ public:
         return 0;
     }
 
+    void compareColumn(const IColumn &, size_t, PaddedPODArray<UInt64> *, PaddedPODArray<Int8> &, int, int) const override
+    {
+        throw Exception("Method compareColumn is not supported for ColumnAggregateFunction", ErrorCodes::NOT_IMPLEMENTED);
+    }
+
     void getPermutation(bool reverse, size_t limit, int nan_direction_hint, Permutation & res) const override;
 
     /** More efficient manipulation methods */

--- a/dbms/src/Columns/ColumnArray.cpp
+++ b/dbms/src/Columns/ColumnArray.cpp
@@ -23,6 +23,7 @@
 #include <Common/Exception.h>
 #include <Common/HashTable/Hash.h>
 #include <Common/SipHash.h>
+#include <Common/assert_cast.h>
 #include <Common/typeid_cast.h>
 #include <DataStreams/ColumnGathererStream.h>
 #include <string.h> // memcpy
@@ -320,6 +321,11 @@ int ColumnArray::compareAt(size_t n, size_t m, const IColumn & rhs_, int nan_dir
         : (lhs_size == rhs_size
                ? 0
                : 1);
+}
+
+void ColumnArray::compareColumn(const IColumn & rhs, size_t rhs_row_num, PaddedPODArray<UInt64> * row_indexes, PaddedPODArray<Int8> & compare_results, int direction, int nan_direction_hint) const
+{
+    return doCompareColumn<ColumnArray>(assert_cast<const ColumnArray &>(rhs), rhs_row_num, row_indexes, compare_results, direction, nan_direction_hint);
 }
 
 

--- a/dbms/src/Columns/ColumnArray.h
+++ b/dbms/src/Columns/ColumnArray.h
@@ -108,6 +108,13 @@ public:
     ColumnPtr filter(const Filter & filt, ssize_t result_size_hint) const override;
     ColumnPtr permute(const Permutation & perm, size_t limit) const override;
     int compareAt(size_t n, size_t m, const IColumn & rhs_, int nan_direction_hint) const override;
+    void compareColumn(
+        const IColumn & rhs,
+        size_t rhs_row_num,
+        PaddedPODArray<UInt64> * row_indexes,
+        PaddedPODArray<Int8> & compare_results,
+        int direction,
+        int nan_direction_hint) const override;
     void getPermutation(bool reverse, size_t limit, int nan_direction_hint, Permutation & res) const override;
     void reserve(size_t n) override;
     size_t byteSize() const override;

--- a/dbms/src/Columns/ColumnConst.cpp
+++ b/dbms/src/Columns/ColumnConst.cpp
@@ -83,6 +83,19 @@ ColumnPtr ColumnConst::permute(const Permutation & perm, size_t limit) const
     return ColumnConst::create(data, limit);
 }
 
+void ColumnConst::compareColumn(
+    const IColumn & rhs,
+    size_t,
+    PaddedPODArray<UInt64> *,
+    PaddedPODArray<Int8> & compare_results,
+    int,
+    int nan_direction_hint)
+    const
+{
+    Int8 res = compareAt(1, 1, rhs, nan_direction_hint);
+    std::fill(compare_results.begin(), compare_results.end(), res);
+}
+
 MutableColumns ColumnConst::scatter(ColumnIndex num_columns, const Selector & selector) const
 {
     if (s != selector.size())

--- a/dbms/src/Columns/ColumnConst.h
+++ b/dbms/src/Columns/ColumnConst.h
@@ -209,6 +209,14 @@ public:
         return data->compareAt(0, 0, *static_cast<const ColumnConst &>(rhs).data, nan_direction_hint);
     }
 
+    void compareColumn(
+        const IColumn & rhs,
+        size_t rhs_row_num,
+        PaddedPODArray<UInt64> * row_indexes,
+        PaddedPODArray<Int8> & compare_results,
+        int direction,
+        int nan_direction_hint) const override;
+
     MutableColumns scatter(ColumnIndex num_columns, const Selector & selector) const override;
 
     void scatterTo(ScatterColumns & columns, const Selector & selector) const override;

--- a/dbms/src/Columns/ColumnDecimal.cpp
+++ b/dbms/src/Columns/ColumnDecimal.cpp
@@ -50,6 +50,18 @@ int ColumnDecimal<T>::compareAt(size_t n, size_t m, const IColumn & rhs_, int) c
 }
 
 template <typename T>
+void ColumnDecimal<T>::compareColumn(
+    const IColumn & rhs,
+    size_t rhs_row_num,
+    PaddedPODArray<UInt64> * row_indexes,
+    PaddedPODArray<Int8> & compare_results,
+    int direction,
+    int nan_direction_hint) const
+{
+    return this->template doCompareColumn<ColumnDecimal<T>>(static_cast<const Self &>(rhs), rhs_row_num, row_indexes, compare_results, direction, nan_direction_hint);
+}
+
+template <typename T>
 StringRef ColumnDecimal<T>::serializeValueIntoArena(size_t n, Arena & arena, char const *& begin, const TiDB::TiDBCollatorPtr &, String &) const
 {
     if constexpr (is_Decimal256)

--- a/dbms/src/Columns/ColumnDecimal.h
+++ b/dbms/src/Columns/ColumnDecimal.h
@@ -144,6 +144,13 @@ public:
     void updateHashWithValues(IColumn::HashValues & hash_values, const TiDB::TiDBCollatorPtr &, String &) const override;
     void updateWeakHash32(WeakHash32 & hash, const TiDB::TiDBCollatorPtr &, String &) const override;
     int compareAt(size_t n, size_t m, const IColumn & rhs_, int nan_direction_hint) const override;
+    void compareColumn(
+        const IColumn & rhs,
+        size_t rhs_row_num,
+        PaddedPODArray<UInt64> * row_indexes,
+        PaddedPODArray<Int8> & compare_results,
+        int direction,
+        int nan_direction_hint) const override;
     void getPermutation(bool reverse, size_t limit, int nan_direction_hint, IColumn::Permutation & res) const override;
 
     MutableColumnPtr cloneResized(size_t size) const override;

--- a/dbms/src/Columns/ColumnFixedString.h
+++ b/dbms/src/Columns/ColumnFixedString.h
@@ -18,6 +18,8 @@
 #include <Common/PODArray.h>
 #include <string.h> // memcpy
 
+#include "Common/assert_cast.h"
+
 
 namespace DB
 {
@@ -130,8 +132,19 @@ public:
 
     int compareAt(size_t p1, size_t p2, const IColumn & rhs_, int /*nan_direction_hint*/) const override
     {
-        const ColumnFixedString & rhs = static_cast<const ColumnFixedString &>(rhs_);
+        const auto & rhs = static_cast<const ColumnFixedString &>(rhs_);
         return memcmp(&chars[p1 * n], &rhs.chars[p2 * n], n);
+    }
+
+    void compareColumn(
+        const IColumn & rhs,
+        size_t rhs_row_num,
+        PaddedPODArray<UInt64> * row_indexes,
+        PaddedPODArray<Int8> & compare_results,
+        int direction,
+        int nan_direction_hint) const override
+    {
+        return doCompareColumn<ColumnFixedString>(assert_cast<const ColumnFixedString &>(rhs), rhs_row_num, row_indexes, compare_results, direction, nan_direction_hint);
     }
 
     void getPermutation(bool reverse, size_t limit, int nan_direction_hint, Permutation & res) const override;

--- a/dbms/src/Columns/ColumnFunction.h
+++ b/dbms/src/Columns/ColumnFunction.h
@@ -136,6 +136,11 @@ public:
         throw Exception("compareAt is not implemented for " + getName(), ErrorCodes::NOT_IMPLEMENTED);
     }
 
+    void compareColumn(const IColumn &, size_t, PaddedPODArray<UInt64> *, PaddedPODArray<Int8> &, int, int) const override
+    {
+        throw Exception("compareColumn is not implemented for " + getName(), ErrorCodes::NOT_IMPLEMENTED);
+    }
+
     void getPermutation(bool, size_t, int, Permutation &) const override
     {
         throw Exception("getPermutation is not implemented for " + getName(), ErrorCodes::NOT_IMPLEMENTED);

--- a/dbms/src/Columns/ColumnNullable.cpp
+++ b/dbms/src/Columns/ColumnNullable.cpp
@@ -332,6 +332,17 @@ int ColumnNullable::compareAt(size_t n, size_t m, const IColumn & rhs_, int null
     return getNestedColumn().compareAt(n, m, nested_rhs, null_direction_hint);
 }
 
+void ColumnNullable::compareColumn(
+    const IColumn & rhs,
+    size_t rhs_row_num,
+    PaddedPODArray<UInt64> * row_indexes,
+    PaddedPODArray<Int8> & compare_results,
+    int direction,
+    int nan_direction_hint) const
+{
+    return doCompareColumn<ColumnNullable>(assert_cast<const ColumnNullable &>(rhs), rhs_row_num, row_indexes, compare_results, direction, nan_direction_hint);
+}
+
 void ColumnNullable::getPermutation(
     const ICollator & collator,
     bool reverse,

--- a/dbms/src/Columns/ColumnNullable.h
+++ b/dbms/src/Columns/ColumnNullable.h
@@ -94,6 +94,13 @@ public:
     std::tuple<bool, int> compareAtCheckNull(size_t n, size_t m, const ColumnNullable & rhs, int null_direction_hint) const;
     int compareAt(size_t n, size_t m, const IColumn & rhs_, int null_direction_hint) const override;
     int compareAt(size_t n, size_t m, const IColumn & rhs_, int null_direction_hint, const ICollator & collator) const override;
+    void compareColumn(
+        const IColumn & rhs,
+        size_t rhs_row_num,
+        PaddedPODArray<UInt64> * row_indexes,
+        PaddedPODArray<Int8> & compare_results,
+        int direction,
+        int nan_direction_hint) const override;
     void getPermutation(bool reverse, size_t limit, int null_direction_hint, Permutation & res) const override;
     void getPermutation(const ICollator & collator, bool reverse, size_t limit, int null_direction_hint, Permutation & res) const override;
     void adjustPermutationWithNullDirection(bool reverse, size_t limit, int null_direction_hint, Permutation & res) const;

--- a/dbms/src/Columns/ColumnString.cpp
+++ b/dbms/src/Columns/ColumnString.cpp
@@ -16,6 +16,7 @@
 #include <Columns/ColumnString.h>
 #include <Columns/ColumnsCommon.h>
 #include <Common/HashTable/Hash.h>
+#include <Common/assert_cast.h>
 #include <DataStreams/ColumnGathererStream.h>
 #include <Storages/Transaction/CollatorUtils.h>
 #include <common/memcpy.h>
@@ -322,6 +323,17 @@ int ColumnString::compareAtWithCollationImpl(size_t n, size_t m, const IColumn &
     auto b = rhs.getDataAt(m);
 
     return collator.compare(a.data, a.size, b.data, b.size);
+}
+
+void ColumnString::compareColumn(
+    const IColumn & rhs,
+    size_t rhs_row_num,
+    PaddedPODArray<UInt64> * row_indexes,
+    PaddedPODArray<Int8> & compare_results,
+    int direction,
+    int nan_direction_hint) const
+{
+    return doCompareColumn<ColumnString>(assert_cast<const ColumnString &>(rhs), rhs_row_num, row_indexes, compare_results, direction, nan_direction_hint);
 }
 
 // Derived must implement function `int compare(const char *, size_t, const char *, size_t)`.

--- a/dbms/src/Columns/ColumnString.h
+++ b/dbms/src/Columns/ColumnString.h
@@ -311,6 +311,15 @@ public:
     {
         return compareAtWithCollationImpl(n, m, rhs_, collator);
     }
+
+    void compareColumn(
+        const IColumn & rhs,
+        size_t rhs_row_num,
+        PaddedPODArray<UInt64> * row_indexes,
+        PaddedPODArray<Int8> & compare_results,
+        int direction,
+        int nan_direction_hint) const override;
+
     /// Variant of compareAt for string comparison with respect of collation.
     int compareAtWithCollationImpl(size_t n, size_t m, const IColumn & rhs_, const ICollator & collator) const;
 

--- a/dbms/src/Columns/ColumnTuple.cpp
+++ b/dbms/src/Columns/ColumnTuple.cpp
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include <Columns/ColumnTuple.h>
-#include <DataStreams/ColumnGathererStream.h>
 #include <Common/assert_cast.h>
+#include <DataStreams/ColumnGathererStream.h>
 
 #include <ext/map.h>
 #include <ext/range.h>

--- a/dbms/src/Columns/ColumnTuple.cpp
+++ b/dbms/src/Columns/ColumnTuple.cpp
@@ -14,6 +14,7 @@
 
 #include <Columns/ColumnTuple.h>
 #include <DataStreams/ColumnGathererStream.h>
+#include <Common/assert_cast.h>
 
 #include <ext/map.h>
 #include <ext/range.h>
@@ -275,6 +276,11 @@ int ColumnTuple::compareAt(size_t n, size_t m, const IColumn & rhs, int nan_dire
             return res;
 
     return 0;
+}
+
+void ColumnTuple::compareColumn(const IColumn & rhs, size_t rhs_row_num, PaddedPODArray<UInt64> * row_indexes, PaddedPODArray<Int8> & compare_results, int direction, int nan_direction_hint) const
+{
+    return doCompareColumn<ColumnTuple>(assert_cast<const ColumnTuple &>(rhs), rhs_row_num, row_indexes, compare_results, direction, nan_direction_hint);
 }
 
 template <bool positive>

--- a/dbms/src/Columns/ColumnTuple.h
+++ b/dbms/src/Columns/ColumnTuple.h
@@ -103,6 +103,7 @@ public:
     void scatterTo(ScatterColumns & scatterColumns, const Selector & selector) const override;
     void gather(ColumnGathererStream & gatherer_stream) override;
     int compareAt(size_t n, size_t m, const IColumn & rhs, int nan_direction_hint) const override;
+    void compareColumn(const IColumn & rhs, size_t rhs_row_num, PaddedPODArray<UInt64> * row_indexes, PaddedPODArray<Int8> & compare_results, int direction, int nan_direction_hint) const override;
     void getExtremes(Field & min, Field & max) const override;
     void getPermutation(bool reverse, size_t limit, int nan_direction_hint, Permutation & res) const override;
     void reserve(size_t n) override;

--- a/dbms/src/Columns/ColumnVector.h
+++ b/dbms/src/Columns/ColumnVector.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <Columns/ColumnVectorHelper.h>
+#include <Common/assert_cast.h>
 #include <IO/Endian.h>
 
 #include <cmath>
@@ -347,6 +348,11 @@ public:
     int compareAt(size_t n, size_t m, const IColumn & rhs_, int nan_direction_hint) const override
     {
         return CompareHelper<T>::compare(data[n], static_cast<const Self &>(rhs_).data[m], nan_direction_hint);
+    }
+
+    void compareColumn(const IColumn & rhs, size_t rhs_row_num, PaddedPODArray<UInt64> * row_indexes, PaddedPODArray<Int8> & compare_results, int direction, int nan_direction_hint) const override
+    {
+        return this->template doCompareColumn<Self>(assert_cast<const Self &>(rhs), rhs_row_num, row_indexes, compare_results, direction, nan_direction_hint);
     }
 
     void getPermutation(bool reverse, size_t limit, int nan_direction_hint, IColumn::Permutation & res) const override;

--- a/dbms/src/Columns/IColumnDummy.h
+++ b/dbms/src/Columns/IColumnDummy.h
@@ -57,6 +57,9 @@ public:
     size_t byteSize() const override { return 0; }
     size_t allocatedBytes() const override { return 0; }
     int compareAt(size_t, size_t, const IColumn &, int) const override { return 0; }
+    void compareColumn(const IColumn &, size_t, PaddedPODArray<UInt64> *, PaddedPODArray<Int8> &, int, int) const override
+    {
+    }
 
     Field operator[](size_t) const override { throw Exception("Cannot get value from " + getName(), ErrorCodes::NOT_IMPLEMENTED); }
     void get(size_t, Field &) const override { throw Exception("Cannot get value from " + getName(), ErrorCodes::NOT_IMPLEMENTED); };

--- a/dbms/src/Core/SortDescription.h
+++ b/dbms/src/Core/SortDescription.h
@@ -87,7 +87,8 @@ struct SortColumnDescriptionWithColumnIndex
     size_t column_number;
 
     SortColumnDescriptionWithColumnIndex(SortColumnDescription description_, size_t column_number_)
-        : base(std::move(description_)), column_number(column_number_)
+        : base(std::move(description_))
+        , column_number(column_number_)
     {
     }
 };

--- a/dbms/src/Core/SortDescription.h
+++ b/dbms/src/Core/SortDescription.h
@@ -81,4 +81,18 @@ struct SortColumnDescription
 /// Description of the sorting rule for several columns.
 using SortDescription = std::vector<SortColumnDescription>;
 
+struct SortColumnDescriptionWithColumnIndex
+{
+    SortColumnDescription base;
+    size_t column_number;
+
+    SortColumnDescriptionWithColumnIndex(SortColumnDescription description_, size_t column_number_)
+        : base(std::move(description_)), column_number(column_number_)
+    {
+    }
+};
+
+/// Description of the sorting rule for several columns.
+using SortDescriptionWithPositions = std::vector<SortColumnDescriptionWithColumnIndex>;
+
 } // namespace DB

--- a/dbms/src/DataStreams/PartialSortingBlockInputStream.cpp
+++ b/dbms/src/DataStreams/PartialSortingBlockInputStream.cpp
@@ -19,11 +19,181 @@
 
 namespace DB
 {
+namespace
+{
+ColumnRawPtrs extractRawColumns(const Block & block, const SortDescriptionWithPositions & description)
+{
+    size_t size = description.size();
+    ColumnRawPtrs result(size);
+
+    for (size_t i = 0; i < size; ++i)
+        result[i] = block.safeGetByPosition(description[i].column_number).column.get();
+
+    return result;
+}
+
+size_t getFilterMask(
+    const ColumnRawPtrs & raw_block_columns,
+    const Columns & threshold_columns,
+    const SortDescription & description,
+    size_t num_rows,
+    IColumn::Filter & filter,
+    PaddedPODArray<UInt64> & rows_to_compare,
+    PaddedPODArray<Int8> & compare_results)
+{
+    filter.resize(num_rows);
+    compare_results.resize(num_rows);
+
+    if (description.size() == 1)
+    {
+        /// Fast path for single column
+        raw_block_columns[0]->compareColumn(
+            *threshold_columns[0],
+            0,
+            nullptr,
+            compare_results,
+            description[0].direction,
+            description[0].nulls_direction);
+    }
+    else
+    {
+        rows_to_compare.resize(num_rows);
+
+        for (size_t i = 0; i < num_rows; ++i)
+            rows_to_compare[i] = i;
+
+        size_t size = description.size();
+        for (size_t i = 0; i < size; ++i)
+        {
+            raw_block_columns[i]
+                ->compareColumn(
+                    *threshold_columns[i],
+                    0,
+                    &rows_to_compare,
+                    compare_results,
+                    description[i].direction,
+                    description[i].nulls_direction);
+
+            if (rows_to_compare.empty())
+                break;
+        }
+    }
+
+    size_t result_size_hint = 0;
+    for (size_t i = 0; i < num_rows; ++i)
+    {
+        /// Leave only rows that are less then row from rhs.
+        filter[i] = compare_results[i] < 0;
+        result_size_hint += filter[i];
+    }
+
+    return result_size_hint;
+}
+
+bool compareWithThreshold(
+    const ColumnRawPtrs & raw_block_columns,
+    size_t min_block_index,
+    const Columns & threshold_columns,
+    const SortDescription & sort_description)
+{
+    assert(raw_block_columns.size() == threshold_columns.size());
+    assert(raw_block_columns.size() == sort_description.size());
+
+    size_t raw_block_columns_size = raw_block_columns.size();
+    for (size_t i = 0; i < raw_block_columns_size; ++i)
+    {
+        int res = sort_description[i].direction
+            * raw_block_columns[i]
+                  ->compareAt(
+                      min_block_index,
+                      0,
+                      *threshold_columns[i],
+                      sort_description[i].nulls_direction);
+        return res < 0;
+    }
+
+    return false;
+}
+} // namespace
+
 Block PartialSortingBlockInputStream::readImpl()
 {
-    Block res = children.back()->read();
-    sortBlock(res, description, limit);
-    return res;
+    Block block = children.back()->read();
+    if (block.rows() == 0)
+    {
+        return {};
+    }
+
+    size_t block_rows_before_filter = block.rows();
+
+    /** If we've saved columns from previously blocks we could filter all rows from current block
+      * which are unnecessary for sortBlock(...) because they obviously won't be in the top LIMIT rows.
+      */
+    if (!sort_description_threshold_columns.empty())
+    {
+        UInt64 rows_num = block.rows();
+        auto block_columns = extractRawColumns(block, description_with_positions);
+
+        size_t result_size_hint = getFilterMask(
+            block_columns,
+            sort_description_threshold_columns,
+            description,
+            rows_num,
+            filter,
+            rows_to_compare,
+            compare_results);
+
+        /// Everything was filtered. Skip whole chunk.
+        if (result_size_hint == 0)
+            return {};
+
+        if (result_size_hint < rows_num)
+        {
+            for (auto & column : block)
+                column.column = column.column->filter(filter, result_size_hint);
+        }
+    }
+
+    sortBlock(block, description, limit);
+
+    size_t block_rows_after_filter = block.rows();
+
+    /// Check if we can use this block for optimization.
+    if (min_limit_for_partial_sort_optimization <= limit
+        && block_rows_after_filter > 0 && limit <= block_rows_before_filter)
+    {
+        /** If we filtered more than limit rows from block take block last row.
+          * Otherwise take last limit row.
+          *
+          * If current threshold value is empty, update current threshold value.
+          * If min block value is less than current threshold value, update current threshold value.
+          */
+        //
+        size_t min_row_to_compare = limit <= block_rows_after_filter ? (limit - 1) : (block_rows_after_filter - 1);
+        auto raw_block_columns = extractRawColumns(block, description_with_positions);
+
+        if (sort_description_threshold_columns.empty()
+            || compareWithThreshold(
+                raw_block_columns,
+                min_row_to_compare,
+                sort_description_threshold_columns,
+                description))
+        {
+            // update the threshold value
+            size_t raw_block_columns_size = raw_block_columns.size();
+            Columns sort_description_threshold_columns_updated(raw_block_columns_size);
+
+            for (size_t i = 0; i < raw_block_columns_size; ++i)
+            {
+                MutableColumnPtr sort_description_threshold_column_updated = raw_block_columns[i]->cloneEmpty();
+                sort_description_threshold_column_updated->insertFrom(*raw_block_columns[i], min_row_to_compare);
+                sort_description_threshold_columns_updated[i] = std::move(sort_description_threshold_column_updated);
+            }
+
+            sort_description_threshold_columns = std::move(sort_description_threshold_columns_updated);
+        }
+    }
+    return block;
 }
 
 void PartialSortingBlockInputStream::appendInfo(FmtBuffer & buffer) const

--- a/dbms/src/DataStreams/TiRemoteBlockInputStream.h
+++ b/dbms/src/DataStreams/TiRemoteBlockInputStream.h
@@ -66,6 +66,8 @@ class TiRemoteBlockInputStream : public IProfilingBlockInputStream
     {
         while (true)
         {
+            if (isCancelled())
+                return false;
             auto result = remote_reader->nextResult(block_queue, sample_block, stream_id, decoder_ptr);
             if (result.meet_error)
             {

--- a/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
@@ -492,8 +492,7 @@ void DAGStorageInterpreter::executeCastAfterTableScan(
     auto [has_cast, extra_cast] = addExtraCastsAfterTs(*analyzer, is_need_add_cast_column, table_scan);
     if (has_cast)
     {
-        auto source_num = group_builder.group.size();
-        assert(remote_read_sources_start_index <= source_num);
+        assert(remote_read_sources_start_index <= group_builder.group.size());
         size_t i = 0;
         // local sources
         while (i < remote_read_sources_start_index)

--- a/dbms/src/Flash/executeQuery.cpp
+++ b/dbms/src/Flash/executeQuery.cpp
@@ -112,7 +112,7 @@ QueryExecutorPtr doExecuteAsBlockIO(IQuerySource & dag, Context & context, bool 
     return std::make_unique<DataStreamExecutor>(memory_tracker, context, logger->identifier(), res.in);
 }
 
-std::optional<QueryExecutorPtr> executeAsPipeline(Context & context, bool internal)
+std::optional<QueryExecutorPtr> executeAsPipeline[[maybe_unused]](Context & context, bool internal)
 {
     RUNTIME_ASSERT(context.getDAGContext());
     auto & dag_context = *context.getDAGContext();
@@ -163,13 +163,13 @@ QueryExecutorPtr executeAsBlockIO(Context & context, bool internal)
 QueryExecutorPtr queryExecute(Context & context, bool internal)
 {
     // now only support pipeline model in test mode.
-    if (context.getSettingsRef().enable_planner
-        && context.getSettingsRef().enable_pipeline
-        && context.getSharedContextDisagg()->notDisaggregatedMode())
-    {
-        if (auto res = executeAsPipeline(context, internal); res)
-            return std::move(*res);
-    }
+    // if (context.getSettingsRef().enable_planner
+    //     && context.getSettingsRef().enable_pipeline
+    //     && context.getSharedContextDisagg()->notDisaggregatedMode())
+    // {
+    //     if (auto res = executeAsPipeline(context, internal); res)
+    //         return std::move(*res);
+    // }
     return executeAsBlockIO(context, internal);
 }
 } // namespace DB

--- a/dbms/src/Flash/executeQuery.cpp
+++ b/dbms/src/Flash/executeQuery.cpp
@@ -112,7 +112,7 @@ QueryExecutorPtr doExecuteAsBlockIO(IQuerySource & dag, Context & context, bool 
     return std::make_unique<DataStreamExecutor>(memory_tracker, context, logger->identifier(), res.in);
 }
 
-std::optional<QueryExecutorPtr> executeAsPipeline[[maybe_unused]](Context & context, bool internal)
+std::optional<QueryExecutorPtr> executeAsPipeline [[maybe_unused]] (Context & context, bool internal)
 {
     RUNTIME_ASSERT(context.getDAGContext());
     auto & dag_context = *context.getDAGContext();

--- a/dbms/src/Flash/executeQuery.cpp
+++ b/dbms/src/Flash/executeQuery.cpp
@@ -163,13 +163,13 @@ QueryExecutorPtr executeAsBlockIO(Context & context, bool internal)
 QueryExecutorPtr queryExecute(Context & context, bool internal)
 {
     // now only support pipeline model in test mode.
-    // if (context.getSettingsRef().enable_planner
-    //     && context.getSettingsRef().enable_pipeline
-    //     && context.getSharedContextDisagg()->notDisaggregatedMode())
-    // {
-    //     if (auto res = executeAsPipeline(context, internal); res)
-    //         return std::move(*res);
-    // }
+    if (context.getSettingsRef().enable_planner
+        && context.getSettingsRef().enable_pipeline
+        && context.getSharedContextDisagg()->notDisaggregatedMode())
+    {
+        if (auto res = executeAsPipeline(context, internal); res)
+            return std::move(*res);
+    }
     return executeAsBlockIO(context, internal);
 }
 } // namespace DB


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:
TPCH 1 node 100g:
select  l_orderkey,  sum(l_quantity) from  lineitem group by  l_orderkey order by  sum(l_quantity) desc limit  2000, 100;
sort consume time from 2.0s to 0.2s..
+------------------------------------------+--------------+
### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
