### PR TITLE
Support right outer join with other conditions

### DIFF
--- a/dbms/src/DataStreams/ScanHashMapAfterProbeBlockInputStream.cpp
+++ b/dbms/src/DataStreams/ScanHashMapAfterProbeBlockInputStream.cpp
@@ -218,6 +218,12 @@ Block ScanHashMapAfterProbeBlockInputStream::readImpl()
             else
                 fillColumnsUsingCurrentPartition<false, false>(num_columns_left, columns_left, num_columns_right, columns_right, row_counter_column);
             break;
+        case ASTTableJoin::Kind::RightOuter:
+            if (parent.has_other_condition)
+                fillColumnsUsingCurrentPartition<true, false>(num_columns_left, columns_left, num_columns_right, columns_right, row_counter_column);
+            else
+                fillColumnsUsingCurrentPartition<false, false>(num_columns_left, columns_left, num_columns_right, columns_right, row_counter_column);
+            break;
         default:
             fillColumnsUsingCurrentPartition<false, false>(num_columns_left, columns_left, num_columns_right, columns_right, row_counter_column);
         }

--- a/dbms/src/DataStreams/ScanHashMapAfterProbeBlockInputStream.cpp
+++ b/dbms/src/DataStreams/ScanHashMapAfterProbeBlockInputStream.cpp
@@ -213,11 +213,6 @@ Block ScanHashMapAfterProbeBlockInputStream::readImpl()
                 fillColumnsUsingCurrentPartition<false, true>(num_columns_left, columns_left, num_columns_right, columns_right, row_counter_column);
             break;
         case ASTTableJoin::Kind::RightAnti:
-            if (parent.has_other_condition)
-                fillColumnsUsingCurrentPartition<true, false>(num_columns_left, columns_left, num_columns_right, columns_right, row_counter_column);
-            else
-                fillColumnsUsingCurrentPartition<false, false>(num_columns_left, columns_left, num_columns_right, columns_right, row_counter_column);
-            break;
         case ASTTableJoin::Kind::RightOuter:
             if (parent.has_other_condition)
                 fillColumnsUsingCurrentPartition<true, false>(num_columns_left, columns_left, num_columns_right, columns_right, row_counter_column);

--- a/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
@@ -492,8 +492,8 @@ void DAGStorageInterpreter::executeCastAfterTableScan(
     auto [has_cast, extra_cast] = addExtraCastsAfterTs(*analyzer, is_need_add_cast_column, table_scan);
     if (has_cast)
     {
-        auto source_num = group_builder.group.size();
-        assert(remote_read_sources_start_index <= source_num);
+        //auto source_num = group_builder.group.size();
+        //assert(remote_read_sources_start_index <= source_num);
         size_t i = 0;
         // local sources
         while (i < remote_read_sources_start_index)

--- a/dbms/src/Flash/Coprocessor/JoinInterpreterHelper.cpp
+++ b/dbms/src/Flash/Coprocessor/JoinInterpreterHelper.cpp
@@ -232,7 +232,7 @@ String TiFlashJoin::genMatchHelperName(const Block & header1, const Block & head
 
 String TiFlashJoin::genFlagMappedEntryHelperName(const Block & header1, const Block & header2, bool has_other_condition) const
 {
-    if (!isRightSemiFamily(kind) || !has_other_condition)
+    if ((!isRightSemiFamily(kind) && kind != ASTTableJoin::Kind::RightOuter) || !has_other_condition)
     {
         return "";
     }

--- a/dbms/src/Flash/Coprocessor/JoinInterpreterHelper.cpp
+++ b/dbms/src/Flash/Coprocessor/JoinInterpreterHelper.cpp
@@ -232,7 +232,7 @@ String TiFlashJoin::genMatchHelperName(const Block & header1, const Block & head
 
 String TiFlashJoin::genFlagMappedEntryHelperName(const Block & header1, const Block & header2, bool has_other_condition) const
 {
-    if ((!isRightSemiFamily(kind) && kind != ASTTableJoin::Kind::RightOuter) || !has_other_condition)
+    if (!useRowFlaggedHashMap(kind, has_other_condition))
     {
         return "";
     }

--- a/dbms/src/Flash/Coprocessor/JoinInterpreterHelper.h
+++ b/dbms/src/Flash/Coprocessor/JoinInterpreterHelper.h
@@ -164,7 +164,7 @@ struct TiFlashJoin
     /// return "" for everything else.
     String genMatchHelperName(const Block & header1, const Block & header2) const;
 
-    /// return a name that is unique in header1 and header2 for right semi/anti joins that has_other_condition,
+    /// return a name that is unique in header1 and header2 for right semi/anti/outer joins that has_other_condition,
     /// return "" for everything else.
     String genFlagMappedEntryHelperName(const Block & header1, const Block & header2, bool has_other_condition) const;
 

--- a/dbms/src/Flash/tests/gtest_join_executor.cpp
+++ b/dbms/src/Flash/tests/gtest_join_executor.cpp
@@ -1737,7 +1737,6 @@ try
 }
 CATCH
 
-
 TEST_F(JoinExecutorTestRunner, RightSemiFamilyJoin)
 try
 {
@@ -1860,6 +1859,219 @@ try
                                  0)
                            .build(context);
         executeAndAssertColumnsEqual(request, res);
+    }
+}
+CATCH
+
+/// please ensure that left table output columns' size == right table output columns' size
+ColumnsWithTypeAndName swapLeftRightTableColumns(const ColumnsWithTypeAndName & left_outer_result)
+{
+    auto right_outer_result = left_outer_result;
+    auto size = left_outer_result.size();
+    assert(size % 2 == 0);
+    auto half_size = size >> 1;
+    for (size_t i = 0; i < half_size; ++i)
+        right_outer_result[i] = left_outer_result[half_size + i];
+    for (size_t i = half_size; i < size; ++i)
+        right_outer_result[i] = left_outer_result[i - half_size];
+    return right_outer_result;
+}
+
+TEST_F(JoinExecutorTestRunner, RightOuterJoin)
+try
+{
+    using tipb::JoinType;
+    /// One join key(t.a = s.a) + no left/right condition + no other condition.
+    /// type + left table(t) + right table(s) + result column.
+    const std::vector<std::tuple<JoinType, ColumnsWithTypeAndName, ColumnsWithTypeAndName>> t1 = {
+        {JoinType::TypeRightOuterJoin,
+         {toNullableVec<Int32>("a", {1, 2, {}, 4, 5})},
+         {toNullableVec<Int32>("a", {1, 3, {}, 4})}},
+        {JoinType::TypeRightOuterJoin,
+         {toNullableVec<Int32>("a", {1, 2, {}, 4, 5})},
+         {toNullableVec<Int32>("a", {2, 3, {}, 7})}},
+        {JoinType::TypeRightOuterJoin,
+         {toNullableVec<Int32>("a", {1, 1, {}, 4, 5})},
+         {toNullableVec<Int32>("a", {1, 2, {}, 4, 5})}},
+        {JoinType::TypeRightOuterJoin,
+         {toNullableVec<Int32>("a", {1, 2, {}, 4, 5})},
+         {toNullableVec<Int32>("a", {1, 3, {}, 4})}},
+        {JoinType::TypeRightOuterJoin,
+         {toNullableVec<Int32>("a", {1, 2, {}, 4, 5})},
+         {toNullableVec<Int32>("a", {1, 2, {}, 4, 5})}},
+        {JoinType::TypeRightOuterJoin,
+         {toNullableVec<Int32>("a", {1, 2, 2, {}, {}, 5, 5})},
+         {toNullableVec<Int32>("a", {3, 2, {}, 7})}}};
+
+    for (const auto & [type, left, right] : t1)
+    {
+        context.addMockTable("right_outer", "t", {{"a", TiDB::TP::TypeLong}}, left);
+        context.addMockTable("right_outer", "s", {{"a", TiDB::TP::TypeLong}}, right);
+
+        auto request = context.scan("right_outer", "s")
+                           .join(context.scan("right_outer", "t"),
+                                 JoinType::TypeLeftOuterJoin,
+                                 {col("a")},
+                                 {},
+                                 {},
+                                 {},
+                                 {},
+                                 0,
+                                 false,
+                                 1)
+                           .build(context);
+        auto expect = executeStreams(request, 1);
+        auto swap_expect = swapLeftRightTableColumns(expect);
+        auto request2 = context.scan("right_outer", "t")
+                            .join(context.scan("right_outer", "s"),
+                                  type,
+                                  {col("a")},
+                                  {},
+                                  {},
+                                  {},
+                                  {},
+                                  0,
+                                  false,
+                                  1)
+                            .build(context);
+        executeAndAssertColumnsEqual(request2, swap_expect);
+    }
+
+    /// One join key(t.a = s.a) + no left/right condition + other condition(t.c < s.c).
+    /// left table(t) + right table(s) + result column.
+    const std::vector<std::tuple<JoinType, ColumnsWithTypeAndName, ColumnsWithTypeAndName>> t2 = {
+        {
+            JoinType::TypeRightOuterJoin,
+            {toNullableVec<Int32>("a", {1, 2, {}, 4, 5}), toNullableVec<Int32>("c", {1, 1, 1, 2, 1})},
+            {toNullableVec<Int32>("a", {1, 2, {}, 4, 5}), toNullableVec<Int32>("c", {2, 2, 2, 2, 2})},
+        },
+        {
+            JoinType::TypeRightOuterJoin,
+            {toNullableVec<Int32>("a", {1, 2, {}, 4, 5}), toNullableVec<Int32>("c", {1, 1, 1, 1, 1})},
+            {toNullableVec<Int32>("a", {3, 2, {}, 4, 6}), toNullableVec<Int32>("c", {2, 2, 2, 2, 2})},
+        },
+        {
+            JoinType::TypeRightOuterJoin,
+            {toNullableVec<Int32>("a", {1, 1, 2, {}, 4, 4, 5}), toNullableVec<Int32>("c", {1, 2, 3, 4, 5, 6, 7})},
+            {toNullableVec<Int32>("a", {1, 4, 4, 4}), toNullableVec<Int32>("c", {2, 9, 3, 10})},
+        },
+        {
+            JoinType::TypeRightOuterJoin,
+            {toNullableVec<Int32>("a", {1, 2, {}, 4, 5}), toNullableVec<Int32>("c", {1, 1, 2, 7, 1})},
+            {toNullableVec<Int32>("a", {1, 5, 8}), toNullableVec<Int32>("c", {0, 2, 8})},
+        },
+        {
+            JoinType::TypeRightOuterJoin,
+            {toNullableVec<Int32>("a", {1, 2, {}, 4, 5}), toNullableVec<Int32>("c", {1, 2, 3, 4, 5})},
+            {toNullableVec<Int32>("a", {1, 2, {}, 4, 5}), toNullableVec<Int32>("c", {0, 1, 5, 6, 7})},
+        },
+        {
+            JoinType::TypeRightOuterJoin,
+            {toNullableVec<Int32>("a", {1, 1, 2, 2, {}, {}, 4, 5}), toNullableVec<Int32>("c", {1, 2, 3, 4, 5, 6, 7, 8})},
+            {toNullableVec<Int32>("a", {1, 2, {}, 4, 5}), toNullableVec<Int32>("c", {2, 1, 5, 6, 7})},
+        }};
+
+    for (const auto & [type, left, right] : t2)
+    {
+        context.addMockTable("right_outer", "t", {{"a", TiDB::TP::TypeLong}, {"c", TiDB::TP::TypeLong}}, left);
+        context.addMockTable("right_outer", "s", {{"a", TiDB::TP::TypeLong}, {"c", TiDB::TP::TypeLong}}, right);
+
+        auto request = context.scan("right_outer", "s")
+                           .join(context.scan("right_outer", "t"),
+                                 JoinType::TypeLeftOuterJoin,
+                                 {col("a")},
+                                 {},
+                                 {},
+                                 {lt(col("t.c"), col("s.c"))},
+                                 {},
+                                 0,
+                                 false,
+                                 1)
+                           .build(context);
+        auto expect = executeStreams(request, 1);
+        auto swap_expect = swapLeftRightTableColumns(expect);
+        auto request2 = context.scan("right_outer", "t")
+                            .join(context.scan("right_outer", "s"),
+                                  type,
+                                  {col("a")},
+                                  {},
+                                  {},
+                                  {lt(col("t.c"), col("s.c"))},
+                                  {},
+                                  0,
+                                  false,
+                                  1)
+                            .build(context);
+        executeAndAssertColumnsEqual(request2, swap_expect);
+    }
+
+    /// One join key(t.a = s.a) + left/right condition + other condition(t.c < s.c).
+    /// left table(t) + right table(s) + result column.
+    const std::vector<std::tuple<JoinType, ColumnsWithTypeAndName, ColumnsWithTypeAndName>> t3 = {
+        {
+            JoinType::TypeRightOuterJoin,
+            {toNullableVec<Int32>("a", {1, 2, {}, 4, 5}), toNullableVec<Int32>("c", {1, 1, 1, 2, 1})},
+            {toNullableVec<Int32>("a", {1, 2, {}, 4, 5}), toNullableVec<Int32>("c", {2, 2, 2, 2, 2})},
+        },
+        {
+            JoinType::TypeRightOuterJoin,
+            {toNullableVec<Int32>("a", {1, 2, {}, 4, 5}), toNullableVec<Int32>("c", {1, 1, 1, 1, 1})},
+            {toNullableVec<Int32>("a", {3, 2, {}, 4, 6}), toNullableVec<Int32>("c", {2, 2, 2, 2, 2})},
+        },
+        {
+            JoinType::TypeRightOuterJoin,
+            {toNullableVec<Int32>("a", {1, 1, 2, {}, 4, 4, 5}), toNullableVec<Int32>("c", {1, 2, 3, 4, 5, 6, 7})},
+            {toNullableVec<Int32>("a", {1, 4, 4, 4}), toNullableVec<Int32>("c", {2, 9, 3, 10})},
+        },
+        {
+            JoinType::TypeRightOuterJoin,
+            {toNullableVec<Int32>("a", {1, 2, {}, 4, 5}), toNullableVec<Int32>("c", {1, 1, 2, 7, 1})},
+            {toNullableVec<Int32>("a", {1, 5, 8}), toNullableVec<Int32>("c", {0, 2, 8})},
+        },
+        {
+            JoinType::TypeRightOuterJoin,
+            {toNullableVec<Int32>("a", {1, 2, {}, 4, 5}), toNullableVec<Int32>("c", {1, 2, 3, 4, 5})},
+            {toNullableVec<Int32>("a", {1, 2, {}, 4, 5}), toNullableVec<Int32>("c", {0, 1, 5, 6, 7})},
+        },
+        {
+            JoinType::TypeRightOuterJoin,
+            {toNullableVec<Int32>("a", {1, 1, 2, 2, {}, {}, 4, 5}), toNullableVec<Int32>("c", {1, 2, 3, 4, 5, 6, 7, 8})},
+            {toNullableVec<Int32>("a", {1, 2, {}, 4, 5}), toNullableVec<Int32>("c", {2, 1, 5, 6, 7})},
+        }};
+
+    auto literal_integer = lit(Field(static_cast<Int64>(2)));
+    for (const auto & [type, left, right] : t3)
+    {
+        context.addMockTable("right_outer", "t", {{"a", TiDB::TP::TypeLong}, {"c", TiDB::TP::TypeLong}}, left);
+        context.addMockTable("right_outer", "s", {{"a", TiDB::TP::TypeLong}, {"c", TiDB::TP::TypeLong}}, right);
+
+        auto request = context.scan("right_outer", "s")
+                           .join(context.scan("right_outer", "t"),
+                                 JoinType::TypeLeftOuterJoin,
+                                 {col("a")},
+                                 {lt(col("s.a"), literal_integer)},
+                                 {},
+                                 {lt(col("t.c"), col("s.c"))},
+                                 {},
+                                 0,
+                                 false,
+                                 1)
+                           .build(context);
+        auto expect = executeStreams(request, 1);
+        auto swap_expect = swapLeftRightTableColumns(expect);
+        auto request2 = context.scan("right_outer", "t")
+                            .join(context.scan("right_outer", "s"),
+                                  type,
+                                  {col("a")},
+                                  {},
+                                  {lt(col("s.a"), literal_integer)},
+                                  {lt(col("t.c"), col("s.c"))},
+                                  {},
+                                  0,
+                                  false,
+                                  1)
+                            .build(context);
+        executeAndAssertColumnsEqual(request2, swap_expect);
     }
 }
 CATCH

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -890,7 +890,7 @@ Block Join::doJoinBlockHash(ProbeProcessInfo & probe_process_info) const
         assert(offsets_to_replicate != nullptr);
         handleOtherConditions(block, filter, offsets_to_replicate, right_table_column_indexes);
 
-        if (isNecessaryKindToUseRowFlaggedHashMap(kind))
+        if (useRowFlaggedHashMap(kind, has_other_condition))
         {
             // set hash table used flag using SemiMapped column
             auto & mapped_column = block.getByName(flag_mapped_entry_helper_name).column;

--- a/dbms/src/Interpreters/JoinPartition.cpp
+++ b/dbms/src/Interpreters/JoinPartition.cpp
@@ -209,7 +209,7 @@ void JoinPartition::initMap()
     if (isCrossJoin(kind))
         return;
 
-    if (useRowFlaggedHashMapIfHasOtherCondition(kind))
+    if (isNecessaryKindToUseRowFlaggedHashMap(kind))
     {
         if (has_other_condition)
             initImpl(maps_all_full_with_row_flag, join_map_method);
@@ -667,7 +667,7 @@ template <typename Map>
 Map & JoinPartition::getHashMap()
 {
     assert(!spill);
-    if (useRowFlaggedHashMapIfHasOtherCondition(kind))
+    if (isNecessaryKindToUseRowFlaggedHashMap(kind))
     {
         if (has_other_condition)
             return getMapImpl<Map>(maps_all_full_with_row_flag, join_map_method);
@@ -713,7 +713,7 @@ void JoinPartition::insertBlockIntoMaps(
         else
             insertBlockIntoMapsImpl<ASTTableJoin::Strictness::All, MapsAll>(join_partitions, rows, key_columns, key_sizes, collators, stored_block, null_map, stream_index, insert_concurrency, enable_fine_grained_shuffle, enable_join_spill);
     }
-    else if (useRowFlaggedHashMapIfHasOtherCondition(current_kind))
+    else if (isNecessaryKindToUseRowFlaggedHashMap(current_kind))
     {
         if (current_join_partition->has_other_condition)
             insertBlockIntoMapsImpl<ASTTableJoin::Strictness::All, MapsAllFullWithRowFlag>(join_partitions, rows, key_columns, key_sizes, collators, stored_block, null_map, stream_index, insert_concurrency, enable_fine_grained_shuffle, enable_join_spill);

--- a/dbms/src/Interpreters/JoinPartition.cpp
+++ b/dbms/src/Interpreters/JoinPartition.cpp
@@ -227,7 +227,9 @@ void JoinPartition::initMap()
     {
         if (strictness == ASTTableJoin::Strictness::Any)
             initImpl(maps_any_full, join_map_method);
-        else
+        else if (kind == ASTTableJoin::Kind::RightOuter && has_other_condition)
+            initImpl(maps_all_full_with_row_flag, join_map_method);
+	else
             initImpl(maps_all_full, join_map_method);
     }
 }
@@ -678,6 +680,8 @@ Map & JoinPartition::getHashMap()
     {
         if (strictness == ASTTableJoin::Strictness::Any)
             return getMapImpl<Map>(maps_any_full, join_map_method);
+	else if (kind == ASTTableJoin::Kind::RightOuter && has_other_condition)
+            return getMapImpl<Map>(maps_all_full_with_row_flag, join_map_method);
         else
             return getMapImpl<Map>(maps_all_full, join_map_method);
     }
@@ -724,6 +728,8 @@ void JoinPartition::insertBlockIntoMaps(
     {
         if (current_join_partition->strictness == ASTTableJoin::Strictness::Any)
             insertBlockIntoMapsImpl<ASTTableJoin::Strictness::Any, MapsAnyFull>(join_partitions, rows, key_columns, key_sizes, collators, stored_block, null_map, stream_index, insert_concurrency, enable_fine_grained_shuffle, enable_join_spill);
+	else if (current_kind == ASTTableJoin::Kind::RightOuter && current_join_partition->has_other_condition)
+            insertBlockIntoMapsImpl<ASTTableJoin::Strictness::All, MapsAllFullWithRowFlag>(join_partitions, rows, key_columns, key_sizes, collators, stored_block, null_map, stream_index, insert_concurrency, enable_fine_grained_shuffle, enable_join_spill);
         else
             insertBlockIntoMapsImpl<ASTTableJoin::Strictness::All, MapsAllFull>(join_partitions, rows, key_columns, key_sizes, collators, stored_block, null_map, stream_index, insert_concurrency, enable_fine_grained_shuffle, enable_join_spill);
     }

--- a/dbms/src/Interpreters/JoinPartition.cpp
+++ b/dbms/src/Interpreters/JoinPartition.cpp
@@ -209,7 +209,7 @@ void JoinPartition::initMap()
     if (isCrossJoin(kind))
         return;
 
-    if (isRightSemiFamily(kind))
+    if (useRowFlaggedHashMapIfHasOtherCondition(kind))
     {
         if (has_other_condition)
             initImpl(maps_all_full_with_row_flag, join_map_method);
@@ -227,8 +227,6 @@ void JoinPartition::initMap()
     {
         if (strictness == ASTTableJoin::Strictness::Any)
             initImpl(maps_any_full, join_map_method);
-        else if (kind == ASTTableJoin::Kind::RightOuter && has_other_condition)
-            initImpl(maps_all_full_with_row_flag, join_map_method);
         else
             initImpl(maps_all_full, join_map_method);
     }
@@ -669,7 +667,7 @@ template <typename Map>
 Map & JoinPartition::getHashMap()
 {
     assert(!spill);
-    if (isRightSemiFamily(kind))
+    if (useRowFlaggedHashMapIfHasOtherCondition(kind))
     {
         if (has_other_condition)
             return getMapImpl<Map>(maps_all_full_with_row_flag, join_map_method);
@@ -680,8 +678,6 @@ Map & JoinPartition::getHashMap()
     {
         if (strictness == ASTTableJoin::Strictness::Any)
             return getMapImpl<Map>(maps_any_full, join_map_method);
-        else if (kind == ASTTableJoin::Kind::RightOuter && has_other_condition)
-            return getMapImpl<Map>(maps_all_full_with_row_flag, join_map_method);
         else
             return getMapImpl<Map>(maps_all_full, join_map_method);
     }
@@ -717,7 +713,7 @@ void JoinPartition::insertBlockIntoMaps(
         else
             insertBlockIntoMapsImpl<ASTTableJoin::Strictness::All, MapsAll>(join_partitions, rows, key_columns, key_sizes, collators, stored_block, null_map, stream_index, insert_concurrency, enable_fine_grained_shuffle, enable_join_spill);
     }
-    else if (isRightSemiFamily(current_kind))
+    else if (useRowFlaggedHashMapIfHasOtherCondition(current_kind))
     {
         if (current_join_partition->has_other_condition)
             insertBlockIntoMapsImpl<ASTTableJoin::Strictness::All, MapsAllFullWithRowFlag>(join_partitions, rows, key_columns, key_sizes, collators, stored_block, null_map, stream_index, insert_concurrency, enable_fine_grained_shuffle, enable_join_spill);
@@ -728,8 +724,6 @@ void JoinPartition::insertBlockIntoMaps(
     {
         if (current_join_partition->strictness == ASTTableJoin::Strictness::Any)
             insertBlockIntoMapsImpl<ASTTableJoin::Strictness::Any, MapsAnyFull>(join_partitions, rows, key_columns, key_sizes, collators, stored_block, null_map, stream_index, insert_concurrency, enable_fine_grained_shuffle, enable_join_spill);
-        else if (current_kind == ASTTableJoin::Kind::RightOuter && current_join_partition->has_other_condition)
-            insertBlockIntoMapsImpl<ASTTableJoin::Strictness::All, MapsAllFullWithRowFlag>(join_partitions, rows, key_columns, key_sizes, collators, stored_block, null_map, stream_index, insert_concurrency, enable_fine_grained_shuffle, enable_join_spill);
         else
             insertBlockIntoMapsImpl<ASTTableJoin::Strictness::All, MapsAllFull>(join_partitions, rows, key_columns, key_sizes, collators, stored_block, null_map, stream_index, insert_concurrency, enable_fine_grained_shuffle, enable_join_spill);
     }
@@ -747,10 +741,14 @@ namespace
 template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS, typename Map>
 struct Adder;
 
+/// code for row flagged hash map probe
+template <typename Map>
+struct RowFlaggedHashMapAdder;
+
 template <typename Map>
 struct Adder<ASTTableJoin::Kind::LeftOuter, ASTTableJoin::Strictness::Any, Map>
 {
-    static bool addFound(const typename Map::ConstLookupResult & it, size_t num_columns_to_add, MutableColumns & added_columns, size_t /*i*/, IColumn::Filter * /*filter*/, IColumn::Offset & /*current_offset*/, IColumn::Offsets * /*offsets*/, const std::vector<size_t> & right_indexes, ProbeProcessInfo & /*probe_process_info*/, MutableColumnPtr & /* ptr_col */)
+    static bool addFound(const typename Map::ConstLookupResult & it, size_t num_columns_to_add, MutableColumns & added_columns, size_t /*i*/, IColumn::Filter * /*filter*/, IColumn::Offset & /*current_offset*/, IColumn::Offsets * /*offsets*/, const std::vector<size_t> & right_indexes, ProbeProcessInfo & /*probe_process_info*/)
     {
         for (size_t j = 0; j < num_columns_to_add; ++j)
             added_columns[j]->insertFrom(*it->getMapped().block->getByPosition(right_indexes[j]).column.get(), it->getMapped().row_num);
@@ -768,7 +766,7 @@ struct Adder<ASTTableJoin::Kind::LeftOuter, ASTTableJoin::Strictness::Any, Map>
 template <typename Map>
 struct Adder<ASTTableJoin::Kind::Inner, ASTTableJoin::Strictness::Any, Map>
 {
-    static bool addFound(const typename Map::ConstLookupResult & it, size_t num_columns_to_add, MutableColumns & added_columns, size_t i, IColumn::Filter * filter, IColumn::Offset & /*current_offset*/, IColumn::Offsets * /*offsets*/, const std::vector<size_t> & right_indexes, ProbeProcessInfo & /*probe_process_info*/, MutableColumnPtr & /* ptr_col */)
+    static bool addFound(const typename Map::ConstLookupResult & it, size_t num_columns_to_add, MutableColumns & added_columns, size_t i, IColumn::Filter * filter, IColumn::Offset & /*current_offset*/, IColumn::Offsets * /*offsets*/, const std::vector<size_t> & right_indexes, ProbeProcessInfo & /*probe_process_info*/)
     {
         (*filter)[i] = 1;
 
@@ -788,7 +786,7 @@ struct Adder<ASTTableJoin::Kind::Inner, ASTTableJoin::Strictness::Any, Map>
 template <typename Map>
 struct Adder<ASTTableJoin::Kind::Anti, ASTTableJoin::Strictness::Any, Map>
 {
-    static bool addFound(const typename Map::ConstLookupResult & /*it*/, size_t /*num_columns_to_add*/, MutableColumns & /*added_columns*/, size_t i, IColumn::Filter * filter, IColumn::Offset & /*current_offset*/, IColumn::Offsets * /*offsets*/, const std::vector<size_t> & /*right_indexes*/, ProbeProcessInfo & /*probe_process_info*/, MutableColumnPtr & /* ptr_col */)
+    static bool addFound(const typename Map::ConstLookupResult & /*it*/, size_t /*num_columns_to_add*/, MutableColumns & /*added_columns*/, size_t i, IColumn::Filter * filter, IColumn::Offset & /*current_offset*/, IColumn::Offsets * /*offsets*/, const std::vector<size_t> & /*right_indexes*/, ProbeProcessInfo & /*probe_process_info*/)
     {
         (*filter)[i] = 0;
         return false;
@@ -806,7 +804,7 @@ struct Adder<ASTTableJoin::Kind::Anti, ASTTableJoin::Strictness::Any, Map>
 template <typename Map>
 struct Adder<ASTTableJoin::Kind::LeftOuterSemi, ASTTableJoin::Strictness::Any, Map>
 {
-    static bool addFound(const typename Map::ConstLookupResult & /*it*/, size_t num_columns_to_add, MutableColumns & added_columns, size_t /*i*/, IColumn::Filter * /*filter*/, IColumn::Offset & /*current_offset*/, IColumn::Offsets * /*offsets*/, const std::vector<size_t> & /*right_indexes*/, ProbeProcessInfo & /*probe_process_info*/, MutableColumnPtr & /* ptr_col */)
+    static bool addFound(const typename Map::ConstLookupResult & /*it*/, size_t num_columns_to_add, MutableColumns & added_columns, size_t /*i*/, IColumn::Filter * /*filter*/, IColumn::Offset & /*current_offset*/, IColumn::Offsets * /*offsets*/, const std::vector<size_t> & /*right_indexes*/, ProbeProcessInfo & /*probe_process_info*/)
     {
         for (size_t j = 0; j < num_columns_to_add - 1; ++j)
             added_columns[j]->insertDefault();
@@ -826,7 +824,7 @@ struct Adder<ASTTableJoin::Kind::LeftOuterSemi, ASTTableJoin::Strictness::Any, M
 template <typename Map>
 struct Adder<ASTTableJoin::Kind::LeftOuterSemi, ASTTableJoin::Strictness::All, Map>
 {
-    static bool addFound(const typename Map::ConstLookupResult & it, size_t num_columns_to_add, MutableColumns & added_columns, size_t i, IColumn::Filter * /*filter*/, IColumn::Offset & current_offset, IColumn::Offsets * offsets, const std::vector<size_t> & right_indexes, ProbeProcessInfo & /*probe_process_info*/, MutableColumnPtr & /* ptr_col */)
+    static bool addFound(const typename Map::ConstLookupResult & it, size_t num_columns_to_add, MutableColumns & added_columns, size_t i, IColumn::Filter * /*filter*/, IColumn::Offset & current_offset, IColumn::Offsets * offsets, const std::vector<size_t> & right_indexes, ProbeProcessInfo & /*probe_process_info*/)
     {
         for (auto current = &static_cast<const typename Map::mapped_type::Base_t &>(it->getMapped()); current != nullptr; current = current->next)
         {
@@ -853,78 +851,11 @@ struct Adder<ASTTableJoin::Kind::LeftOuterSemi, ASTTableJoin::Strictness::All, M
     }
 };
 
-template <typename Map>
-struct Adder<ASTTableJoin::Kind::RightSemi, ASTTableJoin::Strictness::All, Map>
-{
-    static bool addFound(const typename Map::ConstLookupResult & it, size_t num_columns_to_add, MutableColumns & added_columns, size_t i, IColumn::Filter * /*filter*/, IColumn::Offset & current_offset, IColumn::Offsets * offsets, const std::vector<size_t> & right_indexes, ProbeProcessInfo & probe_process_info, MutableColumnPtr & ptr_col)
-    {
-        size_t rows_joined = 0;
-        // If there are too many rows in the column to split, record the number of rows that have been expanded for next read.
-        // and it means the rows in this block are not joined finish.
-
-        for (auto current = &static_cast<const typename Map::mapped_type::Base_t &>(it->getMapped()); current != nullptr; current = current->next)
-            ++rows_joined;
-
-        if (current_offset && current_offset + rows_joined > probe_process_info.max_block_size)
-        {
-            return true;
-        }
-
-        auto & actual_ptr_col = static_cast<PointerHelper::ColumnType &>(*ptr_col);
-        auto & container = static_cast<PointerHelper::ArrayType &>(actual_ptr_col.getData());
-        for (auto current = &static_cast<const typename Map::mapped_type::Base_t &>(it->getMapped()); current != nullptr; current = current->next)
-        {
-            for (size_t j = 0; j < num_columns_to_add; ++j)
-                added_columns[j]->insertFrom(*current->block->getByPosition(right_indexes[j]).column.get(), current->row_num);
-
-            container.template push_back(reinterpret_cast<std::intptr_t>(current));
-            ++current_offset;
-        }
-        (*offsets)[i] = current_offset;
-        return false;
-    }
-
-    static bool addNotFound(size_t /*num_columns_to_add*/, MutableColumns & /*added_columns*/, size_t i, IColumn::Filter * /*filter*/, IColumn::Offset & current_offset, IColumn::Offsets * offsets, ProbeProcessInfo & /*probe_process_info*/)
-    {
-        (*offsets)[i] = current_offset;
-        return false;
-    }
-};
-
-template <typename Map>
-struct Adder<ASTTableJoin::Kind::RightAnti, ASTTableJoin::Strictness::All, Map>
-{
-    static bool addFound(const typename Map::ConstLookupResult & it, size_t num_columns_to_add, MutableColumns & added_columns, size_t i, IColumn::Filter * filter, IColumn::Offset & current_offset, IColumn::Offsets * offsets, const std::vector<size_t> & right_indexes, ProbeProcessInfo & probe_process_info, MutableColumnPtr & ptr_col)
-    {
-        return Adder<ASTTableJoin::Kind::RightSemi, ASTTableJoin::Strictness::All, Map>::addFound(it, num_columns_to_add, added_columns, i, filter, current_offset, offsets, right_indexes, probe_process_info, ptr_col);
-    }
-
-    static bool addNotFound(size_t /*num_columns_to_add*/, MutableColumns & /*added_columns*/, size_t i, IColumn::Filter * /*filter*/, IColumn::Offset & current_offset, IColumn::Offsets * offsets, ProbeProcessInfo & /*probe_process_info*/)
-    {
-        (*offsets)[i] = current_offset;
-        return false;
-    }
-};
-
-template <typename Map>
-struct Adder<ASTTableJoin::Kind::RightOuter, ASTTableJoin::Strictness::All, Map>
-{
-    static bool addFound(const typename Map::ConstLookupResult & it, size_t num_columns_to_add, MutableColumns & added_columns, size_t i, IColumn::Filter * filter, IColumn::Offset & current_offset, IColumn::Offsets * offsets, const std::vector<size_t> & right_indexes, ProbeProcessInfo & probe_process_info, MutableColumnPtr & ptr_col)
-    {
-        return Adder<ASTTableJoin::Kind::RightSemi, ASTTableJoin::Strictness::All, Map>::addFound(it, num_columns_to_add, added_columns, i, filter, current_offset, offsets, right_indexes, probe_process_info, ptr_col);
-    }
-
-    static bool addNotFound(size_t /*num_columns_to_add*/, MutableColumns & /*added_columns*/, size_t i, IColumn::Filter * /*filter*/, IColumn::Offset & current_offset, IColumn::Offsets * offsets, ProbeProcessInfo & /*probe_process_info*/)
-    {
-        (*offsets)[i] = current_offset;
-        return false;
-    }
-};
-
 template <ASTTableJoin::Kind KIND, typename Map>
 struct Adder<KIND, ASTTableJoin::Strictness::All, Map>
 {
-    static bool addFound(const typename Map::ConstLookupResult & it, size_t num_columns_to_add, MutableColumns & added_columns, size_t i, IColumn::Filter * filter, IColumn::Offset & current_offset, IColumn::Offsets * offsets, const std::vector<size_t> & right_indexes, ProbeProcessInfo & probe_process_info, MutableColumnPtr & /* ptr_col */)
+    static_assert(KIND != ASTTableJoin::Kind::RightSemi && KIND != ASTTableJoin::Kind::RightAnti);
+    static bool addFound(const typename Map::ConstLookupResult & it, size_t num_columns_to_add, MutableColumns & added_columns, size_t i, IColumn::Filter * filter, IColumn::Offset & current_offset, IColumn::Offsets * offsets, const std::vector<size_t> & right_indexes, ProbeProcessInfo & probe_process_info)
     {
         size_t rows_joined = 0;
         // If there are too many rows in the column to split, record the number of rows that have been expanded for next read.
@@ -978,7 +909,47 @@ struct Adder<KIND, ASTTableJoin::Strictness::All, Map>
         return false;
     }
 };
-template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS, typename KeyGetter, typename Map, bool has_null_map>
+
+
+template <typename Map>
+struct RowFlaggedHashMapAdder
+{
+    static bool addFound(const typename Map::ConstLookupResult & it, size_t num_columns_to_add, MutableColumns & added_columns, size_t i, IColumn::Offset & current_offset, IColumn::Offsets * offsets, const std::vector<size_t> & right_indexes, ProbeProcessInfo & probe_process_info, MutableColumnPtr & ptr_col)
+    {
+        size_t rows_joined = 0;
+        // If there are too many rows in the column to split, record the number of rows that have been expanded for next read.
+        // and it means the rows in this block are not joined finish.
+
+        for (auto current = &static_cast<const typename Map::mapped_type::Base_t &>(it->getMapped()); current != nullptr; current = current->next)
+            ++rows_joined;
+
+        if (current_offset && current_offset + rows_joined > probe_process_info.max_block_size)
+        {
+            return true;
+        }
+
+        auto & actual_ptr_col = static_cast<PointerHelper::ColumnType &>(*ptr_col);
+        auto & container = static_cast<PointerHelper::ArrayType &>(actual_ptr_col.getData());
+        for (auto current = &static_cast<const typename Map::mapped_type::Base_t &>(it->getMapped()); current != nullptr; current = current->next)
+        {
+            for (size_t j = 0; j < num_columns_to_add; ++j)
+                added_columns[j]->insertFrom(*current->block->getByPosition(right_indexes[j]).column.get(), current->row_num);
+
+            container.template push_back(reinterpret_cast<std::intptr_t>(current));
+            ++current_offset;
+        }
+        (*offsets)[i] = current_offset;
+        return false;
+    }
+
+    static bool addNotFound(size_t i, IColumn::Offset & current_offset, IColumn::Offsets * offsets)
+    {
+        (*offsets)[i] = current_offset;
+        return false;
+    }
+};
+
+template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS, typename KeyGetter, typename Map, bool has_null_map, bool row_flagged_map>
 void NO_INLINE probeBlockImplTypeCase(
     const JoinPartitions & join_partitions,
     size_t rows,
@@ -1043,19 +1014,15 @@ void NO_INLINE probeBlockImplTypeCase(
     {
         if (has_null_map && (*null_map)[i])
         {
-            if constexpr (KIND == ASTTableJoin::Kind::RightSemi || KIND == ASTTableJoin::Kind::RightAnti || KIND == ASTTableJoin::Kind::RightOuter)
+            if constexpr (row_flagged_map)
             {
-                if (record_mapped_entry_column || KIND == ASTTableJoin::Kind::RightOuter)
-                    block_full = Adder<KIND, STRICTNESS, Map>::addNotFound(
-                        num_columns_to_add,
-                        added_columns,
-                        i,
-                        filter.get(),
-                        current_offset,
-                        offsets_to_replicate.get(),
-                        probe_process_info);
+                block_full = RowFlaggedHashMapAdder<Map>::addNotFound(
+                    i,
+                    current_offset,
+                    offsets_to_replicate.get());
             }
-            else
+            /// RightSemi/RightAnti without other conditions, just ignore not matched probe rows
+            else if constexpr (KIND != ASTTableJoin::Kind::RightSemi && KIND != ASTTableJoin::Kind::RightAnti)
             {
                 block_full = Adder<KIND, STRICTNESS, Map>::addNotFound(
                     num_columns_to_add,
@@ -1116,52 +1083,23 @@ void NO_INLINE probeBlockImplTypeCase(
             auto it = internal_map.find(key, hash_value);
             if (it != internal_map.end())
             {
-                if constexpr (KIND == ASTTableJoin::Kind::RightSemi || KIND == ASTTableJoin::Kind::RightAnti)
+                if constexpr (row_flagged_map)
                 {
-                    if (record_mapped_entry_column)
-                        block_full = Adder<KIND, STRICTNESS, Map>::addFound(
-                            it,
-                            num_columns_to_add,
-                            added_columns,
-                            i,
-                            filter.get(),
-                            current_offset,
-                            offsets_to_replicate.get(),
-                            right_indexes,
-                            probe_process_info,
-                            record_mapped_entry_column);
-                    else
-                        it->getMapped().setUsed();
+                    block_full = RowFlaggedHashMapAdder<Map>::addFound(
+                        it,
+                        num_columns_to_add,
+                        added_columns,
+                        i,
+                        current_offset,
+                        offsets_to_replicate.get(),
+                        right_indexes,
+                        probe_process_info,
+                        record_mapped_entry_column);
                 }
-                else if constexpr (KIND == ASTTableJoin::Kind::RightOuter)
+                else if constexpr (KIND == ASTTableJoin::Kind::RightSemi || KIND == ASTTableJoin::Kind::RightAnti)
                 {
-                    if (record_mapped_entry_column)
-                        block_full = Adder<KIND, STRICTNESS, Map>::addFound(
-                            it,
-                            num_columns_to_add,
-                            added_columns,
-                            i,
-                            filter.get(),
-                            current_offset,
-                            offsets_to_replicate.get(),
-                            right_indexes,
-                            probe_process_info,
-                            record_mapped_entry_column);
-                    else
-                    {
-                        it->getMapped().setUsed();
-                        block_full = Adder<ASTTableJoin::Kind::Inner, STRICTNESS, Map>::addFound(
-                            it,
-                            num_columns_to_add,
-                            added_columns,
-                            i,
-                            filter.get(),
-                            current_offset,
-                            offsets_to_replicate.get(),
-                            right_indexes,
-                            probe_process_info,
-                            record_mapped_entry_column);
-                    }
+                    /// For RightSemi/RightAnti without other conditions, just flag the hash entry is enough
+                    it->getMapped().setUsed();
                 }
                 else
                 {
@@ -1175,25 +1113,20 @@ void NO_INLINE probeBlockImplTypeCase(
                         current_offset,
                         offsets_to_replicate.get(),
                         right_indexes,
-                        probe_process_info,
-                        record_mapped_entry_column);
+                        probe_process_info);
                 }
             }
             else
             {
-                if constexpr (KIND == ASTTableJoin::Kind::RightSemi || KIND == ASTTableJoin::Kind::RightAnti || KIND == ASTTableJoin::Kind::RightOuter)
+                if constexpr (row_flagged_map)
                 {
-                    if (record_mapped_entry_column || KIND == ASTTableJoin::Kind::RightOuter)
-                        block_full = Adder<KIND, STRICTNESS, Map>::addNotFound(
-                            num_columns_to_add,
-                            added_columns,
-                            i,
-                            filter.get(),
-                            current_offset,
-                            offsets_to_replicate.get(),
-                            probe_process_info);
+                    block_full = RowFlaggedHashMapAdder<Map>::addNotFound(
+                        i,
+                        current_offset,
+                        offsets_to_replicate.get());
                 }
-                else
+                /// RightSemi/RightAnti without other conditions, just ignore not matched probe rows
+                else if constexpr (KIND != ASTTableJoin::Kind::RightSemi && KIND != ASTTableJoin::Kind::RightAnti)
                 {
                     block_full = Adder<KIND, STRICTNESS, Map>::addNotFound(
                         num_columns_to_add,
@@ -1219,7 +1152,7 @@ void NO_INLINE probeBlockImplTypeCase(
     probe_process_info.all_rows_joined_finish = (i == rows);
 }
 
-template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS, typename KeyGetter, typename Map>
+template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS, typename KeyGetter, typename Map, bool row_flagged_map>
 void probeBlockImplType(
     const JoinPartitions & join_partitions,
     size_t rows,
@@ -1237,7 +1170,8 @@ void probeBlockImplType(
     MutableColumnPtr & record_mapped_entry_column)
 {
     if (null_map)
-        probeBlockImplTypeCase<KIND, STRICTNESS, KeyGetter, Map, true>(
+    {
+        probeBlockImplTypeCase<KIND, STRICTNESS, KeyGetter, Map, true, row_flagged_map>(
             join_partitions,
             rows,
             key_columns,
@@ -1252,8 +1186,10 @@ void probeBlockImplType(
             join_build_info,
             probe_process_info,
             record_mapped_entry_column);
+    }
     else
-        probeBlockImplTypeCase<KIND, STRICTNESS, KeyGetter, Map, false>(
+    {
+        probeBlockImplTypeCase<KIND, STRICTNESS, KeyGetter, Map, false, row_flagged_map>(
             join_partitions,
             rows,
             key_columns,
@@ -1268,6 +1204,7 @@ void probeBlockImplType(
             join_build_info,
             probe_process_info,
             record_mapped_entry_column);
+    }
 }
 template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS, typename KeyGetter, typename Map, bool has_null_map, bool has_filter_map>
 std::pair<PaddedPODArray<NASemiJoinResult<KIND, STRICTNESS>>, std::list<NASemiJoinResult<KIND, STRICTNESS> *>> NO_INLINE probeBlockNullAwareInternal(
@@ -1481,67 +1418,67 @@ void JoinPartition::probeBlock(
     auto strictness = current_partition->strictness;
     assert(rows == 0 || !current_partition->spill);
 
-#define CALL(KIND, STRICTNESS, MAP)        \
-    probeBlockImpl<KIND, STRICTNESS, MAP>( \
-        join_partitions,                   \
-        rows,                              \
-        key_columns,                       \
-        key_sizes,                         \
-        added_columns,                     \
-        null_map,                          \
-        filter,                            \
-        current_offset,                    \
-        offsets_to_replicate,              \
-        right_indexes,                     \
-        collators,                         \
-        join_build_info,                   \
-        probe_process_info,                \
+#define CALL(KIND, STRICTNESS, MAP, row_flagged_map)        \
+    probeBlockImpl<KIND, STRICTNESS, MAP, row_flagged_map>( \
+        join_partitions,                                    \
+        rows,                                               \
+        key_columns,                                        \
+        key_sizes,                                          \
+        added_columns,                                      \
+        null_map,                                           \
+        filter,                                             \
+        current_offset,                                     \
+        offsets_to_replicate,                               \
+        right_indexes,                                      \
+        collators,                                          \
+        join_build_info,                                    \
+        probe_process_info,                                 \
         record_mapped_entry_column);
 
     if (kind == LeftOuter && strictness == Any)
-        CALL(LeftOuter, Any, MapsAny)
+        CALL(LeftOuter, Any, MapsAny, false)
     else if (kind == Inner && strictness == Any)
-        CALL(Inner, Any, MapsAny)
+        CALL(Inner, Any, MapsAny, false)
     else if (kind == LeftOuter && strictness == All)
-        CALL(LeftOuter, All, MapsAll)
+        CALL(LeftOuter, All, MapsAll, false)
     else if (kind == Inner && strictness == All)
-        CALL(Inner, All, MapsAll)
+        CALL(Inner, All, MapsAll, false)
     else if (kind == Full && strictness == Any)
-        CALL(LeftOuter, Any, MapsAnyFull)
+        CALL(LeftOuter, Any, MapsAnyFull, false)
     else if (kind == RightOuter && strictness == Any)
-        CALL(Inner, Any, MapsAnyFull)
+        CALL(Inner, Any, MapsAnyFull, false)
     else if (kind == Full && strictness == All)
-        CALL(LeftOuter, All, MapsAllFull)
+        CALL(LeftOuter, All, MapsAllFull, false)
     else if (kind == RightOuter && strictness == All && !record_mapped_entry_column)
-        CALL(Inner, All, MapsAllFull)
+        CALL(Inner, All, MapsAllFull, false)
     else if (kind == RightOuter && strictness == All && record_mapped_entry_column)
-        CALL(RightOuter, All, MapsAllFullWithRowFlag)
+        CALL(RightOuter, All, MapsAllFullWithRowFlag, true)
     else if (kind == Anti && strictness == Any)
-        CALL(Anti, Any, MapsAny)
+        CALL(Anti, Any, MapsAny, false)
     else if (kind == Anti && strictness == All)
-        CALL(Anti, All, MapsAll)
+        CALL(Anti, All, MapsAll, false)
     else if (kind == LeftOuterSemi && strictness == Any)
-        CALL(LeftOuterSemi, Any, MapsAny)
+        CALL(LeftOuterSemi, Any, MapsAny, false)
     else if (kind == LeftOuterSemi && strictness == All)
-        CALL(LeftOuterSemi, All, MapsAll)
+        CALL(LeftOuterSemi, All, MapsAll, false)
     else if (kind == LeftOuterAnti && strictness == Any)
-        CALL(LeftOuterSemi, Any, MapsAny)
+        CALL(LeftOuterSemi, Any, MapsAny, false)
     else if (kind == LeftOuterAnti && strictness == All)
-        CALL(LeftOuterSemi, All, MapsAll)
+        CALL(LeftOuterSemi, All, MapsAll, false)
     else if (kind == RightSemi && record_mapped_entry_column)
-        CALL(RightSemi, All, MapsAllFullWithRowFlag)
+        CALL(RightSemi, All, MapsAllFullWithRowFlag, true)
     else if (kind == RightSemi && !record_mapped_entry_column)
-        CALL(RightSemi, All, MapsAllFull)
+        CALL(RightSemi, All, MapsAllFull, false)
     else if (kind == RightAnti && record_mapped_entry_column)
-        CALL(RightAnti, All, MapsAllFullWithRowFlag)
+        CALL(RightAnti, All, MapsAllFullWithRowFlag, true)
     else if (kind == RightAnti && !record_mapped_entry_column)
-        CALL(RightAnti, All, MapsAllFull)
+        CALL(RightAnti, All, MapsAllFull, false)
     else
         throw Exception("Logical error: unknown combination of JOIN", ErrorCodes::LOGICAL_ERROR);
 #undef CALL
 }
 
-template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS, typename Maps>
+template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS, typename Maps, bool row_flagged_map>
 void JoinPartition::probeBlockImpl(
     const JoinPartitions & join_partitions,
     size_t rows,
@@ -1562,23 +1499,23 @@ void JoinPartition::probeBlockImpl(
     auto method = current_join_partition->join_map_method;
     switch (method)
     {
-#define M(METHOD)                                                                                                                                               \
-    case JoinMapMethod::METHOD:                                                                                                                                 \
-        probeBlockImplType<KIND, STRICTNESS, typename KeyGetterForType<JoinMapMethod::METHOD, typename Maps::METHOD##Type>::Type, typename Maps::METHOD##Type>( \
-            join_partitions,                                                                                                                                    \
-            rows,                                                                                                                                               \
-            key_columns,                                                                                                                                        \
-            key_sizes,                                                                                                                                          \
-            added_columns,                                                                                                                                      \
-            null_map,                                                                                                                                           \
-            filter,                                                                                                                                             \
-            current_offset,                                                                                                                                     \
-            offsets_to_replicate,                                                                                                                               \
-            right_indexes,                                                                                                                                      \
-            collators,                                                                                                                                          \
-            join_build_info,                                                                                                                                    \
-            probe_process_info,                                                                                                                                 \
-            record_mapped_entry_column);                                                                                                                        \
+#define M(METHOD)                                                                                                                                                                \
+    case JoinMapMethod::METHOD:                                                                                                                                                  \
+        probeBlockImplType<KIND, STRICTNESS, typename KeyGetterForType<JoinMapMethod::METHOD, typename Maps::METHOD##Type>::Type, typename Maps::METHOD##Type, row_flagged_map>( \
+            join_partitions,                                                                                                                                                     \
+            rows,                                                                                                                                                                \
+            key_columns,                                                                                                                                                         \
+            key_sizes,                                                                                                                                                           \
+            added_columns,                                                                                                                                                       \
+            null_map,                                                                                                                                                            \
+            filter,                                                                                                                                                              \
+            current_offset,                                                                                                                                                      \
+            offsets_to_replicate,                                                                                                                                                \
+            right_indexes,                                                                                                                                                       \
+            collators,                                                                                                                                                           \
+            join_build_info,                                                                                                                                                     \
+            probe_process_info,                                                                                                                                                  \
+            record_mapped_entry_column);                                                                                                                                         \
         break;
         APPLY_FOR_JOIN_VARIANTS(M)
 #undef M

--- a/dbms/src/Interpreters/JoinPartition.h
+++ b/dbms/src/Interpreters/JoinPartition.h
@@ -172,7 +172,7 @@ public:
         const JoinBuildInfo & join_build_info,
         ProbeProcessInfo & probe_process_info,
         MutableColumnPtr & record_mapped_entry_column);
-    template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS, typename Maps>
+    template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS, typename Maps, bool row_flagged_map>
     static void probeBlockImpl(
         const JoinPartitions & join_partitions,
         size_t rows,

--- a/dbms/src/Interpreters/JoinPartition.h
+++ b/dbms/src/Interpreters/JoinPartition.h
@@ -218,8 +218,8 @@ private:
     MapsAll maps_all; /// For ALL LEFT|INNER JOIN
     MapsAnyFull maps_any_full; /// For ANY RIGHT|FULL JOIN
     MapsAllFull maps_all_full; /// For ALL RIGHT|FULL JOIN
-    MapsAllFullWithRowFlag maps_all_full_with_row_flag; /// For RIGHT_SEMI | RIGHT_ANTI_SEMI with other conditions
-    /// For right/full/rightSemi/rightAnti join, including
+    MapsAllFullWithRowFlag maps_all_full_with_row_flag; /// For RIGHT_SEMI | RIGHT_ANTI_SEMI | RIGHT_OUTER with other conditions
+    /// For right outer/full/rightSemi/rightAnti join, including
     /// 1. Rows with NULL join keys
     /// 2. Rows that are filtered by right join conditions
     /// For null-aware semi join family, including rows with NULL join keys.

--- a/dbms/src/Interpreters/JoinUtils.h
+++ b/dbms/src/Interpreters/JoinUtils.h
@@ -74,15 +74,17 @@ inline bool needScanHashMapAfterProbe(ASTTableJoin::Kind kind)
 {
     return getFullness(kind) || isRightSemiFamily(kind);
 }
-inline bool useRowFlaggedHashMap(ASTTableJoin::Kind kind, bool has_other_condition)
-{
-    return has_other_condition && (isRightSemiFamily(kind) || kind == ASTTableJoin::Kind::RightOuter);
-}
 
-inline bool useRowFlaggedHashMapIfHasOtherCondition(ASTTableJoin::Kind kind)
+inline bool isNecessaryKindToUseRowFlaggedHashMap(ASTTableJoin::Kind kind)
 {
     return isRightSemiFamily(kind) || kind == ASTTableJoin::Kind::RightOuter;
 }
+
+inline bool useRowFlaggedHashMap(ASTTableJoin::Kind kind, bool has_other_condition)
+{
+    return has_other_condition && isNecessaryKindToUseRowFlaggedHashMap(kind);
+}
+
 
 bool mayProbeSideExpandedAfterJoin(ASTTableJoin::Kind kind, ASTTableJoin::Strictness strictness);
 

--- a/dbms/src/Interpreters/JoinUtils.h
+++ b/dbms/src/Interpreters/JoinUtils.h
@@ -74,6 +74,15 @@ inline bool needScanHashMapAfterProbe(ASTTableJoin::Kind kind)
 {
     return getFullness(kind) || isRightSemiFamily(kind);
 }
+inline bool useRowFlaggedHashMap(ASTTableJoin::Kind kind, bool has_other_condition)
+{
+    return has_other_condition && (isRightSemiFamily(kind) || kind == ASTTableJoin::Kind::RightOuter);
+}
+
+inline bool useRowFlaggedHashMapIfHasOtherCondition(ASTTableJoin::Kind kind)
+{
+    return isRightSemiFamily(kind) || kind == ASTTableJoin::Kind::RightOuter;
+}
 
 bool mayProbeSideExpandedAfterJoin(ASTTableJoin::Kind kind, ASTTableJoin::Strictness strictness);
 

--- a/dbms/src/Interpreters/JoinUtils.h
+++ b/dbms/src/Interpreters/JoinUtils.h
@@ -85,7 +85,6 @@ inline bool useRowFlaggedHashMap(ASTTableJoin::Kind kind, bool has_other_conditi
     return has_other_condition && isNecessaryKindToUseRowFlaggedHashMap(kind);
 }
 
-
 bool mayProbeSideExpandedAfterJoin(ASTTableJoin::Kind kind, ASTTableJoin::Strictness strictness);
 
 struct ProbeProcessInfo

--- a/tests/fullstack-test/mpp/right_join.test
+++ b/tests/fullstack-test/mpp/right_join.test
@@ -37,7 +37,23 @@ mysql> use test; set @@tidb_isolation_read_engines='tiflash'; set tidb_enforce_m
 |    0 | a     | NULL | NULL  |
 +------+-------+------+-------+
 
-mysql> use test; set @@tidb_isolation_read_engines='tiflash'; set tidb_enforce_mpp= 1; set tidb_broadcast_join_threshold_count = 0; set tidb_opt_mpp_outer_join_fixed_build_side = 0; set tidb_broadcast_join_threshold_size=0; select * from a left join b on a.id = b.id + 10 where a.id > 2 or b.id = 1; 
+mysql> use test; set @@tidb_isolation_read_engines='tiflash'; set tidb_enforce_mpp= 1; set tidb_broadcast_join_threshold_count = 0; set tidb_opt_mpp_outer_join_fixed_build_side = 0; set tidb_broadcast_join_threshold_size=0; select * from a left join b on a.id = b.id + 10 where a.id > 2 or b.id = 1;
+
+mysql> use test; set @@tidb_isolation_read_engines='tiflash'; set tidb_enforce_mpp= 1; set tidb_broadcast_join_threshold_count = 0; set tidb_opt_mpp_outer_join_fixed_build_side = 0; set tidb_broadcast_join_threshold_size=0; select * from b right join a on a.id = b.id and a.value <= b.value;
++------+-------+------+-------+
+| id   | value | id   | value |
++------+-------+------+-------+
+| NULL | NULL  |    0 | a     |
+|    2 | b     |    2 | b     |
++------+-------+------+-------+
+
+mysql> use test; set @@tidb_isolation_read_engines='tiflash'; set tidb_enforce_mpp= 1; set tidb_broadcast_join_threshold_count = 100; set tidb_opt_mpp_outer_join_fixed_build_side = 0; set tidb_broadcast_join_threshold_size=1000; select * from b right join a on a.id = b.id and a.value <= b.value;
++------+-------+------+-------+
+| id   | value | id   | value |
++------+-------+------+-------+
+| NULL | NULL  |    0 | a     |
+|    2 | b     |    2 | b     |
++------+-------+------+-------+
 
 # Clean up.
 mysql> drop table if exists test.a


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #7280 

Problem Summary:

### What is changed and how it works?
Add support for RightOuter kind join with other conditions, and do a little refact:
1. Add a new "RowFlaggedHashMapAdder" for RightSemi/RightAnti/RightOuter joins with other conditions
2. Add 'row_flagged_map' template parameter to simplify some logics

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
