### PR TITLE
Fix large write cause tiflash crash (release-6.5)

### DIFF
--- a/dbms/src/Common/FailPoint.h
+++ b/dbms/src/Common/FailPoint.h
@@ -19,11 +19,11 @@
 #include <fiu-local.h>
 #include <fiu.h>
 
+#include <any>
 #include <unordered_map>
 
 namespace Poco
 {
-class Logger;
 namespace Util
 {
 class LayeredConfiguration;
@@ -48,7 +48,9 @@ class FailPointChannel;
 class FailPointHelper
 {
 public:
-    static void enableFailPoint(const String & fail_point_name);
+    static void enableFailPoint(const String & fail_point_name, std::optional<std::any> v = std::nullopt);
+
+    static std::optional<std::any> getFailPointVal(const String & fail_point_name);
 
     static void enablePauseFailPoint(const String & fail_point_name, UInt64 time);
 
@@ -67,6 +69,9 @@ public:
     static void enableRandomFailPoint(const String & fail_point_name, double rate);
 
 private:
+#ifdef FIU_ENABLE
     static std::unordered_map<String, std::shared_ptr<FailPointChannel>> fail_point_wait_channels;
+    static std::unordered_map<String, std::any> fail_point_val;
+#endif
 };
 } // namespace DB

--- a/dbms/src/Common/TiFlashMetrics.h
+++ b/dbms/src/Common/TiFlashMetrics.h
@@ -261,7 +261,7 @@ namespace DB
     M(tiflash_storage_read_thread_seconds, "Bucketed histogram of read thread", Histogram,                                                \
         F(type_merged_task, {{"type", "merged_task"}}, ExpBuckets{0.001, 2, 20}))                                                         \
     M(tiflash_mpp_task_manager, "The gauge of mpp task manager", Gauge,                                                                   \
-        F(type_mpp_query_count, {"type", "mpp_query_count"}))                                                                             \
+        F(type_mpp_query_count, {"type", "mpp_query_count"})) \
 // clang-format on
 
 /// Buckets with boundaries [start * base^0, start * base^1, ..., start * base^(size-1)]

--- a/dbms/src/IO/MemoryReadWriteBuffer.cpp
+++ b/dbms/src/IO/MemoryReadWriteBuffer.cpp
@@ -49,7 +49,7 @@ public:
         return setChunk();
     }
 
-    ~ReadBufferFromMemoryWriteBuffer()
+    ~ReadBufferFromMemoryWriteBuffer() override
     {
         for (const auto & range : chunk_list)
             free(range.begin(), range.size());
@@ -138,7 +138,7 @@ void MemoryWriteBuffer::addChunk()
         }
     }
 
-    Position begin = reinterpret_cast<Position>(alloc(next_chunk_size));
+    auto * begin = reinterpret_cast<Position>(alloc(next_chunk_size));
     chunk_tail = chunk_list.emplace_after(chunk_tail, begin, begin + next_chunk_size);
     total_chunks_size += next_chunk_size;
 

--- a/dbms/src/Storages/Page/V3/Blob/BlobStat.h
+++ b/dbms/src/Storages/Page/V3/Blob/BlobStat.h
@@ -39,18 +39,6 @@ public:
         READ_ONLY = 2
     };
 
-    static String blobTypeToString(BlobStatType type)
-    {
-        switch (type)
-        {
-        case BlobStatType::NORMAL:
-            return "normal";
-        case BlobStatType::READ_ONLY:
-            return "read only";
-        }
-        return "Invalid";
-    }
-
     struct BlobStat
     {
         const BlobFileId id;

--- a/dbms/src/Storages/Page/V3/BlobStore.cpp
+++ b/dbms/src/Storages/Page/V3/BlobStore.cpp
@@ -304,7 +304,7 @@ PageEntriesEdit BlobStore::handleLargeWrite(DB::WriteBatch && wb, const WriteLim
     return edit;
 }
 
-PageEntriesEdit BlobStore::write(DB::WriteBatch & wb, const WriteLimiterPtr & write_limiter)
+PageEntriesEdit BlobStore::write(DB::WriteBatch && wb, const WriteLimiterPtr & write_limiter)
 {
     ProfileEvents::increment(ProfileEvents::PSMWritePages, wb.putWriteCount());
 

--- a/dbms/src/Storages/Page/V3/BlobStore.cpp
+++ b/dbms/src/Storages/Page/V3/BlobStore.cpp
@@ -32,6 +32,7 @@
 #include <Storages/Page/WriteBatch.h>
 #include <boost_wrapper/string_split.h>
 #include <common/logger_useful.h>
+#include <fiu.h>
 
 #include <boost/algorithm/string/classification.hpp>
 #include <ext/scope_guard.h>
@@ -58,6 +59,7 @@ extern const int CHECKSUM_DOESNT_MATCH;
 namespace FailPoints
 {
 extern const char force_change_all_blobs_to_read_only[];
+extern const char exception_after_large_write_exceed[];
 } // namespace FailPoints
 
 namespace PS::V3
@@ -66,6 +68,8 @@ static constexpr bool BLOBSTORE_CHECKSUM_ON_READ = true;
 
 using BlobStatPtr = BlobStats::BlobStatPtr;
 using ChecksumClass = Digest::CRC64;
+static_assert(!std::is_same_v<ChecksumClass, Digest::XXH3>, "The checksum must support streaming checksum");
+static_assert(!std::is_same_v<ChecksumClass, Digest::City128>, "The checksum must support streaming checksum");
 
 /**********************
   * BlobStore methods *
@@ -159,7 +163,7 @@ FileUsageStatistics BlobStore::getFileUsageStatistics() const
     return usage;
 }
 
-PageEntriesEdit BlobStore::handleLargeWrite(DB::WriteBatch & wb, const WriteLimiterPtr & write_limiter)
+PageEntriesEdit BlobStore::handleLargeWrite(DB::WriteBatch && wb, const WriteLimiterPtr & write_limiter)
 {
     PageEntriesEdit edit;
     for (auto & write : wb.getWrites())
@@ -168,52 +172,113 @@ PageEntriesEdit BlobStore::handleLargeWrite(DB::WriteBatch & wb, const WriteLimi
         {
         case WriteBatchWriteType::PUT:
         {
+            const auto [blob_id, offset_in_file] = getPosFromStats(write.size);
+            auto blob_file = getBlobFile(blob_id);
             ChecksumClass digest;
-            PageEntryV3 entry;
+            // swap from WriteBatch instead of copying
+            PageFieldOffsetChecksums field_offset_and_checksum;
+            field_offset_and_checksum.swap(write.offsets);
 
-            auto [blob_id, offset_in_file] = getPosFromStats(write.size);
-
-            entry.file_id = blob_id;
-            entry.size = write.size;
-            entry.tag = write.tag;
-            entry.offset = offset_in_file;
-            // padding size won't work on big write batch
-            entry.padded_size = 0;
-
-            BufferBase::Buffer data_buf = write.read_buffer->buffer();
-
-            digest.update(data_buf.begin(), write.size);
-            entry.checksum = digest.checksum();
-
-            UInt64 field_begin, field_end;
-
-            for (size_t i = 0; i < write.offsets.size(); ++i)
+            ChecksumClass field_digest;
+            size_t cur_field_index = 0;
+            UInt64 cur_field_begin = 0, cur_field_end = 0;
+            if (!field_offset_and_checksum.empty())
             {
-                ChecksumClass field_digest;
-                field_begin = write.offsets[i].first;
-                field_end = (i == write.offsets.size() - 1) ? write.size : write.offsets[i + 1].first;
-
-                field_digest.update(data_buf.begin() + field_begin, field_end - field_begin);
-                write.offsets[i].second = field_digest.checksum();
-            }
-
-            if (!write.offsets.empty())
-            {
-                // we can swap from WriteBatch instead of copying
-                entry.field_offsets.swap(write.offsets);
+                cur_field_begin = field_offset_and_checksum[cur_field_index].first;
+                cur_field_end = (cur_field_index == field_offset_and_checksum.size() - 1) ? write.size : field_offset_and_checksum[cur_field_index + 1].first;
             }
 
             try
             {
-                auto blob_file = getBlobFile(blob_id);
-                blob_file->write(data_buf.begin(), offset_in_file, write.size, write_limiter);
+                UInt64 buffer_begin_in_page = 0, buffer_end_in_page = 0;
+
+                while (true)
+                {
+                    // The write batch data size is large, we do NOT copy the data into a temporary buffer in order to
+                    // make the memory usage of tiflash more smooth. Instead, we process the data in ReadBuffer in a
+                    // streaming manner.
+                    BufferBase::Buffer data_buf = write.read_buffer->buffer();
+                    buffer_end_in_page = buffer_begin_in_page + data_buf.size();
+
+                    // TODO: Add static check to make sure the checksum support streaming
+                    digest.update(data_buf.begin(), data_buf.size()); // the checksum of the whole page
+
+                    // the checksum of each field
+                    if (!field_offset_and_checksum.empty())
+                    {
+                        while (true)
+                        {
+                            auto field_begin_in_buf = cur_field_begin <= buffer_begin_in_page ? 0 : cur_field_begin - buffer_begin_in_page;
+                            auto field_length_in_buf = cur_field_end > buffer_end_in_page ? data_buf.size() - field_begin_in_buf : cur_field_end - buffer_begin_in_page - field_begin_in_buf;
+                            field_digest.update(data_buf.begin() + field_begin_in_buf, field_length_in_buf);
+
+                            /*
+                             * This piece of buffer does not contain all data of current field, break the loop
+                             * PageBegin                                                            PageEnd
+                             *     │       │----------- Buffer Range -----------│                       │
+                             *     │    │------------- Current Field --------------│                    |
+                             *             ↑                                    ↑  Update field checksum
+                             */
+                            if (cur_field_end > buffer_end_in_page)
+                                break;
+
+                            /*
+                             * This piece of buffer contains all data of current field, update
+                             * checksum and continue to try get the checksum of next field until
+                             * this piece of buffer does not contain all data of field.
+                             * PageBegin                                                            PageEnd
+                             *     │       │----------- Buffer Range -----------│                       │
+                             *     │     │---- Field i ----│---- Field j ----│--- Field k ---│          |
+                             *             ↑               ↑                 ↑  ↑ Update field checksum
+                             */
+                            field_offset_and_checksum[cur_field_index].second = field_digest.checksum();
+
+                            // all fields' checksum is OK, break the loop
+                            if (cur_field_index >= field_offset_and_checksum.size() - 1)
+                                break;
+
+                            field_digest = ChecksumClass(); // reset
+                            cur_field_index += 1;
+                            cur_field_begin = field_offset_and_checksum[cur_field_index].first;
+                            cur_field_end = (cur_field_index == field_offset_and_checksum.size() - 1) ? write.size : field_offset_and_checksum[cur_field_index + 1].first;
+                        }
+                    }
+
+                    blob_file->write(data_buf.begin(), offset_in_file + buffer_begin_in_page, data_buf.size(), write_limiter);
+                    buffer_begin_in_page += data_buf.size();
+
+                    fiu_do_on(FailPoints::exception_after_large_write_exceed, {
+                        if (auto v = FailPointHelper::getFailPointVal(FailPoints::exception_after_large_write_exceed); v)
+                        {
+                            auto failpoint_bound = std::any_cast<size_t>(v.value());
+                            if (buffer_end_in_page > failpoint_bound)
+                            {
+                                throw Exception(ErrorCodes::FAIL_POINT_ERROR, "failpoint throw exception buffer_end={} write_end={}", buffer_end_in_page, failpoint_bound);
+                            }
+                        }
+                    });
+
+                    if (!write.read_buffer->next())
+                        break;
+                }
             }
             catch (DB::Exception & e)
             {
+                // If exception happens, remove the allocated space in BlobStat
                 removePosFromStats(blob_id, offset_in_file, write.size);
-                LOG_ERROR(log, "[blob_id={}] [offset_in_file={}] [size={}] write failed.", blob_id, offset_in_file, write.size);
+                LOG_ERROR(log, "large write failed, blob_id={} offset_in_file={} size={} msg={}", blob_id, offset_in_file, write.size, e.message());
                 throw e;
             }
+
+            const auto entry = PageEntryV3{
+                .file_id = blob_id,
+                .size = write.size,
+                .padded_size = 0, // padding size won't work on large write batch
+                .tag = write.tag,
+                .offset = offset_in_file,
+                .checksum = digest.checksum(),
+                .field_offsets = std::move(field_offset_and_checksum),
+            };
 
             edit.put(wb.getFullPageId(write.page_id), entry);
             break;
@@ -285,7 +350,8 @@ PageEntriesEdit BlobStore::write(DB::WriteBatch & wb, const WriteLimiterPtr & wr
     // This can avoid allocating a big buffer for writing data and can smooth memory usage.
     if (all_page_data_size > config.file_limit_size)
     {
-        return handleLargeWrite(wb, write_limiter);
+        LOG_INFO(log, "handling large write, all_page_data_size={}", all_page_data_size);
+        return handleLargeWrite(std::move(wb), write_limiter);
     }
 
     char * buffer = static_cast<char *>(alloc(all_page_data_size));
@@ -398,7 +464,7 @@ PageEntriesEdit BlobStore::write(DB::WriteBatch & wb, const WriteLimiterPtr & wr
     catch (DB::Exception & e)
     {
         removePosFromStats(blob_id, offset_in_file, actually_allocated_size);
-        LOG_ERROR(log, "[blob_id={}] [offset_in_file={}] [size={}] [actually_allocated_size={}] write failed [error={}]", blob_id, offset_in_file, all_page_data_size, actually_allocated_size, e.message());
+        LOG_ERROR(log, "write failed, blob_id={} offset_in_file={} size={} actually_allocated_size={} msg={}", blob_id, offset_in_file, all_page_data_size, actually_allocated_size, e.message());
         throw e;
     }
 
@@ -642,8 +708,8 @@ PageMap BlobStore::read(FieldReadInfos & to_read, const ReadLimiterPtr & read_li
                 auto field_checksum = digest.checksum();
                 if (unlikely(entry.size != 0 && field_checksum != expect_checksum))
                 {
-                    throw Exception(
-                        fmt::format("Reading with fields meet checksum not match "
+                    throw Exception(ErrorCodes::CHECKSUM_DOESNT_MATCH,
+                                    "Reading with fields meet checksum not match "
                                     "[page_id={}] [expected=0x{:X}] [actual=0x{:X}] "
                                     "[field_index={}] [field_offset={}] [field_size={}] "
                                     "[entry={}] [file={}]",
@@ -654,8 +720,7 @@ PageMap BlobStore::read(FieldReadInfos & to_read, const ReadLimiterPtr & read_li
                                     beg_offset,
                                     size_to_read,
                                     toDebugString(entry),
-                                    blob_file->getPath()),
-                        ErrorCodes::CHECKSUM_DOESNT_MATCH);
+                                    blob_file->getPath());
                 }
             }
 

--- a/dbms/src/Storages/Page/V3/BlobStore.h
+++ b/dbms/src/Storages/Page/V3/BlobStore.h
@@ -60,7 +60,7 @@ public:
                        const WriteLimiterPtr & write_limiter = nullptr,
                        const ReadLimiterPtr & read_limiter = nullptr);
 
-    PageEntriesEdit write(DB::WriteBatch & wb, const WriteLimiterPtr & write_limiter = nullptr);
+    PageEntriesEdit write(DB::WriteBatch && wb, const WriteLimiterPtr & write_limiter = nullptr);
 
     void remove(const PageEntriesV3 & del_entries);
 

--- a/dbms/src/Storages/Page/V3/BlobStore.h
+++ b/dbms/src/Storages/Page/V3/BlobStore.h
@@ -87,7 +87,7 @@ public:
 private:
 #endif
 
-    PageEntriesEdit handleLargeWrite(DB::WriteBatch & wb, const WriteLimiterPtr & write_limiter = nullptr);
+    PageEntriesEdit handleLargeWrite(DB::WriteBatch && wb, const WriteLimiterPtr & write_limiter = nullptr);
 
     BlobFilePtr read(const PageIdV3Internal & page_id_v3, BlobFileId blob_id, BlobFileOffset offset, char * buffers, size_t size, const ReadLimiterPtr & read_limiter = nullptr, bool background = false);
 

--- a/dbms/src/Storages/Page/V3/PageStorageImpl.cpp
+++ b/dbms/src/Storages/Page/V3/PageStorageImpl.cpp
@@ -133,7 +133,7 @@ void PageStorageImpl::writeImpl(DB::WriteBatch && write_batch, const WriteLimite
     SCOPE_EXIT({ GET_METRIC(tiflash_storage_page_write_duration_seconds, type_total).Observe(watch.elapsedSeconds()); });
 
     // Persist Page data to BlobStore
-    auto edit = blob_store.write(write_batch, write_limiter);
+    auto edit = blob_store.write(std::move(write_batch), write_limiter);
     page_directory->apply(std::move(edit), write_limiter);
 }
 

--- a/dbms/src/Storages/Page/V3/tests/gtest_blob_store.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_blob_store.cpp
@@ -12,11 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Common/FailPoint.h>
 #include <Common/Logger.h>
 #include <Encryption/RateLimiter.h>
 #include <IO/ReadBufferFromMemory.h>
 #include <Poco/Logger.h>
+#include <Storages/Page/PageConstants.h>
 #include <Storages/Page/PageDefines.h>
+#include <Storages/Page/PageDefinesBase.h>
 #include <Storages/Page/V3/BlobStore.h>
 #include <Storages/Page/V3/PageDirectory.h>
 #include <Storages/Page/V3/PageEntriesEdit.h>
@@ -27,6 +30,11 @@
 #include <TestUtils/MockDiskDelegator.h>
 #include <TestUtils/MockReadLimiter.h>
 #include <TestUtils/TiFlashTestBasic.h>
+
+namespace DB::FailPoints
+{
+extern const char exception_after_large_write_exceed[];
+} // namespace DB::FailPoints
 
 namespace DB::PS::V3::tests
 {
@@ -47,6 +55,11 @@ public:
             paths.emplace_back(fmt::format("{}/{}", path, i));
         }
         delegator = std::make_shared<DB::tests::MockDiskDelegatorMulti>(paths);
+
+        for (size_t i = 0; i < fixed_buffer_size; ++i)
+        {
+            fixed_buffer[i] = i % 0xff;
+        }
     }
 
     static size_t getTotalStatsNum(const BlobStats::StatsMap & stats_map)
@@ -62,6 +75,9 @@ public:
 protected:
     BlobConfig config;
     PSDiskDelegatorPtr delegator;
+
+    char fixed_buffer[1024]{};
+    const size_t fixed_buffer_size = sizeof(fixed_buffer);
 };
 
 TEST_F(BlobStoreTest, Restore)
@@ -1126,85 +1142,96 @@ try
 }
 CATCH
 
-TEST_F(BlobStoreTest, TestBigBlob)
+TEST_F(BlobStoreTest, LargeWrite)
 try
 {
-    const auto file_provider = DB::tests::TiFlashTestEnv::getContext().getFileProvider();
+    const auto file_provider = DB::tests::TiFlashTestEnv::getMockFileProvider();
     PageId fixed_page_id = 50;
     PageId page_id = fixed_page_id;
 
-    BlobConfig config_with_small_file_limit_size;
-    config_with_small_file_limit_size.file_limit_size = 400;
-    auto blob_store = BlobStore(getCurrentTestName(), file_provider, delegator, config_with_small_file_limit_size);
+    BlobConfig test_config;
+    test_config.file_limit_size = 4 * MB;
+    auto blob_store = BlobStore(getCurrentTestName(), file_provider, delegator, test_config);
 
-    // PUT page_id 50 into blob 1 range [0,200]
+    // PUT page_id 50 into blob 1 (normal write)
     {
-        size_t size_200 = 200;
-        char c_buff[size_200];
+        MemoryWriteBuffer buffer;
+        size_t serialized_size = 200;
+        buffer.write(fixed_buffer, serialized_size);
 
         WriteBatch wb;
-        ReadBufferPtr buff = std::make_shared<ReadBufferFromMemory>(const_cast<char *>(c_buff), size_200);
-        wb.putPage(page_id, /* tag */ 0, buff, size_200);
-        PageEntriesEdit edit = blob_store.write(wb, nullptr);
+        ReadBufferPtr read_buff = buffer.tryGetReadBuffer();
+        wb.putPage(page_id, /* tag */ 0, read_buff, serialized_size);
+        PageEntriesEdit edit = blob_store.write(std::move(wb), nullptr);
 
         const auto & records = edit.getRecords();
         ASSERT_EQ(records.size(), 1);
         ASSERT_EQ(records[0].entry.file_id, 1);
         ASSERT_EQ(records[0].entry.offset, 0);
-        ASSERT_EQ(records[0].entry.size, 200);
+        ASSERT_EQ(records[0].entry.size, serialized_size);
 
         const auto & stat = blob_store.blob_stats.blobIdToStat(1);
         ASSERT_TRUE(stat->isNormal());
-        ASSERT_EQ(stat->sm_max_caps, 200);
+        ASSERT_EQ(stat->sm_max_caps, test_config.file_limit_size - serialized_size);
         ASSERT_DOUBLE_EQ(stat->sm_valid_rate, 1.0);
-        ASSERT_EQ(stat->sm_valid_size, 200);
-        ASSERT_EQ(stat->sm_total_size, 200);
+        ASSERT_EQ(stat->sm_valid_size, serialized_size);
+        ASSERT_EQ(stat->sm_total_size, serialized_size);
+
+        // Verify read
+        Page page = blob_store.read(std::make_pair(buildV3Id(TEST_NAMESPACE_ID, page_id), records[0].entry), nullptr);
+        ASSERT_TRUE(page.isValid());
+        ASSERT_EQ(page.data.size(), serialized_size);
 
         page_id++;
-        wb.clear();
     }
 
-    // PUT page_id 51 into blob 2 range [0,500]
+    // PUT page_id 51 into blob 2 (large write)
     {
-        size_t size_500 = 500;
-        char c_buff[size_500];
+        MemoryWriteBuffer buffer;
+        size_t serialized_size = 0;
+        while (buffer.count() < test_config.file_limit_size * 2)
+        {
+            buffer.write(fixed_buffer, fixed_buffer_size);
+            serialized_size += fixed_buffer_size;
+        }
 
         WriteBatch wb;
-        ReadBufferPtr buff = std::make_shared<ReadBufferFromMemory>(const_cast<char *>(c_buff), size_500);
-        wb.putPage(page_id, /* tag */ 0, buff, size_500);
-        PageEntriesEdit edit = blob_store.write(wb, nullptr);
+        ReadBufferPtr read_buff = buffer.tryGetReadBuffer();
+        wb.putPage(page_id, /* tag */ 0, read_buff, serialized_size);
+        PageEntriesEdit edit = blob_store.write(std::move(wb), nullptr);
 
         const auto & records = edit.getRecords();
         ASSERT_EQ(records.size(), 1);
         ASSERT_EQ(records[0].entry.file_id, 2);
         ASSERT_EQ(records[0].entry.offset, 0);
-        ASSERT_EQ(records[0].entry.size, 500);
+        ASSERT_EQ(records[0].entry.size, serialized_size);
 
         // verify blobstat
         const auto & stat = blob_store.blob_stats.blobIdToStat(2);
+        ASSERT_TRUE(stat->isReadOnly()); // large write, this stat is read only
         ASSERT_EQ(stat->sm_max_caps, 0);
         ASSERT_DOUBLE_EQ(stat->sm_valid_rate, 1.0);
-        ASSERT_EQ(stat->sm_valid_size, 500);
-        ASSERT_EQ(stat->sm_total_size, 500);
+        ASSERT_EQ(stat->sm_valid_size, serialized_size);
+        ASSERT_EQ(stat->sm_total_size, serialized_size);
 
         // Verify read
         Page page = blob_store.read(std::make_pair(buildV3Id(TEST_NAMESPACE_ID, page_id), records[0].entry), nullptr);
         ASSERT_TRUE(page.isValid());
-        ASSERT_EQ(page.data.size(), size_500);
+        ASSERT_EQ(page.data.size(), serialized_size);
 
         page_id++;
-        wb.clear();
     }
 
-    // PUT page_id 52 into blob 1 range [200,100]
+    // PUT page_id 52 into blob 1 (normal write)
     {
-        size_t size_100 = 100;
-        char c_buff[size_100];
+        MemoryWriteBuffer buffer;
+        size_t serialized_size = 100;
+        buffer.write(fixed_buffer, serialized_size);
 
         WriteBatch wb;
-        ReadBufferPtr buff = std::make_shared<ReadBufferFromMemory>(const_cast<char *>(c_buff), size_100);
-        wb.putPage(page_id, /* tag */ 0, buff, size_100);
-        PageEntriesEdit edit = blob_store.write(wb, nullptr);
+        ReadBufferPtr read_buff = buffer.tryGetReadBuffer();
+        wb.putPage(page_id, /* tag */ 0, read_buff, serialized_size);
+        PageEntriesEdit edit = blob_store.write(std::move(wb), nullptr);
 
         const auto & records = edit.getRecords();
         ASSERT_EQ(records.size(), 1);
@@ -1214,88 +1241,277 @@ try
 
         const auto & stat = blob_store.blob_stats.blobIdToStat(1);
         ASSERT_TRUE(stat->isNormal());
-        ASSERT_EQ(stat->sm_max_caps, 100);
+        ASSERT_EQ(stat->sm_max_caps, test_config.file_limit_size - 200 - 100);
         ASSERT_DOUBLE_EQ(stat->sm_valid_rate, 1.0);
         ASSERT_EQ(stat->sm_valid_size, 300);
         ASSERT_EQ(stat->sm_total_size, 300);
 
+        // Verify read
+        Page page = blob_store.read(std::make_pair(buildV3Id(TEST_NAMESPACE_ID, page_id), records[0].entry), nullptr);
+        ASSERT_TRUE(page.isValid());
+        ASSERT_EQ(page.data.size(), serialized_size);
+
         page_id++;
-        wb.clear();
     }
 
     // PUT page_id 53 into blob 3 range [0,300]
     {
-        size_t size_300 = 300;
-        char c_buff[size_300];
+        MemoryWriteBuffer buffer;
+        size_t serialized_size = 0;
+        while (buffer.count() < test_config.file_limit_size * 1.5)
+        {
+            buffer.write(fixed_buffer, fixed_buffer_size);
+            serialized_size += fixed_buffer_size;
+        }
 
         WriteBatch wb;
-        ReadBufferPtr buff = std::make_shared<ReadBufferFromMemory>(const_cast<char *>(c_buff), size_300);
-        wb.putPage(page_id, /* tag */ 0, buff, size_300);
-        PageEntriesEdit edit = blob_store.write(wb, nullptr);
+        ReadBufferPtr read_buff = buffer.tryGetReadBuffer();
+        wb.putPage(page_id, /* tag */ 0, read_buff, serialized_size);
+        PageEntriesEdit edit = blob_store.write(std::move(wb), nullptr);
 
         const auto & records = edit.getRecords();
         ASSERT_EQ(records.size(), 1);
         ASSERT_EQ(records[0].entry.file_id, 3);
         ASSERT_EQ(records[0].entry.offset, 0);
-        ASSERT_EQ(records[0].entry.size, 300);
+        ASSERT_EQ(records[0].entry.size, serialized_size);
 
         const auto & stat = blob_store.blob_stats.blobIdToStat(3);
-        ASSERT_TRUE(stat->isNormal());
-        ASSERT_EQ(stat->sm_max_caps, 100);
+        ASSERT_TRUE(stat->isReadOnly()); // large write, this stat is read only
+        ASSERT_EQ(stat->sm_max_caps, 0);
         ASSERT_DOUBLE_EQ(stat->sm_valid_rate, 1.0);
-        ASSERT_EQ(stat->sm_valid_size, 300);
-        ASSERT_EQ(stat->sm_total_size, 300);
+        ASSERT_EQ(stat->sm_valid_size, serialized_size);
+        ASSERT_EQ(stat->sm_total_size, serialized_size);
+
+        // Verify read
+        Page page = blob_store.read(std::make_pair(buildV3Id(TEST_NAMESPACE_ID, page_id), records[0].entry), nullptr);
+        ASSERT_TRUE(page.isValid());
+        ASSERT_EQ(page.data.size(), serialized_size);
 
         page_id++;
     }
 
-    // Test mix BigBlob
+    // Large write compose by multiple puts
     {
-        char c_buff1[600];
-        char c_buff2[10];
-        char c_buff3[500];
-        char c_buff4[200];
+        std::vector<double> test_scales = {1.5, 0.2, 0.4, 1.1};
+        std::vector<size_t> actual_size;
 
         WriteBatch wb;
-        wb.putPage(page_id++, /* tag */ 0, std::make_shared<ReadBufferFromMemory>(const_cast<char *>(c_buff1), sizeof(c_buff1)), sizeof(c_buff1));
-        wb.putPage(page_id++, /* tag */ 0, std::make_shared<ReadBufferFromMemory>(const_cast<char *>(c_buff2), sizeof(c_buff2)), sizeof(c_buff2));
-        wb.putPage(page_id++, /* tag */ 0, std::make_shared<ReadBufferFromMemory>(const_cast<char *>(c_buff3), sizeof(c_buff3)), sizeof(c_buff3));
-        wb.putPage(page_id++, /* tag */ 0, std::make_shared<ReadBufferFromMemory>(const_cast<char *>(c_buff4), sizeof(c_buff4)), sizeof(c_buff4));
+        for (const auto & scale : test_scales)
+        {
+            size_t serialized_size = 0;
+            MemoryWriteBuffer buffer;
+            while (buffer.count() < test_config.file_limit_size * scale)
+            {
+                buffer.write(fixed_buffer, fixed_buffer_size);
+                serialized_size += fixed_buffer_size;
+            }
+            wb.putPage(page_id++, /* tag */ 0, buffer.tryGetReadBuffer(), serialized_size);
+            actual_size.emplace_back(serialized_size);
+        }
+        ASSERT_EQ(test_scales.size(), actual_size.size());
 
-        PageEntriesEdit edit = blob_store.write(wb, nullptr);
+        PageEntriesEdit edit = blob_store.write(std::move(wb), nullptr);
 
         const auto & records = edit.getRecords();
         ASSERT_EQ(records.size(), 4);
 
-        // PUT page_id 54 into blob 4 range [0,600]
+        // PUT page_id 54 into blob 4 (large write)
         ASSERT_EQ(records[0].page_id.low, 54);
         ASSERT_EQ(records[0].entry.file_id, 4);
         ASSERT_EQ(records[0].entry.offset, 0);
-        ASSERT_EQ(records[0].entry.size, 600);
+        ASSERT_EQ(records[0].entry.size, actual_size[0]);
 
         // PUT page_id 55 into blob 1 or 3
         ASSERT_EQ(records[1].page_id.low, 55);
         ASSERT_TRUE(records[1].entry.file_id == 1 || records[1].entry.file_id == 3);
+        ASSERT_EQ(records[1].entry.size, actual_size[1]);
 
-        // PUT page_id 56 into blob 5 range [0,600]
+        // PUT page_id 56 into blob 5
         ASSERT_EQ(records[2].page_id.low, 56);
-        ASSERT_EQ(records[2].entry.file_id, 5);
-        ASSERT_EQ(records[2].entry.offset, 0);
-        ASSERT_EQ(records[2].entry.size, 500);
+        ASSERT_TRUE(records[2].entry.file_id == 1 || records[2].entry.file_id == 3);
+        ASSERT_EQ(records[2].entry.size, actual_size[2]);
 
-        // PUT page_id 57 into blob 6 range [0,200]
+        // PUT page_id 57 into blob 6 (large write)
         ASSERT_EQ(records[3].page_id.low, 57);
-        ASSERT_EQ(records[3].entry.file_id, 6);
+        ASSERT_EQ(records[3].entry.file_id, 5);
         ASSERT_EQ(records[3].entry.offset, 0);
-        ASSERT_EQ(records[3].entry.size, 200);
+        ASSERT_EQ(records[3].entry.size, actual_size[3]);
     }
 }
 CATCH
 
-TEST_F(BlobStoreTest, TestBigBlobRemove)
+TEST_F(BlobStoreTest, LargeWriteWithFields)
 try
 {
-    const auto file_provider = DB::tests::TiFlashTestEnv::getContext().getFileProvider();
+    const auto file_provider = DB::tests::TiFlashTestEnv::getMockFileProvider();
+    PageId fixed_page_id = 50;
+    PageId page_id = fixed_page_id;
+
+    BlobConfig test_config;
+    test_config.file_limit_size = 4 * MB;
+    auto blob_store = BlobStore(getCurrentTestName(), file_provider, delegator, test_config);
+
+    // PUT page_id 50 into blob 1 (large write)
+    {
+        MemoryWriteBuffer buffer;
+        size_t serialized_size = 0;
+        while (buffer.count() < test_config.file_limit_size * 2)
+        {
+            buffer.write(fixed_buffer, fixed_buffer_size);
+            serialized_size += fixed_buffer_size;
+        }
+
+        WriteBatch wb;
+        ReadBufferPtr read_buff = buffer.tryGetReadBuffer();
+        PageFieldSizes field_sizes = [&]() {
+            PageFieldSizes sizes{1035, 1 * MB + 24, 30, 50, 70, 67, 89, 97};
+            auto sum_of_sizes = std::accumulate(field_sizes.begin(), field_sizes.end(), 0UL);
+            field_sizes.emplace_back(serialized_size - sum_of_sizes);
+            return sizes;
+        }();
+        wb.putPage(page_id, /* tag */ 0, read_buff, serialized_size, field_sizes);
+        PageEntriesEdit edit = blob_store.write(std::move(wb), nullptr);
+
+        const auto & records = edit.getRecords();
+        ASSERT_EQ(records.size(), 1);
+        ASSERT_EQ(records[0].entry.file_id, 1);
+        ASSERT_EQ(records[0].entry.offset, 0);
+        ASSERT_EQ(records[0].entry.size, serialized_size);
+
+        // verify blobstat
+        const auto & stat = blob_store.blob_stats.blobIdToStat(1);
+        ASSERT_TRUE(stat->isReadOnly()); // large write, this stat is read only
+        ASSERT_EQ(stat->sm_max_caps, 0);
+        ASSERT_DOUBLE_EQ(stat->sm_valid_rate, 1.0);
+        ASSERT_EQ(stat->sm_valid_size, serialized_size);
+        ASSERT_EQ(stat->sm_total_size, serialized_size);
+
+        // Verify read
+        {
+            Page page = blob_store.read(std::make_pair(buildV3Id(TEST_NAMESPACE_ID, page_id), records[0].entry), nullptr);
+            ASSERT_TRUE(page.isValid());
+            ASSERT_EQ(page.data.size(), serialized_size);
+        }
+
+        // Verify read with fields
+        {
+            BlobStore::FieldReadInfos to_read{
+                BlobStore::FieldReadInfo(buildV3Id(TEST_NAMESPACE_ID, page_id), records[0].entry, {0, 1, 2, 3, 4, 5, 6, 7, 8}),
+            };
+            BlobStore::PageMap page_map = blob_store.read(to_read, nullptr);
+            ASSERT_NE(page_map.find(page_id), page_map.end());
+            ASSERT_EQ(page_map.at(page_id).fieldSize(), to_read[0].fields.size());
+        }
+
+        // Verify read with fields
+        {
+            BlobStore::FieldReadInfos to_read{
+                BlobStore::FieldReadInfo(buildV3Id(TEST_NAMESPACE_ID, page_id), records[0].entry, {0, 1, 2, 3, 4, 5, 6}),
+            };
+            BlobStore::PageMap page_map = blob_store.read(to_read, nullptr);
+            ASSERT_NE(page_map.find(page_id), page_map.end());
+            ASSERT_EQ(page_map.at(page_id).fieldSize(), to_read[0].fields.size());
+        }
+
+        // Verify read with fields
+        {
+            BlobStore::FieldReadInfos to_read{
+                BlobStore::FieldReadInfo(buildV3Id(TEST_NAMESPACE_ID, page_id), records[0].entry, {1, 2, 3, 5, 6, 8}),
+            };
+            BlobStore::PageMap page_map = blob_store.read(to_read, nullptr);
+            ASSERT_NE(page_map.find(page_id), page_map.end());
+            ASSERT_EQ(page_map.at(page_id).fieldSize(), to_read[0].fields.size());
+        }
+
+        page_id++;
+    }
+}
+CATCH
+
+
+TEST_F(BlobStoreTest, LargeWriteWithFailed)
+try
+{
+    const auto file_provider = DB::tests::TiFlashTestEnv::getMockFileProvider();
+    PageId fixed_page_id = 50;
+    PageId page_id = fixed_page_id;
+
+    BlobConfig test_config;
+    test_config.file_limit_size = 4 * MB;
+    auto blob_store = BlobStore(getCurrentTestName(), file_provider, delegator, test_config);
+
+    // PUT page_id 50 into blob 1 (normal write)
+    {
+        MemoryWriteBuffer buffer;
+        size_t serialized_size = 200;
+        buffer.write(fixed_buffer, serialized_size);
+
+        WriteBatch wb;
+        ReadBufferPtr read_buff = buffer.tryGetReadBuffer();
+        wb.putPage(page_id, /* tag */ 0, read_buff, serialized_size);
+        PageEntriesEdit edit = blob_store.write(std::move(wb), nullptr);
+
+        const auto & records = edit.getRecords();
+        ASSERT_EQ(records.size(), 1);
+        ASSERT_EQ(records[0].entry.file_id, 1);
+        ASSERT_EQ(records[0].entry.offset, 0);
+        ASSERT_EQ(records[0].entry.size, serialized_size);
+
+        const auto & stat = blob_store.blob_stats.blobIdToStat(1);
+        ASSERT_TRUE(stat->isNormal());
+        ASSERT_EQ(stat->sm_max_caps, test_config.file_limit_size - serialized_size);
+        ASSERT_DOUBLE_EQ(stat->sm_valid_rate, 1.0);
+        ASSERT_EQ(stat->sm_valid_size, serialized_size);
+        ASSERT_EQ(stat->sm_total_size, serialized_size);
+
+        // Verify read
+        Page page = blob_store.read(std::make_pair(buildV3Id(TEST_NAMESPACE_ID, page_id), records[0].entry), nullptr);
+        ASSERT_TRUE(page.isValid());
+        ASSERT_EQ(page.data.size(), serialized_size);
+
+        page_id++;
+    }
+
+    // PUT page_id 51 into blob 2 (large write, fail happen)
+    {
+        MemoryWriteBuffer buffer;
+        size_t serialized_size = 0;
+        while (buffer.count() < test_config.file_limit_size * 2)
+        {
+            buffer.write(fixed_buffer, fixed_buffer_size);
+            serialized_size += fixed_buffer_size;
+        }
+
+        const auto num_stats = blob_store.blob_stats.getStats().size();
+        ASSERT_EQ(num_stats, 1);
+
+        WriteBatch wb;
+        ReadBufferPtr read_buff = buffer.tryGetReadBuffer();
+        wb.putPage(page_id, /* tag */ 0, read_buff, serialized_size);
+
+        // throw an exception after write exceed `test_config.file_limit_size`
+        FailPointHelper::enableFailPoint(FailPoints::exception_after_large_write_exceed, static_cast<size_t>(test_config.file_limit_size));
+        try
+        {
+            blob_store.write(std::move(wb), nullptr);
+        }
+        catch (DB::Exception & e)
+        {
+            ASSERT_EQ(e.code(), ErrorCodes::FAIL_POINT_ERROR);
+        }
+
+        // no new-added stat
+        ASSERT_EQ(blob_store.blob_stats.blobIdToStat(2, /*ignore_not_exist*/ true), nullptr);
+
+        page_id++;
+    }
+}
+CATCH
+
+TEST_F(BlobStoreTest, LargeWriteRemove)
+try
+{
+    const auto file_provider = DB::tests::TiFlashTestEnv::getMockFileProvider();
     PageId fixed_page_id = 50;
     PageId page_id = fixed_page_id;
 
@@ -1310,7 +1526,7 @@ try
         WriteBatch wb;
         ReadBufferPtr buff = std::make_shared<ReadBufferFromMemory>(const_cast<char *>(c_buff), size_500);
         wb.putPage(page_id, /* tag */ 0, buff, size_500);
-        PageEntriesEdit edit = blob_store.write(wb, nullptr);
+        PageEntriesEdit edit = blob_store.write(std::move(wb), nullptr);
 
         const auto & gc_info = blob_store.getGCStats();
         ASSERT_TRUE(gc_info.empty());
@@ -1324,10 +1540,10 @@ try
 }
 CATCH
 
-TEST_F(BlobStoreTest, TestBigBlobRegisterPath)
+TEST_F(BlobStoreTest, LargeWriteRegisterPath)
 try
 {
-    const auto file_provider = DB::tests::TiFlashTestEnv::getContext().getFileProvider();
+    const auto file_provider = DB::tests::TiFlashTestEnv::getMockFileProvider();
     PageId fixed_page_id = 50;
     PageId page_id = fixed_page_id;
 
@@ -1343,7 +1559,7 @@ try
         WriteBatch wb;
         ReadBufferPtr buff = std::make_shared<ReadBufferFromMemory>(const_cast<char *>(c_buff), size_500);
         wb.putPage(page_id, /* tag */ 0, buff, size_500);
-        auto edit = blob_store.write(wb, nullptr);
+        auto edit = blob_store.write(std::move(wb), nullptr);
         const auto & records = edit.getRecords();
         ASSERT_EQ(records.size(), 1);
         entry_from_write = records[0].entry;
@@ -1367,7 +1583,7 @@ CATCH
 TEST_F(BlobStoreTest, TestRestartWithSmallerFileLimitSize)
 try
 {
-    const auto file_provider = DB::tests::TiFlashTestEnv::getContext().getFileProvider();
+    const auto file_provider = DB::tests::TiFlashTestEnv::getMockFileProvider();
     PageId page_id = 50;
 
     BlobConfig config_with_small_file_limit_size;
@@ -1387,7 +1603,7 @@ try
         ReadBufferPtr buff2 = std::make_shared<ReadBufferFromMemory>(const_cast<char *>(c_buff2), size_200);
         wb.putPage(page_id, /* tag */ 0, buff1, size_500);
         wb.putPage(page_id + 1, /* tag */ 0, buff2, size_200);
-        auto edit = blob_store.write(wb, nullptr);
+        auto edit = blob_store.write(std::move(wb), nullptr);
         const auto & records = edit.getRecords();
         ASSERT_EQ(records.size(), 2);
         entry_from_write1 = records[0].entry;
@@ -1421,7 +1637,7 @@ try
         WriteBatch wb;
         ReadBufferPtr buff = std::make_shared<ReadBufferFromMemory>(const_cast<char *>(c_buff), size_100);
         wb.putPage(page_id, /* tag */ 0, buff, size_100);
-        auto edit = blob_store.write(wb, nullptr);
+        auto edit = blob_store.write(std::move(wb), nullptr);
         const auto & records = edit.getRecords();
         ASSERT_EQ(records.size(), 1);
         ASSERT_EQ(records[0].entry.file_id, 2);
@@ -1434,10 +1650,10 @@ try
 }
 CATCH
 
-TEST_F(BlobStoreTest, TestBigBlobGC)
+TEST_F(BlobStoreTest, LargeWriteGC)
 try
 {
-    const auto file_provider = DB::tests::TiFlashTestEnv::getContext().getFileProvider();
+    const auto file_provider = DB::tests::TiFlashTestEnv::getMockFileProvider();
     PageId page_id1 = 50;
     PageId page_id2 = 51;
     PageId page_id3 = 52;
@@ -1464,7 +1680,7 @@ try
         wb.putPage(page_id1, /* tag */ 0, buff1, size_100);
         wb.putPage(page_id2, /* tag */ 0, buff2, size_500);
         wb.putPage(page_id3, /* tag */ 0, buff3, size_200);
-        auto edit = blob_store.write(wb, nullptr);
+        auto edit = blob_store.write(std::move(wb), nullptr);
         const auto & records = edit.getRecords();
         ASSERT_EQ(records.size(), 3);
         entry_from_write1 = records[0].entry;

--- a/dbms/src/Storages/Transaction/RegionPersister.cpp
+++ b/dbms/src/Storages/Transaction/RegionPersister.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Common/Exception.h>
 #include <Common/FailPoint.h>
 #include <IO/MemoryReadWriteBuffer.h>
 #include <Interpreters/Context.h>
@@ -128,6 +129,7 @@ void RegionPersister::doPersist(RegionCacheWriteElement & region_write_buffer, c
     }
 
     auto read_buf = buffer.tryGetReadBuffer();
+    RUNTIME_CHECK_MSG(read_buf != nullptr, "failed to gen buffer for {}", region.toString(true));
     if (page_writer)
     {
         DB::WriteBatch wb{ns_id};

--- a/dbms/src/Storages/Transaction/tests/gtest_region_persister.cpp
+++ b/dbms/src/Storages/Transaction/tests/gtest_region_persister.cpp
@@ -208,6 +208,7 @@ class RegionPersisterTest : public ::testing::Test
 public:
     RegionPersisterTest()
         : dir_path(TiFlashTestEnv::getTemporaryPath("/region_persister_test"))
+        , log(Logger::get())
     {
     }
 
@@ -235,6 +236,7 @@ protected:
     String dir_path;
 
     std::unique_ptr<PathPool> mocked_path_pool;
+    LoggerPtr log;
 };
 
 TEST_F(RegionPersisterTest, persister)

--- a/dbms/src/Storages/Transaction/tests/gtest_region_persister.cpp
+++ b/dbms/src/Storages/Transaction/tests/gtest_region_persister.cpp
@@ -16,6 +16,7 @@
 #include <Common/Stopwatch.h>
 #include <IO/ReadBufferFromFile.h>
 #include <IO/WriteBufferFromFile.h>
+#include <RaftStoreProxyFFI/ColumnFamily.h>
 #include <Storages/Page/PageStorage.h>
 #include <Storages/PathPool.h>
 #include <Storages/Transaction/Region.h>
@@ -390,9 +391,9 @@ try
         {
             auto region = std::make_shared<Region>(createRegionMeta(i, table_id));
             TiKVKey key = RecordKVFormat::genKey(table_id, i, tso++);
-            region->insert("default", TiKVKey::copyFrom(key), TiKVValue("value1"));
-            region->insert("write", TiKVKey::copyFrom(key), RecordKVFormat::encodeWriteCfValue('P', 0));
-            region->insert("lock", TiKVKey::copyFrom(key), RecordKVFormat::encodeLockCfValue('P', "", 0, 0));
+            region->insert(ColumnFamilyType::Default, TiKVKey::copyFrom(key), TiKVValue("value1"));
+            region->insert(ColumnFamilyType::Write, TiKVKey::copyFrom(key), RecordKVFormat::encodeWriteCfValue('P', 0));
+            region->insert(ColumnFamilyType::Lock, TiKVKey::copyFrom(key), RecordKVFormat::encodeLockCfValue('P', "", 0, 0));
 
             persister.persist(*region);
 
@@ -416,6 +417,74 @@ try
             auto new_region = new_regions[i];
             ASSERT_EQ(*new_region, *old_region) << " region:" << i;
         }
+    }
+}
+CATCH
+
+
+TEST_F(RegionPersisterTest, LargeRegion)
+try
+{
+    RegionManager region_manager;
+
+    auto ctx = TiFlashTestEnv::getGlobalContext();
+
+    const TableID table_id = 100;
+    const RegionID region_id_base = 20;
+    const String large_value(1024 * 512, 'v');
+
+    PageStorageConfig config;
+    config.blob_file_limit_size = 32 * MB;
+    RegionMap regions;
+    {
+        UInt64 tso = 0;
+        RegionPersister persister(ctx, region_manager);
+        persister.restore(*mocked_path_pool, nullptr, config);
+
+        // Persist region
+        auto gen_region_data = [&](RegionID region_id, UInt64 expect_size) {
+            auto region = std::make_shared<Region>(createRegionMeta(region_id, table_id));
+            UInt64 handle_id = 0;
+            while (true)
+            {
+                if (auto data_size = region->dataSize(); data_size > expect_size)
+                {
+                    LOG_INFO(log, "will persist region_id={} size={}", region_id, data_size);
+                    break;
+                }
+                TiKVKey key = RecordKVFormat::genKey(table_id, handle_id, tso++);
+                region->insert(ColumnFamilyType::Default, TiKVKey::copyFrom(key), TiKVValue(large_value.data()));
+                region->insert(ColumnFamilyType::Write, TiKVKey::copyFrom(key), RecordKVFormat::encodeWriteCfValue('P', 0));
+                region->insert(ColumnFamilyType::Lock, TiKVKey::copyFrom(key), RecordKVFormat::encodeLockCfValue('P', "", 0, 0));
+                handle_id += 1;
+            }
+            return region;
+        };
+
+        std::vector<double> test_scales{0.5, 1.0, 1.5, 2.5};
+        for (size_t idx = 0; idx < test_scales.size(); ++idx)
+        {
+            auto scale = test_scales[idx];
+            auto region = gen_region_data(region_id_base + idx, config.blob_file_limit_size * scale);
+            persister.persist(*region);
+            regions.emplace(region->id(), region);
+        }
+        ASSERT_EQ(regions.size(), test_scales.size());
+    }
+
+    RegionMap restored_regions;
+    {
+        RegionPersister persister(ctx, region_manager);
+        restored_regions = persister.restore(*mocked_path_pool, nullptr, config);
+    }
+    ASSERT_EQ(restored_regions.size(), regions.size());
+    for (const auto & [region_id, region] : regions)
+    {
+        ASSERT_NE(restored_regions.find(region_id), restored_regions.end()) << region_id;
+        auto & new_region = restored_regions.at(region_id);
+        ASSERT_EQ(new_region->id(), region_id);
+        ASSERT_EQ(new_region->confVer(), region->confVer()) << region_id;
+        ASSERT_EQ(new_region->dataSize(), region->dataSize()) << region_id;
     }
 }
 CATCH

--- a/dbms/src/TestUtils/TiFlashTestEnv.cpp
+++ b/dbms/src/TestUtils/TiFlashTestEnv.cpp
@@ -177,4 +177,10 @@ void TiFlashTestEnv::setupLogger(const String & level, std::ostream & os)
     Poco::Logger::root().setChannel(formatting_channel);
     Poco::Logger::root().setLevel(level);
 }
+
+FileProviderPtr TiFlashTestEnv::getMockFileProvider()
+{
+    bool encryption_enabled = false;
+    return std::make_shared<FileProvider>(std::make_shared<MockKeyManager>(encryption_enabled), encryption_enabled);
+}
 } // namespace DB::tests

--- a/dbms/src/TestUtils/TiFlashTestEnv.h
+++ b/dbms/src/TestUtils/TiFlashTestEnv.h
@@ -76,6 +76,8 @@ public:
     static int globalContextSize() { return global_contexts.size(); }
     static void shutdown();
 
+    static FileProviderPtr getMockFileProvider();
+
     TiFlashTestEnv() = delete;
 
 private:


### PR DESCRIPTION
Manual cherry-pick of https://github.com/pingcap/tiflash/pull/7335

* * *

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/7316

Problem Summary:

The root cause is `BlobStore<Trait>::handleLargeWrite` get a buffer from `MemoryWriteBuffer` and access the memory by `write.size`, which exceed the memory bound. `MemoryWriteBuffer` actually is composed by a list of `chunk`s

https://github.com/pingcap/tiflash/blob/b2b976edbe33b4bb130d9abff44948877d86cda5/dbms/src/Storages/Page/V3/BlobStore.cpp#L190-L216

### What is changed and how it works?

The write batch data size is large, we do NOT copy the data into a temporary buffer in order to make the memory usage of tiflash more smooth. Instead, we process the data in ReadBuffer in a streaming manner.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix a crash issue when tiflash persists the data of a large Region
```
