### PR TITLE
Pipeline: Fix crash for `random_pipeline_model_task_construct_failpoint`

### DIFF
--- a/dbms/src/Flash/Executor/DataStreamExecutor.cpp
+++ b/dbms/src/Flash/Executor/DataStreamExecutor.cpp
@@ -39,15 +39,15 @@ ExecutionResult DataStreamExecutor::execute(ResultHandler && result_handler)
     try
     {
         data_stream->readPrefix();
-        if (result_handler.isIgnored())
-        {
-            while (data_stream->read())
-                continue;
-        }
-        else
+        if (result_handler)
         {
             while (Block block = data_stream->read())
                 result_handler(block);
+        }
+        else
+        {
+            while (data_stream->read())
+                continue;
         }
         data_stream->readSuffix();
         return ExecutionResult::success();

--- a/dbms/src/Flash/Executor/PipelineExecutor.h
+++ b/dbms/src/Flash/Executor/PipelineExecutor.h
@@ -77,7 +77,7 @@ private:
 
     void wait();
 
-    void consume(const ResultQueuePtr & result_queue, ResultHandler && result_handler);
+    void consume(ResultHandler & result_handler);
 
 private:
     PipelinePtr root_pipeline;

--- a/dbms/src/Flash/Executor/PipelineExecutorStatus.cpp
+++ b/dbms/src/Flash/Executor/PipelineExecutorStatus.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <Flash/Executor/PipelineExecutorStatus.h>
-#include <assert.h>
 
 namespace DB
 {
@@ -58,12 +57,17 @@ void PipelineExecutorStatus::onErrorOccurred(const String & err_msg) noexcept
 
 bool PipelineExecutorStatus::setExceptionPtr(const std::exception_ptr & exception_ptr_) noexcept
 {
-    assert(exception_ptr_ != nullptr);
+    RUNTIME_ASSERT(exception_ptr_ != nullptr);
     std::lock_guard lock(mu);
     if (exception_ptr != nullptr)
         return false;
     exception_ptr = exception_ptr_;
     return true;
+}
+
+bool PipelineExecutorStatus::isWaitMode() noexcept
+{
+    return !result_queue.has_value();
 }
 
 void PipelineExecutorStatus::onErrorOccurred(const std::exception_ptr & exception_ptr_) noexcept
@@ -79,9 +83,29 @@ void PipelineExecutorStatus::wait() noexcept
 {
     {
         std::unique_lock lock(mu);
+        RUNTIME_ASSERT(isWaitMode());
         cv.wait(lock, [&] { return 0 == active_event_count; });
     }
     LOG_DEBUG(log, "query finished and wait done");
+}
+
+ResultQueuePtr PipelineExecutorStatus::getConsumedResultQueue() noexcept
+{
+    std::lock_guard lock(mu);
+    RUNTIME_ASSERT(!isWaitMode());
+    auto consumed_result_queue = *result_queue;
+    assert(consumed_result_queue);
+    return consumed_result_queue;
+}
+
+void PipelineExecutorStatus::consume(ResultHandler & result_handler) noexcept
+{
+    RUNTIME_ASSERT(result_handler);
+    auto consumed_result_queue = getConsumedResultQueue();
+    Block ret;
+    while (consumed_result_queue->pop(ret) == MPMCQueueResult::OK)
+        result_handler(ret);
+    LOG_DEBUG(log, "query finished and consume done");
 }
 
 void PipelineExecutorStatus::onEventSchedule() noexcept
@@ -92,23 +116,25 @@ void PipelineExecutorStatus::onEventSchedule() noexcept
 
 void PipelineExecutorStatus::onEventFinish() noexcept
 {
-    bool query_finished = false;
+    std::lock_guard lock(mu);
+    RUNTIME_ASSERT(active_event_count > 0);
+    --active_event_count;
+    if (0 == active_event_count)
     {
-        std::lock_guard lock(mu);
-        assert(active_event_count > 0);
-        --active_event_count;
-        if (0 == active_event_count)
-        {
-            // It is not expected for a query to be finished more than one time.
-            RUNTIME_ASSERT(!is_finished);
-            is_finished = true;
+        // It is not expected for a query to be finished more than one time.
+        RUNTIME_ASSERT(!is_finished);
+        is_finished = true;
 
+        if (isWaitMode())
+        {
             cv.notify_all();
-            query_finished = true;
+        }
+        else
+        {
+            assert(*result_queue);
+            (*result_queue)->finish();
         }
     }
-    if (query_finished && result_queue.has_value())
-        (*result_queue)->finish();
 }
 
 void PipelineExecutorStatus::cancel() noexcept
@@ -116,9 +142,10 @@ void PipelineExecutorStatus::cancel() noexcept
     is_cancelled.store(true, std::memory_order_release);
 }
 
-ResultQueuePtr PipelineExecutorStatus::registerResultQueue(size_t queue_size) noexcept
+ResultQueuePtr PipelineExecutorStatus::toConsumeMode(size_t queue_size) noexcept
 {
-    assert(!result_queue.has_value());
+    std::lock_guard lock(mu);
+    RUNTIME_ASSERT(!result_queue.has_value());
     result_queue.emplace(std::make_shared<ResultQueue>(queue_size));
     return *result_queue;
 }

--- a/dbms/src/Flash/Executor/PipelineExecutorStatus.h
+++ b/dbms/src/Flash/Executor/PipelineExecutorStatus.h
@@ -96,6 +96,12 @@ public:
                 break;
             }
         }
+        // In order to ensure that `onEventFinish` has finished calling at this point
+        // and avoid referencing the already destructed `mu` in `onEventFinish`.
+        {
+            std::lock_guard lock(mu);
+            RUNTIME_ASSERT(0 == active_event_count);
+        }
         LOG_DEBUG(log, "query finished and consume done");
     }
 

--- a/dbms/src/Flash/Executor/PipelineExecutorStatus.h
+++ b/dbms/src/Flash/Executor/PipelineExecutorStatus.h
@@ -16,6 +16,7 @@
 
 #include <Common/Logger.h>
 #include <Flash/Executor/ExecutionResult.h>
+#include <Flash/Executor/ResultHandler.h>
 #include <Flash/Executor/ResultQueue.h>
 
 #include <atomic>
@@ -57,6 +58,7 @@ public:
         bool is_timeout = false;
         {
             std::unique_lock lock(mu);
+            RUNTIME_ASSERT(isWaitMode());
             is_timeout = !cv.wait_for(lock, timeout_duration, [&] { return 0 == active_event_count; });
         }
         if (is_timeout)
@@ -68,6 +70,35 @@ public:
         LOG_DEBUG(log, "query finished and wait done");
     }
 
+    void consume(ResultHandler & result_handler) noexcept;
+
+    template <typename Duration>
+    void consumeFor(ResultHandler & result_handler, const Duration & timeout_duration)
+    {
+        RUNTIME_ASSERT(result_handler);
+        auto consumed_result_queue = getConsumedResultQueue();
+        Block ret;
+        while (true)
+        {
+            auto res = consumed_result_queue->popTimeout(ret, timeout_duration);
+            if (res == MPMCQueueResult::TIMEOUT)
+            {
+                LOG_WARNING(log, "consume timeout");
+                onErrorOccurred(timeout_err_msg);
+                throw Exception(timeout_err_msg);
+            }
+            else if (res == MPMCQueueResult::OK)
+            {
+                result_handler(ret);
+            }
+            else
+            {
+                break;
+            }
+        }
+        LOG_DEBUG(log, "query finished and consume done");
+    }
+
     void cancel() noexcept;
 
     ALWAYS_INLINE bool isCancelled() noexcept
@@ -75,10 +106,15 @@ public:
         return is_cancelled.load(std::memory_order_acquire);
     }
 
-    ResultQueuePtr registerResultQueue(size_t queue_size) noexcept;
+    ResultQueuePtr toConsumeMode(size_t queue_size) noexcept;
 
 private:
     bool setExceptionPtr(const std::exception_ptr & exception_ptr_) noexcept;
+
+    // Need to be called under lock.
+    bool isWaitMode() noexcept;
+
+    ResultQueuePtr getConsumedResultQueue() noexcept;
 
 private:
     LoggerPtr log;
@@ -93,8 +129,6 @@ private:
     bool is_finished{false};
 
     // `result_queue.finish` can only be called in `onEventFinish` because `result_queue.pop` cannot end until events end.
-    // `registerResultQueue` is called before event scheduled, so is safe to use result_queue without lock.
-    // If `registerResultQueue` is called, `result_queue` must be safely visible in `onEventFinish`.
     std::optional<ResultQueuePtr> result_queue;
 };
 } // namespace DB

--- a/dbms/src/Flash/Executor/ResultHandler.h
+++ b/dbms/src/Flash/Executor/ResultHandler.h
@@ -32,7 +32,7 @@ public:
         : is_ignored(true)
     {}
 
-    bool isIgnored() const { return is_ignored; }
+    explicit operator bool() const noexcept { return !is_ignored; }
 
     void operator()(const Block & block) const
     {

--- a/dbms/src/Flash/Pipeline/Exec/tests/gtest_simple_operator.cpp
+++ b/dbms/src/Flash/Pipeline/Exec/tests/gtest_simple_operator.cpp
@@ -36,7 +36,7 @@ public:
         : SinkOp(exec_status_, req_id)
         , result_handler(std::move(result_handler_))
     {
-        assert(!result_handler.isIgnored());
+        assert(result_handler);
     }
 
     String getName() const override

--- a/dbms/src/Flash/Pipeline/Schedule/Events/Event.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/Events/Event.cpp
@@ -41,7 +41,7 @@ extern const char random_pipeline_model_event_finish_failpoint[];
 void Event::addInput(const EventPtr & input) noexcept
 {
     RUNTIME_ASSERT(status == EventStatus::INIT);
-    assert(input.get() != this);
+    RUNTIME_ASSERT(input.get() != this);
     input->addOutput(shared_from_this());
     ++unfinished_inputs;
     is_source = false;
@@ -51,20 +51,20 @@ void Event::addOutput(const EventPtr & output) noexcept
 {
     /// Output will also be added in the Finished state, as can be seen in the `insertEvent`.
     RUNTIME_ASSERT(status == EventStatus::INIT || status == EventStatus::FINISHED);
-    assert(output.get() != this);
+    RUNTIME_ASSERT(output.get() != this);
     outputs.push_back(output);
 }
 
 void Event::insertEvent(const EventPtr & insert_event) noexcept
 {
     RUNTIME_ASSERT(status == EventStatus::FINISHED);
-    assert(insert_event);
+    RUNTIME_ASSERT(insert_event);
     /// eventA───────►eventB ===> eventA─────────────►eventB
     ///                             │                    ▲
     ///                             └────►insert_event───┘
     for (const auto & output : outputs)
     {
-        assert(output);
+        RUNTIME_ASSERT(output);
         output->addInput(insert_event);
     }
     insert_event->addInput(shared_from_this());
@@ -177,7 +177,7 @@ void Event::finish() noexcept
         // finished processing the event, now we can schedule output events.
         for (auto & output : outputs)
         {
-            assert(output);
+            RUNTIME_ASSERT(output);
             output->onInputFinish();
             output.reset();
         }

--- a/dbms/src/Flash/Pipeline/Schedule/Events/Event.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/Events/Event.cpp
@@ -136,7 +136,7 @@ void Event::scheduleTasks() noexcept
     if (!tasks.empty())
     {
         // If query has already been cancelled, we can skip scheduling tasks.
-        // And then tasks will be destroyed and call `onTaskFinish`.
+        // Then tasks will be destroyed and call `onTaskFinish`.
         if (likely(!exec_status.isCancelled()))
         {
             LOG_DEBUG(log, "{} tasks scheduled by event", tasks.size());

--- a/dbms/src/Flash/Pipeline/Schedule/Events/Event.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/Events/Event.cpp
@@ -132,6 +132,7 @@ void Event::schedule() noexcept
 void Event::scheduleTasks() noexcept
 {
     assert(status == EventStatus::SCHEDULED);
+    assert(tasks.size() == static_cast<size_t>(unfinished_tasks));
     if (!tasks.empty())
     {
         // If query has already been cancelled, we can skip scheduling tasks.
@@ -152,7 +153,7 @@ void Event::scheduleTasks() noexcept
 
 void Event::onTaskFinish() noexcept
 {
-    assert(status != EventStatus::FINISHED);
+    assert(status == EventStatus::SCHEDULED);
     int32_t remaining_tasks = unfinished_tasks.fetch_sub(1) - 1;
     assert(remaining_tasks >= 0);
     LOG_DEBUG(log, "one task finished, {} tasks remaining", remaining_tasks);

--- a/dbms/src/Flash/Pipeline/Schedule/Events/Event.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/Events/Event.cpp
@@ -38,20 +38,20 @@ extern const char random_pipeline_model_event_finish_failpoint[];
         exec_status.onErrorOccurred(std::current_exception());   \
     }
 
-void Event::addInput(const EventPtr & input)
+void Event::addInput(const EventPtr & input) noexcept
 {
-    RUNTIME_CHECK(status == EventStatus::INIT);
-    RUNTIME_CHECK(input.get() != this);
+    assert(status == EventStatus::INIT);
+    assert(input.get() != this);
     input->addOutput(shared_from_this());
     ++unfinished_inputs;
     is_source = false;
 }
 
-void Event::addOutput(const EventPtr & output)
+void Event::addOutput(const EventPtr & output) noexcept
 {
     /// Output will also be added in the Finished state, as can be seen in the `insertEvent`.
-    RUNTIME_CHECK(status == EventStatus::INIT || status == EventStatus::FINISHED);
-    RUNTIME_CHECK(output.get() != this);
+    assert(status == EventStatus::INIT || status == EventStatus::FINISHED);
+    assert(output.get() != this);
     outputs.push_back(output);
 }
 
@@ -79,9 +79,9 @@ void Event::onInputFinish() noexcept
         schedule();
 }
 
-bool Event::prepare()
+bool Event::prepare() noexcept
 {
-    RUNTIME_CHECK(status == EventStatus::INIT);
+    assert(status == EventStatus::INIT);
     if (is_source)
     {
         // For source event, `exec_status.onEventSchedule()` needs to be called before schedule.

--- a/dbms/src/Flash/Pipeline/Schedule/Events/Event.h
+++ b/dbms/src/Flash/Pipeline/Schedule/Events/Event.h
@@ -50,7 +50,7 @@ public:
     {}
     virtual ~Event() = default;
 
-    void addInput(const EventPtr & input);
+    void addInput(const EventPtr & input) noexcept;
 
     // schedule, onTaskFinish and finish maybe called directly in TaskScheduler,
     // so these functions must be noexcept.
@@ -59,7 +59,7 @@ public:
     void onTaskFinish() noexcept;
 
     // return true for source event.
-    bool prepare();
+    bool prepare() noexcept;
 
 protected:
     // add task ready to be scheduled.
@@ -80,7 +80,7 @@ private:
 
     void finish() noexcept;
 
-    void addOutput(const EventPtr & output);
+    void addOutput(const EventPtr & output) noexcept;
 
     void onInputFinish() noexcept;
 

--- a/dbms/src/Flash/Pipeline/Schedule/Events/Event.h
+++ b/dbms/src/Flash/Pipeline/Schedule/Events/Event.h
@@ -62,8 +62,11 @@ public:
     bool prepare();
 
 protected:
-    // Returns the tasks ready to be scheduled.
-    virtual std::vector<TaskPtr> scheduleImpl() { return {}; }
+    // add task ready to be scheduled.
+    void addTask(TaskPtr && task) noexcept;
+
+    // Generate the tasks ready to be scheduled and use `addTask` to add the tasks.
+    virtual void scheduleImpl() {}
 
     // So far the ownership and the life-cycle of the resources are not very well-defined so we still rely on things like "A must be released before B".
     // And this is the explicit place to release all the resources that need to be cleaned up before event destruction, so that we can satisfy the above constraints.
@@ -73,7 +76,7 @@ protected:
     void insertEvent(const EventPtr & insert_event) noexcept;
 
 private:
-    void scheduleTasks(std::vector<TaskPtr> & tasks) noexcept;
+    void scheduleTasks() noexcept;
 
     void finish() noexcept;
 
@@ -94,6 +97,9 @@ private:
     Events outputs;
 
     std::atomic_int32_t unfinished_inputs{0};
+
+    // hold the tasks that ready to be scheduled.
+    std::vector<TaskPtr> tasks;
 
     std::atomic_int32_t unfinished_tasks{0};
 

--- a/dbms/src/Flash/Pipeline/Schedule/Events/FineGrainedPipelineEvent.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/Events/FineGrainedPipelineEvent.cpp
@@ -17,10 +17,8 @@
 
 namespace DB
 {
-std::vector<TaskPtr> FineGrainedPipelineEvent::scheduleImpl()
+void FineGrainedPipelineEvent::scheduleImpl()
 {
-    std::vector<TaskPtr> tasks;
-    tasks.push_back(std::make_unique<PipelineTask>(mem_tracker, log->identifier(), exec_status, shared_from_this(), std::move(pipeline_exec)));
-    return tasks;
+    addTask(std::make_unique<PipelineTask>(mem_tracker, log->identifier(), exec_status, shared_from_this(), std::move(pipeline_exec)));
 }
 } // namespace DB

--- a/dbms/src/Flash/Pipeline/Schedule/Events/FineGrainedPipelineEvent.h
+++ b/dbms/src/Flash/Pipeline/Schedule/Events/FineGrainedPipelineEvent.h
@@ -34,7 +34,7 @@ public:
     }
 
 protected:
-    std::vector<TaskPtr> scheduleImpl() override;
+    void scheduleImpl() override;
 
 private:
     // The pipeline exec for executing the specific fine-grained partition.

--- a/dbms/src/Flash/Pipeline/Schedule/Events/PlainPipelineEvent.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/Events/PlainPipelineEvent.cpp
@@ -18,16 +18,13 @@
 
 namespace DB
 {
-std::vector<TaskPtr> PlainPipelineEvent::scheduleImpl()
+void PlainPipelineEvent::scheduleImpl()
 {
     RUNTIME_CHECK(pipeline);
     auto pipeline_exec_group = pipeline->buildExecGroup(exec_status, context, concurrency);
     RUNTIME_CHECK(!pipeline_exec_group.empty());
-    std::vector<TaskPtr> tasks;
-    tasks.reserve(pipeline_exec_group.size());
     for (auto & pipeline_exec : pipeline_exec_group)
-        tasks.push_back(std::make_unique<PipelineTask>(mem_tracker, log->identifier(), exec_status, shared_from_this(), std::move(pipeline_exec)));
-    return tasks;
+        addTask(std::make_unique<PipelineTask>(mem_tracker, log->identifier(), exec_status, shared_from_this(), std::move(pipeline_exec)));
 }
 
 void PlainPipelineEvent::finishImpl()

--- a/dbms/src/Flash/Pipeline/Schedule/Events/PlainPipelineEvent.h
+++ b/dbms/src/Flash/Pipeline/Schedule/Events/PlainPipelineEvent.h
@@ -38,7 +38,7 @@ public:
     {}
 
 protected:
-    std::vector<TaskPtr> scheduleImpl() override;
+    void scheduleImpl() override;
 
     void finishImpl() override;
 

--- a/dbms/src/Flash/Pipeline/Schedule/Events/tests/gtest_event.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/Events/tests/gtest_event.cpp
@@ -109,7 +109,7 @@ protected:
     void scheduleImpl() override
     {
         if (!with_tasks)
-            return {};
+            return;
 
         for (size_t i = 0; i < 10; ++i)
             addTask(std::make_unique<RunTask>(exec_status, shared_from_this()));
@@ -153,7 +153,7 @@ protected:
         {
             while (!exec_status.isCancelled())
                 std::this_thread::sleep_for(std::chrono::milliseconds(1));
-            return {};
+            return;
         }
 
         for (size_t i = 0; i < 10; ++i)

--- a/dbms/src/Flash/Pipeline/Schedule/Events/tests/gtest_event.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/Events/tests/gtest_event.cpp
@@ -59,12 +59,10 @@ public:
     static constexpr auto task_num = 10;
 
 protected:
-    std::vector<TaskPtr> scheduleImpl() override
+    void scheduleImpl() override
     {
-        std::vector<TaskPtr> tasks;
         for (size_t i = 0; i < task_num; ++i)
-            tasks.push_back(std::make_unique<BaseTask>(exec_status, shared_from_this(), counter));
-        return tasks;
+            addTask(std::make_unique<BaseTask>(exec_status, shared_from_this(), counter));
     }
 
     void finishImpl() override
@@ -108,15 +106,13 @@ public:
     {}
 
 protected:
-    std::vector<TaskPtr> scheduleImpl() override
+    void scheduleImpl() override
     {
         if (!with_tasks)
             return {};
 
-        std::vector<TaskPtr> tasks;
         for (size_t i = 0; i < 10; ++i)
-            tasks.push_back(std::make_unique<RunTask>(exec_status, shared_from_this()));
-        return tasks;
+            addTask(std::make_unique<RunTask>(exec_status, shared_from_this()));
     }
 
 private:
@@ -151,7 +147,7 @@ public:
     {}
 
 protected:
-    std::vector<TaskPtr> scheduleImpl() override
+    void scheduleImpl() override
     {
         if (!with_tasks)
         {
@@ -160,10 +156,8 @@ protected:
             return {};
         }
 
-        std::vector<TaskPtr> tasks;
         for (size_t i = 0; i < 10; ++i)
-            tasks.push_back(std::make_unique<DeadLoopTask>(exec_status, shared_from_this()));
-        return tasks;
+            addTask(std::make_unique<DeadLoopTask>(exec_status, shared_from_this()));
     }
 
 private:
@@ -180,10 +174,9 @@ public:
     static constexpr auto err_msg = "error from OnErrEvent";
 
 protected:
-    std::vector<TaskPtr> scheduleImpl() override
+    void scheduleImpl() override
     {
         exec_status.onErrorOccurred(err_msg);
-        return {};
     }
 };
 
@@ -195,10 +188,9 @@ public:
     {}
 
 protected:
-    std::vector<TaskPtr> scheduleImpl() override
+    void scheduleImpl() override
     {
         assert(mem_tracker.get() == current_memory_tracker);
-        return {};
     }
 
     void finishImpl() override
@@ -234,15 +226,13 @@ public:
     {}
 
 protected:
-    std::vector<TaskPtr> scheduleImpl() override
+    void scheduleImpl() override
     {
         if (!with_task)
             throw Exception("throw exception in scheduleImpl");
 
-        std::vector<TaskPtr> tasks;
         for (size_t i = 0; i < 10; ++i)
-            tasks.push_back(std::make_unique<ThrowExceptionTask>(exec_status, shared_from_this()));
-        return tasks;
+            addTask(std::make_unique<ThrowExceptionTask>(exec_status, shared_from_this()));
     }
 
     void finishImpl() override
@@ -266,15 +256,13 @@ public:
     {}
 
 protected:
-    std::vector<TaskPtr> scheduleImpl() override
+    void scheduleImpl() override
     {
         if (0 == task_num)
-            return {};
+            return;
 
-        std::vector<TaskPtr> tasks;
         for (size_t i = 0; i < task_num; ++i)
-            tasks.push_back(std::make_unique<RunTask>(exec_status, shared_from_this()));
-        return tasks;
+            addTask(std::make_unique<RunTask>(exec_status, shared_from_this()));
     }
 
 private:
@@ -294,11 +282,9 @@ public:
     }
 
 protected:
-    std::vector<TaskPtr> scheduleImpl() override
+    void scheduleImpl() override
     {
-        std::vector<TaskPtr> tasks;
-        tasks.push_back(std::make_unique<RunTask>(exec_status, shared_from_this()));
-        return tasks;
+        addTask(std::make_unique<RunTask>(exec_status, shared_from_this()));
     }
 
     void finishImpl() override


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6518  close #7361

Problem Summary:

### What is changed and how it works?
- If task creation fails and one task has already been successfully created, the task that has been created will be destructed in `scheduleImpl`. This will trigger `onTaskFinish`, leading to unexpected problems.
- refine the code of `scheduleImpl` and use `Event::tasks` to hold the tasks that ready to be scheduled.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
