### PR TITLE
truncate should always be treated as warning in cast decimal as decimal

### DIFF
--- a/dbms/src/Functions/FunctionsTiDBConversion.h
+++ b/dbms/src/Functions/FunctionsTiDBConversion.h
@@ -951,8 +951,8 @@ struct TiDBConvertToDecimal
         }
         else if (v_scale > scale)
         {
-            context.getDAGContext()->handleTruncateError("cast decimal as decimal");
             const bool need_to_round = ((value < 0 ? -value : value) % scale_mul) >= (scale_mul / 2);
+            auto old_value = value;
             value /= scale_mul;
             if (need_to_round)
             {
@@ -961,6 +961,8 @@ struct TiDBConvertToDecimal
                 else
                     ++value;
             }
+            if (old_value != value * scale_mul)
+                context.getDAGContext()->appendWarning("Truncate in cast decimal as decimal");
         }
         else
         {

--- a/dbms/src/Functions/tests/gtest_tidb_conversion.cpp
+++ b/dbms/src/Functions/tests/gtest_tidb_conversion.cpp
@@ -1308,6 +1308,22 @@ try
 }
 CATCH
 
+TEST_F(TestTidbConversion, truncateInCastDecimalAsDecimal)
+try
+{
+    DAGContext * dag_context = context->getDAGContext();
+    UInt64 ori_flags = dag_context->getFlags();
+    dag_context->addFlag(TiDBSQLFlags::IN_INSERT_STMT | TiDBSQLFlags::IN_UPDATE_OR_DELETE_STMT);
+    dag_context->clearWarnings();
+
+    ASSERT_COLUMN_EQ(createColumn<Decimal32>(std::make_tuple(5, 2), {"1.23", "1.56", "1.01", "1.00", "-1.23", "-1.56", "-1.01", "-1.00"}),
+                     executeFunction(func_name, {createColumn<Decimal32>(std::make_tuple(5, 4), {"1.2300", "1.5600", "1.0056", "1.0023", "-1.2300", "-1.5600", "-1.0056", "-1.0023"}), createCastTypeConstColumn("Decimal(5,2)")}));
+    ASSERT_EQ(dag_context->getWarningCount(), 4);
+    dag_context->setFlags(ori_flags);
+    dag_context->clearWarnings();
+}
+CATCH
+
 TEST_F(TestTidbConversion, castDecimalAsDecimalWithRound)
 try
 {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #7348

Problem Summary:
Accoring to TiDB's implementation, truncate in cast decimal as decimal should be always treated as a warning instead of error.
https://github.com/pingcap/tidb/blob/96fa4692b09b43ae587ea449e5891a9d9fd6e5c8/types/datum.go#L1512-L1519

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
