### PR TITLE
storage: Fix UAFs in PageStorage

### DIFF
--- a/dbms/src/Functions/FunctionsGrouping.h
+++ b/dbms/src/Functions/FunctionsGrouping.h
@@ -36,7 +36,7 @@ extern const int TOO_LESS_ARGUMENTS_FOR_FUNCTION;
 extern const int TOO_MANY_ARGUMENTS_FOR_FUNCTION;
 } // namespace ErrorCodes
 
-static bool isPowerOf2(uint64_t num)
+[[maybe_unused]] static bool isPowerOf2(uint64_t num)
 {
     return (num & (num - 1)) == 0;
 }

--- a/dbms/src/Storages/Page/V3/PageDirectory.cpp
+++ b/dbms/src/Storages/Page/V3/PageDirectory.cpp
@@ -1748,8 +1748,6 @@ PageDirectory<Trait>::getEntriesByBlobIds(const std::vector<BlobFileId> & blob_i
 
         while (true)
         {
-            // `iter` is an iter that won't be invalid cause by `apply`/`gcApply`.
-            // do scan on the version list without lock on `mvcc_table_directory`.
             fiu_do_on(FailPoints::pause_before_full_gc_prepare, {
                 if constexpr (std::is_same_v<Trait, u128::PageDirectoryTrait>)
                 {

--- a/dbms/src/Storages/Page/V3/PageDirectory.cpp
+++ b/dbms/src/Storages/Page/V3/PageDirectory.cpp
@@ -1888,18 +1888,18 @@ void PageDirectory<Trait>::copyCheckpointInfoFromEdit(PageEntriesEdit & edit)
 
         // TODO: Improve from O(nlogn) to O(n).
 
-        typename MVCCMapType::iterator iter;
+        VersionedPageEntriesPtr entries;
         {
             std::shared_lock read_lock(table_rw_mutex);
-            iter = mvcc_table_directory.find(rec.page_id);
+            auto iter = mvcc_table_directory.find(rec.page_id);
             if (iter == mvcc_table_directory.end())
                 // There may be obsolete entries deleted.
                 // For example, if there is a `Put 1` with sequence 10, `Del 1` with sequence 11,
                 // and the snapshot sequence is 12, Page with id 1 may be deleted by the gc process.
                 continue;
+            entries = iter->second;
         }
 
-        auto & entries = iter->second;
         entries->copyCheckpointInfoFromEdit(rec);
     }
 }

--- a/dbms/src/Storages/Page/V3/PageDirectory.cpp
+++ b/dbms/src/Storages/Page/V3/PageDirectory.cpp
@@ -1058,10 +1058,10 @@ typename PageDirectory<Trait>::PageIdAndEntry PageDirectory<Trait>::getByIDImpl(
     bool ok = true;
     while (ok)
     {
-        typename MVCCMapType::const_iterator iter;
+        VersionedPageEntriesPtr iter_v;
         {
             std::shared_lock read_lock(table_rw_mutex);
-            iter = mvcc_table_directory.find(id_to_resolve);
+            auto iter = mvcc_table_directory.find(id_to_resolve);
             if (iter == mvcc_table_directory.end())
             {
                 if (throw_on_not_exist)
@@ -1078,8 +1078,9 @@ typename PageDirectory<Trait>::PageIdAndEntry PageDirectory<Trait>::getByIDImpl(
                     return PageIdAndEntry{page_id, PageEntryV3{.file_id = INVALID_BLOBFILE_ID}};
                 }
             }
+            iter_v = iter->second;
         }
-        auto [resolve_state, next_id_to_resolve, next_ver_to_resolve] = iter->second->resolveToPageId(ver_to_resolve.sequence, /*ignore_delete=*/id_to_resolve != page_id, &entry_got);
+        auto [resolve_state, next_id_to_resolve, next_ver_to_resolve] = iter_v->resolveToPageId(ver_to_resolve.sequence, /*ignore_delete=*/id_to_resolve != page_id, &entry_got);
         switch (resolve_state)
         {
         case ResolveResult::TO_NORMAL:
@@ -1125,10 +1126,10 @@ PageDirectory<Trait>::getByIDsImpl(const typename PageDirectory<Trait>::PageIds 
         bool ok = true;
         while (ok)
         {
-            typename MVCCMapType::const_iterator iter;
+            VersionedPageEntriesPtr iter_v;
             {
                 std::shared_lock read_lock(table_rw_mutex);
-                iter = mvcc_table_directory.find(id_to_resolve);
+                auto iter = mvcc_table_directory.find(id_to_resolve);
                 if (iter == mvcc_table_directory.end())
                 {
                     if (throw_on_not_exist)
@@ -1140,8 +1141,9 @@ PageDirectory<Trait>::getByIDsImpl(const typename PageDirectory<Trait>::PageIds 
                         return false;
                     }
                 }
+                iter_v = iter->second;
             }
-            auto [resolve_state, next_id_to_resolve, next_ver_to_resolve] = iter->second->resolveToPageId(ver_to_resolve.sequence, /*ignore_delete=*/id_to_resolve != page_id, &entry_got);
+            auto [resolve_state, next_id_to_resolve, next_ver_to_resolve] = iter_v->resolveToPageId(ver_to_resolve.sequence, /*ignore_delete=*/id_to_resolve != page_id, &entry_got);
             switch (resolve_state)
             {
             case ResolveResult::TO_NORMAL:
@@ -1196,10 +1198,10 @@ typename PageDirectory<Trait>::PageId PageDirectory<Trait>::getNormalPageId(cons
     bool keep_resolve = true;
     while (keep_resolve)
     {
-        typename MVCCMapType::const_iterator iter;
+        VersionedPageEntriesPtr iter_v;
         {
             std::shared_lock read_lock(table_rw_mutex);
-            iter = mvcc_table_directory.find(id_to_resolve);
+            auto iter = mvcc_table_directory.find(id_to_resolve);
             if (iter == mvcc_table_directory.end())
             {
                 if (throw_on_not_exist)
@@ -1211,8 +1213,9 @@ typename PageDirectory<Trait>::PageId PageDirectory<Trait>::getNormalPageId(cons
                     return Trait::PageIdTrait::getInvalidID();
                 }
             }
+            iter_v = iter->second;
         }
-        auto [resolve_state, next_id_to_resolve, next_ver_to_resolve] = iter->second->resolveToPageId(ver_to_resolve.sequence, /*ignore_delete=*/id_to_resolve != page_id, nullptr);
+        auto [resolve_state, next_id_to_resolve, next_ver_to_resolve] = iter_v->resolveToPageId(ver_to_resolve.sequence, /*ignore_delete=*/id_to_resolve != page_id, nullptr);
         switch (resolve_state)
         {
         case ResolveResult::TO_NORMAL:
@@ -1731,20 +1734,22 @@ PageDirectory<Trait>::getEntriesByBlobIds(const std::vector<BlobFileId> & blob_i
     std::map<PageId, std::tuple<PageId, PageVersion>> ref_ids_maybe_rewrite;
 
     {
-        typename MVCCMapType::const_iterator iter;
+        PageId page_id;
+        VersionedPageEntriesPtr version_entries;
+
         {
             std::shared_lock read_lock(table_rw_mutex);
-            iter = mvcc_table_directory.cbegin();
+            auto iter = mvcc_table_directory.cbegin();
             if (iter == mvcc_table_directory.end())
                 return {blob_versioned_entries, total_page_size};
+            page_id = iter->first;
+            version_entries = iter->second;
         }
 
         while (true)
         {
             // `iter` is an iter that won't be invalid cause by `apply`/`gcApply`.
             // do scan on the version list without lock on `mvcc_table_directory`.
-            auto page_id = iter->first;
-            const auto & version_entries = iter->second;
             fiu_do_on(FailPoints::pause_before_full_gc_prepare, {
                 if constexpr (std::is_same_v<Trait, u128::PageDirectoryTrait>)
                 {
@@ -1761,9 +1766,11 @@ PageDirectory<Trait>::getEntriesByBlobIds(const std::vector<BlobFileId> & blob_i
 
             {
                 std::shared_lock read_lock(table_rw_mutex);
-                iter++;
+                auto iter = mvcc_table_directory.upper_bound(page_id);
                 if (iter == mvcc_table_directory.end())
                     break;
+                page_id = iter->first;
+                version_entries = iter->second;
             }
         }
     }
@@ -1775,13 +1782,14 @@ PageDirectory<Trait>::getEntriesByBlobIds(const std::vector<BlobFileId> & blob_i
     {
         const auto ori_id = std::get<0>(ori_id_ver);
         const auto ver = std::get<1>(ori_id_ver);
-        typename MVCCMapType::const_iterator page_iter;
+
+        VersionedPageEntriesPtr version_entries;
         {
             std::shared_lock read_lock(table_rw_mutex);
-            page_iter = mvcc_table_directory.find(ori_id);
+            auto page_iter = mvcc_table_directory.find(ori_id);
             RUNTIME_CHECK(page_iter != mvcc_table_directory.end(), ref_id, ori_id, ver);
+            version_entries = page_iter->second;
         }
-        const auto & version_entries = page_iter->second;
         // After storing all data in one PageStorage instance, we will run full gc
         // with external pages. Skip rewriting if it is an external pages.
         if (version_entries->isExternalPage())


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/7290

Problem Summary:

### What is changed and how it works?

`iter`, `iter->first`, `iter->second` will be all invalidated when iter is erased:

```c++
int main() {
    std::map<int, int> a;
    a.emplace(1, 2);
    auto it = a.find(1);
    a.erase(1);
    std::cout << it->second << std::endl;
    return 0;
}

==36182==ERROR: AddressSanitizer: heap-use-after-free on address 0x000105600cb0 at pc 0x0001025d5dac bp 0x00016d82b2b0 sp 0x00016d82b2a8
READ of size 4 at 0x000105600cb0 thread T0
    #0 0x1025d5da8 in main main.cpp:22
    #1 0x102971084 in start+0x200 (dyld:arm64+0x5084) (BuildId: fbb89662e6f23434b542f75185ac5e7432000000200000000100000000030c00)
    #2 0xb308fffffffffffc  (<unknown module>)

```

Thus we must only access iter inside a lock.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
