### PR TITLE
storage: Fix counter race in disaggregated mode

### DIFF
--- a/dbms/src/Functions/FunctionsGrouping.h
+++ b/dbms/src/Functions/FunctionsGrouping.h
@@ -36,7 +36,7 @@ extern const int TOO_LESS_ARGUMENTS_FOR_FUNCTION;
 extern const int TOO_MANY_ARGUMENTS_FOR_FUNCTION;
 } // namespace ErrorCodes
 
-static bool isPowerOf2(uint64_t num)
+[[maybe_unused]] static bool isPowerOf2(uint64_t num)
 {
     return (num & (num - 1)) == 0;
 }

--- a/dbms/src/Storages/DeltaMerge/Remote/RNRemoteReadTask.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/RNRemoteReadTask.h
@@ -216,7 +216,10 @@ public:
     bool addConsumedMsg()
     {
         num_msg_consumed += 1;
-        RUNTIME_CHECK(num_msg_consumed <= num_msg_to_consume);
+        RUNTIME_CHECK(
+            num_msg_consumed <= num_msg_to_consume,
+            num_msg_consumed,
+            num_msg_to_consume);
 
         // return there are more pending msg or not
         return num_msg_consumed < num_msg_to_consume;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/7303

Problem Summary:

### What is changed and how it works?

We increase the total task counter **before** (instead of **after**) pushing to the queue, because the task may be consumed immediately after we pushing to the queue.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
