### PR TITLE
Retry when 'Resource temporarily unavailable'

### DIFF
--- a/dbms/src/Common/TiFlashMetrics.h
+++ b/dbms/src/Common/TiFlashMetrics.h
@@ -351,7 +351,8 @@ namespace DB
         F(type_complete_multi_part_upload, {{"type", "complete_multi_part_upload"}}, ExpBuckets{0.001, 2, 20}),                                     \
         F(type_list_objects, {{"type", "list_objects"}}, ExpBuckets{0.001, 2, 20}),                                                                 \
         F(type_delete_object, {{"type", "delete_object"}}, ExpBuckets{0.001, 2, 20}),                                                               \
-        F(type_head_object, {{"type", "head_object"}}, ExpBuckets{0.001, 2, 20}))                                                                   \
+        F(type_head_object, {{"type", "head_object"}}, ExpBuckets{0.001, 2, 20}),                                                                   \
+        F(type_read_stream, {{"type", "read_stream"}}, ExpBuckets{0.0001, 2, 20}))                                                                  \
     M(tiflash_pipeline_scheduler, "pipeline scheduler", Gauge,                                                                                      \
         F(type_waiting_tasks_count, {"type", "waiting_tasks_count"}),                                                                               \
         F(type_cpu_pending_tasks_count, {"type", "cpu_pending_tasks_count"}),                                                                       \

--- a/dbms/src/Storages/S3/S3RandomAccessFile.cpp
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.cpp
@@ -100,6 +100,7 @@ ssize_t S3RandomAccessFile::readImpl(char * buf, size_t size)
         return -1;
     }
     auto elapsed_ns = sw.elapsed();
+    GET_METRIC(tiflash_storage_s3_request_seconds, type_read_stream).Observe(elapsed_ns / 1000000000.0);
     if (elapsed_ns > 10000000) // 10ms
     {
         LOG_DEBUG(
@@ -154,6 +155,7 @@ off_t S3RandomAccessFile::seekImpl(off_t offset_, int whence)
         return -1;
     }
     auto elapsed_ns = sw.elapsed();
+    GET_METRIC(tiflash_storage_s3_request_seconds, type_read_stream).Observe(elapsed_ns / 1000000000.0);
     if (elapsed_ns > 10000000) // 10ms
     {
         LOG_DEBUG(


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #7354

```
[2023/04/23 20:14:45.180 +08:00] [DEBUG] [PocoHTTPClient.cpp:200] ["Make request"] [source="URI=http://minio-peer:9000/cse-keyspace/cluster1_data/s8/data/t_2686/dmf_1480/8.dat pool=true"] [thread_id=471]
[2023/04/23 20:14:45.180 +08:00] [DEBUG] [PocoHTTPClient.cpp:331] ["connect cost 0ms"] [source="URI=http://minio-peer:9000/cse-keyspace/cluster1_data/s8/data/t_2686/dmf_1480/8.dat pool=true"] [thread_id=471]
[2023/04/23 20:14:45.180 +08:00] [DEBUG] [PocoHTTPClient.cpp:350] ["Receiving response..."] [source="URI=http://minio-peer:9000/cse-keyspace/cluster1_data/s8/data/t_2686/dmf_1480/8.dat pool=true"] [thread_id=471]
[2023/04/23 20:14:45.191 +08:00] [DEBUG] [PocoHTTPClient.cpp:361] ["Response status: 206, Partial Content"] [source="URI=http://minio-peer:9000/cse-keyspace/cluster1_data/s8/data/t_2686/dmf_1480/8.dat pool=true"] [thread_id=471]
[2023/04/23 20:14:45.191 +08:00] [DEBUG] [PocoHTTPClient.cpp:392] ["Received headers: Accept-Ranges: bytes; Content-Length: 18088392; Content-Range: bytes 0-18088391/18088392; Content-Security-Policy: block-all-mixed-content; Content-Type: binary/octet-stream; ETag: \"a89aaf4f317befeea05e8210ff4a8d46\"; Last-Modified: Sun, 23 Apr 2023 02:35:05 GMT; Server: MinIO; Strict-Transport-Security: max-age=31536000; includeSubDomains; Vary: Origin; Vary: Accept-Encoding; X-Amz-Id-2: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855; X-Amz-Request-Id: 17588F5BC7E272BD; X-Content-Type-Options: nosniff; X-Xss-Protection: 1; mode=block; Date: Sun, 23 Apr 2023 12:14:45 GMT; "] [source="URI=http://minio-peer:9000/cse-keyspace/cluster1_data/s8/data/t_2686/dmf_1480/8.dat pool=true"] [thread_id=471]
[2023/04/23 20:16:15.700 +08:00] [ERROR] [S3RandomAccessFile.cpp:92] ["Cannot read from istream, gcount=0, eof=false, cur_offset=0, content_length=18088392 errmsg=Resource temporarily unavailable"] [source=s8/data/t_2686/dmf_1480/8.dat] [thread_id=471]
```
The direct reason should be:
2023/04/23 20:14:45->GetObject successful
... (No logs of this thread, don't know what happened)
2023/04/23 20:16:15->First read, more than 1 minute has passed, and the TCP connection has been disconnected.

### What is changed and how it works?

- Retry when encountering 'Resource temporarily unavailable'.
- Suspect that it is caused by reading data from minio is too slow, so add metrics of read operations and logging when read operations are slow.

- [ ] Another possible method is to lazily `GetObject` before first read.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
