### PR TITLE
Move join projection inside HashJoinProbeInputStream

### DIFF
--- a/dbms/src/DataStreams/ScanHashMapAfterProbeBlockInputStream.cpp
+++ b/dbms/src/DataStreams/ScanHashMapAfterProbeBlockInputStream.cpp
@@ -130,8 +130,8 @@ ScanHashMapAfterProbeBlockInputStream::ScanHashMapAfterProbeBlockInputStream(con
         num_columns_left = 0;
     else
         result_sample_block = materializeBlock(left_sample_block);
-    size_t num_columns_right = parent.sample_block_with_columns_to_add.columns();
 
+    size_t num_columns_right = parent.sample_block_with_columns_to_add.columns();
     /// Add columns from the right-side table to the block.
     for (size_t i = 0; i < num_columns_right; ++i)
     {
@@ -163,6 +163,12 @@ ScanHashMapAfterProbeBlockInputStream::ScanHashMapAfterProbeBlockInputStream(con
     columns_left.resize(num_columns_left);
     columns_right.resize(num_columns_right);
     current_partition_index = index;
+
+    for (const auto & name : parent.tidb_output_column_names)
+    {
+        auto & column = result_sample_block.getByName(name);
+        projected_sample_block.insert(column);
+    }
 }
 
 Block ScanHashMapAfterProbeBlockInputStream::readImpl()
@@ -232,7 +238,14 @@ Block ScanHashMapAfterProbeBlockInputStream::readImpl()
     for (size_t i = 0; i < num_columns_right; ++i)
         res.getByPosition(column_indices_right[i]).column = std::move(columns_right[i]);
 
-    return res;
+    /// remove useless columns
+    Block projected_block;
+    for (const auto & name : parent.tidb_output_column_names)
+    {
+        auto & column = res.getByName(name);
+        projected_block.insert(std::move(column));
+    }
+    return projected_block;
 }
 
 template <bool row_flagged, bool output_joined_rows>

--- a/dbms/src/DataStreams/ScanHashMapAfterProbeBlockInputStream.h
+++ b/dbms/src/DataStreams/ScanHashMapAfterProbeBlockInputStream.h
@@ -28,7 +28,7 @@ public:
 
     String getName() const override { return "ScanHashMapAfterProbe"; }
 
-    Block getHeader() const override { return result_sample_block; };
+    Block getHeader() const override { return projected_sample_block; };
 
     size_t getIndex() const { return index; }
 
@@ -54,6 +54,7 @@ private:
 
 
     Block result_sample_block;
+    Block projected_sample_block; /// same schema with join's final schema
     /// Indices of columns in result_sample_block that come from the left-side table (except key columns).
     ColumnNumbers column_indices_left;
     /// Indices of columns that come from the right-side table.

--- a/dbms/src/Flash/Planner/Plans/PhysicalJoin.h
+++ b/dbms/src/Flash/Planner/Plans/PhysicalJoin.h
@@ -65,8 +65,6 @@ private:
 
     void buildSideTransform(DAGPipeline & build_pipeline, Context & context, size_t max_streams);
 
-    void doSchemaProject(DAGPipeline & pipeline);
-
     void buildBlockInputStreamImpl(DAGPipeline & pipeline, Context & context, size_t max_streams) override;
 
     /// the right side is the build side.

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -108,6 +108,7 @@ Join::Join(
     const SpillConfig & build_spill_config_,
     const SpillConfig & probe_spill_config_,
     Int64 join_restore_concurrency_,
+    const Names & tidb_output_column_names_,
     const TiDB::TiDBCollators & collators_,
     const JoinNonEqualConditions & non_equal_conditions_,
     size_t max_block_size_,
@@ -135,6 +136,7 @@ Join::Join(
     , build_spill_config(build_spill_config_)
     , probe_spill_config(probe_spill_config_)
     , join_restore_concurrency(join_restore_concurrency_)
+    , tidb_output_column_names(tidb_output_column_names_)
     , is_test(is_test_)
     , log(Logger::get(req_id))
     , enable_fine_grained_shuffle(enable_fine_grained_shuffle_)
@@ -301,6 +303,7 @@ std::shared_ptr<Join> Join::createRestoreJoin(size_t max_bytes_before_external_j
         createSpillConfigWithNewSpillId(build_spill_config, fmt::format("{}_hash_join_{}_build", log->identifier(), restore_round + 1)),
         createSpillConfigWithNewSpillId(probe_spill_config, fmt::format("{}_hash_join_{}_probe", log->identifier(), restore_round + 1)),
         join_restore_concurrency,
+        tidb_output_column_names,
         collators,
         non_equal_conditions,
         max_block_size,
@@ -1770,7 +1773,14 @@ Block Join::joinBlock(ProbeProcessInfo & probe_process_info, bool dry_run) const
         block.getByName(match_helper_name).column = ColumnNullable::create(std::move(col_non_matched), std::move(nullable_column->getNullMapColumnPtr()));
     }
 
-    return block;
+    /// remove useless columns
+    Block projected_block;
+    for (const auto & name : tidb_output_column_names)
+    {
+        auto & column = block.getByName(name);
+        projected_block.insert(std::move(column));
+    }
+    return projected_block;
 }
 
 BlockInputStreamPtr Join::createScanHashMapAfterProbeStream(const Block & left_sample_block, size_t index, size_t step, size_t max_block_size) const

--- a/dbms/src/Interpreters/Join.h
+++ b/dbms/src/Interpreters/Join.h
@@ -143,6 +143,7 @@ public:
          const SpillConfig & build_spill_config_,
          const SpillConfig & probe_spill_config_,
          Int64 join_restore_concurrency_,
+         const Names & tidb_output_column_names_,
          const TiDB::TiDBCollators & collators_ = TiDB::dummy_collators,
          const JoinNonEqualConditions & non_equal_conditions_ = {},
          size_t max_block_size = 0,
@@ -345,6 +346,8 @@ private:
     Block sample_block_with_columns_to_add;
     /// Block with key columns in the same order they appear in the right-side table.
     Block sample_block_with_keys;
+
+    Names tidb_output_column_names;
 
     bool is_test;
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6233

Problem Summary:

### What is changed and how it works?
Move join projection which is used to remove useless columns inside HashJoinProbe input stream.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
