### PR TITLE
add lock for `SegmentReadTaskScheduler::add`

### DIFF
--- a/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.cpp
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.cpp
@@ -33,6 +33,7 @@ SegmentReadTaskScheduler::~SegmentReadTaskScheduler()
 void SegmentReadTaskScheduler::add(const SegmentReadTaskPoolPtr & pool)
 {
     Stopwatch sw_add;
+    std::lock_guard lock(add_mtx);
     std::lock_guard lock(mtx);
     Stopwatch sw_do_add;
     read_pools.add(pool);

--- a/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.h
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.h
@@ -68,6 +68,8 @@ private:
     std::optional<std::pair<uint64_t, std::vector<uint64_t>>> scheduleSegmentUnlock(const SegmentReadTaskPoolPtr & pool);
     SegmentReadTaskPoolPtr scheduleSegmentReadTaskPoolUnlock();
 
+    // To restrict the instantaneous concurrency of `add` and avoid `schedule` from always failing to acquire the lock.
+    std::mutex add_mtx;
     std::mutex mtx;
     SegmentReadTaskPoolList read_pools;
     // table_id -> {seg_id -> pool_ids, seg_id -> pool_ids, ...}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6518

Problem Summary:

### What is changed and how it works?
Use `std::mutex add_mtx` to restrict the instantaneous concurrency of `add` and avoid `schedule` from always failing to acquire the lock.
similar to https://github.com/pingcap/tiflash/pull/7182

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
