### PR TITLE
Refine metrics of uploading DMFile.

### DIFF
--- a/dbms/src/Common/ProfileEvents.cpp
+++ b/dbms/src/Common/ProfileEvents.cpp
@@ -141,7 +141,10 @@
     M(S3PutObjectRetry)                        \
     M(FileCacheHit)                            \
     M(FileCacheMiss)                           \
-    M(FileCacheEvict)
+    M(FileCacheEvict)                          \
+    M(S3PutDMFile)                             \
+    M(S3PutDMFileRetry)                        \
+    M(S3WriteDMFileBytes)
 
 namespace ProfileEvents
 {

--- a/dbms/src/Common/TiFlashMetrics.h
+++ b/dbms/src/Common/TiFlashMetrics.h
@@ -344,6 +344,7 @@ namespace DB
         F(type_unknown, {"type", "unknown"}))                                                                                                       \
     M(tiflash_storage_s3_request_seconds, "S3 request duration in seconds", Histogram,                                                              \
         F(type_put_object, {{"type", "put_object"}}, ExpBuckets{0.001, 2, 20}),                                                                     \
+        F(type_put_dmfile, {{"type", "put_dmfile"}}, ExpBuckets{0.001, 2, 20}),                                                                     \
         F(type_copy_object, {{"type", "copy_object"}}, ExpBuckets{0.001, 2, 20}),                                                                   \
         F(type_get_object, {{"type", "get_object"}}, ExpBuckets{0.001, 2, 20}),                                                                     \
         F(type_create_multi_part_upload, {{"type", "create_multi_part_upload"}}, ExpBuckets{0.001, 2, 20}),                                         \

--- a/dbms/src/Storages/S3/S3Common.cpp
+++ b/dbms/src/Storages/S3/S3Common.cpp
@@ -27,6 +27,7 @@
 #include <Storages/S3/PocoHTTPClient.h>
 #include <Storages/S3/PocoHTTPClientFactory.h>
 #include <Storages/S3/S3Common.h>
+#include <Storages/S3/S3Filename.h>
 #include <aws/core/auth/AWSCredentials.h>
 #include <aws/core/auth/STSCredentialsProvider.h>
 #include <aws/core/auth/signer/AWSAuthV4Signer.h>
@@ -76,7 +77,6 @@
 #include <mutex>
 #include <string_view>
 #include <thread>
-
 namespace ProfileEvents
 {
 extern const Event S3HeadObject;
@@ -88,6 +88,9 @@ extern const Event S3ListObjects;
 extern const Event S3DeleteObject;
 extern const Event S3CopyObject;
 extern const Event S3PutObjectRetry;
+extern const Event S3PutDMFile;
+extern const Event S3PutDMFileRetry;
+extern const Event S3WriteDMFileBytes;
 } // namespace ProfileEvents
 
 namespace
@@ -580,6 +583,7 @@ void uploadEmptyFile(const TiFlashS3Client & client, const String & key, const S
 static bool doUploadFile(const TiFlashS3Client & client, const String & local_fname, const String & remote_fname, Int32 max_retry_times, Int32 current_retry)
 {
     Stopwatch sw;
+    auto is_dmfile = S3FilenameView::fromKey(remote_fname).isDMFile();
     Aws::S3::Model::PutObjectRequest req;
     client.setBucketAndKeyWithRoot(req, remote_fname);
     req.SetContentType("binary/octet-stream");
@@ -587,10 +591,10 @@ static bool doUploadFile(const TiFlashS3Client & client, const String & local_fn
     RUNTIME_CHECK_MSG(istr->is_open(), "Open {} fail: {}", local_fname, strerror(errno));
     auto write_bytes = std::filesystem::file_size(local_fname);
     req.SetBody(istr);
-    ProfileEvents::increment(ProfileEvents::S3PutObject);
+    ProfileEvents::increment(is_dmfile ? ProfileEvents::S3PutDMFile : ProfileEvents::S3PutObject);
     if (current_retry > 0)
     {
-        ProfileEvents::increment(ProfileEvents::S3PutObjectRetry);
+        ProfileEvents::increment(is_dmfile ? ProfileEvents::S3PutDMFileRetry : ProfileEvents::S3PutObjectRetry);
     }
     auto result = client.PutObject(req);
     if (!result.IsSuccess())
@@ -614,9 +618,16 @@ static bool doUploadFile(const TiFlashS3Client & client, const String & local_fn
             return false;
         }
     }
-    ProfileEvents::increment(ProfileEvents::S3WriteBytes, write_bytes);
+    ProfileEvents::increment(is_dmfile ? ProfileEvents::S3WriteDMFileBytes : ProfileEvents::S3WriteBytes, write_bytes);
     auto elapsed_seconds = sw.elapsedSeconds();
-    GET_METRIC(tiflash_storage_s3_request_seconds, type_put_object).Observe(elapsed_seconds);
+    if (is_dmfile)
+    {
+        GET_METRIC(tiflash_storage_s3_request_seconds, type_put_dmfile).Observe(elapsed_seconds);
+    }
+    else
+    {
+        GET_METRIC(tiflash_storage_s3_request_seconds, type_put_object).Observe(elapsed_seconds);
+    }
     LOG_DEBUG(client.log, "uploadFile local_fname={}, key={}, write_bytes={} cost={:.3f}s", local_fname, remote_fname, write_bytes, elapsed_seconds);
     return true;
 }

--- a/metrics/grafana/tiflash_summary.json
+++ b/metrics/grafana/tiflash_summary.json
@@ -12477,6 +12477,14 @@
               "interval": "",
               "legendFormat": "S3ReadBytes",
               "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(rate(tiflash_system_profile_event_S3WriteDMFileBytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (type)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "S3WriteDMFileBytes",
+              "refId": "C"
             }
           ],
           "thresholds": [],
@@ -12643,6 +12651,14 @@
               "interval": "",
               "legendFormat": "S3CompleteMultipartUpload",
               "refId": "I"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(rate(tiflash_system_profile_event_S3PutDMFile{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (type)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "S3PutDMFile",
+              "refId": "J"
             }
           ],
           "thresholds": [],
@@ -12753,6 +12769,14 @@
               "interval": "",
               "legendFormat": "S3PutObjectRetry",
               "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(rate(tiflash_system_profile_event_S3PutDMFileRetry{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (type)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "S3PutDMFileRetry",
+              "refId": "C"
             }
           ],
           "thresholds": [],

--- a/metrics/grafana/tiflash_summary.json
+++ b/metrics/grafana/tiflash_summary.json
@@ -12508,7 +12508,7 @@
           "yaxes": [
             {
               "decimals": null,
-              "format": "bytes",
+              "format": "binBps",
               "label": null,
               "logBase": 1,
               "max": null,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6827

Problem Summary:

- Currently, both uploading checkpoints and dmfiles are using `S3 PutObject`.
- But the difference between checkpoints and dmfiles is quite significant, separating metics is helpful when we need to locate  problems.

### What is changed and how it works?

- Add metrics: 
  - `S3WriteDMFileBytes`
  - `S3PutDMFile` ops
  - `S3PutDMFileRetry` ops
  - `put_dmfile` duration

![image](https://user-images.githubusercontent.com/6143402/236374550-c27bfb65-5475-4e02-a8ea-68d364cd7cb3.png)
![image](https://user-images.githubusercontent.com/6143402/236127078-55175896-c50e-4610-8076-d31ce3c17b42.png)
![image](https://user-images.githubusercontent.com/6143402/236127157-c07af8cb-6029-439c-bd79-ad1915baf595.png)
![image](https://user-images.githubusercontent.com/6143402/236127210-a1d05ad1-996d-454a-a18b-8d527b1d4798.png)

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
