### PR TITLE
WIP: Lazily GetObject from S3

### DIFF
--- a/dbms/src/Server/StorageConfigParser.cpp
+++ b/dbms/src/Server/StorageConfigParser.cpp
@@ -566,6 +566,7 @@ void StorageS3Config::parse(const String & content)
     RUNTIME_CHECK(request_timeout_ms > 0);
     readConfig(table, "root", root);
     root = getNormalizedS3Root(root); // ensure ends with '/'
+    readConfig(table, "lazy_init_s3_file", lazy_init_s3_file);
 
     auto read_s3_auth_info_from_env = [&]() {
         access_key_id = Poco::Environment::get(S3_ACCESS_KEY_ID, /*default*/ "");
@@ -592,7 +593,8 @@ String StorageS3Config::toString() const
         "endpoint={} bucket={} root={} "
         "max_connections={} max_redirections={} "
         "connection_timeout_ms={} request_timeout_ms={} "
-        "access_key_id_size={} secret_access_key_size={}"
+        "access_key_id_size={} secret_access_key_size={} "
+        "lazy_init_s3_file {}"
         "}}",
         endpoint,
         bucket,
@@ -602,7 +604,8 @@ String StorageS3Config::toString() const
         connection_timeout_ms,
         request_timeout_ms,
         access_key_id.size(),
-        secret_access_key.size());
+        secret_access_key.size(),
+        lazy_init_s3_file);
 }
 
 void StorageS3Config::enable(bool check_requirements, const LoggerPtr & log)

--- a/dbms/src/Server/StorageConfigParser.h
+++ b/dbms/src/Server/StorageConfigParser.h
@@ -109,6 +109,7 @@ struct StorageS3Config
     UInt64 request_timeout_ms = 30000;
     UInt64 max_redirections = 10;
     String root;
+    bool lazy_init_s3_file = true;
 
     inline static String S3_ACCESS_KEY_ID = "S3_ACCESS_KEY_ID";
     inline static String S3_SECRET_ACCESS_KEY = "S3_SECRET_ACCESS_KEY";

--- a/dbms/src/Storages/DeltaMerge/workload/MainEntry.cpp
+++ b/dbms/src/Storages/DeltaMerge/workload/MainEntry.cpp
@@ -484,7 +484,7 @@ void getRandomObject(const DB::DM::tests::WorkloadOptions & opts)
     auto local_fname = fmt::format("{}/{}/{}", opts.s3_temp_dir, tid, index++);
     auto client = getS3Client(opts);
     Stopwatch sw;
-    S3::downloadFileByS3RandomAccessFile(client, local_fname, remote_fname);
+    S3::downloadFileByS3RandomAccessFile(client, local_fname, remote_fname, S3::ClientFactory::instance().getConfig().lazy_init_s3_file);
     s3_stat.addGetStat(remote_fname, sw.elapsedSeconds());
     auto download_size = std::filesystem::file_size(local_fname);
     std::cout << fmt::format("GetObject {} bytes={} cost={:.3f}s", remote_fname, download_size, sw.elapsedSeconds()) << std::endl;

--- a/dbms/src/Storages/Page/V3/Universal/S3PageReader.cpp
+++ b/dbms/src/Storages/Page/V3/Universal/S3PageReader.cpp
@@ -30,17 +30,18 @@ Page S3PageReader::read(const UniversalPageIdAndEntry & page_id_and_entry)
     auto remote_name_view = S3::S3FilenameView::fromKey(remote_name);
     RandomAccessFilePtr remote_file;
     auto s3_client = S3::ClientFactory::instance().sharedTiFlashClient();
+    auto lazy_init_s3_file = S3::ClientFactory::instance().getConfig().lazy_init_s3_file;
 #ifdef DBMS_PUBLIC_GTEST
     if (remote_name_view.isLockFile())
     {
 #endif
-        remote_file = std::make_shared<S3::S3RandomAccessFile>(s3_client, remote_name_view.asDataFile().toFullKey());
+        remote_file = std::make_shared<S3::S3RandomAccessFile>(s3_client, remote_name_view.asDataFile().toFullKey(), lazy_init_s3_file);
 #ifdef DBMS_PUBLIC_GTEST
     }
     else
     {
         // Just used in unit test which want to just focus on read write logic
-        remote_file = std::make_shared<S3::S3RandomAccessFile>(s3_client, *location.data_file_id);
+        remote_file = std::make_shared<S3::S3RandomAccessFile>(s3_client, *location.data_file_id, lazy_init_s3_file);
     }
 #endif
     ReadBufferFromRandomAccessFile buf(remote_file);

--- a/dbms/src/Storages/S3/S3Common.cpp
+++ b/dbms/src/Storages/S3/S3Common.cpp
@@ -646,10 +646,10 @@ void downloadFile(const TiFlashS3Client & client, const String & local_fname, co
 }
 
 
-void downloadFileByS3RandomAccessFile(std::shared_ptr<TiFlashS3Client> client, const String & local_fname, const String & remote_fname)
+void downloadFileByS3RandomAccessFile(std::shared_ptr<TiFlashS3Client> client, const String & local_fname, const String & remote_fname, bool lazy_init_s3_file)
 {
     Stopwatch sw;
-    S3RandomAccessFile file(client, remote_fname);
+    S3RandomAccessFile file(client, remote_fname, lazy_init_s3_file);
     Aws::OFStream ostr(local_fname, std::ios_base::out | std::ios_base::binary);
     RUNTIME_CHECK_MSG(ostr.is_open(), "Open {} fail: {}", local_fname, strerror(errno));
 

--- a/dbms/src/Storages/S3/S3Common.h
+++ b/dbms/src/Storages/S3/S3Common.h
@@ -128,6 +128,11 @@ public:
 
     S3GCMethod gc_method = S3GCMethod::Lifecycle;
 
+    const StorageS3Config & getConfig() const
+    {
+        RUNTIME_CHECK(client_is_inited);
+        return config;
+    }
 private:
     ClientFactory() = default;
     DISALLOW_COPY_AND_MOVE(ClientFactory);
@@ -167,7 +172,7 @@ bool ensureLifecycleRuleExist(const TiFlashS3Client & client, Int32 expire_days)
 void uploadEmptyFile(const TiFlashS3Client & client, const String & key, const String & tagging = "", int max_retry_times = 3);
 
 void downloadFile(const TiFlashS3Client & client, const String & local_fname, const String & remote_fname);
-void downloadFileByS3RandomAccessFile(std::shared_ptr<TiFlashS3Client> client, const String & local_fname, const String & remote_fname);
+void downloadFileByS3RandomAccessFile(std::shared_ptr<TiFlashS3Client> client, const String & local_fname, const String & remote_fname, bool lazy_init_s3_file);
 
 void rewriteObjectWithTagging(const TiFlashS3Client & client, const String & key, const String & tagging);
 

--- a/dbms/src/Storages/S3/S3RandomAccessFile.h
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.h
@@ -48,6 +48,7 @@ public:
     S3RandomAccessFile(
         std::shared_ptr<TiFlashS3Client> client_ptr_,
         const String & remote_fname_,
+        bool lazy_init_,
         std::optional<std::pair<UInt64, UInt64>> offset_and_size_ = std::nullopt);
 
     // Can only seek forward.
@@ -98,6 +99,7 @@ private:
     off_t seekImpl(off_t offset, int whence);
     ssize_t readImpl(char * buf, size_t size);
     String readRangeOfObject();
+    void initializeIfNeccessary();
 
     // When reading, it is necessary to pass the extra information of file, such file size, the merged file information to S3RandomAccessFile::create.
     // It is troublesome to pass parameters layer by layer. So currently, use thread_local global variable to pass parameters.
@@ -119,6 +121,8 @@ private:
 
     Int32 cur_retry = 0;
     static constexpr Int32 max_retry = 3;
+
+    bool is_inited = false;
 };
 
 } // namespace DB::S3


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #7390

### What is changed and how it works?

- Lazily GetObject from S3 before first read so that reducing the probability that the interval between the first read and GetObject is more than one minute.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
