### PR TITLE
Tsan: fix data race on `Event::insertEvent`

### DIFF
--- a/dbms/src/Flash/Pipeline/Schedule/Events/Event.h
+++ b/dbms/src/Flash/Pipeline/Schedule/Events/Event.h
@@ -86,8 +86,6 @@ private:
 
     void assertStatus(EventStatus expect);
 
-    void assertStatus(EventStatus expect1, EventStatus expect2);
-
 protected:
     PipelineExecutorStatus & exec_status;
 

--- a/dbms/src/Flash/Pipeline/Schedule/TaskScheduler.h
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskScheduler.h
@@ -76,8 +76,5 @@ private:
     WaitReactor wait_reactor;
 
     LoggerPtr logger = Logger::get();
-
-    friend class TaskThreadPool<CPUImpl>;
-    friend class WaitReactor;
 };
 } // namespace DB


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #7409

Problem Summary:

### What is changed and how it works?

In the original implementation, `output->addInput` may be called by multiple threads, leading to data race issues.
Here we change 
```
    /// eventA───────►eventB ===> eventA─────────────►eventB
    ///                             │                    ▲
    ///                             └────►insert_event───┘
```
to
```
    /// eventA───────►eventB ===> eventA───►insert_event───►eventB
```
, so that it will not cause data race issues.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Tsan
- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
