### PR TITLE
add info log to log tunnel time for local tunnel

### DIFF
--- a/dbms/src/Flash/EstablishCall.cpp
+++ b/dbms/src/Flash/EstablishCall.cpp
@@ -215,7 +215,7 @@ void EstablishCallData::writeDone(String msg, const grpc::Status & status)
 
     if (async_tunnel_sender)
     {
-        LOG_INFO(async_tunnel_sender->getLogger(), "connection for {} cost {}ms, including {}ms to waiting task.", async_tunnel_sender->getTunnelId(), stopwatch->elapsedMilliseconds(), waiting_task_time_ms);
+        LOG_INFO(async_tunnel_sender->getLogger(), "connection for {} cost {} ms, including {} ms to wait task.", async_tunnel_sender->getTunnelId(), stopwatch->elapsedMilliseconds(), waiting_task_time_ms);
 
         RUNTIME_ASSERT(!async_tunnel_sender->isConsumerFinished(), async_tunnel_sender->getLogger(), "tunnel {} consumer finished in advance", async_tunnel_sender->getTunnelId());
 

--- a/dbms/src/Flash/FlashService.cpp
+++ b/dbms/src/Flash/FlashService.cpp
@@ -422,6 +422,7 @@ grpc::Status FlashService::EstablishMPPConnection(grpc::ServerContext * grpc_con
     auto task_manager = tmt_context.getMPPTaskManager();
     std::chrono::seconds timeout(10);
     auto [tunnel, err_msg] = task_manager->findTunnelWithTimeout(request, timeout);
+    auto waiting_task_time = watch.elapsedMilliseconds();
     if (tunnel == nullptr)
     {
         if (!sync_writer->Write(getPacketWithError(err_msg)))
@@ -436,7 +437,7 @@ grpc::Status FlashService::EstablishMPPConnection(grpc::ServerContext * grpc_con
         SyncPacketWriter writer(sync_writer);
         tunnel->connectSync(&writer);
         tunnel->waitForFinish();
-        LOG_INFO(tunnel->getLogger(), "connection for {} cost {} ms.", tunnel->id(), stopwatch.elapsedMilliseconds());
+        LOG_INFO(tunnel->getLogger(), "connection for {} cost {} ms, including {} ms to wait task.", tunnel->id(), stopwatch.elapsedMilliseconds(), waiting_task_time);
     }
     return grpc::Status::OK;
 }

--- a/dbms/src/Flash/FlashService.cpp
+++ b/dbms/src/Flash/FlashService.cpp
@@ -409,6 +409,7 @@ grpc::Status FlashService::EstablishMPPConnection(grpc::ServerContext * grpc_con
         GET_METRIC(tiflash_thread_count, type_max_threads_of_establish_mpp).Set(std::max(GET_METRIC(tiflash_thread_count, type_max_threads_of_establish_mpp).Value(), GET_METRIC(tiflash_thread_count, type_active_threads_of_establish_mpp).Value()));
         GET_METRIC(tiflash_thread_count, type_max_threads_of_raw).Set(std::max(GET_METRIC(tiflash_thread_count, type_max_threads_of_raw).Value(), GET_METRIC(tiflash_thread_count, type_total_threads_of_raw).Value()));
     }
+    Stopwatch watch;
     SCOPE_EXIT({
         GET_METRIC(tiflash_thread_count, type_total_threads_of_raw).Decrement();
         GET_METRIC(tiflash_thread_count, type_active_threads_of_establish_mpp).Decrement();
@@ -417,7 +418,6 @@ grpc::Status FlashService::EstablishMPPConnection(grpc::ServerContext * grpc_con
         // TODO: update the value of metric tiflash_coprocessor_response_bytes.
     });
 
-    Stopwatch watch;
     auto & tmt_context = context->getTMTContext();
     auto task_manager = tmt_context.getMPPTaskManager();
     std::chrono::seconds timeout(10);

--- a/dbms/src/Flash/Mpp/GRPCReceiverContext.cpp
+++ b/dbms/src/Flash/Mpp/GRPCReceiverContext.cpp
@@ -299,6 +299,7 @@ void GRPCReceiverContext::establishMPPConnectionLocalV2(
 
     auto [tunnel, err_msg] = task_manager->findTunnelWithTimeout(request.req.get(), std::chrono::seconds(10));
     checkLocalTunnel(tunnel, err_msg);
+    local_request_handler.recordWaitingTaskTime();
     tunnel->connectLocalV2(source_index, local_request_handler, is_fine_grained, has_remote_conn);
 }
 

--- a/dbms/src/Flash/Mpp/LocalRequestHandler.h
+++ b/dbms/src/Flash/Mpp/LocalRequestHandler.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <Common/Stopwatch.h>
 #include <Flash/Mpp/ReceiverChannelWriter.h>
 
 namespace DB
@@ -59,10 +60,27 @@ struct LocalRequestHandler
         add_local_conn_num();
     }
 
+    void recordWaitingTaskTime()
+    {
+        waiting_task_time = watch.elapsedMilliseconds();
+    }
+
+    UInt64 getTotalElapsedTime() const
+    {
+        return watch.elapsedMilliseconds();
+    }
+
+    UInt64 getWaitingTaskTime() const
+    {
+        return waiting_task_time;
+    }
+
     MemoryTracker * recv_mem_tracker;
     std::function<void(bool, const String &)> notify_write_done;
     std::function<void()> notify_close;
     std::function<void()> add_local_conn_num;
     ReceiverChannelWriter channel_writer;
+    UInt64 waiting_task_time = 0;
+    Stopwatch watch;
 };
 } // namespace DB

--- a/dbms/src/Flash/Mpp/MPPTask.cpp
+++ b/dbms/src/Flash/Mpp/MPPTask.cpp
@@ -397,7 +397,7 @@ void MPPTask::runImpl()
         scheduleOrWait();
 
         auto time_cost_in_schedule_ms = stopwatch.elapsedMilliseconds() - time_cost_in_preprocess_ms;
-        LOG_INFO(log, "task starts running, time cost in schedule: {} ms, time cost in preprocess", time_cost_in_schedule_ms, time_cost_in_preprocess_ms);
+        LOG_INFO(log, "task starts running, time cost in schedule: {} ms, time cost in preprocess: {} ms", time_cost_in_schedule_ms, time_cost_in_preprocess_ms);
         if (status.load() != RUNNING)
         {
             /// when task is in running state, canceling the task will call sendCancelToQuery to do the cancellation, however

--- a/dbms/src/Flash/Mpp/MPPTunnel.h
+++ b/dbms/src/Flash/Mpp/MPPTunnel.h
@@ -384,6 +384,7 @@ private:
         {
             consumer_state.setMsg(local_err_msg);
             local_request_handler.writeDone(meet_error, local_err_msg);
+            LOG_INFO(log, "connection for {} cost {} ms, including {} ms to wait task.", tunnel_id, local_request_handler.getTotalElapsedTime(), local_request_handler.getWaitingTaskTime());
         }
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6233

Problem Summary:

### What is changed and how it works?
For both sync tunnel and async tunnel, when a tunnel is finished, there is a info log to record the tunnel cost time, but for local tunnel, there is no such logs, this pr add this log for local tunnel.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
