### PR TITLE
Donot reserve memory for non-fixed type columns in decodeAndSquash

### DIFF
--- a/dbms/src/Flash/Coprocessor/CHBlockChunkCodecV1.cpp
+++ b/dbms/src/Flash/Coprocessor/CHBlockChunkCodecV1.cpp
@@ -104,7 +104,8 @@ static inline void decodeColumnsByBlock(ReadBuffer & istr, Block & res, size_t r
         auto && column = mutable_columns[i];
         /// For non-fixed size type, reserve function might cause too much memory usage, i.e. string type column reserves 64 bytes
         /// size for each element.
-        if (removeNullable(name_and_type_list[i].type)->isValueUnambiguouslyRepresentedInFixedSizeContiguousMemoryRegion())
+        const auto & type_removed_nullable = removeNullable(name_and_type_list[i].type);
+        if (type_removed_nullable->isValueRepresentedByNumber() || type_removed_nullable->isFixedString())
         {
             if (reserve_size > 0)
                 column->reserve(std::max(rows_to_read, reserve_size));


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #7416 

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix the issue that the query might use much larger memories than actual needed when Join build side data is very large and contains many small-size string type columns. 
```
