### PR TITLE
use `Block::estimateByteSizeForSpill` to estimate block memory in spill

### DIFF
--- a/dbms/src/Columns/ColumnAggregateFunction.cpp
+++ b/dbms/src/Columns/ColumnAggregateFunction.cpp
@@ -210,9 +210,9 @@ size_t ColumnAggregateFunction::estimateByteSizeForSpill() const
     }
     else
     {
-        /// For non-trivial agg like uniqXXX/group_concat, can't estimate the memory usage, so just return byteSize(),
+        /// For non-trivial agg like uniqXXX/group_concat, can't estimate the memory usage, so just return allocateBytes(),
         /// it will highly overestimates size of a column if it was produced in AggregatingBlockInputStream (it contains size of other columns)
-        return byteSize();
+        return allocatedBytes();
     }
 }
 

--- a/dbms/src/Columns/IColumn.h
+++ b/dbms/src/Columns/IColumn.h
@@ -327,8 +327,8 @@ public:
     /// Size of column data in memory (may be approximate) - for profiling. Zero, if could not be determined.
     virtual size_t byteSize() const = 0;
 
-    /// Size of the column if it is spilled, the same as byteSize() except for ColumnAggregateFunction
-    virtual size_t estimateByteSizeForSpill() const { return byteSize(); }
+    /// Size of the column if it is spilled, the same as allocatedBytes() except for ColumnAggregateFunction
+    virtual size_t estimateByteSizeForSpill() const { return allocatedBytes(); }
 
     /// Size of column data between [offset, offset+limit) in memory (may be approximate) - for profiling.
     /// This method throws NOT_IMPLEMENTED exception if it is called with unimplemented subclass.

--- a/dbms/src/Core/tests/gtest_block.cpp
+++ b/dbms/src/Core/tests/gtest_block.cpp
@@ -51,7 +51,7 @@ try
         }
     }
     Block block(columns);
-    ASSERT_TRUE(block.bytes() == block.estimateBytesForSpill());
+    ASSERT_TRUE(block.allocatedBytes() == block.estimateBytesForSpill());
 }
 CATCH
 
@@ -81,7 +81,7 @@ try
         ColumnsWithTypeAndName columns;
         columns.emplace_back(std::move(agg_column), agg_data_type);
         Block block(columns);
-        ASSERT_NE(block.estimateBytesForSpill(), block.bytes());
+        ASSERT_NE(block.estimateBytesForSpill(), block.allocatedBytes());
         ASSERT_EQ(block.estimateBytesForSpill(), data_size[i] * 10);
     }
     /// case 2, agg function allocate memory in arena
@@ -102,7 +102,7 @@ try
         ColumnsWithTypeAndName columns;
         columns.emplace_back(std::move(agg_column), agg_data_type);
         Block block(columns);
-        ASSERT_EQ(block.estimateBytesForSpill(), block.bytes());
+        ASSERT_EQ(block.estimateBytesForSpill(), block.allocatedBytes());
     }
 }
 CATCH

--- a/dbms/src/DataStreams/MergeSortingBlockInputStream.cpp
+++ b/dbms/src/DataStreams/MergeSortingBlockInputStream.cpp
@@ -71,7 +71,7 @@ Block MergeSortingBlockInputStream::readImpl()
             SortHelper::removeConstantsFromBlock(block);
 
             blocks.push_back(block);
-            sum_bytes_in_blocks += block.bytes();
+            sum_bytes_in_blocks += block.estimateBytesForSpill();
 
             /** If too many of them and if external sorting is enabled,
               *  will merge blocks that we have in memory at this moment and write merged stream to temporary (compressed) file.

--- a/dbms/src/Interpreters/JoinPartition.cpp
+++ b/dbms/src/Interpreters/JoinPartition.cpp
@@ -235,7 +235,7 @@ void JoinPartition::initMap()
 void JoinPartition::insertBlockForBuild(Block && block)
 {
     size_t rows = block.rows();
-    size_t bytes = block.bytes();
+    size_t bytes = block.estimateBytesForSpill();
     build_partition.rows += rows;
     build_partition.bytes += bytes;
     build_partition.blocks.push_back(block);
@@ -246,7 +246,7 @@ void JoinPartition::insertBlockForBuild(Block && block)
 void JoinPartition::insertBlockForProbe(Block && block)
 {
     size_t rows = block.rows();
-    size_t bytes = block.bytes();
+    size_t bytes = block.estimateBytesForSpill();
     probe_partition.rows += rows;
     probe_partition.bytes += bytes;
     probe_partition.blocks.push_back(std::move(block));

--- a/dbms/src/Operators/LocalSortTransformOp.cpp
+++ b/dbms/src/Operators/LocalSortTransformOp.cpp
@@ -144,7 +144,7 @@ OperatorStatus LocalSortTransformOp::transformImpl(Block & block)
         // execute partial sort and store the sorted block in `sorted_blocks`.
         SortHelper::removeConstantsFromBlock(block);
         sortBlock(block, order_desc, limit);
-        sum_bytes_in_blocks += block.bytes();
+        sum_bytes_in_blocks += block.estimateBytesForSpill();
         sorted_blocks.emplace_back(std::move(block));
 
         if (max_bytes_before_external_sort && sum_bytes_in_blocks > max_bytes_before_external_sort)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #7417

Problem Summary:

### What is changed and how it works?
use `Block::estimateByteSizeForSpill` to estimate block memory usage in spill
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
