### PR TITLE
make mpp_fail test stable

### DIFF
--- a/tests/fullstack-test/mpp/having.test
+++ b/tests/fullstack-test/mpp/having.test
@@ -37,5 +37,5 @@ mysql> use test; set @@tidb_isolation_read_engines='tiflash'; set @@tidb_enforce
 +------+-------+
 
 # Clean up.
-# mysql> drop table if exists test.t1
-# mysql> drop table if exists test.t2
+mysql> drop table if exists test.t1
+mysql> drop table if exists test.t2

--- a/tests/fullstack-test/mpp/late_materialization_generate_column.test
+++ b/tests/fullstack-test/mpp/late_materialization_generate_column.test
@@ -71,3 +71,4 @@ mysql> set tidb_isolation_read_engines='tiflash'; select * from test.IDT_26539 w
 +--------+--------+------+------+------+------+------+
 
 mysql> set tidb_isolation_read_engines='tiflash'; select * from test.IDT_26539 where col1 is not NULL and col4 is not NULL;
+mysql> drop TABLE if exists test.`IDT_26539`;

--- a/tests/fullstack-test/mpp/left_semi_family_joins.test
+++ b/tests/fullstack-test/mpp/left_semi_family_joins.test
@@ -314,3 +314,6 @@ mysql> set @@tidb_isolation_read_engines='tiflash'; set tidb_enforce_mpp=1;selec
 | NULL |                    NULL |                        NULL |
 +------+-------------------------+-----------------------------+
 
+mysql> drop table if exists test.t;
+mysql> drop table if exists test.build;
+mysql> drop table if exists test.probe;

--- a/tests/fullstack-test/mpp/mpp_fail.test
+++ b/tests/fullstack-test/mpp/mpp_fail.test
@@ -148,5 +148,5 @@ mysql> use test; set @@tidb_isolation_read_engines='tiflash'; set @@tidb_allow_m
 => DBGInvoke __disable_fail_point(exception_mpp_hash_build)
 
 # Clean up.
-# mysql> drop table if exists test.t
-# mysql> drop table if exists test.t1
+mysql> drop table if exists test.t
+mysql> drop table if exists test.t1


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #7428

Problem Summary:

### What is changed and how it works?
The root cause is here is some random internal mpp query generated by auto analyze, and the fix is drop useless table to so not to trigger auto analyze job.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
