### PR TITLE
Fix read duration type column failed in disaggregated mode

### DIFF
--- a/dbms/src/Flash/Coprocessor/GenSchemaAndColumn.cpp
+++ b/dbms/src/Flash/Coprocessor/GenSchemaAndColumn.cpp
@@ -96,7 +96,6 @@ std::tuple<DM::ColumnDefinesPtr, size_t> genColumnDefinesForDisaggregatedRead(co
         // Even if the id is pk_column or extra_table_id, we still output it as
         // a exchange receiver output column
         const auto output_name = genNameForExchangeReceiver(i);
-        // TODO: Support generated column, which is a virtual column.
         switch (column_info.id)
         {
         case TiDBPkColumnID:

--- a/dbms/src/Flash/Coprocessor/GenSchemaAndColumn.cpp
+++ b/dbms/src/Flash/Coprocessor/GenSchemaAndColumn.cpp
@@ -85,14 +85,14 @@ NamesAndTypes genNamesAndTypes(const TiDBTableScan & table_scan, const StringRef
 
 std::tuple<DM::ColumnDefinesPtr, size_t> genColumnDefinesForDisaggregatedRead(const TiDBTableScan & table_scan)
 {
-    // Now the upper level seems treat disagg read as an ExchangeReceiver output, so
-    // use this as output column prefix.
     auto column_defines = std::make_shared<DM::ColumnDefines>();
     size_t extra_table_id_index = InvalidColumnID;
     column_defines->reserve(table_scan.getColumnSize());
     for (Int32 i = 0; i < table_scan.getColumnSize(); ++i)
     {
         const auto & column_info = table_scan.getColumns()[i];
+        // Now the upper level seems treat disagg read as an ExchangeReceiver output, so
+        // use this as output column prefix.
         // Even if the id is pk_column or extra_table_id, we still output it as
         // a exchange receiver output column
         const auto output_name = genNameForExchangeReceiver(i);

--- a/dbms/src/Flash/Coprocessor/GenSchemaAndColumn.cpp
+++ b/dbms/src/Flash/Coprocessor/GenSchemaAndColumn.cpp
@@ -54,7 +54,7 @@ NamesAndTypes genNamesAndTypesForExchangeReceiver(const TiDBTableScan & table_sc
 
 String genNameForExchangeReceiver(Int32 col_index)
 {
-    return "exchange_receiver_" + std::to_string(col_index);
+    return fmt::format("exchange_receiver_{}", col_index);
 }
 
 NamesAndTypes genNamesAndTypes(const ColumnInfos & column_infos, const StringRef & column_prefix)
@@ -87,7 +87,6 @@ std::tuple<DM::ColumnDefinesPtr, size_t> genColumnDefinesForDisaggregatedRead(co
 {
     // Now the upper level seems treat disagg read as an ExchangeReceiver output, so
     // use this as output column prefix.
-    constexpr std::string_view column_prefix = "exchange_receiver";
     auto column_defines = std::make_shared<DM::ColumnDefines>();
     size_t extra_table_id_index = InvalidColumnID;
     column_defines->reserve(table_scan.getColumnSize());
@@ -96,7 +95,8 @@ std::tuple<DM::ColumnDefinesPtr, size_t> genColumnDefinesForDisaggregatedRead(co
         const auto & column_info = table_scan.getColumns()[i];
         // Even if the id is pk_column or extra_table_id, we still output it as
         // a exchange receiver output column
-        const auto output_name = fmt::format("{}_{}", column_prefix, i);
+        const auto output_name = genNameForExchangeReceiver(i);
+        // TODO: Support generated column, which is a virtual column.
         switch (column_info.id)
         {
         case TiDBPkColumnID:
@@ -119,7 +119,7 @@ std::tuple<DM::ColumnDefinesPtr, size_t> genColumnDefinesForDisaggregatedRead(co
             column_defines->emplace_back(DM::ColumnDefine{
                 column_info.id,
                 output_name,
-                getDataTypeByColumnInfoForComputingLayer(column_info),
+                getDataTypeByColumnInfoForDisaggregatedStorageLayer(column_info),
                 column_info.defaultValueToField()});
             break;
         }

--- a/dbms/src/Storages/StorageDisaggregated.cpp
+++ b/dbms/src/Storages/StorageDisaggregated.cpp
@@ -47,8 +47,7 @@ BlockInputStreams StorageDisaggregated::read(
     size_t,
     unsigned num_streams)
 {
-    /// S3 config is enabled on the TiFlash compute node, let's read
-    /// data from S3.
+    /// S3 config is enabled on the TiFlash compute node, let's read data from S3.
     bool remote_data_read = S3::ClientFactory::instance().isEnabled();
     if (remote_data_read)
         return readThroughS3(db_context, query_info, num_streams);

--- a/dbms/src/Storages/StorageDisaggregated.h
+++ b/dbms/src/Storages/StorageDisaggregated.h
@@ -84,10 +84,12 @@ public:
 
 private:
     // helper functions for building the task read from a shared remote storage system (e.g. S3)
-    BlockInputStreams readFromWriteNode(
+    BlockInputStreams readThroughS3(
         const Context & db_context,
         const SelectQueryInfo & query_info,
         unsigned num_streams);
+    /// helper functions for building the task fetch all data from write node through MPP exchange sender/receiver
+    BlockInputStreams readThroughExchange(unsigned num_streams);
     DM::RNRemoteReadTaskPtr buildDisaggTasks(
         const Context & db_context,
         const DM::ScanContextPtr & scan_context,
@@ -119,7 +121,8 @@ private:
         const std::vector<RemoteTableRange> & remote_table_ranges,
         const pingcap::kv::LabelFilter & label_filter);
     void buildReceiverStreams(const std::vector<RequestAndRegionIDs> & dispatch_reqs, unsigned num_streams, DAGPipeline & pipeline);
-    void filterConditions(NamesAndTypes && source_columns, DAGPipeline & pipeline);
+    void filterConditions(DAGExpressionAnalyzer & analyzer, DAGPipeline & pipeline);
+    void extraCast(DAGExpressionAnalyzer & analyzer, DAGPipeline & pipeline);
     tipb::Executor buildTableScanTiPB();
 
     Context & context;

--- a/dbms/src/Storages/StorageDisaggregatedRemote.cpp
+++ b/dbms/src/Storages/StorageDisaggregatedRemote.cpp
@@ -17,6 +17,7 @@
 #include <Common/ThreadManager.h>
 #include <Common/TiFlashMetrics.h>
 #include <Core/NamesAndTypes.h>
+#include <DataStreams/ExpressionBlockInputStream.h>
 #include <DataStreams/IBlockInputStream.h>
 #include <DataStreams/TiRemoteBlockInputStream.h>
 #include <DataStreams/UnionBlockInputStream.h>
@@ -91,7 +92,7 @@ namespace ErrorCodes
 extern const int DISAGG_ESTABLISH_RETRYABLE_ERROR;
 } // namespace ErrorCodes
 
-BlockInputStreams StorageDisaggregated::readFromWriteNode(
+BlockInputStreams StorageDisaggregated::readThroughS3(
     const Context & db_context,
     const SelectQueryInfo & query_info,
     unsigned num_streams)
@@ -147,8 +148,64 @@ BlockInputStreams StorageDisaggregated::readFromWriteNode(
     // Build InputStream according to the remote segment read tasks
     DAGPipeline pipeline;
     buildRemoteSegmentInputStreams(db_context, remote_read_tasks, query_info, num_streams, pipeline);
-    NamesAndTypes source_columns = genNamesAndTypesForExchangeReceiver(table_scan);
-    filterConditions(std::move(source_columns), pipeline);
+
+    NamesAndTypes source_columns;
+    source_columns.reserve(table_scan.getColumnSize());
+    const auto & remote_segment_stream_header = pipeline.firstStream()->getHeader();
+    for (const auto & col : remote_segment_stream_header)
+    {
+        source_columns.emplace_back(col.name, col.type);
+    }
+
+    analyzer = std::make_unique<DAGExpressionAnalyzer>(std::move(source_columns), context);
+
+    // Handle duration type column
+    std::vector<ExtraCastAfterTSMode> need_cast_column;
+    need_cast_column.reserve(table_scan.getColumnSize());
+    std::unordered_set<ColumnID> col_id_set;
+    for (const auto & expr : table_scan.getPushedDownFilters())
+    {
+        getColumnIDsFromExpr(expr, table_scan.getColumns(), col_id_set);
+    }
+    bool has_need_cast_column = false;
+    for (const auto & col : table_scan.getColumns())
+    {
+        if (col_id_set.contains(col.id))
+        {
+            need_cast_column.push_back(ExtraCastAfterTSMode::None);
+        }
+        else
+        {
+            if (col.id != -1 && col.tp == TiDB::TypeTimestamp)
+            {
+                need_cast_column.push_back(ExtraCastAfterTSMode::AppendTimeZoneCast);
+                has_need_cast_column = true;
+            }
+            else if (col.id != -1 && col.tp == TiDB::TypeTime)
+            {
+                need_cast_column.push_back(ExtraCastAfterTSMode::AppendDurationCast);
+                has_need_cast_column = true;
+            }
+            else
+            {
+                need_cast_column.push_back(ExtraCastAfterTSMode::None);
+            }
+        }
+    }
+    ExpressionActionsChain chain;
+    if (has_need_cast_column && analyzer->appendExtraCastsAfterTS(chain, need_cast_column, table_scan))
+    {
+        ExpressionActionsPtr extra_cast = chain.getLastActions();
+        chain.finalize();
+        chain.clear();
+        for (auto & stream : pipeline.streams)
+        {
+            stream = std::make_shared<ExpressionBlockInputStream>(stream, extra_cast, log->identifier());
+            stream->setExtraInfo("cast after local tableScan");
+        }
+    }
+
+    filterConditions(*analyzer, pipeline);
     return pipeline.streams;
 }
 

--- a/dbms/src/Storages/StorageDisaggregatedRemote.cpp
+++ b/dbms/src/Storages/StorageDisaggregatedRemote.cpp
@@ -160,6 +160,7 @@ BlockInputStreams StorageDisaggregated::readThroughS3(
     analyzer = std::make_unique<DAGExpressionAnalyzer>(std::move(source_columns), context);
 
     // Handle duration type column
+    // If the column is not in the columns of pushed down filter, append a cast to the column.
     std::vector<ExtraCastAfterTSMode> need_cast_column;
     need_cast_column.reserve(table_scan.getColumnSize());
     std::unordered_set<ColumnID> col_id_set;

--- a/dbms/src/Storages/Transaction/TypeMapping.cpp
+++ b/dbms/src/Storages/Transaction/TypeMapping.cpp
@@ -195,6 +195,16 @@ DataTypePtr getDataTypeByColumnInfoForComputingLayer(const ColumnInfo & column_i
     return base;
 }
 
+DataTypePtr getDataTypeByColumnInfoForDisaggregatedStorageLayer(const ColumnInfo & column_info)
+{
+    DataTypePtr base = TypeMapping::instance().getDataType(column_info);
+    if (!column_info.hasNotNullFlag())
+    {
+        return std::make_shared<DataTypeNullable>(base);
+    }
+    return base;
+}
+
 DataTypePtr getDataTypeByFieldType(const tipb::FieldType & field_type)
 {
     ColumnInfo ci = TiDB::fieldTypeToColumnInfo(field_type);

--- a/dbms/src/Storages/Transaction/TypeMapping.h
+++ b/dbms/src/Storages/Transaction/TypeMapping.h
@@ -37,6 +37,8 @@ DataTypePtr getDataTypeByColumnInfoForComputingLayer(const ColumnInfo & column_i
 DataTypePtr getDataTypeByFieldType(const tipb::FieldType & field_type);
 DataTypePtr getDataTypeByFieldTypeForComputingLayer(const tipb::FieldType & field_type);
 
+DataTypePtr getDataTypeByColumnInfoForDisaggregatedStorageLayer(const ColumnInfo & column_info);
+
 TiDB::CodecFlag getCodecFlagByFieldType(const tipb::FieldType & field_type);
 
 // Try best to reverse get TiDB's column info from TiFlash info.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #7414

Problem Summary:

### What is changed and how it works?

View duration type as int64 to read, and add an extra cast after read.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)

```
./bin/tiup-playground nightly --mode=tidb-disagg --disagg.s3_endpoint=xxxx:xxx --tiflash.binpath ../tiflash/tiflash/tiflash
```
	
```
create table if not exists test.t(a time(4));
insert into test.t values('700:10:10.123456');
insert into test.t values('-700:10:10.123456');
alter table test.t set tiflash replica 1;
set tidb_isolation_read_engines='tiflash'; select a from t;
set tidb_isolation_read_engines='tiflash'; select hour(a) from t;

create table t1(t varchar(100));
insert into test.t1 values('700:10:10.123456');
set tidb_isolation_read_engines='tiflash'; select t from t1;
set tidb_isolation_read_engines='tiflash'; select hour(t) from t1;
```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
