### PR TITLE
Add `reserveWithTotalMemoryHint` to IColumn

### DIFF
--- a/dbms/src/Columns/ColumnNullable.cpp
+++ b/dbms/src/Columns/ColumnNullable.cpp
@@ -432,6 +432,13 @@ void ColumnNullable::reserve(size_t n)
     getNullMapData().reserve(n);
 }
 
+void ColumnNullable::reserveWithTotalMemoryHint(size_t n, Int64 total_memory_hint)
+{
+    getNullMapColumn().reserve(n);
+    total_memory_hint -= n * sizeof(UInt8);
+    getNestedColumn().reserveWithTotalMemoryHint(n, total_memory_hint);
+}
+
 size_t ColumnNullable::byteSize() const
 {
     return getNestedColumn().byteSize() + getNullMapColumn().byteSize();

--- a/dbms/src/Columns/ColumnNullable.h
+++ b/dbms/src/Columns/ColumnNullable.h
@@ -98,6 +98,7 @@ public:
     void getPermutation(const ICollator & collator, bool reverse, size_t limit, int null_direction_hint, Permutation & res) const override;
     void adjustPermutationWithNullDirection(bool reverse, size_t limit, int null_direction_hint, Permutation & res) const;
     void reserve(size_t n) override;
+    void reserveWithTotalMemoryHint(size_t n, Int64 total_memory_hint) override;
     size_t byteSize() const override;
     size_t byteSize(size_t offset, size_t limit) const override;
     size_t allocatedBytes() const override;

--- a/dbms/src/Columns/ColumnString.cpp
+++ b/dbms/src/Columns/ColumnString.cpp
@@ -285,6 +285,16 @@ void ColumnString::reserve(size_t n)
     chars.reserve(n * APPROX_STRING_SIZE);
 }
 
+void ColumnString::reserveWithTotalMemoryHint(size_t n, Int64 total_memory_hint)
+{
+    offsets.reserve(n);
+    total_memory_hint -= n * sizeof(offsets[0]);
+    if (total_memory_hint >= 0)
+        chars.reserve(total_memory_hint);
+    else
+        chars.reserve(n * APPROX_STRING_SIZE);
+}
+
 
 void ColumnString::getExtremes(Field & min, Field & max) const
 {

--- a/dbms/src/Columns/ColumnString.h
+++ b/dbms/src/Columns/ColumnString.h
@@ -340,6 +340,8 @@ public:
 
     void reserve(size_t n) override;
 
+    void reserveWithTotalMemoryHint(size_t n, Int64 total_memory_hint) override;
+
     void getExtremes(Field & min, Field & max) const override;
 
 

--- a/dbms/src/Columns/IColumn.h
+++ b/dbms/src/Columns/IColumn.h
@@ -324,8 +324,8 @@ public:
     /// It affects performance only (not correctness).
     virtual void reserve(size_t /*n*/){};
 
-    /// Reserve memory for specified amount of elements with a total memory hint, used for
-    /// columns with non-fixed size elements
+    /// Reserve memory for specified amount of elements with a total memory hint, the default impl is
+    /// calling `reserve(n)`, columns with non-fixed size elements can overwrite it for better reserve
     virtual void reserveWithTotalMemoryHint(size_t n, Int64 /*total_memory_hint*/) { reserve(n); };
 
     /// Size of column data in memory (may be approximate) - for profiling. Zero, if could not be determined.

--- a/dbms/src/Columns/IColumn.h
+++ b/dbms/src/Columns/IColumn.h
@@ -324,6 +324,10 @@ public:
     /// It affects performance only (not correctness).
     virtual void reserve(size_t /*n*/){};
 
+    /// Reserve memory for specified amount of elements with a total memory hint, used for
+    /// columns with non-fixed size elements
+    virtual void reserveWithTotalMemoryHint(size_t n, Int64 /*total_memory_hint*/) { reserve(n); };
+
     /// Size of column data in memory (may be approximate) - for profiling. Zero, if could not be determined.
     virtual size_t byteSize() const = 0;
 

--- a/dbms/src/Core/Block.cpp
+++ b/dbms/src/Core/Block.cpp
@@ -546,6 +546,7 @@ Block hstackBlocks(Blocks && blocks, const Block & header)
 }
 
 /// join blocks by rows
+template <bool check_reserve>
 Block vstackBlocks(Blocks && blocks)
 {
     if (blocks.empty())
@@ -582,6 +583,12 @@ Block vstackBlocks(Blocks && blocks)
             dst_columns[i]->reserveWithTotalMemoryHint(result_rows, total_memory);
         }
     }
+    size_t total_allocated_bytes [[maybe_unused]] = 0;
+    if constexpr (check_reserve)
+    {
+        for (const auto & column : dst_columns)
+            total_allocated_bytes += column->allocatedBytes();
+    }
 
     for (size_t i = 1; i < blocks.size(); ++i)
     {
@@ -593,6 +600,14 @@ Block vstackBlocks(Blocks && blocks)
                 dst_columns[idx]->insertRangeFrom(*blocks[i].getByPosition(idx).column, 0, blocks[i].rows());
             }
         }
+    }
+
+    if constexpr (check_reserve)
+    {
+        size_t updated_total_allocated_bytes = 0;
+        for (const auto & column : dst_columns)
+            updated_total_allocated_bytes += column->allocatedBytes();
+        RUNTIME_CHECK_MSG(total_allocated_bytes == updated_total_allocated_bytes, "vstackBlock's reserve does not reserve enough bytes");
     }
     return first_block.cloneWithColumns(std::move(dst_columns));
 }
@@ -707,5 +722,8 @@ void Block::updateHash(SipHash & hash) const
         for (const auto & col : data)
             col.column->updateHashWithValue(row_no, hash);
 }
+
+template Block vstackBlocks<false>(Blocks && blocks);
+template Block vstackBlocks<true>(Blocks && blocks);
 
 } // namespace DB

--- a/dbms/src/Core/Block.h
+++ b/dbms/src/Core/Block.h
@@ -187,6 +187,7 @@ Block hstackBlocks(Blocks && blocks, const Block & header);
 /// block1: (a UInt32, b UInt32, c UInt32), rows: 2
 /// block2: (a UInt32, b UInt32, c UInt32), rows: 3
 /// result: (a UInt32, b UInt32, c UInt32), rows: 5
+template <bool check_reserve = false>
 Block vstackBlocks(Blocks && blocks);
 
 Block popBlocksListFront(BlocksList & blocks);

--- a/dbms/src/Core/tests/gtest_block.cpp
+++ b/dbms/src/Core/tests/gtest_block.cpp
@@ -107,5 +107,48 @@ try
 }
 CATCH
 
+TEST_F(BlockTest, TestReserveInVstackBlocks)
+try
+{
+    size_t block_size = 50;
+    size_t rows_per_block = 100;
+    /// for both big and small string, the reserve in vstackBlock is expected to reserve enough memory before actually insert
+    /// for small string, the reserve in vstackBlock is expected to not reserve too much memory
+    String long_str(ColumnString::APPROX_STRING_SIZE * 5, 'a');
+    String short_str(std::max(1, ColumnString::APPROX_STRING_SIZE / 10), 'a');
+    std::vector<String> string_values{short_str, long_str};
+    std::vector<String> types{"String", "Nullable(String)"};
+    for (const auto & string_value : string_values)
+    {
+        for (const auto & type_string : types)
+        {
+            auto data_type = DataTypeFactory::instance().get(type_string);
+            Blocks blocks;
+            for (size_t i = 0; i < block_size; i++)
+            {
+                auto column = data_type->createColumn();
+                for (size_t j = 0; j < rows_per_block; j++)
+                {
+                    if (data_type->isNullable() && j % 2 == 0)
+                        column->insert(Field());
+                    else
+                        column->insert(string_value);
+                }
+                ColumnsWithTypeAndName columns;
+                columns.emplace_back(std::move(column), data_type);
+                blocks.emplace_back(std::move(columns));
+            }
+            auto result_block = vstackBlocks<true>(std::move(blocks));
+            ASSERT_EQ(result_block.columns(), 1);
+            if (string_value.size() < ColumnString::APPROX_STRING_SIZE)
+            {
+                size_t allocated_bytes = result_block.getByPosition(0).column->allocatedBytes();
+                ASSERT_TRUE(result_block.rows() * ColumnString::APPROX_STRING_SIZE > allocated_bytes);
+            }
+        }
+    }
+}
+CATCH
+
 } // namespace tests
 } // namespace DB


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #7495

Problem Summary:
As the issue described.
### What is changed and how it works?
- Add a new function `reserveWithTotalMemoryHint` to IColumn
- Use `reserveWithTotalMemoryHint` to reserve memory in `vstackBlocks` for non-fixed-size column
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
