### PR TITLE
*: refine appendExtraCastsAfterTS

### DIFF
--- a/dbms/src/Flash/Coprocessor/DAGExpressionAnalyzer.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGExpressionAnalyzer.cpp
@@ -40,6 +40,7 @@
 #include <Storages/Transaction/TypeMapping.h>
 #include <WindowFunctions/WindowFunctionFactory.h>
 
+
 namespace DB
 {
 namespace ErrorCodes
@@ -900,7 +901,7 @@ String DAGExpressionAnalyzer::appendTimeZoneCast(
 
 std::pair<bool, std::vector<String>> DAGExpressionAnalyzer::buildExtraCastsAfterTS(
     const ExpressionActionsPtr & actions,
-    const std::vector<bool> & may_need_add_cast_column,
+    const std::vector<UInt8> & may_need_add_cast_column,
     const ColumnInfos & table_scan_columns)
 {
     bool has_cast = false;
@@ -947,7 +948,7 @@ std::pair<bool, std::vector<String>> DAGExpressionAnalyzer::buildExtraCastsAfter
 
 bool DAGExpressionAnalyzer::appendExtraCastsAfterTS(
     ExpressionActionsChain & chain,
-    const std::vector<bool> & may_need_add_cast_column,
+    const std::vector<UInt8> & may_need_add_cast_column,
     const TiDBTableScan & table_scan)
 {
     auto & step = initAndGetLastStep(chain);

--- a/dbms/src/Flash/Coprocessor/DAGExpressionAnalyzer.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGExpressionAnalyzer.cpp
@@ -900,12 +900,12 @@ String DAGExpressionAnalyzer::appendTimeZoneCast(
 
 std::pair<bool, std::vector<String>> DAGExpressionAnalyzer::buildExtraCastsAfterTS(
     const ExpressionActionsPtr & actions,
-    const std::vector<ExtraCastAfterTSMode> & need_cast_column,
+    const std::vector<bool> & may_need_add_cast_column,
     const ColumnInfos & table_scan_columns)
 {
     bool has_cast = false;
     std::vector<String> casted_columns;
-    casted_columns.reserve(need_cast_column.size());
+    casted_columns.reserve(may_need_add_cast_column.size());
     // For TimeZone
     tipb::Expr tz_expr = constructTZExpr(context.getTimezoneInfo());
     String tz_col = getActions(tz_expr, actions);
@@ -916,16 +916,16 @@ std::pair<bool, std::vector<String>> DAGExpressionAnalyzer::buildExtraCastsAfter
     // For Duration
     String fsp_col;
     static const String dur_func_name = "FunctionConvertDurationFromNanos";
-    for (size_t i = 0; i < need_cast_column.size(); ++i)
+    for (size_t i = 0; i < may_need_add_cast_column.size(); ++i)
     {
         String casted_name = source_columns[i].name;
-        if (!context.getTimezoneInfo().is_utc_timezone && need_cast_column[i] == ExtraCastAfterTSMode::AppendTimeZoneCast)
+        if (!context.getTimezoneInfo().is_utc_timezone && may_need_add_cast_column[i] && table_scan_columns[i].tp == TiDB::TypeTimestamp)
         {
             casted_name = appendTimeZoneCast(tz_col, source_columns[i].name, timezone_func_name, actions);
             has_cast = true;
         }
 
-        if (need_cast_column[i] == ExtraCastAfterTSMode::AppendDurationCast)
+        if (may_need_add_cast_column[i] && table_scan_columns[i].tp == TiDB::TypeTime)
         {
             if (table_scan_columns[i].decimal > 6)
                 throw Exception("fsp must <= 6", ErrorCodes::LOGICAL_ERROR);
@@ -947,13 +947,13 @@ std::pair<bool, std::vector<String>> DAGExpressionAnalyzer::buildExtraCastsAfter
 
 bool DAGExpressionAnalyzer::appendExtraCastsAfterTS(
     ExpressionActionsChain & chain,
-    const std::vector<ExtraCastAfterTSMode> & need_cast_column,
+    const std::vector<bool> & may_need_add_cast_column,
     const TiDBTableScan & table_scan)
 {
     auto & step = initAndGetLastStep(chain);
     auto & actions = step.actions;
 
-    auto [has_cast, casted_columns] = buildExtraCastsAfterTS(actions, need_cast_column, table_scan.getColumns());
+    auto [has_cast, casted_columns] = buildExtraCastsAfterTS(actions, may_need_add_cast_column, table_scan.getColumns());
 
     if (!has_cast)
         return false;
@@ -964,7 +964,7 @@ bool DAGExpressionAnalyzer::appendExtraCastsAfterTS(
     // after the cast, the block will be (a int64, b float, c int64, casted_c MyDuration)
     // After this projection, the block will be (a int64, b float, c MyDuration)
     NamesWithAliases project_cols;
-    for (size_t i = 0; i < need_cast_column.size(); ++i)
+    for (size_t i = 0; i < may_need_add_cast_column.size(); ++i)
         project_cols.emplace_back(casted_columns[i], source_columns[i].name);
     actions->add(ExpressionAction::project(project_cols));
 

--- a/dbms/src/Flash/Coprocessor/DAGExpressionAnalyzer.h
+++ b/dbms/src/Flash/Coprocessor/DAGExpressionAnalyzer.h
@@ -34,13 +34,6 @@ class Set;
 using DAGSetPtr = std::shared_ptr<DAGSet>;
 using DAGPreparedSets = std::unordered_map<const tipb::Expr *, DAGSetPtr>;
 
-enum class ExtraCastAfterTSMode
-{
-    None,
-    AppendTimeZoneCast,
-    AppendDurationCast
-};
-
 struct JoinKeyType;
 using JoinKeyTypes = std::vector<JoinKeyType>;
 
@@ -146,9 +139,10 @@ public:
     // 2) add duration cast after table scan, this is ued for calculation of duration in TiFlash.
     // TiFlash stores duration type in the form of Int64 in storage layer, and need the extra cast which convert
     // Int64 to duration.
+    // may_need_add_cast_column is used to avoid adding extra cast to columns which don't need it, like virtual columns.
     bool appendExtraCastsAfterTS(
         ExpressionActionsChain & chain,
-        const std::vector<ExtraCastAfterTSMode> & need_cast_column,
+        const std::vector<bool> & may_need_add_cast_column,
         const TiDBTableScan & table_scan);
 
     /// return true if some actions is needed
@@ -206,7 +200,7 @@ public:
 
     std::pair<bool, std::vector<String>> buildExtraCastsAfterTS(
         const ExpressionActionsPtr & actions,
-        const std::vector<ExtraCastAfterTSMode> & need_cast_column,
+        const std::vector<bool> & may_need_add_cast_column,
         const ColumnInfos & table_scan_columns);
 
 #ifndef DBMS_PUBLIC_GTEST

--- a/dbms/src/Flash/Coprocessor/DAGExpressionAnalyzer.h
+++ b/dbms/src/Flash/Coprocessor/DAGExpressionAnalyzer.h
@@ -142,7 +142,7 @@ public:
     // may_need_add_cast_column is used to avoid adding extra cast to columns which don't need it, like virtual columns.
     bool appendExtraCastsAfterTS(
         ExpressionActionsChain & chain,
-        const std::vector<bool> & may_need_add_cast_column,
+        const std::vector<UInt8> & may_need_add_cast_column,
         const TiDBTableScan & table_scan);
 
     /// return true if some actions is needed
@@ -200,7 +200,7 @@ public:
 
     std::pair<bool, std::vector<String>> buildExtraCastsAfterTS(
         const ExpressionActionsPtr & actions,
-        const std::vector<bool> & may_need_add_cast_column,
+        const std::vector<UInt8> & may_need_add_cast_column,
         const ColumnInfos & table_scan_columns);
 
 #ifndef DBMS_PUBLIC_GTEST

--- a/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
@@ -180,7 +180,7 @@ bool hasRegionToRead(const DAGContext & dag_context, const TiDBTableScan & table
 // <has_cast, extra_cast, project_for_remote_read>
 std::pair<bool, ExpressionActionsPtr> addExtraCastsAfterTs(
     DAGExpressionAnalyzer & analyzer,
-    const std::vector<bool> & may_need_add_cast_column,
+    const std::vector<UInt8> & may_need_add_cast_column,
     const TiDBTableScan & table_scan)
 {
     // if no column need to add cast, return directly
@@ -1274,7 +1274,7 @@ std::unordered_map<TableID, DAGStorageInterpreter::StorageWithStructureLock> DAG
     return storages_with_lock;
 }
 
-std::tuple<Names, std::vector<bool>> DAGStorageInterpreter::getColumnsForTableScan()
+std::pair<Names, std::vector<UInt8>> DAGStorageInterpreter::getColumnsForTableScan()
 {
     // Get handle column name.
     String handle_column_name = MutableSupport::tidb_pk_column_name;
@@ -1312,7 +1312,7 @@ std::tuple<Names, std::vector<bool>> DAGStorageInterpreter::getColumnsForTableSc
     std::unordered_set<ColumnID> filter_col_id_set;
     for (const auto & expr : table_scan.getPushedDownFilters())
         getColumnIDsFromExpr(expr, table_scan.getColumns(), filter_col_id_set);
-    std::vector<bool> may_need_add_cast_column_tmp;
+    std::vector<UInt8> may_need_add_cast_column_tmp;
     may_need_add_cast_column_tmp.reserve(table_scan.getColumnSize());
     // If the column is not generated column, not in the filter columns and column id is not -1, then it may need cast.
     for (const auto & col : table_scan.getColumns())

--- a/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
@@ -180,18 +180,16 @@ bool hasRegionToRead(const DAGContext & dag_context, const TiDBTableScan & table
 // <has_cast, extra_cast, project_for_remote_read>
 std::pair<bool, ExpressionActionsPtr> addExtraCastsAfterTs(
     DAGExpressionAnalyzer & analyzer,
-    const std::vector<ExtraCastAfterTSMode> & need_cast_column,
+    const std::vector<bool> & may_need_add_cast_column,
     const TiDBTableScan & table_scan)
 {
-    bool has_need_cast_column = false;
-    for (auto b : need_cast_column)
-        has_need_cast_column |= (b != ExtraCastAfterTSMode::None);
-    if (!has_need_cast_column)
+    // if no column need to add cast, return directly
+    if (std::find(may_need_add_cast_column.begin(), may_need_add_cast_column.end(), true) == may_need_add_cast_column.end())
         return {false, nullptr};
 
     ExpressionActionsChain chain;
     // execute timezone cast or duration cast if needed for local table scan
-    if (analyzer.appendExtraCastsAfterTS(chain, need_cast_column, table_scan))
+    if (analyzer.appendExtraCastsAfterTS(chain, may_need_add_cast_column, table_scan))
     {
         ExpressionActionsPtr extra_cast = chain.getLastActions();
         assert(extra_cast);
@@ -495,7 +493,7 @@ void DAGStorageInterpreter::prepare()
     assert(storages_with_structure_lock.find(logical_table_id) != storages_with_structure_lock.end());
     storage_for_logical_table = storages_with_structure_lock[logical_table_id].storage;
 
-    std::tie(required_columns, is_need_add_cast_column) = getColumnsForTableScan();
+    std::tie(required_columns, may_need_add_cast_column) = getColumnsForTableScan();
 }
 
 void DAGStorageInterpreter::executeCastAfterTableScan(
@@ -504,7 +502,7 @@ void DAGStorageInterpreter::executeCastAfterTableScan(
     size_t remote_read_start_index)
 {
     // execute timezone cast or duration cast if needed for local table scan
-    auto [has_cast, extra_cast] = addExtraCastsAfterTs(*analyzer, is_need_add_cast_column, table_scan);
+    auto [has_cast, extra_cast] = addExtraCastsAfterTs(*analyzer, may_need_add_cast_column, table_scan);
     if (has_cast)
     {
         RUNTIME_CHECK(remote_read_start_index <= group_builder.group.size());
@@ -523,7 +521,7 @@ void DAGStorageInterpreter::executeCastAfterTableScan(
     DAGPipeline & pipeline)
 {
     // execute timezone cast or duration cast if needed for local table scan
-    auto [has_cast, extra_cast] = addExtraCastsAfterTs(*analyzer, is_need_add_cast_column, table_scan);
+    auto [has_cast, extra_cast] = addExtraCastsAfterTs(*analyzer, may_need_add_cast_column, table_scan);
     if (has_cast)
     {
         RUNTIME_CHECK(remote_read_streams_start_index <= pipeline.streams.size());
@@ -1276,16 +1274,16 @@ std::unordered_map<TableID, DAGStorageInterpreter::StorageWithStructureLock> DAG
     return storages_with_lock;
 }
 
-std::tuple<Names, std::vector<ExtraCastAfterTSMode>> DAGStorageInterpreter::getColumnsForTableScan()
+std::tuple<Names, std::vector<bool>> DAGStorageInterpreter::getColumnsForTableScan()
 {
-    Names required_columns_tmp;
-    required_columns_tmp.reserve(table_scan.getColumnSize());
-    std::vector<ExtraCastAfterTSMode> need_cast_column;
-    need_cast_column.reserve(table_scan.getColumnSize());
+    // Get handle column name.
     String handle_column_name = MutableSupport::tidb_pk_column_name;
     if (auto pk_handle_col = storage_for_logical_table->getTableInfo().getPKHandleColumn())
         handle_column_name = pk_handle_col->get().name;
 
+    // Get column names for table scan.
+    Names required_columns_tmp;
+    required_columns_tmp.reserve(table_scan.getColumnSize());
     for (Int32 i = 0; i < table_scan.getColumnSize(); ++i)
     {
         auto const & ci = table_scan.getColumns()[i];
@@ -1310,35 +1308,17 @@ std::tuple<Names, std::vector<ExtraCastAfterTSMode>> DAGStorageInterpreter::getC
         required_columns_tmp.emplace_back(std::move(name));
     }
 
-    std::unordered_set<ColumnID> col_id_set;
+    // Get the columns that may need to add extra cast.
+    std::unordered_set<ColumnID> filter_col_id_set;
     for (const auto & expr : table_scan.getPushedDownFilters())
-    {
-        getColumnIDsFromExpr(expr, table_scan.getColumns(), col_id_set);
-    }
+        getColumnIDsFromExpr(expr, table_scan.getColumns(), filter_col_id_set);
+    std::vector<bool> may_need_add_cast_column_tmp;
+    may_need_add_cast_column_tmp.reserve(table_scan.getColumnSize());
+    // If the column is not generated column, not in the filter columns and column id is not -1, then it may need cast.
     for (const auto & col : table_scan.getColumns())
-    {
-        if (col.hasGeneratedColumnFlag())
-        {
-            need_cast_column.push_back(ExtraCastAfterTSMode::None);
-            continue;
-        }
+        may_need_add_cast_column_tmp.push_back(!col.hasGeneratedColumnFlag() && !filter_col_id_set.contains(col.id) && col.id != -1);
 
-        if (col_id_set.contains(col.id))
-        {
-            need_cast_column.push_back(ExtraCastAfterTSMode::None);
-        }
-        else
-        {
-            if (col.id != -1 && col.tp == TiDB::TypeTimestamp)
-                need_cast_column.push_back(ExtraCastAfterTSMode::AppendTimeZoneCast);
-            else if (col.id != -1 && col.tp == TiDB::TypeTime)
-                need_cast_column.push_back(ExtraCastAfterTSMode::AppendDurationCast);
-            else
-                need_cast_column.push_back(ExtraCastAfterTSMode::None);
-        }
-    }
-
-    return {required_columns_tmp, need_cast_column};
+    return {required_columns_tmp, may_need_add_cast_column_tmp};
 }
 
 // Build remote requests from `region_retry_from_local_region` and `table_regions_info.remote_regions`

--- a/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.h
+++ b/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.h
@@ -99,7 +99,7 @@ private:
 
     std::unordered_map<TableID, StorageWithStructureLock> getAndLockStorages(Int64 query_schema_version);
 
-    std::tuple<Names, std::vector<ExtraCastAfterTSMode>> getColumnsForTableScan();
+    std::tuple<Names, std::vector<bool>> getColumnsForTableScan();
 
     std::vector<RemoteRequest> buildRemoteRequests(const DM::ScanContextPtr & scan_context);
 
@@ -135,7 +135,9 @@ private:
     void executeImpl(PipelineExecutorStatus & exec_status, PipelineExecGroupBuilder & group_builder);
 
 private:
-    std::vector<ExtraCastAfterTSMode> is_need_add_cast_column;
+    /// Normally, time and timestamp(when timezone is not UTC) type columns need to be casted after table scan.
+    /// But handle column and virtual column needn't to be casted, we use may_need_add_cast_column to record them.
+    std::vector<bool> may_need_add_cast_column;
     /// it shouldn't be hash map because duplicated region id may occur if merge regions to retry of dag.
     RegionRetryList region_retry_from_local_region;
 

--- a/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.h
+++ b/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.h
@@ -99,7 +99,7 @@ private:
 
     std::unordered_map<TableID, StorageWithStructureLock> getAndLockStorages(Int64 query_schema_version);
 
-    std::tuple<Names, std::vector<bool>> getColumnsForTableScan();
+    std::pair<Names, std::vector<UInt8>> getColumnsForTableScan();
 
     std::vector<RemoteRequest> buildRemoteRequests(const DM::ScanContextPtr & scan_context);
 
@@ -137,7 +137,7 @@ private:
 private:
     /// Normally, time and timestamp(when timezone is not UTC) type columns need to be casted after table scan.
     /// But handle column and virtual column needn't to be casted, we use may_need_add_cast_column to record them.
-    std::vector<bool> may_need_add_cast_column;
+    std::vector<UInt8> may_need_add_cast_column;
     /// it shouldn't be hash map because duplicated region id may occur if merge regions to retry of dag.
     RegionRetryList region_retry_from_local_region;
 

--- a/dbms/src/Storages/StorageDeltaMerge.cpp
+++ b/dbms/src/Storages/StorageDeltaMerge.cpp
@@ -797,7 +797,7 @@ DM::PushDownFilterPtr StorageDeltaMerge::buildPushDownFilter(const RSOperatorPtr
         }
 
         // need_cast_column should be the same size as table_scan_column_info and source_columns_of_analyzer
-        std::vector<bool> may_need_add_cast_column;
+        std::vector<UInt8> may_need_add_cast_column;
         may_need_add_cast_column.reserve(table_scan_column_info.size());
         for (const auto & col : table_scan_column_info)
             may_need_add_cast_column.push_back(!col.hasGeneratedColumnFlag() && filter_col_id_set.contains(col.id) && col.id != -1);

--- a/dbms/src/Storages/StorageDeltaMerge.cpp
+++ b/dbms/src/Storages/StorageDeltaMerge.cpp
@@ -797,37 +797,23 @@ DM::PushDownFilterPtr StorageDeltaMerge::buildPushDownFilter(const RSOperatorPtr
         }
 
         // need_cast_column should be the same size as table_scan_column_info and source_columns_of_analyzer
-        std::vector<ExtraCastAfterTSMode> need_cast_column;
-        need_cast_column.reserve(table_scan_column_info.size());
+        std::vector<bool> may_need_add_cast_column;
+        may_need_add_cast_column.reserve(table_scan_column_info.size());
         for (const auto & col : table_scan_column_info)
-        {
-            if (!filter_col_id_set.contains(col.id))
-                need_cast_column.push_back(ExtraCastAfterTSMode::None);
-            else
-            {
-                if (col.id != -1 && col.tp == TiDB::TypeTimestamp)
-                    need_cast_column.push_back(ExtraCastAfterTSMode::AppendTimeZoneCast);
-                else if (col.id != -1 && col.tp == TiDB::TypeTime)
-                    need_cast_column.push_back(ExtraCastAfterTSMode::AppendDurationCast);
-                else
-                    need_cast_column.push_back(ExtraCastAfterTSMode::None);
-            }
-        }
+            may_need_add_cast_column.push_back(!col.hasGeneratedColumnFlag() && filter_col_id_set.contains(col.id) && col.id != -1);
 
         std::unique_ptr<DAGExpressionAnalyzer> analyzer = std::make_unique<DAGExpressionAnalyzer>(source_columns_of_analyzer, context);
         ExpressionActionsChain chain;
         auto & step = analyzer->initAndGetLastStep(chain);
         auto & actions = step.actions;
         ExpressionActionsPtr extra_cast = nullptr;
-        if (auto [has_cast, casted_columns] = analyzer->buildExtraCastsAfterTS(actions, need_cast_column, table_scan_column_info); has_cast)
+        if (auto [has_cast, casted_columns] = analyzer->buildExtraCastsAfterTS(actions, may_need_add_cast_column, table_scan_column_info); has_cast)
         {
             NamesWithAliases project_cols;
             for (size_t i = 0; i < columns_to_read.size(); ++i)
             {
                 if (filter_col_id_set.contains(columns_to_read[i].id))
-                {
                     project_cols.emplace_back(casted_columns[i], columns_to_read[i].name);
-                }
             }
             actions->add(ExpressionAction::project(project_cols));
 

--- a/dbms/src/Storages/StorageDisaggregated.cpp
+++ b/dbms/src/Storages/StorageDisaggregated.cpp
@@ -24,7 +24,6 @@
 #include <Storages/Transaction/TMTContext.h>
 #include <kvproto/kvrpcpb.pb.h>
 
-#include <algorithm>
 
 namespace DB
 {
@@ -389,7 +388,7 @@ void StorageDisaggregated::filterConditions(
 void StorageDisaggregated::extraCast(DAGExpressionAnalyzer & analyzer, DAGPipeline & pipeline)
 {
     // If the column is not in the columns of pushed down filter, append a cast to the column.
-    std::vector<bool> may_need_add_cast_column;
+    std::vector<UInt8> may_need_add_cast_column;
     may_need_add_cast_column.reserve(table_scan.getColumnSize());
     std::unordered_set<ColumnID> filter_col_id_set;
     for (const auto & expr : table_scan.getPushedDownFilters())


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6233 

Problem Summary:

The logic of appendExtraCastsAfterTS is kind of mess now, which means it is hard to understand.

### What is changed and how it works?

1. remove `ExtraCastAfterTSMode`
2. use a `std::vector<bool>` to record the columns may need to add a cast.
3. judge which really need to add cast in `DAGExpressionAnalyzer::buildExtraCastsAfterTS` uniformly

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
