### PR TITLE
Spiller support constant column

### DIFF
--- a/dbms/src/Core/Spiller.h
+++ b/dbms/src/Core/Spiller.h
@@ -118,6 +118,7 @@ private:
     /// todo remove input_schema if spiller does not rely on BlockInputStream
     const Block input_schema;
     std::vector<size_t> const_column_indexes;
+    Block header_without_constants;
     const LoggerPtr logger;
     std::mutex spill_finished_mutex;
     bool spill_finished = false;

--- a/dbms/src/Core/Spiller.h
+++ b/dbms/src/Core/Spiller.h
@@ -117,6 +117,7 @@ private:
     const UInt64 partition_num;
     /// todo remove input_schema if spiller does not rely on BlockInputStream
     const Block input_schema;
+    std::vector<size_t> const_column_indexes;
     const LoggerPtr logger;
     std::mutex spill_finished_mutex;
     bool spill_finished = false;

--- a/dbms/src/Core/tests/gtest_spiller.cpp
+++ b/dbms/src/Core/tests/gtest_spiller.cpp
@@ -491,33 +491,90 @@ try
 }
 CATCH
 
+TEST_F(SpillerTest, SpillAllConstantBlock)
+try
+{
+    auto constant_header = spiller_test_header;
+    for (auto & type_and_name : constant_header)
+        type_and_name.column = type_and_name.type->createColumnConst(1, Field(static_cast<Int64>(1)));
+
+    Spiller spiller(*spill_config_ptr, false, 1, constant_header, logger);
+    GTEST_FAIL();
+}
+catch (Exception & e)
+{
+    GTEST_ASSERT_EQ(e.message(), "Try to spill blocks containing only constant columns, it is meaningless to spill blocks containing only constant columns");
+}
+
 TEST_F(SpillerTest, SpillAndRestoreConstantData)
 try
 {
-    Spiller spiller(*spill_config_ptr, false, 1, spiller_test_header, logger);
-    Blocks ret;
-    ColumnsWithTypeAndName data;
-    for (const auto & type_and_name : spiller_test_header)
+    NamesAndTypes names_and_types;
+    names_and_types.emplace_back("col0", DataTypeFactory::instance().get("Int64"));
+    names_and_types.emplace_back("col1", DataTypeFactory::instance().get("UInt64"));
+    names_and_types.emplace_back("col2", DataTypeFactory::instance().get("Int64"));
+    names_and_types.emplace_back("col3", DataTypeFactory::instance().get("UInt64"));
+    names_and_types.emplace_back("col4", DataTypeFactory::instance().get("Int64"));
+    names_and_types.emplace_back("col5", DataTypeFactory::instance().get("UInt64"));
+
+    std::vector<std::vector<bool>> const_columns_flags = {
+        {false, false, false, false, false, true},
+        {false, true, true, true, true, true},
+        {true, false, false, false, false, false},
+        {true, true, true, true, true, false},
+        {true, false, true, false, true, false},
+        {false, true, false, true, false, true},
+        {false, true, false, true, false, false},
+        {true, false, true, false, true, true},
+    };
+
+    for (const auto & const_columns_flag : const_columns_flags)
     {
-        auto column = type_and_name.type->createColumnConst(100, Field(static_cast<Int64>(1)));
-        data.push_back(ColumnWithTypeAndName(std::move(column), type_and_name.type, type_and_name.name));
-    }
-    ret.emplace_back(data);
-    auto reference = ret;
-    spiller.spillBlocks(std::move(ret), 0);
-    spiller.finishSpill();
-    auto block_streams = spiller.restoreBlocks(0, 2);
-    GTEST_ASSERT_EQ(block_streams.size(), 1);
-    Blocks restored_blocks;
-    for (auto & block_stream : block_streams)
-    {
-        for (Block block = block_stream->read(); block; block = block_stream->read())
-            restored_blocks.push_back(block);
-    }
-    GTEST_ASSERT_EQ(reference.size(), restored_blocks.size());
-    for (size_t i = 0; i < reference.size(); ++i)
-    {
-        blockEqual(materializeBlock(reference[i]), restored_blocks[i]);
+        ColumnsWithTypeAndName columns;
+        for (size_t i = 0; i < names_and_types.size(); i++)
+        {
+            if (const_columns_flag[i])
+            {
+                /// const column
+                columns.emplace_back(names_and_types[i].type->createColumnConst(1, Field(static_cast<Int64>(1))),
+                                     names_and_types[i].type,
+                                     names_and_types[i].name);
+            }
+            else
+            {
+                /// normal column
+                columns.emplace_back(names_and_types[i].type->createColumn(),
+                                     names_and_types[i].type,
+                                     names_and_types[i].name);
+            }
+        }
+        Block header(columns);
+        Spiller spiller(*spill_config_ptr, false, 1, header, logger);
+        auto all_blocks = generateBlocks(20);
+        for (auto & block : all_blocks)
+        {
+            for (size_t i = 0; i < const_columns_flag.size(); i++)
+            {
+                if (header.getByPosition(i).column->isColumnConst())
+                    block.getByPosition(i).column = header.getByPosition(i).column;
+            }
+        }
+        auto reference = all_blocks;
+        spiller.spillBlocks(std::move(all_blocks), 0);
+        spiller.finishSpill();
+        auto block_streams = spiller.restoreBlocks(0, 1);
+        GTEST_ASSERT_EQ(block_streams.size(), 1);
+        Blocks restored_blocks;
+        for (auto & block_stream : block_streams)
+        {
+            for (Block block = block_stream->read(); block; block = block_stream->read())
+                restored_blocks.push_back(block);
+        }
+        GTEST_ASSERT_EQ(reference.size(), restored_blocks.size());
+        for (size_t i = 0; i < reference.size(); ++i)
+        {
+            blockEqual(materializeBlock(reference[i]), restored_blocks[i]);
+        }
     }
 }
 CATCH

--- a/dbms/src/DataStreams/SpilledFilesInputStream.cpp
+++ b/dbms/src/DataStreams/SpilledFilesInputStream.cpp
@@ -22,16 +22,23 @@ namespace FailPoints
 extern const char random_restore_from_disk_failpoint[];
 } // namespace FailPoints
 
-SpilledFilesInputStream::SpilledFilesInputStream(std::vector<SpilledFileInfo> && spilled_file_infos_, const Block & header_, const std::vector<size_t> & const_column_indexes_, const FileProviderPtr & file_provider_, Int64 max_supported_spill_version_)
+SpilledFilesInputStream::SpilledFilesInputStream(
+    std::vector<SpilledFileInfo> && spilled_file_infos_,
+    const Block & header_,
+    const Block & header_without_constants_,
+    const std::vector<size_t> & const_column_indexes_,
+    const FileProviderPtr & file_provider_,
+    Int64 max_supported_spill_version_)
     : spilled_file_infos(std::move(spilled_file_infos_))
     , header(header_)
+    , header_without_constants(header_without_constants_)
     , const_column_indexes(const_column_indexes_)
     , file_provider(file_provider_)
     , max_supported_spill_version(max_supported_spill_version_)
 {
     RUNTIME_CHECK_MSG(!spilled_file_infos.empty(), "Spilled files must not be empty");
     current_reading_file_index = 0;
-    current_file_stream = std::make_unique<SpilledFileStream>(std::move(spilled_file_infos[0]), header, file_provider, max_supported_spill_version);
+    current_file_stream = std::make_unique<SpilledFileStream>(std::move(spilled_file_infos[0]), header_without_constants, file_provider, max_supported_spill_version);
 }
 
 Block SpilledFilesInputStream::readImpl()

--- a/dbms/src/DataStreams/SpilledFilesInputStream.cpp
+++ b/dbms/src/DataStreams/SpilledFilesInputStream.cpp
@@ -51,6 +51,7 @@ Block SpilledFilesInputStream::readImpl()
         for (const auto index : const_column_indexes)
         {
             const auto & col_type_name = header.getByPosition(index);
+            assert(col_type_name.column->isColumnConst());
             ret.insert(index, {col_type_name.column->cloneResized(rows), col_type_name.type, col_type_name.name});
         }
     }

--- a/dbms/src/DataStreams/SpilledFilesInputStream.h
+++ b/dbms/src/DataStreams/SpilledFilesInputStream.h
@@ -22,7 +22,6 @@
 
 namespace DB
 {
-
 struct SpilledFileInfo
 {
     String path;
@@ -35,12 +34,13 @@ struct SpilledFileInfo
 class SpilledFilesInputStream : public IProfilingBlockInputStream
 {
 public:
-    SpilledFilesInputStream(std::vector<SpilledFileInfo> && spilled_file_infos, const Block & header, const FileProviderPtr & file_provider, Int64 max_supported_spill_version);
+    SpilledFilesInputStream(std::vector<SpilledFileInfo> && spilled_file_infos, const Block & header, const std::vector<size_t> & const_column_indexes, const FileProviderPtr & file_provider, Int64 max_supported_spill_version);
     Block getHeader() const override;
     String getName() const override;
 
 protected:
     Block readImpl() override;
+    Block readInternal();
 
 private:
     struct SpilledFileStream
@@ -68,6 +68,7 @@ private:
     std::vector<SpilledFileInfo> spilled_file_infos;
     size_t current_reading_file_index;
     Block header;
+    std::vector<size_t> const_column_indexes;
     FileProviderPtr file_provider;
     Int64 max_supported_spill_version;
     std::unique_ptr<SpilledFileStream> current_file_stream;

--- a/dbms/src/DataStreams/SpilledFilesInputStream.h
+++ b/dbms/src/DataStreams/SpilledFilesInputStream.h
@@ -34,7 +34,13 @@ struct SpilledFileInfo
 class SpilledFilesInputStream : public IProfilingBlockInputStream
 {
 public:
-    SpilledFilesInputStream(std::vector<SpilledFileInfo> && spilled_file_infos, const Block & header, const std::vector<size_t> & const_column_indexes, const FileProviderPtr & file_provider, Int64 max_supported_spill_version);
+    SpilledFilesInputStream(
+        std::vector<SpilledFileInfo> && spilled_file_infos,
+        const Block & header,
+        const Block & header_without_constants,
+        const std::vector<size_t> & const_column_indexes,
+        const FileProviderPtr & file_provider,
+        Int64 max_supported_spill_version);
     Block getHeader() const override;
     String getName() const override;
 
@@ -68,6 +74,7 @@ private:
     std::vector<SpilledFileInfo> spilled_file_infos;
     size_t current_reading_file_index;
     Block header;
+    Block header_without_constants;
     std::vector<size_t> const_column_indexes;
     FileProviderPtr file_provider;
     Int64 max_supported_spill_version;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #7512

Problem Summary:
In current spiller, if a block contains constant column, the spiller will convert it to full column before spill, a better solution is not spill constant column at all.
### What is changed and how it works?
- remove constant column before spill
- add constant column back after restore
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
