### PR TITLE
Reduce unnecessary S3 read flow after restart

### DIFF
--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalBg.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalBg.cpp
@@ -28,6 +28,8 @@
 #include <magic_enum.hpp>
 #include <memory>
 
+#include "Storages/S3/S3Common.h"
+
 namespace CurrentMetrics
 {
 extern const Metric DT_SnapshotOfDeltaMerge;
@@ -275,11 +277,14 @@ void DeltaMergeStore::setUpBackgroundTask(const DMContextPtr & dm_context)
 
     blockable_background_pool_handle = blockable_background_pool.addTask([this] { return handleBackgroundTask(true); });
 
-    // Generate place delta index tasks
-    for (auto & [end, segment] : segments)
+    if (!S3::ClientFactory::instance().isEnabled())
     {
-        (void)end;
-        checkSegmentUpdate(dm_context, segment, ThreadType::Init);
+        // Generate place delta index tasks
+        for (auto & [end, segment] : segments)
+        {
+            (void)end;
+            checkSegmentUpdate(dm_context, segment, ThreadType::Init);
+        }
     }
 
     // Wake up to do place delta index tasks.

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalBg.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalBg.cpp
@@ -277,7 +277,7 @@ void DeltaMergeStore::setUpBackgroundTask(const DMContextPtr & dm_context)
 
     // Under disagg mode, a write node could serve large amount of data, place delta index tasks
     // after restart is useless and waste of S3 reading. Only do it when deployed non-disagg mode.
-    if (!global_context.getSharedContextDisagg()->notDisaggregatedMode())
+    if (global_context.getSharedContextDisagg()->notDisaggregatedMode())
     {
         // Generate place delta index tasks
         for (auto & [end, segment] : segments)

--- a/dbms/src/Storages/S3/S3RandomAccessFile.cpp
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.cpp
@@ -90,10 +90,9 @@ ssize_t S3RandomAccessFile::readImpl(char * buf, size_t size)
     {
         LOG_ERROR(
             log,
-            "Cannot read from istream, size={} gcount={} eof={} state={:02X} cur_offset={} content_length={} errmsg={} cost={}ns",
+            "Cannot read from istream, size={} gcount={} state=0x{:02X} cur_offset={} content_length={} errmsg={} cost={}ns",
             size,
             gcount,
-            istr.eof(),
             istr.rdstate(),
             cur_offset,
             content_length,

--- a/dbms/src/Storages/S3/S3RandomAccessFile.cpp
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.cpp
@@ -90,9 +90,11 @@ ssize_t S3RandomAccessFile::readImpl(char * buf, size_t size)
     {
         LOG_ERROR(
             log,
-            "Cannot read from istream, gcount={}, eof={}, cur_offset={}, content_length={}, errmsg={}, cost={}ns",
+            "Cannot read from istream, size={} gcount={} eof={} state={:02X} cur_offset={} content_length={} errmsg={} cost={}ns",
+            size,
             gcount,
             istr.eof(),
+            istr.rdstate(),
             cur_offset,
             content_length,
             strerror(errno),


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/7513

Problem Summary:
The segment delta index on wn is useless now. But it introduces high CPU and high S3 read-write flow after restart. And now wn could serve much more data than the coupled arch.
We should disable the segment place index under disagg arch.

### What is changed and how it works?

Only generate place index tasks after restart when deployed with coupled arch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
![image](https://github.com/pingcap/tiflash/assets/4865550/d5949654-d6e6-4be4-98ba-a9effd916ca8)
![image](https://github.com/pingcap/tiflash/assets/4865550/60f8944b-59b8-4473-a18e-10af76bbf67c)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
