### PR TITLE
Filter lock flag 'F'

### DIFF
--- a/dbms/src/Storages/Transaction/TiKVRecordFormat.cpp
+++ b/dbms/src/Storages/Transaction/TiKVRecordFormat.cpp
@@ -117,6 +117,11 @@ inline void decodeLockCfValue(DecodedLockCFValue & res)
                 UNUSED(txn_source_prefic);
                 break;
             }
+            case PESSIMISTIC_LOCK_WITH_CONFLICT_PREFIX:
+            {
+                // https://github.com/pingcap/tidb/issues/43540
+                break;
+            }
             default:
             {
                 std::string msg = std::string("invalid flag ") + flag + " in lock value " + value.toDebugString();

--- a/dbms/src/Storages/Transaction/TiKVRecordFormat.h
+++ b/dbms/src/Storages/Transaction/TiKVRecordFormat.h
@@ -68,6 +68,7 @@ static const char GC_FENCE_PREFIX = 'F';
 static const char LAST_CHANGE_PREFIX = 'l';
 static const char TXN_SOURCE_PREFIX_FOR_WRITE = 'S';
 static const char TXN_SOURCE_PREFIX_FOR_LOCK = 's';
+static const char PESSIMISTIC_LOCK_WITH_CONFLICT_PREFIX = 'F';
 
 static const size_t SHORT_VALUE_MAX_LEN = 64;
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #7563

Problem Summary:

Due to https://github.com/pingcap/tidb/issues/43540, tikv propose a fix that introduce a new flag F that shall be filtered by TiFlash.

The new flag is to persist a special state that guides tikv how to resolve locks.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
