### PR TITLE
DTWorkload: initialize global storage pool every time before creating DeltaMergeStore.

### DIFF
--- a/dbms/src/Storages/DeltaMerge/workload/DTWorkload.cpp
+++ b/dbms/src/Storages/DeltaMerge/workload/DTWorkload.cpp
@@ -51,6 +51,7 @@ DTWorkload::DTWorkload(const WorkloadOptions & opts_, std::shared_ptr<SharedHand
 
     key_gen = KeyGenerator::create(opts_);
     ts_gen = std::make_unique<TimestampGenerator>();
+    // max page id is only updated at restart, so we need recreate page v3 before recreate table
     context->initializeGlobalStoragePoolIfNeed(context->getPathPool());
     Stopwatch sw;
     store = std::make_unique<DeltaMergeStore>(

--- a/dbms/src/Storages/DeltaMerge/workload/DTWorkload.cpp
+++ b/dbms/src/Storages/DeltaMerge/workload/DTWorkload.cpp
@@ -51,7 +51,7 @@ DTWorkload::DTWorkload(const WorkloadOptions & opts_, std::shared_ptr<SharedHand
 
     key_gen = KeyGenerator::create(opts_);
     ts_gen = std::make_unique<TimestampGenerator>();
-
+    context->initializeGlobalStoragePoolIfNeed(context->getPathPool());
     Stopwatch sw;
     store = std::make_unique<DeltaMergeStore>(
         *context,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #7548

Problem Summary:

Previously, PSv3 maintained a maximum ID internally during runtime, but maintaining this maximum ID during uniPS runtime was costly, so it was changed to calculating the maximum ID during restart.

### What is changed and how it works?

Initialize global storage pool every time before creating DeltaMergeStore.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  - Run `./tiflash dtworkload --testing_type=daily_perf`
  - Output:
```
Date,Table Schema,Workload,Init Seconds,Write Speed(rows count),Read Speed(rows count)
20230530,constant,uniform,0.01,438180,5796247
20230530,constant,normal,0.01,455697,2331561
20230530,constant,incremental,0.01,215553,4877337
```

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
