### PR TITLE
Fix "lost cancel" for mpp query

### DIFF
--- a/dbms/src/Flash/Mpp/MPPTaskId.cpp
+++ b/dbms/src/Flash/Mpp/MPPTaskId.cpp
@@ -88,13 +88,12 @@ size_t MPPQueryIdHash::operator()(MPPQueryId const & mpp_query_id) const noexcep
 
 bool MPPGatherId::operator==(const MPPGatherId & rid) const
 {
-    return query_id.query_ts == rid.query_id.query_ts && query_id.local_query_id == rid.query_id.local_query_id && query_id.server_id == rid.query_id.server_id
-        && query_id.start_ts == rid.query_id.start_ts && gather_id == rid.gather_id;
+    return gather_id == rid.gather_id && query_id == rid.query_id;
 }
+
 size_t MPPGatherIdHash::operator()(MPPGatherId const & mpp_gather_id) const noexcept
 {
-    return std::hash<UInt64>()(mpp_gather_id.query_id.query_ts) ^ std::hash<UInt64>()(mpp_gather_id.query_id.local_query_id)
-        ^ std::hash<UInt64>()(mpp_gather_id.query_id.server_id) ^ std::hash<UInt64>()(mpp_gather_id.gather_id);
+    return MPPQueryIdHash()(mpp_gather_id.query_id) ^ std::hash<UInt64>()(mpp_gather_id.gather_id);
 }
 
 String MPPTaskId::toString() const

--- a/dbms/src/Flash/Mpp/MPPTaskId.cpp
+++ b/dbms/src/Flash/Mpp/MPPTaskId.cpp
@@ -86,6 +86,17 @@ size_t MPPQueryIdHash::operator()(MPPQueryId const & mpp_query_id) const noexcep
     return std::hash<UInt64>()(mpp_query_id.query_ts) ^ std::hash<UInt64>()(mpp_query_id.local_query_id) ^ std::hash<UInt64>()(mpp_query_id.server_id);
 }
 
+bool MPPGatherId::operator==(const MPPGatherId & rid) const
+{
+    return query_id.query_ts == rid.query_id.query_ts && query_id.local_query_id == rid.query_id.local_query_id && query_id.server_id == rid.query_id.server_id
+        && query_id.start_ts == rid.query_id.start_ts && gather_id == rid.gather_id;
+}
+size_t MPPGatherIdHash::operator()(MPPGatherId const & mpp_gather_id) const noexcept
+{
+    return std::hash<UInt64>()(mpp_gather_id.query_id.query_ts) ^ std::hash<UInt64>()(mpp_gather_id.query_id.local_query_id)
+        ^ std::hash<UInt64>()(mpp_gather_id.query_id.server_id) ^ std::hash<UInt64>()(mpp_gather_id.gather_id);
+}
+
 String MPPTaskId::toString() const
 {
     return isUnknown() ? "MPP<query_id:N/A,task_id:N/A>" : fmt::format("MPP<query:{},task_id:{}>", query_id.toString(), task_id);

--- a/dbms/src/Flash/Mpp/MPPTaskId.h
+++ b/dbms/src/Flash/Mpp/MPPTaskId.h
@@ -55,6 +55,22 @@ struct MPPQueryIdHash
     size_t operator()(MPPQueryId const & mpp_query_id) const noexcept;
 };
 
+struct MPPGatherId
+{
+    UInt64 gather_id;
+    MPPQueryId query_id;
+    MPPGatherId(Int64 gather_id_, const MPPQueryId & query_id_)
+        : gather_id(gather_id_)
+        , query_id(query_id_)
+    {}
+    bool operator==(const MPPGatherId & rid) const;
+};
+
+struct MPPGatherIdHash
+{
+    size_t operator()(MPPGatherId const & mpp_gather_id) const noexcept;
+};
+
 // Identify a mpp task.
 struct MPPTaskId
 {

--- a/dbms/src/Flash/Mpp/MPPTaskId.h
+++ b/dbms/src/Flash/Mpp/MPPTaskId.h
@@ -55,6 +55,11 @@ struct MPPQueryIdHash
     size_t operator()(MPPQueryId const & mpp_query_id) const noexcept;
 };
 
+/// A MPP query has one or more MPPGathers, each mpp gather has one or more MPPTasks. The mpp tasks in different mpp gathers are independent
+/// to each other, so theoretically speaking, the smallest cancel/retry unit of MPP query could be MPPGather. However, MPPGathers belong to
+/// the same MPP query could have dependence to each other(e.g. for query A join B, if the join is not supported in TiFlash, TiDB will generate
+/// two mpp gathers, one is reading from A and the other is reading from B, the probe side's mpp gather depends on the build side's mpp gather),
+/// so the smallest scheduling unit in TiFlash is still the MPP query
 struct MPPGatherId
 {
     UInt64 gather_id;

--- a/dbms/src/Flash/Mpp/MPPTaskId.h
+++ b/dbms/src/Flash/Mpp/MPPTaskId.h
@@ -60,6 +60,8 @@ struct MPPQueryIdHash
 /// the same MPP query could have dependence to each other(e.g. for query A join B, if the join is not supported in TiFlash, TiDB will generate
 /// two mpp gathers, one is reading from A and the other is reading from B, the probe side's mpp gather depends on the build side's mpp gather),
 /// so the smallest scheduling unit in TiFlash is still the MPP query
+/// Note currently, TiDB does not fill `gather_id` in mpp::TaskMeta, TiFlash hard coded 0 as the gather id for all MPPGatherId, so a mpp query now
+/// only has one MPPGather, and the schedule/cancel/retry unit in TiFlash is MPP query, we may implement mpp gather level's cancel/retry in the future.
 struct MPPGatherId
 {
     UInt64 gather_id;

--- a/dbms/src/Flash/Mpp/MPPTaskManager.cpp
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.cpp
@@ -233,7 +233,7 @@ std::pair<bool, String> MPPTaskManager::registerTask(MPPTaskPtr task)
     auto [query_set, already_aborted] = getQueryTaskSetWithoutLock(task->id.query_id);
     if (already_aborted)
     {
-        if (query_set != nullptr && query_set->error_message.empty())
+        if (query_set != nullptr && !query_set->error_message.empty())
             return {false, fmt::format("query is being aborted, error message = {}", query_set->error_message)};
         else
             return {false, "query is aborted"};

--- a/dbms/src/Flash/Mpp/MPPTaskManager.cpp
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.cpp
@@ -36,7 +36,7 @@ extern const char pause_before_register_non_root_mpp_task[];
 
 MPPTaskManager::MPPTaskManager(MPPTaskSchedulerPtr scheduler_)
     : scheduler(std::move(scheduler_))
-    , cancelled_query_gather_cache(1000)
+    , aborted_query_gather_cache(1000)
     , log(Logger::get())
     , monitor(std::make_shared<MPPTaskMonitor>(log))
 {}
@@ -72,22 +72,23 @@ std::pair<MPPTunnelPtr, String> MPPTaskManager::findAsyncTunnel(const ::mpp::Est
     String req_info = fmt::format("tunnel{}+{}", request->sender_meta().task_id(), request->receiver_meta().task_id());
 
     std::unique_lock lock(mu);
-    auto query_it = mpp_query_map.find(id.query_id);
-    if (query_it != mpp_query_map.end() && !query_it->second->isInNormalState())
+    auto [query_set, already_aborted] = getQueryTaskSetWithoutLock(id.query_id);
+    if (already_aborted)
     {
         /// if the query is aborted, return the error message
         LOG_WARNING(log, fmt::format("{}: Query {} is aborted, all its tasks are invalid.", req_info, id.query_id.toString()));
         /// meet error
-        return {nullptr, query_it->second->error_message};
+        return {nullptr, query_set != nullptr && !query_set->error_message.empty() ? query_set->error_message : "query is aborted"};
     }
 
-    if (query_it == mpp_query_map.end() || query_it->second->task_map.find(id) == query_it->second->task_map.end())
+    if (query_set == nullptr || query_set->task_map.find(id) == query_set->task_map.end())
     {
         /// task not found
         if (!call_data->isWaitingTunnelState())
         {
             /// if call_data is in new_request state, put it to waiting tunnel state
-            auto query_set = query_it == mpp_query_map.end() ? addMPPQueryTaskSet(id.query_id) : query_it->second;
+            if (query_set == nullptr)
+                query_set = addMPPQueryTaskSet(id.query_id);
             auto & alarm = query_set->alarms[sender_task_id][receiver_task_id];
             call_data->setToWaitingTunnelState();
             alarm.Set(cq, Clock::now() + std::chrono::seconds(10), call_data);
@@ -96,9 +97,8 @@ std::pair<MPPTunnelPtr, String> MPPTaskManager::findAsyncTunnel(const ::mpp::Est
         else
         {
             /// if call_data is already in WaitingTunnelState, then remove the alarm and return tunnel not found error
-            if (query_it != mpp_query_map.end())
+            if (query_set != nullptr)
             {
-                auto query_set = query_it->second;
                 auto task_alarm_map_it = query_set->alarms.find(sender_task_id);
                 if (task_alarm_map_it != query_set->alarms.end())
                 {
@@ -119,7 +119,7 @@ std::pair<MPPTunnelPtr, String> MPPTaskManager::findAsyncTunnel(const ::mpp::Est
     }
     /// don't need to delete the alarm here because registerMPPTask will delete all the related alarm
 
-    auto it = query_it->second->task_map.find(id);
+    auto it = query_set->task_map.find(id);
     return it->second->getTunnel(request);
 }
 
@@ -133,22 +133,21 @@ std::pair<MPPTunnelPtr, String> MPPTaskManager::findTunnelWithTimeout(const ::mp
     String error_message;
     std::unique_lock lock(mu);
     auto ret = cv.wait_for(lock, timeout, [&] {
-        auto query_it = mpp_query_map.find(id.query_id);
-        // TODO: how about the query has been cancelled in advance?
-        if (query_it == mpp_query_map.end())
-        {
-            return false;
-        }
-        else if (!query_it->second->isInNormalState())
+        auto [query_set, already_aborted] = getQueryTaskSetWithoutLock(id.query_id);
+        if (already_aborted)
         {
             /// if the query is aborted, return true to stop waiting timeout.
             LOG_WARNING(log, fmt::format("{}: Query {} is aborted, all its tasks are invalid.", req_info, id.query_id.toString()));
             cancelled = true;
-            error_message = query_it->second->error_message;
+            error_message = query_set != nullptr && !query_set->error_message.empty() ? query_set->error_message : "query is aborted";
             return true;
         }
-        it = query_it->second->task_map.find(id);
-        return it != query_it->second->task_map.end();
+        if (query_set == nullptr)
+        {
+            return false;
+        }
+        it = query_set->task_map.find(id);
+        return it != query_set->task_map.end();
     });
     fiu_do_on(FailPoints::random_task_manager_find_task_failure_failpoint, ret = false;);
     if (cancelled)
@@ -171,7 +170,8 @@ void MPPTaskManager::abortMPPQuery(const MPPQueryId & query_id, const String & r
         /// set a flag, so we can abort task one by
         /// one without holding the lock
         std::lock_guard lock(mu);
-        cancelled_query_gather_cache.put(MPPGatherId(0, query_id));
+        /// gather_id is not set by TiDB, so use 0 instead
+        aborted_query_gather_cache.add(MPPGatherId(0, query_id));
         auto it = mpp_query_map.find(query_id);
         if (it == mpp_query_map.end())
         {
@@ -230,25 +230,21 @@ std::pair<bool, String> MPPTaskManager::registerTask(MPPTaskPtr task)
         FAIL_POINT_PAUSE(FailPoints::pause_before_register_non_root_mpp_task);
     }
     std::unique_lock lock(mu);
-    const auto & it = mpp_query_map.find(task->id.query_id);
-    if (it != mpp_query_map.end() && !it->second->isInNormalState())
+    auto [query_set, already_aborted] = getQueryTaskSetWithoutLock(task->id.query_id);
+    if (already_aborted)
     {
-        return {false, fmt::format("query is being aborted, error message = {}", it->second->error_message)};
+        if (query_set != nullptr && query_set->error_message.empty())
+            return {false, fmt::format("query is being aborted, error message = {}", query_set->error_message)};
+        else
+            return {false, "query is aborted"};
     }
-    if (it != mpp_query_map.end() && it->second->task_map.find(task->id) != it->second->task_map.end())
+    if (query_set != nullptr && query_set->task_map.find(task->id) != query_set->task_map.end())
     {
         return {false, "task has been registered"};
     }
-    if (cancelled_query_gather_cache.exists(MPPGatherId(0, task->id.query_id)))
-        return {false, "query is being aborted"};
-    MPPQueryTaskSetPtr query_set;
-    if (it == mpp_query_map.end()) /// the first one
+    if (query_set == nullptr) /// the first one
     {
         query_set = addMPPQueryTaskSet(task->id.query_id);
-    }
-    else
-    {
-        query_set = it->second;
     }
     query_set->task_map.emplace(task->id, task);
     /// cancel all the alarm waiting on this task
@@ -300,13 +296,17 @@ String MPPTaskManager::toString()
     return res + ")";
 }
 
-MPPQueryTaskSetPtr MPPTaskManager::getQueryTaskSetWithoutLock(const MPPQueryId & query_id)
+std::pair<MPPQueryTaskSetPtr, bool> MPPTaskManager::getQueryTaskSetWithoutLock(const MPPQueryId & query_id)
 {
     auto it = mpp_query_map.find(query_id);
-    return it == mpp_query_map.end() ? nullptr : it->second;
+    /// gather_id is not set by TiDB, so use 0 instead
+    bool already_aborted = aborted_query_gather_cache.exists(MPPGatherId(0, query_id));
+    if (it != mpp_query_map.end())
+        already_aborted |= !it->second->isInNormalState();
+    return it == mpp_query_map.end() ? std::make_pair(nullptr, already_aborted) : std::make_pair(it->second, already_aborted);
 }
 
-MPPQueryTaskSetPtr MPPTaskManager::getQueryTaskSet(const MPPQueryId & query_id)
+std::pair<MPPQueryTaskSetPtr, bool> MPPTaskManager::getQueryTaskSet(const MPPQueryId & query_id)
 {
     std::lock_guard lock(mu);
     return getQueryTaskSetWithoutLock(query_id);

--- a/dbms/src/Flash/Mpp/MPPTaskManager.cpp
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.cpp
@@ -302,8 +302,14 @@ std::pair<MPPQueryTaskSetPtr, bool> MPPTaskManager::getQueryTaskSetWithoutLock(c
     /// gather_id is not set by TiDB, so use 0 instead
     bool already_aborted = aborted_query_gather_cache.exists(MPPGatherId(0, query_id));
     if (it != mpp_query_map.end())
+    {
         already_aborted |= !it->second->isInNormalState();
-    return it == mpp_query_map.end() ? std::make_pair(nullptr, already_aborted) : std::make_pair(it->second, already_aborted);
+        return std::make_pair(it->second, already_aborted);
+    }
+    else
+    {
+        return std::make_pair(nullptr, already_aborted);
+    }
 }
 
 std::pair<MPPQueryTaskSetPtr, bool> MPPTaskManager::getQueryTaskSet(const MPPQueryId & query_id)

--- a/dbms/src/Flash/Mpp/MPPTaskManager.h
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.h
@@ -68,11 +68,15 @@ public:
     {}
     bool exists(const MPPGatherId & id)
     {
+        assert(gather_ids_set.size() == gather_ids.size());
         return gather_ids_set.find(id) != gather_ids_set.end();
     }
     void add(const MPPGatherId & id)
     {
-        if (gather_ids_set.size() >= capacity && gather_ids_set.find(id) == gather_ids_set.end())
+        assert(gather_ids_set.size() == gather_ids.size());
+        if (gather_ids_set.find(id) != gather_ids_set.end())
+            return;
+        if (gather_ids_set.size() >= capacity)
         {
             auto evicted_id = gather_ids.back();
             gather_ids.pop_back();

--- a/dbms/src/Flash/Mpp/MinTSOScheduler.cpp
+++ b/dbms/src/Flash/Mpp/MinTSOScheduler.cpp
@@ -77,8 +77,8 @@ bool MinTSOScheduler::tryToSchedule(MPPTaskScheduleEntry & schedule_entry, MPPTa
         return true;
     }
     const auto & id = schedule_entry.getMPPTaskId();
-    auto query_task_set = task_manager.getQueryTaskSetWithoutLock(id.query_id);
-    if (nullptr == query_task_set || !query_task_set->isInNormalState())
+    auto [query_task_set, already_aborted] = task_manager.getQueryTaskSetWithoutLock(id.query_id);
+    if (nullptr == query_task_set || already_aborted)
     {
         LOG_WARNING(log, "{} is scheduled with miss or abort.", id.toString());
         return true;
@@ -104,7 +104,7 @@ void MinTSOScheduler::deleteQuery(const MPPQueryId & query_id, MPPTaskManager & 
 
     if (is_cancelled) /// cancelled queries may have waiting tasks, and finished queries haven't.
     {
-        auto query_task_set = task_manager.getQueryTaskSetWithoutLock(query_id);
+        auto query_task_set = task_manager.getQueryTaskSetWithoutLock(query_id).first;
         if (query_task_set) /// release all waiting tasks
         {
             while (!query_task_set->waiting_tasks.empty())
@@ -149,7 +149,7 @@ void MinTSOScheduler::scheduleWaitingQueries(MPPTaskManager & task_manager)
     while (!waiting_set.empty())
     {
         auto current_query_id = *waiting_set.begin();
-        auto query_task_set = task_manager.getQueryTaskSetWithoutLock(current_query_id);
+        auto query_task_set = task_manager.getQueryTaskSetWithoutLock(current_query_id).first;
         if (nullptr == query_task_set) /// silently solve this rare case
         {
             LOG_ERROR(log, "the waiting query {} is not in the task manager.", current_query_id.toString());

--- a/dbms/src/Flash/Mpp/tests/gtest_aborted_mpp_gather_cache.cpp
+++ b/dbms/src/Flash/Mpp/tests/gtest_aborted_mpp_gather_cache.cpp
@@ -21,18 +21,18 @@ namespace DB
 {
 namespace tests
 {
-class TestCancelledMPPGatherCache : public testing::Test
+class TestAbortedMPPGatherCache : public testing::Test
 {
 };
 
-TEST_F(TestCancelledMPPGatherCache, TestEvict)
+TEST_F(TestAbortedMPPGatherCache, TestEvict)
 try
 {
     size_t capacity = 5;
-    CancelledMPPGatherCache cache(capacity);
+    AbortedMPPGatherCache cache(capacity);
     for (size_t i = 0; i < capacity; i++)
     {
-        cache.put(MPPGatherId(i, MPPQueryId(1, 2, 3, 4)));
+        cache.add(MPPGatherId(i, MPPQueryId(1, 2, 3, 4)));
     }
     for (size_t i = 0; i < capacity; i++)
     {
@@ -40,13 +40,13 @@ try
     }
     for (size_t i = 0; i < capacity; i++)
     {
-        cache.put(MPPGatherId(0, MPPQueryId(1, 2, 3, 4)));
+        cache.add(MPPGatherId(0, MPPQueryId(1, 2, 3, 4)));
     }
     for (size_t i = 0; i < capacity; i++)
     {
         ASSERT_EQ(cache.exists(MPPGatherId(i, MPPQueryId(1, 2, 3, 4))), true);
     }
-    cache.put(MPPGatherId(capacity, MPPQueryId(1, 2, 3, 4)));
+    cache.add(MPPGatherId(capacity, MPPQueryId(1, 2, 3, 4)));
     ASSERT_EQ(cache.exists(MPPGatherId(0, MPPQueryId(1, 2, 3, 4))), false);
     for (size_t i = 0; i < capacity; i++)
     {

--- a/dbms/src/Flash/Mpp/tests/gtest_cancelled_mpp_gather_cache.cpp
+++ b/dbms/src/Flash/Mpp/tests/gtest_cancelled_mpp_gather_cache.cpp
@@ -1,0 +1,59 @@
+// Copyright 2022 PingCAP, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Flash/Mpp/MPPTaskManager.h>
+#include <TestUtils/TiFlashTestBasic.h>
+#include <gtest/gtest.h>
+
+
+namespace DB
+{
+namespace tests
+{
+class TestCancelledMPPGatherCache : public testing::Test
+{
+};
+
+TEST_F(TestCancelledMPPGatherCache, TestEvict)
+try
+{
+    size_t capacity = 5;
+    CancelledMPPGatherCache cache(capacity);
+    for (size_t i = 0; i < capacity; i++)
+    {
+        cache.put(MPPGatherId(i, MPPQueryId(1, 2, 3, 4)));
+    }
+    for (size_t i = 0; i < capacity; i++)
+    {
+        ASSERT_EQ(cache.exists(MPPGatherId(i, MPPQueryId(1, 2, 3, 4))), true);
+    }
+    for (size_t i = 0; i < capacity; i++)
+    {
+        cache.put(MPPGatherId(0, MPPQueryId(1, 2, 3, 4)));
+    }
+    for (size_t i = 0; i < capacity; i++)
+    {
+        ASSERT_EQ(cache.exists(MPPGatherId(i, MPPQueryId(1, 2, 3, 4))), true);
+    }
+    cache.put(MPPGatherId(capacity, MPPQueryId(1, 2, 3, 4)));
+    ASSERT_EQ(cache.exists(MPPGatherId(0, MPPQueryId(1, 2, 3, 4))), false);
+    for (size_t i = 0; i < capacity; i++)
+    {
+        ASSERT_EQ(cache.exists(MPPGatherId(i + 1, MPPQueryId(1, 2, 3, 4))), true);
+    }
+}
+CATCH
+
+} // namespace tests
+} // namespace DB

--- a/dbms/src/TestUtils/MPPTaskTestUtils.cpp
+++ b/dbms/src/TestUtils/MPPTaskTestUtils.cpp
@@ -149,7 +149,7 @@ String MPPTaskTestUtils::queryInfo(size_t server_id)
     for (int i = test_meta.context_idx; i < TiFlashTestEnv::globalContextSize(); ++i)
     {
         // wait until the task is empty for <query:start_ts>
-        while (TiFlashTestEnv::getGlobalContext(i).getTMTContext().getMPPTaskManager()->getQueryTaskSet(query_id) != nullptr)
+        while (TiFlashTestEnv::getGlobalContext(i).getTMTContext().getMPPTaskManager()->getQueryTaskSet(query_id).first != nullptr)
         {
             std::this_thread::sleep_for(seconds);
             retry_times++;
@@ -167,7 +167,7 @@ String MPPTaskTestUtils::queryInfo(size_t server_id)
 {
     for (int i = test_meta.context_idx; i < TiFlashTestEnv::globalContextSize(); ++i)
     {
-        if (TiFlashTestEnv::getGlobalContext(i).getTMTContext().getMPPTaskManager()->getQueryTaskSet(query_id) == nullptr)
+        if (TiFlashTestEnv::getGlobalContext(i).getTMTContext().getMPPTaskManager()->getQueryTaskSet(query_id).first == nullptr)
         {
             return ::testing::AssertionFailure() << "Query " << query_id.toString() << "not active" << std::endl;
         }

--- a/dbms/src/TestUtils/MPPTaskTestUtils.cpp
+++ b/dbms/src/TestUtils/MPPTaskTestUtils.cpp
@@ -77,20 +77,32 @@ size_t MPPTaskTestUtils::serverNum()
     return server_num;
 }
 
-std::tuple<MPPQueryId, std::vector<BlockInputStreamPtr>> MPPTaskTestUtils::prepareMPPStreams(DAGRequestBuilder builder)
+void MPPTaskTestUtils::setCancelTest()
+{
+    for (int i = test_meta.context_idx; i < TiFlashTestEnv::globalContextSize(); ++i)
+        TiFlashTestEnv::getGlobalContext(i).setCancelTest();
+}
+
+std::tuple<MPPQueryId, std::vector<BlockInputStreamPtr>> MPPTaskTestUtils::prepareAndRunMPPStreams(DAGRequestBuilder builder)
+{
+    auto [properties, tasks] = prepareMPPStreams(builder);
+    auto res = executeMPPQueryWithMultipleContext(properties, tasks, MockComputeServerManager::instance().getServerConfigMap());
+    return {MPPQueryId(properties.query_ts, properties.local_query_id, properties.server_id, properties.start_ts), res};
+}
+
+std::tuple<DAGProperties, std::vector<QueryTask>> MPPTaskTestUtils::prepareMPPStreams(DAGRequestBuilder builder)
 {
     auto properties = DB::tests::getDAGPropertiesForTest(serverNum());
     auto tasks = builder.buildMPPTasks(context, properties);
     for (int i = test_meta.context_idx; i < TiFlashTestEnv::globalContextSize(); ++i)
         TiFlashTestEnv::getGlobalContext(i).setCancelTest();
     MockComputeServerManager::instance().setMockStorage(context.mockStorage());
-    auto res = executeMPPQueryWithMultipleContext(properties, tasks, MockComputeServerManager::instance().getServerConfigMap());
-    return {MPPQueryId(properties.query_ts, properties.local_query_id, properties.server_id, properties.start_ts), res};
+    return {properties, tasks};
 }
 
-ColumnsWithTypeAndName MPPTaskTestUtils::executeMPPTasks(QueryTasks & tasks, const DAGProperties & properties, std::unordered_map<size_t, MockServerConfig> & server_config_map)
+ColumnsWithTypeAndName MPPTaskTestUtils::executeMPPTasks(QueryTasks & tasks, const DAGProperties & properties)
 {
-    auto res = executeMPPQueryWithMultipleContext(properties, tasks, server_config_map);
+    auto res = executeMPPQueryWithMultipleContext(properties, tasks, MockComputeServerManager::instance().getServerConfigMap());
     return readBlocks(res);
 }
 
@@ -183,6 +195,6 @@ ColumnsWithTypeAndName MPPTaskTestUtils::buildAndExecuteMPPTasks(DAGRequestBuild
     auto tasks = (builder).buildMPPTasks(context, properties);
     MockComputeServerManager::instance().resetMockMPPServerInfo(serverNum());
     MockComputeServerManager::instance().setMockStorage(context.mockStorage());
-    return executeMPPTasks(tasks, properties, MockComputeServerManager::instance().getServerConfigMap());
+    return executeMPPTasks(tasks, properties);
 }
 } // namespace DB::tests


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #7587, close #6727

Problem Summary:

### What is changed and how it works?
When TiDB cancel a mpp query, there is a chance that the `cancel` is lost:
| time | TiDB | TiFlash |
|-----|------|---------|
| t1 | Send Disptach MPPTask to TiFlash| Dispatch request is not received yet |
| t2 | Send CancelMPPTask request to TiFlash| Received CancelMPPTask, and found nothing to cancel |
| t3 |   | Receive Dispatch request of t1, then the cancel is lost | 

This pr add a `AbortedMPPGatherCache` to avoid this cancel lost
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
