### PR TITLE
Initialize the pipeline task scheduler by default

### DIFF
--- a/dbms/src/Flash/FlashService.cpp
+++ b/dbms/src/Flash/FlashService.cpp
@@ -144,6 +144,7 @@ void updateSettingsFromTiDB(const grpc::ServerContext * grpc_context, ContextPtr
         std::make_pair("tidb_max_bytes_before_tiflash_external_join", "max_bytes_before_external_join"),
         std::make_pair("tidb_max_bytes_before_tiflash_external_group_by", "max_bytes_before_external_group_by"),
         std::make_pair("tidb_max_bytes_before_tiflash_external_sort", "max_bytes_before_external_sort"),
+        std::make_pair("tidb_enable_tiflash_pipeline_model", "enable_pipeline"),
     };
     for (const auto & names : tidb_varname_to_tiflash_varname)
     {

--- a/dbms/src/Flash/executeQuery.cpp
+++ b/dbms/src/Flash/executeQuery.cpp
@@ -119,9 +119,14 @@ std::optional<QueryExecutorPtr> executeAsPipeline(Context & context, bool intern
     const auto & logger = dag_context.log;
     RUNTIME_ASSERT(logger);
 
-    if (!TaskScheduler::instance || !Pipeline::isSupported(*dag_context.dag_request, context.getSettingsRef()))
+    if unlikely (!TaskScheduler::instance)
     {
-        LOG_DEBUG(logger, "Can't run by pipeline model, fallback to block inputstream model");
+        LOG_WARNING(logger, "The task scheduler of the pipeline model has not been initialized, which is an exception. It is necessary to restart the TiFlash node.");
+        return {};
+    }
+    if (!Pipeline::isSupported(*dag_context.dag_request, context.getSettingsRef()))
+    {
+        LOG_DEBUG(logger, "Can't executed by pipeline model due to unsupported operator, and then fallback to block inputstream model");
         return {};
     }
 
@@ -164,6 +169,9 @@ QueryExecutorPtr queryExecute(Context & context, bool internal)
 {
     if (context.getSettingsRef().enforce_enable_pipeline)
     {
+        RUNTIME_CHECK_MSG(
+            !TaskScheduler::instance,
+            "The task scheduler of the pipeline model has not been initialized, which is an exception. It is necessary to restart the TiFlash node.");
         RUNTIME_CHECK_MSG(
             context.getSharedContextDisagg()->notDisaggregatedMode() || !S3::ClientFactory::instance().isEnabled(),
             "The pipeline model does not support storage-computing separation with S3 mode, and an error is reported because the setting enforce_enable_pipeline is true.");

--- a/dbms/src/Flash/executeQuery.cpp
+++ b/dbms/src/Flash/executeQuery.cpp
@@ -170,7 +170,7 @@ QueryExecutorPtr queryExecute(Context & context, bool internal)
     if (context.getSettingsRef().enforce_enable_pipeline)
     {
         RUNTIME_CHECK_MSG(
-            !TaskScheduler::instance,
+            TaskScheduler::instance,
             "The task scheduler of the pipeline model has not been initialized, which is an exception. It is necessary to restart the TiFlash node.");
         RUNTIME_CHECK_MSG(
             context.getSharedContextDisagg()->notDisaggregatedMode() || !S3::ClientFactory::instance().isEnabled(),

--- a/dbms/src/Operators/SharedQueue.h
+++ b/dbms/src/Operators/SharedQueue.h
@@ -57,7 +57,7 @@ public:
     {
     }
 
-    ~SharedQueueSinkOp()
+    ~SharedQueueSinkOp() override
     {
         shared_queue->producerFinish();
     }

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -1496,8 +1496,8 @@ int Server::main(const std::vector<std::string> & /*args*/)
     });
 
     // For test mode, TaskScheduler is controlled by test case.
-    bool enable_pipeline = (settings.enable_pipeline || settings.enforce_enable_pipeline) && !global_context->isTest();
-    if (enable_pipeline)
+    bool is_prod = !global_context->isTest();
+    if (is_prod)
     {
         auto get_pool_size = [](const auto & setting) {
             return setting == 0 ? getNumberOfLogicalCPUCores() : static_cast<size_t>(setting);
@@ -1506,11 +1506,12 @@ int Server::main(const std::vector<std::string> & /*args*/)
             {get_pool_size(settings.pipeline_cpu_task_thread_pool_size), settings.pipeline_cpu_task_thread_pool_queue_type},
             {get_pool_size(settings.pipeline_io_task_thread_pool_size), settings.pipeline_io_task_thread_pool_queue_type},
         };
-        assert(!TaskScheduler::instance);
+        RUNTIME_CHECK(!TaskScheduler::instance);
         TaskScheduler::instance = std::make_unique<TaskScheduler>(config);
+        LOG_INFO(log, "init pipeline task scheduler");
     }
     SCOPE_EXIT({
-        if (enable_pipeline)
+        if (is_prod)
         {
             assert(TaskScheduler::instance);
             TaskScheduler::instance.reset();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6518 

Problem Summary:

### What is changed and how it works?
- Initialize the pipeline task scheduler by default, and then `enable_pipeline` and `enforce_enable_pipeline` can take effect immediately without restarting the tiflash process.
- The three groups of threads in pipeline task scheduler(WaitReactor, CPU/IO Task Thread Pool) are blocked when no tasks are submitted, the cpu utilization rates are 0, and the default total number of threads is `1 + 2 * cpu core num`, so the impact of the default Initializing is small.
![1MX0vrXRZx](https://github.com/pingcap/tiflash/assets/24507159/e8150282-d3e5-46e3-8417-27591e48d35e)
from https://github.com/pingcap/tiflash/pull/7584
- support set `enable_pipeline` from tidb, related to https://github.com/pingcap/tidb/pull/44467

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
