### PR TITLE
*: call PODArray::resize_fill(size_t n) instead of resize_fill(size_t n, 0)

### DIFF
--- a/dbms/src/Columns/ColumnFixedString.cpp
+++ b/dbms/src/Columns/ColumnFixedString.cpp
@@ -59,13 +59,7 @@ MutableColumnPtr ColumnFixedString::cloneResized(size_t size) const
 void ColumnFixedString::insert(const Field & x)
 {
     const auto & s = DB::get<const String &>(x);
-
-    if (s.size() > n)
-        throw Exception("Too large string '" + s + "' for FixedString column", ErrorCodes::TOO_LARGE_STRING_SIZE);
-
-    size_t old_size = chars.size();
-    chars.resize_fill(old_size + n);
-    memcpy(&chars[old_size], s.data(), s.size());
+    insertData(s.data(), s.size());
 }
 
 void ColumnFixedString::insertFrom(const IColumn & src_, size_t index)
@@ -112,8 +106,9 @@ void ColumnFixedString::insertData(const char * pos, size_t length)
         throw Exception("Too large string for FixedString column", ErrorCodes::TOO_LARGE_STRING_SIZE);
 
     size_t old_size = chars.size();
-    chars.resize_fill(old_size + n);
-    memcpy(&chars[old_size], pos, length);
+    chars.resize(old_size + n);
+    memcpy(chars.data() + old_size, pos, length);
+    memset(chars.data() + old_size + length, 0, n - length);
 }
 
 StringRef ColumnFixedString::serializeValueIntoArena(size_t index, Arena & arena, char const *& begin, const TiDB::TiDBCollatorPtr &, String &) const

--- a/dbms/src/Columns/ColumnNullable.h
+++ b/dbms/src/Columns/ColumnNullable.h
@@ -17,6 +17,8 @@
 #include <Columns/ColumnsNumber.h>
 #include <Columns/IColumn.h>
 
+#include <cstring>
+
 namespace DB
 {
 using NullMap = ColumnUInt8::Container;
@@ -85,7 +87,9 @@ public:
     {
         getNestedColumn().insertManyDefaults(length);
         auto & map = getNullMapData();
-        map.resize_fill(map.size() + length, 1);
+        size_t old_size = map.size();
+        map.resize(old_size + length);
+        memset(map.data() + old_size, 1, length);
     }
 
     void popBack(size_t n) override;

--- a/dbms/src/Columns/ColumnVector.h
+++ b/dbms/src/Columns/ColumnVector.h
@@ -128,7 +128,7 @@ inline UInt64 unionCastToUInt64(Float64 x)
     union
     {
         Float64 src;
-        UInt64 res;
+        UInt64 res{};
     };
 
     src = x;
@@ -141,7 +141,7 @@ inline UInt64 unionCastToUInt64(Float32 x)
     union
     {
         Float32 src;
-        UInt64 res;
+        UInt64 res{};
     };
 
     res = 0;
@@ -149,20 +149,20 @@ inline UInt64 unionCastToUInt64(Float32 x)
     return res;
 }
 
-template <typename targetType, typename encodeType>
-inline targetType decodeInt(const char * pos)
+template <typename TargetType, typename EncodeType>
+inline TargetType decodeInt(const char * pos)
 {
-    if constexpr (std::is_same_v<targetType, Null>)
+    if constexpr (std::is_same_v<TargetType, Null>)
     {
         return Null{};
     }
-    else if constexpr (is_signed_v<targetType>)
+    else if constexpr (is_signed_v<TargetType>)
     {
-        return static_cast<targetType>(static_cast<std::make_signed_t<encodeType>>(readLittleEndian<encodeType>(pos)));
+        return static_cast<TargetType>(static_cast<std::make_signed_t<EncodeType>>(readLittleEndian<EncodeType>(pos)));
     }
     else
     {
-        return static_cast<targetType>(static_cast<std::make_unsigned_t<encodeType>>(readLittleEndian<encodeType>(pos)));
+        return static_cast<TargetType>(static_cast<std::make_unsigned_t<EncodeType>>(readLittleEndian<EncodeType>(pos)));
     }
 }
 
@@ -249,7 +249,7 @@ public:
             {
                 throw Exception("Invalid float value length " + std::to_string(length), ErrorCodes::LOGICAL_ERROR);
             }
-            constexpr UInt64 SIGN_MASK = UInt64(1) << 63;
+            constexpr UInt64 SIGN_MASK = static_cast<UInt64>(1) << 63;
             auto num = readBigEndian<UInt64>(raw_value.c_str() + cursor);
             if (num & SIGN_MASK)
                 num ^= SIGN_MASK;

--- a/dbms/src/DataStreams/NativeBlockInputStream.cpp
+++ b/dbms/src/DataStreams/NativeBlockInputStream.cpp
@@ -235,7 +235,7 @@ void NativeBlockInputStream::updateAvgValueSizeHints(const Block & block)
     if (rows < 10)
         return;
 
-    avg_value_size_hints.resize_fill(block.columns(), 0);
+    avg_value_size_hints.resize_fill(block.columns());
 
     for (auto idx : ext::range(0, block.columns()))
     {

--- a/dbms/src/DataTypes/DataTypeNumberBase.cpp
+++ b/dbms/src/DataTypes/DataTypeNumberBase.cpp
@@ -207,7 +207,7 @@ void DataTypeNumberBase<T>::deserializeBinary(Field & field, ReadBuffer & istr) 
 {
     typename ColumnVector<T>::value_type x;
     readBinary(x, istr);
-    field = typename NearestFieldType<FieldType>::Type(x);
+    field = static_cast<typename NearestFieldType<FieldType>::Type>(x);
 }
 
 template <typename T>

--- a/dbms/src/Functions/FunctionsGrouping.h
+++ b/dbms/src/Functions/FunctionsGrouping.h
@@ -140,7 +140,7 @@ private:
         // get result's data container
         auto col_vec_res = ColumnVector<ResultType>::create();
         typename ColumnVector<ResultType>::Container & vec_res = col_vec_res->getData();
-        vec_res.resize_fill(row_num, static_cast<ResultType>(0));
+        vec_res.resize_fill(row_num);
 
         for (size_t i = 0; i < row_num; ++i)
         {

--- a/dbms/src/Functions/FunctionsString.cpp
+++ b/dbms/src/Functions/FunctionsString.cpp
@@ -4914,7 +4914,7 @@ public:
 
     DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override
     {
-        auto first_argument = arguments[0];
+        const auto & first_argument = arguments[0];
         if (!first_argument->isNumber() && !first_argument->isDecimal())
             throw Exception(
                 fmt::format("Illegal type {} of first argument of function {}", first_argument->getName(), getName()),

--- a/dbms/src/Interpreters/Aggregator.h
+++ b/dbms/src/Interpreters/Aggregator.h
@@ -283,7 +283,7 @@ struct AggregationMethodFastPathTwoKeysNoCache
     ALWAYS_INLINE static inline void initAggKeys(size_t rows, IColumn * key_column)
     {
         auto * column = static_cast<typename KeyType::ColumnType *>(key_column);
-        column->getData().resize_fill(rows, 0);
+        column->getData().resize_fill(rows);
     }
 
     ALWAYS_INLINE static inline const char * insertAggKeyIntoColumnString(const char * pos, IColumn * key_column)

--- a/dbms/src/Storages/DeltaMerge/convertColumnTypeHelpers.cpp
+++ b/dbms/src/Storages/DeltaMerge/convertColumnTypeHelpers.cpp
@@ -358,7 +358,7 @@ void convertColumnByColumnDefine(const DataTypePtr & disk_type,
         // not null -> nullable, set null map to all not null
         auto & memory_nullable_col = typeid_cast<ColumnNullable &>(*memory_col);
         auto & nullmap_data = memory_nullable_col.getNullMapData();
-        nullmap_data.resize_fill(rows_offset + rows_limit, 0);
+        nullmap_data.resize_fill(rows_offset + rows_limit);
 
         disk_col_not_null = disk_col;
         memory_col_not_null = memory_nullable_col.getNestedColumn().getPtr();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6233 

Problem Summary:

### What is changed and how it works?

resize_fill() with initializer uses std::fill() which is a loop over all
elements, while resize_fill() without argument uses memset().

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
