### PR TITLE
Use memory bounded buffer in executors

### DIFF
--- a/dbms/src/Common/CapacityLimits.h
+++ b/dbms/src/Common/CapacityLimits.h
@@ -1,0 +1,30 @@
+// Copyright 2022 PingCAP, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <common/types.h>
+
+namespace DB
+{
+struct CapacityLimits
+{
+    size_t max_size;
+    size_t max_bytes;
+    CapacityLimits(size_t max_size_, size_t max_bytes_)
+        : max_size(max_size_)
+        , max_bytes(max_bytes_)
+    {}
+};
+} // namespace DB

--- a/dbms/src/Common/CapacityLimits.h
+++ b/dbms/src/Common/CapacityLimits.h
@@ -20,11 +20,11 @@ namespace DB
 {
 struct CapacityLimits
 {
-    size_t max_size;
-    size_t max_bytes;
-    CapacityLimits(size_t max_size_, size_t max_bytes_)
-        : max_size(max_size_)
-        , max_bytes(max_bytes_)
+    Int64 max_size;
+    Int64 max_bytes;
+    CapacityLimits(Int64 max_size_, Int64 max_bytes_ = std::numeric_limits<Int64>::max())
+        : max_size(std::max(1, max_size_))
+        , max_bytes(max_bytes_ <= 0 ? std::numeric_limits<Int64>::max() : max_bytes_)
     {}
 };
 } // namespace DB

--- a/dbms/src/Common/tests/gtest_loose_bounded_mpmc_queue.cpp
+++ b/dbms/src/Common/tests/gtest_loose_bounded_mpmc_queue.cpp
@@ -225,7 +225,7 @@ try
         /// case 2: less auxiliary memory bound than the capacity bound
         size_t actual_max_size = 5;
         auxiliary_memory_bound = sizeof(Int64) * actual_max_size;
-        LooseBoundedMPMCQueue<Int64> queue(max_size, auxiliary_memory_bound, [](const Int64 &) { return sizeof(Int64); });
+        LooseBoundedMPMCQueue<Int64> queue(CapacityLimits(max_size, auxiliary_memory_bound), [](const Int64 &) { return sizeof(Int64); });
         for (size_t i = 0; i < actual_max_size; i++)
             ASSERT_TRUE(queue.tryPush(i) == MPMCQueueResult::OK);
         ASSERT_TRUE(queue.tryPush(actual_max_size) == MPMCQueueResult::FULL);
@@ -237,7 +237,7 @@ try
     {
         /// case 3: less capacity bound than the auxiliary memory bound
         auxiliary_memory_bound = sizeof(Int64) * (max_size * 10);
-        LooseBoundedMPMCQueue<Int64> queue(max_size, auxiliary_memory_bound, [](const Int64 &) { return sizeof(Int64); });
+        LooseBoundedMPMCQueue<Int64> queue(CapacityLimits(max_size, auxiliary_memory_bound), [](const Int64 &) { return sizeof(Int64); });
         for (size_t i = 0; i < max_size; i++)
             ASSERT_TRUE(queue.tryPush(i) == MPMCQueueResult::OK);
         ASSERT_TRUE(queue.tryPush(max_size) == MPMCQueueResult::FULL);
@@ -248,7 +248,7 @@ try
         std::vector<Int64> bounds{0, -1};
         for (const auto & bound : bounds)
         {
-            LooseBoundedMPMCQueue<Int64> queue(max_size, bound, [](const Int64 &) { return 1024 * 1024; });
+            LooseBoundedMPMCQueue<Int64> queue(CapacityLimits(max_size, bound), [](const Int64 &) { return 1024 * 1024; });
             for (size_t i = 0; i < max_size; i++)
                 ASSERT_TRUE(queue.tryPush(i) == MPMCQueueResult::OK);
             ASSERT_TRUE(queue.tryPush(max_size) == MPMCQueueResult::FULL);
@@ -257,7 +257,7 @@ try
 
     {
         /// case 5 even if the element's auxiliary memory is out of bound, at least one element can be pushed
-        LooseBoundedMPMCQueue<Int64> queue(max_size, 1, [](const Int64 &) { return 10; });
+        LooseBoundedMPMCQueue<Int64> queue(CapacityLimits(max_size, 1), [](const Int64 &) { return 10; });
         ASSERT_TRUE(queue.tryPush(1) == MPMCQueueResult::OK);
         ASSERT_TRUE(queue.tryPush(2) == MPMCQueueResult::FULL);
         ASSERT_TRUE(queue.tryPop(value) == MPMCQueueResult::OK);
@@ -267,7 +267,7 @@ try
 
     {
         /// case 6 after pop a huge element, more than one small push can be notified without further pop
-        LooseBoundedMPMCQueue<Int64> queue(max_size, 20, [](const Int64 & element) { return std::abs(element); });
+        LooseBoundedMPMCQueue<Int64> queue(CapacityLimits(max_size, 20), [](const Int64 & element) { return std::abs(element); });
         ASSERT_TRUE(queue.tryPush(100) == MPMCQueueResult::OK);
         ASSERT_TRUE(queue.tryPush(5) == MPMCQueueResult::FULL);
         auto thread_manager = newThreadManager();
@@ -298,7 +298,7 @@ try
 
     {
         /// case 7, force push does not limited by memory bound
-        LooseBoundedMPMCQueue<Int64> queue(max_size, sizeof(Int64) * max_size / 2, [](const Int64 &) { return sizeof(Int64); });
+        LooseBoundedMPMCQueue<Int64> queue(CapacityLimits(max_size, sizeof(Int64) * max_size / 2), [](const Int64 &) { return sizeof(Int64); });
         for (size_t i = 0; i < max_size / 2; i++)
             ASSERT_TRUE(queue.tryPush(i) == MPMCQueueResult::OK);
         for (size_t i = max_size / 2; i < max_size; i++)

--- a/dbms/src/Common/tests/gtest_mpmc_queue.cpp
+++ b/dbms/src/Common/tests/gtest_mpmc_queue.cpp
@@ -705,7 +705,7 @@ try
         /// case 2: less auxiliary memory bound than the capacity bound
         size_t actual_max_size = 5;
         auxiliary_memory_bound = sizeof(Int64) * actual_max_size;
-        MPMCQueue<Int64> queue(max_size, auxiliary_memory_bound, [](const Int64 &) { return sizeof(Int64); });
+        MPMCQueue<Int64> queue(CapacityLimits(max_size, auxiliary_memory_bound), [](const Int64 &) { return sizeof(Int64); });
         for (size_t i = 0; i < actual_max_size; i++)
             ASSERT_TRUE(queue.tryPush(i) == MPMCQueueResult::OK);
         ASSERT_TRUE(queue.tryPush(actual_max_size) == MPMCQueueResult::FULL);
@@ -717,7 +717,7 @@ try
     {
         /// case 3: less capacity bound than the auxiliary memory bound
         auxiliary_memory_bound = sizeof(Int64) * (max_size * 10);
-        MPMCQueue<Int64> queue(max_size, auxiliary_memory_bound, [](const Int64 &) { return sizeof(Int64); });
+        MPMCQueue<Int64> queue(CapacityLimits(max_size, auxiliary_memory_bound), [](const Int64 &) { return sizeof(Int64); });
         for (size_t i = 0; i < max_size; i++)
             ASSERT_TRUE(queue.tryPush(i) == MPMCQueueResult::OK);
         ASSERT_TRUE(queue.tryPush(max_size) == MPMCQueueResult::FULL);
@@ -728,7 +728,7 @@ try
         std::vector<Int64> bounds{0, -1};
         for (const auto & bound : bounds)
         {
-            MPMCQueue<Int64> queue(max_size, bound, [](const Int64 &) { return 1024 * 1024; });
+            MPMCQueue<Int64> queue(CapacityLimits(max_size, bound), [](const Int64 &) { return 1024 * 1024; });
             for (size_t i = 0; i < max_size; i++)
                 ASSERT_TRUE(queue.tryPush(i) == MPMCQueueResult::OK);
             ASSERT_TRUE(queue.tryPush(max_size) == MPMCQueueResult::FULL);
@@ -737,7 +737,7 @@ try
 
     {
         /// case 5 even if the element's auxiliary memory is out of bound, at least one element can be pushed
-        MPMCQueue<Int64> queue(max_size, 1, [](const Int64 &) { return 10; });
+        MPMCQueue<Int64> queue(CapacityLimits(max_size, 1), [](const Int64 &) { return 10; });
         ASSERT_TRUE(queue.tryPush(1) == MPMCQueueResult::OK);
         ASSERT_TRUE(queue.tryPush(2) == MPMCQueueResult::FULL);
         ASSERT_TRUE(queue.tryPop(value) == MPMCQueueResult::OK);
@@ -747,7 +747,7 @@ try
 
     {
         /// case 6 after pop a huge element, more than one small push can be notified without further pop
-        MPMCQueue<Int64> queue(max_size, 20, [](const Int64 & element) { return std::abs(element); });
+        MPMCQueue<Int64> queue(CapacityLimits(max_size, 20), [](const Int64 & element) { return std::abs(element); });
         ASSERT_TRUE(queue.tryPush(100) == MPMCQueueResult::OK);
         ASSERT_TRUE(queue.tryPush(5) == MPMCQueueResult::FULL);
         auto thread_manager = newThreadManager();

--- a/dbms/src/DataStreams/ParallelAggregatingBlockInputStream.cpp
+++ b/dbms/src/DataStreams/ParallelAggregatingBlockInputStream.cpp
@@ -99,7 +99,7 @@ Block ParallelAggregatingBlockInputStream::readImpl()
                     BlockInputStreams merging_streams;
                     for (size_t i = 0; i < merging_buckets->getConcurrency(); ++i)
                         merging_streams.push_back(std::make_shared<MergingAndConvertingBlockInputStream>(merging_buckets, i, log->identifier()));
-                    impl = std::make_unique<UnionBlockInputStream<>>(merging_streams, BlockInputStreams{}, max_threads, log->identifier(), max_buffered_bytes);
+                    impl = std::make_unique<UnionBlockInputStream<>>(merging_streams, BlockInputStreams{}, max_threads, max_buffered_bytes, log->identifier());
                 }
                 else
                 {

--- a/dbms/src/DataStreams/ParallelAggregatingBlockInputStream.cpp
+++ b/dbms/src/DataStreams/ParallelAggregatingBlockInputStream.cpp
@@ -29,6 +29,7 @@ ParallelAggregatingBlockInputStream::ParallelAggregatingBlockInputStream(
     const Aggregator::Params & params_,
     bool final_,
     size_t max_threads_,
+    Int64 max_buffered_bytes_,
     size_t temporary_data_merge_threads_,
     const String & req_id)
     : log(Logger::get(req_id))
@@ -36,6 +37,7 @@ ParallelAggregatingBlockInputStream::ParallelAggregatingBlockInputStream(
     , aggregator(params, req_id)
     , final(final_)
     , max_threads(std::min(inputs.size(), max_threads_))
+    , max_buffered_bytes(max_buffered_bytes_)
     , temporary_data_merge_threads(temporary_data_merge_threads_)
     , keys_size(params.keys_size)
     , aggregates_size(params.aggregates_size)
@@ -97,7 +99,7 @@ Block ParallelAggregatingBlockInputStream::readImpl()
                     BlockInputStreams merging_streams;
                     for (size_t i = 0; i < merging_buckets->getConcurrency(); ++i)
                         merging_streams.push_back(std::make_shared<MergingAndConvertingBlockInputStream>(merging_buckets, i, log->identifier()));
-                    impl = std::make_unique<UnionBlockInputStream<>>(merging_streams, BlockInputStreams{}, max_threads, log->identifier());
+                    impl = std::make_unique<UnionBlockInputStream<>>(merging_streams, BlockInputStreams{}, max_threads, log->identifier(), max_buffered_bytes);
                 }
                 else
                 {

--- a/dbms/src/DataStreams/ParallelAggregatingBlockInputStream.h
+++ b/dbms/src/DataStreams/ParallelAggregatingBlockInputStream.h
@@ -37,6 +37,7 @@ public:
         const Aggregator::Params & params_,
         bool final_,
         size_t max_threads_,
+        Int64 max_buffered_bytes_,
         size_t temporary_data_merge_threads_,
         const String & req_id);
 
@@ -69,6 +70,7 @@ private:
     Aggregator aggregator;
     bool final;
     size_t max_threads;
+    Int64 max_buffered_bytes;
     size_t temporary_data_merge_threads;
 
     size_t keys_size;

--- a/dbms/src/DataStreams/SharedQueryBlockInputStream.h
+++ b/dbms/src/DataStreams/SharedQueryBlockInputStream.h
@@ -38,8 +38,8 @@ class SharedQueryBlockInputStream : public IProfilingBlockInputStream
     static constexpr auto NAME = "SharedQuery";
 
 public:
-    SharedQueryBlockInputStream(size_t clients, const BlockInputStreamPtr & in_, const String & req_id)
-        : queue(clients)
+    SharedQueryBlockInputStream(size_t clients, Int64 max_buffered_bytes, const BlockInputStreamPtr & in_, const String & req_id)
+        : queue(CapacityLimits(clients, max_buffered_bytes))
         , log(Logger::get(req_id))
         , in(in_)
     {

--- a/dbms/src/DataStreams/SharedQueryBlockInputStream.h
+++ b/dbms/src/DataStreams/SharedQueryBlockInputStream.h
@@ -39,7 +39,7 @@ class SharedQueryBlockInputStream : public IProfilingBlockInputStream
 
 public:
     SharedQueryBlockInputStream(size_t clients, Int64 max_buffered_bytes, const BlockInputStreamPtr & in_, const String & req_id)
-        : queue(CapacityLimits(clients, max_buffered_bytes))
+        : queue(CapacityLimits(clients, max_buffered_bytes), [](const Block & block) { return block.allocatedBytes(); })
         , log(Logger::get(req_id))
         , in(in_)
     {

--- a/dbms/src/DataStreams/UnionBlockInputStream.h
+++ b/dbms/src/DataStreams/UnionBlockInputStream.h
@@ -97,8 +97,8 @@ public:
         BlockInputStreams inputs,
         BlockInputStreams additional_inputs_at_end,
         size_t max_threads,
-        const String & req_id,
         Int64 max_buffered_bytes,
+        const String & req_id,
         ExceptionCallback exception_callback_ = ExceptionCallback())
         : output_queue(
             CapacityLimits(std::min(std::max(inputs.size(), additional_inputs_at_end.size()), max_threads) * 5, max_buffered_bytes),

--- a/dbms/src/Debug/dbgQueryExecutor.cpp
+++ b/dbms/src/Debug/dbgQueryExecutor.cpp
@@ -72,9 +72,7 @@ BlockInputStreamPtr constructExchangeReceiverStream(Context & context, tipb::Exc
             /*req_id=*/"",
             /*executor_id=*/"",
             /*fine_grained_shuffle_stream_count=*/0,
-            context.getSettings().local_tunnel_version,
-            context.getSettings().async_recv_version,
-            context.getSettings().recv_queue_size);
+            context.getSettingsRef());
     BlockInputStreamPtr ret = std::make_shared<ExchangeReceiverInputStream>(exchange_receiver, /*req_id=*/"", /*executor_id=*/"", /*stream_id*/ 0);
     return ret;
 }

--- a/dbms/src/Debug/dbgQueryExecutor.cpp
+++ b/dbms/src/Debug/dbgQueryExecutor.cpp
@@ -285,7 +285,7 @@ BlockInputStreamPtr executeMPPQueryWithMultipleContext(const DAGProperties & pro
         auto partition_id = root_task_partition_ids[i];
         res.emplace_back(prepareRootExchangeReceiverWithMultipleContext(TiFlashTestEnv::getGlobalContext(TiFlashTestEnv::globalContextSize() - i - 1), properties, id, root_task_schema, server_config_map[partition_id].addr, addr));
     }
-    auto top_stream = std::make_shared<UnionBlockInputStream<>>(res, BlockInputStreams{}, res.size(), "mpp_root");
+    auto top_stream = std::make_shared<UnionBlockInputStream<>>(res, BlockInputStreams{}, res.size(), 0, "mpp_root");
     return top_stream;
 }
 

--- a/dbms/src/Flash/Coprocessor/InterpreterUtils.cpp
+++ b/dbms/src/Flash/Coprocessor/InterpreterUtils.cpp
@@ -70,9 +70,9 @@ void executeUnion(
     {
         BlockInputStreamPtr stream;
         if (ignore_block)
-            stream = std::make_shared<UnionWithoutBlock>(pipeline.streams, BlockInputStreams{}, max_streams, log->identifier(), max_buffered_bytes);
+            stream = std::make_shared<UnionWithoutBlock>(pipeline.streams, BlockInputStreams{}, max_streams, max_buffered_bytes, log->identifier());
         else
-            stream = std::make_shared<UnionWithBlock>(pipeline.streams, BlockInputStreams{}, max_streams, log->identifier(), max_buffered_bytes);
+            stream = std::make_shared<UnionWithBlock>(pipeline.streams, BlockInputStreams{}, max_streams, max_buffered_bytes, log->identifier());
         stream->setExtraInfo(extra_info);
 
         pipeline.streams.resize(1);

--- a/dbms/src/Flash/Coprocessor/InterpreterUtils.h
+++ b/dbms/src/Flash/Coprocessor/InterpreterUtils.h
@@ -47,11 +47,13 @@ void restoreConcurrency(
     PipelineExecutorStatus & exec_status,
     PipelineExecGroupBuilder & group_builder,
     size_t concurrency,
+    Int64 max_buffered_bytes,
     const LoggerPtr & log);
 
 void executeUnion(
     PipelineExecutorStatus & exec_status,
     PipelineExecGroupBuilder & group_builder,
+    Int64 max_buffered_bytes,
     const LoggerPtr & log);
 
 ExpressionActionsPtr generateProjectExpressionActions(

--- a/dbms/src/Flash/Coprocessor/InterpreterUtils.h
+++ b/dbms/src/Flash/Coprocessor/InterpreterUtils.h
@@ -32,11 +32,13 @@ class PipelineExecGroupBuilder;
 void restoreConcurrency(
     DAGPipeline & pipeline,
     size_t concurrency,
+    Int64 max_buffered_bytes,
     const LoggerPtr & log);
 
 void executeUnion(
     DAGPipeline & pipeline,
     size_t max_streams,
+    Int64 max_buffered_bytes,
     const LoggerPtr & log,
     bool ignore_block = false,
     const String & extra_info = "");

--- a/dbms/src/Flash/Mpp/ExchangeReceiver.cpp
+++ b/dbms/src/Flash/Mpp/ExchangeReceiver.cpp
@@ -323,15 +323,13 @@ ExchangeReceiverBase<RPCContext>::ExchangeReceiverBase(
     const String & req_id,
     const String & executor_id,
     uint64_t fine_grained_shuffle_stream_count_,
-    Int32 local_tunnel_version_,
-    Int32 async_recv_version_,
-    Int32 recv_queue_size,
+    const Settings & config,
     const std::vector<RequestAndRegionIDs> & disaggregated_dispatch_reqs_)
     : rpc_context(std::move(rpc_context_))
     , source_num(source_num_)
     , enable_fine_grained_shuffle_flag(enableFineGrainedShuffle(fine_grained_shuffle_stream_count_))
     , output_stream_count(enable_fine_grained_shuffle_flag ? std::min(max_streams_, fine_grained_shuffle_stream_count_) : max_streams_)
-    , max_buffer_size(getMaxBufferSize(source_num, recv_queue_size))
+    , max_buffer_size(getMaxBufferSize(source_num, config.recv_queue_size))
     , connection_uncreated_num(source_num)
     , thread_manager(newThreadManager())
     , async_wait_rewrite_queue(std::make_shared<AsyncRequestHandlerWaitQueue>())
@@ -340,8 +338,8 @@ ExchangeReceiverBase<RPCContext>::ExchangeReceiverBase(
     , state(ExchangeReceiverState::NORMAL)
     , exc_log(Logger::get(req_id, executor_id))
     , collected(false)
-    , local_tunnel_version(local_tunnel_version_)
-    , async_recv_version(async_recv_version_)
+    , local_tunnel_version(config.local_tunnel_version)
+    , async_recv_version(config.async_recv_version)
     , data_size_in_queue(0)
     , disaggregated_dispatch_reqs(disaggregated_dispatch_reqs_)
 {

--- a/dbms/src/Flash/Mpp/ExchangeReceiver.cpp
+++ b/dbms/src/Flash/Mpp/ExchangeReceiver.cpp
@@ -323,13 +323,13 @@ ExchangeReceiverBase<RPCContext>::ExchangeReceiverBase(
     const String & req_id,
     const String & executor_id,
     uint64_t fine_grained_shuffle_stream_count_,
-    const Settings & config,
+    const Settings & settings,
     const std::vector<RequestAndRegionIDs> & disaggregated_dispatch_reqs_)
     : rpc_context(std::move(rpc_context_))
     , source_num(source_num_)
     , enable_fine_grained_shuffle_flag(enableFineGrainedShuffle(fine_grained_shuffle_stream_count_))
     , output_stream_count(enable_fine_grained_shuffle_flag ? std::min(max_streams_, fine_grained_shuffle_stream_count_) : max_streams_)
-    , max_buffer_size(getMaxBufferSize(source_num, config.recv_queue_size))
+    , max_buffer_size(getMaxBufferSize(source_num, settings.recv_queue_size))
     , connection_uncreated_num(source_num)
     , thread_manager(newThreadManager())
     , async_wait_rewrite_queue(std::make_shared<AsyncRequestHandlerWaitQueue>())
@@ -338,8 +338,8 @@ ExchangeReceiverBase<RPCContext>::ExchangeReceiverBase(
     , state(ExchangeReceiverState::NORMAL)
     , exc_log(Logger::get(req_id, executor_id))
     , collected(false)
-    , local_tunnel_version(config.local_tunnel_version)
-    , async_recv_version(config.async_recv_version)
+    , local_tunnel_version(settings.local_tunnel_version)
+    , async_recv_version(settings.async_recv_version)
     , data_size_in_queue(0)
     , disaggregated_dispatch_reqs(disaggregated_dispatch_reqs_)
 {

--- a/dbms/src/Flash/Mpp/ExchangeReceiver.cpp
+++ b/dbms/src/Flash/Mpp/ExchangeReceiver.cpp
@@ -25,6 +25,7 @@
 #include <Flash/Mpp/MPPTunnel.h>
 #include <Flash/Mpp/ReceiverChannelTryWriter.h>
 #include <Flash/Mpp/ReceiverChannelWriter.h>
+#include <Interpreters/Settings.h>
 #include <common/logger_useful.h>
 #include <fmt/core.h>
 #include <grpcpp/alarm.h>

--- a/dbms/src/Flash/Mpp/ExchangeReceiver.h
+++ b/dbms/src/Flash/Mpp/ExchangeReceiver.h
@@ -20,13 +20,12 @@
 #include <Flash/Mpp/AsyncRequestHandler.h>
 #include <Flash/Mpp/GRPCReceiveQueue.h>
 #include <Flash/Mpp/GRPCReceiverContext.h>
+#include <Interpreters/Settings.h>
 
 #include <future>
 #include <memory>
 #include <mutex>
 #include <thread>
-
-#include "Interpreters/Settings.h"
 
 namespace DB
 {

--- a/dbms/src/Flash/Mpp/ExchangeReceiver.h
+++ b/dbms/src/Flash/Mpp/ExchangeReceiver.h
@@ -20,7 +20,6 @@
 #include <Flash/Mpp/AsyncRequestHandler.h>
 #include <Flash/Mpp/GRPCReceiveQueue.h>
 #include <Flash/Mpp/GRPCReceiverContext.h>
-#include <Interpreters/Settings.h>
 
 #include <future>
 #include <memory>
@@ -30,6 +29,7 @@
 namespace DB
 {
 constexpr Int32 batch_packet_count_v1 = 16;
+struct Settings;
 
 struct ExchangeReceiverResult
 {

--- a/dbms/src/Flash/Mpp/ExchangeReceiver.h
+++ b/dbms/src/Flash/Mpp/ExchangeReceiver.h
@@ -26,6 +26,8 @@
 #include <mutex>
 #include <thread>
 
+#include "Interpreters/Settings.h"
+
 namespace DB
 {
 constexpr Int32 batch_packet_count_v1 = 16;
@@ -112,9 +114,7 @@ public:
         const String & req_id,
         const String & executor_id,
         uint64_t fine_grained_shuffle_stream_count,
-        Int32 local_tunnel_version_,
-        Int32 async_recv_version_,
-        Int32 recv_queue_size,
+        const Settings & config,
         const std::vector<RequestAndRegionIDs> & disaggregated_dispatch_reqs_ = {});
 
     ~ExchangeReceiverBase();

--- a/dbms/src/Flash/Mpp/ExchangeReceiver.h
+++ b/dbms/src/Flash/Mpp/ExchangeReceiver.h
@@ -114,7 +114,7 @@ public:
         const String & req_id,
         const String & executor_id,
         uint64_t fine_grained_shuffle_stream_count,
-        const Settings & config,
+        const Settings & settings,
         const std::vector<RequestAndRegionIDs> & disaggregated_dispatch_reqs_ = {});
 
     ~ExchangeReceiverBase();

--- a/dbms/src/Flash/Mpp/GRPCSendQueue.h
+++ b/dbms/src/Flash/Mpp/GRPCSendQueue.h
@@ -77,8 +77,10 @@ template <typename T>
 class GRPCSendQueue
 {
 public:
-    GRPCSendQueue(const CapacityLimits & queue_limits, grpc_call * call, const LoggerPtr & l)
-        : send_queue(queue_limits)
+    using ElementAuxiliaryMemoryUsageFunc = std::function<Int64(const T & element)>;
+
+    GRPCSendQueue(const CapacityLimits & queue_limits, ElementAuxiliaryMemoryUsageFunc && get_auxiliary_memory_usage, grpc_call * call, const LoggerPtr & l)
+        : send_queue(queue_limits, std::move(get_auxiliary_memory_usage))
         , log(l)
         , kick_send_tag([this]() { return kickTagAction(); })
     {
@@ -92,8 +94,8 @@ public:
     }
 
     // For gtest usage.
-    GRPCSendQueue(const CapacityLimits & queue_limits, GRPCSendKickFunc func)
-        : send_queue(queue_limits)
+    GRPCSendQueue(const CapacityLimits & queue_limits, ElementAuxiliaryMemoryUsageFunc && get_auxiliary_memory_usage, GRPCSendKickFunc func)
+        : send_queue(queue_limits, std::move(get_auxiliary_memory_usage))
         , log(Logger::get())
         , kick_func(func)
         , kick_send_tag([this]() { return kickTagAction(); })

--- a/dbms/src/Flash/Mpp/GRPCSendQueue.h
+++ b/dbms/src/Flash/Mpp/GRPCSendQueue.h
@@ -77,8 +77,8 @@ template <typename T>
 class GRPCSendQueue
 {
 public:
-    GRPCSendQueue(size_t queue_size, grpc_call * call, const LoggerPtr & l)
-        : send_queue(queue_size)
+    GRPCSendQueue(const CapacityLimits & queue_limits, grpc_call * call, const LoggerPtr & l)
+        : send_queue(queue_limits)
         , log(l)
         , kick_send_tag([this]() { return kickTagAction(); })
     {
@@ -92,8 +92,8 @@ public:
     }
 
     // For gtest usage.
-    GRPCSendQueue(size_t queue_size, GRPCSendKickFunc func)
-        : send_queue(queue_size)
+    GRPCSendQueue(const CapacityLimits & queue_limits, GRPCSendKickFunc func)
+        : send_queue(queue_limits)
         , log(Logger::get())
         , kick_func(func)
         , kick_send_tag([this]() { return kickTagAction(); })

--- a/dbms/src/Flash/Mpp/MPPTask.cpp
+++ b/dbms/src/Flash/Mpp/MPPTask.cpp
@@ -16,6 +16,7 @@
 #include <Common/FailPoint.h>
 #include <Common/ThreadFactory.h>
 #include <Common/ThreadManager.h>
+#include <Common/ThresholdUtils.h>
 #include <Common/TiFlashMetrics.h>
 #include <DataStreams/IProfilingBlockInputStream.h>
 #include <DataStreams/SquashingBlockOutputStream.h>
@@ -174,6 +175,8 @@ void MPPTask::registerTunnels(const mpp::DispatchTaskRequest & task_request)
     auto tunnel_set_local = std::make_shared<MPPTunnelSet>(log->identifier());
     std::chrono::seconds timeout(task_request.timeout());
     const auto & exchange_sender = dag_context->dag_request.rootExecutor().exchange_sender();
+    size_t tunnel_queue_memory_bound = getAverageThreshold(context->getSettingsRef().max_buffered_bytes_in_executor, exchange_sender.encoded_task_meta_size());
+    CapacityLimits queue_limit(std::max(5, context->getSettingsRef().max_threads * 5), tunnel_queue_memory_bound); // MPMCQueue can benefit from a slightly larger queue size
 
     for (int i = 0; i < exchange_sender.encoded_task_meta_size(); ++i)
     {
@@ -184,7 +187,14 @@ void MPPTask::registerTunnels(const mpp::DispatchTaskRequest & task_request)
 
         bool is_local = context->getSettingsRef().enable_local_tunnel && meta.address() == task_meta.address();
         bool is_async = !is_local && context->getSettingsRef().enable_async_server;
-        MPPTunnelPtr tunnel = std::make_shared<MPPTunnel>(task_meta, task_request.meta(), timeout, context->getSettingsRef().max_threads, is_local, is_async, log->identifier());
+        MPPTunnelPtr tunnel = std::make_shared<MPPTunnel>(
+            task_meta,
+            task_request.meta(),
+            timeout,
+            queue_limit,
+            is_local,
+            is_async,
+            log->identifier());
 
         LOG_DEBUG(log, "begin to register the tunnel {}, is_local: {}, is_async: {}", tunnel->id(), is_local, is_async);
 
@@ -225,9 +235,7 @@ void MPPTask::initExchangeReceivers()
                 log->identifier(),
                 executor_id,
                 executor.fine_grained_shuffle_stream_count(),
-                context->getSettings().local_tunnel_version,
-                context->getSettings().async_recv_version,
-                context->getSettings().recv_queue_size);
+                context->getSettingsRef());
 
             if (status != RUNNING)
                 throw Exception("exchange receiver map can not be initialized, because the task is not in running state");

--- a/dbms/src/Flash/Mpp/MPPTunnel.cpp
+++ b/dbms/src/Flash/Mpp/MPPTunnel.cpp
@@ -71,17 +71,17 @@ MPPTunnel::MPPTunnel(
     const mpp::TaskMeta & receiver_meta_,
     const mpp::TaskMeta & sender_meta_,
     const std::chrono::seconds timeout_,
-    int input_steams_num_,
+    const CapacityLimits & queue_limits_,
     bool is_local_,
     bool is_async_,
     const String & req_id)
-    : MPPTunnel(fmt::format("tunnel{}+{}", sender_meta_.task_id(), receiver_meta_.task_id()), timeout_, input_steams_num_, is_local_, is_async_, req_id)
+    : MPPTunnel(fmt::format("tunnel{}+{}", sender_meta_.task_id(), receiver_meta_.task_id()), timeout_, queue_limits_, is_local_, is_async_, req_id)
 {}
 
 MPPTunnel::MPPTunnel(
     const String & tunnel_id_,
     const std::chrono::seconds timeout_,
-    int input_steams_num_,
+    const CapacityLimits & queue_limits_,
     bool is_local_,
     bool is_async_,
     const String & req_id)
@@ -90,7 +90,7 @@ MPPTunnel::MPPTunnel(
     , timeout_nanoseconds(timeout_.count() * 1000000000ULL)
     , tunnel_id(tunnel_id_)
     , mem_tracker(current_memory_tracker ? current_memory_tracker->shared_from_this() : nullptr)
-    , queue_limit(std::max(5, input_steams_num_ * 5)) // MPMCQueue can benefit from a slightly larger queue size
+    , queue_limit(queue_limits_)
     , log(Logger::get(req_id, tunnel_id))
     , data_size_in_queue(0)
 {

--- a/dbms/src/Flash/Mpp/MPPTunnel.h
+++ b/dbms/src/Flash/Mpp/MPPTunnel.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <Common/CapacityLimits.h>
 #include <Common/Exception.h>
 #include <Common/Logger.h>
 #include <Common/LooseBoundedMPMCQueue.h>
@@ -176,9 +177,9 @@ protected:
 class SyncTunnelSender : public TunnelSender
 {
 public:
-    SyncTunnelSender(size_t queue_size, MemoryTrackerPtr & memory_tracker_, const LoggerPtr & log_, const String & tunnel_id_, std::atomic<Int64> * data_size_in_queue_)
+    SyncTunnelSender(const CapacityLimits & queue_limits, MemoryTrackerPtr & memory_tracker_, const LoggerPtr & log_, const String & tunnel_id_, std::atomic<Int64> * data_size_in_queue_)
         : TunnelSender(memory_tracker_, log_, tunnel_id_, data_size_in_queue_)
-        , send_queue(LooseBoundedMPMCQueue<TrackedMppDataPacketPtr>(queue_size))
+        , send_queue(LooseBoundedMPMCQueue<TrackedMppDataPacketPtr>(queue_limits))
     {}
 
     ~SyncTunnelSender() override;
@@ -220,15 +221,15 @@ private:
 class AsyncTunnelSender : public TunnelSender
 {
 public:
-    AsyncTunnelSender(size_t queue_size, MemoryTrackerPtr & memory_tracker, const LoggerPtr & log_, const String & tunnel_id_, grpc_call * call_, std::atomic<Int64> * data_size_in_queue)
+    AsyncTunnelSender(const CapacityLimits & queue_limits, MemoryTrackerPtr & memory_tracker, const LoggerPtr & log_, const String & tunnel_id_, grpc_call * call_, std::atomic<Int64> * data_size_in_queue)
         : TunnelSender(memory_tracker, log_, tunnel_id_, data_size_in_queue)
-        , queue(queue_size, call_, log_)
+        , queue(queue_limits, call_, log_)
     {}
 
     /// For gtest usage.
-    AsyncTunnelSender(size_t queue_size, MemoryTrackerPtr & memoryTracker, const LoggerPtr & log_, const String & tunnel_id_, GRPCSendKickFunc func, std::atomic<Int64> * data_size_in_queue)
+    AsyncTunnelSender(const CapacityLimits & queue_limits, MemoryTrackerPtr & memoryTracker, const LoggerPtr & log_, const String & tunnel_id_, GRPCSendKickFunc func, std::atomic<Int64> * data_size_in_queue)
         : TunnelSender(memoryTracker, log_, tunnel_id_, data_size_in_queue)
-        , queue(queue_size, func)
+        , queue(queue_limits, func)
     {}
 
     bool push(TrackedMppDataPacketPtr && data) override
@@ -401,9 +402,9 @@ public:
     using Base = TunnelSender;
     using Base::Base;
 
-    LocalTunnelSenderV1(size_t queue_size, MemoryTrackerPtr & memory_tracker_, const LoggerPtr & log_, const String & tunnel_id_, std::atomic<Int64> * data_size_in_queue_)
+    LocalTunnelSenderV1(const CapacityLimits & queue_limits, MemoryTrackerPtr & memory_tracker_, const LoggerPtr & log_, const String & tunnel_id_, std::atomic<Int64> * data_size_in_queue_)
         : TunnelSender(memory_tracker_, log_, tunnel_id_, data_size_in_queue_)
-        , send_queue(queue_size)
+        , send_queue(queue_limits)
     {}
 
     TrackedMppDataPacketPtr readForLocal();
@@ -591,7 +592,7 @@ private:
     String tunnel_id;
 
     std::shared_ptr<MemoryTracker> mem_tracker;
-    const size_t queue_size;
+    const CapacityLimits queue_limit;
     ConnectionProfileInfo connection_profile_info;
     const LoggerPtr log;
     TunnelSenderMode mode; // Tunnel transfer data mode

--- a/dbms/src/Flash/Mpp/ReceivedMessageQueue.h
+++ b/dbms/src/Flash/Mpp/ReceivedMessageQueue.h
@@ -64,7 +64,7 @@ public:
     ReceivedMessageQueue(
         const AsyncRequestHandlerWaitQueuePtr & conn_wait_queue,
         const LoggerPtr & log_,
-        size_t max_buffer_size,
+        const CapacityLimits & queue_limits,
         bool enable_fine_grained,
         size_t fine_grained_channel_size_);
 

--- a/dbms/src/Flash/Mpp/tests/gtest_grpc_send_queue.cpp
+++ b/dbms/src/Flash/Mpp/tests/gtest_grpc_send_queue.cpp
@@ -28,11 +28,14 @@ class TestGRPCSendQueue : public testing::Test
 protected:
     TestGRPCSendQueue()
         : tag(nullptr)
-        , queue(10, [this](KickSendTag * t) -> grpc_call_error {
-            bool no_use;
-            t->FinalizeResult(&tag, &no_use);
-            return grpc_call_error::GRPC_CALL_OK;
-        })
+        , queue(
+              10,
+              [](const int &) { return 0; },
+              [this](KickSendTag * t) -> grpc_call_error {
+                  bool no_use;
+                  t->FinalizeResult(&tag, &no_use);
+                  return grpc_call_error::GRPC_CALL_OK;
+              })
     {}
     void * tag;
     GRPCSendQueue<int> queue;

--- a/dbms/src/Flash/Planner/PhysicalPlanNode.cpp
+++ b/dbms/src/Flash/Planner/PhysicalPlanNode.cpp
@@ -87,7 +87,7 @@ void PhysicalPlanNode::buildBlockInputStream(DAGPipeline & pipeline, Context & c
     if (is_restore_concurrency)
     {
         context.getDAGContext()->updateFinalConcurrency(pipeline.streams.size(), max_streams);
-        restoreConcurrency(pipeline, context.getDAGContext()->final_concurrency, log);
+        restoreConcurrency(pipeline, context.getDAGContext()->final_concurrency, context.getSettingsRef().max_buffered_bytes_in_executor, log);
     }
 }
 

--- a/dbms/src/Flash/Planner/Plans/PhysicalAggregation.cpp
+++ b/dbms/src/Flash/Planner/Plans/PhysicalAggregation.cpp
@@ -137,13 +137,14 @@ void PhysicalAggregation::buildBlockInputStreamImpl(DAGPipeline & pipeline, Cont
             params,
             true,
             max_streams,
+            settings.max_buffered_bytes_in_executor,
             settings.aggregation_memory_efficient_merge_threads ? static_cast<size_t>(settings.aggregation_memory_efficient_merge_threads) : static_cast<size_t>(settings.max_threads),
             log->identifier());
 
         pipeline.streams.resize(1);
         pipeline.firstStream() = std::move(stream);
 
-        restoreConcurrency(pipeline, context.getDAGContext()->final_concurrency, log);
+        restoreConcurrency(pipeline, context.getDAGContext()->final_concurrency, context.getSettingsRef().max_buffered_bytes_in_executor, log);
     }
     else
     {

--- a/dbms/src/Flash/Planner/Plans/PhysicalExchangeSender.cpp
+++ b/dbms/src/Flash/Planner/Plans/PhysicalExchangeSender.cpp
@@ -58,7 +58,7 @@ void PhysicalExchangeSender::buildBlockInputStreamImpl(DAGPipeline & pipeline, C
     child->buildBlockInputStream(pipeline, context, max_streams);
 
     auto & dag_context = *context.getDAGContext();
-    restoreConcurrency(pipeline, dag_context.final_concurrency, log);
+    restoreConcurrency(pipeline, dag_context.final_concurrency, context.getSettingsRef().max_buffered_bytes_in_executor, log);
 
     String extra_info;
     if (fine_grained_shuffle.enable())

--- a/dbms/src/Flash/Planner/Plans/PhysicalJoin.cpp
+++ b/dbms/src/Flash/Planner/Plans/PhysicalJoin.cpp
@@ -221,7 +221,7 @@ void PhysicalJoin::buildSideTransform(DAGPipeline & build_pipeline, Context & co
     };
     build_streams(build_pipeline.streams);
     // for test, join executor need the return blocks to output.
-    executeUnion(build_pipeline, max_streams, log, /*ignore_block=*/!context.isTest(), "for join");
+    executeUnion(build_pipeline, max_streams, context.getSettingsRef().max_buffered_bytes_in_executor, log, /*ignore_block=*/!context.isTest(), "for join");
 
     SubqueryForSet build_query;
     build_query.source = build_pipeline.firstStream();

--- a/dbms/src/Flash/Planner/Plans/PhysicalLimit.cpp
+++ b/dbms/src/Flash/Planner/Plans/PhysicalLimit.cpp
@@ -49,7 +49,7 @@ void PhysicalLimit::buildBlockInputStreamImpl(DAGPipeline & pipeline, Context & 
     pipeline.transform([&](auto & stream) { stream = std::make_shared<LimitBlockInputStream>(stream, limit, /*offset*/ 0, log->identifier()); });
     if (pipeline.hasMoreThanOneStream())
     {
-        executeUnion(pipeline, max_streams, log, false, "for partial limit");
+        executeUnion(pipeline, max_streams, context.getSettingsRef().max_buffered_bytes_in_executor, log, false, "for partial limit");
         pipeline.transform([&](auto & stream) { stream = std::make_shared<LimitBlockInputStream>(stream, limit, /*offset*/ 0, log->identifier()); });
     }
 }

--- a/dbms/src/Flash/Planner/Plans/PhysicalTopN.cpp
+++ b/dbms/src/Flash/Planner/Plans/PhysicalTopN.cpp
@@ -85,7 +85,7 @@ void PhysicalTopN::buildPipelineExecGroup(
     {
         executeFinalSort(exec_status, group_builder, order_descr, limit, context, log);
         if (is_restore_concurrency)
-            restoreConcurrency(exec_status, group_builder, concurrency, log);
+            restoreConcurrency(exec_status, group_builder, concurrency, context.getSettingsRef().max_buffered_bytes_in_executor, log);
     }
 }
 

--- a/dbms/src/Flash/Planner/Plans/PhysicalWindow.cpp
+++ b/dbms/src/Flash/Planner/Plans/PhysicalWindow.cpp
@@ -81,7 +81,7 @@ void PhysicalWindow::buildBlockInputStreamImpl(DAGPipeline & pipeline, Context &
     else
     {
         /// If there are several streams, we merge them into one.
-        executeUnion(pipeline, max_streams, log, false, "merge into one for window input");
+        executeUnion(pipeline, max_streams, context.getSettingsRef().max_buffered_bytes_in_executor, log, false, "merge into one for window input");
         RUNTIME_CHECK(pipeline.streams.size() == 1);
         pipeline.firstStream() = std::make_shared<WindowBlockInputStream>(pipeline.firstStream(), window_description, log->identifier());
     }

--- a/dbms/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterSelectQuery.cpp
@@ -920,6 +920,7 @@ void InterpreterSelectQuery::executeAggregation(Pipeline & pipeline, const Expre
             params,
             final,
             max_streams,
+            settings.max_buffered_bytes_in_executor,
             settings.aggregation_memory_efficient_merge_threads
                 ? static_cast<size_t>(settings.aggregation_memory_efficient_merge_threads)
                 : static_cast<size_t>(settings.max_threads),
@@ -1137,7 +1138,8 @@ void InterpreterSelectQuery::executeUnion(Pipeline & pipeline)
             pipeline.streams,
             BlockInputStreams{},
             max_streams,
-            /*req_id=*/"");
+            /*req_id=*/"",
+            0);
         ;
 
         pipeline.streams.resize(1);

--- a/dbms/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterSelectQuery.cpp
@@ -1138,8 +1138,8 @@ void InterpreterSelectQuery::executeUnion(Pipeline & pipeline)
             pipeline.streams,
             BlockInputStreams{},
             max_streams,
-            /*req_id=*/"",
-            0);
+            0,
+            /*req_id=*/"");
         ;
 
         pipeline.streams.resize(1);

--- a/dbms/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
@@ -224,7 +224,7 @@ BlockIO InterpreterSelectWithUnionQuery::execute()
     }
     else
     {
-        result_stream = std::make_shared<UnionBlockInputStream<>>(nested_streams, BlockInputStreams{}, settings.max_threads, /*req_id=*/"", 0);
+        result_stream = std::make_shared<UnionBlockInputStream<>>(nested_streams, BlockInputStreams{}, settings.max_threads, 0, /*req_id=*/"");
         nested_streams.clear();
     }
 

--- a/dbms/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
@@ -224,7 +224,7 @@ BlockIO InterpreterSelectWithUnionQuery::execute()
     }
     else
     {
-        result_stream = std::make_shared<UnionBlockInputStream<>>(nested_streams, BlockInputStreams{}, settings.max_threads, /*req_id=*/"");
+        result_stream = std::make_shared<UnionBlockInputStream<>>(nested_streams, BlockInputStreams{}, settings.max_threads, /*req_id=*/"", 0);
         nested_streams.clear();
     }
 

--- a/dbms/src/Interpreters/Settings.h
+++ b/dbms/src/Interpreters/Settings.h
@@ -301,7 +301,7 @@ struct Settings
     M(SettingUInt64, async_recv_version, 1, "1: reactor mode, 2: no additional threads")                                                                                                                                                \
     M(SettingUInt64, recv_queue_size, 0, "size of ExchangeReceiver queue, 0 means the size is set to data_source_mpp_task_num * 50")                                                                                                    \
     M(SettingUInt64, shallow_copy_cross_probe_threshold, 0, "minimum right rows to use shallow copy probe mode for cross join, default is max(1, max_block_size/10)")                                                                   \
-    M(SettingInt64, max_buffered_bytes_in_executor, 100LL * 1024 * 1024, "The max buffered size in each executor, 0 mean unlimited, use 100MB as the default value")
+    M(SettingInt64, max_buffered_bytes_in_executor, 200LL * 1024 * 1024, "The max buffered size in each executor, 0 mean unlimited, use 200MB as the default value")
 
 // clang-format on
 #define DECLARE(TYPE, NAME, DEFAULT, DESCRIPTION) TYPE NAME{DEFAULT};

--- a/dbms/src/Interpreters/Settings.h
+++ b/dbms/src/Interpreters/Settings.h
@@ -300,7 +300,8 @@ struct Settings
     M(SettingBool, force_push_down_all_filters_to_scan, false, "Push down all filters to scan, only used for test")                                                                                                                     \
     M(SettingUInt64, async_recv_version, 1, "1: reactor mode, 2: no additional threads")                                                                                                                                                \
     M(SettingUInt64, recv_queue_size, 0, "size of ExchangeReceiver queue, 0 means the size is set to data_source_mpp_task_num * 50")                                                                                                    \
-    M(SettingUInt64, shallow_copy_cross_probe_threshold, 0, "minimum right rows to use shallow copy probe mode for cross join, default is max(1, max_block_size/10)")
+    M(SettingUInt64, shallow_copy_cross_probe_threshold, 0, "minimum right rows to use shallow copy probe mode for cross join, default is max(1, max_block_size/10)")                                                                   \
+    M(SettingInt64, max_buffered_bytes_in_executor, 0, "The max buffered size in each executor, 0 mean unlimited")
 
 // clang-format on
 #define DECLARE(TYPE, NAME, DEFAULT, DESCRIPTION) TYPE NAME{DEFAULT};

--- a/dbms/src/Interpreters/Settings.h
+++ b/dbms/src/Interpreters/Settings.h
@@ -301,7 +301,7 @@ struct Settings
     M(SettingUInt64, async_recv_version, 1, "1: reactor mode, 2: no additional threads")                                                                                                                                                \
     M(SettingUInt64, recv_queue_size, 0, "size of ExchangeReceiver queue, 0 means the size is set to data_source_mpp_task_num * 50")                                                                                                    \
     M(SettingUInt64, shallow_copy_cross_probe_threshold, 0, "minimum right rows to use shallow copy probe mode for cross join, default is max(1, max_block_size/10)")                                                                   \
-    M(SettingInt64, max_buffered_bytes_in_executor, 0, "The max buffered size in each executor, 0 mean unlimited")
+    M(SettingInt64, max_buffered_bytes_in_executor, 100LL * 1024 * 1024, "The max buffered size in each executor, 0 mean unlimited, use 100MB as the default value")
 
 // clang-format on
 #define DECLARE(TYPE, NAME, DEFAULT, DESCRIPTION) TYPE NAME{DEFAULT};

--- a/dbms/src/Interpreters/SharedQueries.h
+++ b/dbms/src/Interpreters/SharedQueries.h
@@ -133,7 +133,7 @@ public:
         else
         {
             BlockIO io = creator();
-            io.in = std::make_shared<SharedQueryBlockInputStream>(clients, io.in, /*req_id=*/"");
+            io.in = std::make_shared<SharedQueryBlockInputStream>(clients, 0, io.in, /*req_id=*/"");
             queries.emplace(query_id, std::make_shared<SharedQuery>(query_id, clients, io.in));
 
             LOG_TRACE(log, "getOrCreateBlockIO, query_id: {}, clients: {}, connected_clients: 1", query_id, clients);

--- a/dbms/src/Operators/SharedQueue.h
+++ b/dbms/src/Operators/SharedQueue.h
@@ -31,9 +31,9 @@ using SharedQueuePtr = std::shared_ptr<SharedQueue>;
 class SharedQueue
 {
 public:
-    static SharedQueuePtr build(size_t producer, size_t consumer);
+    static SharedQueuePtr build(size_t producer, size_t consumer, Int64 max_buffered_bytes);
 
-    SharedQueue(size_t queue_size, size_t init_producer);
+    SharedQueue(CapacityLimits queue_limits, size_t init_producer);
 
     MPMCQueueResult tryPush(Block && block);
     MPMCQueueResult tryPop(Block & block);

--- a/dbms/src/Operators/tests/gtest_shared_queue.cpp
+++ b/dbms/src/Operators/tests/gtest_shared_queue.cpp
@@ -26,7 +26,7 @@ class TestSharedQueue : public ::testing::Test
 TEST_F(TestSharedQueue, base)
 try
 {
-    auto shared_queue = SharedQueue::build(2, 1);
+    auto shared_queue = SharedQueue::build(2, 1, 0);
     {
         Block block{ColumnGenerator::instance().generate({2, "Int32", DataDistribution::RANDOM})};
         ASSERT_EQ(shared_queue->tryPush(std::move(block)), MPMCQueueResult::OK);

--- a/dbms/src/Storages/StorageDisaggregated.cpp
+++ b/dbms/src/Storages/StorageDisaggregated.cpp
@@ -308,9 +308,7 @@ void StorageDisaggregated::buildExchangeReceiver(const std::vector<RequestAndReg
         log->identifier(),
         executor_id,
         /*fine_grained_shuffle_stream_count=*/0,
-        context.getSettingsRef().local_tunnel_version,
-        context.getSettings().async_recv_version,
-        context.getSettings().recv_queue_size,
+        context.getSettingsRef(),
         dispatch_reqs);
 
     // MPPTask::receiver_set will record this ExchangeReceiver, so can cancel it in ReceiverSet::cancel().


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #7531

Problem Summary:

### What is changed and how it works?
- Use memory bounded buffer in ExchangeReceiver/MPPTunnel/UnionBlockInputStream/SharedQueryBlockInputStream/SharedQueue
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
In a 3 nodes TiFlash cluster, run `explain analyze select * from lineitem` on TPCH-100

| max_buffered_bytes_in_executor | Peak memory usages in one TiFlash node |
|---------|------------------------------------------|
| 0(unlimited) |  2.37 GiB  |
| 200 MB(default value) |   1.55 GiB    |
| 1 byte | 1.39 GiB |

The query time is almost the same as it is a really simple query
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
