### PR TITLE
Tsan: fix data race on `ComputeServerRunner`

### DIFF
--- a/dbms/src/Common/FailPoint.cpp
+++ b/dbms/src/Common/FailPoint.cpp
@@ -49,6 +49,7 @@ namespace DB
     M(exception_during_mpp_register_tunnel_for_non_root_mpp_task) \
     M(exception_before_mpp_non_root_task_run)                     \
     M(exception_during_mpp_non_root_task_run)                     \
+    M(exception_during_query_run)                                 \
     M(exception_before_mpp_register_root_mpp_task)                \
     M(exception_before_mpp_register_tunnel_for_root_mpp_task)     \
     M(exception_before_mpp_root_task_run)                         \

--- a/dbms/src/Common/FailPoint.h
+++ b/dbms/src/Common/FailPoint.h
@@ -39,12 +39,17 @@ namespace ErrorCodes
 extern const int FAIL_POINT_ERROR;
 };
 
+#ifndef NDEBUG
 /// Macros to set failpoints.
 // When `fail_point` is enabled, throw an exception
 #define FAIL_POINT_TRIGGER_EXCEPTION(fail_point) \
     fiu_do_on(fail_point, throw Exception("Fail point " #fail_point " is triggered.", ErrorCodes::FAIL_POINT_ERROR);)
 // When `fail_point` is enabled, wait till it is disabled
 #define FAIL_POINT_PAUSE(fail_point) fiu_do_on(fail_point, FailPointHelper::wait(fail_point);)
+#else
+#define FAIL_POINT_TRIGGER_EXCEPTION(fail_point) ;
+#define FAIL_POINT_PAUSE(fail_point) ;
+#endif
 
 class FailPointChannel;
 class FailPointHelper

--- a/dbms/src/DataStreams/ExchangeSenderBlockInputStream.cpp
+++ b/dbms/src/DataStreams/ExchangeSenderBlockInputStream.cpp
@@ -12,31 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <Common/FailPoint.h>
 #include <DataStreams/ExchangeSenderBlockInputStream.h>
-#include <Flash/Coprocessor/DAGContext.h>
 
 namespace DB
 {
-namespace FailPoints
-{
-extern const char hang_in_execution[];
-extern const char exception_during_mpp_non_root_task_run[];
-extern const char exception_during_mpp_root_task_run[];
-} // namespace FailPoints
-
 Block ExchangeSenderBlockInputStream::readImpl()
 {
-    FAIL_POINT_PAUSE(FailPoints::hang_in_execution);
-    if (writer->dagContext().isRootMPPTask())
-    {
-        FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::exception_during_mpp_root_task_run);
-    }
-    else
-    {
-        FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::exception_during_mpp_non_root_task_run);
-    }
-
     Block block = children.back()->read();
     if (block)
     {

--- a/dbms/src/DataStreams/IProfilingBlockInputStream.cpp
+++ b/dbms/src/DataStreams/IProfilingBlockInputStream.cpp
@@ -12,13 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Common/FailPoint.h>
 #include <DataStreams/IProfilingBlockInputStream.h>
 #include <Interpreters/ProcessList.h>
 #include <Interpreters/Quota.h>
 
-
 namespace DB
 {
+namespace FailPoints
+{
+extern const char exception_during_query_run[];
+} // namespace FailPoints
 
 namespace ErrorCodes
 {
@@ -45,6 +49,8 @@ Block IProfilingBlockInputStream::read()
 
 Block IProfilingBlockInputStream::read(FilterPtr & res_filter, bool return_filter)
 {
+    FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::exception_during_query_run);
+
     if (total_rows_approx)
     {
         progressImpl(Progress(0, 0, total_rows_approx));

--- a/dbms/src/Flash/Coprocessor/DAGResponseWriter.h
+++ b/dbms/src/Flash/Coprocessor/DAGResponseWriter.h
@@ -42,7 +42,6 @@ public:
     /// flush cached blocks for batch writer
     virtual void flush() = 0;
     virtual ~DAGResponseWriter() = default;
-    const DAGContext & dagContext() const { return dag_context; }
 
 protected:
     Int64 records_per_chunk;

--- a/dbms/src/Flash/Executor/DataStreamExecutor.cpp
+++ b/dbms/src/Flash/Executor/DataStreamExecutor.cpp
@@ -76,6 +76,9 @@ int DataStreamExecutor::estimateNewThreadCount()
     return estimate_thread_cnt;
 }
 
+// TODO fix the data race on BlockStreamProfileInfo when the stream throws an error
+// and remove `race:dbms/src/DataStreams/BlockStreamProfileInfo.h` in tests/sanitize/tsan.suppression.
+// https://github.com/pingcap/tiflash/issues/7631
 RU DataStreamExecutor::collectRequestUnit()
 {
     // The cputime returned by BlockInputSrream is a count of the execution time of each thread.

--- a/dbms/src/Flash/Executor/QueryExecutor.cpp
+++ b/dbms/src/Flash/Executor/QueryExecutor.cpp
@@ -12,18 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Common/FailPoint.h>
 #include <Flash/Executor/QueryExecutor.h>
 #include <Interpreters/Context.h>
 
 namespace DB
 {
+namespace FailPoints
+{
+extern const char hang_in_execution[];
+} // namespace FailPoints
+
 ExecutionResult QueryExecutor::execute()
 {
+    FAIL_POINT_PAUSE(FailPoints::hang_in_execution);
     return execute(ResultHandler{});
 }
 
 ExecutionResult QueryExecutor::execute(ResultHandler::Handler handler)
 {
+    FAIL_POINT_PAUSE(FailPoints::hang_in_execution);
     return execute(ResultHandler{handler});
 }
 

--- a/dbms/src/Flash/Mpp/MPPHandler.cpp
+++ b/dbms/src/Flash/Mpp/MPPHandler.cpp
@@ -50,14 +50,6 @@ void addRetryRegion(const ContextPtr & context, mpp::DispatchTaskResponse * resp
         }
     }
 }
-
-void injectFailPointBeforeMPPTaskRun(bool is_root_task)
-{
-    if (is_root_task)
-        FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::exception_before_mpp_root_task_run);
-    else
-        FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::exception_before_mpp_non_root_task_run);
-}
 } // namespace
 
 void MPPHandler::handleError(const MPPTaskPtr & task, String error)
@@ -89,7 +81,13 @@ grpc::Status MPPHandler::execute(const ContextPtr & context, mpp::DispatchTaskRe
         task->prepare(task_request);
 
         addRetryRegion(context, response);
-        injectFailPointBeforeMPPTaskRun(task->isRootMPPTask());
+
+#ifndef NDEBUG
+        if (task->isRootMPPTask())
+            FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::exception_before_mpp_root_task_run);
+        else
+            FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::exception_before_mpp_non_root_task_run);
+#endif
 
         task->run();
         LOG_INFO(log, "processing dispatch is over; the time cost is {} ms", stopwatch.elapsedMilliseconds());

--- a/dbms/src/Flash/Mpp/MPPTask.cpp
+++ b/dbms/src/Flash/Mpp/MPPTask.cpp
@@ -50,6 +50,8 @@ extern const char exception_before_mpp_register_tunnel_for_non_root_mpp_task[];
 extern const char exception_before_mpp_register_tunnel_for_root_mpp_task[];
 extern const char exception_during_mpp_register_tunnel_for_non_root_mpp_task[];
 extern const char force_no_local_region_for_mpp_task[];
+extern const char exception_during_mpp_non_root_task_run[];
+extern const char exception_during_mpp_root_task_run[];
 } // namespace FailPoints
 
 namespace
@@ -433,6 +435,17 @@ void MPPTask::runImpl()
             throw Exception("task not in running state, may be cancelled");
         }
         mpp_task_statistics.start();
+
+#ifndef NDEBUG
+        if (isRootMPPTask())
+        {
+            FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::exception_during_mpp_root_task_run);
+        }
+        else
+        {
+            FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::exception_during_mpp_non_root_task_run);
+        }
+#endif
 
         auto result = query_executor_holder->execute();
         LOG_INFO(log, "mpp task finish execute, success: {}", result.is_success);

--- a/dbms/src/Flash/Pipeline/Schedule/Tasks/EventTask.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/Tasks/EventTask.cpp
@@ -23,6 +23,7 @@ namespace FailPoints
 {
 extern const char random_pipeline_model_task_run_failpoint[];
 extern const char random_pipeline_model_cancel_failpoint[];
+extern const char exception_during_query_run[];
 } // namespace FailPoints
 
 #define EXECUTE(function)                                                                   \
@@ -33,6 +34,7 @@ extern const char random_pipeline_model_cancel_failpoint[];
     {                                                                                       \
         auto status = (function());                                                         \
         FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::random_pipeline_model_task_run_failpoint); \
+        FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::exception_during_query_run);               \
         return status;                                                                      \
     }                                                                                       \
     catch (...)                                                                             \

--- a/dbms/src/Flash/tests/gtest_compute_server.cpp
+++ b/dbms/src/Flash/tests/gtest_compute_server.cpp
@@ -30,7 +30,9 @@ extern const char exception_before_mpp_non_root_task_run[];
 extern const char exception_before_mpp_root_task_run[];
 extern const char exception_during_mpp_non_root_task_run[];
 extern const char exception_during_mpp_root_task_run[];
+extern const char exception_during_query_run[];
 } // namespace FailPoints
+
 namespace tests
 {
 LoggerPtr MPPTaskTestUtils::log_ptr = nullptr;
@@ -810,6 +812,7 @@ try
         FailPoints::exception_before_mpp_root_task_run,
         FailPoints::exception_during_mpp_non_root_task_run,
         FailPoints::exception_during_mpp_root_task_run,
+        FailPoints::exception_during_query_run,
     };
     size_t query_index = 0;
     for (const auto & failpoint : failpoint_names)

--- a/dbms/src/Flash/tests/gtest_compute_server.cpp
+++ b/dbms/src/Flash/tests/gtest_compute_server.cpp
@@ -797,6 +797,7 @@ CATCH
 TEST_F(ComputeServerRunner, testErrorMessage)
 try
 {
+    WRAP_FOR_SERVER_TEST_BEGIN
     startServers(3);
     setCancelTest();
     std::vector<String> failpoint_names{
@@ -841,6 +842,7 @@ try
             GTEST_FAIL();
         }
     }
+    WRAP_FOR_SERVER_TEST_END
 }
 CATCH
 

--- a/dbms/src/Operators/ExchangeSenderSinkOp.cpp
+++ b/dbms/src/Operators/ExchangeSenderSinkOp.cpp
@@ -12,19 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <Common/FailPoint.h>
-#include <Flash/Coprocessor/DAGContext.h>
 #include <Operators/ExchangeSenderSinkOp.h>
 
 namespace DB
 {
-namespace FailPoints
-{
-extern const char hang_in_execution[];
-extern const char exception_during_mpp_non_root_task_run[];
-extern const char exception_during_mpp_root_task_run[];
-} // namespace FailPoints
-
 void ExchangeSenderSinkOp::operatePrefix()
 {
     writer->prepare(getHeader());
@@ -37,18 +28,6 @@ void ExchangeSenderSinkOp::operateSuffix()
 
 OperatorStatus ExchangeSenderSinkOp::writeImpl(Block && block)
 {
-#ifndef NDEBUG
-    FAIL_POINT_PAUSE(FailPoints::hang_in_execution);
-    if (writer->dagContext().isRootMPPTask())
-    {
-        FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::exception_during_mpp_root_task_run);
-    }
-    else
-    {
-        FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::exception_during_mpp_non_root_task_run);
-    }
-#endif
-
     if (!block)
     {
         writer->flush();

--- a/tests/fullstack-test/mpp/mpp_fail.test
+++ b/tests/fullstack-test/mpp/mpp_fail.test
@@ -115,6 +115,12 @@ mysql> use test; set @@tidb_isolation_read_engines='tiflash'; set @@tidb_allow_m
 {#REGEXP}.*Fail point FailPoints::exception_during_mpp_root_task_run is triggered.*
 => DBGInvoke __disable_fail_point(exception_during_mpp_root_task_run)
 
+## exception during query run
+=> DBGInvoke __enable_fail_point(exception_during_query_run)
+mysql> use test; set @@tidb_isolation_read_engines='tiflash'; set @@tidb_allow_mpp=1; select count(value), id from t group by id;
+{#REGEXP}.*Fail point FailPoints::exception_during_query_run is triggered.*
+=> DBGInvoke __disable_fail_point(exception_during_query_run)
+
 ## exception during mpp hash build
 ## desc format='brief' select t1.id from test.t t1 join test.t t2 on t1.id = t2.id and t1.id <2 join (select id from test.t group by id) t3 on t2.id=t3.id;
 ## +-----------------------------------------+---------+-------------------+---------------+-------------------------------------------------------------------------+

--- a/tests/sanitize/tsan.suppression
+++ b/tests/sanitize/tsan.suppression
@@ -2,3 +2,4 @@ race:dbms/src/Common/TiFlashMetrics.h
 race:DB::Context::setCancelTest
 race:DB::getCurrentExceptionMessage
 race:fiu_fail
+race:dbms/src/DataStreams/BlockStreamProfileInfo.h

--- a/tests/sanitize/tsan.suppression
+++ b/tests/sanitize/tsan.suppression
@@ -1,3 +1,4 @@
 race:dbms/src/Common/TiFlashMetrics.h
 race:DB::Context::setCancelTest
 race:DB::getCurrentExceptionMessage
+race:fiu_fail


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #7626

Problem Summary:

### What is changed and how it works?
- ignore data race of `Failpoint` and `BlockStreamProfileInfo`
    - https://github.com/pingcap/tiflash/issues/7631
    - add todo to fix the data race on `BlockStreamProfileInfo`
- move failpoint `exception_during_mpp_non_root_task_run`, `exception_during_mpp_root_task_run` and `hang_in_execution` to more suitable positions.
- add failpoint `exception_during_query_run`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
