### PR TITLE
Introduce mpp query level processListEntry

### DIFF
--- a/dbms/src/Common/TiFlashMetrics.h
+++ b/dbms/src/Common/TiFlashMetrics.h
@@ -77,7 +77,8 @@ namespace DB
     M(tiflash_coprocessor_request_memory_usage, "Bucketed histogram of request memory usage", Histogram,                                            \
         F(type_cop, {{"type", "cop"}}, ExpBuckets{1024 * 1024, 2, 16}),                                                                             \
         F(type_batch, {{"type", "batch"}}, ExpBuckets{1024 * 1024, 2, 20}),                                                                         \
-        F(type_run_mpp_task, {{"type", "run_mpp_task"}}, ExpBuckets{1024 * 1024, 2, 20}))                                                           \
+        F(type_run_mpp_task, {{"type", "run_mpp_task"}}, ExpBuckets{1024 * 1024, 2, 20}),                                                           \
+        F(type_run_mpp_query, {{"type", "run_mpp_query"}}, ExpBuckets{1024 * 1024, 2, 20}))                                                         \
     M(tiflash_coprocessor_request_error, "Total number of request error", Counter, F(reason_meet_lock, {"reason", "meet_lock"}),                    \
         F(reason_region_not_found, {"reason", "region_not_found"}), F(reason_epoch_not_match, {"reason", "epoch_not_match"}),                       \
         F(reason_kv_client_error, {"reason", "kv_client_error"}), F(reason_internal_error, {"reason", "internal_error"}),                           \

--- a/dbms/src/Debug/dbgQueryExecutor.cpp
+++ b/dbms/src/Debug/dbgQueryExecutor.cpp
@@ -39,7 +39,7 @@ void setTipbRegionInfo(coprocessor::RegionInfo * tipb_region_info, const std::pa
     range->set_end(RecordKVFormat::genRawKey(table_id, handle_range.second.handle_id));
 }
 
-BlockInputStreamPtr constructExchangeReceiverStream(Context & context, tipb::ExchangeReceiver & tipb_exchange_receiver, const DAGProperties & properties, DAGSchema & root_task_schema, const String & root_addr, bool enable_local_tunnel)
+BlockInputStreamPtr constructRootExchangeReceiverStream(Context & context, tipb::ExchangeReceiver & tipb_exchange_receiver, const DAGProperties & properties, DAGSchema & root_task_schema, const String & root_addr)
 {
     for (auto & field : root_task_schema)
     {
@@ -65,7 +65,7 @@ BlockInputStreamPtr constructExchangeReceiverStream(Context & context, tipb::Exc
                 root_tm,
                 context.getTMTContext().getKVCluster(),
                 context.getTMTContext().getMPPTaskManager(),
-                enable_local_tunnel,
+                false,
                 context.getSettingsRef().enable_async_grpc_client),
             tipb_exchange_receiver.encoded_task_meta_size(),
             10,
@@ -77,7 +77,7 @@ BlockInputStreamPtr constructExchangeReceiverStream(Context & context, tipb::Exc
     return ret;
 }
 
-BlockInputStreamPtr prepareRootExchangeReceiver(Context & context, const DAGProperties & properties, std::vector<Int64> & root_task_ids, DAGSchema & root_task_schema, bool enable_local_tunnel)
+BlockInputStreamPtr prepareRootExchangeReceiver(Context & context, const DAGProperties & properties, std::vector<Int64> & root_task_ids, DAGSchema & root_task_schema)
 {
     tipb::ExchangeReceiver tipb_exchange_receiver;
     for (const auto root_task_id : root_task_ids)
@@ -93,7 +93,7 @@ BlockInputStreamPtr prepareRootExchangeReceiver(Context & context, const DAGProp
         auto * tm_string = tipb_exchange_receiver.add_encoded_task_meta();
         tm.AppendToString(tm_string);
     }
-    return constructExchangeReceiverStream(context, tipb_exchange_receiver, properties, root_task_schema, Debug::LOCAL_HOST, enable_local_tunnel);
+    return constructRootExchangeReceiverStream(context, tipb_exchange_receiver, properties, root_task_schema, Debug::LOCAL_HOST);
 }
 
 void prepareExchangeReceiverMetaWithMultipleContext(tipb::ExchangeReceiver & tipb_exchange_receiver, const DAGProperties & properties, Int64 task_id, String & addr)
@@ -116,7 +116,7 @@ BlockInputStreamPtr prepareRootExchangeReceiverWithMultipleContext(Context & con
 
     prepareExchangeReceiverMetaWithMultipleContext(tipb_exchange_receiver, properties, task_id, addr);
 
-    return constructExchangeReceiverStream(context, tipb_exchange_receiver, properties, root_task_schema, root_addr, true);
+    return constructRootExchangeReceiverStream(context, tipb_exchange_receiver, properties, root_task_schema, root_addr);
 }
 
 void prepareDispatchTaskRequest(QueryTask & task, std::shared_ptr<mpp::DispatchTaskRequest> req, const DAGProperties & properties, std::vector<Int64> & root_task_ids, DAGSchema & root_task_schema, String & addr)
@@ -222,7 +222,7 @@ BlockInputStreamPtr executeMPPQuery(Context & context, const DAGProperties & pro
         if (call.getResp()->has_error())
             throw Exception("Meet error while dispatch mpp task: " + call.getResp()->error().msg());
     }
-    return prepareRootExchangeReceiver(context, properties, root_task_ids, root_task_schema, context.getSettingsRef().enable_local_tunnel);
+    return prepareRootExchangeReceiver(context, properties, root_task_ids, root_task_schema);
 }
 
 BlockInputStreamPtr executeNonMPPQuery(Context & context, RegionID region_id, const DAGProperties & properties, QueryTasks & query_tasks, MakeResOutputStream & func_wrap_output_stream)

--- a/dbms/src/Flash/Mpp/ExchangeReceiver.cpp
+++ b/dbms/src/Flash/Mpp/ExchangeReceiver.cpp
@@ -562,7 +562,6 @@ void ExchangeReceiverBase<RPCContext>::setUpLocalConnections(std::vector<Request
             LoggerPtr local_log = Logger::get(fmt::format("{} {}", exc_log->identifier(), req_info));
 
             LocalRequestHandler local_request_handler(
-                getMemoryTracker(),
                 [this, log = local_log](bool meet_error, const String & local_err_msg) {
                     this->connectionDone(meet_error, local_err_msg, log);
                 },

--- a/dbms/src/Flash/Mpp/LocalRequestHandler.h
+++ b/dbms/src/Flash/Mpp/LocalRequestHandler.h
@@ -22,13 +22,11 @@ namespace DB
 struct LocalRequestHandler
 {
     LocalRequestHandler(
-        MemoryTracker * recv_mem_tracker_,
         std::function<void(bool, const String &)> && notify_write_done_,
         std::function<void()> && notify_close_,
         std::function<void()> && add_local_conn_num_,
         ReceiverChannelWriter && channel_writer_)
-        : recv_mem_tracker(recv_mem_tracker_)
-        , notify_write_done(std::move(notify_write_done_))
+        : notify_write_done(std::move(notify_write_done_))
         , notify_close(std::move(notify_close_))
         , add_local_conn_num(std::move(add_local_conn_num_))
         , channel_writer(std::move(channel_writer_))
@@ -75,7 +73,6 @@ struct LocalRequestHandler
         return waiting_task_time;
     }
 
-    MemoryTracker * recv_mem_tracker;
     std::function<void(bool, const String &)> notify_write_done;
     std::function<void()> notify_close;
     std::function<void()> add_local_conn_num;

--- a/dbms/src/Flash/Mpp/MPPTask.cpp
+++ b/dbms/src/Flash/Mpp/MPPTask.cpp
@@ -524,7 +524,6 @@ void MPPTask::runImpl()
             /// note that memory_tracker is shared by all the mpp tasks, the peak memory usage is not accurate
             /// todo log executor level peak memory usage instead
             auto peak_memory = process_list_entry->get().getMemoryTrackerPtr()->getPeak();
-            GET_METRIC(tiflash_coprocessor_request_memory_usage, type_run_mpp_task).Observe(peak_memory);
             mpp_task_statistics.setMemoryPeak(peak_memory);
         }
     }

--- a/dbms/src/Flash/Mpp/MPPTask.cpp
+++ b/dbms/src/Flash/Mpp/MPPTask.cpp
@@ -311,6 +311,7 @@ void MPPTask::initProcessListEntry(MPPTaskManagerPtr & task_manager)
     assert(query_process_list_entry != nullptr);
     process_list_entry = query_process_list_entry;
     dag_context->setProcessListEntry(process_list_entry);
+    context->setProcessListElement(&process_list_entry->get());
     current_memory_tracker = process_list_entry->get().getMemoryTrackerPtr().get();
 }
 

--- a/dbms/src/Flash/Mpp/MPPTask.cpp
+++ b/dbms/src/Flash/Mpp/MPPTask.cpp
@@ -304,12 +304,13 @@ void MPPTask::unregisterTask()
 
 void MPPTask::initMemoryTracker(MPPTaskManagerPtr & task_manager)
 {
+    /// all the mpp tasks of the same mpp query shares the same memory tracker
     auto [query_memory_tracker, aborted_reason] = task_manager->getOrCreateQueryMemoryTracker(id.query_id, context);
     if (!aborted_reason.empty())
         throw TiFlashException(fmt::format("MPP query is already aborted, aborted reason: {}", aborted_reason), Errors::Coprocessor::Internal);
-    /// all the mpp tasks of the same mpp query shares the same memory tracker
-    memory_tracker = query_memory_tracker;
-    current_memory_tracker = memory_tracker.get();
+    assert(query_memory_tracker != nullptr);
+    /// set query_memory_tracker to current_memory_tracker, and it will eventually be saved in `process_list_entry`
+    current_memory_tracker = query_memory_tracker.get();
 }
 
 void MPPTask::prepare(const mpp::DispatchTaskRequest & task_request)

--- a/dbms/src/Flash/Mpp/MPPTask.cpp
+++ b/dbms/src/Flash/Mpp/MPPTask.cpp
@@ -99,7 +99,10 @@ void MPPTaskMonitorHelper::initAndAddself(MPPTaskManager * manager_, const Strin
 MPPTaskMonitorHelper::~MPPTaskMonitorHelper()
 {
     if (initialized)
+    {
+        current_memory_tracker = nullptr;
         manager->removeMonitoredTask(task_unique_id);
+    }
 }
 
 MPPTask::MPPTask(const mpp::TaskMeta & meta_, const ContextPtr & context_)

--- a/dbms/src/Flash/Mpp/MPPTask.cpp
+++ b/dbms/src/Flash/Mpp/MPPTask.cpp
@@ -521,8 +521,9 @@ void MPPTask::runImpl()
             // todo when error happens, should try to update the metrics if it is available
             if (auto throughput = dag_context->getTableScanThroughput(); throughput.first)
                 GET_METRIC(tiflash_storage_logical_throughput_bytes).Observe(throughput.second);
-            auto process_info = context->getProcessListElement()->getInfo();
-            auto peak_memory = process_info.peak_memory_usage > 0 ? process_info.peak_memory_usage : 0;
+            /// note that memory_tracker is shared by all the mpp tasks, the peak memory usage is not accurate
+            /// todo log executor level peak memory usage instead
+            auto peak_memory = process_list_entry->get().getMemoryTrackerPtr()->getPeak();
             GET_METRIC(tiflash_coprocessor_request_memory_usage, type_run_mpp_task).Observe(peak_memory);
             mpp_task_statistics.setMemoryPeak(peak_memory);
         }

--- a/dbms/src/Flash/Mpp/MPPTask.h
+++ b/dbms/src/Flash/Mpp/MPPTask.h
@@ -132,6 +132,17 @@ private:
     void setErrString(const String & message);
 
 private:
+    struct ProcessListEntryHolder
+    {
+        std::shared_ptr<ProcessListEntry> process_list_entry;
+        ~ProcessListEntryHolder()
+        {
+            /// Because MemoryTracker is now saved in `MPPQueryTaskSet` and shared by all the mpp tasks belongs to the same mpp query,
+            /// it may not be destructed when MPPTask is destructed, so need to manually reset current_memory_tracker to nullptr at the
+            /// end of the destructor of MPPTask, otherwise, current_memory_tracker may point to a invalid memory tracker
+            current_memory_tracker = nullptr;
+        }
+    };
     // We must ensure this member variable is put at this place to be destructed at proper time
     MPPTaskMonitorHelper mpp_task_monitor_helper;
 
@@ -147,11 +158,10 @@ private:
 
     MPPTaskScheduleEntry schedule_entry;
 
+    ProcessListEntryHolder process_list_entry_holder;
     // `dag_context` holds inputstreams which could hold ref to `context` so it should be destructed
     // before `context`.
     std::unique_ptr<DAGContext> dag_context;
-
-    std::shared_ptr<ProcessListEntry> process_list_entry;
 
     QueryExecutorHolder query_executor_holder;
 

--- a/dbms/src/Flash/Mpp/MPPTask.h
+++ b/dbms/src/Flash/Mpp/MPPTask.h
@@ -124,7 +124,7 @@ private:
 
     void registerTunnels(const mpp::DispatchTaskRequest & task_request);
 
-    void initMemoryTracker(MPPTaskManagerPtr & task_manager);
+    void initProcessListEntry(MPPTaskManagerPtr & task_manager);
 
     void initExchangeReceivers();
 

--- a/dbms/src/Flash/Mpp/MPPTask.h
+++ b/dbms/src/Flash/Mpp/MPPTask.h
@@ -140,7 +140,6 @@ private:
     mpp::TaskMeta meta;
     MPPTaskId id;
 
-    MemoryTrackerPtr memory_tracker;
     ContextPtr context;
 
     MPPTaskManager * manager;

--- a/dbms/src/Flash/Mpp/MPPTask.h
+++ b/dbms/src/Flash/Mpp/MPPTask.h
@@ -131,6 +131,8 @@ private:
     String getErrString() const;
     void setErrString(const String & message);
 
+    MemoryTracker * getMemoryTracker() const;
+
 private:
     struct ProcessListEntryHolder
     {

--- a/dbms/src/Flash/Mpp/MPPTask.h
+++ b/dbms/src/Flash/Mpp/MPPTask.h
@@ -37,6 +37,7 @@
 namespace DB
 {
 class MPPTaskManager;
+using MPPTaskManagerPtr = std::shared_ptr<MPPTaskManager>;
 class DAGContext;
 class ProcessListEntry;
 
@@ -123,6 +124,8 @@ private:
 
     void registerTunnels(const mpp::DispatchTaskRequest & task_request);
 
+    void initMemoryTracker(MPPTaskManagerPtr & task_manager);
+
     void initExchangeReceivers();
 
     String getErrString() const;
@@ -137,6 +140,7 @@ private:
     mpp::TaskMeta meta;
     MPPTaskId id;
 
+    MemoryTrackerPtr memory_tracker;
     ContextPtr context;
 
     MPPTaskManager * manager;

--- a/dbms/src/Flash/Mpp/MPPTaskManager.cpp
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.cpp
@@ -247,13 +247,12 @@ std::pair<bool, String> MPPTaskManager::registerTask(MPPTaskPtr task)
     {
         return {false, fmt::format("query is being aborted, error message = {}", error_msg)};
     }
-    if (query_set != nullptr && query_set->task_map.find(task->id) != query_set->task_map.end())
+    /// query_set must not be nullptr if the current query is not aborted since MPPTask::initProcessListEntry
+    /// will always create the query_set
+    RUNTIME_CHECK_MSG(query_set != nullptr, "query set must not be null when register task");
+    if (query_set->task_map.find(task->id) != query_set->task_map.end())
     {
         return {false, "task has been registered"};
-    }
-    if (query_set == nullptr) /// the first one
-    {
-        query_set = addMPPQueryTaskSet(task->id.query_id);
     }
     query_set->task_map.emplace(task->id, task);
     /// cancel all the alarm waiting on this task

--- a/dbms/src/Flash/Mpp/MPPTaskManager.cpp
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.cpp
@@ -22,7 +22,6 @@
 
 #include <magic_enum.hpp>
 #include <memory>
-#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <utility>

--- a/dbms/src/Flash/Mpp/MPPTaskManager.h
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.h
@@ -40,6 +40,7 @@ struct MPPQueryTaskSet
     /// task can only be registered state is Normal
     State state = Normal;
     String error_message;
+    MemoryTrackerPtr memory_tracker;
     MPPTaskMap task_map;
     std::unordered_map<Int64, std::unordered_map<Int64, grpc::Alarm>> alarms;
     /// only used in scheduler
@@ -192,6 +193,8 @@ public:
     std::pair<MPPTunnelPtr, String> findAsyncTunnel(const ::mpp::EstablishMPPConnectionRequest * request, EstablishCallData * call_data, grpc::CompletionQueue * cq);
 
     void abortMPPQuery(const MPPQueryId & query_id, const String & reason, AbortType abort_type);
+
+    std::pair<MemoryTrackerPtr, String> getOrCreateQueryMemoryTracker(const MPPQueryId & query_id, const ContextPtr & context);
 
     String toString();
 

--- a/dbms/src/Flash/Mpp/MPPTaskManager.h
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.h
@@ -53,6 +53,7 @@ struct MPPQueryTaskSet
     {
         return state == Normal || state == Aborted;
     }
+    ~MPPQueryTaskSet();
 };
 
 /// A simple thread unsafe FIFO cache used to fix the "lost cancel" issues

--- a/dbms/src/Flash/Mpp/MPPTaskManager.h
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.h
@@ -40,7 +40,7 @@ struct MPPQueryTaskSet
     /// task can only be registered state is Normal
     State state = Normal;
     String error_message;
-    MemoryTrackerPtr memory_tracker;
+    std::shared_ptr<ProcessListEntry> process_list_entry;
     MPPTaskMap task_map;
     std::unordered_map<Int64, std::unordered_map<Int64, grpc::Alarm>> alarms;
     /// only used in scheduler
@@ -194,7 +194,7 @@ public:
 
     void abortMPPQuery(const MPPQueryId & query_id, const String & reason, AbortType abort_type);
 
-    std::pair<MemoryTrackerPtr, String> getOrCreateQueryMemoryTracker(const MPPQueryId & query_id, const ContextPtr & context);
+    std::pair<std::shared_ptr<ProcessListEntry>, String> getOrCreateQueryProcessListEntry(const MPPQueryId & query_id, const ContextPtr & context);
 
     String toString();
 

--- a/dbms/src/Flash/Mpp/MPPTunnel.cpp
+++ b/dbms/src/Flash/Mpp/MPPTunnel.cpp
@@ -459,9 +459,6 @@ std::shared_ptr<DB::TrackedMppDataPacket> LocalTunnelSenderV1::readForLocal()
     if (result == MPMCQueueResult::OK)
     {
         MPPTunnelMetric::subDataSizeMetric(*data_size_in_queue, res->getPacket().ByteSizeLong());
-
-        // switch tunnel's memory tracker into receiver's
-        res->switchMemTracker(current_memory_tracker);
         return res;
     }
     else if (result == MPMCQueueResult::CANCELLED)

--- a/dbms/src/Flash/Mpp/MPPTunnel.h
+++ b/dbms/src/Flash/Mpp/MPPTunnel.h
@@ -354,11 +354,6 @@ private:
         if (unlikely(checkPacketErr(data)))
             return false;
 
-        // receiver_mem_tracker pointer will always be valid because ExchangeReceiverBase won't be destructed
-        // before all local tunnels are destructed so that the MPPTask which contains ExchangeReceiverBase and
-        // is responsible for deleting receiver_mem_tracker must be destroyed after these local tunnels.
-        data->switchMemTracker(local_request_handler.recv_mem_tracker);
-
         // When ExchangeReceiver receives data from local and remote tiflash, number of local tunnel threads
         // is very large and causes the time of transfering data by grpc threads becomes longer, because
         // grpc thread is hard to get chance to push data into MPMCQueue in ExchangeReceiver.

--- a/dbms/src/Flash/Mpp/TrackedMppDataPacket.h
+++ b/dbms/src/Flash/Mpp/TrackedMppDataPacket.h
@@ -110,7 +110,7 @@ struct MemTrackerWrapper
 
 struct TrackedMppDataPacket
 {
-    explicit TrackedMppDataPacket(const mpp::MPPDataPacket & data, MemoryTracker * memory_tracker)
+    TrackedMppDataPacket(const mpp::MPPDataPacket & data, MemoryTracker * memory_tracker)
         : mem_tracker_wrapper(estimateAllocatedSize(data), memory_tracker)
     {
         packet = data;

--- a/dbms/src/Flash/Mpp/tests/gtest_mpptunnel.cpp
+++ b/dbms/src/Flash/Mpp/tests/gtest_mpptunnel.cpp
@@ -191,7 +191,6 @@ public:
         for (auto & tunnel : tunnels)
         {
             LocalRequestHandler local_request_handler(
-                nullptr,
                 [this](bool meet_error, const String & local_err_msg) {
                     this->connectionDone(meet_error, local_err_msg);
                 },
@@ -655,7 +654,6 @@ try
     ReceivedMessageQueue received_message_queue(mock_ptr, Logger::get(), 1, false, 0);
 
     LocalRequestHandler local_req_handler(
-        nullptr,
         [](bool, const String &) {},
         []() {},
         []() {},
@@ -676,7 +674,6 @@ try
     AsyncRequestHandlerWaitQueuePtr mock_ptr = std::make_shared<AsyncRequestHandlerWaitQueue>();
     ReceivedMessageQueue queue(mock_ptr, Logger::get(), 1, false, 0);
     LocalRequestHandler local_req_handler(
-        nullptr,
         [](bool, const String &) {},
         []() {},
         []() {},

--- a/dbms/src/Flash/executeQuery.cpp
+++ b/dbms/src/Flash/executeQuery.cpp
@@ -60,7 +60,7 @@ ProcessList::EntryPtr getProcessListEntry(Context & context, DAGContext & dag_co
 {
     if (dag_context.is_mpp_task)
     {
-        /// for MPPTask, process list entry is created in MPPTask::prepare()
+        /// for MPPTask, process list entry is set in MPPTask::initProcessListEntry()
         RUNTIME_ASSERT(dag_context.getProcessListEntry() != nullptr, "process list entry for MPP task must not be nullptr");
         return dag_context.getProcessListEntry();
     }

--- a/dbms/src/Flash/executeQuery.cpp
+++ b/dbms/src/Flash/executeQuery.cpp
@@ -70,7 +70,8 @@ ProcessList::EntryPtr getProcessListEntry(Context & context, DAGContext & dag_co
         auto process_list_entry = setProcessListElement(
             context,
             dag_context.dummy_query_string,
-            dag_context.dummy_ast.get());
+            dag_context.dummy_ast.get(),
+            true);
         dag_context.setProcessListEntry(process_list_entry);
         return process_list_entry;
     }

--- a/dbms/src/Interpreters/ProcessList.cpp
+++ b/dbms/src/Interpreters/ProcessList.cpp
@@ -84,7 +84,7 @@ ProcessList::EntryPtr ProcessList::insert(
     const ClientInfo & client_info,
     const Settings & settings,
     const UInt64 total_memory,
-    bool use_current_memory_tracker)
+    bool is_dag_task)
 {
     EntryPtr res;
 
@@ -142,7 +142,7 @@ ProcessList::EntryPtr ProcessList::insert(
 
         ++cur_size;
 
-        res = std::make_shared<Entry>(*this, cont.emplace(cont.end(), query_, client_info, settings.max_memory_usage.getActualBytes(total_memory), settings.memory_tracker_fault_probability, priorities.insert(settings.priority), use_current_memory_tracker));
+        res = std::make_shared<Entry>(*this, cont.emplace(cont.end(), query_, client_info, settings.max_memory_usage.getActualBytes(total_memory), settings.memory_tracker_fault_probability, priorities.insert(settings.priority), is_dag_task));
 
         ProcessListForUser & user_process_list = user_to_queries[client_info.current_user];
         user_process_list.queries.emplace(client_info.current_query_id, &res->get());
@@ -218,11 +218,11 @@ ProcessListEntry::~ProcessListEntry()
     auto range = user_process_list.queries.equal_range(query_id);
     if (range.first != range.second)
     {
-        for (auto it = range.first; it != range.second; ++it)
+        for (auto current_it = range.first; current_it != range.second; ++current_it)
         {
-            if (it->second == process_list_element_ptr)
+            if (current_it->second == process_list_element_ptr)
             {
-                user_process_list.queries.erase(it);
+                user_process_list.queries.erase(current_it);
                 found = true;
                 break;
             }
@@ -255,6 +255,8 @@ ProcessListEntry::~ProcessListEntry()
 
 void ProcessListElement::setQueryStreams(const BlockIO & io)
 {
+    if likely (for_dag_task)
+        return;
     std::lock_guard lock(query_streams_mutex);
 
     query_stream_in = io.in;
@@ -264,6 +266,8 @@ void ProcessListElement::setQueryStreams(const BlockIO & io)
 
 void ProcessListElement::releaseQueryStreams()
 {
+    if likely (for_dag_task)
+        return;
     BlockInputStreamPtr in;
     BlockOutputStreamPtr out;
 
@@ -280,6 +284,7 @@ void ProcessListElement::releaseQueryStreams()
 
 bool ProcessListElement::streamsAreReleased()
 {
+    RUNTIME_CHECK_MSG(!for_dag_task, "Should not reach here for dag task");
     std::lock_guard lock(query_streams_mutex);
 
     return query_streams_status == QueryStreamsStatus::Released;
@@ -287,6 +292,7 @@ bool ProcessListElement::streamsAreReleased()
 
 bool ProcessListElement::tryGetQueryStreams(BlockInputStreamPtr & in, BlockOutputStreamPtr & out) const
 {
+    RUNTIME_CHECK_MSG(!for_dag_task, "Should not reach here for dag task");
     std::lock_guard lock(query_streams_mutex);
 
     if (query_streams_status != QueryStreamsStatus::Initialized)

--- a/dbms/src/Interpreters/ProcessList.cpp
+++ b/dbms/src/Interpreters/ProcessList.cpp
@@ -83,7 +83,8 @@ ProcessList::EntryPtr ProcessList::insert(
     const IAST * ast,
     const ClientInfo & client_info,
     const Settings & settings,
-    const UInt64 total_memory)
+    const UInt64 total_memory,
+    bool use_current_memory_tracker)
 {
     EntryPtr res;
 
@@ -141,7 +142,7 @@ ProcessList::EntryPtr ProcessList::insert(
 
         ++cur_size;
 
-        res = std::make_shared<Entry>(*this, cont.emplace(cont.end(), query_, client_info, settings.max_memory_usage.getActualBytes(total_memory), settings.memory_tracker_fault_probability, priorities.insert(settings.priority)));
+        res = std::make_shared<Entry>(*this, cont.emplace(cont.end(), query_, client_info, settings.max_memory_usage.getActualBytes(total_memory), settings.memory_tracker_fault_probability, priorities.insert(settings.priority), use_current_memory_tracker));
 
         ProcessListForUser & user_process_list = user_to_queries[client_info.current_user];
         user_process_list.queries.emplace(client_info.current_query_id, &res->get());

--- a/dbms/src/Interpreters/ProcessList.h
+++ b/dbms/src/Interpreters/ProcessList.h
@@ -85,6 +85,8 @@ private:
 
     QueryPriorities::Handle priority_handle;
 
+    /// if for_dag_task is true, it means the request comes from TiDB, processList is only used to
+    /// maintain the memory tracker, all the query streams related field is useless
     bool for_dag_task;
 
     std::atomic<bool> is_killed{false};

--- a/dbms/src/Interpreters/executeQuery.cpp
+++ b/dbms/src/Interpreters/executeQuery.cpp
@@ -401,7 +401,8 @@ void prepareForInputStream(
 std::shared_ptr<ProcessListEntry> setProcessListElement(
     Context & context,
     const String & query,
-    const IAST * ast)
+    const IAST * ast,
+    bool use_current_memory_tracker)
 {
     assert(ast);
     auto total_memory = context.getServerInfo().has_value() ? context.getServerInfo()->memory_info.capacity : 0;
@@ -410,7 +411,8 @@ std::shared_ptr<ProcessListEntry> setProcessListElement(
         ast,
         context.getClientInfo(),
         context.getSettingsRef(),
-        total_memory);
+        total_memory,
+        use_current_memory_tracker);
     context.setProcessListElement(&process_list_entry->get());
     return process_list_entry;
 }

--- a/dbms/src/Interpreters/executeQuery.cpp
+++ b/dbms/src/Interpreters/executeQuery.cpp
@@ -402,7 +402,7 @@ std::shared_ptr<ProcessListEntry> setProcessListElement(
     Context & context,
     const String & query,
     const IAST * ast,
-    bool use_current_memory_tracker)
+    bool is_dag_task)
 {
     assert(ast);
     auto total_memory = context.getServerInfo().has_value() ? context.getServerInfo()->memory_info.capacity : 0;
@@ -412,7 +412,7 @@ std::shared_ptr<ProcessListEntry> setProcessListElement(
         context.getClientInfo(),
         context.getSettingsRef(),
         total_memory,
-        use_current_memory_tracker);
+        is_dag_task);
     context.setProcessListElement(&process_list_entry->get());
     return process_list_entry;
 }

--- a/dbms/src/Interpreters/executeQuery.cpp
+++ b/dbms/src/Interpreters/executeQuery.cpp
@@ -205,7 +205,7 @@ std::tuple<ASTPtr, BlockIO> executeQueryImpl(
         ProcessList::EntryPtr process_list_entry;
         if (!internal && nullptr == typeid_cast<const ASTShowProcesslistQuery *>(&*ast))
         {
-            process_list_entry = setProcessListElement(context, query, ast.get());
+            process_list_entry = setProcessListElement(context, query, ast.get(), false);
         }
 
         FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::random_interpreter_failpoint);

--- a/dbms/src/Interpreters/executeQuery.cpp
+++ b/dbms/src/Interpreters/executeQuery.cpp
@@ -147,7 +147,7 @@ void onExceptionBeforeStart(const String & query, Context & context, time_t curr
 }
 
 std::tuple<ASTPtr, BlockIO> executeQueryImpl(
-    IQuerySource & query_src,
+    SQLQuerySource & query_src,
     Context & context,
     bool internal,
     QueryProcessingStage::Enum stage)

--- a/dbms/src/Interpreters/executeQuery.h
+++ b/dbms/src/Interpreters/executeQuery.h
@@ -56,7 +56,7 @@ std::shared_ptr<ProcessListEntry> setProcessListElement(
     Context & context,
     const String & query,
     const IAST * ast,
-    bool use_current_memory_tracker = false);
+    bool is_dag_task);
 
 void logQueryPipeline(const LoggerPtr & logger, const BlockInputStreamPtr & in);
 

--- a/dbms/src/Interpreters/executeQuery.h
+++ b/dbms/src/Interpreters/executeQuery.h
@@ -55,7 +55,8 @@ BlockIO executeQuery(
 std::shared_ptr<ProcessListEntry> setProcessListElement(
     Context & context,
     const String & query,
-    const IAST * ast);
+    const IAST * ast,
+    bool use_current_memory_tracker = false);
 
 void logQueryPipeline(const LoggerPtr & logger, const BlockInputStreamPtr & in);
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #7643

Problem Summary:
- Introduce query level processListEntry for mpp query, so all the mpp tasks belong to the same mpp query will share the same processListEntry(and the same memory_tracker)
- Remove `switchMemTracker` for local tunnel since the memory tracker is now the same in source mpp task and target mpp task. 
- Disable local tunnel in ut if sender task is the root task
### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
