### PR TITLE
Fix unstable unittest `ThreadedWorker.ErrorInWorkerWithNonEmptyQueue`

### DIFF
--- a/dbms/src/Common/tests/gtest_threaded_worker.cpp
+++ b/dbms/src/Common/tests/gtest_threaded_worker.cpp
@@ -289,7 +289,6 @@ TEST(ThreadedWorker, ErrorInWorkerWithNonEmptyQueue)
             error_happened = true;
             break;
         }
-        ASSERT_NE(r, 13);
     }
     ASSERT_TRUE(error_happened);
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/7653

Problem Summary: `ThreadedWorker.ErrorInWorkerWithNonEmptyQueue` is not stable

### What is changed and how it works?

Because the test workers concurrency is 2, there could be a chance that some new result is pushed into the result_queue before exception cancel all the wokers.
As long as the queue is cancelled before all elements are handled, consider this test passed. 

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
