### PR TITLE
Reduce UniPS snapshot stat overhead

### DIFF
--- a/dbms/CMakeLists.txt
+++ b/dbms/CMakeLists.txt
@@ -383,4 +383,4 @@ add_target_pch("pch-stl.h" libprotobuf kvproto tipb libprotoc)
 add_target_pch("pch-stl.h" Net Crypto Util Data NetSSL)
 add_target_pch("$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/pch-stl.h>" XML Foundation JSON)
 
-message (STATUS "Will build ${VERSION_FULL} (TiFlash ${TIFLASH_RELEASE_VERSION})")
+message (STATUS "Will build TiFlash ${TIFLASH_RELEASE_VERSION}")

--- a/dbms/src/Common/TiFlashMetrics.h
+++ b/dbms/src/Common/TiFlashMetrics.h
@@ -51,13 +51,15 @@ namespace DB
         F(type_batch_executing, {"type", "batch_executing"}), F(type_dispatch_mpp_task, {"type", "dispatch_mpp_task"}),                             \
         F(type_mpp_establish_conn, {"type", "mpp_establish_conn"}), F(type_cancel_mpp_task, {"type", "cancel_mpp_task"}),                           \
         F(type_run_mpp_task, {"type", "run_mpp_task"}), F(type_remote_read, {"type", "remote_read"}),                                               \
-        F(type_remote_read_constructed, {"type", "remote_read_constructed"}), F(type_remote_read_sent, {"type", "remote_read_sent"}))               \
+        F(type_remote_read_constructed, {"type", "remote_read_constructed"}), F(type_remote_read_sent, {"type", "remote_read_sent"}),               \
+        F(type_disagg_establish_task, {"type", "disagg_establish_task"}), F(type_disagg_fetch_pages, {"type", "disagg_fetch_pages"}))               \
     M(tiflash_coprocessor_handling_request_count, "Number of handling request", Gauge, F(type_cop, {"type", "cop"}),                                \
         F(type_cop_executing, {"type", "cop_executing"}), F(type_batch, {"type", "batch"}),                                                         \
         F(type_batch_executing, {"type", "batch_executing"}), F(type_dispatch_mpp_task, {"type", "dispatch_mpp_task"}),                             \
         F(type_mpp_establish_conn, {"type", "mpp_establish_conn"}), F(type_cancel_mpp_task, {"type", "cancel_mpp_task"}),                           \
         F(type_run_mpp_task, {"type", "run_mpp_task"}), F(type_remote_read, {"type", "remote_read"}),                                               \
-        F(type_remote_read_executing, {"type", "remote_read_executing"}))                                                                           \
+        F(type_remote_read_executing, {"type", "remote_read_executing"}),                                                                           \
+        F(type_disagg_establish_task, {"type", "disagg_establish_task"}), F(type_disagg_fetch_pages, {"type", "disagg_fetch_pages"}))               \
     M(tiflash_coprocessor_executor_count, "Total number of each executor", Counter, F(type_ts, {"type", "table_scan"}),                             \
         F(type_sel, {"type", "selection"}), F(type_agg, {"type", "aggregation"}), F(type_topn, {"type", "top_n"}),                                  \
         F(type_limit, {"type", "limit"}), F(type_join, {"type", "join"}), F(type_exchange_sender, {"type", "exchange_sender"}),                     \
@@ -72,7 +74,9 @@ namespace DB
         F(type_dispatch_mpp_task, {{"type", "dispatch_mpp_task"}}, ExpBuckets{0.001, 2, 20}),                                                       \
         F(type_mpp_establish_conn, {{"type", "mpp_establish_conn"}}, ExpBuckets{0.001, 2, 20}),                                                     \
         F(type_cancel_mpp_task, {{"type", "cancel_mpp_task"}}, ExpBuckets{0.001, 2, 20}),                                                           \
-        F(type_run_mpp_task, {{"type", "run_mpp_task"}}, ExpBuckets{0.001, 2, 20}))                                                                 \
+        F(type_run_mpp_task, {{"type", "run_mpp_task"}}, ExpBuckets{0.001, 2, 20}),                                                                 \
+        F(type_disagg_establish_task, {{"type", "disagg_establish_task"}}, ExpBuckets{0.001, 2, 20}),                                               \
+        F(type_disagg_fetch_pages, {{"type", "type_disagg_fetch_pages"}}, ExpBuckets{0.001, 2, 20}))                                                \
     M(tiflash_coprocessor_request_memory_usage, "Bucketed histogram of request memory usage", Histogram,                                            \
         F(type_cop, {{"type", "cop"}}, ExpBuckets{1024 * 1024, 2, 16}),                                                                             \
         F(type_batch, {{"type", "batch"}}, ExpBuckets{1024 * 1024, 2, 20}),                                                                         \
@@ -91,7 +95,8 @@ namespace DB
         F(type_dispatch_mpp_task, {{"type", "dispatch_mpp_task"}}),                                                                                 \
         F(type_mpp_establish_conn, {{"type", "mpp_tunnel"}}),                                                                                       \
         F(type_mpp_establish_conn_local, {{"type", "mpp_tunnel_local"}}),                                                                           \
-        F(type_cancel_mpp_task, {{"type", "cancel_mpp_task"}}))                                                                                     \
+        F(type_cancel_mpp_task, {{"type", "cancel_mpp_task"}}),                                                                                     \
+        F(type_disagg_establish_task, {{"type", "type_disagg_establish_task"}}))                                                                    \
     M(tiflash_exchange_data_bytes, "Total bytes sent by exchange operators", Counter,                                                               \
         F(type_hash_original, {"type", "hash_original"}),                                                                                           \
         F(type_hash_none_compression_remote, {"type", "hash_none_compression_remote"}),                                                             \

--- a/dbms/src/Flash/Disaggregated/WNEstablishDisaggTaskHandler.cpp
+++ b/dbms/src/Flash/Disaggregated/WNEstablishDisaggTaskHandler.cpp
@@ -54,15 +54,6 @@ void WNEstablishDisaggTaskHandler::prepare(const disaggregated::EstablishDisaggT
     auto start_ts = meta.start_ts();
     context->setSetting("read_tso", start_ts);
 
-    if (request->timeout_s() < 0)
-    {
-        throw TiFlashException(Errors::Coprocessor::BadRequest, "invalid timeout={}", request->timeout_s());
-    }
-    else if (request->timeout_s() > 0)
-    {
-        context->setSetting("disagg_task_snapshot_timeout", request->timeout_s());
-    } // use default timeout if it is 0
-
     // Parse the encoded plan into `dag_req`
     dag_req = getDAGRequestFromStringWithRetry(request->encoded_plan());
     LOG_DEBUG(log, "DAGReq: {}", dag_req.ShortDebugString());

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -16,6 +16,7 @@
 #include <Common/FailPoint.h>
 #include <Common/FmtUtils.h>
 #include <Common/Logger.h>
+#include <Common/Stopwatch.h>
 #include <Common/SyncPoint/SyncPoint.h>
 #include <Common/TiFlashMetrics.h>
 #include <Common/assert_cast.h>
@@ -1743,6 +1744,7 @@ SegmentReadTasks DeltaMergeStore::getReadTasksByRanges(
     bool try_split_task)
 {
     SegmentReadTasks tasks;
+    Stopwatch watch;
 
     std::shared_lock lock(read_write_mutex);
 
@@ -1754,12 +1756,7 @@ SegmentReadTasks DeltaMergeStore::getReadTasksByRanges(
     auto range_it = sorted_ranges.begin();
     auto seg_it = segments.upper_bound(range_it->getStart());
 
-    if (seg_it == segments.end())
-    {
-        throw Exception(
-            fmt::format("Failed to locate segment begin with start in range: {}", range_it->toDebugString()),
-            ErrorCodes::LOGICAL_ERROR);
-    }
+    RUNTIME_CHECK_MSG(seg_it != segments.end(), "Failed to locate segment begin with start in range: {}", range_it->toDebugString());
 
     while (range_it != sorted_ranges.end() && seg_it != segments.end())
     {
@@ -1771,8 +1768,7 @@ SegmentReadTasks DeltaMergeStore::getReadTasksByRanges(
             {
                 auto segment = seg_it->second;
                 auto segment_snap = segment->createSnapshot(dm_context, false, CurrentMetrics::DT_SnapshotOfRead);
-                if (unlikely(!segment_snap))
-                    throw Exception("Failed to get segment snap", ErrorCodes::LOGICAL_ERROR);
+                RUNTIME_CHECK_MSG(segment_snap, "Failed to get segment snap");
                 tasks.push_back(std::make_shared<SegmentReadTask>(segment, segment_snap));
             }
 
@@ -1800,7 +1796,7 @@ SegmentReadTasks DeltaMergeStore::getReadTasksByRanges(
                 ++seg_it;
         }
     }
-    auto tasks_before_split = tasks.size();
+    const auto tasks_before_split = tasks.size();
     if (try_split_task)
     {
         /// Try to make task number larger or equal to expected_tasks_count.
@@ -1818,7 +1814,8 @@ SegmentReadTasks DeltaMergeStore::getReadTasksByRanges(
     auto tracing_logger = log->getChild(getLogTracingId(dm_context));
     LOG_DEBUG(
         tracing_logger,
-        "[sorted_ranges: {}] [tasks before split: {}] [tasks final: {}] [ranges final: {}]",
+        "Segment read tasks build done, cost={}ms sorted_ranges={} n_tasks_before_split={} n_tasks_final={} n_ranges_final={}",
+        watch.elapsedMilliseconds(),
         sorted_ranges.size(),
         tasks_before_split,
         tasks.size(),

--- a/dbms/src/Storages/DeltaMerge/Segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/Segment.cpp
@@ -695,8 +695,9 @@ SegmentPtr Segment::ingestDataForTest(DMContext & dm_context,
 SegmentSnapshotPtr Segment::createSnapshot(const DMContext & dm_context, bool for_update, CurrentMetrics::Metric metric) const
 {
     Stopwatch watch;
-    SCOPE_EXIT(
-        dm_context.scan_context->total_create_snapshot_time_ns += watch.elapsed(););
+    SCOPE_EXIT({
+        dm_context.scan_context->total_create_snapshot_time_ns += watch.elapsed();
+    });
     auto delta_snap = delta->createSnapshot(dm_context, for_update, metric);
     auto stable_snap = stable->createSnapshot();
     if (!delta_snap || !stable_snap)

--- a/dbms/src/Storages/Transaction/PDTiKVClient.h
+++ b/dbms/src/Storages/Transaction/PDTiKVClient.h
@@ -79,7 +79,7 @@ struct PDClientHelper
         if (enable_safepoint_v2 && keyspace_id != NullspaceID)
         {
             auto gc_safe_point = getGCSafePointV2WithRetry(pd_client, keyspace_id, ignore_cache, safe_point_update_interval_seconds);
-            LOG_DEBUG(Logger::get(), "use safe point v2, keyspace_id={},gc_safe_point={}", keyspace_id, gc_safe_point);
+            LOG_DEBUG(Logger::get(), "use safe point v2, keyspace={} gc_safe_point={}", keyspace_id, gc_safe_point);
             return gc_safe_point;
         }
 

--- a/dbms/src/TiDB/Schema/TiDBSchemaSyncer.cpp
+++ b/dbms/src/TiDB/Schema/TiDBSchemaSyncer.cpp
@@ -55,7 +55,6 @@ bool TiDBSchemaSyncer<mock_getter, mock_mapper>::syncSchemas(Context & context)
     {
         if (version <= cur_version)
         {
-            LOG_INFO(log, " version {} is the same as cur_version {}, so do nothing", version, cur_version);
             return false;
         }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/7713

Problem Summary:

When there are many DeltaMergeStore in one tiflash instance, each `DeltaMergeStore::getStoreStats` will try to get the snapshot stats from PSV3/UniPS. But the PSV3/UniPS is a global instance that brings much CPU waste and locks contention. So it causes slow queries.

### What is changed and how it works?

* Only get snapshot stats under `PageStorageRunMode::ONLY_V2`, because PSV2 have different PS instances for different table
* Reduce the lock scope of `read_write_mutex` in `DeltaMergeStore::getStoreStats`
* Add metrics about disagg RPC requests
* Refine some loggings

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
