### PR TITLE
Pipeline: support io priority queue

### DIFF
--- a/dbms/src/Flash/Pipeline/Exec/PipelineExec.cpp
+++ b/dbms/src/Flash/Pipeline/Exec/PipelineExec.cpp
@@ -16,6 +16,8 @@
 #include <Flash/Pipeline/Exec/PipelineExec.h>
 #include <Operators/OperatorHelper.h>
 
+#include "Operators/Operator.h"
+
 namespace DB
 {
 namespace FailPoints
@@ -33,7 +35,8 @@ extern const char random_pipeline_model_execute_suffix_failpoint[];
     case (expect_status):                                                                              \
         break;                                                                                         \
     /* For the io status, the operator needs to be filled in io_op for later use in executeIO. */      \
-    case OperatorStatus::IO:                                                                           \
+    case OperatorStatus::IO_IN:                                                                        \
+    case OperatorStatus::IO_OUT:                                                                       \
         fillIOOp((op).get());                                                                          \
         return (op_status);                                                                            \
     /* For the waiting status, the operator needs to be filled in awaitable for later use in await. */ \
@@ -50,7 +53,8 @@ extern const char random_pipeline_model_execute_suffix_failpoint[];
     switch (op_status)                                                                                 \
     {                                                                                                  \
     /* For the io status, the operator needs to be filled in io_op for later use in executeIO. */      \
-    case OperatorStatus::IO:                                                                           \
+    case OperatorStatus::IO_IN:                                                                        \
+    case OperatorStatus::IO_OUT:                                                                       \
         fillIOOp((op).get());                                                                          \
         return (op_status);                                                                            \
     /* For the waiting status, the operator needs to be filled in awaitable for later use in await. */ \
@@ -160,7 +164,7 @@ OperatorStatus PipelineExec::executeIOImpl()
     auto op_status = io_op->executeIO();
     if (op_status == OperatorStatus::WAITING)
         fillAwaitable(io_op);
-    if (op_status != OperatorStatus::IO)
+    if (op_status != OperatorStatus::IO_IN && op_status != OperatorStatus::IO_OUT)
         io_op = nullptr;
     return op_status;
 }
@@ -179,7 +183,7 @@ OperatorStatus PipelineExec::awaitImpl()
 {
     assert(awaitable);
     auto op_status = awaitable->await();
-    if (op_status == OperatorStatus::IO)
+    if (op_status == OperatorStatus::IO_IN || op_status == OperatorStatus::IO_OUT)
         fillIOOp(awaitable);
     if (op_status != OperatorStatus::WAITING)
         awaitable = nullptr;

--- a/dbms/src/Flash/Pipeline/Exec/PipelineExec.cpp
+++ b/dbms/src/Flash/Pipeline/Exec/PipelineExec.cpp
@@ -16,8 +16,6 @@
 #include <Flash/Pipeline/Exec/PipelineExec.h>
 #include <Operators/OperatorHelper.h>
 
-#include "Operators/Operator.h"
-
 namespace DB
 {
 namespace FailPoints

--- a/dbms/src/Flash/Pipeline/Schedule/Events/tests/gtest_event.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/Events/tests/gtest_event.cpp
@@ -338,7 +338,7 @@ protected:
             cpu_execute_time += per_execute_time;
             return ExecTaskStatus::RUNNING;
         }
-        return ExecTaskStatus::IO;
+        return ExecTaskStatus::IO_IN;
     }
 
     ExecTaskStatus doExecuteIOImpl() override
@@ -347,7 +347,7 @@ protected:
         {
             std::this_thread::sleep_for(std::chrono::nanoseconds(per_execute_time));
             io_execute_time += per_execute_time;
-            return ExecTaskStatus::IO;
+            return ExecTaskStatus::IO_IN;
         }
         return ExecTaskStatus::WAITING;
     }

--- a/dbms/src/Flash/Pipeline/Schedule/Reactor/WaitReactor.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/Reactor/WaitReactor.cpp
@@ -44,7 +44,8 @@ bool WaitReactor::awaitAndCollectReadyTask(WaitingTask && task)
         task_ptr->profile_info.elapsedAwaitTime();
         cpu_tasks.push_back(std::move(task.first));
         return true;
-    case ExecTaskStatus::IO:
+    case ExecTaskStatus::IO_IN:
+    case ExecTaskStatus::IO_OUT:
         task_ptr->profile_info.elapsedAwaitTime();
         io_tasks.push_back(std::move(task.first));
         return true;

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/FIFOTaskQueue.h
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/FIFOTaskQueue.h
@@ -32,7 +32,7 @@ public:
 
     bool take(TaskPtr & task) override;
 
-    void updateStatistics(const TaskPtr &, size_t) override {}
+    void updateStatistics(const TaskPtr &, ExecTaskStatus, size_t) override {}
 
     bool empty() const override;
 

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/FIFOTaskQueue.h
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/FIFOTaskQueue.h
@@ -32,7 +32,7 @@ public:
 
     bool take(TaskPtr & task) override;
 
-    void updateStatistics(const TaskPtr &, ExecTaskStatus, size_t) override {}
+    void updateStatistics(const TaskPtr &, ExecTaskStatus, UInt64) override {}
 
     bool empty() const override;
 

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/IOPriorityQueue.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/IOPriorityQueue.cpp
@@ -55,10 +55,10 @@ void IOPriorityQueue::updateStatistics(const TaskPtr &, ExecTaskStatus exec_task
     switch (exec_task_status)
     {
     case ExecTaskStatus::IO_IN:
-        total_io_in_time_ms += (inc_ns / 1'000'000);
+        total_io_in_time_ms += ceil(inc_ns / 1'000'000);
         break;
     case ExecTaskStatus::IO_OUT:
-        total_io_out_time_ms += (inc_ns / 1'000'000);
+        total_io_out_time_ms += ceil(inc_ns / 1'000'000);
         break;
     default:; // ignore not io status.
     }

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/IOPriorityQueue.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/IOPriorityQueue.cpp
@@ -1,0 +1,113 @@
+// Copyright 2023 PingCAP, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Flash/Pipeline/Schedule/TaskQueues/IOPriorityQueue.h>
+#include <Flash/Pipeline/Schedule/Tasks/TaskHelper.h>
+#include <common/likely.h>
+
+namespace DB
+{
+IOPriorityQueue::~IOPriorityQueue()
+{
+    RUNTIME_ASSERT(io_in_task_queue.empty(), logger, "all task should be taken before it is destructed");
+    RUNTIME_ASSERT(io_out_task_queue.empty(), logger, "all task should be taken before it is destructed");
+}
+
+bool IOPriorityQueue::take(TaskPtr & task)
+{
+    std::unique_lock lock(mu);
+    while (true)
+    {
+        if (!io_out_task_queue.empty())
+        {
+            task = std::move(io_out_task_queue.front());
+            io_out_task_queue.pop_front();
+            return true;
+        }
+        if (!io_in_task_queue.empty())
+        {
+            task = std::move(io_in_task_queue.front());
+            io_in_task_queue.pop_front();
+            return true;
+        }
+        if (unlikely(is_finished))
+            return false;
+        cv.wait(lock);
+    }
+}
+
+bool IOPriorityQueue::empty() const
+{
+    std::lock_guard lock(mu);
+    return io_out_task_queue.empty() && io_in_task_queue.empty();
+}
+
+void IOPriorityQueue::finish()
+{
+    {
+        std::lock_guard lock(mu);
+        is_finished = true;
+    }
+    cv.notify_all();
+}
+
+void IOPriorityQueue::submitTaskWithoutLock(TaskPtr && task)
+{
+    auto status = task->getStatus();
+    switch (status)
+    {
+    case ExecTaskStatus::IO_IN:
+        io_in_task_queue.push_back(std::move(task));
+        break;
+    case ExecTaskStatus::IO_OUT:
+        io_out_task_queue.push_back(std::move(task));
+        break;
+    default:
+        throw Exception(fmt::format("Unexpected status: {}, IOPriorityQueue only accepts tasks with IO status", magic_enum::enum_name(status)));
+    }
+}
+
+void IOPriorityQueue::submit(TaskPtr && task)
+{
+    if unlikely (is_finished)
+    {
+        FINALIZE_TASK(task);
+        return;
+    }
+
+    {
+        std::lock_guard lock(mu);
+        submitTaskWithoutLock(std::move(task));
+    }
+    cv.notify_one();
+}
+
+void IOPriorityQueue::submit(std::vector<TaskPtr> & tasks)
+{
+    if unlikely (is_finished)
+    {
+        FINALIZE_TASKS(tasks);
+        return;
+    }
+
+    if (tasks.empty())
+        return;
+    std::lock_guard lock(mu);
+    for (auto & task : tasks)
+    {
+        submitTaskWithoutLock(std::move(task));
+        cv.notify_one();
+    }
+}
+} // namespace DB

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/IOPriorityQueue.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/IOPriorityQueue.cpp
@@ -29,7 +29,7 @@ bool IOPriorityQueue::take(TaskPtr & task)
     std::unique_lock lock(mu);
     while (true)
     {
-        bool io_out_first = ratio_of_out_to_in * total_io_in_time_ms >= total_io_out_time_ms;
+        bool io_out_first = ratio_of_out_to_in * total_io_in_time_microsecond >= total_io_out_time_microsecond;
         auto & first_queue = io_out_first ? io_out_task_queue : io_in_task_queue;
         auto & next_queue = io_out_first ? io_in_task_queue : io_out_task_queue;
         if (!first_queue.empty())
@@ -55,10 +55,10 @@ void IOPriorityQueue::updateStatistics(const TaskPtr &, ExecTaskStatus exec_task
     switch (exec_task_status)
     {
     case ExecTaskStatus::IO_IN:
-        total_io_in_time_ms += ceil(inc_ns / 1'000'000.0);
+        total_io_in_time_microsecond += (inc_ns / 1000);
         break;
     case ExecTaskStatus::IO_OUT:
-        total_io_out_time_ms += ceil(inc_ns / 1'000'000.0);
+        total_io_out_time_microsecond += (inc_ns / 1000);
         break;
     default:; // ignore not io status.
     }

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/IOPriorityQueue.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/IOPriorityQueue.cpp
@@ -55,10 +55,10 @@ void IOPriorityQueue::updateStatistics(const TaskPtr &, ExecTaskStatus exec_task
     switch (exec_task_status)
     {
     case ExecTaskStatus::IO_IN:
-        total_io_in_time_ms += ceil(inc_ns / 1'000'000);
+        total_io_in_time_ms += ceil(inc_ns / 1'000'000.0);
         break;
     case ExecTaskStatus::IO_OUT:
-        total_io_out_time_ms += ceil(inc_ns / 1'000'000);
+        total_io_out_time_ms += ceil(inc_ns / 1'000'000.0);
         break;
     default:; // ignore not io status.
     }

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/IOPriorityQueue.h
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/IOPriorityQueue.h
@@ -1,0 +1,52 @@
+// Copyright 2023 PingCAP, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <Flash/Pipeline/Schedule/TaskQueues/TaskQueue.h>
+
+#include <deque>
+#include <mutex>
+
+namespace DB
+{
+/// 
+class IOPriorityQueue : public TaskQueue
+{
+public:
+    ~IOPriorityQueue() override;
+
+    void submit(TaskPtr && task) override;
+
+    void submit(std::vector<TaskPtr> & tasks) override;
+
+    bool take(TaskPtr & task) override;
+
+    void updateStatistics(const TaskPtr &, size_t) override {}
+
+    bool empty() const override;
+
+    void finish() override;
+
+private:
+    void submitTaskWithoutLock(TaskPtr && task);
+
+private:
+    mutable std::mutex mu;
+    std::condition_variable cv;
+    std::atomic_bool is_finished = false;
+    std::deque<TaskPtr> io_in_task_queue;
+    std::deque<TaskPtr> io_out_task_queue;
+};
+} // namespace DB

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/IOPriorityQueue.h
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/IOPriorityQueue.h
@@ -29,6 +29,9 @@ namespace DB
 class IOPriorityQueue : public TaskQueue
 {
 public:
+    // // The ratio of total execution time between io_in and io_out is 1:3.
+    static constexpr size_t ratio_of_in_to_out = 3;
+
     ~IOPriorityQueue() override;
 
     void submit(TaskPtr && task) override;
@@ -37,7 +40,7 @@ public:
 
     bool take(TaskPtr & task) override;
 
-    void updateStatistics(const TaskPtr &, size_t) override {}
+    void updateStatistics(const TaskPtr &, ExecTaskStatus exec_task_status, size_t inc_value) override;
 
     bool empty() const override;
 
@@ -50,7 +53,11 @@ private:
     mutable std::mutex mu;
     std::condition_variable cv;
     std::atomic_bool is_finished = false;
+
     std::deque<TaskPtr> io_in_task_queue;
+    size_t total_io_in_time{0};
+
     std::deque<TaskPtr> io_out_task_queue;
+    size_t total_io_out_time{0};
 };
 } // namespace DB

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/IOPriorityQueue.h
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/IOPriorityQueue.h
@@ -21,7 +21,11 @@
 
 namespace DB
 {
-/// 
+/// The queue only used by io thread pool.
+/// IOPriorityQueue pops IO_OUT tasks first, and then pops IO_IN tasks.
+/// Because the IO_OUT task usually writes the data in the memory to the external storage and releases the occupied memory,
+/// while the IO_IN task usually reads the data from the external storage into the memory and occupies the memory.
+/// Prioritizing the execution of IO_OUT tasks can effectively reduce the memory usage.
 class IOPriorityQueue : public TaskQueue
 {
 public:

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/IOPriorityQueue.h
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/IOPriorityQueue.h
@@ -55,9 +55,9 @@ private:
     std::atomic_bool is_finished = false;
 
     std::deque<TaskPtr> io_in_task_queue;
-    std::atomic_uint64_t total_io_in_time_ms{0};
+    std::atomic_uint64_t total_io_in_time_microsecond{0};
 
     std::deque<TaskPtr> io_out_task_queue;
-    std::atomic_uint64_t total_io_out_time_ms{0};
+    std::atomic_uint64_t total_io_out_time_microsecond{0};
 };
 } // namespace DB

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/MultiLevelFeedbackQueue.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/MultiLevelFeedbackQueue.cpp
@@ -176,7 +176,7 @@ bool MultiLevelFeedbackQueue<TimeGetter>::take(TaskPtr & task)
 }
 
 template <typename TimeGetter>
-void MultiLevelFeedbackQueue<TimeGetter>::updateStatistics(const TaskPtr & task, size_t inc_value)
+void MultiLevelFeedbackQueue<TimeGetter>::updateStatistics(const TaskPtr & task, ExecTaskStatus, size_t inc_value)
 {
     assert(task);
     level_queues[task->mlfq_level]->accu_consume_time += inc_value;

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/MultiLevelFeedbackQueue.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/MultiLevelFeedbackQueue.cpp
@@ -179,7 +179,7 @@ template <typename TimeGetter>
 void MultiLevelFeedbackQueue<TimeGetter>::updateStatistics(const TaskPtr & task, ExecTaskStatus, UInt64 inc_ns)
 {
     assert(task);
-    level_queues[task->mlfq_level]->accu_consume_time_ms += ceil(inc_ns / 1'000'000);
+    level_queues[task->mlfq_level]->accu_consume_time_ms += ceil(inc_ns / 1'000'000.0);
 }
 
 template <typename TimeGetter>

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/MultiLevelFeedbackQueue.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/MultiLevelFeedbackQueue.cpp
@@ -39,9 +39,9 @@ void UnitQueue::submit(TaskPtr && task)
     task_queue.push_back(std::move(task));
 }
 
-double UnitQueue::normalizedTimeMs()
+double UnitQueue::normalizedTimeMicrosecond()
 {
-    return accu_consume_time_ms / info.factor_for_normal;
+    return accu_consume_time_microsecond / info.factor_for_normal;
 }
 
 template <typename TimeGetter>
@@ -142,7 +142,7 @@ bool MultiLevelFeedbackQueue<TimeGetter>::take(TaskPtr & task)
     {
         // -1 means no candidates; else has candidate.
         int queue_idx = -1;
-        double target_accu_time_ms = 0;
+        double target_accu_time_microsecond = 0;
         std::unique_lock lock(mu);
         while (true)
         {
@@ -153,10 +153,10 @@ bool MultiLevelFeedbackQueue<TimeGetter>::take(TaskPtr & task)
                 const auto & cur_queue = level_queues[i];
                 if (!cur_queue->empty())
                 {
-                    double local_target_time_ms = cur_queue->normalizedTimeMs();
-                    if (queue_idx < 0 || local_target_time_ms < target_accu_time_ms)
+                    double local_target_time_microsecond = cur_queue->normalizedTimeMicrosecond();
+                    if (queue_idx < 0 || local_target_time_microsecond < target_accu_time_microsecond)
                     {
-                        target_accu_time_ms = local_target_time_ms;
+                        target_accu_time_microsecond = local_target_time_microsecond;
                         queue_idx = i;
                     }
                 }
@@ -179,7 +179,7 @@ template <typename TimeGetter>
 void MultiLevelFeedbackQueue<TimeGetter>::updateStatistics(const TaskPtr & task, ExecTaskStatus, UInt64 inc_ns)
 {
     assert(task);
-    level_queues[task->mlfq_level]->accu_consume_time_ms += ceil(inc_ns / 1'000'000.0);
+    level_queues[task->mlfq_level]->accu_consume_time_microsecond += (inc_ns / 1000);
 }
 
 template <typename TimeGetter>

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/MultiLevelFeedbackQueue.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/MultiLevelFeedbackQueue.cpp
@@ -17,8 +17,6 @@
 #include <assert.h>
 #include <common/likely.h>
 
-#include <cmath>
-
 namespace DB
 {
 void UnitQueue::take(TaskPtr & task)

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/MultiLevelFeedbackQueue.h
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/MultiLevelFeedbackQueue.h
@@ -62,7 +62,7 @@ struct UnitQueueInfo
     UInt64 time_slice;
 
     // factor for normalization.
-    // The priority value is equal to `accu_consume_time_ms / factor_for_normal`.
+    // The priority value is equal to `accu_consume_time_microsecond / factor_for_normal`.
     // The smaller the value, the higher the priority.
     // Therefore, the higher the priority of the queue, the larger the value of factor_for_normal.
     double factor_for_normal;
@@ -81,11 +81,11 @@ public:
 
     bool empty() const;
 
-    double normalizedTimeMs();
+    double normalizedTimeMicrosecond();
 
 public:
     const UnitQueueInfo info;
-    std::atomic_uint64_t accu_consume_time_ms{0};
+    std::atomic_uint64_t accu_consume_time_microsecond{0};
 
 private:
     std::deque<TaskPtr> task_queue;

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/MultiLevelFeedbackQueue.h
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/MultiLevelFeedbackQueue.h
@@ -106,7 +106,7 @@ public:
 
     bool take(TaskPtr & task) override;
 
-    void updateStatistics(const TaskPtr & task, size_t inc_value) override;
+    void updateStatistics(const TaskPtr & task, ExecTaskStatus, size_t inc_value) override;
 
     bool empty() const override;
 

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/MultiLevelFeedbackQueue.h
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/MultiLevelFeedbackQueue.h
@@ -62,7 +62,7 @@ struct UnitQueueInfo
     UInt64 time_slice;
 
     // factor for normalization.
-    // The priority value is equal to `accu_consume_time / factor_for_normal`.
+    // The priority value is equal to `accu_consume_time_ms / factor_for_normal`.
     // The smaller the value, the higher the priority.
     // Therefore, the higher the priority of the queue, the larger the value of factor_for_normal.
     double factor_for_normal;
@@ -81,11 +81,11 @@ public:
 
     bool empty() const;
 
-    double normalizedTime();
+    double normalizedTimeMs();
 
 public:
     const UnitQueueInfo info;
-    std::atomic_uint64_t accu_consume_time{0};
+    std::atomic_uint64_t accu_consume_time_ms{0};
 
 private:
     std::deque<TaskPtr> task_queue;
@@ -106,7 +106,7 @@ public:
 
     bool take(TaskPtr & task) override;
 
-    void updateStatistics(const TaskPtr & task, ExecTaskStatus, size_t inc_value) override;
+    void updateStatistics(const TaskPtr & task, ExecTaskStatus, UInt64 inc_ns) override;
 
     bool empty() const override;
 

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/TaskQueue.h
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/TaskQueue.h
@@ -36,7 +36,7 @@ public:
 
     // Update the execution metrics of the task taken from the queue.
     // Used to adjust the priority of tasks within a queue.
-    virtual void updateStatistics(const TaskPtr & task, ExecTaskStatus exec_task_status, size_t inc_value) = 0;
+    virtual void updateStatistics(const TaskPtr & task, ExecTaskStatus exec_task_status, UInt64 inc_ns) = 0;
 
     virtual bool empty() const = 0;
 

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/TaskQueue.h
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/TaskQueue.h
@@ -36,7 +36,7 @@ public:
 
     // Update the execution metrics of the task taken from the queue.
     // Used to adjust the priority of tasks within a queue.
-    virtual void updateStatistics(const TaskPtr & task, size_t inc_value) = 0;
+    virtual void updateStatistics(const TaskPtr & task, ExecTaskStatus exec_task_status, size_t inc_value) = 0;
 
     virtual bool empty() const = 0;
 

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/TaskQueueType.h
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/TaskQueueType.h
@@ -22,5 +22,6 @@ enum class TaskQueueType
     DEFAULT, // Determined internally by the task thread pool.
     FIFO, // fifo queue
     MLFQ, // multi-level feedback queue
+    IO_PRIORITY, // io priority queue
 };
 } // namespace DB

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/tests/gtest_fifo.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/tests/gtest_fifo.cpp
@@ -37,11 +37,11 @@ public:
 };
 } // namespace
 
-class FIFOTestRunner : public ::testing::Test
+class TestFIFOTaskQueue : public ::testing::Test
 {
 };
 
-TEST_F(FIFOTestRunner, base)
+TEST_F(TestFIFOTaskQueue, base)
 try
 {
     FIFOTaskQueue queue;

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/tests/gtest_io_priority.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/tests/gtest_io_priority.cpp
@@ -34,11 +34,11 @@ public:
 };
 } // namespace
 
-class IOPriorityTestRunner : public ::testing::Test
+class TestIOPriorityTaskQueue : public ::testing::Test
 {
 };
 
-TEST_F(IOPriorityTestRunner, base)
+TEST_F(TestIOPriorityTaskQueue, base)
 try
 {
     IOPriorityQueue queue;
@@ -80,7 +80,7 @@ try
 }
 CATCH
 
-TEST_F(IOPriorityTestRunner, priority)
+TEST_F(TestIOPriorityTaskQueue, priority)
 try
 {
     // in 0 : out 0

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/tests/gtest_io_priority.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/tests/gtest_io_priority.cpp
@@ -105,7 +105,7 @@ try
     {
         IOPriorityQueue queue;
         queue.updateStatistics(nullptr, ExecTaskStatus::IO_IN, time_unit_ns);
-        queue.updateStatistics(nullptr, ExecTaskStatus::IO_OUT, time_unit_ns * IOPriorityQueue::ratio_of_in_to_out);
+        queue.updateStatistics(nullptr, ExecTaskStatus::IO_OUT, time_unit_ns * IOPriorityQueue::ratio_of_out_to_in);
         queue.submit(std::make_unique<MockIOTask>(true));
         queue.submit(std::make_unique<MockIOTask>(false));
         TaskPtr task;
@@ -123,7 +123,7 @@ try
     {
         IOPriorityQueue queue;
         queue.updateStatistics(nullptr, ExecTaskStatus::IO_IN, time_unit_ns);
-        queue.updateStatistics(nullptr, ExecTaskStatus::IO_OUT, time_unit_ns * (1 + IOPriorityQueue::ratio_of_in_to_out));
+        queue.updateStatistics(nullptr, ExecTaskStatus::IO_OUT, time_unit_ns * (1 + IOPriorityQueue::ratio_of_out_to_in));
         queue.submit(std::make_unique<MockIOTask>(true));
         queue.submit(std::make_unique<MockIOTask>(false));
         TaskPtr task;

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/tests/gtest_io_priority.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/tests/gtest_io_priority.cpp
@@ -141,7 +141,7 @@ try
     {
         IOPriorityQueue queue;
         queue.updateStatistics(nullptr, ExecTaskStatus::IO_IN, time_unit_ns);
-        queue.updateStatistics(nullptr, ExecTaskStatus::IO_OUT, time_unit_ns * (IOPriorityQueue::ratio_of_in_to_out - 1));
+        queue.updateStatistics(nullptr, ExecTaskStatus::IO_OUT, time_unit_ns * (IOPriorityQueue::ratio_of_out_to_in - 1));
         queue.submit(std::make_unique<MockIOTask>(true));
         queue.submit(std::make_unique<MockIOTask>(false));
         TaskPtr task;

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/tests/gtest_io_priority.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/tests/gtest_io_priority.cpp
@@ -36,6 +36,8 @@ public:
 
 class TestIOPriorityTaskQueue : public ::testing::Test
 {
+public:
+    static constexpr UInt64 time_unit_ns = 100'000'000; // 100ms
 };
 
 TEST_F(TestIOPriorityTaskQueue, base)
@@ -102,8 +104,8 @@ try
     // in 1 : out ratio_of_in_to_out
     {
         IOPriorityQueue queue;
-        queue.updateStatistics(nullptr, ExecTaskStatus::IO_IN, 1000);
-        queue.updateStatistics(nullptr, ExecTaskStatus::IO_OUT, 1000 * IOPriorityQueue::ratio_of_in_to_out);
+        queue.updateStatistics(nullptr, ExecTaskStatus::IO_IN, time_unit_ns);
+        queue.updateStatistics(nullptr, ExecTaskStatus::IO_OUT, time_unit_ns * IOPriorityQueue::ratio_of_in_to_out);
         queue.submit(std::make_unique<MockIOTask>(true));
         queue.submit(std::make_unique<MockIOTask>(false));
         TaskPtr task;
@@ -120,8 +122,8 @@ try
     // in 1 : out ratio_of_in_to_out+1
     {
         IOPriorityQueue queue;
-        queue.updateStatistics(nullptr, ExecTaskStatus::IO_IN, 1000);
-        queue.updateStatistics(nullptr, ExecTaskStatus::IO_OUT, 1000 * (1 + IOPriorityQueue::ratio_of_in_to_out));
+        queue.updateStatistics(nullptr, ExecTaskStatus::IO_IN, time_unit_ns);
+        queue.updateStatistics(nullptr, ExecTaskStatus::IO_OUT, time_unit_ns * (1 + IOPriorityQueue::ratio_of_in_to_out));
         queue.submit(std::make_unique<MockIOTask>(true));
         queue.submit(std::make_unique<MockIOTask>(false));
         TaskPtr task;
@@ -138,8 +140,8 @@ try
     // in 1 : out ratio_of_in_to_out-1
     {
         IOPriorityQueue queue;
-        queue.updateStatistics(nullptr, ExecTaskStatus::IO_IN, 1000);
-        queue.updateStatistics(nullptr, ExecTaskStatus::IO_OUT, 1000 * (IOPriorityQueue::ratio_of_in_to_out - 1));
+        queue.updateStatistics(nullptr, ExecTaskStatus::IO_IN, time_unit_ns);
+        queue.updateStatistics(nullptr, ExecTaskStatus::IO_OUT, time_unit_ns * (IOPriorityQueue::ratio_of_in_to_out - 1));
         queue.submit(std::make_unique<MockIOTask>(true));
         queue.submit(std::make_unique<MockIOTask>(false));
         TaskPtr task;

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/tests/gtest_io_priority.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/tests/gtest_io_priority.cpp
@@ -1,0 +1,83 @@
+// Copyright 2023 PingCAP, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Common/ThreadManager.h>
+#include <Flash/Pipeline/Schedule/TaskQueues/IOPriorityQueue.h>
+#include <Flash/Pipeline/Schedule/Tasks/TaskHelper.h>
+#include <TestUtils/TiFlashTestBasic.h>
+#include <gtest/gtest.h>
+
+#include <thread>
+
+namespace DB::tests
+{
+namespace
+{
+class MockIOTask : public Task
+{
+public:
+    explicit MockIOTask(bool is_io_in)
+    {
+        task_status = is_io_in ? ExecTaskStatus::IO_IN : ExecTaskStatus::IO_OUT;
+    }
+
+    ExecTaskStatus executeImpl() noexcept override { return ExecTaskStatus::FINISHED; }
+};
+} // namespace
+
+class IOPriorityTestRunner : public ::testing::Test
+{
+};
+
+TEST_F(IOPriorityTestRunner, base)
+try
+{
+    IOPriorityQueue queue;
+
+    size_t task_num_per_status = 1000;
+
+    for (size_t i = 0; i < task_num_per_status; ++i)
+    {
+        queue.submit(std::make_unique<MockIOTask>(true));
+    }
+    for (size_t i = 0; i < task_num_per_status; ++i)
+    {
+        queue.submit(std::make_unique<MockIOTask>(false));
+    }
+    queue.finish();
+
+    TaskPtr task;
+    for (size_t i = 0; i < task_num_per_status; ++i)
+    {
+        ASSERT_TRUE(queue.take(task));
+        ASSERT_TRUE(task);
+        ASSERT_EQ(task->getStatus(), ExecTaskStatus::IO_OUT);
+        FINALIZE_TASK(task);
+    }
+    for (size_t i = 0; i < task_num_per_status; ++i)
+    {
+        ASSERT_TRUE(queue.take(task));
+        ASSERT_TRUE(task);
+        ASSERT_EQ(task->getStatus(), ExecTaskStatus::IO_IN);
+        FINALIZE_TASK(task);
+    }
+    ASSERT_FALSE(queue.take(task));
+
+    // No tasks can be submitted after the queue is finished.
+    queue.submit(std::make_unique<MockIOTask>(true));
+    ASSERT_FALSE(queue.take(task));
+}
+CATCH
+
+} // namespace DB::tests

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/tests/gtest_mlfq.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/tests/gtest_mlfq.cpp
@@ -20,6 +20,8 @@
 
 #include <thread>
 
+#include "Flash/Pipeline/Schedule/Tasks/Task.h"
+
 namespace DB::tests
 {
 namespace
@@ -80,7 +82,7 @@ try
         {
             TaskPtr task = std::make_unique<PlainTask>();
             auto value = mock_value();
-            queue->updateStatistics(task, value);
+            queue->updateStatistics(task, ExecTaskStatus::INIT, value);
             task->profile_info.addCPUExecuteTime(value);
             queue->submit(std::move(task));
         }
@@ -115,7 +117,7 @@ try
             ASSERT_EQ(task->mlfq_level, level);
             ASSERT_TRUE(task);
             auto value = CPUMultiLevelFeedbackQueue::LEVEL_TIME_SLICE_BASE_NS;
-            queue.updateStatistics(task, value);
+            queue.updateStatistics(task, ExecTaskStatus::INIT, value);
             task->profile_info.addCPUExecuteTime(value);
             bool need_break = CPUTimeGetter::get(task) >= queue.getUnitQueueInfo(level).time_slice;
             queue.submit(std::move(task));
@@ -142,7 +144,7 @@ try
         TaskPtr task = std::make_unique<PlainTask>();
         task->mlfq_level = CPUMultiLevelFeedbackQueue::QUEUE_SIZE - 1;
         auto value = queue.getUnitQueueInfo(task->mlfq_level).time_slice;
-        queue.updateStatistics(task, value);
+        queue.updateStatistics(task, ExecTaskStatus::INIT, value);
         task->profile_info.addCPUExecuteTime(value);
         queue.submit(std::move(task));
     }
@@ -150,7 +152,7 @@ try
         // level `0`
         TaskPtr task = std::make_unique<PlainTask>();
         auto value = queue.getUnitQueueInfo(0).time_slice - 1;
-        queue.updateStatistics(task, value);
+        queue.updateStatistics(task, ExecTaskStatus::INIT, value);
         task->profile_info.addCPUExecuteTime(value);
         queue.submit(std::move(task));
     }
@@ -176,7 +178,7 @@ try
         // level `0`
         TaskPtr task = std::make_unique<PlainTask>();
         auto value = queue.getUnitQueueInfo(0).time_slice - 1;
-        queue.updateStatistics(task, value);
+        queue.updateStatistics(task, ExecTaskStatus::INIT, value);
         task->profile_info.addCPUExecuteTime(value);
         queue.submit(std::move(task));
     }
@@ -185,7 +187,7 @@ try
         TaskPtr task = std::make_unique<PlainTask>();
         task->mlfq_level = CPUMultiLevelFeedbackQueue::QUEUE_SIZE - 1;
         auto value = queue.getUnitQueueInfo(task->mlfq_level).time_slice;
-        queue.updateStatistics(task, value);
+        queue.updateStatistics(task, ExecTaskStatus::INIT, value);
         task->profile_info.addCPUExecuteTime(value);
         queue.submit(std::move(task));
     }

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/tests/gtest_mlfq.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/tests/gtest_mlfq.cpp
@@ -18,10 +18,6 @@
 #include <TestUtils/TiFlashTestBasic.h>
 #include <gtest/gtest.h>
 
-#include <thread>
-
-#include "Flash/Pipeline/Schedule/Tasks/Task.h"
-
 namespace DB::tests
 {
 namespace

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/tests/gtest_mlfq.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/tests/gtest_mlfq.cpp
@@ -27,9 +27,7 @@ namespace
 class PlainTask : public Task
 {
 public:
-    PlainTask()
-        : Task()
-    {}
+    PlainTask() = default;
 
     ExecTaskStatus executeImpl() noexcept override { return ExecTaskStatus::FINISHED; }
 };

--- a/dbms/src/Flash/Pipeline/Schedule/Tasks/AggregateFinalSpillTask.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/Tasks/AggregateFinalSpillTask.cpp
@@ -24,7 +24,7 @@ AggregateFinalSpillTask::AggregateFinalSpillTask(
     const EventPtr & event_,
     AggregateContextPtr agg_context_,
     size_t index_)
-    : IOEventTask(std::move(mem_tracker_), req_id, exec_status_, event_)
+    : OutputIOEventTask(std::move(mem_tracker_), req_id, exec_status_, event_)
     , agg_context(std::move(agg_context_))
     , index(index_)
 {

--- a/dbms/src/Flash/Pipeline/Schedule/Tasks/AggregateFinalSpillTask.h
+++ b/dbms/src/Flash/Pipeline/Schedule/Tasks/AggregateFinalSpillTask.h
@@ -21,7 +21,7 @@ namespace DB
 class AggregateContext;
 using AggregateContextPtr = std::shared_ptr<AggregateContext>;
 
-class AggregateFinalSpillTask : public IOEventTask
+class AggregateFinalSpillTask : public OutputIOEventTask
 {
 public:
     AggregateFinalSpillTask(

--- a/dbms/src/Flash/Pipeline/Schedule/Tasks/IOEventTask.h
+++ b/dbms/src/Flash/Pipeline/Schedule/Tasks/IOEventTask.h
@@ -18,6 +18,7 @@
 
 namespace DB
 {
+template <bool is_input>
 class IOEventTask : public EventTask
 {
 public:
@@ -33,12 +34,22 @@ public:
 private:
     ExecTaskStatus doExecuteImpl() override
     {
-        return ExecTaskStatus::IO;
+        if constexpr (is_input)
+            return ExecTaskStatus::IO_IN;
+        else
+            return ExecTaskStatus::IO_OUT;
     }
 
     ExecTaskStatus doAwaitImpl() override
     {
-        return ExecTaskStatus::IO;
+        if constexpr (is_input)
+            return ExecTaskStatus::IO_IN;
+        else
+            return ExecTaskStatus::IO_OUT;
     }
 };
+
+using InputIOEventTask = IOEventTask<true>;
+using OutputIOEventTask = IOEventTask<false>;
+
 } // namespace DB

--- a/dbms/src/Flash/Pipeline/Schedule/Tasks/LoadBucketTask.h
+++ b/dbms/src/Flash/Pipeline/Schedule/Tasks/LoadBucketTask.h
@@ -20,7 +20,7 @@ namespace DB
 {
 class SpilledBucketInput;
 
-class LoadBucketTask : public IOEventTask
+class LoadBucketTask : public InputIOEventTask
 {
 public:
     LoadBucketTask(

--- a/dbms/src/Flash/Pipeline/Schedule/Tasks/PipelineTask.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/Tasks/PipelineTask.cpp
@@ -51,9 +51,13 @@ void PipelineTask::doFinalizeImpl()
     {                                     \
         return ExecTaskStatus::CANCELLED; \
     }                                     \
-    case OperatorStatus::IO:              \
+    case OperatorStatus::IO_IN:           \
     {                                     \
-        return ExecTaskStatus::IO;        \
+        return ExecTaskStatus::IO_IN;     \
+    }                                     \
+    case OperatorStatus::IO_OUT:          \
+    {                                     \
+        return ExecTaskStatus::IO_OUT;    \
     }                                     \
     case OperatorStatus::WAITING:         \
     {                                     \

--- a/dbms/src/Flash/Pipeline/Schedule/Tasks/Task.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/Tasks/Task.cpp
@@ -53,7 +53,8 @@ ALWAYS_INLINE void addToStatusMetrics(ExecTaskStatus to)
     {
         M(ExecTaskStatus::WAITING, type_to_waiting)
         M(ExecTaskStatus::RUNNING, type_to_running)
-        M(ExecTaskStatus::IO, type_to_io)
+        M(ExecTaskStatus::IO_IN, type_to_io)
+        M(ExecTaskStatus::IO_OUT, type_to_io)
         M(ExecTaskStatus::FINISHED, type_to_finished)
         M(ExecTaskStatus::ERROR, type_to_error)
         M(ExecTaskStatus::CANCELLED, type_to_cancelled)
@@ -106,7 +107,7 @@ ExecTaskStatus Task::execute()
 ExecTaskStatus Task::executeIO()
 {
     assert(mem_tracker_ptr == current_memory_tracker);
-    assert(task_status == ExecTaskStatus::IO || task_status == ExecTaskStatus::INIT);
+    assert(task_status == ExecTaskStatus::IO_IN || task_status == ExecTaskStatus::IO_OUT || task_status == ExecTaskStatus::INIT);
     switchStatus(executeIOImpl());
     return task_status;
 }

--- a/dbms/src/Flash/Pipeline/Schedule/Tasks/Task.h
+++ b/dbms/src/Flash/Pipeline/Schedule/Tasks/Task.h
@@ -53,6 +53,8 @@ public:
 
     virtual ~Task();
 
+    ExecTaskStatus getStatus() const { return task_status; }
+
     ExecTaskStatus execute();
 
     ExecTaskStatus executeIO();

--- a/dbms/src/Flash/Pipeline/Schedule/Tasks/Task.h
+++ b/dbms/src/Flash/Pipeline/Schedule/Tasks/Task.h
@@ -25,19 +25,20 @@ namespace DB
  *           CANCELLED/ERROR/FINISHED
  *                      ▲
  *                      │
- *         ┌────────────────────────┐
- *         │     ┌──►RUNNING◄──┐    │
- * INIT───►│     │             │    │
- *         │     ▼             ▼    │
- *         │ WATITING◄────────►IO   │
- *         └────────────────────────┘
+ *         ┌───────────────────────────────┐
+ *         │     ┌──►RUNNING◄──┐           │
+ * INIT───►│     │             │           │
+ *         │     ▼             ▼           │
+ *         │ WATITING◄────────►IO_IN/OUT   │
+ *         └───────────────────────────────┘
  */
 enum class ExecTaskStatus
 {
     INIT,
     WAITING,
     RUNNING,
-    IO,
+    IO_IN,
+    IO_OUT,
     FINISHED,
     ERROR,
     CANCELLED,

--- a/dbms/src/Flash/Pipeline/Schedule/ThreadPool/TaskThreadPool.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/ThreadPool/TaskThreadPool.cpp
@@ -93,21 +93,22 @@ void TaskThreadPool<Impl>::handleTask(TaskPtr & task)
     metrics.incExecutingTask();
     metrics.elapsedPendingTime(task);
 
-    ExecTaskStatus status;
+    ExecTaskStatus cur_status = task->getStatus();
     UInt64 total_time_spent = 0;
     while (true)
     {
-        status = Impl::exec(task);
+        auto after_status = Impl::exec(task);
         auto inc_time_spent = task->profile_info.elapsedFromPrev();
-        task_queue->updateStatistics(task, inc_time_spent);
+        task_queue->updateStatistics(task, cur_status, inc_time_spent);
+        cur_status = after_status;
         total_time_spent += inc_time_spent;
         // The executing task should yield if it takes more than `YIELD_MAX_TIME_SPENT_NS`.
-        if (!Impl::isTargetStatus(status) || total_time_spent >= YIELD_MAX_TIME_SPENT_NS)
+        if (!Impl::isTargetStatus(cur_status) || total_time_spent >= YIELD_MAX_TIME_SPENT_NS)
             break;
     }
     metrics.addExecuteTime(task, total_time_spent);
     metrics.decExecutingTask();
-    switch (status)
+    switch (cur_status)
     {
     case ExecTaskStatus::RUNNING:
         task->endTraceMemory();
@@ -128,7 +129,7 @@ void TaskThreadPool<Impl>::handleTask(TaskPtr & task)
         task.reset();
         break;
     default:
-        UNEXPECTED_STATUS(task->log, status);
+        UNEXPECTED_STATUS(task->log, cur_status);
     }
 }
 

--- a/dbms/src/Flash/Pipeline/Schedule/ThreadPool/TaskThreadPool.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/ThreadPool/TaskThreadPool.cpp
@@ -102,7 +102,7 @@ void TaskThreadPool<Impl>::handleTask(TaskPtr & task)
         task_queue->updateStatistics(task, inc_time_spent);
         total_time_spent += inc_time_spent;
         // The executing task should yield if it takes more than `YIELD_MAX_TIME_SPENT_NS`.
-        if (Impl::isTargetStatus(status) || total_time_spent >= YIELD_MAX_TIME_SPENT_NS)
+        if (!Impl::isTargetStatus(status) || total_time_spent >= YIELD_MAX_TIME_SPENT_NS)
             break;
     }
     metrics.addExecuteTime(task, total_time_spent);

--- a/dbms/src/Flash/Pipeline/Schedule/ThreadPool/TaskThreadPool.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/ThreadPool/TaskThreadPool.cpp
@@ -102,7 +102,7 @@ void TaskThreadPool<Impl>::handleTask(TaskPtr & task)
         task_queue->updateStatistics(task, inc_time_spent);
         total_time_spent += inc_time_spent;
         // The executing task should yield if it takes more than `YIELD_MAX_TIME_SPENT_NS`.
-        if (status != Impl::TargetStatus || total_time_spent >= YIELD_MAX_TIME_SPENT_NS)
+        if (Impl::isTargetStatus(status) || total_time_spent >= YIELD_MAX_TIME_SPENT_NS)
             break;
     }
     metrics.addExecuteTime(task, total_time_spent);
@@ -113,7 +113,8 @@ void TaskThreadPool<Impl>::handleTask(TaskPtr & task)
         task->endTraceMemory();
         scheduler.submitToCPUTaskThreadPool(std::move(task));
         break;
-    case ExecTaskStatus::IO:
+    case ExecTaskStatus::IO_IN:
+    case ExecTaskStatus::IO_OUT:
         task->endTraceMemory();
         scheduler.submitToIOTaskThreadPool(std::move(task));
         break;

--- a/dbms/src/Flash/Pipeline/Schedule/ThreadPool/TaskThreadPoolImpl.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/ThreadPool/TaskThreadPoolImpl.cpp
@@ -12,9 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Common/Exception.h>
 #include <Flash/Pipeline/Schedule/TaskQueues/FIFOTaskQueue.h>
+#include <Flash/Pipeline/Schedule/TaskQueues/IOPriorityQueue.h>
 #include <Flash/Pipeline/Schedule/TaskQueues/MultiLevelFeedbackQueue.h>
 #include <Flash/Pipeline/Schedule/ThreadPool/TaskThreadPoolImpl.h>
+
+#include <magic_enum.hpp>
 
 namespace DB
 {
@@ -28,6 +32,8 @@ TaskQueuePtr CPUImpl::newTaskQueue(TaskQueueType type)
         return std::make_unique<CPUMultiLevelFeedbackQueue>();
     case TaskQueueType::FIFO:
         return std::make_unique<FIFOTaskQueue>();
+    default:
+        throw Exception(fmt::format("Unsupported queue type: {}", magic_enum::enum_name(type)));
     }
 }
 
@@ -41,6 +47,10 @@ TaskQueuePtr IOImpl::newTaskQueue(TaskQueueType type)
         return std::make_unique<FIFOTaskQueue>();
     case TaskQueueType::MLFQ:
         return std::make_unique<IOMultiLevelFeedbackQueue>();
+    case TaskQueueType::IO_PRIORITY:
+        return std::make_unique<IOPriorityQueue>();
+    default:
+        throw Exception(fmt::format("Unsupported queue type: {}", magic_enum::enum_name(type)));
     }
 }
 } // namespace DB

--- a/dbms/src/Flash/Pipeline/Schedule/ThreadPool/TaskThreadPoolImpl.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/ThreadPool/TaskThreadPoolImpl.cpp
@@ -41,14 +41,14 @@ TaskQueuePtr IOImpl::newTaskQueue(TaskQueueType type)
 {
     switch (type)
     {
-    // the default queue is fifo queue.
+    // the default queue is io priority queue.
     case TaskQueueType::DEFAULT:
+    case TaskQueueType::IO_PRIORITY:
+        return std::make_unique<IOPriorityQueue>();
     case TaskQueueType::FIFO:
         return std::make_unique<FIFOTaskQueue>();
     case TaskQueueType::MLFQ:
         return std::make_unique<IOMultiLevelFeedbackQueue>();
-    case TaskQueueType::IO_PRIORITY:
-        return std::make_unique<IOPriorityQueue>();
     default:
         throw Exception(fmt::format("Unsupported queue type: {}", magic_enum::enum_name(type)));
     }

--- a/dbms/src/Flash/Pipeline/Schedule/ThreadPool/TaskThreadPoolImpl.h
+++ b/dbms/src/Flash/Pipeline/Schedule/ThreadPool/TaskThreadPoolImpl.h
@@ -27,7 +27,10 @@ struct CPUImpl
 
     static constexpr bool is_cpu = true;
 
-    static constexpr auto TargetStatus = ExecTaskStatus::RUNNING;
+    static bool isTargetStatus(ExecTaskStatus status)
+    {
+        return status == ExecTaskStatus::RUNNING;
+    }
 
     static ExecTaskStatus exec(TaskPtr & task)
     {
@@ -43,7 +46,10 @@ struct IOImpl
 
     static constexpr bool is_cpu = false;
 
-    static constexpr auto TargetStatus = ExecTaskStatus::IO;
+    static bool isTargetStatus(ExecTaskStatus status)
+    {
+        return status == ExecTaskStatus::IO_IN || status == ExecTaskStatus::IO_OUT;
+    }
 
     static ExecTaskStatus exec(TaskPtr & task)
     {

--- a/dbms/src/Flash/Pipeline/Schedule/tests/gtest_task_scheduler.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/tests/gtest_task_scheduler.cpp
@@ -142,7 +142,7 @@ protected:
         if (loop_count > 0)
         {
             if ((loop_count % 2) == 0)
-                return ExecTaskStatus::IO;
+                return ExecTaskStatus::IO_IN;
             else
             {
                 --loop_count;
@@ -159,7 +159,7 @@ protected:
             if ((loop_count % 2) == 0)
             {
                 --loop_count;
-                return ExecTaskStatus::IO;
+                return ExecTaskStatus::IO_IN;
             }
             else
                 return ExecTaskStatus::RUNNING;
@@ -192,7 +192,7 @@ protected:
     ExecTaskStatus executeImpl() noexcept override
     {
         CurrentMemoryTracker::alloc(MEMORY_TRACER_SUBMIT_THRESHOLD - 10);
-        return ExecTaskStatus::IO;
+        return ExecTaskStatus::IO_IN;
     }
 
     ExecTaskStatus executeIOImpl() override
@@ -221,7 +221,7 @@ protected:
 
     ExecTaskStatus awaitImpl() override
     {
-        return ExecTaskStatus::IO;
+        return ExecTaskStatus::IO_IN;
     }
 
     ExecTaskStatus executeIOImpl() override

--- a/dbms/src/Operators/AggregateBuildSinkOp.cpp
+++ b/dbms/src/Operators/AggregateBuildSinkOp.cpp
@@ -25,7 +25,7 @@ OperatorStatus AggregateBuildSinkOp::writeImpl(Block && block)
         {
             RUNTIME_CHECK(!is_final_spill);
             is_final_spill = true;
-            return OperatorStatus::IO;
+            return OperatorStatus::IO_OUT;
         }
         return OperatorStatus::FINISHED;
     }
@@ -33,7 +33,7 @@ OperatorStatus AggregateBuildSinkOp::writeImpl(Block && block)
     total_rows += block.rows();
     block.clear();
     return agg_context->needSpill(index)
-        ? OperatorStatus::IO
+        ? OperatorStatus::IO_OUT
         : OperatorStatus::NEED_INPUT;
 }
 

--- a/dbms/src/Operators/DMSegmentThreadSourceOp.cpp
+++ b/dbms/src/Operators/DMSegmentThreadSourceOp.cpp
@@ -71,7 +71,7 @@ OperatorStatus DMSegmentThreadSourceOp::readImpl(Block & block)
         total_rows += block.rows();
         return OperatorStatus::HAS_OUTPUT;
     }
-    return OperatorStatus::IO;
+    return OperatorStatus::IO_IN;
 }
 
 OperatorStatus DMSegmentThreadSourceOp::executeIOImpl()
@@ -108,7 +108,7 @@ OperatorStatus DMSegmentThreadSourceOp::executeIOImpl()
         LOG_TRACE(log, "Finish reading segment, segment={}", cur_segment->simpleInfo());
         cur_segment = {};
         cur_stream = {};
-        return OperatorStatus::IO;
+        return OperatorStatus::IO_IN;
     }
 }
 

--- a/dbms/src/Operators/LocalAggregateTransform.cpp
+++ b/dbms/src/Operators/LocalAggregateTransform.cpp
@@ -75,13 +75,14 @@ OperatorStatus LocalAggregateTransform::fromBuildToFinalSpillOrRestore()
     if (agg_context.needSpill(task_index, /*try_mark_need_spill=*/true))
     {
         status = LocalAggStatus::final_spill;
+        return OperatorStatus::IO_OUT;
     }
     else
     {
         restorer = agg_context.buildLocalRestorer();
         status = LocalAggStatus::restore;
+        return OperatorStatus::IO_IN;
     }
-    return OperatorStatus::IO;
 }
 
 OperatorStatus LocalAggregateTransform::tryFromBuildToSpill()
@@ -90,7 +91,7 @@ OperatorStatus LocalAggregateTransform::tryFromBuildToSpill()
     if (agg_context.needSpill(task_index))
     {
         status = LocalAggStatus::spill;
-        return OperatorStatus::IO;
+        return OperatorStatus::IO_OUT;
     }
     return OperatorStatus::NEED_INPUT;
 }
@@ -107,7 +108,7 @@ OperatorStatus LocalAggregateTransform::tryOutputImpl(Block & block)
     case LocalAggStatus::restore:
         return restorer->tryPop(block)
             ? OperatorStatus::HAS_OUTPUT
-            : OperatorStatus::IO;
+            : OperatorStatus::IO_IN;
     default:
         throw Exception(fmt::format("Unexpected status: {}", magic_enum::enum_name(status)));
     }
@@ -128,7 +129,7 @@ OperatorStatus LocalAggregateTransform::executeIOImpl()
         agg_context.spillData(task_index);
         restorer = agg_context.buildLocalRestorer();
         status = LocalAggStatus::restore;
-        return OperatorStatus::IO;
+        return OperatorStatus::IO_IN;
     }
     case LocalAggStatus::restore:
     {

--- a/dbms/src/Operators/MergeSortTransformOp.cpp
+++ b/dbms/src/Operators/MergeSortTransformOp.cpp
@@ -106,7 +106,7 @@ OperatorStatus MergeSortTransformOp::fromPartialToRestore()
     /// merge the spilled data and memory data.
     merge_impl = std::make_unique<MergingSortedBlockInputStream>(inputs_to_merge, order_desc, max_block_size, limit);
     merge_impl->readPrefix();
-    return OperatorStatus::IO;
+    return OperatorStatus::IO_IN;
 }
 
 OperatorStatus MergeSortTransformOp::fromPartialToSpill()
@@ -124,7 +124,7 @@ OperatorStatus MergeSortTransformOp::fromPartialToSpill()
     // fallback to partial phase.
     if (!cached_handler->batchRead())
         return fromSpillToPartial();
-    return OperatorStatus::IO;
+    return OperatorStatus::IO_OUT;
 }
 
 OperatorStatus MergeSortTransformOp::fromSpillToPartial()
@@ -176,7 +176,7 @@ OperatorStatus MergeSortTransformOp::tryOutputImpl(Block & block)
     {
         assert(cached_handler);
         return cached_handler->batchRead()
-            ? OperatorStatus::IO
+            ? OperatorStatus::IO_OUT
             : fromSpillToPartial();
     }
     case MergeSortStatus::MERGE:
@@ -192,7 +192,7 @@ OperatorStatus MergeSortTransformOp::tryOutputImpl(Block & block)
             block = restored_result.output();
             return OperatorStatus::HAS_OUTPUT;
         }
-        return OperatorStatus::IO;
+        return OperatorStatus::IO_IN;
     }
     default:
         throw Exception(fmt::format("Unexpected status: {}.", magic_enum::enum_name(status)));

--- a/dbms/src/Operators/Operator.h
+++ b/dbms/src/Operators/Operator.h
@@ -38,7 +38,8 @@ enum class OperatorStatus
     /// waiting status
     WAITING,
     /// io status
-    IO,
+    IO_IN,
+    IO_OUT,
     /// running status
     // means that TransformOp/SinkOp needs to input a block to do the calculation,
     NEED_INPUT,

--- a/dbms/src/Operators/OperatorHelper.cpp
+++ b/dbms/src/Operators/OperatorHelper.cpp
@@ -28,7 +28,8 @@ void assertOperatorStatus(
     // cancel status, waiting and io status can be returned in all method of operator.
     case OperatorStatus::CANCELLED:
     case OperatorStatus::WAITING:
-    case OperatorStatus::IO:
+    case OperatorStatus::IO_IN:
+    case OperatorStatus::IO_OUT:
         return;
     default:
     {

--- a/dbms/src/Storages/DeltaMerge/Remote/RNSegmentSourceOp.cpp
+++ b/dbms/src/Storages/DeltaMerge/Remote/RNSegmentSourceOp.cpp
@@ -67,7 +67,7 @@ OperatorStatus RNSegmentSourceOp::readImpl(Block & block)
         return OperatorStatus::HAS_OUTPUT;
     }
 
-    return current_seg_task ? OperatorStatus::IO : startGettingNextReadyTask();
+    return current_seg_task ? OperatorStatus::IO_IN : startGettingNextReadyTask();
 }
 
 OperatorStatus RNSegmentSourceOp::awaitImpl()
@@ -81,7 +81,7 @@ OperatorStatus RNSegmentSourceOp::awaitImpl()
     if unlikely (current_seg_task)
     {
         duration_wait_ready_task_sec += wait_stop_watch.elapsedSeconds();
-        return OperatorStatus::IO;
+        return OperatorStatus::IO_IN;
     }
 
     auto pop_result = workers->getReadyChannel()->tryPop(current_seg_task);
@@ -91,7 +91,7 @@ OperatorStatus RNSegmentSourceOp::awaitImpl()
         processed_seg_tasks += 1;
         RUNTIME_CHECK(current_seg_task != nullptr);
         duration_wait_ready_task_sec += wait_stop_watch.elapsedSeconds();
-        return OperatorStatus::IO;
+        return OperatorStatus::IO_IN;
     case MPMCQueueResult::EMPTY:
         return OperatorStatus::WAITING;
     case MPMCQueueResult::FINISHED:


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6518

Problem Summary:

### What is changed and how it works?
- spilt `Status::IO` to `Status::IO_IN` and `Status::IO_OUT`
- add `IOPriorityQueue` for io thread pool to execute spilling before restoring.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
