### PR TITLE
update proxy of release-7.1 to raftstore-proxy

### DIFF
--- a/dbms/src/Debug/MockRaftStoreProxy.cpp
+++ b/dbms/src/Debug/MockRaftStoreProxy.cpp
@@ -24,6 +24,7 @@
 #include <Storages/Transaction/ProxyFFICommon.h>
 #include <Storages/Transaction/RegionMeta.h>
 #include <Storages/Transaction/RegionTable.h>
+#include <Storages/Transaction/RowCodec.h>
 #include <Storages/Transaction/TMTContext.h>
 #include <Storages/Transaction/tests/region_helper.h>
 #include <TestUtils/TiFlashTestEnv.h>
@@ -134,6 +135,14 @@ KVGetStatus fn_get_region_local_state(RaftStoreProxyPtr ptr, uint64_t region_id,
         return KVGetStatus::NotFound;
 }
 
+RaftstoreVer fn_get_cluster_raftstore_version(RaftStoreProxyPtr ptr,
+                                              uint8_t,
+                                              int64_t)
+{
+    auto & x = as_ref(ptr);
+    return x.cluster_ver;
+}
+
 TiFlashRaftProxyHelper MockRaftStoreProxy::SetRaftStoreProxyFFIHelper(RaftStoreProxyPtr proxy_ptr)
 {
     TiFlashRaftProxyHelper res{};
@@ -143,6 +152,7 @@ TiFlashRaftProxyHelper MockRaftStoreProxy::SetRaftStoreProxyFFIHelper(RaftStoreP
     res.fn_make_async_waker = fn_make_async_waker;
     res.fn_handle_batch_read_index = fn_handle_batch_read_index;
     res.fn_get_region_local_state = fn_get_region_local_state;
+    res.fn_get_cluster_raftstore_version = fn_get_cluster_raftstore_version;
     {
         // make sure such function pointer will be set at most once.
         static std::once_flag flag;
@@ -438,7 +448,8 @@ std::tuple<uint64_t, uint64_t> MockRaftStoreProxy::rawWrite(
     std::vector<std::string> && keys,
     std::vector<std::string> && vals,
     std::vector<WriteCmdType> && cmd_types,
-    std::vector<ColumnFamilyType> && cmd_cf)
+    std::vector<ColumnFamilyType> && cmd_cf,
+    std::optional<uint64_t> forced_index)
 {
     uint64_t index = 0;
     uint64_t term = 0;
@@ -446,7 +457,8 @@ std::tuple<uint64_t, uint64_t> MockRaftStoreProxy::rawWrite(
         auto region = getRegion(region_id);
         assert(region != nullptr);
         // We have a new entry.
-        index = region->getLatestCommitIndex() + 1;
+        index = forced_index.value_or(region->getLatestCommitIndex() + 1);
+        RUNTIME_CHECK(index > region->getLatestCommitIndex());
         term = region->getLatestCommitTerm();
         // The new entry is committed on Proxy's side.
         region->updateCommitIndex(index);
@@ -464,7 +476,11 @@ std::tuple<uint64_t, uint64_t> MockRaftStoreProxy::rawWrite(
 }
 
 
-std::tuple<uint64_t, uint64_t> MockRaftStoreProxy::compactLog(UInt64 region_id, UInt64 compact_index)
+std::tuple<uint64_t, uint64_t> MockRaftStoreProxy::adminCommand(
+    UInt64 region_id,
+    raft_cmdpb::AdminRequest && request,
+    raft_cmdpb::AdminResponse && response,
+    std::optional<uint64_t> forced_index)
 {
     uint64_t index = 0;
     uint64_t term = 0;
@@ -472,7 +488,8 @@ std::tuple<uint64_t, uint64_t> MockRaftStoreProxy::compactLog(UInt64 region_id, 
         auto region = getRegion(region_id);
         assert(region != nullptr);
         // We have a new entry.
-        index = region->getLatestCommitIndex() + 1;
+        index = forced_index.value_or(region->getLatestCommitIndex() + 1);
+        RUNTIME_CHECK(index > region->getLatestCommitIndex());
         term = region->getLatestCommitTerm();
         // The new entry is committed on Proxy's side.
         region->updateCommitIndex(index);
@@ -495,6 +512,98 @@ std::tuple<uint64_t, uint64_t> MockRaftStoreProxy::compactLog(UInt64 region_id, 
             }};
     }
     return std::make_tuple(index, term);
+}
+
+std::tuple<raft_cmdpb::AdminRequest, raft_cmdpb::AdminResponse> MockRaftStoreProxy::composeCompactLog(MockProxyRegionPtr region, UInt64 compact_index)
+{
+    raft_cmdpb::AdminRequest request;
+    raft_cmdpb::AdminResponse response;
+    request.set_cmd_type(raft_cmdpb::AdminCmdType::CompactLog);
+    request.mutable_compact_log()->set_compact_index(compact_index);
+    // Find compact term, otherwise log must have been compacted.
+    if (region->commands.contains(compact_index))
+    {
+        request.mutable_compact_log()->set_compact_term(region->commands[compact_index].term);
+    }
+    return std::make_tuple(request, response);
+}
+
+std::tuple<raft_cmdpb::AdminRequest, raft_cmdpb::AdminResponse> MockRaftStoreProxy::composeChangePeer(metapb::Region && meta, std::vector<UInt64> peer_ids, bool is_v2)
+{
+    raft_cmdpb::AdminRequest request;
+    raft_cmdpb::AdminResponse response;
+    if (is_v2)
+    {
+        request.set_cmd_type(raft_cmdpb::AdminCmdType::ChangePeerV2);
+    }
+    else
+    {
+        request.set_cmd_type(raft_cmdpb::AdminCmdType::ChangePeer);
+    }
+    meta.mutable_peers()->Clear();
+    for (auto i : peer_ids)
+    {
+        meta.add_peers()->set_id(i);
+    }
+    *response.mutable_change_peer()->mutable_region() = meta;
+    return std::make_tuple(request, response);
+}
+
+std::tuple<raft_cmdpb::AdminRequest, raft_cmdpb::AdminResponse> MockRaftStoreProxy::composePrepareMerge(metapb::Region && target, UInt64 min_index)
+{
+    raft_cmdpb::AdminRequest request;
+    raft_cmdpb::AdminResponse response;
+    request.set_cmd_type(raft_cmdpb::AdminCmdType::PrepareMerge);
+    auto * prepare_merge = request.mutable_prepare_merge();
+    prepare_merge->set_min_index(min_index);
+    *prepare_merge->mutable_target() = target;
+    return std::make_tuple(request, response);
+}
+
+std::tuple<raft_cmdpb::AdminRequest, raft_cmdpb::AdminResponse> MockRaftStoreProxy::composeCommitMerge(metapb::Region && source, UInt64 commit)
+{
+    raft_cmdpb::AdminRequest request;
+    raft_cmdpb::AdminResponse response;
+    request.set_cmd_type(raft_cmdpb::AdminCmdType::CommitMerge);
+    auto * commit_merge = request.mutable_commit_merge();
+    commit_merge->set_commit(commit);
+    *commit_merge->mutable_source() = source;
+    return std::make_tuple(request, response);
+}
+
+std::tuple<raft_cmdpb::AdminRequest, raft_cmdpb::AdminResponse> MockRaftStoreProxy::composeRollbackMerge(UInt64 commit)
+{
+    raft_cmdpb::AdminRequest request;
+    raft_cmdpb::AdminResponse response;
+    request.set_cmd_type(raft_cmdpb::AdminCmdType::RollbackMerge);
+    auto * rollback_merge = request.mutable_rollback_merge();
+    rollback_merge->set_commit(commit);
+    return std::make_tuple(request, response);
+}
+
+std::tuple<raft_cmdpb::AdminRequest, raft_cmdpb::AdminResponse> MockRaftStoreProxy::composeBatchSplit(std::vector<UInt64> && region_ids, std::vector<std::pair<std::string, std::string>> && ranges, metapb::RegionEpoch old_epoch)
+{
+    RUNTIME_CHECK_MSG(region_ids.size() == ranges.size(), "error composeBatchSplit input");
+    auto n = region_ids.size();
+    raft_cmdpb::AdminRequest request;
+    raft_cmdpb::AdminResponse response;
+    request.set_cmd_type(raft_cmdpb::AdminCmdType::BatchSplit);
+    metapb::RegionEpoch new_epoch;
+    new_epoch.set_version(old_epoch.version() + 1);
+    new_epoch.set_conf_ver(old_epoch.conf_ver());
+    {
+        raft_cmdpb::BatchSplitResponse * splits = response.mutable_splits();
+        for (size_t i = 0; i < n; ++i)
+        {
+            auto * region = splits->add_regions();
+            region->set_id(region_ids[i]);
+            region->set_start_key(ranges[i].first);
+            region->set_end_key(ranges[i].second);
+            region->add_peers();
+            *region->mutable_region_epoch() = new_epoch;
+        }
+    }
+    return std::make_tuple(request, response);
 }
 
 void MockRaftStoreProxy::doApply(
@@ -651,17 +760,19 @@ void MockRaftStoreProxy::Cf::insert_raw(std::string key, std::string val)
     kvs.emplace_back(std::move(key), std::move(val));
 }
 
-void MockRaftStoreProxy::snapshot(
+RegionPtr MockRaftStoreProxy::snapshot(
     KVStore & kvs,
     TMTContext & tmt,
     UInt64 region_id,
     std::vector<Cf> && cfs,
     uint64_t index,
-    uint64_t term)
+    uint64_t term,
+    std::optional<uint64_t> deadline_index)
 {
     auto region = getRegion(region_id);
     auto old_kv_region = kvs.getRegion(region_id);
     // We have catch up to index by snapshot.
+    // So we assume there are new data updated, so we inc index by 1.
     if (index == 0)
     {
         index = region->getLatestCommitIndex() + 1;
@@ -687,12 +798,16 @@ void MockRaftStoreProxy::snapshot(
         snaps,
         index,
         term,
+        deadline_index,
         tmt);
 
     kvs.checkAndApplyPreHandledSnapshot<RegionPtrWithSnapshotFiles>(RegionPtrWithSnapshotFiles{new_kv_region, std::move(ingest_ids)}, tmt);
     region->updateAppliedIndex(index);
     // PreHandledSnapshotWithFiles will do that, however preHandleSnapshotToFiles will not.
     new_kv_region->setApplied(index, term);
+
+    // Region changes during applying snapshot, must re-get.
+    return kvs.getRegion(region_id);
 }
 
 TableID MockRaftStoreProxy::bootstrap_table(
@@ -716,18 +831,18 @@ TableID MockRaftStoreProxy::bootstrap_table(
     return table_id;
 }
 
-void MockRaftStoreProxy::clear_tables(
-    Context & ctx,
-    KVStore & kvs,
-    TMTContext & tmt)
+std::pair<std::string, std::string> MockRaftStoreProxy::generateTiKVKeyValue(uint64_t tso, int64_t t) const
 {
-    UNUSED(kvs);
-    UNUSED(tmt);
-    if (this->table_id != 1)
-    {
-        MockTiDB::instance().dropTable(ctx, "d", "t", false);
-    }
-    this->table_id = 1;
+    WriteBufferFromOwnString buff;
+    writeChar(RecordKVFormat::CFModifyFlag::PutFlag, buff);
+    EncodeVarUInt(tso, buff);
+    std::string value_write = buff.releaseStr();
+    buff.restart();
+    auto && table_info = MockTiDB::instance().getTableInfoByID(table_id);
+    std::vector<Field> f{Field{std::move(t)}};
+    encodeRowV1(*table_info, f, buff);
+    std::string value_default = buff.releaseStr();
+    return std::make_pair(value_write, value_default);
 }
 
 void GCMonitor::add(RawObjType type, int64_t diff)

--- a/dbms/src/Debug/dbgFuncMockRaftSnapshot.cpp
+++ b/dbms/src/Debug/dbgFuncMockRaftSnapshot.cpp
@@ -255,6 +255,7 @@ void MockRaftCommand::dbgFuncRegionSnapshot(Context & context, const ASTs & args
         SSTViewVec{nullptr, 0},
         MockTiKV::instance().getRaftIndex(region_id),
         RAFT_INIT_LOG_TERM,
+        std::nullopt,
         tmt);
 
     output(fmt::format("put region #{}, range[{}, {}) to table #{} with raft commands", region_id, RecordKVFormat::DecodedTiKVKeyToDebugString<true>(start_decoded_key), RecordKVFormat::DecodedTiKVKeyToDebugString<false>(end_decoded_key), table_id));
@@ -730,6 +731,7 @@ void MockRaftCommand::dbgFuncRegionSnapshotPreHandleDTFiles(Context & context, c
         SSTViewVec{sst_views.data(), sst_views.size()},
         index,
         MockTiKV::instance().getRaftTerm(region_id),
+        std::nullopt,
         tmt);
     GLOBAL_REGION_MAP.insertRegionSnap(region_name, {new_region, ingest_ids});
 
@@ -827,6 +829,7 @@ void MockRaftCommand::dbgFuncRegionSnapshotPreHandleDTFilesWithHandles(Context &
         SSTViewVec{sst_views.data(), sst_views.size()},
         index,
         MockTiKV::instance().getRaftTerm(region_id),
+        std::nullopt,
         tmt);
     GLOBAL_REGION_MAP.insertRegionSnap(region_name, {new_region, ingest_ids});
 

--- a/dbms/src/Debug/dbgFuncRegion.cpp
+++ b/dbms/src/Debug/dbgFuncRegion.cpp
@@ -116,7 +116,7 @@ void dbgFuncTryFlushRegion(Context & context, const ASTs & args, DBGInvoker::Pri
     auto region_id = static_cast<RegionID>(safeGet<UInt64>(typeid_cast<const ASTLiteral &>(*args[0]).value));
 
     TMTContext & tmt = context.getTMTContext();
-    tmt.getRegionTable().tryFlushRegion(region_id);
+    tmt.getRegionTable().tryWriteBlockByRegionAndFlush(region_id);
 
     output(fmt::format("region_table try flush region {}", region_id));
 }

--- a/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.cpp
@@ -159,6 +159,7 @@ Block SSTFilesToBlockInputStream::read()
             // else continue to decode key-value from write CF.
         }
     }
+
     // Load all key-value pairs from other CFs
     loadCFDataFromSST(ColumnFamilyType::Default, nullptr);
     loadCFDataFromSST(ColumnFamilyType::Lock, nullptr);

--- a/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.cpp
@@ -261,7 +261,17 @@ Block SSTFilesToBlockInputStream::readCommitedBlock()
         if (e.code() == ErrorCodes::ILLFORMAT_RAFT_ROW)
         {
             // br or lighting may write illegal data into tikv, stop decoding.
-            LOG_WARNING(log, "Got error while reading region committed cache: {}. Stop decoding rows into DTFiles and keep uncommitted data in region.", e.displayText());
+            const auto & start_key = region->getMetaRegion().start_key();
+            const auto & end_key = region->getMetaRegion().end_key();
+            LOG_WARNING(log, "Got error while reading region committed cache: {}. Stop decoding rows into DTFiles and keep uncommitted data in region."
+                             "region_id: {}, applied_index: {}, version: {}, conf_version {}, start_key: {}, end_key: {}",
+                        e.displayText(),
+                        region->id(),
+                        region->appliedIndex(),
+                        region->version(),
+                        region->confVer(),
+                        Redact::keyToDebugString(start_key.data(), start_key.size()),
+                        Redact::keyToDebugString(end_key.data(), end_key.size()));
             // Cancel the decoding process.
             // Note that we still need to scan data from CFs and keep them in `region`
             is_decode_cancelled = true;

--- a/dbms/src/Storages/Transaction/ApplySnapshot.cpp
+++ b/dbms/src/Storages/Transaction/ApplySnapshot.cpp
@@ -246,6 +246,7 @@ void KVStore::onSnapshot(const RegionPtrWrap & new_region_wrap, RegionPtr old_re
                     manage_lock.index.remove(range, region_id);
                 }
             }
+            // Reuse the old region for non-region-related data.
             old_region->assignRegion(std::move(*new_region));
             new_region = old_region;
             {
@@ -272,11 +273,14 @@ std::vector<DM::ExternalDTFileInfo> KVStore::preHandleSnapshotToFiles(
     const SSTViewVec snaps,
     uint64_t index,
     uint64_t term,
+    std::optional<uint64_t> deadline_index,
     TMTContext & tmt)
 {
     std::vector<DM::ExternalDTFileInfo> external_files;
+    new_region->beforePrehandleSnapshot(new_region->id(), deadline_index);
     try
     {
+        SCOPE_EXIT({ new_region->afterPrehandleSnapshot(); });
         external_files = preHandleSSTsToDTFiles(new_region, snaps, index, term, DM::FileConvertJobType::ApplySnapshot, tmt);
     }
     catch (DB::Exception & e)
@@ -475,10 +479,11 @@ void KVStore::handleApplySnapshot(
     const SSTViewVec snaps,
     uint64_t index,
     uint64_t term,
+    std::optional<uint64_t> deadline_index,
     TMTContext & tmt)
 {
     auto new_region = genRegionPtr(std::move(region), peer_id, index, term);
-    auto external_files = preHandleSnapshotToFiles(new_region, snaps, index, term, tmt);
+    auto external_files = preHandleSnapshotToFiles(new_region, snaps, index, term, deadline_index, tmt);
     applyPreHandledSnapshot(RegionPtrWithSnapshotFiles{new_region, std::move(external_files)}, tmt);
 }
 

--- a/dbms/src/Storages/Transaction/KVStore.cpp
+++ b/dbms/src/Storages/Transaction/KVStore.cpp
@@ -172,15 +172,12 @@ bool KVStore::tryFlushRegionCacheInStorage(TMTContext & tmt, const Region & regi
     return true;
 }
 
-void KVStore::tryPersist(RegionID region_id)
+void KVStore::tryPersistRegion(RegionID region_id)
 {
     auto region = getRegion(region_id);
     if (region)
     {
-        LOG_INFO(log, "Try to persist {}", region->toString(false));
-        RUNTIME_CHECK_MSG(region_persister, "try access to region_persister without initialization, stack={}", StackTrace().toString());
-        region_persister->persist(*region);
-        LOG_INFO(log, "After persisted {}, cache {} bytes", region->toString(false), region->dataSize());
+        persistRegion(*region, std::nullopt, "");
     }
 }
 
@@ -333,12 +330,21 @@ void KVStore::setRegionCompactLogConfig(UInt64 sec, UInt64 rows, UInt64 bytes)
         bytes);
 }
 
-void KVStore::persistRegion(const Region & region, const RegionTaskLock & region_task_lock, const char * caller)
+void KVStore::persistRegion(const Region & region, std::optional<const RegionTaskLock *> region_task_lock, const char * caller)
 {
-    LOG_INFO(log, "Start to persist {}, cache size: {} bytes for `{}`", region.toString(true), region.dataSize(), caller);
     RUNTIME_CHECK_MSG(region_persister, "try access to region_persister without initialization, stack={}", StackTrace().toString());
-    region_persister->persist(region, region_task_lock);
-    LOG_DEBUG(log, "Persist {} done", region.toString(false));
+    if (region_task_lock.has_value())
+    {
+        LOG_INFO(log, "Start to persist {}, cache size: {} bytes for `{}`", region.toString(true), region.dataSize(), caller);
+        region_persister->persist(region, *region_task_lock.value());
+        LOG_DEBUG(log, "Persist {} done", region.toString(false));
+    }
+    else
+    {
+        LOG_INFO(log, "Try to persist {}", region.toString(false));
+        region_persister->persist(region);
+        LOG_INFO(log, "After persisted {}, cache {} bytes", region.toString(false), region.dataSize());
+    }
 }
 
 bool KVStore::needFlushRegionData(UInt64 region_id, TMTContext & tmt)
@@ -422,7 +428,7 @@ bool KVStore::forceFlushRegionDataImpl(Region & curr_region, bool try_until_succ
     }
     if (tryFlushRegionCacheInStorage(tmt, curr_region, log, try_until_succeed))
     {
-        persistRegion(curr_region, region_task_lock, "tryFlushRegionData");
+        persistRegion(curr_region, &region_task_lock, "tryFlushRegionData");
         curr_region.markCompactLog();
         curr_region.cleanApproxMemCacheInfo();
         GET_METRIC(tiflash_raft_apply_write_command_duration_seconds, type_flush_region).Observe(watch.elapsedSeconds());
@@ -474,7 +480,7 @@ EngineStoreApplyRes KVStore::handleUselessAdminRaftCmd(
         || cmd_type == raft_cmdpb::AdminCmdType::BatchSwitchWitness)
     {
         tryFlushRegionCacheInStorage(tmt, curr_region, log);
-        persistRegion(curr_region, region_task_lock, fmt::format("admin cmd useless {}", cmd_type).c_str());
+        persistRegion(curr_region, &region_task_lock, fmt::format("admin cmd useless {}", cmd_type).c_str());
         return EngineStoreApplyRes::Persist;
     }
     return EngineStoreApplyRes::None;
@@ -539,7 +545,7 @@ EngineStoreApplyRes KVStore::handleAdminRaftCmd(raft_cmdpb::AdminRequest && requ
         const auto try_to_flush_region = [&tmt](const RegionPtr & region) {
             try
             {
-                tmt.getRegionTable().tryFlushRegion(region, false);
+                tmt.getRegionTable().tryWriteBlockByRegionAndFlush(region, false);
             }
             catch (...)
             {
@@ -549,7 +555,7 @@ EngineStoreApplyRes KVStore::handleAdminRaftCmd(raft_cmdpb::AdminRequest && requ
 
         const auto persist_and_sync = [&](const Region & region) {
             tryFlushRegionCacheInStorage(tmt, region, log);
-            persistRegion(region, region_task_lock, "admin raft cmd");
+            persistRegion(region, &region_task_lock, "admin raft cmd");
         };
 
         const auto handle_batch_split = [&](Regions & split_regions) {

--- a/dbms/src/Storages/Transaction/KVStore.h
+++ b/dbms/src/Storages/Transaction/KVStore.h
@@ -119,15 +119,18 @@ public:
     /**
      * Only used in tests. In production we will call preHandleSnapshotToFiles + applyPreHandledSnapshot.
      */
-    void handleApplySnapshot(metapb::Region && region, uint64_t peer_id, SSTViewVec, uint64_t index, uint64_t term, TMTContext & tmt);
+    void handleApplySnapshot(metapb::Region && region, uint64_t peer_id, SSTViewVec, uint64_t index, uint64_t term, std::optional<uint64_t>, TMTContext & tmt);
 
     void handleIngestCheckpoint(RegionPtr region, CheckpointInfoPtr checkpoint_info, TMTContext & tmt);
 
+    // For Raftstore V2, there could be some orphan keys in the write column family being left to `new_region` after pre-handled.
+    // All orphan write keys are asserted to be replayed before reaching `deadline_index`.
     std::vector<DM::ExternalDTFileInfo> preHandleSnapshotToFiles(
         RegionPtr new_region,
         SSTViewVec,
         uint64_t index,
         uint64_t term,
+        std::optional<uint64_t> deadline_index,
         TMTContext & tmt);
     template <typename RegionPtrWrap>
     void applyPreHandledSnapshot(const RegionPtrWrap &, TMTContext & tmt);

--- a/dbms/src/Storages/Transaction/KVStore.h
+++ b/dbms/src/Storages/Transaction/KVStore.h
@@ -93,7 +93,7 @@ public:
 
     void gcRegionPersistedCache(Seconds gc_persist_period = Seconds(60 * 5));
 
-    void tryPersist(RegionID region_id);
+    void tryPersistRegion(RegionID region_id);
 
     static bool tryFlushRegionCacheInStorage(TMTContext & tmt, const Region & region, const LoggerPtr & log, bool try_until_succeed = true);
 
@@ -246,7 +246,7 @@ private:
     bool canFlushRegionDataImpl(const RegionPtr & curr_region_ptr, UInt8 flush_if_possible, bool try_until_succeed, TMTContext & tmt, const RegionTaskLock & region_task_lock, UInt64 index, UInt64 term);
     bool forceFlushRegionDataImpl(Region & curr_region, bool try_until_succeed, TMTContext & tmt, const RegionTaskLock & region_task_lock, UInt64 index, UInt64 term);
 
-    void persistRegion(const Region & region, const RegionTaskLock & region_task_lock, const char * caller);
+    void persistRegion(const Region & region, std::optional<const RegionTaskLock *> region_task_lock, const char * caller);
     void releaseReadIndexWorkers();
     void handleDestroy(UInt64 region_id, TMTContext & tmt, const KVStoreTaskLock &);
 

--- a/dbms/src/Storages/Transaction/ProxyFFI.cpp
+++ b/dbms/src/Storages/Transaction/ProxyFFI.cpp
@@ -621,9 +621,9 @@ RawCppPtr PreHandleSnapshot(
         }
 #endif
 
-
         // Pre-decode and save as DTFiles
-        auto ingest_ids = kvstore->preHandleSnapshotToFiles(new_region, snaps, index, term, tmt);
+        // TODO Forward deadline_index when TiKV supports.
+        auto ingest_ids = kvstore->preHandleSnapshotToFiles(new_region, snaps, index, term, std::nullopt, tmt);
         auto * res = new PreHandledSnapshotWithFiles{new_region, std::move(ingest_ids)};
         return GenRawCppPtr(res, RawCppPtrTypeImpl::PreHandledSnapshotWithFiles);
     }

--- a/dbms/src/Storages/Transaction/Region.cpp
+++ b/dbms/src/Storages/Transaction/Region.cpp
@@ -47,9 +47,9 @@ RegionData::WriteCFIter Region::removeDataByWriteIt(const RegionData::WriteCFIte
     return data.removeDataByWriteIt(write_it);
 }
 
-RegionDataReadInfo Region::readDataByWriteIt(const RegionData::ConstWriteCFIter & write_it, bool need_value) const
+std::optional<RegionDataReadInfo> Region::readDataByWriteIt(const RegionData::ConstWriteCFIter & write_it, bool need_value, bool hard_error)
 {
-    return data.readDataByWriteIt(write_it, need_value);
+    return data.readDataByWriteIt(write_it, need_value, id(), appliedIndex(), hard_error);
 }
 
 DecodedLockCFValuePtr Region::getLockInfo(const RegionLockReadQuery & query) const
@@ -70,6 +70,18 @@ void Region::insert(ColumnFamilyType type, TiKVKey && key, TiKVValue && value, D
 
 void Region::doInsert(ColumnFamilyType type, TiKVKey && key, TiKVValue && value, DupCheck mode)
 {
+    if (getClusterRaftstoreVer() == RaftstoreVer::V2)
+    {
+        if (type == ColumnFamilyType::Write)
+        {
+            if (orphanKeysInfo().observeKeyFromNormalWrite(key))
+            {
+                // We can't assert the key exists in write_cf here,
+                // since it may be already written into DeltaTree.
+                return;
+            }
+        }
+    }
     data.insert(type, std::move(key), std::move(value), mode);
 }
 
@@ -477,9 +489,9 @@ Timepoint Region::lastCompactLogTime() const
     return last_compact_log_time;
 }
 
-Region::CommittedScanner Region::createCommittedScanner(bool use_lock)
+Region::CommittedScanner Region::createCommittedScanner(bool use_lock, bool need_value)
 {
-    return Region::CommittedScanner(this->shared_from_this(), use_lock);
+    return Region::CommittedScanner(this->shared_from_this(), use_lock, need_value);
 }
 
 Region::CommittedRemover Region::createCommittedRemover(bool use_lock)
@@ -495,6 +507,40 @@ std::string Region::toString(bool dump_status) const
 ImutRegionRangePtr Region::getRange() const
 {
     return meta.getRange();
+}
+
+RaftstoreVer Region::getClusterRaftstoreVer()
+{
+    // In non-debug/test mode, we should assert the proxy_ptr be always not null.
+    if (likely(proxy_helper != nullptr))
+    {
+        if (likely(proxy_helper->fn_get_cluster_raftstore_version))
+        {
+            // Make debug funcs happy.
+            return proxy_helper->fn_get_cluster_raftstore_version(proxy_helper->proxy_ptr, 0, 0);
+        }
+    }
+    return RaftstoreVer::Uncertain;
+}
+
+void Region::beforePrehandleSnapshot(uint64_t region_id, std::optional<uint64_t> deadline_index)
+{
+    if (getClusterRaftstoreVer() == RaftstoreVer::V2)
+    {
+        data.orphan_keys_info.snapshot_index = appliedIndex();
+        data.orphan_keys_info.pre_handling = true;
+        data.orphan_keys_info.deadline_index = deadline_index;
+        data.orphan_keys_info.region_id = region_id;
+    }
+}
+
+void Region::afterPrehandleSnapshot()
+{
+    if (getClusterRaftstoreVer() == RaftstoreVer::V2)
+    {
+        data.orphan_keys_info.pre_handling = false;
+        LOG_INFO(log, "After prehandle, remains {} orphan keys [region_id={}]", data.orphan_keys_info.remainedKeyCount(), id());
+    }
 }
 
 kvrpcpb::ReadIndexRequest GenRegionReadIndexReq(const Region & region, UInt64 start_ts)

--- a/dbms/src/Storages/Transaction/RegionCFDataBase.cpp
+++ b/dbms/src/Storages/Transaction/RegionCFDataBase.cpp
@@ -44,6 +44,7 @@ RegionDataRes RegionCFDataBase<Trait>::insert(TiKVKey && key, TiKVValue && value
 {
     const auto & raw_key = RecordKVFormat::decodeTiKVKey(key);
     auto kv_pair = Trait::genKVPair(std::move(key), raw_key, std::move(value));
+
     if (!kv_pair)
         return 0;
 
@@ -73,6 +74,7 @@ RegionDataRes RegionCFDataBase<Trait>::insert(std::pair<Key, Value> && kv_pair, 
     // We support duplicated kv pairs if they are the same in snapshot.
     // This is because kvs in raftstore v2's snapshot may be overlapped.
     // However, we still not permit duplicated kvs from raft cmd.
+
     if (!ok)
     {
         if (mode == DupCheck::Deny)

--- a/dbms/src/Storages/Transaction/RegionData.cpp
+++ b/dbms/src/Storages/Transaction/RegionData.cpp
@@ -109,13 +109,12 @@ RegionData::WriteCFIter RegionData::removeDataByWriteIt(const WriteCFIter & writ
     return write_cf.getDataMut().erase(write_it);
 }
 
-RegionDataReadInfo RegionData::readDataByWriteIt(const ConstWriteCFIter & write_it, bool need_value) const
+std::optional<RegionDataReadInfo> RegionData::readDataByWriteIt(const ConstWriteCFIter & write_it, bool need_value, RegionID region_id, UInt64 applied, bool hard_error)
 {
     const auto & [key, value, decoded_val] = write_it->second;
     const auto & [pk, ts] = write_it->first;
 
     std::ignore = value;
-
     if (pk->empty())
     {
         throw Exception("Observe empty PK: raw key " + key->toDebugString(), ErrorCodes::ILLFORMAT_RAFT_ROW);
@@ -133,9 +132,40 @@ RegionDataReadInfo RegionData::readDataByWriteIt(const ConstWriteCFIter & write_
         if (auto data_it = map.find({pk, decoded_val.prewrite_ts}); data_it != map.end())
             return std::make_tuple(pk, decoded_val.write_type, ts, RegionDefaultCFDataTrait::getTiKVValue(data_it));
         else
-            throw Exception("Raw TiDB PK: " + (pk.toDebugString()) + ", Prewrite ts: " + std::to_string(decoded_val.prewrite_ts)
-                                + " can not found in default cf for key: " + key->toDebugString(),
+        {
+            if (!hard_error)
+            {
+                if (orphan_keys_info.pre_handling)
+                {
+                    RUNTIME_CHECK_MSG(orphan_keys_info.snapshot_index.has_value(),
+                                      "Snapshot index shall be set when Applying snapshot");
+                    // While pre-handling snapshot from raftstore v2, we accept and store the orphan keys in memory
+                    // These keys should be resolved in later raft logs
+                    orphan_keys_info.observeExtraKey(TiKVKey::copyFrom(*key));
+                    return std::nullopt;
+                }
+                else
+                {
+                    // We can't delete this orphan key here, since it can be triggered from `onSnapshot`.
+                    if (orphan_keys_info.containsExtraKey(*key))
+                    {
+                        return std::nullopt;
+                    }
+                    // Otherwise, this is still a hard error.
+                    // TODO We still need to check if there are remained orphan keys after we have applied after peer's flushed_index.
+                    // Since the registered orphan write key may come from a raft log smaller than snapshot_index with its default key lost,
+                    // thus this write key will not be replicated any more, which cause a slient data loss.
+                }
+            }
+            throw Exception(fmt::format("Raw TiDB PK: {}, Prewrite ts: {} can not found in default cf for key: {}, region_id: {}, applied: {}{}",
+                                        pk.toDebugString(),
+                                        decoded_val.prewrite_ts,
+                                        key->toDebugString(),
+                                        region_id,
+                                        applied,
+                                        hard_error ? "" : ", not orphan key"),
                             ErrorCodes::ILLFORMAT_RAFT_ROW);
+        }
     }
 
     return std::make_tuple(pk, decoded_val.write_type, ts, decoded_val.short_value);
@@ -194,6 +224,7 @@ void RegionData::assignRegionData(RegionData && new_region_data)
     default_cf = std::move(new_region_data.default_cf);
     write_cf = std::move(new_region_data.write_cf);
     lock_cf = std::move(new_region_data.lock_cf);
+    orphan_keys_info = std::move(new_region_data.orphan_keys_info);
 
     cf_data_size = new_region_data.cf_data_size.load();
 }
@@ -260,6 +291,49 @@ RegionData & RegionData::operator=(RegionData && rhs)
     lock_cf = std::move(rhs.lock_cf);
     cf_data_size = rhs.cf_data_size.load();
     return *this;
+}
+
+void RegionData::OrphanKeysInfo::observeExtraKey(TiKVKey && key)
+{
+    remained_keys.insert(std::move(key));
+}
+
+bool RegionData::OrphanKeysInfo::observeKeyFromNormalWrite(const TiKVKey & key)
+{
+    return remained_keys.erase(key);
+}
+
+bool RegionData::OrphanKeysInfo::containsExtraKey(const TiKVKey & key)
+{
+    return remained_keys.contains(key);
+}
+
+uint64_t RegionData::OrphanKeysInfo::remainedKeyCount() const
+{
+    return remained_keys.size();
+}
+
+
+void RegionData::OrphanKeysInfo::mergeFrom(const RegionData::OrphanKeysInfo & other)
+{
+    // TODO support move.
+    for (const auto & remained_key : other.remained_keys)
+    {
+        remained_keys.insert(TiKVKey::copyFrom(remained_key));
+    }
+}
+
+void RegionData::OrphanKeysInfo::advanceAppliedIndex(uint64_t applied_index)
+{
+    if (deadline_index && snapshot_index)
+    {
+        auto count = remainedKeyCount();
+        if (applied_index >= deadline_index.value() && count > 0)
+        {
+            auto one = remained_keys.begin()->toDebugString();
+            throw Exception(fmt::format("Orphan keys from snapshot still exists. One of total {} is {}. region_id={} snapshot_index={} deadline_index={} applied_index={}", count, one, region_id, snapshot_index.value(), deadline_index.value(), applied_index));
+        }
+    }
 }
 
 } // namespace DB

--- a/dbms/src/Storages/Transaction/RegionData.h
+++ b/dbms/src/Storages/Transaction/RegionData.h
@@ -42,7 +42,7 @@ public:
 
     WriteCFIter removeDataByWriteIt(const WriteCFIter & write_it);
 
-    RegionDataReadInfo readDataByWriteIt(const ConstWriteCFIter & write_it, bool need_value = true) const;
+    std::optional<RegionDataReadInfo> readDataByWriteIt(const ConstWriteCFIter & write_it, bool need_value, RegionID region_id, UInt64 applied, bool hard_error);
 
     DecodedLockCFValuePtr getLockInfo(const RegionLockReadQuery & query) const;
 
@@ -73,6 +73,37 @@ public:
     RegionData(RegionData && data);
     RegionData & operator=(RegionData &&);
 
+    struct OrphanKeysInfo
+    {
+        // Protected by region task lock.
+        void observeExtraKey(TiKVKey && key);
+
+        bool observeKeyFromNormalWrite(const TiKVKey & key);
+
+        bool containsExtraKey(const TiKVKey & key);
+
+        uint64_t remainedKeyCount() const;
+
+        void mergeFrom(const OrphanKeysInfo & other);
+
+        void advanceAppliedIndex(uint64_t);
+
+        // Providing a `snapshot_index` indicates we can scanning a snapshot of index `snapshot_index`.
+        // `snapshot_index` can be set to null if TiFlash is not in a raftstore v2 cluster.
+        std::optional<uint64_t> snapshot_index;
+        // When applied raft log to `deadline_index`, `remained_keys` shall be cleared.
+        // Otherwise, raise a hard error.
+        std::optional<uint64_t> deadline_index;
+        // Marks if we are prehandling a snapshot. We only register orphan key when prehandling.
+        // See `RegionData::readDataByWriteIt`.
+        bool pre_handling = false;
+        uint64_t region_id = 0;
+
+    private:
+        // Stores orphan write cf keys while handling a raftstore v2 snapshot.
+        std::unordered_set<TiKVKey> remained_keys;
+    };
+
 private:
     friend class Region;
 
@@ -80,6 +111,7 @@ private:
     RegionWriteCFData write_cf;
     RegionDefaultCFData default_cf;
     RegionLockCFData lock_cf;
+    OrphanKeysInfo orphan_keys_info;
 
     // Size of data cf & write cf, without lock cf.
     std::atomic<size_t> cf_data_size = 0;

--- a/dbms/src/Storages/Transaction/RegionScanner.cpp
+++ b/dbms/src/Storages/Transaction/RegionScanner.cpp
@@ -1,0 +1,85 @@
+// Copyright 2022 PingCAP, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Storages/Transaction/ProxyFFI.h>
+#include <Storages/Transaction/Region.h>
+
+namespace DB
+{
+Region::CommittedScanner::CommittedScanner(const RegionPtr & region_, bool use_lock, bool need_value)
+    : region(region_)
+    , need_val(need_value)
+{
+    if (use_lock)
+        lock = std::shared_lock<std::shared_mutex>(region_->mutex);
+
+    const auto & data = region->data.writeCF().getData();
+
+    write_map_size = data.size();
+    write_map_it = data.begin();
+    write_map_it_end = data.end();
+
+    hard_error = true;
+    if (region->getClusterRaftstoreVer() == DB::RaftstoreVer::V2)
+    {
+        hard_error = false;
+    }
+}
+
+bool Region::CommittedScanner::hasNext()
+{
+    if (peeked)
+    {
+        return true;
+    }
+    else
+    {
+        if (write_map_size == 0)
+            return false;
+        while (write_map_it != write_map_it_end)
+        {
+            if (tryNext())
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+bool Region::CommittedScanner::tryNext()
+{
+    RUNTIME_CHECK_MSG(!peeked.has_value(), "Can't call CommittedScanner::tryNext() twice");
+    assert(write_map_it != write_map_it_end);
+    auto ans = region->readDataByWriteIt(write_map_it++, need_val, hard_error);
+    if (ans)
+    {
+        peeked = std::move(ans.value());
+        return true;
+    }
+    else
+    {
+        // Returning nullopt only means we encoutered a orphan write key.
+        return false;
+    }
+}
+
+RegionDataReadInfo Region::CommittedScanner::next()
+{
+    RUNTIME_CHECK_MSG(peeked.has_value(), "Call CommittedScanner::next() with empty prefetched value");
+    auto res = std::move(peeked.value());
+    peeked.reset();
+    return res;
+}
+} // namespace DB

--- a/dbms/src/Storages/Transaction/RegionTable.h
+++ b/dbms/src/Storages/Transaction/RegionTable.h
@@ -163,7 +163,7 @@ public:
     // This function is only for debug.
     bool tryFlushRegions();
 
-    // Protects writeBlockByRegionAndFlush and ensures it's executed by only one thread at the smae time.
+    // Protects writeBlockByRegionAndFlush and ensures it's executed by only one thread at the same time.
     // Only one thread can do this at the same time.
     // The original name for this function is tryFlushRegion.
     RegionDataReadInfoList tryWriteBlockByRegionAndFlush(RegionID region_id, bool try_persist = false);

--- a/dbms/src/Storages/Transaction/RegionTable.h
+++ b/dbms/src/Storages/Transaction/RegionTable.h
@@ -159,9 +159,15 @@ public:
 
     void removeRegion(RegionID region_id, bool remove_data, const RegionTaskLock &);
 
+    // Find all regions with data, call writeBlockByRegionAndFlush with try_persist = true.
+    // This function is only for debug.
     bool tryFlushRegions();
-    RegionDataReadInfoList tryFlushRegion(RegionID region_id, bool try_persist = false);
-    RegionDataReadInfoList tryFlushRegion(const RegionPtrWithBlock & region, bool try_persist);
+
+    // Protects writeBlockByRegionAndFlush and ensures it's executed by only one thread at the smae time.
+    // Only one thread can do this at the same time.
+    // The original name for this function is tryFlushRegion.
+    RegionDataReadInfoList tryWriteBlockByRegionAndFlush(RegionID region_id, bool try_persist = false);
+    RegionDataReadInfoList tryWriteBlockByRegionAndFlush(const RegionPtrWithBlock & region, bool try_persist);
 
     void handleInternalRegionsByTable(KeyspaceID keyspace_id, TableID table_id, std::function<void(const InternalRegions &)> && callback) const;
     std::vector<std::pair<RegionID, RegionPtr>> getRegionsByTable(KeyspaceID keyspace_id, TableID table_id) const;
@@ -191,7 +197,6 @@ public:
     /// extend range for possible InternalRegion or add one.
     void extendRegionRange(RegionID region_id, const RegionRangeKeys & region_range_keys);
 
-
     void updateSafeTS(UInt64 region_id, UInt64 leader_safe_ts, UInt64 self_safe_ts);
 
     // unit: ms. If safe_ts diff is larger than 2min, we think the data synchronization progress is far behind the leader.
@@ -211,7 +216,10 @@ private:
     InternalRegion & insertRegion(Table & table, const Region & region);
     InternalRegion & doGetInternalRegion(KeyspaceTableID ks_tb_id, RegionID region_id);
 
-    RegionDataReadInfoList flushRegion(const RegionPtrWithBlock & region, bool try_persist) const;
+    // Try write the committed kvs into cache of columnar DeltaMergeStore.
+    // Flush the cache if try_persist is set to true.
+    // The original name for this method is flushRegion.
+    RegionDataReadInfoList writeBlockByRegionAndFlush(const RegionPtrWithBlock & region, bool try_persist) const;
     bool shouldFlush(const InternalRegion & region) const;
     RegionID pickRegionToFlush();
 

--- a/dbms/src/Storages/Transaction/SSTReader.cpp
+++ b/dbms/src/Storages/Transaction/SSTReader.cpp
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+
 #include <Storages/Transaction/SSTReader.h>
 
+#include <magic_enum.hpp>
 #include <vector>
 
 namespace DB
@@ -34,7 +36,7 @@ bool MonoSSTReader::remained() const
         {
             if (!tail_checked)
             {
-                LOG_DEBUG(log, "Observed extra data in tablet snapshot {} beyond {}, cf {}", Redact::keyToDebugString(key.data(), key.size()), r.second.key.toDebugString(), getDebugCfType());
+                LOG_DEBUG(log, "Observed extra data in tablet snapshot {} beyond {}, cf {}", Redact::keyToDebugString(key.data(), key.size()), r.second.key.toDebugString(), magic_enum::enum_name(type));
                 tail_checked = true;
             }
             return false;
@@ -68,7 +70,7 @@ MonoSSTReader::MonoSSTReader(const TiFlashRaftProxyHelper * proxy_helper_, SSTVi
     {
         auto && r = range->comparableKeys();
         auto start = r.first.key.toString();
-        LOG_DEBUG(log, "Seek cf {} to {}", getDebugCfType(), Redact::keyToDebugString(start.data(), start.size()));
+        LOG_DEBUG(log, "Seek cf {} to {}", magic_enum::enum_name(type), Redact::keyToDebugString(start.data(), start.size()));
         if (!start.empty())
         {
             proxy_helper->sst_reader_interfaces.fn_seek(inner, view.type, EngineIteratorSeekType::Key, BaseBuffView{start.data(), start.size()});

--- a/dbms/src/Storages/Transaction/SSTReader.h
+++ b/dbms/src/Storages/Transaction/SSTReader.h
@@ -48,12 +48,6 @@ public:
     ~MonoSSTReader() override;
 
 private:
-    auto getDebugCfType() const
-    {
-        return static_cast<std::underlying_type<decltype(type)>::type>(type);
-    }
-
-private:
     const TiFlashRaftProxyHelper * proxy_helper;
     SSTReaderPtr inner;
     ColumnFamilyType type;

--- a/dbms/src/Storages/Transaction/SSTReader.h
+++ b/dbms/src/Storages/Transaction/SSTReader.h
@@ -48,11 +48,18 @@ public:
     ~MonoSSTReader() override;
 
 private:
+    auto getDebugCfType() const
+    {
+        return static_cast<std::underlying_type<decltype(type)>::type>(type);
+    }
+
+private:
     const TiFlashRaftProxyHelper * proxy_helper;
     SSTReaderPtr inner;
     ColumnFamilyType type;
     RegionRangeFilter range;
     SSTFormatKind kind;
+    mutable bool tail_checked;
     Poco::Logger * log;
 };
 

--- a/dbms/src/Storages/Transaction/TiKVKeyValue.h
+++ b/dbms/src/Storages/Transaction/TiKVKeyValue.h
@@ -27,11 +27,6 @@ struct StringObject : std::string
 public:
     using Base = std::string;
 
-    struct Hash
-    {
-        std::size_t operator()(const StringObject & x) const { return std::hash<Base>()(x); }
-    };
-
     StringObject() = default;
     StringObject(Base && str_)
         : Base(std::move(str_))
@@ -46,6 +41,12 @@ public:
         : Base(str)
     {}
     static StringObject copyFrom(const Base & str) { return StringObject(str); }
+
+    template <bool a, typename = std::enable_if_t<a == is_key>>
+    static StringObject<is_key> copyFromObj(const StringObject<a> & other)
+    {
+        return StringObject(other.data(), other.dataSize());
+    }
 
     DISALLOW_COPY(StringObject);
     StringObject & operator=(StringObject && a)
@@ -147,3 +148,15 @@ private:
 };
 
 } // namespace DB
+
+namespace std
+{
+template <bool is_key>
+struct hash<DB::StringObject<is_key>>
+{
+    size_t operator()(const DB::StringObject<is_key> & k) const
+    {
+        return std::hash<std::string>()(k);
+    }
+};
+} // namespace std

--- a/dbms/src/Storages/Transaction/tests/gtest_kvstore.cpp
+++ b/dbms/src/Storages/Transaction/tests/gtest_kvstore.cpp
@@ -35,7 +35,7 @@ TEST_F(RegionKVStoreTest, NewProxy)
         }
     }
     {
-        kvs.tryPersist(1);
+        kvs.tryPersistRegion(1);
         kvs.gcRegionPersistedCache(Seconds{0});
     }
     {
@@ -796,7 +796,7 @@ TEST_F(RegionKVStoreTest, KVStore)
         }
     }
     {
-        kvs.tryPersist(1);
+        kvs.tryPersistRegion(1);
         kvs.gcRegionPersistedCache(Seconds{0});
     }
     {
@@ -1329,9 +1329,9 @@ TEST_F(RegionKVStoreTest, KVStoreRestore)
                 lock.index.add(region);
             }
         }
-        kvs.tryPersist(1);
-        kvs.tryPersist(2);
-        kvs.tryPersist(3);
+        kvs.tryPersistRegion(1);
+        kvs.tryPersistRegion(2);
+        kvs.tryPersistRegion(3);
     }
     {
         KVStore & kvs = reloadKVSFromDisk();

--- a/dbms/src/Storages/Transaction/tests/gtest_new_kvstore.cpp
+++ b/dbms/src/Storages/Transaction/tests/gtest_new_kvstore.cpp
@@ -40,7 +40,7 @@ try
             proxy_instance->doApply(kvs, ctx.getTMTContext(), cond, region_id, index);
             ASSERT_EQ(r1->getLatestAppliedIndex(), applied_index + 1);
             ASSERT_EQ(kvr1->appliedIndex(), applied_index + 1);
-            kvs.tryPersist(region_id);
+            kvs.tryPersistRegion(region_id);
         }
         {
             const KVStore & kvs = reloadKVSFromDisk();
@@ -70,7 +70,7 @@ try
             proxy_instance->doApply(kvs, ctx.getTMTContext(), cond, region_id, index);
             ASSERT_EQ(r1->getLatestAppliedIndex(), applied_index);
             ASSERT_EQ(kvr1->appliedIndex(), applied_index);
-            kvs.tryPersist(region_id);
+            kvs.tryPersistRegion(region_id);
         }
         {
             KVStore & kvs = reloadKVSFromDisk();
@@ -103,7 +103,7 @@ try
             proxy_instance->doApply(kvs, ctx.getTMTContext(), cond, region_id, index);
             ASSERT_EQ(r1->getLatestAppliedIndex(), applied_index);
             ASSERT_EQ(kvr1->appliedIndex(), applied_index);
-            kvs.tryPersist(region_id);
+            kvs.tryPersistRegion(region_id);
         }
         {
             KVStore & kvs = reloadKVSFromDisk();
@@ -135,7 +135,7 @@ try
             proxy_instance->doApply(kvs, ctx.getTMTContext(), cond, region_id, index);
             ASSERT_EQ(r1->getLatestAppliedIndex(), applied_index);
             ASSERT_EQ(kvr1->appliedIndex(), applied_index + 1);
-            kvs.tryPersist(region_id);
+            kvs.tryPersistRegion(region_id);
         }
         {
             MockRaftStoreProxy::FailCond cond;

--- a/dbms/src/Storages/Transaction/tests/gtest_new_kvstore.cpp
+++ b/dbms/src/Storages/Transaction/tests/gtest_new_kvstore.cpp
@@ -218,7 +218,8 @@ try
 
             kvr1->markCompactLog();
             kvs.setRegionCompactLogConfig(0, 0, 0);
-            auto [index2, term2] = proxy_instance->compactLog(region_id, index);
+            auto && [request, response] = MockRaftStoreProxy::composeCompactLog(r1, index);
+            auto && [index2, term2] = proxy_instance->adminCommand(region_id, std::move(request), std::move(response));
             // In tryFlushRegionData we will call handleWriteRaftCmd, which will already cause an advance.
             // Notice kvs is not tmt->getKVStore(), so we can't use the ProxyFFI version.
             ASSERT_TRUE(kvs.tryFlushRegionData(region_id, false, true, ctx.getTMTContext(), index2, term));
@@ -352,7 +353,7 @@ try
                 validate(kvs, proxy_instance, region_id, default_cf, ColumnFamilyType::Default, 3, 6);
 
                 kvs.mutProxyHelperUnsafe()->sst_reader_interfaces = make_mock_sst_reader_interface();
-                proxy_instance->snapshot(kvs, ctx.getTMTContext(), region_id, {default_cf}, 0, 0);
+                proxy_instance->snapshot(kvs, ctx.getTMTContext(), region_id, {default_cf}, 0, 0, std::nullopt);
 
                 MockRaftStoreProxy::FailCond cond;
                 {
@@ -375,7 +376,7 @@ try
                 default_cf.freeze();
 
                 kvs.mutProxyHelperUnsafe()->sst_reader_interfaces = make_mock_sst_reader_interface();
-                proxy_instance->snapshot(kvs, ctx.getTMTContext(), region_id, {default_cf}, 0, 0);
+                proxy_instance->snapshot(kvs, ctx.getTMTContext(), region_id, {default_cf}, 0, 0, std::nullopt);
 
                 MockRaftStoreProxy::FailCond cond;
                 {
@@ -403,7 +404,7 @@ try
                 write_cf.freeze();
 
                 kvs.mutProxyHelperUnsafe()->sst_reader_interfaces = make_mock_sst_reader_interface();
-                proxy_instance->snapshot(kvs, ctx.getTMTContext(), region_id, {default_cf, write_cf}, 0, 0);
+                proxy_instance->snapshot(kvs, ctx.getTMTContext(), region_id, {default_cf, write_cf}, 0, 0, std::nullopt);
 
                 MockRaftStoreProxy::FailCond cond;
                 {
@@ -429,7 +430,7 @@ try
 
                 kvs.mutProxyHelperUnsafe()->sst_reader_interfaces = make_mock_sst_reader_interface();
                 // Shall not panic.
-                proxy_instance->snapshot(kvs, ctx.getTMTContext(), region_id, {default_cf, write_cf}, 0, 0);
+                proxy_instance->snapshot(kvs, ctx.getTMTContext(), region_id, {default_cf, write_cf}, 0, 0, std::nullopt);
             }
             {
                 // Test of ingesting duplicated key with different values.
@@ -447,7 +448,7 @@ try
 
                 kvs.mutProxyHelperUnsafe()->sst_reader_interfaces = make_mock_sst_reader_interface();
                 // Found existing key ...
-                EXPECT_THROW(proxy_instance->snapshot(kvs, ctx.getTMTContext(), region_id, {default_cf, write_cf}, 0, 0), Exception);
+                EXPECT_THROW(proxy_instance->snapshot(kvs, ctx.getTMTContext(), region_id, {default_cf, write_cf}, 0, 0, std::nullopt), Exception);
             }
         }
     }
@@ -505,7 +506,7 @@ try
             // Shall filter out of range kvs.
             // RegionDefaultCFDataTrait will "reconstruct" TiKVKey, without table_id, it is correct since different tables ares in different regions.
             // so we may find conflict if we set the same handle_id here.
-            // hall we remove this constraint?
+            // Shall we remove this constraint?
             auto klo = RecordKVFormat::genKey(table_id - 1, 1, 111);
             auto klo2 = RecordKVFormat::genKey(table_id - 1, 9999, 222);
             auto kro = RecordKVFormat::genKey(table_id + 1, 0, 333);
@@ -533,7 +534,7 @@ try
             validate(kvs, proxy_instance, region_id, write_cf, ColumnFamilyType::Write, 1, 0);
 
             proxy_helper->sst_reader_interfaces = make_mock_sst_reader_interface();
-            proxy_instance->snapshot(kvs, ctx.getTMTContext(), region_id, {default_cf, write_cf}, 0, 0);
+            proxy_instance->snapshot(kvs, ctx.getTMTContext(), region_id, {default_cf, write_cf}, 0, 0, std::nullopt);
             MockRaftStoreProxy::FailCond cond;
             {
                 auto [index, term] = proxy_instance->rawWrite(region_id, {klo}, {"v1"}, {WriteCmdType::Put}, {ColumnFamilyType::Default});
@@ -587,6 +588,174 @@ try
                 auto [index, term] = proxy_instance->rawWrite(region_id, {klo}, {"v1"}, {WriteCmdType::Put}, {ColumnFamilyType::Default});
                 EXPECT_THROW(proxy_instance->doApply(kvs, ctx.getTMTContext(), cond, region_id, index), Exception);
             }
+        }
+    }
+}
+CATCH
+
+TEST_F(RegionKVStoreTest, KVStoreExtraDataSnapshot1)
+try
+{
+    auto ctx = TiFlashTestEnv::getGlobalContext();
+    proxy_instance->cluster_ver = RaftstoreVer::V2;
+    ASSERT_NE(proxy_helper->sst_reader_interfaces.fn_key, nullptr);
+    UInt64 region_id = 1;
+    TableID table_id;
+    {
+        region_id = 2;
+        initStorages();
+        KVStore & kvs = getKVS();
+        // ctx.getTMTContext().debugSetKVStore(kvstore);
+        table_id = proxy_instance->bootstrapTable(ctx, kvs, ctx.getTMTContext());
+        auto start = RecordKVFormat::genKey(table_id, 0);
+        auto end = RecordKVFormat::genKey(table_id, 10);
+        proxy_instance->bootstrapWithRegion(kvs, ctx.getTMTContext(), region_id, std::make_pair(start.toString(), end.toString()));
+        auto r1 = proxy_instance->getRegion(region_id);
+
+        // See `decodeWriteCfValue`.
+        auto [value_write, value_default] = proxy_instance->generateTiKVKeyValue(111, 999);
+
+        {
+            auto k1 = RecordKVFormat::genKey(table_id, 1, 111);
+            auto k2 = RecordKVFormat::genKey(table_id, 2, 111);
+            MockSSTReader::getMockSSTData().clear();
+            MockRaftStoreProxy::Cf default_cf{region_id, table_id, ColumnFamilyType::Default};
+            default_cf.insert_raw(k1, value_default);
+            default_cf.finish_file(SSTFormatKind::KIND_TABLET);
+            default_cf.freeze();
+            MockRaftStoreProxy::Cf write_cf{region_id, table_id, ColumnFamilyType::Write};
+            write_cf.insert_raw(k1, value_write);
+            write_cf.insert_raw(k2, value_write);
+            write_cf.finish_file(SSTFormatKind::KIND_TABLET);
+            write_cf.freeze();
+
+            auto kvr1 = proxy_instance->snapshot(kvs, ctx.getTMTContext(), region_id, {default_cf, write_cf}, 0, 0, std::nullopt);
+            ASSERT_EQ(kvr1->orphanKeysInfo().remainedKeyCount(), 1);
+            ASSERT_EQ(kvr1->writeCFCount(), 1); // k2
+        }
+        MockRaftStoreProxy::FailCond cond;
+        {
+            // Add a new key to trigger another row2col transform.
+            auto kvr1 = kvs.getRegion(region_id);
+            auto k = RecordKVFormat::genKey(table_id, 3, 111);
+            auto [index, term] = proxy_instance->rawWrite(region_id, {k}, {value_default}, {WriteCmdType::Put}, {ColumnFamilyType::Default});
+            auto [index2, term2] = proxy_instance->rawWrite(region_id, {k}, {value_write}, {WriteCmdType::Put}, {ColumnFamilyType::Write});
+            proxy_instance->doApply(kvs, ctx.getTMTContext(), cond, region_id, index);
+            proxy_instance->doApply(kvs, ctx.getTMTContext(), cond, region_id, index2);
+            ASSERT_EQ(kvr1->orphanKeysInfo().remainedKeyCount(), 1);
+            ASSERT_EQ(kvr1->writeCFCount(), 1); // k2
+            UNUSED(term);
+            UNUSED(term2);
+        }
+        {
+            // A normal write to "save" the orphan key.
+            auto k2 = RecordKVFormat::genKey(table_id, 2, 111);
+            auto kvr1 = kvs.getRegion(region_id);
+            auto [index, term] = proxy_instance->rawWrite(region_id, {k2}, {value_default}, {WriteCmdType::Put}, {ColumnFamilyType::Default});
+            proxy_instance->doApply(kvs, ctx.getTMTContext(), cond, region_id, index);
+            // After applied this log, the write record is not orphan any more.
+            ASSERT_EQ(kvr1->writeCFCount(), 0);
+            auto [index2, term2] = proxy_instance->rawWrite(region_id, {k2}, {value_write}, {WriteCmdType::Put}, {ColumnFamilyType::Write});
+            proxy_instance->doApply(kvs, ctx.getTMTContext(), cond, region_id, index2);
+            ASSERT_EQ(kvr1->writeCFCount(), 0);
+            ASSERT_EQ(kvr1->orphanKeysInfo().remainedKeyCount(), 0);
+            UNUSED(term);
+            UNUSED(term2);
+        }
+        {
+            // An orphan key in normal write will still trigger a hard error.
+            auto k = RecordKVFormat::genKey(table_id, 4, 111);
+            auto [index, term2] = proxy_instance->rawWrite(region_id, {k}, {value_write}, {WriteCmdType::Put}, {ColumnFamilyType::Write});
+            UNUSED(term2);
+            EXPECT_THROW(proxy_instance->doApply(kvs, ctx.getTMTContext(), cond, region_id, index), Exception);
+        }
+    }
+}
+CATCH
+
+TEST_F(RegionKVStoreTest, KVStoreExtraDataSnapshot2)
+try
+{
+    auto ctx = TiFlashTestEnv::getGlobalContext();
+    proxy_instance->cluster_ver = RaftstoreVer::V2;
+    UInt64 region_id = 1;
+    TableID table_id;
+    {
+        region_id = 2;
+        initStorages();
+        KVStore & kvs = getKVS();
+        table_id = proxy_instance->bootstrapTable(ctx, kvs, ctx.getTMTContext());
+        auto start = RecordKVFormat::genKey(table_id, 0);
+        auto end = RecordKVFormat::genKey(table_id, 10);
+        proxy_instance->bootstrapWithRegion(kvs, ctx.getTMTContext(), region_id, std::make_pair(start.toString(), end.toString()));
+        auto r1 = proxy_instance->getRegion(region_id);
+
+        // See `decodeWriteCfValue`.
+        auto && [value_write, value_default] = proxy_instance->generateTiKVKeyValue(111, 999);
+
+        {
+            auto k1 = RecordKVFormat::genKey(table_id, 1, 111);
+            MockSSTReader::getMockSSTData().clear();
+            MockRaftStoreProxy::Cf default_cf{region_id, table_id, ColumnFamilyType::Default};
+            default_cf.finish_file(SSTFormatKind::KIND_TABLET);
+            default_cf.freeze();
+            MockRaftStoreProxy::Cf write_cf{region_id, table_id, ColumnFamilyType::Write};
+            write_cf.insert_raw(k1, value_write);
+            write_cf.finish_file(SSTFormatKind::KIND_TABLET);
+            write_cf.freeze();
+
+            auto kvr1 = proxy_instance->snapshot(kvs, ctx.getTMTContext(), region_id, {default_cf, write_cf}, 0, 0, std::nullopt);
+            ASSERT_EQ(kvr1->orphanKeysInfo().remainedKeyCount(), 1);
+        }
+        {
+            auto k2 = RecordKVFormat::genKey(table_id, 2, 111);
+            MockSSTReader::getMockSSTData().clear();
+            MockRaftStoreProxy::Cf default_cf{region_id, table_id, ColumnFamilyType::Default};
+            default_cf.finish_file(SSTFormatKind::KIND_TABLET);
+            default_cf.freeze();
+            MockRaftStoreProxy::Cf write_cf{region_id, table_id, ColumnFamilyType::Write};
+            write_cf.insert_raw(k2, value_write);
+            write_cf.finish_file(SSTFormatKind::KIND_TABLET);
+            write_cf.freeze();
+
+            auto kvr1 = proxy_instance->snapshot(kvs, ctx.getTMTContext(), region_id, {default_cf, write_cf}, 0, 0, 10);
+            // Every snapshot contains a full copy of this region. So we will drop all orphan keys in the previous region.
+            ASSERT_EQ(kvr1->orphanKeysInfo().remainedKeyCount(), 1);
+        }
+        MockRaftStoreProxy::FailCond cond;
+        {
+            auto k3 = RecordKVFormat::genKey(table_id, 3, 111);
+            auto kvr1 = kvs.getRegion(region_id);
+            proxy_instance->rawWrite(region_id, {k3, k3}, {value_default, value_write}, {WriteCmdType::Put, WriteCmdType::Put}, {ColumnFamilyType::Default, ColumnFamilyType::Write}, 8);
+            proxy_instance->doApply(kvs, ctx.getTMTContext(), cond, region_id, 8);
+
+            auto k4 = RecordKVFormat::genKey(table_id, 4, 111);
+            proxy_instance->rawWrite(region_id, {k4, k4}, {value_default, value_write}, {WriteCmdType::Put, WriteCmdType::Put}, {ColumnFamilyType::Default, ColumnFamilyType::Write}, 10);
+            // Remaining orphan keys of k2.
+            EXPECT_THROW(proxy_instance->doApply(kvs, ctx.getTMTContext(), cond, region_id, 10), Exception);
+        }
+        {
+            auto k5 = RecordKVFormat::genKey(table_id, 5, 111);
+            MockSSTReader::getMockSSTData().clear();
+            MockRaftStoreProxy::Cf default_cf{region_id, table_id, ColumnFamilyType::Default};
+            default_cf.finish_file(SSTFormatKind::KIND_TABLET);
+            default_cf.freeze();
+            MockRaftStoreProxy::Cf write_cf{region_id, table_id, ColumnFamilyType::Write};
+            write_cf.insert_raw(k5, value_write);
+            write_cf.finish_file(SSTFormatKind::KIND_TABLET);
+            write_cf.freeze();
+
+            auto kvr1 = proxy_instance->snapshot(kvs, ctx.getTMTContext(), region_id, {default_cf, write_cf}, 15, 0, 20);
+            ASSERT_EQ(kvr1->orphanKeysInfo().remainedKeyCount(), 1);
+        }
+        {
+            auto k6 = RecordKVFormat::genKey(table_id, 6, 111);
+            auto kvr1 = kvs.getRegion(region_id);
+            auto r1 = proxy_instance->getRegion(region_id);
+
+            auto && [req, res] = MockRaftStoreProxy::composeCompactLog(r1, 10);
+            proxy_instance->adminCommand(region_id, std::move(req), std::move(res), 20);
+            EXPECT_THROW(proxy_instance->doApply(kvs, ctx.getTMTContext(), cond, region_id, 20), Exception);
         }
     }
 }

--- a/dbms/src/Storages/Transaction/tests/kvstore_helper.h
+++ b/dbms/src/Storages/Transaction/tests/kvstore_helper.h
@@ -133,7 +133,6 @@ protected:
     }
 
 protected:
-    static void testRaftSplit(KVStore & kvs, TMTContext & tmt);
     static void testRaftMerge(KVStore & kvs, TMTContext & tmt);
     static void testRaftChangePeer(KVStore & kvs, TMTContext & tmt);
     static void testRaftMergeRollback(KVStore & kvs, TMTContext & tmt);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #4982

Problem Summary:
 update proxy to raftstore-proxy
 Proxy PR: 
 Including:\nSubmodule contrib/tiflash-proxy 601d803562..7aed51bfdf:
  > diagnostic: fix index out of bounds error in sysinfo (#333)
  > Add debug utils for tablet snapshot (#331)
  > Support replace url with a host string (#337)
  > Use addr's ip if status_addr's is is empty (#334)
  > Get raftstore version of cluster by requesting TiKV's status server (#332)

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
