### PR TITLE
update proxy of release-7.1 to raftstore-proxy

### DIFF
--- a/dbms/src/Debug/MockRaftStoreProxy.cpp
+++ b/dbms/src/Debug/MockRaftStoreProxy.cpp
@@ -24,6 +24,7 @@
 #include <Storages/Transaction/ProxyFFICommon.h>
 #include <Storages/Transaction/RegionMeta.h>
 #include <Storages/Transaction/RegionTable.h>
+#include <Storages/Transaction/RowCodec.h>
 #include <Storages/Transaction/TMTContext.h>
 #include <Storages/Transaction/tests/region_helper.h>
 #include <TestUtils/TiFlashTestEnv.h>
@@ -134,6 +135,14 @@ KVGetStatus fn_get_region_local_state(RaftStoreProxyPtr ptr, uint64_t region_id,
         return KVGetStatus::NotFound;
 }
 
+RaftstoreVer fn_get_cluster_raftstore_version(RaftStoreProxyPtr ptr,
+                                              uint8_t,
+                                              int64_t)
+{
+    auto & x = as_ref(ptr);
+    return x.cluster_ver;
+}
+
 TiFlashRaftProxyHelper MockRaftStoreProxy::SetRaftStoreProxyFFIHelper(RaftStoreProxyPtr proxy_ptr)
 {
     TiFlashRaftProxyHelper res{};
@@ -143,6 +152,7 @@ TiFlashRaftProxyHelper MockRaftStoreProxy::SetRaftStoreProxyFFIHelper(RaftStoreP
     res.fn_make_async_waker = fn_make_async_waker;
     res.fn_handle_batch_read_index = fn_handle_batch_read_index;
     res.fn_get_region_local_state = fn_get_region_local_state;
+    res.fn_get_cluster_raftstore_version = fn_get_cluster_raftstore_version;
     {
         // make sure such function pointer will be set at most once.
         static std::once_flag flag;
@@ -464,7 +474,8 @@ std::tuple<uint64_t, uint64_t> MockRaftStoreProxy::rawWrite(
     std::vector<std::string> && keys,
     std::vector<std::string> && vals,
     std::vector<WriteCmdType> && cmd_types,
-    std::vector<ColumnFamilyType> && cmd_cf)
+    std::vector<ColumnFamilyType> && cmd_cf,
+    std::optional<uint64_t> forced_index)
 {
     uint64_t index = 0;
     uint64_t term = 0;
@@ -472,7 +483,8 @@ std::tuple<uint64_t, uint64_t> MockRaftStoreProxy::rawWrite(
         auto region = getRegion(region_id);
         assert(region != nullptr);
         // We have a new entry.
-        index = region->getLatestCommitIndex() + 1;
+        index = forced_index.value_or(region->getLatestCommitIndex() + 1);
+        RUNTIME_CHECK(index > region->getLatestCommitIndex());
         term = region->getLatestCommitTerm();
         // The new entry is committed on Proxy's side.
         region->updateCommitIndex(index);
@@ -490,7 +502,11 @@ std::tuple<uint64_t, uint64_t> MockRaftStoreProxy::rawWrite(
 }
 
 
-std::tuple<uint64_t, uint64_t> MockRaftStoreProxy::adminCommand(UInt64 region_id, raft_cmdpb::AdminRequest && request, raft_cmdpb::AdminResponse && response)
+std::tuple<uint64_t, uint64_t> MockRaftStoreProxy::adminCommand(
+    UInt64 region_id,
+    raft_cmdpb::AdminRequest && request,
+    raft_cmdpb::AdminResponse && response,
+    std::optional<uint64_t> forced_index)
 {
     uint64_t index = 0;
     uint64_t term = 0;
@@ -498,7 +514,8 @@ std::tuple<uint64_t, uint64_t> MockRaftStoreProxy::adminCommand(UInt64 region_id
         auto region = getRegion(region_id);
         assert(region != nullptr);
         // We have a new entry.
-        index = region->getLatestCommitIndex() + 1;
+        index = forced_index.value_or(region->getLatestCommitIndex() + 1);
+        RUNTIME_CHECK(index > region->getLatestCommitIndex());
         term = region->getLatestCommitTerm();
         // The new entry is committed on Proxy's side.
         region->updateCommitIndex(index);
@@ -513,10 +530,8 @@ std::tuple<uint64_t, uint64_t> MockRaftStoreProxy::adminCommand(UInt64 region_id
     return std::make_tuple(index, term);
 }
 
-std::tuple<uint64_t, uint64_t> MockRaftStoreProxy::compactLog(UInt64 region_id, UInt64 compact_index)
+std::tuple<raft_cmdpb::AdminRequest, raft_cmdpb::AdminResponse> MockRaftStoreProxy::composeCompactLog(MockProxyRegionPtr region, UInt64 compact_index)
 {
-    auto region = getRegion(region_id);
-    assert(region != nullptr);
     raft_cmdpb::AdminRequest request;
     raft_cmdpb::AdminResponse response;
     request.set_cmd_type(raft_cmdpb::AdminCmdType::CompactLog);
@@ -526,7 +541,7 @@ std::tuple<uint64_t, uint64_t> MockRaftStoreProxy::compactLog(UInt64 region_id, 
     {
         request.mutable_compact_log()->set_compact_term(region->commands[compact_index].term);
     }
-    return adminCommand(region_id, std::move(request), std::move(response));
+    return std::make_tuple(request, response);
 }
 
 std::tuple<raft_cmdpb::AdminRequest, raft_cmdpb::AdminResponse> MockRaftStoreProxy::composeChangePeer(metapb::Region && meta, std::vector<UInt64> peer_ids, bool is_v2)
@@ -761,17 +776,19 @@ void MockRaftStoreProxy::Cf::insert_raw(std::string key, std::string val)
     kvs.emplace_back(std::move(key), std::move(val));
 }
 
-void MockRaftStoreProxy::snapshot(
+RegionPtr MockRaftStoreProxy::snapshot(
     KVStore & kvs,
     TMTContext & tmt,
     UInt64 region_id,
     std::vector<Cf> && cfs,
     uint64_t index,
-    uint64_t term)
+    uint64_t term,
+    std::optional<uint64_t> deadline_index)
 {
     auto region = getRegion(region_id);
     auto old_kv_region = kvs.getRegion(region_id);
     // We have catch up to index by snapshot.
+    // So we assume there are new data updated, so we inc index by 1.
     if (index == 0)
     {
         index = region->getLatestCommitIndex() + 1;
@@ -797,12 +814,16 @@ void MockRaftStoreProxy::snapshot(
         snaps,
         index,
         term,
+        deadline_index,
         tmt);
 
     kvs.checkAndApplyPreHandledSnapshot<RegionPtrWithSnapshotFiles>(RegionPtrWithSnapshotFiles{new_kv_region, std::move(ingest_ids)}, tmt);
     region->updateAppliedIndex(index);
     // PreHandledSnapshotWithFiles will do that, however preHandleSnapshotToFiles will not.
     new_kv_region->setApplied(index, term);
+
+    // Region changes during applying snapshot, must re-get.
+    return kvs.getRegion(region_id);
 }
 
 TableID MockRaftStoreProxy::bootstrapTable(
@@ -829,6 +850,20 @@ TableID MockRaftStoreProxy::bootstrapTable(
     schema_syncer->syncSchemas(ctx, NullspaceID);
     this->table_id = table_id;
     return table_id;
+}
+
+std::pair<std::string, std::string> MockRaftStoreProxy::generateTiKVKeyValue(uint64_t tso, int64_t t) const
+{
+    WriteBufferFromOwnString buff;
+    writeChar(RecordKVFormat::CFModifyFlag::PutFlag, buff);
+    EncodeVarUInt(tso, buff);
+    std::string value_write = buff.releaseStr();
+    buff.restart();
+    auto && table_info = MockTiDB::instance().getTableInfoByID(table_id);
+    std::vector<Field> f{Field{std::move(t)}};
+    encodeRowV1(*table_info, f, buff);
+    std::string value_default = buff.releaseStr();
+    return std::make_pair(value_write, value_default);
 }
 
 void GCMonitor::add(RawObjType type, int64_t diff)

--- a/dbms/src/Debug/MockRaftStoreProxy.cpp
+++ b/dbms/src/Debug/MockRaftStoreProxy.cpp
@@ -387,7 +387,7 @@ void MockRaftStoreProxy::bootstrapWithRegion(
         auto _ = genLockGuard();
         RUNTIME_CHECK_MSG(regions.empty(), "Mock Proxy regions are not cleared");
         auto task_lock = kvs.genTaskLock();
-        auto lock = kvs.genRegionWriteLock(task_lock);
+        auto lock = kvs.genRegionMgrWriteLock(task_lock);
         RUNTIME_CHECK_MSG(lock.regions.empty(), "KVStore regions are not cleared");
     }
     auto start = RecordKVFormat::genKey(table_id, 0);
@@ -405,7 +405,7 @@ void MockRaftStoreProxy::debugAddRegions(
     int n = ranges.size();
     auto _ = genLockGuard();
     auto task_lock = kvs.genTaskLock();
-    auto lock = kvs.genRegionWriteLock(task_lock);
+    auto lock = kvs.genRegionMgrWriteLock(task_lock);
     for (int i = 0; i < n; ++i)
     {
         regions.emplace(region_ids[i], std::make_shared<MockProxyRegion>(region_ids[i]));

--- a/dbms/src/Debug/MockRaftStoreProxy.cpp
+++ b/dbms/src/Debug/MockRaftStoreProxy.cpp
@@ -324,6 +324,15 @@ void MockRaftStoreProxy::init(size_t region_num)
     }
 }
 
+std::unique_ptr<TiFlashRaftProxyHelper> MockRaftStoreProxy::generateProxyHelper()
+{
+    auto proxy_helper = std::make_unique<TiFlashRaftProxyHelper>(MockRaftStoreProxy::SetRaftStoreProxyFFIHelper(
+        RaftStoreProxyPtr{this}));
+    // Bind ffi to MockSSTReader.
+    proxy_helper->sst_reader_interfaces = make_mock_sst_reader_interface();
+    return proxy_helper;
+}
+
 size_t MockRaftStoreProxy::size() const
 {
     auto _ = genLockGuard();

--- a/dbms/src/Debug/MockRaftStoreProxy.cpp
+++ b/dbms/src/Debug/MockRaftStoreProxy.cpp
@@ -300,7 +300,7 @@ MockReadIndexTask * MockRaftStoreProxy::makeReadIndexTask(kvrpcpb::ReadIndexRequ
 {
     auto _ = genLockGuard();
 
-    wake();
+    wakeNotifier();
 
     auto region = doGetRegion(req.context().region_id());
     if (region)
@@ -309,7 +309,7 @@ MockReadIndexTask * MockRaftStoreProxy::makeReadIndexTask(kvrpcpb::ReadIndexRequ
         r->data = std::make_shared<RawMockReadIndexTask>();
         r->data->req = std::move(req);
         r->data->region = region;
-        tasks.push_back(r->data);
+        read_index_tasks.push_back(r->data);
         return r;
     }
     return nullptr;
@@ -330,7 +330,7 @@ size_t MockRaftStoreProxy::size() const
     return regions.size();
 }
 
-void MockRaftStoreProxy::wake()
+void MockRaftStoreProxy::wakeNotifier()
 {
     notifier.wake();
 }
@@ -347,17 +347,18 @@ void MockRaftStoreProxy::testRunNormal(const std::atomic_bool & over)
 void MockRaftStoreProxy::runOneRound()
 {
     auto _ = genLockGuard();
-    while (!tasks.empty())
+    while (!read_index_tasks.empty())
     {
-        auto & t = *tasks.front();
-        if (!region_id_to_drop.count(t.req.context().region_id()))
+        auto & t = *read_index_tasks.front();
+        auto region_id = t.req.context().region_id();
+        if (!region_id_to_drop.contains(region_id))
         {
-            if (region_id_to_error.count(t.req.context().region_id()))
+            if (region_id_to_error.contains(region_id))
                 t.update(false, true);
             else
                 t.update(false, false);
         }
-        tasks.pop_front();
+        read_index_tasks.pop_front();
     }
 }
 
@@ -367,24 +368,40 @@ void MockRaftStoreProxy::unsafeInvokeForTest(std::function<void(MockRaftStorePro
     cb(*this);
 }
 
-void MockRaftStoreProxy::bootstrap(
+void MockRaftStoreProxy::bootstrapWithRegion(
     KVStore & kvs,
     TMTContext & tmt,
     UInt64 region_id,
     std::optional<std::pair<std::string, std::string>> maybe_range)
 {
-    UNUSED(tmt);
-    auto _ = genLockGuard();
-    regions.emplace(region_id, std::make_shared<MockProxyRegion>(region_id));
+    {
+        auto _ = genLockGuard();
+        RUNTIME_CHECK_MSG(regions.empty(), "Mock Proxy regions are not cleared");
+        auto task_lock = kvs.genTaskLock();
+        auto lock = kvs.genRegionWriteLock(task_lock);
+        RUNTIME_CHECK_MSG(lock.regions.empty(), "KVStore regions are not cleared");
+    }
+    auto start = RecordKVFormat::genKey(table_id, 0);
+    auto end = RecordKVFormat::genKey(table_id + 1, 0);
+    debugAddRegions(kvs, tmt, {region_id}, {maybe_range.value_or(std::make_pair(start.toString(), end.toString()))});
+}
 
+void MockRaftStoreProxy::debugAddRegions(
+    KVStore & kvs,
+    TMTContext & tmt,
+    std::vector<UInt64> region_ids,
+    std::vector<std::pair<std::string, std::string>> && ranges)
+{
+    UNUSED(tmt);
+    int n = ranges.size();
+    auto _ = genLockGuard();
     auto task_lock = kvs.genTaskLock();
     auto lock = kvs.genRegionWriteLock(task_lock);
+    for (int i = 0; i < n; ++i)
     {
-        auto start = RecordKVFormat::genKey(table_id, 0);
-        auto end = RecordKVFormat::genKey(table_id + 1, 0);
-        auto range = maybe_range.value_or(std::make_pair(start.toString(), end.toString()));
-        auto region = tests::makeRegion(region_id, range.first, range.second);
-        lock.regions.emplace(region_id, region);
+        regions.emplace(region_ids[i], std::make_shared<MockProxyRegion>(region_ids[i]));
+        auto region = tests::makeRegion(region_ids[i], ranges[i].first, ranges[i].second, kvs.getProxyHelper());
+        lock.regions.emplace(region_ids[i], region);
         lock.index.add(region);
     }
 }
@@ -464,7 +481,7 @@ std::tuple<uint64_t, uint64_t> MockRaftStoreProxy::rawWrite(
 }
 
 
-std::tuple<uint64_t, uint64_t> MockRaftStoreProxy::compactLog(UInt64 region_id, UInt64 compact_index)
+std::tuple<uint64_t, uint64_t> MockRaftStoreProxy::adminCommand(UInt64 region_id, raft_cmdpb::AdminRequest && request, raft_cmdpb::AdminResponse && response)
 {
     uint64_t index = 0;
     uint64_t term = 0;
@@ -477,16 +494,6 @@ std::tuple<uint64_t, uint64_t> MockRaftStoreProxy::compactLog(UInt64 region_id, 
         // The new entry is committed on Proxy's side.
         region->updateCommitIndex(index);
         // We record them, as persisted raft log, for potential recovery.
-        raft_cmdpb::AdminRequest request;
-        raft_cmdpb::AdminResponse response;
-        request.mutable_compact_log();
-        request.set_cmd_type(raft_cmdpb::AdminCmdType::CompactLog);
-        request.mutable_compact_log()->set_compact_index(compact_index);
-        // Find compact term, otherwise log must have been compacted.
-        if (region->commands.count(compact_index))
-        {
-            request.mutable_compact_log()->set_compact_term(region->commands[index].term);
-        }
         region->commands[index] = {
             term,
             MockProxyRegion::AdminCommand{
@@ -495,6 +502,100 @@ std::tuple<uint64_t, uint64_t> MockRaftStoreProxy::compactLog(UInt64 region_id, 
             }};
     }
     return std::make_tuple(index, term);
+}
+
+std::tuple<uint64_t, uint64_t> MockRaftStoreProxy::compactLog(UInt64 region_id, UInt64 compact_index)
+{
+    auto region = getRegion(region_id);
+    assert(region != nullptr);
+    raft_cmdpb::AdminRequest request;
+    raft_cmdpb::AdminResponse response;
+    request.set_cmd_type(raft_cmdpb::AdminCmdType::CompactLog);
+    request.mutable_compact_log()->set_compact_index(compact_index);
+    // Find compact term, otherwise log must have been compacted.
+    if (region->commands.contains(compact_index))
+    {
+        request.mutable_compact_log()->set_compact_term(region->commands[compact_index].term);
+    }
+    return adminCommand(region_id, std::move(request), std::move(response));
+}
+
+std::tuple<raft_cmdpb::AdminRequest, raft_cmdpb::AdminResponse> MockRaftStoreProxy::composeChangePeer(metapb::Region && meta, std::vector<UInt64> peer_ids, bool is_v2)
+{
+    raft_cmdpb::AdminRequest request;
+    raft_cmdpb::AdminResponse response;
+    if (is_v2)
+    {
+        request.set_cmd_type(raft_cmdpb::AdminCmdType::ChangePeerV2);
+    }
+    else
+    {
+        request.set_cmd_type(raft_cmdpb::AdminCmdType::ChangePeer);
+    }
+    meta.mutable_peers()->Clear();
+    for (auto i : peer_ids)
+    {
+        meta.add_peers()->set_id(i);
+    }
+    *response.mutable_change_peer()->mutable_region() = meta;
+    return std::make_tuple(request, response);
+}
+
+std::tuple<raft_cmdpb::AdminRequest, raft_cmdpb::AdminResponse> MockRaftStoreProxy::composePrepareMerge(metapb::Region && target, UInt64 min_index)
+{
+    raft_cmdpb::AdminRequest request;
+    raft_cmdpb::AdminResponse response;
+    request.set_cmd_type(raft_cmdpb::AdminCmdType::PrepareMerge);
+    auto * prepare_merge = request.mutable_prepare_merge();
+    prepare_merge->set_min_index(min_index);
+    *prepare_merge->mutable_target() = target;
+    return std::make_tuple(request, response);
+}
+
+std::tuple<raft_cmdpb::AdminRequest, raft_cmdpb::AdminResponse> MockRaftStoreProxy::composeCommitMerge(metapb::Region && source, UInt64 commit)
+{
+    raft_cmdpb::AdminRequest request;
+    raft_cmdpb::AdminResponse response;
+    request.set_cmd_type(raft_cmdpb::AdminCmdType::CommitMerge);
+    auto * commit_merge = request.mutable_commit_merge();
+    commit_merge->set_commit(commit);
+    *commit_merge->mutable_source() = source;
+    return std::make_tuple(request, response);
+}
+
+std::tuple<raft_cmdpb::AdminRequest, raft_cmdpb::AdminResponse> MockRaftStoreProxy::composeRollbackMerge(UInt64 commit)
+{
+    raft_cmdpb::AdminRequest request;
+    raft_cmdpb::AdminResponse response;
+    request.set_cmd_type(raft_cmdpb::AdminCmdType::RollbackMerge);
+    auto * rollback_merge = request.mutable_rollback_merge();
+    rollback_merge->set_commit(commit);
+    return std::make_tuple(request, response);
+}
+
+std::tuple<raft_cmdpb::AdminRequest, raft_cmdpb::AdminResponse> MockRaftStoreProxy::composeBatchSplit(std::vector<UInt64> && region_ids, std::vector<std::pair<std::string, std::string>> && ranges, metapb::RegionEpoch old_epoch)
+{
+    RUNTIME_CHECK_MSG(region_ids.size() == ranges.size(), "error composeBatchSplit input");
+    auto n = region_ids.size();
+    raft_cmdpb::AdminRequest request;
+    raft_cmdpb::AdminResponse response;
+    request.set_cmd_type(raft_cmdpb::AdminCmdType::BatchSplit);
+    metapb::RegionEpoch new_epoch;
+    new_epoch.set_version(old_epoch.version() + 1);
+    new_epoch.set_conf_ver(old_epoch.conf_ver());
+    {
+        raft_cmdpb::BatchSplitResponse * splits = response.mutable_splits();
+        for (size_t i = 0; i < n; ++i)
+        {
+            auto * region = splits->add_regions();
+            region->set_id(region_ids[i]);
+            region->set_start_key(ranges[i].first);
+            region->set_end_key(ranges[i].second);
+            region->add_peers();
+            *region->mutable_region_epoch() = new_epoch;
+        }
+    }
+    return std::make_tuple(request, response);
 }
 
 void MockRaftStoreProxy::doApply(
@@ -668,7 +769,7 @@ void MockRaftStoreProxy::snapshot(
         term = region->getLatestCommitTerm();
     }
 
-    auto new_kv_region = kvs.genRegionPtr(old_kv_region->getMetaRegion(), old_kv_region->mutMeta().peerId(), index, term);
+    auto new_kv_region = kvs.genRegionPtr(old_kv_region->cloneMetaRegion(), old_kv_region->mutMeta().peerId(), index, term);
     // The new entry is committed on Proxy's side.
     region->updateCommitIndex(index);
 
@@ -695,16 +796,21 @@ void MockRaftStoreProxy::snapshot(
     new_kv_region->setApplied(index, term);
 }
 
-TableID MockRaftStoreProxy::bootstrap_table(
+TableID MockRaftStoreProxy::bootstrapTable(
     Context & ctx,
     KVStore & kvs,
-    TMTContext & tmt)
+    TMTContext & tmt,
+    bool drop_at_first)
 {
     UNUSED(kvs);
     ColumnsDescription columns;
     auto & data_type_factory = DataTypeFactory::instance();
     columns.ordinary = NamesAndTypesList({NameAndTypePair{"a", data_type_factory.get("Int64")}});
     auto tso = tmt.getPDClient()->getTS();
+    if (drop_at_first)
+    {
+        MockTiDB::instance().dropDB(ctx, "d", true);
+    }
     MockTiDB::instance().newDataBase("d");
     // Make sure there is a table with smaller id.
     MockTiDB::instance().newTable("d", "prevt" + toString(random()), columns, tso, "", "dt");
@@ -714,20 +820,6 @@ TableID MockRaftStoreProxy::bootstrap_table(
     schema_syncer->syncSchemas(ctx, NullspaceID);
     this->table_id = table_id;
     return table_id;
-}
-
-void MockRaftStoreProxy::clear_tables(
-    Context & ctx,
-    KVStore & kvs,
-    TMTContext & tmt)
-{
-    UNUSED(kvs);
-    UNUSED(tmt);
-    if (this->table_id != 1)
-    {
-        MockTiDB::instance().dropTable(ctx, "d", "t", false);
-    }
-    this->table_id = 1;
 }
 
 void GCMonitor::add(RawObjType type, int64_t diff)

--- a/dbms/src/Debug/MockRaftStoreProxy.h
+++ b/dbms/src/Debug/MockRaftStoreProxy.h
@@ -223,13 +223,13 @@ struct MockRaftStoreProxy : MutexLockWrap
         std::vector<std::string> && keys,
         std::vector<std::string> && vals,
         std::vector<WriteCmdType> && cmd_types,
-        std::vector<ColumnFamilyType> && cmd_cf);
+        std::vector<ColumnFamilyType> && cmd_cf,
+        std::optional<uint64_t> forced_index = std::nullopt);
 
-    /// Create a compactLog admin command, returns (index, term) of the admin command itself.
-    std::tuple<uint64_t, uint64_t> compactLog(UInt64 region_id, UInt64 compact_index);
 
-    std::tuple<uint64_t, uint64_t> adminCommand(UInt64 region_id, raft_cmdpb::AdminRequest &&, raft_cmdpb::AdminResponse &&);
+    std::tuple<uint64_t, uint64_t> adminCommand(UInt64 region_id, raft_cmdpb::AdminRequest &&, raft_cmdpb::AdminResponse &&, std::optional<uint64_t> forced_index = std::nullopt);
 
+    static std::tuple<raft_cmdpb::AdminRequest, raft_cmdpb::AdminResponse> composeCompactLog(MockProxyRegionPtr region, UInt64 compact_index);
     static std::tuple<raft_cmdpb::AdminRequest, raft_cmdpb::AdminResponse> composeChangePeer(metapb::Region && meta, std::vector<UInt64> peer_ids, bool is_v2 = true);
     static std::tuple<raft_cmdpb::AdminRequest, raft_cmdpb::AdminResponse> composePrepareMerge(metapb::Region && target, UInt64 min_index);
     static std::tuple<raft_cmdpb::AdminRequest, raft_cmdpb::AdminResponse> composeCommitMerge(metapb::Region && source, UInt64 commit);
@@ -267,13 +267,14 @@ struct MockRaftStoreProxy : MutexLockWrap
         bool freezed;
     };
 
-    void snapshot(
+    RegionPtr snapshot(
         KVStore & kvs,
         TMTContext & tmt,
         UInt64 region_id,
         std::vector<Cf> && cfs,
         uint64_t index,
-        uint64_t term);
+        uint64_t term,
+        std::optional<uint64_t> deadline_index);
 
     void doApply(
         KVStore & kvs,
@@ -294,10 +295,13 @@ struct MockRaftStoreProxy : MutexLockWrap
         regions.clear();
     }
 
+    std::pair<std::string, std::string> generateTiKVKeyValue(uint64_t tso, int64_t t) const;
+
     MockRaftStoreProxy()
     {
         log = Logger::get("MockRaftStoreProxy");
         table_id = 1;
+        cluster_ver = RaftstoreVer::V1;
     }
 
     // Mock Proxy will drop read index requests to these regions
@@ -308,6 +312,7 @@ struct MockRaftStoreProxy : MutexLockWrap
     std::list<std::shared_ptr<RawMockReadIndexTask>> read_index_tasks;
     AsyncWaker::Notifier notifier;
     TableID table_id;
+    RaftstoreVer cluster_ver;
     LoggerPtr log;
 };
 

--- a/dbms/src/Debug/MockRaftStoreProxy.h
+++ b/dbms/src/Debug/MockRaftStoreProxy.h
@@ -161,10 +161,11 @@ struct MockRaftStoreProxy : MutexLockWrap
 
     size_t size() const;
 
-    void wake();
+    void wakeNotifier();
 
     void testRunNormal(const std::atomic_bool & over);
 
+    /// Handle one read index task.
     void runOneRound();
 
     void unsafeInvokeForTest(std::function<void(MockRaftStoreProxy &)> && cb);
@@ -183,27 +184,33 @@ struct MockRaftStoreProxy : MutexLockWrap
         Type type = NORMAL;
     };
 
-    /// boostrap a region.
-    void bootstrap(
+    /// Boostrap with a given region.
+    /// Similar to TiKV's `bootstrap_region`.
+    void bootstrapWithRegion(
         KVStore & kvs,
         TMTContext & tmt,
         UInt64 region_id,
         std::optional<std::pair<std::string, std::string>> maybe_range);
 
-    /// boostrap a table, since applying snapshot needs table schema.
-    TableID bootstrap_table(
+    /// Boostrap a table.
+    /// Must be called if:
+    /// 1. Applying snapshot which needs table schema
+    /// 2. Doing row2col.
+    TableID bootstrapTable(
         Context & ctx,
         KVStore & kvs,
-        TMTContext & tmt);
+        TMTContext & tmt,
+        bool drop_at_first = true);
 
-    /// clear tables.
-    void clear_tables(
-        Context & ctx,
+    /// Manually add a region.
+    void debugAddRegions(
         KVStore & kvs,
-        TMTContext & tmt);
+        TMTContext & tmt,
+        std::vector<UInt64> region_ids,
+        std::vector<std::pair<std::string, std::string>> && ranges);
 
     /// We assume that we generate one command, and immediately commit.
-    /// normal write to a region.
+    /// Normal write to a region.
     std::tuple<uint64_t, uint64_t> normalWrite(
         UInt64 region_id,
         std::vector<HandleID> && keys,
@@ -220,6 +227,14 @@ struct MockRaftStoreProxy : MutexLockWrap
 
     /// Create a compactLog admin command, returns (index, term) of the admin command itself.
     std::tuple<uint64_t, uint64_t> compactLog(UInt64 region_id, UInt64 compact_index);
+
+    std::tuple<uint64_t, uint64_t> adminCommand(UInt64 region_id, raft_cmdpb::AdminRequest &&, raft_cmdpb::AdminResponse &&);
+
+    static std::tuple<raft_cmdpb::AdminRequest, raft_cmdpb::AdminResponse> composeChangePeer(metapb::Region && meta, std::vector<UInt64> peer_ids, bool is_v2 = true);
+    static std::tuple<raft_cmdpb::AdminRequest, raft_cmdpb::AdminResponse> composePrepareMerge(metapb::Region && target, UInt64 min_index);
+    static std::tuple<raft_cmdpb::AdminRequest, raft_cmdpb::AdminResponse> composeCommitMerge(metapb::Region && source, UInt64 commit);
+    static std::tuple<raft_cmdpb::AdminRequest, raft_cmdpb::AdminResponse> composeRollbackMerge(UInt64 commit);
+    static std::tuple<raft_cmdpb::AdminRequest, raft_cmdpb::AdminResponse> composeBatchSplit(std::vector<UInt64> && region_ids, std::vector<std::pair<std::string, std::string>> && ranges, metapb::RegionEpoch old_epoch);
 
     struct Cf
     {
@@ -273,16 +288,24 @@ struct MockRaftStoreProxy : MutexLockWrap
         uint64_t region_id,
         uint64_t to);
 
+    void clear()
+    {
+        auto _ = genLockGuard();
+        regions.clear();
+    }
+
     MockRaftStoreProxy()
     {
         log = Logger::get("MockRaftStoreProxy");
         table_id = 1;
     }
 
+    // Mock Proxy will drop read index requests to these regions
     std::unordered_set<uint64_t> region_id_to_drop;
+    // Mock Proxy will return error read index response to these regions
     std::unordered_set<uint64_t> region_id_to_error;
     std::map<uint64_t, MockProxyRegionPtr> regions;
-    std::list<std::shared_ptr<RawMockReadIndexTask>> tasks;
+    std::list<std::shared_ptr<RawMockReadIndexTask>> read_index_tasks;
     AsyncWaker::Notifier notifier;
     TableID table_id;
     LoggerPtr log;

--- a/dbms/src/Debug/MockSSTReader.h
+++ b/dbms/src/Debug/MockSSTReader.h
@@ -114,19 +114,4 @@ private:
 };
 
 SSTReaderInterfaces make_mock_sst_reader_interface();
-
-class RegionMockTest final
-{
-public:
-    RegionMockTest(KVStore * kvstore_, RegionPtr region_);
-    ~RegionMockTest();
-
-    DISALLOW_COPY_AND_MOVE(RegionMockTest);
-
-private:
-    TiFlashRaftProxyHelper mock_proxy_helper{};
-    const TiFlashRaftProxyHelper * ori_proxy_helper{};
-    KVStore * kvstore;
-    RegionPtr region;
-};
 } // namespace DB

--- a/dbms/src/Debug/dbgFuncMockRaftCommand.cpp
+++ b/dbms/src/Debug/dbgFuncMockRaftCommand.cpp
@@ -171,7 +171,7 @@ void MockRaftCommand::dbgFuncPrepareMerge(Context & context, const ASTs & args, 
             prepare_merge->set_min_index(min_index);
 
             metapb::Region * target = prepare_merge->mutable_target();
-            *target = target_region->getMetaRegion();
+            *target = target_region->cloneMetaRegion();
         }
     }
 
@@ -207,7 +207,7 @@ void MockRaftCommand::dbgFuncCommitMerge(Context & context, const ASTs & args, D
         auto * commit_merge = request.mutable_commit_merge();
         {
             commit_merge->set_commit(source_region->appliedIndex());
-            *commit_merge->mutable_source() = source_region->getMetaRegion();
+            *commit_merge->mutable_source() = source_region->cloneMetaRegion();
         }
     }
 
@@ -241,7 +241,7 @@ void MockRaftCommand::dbgFuncRollbackMerge(Context & context, const ASTs & args,
 
         auto * rollback_merge = request.mutable_rollback_merge();
         {
-            auto merge_state = region->getMergeState();
+            auto merge_state = region->cloneMergeState();
             rollback_merge->set_commit(merge_state.commit());
         }
     }

--- a/dbms/src/Debug/dbgFuncMockRaftSnapshot.cpp
+++ b/dbms/src/Debug/dbgFuncMockRaftSnapshot.cpp
@@ -262,6 +262,21 @@ void MockRaftCommand::dbgFuncRegionSnapshot(Context & context, const ASTs & args
 
 std::map<MockSSTReader::Key, MockSSTReader::Data> MockSSTReader::MockSSTData;
 
+class RegionMockTest final
+{
+public:
+    RegionMockTest(KVStore * kvstore_, RegionPtr region_);
+    ~RegionMockTest();
+
+    DISALLOW_COPY_AND_MOVE(RegionMockTest);
+
+private:
+    TiFlashRaftProxyHelper mock_proxy_helper{};
+    const TiFlashRaftProxyHelper * ori_proxy_helper{};
+    KVStore * kvstore;
+    RegionPtr region;
+};
+
 RegionMockTest::RegionMockTest(KVStore * kvstore_, RegionPtr region_)
     : kvstore(kvstore_)
     , region(region_)

--- a/dbms/src/Debug/dbgFuncMockRaftSnapshot.cpp
+++ b/dbms/src/Debug/dbgFuncMockRaftSnapshot.cpp
@@ -255,6 +255,7 @@ void MockRaftCommand::dbgFuncRegionSnapshot(Context & context, const ASTs & args
         SSTViewVec{nullptr, 0},
         MockTiKV::instance().getRaftIndex(region_id),
         RAFT_INIT_LOG_TERM,
+        std::nullopt,
         tmt);
 
     output(fmt::format("put region #{}, range[{}, {}) to table #{} with raft commands", region_id, RecordKVFormat::DecodedTiKVKeyToDebugString<true>(start_decoded_key), RecordKVFormat::DecodedTiKVKeyToDebugString<false>(end_decoded_key), table_id));
@@ -745,6 +746,7 @@ void MockRaftCommand::dbgFuncRegionSnapshotPreHandleDTFiles(Context & context, c
         SSTViewVec{sst_views.data(), sst_views.size()},
         index,
         MockTiKV::instance().getRaftTerm(region_id),
+        std::nullopt,
         tmt);
     GLOBAL_REGION_MAP.insertRegionSnap(region_name, {new_region, ingest_ids});
 
@@ -842,6 +844,7 @@ void MockRaftCommand::dbgFuncRegionSnapshotPreHandleDTFilesWithHandles(Context &
         SSTViewVec{sst_views.data(), sst_views.size()},
         index,
         MockTiKV::instance().getRaftTerm(region_id),
+        std::nullopt,
         tmt);
     GLOBAL_REGION_MAP.insertRegionSnap(region_name, {new_region, ingest_ids});
 

--- a/dbms/src/Debug/dbgFuncMockTiDBTable.cpp
+++ b/dbms/src/Debug/dbgFuncMockTiDBTable.cpp
@@ -288,7 +288,7 @@ void MockTiDBTable::dbgFuncCleanUpRegions(DB::Context & context, const DB::ASTs 
     auto & region_table = context.getTMTContext().getRegionTable();
     {
         {
-            auto manage_lock = kvstore->genRegionReadLock();
+            auto manage_lock = kvstore->genRegionMgrReadLock();
             for (const auto & e : manage_lock.regions)
                 regions.emplace_back(e.first);
         }

--- a/dbms/src/Debug/dbgFuncRegion.cpp
+++ b/dbms/src/Debug/dbgFuncRegion.cpp
@@ -116,7 +116,7 @@ void dbgFuncTryFlushRegion(Context & context, const ASTs & args, DBGInvoker::Pri
     auto region_id = static_cast<RegionID>(safeGet<UInt64>(typeid_cast<const ASTLiteral &>(*args[0]).value));
 
     TMTContext & tmt = context.getTMTContext();
-    tmt.getRegionTable().tryFlushRegion(region_id);
+    tmt.getRegionTable().tryWriteBlockByRegionAndFlush(region_id);
 
     output(fmt::format("region_table try flush region {}", region_id));
 }

--- a/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.cpp
@@ -159,6 +159,7 @@ Block SSTFilesToBlockInputStream::read()
             // else continue to decode key-value from write CF.
         }
     }
+
     // Load all key-value pairs from other CFs
     loadCFDataFromSST(ColumnFamilyType::Default, nullptr);
     loadCFDataFromSST(ColumnFamilyType::Lock, nullptr);

--- a/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.cpp
@@ -261,7 +261,17 @@ Block SSTFilesToBlockInputStream::readCommitedBlock()
         if (e.code() == ErrorCodes::ILLFORMAT_RAFT_ROW)
         {
             // br or lighting may write illegal data into tikv, stop decoding.
-            LOG_WARNING(log, "Got error while reading region committed cache: {}. Stop decoding rows into DTFiles and keep uncommitted data in region.", e.displayText());
+            const auto & start_key = region->getMetaRegion().start_key();
+            const auto & end_key = region->getMetaRegion().end_key();
+            LOG_WARNING(log, "Got error while reading region committed cache: {}. Stop decoding rows into DTFiles and keep uncommitted data in region."
+                             "region_id: {}, applied_index: {}, version: {}, conf_version {}, start_key: {}, end_key: {}",
+                        e.displayText(),
+                        region->id(),
+                        region->appliedIndex(),
+                        region->version(),
+                        region->confVer(),
+                        Redact::keyToDebugString(start_key.data(), start_key.size()),
+                        Redact::keyToDebugString(end_key.data(), end_key.size()));
             // Cancel the decoding process.
             // Note that we still need to scan data from CFs and keep them in `region`
             is_decode_cancelled = true;

--- a/dbms/src/Storages/Transaction/ApplySnapshot.cpp
+++ b/dbms/src/Storages/Transaction/ApplySnapshot.cpp
@@ -546,7 +546,7 @@ RegionPtr KVStore::handleIngestSSTByDTFile(const RegionPtr & region, const SSTVi
     // Create a tmp region to store uncommitted data
     RegionPtr tmp_region;
     {
-        auto meta_region = region->getMetaRegion();
+        auto meta_region = region->cloneMetaRegion();
         auto meta_snap = region->dumpRegionMetaSnapshot();
         auto peer_id = meta_snap.peer.id();
         tmp_region = genRegionPtr(std::move(meta_region), peer_id, index, term);

--- a/dbms/src/Storages/Transaction/ApplySnapshot.cpp
+++ b/dbms/src/Storages/Transaction/ApplySnapshot.cpp
@@ -246,6 +246,7 @@ void KVStore::onSnapshot(const RegionPtrWrap & new_region_wrap, RegionPtr old_re
                     manage_lock.index.remove(range, region_id);
                 }
             }
+            // Reuse the old region for non-region-related data.
             old_region->assignRegion(std::move(*new_region));
             new_region = old_region;
             {
@@ -272,11 +273,14 @@ std::vector<DM::ExternalDTFileInfo> KVStore::preHandleSnapshotToFiles(
     const SSTViewVec snaps,
     uint64_t index,
     uint64_t term,
+    std::optional<uint64_t> deadline_index,
     TMTContext & tmt)
 {
     std::vector<DM::ExternalDTFileInfo> external_files;
+    new_region->beforePrehandleSnapshot(new_region->id(), deadline_index);
     try
     {
+        SCOPE_EXIT({ new_region->afterPrehandleSnapshot(); });
         external_files = preHandleSSTsToDTFiles(new_region, snaps, index, term, DM::FileConvertJobType::ApplySnapshot, tmt);
     }
     catch (DB::Exception & e)
@@ -475,10 +479,11 @@ void KVStore::handleApplySnapshot(
     const SSTViewVec snaps,
     uint64_t index,
     uint64_t term,
+    std::optional<uint64_t> deadline_index,
     TMTContext & tmt)
 {
     auto new_region = genRegionPtr(std::move(region), peer_id, index, term);
-    auto external_files = preHandleSnapshotToFiles(new_region, snaps, index, term, tmt);
+    auto external_files = preHandleSnapshotToFiles(new_region, snaps, index, term, deadline_index, tmt);
     applyPreHandledSnapshot(RegionPtrWithSnapshotFiles{new_region, std::move(external_files)}, tmt);
 }
 

--- a/dbms/src/Storages/Transaction/ApplySnapshot.cpp
+++ b/dbms/src/Storages/Transaction/ApplySnapshot.cpp
@@ -242,7 +242,7 @@ void KVStore::onSnapshot(const RegionPtrWrap & new_region_wrap, RegionPtr old_re
                 // remove index first
                 const auto & range = old_region->makeRaftCommandDelegate(task_lock).getRange().comparableKeys();
                 {
-                    auto manage_lock = genRegionWriteLock(task_lock);
+                    auto manage_lock = genRegionMgrWriteLock(task_lock);
                     manage_lock.index.remove(range, region_id);
                 }
             }
@@ -250,13 +250,13 @@ void KVStore::onSnapshot(const RegionPtrWrap & new_region_wrap, RegionPtr old_re
             new_region = old_region;
             {
                 // add index
-                auto manage_lock = genRegionWriteLock(task_lock);
+                auto manage_lock = genRegionMgrWriteLock(task_lock);
                 manage_lock.index.add(new_region);
             }
         }
         else
         {
-            auto manage_lock = genRegionWriteLock(task_lock);
+            auto manage_lock = genRegionMgrWriteLock(task_lock);
             manage_lock.regions.emplace(region_id, new_region);
             manage_lock.index.add(new_region);
         }

--- a/dbms/src/Storages/Transaction/KVStore.cpp
+++ b/dbms/src/Storages/Transaction/KVStore.cpp
@@ -560,6 +560,7 @@ EngineStoreApplyRes KVStore::handleAdminRaftCmd(raft_cmdpb::AdminRequest && requ
 
         const auto handle_batch_split = [&](Regions & split_regions) {
             {
+                // `split_regions` doesn't include the derived region.
                 auto manage_lock = genRegionWriteLock(task_lock);
 
                 for (auto & new_region : split_regions)

--- a/dbms/src/Storages/Transaction/KVStore.cpp
+++ b/dbms/src/Storages/Transaction/KVStore.cpp
@@ -172,15 +172,12 @@ bool KVStore::tryFlushRegionCacheInStorage(TMTContext & tmt, const Region & regi
     return true;
 }
 
-void KVStore::tryPersist(RegionID region_id)
+void KVStore::tryPersistRegion(RegionID region_id)
 {
     auto region = getRegion(region_id);
     if (region)
     {
-        LOG_INFO(log, "Try to persist {}", region->toString(false));
-        RUNTIME_CHECK_MSG(region_persister, "try access to region_persister without initialization, stack={}", StackTrace().toString());
-        region_persister->persist(*region);
-        LOG_INFO(log, "After persisted {}, cache {} bytes", region->toString(false), region->dataSize());
+        persistRegion(*region, std::nullopt, "");
     }
 }
 
@@ -333,12 +330,21 @@ void KVStore::setRegionCompactLogConfig(UInt64 sec, UInt64 rows, UInt64 bytes)
         bytes);
 }
 
-void KVStore::persistRegion(const Region & region, const RegionTaskLock & region_task_lock, const char * caller)
+void KVStore::persistRegion(const Region & region, std::optional<const RegionTaskLock *> region_task_lock, const char * caller)
 {
-    LOG_INFO(log, "Start to persist {}, cache size: {} bytes for `{}`", region.toString(true), region.dataSize(), caller);
     RUNTIME_CHECK_MSG(region_persister, "try access to region_persister without initialization, stack={}", StackTrace().toString());
-    region_persister->persist(region, region_task_lock);
-    LOG_DEBUG(log, "Persist {} done", region.toString(false));
+    if (region_task_lock.has_value())
+    {
+        LOG_INFO(log, "Start to persist {}, cache size: {} bytes for `{}`", region.toString(true), region.dataSize(), caller);
+        region_persister->persist(region, *region_task_lock.value());
+        LOG_DEBUG(log, "Persist {} done", region.toString(false));
+    }
+    else
+    {
+        LOG_INFO(log, "Try to persist {}", region.toString(false));
+        region_persister->persist(region);
+        LOG_INFO(log, "After persisted {}, cache {} bytes", region.toString(false), region.dataSize());
+    }
 }
 
 bool KVStore::needFlushRegionData(UInt64 region_id, TMTContext & tmt)
@@ -422,7 +428,7 @@ bool KVStore::forceFlushRegionDataImpl(Region & curr_region, bool try_until_succ
     }
     if (tryFlushRegionCacheInStorage(tmt, curr_region, log, try_until_succeed))
     {
-        persistRegion(curr_region, region_task_lock, "tryFlushRegionData");
+        persistRegion(curr_region, &region_task_lock, "tryFlushRegionData");
         curr_region.markCompactLog();
         curr_region.cleanApproxMemCacheInfo();
         GET_METRIC(tiflash_raft_apply_write_command_duration_seconds, type_flush_region).Observe(watch.elapsedSeconds());
@@ -474,7 +480,7 @@ EngineStoreApplyRes KVStore::handleUselessAdminRaftCmd(
         || cmd_type == raft_cmdpb::AdminCmdType::BatchSwitchWitness)
     {
         tryFlushRegionCacheInStorage(tmt, curr_region, log);
-        persistRegion(curr_region, region_task_lock, fmt::format("admin cmd useless {}", cmd_type).c_str());
+        persistRegion(curr_region, &region_task_lock, fmt::format("admin cmd useless {}", cmd_type).c_str());
         return EngineStoreApplyRes::Persist;
     }
     return EngineStoreApplyRes::None;
@@ -539,7 +545,7 @@ EngineStoreApplyRes KVStore::handleAdminRaftCmd(raft_cmdpb::AdminRequest && requ
         const auto try_to_flush_region = [&tmt](const RegionPtr & region) {
             try
             {
-                tmt.getRegionTable().tryFlushRegion(region, false);
+                tmt.getRegionTable().tryWriteBlockByRegionAndFlush(region, false);
             }
             catch (...)
             {
@@ -549,7 +555,7 @@ EngineStoreApplyRes KVStore::handleAdminRaftCmd(raft_cmdpb::AdminRequest && requ
 
         const auto persist_and_sync = [&](const Region & region) {
             tryFlushRegionCacheInStorage(tmt, region, log);
-            persistRegion(region, region_task_lock, "admin raft cmd");
+            persistRegion(region, &region_task_lock, "admin raft cmd");
         };
 
         const auto handle_batch_split = [&](Regions & split_regions) {

--- a/dbms/src/Storages/Transaction/KVStore.cpp
+++ b/dbms/src/Storages/Transaction/KVStore.cpp
@@ -61,7 +61,7 @@ void KVStore::restore(PathPool & path_pool, const TiFlashRaftProxyHelper * proxy
         return;
 
     auto task_lock = genTaskLock();
-    auto manage_lock = genRegionWriteLock(task_lock);
+    auto manage_lock = genRegionMgrWriteLock(task_lock);
 
     this->proxy_helper = proxy_helper;
     manage_lock.regions = region_persister->restore(path_pool, proxy_helper);
@@ -97,14 +97,14 @@ void KVStore::restore(PathPool & path_pool, const TiFlashRaftProxyHelper * proxy
 
 RegionPtr KVStore::getRegion(RegionID region_id) const
 {
-    auto manage_lock = genRegionReadLock();
+    auto manage_lock = genRegionMgrReadLock();
     if (auto it = manage_lock.regions.find(region_id); it != manage_lock.regions.end())
         return it->second;
     return nullptr;
 }
 RegionMap KVStore::getRegionsByRangeOverlap(const RegionRange & range) const
 {
-    auto manage_lock = genRegionReadLock();
+    auto manage_lock = genRegionMgrReadLock();
     return manage_lock.index.findByRangeOverlap(range);
 }
 
@@ -126,13 +126,13 @@ RegionTaskLock RegionManager::genRegionTaskLock(RegionID region_id) const
 
 size_t KVStore::regionSize() const
 {
-    auto manage_lock = genRegionReadLock();
+    auto manage_lock = genRegionMgrReadLock();
     return manage_lock.regions.size();
 }
 
 void KVStore::traverseRegions(std::function<void(RegionID, const RegionPtr &)> && callback) const
 {
-    auto manage_lock = genRegionReadLock();
+    auto manage_lock = genRegionMgrReadLock();
     for (const auto & region : manage_lock.regions)
         callback(region.first, region.second);
 }
@@ -201,7 +201,7 @@ void KVStore::removeRegion(RegionID region_id, bool remove_data, RegionTable & r
     LOG_INFO(log, "Start to remove [region {}]", region_id);
 
     {
-        auto manage_lock = genRegionWriteLock(task_lock);
+        auto manage_lock = genRegionMgrWriteLock(task_lock);
         auto it = manage_lock.regions.find(region_id);
         manage_lock.index.remove(it->second->makeRaftCommandDelegate(task_lock).getRange().comparableKeys(), region_id); // remove index
         manage_lock.regions.erase(it);
@@ -228,14 +228,14 @@ KVStoreTaskLock KVStore::genTaskLock() const
     return KVStoreTaskLock(task_mutex);
 }
 
-RegionManager::RegionReadLock KVStore::genRegionReadLock() const
+RegionManager::RegionReadLock KVStore::genRegionMgrReadLock() const
 {
-    return region_manager.genRegionReadLock();
+    return region_manager.genReadLock();
 }
 
-RegionManager::RegionWriteLock KVStore::genRegionWriteLock(const KVStoreTaskLock &)
+RegionManager::RegionWriteLock KVStore::genRegionMgrWriteLock(const KVStoreTaskLock &)
 {
-    return region_manager.genRegionWriteLock();
+    return region_manager.genWriteLock();
 }
 
 EngineStoreApplyRes KVStore::handleWriteRaftCmd(
@@ -561,7 +561,7 @@ EngineStoreApplyRes KVStore::handleAdminRaftCmd(raft_cmdpb::AdminRequest && requ
         const auto handle_batch_split = [&](Regions & split_regions) {
             {
                 // `split_regions` doesn't include the derived region.
-                auto manage_lock = genRegionWriteLock(task_lock);
+                auto manage_lock = genRegionMgrWriteLock(task_lock);
 
                 for (auto & new_region : split_regions)
                 {
@@ -633,7 +633,7 @@ EngineStoreApplyRes KVStore::handleAdminRaftCmd(raft_cmdpb::AdminRequest && requ
                     region_manager.genRegionTaskLock(source_region_id));
             }
             {
-                auto manage_lock = genRegionWriteLock(task_lock);
+                auto manage_lock = genRegionMgrWriteLock(task_lock);
                 manage_lock.index.remove(result.ori_region_range->comparableKeys(), curr_region_id);
                 manage_lock.index.add(curr_region_ptr);
             }

--- a/dbms/src/Storages/Transaction/KVStore.h
+++ b/dbms/src/Storages/Transaction/KVStore.h
@@ -120,15 +120,18 @@ public:
     /**
      * Only used in tests. In production we will call preHandleSnapshotToFiles + applyPreHandledSnapshot.
      */
-    void handleApplySnapshot(metapb::Region && region, uint64_t peer_id, SSTViewVec, uint64_t index, uint64_t term, TMTContext & tmt);
+    void handleApplySnapshot(metapb::Region && region, uint64_t peer_id, SSTViewVec, uint64_t index, uint64_t term, std::optional<uint64_t>, TMTContext & tmt);
 
     void handleIngestCheckpoint(RegionPtr region, CheckpointInfoPtr checkpoint_info, TMTContext & tmt);
 
+    // For Raftstore V2, there could be some orphan keys in the write column family being left to `new_region` after pre-handled.
+    // All orphan write keys are asserted to be replayed before reaching `deadline_index`.
     std::vector<DM::ExternalDTFileInfo> preHandleSnapshotToFiles(
         RegionPtr new_region,
         SSTViewVec,
         uint64_t index,
         uint64_t term,
+        std::optional<uint64_t> deadline_index,
         TMTContext & tmt);
     template <typename RegionPtrWrap>
     void applyPreHandledSnapshot(const RegionPtrWrap &, TMTContext & tmt);

--- a/dbms/src/Storages/Transaction/KVStore.h
+++ b/dbms/src/Storages/Transaction/KVStore.h
@@ -230,9 +230,9 @@ private:
     void mockRemoveRegion(RegionID region_id, RegionTable & region_table);
     KVStoreTaskLock genTaskLock() const;
 
-    RegionManager::RegionReadLock genRegionReadLock() const;
+    RegionManager::RegionReadLock genRegionMgrReadLock() const;
 
-    RegionManager::RegionWriteLock genRegionWriteLock(const KVStoreTaskLock &);
+    RegionManager::RegionWriteLock genRegionMgrWriteLock(const KVStoreTaskLock &);
 
     EngineStoreApplyRes handleUselessAdminRaftCmd(
         raft_cmdpb::AdminCmdType cmd_type,

--- a/dbms/src/Storages/Transaction/KVStore.h
+++ b/dbms/src/Storages/Transaction/KVStore.h
@@ -93,7 +93,7 @@ public:
 
     void gcRegionPersistedCache(Seconds gc_persist_period = Seconds(60 * 5));
 
-    void tryPersist(RegionID region_id);
+    void tryPersistRegion(RegionID region_id);
 
     static bool tryFlushRegionCacheInStorage(TMTContext & tmt, const Region & region, const LoggerPtr & log, bool try_until_succeed = true);
 
@@ -246,7 +246,7 @@ private:
     bool canFlushRegionDataImpl(const RegionPtr & curr_region_ptr, UInt8 flush_if_possible, bool try_until_succeed, TMTContext & tmt, const RegionTaskLock & region_task_lock, UInt64 index, UInt64 term);
     bool forceFlushRegionDataImpl(Region & curr_region, bool try_until_succeed, TMTContext & tmt, const RegionTaskLock & region_task_lock, UInt64 index, UInt64 term);
 
-    void persistRegion(const Region & region, const RegionTaskLock & region_task_lock, const char * caller);
+    void persistRegion(const Region & region, std::optional<const RegionTaskLock *> region_task_lock, const char * caller);
     void releaseReadIndexWorkers();
     void handleDestroy(UInt64 region_id, TMTContext & tmt, const KVStoreTaskLock &);
 

--- a/dbms/src/Storages/Transaction/KVStore.h
+++ b/dbms/src/Storages/Transaction/KVStore.h
@@ -16,6 +16,7 @@
 
 #include <Storages/Transaction/RegionDataRead.h>
 #include <Storages/Transaction/RegionManager.h>
+#include <Storages/Transaction/RegionRangeKeys.h>
 #include <Storages/Transaction/StorageEngineType.h>
 
 namespace TiDB
@@ -85,7 +86,7 @@ public:
 
     RegionPtr getRegion(RegionID region_id) const;
 
-    using RegionRange = std::pair<TiKVRangeKey, TiKVRangeKey>;
+    using RegionRange = RegionRangeKeys::RegionRange;
 
     RegionMap getRegionsByRangeOverlap(const RegionRange & range) const;
 

--- a/dbms/src/Storages/Transaction/LearnerRead.cpp
+++ b/dbms/src/Storages/Transaction/LearnerRead.cpp
@@ -96,7 +96,8 @@ class MvccQueryInfoWrap
     using Base = MvccQueryInfo;
     Base & inner;
     std::optional<Base::RegionsQueryInfo> regions_info;
-    Base::RegionsQueryInfo * regions_info_ptr;
+    // Points to either `regions_info` or `mvcc_query_info.regions_query_info`.
+    Base::RegionsQueryInfo * regions_query_info_ptr;
 
 public:
     MvccQueryInfoWrap(Base & mvcc_query_info, TMTContext & tmt, const TiDB::TableID logical_table_id)
@@ -104,28 +105,28 @@ public:
     {
         if (likely(!inner.regions_query_info.empty()))
         {
-            regions_info_ptr = &inner.regions_query_info;
+            regions_query_info_ptr = &inner.regions_query_info;
         }
         else
         {
             regions_info = Base::RegionsQueryInfo();
-            regions_info_ptr = &*regions_info;
-            // Only for test, because regions_query_info should never be empty if query is from TiDB or TiSpark.
+            regions_query_info_ptr = &*regions_info;
+            // Only for (integration) test, because regions_query_info should never be empty if query is from TiDB or TiSpark.
             // todo support partition table
             auto regions = tmt.getRegionTable().getRegionsByTable(NullspaceID, logical_table_id);
-            regions_info_ptr->reserve(regions.size());
+            regions_query_info_ptr->reserve(regions.size());
             for (const auto & [id, region] : regions)
             {
                 if (region == nullptr)
                     continue;
-                regions_info_ptr->emplace_back(
+                regions_query_info_ptr->emplace_back(
                     RegionQueryInfo{id, region->version(), region->confVer(), logical_table_id, region->getRange()->rawKeys(), {}});
             }
         }
     }
     Base * operator->() { return &inner; }
 
-    const Base::RegionsQueryInfo & getRegionsInfo() const { return *regions_info_ptr; }
+    const Base::RegionsQueryInfo & getRegionsInfo() const { return *regions_query_info_ptr; }
     void addReadIndexRes(RegionID region_id, UInt64 read_index)
     {
         inner.read_index_res[region_id] = read_index;
@@ -228,6 +229,7 @@ LearnerReadSnapshot doLearnerRead(
                 }
             }
         }
+
         GET_METRIC(tiflash_stale_read_count).Increment(stats.num_stale_read);
         GET_METRIC(tiflash_raft_read_index_count).Increment(batch_read_index_req.size());
 
@@ -457,6 +459,7 @@ void validateQueryInfo(
         if (auto iter = regions_snapshot.find(region_query_info.region_id); //
             iter == regions_snapshot.end() || iter->second != region)
         {
+            // If snapshot is applied during learner read, we should abort with an exception later.
             status = RegionException::RegionReadStatus::NOT_FOUND;
         }
         else if (region->version() != region_query_info.version)

--- a/dbms/src/Storages/Transaction/ProxyFFI.cpp
+++ b/dbms/src/Storages/Transaction/ProxyFFI.cpp
@@ -621,9 +621,9 @@ RawCppPtr PreHandleSnapshot(
         }
 #endif
 
-
         // Pre-decode and save as DTFiles
-        auto ingest_ids = kvstore->preHandleSnapshotToFiles(new_region, snaps, index, term, tmt);
+        // TODO Forward deadline_index when TiKV supports.
+        auto ingest_ids = kvstore->preHandleSnapshotToFiles(new_region, snaps, index, term, std::nullopt, tmt);
         auto * res = new PreHandledSnapshotWithFiles{new_region, std::move(ingest_ids)};
         return GenRawCppPtr(res, RawCppPtrTypeImpl::PreHandledSnapshotWithFiles);
     }

--- a/dbms/src/Storages/Transaction/Region.cpp
+++ b/dbms/src/Storages/Transaction/Region.cpp
@@ -47,9 +47,9 @@ RegionData::WriteCFIter Region::removeDataByWriteIt(const RegionData::WriteCFIte
     return data.removeDataByWriteIt(write_it);
 }
 
-RegionDataReadInfo Region::readDataByWriteIt(const RegionData::ConstWriteCFIter & write_it, bool need_value) const
+std::optional<RegionDataReadInfo> Region::readDataByWriteIt(const RegionData::ConstWriteCFIter & write_it, bool need_value, bool hard_error)
 {
-    return data.readDataByWriteIt(write_it, need_value, id(), appliedIndex());
+    return data.readDataByWriteIt(write_it, need_value, id(), appliedIndex(), hard_error);
 }
 
 DecodedLockCFValuePtr Region::getLockInfo(const RegionLockReadQuery & query) const
@@ -70,6 +70,18 @@ void Region::insert(ColumnFamilyType type, TiKVKey && key, TiKVValue && value, D
 
 void Region::doInsert(ColumnFamilyType type, TiKVKey && key, TiKVValue && value, DupCheck mode)
 {
+    if (getClusterRaftstoreVer() == RaftstoreVer::V2)
+    {
+        if (type == ColumnFamilyType::Write)
+        {
+            if (orphanKeysInfo().observeKeyFromNormalWrite(key))
+            {
+                // We can't assert the key exists in write_cf here,
+                // since it may be already written into DeltaTree.
+                return;
+            }
+        }
+    }
     data.insert(type, std::move(key), std::move(value), mode);
 }
 
@@ -477,9 +489,9 @@ Timepoint Region::lastCompactLogTime() const
     return last_compact_log_time;
 }
 
-Region::CommittedScanner Region::createCommittedScanner(bool use_lock)
+Region::CommittedScanner Region::createCommittedScanner(bool use_lock, bool need_value)
 {
-    return Region::CommittedScanner(this->shared_from_this(), use_lock);
+    return Region::CommittedScanner(this->shared_from_this(), use_lock, need_value);
 }
 
 Region::CommittedRemover Region::createCommittedRemover(bool use_lock)
@@ -495,6 +507,40 @@ std::string Region::toString(bool dump_status) const
 ImutRegionRangePtr Region::getRange() const
 {
     return meta.getRange();
+}
+
+RaftstoreVer Region::getClusterRaftstoreVer()
+{
+    // In non-debug/test mode, we should assert the proxy_ptr be always not null.
+    if (likely(proxy_helper != nullptr))
+    {
+        if (likely(proxy_helper->fn_get_cluster_raftstore_version))
+        {
+            // Make debug funcs happy.
+            return proxy_helper->fn_get_cluster_raftstore_version(proxy_helper->proxy_ptr, 0, 0);
+        }
+    }
+    return RaftstoreVer::Uncertain;
+}
+
+void Region::beforePrehandleSnapshot(uint64_t region_id, std::optional<uint64_t> deadline_index)
+{
+    if (getClusterRaftstoreVer() == RaftstoreVer::V2)
+    {
+        data.orphan_keys_info.snapshot_index = appliedIndex();
+        data.orphan_keys_info.pre_handling = true;
+        data.orphan_keys_info.deadline_index = deadline_index;
+        data.orphan_keys_info.region_id = region_id;
+    }
+}
+
+void Region::afterPrehandleSnapshot()
+{
+    if (getClusterRaftstoreVer() == RaftstoreVer::V2)
+    {
+        data.orphan_keys_info.pre_handling = false;
+        LOG_INFO(log, "After prehandle, remains {} orphan keys [region_id={}]", data.orphan_keys_info.remainedKeyCount(), id());
+    }
 }
 
 kvrpcpb::ReadIndexRequest GenRegionReadIndexReq(const Region & region, UInt64 start_ts)

--- a/dbms/src/Storages/Transaction/Region.cpp
+++ b/dbms/src/Storages/Transaction/Region.cpp
@@ -49,7 +49,7 @@ RegionData::WriteCFIter Region::removeDataByWriteIt(const RegionData::WriteCFIte
 
 RegionDataReadInfo Region::readDataByWriteIt(const RegionData::ConstWriteCFIter & write_it, bool need_value) const
 {
-    return data.readDataByWriteIt(write_it, need_value);
+    return data.readDataByWriteIt(write_it, need_value, id(), appliedIndex());
 }
 
 DecodedLockCFValuePtr Region::getLockInfo(const RegionLockReadQuery & query) const

--- a/dbms/src/Storages/Transaction/Region.cpp
+++ b/dbms/src/Storages/Transaction/Region.cpp
@@ -804,11 +804,19 @@ UInt64 RegionRaftCommandDelegate::appliedIndex()
 {
     return meta.makeRaftCommandDelegate().applyState().applied_index();
 }
-metapb::Region Region::getMetaRegion() const
+metapb::Region Region::cloneMetaRegion() const
+{
+    return meta.cloneMetaRegion();
+}
+const metapb::Region & Region::getMetaRegion() const
 {
     return meta.getMetaRegion();
 }
-raft_serverpb::MergeState Region::getMergeState() const
+raft_serverpb::MergeState Region::cloneMergeState() const
+{
+    return meta.cloneMergeState();
+}
+const raft_serverpb::MergeState & Region::getMergeState() const
 {
     return meta.getMergeState();
 }

--- a/dbms/src/Storages/Transaction/Region.cpp
+++ b/dbms/src/Storages/Transaction/Region.cpp
@@ -533,9 +533,10 @@ std::tuple<WaitIndexResult, double> Region::waitIndex(UInt64 index, const UInt64
         {
             Stopwatch wait_index_watch;
             LOG_DEBUG(log,
-                      "{} need to wait learner index {}",
+                      "{} need to wait learner index {} timeout {}",
                       toString(),
-                      index);
+                      index,
+                      timeout_ms);
             auto wait_idx_res = meta.waitIndex(index, timeout_ms, std::move(check_running));
             auto elapsed_secs = wait_index_watch.elapsedSeconds();
             switch (wait_idx_res)
@@ -579,7 +580,6 @@ void Region::assignRegion(Region && new_region)
     std::unique_lock<std::shared_mutex> lock(mutex);
 
     data.assignRegionData(std::move(new_region.data));
-
     meta.assignRegionMeta(std::move(new_region.meta));
     meta.notifyAll();
 }

--- a/dbms/src/Storages/Transaction/Region.h
+++ b/dbms/src/Storages/Transaction/Region.h
@@ -189,8 +189,10 @@ public:
     void tryCompactionFilter(const Timestamp safe_point);
 
     RegionRaftCommandDelegate & makeRaftCommandDelegate(const KVStoreTaskLock &);
-    metapb::Region getMetaRegion() const;
-    raft_serverpb::MergeState getMergeState() const;
+    metapb::Region cloneMetaRegion() const;
+    const metapb::Region & getMetaRegion() const;
+    raft_serverpb::MergeState cloneMergeState() const;
+    const raft_serverpb::MergeState & getMergeState() const;
 
     TableID getMappedTableID() const;
     KeyspaceID getKeyspaceID() const;

--- a/dbms/src/Storages/Transaction/Region.h
+++ b/dbms/src/Storages/Transaction/Region.h
@@ -161,6 +161,7 @@ public:
         return region1.meta == region2.meta && region1.data == region2.data;
     }
 
+    // Check if we can read by this index.
     bool checkIndex(UInt64 index) const;
 
     // Return <WaitIndexResult, time cost(seconds)> for wait-index.
@@ -178,13 +179,8 @@ public:
 
     RegionMetaSnapshot dumpRegionMetaSnapshot() const;
 
+    // Assign data and meta by moving from `new_region`.
     void assignRegion(Region && new_region);
-
-    using HandleMap = std::unordered_map<HandleID, std::tuple<Timestamp, UInt8>>;
-
-    /// Only can be used for applying snapshot. only can be called by single thread.
-    /// Try to fill record with delmark if it exists in ch but has been remove by GC in leader.
-    void compareAndCompleteSnapshot(HandleMap & handle_map, const Timestamp safe_point);
 
     void tryCompactionFilter(const Timestamp safe_point);
 

--- a/dbms/src/Storages/Transaction/Region.h
+++ b/dbms/src/Storages/Transaction/Region.h
@@ -167,7 +167,9 @@ public:
     // Return <WaitIndexResult, time cost(seconds)> for wait-index.
     std::tuple<WaitIndexResult, double> waitIndex(UInt64 index, const UInt64 timeout_ms, std::function<bool(void)> && check_running);
 
+    // Requires RegionMeta's lock
     UInt64 appliedIndex() const;
+    // Requires RegionMeta's lock
     UInt64 appliedIndexTerm() const;
 
     void notifyApplied() { meta.notifyAll(); }

--- a/dbms/src/Storages/Transaction/RegionCFDataBase.cpp
+++ b/dbms/src/Storages/Transaction/RegionCFDataBase.cpp
@@ -44,6 +44,7 @@ RegionDataRes RegionCFDataBase<Trait>::insert(TiKVKey && key, TiKVValue && value
 {
     const auto & raw_key = RecordKVFormat::decodeTiKVKey(key);
     auto kv_pair = Trait::genKVPair(std::move(key), raw_key, std::move(value));
+
     if (!kv_pair)
         return 0;
 
@@ -73,6 +74,7 @@ RegionDataRes RegionCFDataBase<Trait>::insert(std::pair<Key, Value> && kv_pair, 
     // We support duplicated kv pairs if they are the same in snapshot.
     // This is because kvs in raftstore v2's snapshot may be overlapped.
     // However, we still not permit duplicated kvs from raft cmd.
+
     if (!ok)
     {
         if (mode == DupCheck::Deny)

--- a/dbms/src/Storages/Transaction/RegionCFDataBase.h
+++ b/dbms/src/Storages/Transaction/RegionCFDataBase.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <Storages/Transaction/RegionRangeKeys.h>
 #include <Storages/Transaction/TiKVKeyValue.h>
 
 #include <map>
@@ -22,7 +23,7 @@ namespace DB
 {
 
 struct TiKVRangeKey;
-using RegionRange = std::pair<TiKVRangeKey, TiKVRangeKey>;
+using RegionRange = RegionRangeKeys::RegionRange;
 using RegionDataRes = size_t;
 
 enum class DupCheck

--- a/dbms/src/Storages/Transaction/RegionData.cpp
+++ b/dbms/src/Storages/Transaction/RegionData.cpp
@@ -109,13 +109,12 @@ RegionData::WriteCFIter RegionData::removeDataByWriteIt(const WriteCFIter & writ
     return write_cf.getDataMut().erase(write_it);
 }
 
-RegionDataReadInfo RegionData::readDataByWriteIt(const ConstWriteCFIter & write_it, bool need_value, RegionID region_id, UInt64 applied) const
+std::optional<RegionDataReadInfo> RegionData::readDataByWriteIt(const ConstWriteCFIter & write_it, bool need_value, RegionID region_id, UInt64 applied, bool hard_error)
 {
     const auto & [key, value, decoded_val] = write_it->second;
     const auto & [pk, ts] = write_it->first;
 
     std::ignore = value;
-
     if (pk->empty())
     {
         throw Exception("Observe empty PK: raw key " + key->toDebugString(), ErrorCodes::ILLFORMAT_RAFT_ROW);
@@ -133,13 +132,40 @@ RegionDataReadInfo RegionData::readDataByWriteIt(const ConstWriteCFIter & write_
         if (auto data_it = map.find({pk, decoded_val.prewrite_ts}); data_it != map.end())
             return std::make_tuple(pk, decoded_val.write_type, ts, RegionDefaultCFDataTrait::getTiKVValue(data_it));
         else
-            throw Exception(fmt::format("Raw TiDB PK: {}, Prewrite ts: {} can not found in default cf for key: {}, region_id: {}, applied: {}",
+        {
+            if (!hard_error)
+            {
+                if (orphan_keys_info.pre_handling)
+                {
+                    RUNTIME_CHECK_MSG(orphan_keys_info.snapshot_index.has_value(),
+                                      "Snapshot index shall be set when Applying snapshot");
+                    // While pre-handling snapshot from raftstore v2, we accept and store the orphan keys in memory
+                    // These keys should be resolved in later raft logs
+                    orphan_keys_info.observeExtraKey(TiKVKey::copyFrom(*key));
+                    return std::nullopt;
+                }
+                else
+                {
+                    // We can't delete this orphan key here, since it can be triggered from `onSnapshot`.
+                    if (orphan_keys_info.containsExtraKey(*key))
+                    {
+                        return std::nullopt;
+                    }
+                    // Otherwise, this is still a hard error.
+                    // TODO We still need to check if there are remained orphan keys after we have applied after peer's flushed_index.
+                    // Since the registered orphan write key may come from a raft log smaller than snapshot_index with its default key lost,
+                    // thus this write key will not be replicated any more, which cause a slient data loss.
+                }
+            }
+            throw Exception(fmt::format("Raw TiDB PK: {}, Prewrite ts: {} can not found in default cf for key: {}, region_id: {}, applied: {}{}",
                                         pk.toDebugString(),
                                         decoded_val.prewrite_ts,
                                         key->toDebugString(),
                                         region_id,
-                                        applied),
+                                        applied,
+                                        hard_error ? "" : ", not orphan key"),
                             ErrorCodes::ILLFORMAT_RAFT_ROW);
+        }
     }
 
     return std::make_tuple(pk, decoded_val.write_type, ts, decoded_val.short_value);
@@ -198,6 +224,7 @@ void RegionData::assignRegionData(RegionData && new_region_data)
     default_cf = std::move(new_region_data.default_cf);
     write_cf = std::move(new_region_data.write_cf);
     lock_cf = std::move(new_region_data.lock_cf);
+    orphan_keys_info = std::move(new_region_data.orphan_keys_info);
 
     cf_data_size = new_region_data.cf_data_size.load();
 }
@@ -264,6 +291,49 @@ RegionData & RegionData::operator=(RegionData && rhs)
     lock_cf = std::move(rhs.lock_cf);
     cf_data_size = rhs.cf_data_size.load();
     return *this;
+}
+
+void RegionData::OrphanKeysInfo::observeExtraKey(TiKVKey && key)
+{
+    remained_keys.insert(std::move(key));
+}
+
+bool RegionData::OrphanKeysInfo::observeKeyFromNormalWrite(const TiKVKey & key)
+{
+    return remained_keys.erase(key);
+}
+
+bool RegionData::OrphanKeysInfo::containsExtraKey(const TiKVKey & key)
+{
+    return remained_keys.contains(key);
+}
+
+uint64_t RegionData::OrphanKeysInfo::remainedKeyCount() const
+{
+    return remained_keys.size();
+}
+
+
+void RegionData::OrphanKeysInfo::mergeFrom(const RegionData::OrphanKeysInfo & other)
+{
+    // TODO support move.
+    for (const auto & remained_key : other.remained_keys)
+    {
+        remained_keys.insert(TiKVKey::copyFrom(remained_key));
+    }
+}
+
+void RegionData::OrphanKeysInfo::advanceAppliedIndex(uint64_t applied_index)
+{
+    if (deadline_index && snapshot_index)
+    {
+        auto count = remainedKeyCount();
+        if (applied_index >= deadline_index.value() && count > 0)
+        {
+            auto one = remained_keys.begin()->toDebugString();
+            throw Exception(fmt::format("Orphan keys from snapshot still exists. One of total {} is {}. region_id={} snapshot_index={} deadline_index={} applied_index={}", count, one, region_id, snapshot_index.value(), deadline_index.value(), applied_index));
+        }
+    }
 }
 
 } // namespace DB

--- a/dbms/src/Storages/Transaction/RegionData.cpp
+++ b/dbms/src/Storages/Transaction/RegionData.cpp
@@ -109,7 +109,7 @@ RegionData::WriteCFIter RegionData::removeDataByWriteIt(const WriteCFIter & writ
     return write_cf.getDataMut().erase(write_it);
 }
 
-RegionDataReadInfo RegionData::readDataByWriteIt(const ConstWriteCFIter & write_it, bool need_value) const
+RegionDataReadInfo RegionData::readDataByWriteIt(const ConstWriteCFIter & write_it, bool need_value, RegionID region_id, UInt64 applied) const
 {
     const auto & [key, value, decoded_val] = write_it->second;
     const auto & [pk, ts] = write_it->first;
@@ -133,8 +133,12 @@ RegionDataReadInfo RegionData::readDataByWriteIt(const ConstWriteCFIter & write_
         if (auto data_it = map.find({pk, decoded_val.prewrite_ts}); data_it != map.end())
             return std::make_tuple(pk, decoded_val.write_type, ts, RegionDefaultCFDataTrait::getTiKVValue(data_it));
         else
-            throw Exception("Raw TiDB PK: " + (pk.toDebugString()) + ", Prewrite ts: " + std::to_string(decoded_val.prewrite_ts)
-                                + " can not found in default cf for key: " + key->toDebugString(),
+            throw Exception(fmt::format("Raw TiDB PK: {}, Prewrite ts: {} can not found in default cf for key: {}, region_id: {}, applied: {}",
+                                        pk.toDebugString(),
+                                        decoded_val.prewrite_ts,
+                                        key->toDebugString(),
+                                        region_id,
+                                        applied),
                             ErrorCodes::ILLFORMAT_RAFT_ROW);
     }
 

--- a/dbms/src/Storages/Transaction/RegionData.h
+++ b/dbms/src/Storages/Transaction/RegionData.h
@@ -42,7 +42,7 @@ public:
 
     WriteCFIter removeDataByWriteIt(const WriteCFIter & write_it);
 
-    RegionDataReadInfo readDataByWriteIt(const ConstWriteCFIter & write_it, bool need_value, RegionID region_id, UInt64 applied) const;
+    std::optional<RegionDataReadInfo> readDataByWriteIt(const ConstWriteCFIter & write_it, bool need_value, RegionID region_id, UInt64 applied, bool hard_error);
 
     DecodedLockCFValuePtr getLockInfo(const RegionLockReadQuery & query) const;
 
@@ -73,6 +73,37 @@ public:
     RegionData(RegionData && data);
     RegionData & operator=(RegionData &&);
 
+    struct OrphanKeysInfo
+    {
+        // Protected by region task lock.
+        void observeExtraKey(TiKVKey && key);
+
+        bool observeKeyFromNormalWrite(const TiKVKey & key);
+
+        bool containsExtraKey(const TiKVKey & key);
+
+        uint64_t remainedKeyCount() const;
+
+        void mergeFrom(const OrphanKeysInfo & other);
+
+        void advanceAppliedIndex(uint64_t);
+
+        // Providing a `snapshot_index` indicates we can scanning a snapshot of index `snapshot_index`.
+        // `snapshot_index` can be set to null if TiFlash is not in a raftstore v2 cluster.
+        std::optional<uint64_t> snapshot_index;
+        // When applied raft log to `deadline_index`, `remained_keys` shall be cleared.
+        // Otherwise, raise a hard error.
+        std::optional<uint64_t> deadline_index;
+        // Marks if we are prehandling a snapshot. We only register orphan key when prehandling.
+        // See `RegionData::readDataByWriteIt`.
+        bool pre_handling = false;
+        uint64_t region_id = 0;
+
+    private:
+        // Stores orphan write cf keys while handling a raftstore v2 snapshot.
+        std::unordered_set<TiKVKey> remained_keys;
+    };
+
 private:
     friend class Region;
 
@@ -80,6 +111,7 @@ private:
     RegionWriteCFData write_cf;
     RegionDefaultCFData default_cf;
     RegionLockCFData lock_cf;
+    OrphanKeysInfo orphan_keys_info;
 
     // Size of data cf & write cf, without lock cf.
     std::atomic<size_t> cf_data_size = 0;

--- a/dbms/src/Storages/Transaction/RegionData.h
+++ b/dbms/src/Storages/Transaction/RegionData.h
@@ -42,7 +42,7 @@ public:
 
     WriteCFIter removeDataByWriteIt(const WriteCFIter & write_it);
 
-    RegionDataReadInfo readDataByWriteIt(const ConstWriteCFIter & write_it, bool need_value = true) const;
+    RegionDataReadInfo readDataByWriteIt(const ConstWriteCFIter & write_it, bool need_value, RegionID region_id, UInt64 applied) const;
 
     DecodedLockCFValuePtr getLockInfo(const RegionLockReadQuery & query) const;
 

--- a/dbms/src/Storages/Transaction/RegionManager.h
+++ b/dbms/src/Storages/Transaction/RegionManager.h
@@ -55,12 +55,12 @@ struct RegionManager : SharedMutexLockWrap
         RegionsRangeIndex & index;
     };
 
-    RegionReadLock genRegionReadLock() const
+    RegionReadLock genReadLock() const
     {
         return {genSharedLock(), regions, region_range_index};
     }
 
-    RegionWriteLock genRegionWriteLock()
+    RegionWriteLock genWriteLock()
     {
         return {genUniqueLock(), regions, region_range_index};
     }

--- a/dbms/src/Storages/Transaction/RegionMeta.cpp
+++ b/dbms/src/Storages/Transaction/RegionMeta.cpp
@@ -448,16 +448,27 @@ RegionMeta::RegionMeta(metapb::Peer peer_, metapb::Region region, raft_serverpb:
     region_state.setRegion(std::move(region));
 }
 
-metapb::Region RegionMeta::getMetaRegion() const
+metapb::Region RegionMeta::cloneMetaRegion() const
 {
     std::lock_guard lock(mutex);
     return region_state.getRegion();
 }
 
-raft_serverpb::MergeState RegionMeta::getMergeState() const
+const metapb::Region & RegionMeta::getMetaRegion() const
+{
+    std::lock_guard lock(mutex);
+    return region_state.getRegion();
+}
+
+raft_serverpb::MergeState RegionMeta::cloneMergeState() const
 {
     std::lock_guard lock(mutex);
     return region_state.getMergeState();
 }
 
+const raft_serverpb::MergeState & RegionMeta::getMergeState() const
+{
+    std::lock_guard lock(mutex);
+    return region_state.getMergeState();
+}
 } // namespace DB

--- a/dbms/src/Storages/Transaction/RegionMeta.h
+++ b/dbms/src/Storages/Transaction/RegionMeta.h
@@ -109,8 +109,10 @@ public:
     RegionMetaSnapshot dumpRegionMetaSnapshot() const;
     MetaRaftCommandDelegate & makeRaftCommandDelegate();
 
-    metapb::Region getMetaRegion() const;
-    raft_serverpb::MergeState getMergeState() const;
+    const metapb::Region & getMetaRegion() const;
+    metapb::Region cloneMetaRegion() const;
+    const raft_serverpb::MergeState & getMergeState() const;
+    raft_serverpb::MergeState cloneMergeState() const;
 
     RegionMeta() = delete;
 

--- a/dbms/src/Storages/Transaction/RegionRangeKeys.h
+++ b/dbms/src/Storages/Transaction/RegionRangeKeys.h
@@ -41,6 +41,10 @@ struct TiKVRangeKey : boost::noncopyable
     TiKVRangeKey copy() const;
     TiKVRangeKey & operator=(TiKVRangeKey &&);
     std::string toDebugString() const;
+    std::string toString() const
+    {
+        return key.toString();
+    }
 
     State state;
     TiKVKey key;
@@ -53,9 +57,13 @@ public:
     using RegionRange = std::pair<TiKVRangeKey, TiKVRangeKey>;
 
     const RegionRange & comparableKeys() const;
+    static RegionRange cloneRange(const RegionRange & from);
     static RegionRange makeComparableKeys(TiKVKey && start_key, TiKVKey && end_key);
     const std::pair<DecodedTiKVKeyPtr, DecodedTiKVKeyPtr> & rawKeys() const;
     explicit RegionRangeKeys(TiKVKey && start_key, TiKVKey && end_key);
+    explicit RegionRangeKeys(RegionRange && range)
+        : RegionRangeKeys(std::move(range.first.key), std::move(range.second.key))
+    {}
     TableID getMappedTableID() const;
     KeyspaceID getKeyspaceID() const;
     std::string toDebugString() const;

--- a/dbms/src/Storages/Transaction/RegionScanner.cpp
+++ b/dbms/src/Storages/Transaction/RegionScanner.cpp
@@ -1,0 +1,85 @@
+// Copyright 2022 PingCAP, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Storages/Transaction/ProxyFFI.h>
+#include <Storages/Transaction/Region.h>
+
+namespace DB
+{
+Region::CommittedScanner::CommittedScanner(const RegionPtr & region_, bool use_lock, bool need_value)
+    : region(region_)
+    , need_val(need_value)
+{
+    if (use_lock)
+        lock = std::shared_lock<std::shared_mutex>(region_->mutex);
+
+    const auto & data = region->data.writeCF().getData();
+
+    write_map_size = data.size();
+    write_map_it = data.begin();
+    write_map_it_end = data.end();
+
+    hard_error = true;
+    if (region->getClusterRaftstoreVer() == DB::RaftstoreVer::V2)
+    {
+        hard_error = false;
+    }
+}
+
+bool Region::CommittedScanner::hasNext()
+{
+    if (peeked)
+    {
+        return true;
+    }
+    else
+    {
+        if (write_map_size == 0)
+            return false;
+        while (write_map_it != write_map_it_end)
+        {
+            if (tryNext())
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+bool Region::CommittedScanner::tryNext()
+{
+    RUNTIME_CHECK_MSG(!peeked.has_value(), "Can't call CommittedScanner::tryNext() twice");
+    assert(write_map_it != write_map_it_end);
+    auto ans = region->readDataByWriteIt(write_map_it++, need_val, hard_error);
+    if (ans)
+    {
+        peeked = std::move(ans.value());
+        return true;
+    }
+    else
+    {
+        // Returning nullopt only means we encoutered a orphan write key.
+        return false;
+    }
+}
+
+RegionDataReadInfo Region::CommittedScanner::next()
+{
+    RUNTIME_CHECK_MSG(peeked.has_value(), "Call CommittedScanner::next() with empty prefetched value");
+    auto res = std::move(peeked.value());
+    peeked.reset();
+    return res;
+}
+} // namespace DB

--- a/dbms/src/Storages/Transaction/RegionState.cpp
+++ b/dbms/src/Storages/Transaction/RegionState.cpp
@@ -190,6 +190,11 @@ RegionRangeKeys::RegionRange RegionRangeKeys::makeComparableKeys(TiKVKey && star
         TiKVRangeKey::makeTiKVRangeKey<false>(std::move(end_key)));
 }
 
+RegionRangeKeys::RegionRange RegionRangeKeys::cloneRange(const RegionRange & from)
+{
+    return std::make_pair(from.first.copy(), from.second.copy());
+}
+
 std::string TiKVRangeKey::toDebugString() const
 {
     if (this->state == MAX)

--- a/dbms/src/Storages/Transaction/RegionTable.cpp
+++ b/dbms/src/Storages/Transaction/RegionTable.cpp
@@ -46,7 +46,7 @@ RegionTable::Table & RegionTable::getOrCreateTable(const KeyspaceID keyspace_id,
     {
         // Load persisted info.
         it = tables.emplace(ks_tb_id, table_id).first;
-        LOG_INFO(log, "get new table {}", table_id);
+        LOG_INFO(log, "get new table {} of keyspace {}", table_id, keyspace_id);
     }
     return it->second;
 }
@@ -426,7 +426,9 @@ void RegionTable::handleInternalRegionsByTable(const KeyspaceID keyspace_id, con
     std::lock_guard lock(mutex);
 
     if (auto it = tables.find(KeyspaceTableID{keyspace_id, table_id}); it != tables.end())
+    {
         callback(it->second.regions);
+    }
 }
 
 std::vector<std::pair<RegionID, RegionPtr>> RegionTable::getRegionsByTable(const KeyspaceID keyspace_id, const TableID table_id) const

--- a/dbms/src/Storages/Transaction/RegionTable.h
+++ b/dbms/src/Storages/Transaction/RegionTable.h
@@ -163,7 +163,7 @@ public:
     // This function is only for debug.
     bool tryFlushRegions();
 
-    // Protects writeBlockByRegionAndFlush and ensures it's executed by only one thread at the smae time.
+    // Protects writeBlockByRegionAndFlush and ensures it's executed by only one thread at the same time.
     // Only one thread can do this at the same time.
     // The original name for this function is tryFlushRegion.
     RegionDataReadInfoList tryWriteBlockByRegionAndFlush(RegionID region_id, bool try_persist = false);

--- a/dbms/src/Storages/Transaction/RegionTable.h
+++ b/dbms/src/Storages/Transaction/RegionTable.h
@@ -159,9 +159,15 @@ public:
 
     void removeRegion(RegionID region_id, bool remove_data, const RegionTaskLock &);
 
+    // Find all regions with data, call writeBlockByRegionAndFlush with try_persist = true.
+    // This function is only for debug.
     bool tryFlushRegions();
-    RegionDataReadInfoList tryFlushRegion(RegionID region_id, bool try_persist = false);
-    RegionDataReadInfoList tryFlushRegion(const RegionPtrWithBlock & region, bool try_persist);
+
+    // Protects writeBlockByRegionAndFlush and ensures it's executed by only one thread at the smae time.
+    // Only one thread can do this at the same time.
+    // The original name for this function is tryFlushRegion.
+    RegionDataReadInfoList tryWriteBlockByRegionAndFlush(RegionID region_id, bool try_persist = false);
+    RegionDataReadInfoList tryWriteBlockByRegionAndFlush(const RegionPtrWithBlock & region, bool try_persist);
 
     void handleInternalRegionsByTable(KeyspaceID keyspace_id, TableID table_id, std::function<void(const InternalRegions &)> && callback) const;
     std::vector<std::pair<RegionID, RegionPtr>> getRegionsByTable(KeyspaceID keyspace_id, TableID table_id) const;
@@ -191,7 +197,6 @@ public:
     /// extend range for possible InternalRegion or add one.
     void extendRegionRange(RegionID region_id, const RegionRangeKeys & region_range_keys);
 
-
     void updateSafeTS(UInt64 region_id, UInt64 leader_safe_ts, UInt64 self_safe_ts);
 
     // unit: ms. If safe_ts diff is larger than 2min, we think the data synchronization progress is far behind the leader.
@@ -211,7 +216,10 @@ private:
     InternalRegion & insertRegion(Table & table, const Region & region);
     InternalRegion & doGetInternalRegion(KeyspaceTableID ks_tb_id, RegionID region_id);
 
-    RegionDataReadInfoList flushRegion(const RegionPtrWithBlock & region, bool try_persist) const;
+    // Try write the committed kvs into cache of columnar DeltaMergeStore.
+    // Flush the cache if try_persist is set to true.
+    // The original name for this method is flushRegion.
+    RegionDataReadInfoList writeBlockByRegionAndFlush(const RegionPtrWithBlock & region, bool try_persist) const;
     bool shouldFlush(const InternalRegion & region) const;
     RegionID pickRegionToFlush();
 

--- a/dbms/src/Storages/Transaction/RegionsRangeIndex.cpp
+++ b/dbms/src/Storages/Transaction/RegionsRangeIndex.cpp
@@ -24,10 +24,10 @@ bool TiKVRangeKeyCmp::operator()(const TiKVRangeKey & x, const TiKVRangeKey & y)
 
 void RegionsRangeIndex::add(const RegionPtr & new_region)
 {
-    auto region_range = new_region->getRange();
-    const auto & new_range = region_range->comparableKeys();
-    auto begin_it = split(new_range.first);
-    auto end_it = split(new_range.second);
+    auto new_region_range = new_region->getRange();
+    const auto & new_range_keys = new_region_range->comparableKeys();
+    auto begin_it = split(new_range_keys.first);
+    auto end_it = split(new_range_keys.second);
     if (begin_it == end_it)
         throw Exception(
             std::string(__PRETTY_FUNCTION__) + ": range of region " + toString(new_region->id()) + " is empty",
@@ -88,6 +88,11 @@ void RegionsRangeIndex::clear()
     root.clear();
     min_it = root.emplace(TiKVRangeKey::makeTiKVRangeKey<true>(TiKVKey()), IndexNode{}).first;
     max_it = root.emplace(TiKVRangeKey::makeTiKVRangeKey<false>(TiKVKey()), IndexNode{}).first;
+}
+
+void RegionsRangeIndex::tryMergeEmpty()
+{
+    tryMergeEmpty(root.begin());
 }
 
 void RegionsRangeIndex::tryMergeEmpty(RootMap::iterator remove_it)

--- a/dbms/src/Storages/Transaction/RegionsRangeIndex.h
+++ b/dbms/src/Storages/Transaction/RegionsRangeIndex.h
@@ -14,19 +14,19 @@
 
 #pragma once
 
+#include <Storages/Transaction/RegionRangeKeys.h>
 #include <Storages/Transaction/Types.h>
 
 #include <map>
 
 namespace DB
 {
-
 class Region;
 using RegionPtr = std::shared_ptr<Region>;
 using RegionMap = std::unordered_map<RegionID, RegionPtr>;
 
 struct TiKVRangeKey;
-using RegionRange = std::pair<TiKVRangeKey, TiKVRangeKey>;
+using RegionRange = RegionRangeKeys::RegionRange;
 
 struct TiKVRangeKeyCmp
 {
@@ -55,9 +55,12 @@ public:
 
     void clear();
 
+    // TODO Used by RegionKVStoreTest, using a friend decl here.
+    RootMap::iterator split(const TiKVRangeKey & new_start);
+    void tryMergeEmpty();
+
 private:
     void tryMergeEmpty(RootMap::iterator remove_it);
-    RootMap::iterator split(const TiKVRangeKey & new_start);
 
 private:
     RootMap root;

--- a/dbms/src/Storages/Transaction/SSTReader.cpp
+++ b/dbms/src/Storages/Transaction/SSTReader.cpp
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+
 #include <Storages/Transaction/SSTReader.h>
 
+#include <magic_enum.hpp>
 #include <vector>
 
 namespace DB
@@ -34,7 +36,7 @@ bool MonoSSTReader::remained() const
         {
             if (!tail_checked)
             {
-                LOG_DEBUG(log, "Observed extra data in tablet snapshot {} beyond {}, cf {}", Redact::keyToDebugString(key.data(), key.size()), r.second.key.toDebugString(), getDebugCfType());
+                LOG_DEBUG(log, "Observed extra data in tablet snapshot {} beyond {}, cf {}", Redact::keyToDebugString(key.data(), key.size()), r.second.key.toDebugString(), magic_enum::enum_name(type));
                 tail_checked = true;
             }
             return false;
@@ -68,7 +70,7 @@ MonoSSTReader::MonoSSTReader(const TiFlashRaftProxyHelper * proxy_helper_, SSTVi
     {
         auto && r = range->comparableKeys();
         auto start = r.first.key.toString();
-        LOG_DEBUG(log, "Seek cf {} to {}", getDebugCfType(), Redact::keyToDebugString(start.data(), start.size()));
+        LOG_DEBUG(log, "Seek cf {} to {}", magic_enum::enum_name(type), Redact::keyToDebugString(start.data(), start.size()));
         if (!start.empty())
         {
             proxy_helper->sst_reader_interfaces.fn_seek(inner, view.type, EngineIteratorSeekType::Key, BaseBuffView{start.data(), start.size()});

--- a/dbms/src/Storages/Transaction/SSTReader.h
+++ b/dbms/src/Storages/Transaction/SSTReader.h
@@ -48,12 +48,6 @@ public:
     ~MonoSSTReader() override;
 
 private:
-    auto getDebugCfType() const
-    {
-        return static_cast<std::underlying_type<decltype(type)>::type>(type);
-    }
-
-private:
     const TiFlashRaftProxyHelper * proxy_helper;
     SSTReaderPtr inner;
     ColumnFamilyType type;

--- a/dbms/src/Storages/Transaction/SSTReader.h
+++ b/dbms/src/Storages/Transaction/SSTReader.h
@@ -48,11 +48,18 @@ public:
     ~MonoSSTReader() override;
 
 private:
+    auto getDebugCfType() const
+    {
+        return static_cast<std::underlying_type<decltype(type)>::type>(type);
+    }
+
+private:
     const TiFlashRaftProxyHelper * proxy_helper;
     SSTReaderPtr inner;
     ColumnFamilyType type;
     RegionRangeFilter range;
     SSTFormatKind kind;
+    mutable bool tail_checked;
     Poco::Logger * log;
 };
 

--- a/dbms/src/Storages/Transaction/TMTContext.cpp
+++ b/dbms/src/Storages/Transaction/TMTContext.cpp
@@ -354,6 +354,10 @@ UInt64 TMTContext::waitIndexTimeout() const
 {
     return wait_index_timeout_ms.load(std::memory_order_relaxed);
 }
+void TMTContext::debugSetWaitIndexTimeout(UInt64 timeout)
+{
+    return wait_index_timeout_ms.store(timeout, std::memory_order_relaxed);
+}
 Int64 TMTContext::waitRegionReadyTimeout() const
 {
     return wait_region_ready_timeout_sec.load(std::memory_order_relaxed);

--- a/dbms/src/Storages/Transaction/TMTContext.h
+++ b/dbms/src/Storages/Transaction/TMTContext.h
@@ -80,6 +80,10 @@ public:
 public:
     const KVStorePtr & getKVStore() const;
     KVStorePtr & getKVStore();
+    void debugSetKVStore(const KVStorePtr & new_kvstore)
+    {
+        kvstore = new_kvstore;
+    }
 
     const ManagedStorages & getStorages() const;
     ManagedStorages & getStorages();
@@ -137,6 +141,7 @@ public:
     UInt64 batchReadIndexTimeout() const;
     // timeout for wait index (ms). "0" means wait infinitely
     UInt64 waitIndexTimeout() const;
+    void debugSetWaitIndexTimeout(UInt64 timeout);
     Int64 waitRegionReadyTimeout() const;
     uint64_t readIndexWorkerTick() const;
 

--- a/dbms/src/Storages/Transaction/TiKVKeyValue.h
+++ b/dbms/src/Storages/Transaction/TiKVKeyValue.h
@@ -27,11 +27,6 @@ struct StringObject : std::string
 public:
     using Base = std::string;
 
-    struct Hash
-    {
-        std::size_t operator()(const StringObject & x) const { return std::hash<Base>()(x); }
-    };
-
     StringObject() = default;
     StringObject(Base && str_)
         : Base(std::move(str_))
@@ -46,6 +41,12 @@ public:
         : Base(str)
     {}
     static StringObject copyFrom(const Base & str) { return StringObject(str); }
+
+    template <bool a, typename = std::enable_if_t<a == is_key>>
+    static StringObject<is_key> copyFromObj(const StringObject<a> & other)
+    {
+        return StringObject(other.data(), other.dataSize());
+    }
 
     DISALLOW_COPY(StringObject);
     StringObject & operator=(StringObject && a)
@@ -147,3 +148,15 @@ private:
 };
 
 } // namespace DB
+
+namespace std
+{
+template <bool is_key>
+struct hash<DB::StringObject<is_key>>
+{
+    size_t operator()(const DB::StringObject<is_key> & k) const
+    {
+        return std::hash<std::string>()(k);
+    }
+};
+} // namespace std

--- a/dbms/src/Storages/Transaction/tests/gtest_kvstore.cpp
+++ b/dbms/src/Storages/Transaction/tests/gtest_kvstore.cpp
@@ -295,7 +295,7 @@ void RegionKVStoreTest::testRaftMergeRollback(KVStore & kvs, TMTContext & tmt)
     }
 }
 
-void RegionKVStoreTest::testRaftSplit(KVStore & kvs, TMTContext & tmt)
+static void testRaftSplit(KVStore & kvs, TMTContext & tmt, std::unique_ptr<MockRaftStoreProxy> & proxy_instance)
 {
     {
         auto region = kvs.getRegion(1);
@@ -310,7 +310,6 @@ void RegionKVStoreTest::testRaftSplit(KVStore & kvs, TMTContext & tmt)
 
         ASSERT_EQ(region->dataInfo(), "[write 2 lock 2 default 2 ]");
     }
-
     // Split region
     RegionID region_id = 1;
     RegionID region_id2 = 7;
@@ -340,13 +339,8 @@ void RegionKVStoreTest::testRaftSplit(KVStore & kvs, TMTContext & tmt)
     // 7 is persisted
     {
         kvs.handleDestroy(1, tmt);
-        {
-            auto task_lock = kvs.genTaskLock();
-            auto lock = kvs.genRegionMgrWriteLock(task_lock);
-            auto region = makeRegion(1, ori_source_range.first.key, ori_source_range.second.key);
-            lock.regions.emplace(1, region);
-            lock.index.add(region);
-        }
+        proxy_instance->debugAddRegions(kvs, tmt, {1}, {{ori_source_range.first.key, ori_source_range.second.key}});
+
         auto table_id = 1;
         auto region = kvs.getRegion(1);
         region->insert("lock", RecordKVFormat::genKey(table_id, 3), RecordKVFormat::encodeLockCfValue(RecordKVFormat::CFModifyFlag::PutFlag, "PK", 3, 20));
@@ -481,7 +475,7 @@ void RegionKVStoreTest::testRaftMerge(KVStore & kvs, TMTContext & tmt)
             // add 7 back
             auto task_lock = kvs.genTaskLock();
             auto lock = kvs.genRegionMgrWriteLock(task_lock);
-            auto region = makeRegion(7, RecordKVFormat::genKey(1, 0), RecordKVFormat::genKey(1, 5));
+            auto region = makeRegion(7, RecordKVFormat::genKey(1, 0), RecordKVFormat::genKey(1, 5), kvs.getProxyHelper());
             lock.regions.emplace(7, region);
             lock.index.add(region);
         }
@@ -540,7 +534,7 @@ TEST_F(RegionKVStoreTest, RegionReadWrite)
         ASSERT_EQ(region->dataInfo(), "[write 1 lock 1 default 1 ]");
         {
             // There is a lock.
-            auto iter = region->createCommittedScanner();
+            auto iter = region->createCommittedScanner(true, true);
             auto lock = iter.getLockInfo({100, nullptr});
             ASSERT_NE(lock, nullptr);
             auto k = lock->intoLockInfo();
@@ -556,7 +550,7 @@ TEST_F(RegionKVStoreTest, RegionReadWrite)
         ASSERT_EQ(0, region->writeCFCount());
         {
             region->remove("lock", RecordKVFormat::genKey(table_id, 3));
-            auto iter = region->createCommittedScanner();
+            auto iter = region->createCommittedScanner(true, true);
             auto lock = iter.getLockInfo({100, nullptr});
             ASSERT_EQ(lock, nullptr);
         }
@@ -780,7 +774,7 @@ TEST_F(RegionKVStoreTest, AdminSplit)
     KVStore & kvs = getKVS();
     proxy_instance->debugAddRegions(kvs, ctx.getTMTContext(), {1}, {{RecordKVFormat::genKey(1, 0), RecordKVFormat::genKey(1, 10)}});
     {
-        testRaftSplit(kvs, ctx.getTMTContext());
+        testRaftSplit(kvs, ctx.getTMTContext(), proxy_instance);
         ASSERT_EQ(kvs.handleAdminRaftCmd(raft_cmdpb::AdminRequest{}, raft_cmdpb::AdminResponse{}, 8192, 5, 6, ctx.getTMTContext()), EngineStoreApplyRes::NotFound);
     }
 }
@@ -888,7 +882,7 @@ try
     });
     // Initially region_19 range is [0, 10000)
     {
-        auto region = makeRegion(region_id, RecordKVFormat::genKey(table_id, 0), RecordKVFormat::genKey(table_id, 10000));
+        auto region = makeRegion(region_id, RecordKVFormat::genKey(table_id, 0), RecordKVFormat::genKey(table_id, 10000), kvs.getProxyHelper());
         GenMockSSTData(DMTestEnv::getMinimalTableInfo(table_id), table_id, region_id_str, 20, 100, 0);
         std::vector<SSTView> sst_views{
             SSTView{
@@ -907,6 +901,7 @@ try
                 SSTViewVec{sst_views.data(), sst_views.size()},
                 8,
                 5,
+                std::nullopt,
                 ctx.getTMTContext());
             ASSERT_EQ(kvs.getRegion(region_id)->checkIndex(8), true);
         }
@@ -922,7 +917,7 @@ try
     }
     // Later, its range is changed to [20000, 50000)
     {
-        auto region = makeRegion(region_id, RecordKVFormat::genKey(table_id, 20000), RecordKVFormat::genKey(table_id, 50000));
+        auto region = makeRegion(region_id, RecordKVFormat::genKey(table_id, 20000), RecordKVFormat::genKey(table_id, 50000), kvs.getProxyHelper());
         GenMockSSTData(DMTestEnv::getMinimalTableInfo(table_id), table_id, region_id_str, 20100, 20200, 0);
         std::vector<SSTView> sst_views{
             SSTView{
@@ -941,6 +936,7 @@ try
                 SSTViewVec{sst_views.data(), sst_views.size()},
                 9,
                 5,
+                std::nullopt,
                 ctx.getTMTContext());
             ASSERT_EQ(kvs.getRegion(region_id)->checkIndex(9), true);
         }
@@ -987,7 +983,7 @@ try
     ASSERT_NE(proxy_helper->sst_reader_interfaces.fn_key, nullptr);
     {
         auto region_id = 19;
-        auto region = makeRegion(region_id, RecordKVFormat::genKey(1, 50), RecordKVFormat::genKey(1, 60));
+        auto region = makeRegion(region_id, RecordKVFormat::genKey(1, 50), RecordKVFormat::genKey(1, 60), kvs.getProxyHelper());
         auto region_id_str = std::to_string(region_id);
         auto & mmp = MockSSTReader::getMockSSTData();
         MockSSTReader::getMockSSTData().clear();
@@ -1002,7 +998,7 @@ try
             ColumnFamilyType::Default,
             BaseBuffView{region_id_str.data(), region_id_str.length()},
         });
-        // Will reject a snapshot with snaller index.
+        // Will reject a snapshot with smaller index.
         {
             // Pre-handle snapshot to DTFiles is ignored because the table is dropped.
             kvs.handleApplySnapshot(
@@ -1011,6 +1007,7 @@ try
                 SSTViewVec{sst_views.data(), sst_views.size()},
                 8,
                 5,
+                std::nullopt,
                 ctx.getTMTContext());
             ASSERT_EQ(kvs.getRegion(region_id)->checkIndex(8), true);
             try
@@ -1021,6 +1018,7 @@ try
                     {}, // empty snap files
                     6, // smaller index
                     5,
+                    std::nullopt,
                     ctx.getTMTContext());
                 ASSERT_TRUE(false);
             }
@@ -1033,23 +1031,25 @@ try
         {
             // Snapshot will be rejected if region overlaps.
             {
-                auto region = makeRegion(22, RecordKVFormat::genKey(55, 50), RecordKVFormat::genKey(55, 100));
+                auto region = makeRegion(22, RecordKVFormat::genKey(55, 50), RecordKVFormat::genKey(55, 100), kvs.getProxyHelper());
                 auto ingest_ids = kvs.preHandleSnapshotToFiles(
                     region,
                     {},
                     9,
                     5,
+                    std::nullopt,
                     ctx.getTMTContext());
                 kvs.checkAndApplyPreHandledSnapshot<RegionPtrWithSnapshotFiles>(RegionPtrWithSnapshotFiles{region, std::move(ingest_ids)}, ctx.getTMTContext());
             }
             try
             {
-                auto region = makeRegion(20, RecordKVFormat::genKey(55, 50), RecordKVFormat::genKey(55, 100));
+                auto region = makeRegion(20, RecordKVFormat::genKey(55, 50), RecordKVFormat::genKey(55, 100), kvs.getProxyHelper());
                 auto ingest_ids = kvs.preHandleSnapshotToFiles(
                     region,
                     {},
                     9,
                     5,
+                    std::nullopt,
                     ctx.getTMTContext());
                 kvs.checkAndApplyPreHandledSnapshot<RegionPtrWithSnapshotFiles>(RegionPtrWithSnapshotFiles{region, std::move(ingest_ids)}, ctx.getTMTContext()); // overlap, but not tombstone
                 ASSERT_TRUE(false);
@@ -1063,20 +1063,22 @@ try
             {
                 // Applying snapshot will throw if proxy is not inited.
                 const auto * ori_ptr = proxy_helper->proxy_ptr.inner;
-                proxy_helper->proxy_ptr.inner = nullptr;
                 SCOPE_EXIT({
                     proxy_helper->proxy_ptr.inner = ori_ptr;
                 });
 
                 try
                 {
-                    auto region = makeRegion(20, RecordKVFormat::genKey(55, 50), RecordKVFormat::genKey(55, 100));
+                    auto region = makeRegion(20, RecordKVFormat::genKey(55, 50), RecordKVFormat::genKey(55, 100), kvs.getProxyHelper());
+                    // preHandleSnapshotToFiles will assert proxy_ptr is not null.
                     auto ingest_ids = kvs.preHandleSnapshotToFiles(
                         region,
                         {},
                         10,
                         5,
+                        std::nullopt,
                         ctx.getTMTContext());
+                    proxy_helper->proxy_ptr.inner = nullptr;
                     kvs.checkAndApplyPreHandledSnapshot<RegionPtrWithSnapshotFiles>(RegionPtrWithSnapshotFiles{region, std::move(ingest_ids)}, ctx.getTMTContext());
                     ASSERT_TRUE(false);
                 }
@@ -1093,12 +1095,13 @@ try
                     s.set_state(::raft_serverpb::PeerState::Tombstone);
                     s;
                 }));
-                auto region = makeRegion(20, RecordKVFormat::genKey(55, 50), RecordKVFormat::genKey(55, 100));
+                auto region = makeRegion(20, RecordKVFormat::genKey(55, 50), RecordKVFormat::genKey(55, 100), kvs.getProxyHelper());
                 auto ingest_ids = kvs.preHandleSnapshotToFiles(
                     region,
                     {},
                     10,
                     5,
+                    std::nullopt,
                     ctx.getTMTContext());
                 kvs.checkAndApplyPreHandledSnapshot<RegionPtrWithSnapshotFiles>(RegionPtrWithSnapshotFiles{region, std::move(ingest_ids)}, ctx.getTMTContext()); // overlap, tombstone, remove previous one
 

--- a/dbms/src/Storages/Transaction/tests/gtest_kvstore.cpp
+++ b/dbms/src/Storages/Transaction/tests/gtest_kvstore.cpp
@@ -342,7 +342,7 @@ void RegionKVStoreTest::testRaftSplit(KVStore & kvs, TMTContext & tmt)
         kvs.handleDestroy(1, tmt);
         {
             auto task_lock = kvs.genTaskLock();
-            auto lock = kvs.genRegionWriteLock(task_lock);
+            auto lock = kvs.genRegionMgrWriteLock(task_lock);
             auto region = makeRegion(1, ori_source_range.first.key, ori_source_range.second.key);
             lock.regions.emplace(1, region);
             lock.index.add(region);
@@ -480,7 +480,7 @@ void RegionKVStoreTest::testRaftMerge(KVStore & kvs, TMTContext & tmt)
         {
             // add 7 back
             auto task_lock = kvs.genTaskLock();
-            auto lock = kvs.genRegionWriteLock(task_lock);
+            auto lock = kvs.genRegionMgrWriteLock(task_lock);
             auto region = makeRegion(7, RecordKVFormat::genKey(1, 0), RecordKVFormat::genKey(1, 5));
             lock.regions.emplace(7, region);
             lock.index.add(region);
@@ -674,7 +674,7 @@ TEST_F(RegionKVStoreTest, Writes)
             }
             catch (Exception & e)
             {
-                ASSERT_EQ(e.message(), "Raw TiDB PK: 800000000000091D, Prewrite ts: 2333 can not found in default cf for key: 7480000000000000FF015F728000000000FF00091D0000000000FAFFFFFFFFFFFFFFFE");
+                ASSERT_EQ(e.message(), "Raw TiDB PK: 800000000000091D, Prewrite ts: 2333 can not found in default cf for key: 7480000000000000FF015F728000000000FF00091D0000000000FAFFFFFFFFFFFFFFFE, region_id: 1, applied: 5");
                 ASSERT_EQ(kvs.getRegion(1)->dataInfo(), "[write 1 lock 1 ]");
                 kvs.getRegion(1)->tryCompactionFilter(1000);
             }

--- a/dbms/src/Storages/Transaction/tests/gtest_kvstore.cpp
+++ b/dbms/src/Storages/Transaction/tests/gtest_kvstore.cpp
@@ -35,7 +35,7 @@ TEST_F(RegionKVStoreTest, NewProxy)
         }
     }
     {
-        kvs.tryPersist(1);
+        kvs.tryPersistRegion(1);
         kvs.gcRegionPersistedCache(Seconds{0});
     }
     {
@@ -796,7 +796,7 @@ TEST_F(RegionKVStoreTest, KVStore)
         }
     }
     {
-        kvs.tryPersist(1);
+        kvs.tryPersistRegion(1);
         kvs.gcRegionPersistedCache(Seconds{0});
     }
     {
@@ -1329,9 +1329,9 @@ TEST_F(RegionKVStoreTest, KVStoreRestore)
                 lock.index.add(region);
             }
         }
-        kvs.tryPersist(1);
-        kvs.tryPersist(2);
-        kvs.tryPersist(3);
+        kvs.tryPersistRegion(1);
+        kvs.tryPersistRegion(2);
+        kvs.tryPersistRegion(3);
     }
     {
         KVStore & kvs = reloadKVSFromDisk();

--- a/dbms/src/Storages/Transaction/tests/gtest_kvstore.cpp
+++ b/dbms/src/Storages/Transaction/tests/gtest_kvstore.cpp
@@ -18,21 +18,14 @@ namespace DB
 {
 namespace tests
 {
-TEST_F(RegionKVStoreTest, NewProxy)
+TEST_F(RegionKVStoreTest, PersistenceV1)
+try
 {
-    createDefaultRegions();
     auto ctx = TiFlashTestEnv::getGlobalContext();
-
     KVStore & kvs = getKVS();
     {
         ASSERT_EQ(kvs.getRegion(0), nullptr);
-        auto task_lock = kvs.genTaskLock();
-        auto lock = kvs.genRegionWriteLock(task_lock);
-        {
-            auto region = makeRegion(1, RecordKVFormat::genKey(1, 0), RecordKVFormat::genKey(1, 10));
-            lock.regions.emplace(1, region);
-            lock.index.add(region);
-        }
+        proxy_instance->bootstrapWithRegion(kvs, ctx.getTMTContext(), 1, std::nullopt);
     }
     {
         kvs.tryPersistRegion(1);
@@ -55,6 +48,7 @@ TEST_F(RegionKVStoreTest, NewProxy)
         ASSERT_EQ(kvs.tryFlushRegionData(1, false, false, ctx.getTMTContext(), 0, 0), false);
     }
 }
+CATCH
 
 TEST_F(RegionKVStoreTest, ReadIndex)
 {
@@ -71,25 +65,11 @@ TEST_F(RegionKVStoreTest, ReadIndex)
 
     {
         ASSERT_EQ(kvs.getRegion(0), nullptr);
-        auto task_lock = kvs.genTaskLock();
-        auto lock = kvs.genRegionWriteLock(task_lock);
-        {
-            auto region = makeRegion(1, RecordKVFormat::genKey(1, 0), RecordKVFormat::genKey(1, 10), kvs.getProxyHelper());
-            lock.regions.emplace(1, region);
-            lock.index.add(region);
-        }
-        {
-            auto region = makeRegion(2, RecordKVFormat::genKey(1, 10), RecordKVFormat::genKey(1, 20), kvs.getProxyHelper());
-            lock.regions.emplace(2, region);
-            lock.index.add(region);
-        }
-        {
-            auto region = makeRegion(3, RecordKVFormat::genKey(1, 30), RecordKVFormat::genKey(1, 40), kvs.getProxyHelper());
-            lock.regions.emplace(3, region);
-            lock.index.add(region);
-        }
+        proxy_instance->debugAddRegions(kvs, ctx.getTMTContext(), {1, 2, 3}, {{{RecordKVFormat::genKey(1, 0), RecordKVFormat::genKey(1, 10)}, {RecordKVFormat::genKey(1, 10), RecordKVFormat::genKey(1, 20)}, {RecordKVFormat::genKey(1, 30), RecordKVFormat::genKey(1, 40)}}});
     }
     {
+        // `read_index_worker_manager` is not set, fallback to v1.
+        // We don't support batch read index version 1 now
         ASSERT_EQ(kvs.read_index_worker_manager, nullptr);
         {
             auto region = kvs.getRegion(1);
@@ -110,22 +90,17 @@ TEST_F(RegionKVStoreTest, ReadIndex)
             },
             1);
         ASSERT_NE(kvs.read_index_worker_manager, nullptr);
-
+    }
+    {
         {
+            // Normal async notifier
             kvs.asyncRunReadIndexWorkers();
             SCOPE_EXIT({
                 kvs.stopReadIndexWorkers();
             });
 
-            auto tar_region_id = 9;
-            {
-                auto task_lock = kvs.genTaskLock();
-                auto lock = kvs.genRegionWriteLock(task_lock);
-
-                auto region = makeRegion(tar_region_id, RecordKVFormat::genKey(2, 0), RecordKVFormat::genKey(2, 10));
-                lock.regions.emplace(region->id(), region);
-                lock.index.add(region);
-            }
+            UInt64 tar_region_id = 9;
+            proxy_instance->debugAddRegions(kvs, ctx.getTMTContext(), {tar_region_id}, {{{RecordKVFormat::genKey(2, 0), RecordKVFormat::genKey(2, 10)}}});
             {
                 ASSERT_EQ(proxy_instance->regions.at(tar_region_id)->getLatestCommitIndex(), 5);
                 proxy_instance->regions.at(tar_region_id)->updateCommitIndex(66);
@@ -149,6 +124,7 @@ TEST_F(RegionKVStoreTest, ReadIndex)
                 EngineStoreApplyRes::None);
         }
         {
+            // Async notifier error
             kvs.asyncRunReadIndexWorkers();
             SCOPE_EXIT({
                 kvs.stopReadIndexWorkers();
@@ -175,15 +151,16 @@ TEST_F(RegionKVStoreTest, ReadIndex)
             ASSERT_EQ(notifier.blockedWaitFor(std::chrono::milliseconds(1000 * 3600)), AsyncNotifier::Status::Normal);
         }
 
+        // Test read index
+        // Note `batchReadIndex` always returns latest committed index in our mock class.
         kvs.asyncRunReadIndexWorkers();
         SCOPE_EXIT({
             kvs.stopReadIndexWorkers();
         });
 
         {
-            // test read index
             auto region = kvs.getRegion(1);
-            auto req = GenRegionReadIndexReq(*region, 8);
+            auto req = GenRegionReadIndexReq(*region, 8); // start_ts = 8
             auto resp = kvs.batchReadIndex({req}, 100);
             ASSERT_EQ(resp[0].first.read_index(), 5);
             {
@@ -200,10 +177,11 @@ TEST_F(RegionKVStoreTest, ReadIndex)
             r.second->updateCommitIndex(667);
         }
         {
+            // Found in `history_success_tasks`
             auto region = kvs.getRegion(1);
             auto req = GenRegionReadIndexReq(*region, 8);
             auto resp = kvs.batchReadIndex({req}, 100);
-            ASSERT_EQ(resp[0].first.read_index(), 5); // history
+            ASSERT_EQ(resp[0].first.read_index(), 5);
         }
         {
             auto region = kvs.getRegion(1);
@@ -221,6 +199,7 @@ TEST_F(RegionKVStoreTest, ReadIndex)
                 ASSERT_EQ(std::get<0>(r), WaitIndexResult::Timeout);
             }
             {
+                // Wait for a new index 667 + 1 to be applied
                 AsyncWaker::Notifier notifier;
                 std::thread t([&]() {
                     notifier.wake();
@@ -239,7 +218,7 @@ TEST_F(RegionKVStoreTest, ReadIndex)
     kvs.stopReadIndexWorkers();
     kvs.releaseReadIndexWorkers();
     over = true;
-    proxy_instance->wake();
+    proxy_instance->wakeNotifier();
     proxy_runner.join();
     ASSERT(GCMonitor::instance().checkClean());
     ASSERT(!GCMonitor::instance().empty());
@@ -252,19 +231,8 @@ void RegionKVStoreTest::testRaftMergeRollback(KVStore & kvs, TMTContext & tmt)
         auto source_region = kvs.getRegion(region_id);
         auto target_region = kvs.getRegion(1);
 
-        raft_cmdpb::AdminRequest request;
-        raft_cmdpb::AdminResponse response;
-        {
-            request.set_cmd_type(raft_cmdpb::AdminCmdType::PrepareMerge);
-            auto * prepare_merge = request.mutable_prepare_merge();
-            {
-                auto min_index = source_region->appliedIndex();
-                prepare_merge->set_min_index(min_index);
 
-                metapb::Region * target = prepare_merge->mutable_target();
-                *target = target_region->getMetaRegion();
-            }
-        }
+        auto && [request, response] = MockRaftStoreProxy::composePrepareMerge(target_region->cloneMetaRegion(), source_region->appliedIndex());
         kvs.handleAdminRaftCmd(std::move(request),
                                std::move(response),
                                region_id,
@@ -275,18 +243,7 @@ void RegionKVStoreTest::testRaftMergeRollback(KVStore & kvs, TMTContext & tmt)
     }
     {
         auto region = kvs.getRegion(region_id);
-
-        raft_cmdpb::AdminRequest request;
-        raft_cmdpb::AdminResponse response;
-        {
-            request.set_cmd_type(raft_cmdpb::AdminCmdType::RollbackMerge);
-
-            auto * rollback_merge = request.mutable_rollback_merge();
-            {
-                auto merge_state = region->getMergeState();
-                rollback_merge->set_commit(merge_state.commit());
-            }
-        }
+        auto && [request, response] = MockRaftStoreProxy::composeRollbackMerge(region->getMergeState().commit());
         region->setStateApplying();
 
         try
@@ -327,18 +284,7 @@ void RegionKVStoreTest::testRaftMergeRollback(KVStore & kvs, TMTContext & tmt)
     }
     {
         auto region = kvs.getRegion(region_id);
-
-        raft_cmdpb::AdminRequest request;
-        raft_cmdpb::AdminResponse response;
-        {
-            request.set_cmd_type(raft_cmdpb::AdminCmdType::RollbackMerge);
-
-            auto * rollback_merge = request.mutable_rollback_merge();
-            {
-                auto merge_state = region->getMergeState();
-                rollback_merge->set_commit(merge_state.commit());
-            }
-        }
+        auto && [request, response] = MockRaftStoreProxy::composeRollbackMerge(region->getMergeState().commit());
         kvs.handleAdminRaftCmd(std::move(request),
                                std::move(response),
                                region_id,
@@ -357,50 +303,20 @@ void RegionKVStoreTest::testRaftSplit(KVStore & kvs, TMTContext & tmt)
         region->insert("lock", RecordKVFormat::genKey(table_id, 3), RecordKVFormat::encodeLockCfValue(RecordKVFormat::CFModifyFlag::PutFlag, "PK", 3, 20));
         region->insert("default", RecordKVFormat::genKey(table_id, 3, 5), TiKVValue("value1"));
         region->insert("write", RecordKVFormat::genKey(table_id, 3, 8), RecordKVFormat::encodeWriteCfValue(RecordKVFormat::CFModifyFlag::PutFlag, 5));
+
         region->insert("lock", RecordKVFormat::genKey(table_id, 8), RecordKVFormat::encodeLockCfValue(RecordKVFormat::CFModifyFlag::PutFlag, "PK", 3, 20));
         region->insert("default", RecordKVFormat::genKey(table_id, 8, 5), TiKVValue("value1"));
         region->insert("write", RecordKVFormat::genKey(table_id, 8, 8), RecordKVFormat::encodeWriteCfValue(RecordKVFormat::CFModifyFlag::PutFlag, 5));
 
         ASSERT_EQ(region->dataInfo(), "[write 2 lock 2 default 2 ]");
     }
-    raft_cmdpb::AdminRequest request;
-    raft_cmdpb::AdminResponse response;
-    {
-        // split region
-        auto region_id = 1;
-        RegionID region_id2 = 7;
-        auto source_region = kvs.getRegion(region_id);
-        metapb::RegionEpoch new_epoch;
-        new_epoch.set_version(source_region->version() + 1);
-        new_epoch.set_conf_ver(source_region->confVer());
-        TiKVKey start_key1, start_key2, end_key1, end_key2;
-        {
-            start_key1 = RecordKVFormat::genKey(1, 5);
-            start_key2 = RecordKVFormat::genKey(1, 0);
-            end_key1 = RecordKVFormat::genKey(1, 10);
-            end_key2 = RecordKVFormat::genKey(1, 5);
-        }
-        {
-            request.set_cmd_type(raft_cmdpb::AdminCmdType::BatchSplit);
-            raft_cmdpb::BatchSplitResponse * splits = response.mutable_splits();
-            {
-                auto * region = splits->add_regions();
-                region->set_id(region_id);
-                region->set_start_key(start_key1);
-                region->set_end_key(end_key1);
-                region->add_peers();
-                *region->mutable_region_epoch() = new_epoch;
-            }
-            {
-                auto * region = splits->add_regions();
-                region->set_id(region_id2);
-                region->set_start_key(start_key2);
-                region->set_end_key(end_key2);
-                region->add_peers();
-                *region->mutable_region_epoch() = new_epoch;
-            }
-        }
-    }
+
+    // Split region
+    RegionID region_id = 1;
+    RegionID region_id2 = 7;
+    auto source_region = kvs.getRegion(region_id);
+    auto old_epoch = source_region->mutMeta().getMetaRegion().region_epoch();
+    auto && [request, response] = MockRaftStoreProxy::composeBatchSplit({region_id, region_id2}, {{RecordKVFormat::genKey(1, 5), RecordKVFormat::genKey(1, 10)}, {RecordKVFormat::genKey(1, 0), RecordKVFormat::genKey(1, 5)}}, old_epoch);
     kvs.handleAdminRaftCmd(raft_cmdpb::AdminRequest(request), raft_cmdpb::AdminResponse(response), 1, 20, 5, tmt);
     {
         auto mmp = kvs.getRegionsByRangeOverlap(RegionRangeKeys::makeComparableKeys(RecordKVFormat::genKey(1, 0), RecordKVFormat::genKey(1, 5)));
@@ -413,10 +329,11 @@ void RegionKVStoreTest::testRaftSplit(KVStore & kvs, TMTContext & tmt)
         ASSERT_EQ(mmp.size(), 1);
     }
     {
+        // We don't force migration of committed data from derived region to dm store.
         ASSERT_EQ(kvs.getRegion(1)->dataInfo(), "[write 1 lock 1 default 1 ]");
         ASSERT_EQ(kvs.getRegion(7)->dataInfo(), "[lock 1 ]");
     }
-    // rollback 1 to before split
+    // Rollback 1 to before split
     // 7 is persisted
     {
         kvs.handleDestroy(1, tmt);
@@ -439,12 +356,13 @@ void RegionKVStoreTest::testRaftSplit(KVStore & kvs, TMTContext & tmt)
         ASSERT_EQ(region->dataInfo(), "[write 2 lock 2 default 2 ]");
     }
     {
+        // Region 1 and 7 overlaps.
         auto mmp = kvs.getRegionsByRangeOverlap(RegionRangeKeys::makeComparableKeys(RecordKVFormat::genKey(1, 0), RecordKVFormat::genKey(1, 5)));
         ASSERT_TRUE(mmp.count(7) != 0);
         ASSERT_TRUE(mmp.count(1) != 0);
         ASSERT_EQ(mmp.size(), 2);
     }
-    // split again
+    // Split again
     kvs.handleAdminRaftCmd(raft_cmdpb::AdminRequest(request), raft_cmdpb::AdminResponse(response), 1, 20, 5, tmt);
     {
         auto mmp = kvs.getRegionsByRangeOverlap(RegionRangeKeys::makeComparableKeys(RecordKVFormat::genKey(1, 0), RecordKVFormat::genKey(1, 5)));
@@ -462,46 +380,12 @@ void RegionKVStoreTest::testRaftSplit(KVStore & kvs, TMTContext & tmt)
     }
 }
 
-void RegionKVStoreTest::testRaftChangePeer(KVStore & kvs, TMTContext & tmt)
-{
-    {
-        auto task_lock = kvs.genTaskLock();
-        auto lock = kvs.genRegionWriteLock(task_lock);
-        auto region = makeRegion(88, RecordKVFormat::genKey(1, 0), RecordKVFormat::genKey(1, 100));
-        lock.regions.emplace(88, region);
-        lock.index.add(region);
-    }
-    {
-        raft_cmdpb::AdminRequest request;
-        raft_cmdpb::AdminResponse response;
-        request.set_cmd_type(raft_cmdpb::AdminCmdType::ChangePeer);
-        auto meta = kvs.getRegion(88)->getMetaRegion();
-        meta.mutable_peers()->Clear();
-        meta.add_peers()->set_id(2);
-        meta.add_peers()->set_id(4);
-        *response.mutable_change_peer()->mutable_region() = meta;
-        kvs.handleAdminRaftCmd(raft_cmdpb::AdminRequest(request), raft_cmdpb::AdminResponse(response), 88, 6, 5, tmt);
-        ASSERT_NE(kvs.getRegion(88), nullptr);
-    }
-    {
-        raft_cmdpb::AdminRequest request;
-        raft_cmdpb::AdminResponse response;
-        request.set_cmd_type(raft_cmdpb::AdminCmdType::ChangePeerV2);
-        auto meta = kvs.getRegion(88)->getMetaRegion();
-        meta.mutable_peers()->Clear();
-        meta.add_peers()->set_id(3);
-        meta.add_peers()->set_id(4);
-        *response.mutable_change_peer()->mutable_region() = meta;
-        kvs.handleAdminRaftCmd(raft_cmdpb::AdminRequest(request), raft_cmdpb::AdminResponse(response), 88, 7, 5, tmt);
-        ASSERT_EQ(kvs.getRegion(88), nullptr);
-    }
-}
-
 void RegionKVStoreTest::testRaftMerge(KVStore & kvs, TMTContext & tmt)
 {
     {
+        auto region_id = 7;
         kvs.getRegion(1)->clearAllData();
-        kvs.getRegion(7)->clearAllData();
+        kvs.getRegion(region_id)->clearAllData();
 
         {
             auto region = kvs.getRegion(1);
@@ -512,7 +396,7 @@ void RegionKVStoreTest::testRaftMerge(KVStore & kvs, TMTContext & tmt)
             ASSERT_EQ(region->dataInfo(), "[write 1 lock 1 default 1 ]");
         }
         {
-            auto region = kvs.getRegion(7);
+            auto region = kvs.getRegion(region_id);
             auto table_id = 1;
             region->insert("lock", RecordKVFormat::genKey(table_id, 2), RecordKVFormat::encodeLockCfValue(RecordKVFormat::CFModifyFlag::PutFlag, "PK", 3, 20));
             region->insert("default", RecordKVFormat::genKey(table_id, 2, 5), TiKVValue("value1"));
@@ -525,23 +409,7 @@ void RegionKVStoreTest::testRaftMerge(KVStore & kvs, TMTContext & tmt)
         auto region_id = 7;
         auto source_region = kvs.getRegion(region_id);
         auto target_region = kvs.getRegion(1);
-
-        raft_cmdpb::AdminRequest request;
-        raft_cmdpb::AdminResponse response;
-
-        {
-            request.set_cmd_type(raft_cmdpb::AdminCmdType::PrepareMerge);
-
-            auto * prepare_merge = request.mutable_prepare_merge();
-            {
-                auto min_index = source_region->appliedIndex();
-                prepare_merge->set_min_index(min_index);
-
-                metapb::Region * target = prepare_merge->mutable_target();
-                *target = target_region->getMetaRegion();
-            }
-        }
-
+        auto && [request, response] = MockRaftStoreProxy::composePrepareMerge(target_region->cloneMetaRegion(), source_region->appliedIndex());
         kvs.handleAdminRaftCmd(std::move(request),
                                std::move(response),
                                source_region->id(),
@@ -554,15 +422,8 @@ void RegionKVStoreTest::testRaftMerge(KVStore & kvs, TMTContext & tmt)
     {
         auto source_id = 7, target_id = 1;
         auto source_region = kvs.getRegion(source_id);
-        raft_cmdpb::AdminRequest request;
-        {
-            request.set_cmd_type(raft_cmdpb::AdminCmdType::CommitMerge);
-            auto * commit_merge = request.mutable_commit_merge();
-            {
-                commit_merge->set_commit(source_region->appliedIndex());
-                *commit_merge->mutable_source() = source_region->getMetaRegion();
-            }
-        }
+
+        auto && [request, response] = MockRaftStoreProxy::composeCommitMerge(source_region->cloneMetaRegion(), source_region->appliedIndex());
         source_region->setStateApplying();
         source_region->makeRaftCommandDelegate(kvs.genTaskLock());
         const auto & source_region_meta_delegate = source_region->meta.makeRaftCommandDelegate();
@@ -593,17 +454,7 @@ void RegionKVStoreTest::testRaftMerge(KVStore & kvs, TMTContext & tmt)
     {
         auto source_id = 7, target_id = 1;
         auto source_region = kvs.getRegion(source_id);
-        raft_cmdpb::AdminRequest request;
-        raft_cmdpb::AdminResponse response;
-
-        {
-            request.set_cmd_type(raft_cmdpb::AdminCmdType::CommitMerge);
-            auto * commit_merge = request.mutable_commit_merge();
-            {
-                commit_merge->set_commit(source_region->appliedIndex());
-                *commit_merge->mutable_source() = source_region->getMetaRegion();
-            }
-        }
+        auto && [request, response] = MockRaftStoreProxy::composeCommitMerge(source_region->cloneMetaRegion(), source_region->appliedIndex());
         {
             auto mmp = kvs.getRegionsByRangeOverlap(RegionRangeKeys::makeComparableKeys(TiKVKey(""), TiKVKey("")));
             ASSERT_TRUE(mmp.count(target_id) != 0);
@@ -652,19 +503,22 @@ void RegionKVStoreTest::testRaftMerge(KVStore & kvs, TMTContext & tmt)
     }
 }
 
-TEST_F(RegionKVStoreTest, Region)
+TEST_F(RegionKVStoreTest, RegionReadWrite)
 {
-    createDefaultRegions();
+    auto ctx = TiFlashTestEnv::getGlobalContext();
     TableID table_id = 100;
+    KVStore & kvs = getKVS();
+    UInt64 region_id = 1;
+    proxy_instance->bootstrapWithRegion(kvs, ctx.getTMTContext(), region_id, std::make_optional(std::make_pair(RecordKVFormat::genKey(table_id, 0), RecordKVFormat::genKey(table_id, 1000))));
+    auto region = kvs.getRegion(region_id);
     {
+        // Test create RegionMeta.
         auto meta = RegionMeta(createPeer(2, true), createRegionInfo(666, RecordKVFormat::genKey(0, 0), RecordKVFormat::genKey(0, 1000)), initialApplyState());
         ASSERT_EQ(meta.peerId(), 2);
     }
-    auto region = makeRegion(1, RecordKVFormat::genKey(table_id, 0), RecordKVFormat::genKey(table_id, 1000));
     {
+        // Test GenRegionReadIndexReq.
         ASSERT_TRUE(region->checkIndex(5));
-    }
-    {
         auto start_ts = 199;
         auto req = GenRegionReadIndexReq(*region, start_ts);
         ASSERT_EQ(req.ranges().size(), 1);
@@ -675,12 +529,14 @@ TEST_F(RegionKVStoreTest, Region)
         ASSERT_EQ(region->getRange()->comparableKeys().second.key, req.ranges()[0].end_key());
     }
     {
+        // Test read committed and lock with CommittedScanner.
         region->insert("lock", RecordKVFormat::genKey(table_id, 3), RecordKVFormat::encodeLockCfValue(RecordKVFormat::CFModifyFlag::PutFlag, "PK", 3, 20));
         region->insert("default", RecordKVFormat::genKey(table_id, 3, 5), TiKVValue("value1"));
         region->insert("write", RecordKVFormat::genKey(table_id, 3, 8), RecordKVFormat::encodeWriteCfValue(RecordKVFormat::CFModifyFlag::PutFlag, 5));
         ASSERT_EQ(1, region->writeCFCount());
         ASSERT_EQ(region->dataInfo(), "[write 1 lock 1 default 1 ]");
         {
+            // There is a lock.
             auto iter = region->createCommittedScanner();
             auto lock = iter.getLockInfo({100, nullptr});
             ASSERT_NE(lock, nullptr);
@@ -688,6 +544,7 @@ TEST_F(RegionKVStoreTest, Region)
             ASSERT_EQ(k->lock_version(), 3);
         }
         {
+            // The record is committed since there is a write record.
             std::optional<RegionDataReadInfoList> data_list_read = ReadRegionCommitCache(region, true);
             ASSERT_TRUE(data_list_read);
             ASSERT_EQ(1, data_list_read->size());
@@ -703,6 +560,7 @@ TEST_F(RegionKVStoreTest, Region)
         region->clearAllData();
     }
     {
+        // Test duplicate and tryCompactionFilter
         region->insert("write", RecordKVFormat::genKey(table_id, 3, 8), RecordKVFormat::encodeWriteCfValue(RecordKVFormat::CFModifyFlag::PutFlag, 5));
         ASSERT_EQ(region->dataInfo(), "[write 1 ]");
 
@@ -719,10 +577,11 @@ TEST_F(RegionKVStoreTest, Region)
         }
         ASSERT_EQ(ori_size, region->dataSize());
 
-        region->tryCompactionFilter(100);
+        region->tryCompactionFilter(101);
         ASSERT_EQ(region->dataInfo(), "[]");
     }
     {
+        // Test read and delete committed Del record.
         region->insert("write", RecordKVFormat::genKey(table_id, 4, 8), RecordKVFormat::encodeWriteCfValue(RecordKVFormat::CFModifyFlag::DelFlag, 5));
         ASSERT_EQ(1, region->writeCFCount());
         region->remove("write", RecordKVFormat::genKey(table_id, 4, 8));
@@ -737,20 +596,17 @@ TEST_F(RegionKVStoreTest, Region)
     }
     {
         ASSERT_EQ(0, region->dataSize());
-
         region->insert("default", RecordKVFormat::genKey(table_id, 3, 5), TiKVValue("value1"));
         ASSERT_LT(0, region->dataSize());
-
         region->remove("default", RecordKVFormat::genKey(table_id, 3, 5));
         ASSERT_EQ(0, region->dataSize());
-
         // remove duplicate records
         region->remove("default", RecordKVFormat::genKey(table_id, 3, 5));
         ASSERT_EQ(0, region->dataSize());
     }
 }
 
-TEST_F(RegionKVStoreTest, KVStore)
+TEST_F(RegionKVStoreTest, Writes)
 {
     createDefaultRegions();
     auto ctx = TiFlashTestEnv::getGlobalContext();
@@ -758,7 +614,6 @@ TEST_F(RegionKVStoreTest, KVStore)
     KVStore & kvs = getKVS();
     {
         // Run without read-index workers
-
         kvs.initReadIndexWorkers(
             []() {
                 return std::chrono::milliseconds(10);
@@ -770,46 +625,32 @@ TEST_F(RegionKVStoreTest, KVStore)
         kvs.releaseReadIndexWorkers();
     }
     {
+        // Test set set id
         auto store = metapb::Store{};
-        store.set_id(1234);
+        store.set_id(2345);
         kvs.setStore(store);
         ASSERT_EQ(kvs.getStoreID(), store.id());
     }
     {
         ASSERT_EQ(kvs.getRegion(0), nullptr);
-        auto task_lock = kvs.genTaskLock();
-        auto lock = kvs.genRegionWriteLock(task_lock);
-        {
-            auto region = makeRegion(1, RecordKVFormat::genKey(1, 0), RecordKVFormat::genKey(1, 10));
-            lock.regions.emplace(1, region);
-            lock.index.add(region);
-        }
-        {
-            auto region = makeRegion(2, RecordKVFormat::genKey(1, 10), RecordKVFormat::genKey(1, 20));
-            lock.regions.emplace(2, region);
-            lock.index.add(region);
-        }
-        {
-            auto region = makeRegion(3, RecordKVFormat::genKey(1, 30), RecordKVFormat::genKey(1, 40));
-            lock.regions.emplace(3, region);
-            lock.index.add(region);
-        }
+        proxy_instance->debugAddRegions(kvs, ctx.getTMTContext(), {1, 2, 3}, {{{RecordKVFormat::genKey(1, 0), RecordKVFormat::genKey(1, 10)}, {RecordKVFormat::genKey(1, 10), RecordKVFormat::genKey(1, 20)}, {RecordKVFormat::genKey(1, 30), RecordKVFormat::genKey(1, 40)}}});
     }
     {
+        // Test gc region persister
         kvs.tryPersistRegion(1);
         kvs.gcRegionPersistedCache(Seconds{0});
     }
     {
+        // Check region range
         ASSERT_EQ(kvs.regionSize(), 3);
         auto mmp = kvs.getRegionsByRangeOverlap(RegionRangeKeys::makeComparableKeys(RecordKVFormat::genKey(1, 15), TiKVKey("")));
         ASSERT_EQ(mmp.size(), 2);
         kvs.handleDestroy(3, ctx.getTMTContext());
         kvs.handleDestroy(3, ctx.getTMTContext());
-    }
-    {
-        RegionMap mmp = kvs.getRegionsByRangeOverlap(RegionRangeKeys::makeComparableKeys(RecordKVFormat::genKey(1, 15), TiKVKey("")));
-        ASSERT_EQ(mmp.size(), 1);
-        ASSERT_EQ(mmp.at(2)->id(), 2);
+
+        RegionMap mmp2 = kvs.getRegionsByRangeOverlap(RegionRangeKeys::makeComparableKeys(RecordKVFormat::genKey(1, 15), TiKVKey("")));
+        ASSERT_EQ(mmp2.size(), 1);
+        ASSERT_EQ(mmp2.at(2)->id(), 2);
     }
     {
         {
@@ -926,223 +767,59 @@ TEST_F(RegionKVStoreTest, KVStore)
         kvs.handleDestroy(2, ctx.getTMTContext());
         ASSERT_EQ(kvs.regionSize(), 1);
     }
+}
+
+
+TEST_F(RegionKVStoreTest, AdminSplit)
+{
+    createDefaultRegions();
+    auto ctx = TiFlashTestEnv::getGlobalContext();
+    KVStore & kvs = getKVS();
+    proxy_instance->debugAddRegions(kvs, ctx.getTMTContext(), {1}, {{RecordKVFormat::genKey(1, 0), RecordKVFormat::genKey(1, 10)}});
     {
         testRaftSplit(kvs, ctx.getTMTContext());
         ASSERT_EQ(kvs.handleAdminRaftCmd(raft_cmdpb::AdminRequest{}, raft_cmdpb::AdminResponse{}, 8192, 5, 6, ctx.getTMTContext()), EngineStoreApplyRes::NotFound);
     }
-    {
-        ASSERT_EQ(kvs.handleAdminRaftCmd(raft_cmdpb::AdminRequest{}, raft_cmdpb::AdminResponse{}, 8192, 5, 6, ctx.getTMTContext()), EngineStoreApplyRes::NotFound);
-    }
-    {
-        raft_cmdpb::AdminRequest request;
-        raft_cmdpb::AdminResponse response;
+}
 
-        request.mutable_compact_log();
-        request.set_cmd_type(::raft_cmdpb::AdminCmdType::CompactLog);
-        raft_cmdpb::AdminResponse first_response = response;
-        ASSERT_EQ(kvs.handleAdminRaftCmd(raft_cmdpb::AdminRequest{request}, std::move(first_response), 7, 22, 6, ctx.getTMTContext()), EngineStoreApplyRes::Persist);
+TEST_F(RegionKVStoreTest, AdminMerge)
+{
+    createDefaultRegions();
+    auto ctx = TiFlashTestEnv::getGlobalContext();
+    KVStore & kvs = getKVS();
+    proxy_instance->debugAddRegions(kvs, ctx.getTMTContext(), {1, 7}, {{RecordKVFormat::genKey(1, 0), RecordKVFormat::genKey(1, 5)}, {RecordKVFormat::genKey(1, 5), RecordKVFormat::genKey(1, 10)}});
 
-        raft_cmdpb::AdminResponse second_response = response;
-        ASSERT_EQ(kvs.handleAdminRaftCmd(raft_cmdpb::AdminRequest{request}, std::move(second_response), 7, 23, 6, ctx.getTMTContext()), EngineStoreApplyRes::Persist);
-
-        request.set_cmd_type(::raft_cmdpb::AdminCmdType::ComputeHash);
-        raft_cmdpb::AdminResponse third_response = response;
-        ASSERT_EQ(kvs.handleAdminRaftCmd(raft_cmdpb::AdminRequest{request}, std::move(third_response), 7, 24, 6, ctx.getTMTContext()), EngineStoreApplyRes::None);
-
-        request.set_cmd_type(::raft_cmdpb::AdminCmdType::VerifyHash);
-        raft_cmdpb::AdminResponse fourth_response = response;
-        ASSERT_EQ(kvs.handleAdminRaftCmd(raft_cmdpb::AdminRequest{request}, std::move(fourth_response), 7, 25, 6, ctx.getTMTContext()), EngineStoreApplyRes::None);
-
-        raft_cmdpb::AdminResponse fifth_response = response;
-        ASSERT_EQ(kvs.handleAdminRaftCmd(raft_cmdpb::AdminRequest{request}, std::move(fifth_response), 8192, 5, 6, ctx.getTMTContext()), EngineStoreApplyRes::NotFound);
-        {
-            kvs.setRegionCompactLogConfig(0, 0, 0);
-            request.set_cmd_type(::raft_cmdpb::AdminCmdType::CompactLog);
-            ASSERT_EQ(kvs.handleAdminRaftCmd(std::move(request), std::move(response), 7, 26, 6, ctx.getTMTContext()), EngineStoreApplyRes::Persist);
-        }
-    }
     {
         testRaftMergeRollback(kvs, ctx.getTMTContext());
         testRaftMerge(kvs, ctx.getTMTContext());
     }
-    {
-        testRaftChangePeer(kvs, ctx.getTMTContext());
-    }
-    {
-        auto region_id = 19;
-        auto region = makeRegion(region_id, RecordKVFormat::genKey(1, 50), RecordKVFormat::genKey(1, 60));
-        auto region_id_str = std::to_string(region_id);
-        auto & mmp = MockSSTReader::getMockSSTData();
-        MockSSTReader::getMockSSTData().clear();
-        MockSSTReader::Data default_kv_list;
-        {
-            default_kv_list.emplace_back(RecordKVFormat::genKey(1, 55, 5).getStr(), TiKVValue("value1").getStr());
-            default_kv_list.emplace_back(RecordKVFormat::genKey(1, 58, 5).getStr(), TiKVValue("value2").getStr());
-        }
-        mmp[MockSSTReader::Key{region_id_str, ColumnFamilyType::Default}] = std::move(default_kv_list);
-        std::vector<SSTView> sst_views;
-        sst_views.push_back(SSTView{
-            ColumnFamilyType::Default,
-            BaseBuffView{region_id_str.data(), region_id_str.length()},
-        });
-        {
-            RegionMockTest mock_test(kvstore.get(), region);
-
-            kvs.handleApplySnapshot(
-                region->getMetaRegion(),
-                2,
-                SSTViewVec{sst_views.data(), sst_views.size()},
-                8,
-                5,
-                ctx.getTMTContext());
-            ASSERT_EQ(kvs.getRegion(region_id)->checkIndex(8), true);
-            try
-            {
-                kvs.handleApplySnapshot(
-                    region->getMetaRegion(),
-                    2,
-                    {}, // empty
-                    6, // smaller index
-                    5,
-                    ctx.getTMTContext());
-                ASSERT_TRUE(false);
-            }
-            catch (Exception & e)
-            {
-                ASSERT_EQ(e.message(), fmt::format("[region {}] already has newer apply-index 8 than 6, should not happen", region_id));
-            }
-        }
-
-        {
-            {
-                auto region = makeRegion(22, RecordKVFormat::genKey(55, 50), RecordKVFormat::genKey(55, 100));
-                auto ingest_ids = kvs.preHandleSnapshotToFiles(
-                    region,
-                    {},
-                    9,
-                    5,
-                    ctx.getTMTContext());
-                kvs.checkAndApplyPreHandledSnapshot<RegionPtrWithSnapshotFiles>(RegionPtrWithSnapshotFiles{region, std::move(ingest_ids)}, ctx.getTMTContext());
-            }
-            try
-            {
-                auto region = makeRegion(20, RecordKVFormat::genKey(55, 50), RecordKVFormat::genKey(55, 100));
-                auto ingest_ids = kvs.preHandleSnapshotToFiles(
-                    region,
-                    {},
-                    9,
-                    5,
-                    ctx.getTMTContext());
-                kvs.checkAndApplyPreHandledSnapshot<RegionPtrWithSnapshotFiles>(RegionPtrWithSnapshotFiles{region, std::move(ingest_ids)}, ctx.getTMTContext()); // overlap, but not tombstone
-                ASSERT_TRUE(false);
-            }
-            catch (Exception & e)
-            {
-                ASSERT_EQ(e.message(), "range of region 20 is overlapped with 22, state: region { id: 22 }");
-            }
-
-            {
-                const auto * ori_ptr = proxy_helper->proxy_ptr.inner;
-                proxy_helper->proxy_ptr.inner = nullptr;
-                SCOPE_EXIT({
-                    proxy_helper->proxy_ptr.inner = ori_ptr;
-                });
-
-                try
-                {
-                    auto region = makeRegion(20, RecordKVFormat::genKey(55, 50), RecordKVFormat::genKey(55, 100));
-                    auto ingest_ids = kvs.preHandleSnapshotToFiles(
-                        region,
-                        {},
-                        10,
-                        5,
-                        ctx.getTMTContext());
-                    kvs.checkAndApplyPreHandledSnapshot<RegionPtrWithSnapshotFiles>(RegionPtrWithSnapshotFiles{region, std::move(ingest_ids)}, ctx.getTMTContext());
-                    ASSERT_TRUE(false);
-                }
-                catch (Exception & e)
-                {
-                    ASSERT_EQ(e.message(), "getRegionLocalState meet internal error: RaftStoreProxyPtr is none");
-                }
-            }
-
-            {
-                proxy_instance->getRegion(22)->setSate(({
-                    raft_serverpb::RegionLocalState s;
-                    s.set_state(::raft_serverpb::PeerState::Tombstone);
-                    s;
-                }));
-                auto region = makeRegion(20, RecordKVFormat::genKey(55, 50), RecordKVFormat::genKey(55, 100));
-                auto ingest_ids = kvs.preHandleSnapshotToFiles(
-                    region,
-                    {},
-                    10,
-                    5,
-                    ctx.getTMTContext());
-                kvs.checkAndApplyPreHandledSnapshot<RegionPtrWithSnapshotFiles>(RegionPtrWithSnapshotFiles{region, std::move(ingest_ids)}, ctx.getTMTContext()); // overlap, tombstone, remove previous one
-
-                auto state = proxy_helper->getRegionLocalState(8192);
-                ASSERT_EQ(state.state(), raft_serverpb::PeerState::Tombstone);
-            }
-
-            kvs.handleDestroy(20, ctx.getTMTContext());
-        }
-    }
-
-    {
-        auto region_id = 19;
-        auto region_id_str = std::to_string(region_id);
-        auto & mmp = MockSSTReader::getMockSSTData();
-        MockSSTReader::getMockSSTData().clear();
-        MockSSTReader::Data default_kv_list;
-        {
-            default_kv_list.emplace_back(RecordKVFormat::genKey(1, 55, 5).getStr(), TiKVValue("value1").getStr());
-            default_kv_list.emplace_back(RecordKVFormat::genKey(1, 58, 5).getStr(), TiKVValue("value2").getStr());
-        }
-        mmp[MockSSTReader::Key{region_id_str, ColumnFamilyType::Default}] = std::move(default_kv_list);
-
-        // Mock SST data for handle [star, end)
-        auto region = kvs.getRegion(region_id);
-
-        RegionMockTest mock_test(kvstore.get(), region);
-
-        {
-            // Mocking ingest a SST for column family "Write"
-            std::vector<SSTView> sst_views;
-            sst_views.push_back(SSTView{
-                ColumnFamilyType::Default,
-                BaseBuffView{region_id_str.data(), region_id_str.length()},
-            });
-            kvs.handleIngestSST(
-                region_id,
-                SSTViewVec{sst_views.data(), sst_views.size()},
-                100,
-                1,
-                ctx.getTMTContext());
-            ASSERT_EQ(kvs.getRegion(region_id)->checkIndex(100), true);
-        }
-    }
-
-    {
-        raft_cmdpb::AdminRequest request;
-        raft_cmdpb::AdminResponse response;
-
-        request.mutable_compact_log();
-        request.set_cmd_type(::raft_cmdpb::AdminCmdType::InvalidAdmin);
-
-        try
-        {
-            kvs.handleAdminRaftCmd(std::move(request), std::move(response), 1, 110, 6, ctx.getTMTContext());
-            ASSERT_TRUE(false);
-        }
-        catch (Exception & e)
-        {
-            ASSERT_EQ(e.message(), "unsupported admin command type InvalidAdmin");
-        }
-    }
 }
 
 
+TEST_F(RegionKVStoreTest, AdminChangePeer)
+{
+    UInt64 region_id = 88;
+    auto ctx = TiFlashTestEnv::getGlobalContext();
+    auto & kvs = getKVS();
+    {
+        proxy_instance->bootstrapWithRegion(kvs, ctx.getTMTContext(), region_id, std::make_optional(std::make_pair(RecordKVFormat::genKey(1, 0), RecordKVFormat::genKey(1, 100))));
+    }
+    {
+        auto meta = kvs.getRegion(region_id)->cloneMetaRegion();
+        auto && [request, response] = MockRaftStoreProxy::composeChangePeer(std::move(meta), {2, 4}, false);
+        kvs.handleAdminRaftCmd(std::move(request), std::move(response), region_id, 6, 5, ctx.getTMTContext());
+        ASSERT_NE(kvs.getRegion(region_id), nullptr);
+    }
+    {
+        auto meta = kvs.getRegion(region_id)->cloneMetaRegion();
+        auto && [request, response] = MockRaftStoreProxy::composeChangePeer(std::move(meta), {3, 4});
+        kvs.handleAdminRaftCmd(std::move(request), std::move(response), region_id, 7, 5, ctx.getTMTContext());
+        ASSERT_EQ(kvs.getRegion(region_id), nullptr);
+    }
+}
+
+// TODO Use test utils in new KVStore test for snapshot test.
+// Otherwise data will not actually be inserted.
 class ApplySnapshotTest
     : public RegionKVStoreTest
     , public testing::WithParamInterface<bool /* ingest_using_split */>
@@ -1223,7 +900,7 @@ try
             RegionMockTest mock_test(kvstore.get(), region);
 
             kvs.handleApplySnapshot(
-                region->getMetaRegion(),
+                region->cloneMetaRegion(),
                 2,
                 SSTViewVec{sst_views.data(), sst_views.size()},
                 8,
@@ -1259,7 +936,7 @@ try
             RegionMockTest mock_test(kvstore.get(), region);
 
             kvs.handleApplySnapshot(
-                region->getMetaRegion(),
+                region->cloneMetaRegion(),
                 2,
                 SSTViewVec{sst_views.data(), sst_views.size()},
                 9,
@@ -1276,14 +953,9 @@ try
     }
     // Finally, the region is migrated out
     {
-        raft_cmdpb::AdminRequest request;
-        raft_cmdpb::AdminResponse response;
-        request.set_cmd_type(raft_cmdpb::AdminCmdType::ChangePeerV2);
-        auto meta = kvs.getRegion(region_id)->getMetaRegion();
-        meta.mutable_peers()->Clear();
-        meta.add_peers()->set_id(3);
-        *response.mutable_change_peer()->mutable_region() = meta;
-        kvs.handleAdminRaftCmd(raft_cmdpb::AdminRequest(request), raft_cmdpb::AdminResponse(response), region_id, 10, 6, ctx.getTMTContext());
+        auto meta = kvs.getRegion(region_id)->cloneMetaRegion();
+        auto && [request, response] = MockRaftStoreProxy::composeChangePeer(std::move(meta), {3});
+        kvs.handleAdminRaftCmd(std::move(request), std::move(response), region_id, 10, 6, ctx.getTMTContext());
         ASSERT_EQ(kvs.getRegion(region_id), nullptr);
     }
     {
@@ -1305,29 +977,181 @@ try
 }
 CATCH
 
-TEST_F(RegionKVStoreTest, KVStoreRestore)
+TEST_F(RegionKVStoreTest, Ingests)
+try
 {
+    createDefaultRegions();
+    auto ctx = TiFlashTestEnv::getGlobalContext();
+    KVStore & kvs = getKVS();
+    // In this test we only deal with meta,
+    ASSERT_EQ(proxy_helper->sst_reader_interfaces.fn_key, nullptr);
+    {
+        auto region_id = 19;
+        auto region = makeRegion(region_id, RecordKVFormat::genKey(1, 50), RecordKVFormat::genKey(1, 60));
+        auto region_id_str = std::to_string(region_id);
+        auto & mmp = MockSSTReader::getMockSSTData();
+        MockSSTReader::getMockSSTData().clear();
+        MockSSTReader::Data default_kv_list;
+        {
+            default_kv_list.emplace_back(RecordKVFormat::genKey(1, 55, 5).getStr(), TiKVValue("value1").getStr());
+            default_kv_list.emplace_back(RecordKVFormat::genKey(1, 58, 5).getStr(), TiKVValue("value2").getStr());
+        }
+        mmp[MockSSTReader::Key{region_id_str, ColumnFamilyType::Default}] = std::move(default_kv_list);
+        std::vector<SSTView> sst_views;
+        sst_views.push_back(SSTView{
+            ColumnFamilyType::Default,
+            BaseBuffView{region_id_str.data(), region_id_str.length()},
+        });
+        // Will reject a snapshot with snaller index.
+        {
+            // Pre-handle snapshot to DTFiles is ignored because the table is dropped.
+            kvs.handleApplySnapshot(
+                region->cloneMetaRegion(),
+                2,
+                SSTViewVec{sst_views.data(), sst_views.size()},
+                8,
+                5,
+                ctx.getTMTContext());
+            ASSERT_EQ(kvs.getRegion(region_id)->checkIndex(8), true);
+            try
+            {
+                kvs.handleApplySnapshot(
+                    region->cloneMetaRegion(),
+                    2,
+                    {}, // empty snap files
+                    6, // smaller index
+                    5,
+                    ctx.getTMTContext());
+                ASSERT_TRUE(false);
+            }
+            catch (Exception & e)
+            {
+                ASSERT_EQ(e.message(), fmt::format("[region {}] already has newer apply-index 8 than 6, should not happen", region_id));
+            }
+        }
+
+        {
+            // Snapshot will be rejected if region overlaps.
+            {
+                auto region = makeRegion(22, RecordKVFormat::genKey(55, 50), RecordKVFormat::genKey(55, 100));
+                auto ingest_ids = kvs.preHandleSnapshotToFiles(
+                    region,
+                    {},
+                    9,
+                    5,
+                    ctx.getTMTContext());
+                kvs.checkAndApplyPreHandledSnapshot<RegionPtrWithSnapshotFiles>(RegionPtrWithSnapshotFiles{region, std::move(ingest_ids)}, ctx.getTMTContext());
+            }
+            try
+            {
+                auto region = makeRegion(20, RecordKVFormat::genKey(55, 50), RecordKVFormat::genKey(55, 100));
+                auto ingest_ids = kvs.preHandleSnapshotToFiles(
+                    region,
+                    {},
+                    9,
+                    5,
+                    ctx.getTMTContext());
+                kvs.checkAndApplyPreHandledSnapshot<RegionPtrWithSnapshotFiles>(RegionPtrWithSnapshotFiles{region, std::move(ingest_ids)}, ctx.getTMTContext()); // overlap, but not tombstone
+                ASSERT_TRUE(false);
+            }
+            catch (Exception & e)
+            {
+                ASSERT_EQ(e.message(), "range of region 20 is overlapped with 22, state: region { id: 22 }");
+            }
+        }
+        {
+            {
+                // Applying snapshot will throw if proxy is not inited.
+                const auto * ori_ptr = proxy_helper->proxy_ptr.inner;
+                proxy_helper->proxy_ptr.inner = nullptr;
+                SCOPE_EXIT({
+                    proxy_helper->proxy_ptr.inner = ori_ptr;
+                });
+
+                try
+                {
+                    auto region = makeRegion(20, RecordKVFormat::genKey(55, 50), RecordKVFormat::genKey(55, 100));
+                    auto ingest_ids = kvs.preHandleSnapshotToFiles(
+                        region,
+                        {},
+                        10,
+                        5,
+                        ctx.getTMTContext());
+                    kvs.checkAndApplyPreHandledSnapshot<RegionPtrWithSnapshotFiles>(RegionPtrWithSnapshotFiles{region, std::move(ingest_ids)}, ctx.getTMTContext());
+                    ASSERT_TRUE(false);
+                }
+                catch (Exception & e)
+                {
+                    ASSERT_EQ(e.message(), "getRegionLocalState meet internal error: RaftStoreProxyPtr is none");
+                }
+            }
+
+            {
+                // A snapshot can set region to Tombstone.
+                proxy_instance->getRegion(22)->setSate(({
+                    raft_serverpb::RegionLocalState s;
+                    s.set_state(::raft_serverpb::PeerState::Tombstone);
+                    s;
+                }));
+                auto region = makeRegion(20, RecordKVFormat::genKey(55, 50), RecordKVFormat::genKey(55, 100));
+                auto ingest_ids = kvs.preHandleSnapshotToFiles(
+                    region,
+                    {},
+                    10,
+                    5,
+                    ctx.getTMTContext());
+                kvs.checkAndApplyPreHandledSnapshot<RegionPtrWithSnapshotFiles>(RegionPtrWithSnapshotFiles{region, std::move(ingest_ids)}, ctx.getTMTContext()); // overlap, tombstone, remove previous one
+
+                auto state = proxy_helper->getRegionLocalState(8192);
+                ASSERT_EQ(state.state(), raft_serverpb::PeerState::Tombstone);
+            }
+
+            kvs.handleDestroy(20, ctx.getTMTContext());
+        }
+    }
+
+    {
+        auto region_id = 19;
+        auto region_id_str = std::to_string(region_id);
+        auto & mmp = MockSSTReader::getMockSSTData();
+        MockSSTReader::getMockSSTData().clear();
+        MockSSTReader::Data default_kv_list;
+        {
+            default_kv_list.emplace_back(RecordKVFormat::genKey(1, 55, 5).getStr(), TiKVValue("value1").getStr());
+            default_kv_list.emplace_back(RecordKVFormat::genKey(1, 58, 5).getStr(), TiKVValue("value2").getStr());
+        }
+        mmp[MockSSTReader::Key{region_id_str, ColumnFamilyType::Default}] = std::move(default_kv_list);
+
+        // Mock SST data for handle [start, end)
+        auto region = kvs.getRegion(region_id);
+
+        {
+            // Mocking ingest a SST for column family "Write"
+            std::vector<SSTView> sst_views;
+            sst_views.push_back(SSTView{
+                ColumnFamilyType::Default,
+                BaseBuffView{region_id_str.data(), region_id_str.length()},
+            });
+            kvs.handleIngestSST(
+                region_id,
+                SSTViewVec{sst_views.data(), sst_views.size()},
+                100,
+                1,
+                ctx.getTMTContext());
+            ASSERT_EQ(kvs.getRegion(region_id)->checkIndex(100), true);
+        }
+    }
+}
+CATCH
+
+TEST_F(RegionKVStoreTest, Restore)
+{
+    auto ctx = TiFlashTestEnv::getGlobalContext();
     {
         KVStore & kvs = getKVS();
         {
             ASSERT_EQ(kvs.getRegion(0), nullptr);
-            auto task_lock = kvs.genTaskLock();
-            auto lock = kvs.genRegionWriteLock(task_lock);
-            {
-                auto region = makeRegion(1, RecordKVFormat::genKey(1, 0), RecordKVFormat::genKey(1, 10));
-                lock.regions.emplace(1, region);
-                lock.index.add(region);
-            }
-            {
-                auto region = makeRegion(2, RecordKVFormat::genKey(1, 10), RecordKVFormat::genKey(1, 20));
-                lock.regions.emplace(2, region);
-                lock.index.add(region);
-            }
-            {
-                auto region = makeRegion(3, RecordKVFormat::genKey(1, 30), RecordKVFormat::genKey(1, 40));
-                lock.regions.emplace(3, region);
-                lock.index.add(region);
-            }
+            proxy_instance->debugAddRegions(kvs, ctx.getTMTContext(), {1, 2, 3}, {{{RecordKVFormat::genKey(1, 0), RecordKVFormat::genKey(1, 10)}, {RecordKVFormat::genKey(1, 10), RecordKVFormat::genKey(1, 20)}, {RecordKVFormat::genKey(1, 30), RecordKVFormat::genKey(1, 40)}}});
         }
         kvs.tryPersistRegion(1);
         kvs.tryPersistRegion(2);
@@ -1341,57 +1165,13 @@ TEST_F(RegionKVStoreTest, KVStoreRestore)
     }
 }
 
-void test_mergeresult()
-{
-    ASSERT_EQ(MetaRaftCommandDelegate::computeRegionMergeResult(createRegionInfo(1, "x", ""), createRegionInfo(1000, "", "x")).source_at_left, false);
-    ASSERT_EQ(MetaRaftCommandDelegate::computeRegionMergeResult(createRegionInfo(1, "", "x"), createRegionInfo(1000, "x", "")).source_at_left, true);
-    ASSERT_EQ(MetaRaftCommandDelegate::computeRegionMergeResult(createRegionInfo(1, "x", "y"), createRegionInfo(1000, "y", "z")).source_at_left, true);
-    ASSERT_EQ(MetaRaftCommandDelegate::computeRegionMergeResult(createRegionInfo(1, "y", "z"), createRegionInfo(1000, "x", "y")).source_at_left, false);
-
-    {
-        RegionState region_state;
-        bool source_at_left;
-        RegionState source_region_state;
-
-        region_state.setStartKey(RecordKVFormat::genKey(1, 0));
-        region_state.setEndKey(RecordKVFormat::genKey(1, 10));
-
-        source_region_state.setStartKey(RecordKVFormat::genKey(1, 10));
-        source_region_state.setEndKey(RecordKVFormat::genKey(1, 20));
-
-        source_at_left = false;
-
-        ChangeRegionStateRange(region_state, source_at_left, source_region_state);
-
-        ASSERT_EQ(region_state.getRange()->comparableKeys().first.key, RecordKVFormat::genKey(1, 0));
-        ASSERT_EQ(region_state.getRange()->comparableKeys().second.key, RecordKVFormat::genKey(1, 20));
-    }
-    {
-        RegionState region_state;
-        bool source_at_left;
-        RegionState source_region_state;
-
-        region_state.setStartKey(RecordKVFormat::genKey(2, 5));
-        region_state.setEndKey(RecordKVFormat::genKey(2, 10));
-
-        source_region_state.setStartKey(RecordKVFormat::genKey(2, 0));
-        source_region_state.setEndKey(RecordKVFormat::genKey(2, 5));
-
-        source_at_left = true;
-
-        ChangeRegionStateRange(region_state, source_at_left, source_region_state);
-
-        ASSERT_EQ(region_state.getRange()->comparableKeys().first.key, RecordKVFormat::genKey(2, 0));
-        ASSERT_EQ(region_state.getRange()->comparableKeys().second.key, RecordKVFormat::genKey(2, 10));
-    }
-}
-
-TEST_F(RegionKVStoreTest, Basic)
+TEST_F(RegionKVStoreTest, RegionRange)
 {
     {
+        // Test findByRangeOverlap.
         RegionsRangeIndex region_index;
         const auto & root_map = region_index.getRoot();
-        ASSERT_EQ(root_map.size(), 2);
+        ASSERT_EQ(root_map.size(), 2); // start and end all equals empty
 
         region_index.add(makeRegion(1, RecordKVFormat::genKey(1, 0), RecordKVFormat::genKey(1, 10)));
 
@@ -1405,8 +1185,10 @@ TEST_F(RegionKVStoreTest, Basic)
 
         region_index.add(makeRegion(4, RecordKVFormat::genKey(1, 1), RecordKVFormat::genKey(1, 4)));
 
+        // -inf,0,1,3,4,10,inf
         ASSERT_EQ(root_map.size(), 7);
 
+        // 1,2,3,4
         res = region_index.findByRangeOverlap(RegionRangeKeys::makeComparableKeys(TiKVKey(""), TiKVKey("")));
         ASSERT_EQ(res.size(), 4);
 
@@ -1440,6 +1222,7 @@ TEST_F(RegionKVStoreTest, Basic)
     }
 
     {
+        // Test add and remove.
         RegionsRangeIndex region_index;
         const auto & root_map = region_index.getRoot();
         try
@@ -1529,8 +1312,51 @@ TEST_F(RegionKVStoreTest, Basic)
         region_index.remove(RegionRangeKeys::makeComparableKeys(RecordKVFormat::genKey(1, 1), RecordKVFormat::genKey(1, 2)), 2);
         ASSERT_EQ(root_map.size(), 2);
     }
+    // Test region range with merge.
     {
-        test_mergeresult();
+        {
+            // Compute `source_at_left` by region range.
+            ASSERT_EQ(MetaRaftCommandDelegate::computeRegionMergeResult(createRegionInfo(1, "x", ""), createRegionInfo(1000, "", "x")).source_at_left, false);
+            ASSERT_EQ(MetaRaftCommandDelegate::computeRegionMergeResult(createRegionInfo(1, "", "x"), createRegionInfo(1000, "x", "")).source_at_left, true);
+            ASSERT_EQ(MetaRaftCommandDelegate::computeRegionMergeResult(createRegionInfo(1, "x", "y"), createRegionInfo(1000, "y", "z")).source_at_left, true);
+            ASSERT_EQ(MetaRaftCommandDelegate::computeRegionMergeResult(createRegionInfo(1, "y", "z"), createRegionInfo(1000, "x", "y")).source_at_left, false);
+        }
+        {
+            RegionState region_state;
+            bool source_at_left;
+            RegionState source_region_state;
+
+            region_state.setStartKey(RecordKVFormat::genKey(1, 0));
+            region_state.setEndKey(RecordKVFormat::genKey(1, 10));
+
+            source_region_state.setStartKey(RecordKVFormat::genKey(1, 10));
+            source_region_state.setEndKey(RecordKVFormat::genKey(1, 20));
+
+            source_at_left = false;
+
+            ChangeRegionStateRange(region_state, source_at_left, source_region_state);
+
+            ASSERT_EQ(region_state.getRange()->comparableKeys().first.key, RecordKVFormat::genKey(1, 0));
+            ASSERT_EQ(region_state.getRange()->comparableKeys().second.key, RecordKVFormat::genKey(1, 20));
+        }
+        {
+            RegionState region_state;
+            bool source_at_left;
+            RegionState source_region_state;
+
+            region_state.setStartKey(RecordKVFormat::genKey(2, 5));
+            region_state.setEndKey(RecordKVFormat::genKey(2, 10));
+
+            source_region_state.setStartKey(RecordKVFormat::genKey(2, 0));
+            source_region_state.setEndKey(RecordKVFormat::genKey(2, 5));
+
+            source_at_left = true;
+
+            ChangeRegionStateRange(region_state, source_at_left, source_region_state);
+
+            ASSERT_EQ(region_state.getRange()->comparableKeys().first.key, RecordKVFormat::genKey(2, 0));
+            ASSERT_EQ(region_state.getRange()->comparableKeys().second.key, RecordKVFormat::genKey(2, 10));
+        }
     }
 }
 

--- a/dbms/src/Storages/Transaction/tests/gtest_kvstore.cpp
+++ b/dbms/src/Storages/Transaction/tests/gtest_kvstore.cpp
@@ -55,7 +55,7 @@ TEST_F(RegionKVStoreTest, ReadIndex)
     createDefaultRegions();
     auto ctx = TiFlashTestEnv::getGlobalContext();
 
-    // start mock proxy in other thread
+    // Start mock proxy in other thread
     std::atomic_bool over{false};
     auto proxy_runner = std::thread([&]() {
         proxy_instance->testRunNormal(over);
@@ -316,15 +316,18 @@ void RegionKVStoreTest::testRaftSplit(KVStore & kvs, TMTContext & tmt)
     RegionID region_id2 = 7;
     auto source_region = kvs.getRegion(region_id);
     auto old_epoch = source_region->mutMeta().getMetaRegion().region_epoch();
-    auto && [request, response] = MockRaftStoreProxy::composeBatchSplit({region_id, region_id2}, {{RecordKVFormat::genKey(1, 5), RecordKVFormat::genKey(1, 10)}, {RecordKVFormat::genKey(1, 0), RecordKVFormat::genKey(1, 5)}}, old_epoch);
+    auto & ori_source_range = source_region->getRange()->comparableKeys();
+    RegionRangeKeys::RegionRange new_source_range = RegionRangeKeys::makeComparableKeys(RecordKVFormat::genKey(1, 5), RecordKVFormat::genKey(1, 10));
+    RegionRangeKeys::RegionRange new_target_range = RegionRangeKeys::makeComparableKeys(RecordKVFormat::genKey(1, 0), RecordKVFormat::genKey(1, 5));
+    auto && [request, response] = MockRaftStoreProxy::composeBatchSplit({region_id, region_id2}, regionRangeToEncodeKeys(new_source_range, new_target_range), old_epoch);
     kvs.handleAdminRaftCmd(raft_cmdpb::AdminRequest(request), raft_cmdpb::AdminResponse(response), 1, 20, 5, tmt);
     {
-        auto mmp = kvs.getRegionsByRangeOverlap(RegionRangeKeys::makeComparableKeys(RecordKVFormat::genKey(1, 0), RecordKVFormat::genKey(1, 5)));
+        auto mmp = kvs.getRegionsByRangeOverlap(new_target_range);
         ASSERT_TRUE(mmp.count(7) != 0);
         ASSERT_EQ(mmp.size(), 1);
     }
     {
-        auto mmp = kvs.getRegionsByRangeOverlap(RegionRangeKeys::makeComparableKeys(RecordKVFormat::genKey(1, 5), RecordKVFormat::genKey(1, 10)));
+        auto mmp = kvs.getRegionsByRangeOverlap(new_source_range);
         ASSERT_TRUE(mmp.count(1) != 0);
         ASSERT_EQ(mmp.size(), 1);
     }
@@ -340,7 +343,7 @@ void RegionKVStoreTest::testRaftSplit(KVStore & kvs, TMTContext & tmt)
         {
             auto task_lock = kvs.genTaskLock();
             auto lock = kvs.genRegionWriteLock(task_lock);
-            auto region = makeRegion(1, RecordKVFormat::genKey(1, 0), RecordKVFormat::genKey(1, 10));
+            auto region = makeRegion(1, ori_source_range.first.key, ori_source_range.second.key);
             lock.regions.emplace(1, region);
             lock.index.add(region);
         }
@@ -357,7 +360,7 @@ void RegionKVStoreTest::testRaftSplit(KVStore & kvs, TMTContext & tmt)
     }
     {
         // Region 1 and 7 overlaps.
-        auto mmp = kvs.getRegionsByRangeOverlap(RegionRangeKeys::makeComparableKeys(RecordKVFormat::genKey(1, 0), RecordKVFormat::genKey(1, 5)));
+        auto mmp = kvs.getRegionsByRangeOverlap(new_target_range);
         ASSERT_TRUE(mmp.count(7) != 0);
         ASSERT_TRUE(mmp.count(1) != 0);
         ASSERT_EQ(mmp.size(), 2);
@@ -365,12 +368,12 @@ void RegionKVStoreTest::testRaftSplit(KVStore & kvs, TMTContext & tmt)
     // Split again
     kvs.handleAdminRaftCmd(raft_cmdpb::AdminRequest(request), raft_cmdpb::AdminResponse(response), 1, 20, 5, tmt);
     {
-        auto mmp = kvs.getRegionsByRangeOverlap(RegionRangeKeys::makeComparableKeys(RecordKVFormat::genKey(1, 0), RecordKVFormat::genKey(1, 5)));
+        auto mmp = kvs.getRegionsByRangeOverlap(new_target_range);
         ASSERT_TRUE(mmp.count(7) != 0);
         ASSERT_EQ(mmp.size(), 1);
     }
     {
-        auto mmp = kvs.getRegionsByRangeOverlap(RegionRangeKeys::makeComparableKeys(RecordKVFormat::genKey(1, 5), RecordKVFormat::genKey(1, 10)));
+        auto mmp = kvs.getRegionsByRangeOverlap(new_source_range);
         ASSERT_TRUE(mmp.count(1) != 0);
         ASSERT_EQ(mmp.size(), 1);
     }
@@ -850,6 +853,7 @@ try
     auto table_id = 101;
     auto region_id = 19;
     auto region_id_str = std::to_string(region_id);
+    ASSERT_NE(proxy_helper->sst_reader_interfaces.fn_key, nullptr);
 
     auto settings_backup = ctx.getGlobalContext().getSettings();
     ctx.getGlobalContext().getSettingsRef().dt_segment_limit_rows = 50;
@@ -897,8 +901,6 @@ try
             },
         };
         {
-            RegionMockTest mock_test(kvstore.get(), region);
-
             kvs.handleApplySnapshot(
                 region->cloneMetaRegion(),
                 2,
@@ -933,8 +935,6 @@ try
             },
         };
         {
-            RegionMockTest mock_test(kvstore.get(), region);
-
             kvs.handleApplySnapshot(
                 region->cloneMetaRegion(),
                 2,
@@ -983,8 +983,8 @@ try
     createDefaultRegions();
     auto ctx = TiFlashTestEnv::getGlobalContext();
     KVStore & kvs = getKVS();
-    // In this test we only deal with meta,
-    ASSERT_EQ(proxy_helper->sst_reader_interfaces.fn_key, nullptr);
+    // In this test we only deal with meta though,
+    ASSERT_NE(proxy_helper->sst_reader_interfaces.fn_key, nullptr);
     {
         auto region_id = 19;
         auto region = makeRegion(region_id, RecordKVFormat::genKey(1, 50), RecordKVFormat::genKey(1, 60));
@@ -1167,6 +1167,15 @@ TEST_F(RegionKVStoreTest, Restore)
 
 TEST_F(RegionKVStoreTest, RegionRange)
 {
+    {
+        // Test util functions.
+        RegionsRangeIndex region_index;
+        region_index.split(TiKVRangeKey::makeTiKVRangeKey<true>(TiKVKey()));
+        region_index.split(TiKVRangeKey::makeTiKVRangeKey<false>(TiKVKey()));
+        region_index.tryMergeEmpty();
+        const auto & root_map = region_index.getRoot();
+        ASSERT_EQ(root_map.size(), 2);
+    }
     {
         // Test findByRangeOverlap.
         RegionsRangeIndex region_index;

--- a/dbms/src/Storages/Transaction/tests/gtest_kvstore_fast_add_peer.cpp
+++ b/dbms/src/Storages/Transaction/tests/gtest_kvstore_fast_add_peer.cpp
@@ -189,7 +189,7 @@ try
     KVStore & kvs = getKVS();
     auto page_storage = global_context.getWriteNodePageStorage();
 
-    proxy_instance->bootstrap(kvs, global_context.getTMTContext(), region_id, std::nullopt);
+    proxy_instance->bootstrapWithRegion(kvs, global_context.getTMTContext(), region_id, std::nullopt);
     auto region = proxy_instance->getRegion(region_id);
     auto store_id = kvs.getStore().store_id.load();
     region->addPeer(store_id, peer_id, metapb::PeerRole::Learner);

--- a/dbms/src/Storages/Transaction/tests/gtest_new_kvstore.cpp
+++ b/dbms/src/Storages/Transaction/tests/gtest_new_kvstore.cpp
@@ -507,7 +507,39 @@ try
 CATCH
 
 
-TEST_F(RegionKVStoreTest, KVStoreSnapshotV2)
+TEST_F(RegionKVStoreTest, KVStoreSnapshotV2Extra)
+try
+{
+    auto ctx = TiFlashTestEnv::getGlobalContext();
+    ASSERT_NE(proxy_helper->sst_reader_interfaces.fn_key, nullptr);
+    UInt64 region_id = 2;
+    TableID table_id;
+    {
+        std::string start_str = "7480000000000000FF795F720000000000FA";
+        std::string end_str = "7480000000000000FF795F720380000000FF0000004003800000FF0000017FCC000000FC";
+        auto start = Redact::hexStringToKey(start_str.data(), start_str.size());
+        auto end = Redact::hexStringToKey(end_str.data(), end_str.size());
+
+        initStorages();
+        KVStore & kvs = getKVS();
+        table_id = proxy_instance->bootstrapTable(ctx, kvs, ctx.getTMTContext());
+        proxy_instance->bootstrapWithRegion(kvs, ctx.getTMTContext(), region_id, std::make_pair(start, end));
+        auto kvr1 = kvs.getRegion(region_id);
+        auto r1 = proxy_instance->getRegion(region_id);
+    }
+    KVStore & kvs = getKVS();
+    {
+        std::string k = "7480000000000000FF795F720380000000FF0000026303800000FF0000017801000000FCF9DE534E2797FB83";
+        MockRaftStoreProxy::Cf write_cf{region_id, table_id, ColumnFamilyType::Write};
+        write_cf.insert_raw(Redact::hexStringToKey(k.data(), k.size()), "v1");
+        write_cf.finish_file(SSTFormatKind::KIND_TABLET);
+        write_cf.freeze();
+        validate(kvs, proxy_instance, region_id, write_cf, ColumnFamilyType::Write, 1, 0);
+    }
+}
+CATCH
+
+TEST_F(RegionKVStoreTest, KVStoreSnapshotV2Basic)
 try
 {
     auto ctx = TiFlashTestEnv::getGlobalContext();

--- a/dbms/src/Storages/Transaction/tests/gtest_new_kvstore.cpp
+++ b/dbms/src/Storages/Transaction/tests/gtest_new_kvstore.cpp
@@ -40,7 +40,7 @@ try
             proxy_instance->doApply(kvs, ctx.getTMTContext(), cond, region_id, index);
             ASSERT_EQ(r1->getLatestAppliedIndex(), applied_index + 1);
             ASSERT_EQ(kvr1->appliedIndex(), applied_index + 1);
-            kvs.tryPersist(region_id);
+            kvs.tryPersistRegion(region_id);
         }
         {
             const KVStore & kvs = reloadKVSFromDisk();
@@ -70,7 +70,7 @@ try
             proxy_instance->doApply(kvs, ctx.getTMTContext(), cond, region_id, index);
             ASSERT_EQ(r1->getLatestAppliedIndex(), applied_index);
             ASSERT_EQ(kvr1->appliedIndex(), applied_index);
-            kvs.tryPersist(region_id);
+            kvs.tryPersistRegion(region_id);
         }
         {
             KVStore & kvs = reloadKVSFromDisk();
@@ -103,7 +103,7 @@ try
             proxy_instance->doApply(kvs, ctx.getTMTContext(), cond, region_id, index);
             ASSERT_EQ(r1->getLatestAppliedIndex(), applied_index);
             ASSERT_EQ(kvr1->appliedIndex(), applied_index);
-            kvs.tryPersist(region_id);
+            kvs.tryPersistRegion(region_id);
         }
         {
             KVStore & kvs = reloadKVSFromDisk();
@@ -135,7 +135,7 @@ try
             proxy_instance->doApply(kvs, ctx.getTMTContext(), cond, region_id, index);
             ASSERT_EQ(r1->getLatestAppliedIndex(), applied_index);
             ASSERT_EQ(kvr1->appliedIndex(), applied_index + 1);
-            kvs.tryPersist(region_id);
+            kvs.tryPersistRegion(region_id);
         }
         {
             MockRaftStoreProxy::FailCond cond;

--- a/dbms/src/Storages/Transaction/tests/gtest_new_kvstore.cpp
+++ b/dbms/src/Storages/Transaction/tests/gtest_new_kvstore.cpp
@@ -218,7 +218,8 @@ try
 
             kvr1->markCompactLog();
             kvs.setRegionCompactLogConfig(0, 0, 0);
-            auto [index2, term2] = proxy_instance->compactLog(region_id, index);
+            auto && [request, response] = MockRaftStoreProxy::composeCompactLog(r1, index);
+            auto && [index2, term2] = proxy_instance->adminCommand(region_id, std::move(request), std::move(response));
             // In tryFlushRegionData we will call handleWriteRaftCmd, which will already cause an advance.
             // Notice kvs is not tmt->getKVStore(), so we can't use the ProxyFFI version.
             ASSERT_TRUE(kvs.tryFlushRegionData(region_id, false, true, ctx.getTMTContext(), index2, term));
@@ -404,7 +405,7 @@ try
                 validate(kvs, proxy_instance, region_id, default_cf, ColumnFamilyType::Default, 3, 6);
 
                 kvs.mutProxyHelperUnsafe()->sst_reader_interfaces = make_mock_sst_reader_interface();
-                proxy_instance->snapshot(kvs, ctx.getTMTContext(), region_id, {default_cf}, 0, 0);
+                proxy_instance->snapshot(kvs, ctx.getTMTContext(), region_id, {default_cf}, 0, 0, std::nullopt);
 
                 MockRaftStoreProxy::FailCond cond;
                 {
@@ -427,7 +428,7 @@ try
                 default_cf.freeze();
 
                 kvs.mutProxyHelperUnsafe()->sst_reader_interfaces = make_mock_sst_reader_interface();
-                proxy_instance->snapshot(kvs, ctx.getTMTContext(), region_id, {default_cf}, 0, 0);
+                proxy_instance->snapshot(kvs, ctx.getTMTContext(), region_id, {default_cf}, 0, 0, std::nullopt);
 
                 MockRaftStoreProxy::FailCond cond;
                 {
@@ -455,7 +456,7 @@ try
                 write_cf.freeze();
 
                 kvs.mutProxyHelperUnsafe()->sst_reader_interfaces = make_mock_sst_reader_interface();
-                proxy_instance->snapshot(kvs, ctx.getTMTContext(), region_id, {default_cf, write_cf}, 0, 0);
+                proxy_instance->snapshot(kvs, ctx.getTMTContext(), region_id, {default_cf, write_cf}, 0, 0, std::nullopt);
 
                 MockRaftStoreProxy::FailCond cond;
                 {
@@ -481,7 +482,7 @@ try
 
                 kvs.mutProxyHelperUnsafe()->sst_reader_interfaces = make_mock_sst_reader_interface();
                 // Shall not panic.
-                proxy_instance->snapshot(kvs, ctx.getTMTContext(), region_id, {default_cf, write_cf}, 0, 0);
+                proxy_instance->snapshot(kvs, ctx.getTMTContext(), region_id, {default_cf, write_cf}, 0, 0, std::nullopt);
             }
             {
                 // Test of ingesting duplicated key with different values.
@@ -499,7 +500,7 @@ try
 
                 kvs.mutProxyHelperUnsafe()->sst_reader_interfaces = make_mock_sst_reader_interface();
                 // Found existing key ...
-                EXPECT_THROW(proxy_instance->snapshot(kvs, ctx.getTMTContext(), region_id, {default_cf, write_cf}, 0, 0), Exception);
+                EXPECT_THROW(proxy_instance->snapshot(kvs, ctx.getTMTContext(), region_id, {default_cf, write_cf}, 0, 0, std::nullopt), Exception);
             }
         }
     }
@@ -558,7 +559,7 @@ try
             // Shall filter out of range kvs.
             // RegionDefaultCFDataTrait will "reconstruct" TiKVKey, without table_id, it is correct since different tables ares in different regions.
             // so we may find conflict if we set the same handle_id here.
-            // hall we remove this constraint?
+            // Shall we remove this constraint?
             auto klo = RecordKVFormat::genKey(table_id - 1, 1, 111);
             auto klo2 = RecordKVFormat::genKey(table_id - 1, 9999, 222);
             auto kro = RecordKVFormat::genKey(table_id + 1, 0, 333);
@@ -586,7 +587,7 @@ try
             validate(kvs, proxy_instance, region_id, write_cf, ColumnFamilyType::Write, 1, 0);
 
             proxy_helper->sst_reader_interfaces = make_mock_sst_reader_interface();
-            proxy_instance->snapshot(kvs, ctx.getTMTContext(), region_id, {default_cf, write_cf}, 0, 0);
+            proxy_instance->snapshot(kvs, ctx.getTMTContext(), region_id, {default_cf, write_cf}, 0, 0, std::nullopt);
             MockRaftStoreProxy::FailCond cond;
             {
                 auto [index, term] = proxy_instance->rawWrite(region_id, {klo}, {"v1"}, {WriteCmdType::Put}, {ColumnFamilyType::Default});
@@ -671,6 +672,174 @@ try
     auto mvcc_query_info2 = MvccQueryInfo(false, 10);
     mvcc_query_info2.regions_query_info.emplace_back(1, kvr1->version(), kvr1->confVer(), table_id, kvr1->getRange()->rawKeys());
     validateQueryInfo(mvcc_query_info2, regions_snapshot, ctx.getTMTContext(), log);
+}
+CATCH
+
+TEST_F(RegionKVStoreTest, KVStoreExtraDataSnapshot1)
+try
+{
+    auto ctx = TiFlashTestEnv::getGlobalContext();
+    proxy_instance->cluster_ver = RaftstoreVer::V2;
+    ASSERT_NE(proxy_helper->sst_reader_interfaces.fn_key, nullptr);
+    UInt64 region_id = 1;
+    TableID table_id;
+    {
+        region_id = 2;
+        initStorages();
+        KVStore & kvs = getKVS();
+        // ctx.getTMTContext().debugSetKVStore(kvstore);
+        table_id = proxy_instance->bootstrapTable(ctx, kvs, ctx.getTMTContext());
+        auto start = RecordKVFormat::genKey(table_id, 0);
+        auto end = RecordKVFormat::genKey(table_id, 10);
+        proxy_instance->bootstrapWithRegion(kvs, ctx.getTMTContext(), region_id, std::make_pair(start.toString(), end.toString()));
+        auto r1 = proxy_instance->getRegion(region_id);
+
+        // See `decodeWriteCfValue`.
+        auto [value_write, value_default] = proxy_instance->generateTiKVKeyValue(111, 999);
+
+        {
+            auto k1 = RecordKVFormat::genKey(table_id, 1, 111);
+            auto k2 = RecordKVFormat::genKey(table_id, 2, 111);
+            MockSSTReader::getMockSSTData().clear();
+            MockRaftStoreProxy::Cf default_cf{region_id, table_id, ColumnFamilyType::Default};
+            default_cf.insert_raw(k1, value_default);
+            default_cf.finish_file(SSTFormatKind::KIND_TABLET);
+            default_cf.freeze();
+            MockRaftStoreProxy::Cf write_cf{region_id, table_id, ColumnFamilyType::Write};
+            write_cf.insert_raw(k1, value_write);
+            write_cf.insert_raw(k2, value_write);
+            write_cf.finish_file(SSTFormatKind::KIND_TABLET);
+            write_cf.freeze();
+
+            auto kvr1 = proxy_instance->snapshot(kvs, ctx.getTMTContext(), region_id, {default_cf, write_cf}, 0, 0, std::nullopt);
+            ASSERT_EQ(kvr1->orphanKeysInfo().remainedKeyCount(), 1);
+            ASSERT_EQ(kvr1->writeCFCount(), 1); // k2
+        }
+        MockRaftStoreProxy::FailCond cond;
+        {
+            // Add a new key to trigger another row2col transform.
+            auto kvr1 = kvs.getRegion(region_id);
+            auto k = RecordKVFormat::genKey(table_id, 3, 111);
+            auto [index, term] = proxy_instance->rawWrite(region_id, {k}, {value_default}, {WriteCmdType::Put}, {ColumnFamilyType::Default});
+            auto [index2, term2] = proxy_instance->rawWrite(region_id, {k}, {value_write}, {WriteCmdType::Put}, {ColumnFamilyType::Write});
+            proxy_instance->doApply(kvs, ctx.getTMTContext(), cond, region_id, index);
+            proxy_instance->doApply(kvs, ctx.getTMTContext(), cond, region_id, index2);
+            ASSERT_EQ(kvr1->orphanKeysInfo().remainedKeyCount(), 1);
+            ASSERT_EQ(kvr1->writeCFCount(), 1); // k2
+            UNUSED(term);
+            UNUSED(term2);
+        }
+        {
+            // A normal write to "save" the orphan key.
+            auto k2 = RecordKVFormat::genKey(table_id, 2, 111);
+            auto kvr1 = kvs.getRegion(region_id);
+            auto [index, term] = proxy_instance->rawWrite(region_id, {k2}, {value_default}, {WriteCmdType::Put}, {ColumnFamilyType::Default});
+            proxy_instance->doApply(kvs, ctx.getTMTContext(), cond, region_id, index);
+            // After applied this log, the write record is not orphan any more.
+            ASSERT_EQ(kvr1->writeCFCount(), 0);
+            auto [index2, term2] = proxy_instance->rawWrite(region_id, {k2}, {value_write}, {WriteCmdType::Put}, {ColumnFamilyType::Write});
+            proxy_instance->doApply(kvs, ctx.getTMTContext(), cond, region_id, index2);
+            ASSERT_EQ(kvr1->writeCFCount(), 0);
+            ASSERT_EQ(kvr1->orphanKeysInfo().remainedKeyCount(), 0);
+            UNUSED(term);
+            UNUSED(term2);
+        }
+        {
+            // An orphan key in normal write will still trigger a hard error.
+            auto k = RecordKVFormat::genKey(table_id, 4, 111);
+            auto [index, term2] = proxy_instance->rawWrite(region_id, {k}, {value_write}, {WriteCmdType::Put}, {ColumnFamilyType::Write});
+            UNUSED(term2);
+            EXPECT_THROW(proxy_instance->doApply(kvs, ctx.getTMTContext(), cond, region_id, index), Exception);
+        }
+    }
+}
+CATCH
+
+TEST_F(RegionKVStoreTest, KVStoreExtraDataSnapshot2)
+try
+{
+    auto ctx = TiFlashTestEnv::getGlobalContext();
+    proxy_instance->cluster_ver = RaftstoreVer::V2;
+    UInt64 region_id = 1;
+    TableID table_id;
+    {
+        region_id = 2;
+        initStorages();
+        KVStore & kvs = getKVS();
+        table_id = proxy_instance->bootstrapTable(ctx, kvs, ctx.getTMTContext());
+        auto start = RecordKVFormat::genKey(table_id, 0);
+        auto end = RecordKVFormat::genKey(table_id, 10);
+        proxy_instance->bootstrapWithRegion(kvs, ctx.getTMTContext(), region_id, std::make_pair(start.toString(), end.toString()));
+        auto r1 = proxy_instance->getRegion(region_id);
+
+        // See `decodeWriteCfValue`.
+        auto && [value_write, value_default] = proxy_instance->generateTiKVKeyValue(111, 999);
+
+        {
+            auto k1 = RecordKVFormat::genKey(table_id, 1, 111);
+            MockSSTReader::getMockSSTData().clear();
+            MockRaftStoreProxy::Cf default_cf{region_id, table_id, ColumnFamilyType::Default};
+            default_cf.finish_file(SSTFormatKind::KIND_TABLET);
+            default_cf.freeze();
+            MockRaftStoreProxy::Cf write_cf{region_id, table_id, ColumnFamilyType::Write};
+            write_cf.insert_raw(k1, value_write);
+            write_cf.finish_file(SSTFormatKind::KIND_TABLET);
+            write_cf.freeze();
+
+            auto kvr1 = proxy_instance->snapshot(kvs, ctx.getTMTContext(), region_id, {default_cf, write_cf}, 0, 0, std::nullopt);
+            ASSERT_EQ(kvr1->orphanKeysInfo().remainedKeyCount(), 1);
+        }
+        {
+            auto k2 = RecordKVFormat::genKey(table_id, 2, 111);
+            MockSSTReader::getMockSSTData().clear();
+            MockRaftStoreProxy::Cf default_cf{region_id, table_id, ColumnFamilyType::Default};
+            default_cf.finish_file(SSTFormatKind::KIND_TABLET);
+            default_cf.freeze();
+            MockRaftStoreProxy::Cf write_cf{region_id, table_id, ColumnFamilyType::Write};
+            write_cf.insert_raw(k2, value_write);
+            write_cf.finish_file(SSTFormatKind::KIND_TABLET);
+            write_cf.freeze();
+
+            auto kvr1 = proxy_instance->snapshot(kvs, ctx.getTMTContext(), region_id, {default_cf, write_cf}, 0, 0, 10);
+            // Every snapshot contains a full copy of this region. So we will drop all orphan keys in the previous region.
+            ASSERT_EQ(kvr1->orphanKeysInfo().remainedKeyCount(), 1);
+        }
+        MockRaftStoreProxy::FailCond cond;
+        {
+            auto k3 = RecordKVFormat::genKey(table_id, 3, 111);
+            auto kvr1 = kvs.getRegion(region_id);
+            proxy_instance->rawWrite(region_id, {k3, k3}, {value_default, value_write}, {WriteCmdType::Put, WriteCmdType::Put}, {ColumnFamilyType::Default, ColumnFamilyType::Write}, 8);
+            proxy_instance->doApply(kvs, ctx.getTMTContext(), cond, region_id, 8);
+
+            auto k4 = RecordKVFormat::genKey(table_id, 4, 111);
+            proxy_instance->rawWrite(region_id, {k4, k4}, {value_default, value_write}, {WriteCmdType::Put, WriteCmdType::Put}, {ColumnFamilyType::Default, ColumnFamilyType::Write}, 10);
+            // Remaining orphan keys of k2.
+            EXPECT_THROW(proxy_instance->doApply(kvs, ctx.getTMTContext(), cond, region_id, 10), Exception);
+        }
+        {
+            auto k5 = RecordKVFormat::genKey(table_id, 5, 111);
+            MockSSTReader::getMockSSTData().clear();
+            MockRaftStoreProxy::Cf default_cf{region_id, table_id, ColumnFamilyType::Default};
+            default_cf.finish_file(SSTFormatKind::KIND_TABLET);
+            default_cf.freeze();
+            MockRaftStoreProxy::Cf write_cf{region_id, table_id, ColumnFamilyType::Write};
+            write_cf.insert_raw(k5, value_write);
+            write_cf.finish_file(SSTFormatKind::KIND_TABLET);
+            write_cf.freeze();
+
+            auto kvr1 = proxy_instance->snapshot(kvs, ctx.getTMTContext(), region_id, {default_cf, write_cf}, 15, 0, 20);
+            ASSERT_EQ(kvr1->orphanKeysInfo().remainedKeyCount(), 1);
+        }
+        {
+            auto k6 = RecordKVFormat::genKey(table_id, 6, 111);
+            auto kvr1 = kvs.getRegion(region_id);
+            auto r1 = proxy_instance->getRegion(region_id);
+
+            auto && [req, res] = MockRaftStoreProxy::composeCompactLog(r1, 10);
+            proxy_instance->adminCommand(region_id, std::move(req), std::move(res), 20);
+            EXPECT_THROW(proxy_instance->doApply(kvs, ctx.getTMTContext(), cond, region_id, 20), Exception);
+        }
+    }
 }
 CATCH
 

--- a/dbms/src/Storages/Transaction/tests/gtest_read_index_worker.cpp
+++ b/dbms/src/Storages/Transaction/tests/gtest_read_index_worker.cpp
@@ -82,10 +82,10 @@ void ReadIndexTest::testError()
                 auto resp = future->poll();
                 ASSERT(!resp);
             }
-            ASSERT_EQ(proxy_instance.tasks.size(), 1);
+            ASSERT_EQ(proxy_instance.read_index_tasks.size(), 1);
 
             // force response region error `data_is_not_ready`
-            proxy_instance.tasks.front()->update(false, true);
+            proxy_instance.read_index_tasks.front()->update(false, true);
 
             for (auto & future : futures)
             {
@@ -129,10 +129,10 @@ void ReadIndexTest::testError()
                 auto resp = future->poll();
                 ASSERT(!resp);
             }
-            ASSERT_EQ(proxy_instance.tasks.size(), 1);
+            ASSERT_EQ(proxy_instance.read_index_tasks.size(), 1);
 
             // force response to have lock
-            proxy_instance.tasks.front()->update(true, false);
+            proxy_instance.read_index_tasks.front()->update(true, false);
 
             proxy_instance.runOneRound();
             for (auto & future : futures)
@@ -445,7 +445,7 @@ void ReadIndexTest::testNormal()
         }
     }
     over = true;
-    proxy_instance.wake();
+    proxy_instance.wakeNotifier();
     proxy_runner.join();
     manager.reset();
     ASSERT(GCMonitor::instance().checkClean());
@@ -588,7 +588,7 @@ void ReadIndexTest::testBatch()
         }
         manager->runOneRoundAll();
         {
-            auto & t = proxy_instance.tasks.back();
+            auto & t = proxy_instance.read_index_tasks.back();
             ASSERT_EQ(t->req.start_ts(), 10);
             t->update(); // only response ts `10`
         }

--- a/dbms/src/Storages/Transaction/tests/kvstore_helper.h
+++ b/dbms/src/Storages/Transaction/tests/kvstore_helper.h
@@ -166,7 +166,6 @@ protected:
     }
 
 protected:
-    static void testRaftSplit(KVStore & kvs, TMTContext & tmt);
     static void testRaftMerge(KVStore & kvs, TMTContext & tmt);
     static void testRaftMergeRollback(KVStore & kvs, TMTContext & tmt);
 

--- a/dbms/src/Storages/Transaction/tests/kvstore_helper.h
+++ b/dbms/src/Storages/Transaction/tests/kvstore_helper.h
@@ -93,7 +93,10 @@ public:
         }
     }
 
-    void TearDown() override {}
+    void TearDown() override
+    {
+        proxy_instance->clear();
+    }
 
 protected:
     KVStore & getKVS() { return *kvstore; }
@@ -135,12 +138,12 @@ protected:
 protected:
     static void testRaftSplit(KVStore & kvs, TMTContext & tmt);
     static void testRaftMerge(KVStore & kvs, TMTContext & tmt);
-    static void testRaftChangePeer(KVStore & kvs, TMTContext & tmt);
     static void testRaftMergeRollback(KVStore & kvs, TMTContext & tmt);
 
     static std::unique_ptr<PathPool> createCleanPathPool(const String & path)
     {
         // Drop files on disk
+        LOG_INFO(Logger::get("Test"), "Clean path {} for bootstrap", path);
         Poco::File file(path);
         if (file.exists())
             file.remove(true);

--- a/dbms/src/Storages/Transaction/tests/kvstore_helper.h
+++ b/dbms/src/Storages/Transaction/tests/kvstore_helper.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#pragma once
+
 #include <Common/FailPoint.h>
 #include <Common/Logger.h>
 #include <Debug/MockRaftStoreProxy.h>
@@ -82,8 +84,7 @@ public:
         reloadKVSFromDisk();
 
         proxy_instance = std::make_unique<MockRaftStoreProxy>();
-        proxy_helper = std::make_unique<TiFlashRaftProxyHelper>(MockRaftStoreProxy::SetRaftStoreProxyFFIHelper(
-            RaftStoreProxyPtr{proxy_instance.get()}));
+        proxy_helper = proxy_instance->generateProxyHelper();
         kvstore->restore(*path_pool, proxy_helper.get());
         {
             auto store = metapb::Store{};
@@ -134,6 +135,35 @@ protected:
         p = path + "/data/";
         TiFlashTestEnv::tryCreatePath(p);
     }
+    void startReadIndexUtils(Context & ctx)
+    {
+        if (proxy_runner)
+        {
+            return;
+        }
+        over.store(false);
+        ctx.getTMTContext().setStatusRunning();
+        // Start mock proxy in other thread
+        proxy_runner.reset(new std::thread([&]() {
+            proxy_instance->testRunNormal(over);
+        }));
+        ASSERT_EQ(kvstore->getProxyHelper(), proxy_helper.get());
+        kvstore->initReadIndexWorkers(
+            []() {
+                return std::chrono::milliseconds(10);
+            },
+            1);
+        ASSERT_NE(kvstore->read_index_worker_manager, nullptr);
+        kvstore->asyncRunReadIndexWorkers();
+    }
+    void stopReadIndexUtils()
+    {
+        kvstore->stopReadIndexWorkers();
+        kvstore->releaseReadIndexWorkers();
+        over = true;
+        proxy_instance->wakeNotifier();
+        proxy_runner->join();
+    }
 
 protected:
     static void testRaftSplit(KVStore & kvs, TMTContext & tmt);
@@ -161,10 +191,14 @@ protected:
     std::string test_path;
 
     std::unique_ptr<PathPool> path_pool;
-    std::unique_ptr<KVStore> kvstore;
+    std::shared_ptr<KVStore> kvstore;
 
     std::unique_ptr<MockRaftStoreProxy> proxy_instance;
     std::unique_ptr<TiFlashRaftProxyHelper> proxy_helper;
+    std::unique_ptr<std::thread> proxy_runner;
+
+    LoggerPtr log = DB::Logger::get("RegionKVStoreTest");
+    std::atomic_bool over{false};
 };
 } // namespace tests
 } // namespace DB

--- a/dbms/src/Storages/Transaction/tests/region_helper.h
+++ b/dbms/src/Storages/Transaction/tests/region_helper.h
@@ -58,16 +58,34 @@ inline metapb::Peer createPeer(UInt64 id, bool)
     return peer;
 }
 
-inline metapb::Region createRegionInfo(UInt64 id, const std::string start_key, const std::string end_key)
+inline metapb::Region createRegionInfo(UInt64 id, const std::string start_key, const std::string end_key, std::optional<metapb::RegionEpoch> maybe_epoch = std::nullopt, std::optional<std::vector<metapb::Peer>> maybe_peers = std::nullopt)
 {
     metapb::Region region_info;
     region_info.set_id(id);
     region_info.set_start_key(start_key);
     region_info.set_end_key(end_key);
-    region_info.mutable_region_epoch()->set_version(5);
-    region_info.mutable_region_epoch()->set_version(6);
-    *(region_info.mutable_peers()->Add()) = createPeer(1, true);
-    *(region_info.mutable_peers()->Add()) = createPeer(2, false);
+    if (maybe_epoch)
+    {
+        *region_info.mutable_region_epoch() = (maybe_epoch.value());
+    }
+    else
+    {
+        region_info.mutable_region_epoch()->set_version(5);
+        region_info.mutable_region_epoch()->set_version(6);
+    }
+    if (maybe_peers)
+    {
+        auto & peers = maybe_peers.value();
+        for (auto it = peers.begin(); it != peers.end(); it++)
+        {
+            *(region_info.mutable_peers()->Add()) = *it;
+        }
+    }
+    else
+    {
+        *(region_info.mutable_peers()->Add()) = createPeer(1, true);
+        *(region_info.mutable_peers()->Add()) = createPeer(2, false);
+    }
 
     return region_info;
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #4982 close #7726

Problem Summary:
 update proxy to raftstore-proxy

We have to pick some TiFlash commits to make it cowork with proxy.

 Proxy PR: 
 Including:\nSubmodule contrib/tiflash-proxy 601d803562..7aed51bfdf:
  > diagnostic: fix index out of bounds error in sysinfo (#333)
  > Add debug utils for tablet snapshot (#331)
  > Support replace url with a host string (#337)
  > Use addr's ip if status_addr's is is empty (#334)
  > Get raftstore version of cluster by requesting TiKV's status server (#332)

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
