### PR TITLE
Cancel MPP task works on Mpp gather level

### DIFF
--- a/dbms/src/Debug/DAGProperties.h
+++ b/dbms/src/Debug/DAGProperties.h
@@ -29,6 +29,7 @@ struct DAGProperties
     bool use_broadcast_join = false;
     Int32 mpp_partition_num = 1;
     Timestamp start_ts = DEFAULT_MAX_READ_TSO;
+    Int64 gather_id = 0;
     UInt64 query_ts = 0;
     UInt64 server_id = 1;
     UInt64 local_query_id = 1;

--- a/dbms/src/Debug/MockComputeServerManager.cpp
+++ b/dbms/src/Debug/MockComputeServerManager.cpp
@@ -120,17 +120,23 @@ void MockComputeServerManager::addServer(size_t partition_id, std::unique_ptr<Fl
     server_map[partition_id] = std::move(server);
 }
 
-void MockComputeServerManager::cancelQuery(const MPPQueryId & query_id)
+void MockComputeServerManager::cancelGather(const MPPGatherId & gather_id)
 {
     mpp::CancelTaskRequest req;
     auto * meta = req.mutable_meta();
-    meta->set_query_ts(query_id.query_ts);
-    meta->set_local_query_id(query_id.local_query_id);
-    meta->set_server_id(query_id.server_id);
-    meta->set_start_ts(query_id.start_ts);
+    meta->set_query_ts(gather_id.query_id.query_ts);
+    meta->set_local_query_id(gather_id.query_id.local_query_id);
+    meta->set_server_id(gather_id.query_id.server_id);
+    meta->set_start_ts(gather_id.query_id.start_ts);
+    meta->set_gather_id(gather_id.gather_id);
     mpp::CancelTaskResponse response;
     for (const auto & server : server_map)
         server.second->flashService()->cancelMPPTaskForTest(&req, &response);
+}
+
+void MockComputeServerManager::cancelQuery(const MPPQueryId & query_id)
+{
+    cancelGather(MPPGatherId(0, query_id));
 }
 
 String MockComputeServerManager::queryInfo()

--- a/dbms/src/Debug/MockComputeServerManager.cpp
+++ b/dbms/src/Debug/MockComputeServerManager.cpp
@@ -134,11 +134,6 @@ void MockComputeServerManager::cancelGather(const MPPGatherId & gather_id)
         server.second->flashService()->cancelMPPTaskForTest(&req, &response);
 }
 
-void MockComputeServerManager::cancelQuery(const MPPQueryId & query_id)
-{
-    cancelGather(MPPGatherId(0, query_id));
-}
-
 String MockComputeServerManager::queryInfo()
 {
     FmtBuffer buf;

--- a/dbms/src/Debug/MockComputeServerManager.h
+++ b/dbms/src/Debug/MockComputeServerManager.h
@@ -48,8 +48,6 @@ public:
 
     void resetMockMPPServerInfo(size_t partition_num);
 
-    void cancelQuery(const MPPQueryId & query_id);
-
     void cancelGather(const MPPGatherId & gather_id);
 
     static String queryInfo();

--- a/dbms/src/Debug/MockComputeServerManager.h
+++ b/dbms/src/Debug/MockComputeServerManager.h
@@ -50,6 +50,8 @@ public:
 
     void cancelQuery(const MPPQueryId & query_id);
 
+    void cancelGather(const MPPGatherId & gather_id);
+
     static String queryInfo();
 
 private:

--- a/dbms/src/Debug/MockExecutor/AstToPB.cpp
+++ b/dbms/src/Debug/MockExecutor/AstToPB.cpp
@@ -703,4 +703,13 @@ void compileFilter(const DAGSchema & input, ASTPtr ast, std::vector<ASTPtr> & co
     compileExpr(input, ast);
 }
 
+void fillTaskMetaWithMPPInfo(mpp::TaskMeta & meta, const MPPInfo & mpp_info)
+{
+    meta.set_start_ts(mpp_info.start_ts);
+    meta.set_gather_id(mpp_info.gather_id);
+    meta.set_query_ts(mpp_info.query_ts);
+    meta.set_local_query_id(mpp_info.local_query_id);
+    meta.set_server_id(mpp_info.server_id);
+}
+
 } // namespace DB

--- a/dbms/src/Debug/MockExecutor/AstToPB.h
+++ b/dbms/src/Debug/MockExecutor/AstToPB.h
@@ -16,6 +16,7 @@
 
 #include <Flash/Coprocessor/ChunkCodec.h>
 #include <Storages/Transaction/TiDB.h>
+#include <kvproto/mpp.pb.h>
 
 namespace DB
 {
@@ -46,6 +47,7 @@ using MPPCtxPtr = std::shared_ptr<MPPCtx>;
 struct MPPInfo
 {
     Timestamp start_ts;
+    Int64 gather_id;
     UInt64 query_ts;
     UInt64 server_id;
     UInt64 local_query_id;
@@ -56,6 +58,7 @@ struct MPPInfo
 
     MPPInfo(
         Timestamp start_ts_,
+        Int64 gather_id_,
         UInt64 query_ts_,
         UInt64 server_id_,
         UInt64 local_query_id_,
@@ -64,6 +67,7 @@ struct MPPInfo
         const std::vector<Int64> & sender_target_task_ids_,
         const std::unordered_map<String, std::vector<Int64>> & receiver_source_task_ids_map_)
         : start_ts(start_ts_)
+        , gather_id(gather_id_)
         , query_ts(query_ts_)
         , server_id(server_id_)
         , local_query_id(local_query_id_)
@@ -92,5 +96,6 @@ void astToPB(const DAGSchema & input, ASTPtr ast, tipb::Expr * expr, int32_t col
 void collectUsedColumnsFromExpr(const DAGSchema & input, ASTPtr ast, std::unordered_set<String> & used_columns);
 TiDB::ColumnInfo compileExpr(const DAGSchema & input, ASTPtr ast);
 void compileFilter(const DAGSchema & input, ASTPtr ast, std::vector<ASTPtr> & conditions);
+void fillTaskMetaWithMPPInfo(mpp::TaskMeta & task_meta, const MPPInfo & mpp_info);
 
 } // namespace DB

--- a/dbms/src/Debug/MockExecutor/ExchangeReceiverBinder.cpp
+++ b/dbms/src/Debug/MockExecutor/ExchangeReceiverBinder.cpp
@@ -51,10 +51,7 @@ bool ExchangeReceiverBinder::toTiPBExecutor(tipb::Executor * tipb_executor, int3
     for (size_t i = 0; i < size; ++i)
     {
         mpp::TaskMeta meta;
-        meta.set_start_ts(mpp_info.start_ts);
-        meta.set_query_ts(mpp_info.query_ts);
-        meta.set_server_id(mpp_info.server_id);
-        meta.set_local_query_id(mpp_info.local_query_id);
+        fillTaskMetaWithMPPInfo(meta, mpp_info);
         meta.set_task_id(it->second[i]);
         meta.set_partition_id(i);
         auto addr = context.isMPPTest() ? tests::MockComputeServerManager::instance().getServerConfigMap()[i].addr : Debug::LOCAL_HOST;

--- a/dbms/src/Debug/MockExecutor/ExchangeSenderBinder.cpp
+++ b/dbms/src/Debug/MockExecutor/ExchangeSenderBinder.cpp
@@ -16,7 +16,6 @@
 #include <Debug/MockExecutor/AstToPB.h>
 #include <Debug/MockExecutor/AstToPBUtils.h>
 #include <Debug/MockExecutor/ExchangeSenderBinder.h>
-#include <Debug/MockExecutor/ExecutorBinder.h>
 #include <Flash/Coprocessor/DAGCodec.h>
 #include <Interpreters/Context.h>
 

--- a/dbms/src/Debug/MockExecutor/ExchangeSenderBinder.cpp
+++ b/dbms/src/Debug/MockExecutor/ExchangeSenderBinder.cpp
@@ -47,10 +47,7 @@ bool ExchangeSenderBinder::toTiPBExecutor(tipb::Executor * tipb_executor, int32_
     for (auto task_id : mpp_info.sender_target_task_ids)
     {
         mpp::TaskMeta meta;
-        meta.set_start_ts(mpp_info.start_ts);
-        meta.set_query_ts(mpp_info.query_ts);
-        meta.set_server_id(mpp_info.server_id);
-        meta.set_local_query_id(mpp_info.local_query_id);
+        fillTaskMetaWithMPPInfo(meta, mpp_info);
         meta.set_task_id(task_id);
         meta.set_partition_id(i);
         auto addr = context.isMPPTest() ? tests::MockComputeServerManager::instance().getServerConfigMap()[i++].addr : Debug::LOCAL_HOST;

--- a/dbms/src/Debug/dbgQueryCompiler.h
+++ b/dbms/src/Debug/dbgQueryCompiler.h
@@ -113,6 +113,7 @@ struct QueryFragment
             {
                 MPPInfo mpp_info(
                     properties.start_ts,
+                    properties.gather_id,
                     properties.query_ts,
                     properties.server_id,
                     properties.local_query_id,
@@ -125,7 +126,7 @@ struct QueryFragment
         }
         else
         {
-            MPPInfo mpp_info(properties.start_ts, properties.query_ts, properties.server_id, properties.local_query_id, /*partition_id*/ -1, /*task_id*/ -1, /*sender_target_task_ids*/ {}, /*receiver_source_task_ids_map*/ {});
+            MPPInfo mpp_info(properties.start_ts, properties.gather_id, properties.query_ts, properties.server_id, properties.local_query_id, /*partition_id*/ -1, /*task_id*/ -1, /*sender_target_task_ids*/ {}, /*receiver_source_task_ids_map*/ {});
             ret.push_back(toQueryTask(properties, mpp_info, context));
         }
         return ret;

--- a/dbms/src/Debug/dbgQueryExecutor.cpp
+++ b/dbms/src/Debug/dbgQueryExecutor.cpp
@@ -27,6 +27,15 @@ namespace DB
 {
 using TiFlashTestEnv = tests::TiFlashTestEnv;
 
+void fillTaskMetaUsingDAGProperties(mpp::TaskMeta & meta, const DAGProperties & properties)
+{
+    meta.set_start_ts(properties.start_ts);
+    meta.set_gather_id(properties.gather_id);
+    meta.set_query_ts(properties.query_ts);
+    meta.set_local_query_id(properties.local_query_id);
+    meta.set_server_id(properties.server_id);
+}
+
 void setTipbRegionInfo(coprocessor::RegionInfo * tipb_region_info, const std::pair<RegionID, RegionPtr> & region, TableID table_id)
 {
     tipb_region_info->set_region_id(region.first);
@@ -50,10 +59,7 @@ BlockInputStreamPtr constructRootExchangeReceiverStream(Context & context, tipb:
     }
 
     mpp::TaskMeta root_tm;
-    root_tm.set_start_ts(properties.start_ts);
-    root_tm.set_query_ts(properties.query_ts);
-    root_tm.set_local_query_id(properties.local_query_id);
-    root_tm.set_server_id(properties.server_id);
+    fillTaskMetaUsingDAGProperties(root_tm, properties);
     root_tm.set_address(root_addr);
     root_tm.set_task_id(-1);
     root_tm.set_partition_id(-1);
@@ -83,10 +89,7 @@ BlockInputStreamPtr prepareRootExchangeReceiver(Context & context, const DAGProp
     for (const auto root_task_id : root_task_ids)
     {
         mpp::TaskMeta tm;
-        tm.set_start_ts(properties.start_ts);
-        tm.set_query_ts(properties.query_ts);
-        tm.set_local_query_id(properties.local_query_id);
-        tm.set_server_id(properties.server_id);
+        fillTaskMetaUsingDAGProperties(tm, properties);
         tm.set_address(Debug::LOCAL_HOST);
         tm.set_task_id(root_task_id);
         tm.set_partition_id(-1);
@@ -99,10 +102,7 @@ BlockInputStreamPtr prepareRootExchangeReceiver(Context & context, const DAGProp
 void prepareExchangeReceiverMetaWithMultipleContext(tipb::ExchangeReceiver & tipb_exchange_receiver, const DAGProperties & properties, Int64 task_id, String & addr)
 {
     mpp::TaskMeta tm;
-    tm.set_start_ts(properties.start_ts);
-    tm.set_query_ts(properties.query_ts);
-    tm.set_local_query_id(properties.local_query_id);
-    tm.set_server_id(properties.server_id);
+    fillTaskMetaUsingDAGProperties(tm, properties);
     tm.set_address(addr);
     tm.set_task_id(task_id);
     tm.set_partition_id(-1);
@@ -127,10 +127,7 @@ void prepareDispatchTaskRequest(QueryTask & task, std::shared_ptr<mpp::DispatchT
         root_task_schema = task.result_schema;
     }
     auto * tm = req->mutable_meta();
-    tm->set_start_ts(properties.start_ts);
-    tm->set_query_ts(properties.query_ts);
-    tm->set_local_query_id(properties.local_query_id);
-    tm->set_server_id(properties.server_id);
+    fillTaskMetaUsingDAGProperties(*tm, properties);
     tm->set_partition_id(task.partition_id);
     tm->set_address(addr);
     tm->set_task_id(task.task_id);
@@ -149,10 +146,7 @@ void prepareDispatchTaskRequestWithMultipleContext(QueryTask & task, std::shared
         root_task_schema = task.result_schema;
     }
     auto * tm = req->mutable_meta();
-    tm->set_start_ts(properties.start_ts);
-    tm->set_query_ts(properties.query_ts);
-    tm->set_local_query_id(properties.local_query_id);
-    tm->set_server_id(properties.server_id);
+    fillTaskMetaUsingDAGProperties(*tm, properties);
     tm->set_partition_id(task.partition_id);
     tm->set_address(addr);
     tm->set_task_id(task.task_id);

--- a/dbms/src/Debug/dbgQueryExecutor.cpp
+++ b/dbms/src/Debug/dbgQueryExecutor.cpp
@@ -27,7 +27,7 @@ namespace DB
 {
 using TiFlashTestEnv = tests::TiFlashTestEnv;
 
-void fillTaskMetaUsingDAGProperties(mpp::TaskMeta & meta, const DAGProperties & properties)
+void fillTaskMetaWithDAGProperties(mpp::TaskMeta & meta, const DAGProperties & properties)
 {
     meta.set_start_ts(properties.start_ts);
     meta.set_gather_id(properties.gather_id);
@@ -59,7 +59,7 @@ BlockInputStreamPtr constructRootExchangeReceiverStream(Context & context, tipb:
     }
 
     mpp::TaskMeta root_tm;
-    fillTaskMetaUsingDAGProperties(root_tm, properties);
+    fillTaskMetaWithDAGProperties(root_tm, properties);
     root_tm.set_address(root_addr);
     root_tm.set_task_id(-1);
     root_tm.set_partition_id(-1);
@@ -89,7 +89,7 @@ BlockInputStreamPtr prepareRootExchangeReceiver(Context & context, const DAGProp
     for (const auto root_task_id : root_task_ids)
     {
         mpp::TaskMeta tm;
-        fillTaskMetaUsingDAGProperties(tm, properties);
+        fillTaskMetaWithDAGProperties(tm, properties);
         tm.set_address(Debug::LOCAL_HOST);
         tm.set_task_id(root_task_id);
         tm.set_partition_id(-1);
@@ -102,7 +102,7 @@ BlockInputStreamPtr prepareRootExchangeReceiver(Context & context, const DAGProp
 void prepareExchangeReceiverMetaWithMultipleContext(tipb::ExchangeReceiver & tipb_exchange_receiver, const DAGProperties & properties, Int64 task_id, String & addr)
 {
     mpp::TaskMeta tm;
-    fillTaskMetaUsingDAGProperties(tm, properties);
+    fillTaskMetaWithDAGProperties(tm, properties);
     tm.set_address(addr);
     tm.set_task_id(task_id);
     tm.set_partition_id(-1);
@@ -127,7 +127,7 @@ void prepareDispatchTaskRequest(QueryTask & task, std::shared_ptr<mpp::DispatchT
         root_task_schema = task.result_schema;
     }
     auto * tm = req->mutable_meta();
-    fillTaskMetaUsingDAGProperties(*tm, properties);
+    fillTaskMetaWithDAGProperties(*tm, properties);
     tm->set_partition_id(task.partition_id);
     tm->set_address(addr);
     tm->set_task_id(task.task_id);
@@ -146,7 +146,7 @@ void prepareDispatchTaskRequestWithMultipleContext(QueryTask & task, std::shared
         root_task_schema = task.result_schema;
     }
     auto * tm = req->mutable_meta();
-    fillTaskMetaUsingDAGProperties(*tm, properties);
+    fillTaskMetaWithDAGProperties(*tm, properties);
     tm->set_partition_id(task.partition_id);
     tm->set_address(addr);
     tm->set_task_id(task.task_id);

--- a/dbms/src/Flash/EstablishCall.cpp
+++ b/dbms/src/Flash/EstablishCall.cpp
@@ -200,6 +200,7 @@ void EstablishCallData::write(const mpp::MPPDataPacket & packet)
 void EstablishCallData::writeErr(const mpp::MPPDataPacket & packet)
 {
     state = ERR_HANDLE;
+    std::cout << "Write error with error message: " << packet.error().msg() << std::endl;
     write(packet);
 }
 
@@ -231,16 +232,18 @@ void EstablishCallData::writeDone(String msg, const grpc::Status & status)
         if (stopwatch != nullptr)
             LOG_WARNING(
                 getLogger(),
-                "EstablishCallData finishes without connected, time cost {}ms, query id: {}, connection id: {}",
+                "EstablishCallData finishes without connected, time cost {}ms, query id: {}, connection id: {}, error message: {}",
                 stopwatch != nullptr ? stopwatch->elapsedMilliseconds() : 0,
                 query_id,
-                connection_id);
+                connection_id,
+                msg);
         else
             LOG_WARNING(
                 getLogger(),
-                "EstablishCallData finishes without connected, query id: {}, connection id: {}",
+                "EstablishCallData finishes without connected, query id: {}, connection id: {}, error message: {}",
                 query_id,
-                connection_id);
+                connection_id,
+                msg);
     }
 
     responder.Finish(status, this);

--- a/dbms/src/Flash/EstablishCall.cpp
+++ b/dbms/src/Flash/EstablishCall.cpp
@@ -200,7 +200,6 @@ void EstablishCallData::write(const mpp::MPPDataPacket & packet)
 void EstablishCallData::writeErr(const mpp::MPPDataPacket & packet)
 {
     state = ERR_HANDLE;
-    std::cout << "Write error with error message: " << packet.error().msg() << std::endl;
     write(packet);
 }
 
@@ -232,18 +231,16 @@ void EstablishCallData::writeDone(String msg, const grpc::Status & status)
         if (stopwatch != nullptr)
             LOG_WARNING(
                 getLogger(),
-                "EstablishCallData finishes without connected, time cost {}ms, query id: {}, connection id: {}, error message: {}",
+                "EstablishCallData finishes without connected, time cost {}ms, query id: {}, connection id: {}",
                 stopwatch != nullptr ? stopwatch->elapsedMilliseconds() : 0,
                 query_id,
-                connection_id,
-                msg);
+                connection_id);
         else
             LOG_WARNING(
                 getLogger(),
-                "EstablishCallData finishes without connected, query id: {}, connection id: {}, error message: {}",
+                "EstablishCallData finishes without connected, query id: {}, connection id: {}",
                 query_id,
-                connection_id,
-                msg);
+                connection_id);
     }
 
     responder.Finish(status, this);

--- a/dbms/src/Flash/FlashService.cpp
+++ b/dbms/src/Flash/FlashService.cpp
@@ -478,7 +478,7 @@ grpc::Status FlashService::CancelMPPTask(
 
     auto & tmt_context = context->getTMTContext();
     auto task_manager = tmt_context.getMPPTaskManager();
-    task_manager->abortMPPQuery(MPPQueryId(request->meta()), "Receive cancel request from TiDB", AbortType::ONCANCELLATION);
+    task_manager->abortMPPGather(MPPGatherId(request->meta()), "Receive cancel request from TiDB", AbortType::ONCANCELLATION);
     return grpc::Status::OK;
 }
 
@@ -521,7 +521,7 @@ std::tuple<ContextPtr, grpc::Status> FlashService::createDBContextForTest() cons
     }
     auto & tmt_context = context->getTMTContext();
     auto task_manager = tmt_context.getMPPTaskManager();
-    task_manager->abortMPPQuery(MPPQueryId(request->meta()), "Receive cancel request from GTest", AbortType::ONCANCELLATION);
+    task_manager->abortMPPGather(MPPGatherId(request->meta()), "Receive cancel request from GTest", AbortType::ONCANCELLATION);
     return grpc::Status::OK;
 }
 

--- a/dbms/src/Flash/FlashService.cpp
+++ b/dbms/src/Flash/FlashService.cpp
@@ -478,6 +478,8 @@ grpc::Status FlashService::CancelMPPTask(
 
     auto & tmt_context = context->getTMTContext();
     auto task_manager = tmt_context.getMPPTaskManager();
+    /// `CancelMPPTask` cancels the current mpp gather. In TiDB side, each gather has its own mpp coordinator, when TiDB cancel
+    /// a query, it will cancel all the coordinators
     task_manager->abortMPPGather(MPPGatherId(request->meta()), "Receive cancel request from TiDB", AbortType::ONCANCELLATION);
     return grpc::Status::OK;
 }

--- a/dbms/src/Flash/Mpp/MPPTask.cpp
+++ b/dbms/src/Flash/Mpp/MPPTask.cpp
@@ -641,7 +641,7 @@ void MPPTask::reportStatus(const String & err_msg)
 void MPPTask::handleError(const String & error_msg)
 {
     auto updated_msg = fmt::format("From {}: {}", id.toString(), error_msg);
-    manager->abortMPPQuery(id.query_id, updated_msg, AbortType::ONERROR);
+    manager->abortMPPGather(id.gather_id, updated_msg, AbortType::ONERROR);
     if (!is_public)
         // if the task is not public, need to cancel it explicitly
         abort(error_msg, AbortType::ONERROR);

--- a/dbms/src/Flash/Mpp/MPPTask.cpp
+++ b/dbms/src/Flash/Mpp/MPPTask.cpp
@@ -228,7 +228,9 @@ void MPPTask::registerTunnels(const mpp::DispatchTaskRequest & task_request)
         if (status != INITIALIZING)
             throw Exception(fmt::format("The tunnel {} can not be registered, because the task is not in initializing state", tunnel->id()));
 
-        tunnel_set_local->registerTunnel(MPPTaskId(task_meta), tunnel);
+        MPPTaskId task_id(task_meta);
+        RUNTIME_CHECK_MSG(id.gather_id.hasMeaningfulGatherId() == task_id.gather_id.hasMeaningfulGatherId(), "MPP query has gather id while mpp task does not have gather id, should be something wrong in TiDB side");
+        tunnel_set_local->registerTunnel(task_id, tunnel);
         injectFailPointDuringRegisterTunnel(dag_context->isRootMPPTask());
     }
     {

--- a/dbms/src/Flash/Mpp/MPPTask.cpp
+++ b/dbms/src/Flash/Mpp/MPPTask.cpp
@@ -229,7 +229,7 @@ void MPPTask::registerTunnels(const mpp::DispatchTaskRequest & task_request)
             throw Exception(fmt::format("The tunnel {} can not be registered, because the task is not in initializing state", tunnel->id()));
 
         MPPTaskId task_id(task_meta);
-        RUNTIME_CHECK_MSG(id.gather_id.hasMeaningfulGatherId() == task_id.gather_id.hasMeaningfulGatherId(), "MPP query has gather id while mpp task does not have gather id, should be something wrong in TiDB side");
+        RUNTIME_CHECK_MSG(id.gather_id.gather_id == task_id.gather_id.gather_id, "MPP query has different gather id, should be something wrong in TiDB side");
         tunnel_set_local->registerTunnel(task_id, tunnel);
         injectFailPointDuringRegisterTunnel(dag_context->isRootMPPTask());
     }

--- a/dbms/src/Flash/Mpp/MPPTask.h
+++ b/dbms/src/Flash/Mpp/MPPTask.h
@@ -141,7 +141,7 @@ private:
         std::shared_ptr<ProcessListEntry> process_list_entry;
         ~ProcessListEntryHolder()
         {
-            /// Because MemoryTracker is now saved in `MPPGatherTaskSet` and shared by all the mpp tasks belongs to the same mpp query,
+            /// Because MemoryTracker is now saved in `MPPQuery` and shared by all the mpp tasks belongs to the same mpp query,
             /// it may not be destructed when MPPTask is destructed, so need to manually reset current_memory_tracker to nullptr at the
             /// end of the destructor of MPPTask, otherwise, current_memory_tracker may point to a invalid memory tracker
             current_memory_tracker = nullptr;

--- a/dbms/src/Flash/Mpp/MPPTask.h
+++ b/dbms/src/Flash/Mpp/MPPTask.h
@@ -141,7 +141,7 @@ private:
         std::shared_ptr<ProcessListEntry> process_list_entry;
         ~ProcessListEntryHolder()
         {
-            /// Because MemoryTracker is now saved in `MPPQueryTaskSet` and shared by all the mpp tasks belongs to the same mpp query,
+            /// Because MemoryTracker is now saved in `MPPGatherTaskSet` and shared by all the mpp tasks belongs to the same mpp query,
             /// it may not be destructed when MPPTask is destructed, so need to manually reset current_memory_tracker to nullptr at the
             /// end of the destructor of MPPTask, otherwise, current_memory_tracker may point to a invalid memory tracker
             current_memory_tracker = nullptr;

--- a/dbms/src/Flash/Mpp/MPPTaskId.cpp
+++ b/dbms/src/Flash/Mpp/MPPTaskId.cpp
@@ -98,7 +98,7 @@ size_t MPPGatherIdHash::operator()(MPPGatherId const & mpp_gather_id) const noex
 
 String MPPTaskId::toString() const
 {
-    return isUnknown() ? "MPP<query_id:N/A,task_id:N/A>" : fmt::format("MPP<query:{},task_id:{}>", query_id.toString(), task_id);
+    return isUnknown() ? "MPP<gather_id:N/A,task_id:N/A>" : fmt::format("MPP<gather_id:{},task_id:{}>", gather_id.toString(), task_id);
 }
 
 const MPPTaskId MPPTaskId::unknown_mpp_task_id = MPPTaskId{};
@@ -108,6 +108,6 @@ const MPPQueryId MPPTaskId::Max_Query_Id = MPPQueryId(MAX_UINT64, MAX_UINT64, MA
 
 bool operator==(const MPPTaskId & lid, const MPPTaskId & rid)
 {
-    return lid.query_id == rid.query_id && lid.task_id == rid.task_id;
+    return lid.gather_id == rid.gather_id && lid.task_id == rid.task_id;
 }
 } // namespace DB

--- a/dbms/src/Flash/Mpp/MPPTaskId.h
+++ b/dbms/src/Flash/Mpp/MPPTaskId.h
@@ -56,12 +56,10 @@ struct MPPQueryIdHash
 };
 
 /// A MPP query has one or more MPPGathers, each mpp gather has one or more MPPTasks. The mpp tasks in different mpp gathers are independent
-/// to each other, so theoretically speaking, the smallest cancel/retry unit of MPP query could be MPPGather. However, MPPGathers belong to
-/// the same MPP query could have dependence to each other(e.g. for query A join B, if the join is not supported in TiFlash, TiDB will generate
-/// two mpp gathers, one is reading from A and the other is reading from B, the probe side's mpp gather depends on the build side's mpp gather),
-/// so the smallest scheduling unit in TiFlash is still the MPP query
-/// Note currently, TiDB does not fill `gather_id` in mpp::TaskMeta, TiFlash hard coded 0 as the gather id for all MPPGatherId, so a mpp query now
-/// only has one MPPGather, and the schedule/cancel/retry unit in TiFlash is MPP query, we may implement mpp gather level's cancel/retry in the future.
+/// to each other, while MPPGathers belong to the same MPP query could have dependence to each other(e.g. for query A join B, if the join is
+/// not supported in TiFlash, TiDB will generate two mpp gathers, one is reading from A and the other is reading from B, the probe side's mpp
+/// gather depends on the build side's mpp gather), so the smallest scheduling unit in TiFlash is MPP query, but the smallest cancel/retry unit
+/// in TiFlash is MPP gather.
 struct MPPGatherId
 {
     Int64 gather_id;
@@ -74,7 +72,7 @@ struct MPPGatherId
         : gather_id(gather_id_)
         , query_id(query_ts, local_query_id, server_id, start_ts)
     {}
-    MPPGatherId(const mpp::TaskMeta & task_meta)
+    explicit MPPGatherId(const mpp::TaskMeta & task_meta)
         : gather_id(task_meta.gather_id())
         , query_id(task_meta)
     {}

--- a/dbms/src/Flash/Mpp/MPPTaskId.h
+++ b/dbms/src/Flash/Mpp/MPPTaskId.h
@@ -82,6 +82,10 @@ struct MPPGatherId
     {
         return fmt::format("<gather_id:{}, query_ts:{}, local_query_id:{}, server_id:{}, start_ts:{}>", gather_id, query_id.query_ts, query_id.local_query_id, query_id.server_id, query_id.start_ts);
     }
+    bool hasMeaningfulGatherId() const
+    {
+        return gather_id > 0;
+    }
     bool operator==(const MPPGatherId & rid) const;
 };
 

--- a/dbms/src/Flash/Mpp/MPPTaskId.h
+++ b/dbms/src/Flash/Mpp/MPPTaskId.h
@@ -64,12 +64,24 @@ struct MPPQueryIdHash
 /// only has one MPPGather, and the schedule/cancel/retry unit in TiFlash is MPP query, we may implement mpp gather level's cancel/retry in the future.
 struct MPPGatherId
 {
-    UInt64 gather_id;
+    Int64 gather_id;
     MPPQueryId query_id;
     MPPGatherId(Int64 gather_id_, const MPPQueryId & query_id_)
         : gather_id(gather_id_)
         , query_id(query_id_)
     {}
+    MPPGatherId(Int64 gather_id_, UInt64 query_ts, UInt64 local_query_id, UInt64 server_id, UInt64 start_ts)
+        : gather_id(gather_id_)
+        , query_id(query_ts, local_query_id, server_id, start_ts)
+    {}
+    MPPGatherId(const mpp::TaskMeta & task_meta)
+        : gather_id(task_meta.gather_id())
+        , query_id(task_meta)
+    {}
+    String toString() const
+    {
+        return fmt::format("<gather_id:{}, query_ts:{}, local_query_id:{}, server_id:{}, start_ts:{}>", gather_id, query_id.query_ts, query_id.local_query_id, query_id.server_id, query_id.start_ts);
+    }
     bool operator==(const MPPGatherId & rid) const;
 };
 
@@ -83,20 +95,20 @@ struct MPPTaskId
 {
     MPPTaskId()
         : task_id(unknown_task_id)
-        , query_id({0, 0, 0, 0}){};
+        , gather_id(0, 0, 0, 0, 0){};
 
-    MPPTaskId(UInt64 start_ts, Int64 task_id_, UInt64 server_id, UInt64 query_ts, UInt64 local_query_id)
+    MPPTaskId(UInt64 start_ts, Int64 task_id_, UInt64 server_id, Int64 gather_id, UInt64 query_ts, UInt64 local_query_id)
         : task_id(task_id_)
-        , query_id(query_ts, local_query_id, server_id, start_ts)
+        , gather_id(gather_id, query_ts, local_query_id, server_id, start_ts)
     {}
 
     explicit MPPTaskId(const mpp::TaskMeta & task_meta)
         : task_id(task_meta.task_id())
-        , query_id(task_meta)
+        , gather_id(task_meta)
     {}
 
     Int64 task_id;
-    MPPQueryId query_id;
+    MPPGatherId gather_id;
 
     bool isUnknown() const { return task_id == unknown_task_id; }
 
@@ -119,7 +131,7 @@ class hash<DB::MPPTaskId>
 public:
     size_t operator()(const DB::MPPTaskId & id) const
     {
-        return DB::MPPQueryIdHash()(id.query_id) ^ hash<Int64>()(id.task_id);
+        return DB::MPPGatherIdHash()(id.gather_id) ^ hash<Int64>()(id.task_id);
     }
 };
 } // namespace std

--- a/dbms/src/Flash/Mpp/MPPTaskManager.cpp
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.cpp
@@ -217,7 +217,6 @@ void MPPTaskManager::abortMPPGather(const MPPGatherId & gather_id, const String 
         /// set a flag, so we can abort task one by
         /// one without holding the lock
         std::lock_guard lock(mu);
-        /// gather_id is not set by TiDB, so use 0 instead
         aborted_query_gather_cache.add(gather_id, reason);
         auto [query, gather_task_set_local, _] = getMPPQueryAndGatherTaskSet(gather_id);
         if (query == nullptr || gather_task_set_local == nullptr)

--- a/dbms/src/Flash/Mpp/MPPTaskManager.cpp
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.cpp
@@ -38,7 +38,15 @@ extern const char pause_before_make_non_root_mpp_task_active[];
 extern const char pause_before_register_non_root_mpp_task[];
 } // namespace FailPoints
 
-MPPQueryTaskSet::~MPPQueryTaskSet()
+MPPTask * MPPGatherTaskSet::findMPPTask(const MPPTaskId & task_id) const
+{
+    const auto & it = task_map.find(task_id);
+    if (it == task_map.end())
+        return nullptr;
+    return it->second.get();
+}
+
+MPPQuery::~MPPQuery()
 {
     if likely (process_list_entry != nullptr)
     {
@@ -47,12 +55,11 @@ MPPQueryTaskSet::~MPPQueryTaskSet()
     }
 }
 
-MPPTask * MPPQueryTaskSet::findMPPTask(const MPPTaskId & task_id) const
+MPPGatherTaskSetPtr MPPQuery::addMPPGatherTaskSet(const MPPGatherId & gather_id)
 {
-    const auto & it = task_map.find(task_id);
-    if (it == task_map.end())
-        return nullptr;
-    return it->second.get();
+    auto ptr = std::make_shared<MPPGatherTaskSet>();
+    mpp_gathers.insert({gather_id, ptr});
+    return ptr;
 }
 
 MPPTaskManager::MPPTaskManager(MPPTaskSchedulerPtr scheduler_)
@@ -69,19 +76,29 @@ MPPTaskManager::~MPPTaskManager()
     monitor->cv.notify_all();
 }
 
-MPPQueryTaskSetPtr MPPTaskManager::addMPPQueryTaskSet(const MPPQueryId & query_id)
+MPPQueryPtr MPPTaskManager::addMPPQuery(const MPPQueryId & query_id)
 {
-    auto ptr = std::make_shared<MPPQueryTaskSet>();
+    auto ptr = std::make_shared<MPPQuery>();
     mpp_query_map.insert({query_id, ptr});
     GET_METRIC(tiflash_mpp_task_manager, type_mpp_query_count).Set(mpp_query_map.size());
     return ptr;
 }
 
-void MPPTaskManager::removeMPPQueryTaskSet(const MPPQueryId & query_id, bool on_abort)
+MPPQueryPtr MPPTaskManager::getMPPQueryWithoutLock(const DB::MPPQueryId & query_id)
 {
-    scheduler->deleteQuery(query_id, *this, on_abort);
-    mpp_query_map.erase(query_id);
-    GET_METRIC(tiflash_mpp_task_manager, type_mpp_query_count).Set(mpp_query_map.size());
+    const auto & query_it = mpp_query_map.find(query_id);
+    return query_it == mpp_query_map.end() ? nullptr : query_it->second;
+}
+
+void MPPTaskManager::removeMPPGatherTaskSet(MPPQueryPtr & query, const MPPGatherId & gather_id, bool on_abort)
+{
+    query->mpp_gathers.erase(gather_id);
+    if (query->mpp_gathers.empty())
+    {
+        scheduler->deleteQuery(gather_id.query_id, *this, on_abort, -1);
+        mpp_query_map.erase(gather_id.query_id);
+        GET_METRIC(tiflash_mpp_task_manager, type_mpp_query_count).Set(mpp_query_map.size());
+    }
 }
 
 std::pair<MPPTunnelPtr, String> MPPTaskManager::findAsyncTunnel(const ::mpp::EstablishMPPConnectionRequest * request, EstablishCallData * call_data, grpc::CompletionQueue * cq)
@@ -93,25 +110,27 @@ std::pair<MPPTunnelPtr, String> MPPTaskManager::findAsyncTunnel(const ::mpp::Est
     String req_info = fmt::format("tunnel{}+{}", request->sender_meta().task_id(), request->receiver_meta().task_id());
 
     std::unique_lock lock(mu);
-    auto [query_set, error_msg] = getQueryTaskSetWithoutLock(id.query_id);
+    auto [query, gather_set, error_msg] = getMPPQueryAndGatherTaskSet(id.gather_id);
     if (!error_msg.empty())
     {
         /// if the query is aborted, return the error message
-        LOG_WARNING(log, fmt::format("{}: Query {} is aborted, all its tasks are invalid.", req_info, id.query_id.toString()));
+        LOG_WARNING(log, fmt::format("{}: Query {} is aborted, all its tasks are invalid.", req_info, id.gather_id.query_id.toString()));
         /// meet error
         return {nullptr, error_msg};
     }
 
-    auto * task = query_set == nullptr ? nullptr : query_set->findMPPTask(id);
+    auto * task = gather_set == nullptr ? nullptr : gather_set->findMPPTask(id);
     if (task == nullptr)
     {
         /// task not found or not visible yet
         if (!call_data->isWaitingTunnelState())
         {
             /// if call_data is in new_request state, put it to waiting tunnel state
-            if (query_set == nullptr)
-                query_set = addMPPQueryTaskSet(id.query_id);
-            auto & alarm = query_set->alarms[sender_task_id][receiver_task_id];
+            if (query == nullptr)
+                query = addMPPQuery(id.gather_id.query_id);
+            if (gather_set == nullptr)
+                gather_set = query->addMPPGatherTaskSet(id.gather_id);
+            auto & alarm = gather_set->alarms[sender_task_id][receiver_task_id];
             call_data->setToWaitingTunnelState();
             alarm.Set(cq, Clock::now() + std::chrono::seconds(10), call_data);
             return {nullptr, ""};
@@ -119,20 +138,21 @@ std::pair<MPPTunnelPtr, String> MPPTaskManager::findAsyncTunnel(const ::mpp::Est
         else
         {
             /// if call_data is already in WaitingTunnelState, then remove the alarm and return tunnel not found error
-            if (query_set != nullptr)
+            if (gather_set != nullptr)
             {
-                auto task_alarm_map_it = query_set->alarms.find(sender_task_id);
-                if (task_alarm_map_it != query_set->alarms.end())
+                assert(query != nullptr);
+                auto task_alarm_map_it = gather_set->alarms.find(sender_task_id);
+                if (task_alarm_map_it != gather_set->alarms.end())
                 {
                     task_alarm_map_it->second.erase(receiver_task_id);
                     if (task_alarm_map_it->second.empty())
-                        query_set->alarms.erase(task_alarm_map_it);
+                        gather_set->alarms.erase(task_alarm_map_it);
                 }
-                if (query_set->alarms.empty() && !query_set->hasMPPTask())
+                /// if the query gather set has no mpp task, it has to be removed if there is no alarms left,
+                /// otherwise the query task set itself may be left in MPPTaskManager forever
+                if (gather_set->alarms.empty() && !gather_set->hasMPPTask())
                 {
-                    /// if the query task set has no mpp task, it has to be removed if there is no alarms left,
-                    /// otherwise the query task set itself may be left in MPPTaskManager forever
-                    removeMPPQueryTaskSet(id.query_id, false);
+                    removeMPPGatherTaskSet(query, id.gather_id, false);
                     cv.notify_all();
                 }
             }
@@ -154,11 +174,11 @@ std::pair<MPPTunnelPtr, String> MPPTaskManager::findTunnelWithTimeout(const ::mp
     String error_message;
     std::unique_lock lock(mu);
     auto ret = cv.wait_for(lock, timeout, [&] {
-        auto [query_set, error_msg] = getQueryTaskSetWithoutLock(id.query_id);
+        auto [query_set, error_msg] = getGatherTaskSetWithoutLock(id.gather_id);
         if (!error_msg.empty())
         {
             /// if the query is aborted, return true to stop waiting timeout.
-            LOG_WARNING(log, fmt::format("{}: Query {} is aborted, all its tasks are invalid.", req_info, id.query_id.toString()));
+            LOG_WARNING(log, fmt::format("{}: Query {} is aborted, all its tasks are invalid.", req_info, id.gather_id.query_id.toString()));
             cancelled = true;
             error_message = error_msg;
             return true;
@@ -182,69 +202,69 @@ std::pair<MPPTunnelPtr, String> MPPTaskManager::findTunnelWithTimeout(const ::mp
     return task->getTunnel(request);
 }
 
-void MPPTaskManager::abortMPPQuery(const MPPQueryId & query_id, const String & reason, AbortType abort_type)
+void MPPTaskManager::abortMPPGather(const MPPGatherId & gather_id, const String & reason, AbortType abort_type)
 {
-    LOG_WARNING(log, fmt::format("Begin to abort query: {}, abort type: {}, reason: {}", query_id.toString(), magic_enum::enum_name(abort_type), reason));
-    MPPQueryTaskSetPtr task_set;
+    LOG_WARNING(log, fmt::format("Begin to abort gather: {}, abort type: {}, reason: {}", gather_id.toString(), magic_enum::enum_name(abort_type), reason));
+    MPPGatherTaskSetPtr gather_set;
     {
         /// abort task may take a long time, so first
         /// set a flag, so we can abort task one by
         /// one without holding the lock
         std::lock_guard lock(mu);
         /// gather_id is not set by TiDB, so use 0 instead
-        aborted_query_gather_cache.add(MPPGatherId(0, query_id), reason);
-        auto it = mpp_query_map.find(query_id);
-        if (it == mpp_query_map.end())
+        aborted_query_gather_cache.add(gather_id, reason);
+        auto [query, gather_set_local, _] = getMPPQueryAndGatherTaskSet(gather_id);
+        if (query == nullptr || gather_set_local == nullptr)
         {
-            LOG_WARNING(log, fmt::format("{} does not found in task manager, skip abort", query_id.toString()));
+            LOG_WARNING(log, fmt::format("{} does not found in task manager, skip abort", gather_id.toString()));
             return;
         }
-        else if (!it->second->isInNormalState())
+        gather_set = gather_set_local;
+        if (!gather_set->isInNormalState())
         {
-            LOG_WARNING(log, fmt::format("{} already in abort process, skip abort", query_id.toString()));
+            LOG_WARNING(log, fmt::format("{} already in abort process, skip abort", gather_id.toString()));
             return;
         }
-        it->second->state = MPPQueryTaskSet::Aborting;
-        it->second->error_message = reason;
+        gather_set->state = MPPGatherTaskSet::Aborting;
+        gather_set->error_message = reason;
         /// cancel all the alarms
-        for (auto & alarms_per_task : it->second->alarms)
+        for (auto & alarms_per_task : gather_set->alarms)
         {
             for (auto & alarm : alarms_per_task.second)
                 alarm.second.Cancel();
         }
-        it->second->alarms.clear();
-        if (!it->second->hasMPPTask())
+        gather_set->alarms.clear();
+        if (!gather_set->hasMPPTask())
         {
-            LOG_INFO(log, fmt::format("There is no mpp task for {}, finish abort", query_id.toString()));
-            removeMPPQueryTaskSet(query_id, true);
+            LOG_INFO(log, fmt::format("There is no mpp task for {}, finish abort", gather_id.toString()));
+            removeMPPGatherTaskSet(query, gather_id, true);
             cv.notify_all();
             return;
         }
-        task_set = it->second;
-        scheduler->deleteQuery(query_id, *this, true);
+        scheduler->deleteQuery(gather_id.query_id, *this, true, gather_id.gather_id);
         cv.notify_all();
     }
 
     FmtBuffer fmt_buf;
-    fmt_buf.fmtAppend("Remaining task in query {} are: ", query_id.toString());
-    task_set->forEachMPPTask([&](const std::pair<MPPTaskId, MPPTaskPtr> & it) {
+    fmt_buf.fmtAppend("Remaining task in gather {} are: ", gather_id.toString());
+    gather_set->forEachMPPTask([&](const std::pair<MPPTaskId, MPPTaskPtr> & it) {
         fmt_buf.fmtAppend("{} ", it.first.toString());
     });
     LOG_WARNING(log, fmt_buf.toString());
 
-    task_set->forEachMPPTask([&](const std::pair<MPPTaskId, MPPTaskPtr> & it) {
+    gather_set->forEachMPPTask([&](const std::pair<MPPTaskId, MPPTaskPtr> & it) {
         if (it.second != nullptr)
             it.second->abort(reason, abort_type);
     });
 
     {
         std::lock_guard lock(mu);
-        auto it = mpp_query_map.find(query_id);
-        RUNTIME_ASSERT(it != mpp_query_map.end(), log, "MPPTaskQuerySet {} should remaining in MPPTaskManager", query_id.toString());
-        it->second->state = MPPQueryTaskSet::Aborted;
+        auto [query, gather, _] = getMPPQueryAndGatherTaskSet(gather_id);
+        RUNTIME_ASSERT(gather != nullptr, log, "MPPTaskQuerySet {} should remaining in MPPTaskManager", gather_id.toString());
+        gather->state = MPPGatherTaskSet::Aborted;
         cv.notify_all();
     }
-    LOG_WARNING(log, "Finish abort query: " + query_id.toString());
+    LOG_WARNING(log, "Finish abort gather: " + gather_id.toString());
 }
 
 std::pair<bool, String> MPPTaskManager::registerTask(MPPTask * task)
@@ -254,30 +274,34 @@ std::pair<bool, String> MPPTaskManager::registerTask(MPPTask * task)
         FAIL_POINT_PAUSE(FailPoints::pause_before_register_non_root_mpp_task);
     }
     std::unique_lock lock(mu);
-    auto [query_set, error_msg] = getQueryTaskSetWithoutLock(task->id.query_id);
+    auto [query, gather_set, error_msg] = getMPPQueryAndGatherTaskSet(task->id.gather_id);
     if (!error_msg.empty())
     {
-        return {false, fmt::format("query is being aborted, error message = {}", error_msg)};
+        return {false, fmt::format("gather is being aborted, error message = {}", error_msg)};
     }
 
     auto & context = task->context;
 
-    if (query_set == nullptr)
-        query_set = addMPPQueryTaskSet(task->id.query_id);
-    if (query_set->process_list_entry == nullptr)
+    if (query == nullptr)
+        query = addMPPQuery(task->id.gather_id.query_id);
+    if (query->process_list_entry == nullptr)
     {
-        query_set->process_list_entry = setProcessListElement(
+        query->process_list_entry = setProcessListElement(
             *context,
             context->getDAGContext()->dummy_query_string,
             context->getDAGContext()->dummy_ast.get(),
             true);
     }
-    if (query_set->isTaskRegistered(task->id))
+    if (gather_set == nullptr)
+    {
+        gather_set = query->addMPPGatherTaskSet(task->id.gather_id);
+    }
+    if (gather_set->isTaskRegistered(task->id))
     {
         return {false, "task is already registered"};
     }
-    query_set->registerTask(task->id);
-    task->initProcessListEntry(query_set->process_list_entry);
+    gather_set->registerTask(task->id);
+    task->initProcessListEntry(query->process_list_entry);
     return {true, ""};
 }
 
@@ -288,28 +312,29 @@ std::pair<bool, String> MPPTaskManager::makeTaskActive(MPPTaskPtr task)
         FAIL_POINT_PAUSE(FailPoints::pause_before_make_non_root_mpp_task_active);
     }
     std::unique_lock lock(mu);
-    auto [query_set, error_msg] = getQueryTaskSetWithoutLock(task->id.query_id);
+    auto [query, gather_set, error_msg] = getMPPQueryAndGatherTaskSet(task->id.gather_id);
     if (!error_msg.empty())
     {
         return {false, fmt::format("query is being aborted, error message = {}", error_msg)};
     }
-    if (query_set->findMPPTask(task->id) != nullptr)
+    /// gather_set must not be nullptr if the current query is not aborted since MPPTaskManager::registerTask
+    /// always create the gather_set
+    RUNTIME_CHECK_MSG(query != nullptr, "query must not be null when make task visible");
+    RUNTIME_CHECK_MSG(gather_set != nullptr, "gather set must not be null when make task visible");
+    if (gather_set->findMPPTask(task->id) != nullptr)
     {
         return {false, "task is already visible"};
     }
-    /// query_set must not be nullptr if the current query is not aborted since MPPTaskManager::registerTask
-    /// always create the query_set
-    RUNTIME_CHECK_MSG(query_set != nullptr, "query set must not be null when make task visible");
-    RUNTIME_CHECK_MSG(query_set->process_list_entry.get() == task->process_list_entry_holder.process_list_entry.get(),
+    RUNTIME_CHECK_MSG(query->process_list_entry.get() == task->process_list_entry_holder.process_list_entry.get(),
                       "Task process list entry should always be the same as query process list entry");
-    query_set->makeTaskActive(task);
+    gather_set->makeTaskActive(task);
     /// cancel all the alarm waiting on this task
-    auto alarm_it = query_set->alarms.find(task->id.task_id);
-    if (alarm_it != query_set->alarms.end())
+    auto alarm_it = gather_set->alarms.find(task->id.task_id);
+    if (alarm_it != gather_set->alarms.end())
     {
         for (auto & alarm : alarm_it->second)
             alarm.second.Cancel();
-        query_set->alarms.erase(alarm_it);
+        gather_set->alarms.erase(alarm_it);
     }
     task->is_public = true;
     cv.notify_all();
@@ -319,18 +344,28 @@ std::pair<bool, String> MPPTaskManager::makeTaskActive(MPPTaskPtr task)
 std::pair<bool, String> MPPTaskManager::unregisterTask(const MPPTaskId & id)
 {
     std::unique_lock lock(mu);
-    auto it = mpp_query_map.end();
+    MPPGatherTaskSetPtr gather_set = nullptr;
+    MPPQueryPtr query = nullptr;
     cv.wait(lock, [&] {
-        it = mpp_query_map.find(id.query_id);
-        return it == mpp_query_map.end() || it->second->allowUnregisterTask();
-    });
-    if (it != mpp_query_map.end())
-    {
-        if (it->second->isTaskRegistered(id))
+        auto query_it = mpp_query_map.find(id.gather_id.query_id);
+        if (query_it != mpp_query_map.end())
         {
-            it->second->removeMPPTask(id);
-            if (!it->second->hasMPPTask() && it->second->alarms.empty())
-                removeMPPQueryTaskSet(id.query_id, false);
+            query = query_it->second;
+            auto gather_it = query_it->second->mpp_gathers.find(id.gather_id);
+            if (gather_it != query_it->second->mpp_gathers.end())
+                gather_set = gather_it->second;
+        }
+        return gather_set == nullptr || gather_set->allowUnregisterTask();
+    });
+    if (gather_set != nullptr)
+    {
+        if (gather_set->isTaskRegistered(id))
+        {
+            gather_set->removeMPPTask(id);
+            if (!gather_set->hasMPPTask() && gather_set->alarms.empty())
+            {
+                removeMPPGatherTaskSet(query, id.gather_id, false);
+            }
             cv.notify_all();
             return {true, ""};
         }
@@ -345,34 +380,47 @@ String MPPTaskManager::toString()
     String res("(");
     for (auto & query_it : mpp_query_map)
     {
-        query_it.second->forEachMPPTask([&](const std::pair<MPPTaskId, MPPTaskPtr> & it) {
-            res += it.first.toString() + ", ";
-        });
+        for (auto & gather_it : query_it.second->mpp_gathers)
+        {
+            gather_it.second->forEachMPPTask([&](const std::pair<MPPTaskId, MPPTaskPtr> & it) {
+                res += it.first.toString() + ", ";
+            });
+        }
     }
     return res + ")";
 }
 
-std::pair<MPPQueryTaskSetPtr, String> MPPTaskManager::getQueryTaskSetWithoutLock(const MPPQueryId & query_id)
+std::pair<MPPGatherTaskSetPtr, String> MPPTaskManager::getGatherTaskSetWithoutLock(const MPPGatherId & gather_id)
 {
-    auto it = mpp_query_map.find(query_id);
-    /// gather_id is not set by TiDB, so use 0 instead
-    auto reason = aborted_query_gather_cache.check(MPPGatherId(0, query_id));
-    if (it != mpp_query_map.end())
+    auto [query, gather, aborted_reason] = getMPPQueryAndGatherTaskSet(gather_id);
+    return {gather, aborted_reason};
+}
+
+std::tuple<MPPQueryPtr, MPPGatherTaskSetPtr, String> MPPTaskManager::getMPPQueryAndGatherTaskSet(const MPPGatherId & gather_id)
+{
+    auto reason = aborted_query_gather_cache.check(gather_id);
+    const auto & query = getMPPQueryWithoutLock(gather_id.query_id);
+    if (query == nullptr)
     {
-        if (!it->second->isInNormalState() && reason.empty())
-            reason = it->second->error_message;
-        return std::make_tuple(it->second, reason);
+        return std::make_tuple(nullptr, nullptr, reason);
+    }
+    auto gather_it = query->mpp_gathers.find(gather_id);
+    if (gather_it != query->mpp_gathers.end())
+    {
+        if (!gather_it->second->isInNormalState() && reason.empty())
+            reason = gather_it->second->error_message;
+        return std::make_tuple(query, gather_it->second, reason);
     }
     else
     {
-        return std::make_tuple(nullptr, reason);
+        return std::make_tuple(query, nullptr, reason);
     }
 }
 
-std::pair<MPPQueryTaskSetPtr, String> MPPTaskManager::getQueryTaskSet(const MPPQueryId & query_id)
+std::pair<MPPGatherTaskSetPtr, String> MPPTaskManager::getGatherTaskSet(const MPPGatherId & gather_id)
 {
     std::lock_guard lock(mu);
-    return getQueryTaskSetWithoutLock(query_id);
+    return getGatherTaskSetWithoutLock(gather_id);
 }
 
 bool MPPTaskManager::tryToScheduleTask(MPPTaskScheduleEntry & schedule_entry)

--- a/dbms/src/Flash/Mpp/MPPTaskManager.cpp
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.cpp
@@ -90,6 +90,12 @@ MPPQueryPtr MPPTaskManager::getMPPQueryWithoutLock(const DB::MPPQueryId & query_
     return query_it == mpp_query_map.end() ? nullptr : query_it->second;
 }
 
+MPPQueryPtr MPPTaskManager::getMPPQuery(const MPPQueryId & query_id)
+{
+    std::unique_lock lock(mu);
+    return getMPPQueryWithoutLock(query_id);
+}
+
 void MPPTaskManager::removeMPPGatherTaskSet(MPPQueryPtr & query, const MPPGatherId & gather_id, bool on_abort)
 {
     query->mpp_gathers.erase(gather_id);

--- a/dbms/src/Flash/Mpp/MPPTaskManager.cpp
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.cpp
@@ -120,7 +120,7 @@ std::pair<MPPTunnelPtr, String> MPPTaskManager::findAsyncTunnel(const ::mpp::Est
     if (!error_msg.empty())
     {
         /// if the gather is aborted, return the error message
-        LOG_WARNING(log, fmt::format("{}: Gather {} is aborted, all its tasks are invalid.", req_info, id.gather_id.toString()));
+        LOG_WARNING(log, "{}: Gather {} is aborted, all its tasks are invalid.", req_info, id.gather_id.toString());
         /// meet error
         return {nullptr, error_msg};
     }
@@ -184,7 +184,7 @@ std::pair<MPPTunnelPtr, String> MPPTaskManager::findTunnelWithTimeout(const ::mp
         if (!error_msg.empty())
         {
             /// if the gather is aborted, return true to stop waiting timeout.
-            LOG_WARNING(log, fmt::format("{}: Gather {} is aborted, all its tasks are invalid.", req_info, id.gather_id.toString()));
+            LOG_WARNING(log, "{}: Gather {} is aborted, all its tasks are invalid.", req_info, id.gather_id.toString());
             cancelled = true;
             error_message = error_msg;
             return true;
@@ -210,7 +210,7 @@ std::pair<MPPTunnelPtr, String> MPPTaskManager::findTunnelWithTimeout(const ::mp
 
 void MPPTaskManager::abortMPPGather(const MPPGatherId & gather_id, const String & reason, AbortType abort_type)
 {
-    LOG_WARNING(log, fmt::format("Begin to abort gather: {}, abort type: {}, reason: {}", gather_id.toString(), magic_enum::enum_name(abort_type), reason));
+    LOG_WARNING(log, "Begin to abort gather: {}, abort type: {}, reason: {}", gather_id.toString(), magic_enum::enum_name(abort_type), reason);
     MPPGatherTaskSetPtr gather_task_set;
     {
         /// abort task may take a long time, so first
@@ -222,13 +222,13 @@ void MPPTaskManager::abortMPPGather(const MPPGatherId & gather_id, const String 
         auto [query, gather_task_set_local, _] = getMPPQueryAndGatherTaskSet(gather_id);
         if (query == nullptr || gather_task_set_local == nullptr)
         {
-            LOG_WARNING(log, fmt::format("{} does not found in task manager, skip abort", gather_id.toString()));
+            LOG_WARNING(log, "{} does not found in task manager, skip abort", gather_id.toString());
             return;
         }
         gather_task_set = gather_task_set_local;
         if (!gather_task_set->isInNormalState())
         {
-            LOG_WARNING(log, fmt::format("{} already in abort process, skip abort", gather_id.toString()));
+            LOG_WARNING(log, "{} already in abort process, skip abort", gather_id.toString());
             return;
         }
         gather_task_set->state = MPPGatherTaskSet::Aborting;
@@ -242,7 +242,7 @@ void MPPTaskManager::abortMPPGather(const MPPGatherId & gather_id, const String 
         gather_task_set->alarms.clear();
         if (!gather_task_set->hasMPPTask())
         {
-            LOG_INFO(log, fmt::format("There is no mpp task for {}, finish abort", gather_id.toString()));
+            LOG_INFO(log, "There is no mpp task for {}, finish abort", gather_id.toString());
             removeMPPGatherTaskSet(query, gather_id, true);
             cv.notify_all();
             return;

--- a/dbms/src/Flash/Mpp/MPPTaskManager.h
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.h
@@ -246,7 +246,7 @@ public:
     MPPQueryPtr getMPPQuery(const MPPQueryId & query_id);
 
 private:
-    MPPQueryPtr addMPPQuery(const MPPGatherId & gather_id);
+    MPPQueryPtr addMPPQuery(const MPPQueryId & query_id, bool has_meaningful_gather_id);
     void removeMPPGatherTaskSet(MPPQueryPtr & mpp_query, const MPPGatherId & gather_id, bool on_abort);
     std::tuple<MPPQueryPtr, MPPGatherTaskSetPtr, String> getMPPQueryAndGatherTaskSet(const MPPGatherId & gather_id);
 };

--- a/dbms/src/Flash/Mpp/MPPTaskManager.h
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.h
@@ -51,7 +51,6 @@ struct MPPGatherTaskSet
     {
         return state == Normal || state == Aborted;
     }
-    ~MPPGatherTaskSet();
     MPPTask * findMPPTask(const MPPTaskId & task_id) const;
     bool isTaskRegistered(const MPPTaskId & task_id) const
     {

--- a/dbms/src/Flash/Mpp/MPPTaskManager.h
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.h
@@ -243,6 +243,8 @@ public:
 
     MPPQueryPtr getMPPQueryWithoutLock(const MPPQueryId & query_id);
 
+    MPPQueryPtr getMPPQuery(const MPPQueryId & query_id);
+
 private:
     MPPQueryPtr addMPPQuery(const MPPGatherId & gather_id);
     void removeMPPGatherTaskSet(MPPQueryPtr & mpp_query, const MPPGatherId & gather_id, bool on_abort);

--- a/dbms/src/Flash/Mpp/MPPTaskManager.h
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.h
@@ -29,7 +29,7 @@
 
 namespace DB
 {
-struct MPPQueryTaskSet
+struct MPPGatherTaskSet
 {
     enum State
     {
@@ -40,7 +40,6 @@ struct MPPQueryTaskSet
     /// task can only be registered state is Normal
     State state = Normal;
     String error_message;
-    std::shared_ptr<ProcessListEntry> process_list_entry;
     std::unordered_map<Int64, std::unordered_map<Int64, grpc::Alarm>> alarms;
     /// only used in scheduler
     std::queue<MPPTaskId> waiting_tasks;
@@ -52,7 +51,7 @@ struct MPPQueryTaskSet
     {
         return state == Normal || state == Aborted;
     }
-    ~MPPQueryTaskSet();
+    ~MPPGatherTaskSet();
     MPPTask * findMPPTask(const MPPTaskId & task_id) const;
     bool isTaskRegistered(const MPPTaskId & task_id) const
     {
@@ -83,6 +82,18 @@ struct MPPQueryTaskSet
 private:
     MPPTaskMap task_map;
 };
+using MPPGatherTaskSetPtr = std::shared_ptr<MPPGatherTaskSet>;
+
+struct MPPQuery
+{
+    MPPGatherTaskSetPtr addMPPGatherTaskSet(const MPPGatherId & gather_id);
+    ~MPPQuery();
+
+    std::shared_ptr<ProcessListEntry> process_list_entry;
+    std::unordered_map<MPPGatherId, MPPGatherTaskSetPtr, MPPGatherIdHash> mpp_gathers;
+};
+using MPPQueryPtr = std::shared_ptr<MPPQuery>;
+
 
 /// A simple thread unsafe FIFO cache used to fix the "lost cancel" issues
 static const size_t ABORTED_MPPGATHER_CACHE_SIZE = 1000;
@@ -127,12 +138,10 @@ public:
     }
 };
 
-using MPPQueryTaskSetPtr = std::shared_ptr<MPPQueryTaskSet>;
-
 /// a map from the mpp query id to mpp query task set, we use
 /// the query_ts + local_query_id + serverID as the query id, because TiDB can't guarantee
 /// the uniqueness of the start ts when stale read or set snapshot
-using MPPQueryMap = std::unordered_map<MPPQueryId, MPPQueryTaskSetPtr, MPPQueryIdHash>;
+using MPPQueryMap = std::unordered_map<MPPQueryId, MPPQueryPtr, MPPQueryIdHash>;
 
 struct MPPTaskMonitor
 {
@@ -205,9 +214,9 @@ public:
 
     void removeMonitoredTask(const String & task_unique_id) { monitor->removeMonitoredTask(task_unique_id); }
 
-    std::pair<MPPQueryTaskSetPtr, String> getQueryTaskSetWithoutLock(const MPPQueryId & query_id);
+    std::pair<MPPGatherTaskSetPtr, String> getGatherTaskSetWithoutLock(const MPPGatherId & gather_id);
 
-    std::pair<MPPQueryTaskSetPtr, String> getQueryTaskSet(const MPPQueryId & query_id);
+    std::pair<MPPGatherTaskSetPtr, String> getGatherTaskSet(const MPPGatherId & gather_id);
 
     /// registerTask make the task info stored in MPPTaskManager, but it is still not visible to other mpp tasks before makeTaskActive.
     /// After registerTask, the related query_task_set can't be cleaned before unregisterTask is called
@@ -225,13 +234,16 @@ public:
 
     std::pair<MPPTunnelPtr, String> findAsyncTunnel(const ::mpp::EstablishMPPConnectionRequest * request, EstablishCallData * call_data, grpc::CompletionQueue * cq);
 
-    void abortMPPQuery(const MPPQueryId & query_id, const String & reason, AbortType abort_type);
+    void abortMPPGather(const MPPGatherId & gather_id, const String & reason, AbortType abort_type);
 
     String toString();
 
+    MPPQueryPtr getMPPQueryWithoutLock(const MPPQueryId & query_id);
+
 private:
-    MPPQueryTaskSetPtr addMPPQueryTaskSet(const MPPQueryId & query_id);
-    void removeMPPQueryTaskSet(const MPPQueryId & query_id, bool on_abort);
+    MPPQueryPtr addMPPQuery(const MPPQueryId & query_id);
+    void removeMPPGatherTaskSet(MPPQueryPtr & mpp_query, const MPPGatherId & gather_id, bool on_abort);
+    std::tuple<MPPQueryPtr, MPPGatherTaskSetPtr, String> getMPPQueryAndGatherTaskSet(const MPPGatherId & gather_id);
 };
 
 } // namespace DB

--- a/dbms/src/Flash/Mpp/MPPTaskManager.h
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.h
@@ -85,11 +85,15 @@ using MPPGatherTaskSetPtr = std::shared_ptr<MPPGatherTaskSet>;
 
 struct MPPQuery
 {
+    MPPQuery(bool has_meaningful_gather_id_)
+        : has_meaningful_gather_id(has_meaningful_gather_id_)
+    {}
     MPPGatherTaskSetPtr addMPPGatherTaskSet(const MPPGatherId & gather_id);
     ~MPPQuery();
 
     std::shared_ptr<ProcessListEntry> process_list_entry;
     std::unordered_map<MPPGatherId, MPPGatherTaskSetPtr, MPPGatherIdHash> mpp_gathers;
+    bool has_meaningful_gather_id;
 };
 using MPPQueryPtr = std::shared_ptr<MPPQuery>;
 
@@ -240,7 +244,7 @@ public:
     MPPQueryPtr getMPPQueryWithoutLock(const MPPQueryId & query_id);
 
 private:
-    MPPQueryPtr addMPPQuery(const MPPQueryId & query_id);
+    MPPQueryPtr addMPPQuery(const MPPGatherId & gather_id);
     void removeMPPGatherTaskSet(MPPQueryPtr & mpp_query, const MPPGatherId & gather_id, bool on_abort);
     std::tuple<MPPQueryPtr, MPPGatherTaskSetPtr, String> getMPPQueryAndGatherTaskSet(const MPPGatherId & gather_id);
 };

--- a/dbms/src/Flash/Mpp/MPPTaskManager.h
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.h
@@ -85,7 +85,7 @@ using MPPGatherTaskSetPtr = std::shared_ptr<MPPGatherTaskSet>;
 
 struct MPPQuery
 {
-    MPPQuery(bool has_meaningful_gather_id_)
+    explicit MPPQuery(bool has_meaningful_gather_id_)
         : has_meaningful_gather_id(has_meaningful_gather_id_)
     {}
     MPPGatherTaskSetPtr addMPPGatherTaskSet(const MPPGatherId & gather_id);
@@ -110,7 +110,7 @@ private:
     size_t capacity;
 
 public:
-    AbortedMPPGatherCache(size_t capacity_)
+    explicit AbortedMPPGatherCache(size_t capacity_)
         : capacity(capacity_)
     {}
     /// return aborted_reason if the mpp gather is aborted, otherwise, return empty string
@@ -141,7 +141,7 @@ public:
     }
 };
 
-/// a map from the mpp query id to mpp query task set, we use
+/// a map from the mpp query id to mpp query, we use
 /// the query_ts + local_query_id + serverID as the query id, because TiDB can't guarantee
 /// the uniqueness of the start ts when stale read or set snapshot
 using MPPQueryMap = std::unordered_map<MPPQueryId, MPPQueryPtr, MPPQueryIdHash>;

--- a/dbms/src/Flash/Mpp/MPPTaskStatistics.cpp
+++ b/dbms/src/Flash/Mpp/MPPTaskStatistics.cpp
@@ -109,7 +109,7 @@ void MPPTaskStatistics::logTracingJson()
         R"(,"read_wait_index_start_timestamp":{},"read_wait_index_end_timestamp":{})"
         R"(,"local_input_bytes":{},"remote_input_bytes":{},"output_bytes":{})"
         R"(,"status":"{}","error_message":"{}","cpu_ru":{},"read_ru":{},"memory_peak":{}}})",
-        id.query_id.start_ts,
+        id.gather_id.query_id.start_ts,
         id.task_id,
         is_root,
         sender_executor_id,

--- a/dbms/src/Flash/Mpp/MinTSOScheduler.cpp
+++ b/dbms/src/Flash/Mpp/MinTSOScheduler.cpp
@@ -77,51 +77,65 @@ bool MinTSOScheduler::tryToSchedule(MPPTaskScheduleEntry & schedule_entry, MPPTa
         return true;
     }
     const auto & id = schedule_entry.getMPPTaskId();
-    auto [query_task_set, aborted_reason] = task_manager.getQueryTaskSetWithoutLock(id.query_id);
+    auto [query_task_set, aborted_reason] = task_manager.getGatherTaskSetWithoutLock(id.gather_id);
     if (nullptr == query_task_set || !aborted_reason.empty())
     {
         LOG_WARNING(log, "{} is scheduled with miss or abort.", id.toString());
         return true;
     }
     bool has_error = false;
-    return scheduleImp(id.query_id, query_task_set, schedule_entry, false, has_error);
+    return scheduleImp(id.gather_id.query_id, query_task_set, schedule_entry, false, has_error);
 }
 
 /// after finishing the query, there would be no threads released soon, so the updated min-query-id query with waiting tasks should be scheduled.
 /// the cancelled query maybe hang, so trigger scheduling as needed when deleting cancelled query.
-void MinTSOScheduler::deleteQuery(const MPPQueryId & query_id, MPPTaskManager & task_manager, const bool is_cancelled)
+void MinTSOScheduler::deleteQuery(const MPPQueryId & query_id, MPPTaskManager & task_manager, const bool is_cancelled, Int64 gather_id)
 {
     if (isDisabled())
     {
         return;
     }
 
-    LOG_DEBUG(log, "{} query {} (is min = {}) is deleted from active set {} left {} or waiting set {} left {}.", is_cancelled ? "Cancelled" : "Finished", query_id.toString(), query_id == min_query_id, active_set.find(query_id) != active_set.end(), active_set.size(), waiting_set.find(query_id) != waiting_set.end(), waiting_set.size());
-    active_set.erase(query_id);
-    waiting_set.erase(query_id);
-    GET_METRIC(tiflash_task_scheduler, type_waiting_queries_count).Set(waiting_set.size());
-    GET_METRIC(tiflash_task_scheduler, type_active_queries_count).Set(active_set.size());
+    bool delete_all_gathers = true;
+    auto query = task_manager.getMPPQueryWithoutLock(query_id);
 
-    if (is_cancelled) /// cancelled queries may have waiting tasks, and finished queries haven't.
+    if (query != nullptr) /// release all waiting tasks
     {
-        auto query_task_set = task_manager.getQueryTaskSetWithoutLock(query_id).first;
-        if (query_task_set) /// release all waiting tasks
+        for (const auto & gather_it : query->mpp_gathers)
         {
-            while (!query_task_set->waiting_tasks.empty())
+            if (gather_id == -1 || gather_it.first.gather_id == gather_id)
             {
-                auto * task = query_task_set->findMPPTask(query_task_set->waiting_tasks.front());
-                if (task != nullptr)
-                    task->scheduleThisTask(ScheduleState::FAILED);
-                query_task_set->waiting_tasks.pop();
-                GET_METRIC(tiflash_task_scheduler, type_waiting_tasks_count).Decrement();
+                if (is_cancelled) /// cancelled queries may have waiting tasks, and finished queries haven't.
+                {
+                    while (!gather_it.second->waiting_tasks.empty())
+                    {
+                        auto * task = gather_it.second->findMPPTask(gather_it.second->waiting_tasks.front());
+                        if (task != nullptr)
+                            task->scheduleThisTask(ScheduleState::FAILED);
+                        gather_it.second->waiting_tasks.pop();
+                        GET_METRIC(tiflash_task_scheduler, type_waiting_tasks_count).Decrement();
+                    }
+                }
+            }
+            else
+            {
+                delete_all_gathers = false;
             }
         }
     }
 
-    /// NOTE: if updated min_query_id query has waiting tasks, they should be scheduled, especially when the soft-limited threads are amost used and active tasks are in resources deadlock which cannot release threads soon.
-    if (updateMinQueryId(query_id, true, is_cancelled ? "when cancelling it" : "as finishing it"))
+    if (delete_all_gathers)
     {
-        scheduleWaitingQueries(task_manager);
+        LOG_DEBUG(log, "{} query {} (is min = {}) is deleted from active set {} left {} or waiting set {} left {}.", is_cancelled ? "Cancelled" : "Finished", query_id.toString(), query_id == min_query_id, active_set.find(query_id) != active_set.end(), active_set.size(), waiting_set.find(query_id) != waiting_set.end(), waiting_set.size());
+        active_set.erase(query_id);
+        waiting_set.erase(query_id);
+        GET_METRIC(tiflash_task_scheduler, type_waiting_queries_count).Set(waiting_set.size());
+        GET_METRIC(tiflash_task_scheduler, type_active_queries_count).Set(active_set.size());
+        /// NOTE: if updated min_query_id query has waiting tasks, they should be scheduled, especially when the soft-limited threads are amost used and active tasks are in resources deadlock which cannot release threads soon.
+        if (updateMinQueryId(query_id, true, is_cancelled ? "when cancelling it" : "as finishing it"))
+        {
+            scheduleWaitingQueries(task_manager);
+        }
     }
 }
 
@@ -149,8 +163,8 @@ void MinTSOScheduler::scheduleWaitingQueries(MPPTaskManager & task_manager)
     while (!waiting_set.empty())
     {
         auto current_query_id = *waiting_set.begin();
-        auto query_task_set = task_manager.getQueryTaskSetWithoutLock(current_query_id).first;
-        if (nullptr == query_task_set) /// silently solve this rare case
+        auto query = task_manager.getMPPQueryWithoutLock(current_query_id);
+        if (nullptr == query) /// silently solve this rare case
         {
             LOG_ERROR(log, "the waiting query {} is not in the task manager.", current_query_id.toString());
             updateMinQueryId(current_query_id, true, "as it is not in the task manager.");
@@ -161,23 +175,26 @@ void MinTSOScheduler::scheduleWaitingQueries(MPPTaskManager & task_manager)
             continue;
         }
 
-        LOG_DEBUG(log, "query {} (is min = {}) with {} tasks is to be scheduled from waiting set (size = {}).", current_query_id.toString(), current_query_id == min_query_id, query_task_set->waiting_tasks.size(), waiting_set.size());
+        LOG_DEBUG(log, "query {} (is min = {}) is to be scheduled from waiting set (size = {}).", current_query_id.toString(), current_query_id == min_query_id, waiting_set.size());
         /// schedule tasks one by one
-        while (!query_task_set->waiting_tasks.empty())
+        for (auto & gather_set : query->mpp_gathers)
         {
-            auto * task = query_task_set->findMPPTask(query_task_set->waiting_tasks.front());
-            bool has_error = false;
-            if (task != nullptr && !scheduleImp(current_query_id, query_task_set, task->getScheduleEntry(), true, has_error))
+            while (!gather_set.second->waiting_tasks.empty())
             {
-                if (has_error)
+                auto * task = gather_set.second->findMPPTask(gather_set.second->waiting_tasks.front());
+                bool has_error = false;
+                if (task != nullptr && !scheduleImp(current_query_id, gather_set.second, task->getScheduleEntry(), true, has_error))
                 {
-                    query_task_set->waiting_tasks.pop(); /// it should be pop from the waiting queue, because the task is scheduled with errors.
-                    GET_METRIC(tiflash_task_scheduler, type_waiting_tasks_count).Decrement();
+                    if (has_error)
+                    {
+                        gather_set.second->waiting_tasks.pop(); /// it should be pop from the waiting queue, because the task is scheduled with errors.
+                        GET_METRIC(tiflash_task_scheduler, type_waiting_tasks_count).Decrement();
+                    }
+                    return;
                 }
-                return;
+                gather_set.second->waiting_tasks.pop();
+                GET_METRIC(tiflash_task_scheduler, type_waiting_tasks_count).Decrement();
             }
-            query_task_set->waiting_tasks.pop();
-            GET_METRIC(tiflash_task_scheduler, type_waiting_tasks_count).Decrement();
         }
         LOG_DEBUG(log, "query {} (is min = {}) is scheduled from waiting set (size = {}).", current_query_id.toString(), current_query_id == min_query_id, waiting_set.size());
         waiting_set.erase(current_query_id); /// all waiting tasks of this query are fully active
@@ -186,7 +203,7 @@ void MinTSOScheduler::scheduleWaitingQueries(MPPTaskManager & task_manager)
 }
 
 /// [directly schedule, from waiting set] * [is min_query_id query, not] * [can schedule, can't] totally 8 cases.
-bool MinTSOScheduler::scheduleImp(const MPPQueryId & query_id, const MPPQueryTaskSetPtr & query_task_set, MPPTaskScheduleEntry & schedule_entry, const bool isWaiting, bool & has_error)
+bool MinTSOScheduler::scheduleImp(const MPPQueryId & query_id, const MPPGatherTaskSetPtr & query_task_set, MPPTaskScheduleEntry & schedule_entry, const bool isWaiting, bool & has_error)
 {
     auto needed_threads = schedule_entry.getNeededThreads();
     auto check_for_new_min_tso = query_id <= min_query_id && estimated_thread_usage + needed_threads <= thread_hard_limit;

--- a/dbms/src/Flash/Mpp/MinTSOScheduler.cpp
+++ b/dbms/src/Flash/Mpp/MinTSOScheduler.cpp
@@ -137,6 +137,10 @@ void MinTSOScheduler::deleteQuery(const MPPQueryId & query_id, MPPTaskManager & 
             scheduleWaitingQueries(task_manager);
         }
     }
+    else
+    {
+        LOG_DEBUG(log, "{} gather {} of query {}, and there are still some other gathers remain", is_cancelled ? "Cancelled" : "Finished", gather_id, query_id.toString());
+    }
 }
 
 /// NOTE: should not throw exceptions due to being called when destruction.

--- a/dbms/src/Flash/Mpp/MinTSOScheduler.cpp
+++ b/dbms/src/Flash/Mpp/MinTSOScheduler.cpp
@@ -96,7 +96,7 @@ void MinTSOScheduler::deleteQuery(const MPPQueryId & query_id, MPPTaskManager & 
         return;
     }
 
-    bool delete_all_gathers = true;
+    bool all_gathers_deleted = true;
     auto query = task_manager.getMPPQueryWithoutLock(query_id);
 
     if (query != nullptr) /// release all waiting tasks
@@ -119,12 +119,12 @@ void MinTSOScheduler::deleteQuery(const MPPQueryId & query_id, MPPTaskManager & 
             }
             else
             {
-                delete_all_gathers = false;
+                all_gathers_deleted = false;
             }
         }
     }
 
-    if (delete_all_gathers)
+    if (all_gathers_deleted)
     {
         LOG_DEBUG(log, "{} query {} (is min = {}) is deleted from active set {} left {} or waiting set {} left {}.", is_cancelled ? "Cancelled" : "Finished", query_id.toString(), query_id == min_query_id, active_set.find(query_id) != active_set.end(), active_set.size(), waiting_set.find(query_id) != waiting_set.end(), waiting_set.size());
         active_set.erase(query_id);

--- a/dbms/src/Flash/Mpp/MinTSOScheduler.h
+++ b/dbms/src/Flash/Mpp/MinTSOScheduler.h
@@ -25,8 +25,8 @@ using MPPTaskSchedulerPtr = std::unique_ptr<MinTSOScheduler>;
 class MPPTaskManager;
 using MPPTaskManagerPtr = std::shared_ptr<MPPTaskManager>;
 
-struct MPPQueryTaskSet;
-using MPPQueryTaskSetPtr = std::shared_ptr<MPPQueryTaskSet>;
+struct MPPGatherTaskSet;
+using MPPGatherTaskSetPtr = std::shared_ptr<MPPGatherTaskSet>;
 
 /// scheduling tasks in the set according to the tso order under the soft limit of threads, but allow the min_query_id query to preempt threads under the hard limit of threads.
 /// The min_query_id query avoids the deadlock resulted from threads competition among nodes.
@@ -43,13 +43,13 @@ public:
 
     /// delete this to-be cancelled/finished query from scheduler and update min_query_id if needed, so that there aren't cancelled/finished queries in the scheduler.
     /// NOTE: call deleteQuery under the lock protection of MPPTaskManager
-    void deleteQuery(const MPPQueryId & query_id, MPPTaskManager & task_manager, const bool is_cancelled);
+    void deleteQuery(const MPPQueryId & query_id, MPPTaskManager & task_manager, const bool is_cancelled, Int64 gather_id);
 
     /// all scheduled tasks should finally call this function to release threads and schedule new tasks
     void releaseThreadsThenSchedule(const int needed_threads, MPPTaskManager & task_manager);
 
 private:
-    bool scheduleImp(const MPPQueryId & query_id, const MPPQueryTaskSetPtr & query_task_set, MPPTaskScheduleEntry & schedule_entry, const bool isWaiting, bool & has_error);
+    bool scheduleImp(const MPPQueryId & query_id, const MPPGatherTaskSetPtr & query_task_set, MPPTaskScheduleEntry & schedule_entry, const bool isWaiting, bool & has_error);
     bool updateMinQueryId(const MPPQueryId & query_id, const bool retired, const String & msg);
     void scheduleWaitingQueries(MPPTaskManager & task_manager);
     bool isDisabled()

--- a/dbms/src/Flash/tests/gtest_compute_server.cpp
+++ b/dbms/src/Flash/tests/gtest_compute_server.cpp
@@ -984,11 +984,13 @@ try
             /// these gathers should not be affected
             assertGatherActive(gather_ids[i]);
         }
+        /// the active query count should not change
         ASSERT_TRUE(TiFlashMetrics::instance().tiflash_task_scheduler.get(tiflash_task_scheduler_metrics::type_active_queries_count).Value() == 2);
         ASSERT_TRUE(TiFlashMetrics::instance().tiflash_task_scheduler.get(tiflash_task_scheduler_metrics::type_waiting_queries_count).Value() == 0);
         /// kill single gather query
         MockComputeServerManager::instance().cancelGather(gather_ids[5]);
         assertGatherCancelled(gather_ids[5]);
+        /// the active query count should be 1
         ASSERT_TRUE(TiFlashMetrics::instance().tiflash_task_scheduler.get(tiflash_task_scheduler_metrics::type_active_queries_count).Value() == 1);
         ASSERT_TRUE(TiFlashMetrics::instance().tiflash_task_scheduler.get(tiflash_task_scheduler_metrics::type_waiting_queries_count).Value() == 0);
         /// kill the rest gathers

--- a/dbms/src/Flash/tests/gtest_compute_server.cpp
+++ b/dbms/src/Flash/tests/gtest_compute_server.cpp
@@ -980,6 +980,9 @@ try
         assertGatherCancelled(gather_ids[1]);
         ASSERT_TRUE(TiFlashMetrics::instance().tiflash_task_scheduler.get(tiflash_task_scheduler_metrics::type_active_queries_count).Value() == 0);
         ASSERT_TRUE(TiFlashMetrics::instance().tiflash_task_scheduler.get(tiflash_task_scheduler_metrics::type_waiting_queries_count).Value() == 0);
+        for (auto & t : running_queries)
+            if (t.joinable())
+                t.join();
     }
     catch (...)
     {

--- a/dbms/src/Flash/tests/gtest_compute_server.cpp
+++ b/dbms/src/Flash/tests/gtest_compute_server.cpp
@@ -139,7 +139,7 @@ public:
             }
         });
     }
-    void addOneGather(size_t query_ts, std::vector<std::thread> & running_queries, std::vector<MPPGatherId> & gather_ids)
+    void addOneQuery(size_t query_ts, std::vector<std::thread> & running_queries, std::vector<MPPGatherId> & gather_ids)
     {
         auto properties = DB::tests::getDAGPropertiesForTest(serverNum(), 1, 1, query_ts);
         addOneGather(running_queries, gather_ids, properties);
@@ -895,13 +895,13 @@ try
         /// case 1, min tso can be added
         for (size_t i = 0; i < active_set_soft_limit; ++i)
         {
-            addOneGather(i + 10, running_queries, gather_ids);
+            addOneQuery(i + 10, running_queries, gather_ids);
         }
         using namespace std::literals::chrono_literals;
         std::this_thread::sleep_for(2s);
         ASSERT_TRUE(TiFlashMetrics::instance().tiflash_task_scheduler.get(tiflash_task_scheduler_metrics::type_active_queries_count).Value() == 2);
         ASSERT_TRUE(TiFlashMetrics::instance().tiflash_task_scheduler.get(tiflash_task_scheduler_metrics::type_waiting_queries_count).Value() == 0);
-        addOneGather(1, running_queries, gather_ids);
+        addOneQuery(1, running_queries, gather_ids);
         std::this_thread::sleep_for(2s);
         ASSERT_TRUE(TiFlashMetrics::instance().tiflash_task_scheduler.get(tiflash_task_scheduler_metrics::type_active_queries_count).Value() == 3);
         ASSERT_TRUE(TiFlashMetrics::instance().tiflash_task_scheduler.get(tiflash_task_scheduler_metrics::type_waiting_queries_count).Value() == 0);
@@ -914,13 +914,13 @@ try
         /// case 2, non-min tso can't be added
         for (size_t i = 0; i < active_set_soft_limit; ++i)
         {
-            addOneGather((i + 1) * 20, running_queries, gather_ids);
+            addOneQuery((i + 1) * 20, running_queries, gather_ids);
         }
         using namespace std::literals::chrono_literals;
         std::this_thread::sleep_for(2s);
         ASSERT_TRUE(TiFlashMetrics::instance().tiflash_task_scheduler.get(tiflash_task_scheduler_metrics::type_active_queries_count).Value() == 2);
         ASSERT_TRUE(TiFlashMetrics::instance().tiflash_task_scheduler.get(tiflash_task_scheduler_metrics::type_waiting_queries_count).Value() == 0);
-        addOneGather(30, running_queries, gather_ids);
+        addOneQuery(30, running_queries, gather_ids);
         std::this_thread::sleep_for(2s);
         ASSERT_TRUE(TiFlashMetrics::instance().tiflash_task_scheduler.get(tiflash_task_scheduler_metrics::type_active_queries_count).Value() == 2);
         ASSERT_TRUE(TiFlashMetrics::instance().tiflash_task_scheduler.get(tiflash_task_scheduler_metrics::type_waiting_queries_count).Value() == 1);

--- a/dbms/src/Storages/DeltaMerge/Remote/DisaggTaskId.cpp
+++ b/dbms/src/Storages/DeltaMerge/Remote/DisaggTaskId.cpp
@@ -24,6 +24,7 @@ DisaggTaskId::DisaggTaskId(const disaggregated::DisaggTaskMeta & task_meta)
         task_meta.start_ts(),
         task_meta.task_id(),
         task_meta.server_id(),
+        task_meta.gather_id(),
         task_meta.query_ts(),
         task_meta.local_query_id())
     , executor_id(task_meta.executor_id())
@@ -33,10 +34,11 @@ DisaggTaskId::DisaggTaskId(const disaggregated::DisaggTaskMeta & task_meta)
 disaggregated::DisaggTaskMeta DisaggTaskId::toMeta() const
 {
     disaggregated::DisaggTaskMeta meta;
-    meta.set_start_ts(mpp_task_id.query_id.start_ts);
-    meta.set_server_id(mpp_task_id.query_id.server_id);
-    meta.set_query_ts(mpp_task_id.query_id.query_ts);
-    meta.set_local_query_id(mpp_task_id.query_id.local_query_id);
+    meta.set_start_ts(mpp_task_id.gather_id.query_id.start_ts);
+    meta.set_server_id(mpp_task_id.gather_id.query_id.server_id);
+    meta.set_query_ts(mpp_task_id.gather_id.query_id.query_ts);
+    meta.set_local_query_id(mpp_task_id.gather_id.query_id.local_query_id);
+    meta.set_gather_id(mpp_task_id.gather_id.gather_id);
     meta.set_task_id(mpp_task_id.task_id);
     meta.set_executor_id(executor_id);
     return meta;

--- a/dbms/src/Storages/StorageDisaggregated.cpp
+++ b/dbms/src/Storages/StorageDisaggregated.cpp
@@ -190,10 +190,11 @@ RequestAndRegionIDs StorageDisaggregated::buildDispatchMPPTaskRequest(
     auto keyspace_id = context.getDAGContext()->getKeyspaceID();
     dispatch_req_meta->set_keyspace_id(keyspace_id);
     dispatch_req_meta->set_api_version(keyspace_id == NullspaceID ? kvrpcpb::APIVersion::V1 : kvrpcpb::APIVersion::V2);
-    dispatch_req_meta->set_start_ts(sender_target_mpp_task_id.query_id.start_ts);
-    dispatch_req_meta->set_query_ts(sender_target_mpp_task_id.query_id.query_ts);
-    dispatch_req_meta->set_local_query_id(sender_target_mpp_task_id.query_id.local_query_id);
-    dispatch_req_meta->set_server_id(sender_target_mpp_task_id.query_id.server_id);
+    dispatch_req_meta->set_start_ts(sender_target_mpp_task_id.gather_id.query_id.start_ts);
+    dispatch_req_meta->set_query_ts(sender_target_mpp_task_id.gather_id.query_id.query_ts);
+    dispatch_req_meta->set_local_query_id(sender_target_mpp_task_id.gather_id.query_id.local_query_id);
+    dispatch_req_meta->set_server_id(sender_target_mpp_task_id.gather_id.query_id.server_id);
+    dispatch_req_meta->set_gather_id(sender_target_mpp_task_id.gather_id.gather_id);
     dispatch_req_meta->set_task_id(sender_target_mpp_task_id.task_id);
     dispatch_req_meta->set_address(batch_cop_task.store_addr);
 

--- a/dbms/src/Storages/StorageDisaggregatedRemote.cpp
+++ b/dbms/src/Storages/StorageDisaggregatedRemote.cpp
@@ -410,7 +410,6 @@ StorageDisaggregated::buildEstablishDisaggTaskReq(
     const auto & settings = db_context.getSettingsRef();
     auto establish_req = std::make_shared<disaggregated::EstablishDisaggTaskRequest>();
     {
-        // todo check if gather_id is needed in disaggregated::DisaggTaskMeta
         disaggregated::DisaggTaskMeta * meta = establish_req->mutable_meta();
         meta->set_start_ts(sender_target_mpp_task_id.gather_id.query_id.start_ts);
         meta->set_query_ts(sender_target_mpp_task_id.gather_id.query_id.query_ts);

--- a/dbms/src/Storages/StorageDisaggregatedRemote.cpp
+++ b/dbms/src/Storages/StorageDisaggregatedRemote.cpp
@@ -65,7 +65,6 @@
 
 namespace DB
 {
-
 namespace ErrorCodes
 {
 extern const int DISAGG_ESTABLISH_RETRYABLE_ERROR;

--- a/dbms/src/TestUtils/MPPTaskTestUtils.cpp
+++ b/dbms/src/TestUtils/MPPTaskTestUtils.cpp
@@ -192,7 +192,7 @@ String MPPTaskTestUtils::queryInfo(size_t server_id)
         while (TiFlashTestEnv::getGlobalContext(i).getTMTContext().getMPPTaskManager()->getGatherTaskSet(gather_id).first != nullptr)
         {
             std::this_thread::sleep_for(seconds);
-            retry_times++;
+            ++retry_times;
             // Currenly we wait for 20 times to ensure all tasks are cancelled.
             if (retry_times > 20)
             {

--- a/dbms/src/TestUtils/MPPTaskTestUtils.cpp
+++ b/dbms/src/TestUtils/MPPTaskTestUtils.cpp
@@ -166,7 +166,7 @@ String MPPTaskTestUtils::queryInfo(size_t server_id)
     for (int i = test_meta.context_idx; i < TiFlashTestEnv::globalContextSize(); ++i)
     {
         // wait until the task is empty for <query:start_ts>
-        while (TiFlashTestEnv::getGlobalContext(i).getTMTContext().getMPPTaskManager()->getQueryTaskSet(query_id).first != nullptr)
+        while (TiFlashTestEnv::getGlobalContext(i).getTMTContext().getMPPTaskManager()->getGatherTaskSet(query_id).first != nullptr)
         {
             std::this_thread::sleep_for(seconds);
             retry_times++;
@@ -184,7 +184,7 @@ String MPPTaskTestUtils::queryInfo(size_t server_id)
 {
     for (int i = test_meta.context_idx; i < TiFlashTestEnv::globalContextSize(); ++i)
     {
-        if (TiFlashTestEnv::getGlobalContext(i).getTMTContext().getMPPTaskManager()->getQueryTaskSet(query_id).first == nullptr)
+        if (TiFlashTestEnv::getGlobalContext(i).getTMTContext().getMPPTaskManager()->getGatherTaskSet(query_id).first == nullptr)
         {
             return ::testing::AssertionFailure() << "Query " << query_id.toString() << "not active" << std::endl;
         }

--- a/dbms/src/TestUtils/MPPTaskTestUtils.cpp
+++ b/dbms/src/TestUtils/MPPTaskTestUtils.cpp
@@ -23,7 +23,7 @@
 
 namespace DB::tests
 {
-DAGProperties getDAGPropertiesForTest(int server_num, int local_query_id, int tidb_server_id, int query_ts)
+DAGProperties getDAGPropertiesForTest(int server_num, int local_query_id, int tidb_server_id, int query_ts, int gather_id)
 {
     DAGProperties properties;
     // enable mpp
@@ -38,6 +38,8 @@ DAGProperties getDAGPropertiesForTest(int server_num, int local_query_id, int ti
         properties.local_query_id = properties.start_ts;
     if (tidb_server_id >= 0)
         properties.server_id = tidb_server_id;
+    if (gather_id > 0)
+        properties.gather_id = gather_id;
     return properties;
 }
 
@@ -166,7 +168,7 @@ String MPPTaskTestUtils::queryInfo(size_t server_id)
     for (int i = test_meta.context_idx; i < TiFlashTestEnv::globalContextSize(); ++i)
     {
         // wait until the task is empty for <query:start_ts>
-        while (TiFlashTestEnv::getGlobalContext(i).getTMTContext().getMPPTaskManager()->getGatherTaskSet(query_id).first != nullptr)
+        while (TiFlashTestEnv::getGlobalContext(i).getTMTContext().getMPPTaskManager()->getMPPQuery(query_id) != nullptr)
         {
             std::this_thread::sleep_for(seconds);
             retry_times++;
@@ -180,17 +182,51 @@ String MPPTaskTestUtils::queryInfo(size_t server_id)
     return ::testing::AssertionSuccess();
 }
 
+::testing::AssertionResult MPPTaskTestUtils::assertGatherCancelled(const MPPGatherId & gather_id)
+{
+    auto seconds = std::chrono::seconds(1);
+    auto retry_times = 0;
+    for (int i = test_meta.context_idx; i < TiFlashTestEnv::globalContextSize(); ++i)
+    {
+        // wait until the task is empty for <query:start_ts>
+        while (TiFlashTestEnv::getGlobalContext(i).getTMTContext().getMPPTaskManager()->getGatherTaskSet(gather_id).first != nullptr)
+        {
+            std::this_thread::sleep_for(seconds);
+            retry_times++;
+            // Currenly we wait for 20 times to ensure all tasks are cancelled.
+            if (retry_times > 20)
+            {
+                return ::testing::AssertionFailure() << "Gather not cancelled, " << queryInfo(i) << std::endl;
+            }
+        }
+    }
+    return ::testing::AssertionSuccess();
+}
+
 ::testing::AssertionResult MPPTaskTestUtils::assertQueryActive(const MPPQueryId & query_id)
 {
     for (int i = test_meta.context_idx; i < TiFlashTestEnv::globalContextSize(); ++i)
     {
-        if (TiFlashTestEnv::getGlobalContext(i).getTMTContext().getMPPTaskManager()->getGatherTaskSet(query_id).first == nullptr)
+        if (TiFlashTestEnv::getGlobalContext(i).getTMTContext().getMPPTaskManager()->getMPPQuery(query_id) == nullptr)
         {
             return ::testing::AssertionFailure() << "Query " << query_id.toString() << "not active" << std::endl;
         }
     }
     return ::testing::AssertionSuccess();
 }
+
+::testing::AssertionResult MPPTaskTestUtils::assertGatherActive(const MPPGatherId & gather_id)
+{
+    for (int i = test_meta.context_idx; i < TiFlashTestEnv::globalContextSize(); ++i)
+    {
+        if (TiFlashTestEnv::getGlobalContext(i).getTMTContext().getMPPTaskManager()->getGatherTaskSet(gather_id).first == nullptr)
+        {
+            return ::testing::AssertionFailure() << "Gather " << gather_id.toString() << "not active" << std::endl;
+        }
+    }
+    return ::testing::AssertionSuccess();
+}
+
 
 ColumnsWithTypeAndName MPPTaskTestUtils::buildAndExecuteMPPTasks(DAGRequestBuilder builder)
 {

--- a/dbms/src/TestUtils/MPPTaskTestUtils.h
+++ b/dbms/src/TestUtils/MPPTaskTestUtils.h
@@ -20,7 +20,7 @@
 
 namespace DB::tests
 {
-DAGProperties getDAGPropertiesForTest(int server_num, int local_query_id = -1, int tidb_server_id = -1, int query_ts = -1);
+DAGProperties getDAGPropertiesForTest(int server_num, int local_query_id = -1, int tidb_server_id = -1, int query_ts = -1, int gather_id = -1);
 class MockTimeStampGenerator : public ext::Singleton<MockTimeStampGenerator>
 {
 public:
@@ -90,6 +90,9 @@ public:
 
     static ::testing::AssertionResult assertQueryCancelled(const MPPQueryId & query_id);
     static ::testing::AssertionResult assertQueryActive(const MPPQueryId & query_id);
+
+    static ::testing::AssertionResult assertGatherCancelled(const MPPGatherId & gather_id);
+    static ::testing::AssertionResult assertGatherActive(const MPPGatherId & gather_id);
 
     static String queryInfo(size_t server_id);
 

--- a/dbms/src/TestUtils/mockExecutor.cpp
+++ b/dbms/src/TestUtils/mockExecutor.cpp
@@ -105,7 +105,7 @@ void DAGRequestBuilder::initDAGRequest(tipb::DAGRequest & dag_request)
 std::shared_ptr<tipb::DAGRequest> DAGRequestBuilder::build(MockDAGRequestContext & mock_context, DAGRequestType type)
 {
     // build tree struct base executor
-    MPPInfo mpp_info(properties.start_ts, properties.query_ts, properties.server_id, properties.local_query_id, -1, -1, {}, mock_context.receiver_source_task_ids_map);
+    MPPInfo mpp_info(properties.start_ts, properties.gather_id, properties.query_ts, properties.server_id, properties.local_query_id, -1, -1, {}, mock_context.receiver_source_task_ids_map);
     std::shared_ptr<tipb::DAGRequest> dag_request_ptr = std::make_shared<tipb::DAGRequest>();
     tipb::DAGRequest & dag_request = *dag_request_ptr;
     initDAGRequest(dag_request);

--- a/tests/fullstack-test/mpp/apply.test
+++ b/tests/fullstack-test/mpp/apply.test
@@ -29,13 +29,34 @@ mysql> insert into test.t select a + 5, b + 5 from test.t
 
 func> wait_table test t
 
-
-mysql> use test; set @@tidb_isolation_read_engines='tiflash'; set @@tidb_enforce_mpp=1; select count(*) from t where a > (select avg(b) from t t1 where t.a > t1.a);
+mysql> use test; set @@tidb_enable_parallel_apply=0; set @@tidb_isolation_read_engines='tiflash'; set @@tidb_enforce_mpp=1; select count(*) from t where a > (select avg(b) from t t1 where t.a > t1.a);
 +----------+
 | count(*) |
 +----------+
 |     4094 |
 +----------+
+
+mysql> use test; set @@tidb_enable_parallel_apply=0; set @@tidb_isolation_read_engines='tiflash'; set @@tidb_enforce_mpp=1; select count(*) from t where a > (select a from t t1 where t.a > t1.a limit 1);
++----------+
+| count(*) |
++----------+
+|     4095 |
++----------+
+
+## parallel apply has bugs, will enable the test after https://github.com/pingcap/tidb/issues/45299 is fixed.
+# mysql> use test; set @@tidb_enable_parallel_apply=1; set @@tidb_isolation_read_engines='tiflash'; set @@tidb_enforce_mpp=1; select count(*) from t where a > (select avg(b) from t t1 where t.a > t1.a);
+# +----------+
+# | count(*) |
+# +----------+
+# |     4094 |
+# +----------+
+
+# mysql> use test; set @@tidb_enable_parallel_apply=1; set @@tidb_isolation_read_engines='tiflash'; set @@tidb_enforce_mpp=1; select count(*) from t where a > (select a from t t1 where t.a > t1.a limit 1);
+# +----------+
+# | count(*) |
+# +----------+
+# |     4095 |
+# +----------+
 
 # Clean up.
 mysql> drop table if exists test.t


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #7746, close #7744

Problem Summary:

### What is changed and how it works?
- Change the organization of MPPTasks in MPPTaskManager from two-level to three-level:
  - Before this pr: `MPPTask`s => `MPPQueryTaskSet`, `MPPQueryTaskSet`s => `MPPTaskMananger` 
  - After this pr: `MPPTask`s => `MPPGatherTaskSet`, `MPPGatherTaskSet`s => `MPPQuery`, `MPPQuery`s => `MPPTaskManager`
- `Cancel/Abort` mpp task works on `MPPGather` level, cancel a mpp gather does not affect other mpp gathers that belongs to the same mpp query
- `Schedule` mpp task still works on `MPPQuery` level, which means if a mpp query is the min-tso query, all the gathers belongs to the same mpp query will be scheduled
- Refine test to support mpp gather
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  - test tpch queries
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
