### PR TITLE
Fix a typo in ingest range check

### DIFF
--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_Ingest.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore_Ingest.cpp
@@ -554,7 +554,7 @@ UInt64 DeltaMergeStore::ingestFiles(
             for (const auto & ext_file : external_files)
             {
                 RUNTIME_CHECK_MSG(
-                    compare(range.getStart(), ext_file.range.getStart()) <= 0 || compare(range.getEnd(), ext_file.range.getEnd()) >= 0,
+                    compare(range.getStart(), ext_file.range.getStart()) <= 0 && compare(range.getEnd(), ext_file.range.getEnd()) >= 0,
                     "Detected illegal region boundary: range={} file_range={} . "
                     "TiFlash will exit to prevent data inconsistency. "
                     "If you accept data inconsistency and want to continue the service, "


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/7766

Problem Summary:

### What is changed and how it works?

Previously there are two checks, so we should use `&&`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
