### PR TITLE
[Bug] Fix the empty values when runtime filter is LOCAL mode

### DIFF
--- a/dbms/src/Flash/tests/gtest_runtime_filter_executor.cpp
+++ b/dbms/src/Flash/tests/gtest_runtime_filter_executor.cpp
@@ -89,9 +89,9 @@ try
         // test empty build side, with runtime filter, table_scan_0 return 0 rows
         mock::MockRuntimeFilter rf(1, col("k1"), col("k1"), "exchange_receiver_1", "table_scan_0");
         auto request = context
-                .scan("test_db", "left_table", std::vector<int>{1})
-                .join(context.receive("right_empty_table"), tipb::JoinType::TypeInnerJoin, {col("k1")}, rf)
-                .build(context);
+                           .scan("test_db", "left_table", std::vector<int>{1})
+                           .join(context.receive("right_empty_table"), tipb::JoinType::TypeInnerJoin, {col("k1")}, rf)
+                           .build(context);
         Expect expect{{"table_scan_0", {0, enable_pipeline ? concurrency : 1}}, {"exchange_receiver_1", {0, concurrency}}, {"Join_2", {0, concurrency}}};
         testForExecutionSummary(request, expect);
     }

--- a/dbms/src/Storages/DeltaMerge/Filter/In.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/In.h
@@ -39,8 +39,9 @@ public:
     String toDebugString() override
     {
         String s = R"({"op":")" + name() + R"(","col":")" + attr.col_name + R"(","value":"[)";
-        if (!values.empty()) {
-            for (auto &v: values)
+        if (!values.empty())
+        {
+            for (auto & v : values)
                 s += "\"" + applyVisitor(FieldVisitorToDebugString(), v) + "\",";
             s.pop_back();
         }
@@ -52,7 +53,8 @@ public:
     {
         // If values is empty (for example where a in ()), all packs will not match.
         // So return none directly.
-        if (values.empty()) {
+        if (values.empty())
+        {
             return RSResult::None;
         }
         GET_RSINDEX_FROM_PARAM_NOT_FOUND_RETURN_SOME(param, attr, rsindex);


### PR DESCRIPTION
Fixed #7798

This PR change the IN RS operator when values is empty. Using return RSResult::None instead of thrown exception when values is empty.

The In RS Operator is only used for runtime filter. When filter is empty (the build side is empty infact), the IN values will be empty. So this is not a exception and it should skip all of scan of packs.

### What problem does this PR solve?

Issue Number: close #7798

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
