### PR TITLE
Fix wrong checkpoint info after restart

### DIFF
--- a/dbms/src/Storages/Page/V3/PageDirectory.cpp
+++ b/dbms/src/Storages/Page/V3/PageDirectory.cpp
@@ -529,8 +529,8 @@ void VersionedPageEntries<Trait>::copyCheckpointInfoFromEdit(const typename Page
     // (the checkpoint info) each page's data was dumped.
     // In this case, there is a living snapshot protecting the data.
 
-    // Pre-check: All ENTRY edit record must contain checkpoint info for copying.
     RUNTIME_CHECK(edit.type == EditRecordType::VAR_ENTRY);
+    // The checkpoint_info from `edit` could be empty when we upload the manifest without any page data
     if (!edit.entry.checkpoint_info.has_value())
         return;
 

--- a/dbms/src/Storages/Page/V3/PageDirectory.cpp
+++ b/dbms/src/Storages/Page/V3/PageDirectory.cpp
@@ -531,7 +531,8 @@ void VersionedPageEntries<Trait>::copyCheckpointInfoFromEdit(const typename Page
 
     // Pre-check: All ENTRY edit record must contain checkpoint info for copying.
     RUNTIME_CHECK(edit.type == EditRecordType::VAR_ENTRY);
-    RUNTIME_CHECK(edit.entry.checkpoint_info.has_value());
+    if (!edit.entry.checkpoint_info.has_value())
+        return;
 
     auto page_lock = acquireLock();
 
@@ -1853,14 +1854,6 @@ size_t PageDirectory<Trait>::copyCheckpointInfoFromEdit(const PageEntriesEdit & 
     const auto & records = edit.getRecords();
     if (records.empty())
         return num_copied;
-
-    // Pre-check: All ENTRY edit record must contain checkpoint info.
-    // We do the pre-check before copying any remote info to avoid partial completion.
-    for (const auto & rec : records)
-    {
-        if (rec.type == EditRecordType::VAR_ENTRY)
-            RUNTIME_CHECK_MSG(rec.entry.checkpoint_info.has_value(), "try to copy checkpoint from an edit with invalid record: {}", rec);
-    }
 
     for (const auto & rec : records)
     {

--- a/dbms/src/Storages/Page/V3/PageEntriesEdit.cpp
+++ b/dbms/src/Storages/Page/V3/PageEntriesEdit.cpp
@@ -64,11 +64,16 @@ typename PageEntriesEdit<UniversalPageId>::EditRecord PageEntriesEdit<UniversalP
     rec.being_ref_count = 1;
     if (rec.type == EditRecordType::VAR_ENTRY)
     {
-        rec.entry.checkpoint_info = OptionalCheckpointInfo{
-            .data_location = CheckpointLocation::fromProto(proto_edit.entry_location(), strings_map),
-            .is_valid = true,
-            .is_local_data_reclaimed = true,
-        };
+        // uploading page data may be disabled
+        auto checkpoint_loc = CheckpointLocation::fromProto(proto_edit.entry_location(), strings_map);
+        if (checkpoint_loc.isValid())
+        {
+            rec.entry.checkpoint_info = OptionalCheckpointInfo{
+                .data_location = std::move(checkpoint_loc),
+                .is_valid = true,
+                .is_local_data_reclaimed = true,
+            };
+        }
         rec.entry.size = proto_edit.entry_size();
         rec.entry.checksum = proto_edit.entry_checksum();
         rec.entry.tag = proto_edit.entry_tag();

--- a/dbms/src/Storages/Page/V3/PageEntryCheckpointInfo.h
+++ b/dbms/src/Storages/Page/V3/PageEntryCheckpointInfo.h
@@ -47,6 +47,8 @@ struct CheckpointLocation
         const CheckpointProto::EntryDataLocation & proto_rec,
         CheckpointProto::StringsInternMap & strings_map);
 
+    bool isValid() const { return !data_file_id->empty(); }
+
     std::string toDebugString() const
     {
         return fmt::format("{{data_file_id: {}, offset_in_file: {}, size_in_file: {}}}", *data_file_id, offset_in_file, size_in_file);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #7799 

Problem Summary: After disable uploading page data when do checkpoint, the data file id in manifest will be empty. And after restart, tiflash may try to recover from the latest manifest file and set a empty checkpoint location which is unexpected and will make tiflash crash in the next round of uploading checkpoint.

### What is changed and how it works?
When restoring from manifest file at restart, check whether the data file id is empty before copy the checkpoint info to memory.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
1. deploy a cluster and load some data;
2. restart and write more data, and then check whether tiflash will crash;
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
