### PR TITLE
Remove more dead codes

### DIFF
--- a/dbms/src/Debug/dbgFuncRegion.cpp
+++ b/dbms/src/Debug/dbgFuncRegion.cpp
@@ -103,9 +103,11 @@ void dbgFuncTryFlushRegion(Context & context, const ASTs & args, DBGInvoker::Pri
     auto region_id = static_cast<RegionID>(safeGet<UInt64>(typeid_cast<const ASTLiteral &>(*args[0]).value));
 
     TMTContext & tmt = context.getTMTContext();
-    tmt.getRegionTable().tryWriteBlockByRegionAndFlush(region_id);
-
-    output(fmt::format("region_table try flush region {}", region_id));
+    if (auto region = tmt.getKVStore()->getRegion(region_id); region)
+    {
+        tmt.getRegionTable().tryWriteBlockByRegionAndFlush(region, false);
+        output(fmt::format("region_table try flush region {}", region_id));
+    }
 }
 
 void dbgFuncDumpAllRegion(Context & context, TableID table_id, bool ignore_none, bool dump_status, DBGInvoker::Printer & output)

--- a/dbms/src/Debug/dbgFuncRegion.cpp
+++ b/dbms/src/Debug/dbgFuncRegion.cpp
@@ -105,7 +105,7 @@ void dbgFuncTryFlushRegion(Context & context, const ASTs & args, DBGInvoker::Pri
     TMTContext & tmt = context.getTMTContext();
     if (auto region = tmt.getKVStore()->getRegion(region_id); region)
     {
-        tmt.getRegionTable().tryWriteBlockByRegionAndFlush(region, false);
+        tmt.getRegionTable().tryWriteBlockByRegionAndFlush(region);
         output(fmt::format("region_table try flush region {}", region_id));
     }
 }

--- a/dbms/src/Storages/Transaction/ApplySnapshot.cpp
+++ b/dbms/src/Storages/Transaction/ApplySnapshot.cpp
@@ -86,7 +86,7 @@ void KVStore::checkAndApplyPreHandledSnapshot(const RegionPtrWrap & new_region, 
             // engine may delete data unsafely.
             auto region_lock = region_manager.genRegionTaskLock(old_region->id());
             old_region->setStateApplying();
-            tmt.getRegionTable().tryWriteBlockByRegionAndFlush(old_region, false);
+            tmt.getRegionTable().tryWriteBlockByRegionAndFlush(old_region);
             tryFlushRegionCacheInStorage(tmt, *old_region, log);
             persistRegion(*old_region, &region_lock, "save previous region before apply");
         }
@@ -224,7 +224,7 @@ void KVStore::onSnapshot(const RegionPtrWrap & new_region_wrap, RegionPtr old_re
         {
             try
             {
-                auto tmp = region_table.tryWriteBlockByRegionAndFlush(new_region_wrap, false);
+                auto tmp = region_table.tryWriteBlockByRegionAndFlush(new_region_wrap);
                 {
                     std::lock_guard lock(bg_gc_region_data_mutex);
                     bg_gc_region_data.push_back(std::move(tmp));
@@ -538,7 +538,7 @@ EngineStoreApplyRes KVStore::handleIngestSST(UInt64 region_id, const SSTViewVec 
             return;
         try
         {
-            tmt.getRegionTable().tryWriteBlockByRegionAndFlush(region, false);
+            tmt.getRegionTable().tryWriteBlockByRegionAndFlush(region);
             tryFlushRegionCacheInStorage(tmt, *region, log);
         }
         catch (Exception & e)

--- a/dbms/src/Storages/Transaction/KVStore.cpp
+++ b/dbms/src/Storages/Transaction/KVStore.cpp
@@ -174,15 +174,6 @@ bool KVStore::tryFlushRegionCacheInStorage(TMTContext & tmt, const Region & regi
     return true;
 }
 
-void KVStore::tryPersistRegion(RegionID region_id) const
-{
-    auto region = getRegion(region_id);
-    if (region)
-    {
-        persistRegion(*region, std::nullopt, "");
-    }
-}
-
 void KVStore::gcRegionPersistedCache(Seconds gc_persist_period)
 {
     {
@@ -564,7 +555,7 @@ EngineStoreApplyRes KVStore::handleAdminRaftCmd(
         const auto try_to_flush_region = [&tmt](const RegionPtr & region) {
             try
             {
-                tmt.getRegionTable().tryWriteBlockByRegionAndFlush(region, false);
+                tmt.getRegionTable().tryWriteBlockByRegionAndFlush(region);
             }
             catch (...)
             {

--- a/dbms/src/Storages/Transaction/KVStore.h
+++ b/dbms/src/Storages/Transaction/KVStore.h
@@ -94,8 +94,6 @@ public:
 
     void gcRegionPersistedCache(Seconds gc_persist_period = Seconds(60 * 5));
 
-    void tryPersistRegion(RegionID region_id) const;
-
     static bool tryFlushRegionCacheInStorage(TMTContext & tmt, const Region & region, const LoggerPtr & log, bool try_until_succeed = true);
 
     size_t regionSize() const;

--- a/dbms/src/Storages/Transaction/RegionTable.cpp
+++ b/dbms/src/Storages/Transaction/RegionTable.cpp
@@ -267,18 +267,6 @@ void RegionTable::removeRegion(const RegionID region_id, bool remove_data, const
     }
 }
 
-RegionDataReadInfoList RegionTable::tryWriteBlockByRegionAndFlush(RegionID region_id, bool try_persist)
-{
-    auto region = context->getTMTContext().getKVStore()->getRegion(region_id);
-    if (!region)
-    {
-        LOG_WARNING(log, "region not found, region_id={}", region_id);
-        return {};
-    }
-
-    return tryWriteBlockByRegionAndFlush(region, try_persist);
-}
-
 RegionDataReadInfoList RegionTable::tryWriteBlockByRegionAndFlush(const RegionPtrWithBlock & region, bool try_persist)
 {
     RegionID region_id = region->id();

--- a/dbms/src/Storages/Transaction/RegionTable.cpp
+++ b/dbms/src/Storages/Transaction/RegionTable.cpp
@@ -102,20 +102,6 @@ void RegionTable::shrinkRegionRange(const Region & region)
     internal_region.cache_bytes = region.dataSize();
 }
 
-RegionDataReadInfoList RegionTable::writeBlockByRegionAndFlush(const RegionPtrWithBlock & region) const
-{
-    LOG_TRACE(log, "table {}, {} original {} bytes", region->getMappedTableID(), region->toString(false), region->dataSize());
-
-    /// Write region data into corresponding storage.
-    RegionDataReadInfoList data_list_to_remove;
-    writeBlockByRegion(*context, region, data_list_to_remove, log);
-
-    size_t cache_size = region->dataSize();
-    LOG_TRACE(log, "table {}, {} after flush {} bytes", region->getMappedTableID(), region->toString(false), cache_size);
-
-    return data_list_to_remove;
-}
-
 RegionTable::RegionTable(Context & context_)
     : context(&context_)
     , log(Logger::get())
@@ -286,7 +272,8 @@ RegionDataReadInfoList RegionTable::tryWriteBlockByRegionAndFlush(const RegionPt
     RegionDataReadInfoList data_list_to_remove;
     try
     {
-        data_list_to_remove = writeBlockByRegionAndFlush(region);
+        /// Write region data into corresponding storage.
+        writeBlockByRegion(*context, region, data_list_to_remove, log);
     }
     catch (const Exception & e)
     {

--- a/dbms/src/Storages/Transaction/RegionTable.cpp
+++ b/dbms/src/Storages/Transaction/RegionTable.cpp
@@ -94,14 +94,6 @@ RegionTable::InternalRegion & RegionTable::getOrInsertRegion(const Region & regi
     return insertRegion(table, region);
 }
 
-void RegionTable::shrinkRegionRange(const Region & region)
-{
-    std::lock_guard lock(mutex);
-    auto & internal_region = getOrInsertRegion(region);
-    internal_region.range_in_table = region.getRange()->rawKeys();
-    internal_region.cache_bytes = region.dataSize();
-}
-
 RegionTable::RegionTable(Context & context_)
     : context(&context_)
     , log(Logger::get())
@@ -327,6 +319,14 @@ std::vector<std::pair<RegionID, RegionPtr>> RegionTable::getRegionsByTable(const
         }
     });
     return regions;
+}
+
+void RegionTable::shrinkRegionRange(const Region & region)
+{
+    std::lock_guard lock(mutex);
+    auto & internal_region = getOrInsertRegion(region);
+    internal_region.range_in_table = region.getRange()->rawKeys();
+    internal_region.cache_bytes = region.dataSize();
 }
 
 void RegionTable::extendRegionRange(const RegionID region_id, const RegionRangeKeys & region_range_keys)

--- a/dbms/src/Storages/Transaction/RegionTable.h
+++ b/dbms/src/Storages/Transaction/RegionTable.h
@@ -131,7 +131,6 @@ public:
     // Protects writeBlockByRegionAndFlush and ensures it's executed by only one thread at the same time.
     // Only one thread can do this at the same time.
     // The original name for this function is tryFlushRegion.
-    RegionDataReadInfoList tryWriteBlockByRegionAndFlush(RegionID region_id, bool try_persist = false);
     RegionDataReadInfoList tryWriteBlockByRegionAndFlush(const RegionPtrWithBlock & region, bool try_persist);
 
     void handleInternalRegionsByTable(KeyspaceID keyspace_id, TableID table_id, std::function<void(const InternalRegions &)> && callback) const;

--- a/dbms/src/Storages/Transaction/RegionTable.h
+++ b/dbms/src/Storages/Transaction/RegionTable.h
@@ -131,7 +131,7 @@ public:
     // Protects writeBlockByRegionAndFlush and ensures it's executed by only one thread at the same time.
     // Only one thread can do this at the same time.
     // The original name for this function is tryFlushRegion.
-    RegionDataReadInfoList tryWriteBlockByRegionAndFlush(const RegionPtrWithBlock & region, bool try_persist);
+    RegionDataReadInfoList tryWriteBlockByRegionAndFlush(const RegionPtrWithBlock & region);
 
     void handleInternalRegionsByTable(KeyspaceID keyspace_id, TableID table_id, std::function<void(const InternalRegions &)> && callback) const;
     std::vector<std::pair<RegionID, RegionPtr>> getRegionsByTable(KeyspaceID keyspace_id, TableID table_id) const;
@@ -183,7 +183,7 @@ private:
     // Try write the committed kvs into cache of columnar DeltaMergeStore.
     // Flush the cache if try_persist is set to true.
     // The original name for this method is flushRegion.
-    RegionDataReadInfoList writeBlockByRegionAndFlush(const RegionPtrWithBlock & region, bool try_persist) const;
+    RegionDataReadInfoList writeBlockByRegionAndFlush(const RegionPtrWithBlock & region) const;
 
 private:
     TableMap tables;

--- a/dbms/src/Storages/Transaction/tests/gtest_kvstore.cpp
+++ b/dbms/src/Storages/Transaction/tests/gtest_kvstore.cpp
@@ -28,7 +28,7 @@ try
         proxy_instance->bootstrapWithRegion(kvs, ctx.getTMTContext(), 1, std::nullopt);
     }
     {
-        kvs.tryPersistRegion(1);
+        tryPersistRegion(kvs, 1);
         kvs.gcRegionPersistedCache(Seconds{0});
     }
     {
@@ -634,7 +634,7 @@ TEST_F(RegionKVStoreTest, Writes)
     }
     {
         // Test gc region persister
-        kvs.tryPersistRegion(1);
+        tryPersistRegion(kvs, 1);
         kvs.gcRegionPersistedCache(Seconds{0});
     }
     {
@@ -1156,9 +1156,9 @@ TEST_F(RegionKVStoreTest, Restore)
             ASSERT_EQ(kvs.getRegion(0), nullptr);
             proxy_instance->debugAddRegions(kvs, ctx.getTMTContext(), {1, 2, 3}, {{{RecordKVFormat::genKey(1, 0), RecordKVFormat::genKey(1, 10)}, {RecordKVFormat::genKey(1, 10), RecordKVFormat::genKey(1, 20)}, {RecordKVFormat::genKey(1, 30), RecordKVFormat::genKey(1, 40)}}});
         }
-        kvs.tryPersistRegion(1);
-        kvs.tryPersistRegion(2);
-        kvs.tryPersistRegion(3);
+        tryPersistRegion(kvs, 1);
+        tryPersistRegion(kvs, 2);
+        tryPersistRegion(kvs, 3);
     }
     {
         KVStore & kvs = reloadKVSFromDisk();

--- a/dbms/src/Storages/Transaction/tests/gtest_new_kvstore.cpp
+++ b/dbms/src/Storages/Transaction/tests/gtest_new_kvstore.cpp
@@ -42,7 +42,7 @@ try
             proxy_instance->doApply(kvs, ctx.getTMTContext(), cond, region_id, index);
             ASSERT_EQ(r1->getLatestAppliedIndex(), applied_index + 1);
             ASSERT_EQ(kvr1->appliedIndex(), applied_index + 1);
-            kvs.tryPersistRegion(region_id);
+            tryPersistRegion(kvs, region_id);
         }
         {
             const KVStore & kvs = reloadKVSFromDisk();
@@ -71,7 +71,7 @@ try
             proxy_instance->doApply(kvs, ctx.getTMTContext(), cond, region_id, index);
             ASSERT_EQ(r1->getLatestAppliedIndex(), applied_index);
             ASSERT_EQ(kvr1->appliedIndex(), applied_index);
-            kvs.tryPersistRegion(region_id);
+            tryPersistRegion(kvs, region_id);
         }
         {
             KVStore & kvs = reloadKVSFromDisk();
@@ -103,7 +103,7 @@ try
             proxy_instance->doApply(kvs, ctx.getTMTContext(), cond, region_id, index);
             ASSERT_EQ(r1->getLatestAppliedIndex(), applied_index);
             ASSERT_EQ(kvr1->appliedIndex(), applied_index);
-            kvs.tryPersistRegion(region_id);
+            tryPersistRegion(kvs, region_id);
         }
         {
             KVStore & kvs = reloadKVSFromDisk();
@@ -134,7 +134,7 @@ try
             proxy_instance->doApply(kvs, ctx.getTMTContext(), cond, region_id, index);
             ASSERT_EQ(r1->getLatestAppliedIndex(), applied_index);
             ASSERT_EQ(kvr1->appliedIndex(), applied_index + 1);
-            kvs.tryPersistRegion(region_id);
+            tryPersistRegion(kvs, region_id);
         }
         {
             MockRaftStoreProxy::FailCond cond;

--- a/dbms/src/Storages/Transaction/tests/kvstore_helper.h
+++ b/dbms/src/Storages/Transaction/tests/kvstore_helper.h
@@ -165,6 +165,14 @@ protected:
         proxy_runner->join();
     }
 
+    static void tryPersistRegion(KVStore & kvs, RegionID region_id)
+    {
+        if (auto region = kvs.getRegion(region_id); region)
+        {
+            kvs.persistRegion(*region, std::nullopt, "");
+        }
+    }
+
 protected:
     static void testRaftMerge(KVStore & kvs, TMTContext & tmt);
     static void testRaftMergeRollback(KVStore & kvs, TMTContext & tmt);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/6233

Problem Summary:

Remove more dead codes after https://github.com/pingcap/tiflash/pull/7853. Make the codebase more clear

### What is changed and how it works?

* Remove the param `try_persist` from `RegionTable::tryWriteBlockByRegionAndFlush` because all are called with `try_persist=false`
* Remove `RegionTable::writeBlockByRegionAndFlush` because `try_persist` is always false and the function is the same as `writeBlockByRegion`
* Move `tryPersistRegion` to `RegionKVStoreTest` to reduce the code complexity in `KVStore `

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
