### PR TITLE
Avoid meanless runtime filter wait when filter failed

### DIFF
--- a/dbms/src/DataStreams/RuntimeFilter.cpp
+++ b/dbms/src/DataStreams/RuntimeFilter.cpp
@@ -19,7 +19,6 @@
 
 namespace DB
 {
-
 namespace ErrorCodes
 {
 extern const int SET_SIZE_LIMIT_EXCEEDED;
@@ -156,7 +155,8 @@ bool RuntimeFilter::await(int64_t ms_remaining)
             return isReady();
         }
         std::unique_lock<std::mutex> lock(inner_mutex);
-        return inner_cv.wait_for(lock, std::chrono::milliseconds(ms_remaining), [this] { return isReady(); });
+        inner_cv.wait_for(lock, std::chrono::milliseconds(ms_remaining), [this] { return isReady() || isFailed(); });
+        return isReady();
     }
     return true;
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #7865 

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
