### PR TITLE
refine TaskQueue::take semantics to drain all tasks when finished

### DIFF
--- a/dbms/CMakeLists.txt
+++ b/dbms/CMakeLists.txt
@@ -359,7 +359,7 @@ if (ENABLE_TESTS)
         )
     target_include_directories(bench_dbms BEFORE PRIVATE ${SPARCEHASH_INCLUDE_DIR} ${benchmark_SOURCE_DIR}/include)
     target_compile_definitions(bench_dbms PUBLIC DBMS_PUBLIC_GTEST)
-    target_link_libraries(bench_dbms gtest dbms test_util_bench_main benchmark tiflash_functions server_for_test)
+    target_link_libraries(bench_dbms gtest dbms test_util_bench_main benchmark tiflash_functions server_for_test delta_merge)
 
     add_check(bench_dbms)
 endif ()

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/IOPriorityQueue.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/IOPriorityQueue.cpp
@@ -88,15 +88,15 @@ bool IOPriorityQueue::take(TaskPtr & task)
 void IOPriorityQueue::drainTaskQueueWithoutLock()
 {
     TaskPtr task;
+    while (popTask(cancel_task_queue, task))
+    {
+        FINALIZE_TASK(task);
+    }
     while (popTask(io_out_task_queue, task))
     {
         FINALIZE_TASK(task);
     }
     while (popTask(io_in_task_queue, task))
-    {
-        FINALIZE_TASK(task);
-    }
-    while (popTask(cancel_task_queue, task))
     {
         FINALIZE_TASK(task);
     }

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/IOPriorityQueue.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/IOPriorityQueue.cpp
@@ -55,9 +55,7 @@ void moveCancelledTasks(std::list<TaskPtr> & normal_queue, std::deque<TaskPtr> &
 
 IOPriorityQueue::~IOPriorityQueue()
 {
-    RUNTIME_ASSERT(cancel_task_queue.empty(), logger, "all task should be taken before it is destructed");
-    RUNTIME_ASSERT(io_in_task_queue.empty(), logger, "all task should be taken before it is destructed");
-    RUNTIME_ASSERT(io_out_task_queue.empty(), logger, "all task should be taken before it is destructed");
+    drainTaskQueueWithoutLock();
 }
 
 bool IOPriorityQueue::take(TaskPtr & task)
@@ -65,11 +63,9 @@ bool IOPriorityQueue::take(TaskPtr & task)
     std::unique_lock lock(mu);
     while (true)
     {
+        // Remaining tasks will be drained in destructor.
         if (unlikely(is_finished))
-        {
-            drainTaskQueueWithoutLock();
             return false;
-        }
 
         if (popTask(cancel_task_queue, task))
             return true;

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/IOPriorityQueue.h
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/IOPriorityQueue.h
@@ -51,6 +51,7 @@ public:
 
 private:
     void submitTaskWithoutLock(TaskPtr && task);
+
     void drainTaskQueueWithoutLock();
 
 private:

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/IOPriorityQueue.h
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/IOPriorityQueue.h
@@ -51,6 +51,7 @@ public:
 
 private:
     void submitTaskWithoutLock(TaskPtr && task);
+    void drainTaskQueueWithoutLock();
 
 private:
     mutable std::mutex mu;

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/MultiLevelFeedbackQueue.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/MultiLevelFeedbackQueue.cpp
@@ -181,6 +181,7 @@ bool MultiLevelFeedbackQueue<TimeGetter>::take(TaskPtr & task)
                 drainTaskQueueWithoutLock();
                 return false;
             }
+
             if (!cancel_task_queue.empty())
             {
                 task = std::move(cancel_task_queue.front());

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/MultiLevelFeedbackQueue.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/MultiLevelFeedbackQueue.cpp
@@ -230,7 +230,7 @@ void MultiLevelFeedbackQueue<TimeGetter>::drainTaskQueueWithoutLock()
         auto & cur_queue = level_queues[i];
         TaskPtr task;
         while (!cur_queue->empty())
-        { 
+        {
             cur_queue->take(task);
             FINALIZE_TASK(task);
         }

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/MultiLevelFeedbackQueue.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/MultiLevelFeedbackQueue.cpp
@@ -178,7 +178,7 @@ bool MultiLevelFeedbackQueue<TimeGetter>::take(TaskPtr & task)
         {
             if (unlikely(is_finished))
             {
-                drainTaskQueue();
+                drainTaskQueueWithoutLock();
                 return false;
             }
             if (!cancel_task_queue.empty())

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/MultiLevelFeedbackQueue.h
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/MultiLevelFeedbackQueue.h
@@ -130,6 +130,7 @@ private:
     void submitTaskWithoutLock(TaskPtr && task);
 
     void drainTaskQueueWithoutLock();
+
 private:
     mutable std::mutex mu;
     std::condition_variable cv;

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/MultiLevelFeedbackQueue.h
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/MultiLevelFeedbackQueue.h
@@ -129,6 +129,7 @@ private:
 
     void submitTaskWithoutLock(TaskPtr && task);
 
+    void drainTaskQueueWithoutLock();
 private:
     mutable std::mutex mu;
     std::condition_variable cv;

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/TaskQueue.h
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/TaskQueue.h
@@ -31,7 +31,7 @@ public:
 
     virtual void submit(std::vector<TaskPtr> & tasks) = 0;
 
-    // Will drain all tasks and return false if finished.
+    // Will return false if finished and all remaining tasks should be drained in destructor.
     virtual bool take(TaskPtr & task) = 0;
 
     // Update the execution metrics of the task taken from the queue.

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/TaskQueue.h
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/TaskQueue.h
@@ -31,7 +31,7 @@ public:
 
     virtual void submit(std::vector<TaskPtr> & tasks) = 0;
 
-    // return false if the queue is empty and finished.
+    // Will drain all tasks and return false if finished.
     virtual bool take(TaskPtr & task) = 0;
 
     // Update the execution metrics of the task taken from the queue.

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/tests/bench_task_queue.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/tests/bench_task_queue.cpp
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Flash/Executor/PipelineExecutorContext.h>
 #include <Flash/Pipeline/Schedule/TaskQueues/MultiLevelFeedbackQueue.h>
 #include <Flash/Pipeline/Schedule/TaskScheduler.h>
-#include <Flash/Executor/PipelineExecutorContext.h>
 #include <TestUtils/TiFlashTestBasic.h>
-
 #include <benchmark/benchmark.h>
+
 #include <random>
 
 namespace DB
@@ -99,13 +99,13 @@ TASKQUEUE_BENCHMARK(MLFQBench, SimpleCPUTask)
 TASKQUEUE_BENCHMARK(IOPriorityBench, SimpleIOTask)
 
 BENCHMARK_REGISTER_F(MLFQBench, Basic)
-    ->Args({10, 1, 1, 10000, 2})     // 10000 * 1 * 2 / 10 = 2s
-    ->Args({10, 15, 15, 1000, 2})    // 1000 * 15 * 2 / 10 = 3s
+    ->Args({10, 1, 1, 10000, 2}) // 10000 * 1 * 2 / 10 = 2s
+    ->Args({10, 15, 15, 1000, 2}) // 1000 * 15 * 2 / 10 = 3s
     ->Args({10, 200, 200, 1000, 2}); // 1000 * 200 * 2 / 10 = 40s
 
 BENCHMARK_REGISTER_F(IOPriorityBench, Basic)
-    ->Args({10, 1, 1, 10000, 2})     // 10000 * 1 * 2 / 10 = 2s
-    ->Args({10, 15, 15, 1000, 2})    // 1000 * 15 * 2 / 10 = 3s
+    ->Args({10, 1, 1, 10000, 2}) // 10000 * 1 * 2 / 10 = 2s
+    ->Args({10, 15, 15, 1000, 2}) // 1000 * 15 * 2 / 10 = 3s
     ->Args({10, 200, 200, 1000, 2}); // 1000 * 200 * 2 / 10 = 40s
 
 } // namespace tests

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/tests/bench_task_queue.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/tests/bench_task_queue.cpp
@@ -1,0 +1,112 @@
+// Copyright 2023 PingCAP, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Flash/Pipeline/Schedule/TaskQueues/MultiLevelFeedbackQueue.h>
+#include <Flash/Pipeline/Schedule/TaskScheduler.h>
+#include <Flash/Executor/PipelineExecutorContext.h>
+#include <TestUtils/TiFlashTestBasic.h>
+
+#include <benchmark/benchmark.h>
+#include <random>
+
+namespace DB
+{
+namespace tests
+{
+
+#define DEFINE_SIMPLE_TASK(TASK_NAME, TASK_RETURN_STATUS)                                     \
+    class TASK_NAME : public Task                                                             \
+    {                                                                                         \
+    public:                                                                                   \
+        explicit TASK_NAME(PipelineExecutorContext & exec_context)                            \
+            : Task(exec_context)                                                              \
+        {}                                                                                    \
+                                                                                              \
+        ExecTaskStatus executeImpl() override                                                 \
+        {                                                                                     \
+            if (task_exec_cur_count <= task_exec_total_count)                                 \
+            {                                                                                 \
+                std::this_thread::sleep_for(std::chrono::milliseconds(task_exec_time_in_ms)); \
+                ++task_exec_cur_count;                                                        \
+                return TASK_RETURN_STATUS;                                                    \
+            }                                                                                 \
+            return ExecTaskStatus::FINISHED;                                                  \
+        }                                                                                     \
+                                                                                              \
+        uint64_t task_exec_time_in_ms = 0;                                                    \
+        uint64_t task_exec_cur_count = 0;                                                     \
+        uint64_t task_exec_total_count = 0;                                                   \
+    }
+
+DEFINE_SIMPLE_TASK(SimpleCPUTask, ExecTaskStatus::RUNNING);
+DEFINE_SIMPLE_TASK(SimpleIOTask, ExecTaskStatus::IO_IN);
+
+#define TASKQUEUE_BENCHMARK(BENCHMARK_NAME, TASK_TYPE)                 \
+    class BENCHMARK_NAME : public benchmark::Fixture                   \
+    {                                                                  \
+    };                                                                 \
+                                                                       \
+    BENCHMARK_DEFINE_F(BENCHMARK_NAME, Basic)                          \
+    (benchmark::State & state)                                         \
+    try                                                                \
+    {                                                                  \
+        const int pool_size = state.range(0);                          \
+        const int min_task = state.range(1);                           \
+        const int max_task = state.range(2);                           \
+        const int task_num = state.range(3);                           \
+        const int task_exec_count = state.range(4);                    \
+                                                                       \
+        std::random_device rand_dev;                                   \
+        std::mt19937 gen(rand_dev());                                  \
+        std::uniform_int_distribution dist(min_task, max_task);        \
+                                                                       \
+        for (auto _ : state)                                           \
+        {                                                              \
+            PipelineExecutorContext exec_context;                      \
+                                                                       \
+            std::vector<TaskPtr> tasks;                                \
+            tasks.resize(task_num);                                    \
+            for (int i = 0; i < task_num; ++i)                         \
+            {                                                          \
+                auto task = std::make_unique<TASK_TYPE>(exec_context); \
+                task->task_exec_time_in_ms = dist(gen);                \
+                task->task_exec_total_count = task_exec_count;         \
+                tasks[i] = std::move(task);                            \
+            }                                                          \
+                                                                       \
+            TaskSchedulerConfig config{pool_size, pool_size};          \
+            TaskScheduler task_scheduler(config);                      \
+                                                                       \
+            task_scheduler.submit(tasks);                              \
+                                                                       \
+            exec_context.wait();                                       \
+        }                                                              \
+    }                                                                  \
+    CATCH
+
+TASKQUEUE_BENCHMARK(MLFQBench, SimpleCPUTask)
+TASKQUEUE_BENCHMARK(IOPriorityBench, SimpleIOTask)
+
+BENCHMARK_REGISTER_F(MLFQBench, Basic)
+    ->Args({10, 1, 1, 10000, 2})     // 10000 * 1 * 2 / 10 = 2s
+    ->Args({10, 15, 15, 1000, 2})    // 1000 * 15 * 2 / 10 = 3s
+    ->Args({10, 200, 200, 1000, 2}); // 1000 * 200 * 2 / 10 = 40s
+
+BENCHMARK_REGISTER_F(IOPriorityBench, Basic)
+    ->Args({10, 1, 1, 10000, 2})     // 10000 * 1 * 2 / 10 = 2s
+    ->Args({10, 15, 15, 1000, 2})    // 1000 * 15 * 2 / 10 = 3s
+    ->Args({10, 200, 200, 1000, 2}); // 1000 * 200 * 2 / 10 = 40s
+
+} // namespace tests
+} // namespace DB

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/tests/gtest_io_priority.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/tests/gtest_io_priority.cpp
@@ -45,11 +45,6 @@ TEST_F(TestIOPriorityTaskQueue, base)
 try
 {
     PipelineExecutorContext context;
-    // To avoid the active ref count being returned to 0 in advance.
-    context.incActiveRefCount();
-    SCOPE_EXIT({
-        context.decActiveRefCount();
-    });
 
     IOPriorityQueue queue;
 
@@ -57,16 +52,15 @@ try
     size_t task_num_per_status = 1000;
 
     // take valid task
+    size_t taken_take_num = 0;
     thread_manager->schedule(false, "take", [&]() {
         TaskPtr task;
-        size_t taken_take_num = 0;
         while (queue.take(task))
         {
             ASSERT_TRUE(task);
             ++taken_take_num;
             FINALIZE_TASK(task);
         }
-        ASSERT_EQ(taken_take_num, 2 * task_num_per_status);
     });
     // submit valid task
     thread_manager->schedule(false, "submit", [&]() {
@@ -80,10 +74,19 @@ try
         }
         queue.finish();
     });
+
+    // 10 seconds is totally enough for 1000 SimpleTask to run.
+    // When waitFor() returns, it means all tasks runs finish and finilize() is called.
+    context.waitFor(std::chrono::seconds(10));
+
+    // Some tasks will not be taken successfully, because queue is already finished.
+    ASSERT_LE(taken_take_num, 2 * task_num_per_status);
+
     // wait
     thread_manager->wait();
 
     // No tasks can be submitted after the queue is finished.
+    context.incActiveRefCount();
     queue.submit(std::make_unique<MockIOTask>(context, false));
     TaskPtr task;
     ASSERT_FALSE(queue.take(task));

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/tests/gtest_io_priority.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/tests/gtest_io_priority.cpp
@@ -78,7 +78,10 @@ try
         {
             queue.submit(std::make_unique<MockIOTask>(context, false));
         }
-        while (!queue.empty()) { std::this_thread::sleep_for(std::chrono::milliseconds(10)); }
+        while (!queue.empty())
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
         queue.finish();
     });
     // wait

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/tests/gtest_mlfq.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/tests/gtest_mlfq.cpp
@@ -99,7 +99,10 @@ try
             task->profile_info.addCPUExecuteTime(value);
             queue->submit(std::move(task));
         }
-        while (!queue->empty()) { std::this_thread::sleep_for(std::chrono::milliseconds(10)); }
+        while (!queue->empty())
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
         queue->finish();
     });
     // take valid task


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #7904

Problem Summary:

### What is changed and how it works?
This pr has no affcets on performance, check:

before this pr:
```
[2023/08/7 12:47:41 Day-219] guojiangtao-arch :: tiflash/build/master_rel ‹f2bb4c4ee*› » ./dbms/bench_dbms --benchmark_filter='MLFQBench*'
2023-08-07T12:47:41+08:00
Running ./dbms/bench_dbms
Run on (20 X 4800 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x10)
  L1 Instruction 32 KiB (x10)
  L2 Unified 1280 KiB (x10)
  L3 Unified 25600 KiB (x1)
Load Average: 0.76, 0.43, 0.53
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
----------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations
----------------------------------------------------------------------------
MLFQBench/Basic/10/1/1/10000/2    3189057026 ns      3275840 ns            1
MLFQBench/Basic/10/15/15/1000/2   4555925890 ns      5612791 ns            1
MLFQBench/Basic/10/200/200/1000/2 60053507747 ns      4526273 ns            1

----------------------------------------------------------------------------------
Benchmark                                        Time             CPU   Iterations
----------------------------------------------------------------------------------
IOPriorityBench/Basic/10/1/1/10000/2    3204130348 ns      3729885 ns            1
IOPriorityBench/Basic/10/15/15/1000/2   4550231291 ns      1301747 ns            1
IOPriorityBench/Basic/10/200/200/1000/2 60061096315 ns      4449832 ns            1
```

after this pr:
```
[2023/08/7 12:41:41 Day-219] guojiangtao-arch :: tiflash/build/master_rel ‹taskqueue_take*› » ./dbms/bench_dbms --benchmark_filter='MLFQBench*'
2023-08-07T12:42:02+08:00
Running ./dbms/bench_dbms
Run on (20 X 4800 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x10)
  L1 Instruction 32 KiB (x10)
  L2 Unified 1280 KiB (x10)
  L3 Unified 25600 KiB (x1)
Load Average: 0.27, 0.38, 0.60
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
----------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations
----------------------------------------------------------------------------
MLFQBench/Basic/10/1/1/10000/2    3189214126 ns      3435699 ns            1
MLFQBench/Basic/10/15/15/1000/2   4556525279 ns      5580156 ns            1
MLFQBench/Basic/10/200/200/1000/2 60065289566 ns      5851380 ns            1

----------------------------------------------------------------------------------
Benchmark                                        Time             CPU   Iterations
----------------------------------------------------------------------------------
IOPriorityBench/Basic/10/1/1/10000/2    3202198480 ns      3656562 ns            1
IOPriorityBench/Basic/10/15/15/1000/2   4551348436 ns      1983537 ns            1
IOPriorityBench/Basic/10/200/200/1000/2 60055732528 ns      6817641 ns            1
```
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
