### PR TITLE
Fix bug in join spill

### DIFF
--- a/dbms/src/DataStreams/HashJoinProbeExec.cpp
+++ b/dbms/src/DataStreams/HashJoinProbeExec.cpp
@@ -253,15 +253,7 @@ Block HashJoinProbeExec::fetchScanHashMapData()
 bool HashJoinProbeExec::onScanHashMapAfterProbeFinish()
 {
     scan_hash_map_after_probe_stream->readSuffix();
-    if (!join->isEnableSpill())
-    {
-        /// if current join is restore join, need to return false so it can restore next join
-        return !join->isRestoreJoin();
-    }
-    else
-    {
-        join->finishOneNonJoin(stream_index);
-        return false;
-    }
+    join->finishOneNonJoin(stream_index);
+    return !join->isSpilled() && !join->isRestoreJoin();
 }
 } // namespace DB

--- a/dbms/src/DataStreams/HashJoinProbeExec.cpp
+++ b/dbms/src/DataStreams/HashJoinProbeExec.cpp
@@ -150,9 +150,8 @@ HashJoinProbeExecPtr HashJoinProbeExec::tryGetRestoreExec()
 
 HashJoinProbeExecPtr HashJoinProbeExec::doTryGetRestoreExec()
 {
-    assert(join->isEnableSpill());
     /// first check if current join has a partition to restore
-    if (join->hasPartitionSpilledWithLock())
+    if (join->isSpilled() && join->hasPartitionSpilledWithLock())
     {
         /// get a restore join
         if (auto restore_info = join->getOneRestoreStream(max_block_size); restore_info)
@@ -231,7 +230,12 @@ bool HashJoinProbeExec::onProbeFinish()
             join->flushProbeSideMarkedSpillData(stream_index, /*is_the_last=*/true);
         join->finalizeProbe();
     }
-    return !need_scan_hash_map_after_probe && !join->isEnableSpill();
+    /// once this function returns true, the join probe for current thread finishes completely.
+    /// it should return true if and only if
+    /// 1. no need to scan hash map after probe
+    /// 2. current join does spill
+    /// 3. current join is not a restore join
+    return !need_scan_hash_map_after_probe && !join->isSpilled() && !join->isRestoreJoin();
 }
 
 void HashJoinProbeExec::onScanHashMapAfterProbeStart()
@@ -251,7 +255,8 @@ bool HashJoinProbeExec::onScanHashMapAfterProbeFinish()
     scan_hash_map_after_probe_stream->readSuffix();
     if (!join->isEnableSpill())
     {
-        return true;
+        /// if current join is restore join, need to return false so it can restore next join
+        return !join->isRestoreJoin();
     }
     else
     {

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -532,11 +532,6 @@ void Join::insertFromBlock(const Block & block, size_t stream_index)
             }
             markBuildSideSpillData(i, std::move(blocks_to_spill), stream_index);
         }
-#ifdef DBMS_PUBLIC_GTEST
-        // for join spill to disk gtest
-        if (restore_round == MAX_RESTORE_ROUND_IN_GTEST)
-            return;
-#endif
         spillMostMemoryUsedPartitionIfNeed(stream_index);
     }
 }

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -1733,13 +1733,16 @@ bool Join::isAllProbeFinished() const
 
 void Join::finishOneNonJoin(size_t partition_index)
 {
-    if likely (build_finished && probe_finished)
+    if (isEnableSpill())
     {
-        /// only clear hash table if not active build/probe threads
-        while (partition_index < build_concurrency)
+        if likely (build_finished && probe_finished)
         {
-            partitions[partition_index]->releasePartition();
-            partition_index += build_concurrency;
+            /// only clear hash table if not active build/probe threads
+            while (partition_index < build_concurrency)
+            {
+                partitions[partition_index]->releasePartition();
+                partition_index += build_concurrency;
+            }
         }
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #7905

Problem Summary:
Introduced by #7741. The root cause is in #7741, for restore join that can not support spill again(restore_round == 4), it disable join spill, so `join->isEnableSpill()` will return false, but in `HashJoinProbeExec`, it assumes that all the child joins should  return true for `join->isEnableSpill()` if parent join spill is triggered.
### What is changed and how it works?
- `HashJoinProbeExec::onScanHashMapAfterProbeFinish` and `HashJoinProbeExec::onProbeFinish` returns right value if spill is triggered
- Update `Join.cpp` so UT can conver this issue
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
