### PR TITLE
Fix memory leak in `ReceivedMessageQueue`

### DIFF
--- a/dbms/src/Flash/Mpp/ReceivedMessageQueue.cpp
+++ b/dbms/src/Flash/Mpp/ReceivedMessageQueue.cpp
@@ -104,7 +104,7 @@ ReceivedMessageQueue::ReceivedMessageQueue(
               : std::function<void(const ReceivedMessagePtr &)>([this](const ReceivedMessagePtr & element) {
                     for (size_t i = 0; i < fine_grained_channel_size; ++i)
                     {
-                        auto result = msg_channels_for_fine_grained_shuffle[i].forcePush(element);
+                        auto result = msg_channels_for_fine_grained_shuffle[i]->forcePush(element);
                         RUNTIME_CHECK_MSG(result == MPMCQueueResult::OK, "push to fine grained channel must success");
                     }
                 }))
@@ -115,7 +115,8 @@ ReceivedMessageQueue::ReceivedMessageQueue(
         msg_channels_for_fine_grained_shuffle.reserve(fine_grained_channel_size);
         for (size_t i = 0; i < fine_grained_channel_size; ++i)
             /// these are unbounded queues
-            msg_channels_for_fine_grained_shuffle.emplace_back(std::numeric_limits<size_t>::max());
+            msg_channels_for_fine_grained_shuffle.push_back(
+                std::make_shared<LooseBoundedMPMCQueue<ReceivedMessagePtr>>(std::numeric_limits<size_t>::max()));
     }
 }
 
@@ -126,9 +127,9 @@ MPMCQueueResult ReceivedMessageQueue::pop(size_t stream_id, ReceivedMessagePtr &
     if (fine_grained_channel_size > 0)
     {
         if constexpr (need_wait)
-            res = msg_channels_for_fine_grained_shuffle[stream_id].pop(recv_msg);
+            res = msg_channels_for_fine_grained_shuffle[stream_id]->pop(recv_msg);
         else
-            res = msg_channels_for_fine_grained_shuffle[stream_id].tryPop(recv_msg);
+            res = msg_channels_for_fine_grained_shuffle[stream_id]->tryPop(recv_msg);
 
         if (res == MPMCQueueResult::OK)
         {

--- a/dbms/src/Flash/Mpp/ReceivedMessageQueue.h
+++ b/dbms/src/Flash/Mpp/ReceivedMessageQueue.h
@@ -26,7 +26,6 @@
 
 namespace DB
 {
-
 namespace ExchangeReceiverMetric
 {
 inline void addDataSizeMetric(std::atomic<Int64> & data_size_in_queue, size_t size)
@@ -87,7 +86,7 @@ public:
         grpc_recv_queue.finish();
         /// msg_channels_for_fine_grained_shuffle must be finished after msg_channel is finished
         for (auto & channel : msg_channels_for_fine_grained_shuffle)
-            channel.finish();
+            channel->finish();
     }
 
     void cancel()
@@ -95,7 +94,7 @@ public:
         grpc_recv_queue.cancel();
         /// msg_channels_for_fine_grained_shuffle must be cancelled after msg_channel is cancelled
         for (auto & channel : msg_channels_for_fine_grained_shuffle)
-            channel.cancel();
+            channel->cancel();
     }
 
     bool isWritable() const { return grpc_recv_queue.isWritable(); }
@@ -116,7 +115,7 @@ private:
     /// write: the writer first write the msg to msg_channel/grpc_recv_queue, if write success, then write msg to msg_channels_for_fine_grained_shuffle
     /// read: the reader read msg from msg_channels_for_fine_grained_shuffle, and reduce the `remaining_consumers` in msg, if `remaining_consumers` is 0, then
     ///       remove the msg from msg_channel/grpc_recv_queue
-    PaddedPODArray<LooseBoundedMPMCQueue<ReceivedMessagePtr>> msg_channels_for_fine_grained_shuffle;
+    std::vector<std::shared_ptr<LooseBoundedMPMCQueue<ReceivedMessagePtr>>> msg_channels_for_fine_grained_shuffle;
     GRPCRecvQueue<ReceivedMessagePtr> grpc_recv_queue;
 };
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #7951

Problem Summary:

### What is changed and how it works?
The root cause is object stored in `PODArray` must be POD object, and clearly `LooseBoundedMessageQueue` is not a POD object
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
