### PR TITLE
Re-enable clang-tidy check

### DIFF
--- a/release-centos7-llvm/scripts/run-clang-tidy.py
+++ b/release-centos7-llvm/scripts/run-clang-tidy.py
@@ -360,5 +360,4 @@ def main():
 
 
 if __name__ == '__main__':
-    #main()
-    pass
+    main()


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/7968

Problem Summary:
We disable the clang-tidy check in https://github.com/pingcap/tiflash/pull/7962 to make the CI passed, now we need to re-enable it for later changes.

### What is changed and how it works?

Re-enable the clang-tidy checks

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
