### PR TITLE
fix the potential problem that some ref id may be lost after restart

### DIFF
--- a/dbms/src/Storages/Page/V3/PageDirectoryFactory.cpp
+++ b/dbms/src/Storages/Page/V3/PageDirectoryFactory.cpp
@@ -346,6 +346,10 @@ void PageDirectoryFactory<Trait>::loadFromDisk(const PageDirectoryPtr & dir, WAL
 {
     DataFileIdSet data_file_ids;
     auto checkpoint_snap_seq = reader->getSnapSeqForCheckpoint();
+    // make sure the max sequence is larger than the checkpoint sequence
+    if (max_applied_ver.sequence < checkpoint_snap_seq)
+        max_applied_ver = PageVersion(checkpoint_snap_seq, 0);
+
     while (reader->remained())
     {
         auto [from_checkpoint, record] = reader->next();

--- a/dbms/src/Storages/Page/V3/PageDirectoryFactory.cpp
+++ b/dbms/src/Storages/Page/V3/PageDirectoryFactory.cpp
@@ -346,7 +346,7 @@ void PageDirectoryFactory<Trait>::loadFromDisk(const PageDirectoryPtr & dir, WAL
 {
     DataFileIdSet data_file_ids;
     auto checkpoint_snap_seq = reader->getSnapSeqForCheckpoint();
-    // make sure the max sequence is larger than the checkpoint sequence
+    // make sure the max sequence is larger or equal than the checkpoint sequence
     if (max_applied_ver.sequence < checkpoint_snap_seq)
         max_applied_ver = PageVersion(checkpoint_snap_seq, 0);
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #7915 

Problem Summary: In some cases, some ref if may be lost when restart. For example, like the following steps
1. do some operations like put, delete or ref;
2. put 100 at seq 1000;
3. delete 100 at seq 1001;
4. dump snapshot with snap_seq to 1001;(now the checkpoint file name will be log_xxx_xxx_1001)
5. restart and because the operations put 100 and delete 100 is not in checkpoint file, the max sequence will be less or equal than 1000(let's say it's 1000);
6. put 200 at seq 1000;
7. ref 201 -> 200 at seq 1001;
8. restart again, and because the snap seq of checkpoint file is 1001, so all ref operations with sequence less or equal than seq 1001 will be ignored, so page id 201 will lost after restart;

### What is changed and how it works?
Make sure the restored max sequence is larger or equal than the snap seq of checkpoint file.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
