### PR TITLE
Fix MinTSOScheduler incorrectly erased waiting_set issue

### DIFF
--- a/dbms/src/Flash/Mpp/MinTSOScheduler.cpp
+++ b/dbms/src/Flash/Mpp/MinTSOScheduler.cpp
@@ -229,9 +229,11 @@ void MinTSOScheduler::scheduleWaitingQueries(MPPTaskManager & task_manager)
             bool has_error = false;
             while (!gather_set.second->waiting_tasks.empty())
             {
+                auto * task = gather_set.second->findMPPTask(gather_set.second->waiting_tasks.front());
+                /// Only when MinTSO task reach hard limit, has_error is set true. Schedule all waiting tasks with
+                /// same query id and gather id to be exceeded state.
                 if (has_error)
                 {
-                    auto * task = gather_set.second->findMPPTask(gather_set.second->waiting_tasks.front());
                     if (task != nullptr)
                         task->getScheduleEntry().schedule(ScheduleState::EXCEEDED);
                     gather_set.second->waiting_tasks.pop();
@@ -239,7 +241,6 @@ void MinTSOScheduler::scheduleWaitingQueries(MPPTaskManager & task_manager)
                     continue;
                 }
 
-                auto * task = gather_set.second->findMPPTask(gather_set.second->waiting_tasks.front());
                 if (task != nullptr)
                 {
                     bool scheduled


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8034 

Problem Summary: Schedule all waiting tasks with same query_id and gather_id to "Exceed" when hard limit reached. Don't rely tidb's cancel request to do this.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
Test randomFailpoint related tests.
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
