### PR TITLE
spill agg blocks using BlockInputStream

### DIFF
--- a/dbms/src/Core/tests/gtest_spiller.cpp
+++ b/dbms/src/Core/tests/gtest_spiller.cpp
@@ -526,7 +526,8 @@ try
 
     auto spiller_config_with_small_max_spill_size = *spill_config_ptr;
     spiller_config_with_small_max_spill_size.max_cached_data_bytes_in_spiller = total_block_size / 50;
-    spiller_config_with_small_max_spill_size.max_spilled_bytes_per_file = spiller_config_with_small_max_spill_size.max_cached_data_bytes_in_spiller;
+    spiller_config_with_small_max_spill_size.max_spilled_bytes_per_file
+        = spiller_config_with_small_max_spill_size.max_cached_data_bytes_in_spiller;
     spiller_config_with_small_max_spill_size.max_spilled_rows_per_file = total_block_rows / 50;
 
     /// case 1, sorted spiller, only 1 file per spill
@@ -534,9 +535,7 @@ try
     BlocksList block_list;
     block_list.insert(block_list.end(), blocks.begin(), blocks.end());
     auto block_input_stream = std::make_shared<BlocksListBlockInputStream>(std::move(block_list));
-    sorted_spiller.spillBlocksUsingBlockInputStream(block_input_stream, 0, []() {
-        return false;
-    });
+    sorted_spiller.spillBlocksUsingBlockInputStream(block_input_stream, 0, []() { return false; });
     sorted_spiller.finishSpill();
     auto restore_streams = sorted_spiller.restoreBlocks(0);
     ASSERT_TRUE(restore_streams.size() == 1);
@@ -546,9 +545,7 @@ try
     block_list.clear();
     block_list.insert(block_list.end(), blocks.begin(), blocks.end());
     block_input_stream = std::make_shared<BlocksListBlockInputStream>(std::move(block_list));
-    non_sorted_spiller.spillBlocksUsingBlockInputStream(block_input_stream, 0, []() {
-        return false;
-    });
+    non_sorted_spiller.spillBlocksUsingBlockInputStream(block_input_stream, 0, []() { return false; });
     non_sorted_spiller.finishSpill();
     restore_streams = non_sorted_spiller.restoreBlocks(0);
     ASSERT_TRUE(restore_streams.size() > 1);

--- a/dbms/src/DataStreams/AggHashTableToBlocksBlockInputStream.h
+++ b/dbms/src/DataStreams/AggHashTableToBlocksBlockInputStream.h
@@ -19,11 +19,11 @@
 
 namespace DB
 {
-
 template <typename Method>
 class AggHashTableToBlocksBlockInputStream : public IProfilingBlockInputStream
 {
     static constexpr auto NAME = "AggHashTableToBlocks";
+
 public:
     AggHashTableToBlocksBlockInputStream(
         Aggregator & aggregator_,
@@ -38,18 +38,21 @@ public:
         , total_bucket(Method::Data::NUM_BUCKETS)
     {}
 
-    Block getHeader() const override
-    {
-        return aggregator.getHeader(false);
-    }
+    Block getHeader() const override { return aggregator.getHeader(false); }
     String getName() const override { return NAME; }
     std::pair<size_t, size_t> maxBlockRowAndBytes() const { return {max_block_rows, max_block_bytes}; }
+
 protected:
     Block readImpl() override
     {
         if (current_bucket < total_bucket)
         {
-            auto block = aggregator.convertOneBucketToBlock(aggregated_data_variants, method, aggregated_data_variants.aggregates_pool, false, current_bucket++);
+            auto block = aggregator.convertOneBucketToBlock(
+                aggregated_data_variants,
+                method,
+                aggregated_data_variants.aggregates_pool,
+                false,
+                current_bucket++);
             size_t block_rows = block.rows();
             size_t block_bytes = block.bytes();
 
@@ -61,6 +64,7 @@ protected:
         }
         return {};
     }
+
 private:
     Aggregator & aggregator;
     AggregatedDataVariants & aggregated_data_variants;

--- a/dbms/src/DataStreams/AggHashTableToBlocksBlockInputStream.h
+++ b/dbms/src/DataStreams/AggHashTableToBlocksBlockInputStream.h
@@ -1,0 +1,74 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <DataStreams/IProfilingBlockInputStream.h>
+#include <Interpreters/Aggregator.h>
+
+namespace DB
+{
+
+template <typename Method>
+class AggHashTableToBlocksBlockInputStream : public IProfilingBlockInputStream
+{
+    static constexpr auto NAME = "AggHashTableToBlocks";
+public:
+    AggHashTableToBlocksBlockInputStream(
+        Aggregator & aggregator_,
+        AggregatedDataVariants & aggregated_data_variants_,
+        Method & method_,
+        size_t & max_block_rows_,
+        size_t & max_block_bytes_)
+        : aggregator(aggregator_)
+        , aggregated_data_variants(aggregated_data_variants_)
+        , method(method_)
+        , max_block_rows(max_block_rows_)
+        , max_block_bytes(max_block_bytes_)
+        , current_bucket(0)
+        , total_bucket(Method::Data::NUM_BUCKETS)
+    {}
+
+    Block getHeader() const override
+    {
+        return aggregator.getHeader(false);
+    }
+    String getName() const override { return NAME; }
+protected:
+    Block readImpl() override
+    {
+        if (current_bucket < total_bucket)
+        {
+            auto block = aggregator.convertOneBucketToBlock(aggregated_data_variants, method, aggregated_data_variants.aggregates_pool, false, current_bucket++);
+            size_t block_rows = block.rows();
+            size_t block_bytes = block.bytes();
+
+            if (block_rows > max_block_rows)
+                max_block_rows = block_rows;
+            if (block_bytes > max_block_bytes)
+                max_block_bytes = block_bytes;
+            return block;
+        }
+        return {};
+    }
+private:
+    Aggregator & aggregator;
+    AggregatedDataVariants & aggregated_data_variants;
+    Method & method;
+    size_t & max_block_rows;
+    size_t & max_block_bytes;
+    size_t current_bucket;
+    size_t total_bucket;
+};
+} // namespace DB

--- a/dbms/src/DataStreams/AggHashTableToBlocksBlockInputStream.h
+++ b/dbms/src/DataStreams/AggHashTableToBlocksBlockInputStream.h
@@ -28,14 +28,12 @@ public:
     AggHashTableToBlocksBlockInputStream(
         Aggregator & aggregator_,
         AggregatedDataVariants & aggregated_data_variants_,
-        Method & method_,
-        size_t & max_block_rows_,
-        size_t & max_block_bytes_)
+        Method & method_)
         : aggregator(aggregator_)
         , aggregated_data_variants(aggregated_data_variants_)
         , method(method_)
-        , max_block_rows(max_block_rows_)
-        , max_block_bytes(max_block_bytes_)
+        , max_block_rows(0)
+        , max_block_bytes(0)
         , current_bucket(0)
         , total_bucket(Method::Data::NUM_BUCKETS)
     {}
@@ -45,6 +43,7 @@ public:
         return aggregator.getHeader(false);
     }
     String getName() const override { return NAME; }
+    std::pair<size_t, size_t> maxBlockRowAndBytes() const { return {max_block_rows, max_block_bytes}; }
 protected:
     Block readImpl() override
     {
@@ -66,8 +65,8 @@ private:
     Aggregator & aggregator;
     AggregatedDataVariants & aggregated_data_variants;
     Method & method;
-    size_t & max_block_rows;
-    size_t & max_block_bytes;
+    size_t max_block_rows;
+    size_t max_block_bytes;
     size_t current_bucket;
     size_t total_bucket;
 };

--- a/dbms/src/Interpreters/Aggregator.cpp
+++ b/dbms/src/Interpreters/Aggregator.cpp
@@ -1021,7 +1021,8 @@ void Aggregator::spillImpl(AggregatedDataVariants & data_variants, Method & meth
         agg_spill_context->getSpiller() != nullptr,
         "spiller must not be nullptr in Aggregator when spilling");
 
-    auto block_input_stream = std::make_shared<AggHashTableToBlocksBlockInputStream<Method>>(*this, data_variants, method);
+    auto block_input_stream
+        = std::make_shared<AggHashTableToBlocksBlockInputStream<Method>>(*this, data_variants, method);
     agg_spill_context->getSpiller()->spillBlocksUsingBlockInputStream(block_input_stream, 0, is_cancelled);
     agg_spill_context->finishOneSpill(thread_num);
 

--- a/dbms/src/Interpreters/Aggregator.h
+++ b/dbms/src/Interpreters/Aggregator.h
@@ -48,6 +48,8 @@ extern const int UNKNOWN_AGGREGATED_DATA_VARIANT;
 }
 
 class IBlockOutputStream;
+template <typename Method>
+class AggHashTableToBlocksBlockInputStream;
 
 
 /** Different data structures that can be used for aggregation
@@ -1374,6 +1376,9 @@ protected:
     void destroyImpl(Table & table) const;
 
     void destroyWithoutKey(AggregatedDataVariants & result) const;
+
+    template <typename Method>
+    friend class AggHashTableToBlocksBlockInputStream;
 };
 
 /** Get the aggregation variant by its type. */


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #7738

Problem Summary:

### What is changed and how it works?
spill aggregation data using `Spiller::spillBlocksUsingBlockInputStream` because it is more memory friendly.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
