### PR TITLE
Refine auto spill for fine grained executor

### DIFF
--- a/dbms/src/Core/FineGrainedOperatorSpillContext.cpp
+++ b/dbms/src/Core/FineGrainedOperatorSpillContext.cpp
@@ -26,19 +26,14 @@ bool FineGrainedOperatorSpillContext::supportFurtherSpill() const
     return false;
 }
 
-bool FineGrainedOperatorSpillContext::isSpillEnabled() const
-{
-    for (const auto & operator_spill_context : operator_spill_contexts)
-        if (operator_spill_context->isSpillEnabled())
-            return true;
-    return false;
-}
-
 void FineGrainedOperatorSpillContext::addOperatorSpillContext(const OperatorSpillContextPtr & operator_spill_context)
 {
     /// fine grained operator spill context only used in auto spill
-    operator_spill_context->setAutoSpillMode();
-    operator_spill_contexts.push_back(operator_spill_context);
+    if likely (operator_spill_context->supportSpill() && operator_spill_context->supportAutoTriggerSpill())
+    {
+        operator_spill_contexts.push_back(operator_spill_context);
+        operator_spill_context->setAutoSpillMode();
+    }
 }
 
 Int64 FineGrainedOperatorSpillContext::getTotalRevocableMemoryImpl()

--- a/dbms/src/Core/FineGrainedOperatorSpillContext.cpp
+++ b/dbms/src/Core/FineGrainedOperatorSpillContext.cpp
@@ -1,0 +1,64 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Core/FineGrainedOperatorSpillContext.h>
+
+namespace DB
+{
+bool FineGrainedOperatorSpillContext::supportFurtherSpill() const
+{
+    for (const auto & operator_spill_context : operator_spill_contexts)
+    {
+        if (operator_spill_context->supportFurtherSpill())
+            return true;
+    }
+    return false;
+}
+
+bool FineGrainedOperatorSpillContext::isSpillEnabled() const
+{
+    for (const auto & operator_spill_context : operator_spill_contexts)
+        if (operator_spill_context->isSpillEnabled())
+            return true;
+    return false;
+}
+
+void FineGrainedOperatorSpillContext::addOperatorSpillContext(const OperatorSpillContextPtr & operator_spill_context)
+{
+    /// fine grained operator spill context only used in auto spill
+    operator_spill_context->setAutoSpillMode();
+    operator_spill_contexts.push_back(operator_spill_context);
+}
+
+Int64 FineGrainedOperatorSpillContext::getTotalRevocableMemoryImpl()
+{
+    Int64 ret = 0;
+    for (auto & operator_spill_context : operator_spill_contexts)
+        ret += operator_spill_context->getTotalRevocableMemory();
+    return ret;
+}
+
+Int64 FineGrainedOperatorSpillContext::triggerSpillImpl(Int64 expected_released_memories)
+{
+    Int64 original_expected_released_memories = expected_released_memories;
+    for (auto & operator_spill_context : operator_spill_contexts)
+    {
+        if (expected_released_memories <= 0)
+            operator_spill_context->triggerSpill(original_expected_released_memories);
+        else
+            expected_released_memories = operator_spill_context->triggerSpill(expected_released_memories);
+    }
+    return expected_released_memories;
+}
+} // namespace DB

--- a/dbms/src/Core/FineGrainedOperatorSpillContext.h
+++ b/dbms/src/Core/FineGrainedOperatorSpillContext.h
@@ -1,0 +1,38 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <Core/OperatorSpillContext.h>
+
+namespace DB
+{
+class FineGrainedOperatorSpillContext : public OperatorSpillContext
+{
+protected:
+    std::vector<OperatorSpillContextPtr> operator_spill_contexts;
+
+    Int64 getTotalRevocableMemoryImpl() override;
+
+public:
+    FineGrainedOperatorSpillContext(UInt64 operator_spill_threshold, const String op_name, const LoggerPtr & log)
+        : OperatorSpillContext(operator_spill_threshold, op_name, log)
+    {}
+    bool isSpillEnabled() const override;
+    bool supportFurtherSpill() const override;
+    bool supportAutoTriggerSpill() const override { return true; }
+    Int64 triggerSpillImpl(Int64 expected_released_memories) override;
+    void addOperatorSpillContext(const OperatorSpillContextPtr & operator_spill_context);
+};
+} // namespace DB

--- a/dbms/src/Core/FineGrainedOperatorSpillContext.h
+++ b/dbms/src/Core/FineGrainedOperatorSpillContext.h
@@ -18,6 +18,16 @@
 
 namespace DB
 {
+/// FineGrainedOperatorSpillContext is a wrap for all the query spill contexts that belongs to a same executor
+/// with fine grained shuffle enable. When fine grained shuffle is enabled, executors like sort and aggregation
+/// will have n independent operators in TiFlash side, each of them have their own operator spill context. However
+/// these n operators are not really independent: them shared a same source operator(exchange receiver), if one of
+/// the operator stop consuming data from exchange receiver(for example, begin spill data), all the others will
+/// be stuck because the exchange receiver has a bounded queue for all the operator, any of the operator stop
+/// consuming will make the queue full, and no other data can be pushed to exchange receiver. If all the n operator
+/// is triggered to spill serially, it will affects the overall performance seriously.
+/// FineGrainedOperatorSpillContext is used to make sure that all the operators belongs to the same executor
+/// will be triggered to spill almost at the same time
 class FineGrainedOperatorSpillContext : public OperatorSpillContext
 {
 protected:

--- a/dbms/src/Core/FineGrainedOperatorSpillContext.h
+++ b/dbms/src/Core/FineGrainedOperatorSpillContext.h
@@ -28,16 +28,17 @@ namespace DB
 /// is triggered to spill serially, it will affects the overall performance seriously.
 /// FineGrainedOperatorSpillContext is used to make sure that all the operators belongs to the same executor
 /// will be triggered to spill almost at the same time
-class FineGrainedOperatorSpillContext : public OperatorSpillContext
+class FineGrainedOperatorSpillContext final : public OperatorSpillContext
 {
-protected:
+private:
     std::vector<OperatorSpillContextPtr> operator_spill_contexts;
 
+protected:
     Int64 getTotalRevocableMemoryImpl() override;
 
 public:
-    FineGrainedOperatorSpillContext(UInt64 operator_spill_threshold, const String op_name, const LoggerPtr & log)
-        : OperatorSpillContext(operator_spill_threshold, op_name, log)
+    FineGrainedOperatorSpillContext(const String op_name, const LoggerPtr & log)
+        : OperatorSpillContext(0, op_name, log)
     {
         auto_spill_mode = true;
     }

--- a/dbms/src/Core/OperatorSpillContext.cpp
+++ b/dbms/src/Core/OperatorSpillContext.cpp
@@ -21,10 +21,12 @@ bool OperatorSpillContext::isSpillEnabled() const
 {
     return enable_spill && (auto_spill_mode || operator_spill_threshold > 0);
 }
+
 bool OperatorSpillContext::supportSpill() const
 {
     return enable_spill && (supportAutoTriggerSpill() || operator_spill_threshold > 0);
 }
+
 Int64 OperatorSpillContext::getTotalRevocableMemory()
 {
     assert(isSpillEnabled());
@@ -33,6 +35,7 @@ Int64 OperatorSpillContext::getTotalRevocableMemory()
     else
         return 0;
 }
+
 void OperatorSpillContext::markSpilled()
 {
     bool init_value = false;
@@ -41,11 +44,13 @@ void OperatorSpillContext::markSpilled()
         LOG_INFO(log, "Begin spill in {}", op_name);
     }
 }
+
 void OperatorSpillContext::finishSpillableStage()
 {
     LOG_INFO(log, "Operator finish spill stage");
     in_spillable_stage = false;
 }
+
 Int64 OperatorSpillContext::triggerSpill(Int64 expected_released_memories)
 {
     assert(isSpillEnabled());
@@ -55,5 +60,13 @@ Int64 OperatorSpillContext::triggerSpill(Int64 expected_released_memories)
     if (getTotalRevocableMemory() >= MIN_SPILL_THRESHOLD)
         return triggerSpillImpl(expected_released_memories);
     return expected_released_memories;
+}
+
+void OperatorSpillContext::setAutoSpillMode()
+{
+    RUNTIME_CHECK_MSG(supportAutoTriggerSpill(), "Only operator that support auto spill can be set in auto spill mode");
+    auto_spill_mode = true;
+    /// once auto spill is enabled, operator_spill_threshold will be ignored
+    operator_spill_threshold = 0;
 }
 } // namespace DB

--- a/dbms/src/Core/OperatorSpillContext.h
+++ b/dbms/src/Core/OperatorSpillContext.h
@@ -52,7 +52,7 @@ public:
         , log(log_)
     {}
     virtual ~OperatorSpillContext() = default;
-    bool isSpillEnabled() const;
+    virtual bool isSpillEnabled() const;
     bool supportSpill() const;
     void disableSpill() { enable_spill = false; }
     virtual bool supportFurtherSpill() const { return in_spillable_stage; }

--- a/dbms/src/Core/OperatorSpillContext.h
+++ b/dbms/src/Core/OperatorSpillContext.h
@@ -52,17 +52,12 @@ public:
         , log(log_)
     {}
     virtual ~OperatorSpillContext() = default;
-    virtual bool isSpillEnabled() const;
+    bool isSpillEnabled() const;
     bool supportSpill() const;
     void disableSpill() { enable_spill = false; }
     virtual bool supportFurtherSpill() const { return in_spillable_stage; }
     bool isInAutoSpillMode() const { return auto_spill_mode; }
-    void setAutoSpillMode()
-    {
-        auto_spill_mode = true;
-        /// once auto spill is enabled, operator_spill_threshold will be ignored
-        operator_spill_threshold = 0;
-    }
+    void setAutoSpillMode();
     Int64 getTotalRevocableMemory();
     UInt64 getOperatorSpillThreshold() const { return operator_spill_threshold; }
     void markSpilled();

--- a/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.cpp
@@ -522,8 +522,12 @@ void DAGQueryBlockInterpreter::executeAggregation(
     if (enable_fine_grained_shuffle)
     {
         std::shared_ptr<FineGrainedOperatorSpillContext> fine_grained_operator_spill_context;
-        if (context.getDAGContext() != nullptr && context.getDAGContext()->isInAutoSpillMode() && pipeline.hasMoreThanOneStream())
-            fine_grained_operator_spill_context = std::make_shared<FineGrainedOperatorSpillContext>(settings.max_bytes_before_external_group_by, "aggregation", log);
+        if (context.getDAGContext() != nullptr && context.getDAGContext()->isInAutoSpillMode()
+            && pipeline.hasMoreThanOneStream())
+            fine_grained_operator_spill_context = std::make_shared<FineGrainedOperatorSpillContext>(
+                settings.max_bytes_before_external_group_by,
+                "aggregation",
+                log);
         /// Go straight forward without merging phase when enable_fine_grained_shuffle
         pipeline.transform([&](auto & stream) {
             stream = std::make_shared<AggregatingBlockInputStream>(

--- a/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.cpp
@@ -15,6 +15,7 @@
 #include <Common/FailPoint.h>
 #include <Common/ThresholdUtils.h>
 #include <Common/TiFlashException.h>
+#include <Core/FineGrainedOperatorSpillContext.h>
 #include <Core/NamesAndTypes.h>
 #include <DataStreams/AggregatingBlockInputStream.h>
 #include <DataStreams/ExchangeSenderBlockInputStream.h>
@@ -51,8 +52,6 @@
 #include <Interpreters/SharedContexts/Disagg.h>
 #include <Parsers/ASTSelectQuery.h>
 #include <Storages/Transaction/TMTContext.h>
-
-#include "Core/FineGrainedOperatorSpillContext.h"
 
 namespace DB
 {

--- a/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.cpp
@@ -523,7 +523,7 @@ void DAGQueryBlockInterpreter::executeAggregation(
         std::shared_ptr<FineGrainedOperatorSpillContext> fine_grained_spill_context;
         if (context.getDAGContext() != nullptr && context.getDAGContext()->isInAutoSpillMode()
             && pipeline.hasMoreThanOneStream())
-            fine_grained_spill_context = std::make_shared<FineGrainedOperatorSpillContext>(0, "aggregation", log);
+            fine_grained_spill_context = std::make_shared<FineGrainedOperatorSpillContext>("aggregation", log);
         /// Go straight forward without merging phase when enable_fine_grained_shuffle
         pipeline.transform([&](auto & stream) {
             stream = std::make_shared<AggregatingBlockInputStream>(

--- a/dbms/src/Flash/Coprocessor/InterpreterUtils.cpp
+++ b/dbms/src/Flash/Coprocessor/InterpreterUtils.cpp
@@ -197,7 +197,7 @@ void orderStreams(
         std::shared_ptr<FineGrainedOperatorSpillContext> fine_grained_spill_context;
         if (context.getDAGContext() != nullptr && context.getDAGContext()->isInAutoSpillMode()
             && pipeline.hasMoreThanOneStream())
-            fine_grained_spill_context = std::make_shared<FineGrainedOperatorSpillContext>(0, "sort", log);
+            fine_grained_spill_context = std::make_shared<FineGrainedOperatorSpillContext>("sort", log);
         pipeline.transform([&](auto & stream) {
             stream = std::make_shared<MergeSortingBlockInputStream>(
                 stream,
@@ -292,7 +292,7 @@ void executeLocalSort(
         std::shared_ptr<FineGrainedOperatorSpillContext> fine_grained_spill_context;
         if (for_fine_grained_executor && context.getDAGContext() != nullptr
             && context.getDAGContext()->isInAutoSpillMode() && group_builder.concurrency() > 1)
-            fine_grained_spill_context = std::make_shared<FineGrainedOperatorSpillContext>(0, "sort", log);
+            fine_grained_spill_context = std::make_shared<FineGrainedOperatorSpillContext>("sort", log);
         SpillConfig spill_config{
             context.getTemporaryPath(),
             fmt::format("{}_sort", log->identifier()),

--- a/dbms/src/Flash/Coprocessor/InterpreterUtils.cpp
+++ b/dbms/src/Flash/Coprocessor/InterpreterUtils.cpp
@@ -196,8 +196,12 @@ void orderStreams(
     if (enable_fine_grained_shuffle)
     {
         std::shared_ptr<FineGrainedOperatorSpillContext> fine_grained_spill_context;
-        if (context.getDAGContext() != nullptr && context.getDAGContext()->isInAutoSpillMode() && pipeline.hasMoreThanOneStream())
-            fine_grained_spill_context = std::make_shared<FineGrainedOperatorSpillContext>(settings.max_bytes_before_external_sort, "sort", log);
+        if (context.getDAGContext() != nullptr && context.getDAGContext()->isInAutoSpillMode()
+            && pipeline.hasMoreThanOneStream())
+            fine_grained_spill_context = std::make_shared<FineGrainedOperatorSpillContext>(
+                settings.max_bytes_before_external_sort,
+                "sort",
+                log);
         pipeline.transform([&](auto & stream) {
             stream = std::make_shared<MergeSortingBlockInputStream>(
                 stream,
@@ -290,8 +294,12 @@ void executeLocalSort(
         size_t max_bytes_before_external_sort
             = getAverageThreshold(settings.max_bytes_before_external_sort, group_builder.concurrency());
         std::shared_ptr<FineGrainedOperatorSpillContext> fine_grained_spill_context;
-        if (for_fine_grained_executor && context.getDAGContext() != nullptr && context.getDAGContext()->isInAutoSpillMode() && group_builder.concurrency() > 1)
-            fine_grained_spill_context = std::make_shared<FineGrainedOperatorSpillContext>(settings.max_bytes_before_external_sort, "sort", log);
+        if (for_fine_grained_executor && context.getDAGContext() != nullptr
+            && context.getDAGContext()->isInAutoSpillMode() && group_builder.concurrency() > 1)
+            fine_grained_spill_context = std::make_shared<FineGrainedOperatorSpillContext>(
+                settings.max_bytes_before_external_sort,
+                "sort",
+                log);
         SpillConfig spill_config{
             context.getTemporaryPath(),
             fmt::format("{}_sort", log->identifier()),

--- a/dbms/src/Flash/Coprocessor/InterpreterUtils.cpp
+++ b/dbms/src/Flash/Coprocessor/InterpreterUtils.cpp
@@ -197,10 +197,7 @@ void orderStreams(
         std::shared_ptr<FineGrainedOperatorSpillContext> fine_grained_spill_context;
         if (context.getDAGContext() != nullptr && context.getDAGContext()->isInAutoSpillMode()
             && pipeline.hasMoreThanOneStream())
-            fine_grained_spill_context = std::make_shared<FineGrainedOperatorSpillContext>(
-                settings.max_bytes_before_external_sort,
-                "sort",
-                log);
+            fine_grained_spill_context = std::make_shared<FineGrainedOperatorSpillContext>(0, "sort", log);
         pipeline.transform([&](auto & stream) {
             stream = std::make_shared<MergeSortingBlockInputStream>(
                 stream,
@@ -295,10 +292,7 @@ void executeLocalSort(
         std::shared_ptr<FineGrainedOperatorSpillContext> fine_grained_spill_context;
         if (for_fine_grained_executor && context.getDAGContext() != nullptr
             && context.getDAGContext()->isInAutoSpillMode() && group_builder.concurrency() > 1)
-            fine_grained_spill_context = std::make_shared<FineGrainedOperatorSpillContext>(
-                settings.max_bytes_before_external_sort,
-                "sort",
-                log);
+            fine_grained_spill_context = std::make_shared<FineGrainedOperatorSpillContext>(0, "sort", log);
         SpillConfig spill_config{
             context.getTemporaryPath(),
             fmt::format("{}_sort", log->identifier()),
@@ -364,7 +358,6 @@ void executeFinalSort(
             settings.max_spilled_rows_per_file,
             settings.max_spilled_bytes_per_file,
             context.getFileProvider()};
-        std::shared_ptr<FineGrainedOperatorSpillContext> fine_grained_spill_context;
         group_builder.transform([&](auto & builder) {
             builder.appendTransformOp(std::make_unique<MergeSortTransformOp>(
                 exec_context,
@@ -374,7 +367,7 @@ void executeFinalSort(
                 settings.max_block_size,
                 settings.max_bytes_before_external_sort,
                 spill_config,
-                fine_grained_spill_context));
+                nullptr));
         });
     }
 }

--- a/dbms/src/Flash/Coprocessor/InterpreterUtils.cpp
+++ b/dbms/src/Flash/Coprocessor/InterpreterUtils.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <Common/ThresholdUtils.h>
+#include <Core/FineGrainedOperatorSpillContext.h>
 #include <DataStreams/CreatingSetsBlockInputStream.h>
 #include <DataStreams/ExpressionBlockInputStream.h>
 #include <DataStreams/FilterBlockInputStream.h>
@@ -34,8 +35,6 @@
 #include <Operators/MergeSortTransformOp.h>
 #include <Operators/PartialSortTransformOp.h>
 #include <Operators/SharedQueue.h>
-
-#include "Core/FineGrainedOperatorSpillContext.h"
 
 namespace DB
 {

--- a/dbms/src/Flash/Coprocessor/InterpreterUtils.h
+++ b/dbms/src/Flash/Coprocessor/InterpreterUtils.h
@@ -82,6 +82,7 @@ void executeLocalSort(
     PipelineExecGroupBuilder & group_builder,
     const SortDescription & order_descr,
     std::optional<size_t> limit,
+    bool for_fine_grained_executor,
     const Context & context,
     const LoggerPtr & log);
 

--- a/dbms/src/Flash/Planner/Plans/PhysicalAggregation.cpp
+++ b/dbms/src/Flash/Planner/Plans/PhysicalAggregation.cpp
@@ -14,6 +14,7 @@
 
 #include <Common/Logger.h>
 #include <Common/TiFlashException.h>
+#include <Core/FineGrainedOperatorSpillContext.h>
 #include <DataStreams/AggregatingBlockInputStream.h>
 #include <DataStreams/ParallelAggregatingBlockInputStream.h>
 #include <Flash/Coprocessor/AggregationInterpreterHelper.h>
@@ -29,8 +30,6 @@
 #include <Flash/Planner/Plans/PhysicalAggregationConvergent.h>
 #include <Interpreters/Context.h>
 #include <Operators/LocalAggregateTransform.h>
-
-#include "Core/FineGrainedOperatorSpillContext.h"
 
 namespace DB
 {

--- a/dbms/src/Flash/Planner/Plans/PhysicalAggregation.cpp
+++ b/dbms/src/Flash/Planner/Plans/PhysicalAggregation.cpp
@@ -30,6 +30,8 @@
 #include <Interpreters/Context.h>
 #include <Operators/LocalAggregateTransform.h>
 
+#include "Core/FineGrainedOperatorSpillContext.h"
+
 namespace DB
 {
 PhysicalPlanNodePtr PhysicalAggregation::build(
@@ -119,6 +121,9 @@ void PhysicalAggregation::buildBlockInputStreamImpl(DAGPipeline & pipeline, Cont
 
     if (fine_grained_shuffle.enable())
     {
+        std::shared_ptr<FineGrainedOperatorSpillContext> fine_grained_operator_spill_context;
+        if (context.getDAGContext() != nullptr && context.getDAGContext()->isInAutoSpillMode() && pipeline.hasMoreThanOneStream())
+            fine_grained_operator_spill_context = std::make_shared<FineGrainedOperatorSpillContext>(context.getSettingsRef().max_bytes_before_external_group_by, "aggregation", log);
         /// For fine_grained_shuffle, just do aggregation in streams independently
         pipeline.transform([&](auto & stream) {
             stream = std::make_shared<AggregatingBlockInputStream>(
@@ -127,13 +132,14 @@ void PhysicalAggregation::buildBlockInputStreamImpl(DAGPipeline & pipeline, Cont
                 true,
                 log->identifier(),
                 [&](const OperatorSpillContextPtr & operator_spill_context) {
-                    if (context.getDAGContext() != nullptr)
-                    {
+                    if (fine_grained_operator_spill_context != nullptr)
+                        fine_grained_operator_spill_context->addOperatorSpillContext(operator_spill_context);
+                    else if (context.getDAGContext() != nullptr)
                         context.getDAGContext()->registerOperatorSpillContext(operator_spill_context);
-                    }
                 });
             stream->setExtraInfo(String(enableFineGrainedShuffleExtraInfo));
         });
+        context.getDAGContext()->registerOperatorSpillContext(fine_grained_operator_spill_context);
     }
     else if (pipeline.streams.size() > 1)
     {
@@ -203,6 +209,9 @@ void PhysicalAggregation::buildPipelineExecGroupImpl(
 
     Block before_agg_header = group_builder.getCurrentHeader();
     size_t concurrency = group_builder.concurrency();
+    std::shared_ptr<FineGrainedOperatorSpillContext> fine_grained_operator_spill_context;
+    if (context.getDAGContext() != nullptr && context.getDAGContext()->isInAutoSpillMode() && concurrency > 1)
+        fine_grained_operator_spill_context = std::make_shared<FineGrainedOperatorSpillContext>(context.getSettingsRef().max_bytes_before_external_group_by, "aggregation", log);
     AggregationInterpreterHelper::fillArgColumnNumbers(aggregate_descriptions, before_agg_header);
     SpillConfig spill_config(
         context.getTemporaryPath(),
@@ -224,8 +233,9 @@ void PhysicalAggregation::buildPipelineExecGroupImpl(
         is_final_agg,
         spill_config);
     group_builder.transform([&](auto & builder) {
-        builder.appendTransformOp(std::make_unique<LocalAggregateTransform>(exec_context, log->identifier(), params));
+        builder.appendTransformOp(std::make_unique<LocalAggregateTransform>(exec_context, log->identifier(), params, fine_grained_operator_spill_context));
     });
+    context.getDAGContext()->registerOperatorSpillContext(fine_grained_operator_spill_context);
 
     executeExpression(exec_context, group_builder, expr_after_agg, log);
 }

--- a/dbms/src/Flash/Planner/Plans/PhysicalAggregation.cpp
+++ b/dbms/src/Flash/Planner/Plans/PhysicalAggregation.cpp
@@ -122,8 +122,12 @@ void PhysicalAggregation::buildBlockInputStreamImpl(DAGPipeline & pipeline, Cont
     if (fine_grained_shuffle.enable())
     {
         std::shared_ptr<FineGrainedOperatorSpillContext> fine_grained_operator_spill_context;
-        if (context.getDAGContext() != nullptr && context.getDAGContext()->isInAutoSpillMode() && pipeline.hasMoreThanOneStream())
-            fine_grained_operator_spill_context = std::make_shared<FineGrainedOperatorSpillContext>(context.getSettingsRef().max_bytes_before_external_group_by, "aggregation", log);
+        if (context.getDAGContext() != nullptr && context.getDAGContext()->isInAutoSpillMode()
+            && pipeline.hasMoreThanOneStream())
+            fine_grained_operator_spill_context = std::make_shared<FineGrainedOperatorSpillContext>(
+                context.getSettingsRef().max_bytes_before_external_group_by,
+                "aggregation",
+                log);
         /// For fine_grained_shuffle, just do aggregation in streams independently
         pipeline.transform([&](auto & stream) {
             stream = std::make_shared<AggregatingBlockInputStream>(
@@ -211,7 +215,10 @@ void PhysicalAggregation::buildPipelineExecGroupImpl(
     size_t concurrency = group_builder.concurrency();
     std::shared_ptr<FineGrainedOperatorSpillContext> fine_grained_operator_spill_context;
     if (context.getDAGContext() != nullptr && context.getDAGContext()->isInAutoSpillMode() && concurrency > 1)
-        fine_grained_operator_spill_context = std::make_shared<FineGrainedOperatorSpillContext>(context.getSettingsRef().max_bytes_before_external_group_by, "aggregation", log);
+        fine_grained_operator_spill_context = std::make_shared<FineGrainedOperatorSpillContext>(
+            context.getSettingsRef().max_bytes_before_external_group_by,
+            "aggregation",
+            log);
     AggregationInterpreterHelper::fillArgColumnNumbers(aggregate_descriptions, before_agg_header);
     SpillConfig spill_config(
         context.getTemporaryPath(),
@@ -233,7 +240,11 @@ void PhysicalAggregation::buildPipelineExecGroupImpl(
         is_final_agg,
         spill_config);
     group_builder.transform([&](auto & builder) {
-        builder.appendTransformOp(std::make_unique<LocalAggregateTransform>(exec_context, log->identifier(), params, fine_grained_operator_spill_context));
+        builder.appendTransformOp(std::make_unique<LocalAggregateTransform>(
+            exec_context,
+            log->identifier(),
+            params,
+            fine_grained_operator_spill_context));
     });
     context.getDAGContext()->registerOperatorSpillContext(fine_grained_operator_spill_context);
 

--- a/dbms/src/Flash/Planner/Plans/PhysicalAggregation.cpp
+++ b/dbms/src/Flash/Planner/Plans/PhysicalAggregation.cpp
@@ -123,7 +123,7 @@ void PhysicalAggregation::buildBlockInputStreamImpl(DAGPipeline & pipeline, Cont
         std::shared_ptr<FineGrainedOperatorSpillContext> fine_grained_spill_context;
         if (context.getDAGContext() != nullptr && context.getDAGContext()->isInAutoSpillMode()
             && pipeline.hasMoreThanOneStream())
-            fine_grained_spill_context = std::make_shared<FineGrainedOperatorSpillContext>(0, "aggregation", log);
+            fine_grained_spill_context = std::make_shared<FineGrainedOperatorSpillContext>("aggregation", log);
         /// For fine_grained_shuffle, just do aggregation in streams independently
         pipeline.transform([&](auto & stream) {
             stream = std::make_shared<AggregatingBlockInputStream>(
@@ -212,7 +212,7 @@ void PhysicalAggregation::buildPipelineExecGroupImpl(
     size_t concurrency = group_builder.concurrency();
     std::shared_ptr<FineGrainedOperatorSpillContext> fine_grained_spill_context;
     if (context.getDAGContext() != nullptr && context.getDAGContext()->isInAutoSpillMode() && concurrency > 1)
-        fine_grained_spill_context = std::make_shared<FineGrainedOperatorSpillContext>(0, "aggregation", log);
+        fine_grained_spill_context = std::make_shared<FineGrainedOperatorSpillContext>("aggregation", log);
     AggregationInterpreterHelper::fillArgColumnNumbers(aggregate_descriptions, before_agg_header);
     SpillConfig spill_config(
         context.getTemporaryPath(),

--- a/dbms/src/Flash/Planner/Plans/PhysicalTopN.cpp
+++ b/dbms/src/Flash/Planner/Plans/PhysicalTopN.cpp
@@ -79,7 +79,7 @@ void PhysicalTopN::buildPipelineExecGroupImpl(
     // TODO find a suitable threshold is necessary; 10000 is just a value picked without much consideration.
     if (group_builder.concurrency() * limit <= 10000)
     {
-        executeLocalSort(exec_context, group_builder, order_descr, limit, context, log);
+        executeLocalSort(exec_context, group_builder, order_descr, limit, false, context, log);
     }
     else
     {

--- a/dbms/src/Flash/Planner/Plans/PhysicalWindowSort.cpp
+++ b/dbms/src/Flash/Planner/Plans/PhysicalWindowSort.cpp
@@ -65,7 +65,7 @@ void PhysicalWindowSort::buildPipelineExecGroupImpl(
     size_t /*concurrency*/)
 {
     if (fine_grained_shuffle.enable())
-        executeLocalSort(exec_context, group_builder, order_descr, {}, context, log);
+        executeLocalSort(exec_context, group_builder, order_descr, {}, true, context, log);
     else
         executeFinalSort(exec_context, group_builder, order_descr, {}, context, log);
 }

--- a/dbms/src/Interpreters/tests/gtest_operator_spill_context.cpp
+++ b/dbms/src/Interpreters/tests/gtest_operator_spill_context.cpp
@@ -193,7 +193,7 @@ CATCH
 TEST_F(TestOperatorSpillContext, FineGrainedOperatorSpillContext)
 try
 {
-    auto fine_grained_spill_context = std::make_shared<FineGrainedOperatorSpillContext>(0, "test", logger);
+    auto fine_grained_spill_context = std::make_shared<FineGrainedOperatorSpillContext>("test", logger);
     /// fine grained spill context should always support auto spill and spill
     ASSERT_TRUE(fine_grained_spill_context->supportAutoTriggerSpill() && fine_grained_spill_context->supportSpill());
 

--- a/dbms/src/Interpreters/tests/gtest_operator_spill_context.cpp
+++ b/dbms/src/Interpreters/tests/gtest_operator_spill_context.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Core/FineGrainedOperatorSpillContext.h>
 #include <Common/Logger.h>
 #include <Encryption/FileProvider.h>
 #include <Encryption/MockKeyManager.h>
@@ -186,6 +187,64 @@ try
     ASSERT_TRUE(spill_context->getTotalRevocableMemory() == 0);
     auto spill_partitions = spill_context->getPartitionsToSpill();
     ASSERT_TRUE(spill_partitions.empty());
+}
+CATCH
+
+TEST_F(TestOperatorSpillContext, FineGrainedOperatorSpillContext)
+try
+{
+    auto fine_grained_spill_context = std::make_shared<FineGrainedOperatorSpillContext>(0, "test", logger);
+    /// fine grained spill context should always support auto spill and spill
+    ASSERT_TRUE(fine_grained_spill_context->supportAutoTriggerSpill() && fine_grained_spill_context->supportSpill());
+
+    /// add to fine grained spill context always makes the operator spill context in auto spill mode
+    auto spill_context_1 = std::make_shared<SortSpillContext>(*spill_config_ptr, 1000, logger);
+    ASSERT_FALSE(spill_context_1->isInAutoSpillMode());
+    fine_grained_spill_context->addOperatorSpillContext(spill_context_1);
+    ASSERT_TRUE(fine_grained_spill_context->getOperatorSpillCount() == 1);
+    ASSERT_TRUE(spill_context_1->isInAutoSpillMode());
+
+    /// operator spill context that not enable spill can not add to fine grained spill context
+    auto spill_context_2 = std::make_shared<SortSpillContext>(*spill_config_ptr, 1000, logger);
+    spill_context_2->disableSpill();
+    fine_grained_spill_context->addOperatorSpillContext(spill_context_2);
+    ASSERT_TRUE(fine_grained_spill_context->getOperatorSpillCount() == 1);
+
+    /// fine grained spill context support multiple operator spill context
+    auto spill_context_3 = std::make_shared<SortSpillContext>(*spill_config_ptr, 1000, logger);
+    fine_grained_spill_context->addOperatorSpillContext(spill_context_3);
+    ASSERT_TRUE(fine_grained_spill_context->getOperatorSpillCount() == 2);
+
+    /// test auto spill trigger if all operator spill contexts inside fine grained spill context have at least OperatorSpillContext::MIN_SPILL_THRESHOLD
+    spill_context_1->updateRevocableMemory(OperatorSpillContext::MIN_SPILL_THRESHOLD);
+    spill_context_3->updateRevocableMemory(OperatorSpillContext::MIN_SPILL_THRESHOLD);
+    ASSERT_TRUE(fine_grained_spill_context->getTotalRevocableMemory() == 2 * OperatorSpillContext::MIN_SPILL_THRESHOLD);
+    fine_grained_spill_context->triggerSpill(OperatorSpillContext::MIN_SPILL_THRESHOLD);
+    ASSERT_TRUE(spill_context_1->needFinalSpill());
+    ASSERT_TRUE(spill_context_3->needFinalSpill());
+    spill_context_1->finishOneSpill();
+    spill_context_3->finishOneSpill();
+
+    /// test auto spill trigger if only part of operators spill context inside fine grained spill context have at least OperatorSpillContext::MIN_SPILL_THRESHOLD
+    spill_context_1->updateRevocableMemory(OperatorSpillContext::MIN_SPILL_THRESHOLD);
+    spill_context_3->updateRevocableMemory(OperatorSpillContext::MIN_SPILL_THRESHOLD - 1);
+    ASSERT_TRUE(fine_grained_spill_context->getTotalRevocableMemory() == 2 * OperatorSpillContext::MIN_SPILL_THRESHOLD - 1);
+    fine_grained_spill_context->triggerSpill(OperatorSpillContext::MIN_SPILL_THRESHOLD);
+    ASSERT_TRUE(spill_context_1->needFinalSpill());
+    ASSERT_FALSE(spill_context_3->needFinalSpill());
+    spill_context_1->finishOneSpill();
+
+    /// test the case that some operator spill context already finish spillable stage
+    spill_context_1->updateRevocableMemory(OperatorSpillContext::MIN_SPILL_THRESHOLD);
+    spill_context_3->updateRevocableMemory(OperatorSpillContext::MIN_SPILL_THRESHOLD);
+    ASSERT_TRUE(fine_grained_spill_context->getTotalRevocableMemory() == 2 * OperatorSpillContext::MIN_SPILL_THRESHOLD);
+    ASSERT_TRUE(fine_grained_spill_context->supportFurtherSpill());
+    spill_context_3->finishSpillableStage();
+    ASSERT_TRUE(fine_grained_spill_context->getTotalRevocableMemory() == OperatorSpillContext::MIN_SPILL_THRESHOLD);
+    ASSERT_TRUE(fine_grained_spill_context->supportFurtherSpill());
+    spill_context_1->finishSpillableStage();
+    ASSERT_TRUE(fine_grained_spill_context->getTotalRevocableMemory() == 0);
+    ASSERT_FALSE(fine_grained_spill_context->supportFurtherSpill());
 }
 CATCH
 } // namespace tests

--- a/dbms/src/Interpreters/tests/gtest_operator_spill_context.cpp
+++ b/dbms/src/Interpreters/tests/gtest_operator_spill_context.cpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <Core/FineGrainedOperatorSpillContext.h>
 #include <Common/Logger.h>
+#include <Core/FineGrainedOperatorSpillContext.h>
 #include <Encryption/FileProvider.h>
 #include <Encryption/MockKeyManager.h>
 #include <Interpreters/AggSpillContext.h>
@@ -228,7 +228,8 @@ try
     /// test auto spill trigger if only part of operators spill context inside fine grained spill context have at least OperatorSpillContext::MIN_SPILL_THRESHOLD
     spill_context_1->updateRevocableMemory(OperatorSpillContext::MIN_SPILL_THRESHOLD);
     spill_context_3->updateRevocableMemory(OperatorSpillContext::MIN_SPILL_THRESHOLD - 1);
-    ASSERT_TRUE(fine_grained_spill_context->getTotalRevocableMemory() == 2 * OperatorSpillContext::MIN_SPILL_THRESHOLD - 1);
+    ASSERT_TRUE(
+        fine_grained_spill_context->getTotalRevocableMemory() == 2 * OperatorSpillContext::MIN_SPILL_THRESHOLD - 1);
     fine_grained_spill_context->triggerSpill(OperatorSpillContext::MIN_SPILL_THRESHOLD);
     ASSERT_TRUE(spill_context_1->needFinalSpill());
     ASSERT_FALSE(spill_context_3->needFinalSpill());

--- a/dbms/src/Operators/LocalAggregateTransform.cpp
+++ b/dbms/src/Operators/LocalAggregateTransform.cpp
@@ -41,7 +41,7 @@ LocalAggregateTransform::LocalAggregateTransform(
         params,
         local_concurrency,
         /*hook=*/[&]() { return exec_context.isCancelled(); },
-        [&] (const OperatorSpillContextPtr & operator_spill_context) {
+        [&](const OperatorSpillContextPtr & operator_spill_context) {
             if (fine_grained_spill_context != nullptr)
                 fine_grained_spill_context->addOperatorSpillContext(operator_spill_context);
             else if (exec_context.getRegisterOperatorSpillContext() != nullptr)

--- a/dbms/src/Operators/LocalAggregateTransform.cpp
+++ b/dbms/src/Operators/LocalAggregateTransform.cpp
@@ -31,7 +31,8 @@ constexpr size_t task_index = 0;
 LocalAggregateTransform::LocalAggregateTransform(
     PipelineExecutorContext & exec_context_,
     const String & req_id,
-    const Aggregator::Params & params_)
+    const Aggregator::Params & params_,
+    std::shared_ptr<FineGrainedOperatorSpillContext> & fine_grained_spill_context)
     : TransformOp(exec_context_, req_id)
     , params(params_)
     , agg_context(req_id)
@@ -40,7 +41,12 @@ LocalAggregateTransform::LocalAggregateTransform(
         params,
         local_concurrency,
         /*hook=*/[&]() { return exec_context.isCancelled(); },
-        exec_context.getRegisterOperatorSpillContext());
+        [&] (const OperatorSpillContextPtr & operator_spill_context) {
+            if (fine_grained_spill_context != nullptr)
+                fine_grained_spill_context->addOperatorSpillContext(operator_spill_context);
+            else if (exec_context.getRegisterOperatorSpillContext() != nullptr)
+                exec_context.getRegisterOperatorSpillContext()(operator_spill_context);
+        });
 }
 
 OperatorStatus LocalAggregateTransform::transformImpl(Block & block)

--- a/dbms/src/Operators/LocalAggregateTransform.cpp
+++ b/dbms/src/Operators/LocalAggregateTransform.cpp
@@ -32,7 +32,7 @@ LocalAggregateTransform::LocalAggregateTransform(
     PipelineExecutorContext & exec_context_,
     const String & req_id,
     const Aggregator::Params & params_,
-    std::shared_ptr<FineGrainedOperatorSpillContext> & fine_grained_spill_context)
+    const std::shared_ptr<FineGrainedOperatorSpillContext> & fine_grained_spill_context)
     : TransformOp(exec_context_, req_id)
     , params(params_)
     , agg_context(req_id)

--- a/dbms/src/Operators/LocalAggregateTransform.h
+++ b/dbms/src/Operators/LocalAggregateTransform.h
@@ -14,10 +14,9 @@
 
 #pragma once
 
+#include <Core/FineGrainedOperatorSpillContext.h>
 #include <Operators/AggregateContext.h>
 #include <Operators/Operator.h>
-
-#include "Core/FineGrainedOperatorSpillContext.h"
 
 namespace DB
 {

--- a/dbms/src/Operators/LocalAggregateTransform.h
+++ b/dbms/src/Operators/LocalAggregateTransform.h
@@ -17,6 +17,8 @@
 #include <Operators/AggregateContext.h>
 #include <Operators/Operator.h>
 
+#include "Core/FineGrainedOperatorSpillContext.h"
+
 namespace DB
 {
 /// Only do build and convert at the current operator, no sharing of objects with other operators.
@@ -26,7 +28,8 @@ public:
     LocalAggregateTransform(
         PipelineExecutorContext & exec_context_,
         const String & req_id,
-        const Aggregator::Params & params_);
+        const Aggregator::Params & params_,
+        std::shared_ptr<FineGrainedOperatorSpillContext> & fine_grained_spill_context);
 
     String getName() const override { return "LocalAggregateTransform"; }
 

--- a/dbms/src/Operators/LocalAggregateTransform.h
+++ b/dbms/src/Operators/LocalAggregateTransform.h
@@ -28,7 +28,7 @@ public:
         PipelineExecutorContext & exec_context_,
         const String & req_id,
         const Aggregator::Params & params_,
-        std::shared_ptr<FineGrainedOperatorSpillContext> & fine_grained_spill_context);
+        const std::shared_ptr<FineGrainedOperatorSpillContext> & fine_grained_spill_context);
 
     String getName() const override { return "LocalAggregateTransform"; }
 

--- a/dbms/src/Operators/MergeSortTransformOp.h
+++ b/dbms/src/Operators/MergeSortTransformOp.h
@@ -35,7 +35,7 @@ public:
         size_t max_block_size_,
         size_t max_bytes_before_external_sort,
         const SpillConfig & spill_config,
-        std::shared_ptr<FineGrainedOperatorSpillContext> & fine_grained_operator_spill_context)
+        const std::shared_ptr<FineGrainedOperatorSpillContext> & fine_grained_operator_spill_context)
         : TransformOp(exec_context_, req_id_)
         , order_desc(order_desc_)
         , limit(limit_)

--- a/dbms/src/Operators/MergeSortTransformOp.h
+++ b/dbms/src/Operators/MergeSortTransformOp.h
@@ -14,14 +14,13 @@
 
 #pragma once
 
+#include <Core/FineGrainedOperatorSpillContext.h>
 #include <Core/SortDescription.h>
 #include <Core/Spiller.h>
 #include <DataStreams/IBlockInputStream.h>
 #include <Flash/Executor/PipelineExecutorContext.h>
 #include <Interpreters/SortSpillContext.h>
 #include <Operators/Operator.h>
-
-#include "Core/FineGrainedOperatorSpillContext.h"
 
 namespace DB
 {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #7738

Problem Summary:
When fine grained shuffle is enabled, due to implicit depentency of all the operator belongs to the same TiDB executor, auto spill will meet a big performance regression if auto spill treated all the operator spill contexts from the same TiDB executor independently. This pr add `FineGrainedOperatorSpillContext` and try to align the spill behavior for fine grained executor.
### What is changed and how it works?
- Add `FineGrainedOperatorSpillContext`
- For operator that comes from the same TiDB executor, auto spill will be triggered at TiDB executor level, instead of triggering each operator independently

Test on TPCH-100 dataset, with 2 TiFlash node
For fine grained agg, test sql is
```
select /*+ mpp_1phase_agg() */ l_orderkey, max(L_COMMENT), max(L_SHIPMODE), max(L_SHIPINSTRUCT), max(L_SHIPDATE), max(L_EXTENDEDPRICE) from lineitem group by l_orderkey having sum(l_quantity) > 314
``` 
per node memory usage limit to 12G:

| without this pr | with this pr| 
|-------------|--------------|
| ~45s            | ~33s |

per node memory usage limit to 7G:

| without this pr | with this pr| 
|-------------|--------------|
| ~37s            | ~30s |

For fine grained sort, test sql is
```
select * from (select L_ORDERKEY,L_COMMENT,L_SHIPINSTRUCT, row_number() over(partition by l_orderkey order by l_orderkey) as rn from lineitem) d where l_orderkey + rn < 50;
```
per node memory usage limit to 12G:

| without this pr | with this pr| 
|-------------|--------------|
| ~45s            | ~24s |

per node memory usage limit to 7G:

| without this pr | with this pr| 
|-------------|--------------|
| ~45s            | ~25s |
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
