### PR TITLE
Add keyspace_id to RNDeltaIndexCache.

### DIFF
--- a/dbms/src/Storages/DeltaMerge/Remote/RNDeltaIndexCache.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/RNDeltaIndexCache.h
@@ -16,6 +16,7 @@
 
 #include <Common/LRUCache.h>
 #include <Storages/DeltaMerge/Remote/RNDeltaIndexCache_fwd.h>
+#include <Storages/Transaction/Types.h>
 #include <common/types.h>
 
 #include <boost/noncopyable.hpp>
@@ -42,6 +43,7 @@ public:
     struct CacheKey
     {
         UInt64 store_id;
+        KeyspaceID keyspace_id;
         Int64 table_id;
         UInt64 segment_id;
         UInt64 segment_epoch;
@@ -49,8 +51,9 @@ public:
 
         bool operator==(const CacheKey & other) const
         {
-            return store_id == other.store_id && table_id == other.table_id && segment_id == other.segment_id
-                && segment_epoch == other.segment_epoch && delta_index_epoch == other.delta_index_epoch;
+            return store_id == other.store_id && keyspace_id == other.keyspace_id && table_id == other.table_id
+                && segment_id == other.segment_id && segment_epoch == other.segment_epoch
+                && delta_index_epoch == other.delta_index_epoch;
         }
     };
 
@@ -72,6 +75,7 @@ public:
             using std::hash;
 
             return hash<UInt64>()(k.store_id) ^ //
+                hash<UInt64>()(k.keyspace_id) ^ //
                 hash<Int64>()(k.table_id) ^ //
                 hash<UInt64>()(k.segment_id) ^ //
                 hash<UInt64>()(k.segment_epoch) ^ //

--- a/dbms/src/Storages/DeltaMerge/Remote/RNReadTask.cpp
+++ b/dbms/src/Storages/DeltaMerge/Remote/RNReadTask.cpp
@@ -75,7 +75,8 @@ RNReadSegmentTaskPtr RNReadSegmentTask::buildFromEstablishResp(
         nullptr,
         nullptr);
 
-    auto segment_snap = Serializer::deserializeSegmentSnapshotFrom(*dm_context, store_id, physical_table_id, proto);
+    auto segment_snap
+        = Serializer::deserializeSegmentSnapshotFrom(*dm_context, store_id, keyspace_id, physical_table_id, proto);
 
     // Note: At this moment, we still cannot read from `task->segment_snap`,
     // because they are constructed using ColumnFileDataProviderNop.

--- a/dbms/src/Storages/DeltaMerge/Remote/Serializer.cpp
+++ b/dbms/src/Storages/DeltaMerge/Remote/Serializer.cpp
@@ -115,6 +115,7 @@ RemotePb::RemoteSegment Serializer::serializeTo(
 SegmentSnapshotPtr Serializer::deserializeSegmentSnapshotFrom(
     const DMContext & dm_context,
     StoreID remote_store_id,
+    KeyspaceID keyspace_id,
     TableID table_id,
     const RemotePb::RemoteSegment & proto)
 {
@@ -140,6 +141,7 @@ SegmentSnapshotPtr Serializer::deserializeSegmentSnapshotFrom(
     {
         delta_snap->shared_delta_index = delta_index_cache->getDeltaIndex({
             .store_id = remote_store_id,
+            .keyspace_id = keyspace_id,
             .table_id = table_id,
             .segment_id = proto.segment_id(),
             .segment_epoch = proto.segment_epoch(),

--- a/dbms/src/Storages/DeltaMerge/Remote/Serializer.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/Serializer.h
@@ -74,6 +74,7 @@ struct Serializer
     static SegmentSnapshotPtr deserializeSegmentSnapshotFrom(
         const DMContext & dm_context,
         StoreID remote_store_id,
+        KeyspaceID keyspace_id,
         TableID table_id,
         const RemotePb::RemoteSegment & proto);
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #7359

Problem Summary:
Keyspace ID is not in RNDeltaIndexCache::CacheKey, it could mixuse delta index of different keyspace ID.

### What is changed and how it works?

Add keyspace ID to RNDeltaIndexCache::CacheKey.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
