### PR TITLE
Fix crash for cancel apply snapshot

### DIFF
--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_Ingest.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore_Ingest.cpp
@@ -112,15 +112,27 @@ void DeltaMergeStore::cleanPreIngestFiles(
 
     for (const auto & f : external_files)
     {
-        auto file_parent_path = delegate.getDTFilePath(f.id);
-        auto file = DM::DMFile::restore(
-            file_provider,
-            f.id,
-            f.id,
-            file_parent_path,
-            DM::DMFile::ReadMetaMode::memoryAndDiskSize());
-        removePreIngestFile(f.id, false);
-        file->remove(file_provider);
+        if (auto remote_data_store = global_context.getSharedContextDisagg()->remote_data_store; !remote_data_store)
+        {
+            auto file_parent_path = delegate.getDTFilePath(f.id);
+            auto file = DM::DMFile::restore(
+                file_provider,
+                f.id,
+                f.id,
+                file_parent_path,
+                DM::DMFile::ReadMetaMode::memoryAndDiskSize());
+            removePreIngestFile(f.id, false);
+            file->remove(file_provider);
+        }
+        else
+        {
+            // For disagg mode
+            // - if the job has been finished, it means the local files is likely all uploaded to S3
+            // - if the job is intrrupted, it means the `SSTFilesToDTFilesOutputStream::cancel` is called
+            //   and local files are also removed.
+            // So we ignore the files on disk.
+            removePreIngestFile(f.id, false);
+        }
     }
 }
 

--- a/dbms/src/Storages/DeltaMerge/SSTFilesToDTFilesOutputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/SSTFilesToDTFilesOutputStream.cpp
@@ -105,8 +105,9 @@ void SSTFilesToDTFilesOutputStream<ChildStream>::writeSuffix()
 
     LOG_INFO(
         log,
-        "Transformed snapshot in SSTFile to DTFiles, region={} job_type={} cost_ms={} rows={} bytes={} bytes_on_disk={}"
-        "write_cf_keys={} default_cf_keys={} lock_cf_keys={} dt_files=[{}]",
+        "Transformed snapshot in SSTFile to DTFiles,"
+        " region={} job_type={} cost_ms={} rows={} bytes={} bytes_on_disk={}"
+        " write_cf_keys={} default_cf_keys={} lock_cf_keys={} dt_files=[{}]",
         child->getRegion()->toString(true),
         magic_enum::enum_name(job_type),
         watch.elapsedMilliseconds(),

--- a/dbms/src/Storages/PathPool.cpp
+++ b/dbms/src/Storages/PathPool.cpp
@@ -474,8 +474,8 @@ String StableDiskDelegator::getDTFilePath(UInt64 file_id, bool throw_on_not_exis
 
 void StableDiskDelegator::addDTFile(UInt64 file_id, size_t file_size, std::string_view path)
 {
-    path.remove_suffix(
-        1 + strlen(StoragePathPool::STABLE_FOLDER_NAME)); // remove '/stable' added in listPathsForStable/getDTFilePath
+    // remove '/stable' added in listPathsForStable/getDTFilePath
+    path.remove_suffix(1 + strlen(StoragePathPool::STABLE_FOLDER_NAME));
     std::lock_guard lock{pool.mutex};
     if (auto iter = pool.dt_file_path_map.find(file_id); unlikely(iter != pool.dt_file_path_map.end()))
     {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/8054

Problem Summary:

introduced by https://github.com/pingcap/tiflash/pull/7876 .
Under disagg mode, we don't record the dt file parent path by `StableDiskDelegator::addDTFile`. It causes exception when cancelling snapshot.

### What is changed and how it works?

As the comments describe, we just ignore the local files under disagg arch.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
