### PR TITLE
Refine API in IAggregateFunction/Aggregator to support aggregate on part of the input `block` formally

### DIFF
--- a/dbms/src/AggregateFunctions/AggregateFunctionCount.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionCount.h
@@ -53,6 +53,7 @@ public:
     }
 
     void addBatchSinglePlace(
+        size_t start_offset,
         size_t batch_size,
         AggregateDataPtr place,
         const IColumn ** columns,
@@ -62,7 +63,7 @@ public:
         if (if_argument_pos >= 0)
         {
             const auto & flags = assert_cast<const ColumnUInt8 &>(*columns[if_argument_pos]).getData();
-            data(place).count += countBytesInFilter(flags);
+            data(place).count += countBytesInFilter(flags, start_offset, batch_size);
         }
         else
         {
@@ -71,6 +72,7 @@ public:
     }
 
     void addBatchSinglePlaceNotNull(
+        size_t start_offset,
         size_t batch_size,
         AggregateDataPtr place,
         const IColumn ** columns,
@@ -81,11 +83,11 @@ public:
         if (if_argument_pos >= 0)
         {
             const auto & flags = assert_cast<const ColumnUInt8 &>(*columns[if_argument_pos]).getData();
-            data(place).count += countBytesInFilterWithNull(flags, null_map);
+            data(place).count += countBytesInFilterWithNull(flags, null_map, start_offset, batch_size);
         }
         else
         {
-            data(place).count += batch_size - countBytesInFilter(null_map, batch_size);
+            data(place).count += batch_size - countBytesInFilter(null_map, start_offset, batch_size);
         }
     }
 

--- a/dbms/src/AggregateFunctions/AggregateFunctionIf.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionIf.h
@@ -77,6 +77,7 @@ public:
     }
 
     void addBatch(
+        size_t start_offset,
         size_t batch_size,
         AggregateDataPtr * places,
         size_t place_offset,
@@ -84,20 +85,22 @@ public:
         Arena * arena,
         ssize_t) const override
     {
-        nested_func->addBatch(batch_size, places, place_offset, columns, arena, num_arguments - 1);
+        nested_func->addBatch(start_offset, batch_size, places, place_offset, columns, arena, num_arguments - 1);
     }
 
     void addBatchSinglePlace(
+        size_t start_offset,
         size_t batch_size,
         AggregateDataPtr place,
         const IColumn ** columns,
         Arena * arena,
         ssize_t) const override
     {
-        nested_func->addBatchSinglePlace(batch_size, place, columns, arena, num_arguments - 1);
+        nested_func->addBatchSinglePlace(start_offset, batch_size, place, columns, arena, num_arguments - 1);
     }
 
     void addBatchSinglePlaceNotNull(
+        size_t start_offset,
         size_t batch_size,
         AggregateDataPtr place,
         const IColumn ** columns,
@@ -105,7 +108,7 @@ public:
         Arena * arena,
         ssize_t) const override
     {
-        nested_func->addBatchSinglePlaceNotNull(batch_size, place, columns, null_map, arena, num_arguments - 1);
+        nested_func->addBatchSinglePlaceNotNull(start_offset, batch_size, place, columns, null_map, arena, num_arguments - 1);
     }
 
     void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs, Arena * arena) const override

--- a/dbms/src/AggregateFunctions/AggregateFunctionIf.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionIf.h
@@ -108,7 +108,8 @@ public:
         Arena * arena,
         ssize_t) const override
     {
-        nested_func->addBatchSinglePlaceNotNull(start_offset, batch_size, place, columns, null_map, arena, num_arguments - 1);
+        nested_func
+            ->addBatchSinglePlaceNotNull(start_offset, batch_size, place, columns, null_map, arena, num_arguments - 1);
     }
 
     void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs, Arena * arena) const override

--- a/dbms/src/AggregateFunctions/AggregateFunctionNull.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionNull.h
@@ -430,8 +430,13 @@ public:
         }
         else
         {
-            this->nested_function
-                ->addBatchSinglePlace(start_offset, batch_size, this->nestedPlace(place), columns, arena, if_argument_pos);
+            this->nested_function->addBatchSinglePlace(
+                start_offset,
+                batch_size,
+                this->nestedPlace(place),
+                columns,
+                arena,
+                if_argument_pos);
             this->setFlag(place);
         }
     }

--- a/dbms/src/AggregateFunctions/AggregateFunctionNull.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionNull.h
@@ -399,6 +399,7 @@ public:
     }
 
     void addBatchSinglePlace( // NOLINT(google-default-arguments)
+        size_t start_offset,
         size_t batch_size,
         AggregateDataPtr place,
         const IColumn ** columns,
@@ -415,6 +416,7 @@ public:
             const UInt8 * null_map = column->getNullMapData().data();
 
             this->nested_function->addBatchSinglePlaceNotNull(
+                start_offset,
                 batch_size,
                 this->nestedPlace(place),
                 &nested_column,
@@ -423,13 +425,13 @@ public:
                 if_argument_pos);
 
             if constexpr (result_is_nullable)
-                if (!mem_utils::memoryIsByte(null_map, batch_size, std::byte{1}))
+                if (!mem_utils::memoryIsByte(null_map + start_offset, batch_size, std::byte{1}))
                     this->setFlag(place);
         }
         else
         {
             this->nested_function
-                ->addBatchSinglePlace(batch_size, this->nestedPlace(place), columns, arena, if_argument_pos);
+                ->addBatchSinglePlace(start_offset, batch_size, this->nestedPlace(place), columns, arena, if_argument_pos);
             this->setFlag(place);
         }
     }

--- a/dbms/src/AggregateFunctions/AggregateFunctionSum.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionSum.h
@@ -338,6 +338,7 @@ public:
 
     /// Vectorized version when there is no GROUP BY keys.
     void addBatchSinglePlace(
+        size_t start_offset,
         size_t batch_size,
         AggregateDataPtr place,
         const IColumn ** columns,
@@ -347,7 +348,7 @@ public:
         if (if_argument_pos >= 0)
         {
             const auto & flags = assert_cast<const ColumnUInt8 &>(*columns[if_argument_pos]).getData();
-            for (size_t i = 0; i < batch_size; ++i)
+            for (size_t i = start_offset; i < batch_size; ++i)
             {
                 if (flags[i])
                     add(place, columns, i, arena);
@@ -356,11 +357,12 @@ public:
         else
         {
             const auto & column = assert_cast<const ColVecType &>(*columns[0]);
-            this->data(place).addMany(column.getData().data(), batch_size);
+            this->data(place).addMany(column.getData().data() + start_offset, batch_size);
         }
     }
 
     void addBatchSinglePlaceNotNull(
+        size_t start_offset,
         size_t batch_size,
         AggregateDataPtr place,
         const IColumn ** columns,
@@ -371,14 +373,14 @@ public:
         if (if_argument_pos >= 0)
         {
             const auto & flags = assert_cast<const ColumnUInt8 &>(*columns[if_argument_pos]).getData();
-            for (size_t i = 0; i < batch_size; ++i)
+            for (size_t i = start_offset; i < batch_size; ++i)
                 if (!null_map[i] && flags[i])
                     add(place, columns, i, arena);
         }
         else
         {
             const auto & column = assert_cast<const ColVecType &>(*columns[0]);
-            this->data(place).addManyNotNull(column.getData().data(), null_map, batch_size);
+            this->data(place).addManyNotNull(column.getData().data() + start_offset, null_map + start_offset, batch_size);
         }
     }
 

--- a/dbms/src/AggregateFunctions/AggregateFunctionSum.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionSum.h
@@ -380,7 +380,10 @@ public:
         else
         {
             const auto & column = assert_cast<const ColVecType &>(*columns[0]);
-            this->data(place).addManyNotNull(column.getData().data() + start_offset, null_map + start_offset, batch_size);
+            this->data(place).addManyNotNull(
+                column.getData().data() + start_offset,
+                null_map + start_offset,
+                batch_size);
         }
     }
 

--- a/dbms/src/AggregateFunctions/AggregateFunctionSum.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionSum.h
@@ -348,7 +348,7 @@ public:
         if (if_argument_pos >= 0)
         {
             const auto & flags = assert_cast<const ColumnUInt8 &>(*columns[if_argument_pos]).getData();
-            for (size_t i = start_offset; i < batch_size; ++i)
+            for (size_t i = start_offset; i < start_offset + batch_size; ++i)
             {
                 if (flags[i])
                     add(place, columns, i, arena);
@@ -373,7 +373,7 @@ public:
         if (if_argument_pos >= 0)
         {
             const auto & flags = assert_cast<const ColumnUInt8 &>(*columns[if_argument_pos]).getData();
-            for (size_t i = start_offset; i < batch_size; ++i)
+            for (size_t i = start_offset; i < start_offset + batch_size; ++i)
                 if (!null_map[i] && flags[i])
                     add(place, columns, i, arena);
         }

--- a/dbms/src/AggregateFunctions/IAggregateFunction.h
+++ b/dbms/src/AggregateFunctions/IAggregateFunction.h
@@ -229,7 +229,7 @@ public:
         if (if_argument_pos >= 0)
         {
             const auto & flags = assert_cast<const ColumnUInt8 &>(*columns[if_argument_pos]).getData();
-            for (size_t i = start_offset; i < batch_size; ++i)
+            for (size_t i = start_offset; i < start_offset + batch_size; ++i)
             {
                 if (flags[i] && places[i - start_offset])
                     static_cast<const Derived *>(this)->add(places[i - start_offset] + place_offset, columns, i, arena);
@@ -237,7 +237,7 @@ public:
         }
         else
         {
-            for (size_t i = start_offset; i < batch_size; ++i)
+            for (size_t i = start_offset; i < start_offset + batch_size; ++i)
                 if (places[i - start_offset])
                     static_cast<const Derived *>(this)->add(places[i - start_offset] + place_offset, columns, i, arena);
         }
@@ -266,7 +266,7 @@ public:
         if (if_argument_pos >= 0)
         {
             const auto & flags = assert_cast<const ColumnUInt8 &>(*columns[if_argument_pos]).getData();
-            for (size_t i = start_offset; i < batch_size; ++i)
+            for (size_t i = start_offset; i < start_offset + batch_size; ++i)
             {
                 if (flags[i])
                     static_cast<const Derived *>(this)->add(place, columns, i, arena);
@@ -274,7 +274,7 @@ public:
         }
         else
         {
-            for (size_t i = start_offset; i < batch_size; ++i)
+            for (size_t i = start_offset; i < start_offset + batch_size; ++i)
                 static_cast<const Derived *>(this)->add(place, columns, i, arena);
         }
     }
@@ -291,13 +291,13 @@ public:
         if (if_argument_pos >= 0)
         {
             const auto & flags = assert_cast<const ColumnUInt8 &>(*columns[if_argument_pos]).getData();
-            for (size_t i = start_offset; i < batch_size; ++i)
+            for (size_t i = start_offset; i < start_offset + batch_size; ++i)
                 if (!null_map[i] && flags[i])
                     static_cast<const Derived *>(this)->add(place, columns, i, arena);
         }
         else
         {
-            for (size_t i = start_offset; i < batch_size; ++i)
+            for (size_t i = start_offset; i < start_offset + batch_size; ++i)
                 if (!null_map[i])
                     static_cast<const Derived *>(this)->add(place, columns, i, arena);
         }
@@ -337,7 +337,7 @@ public:
         size_t i = start_offset;
 
         size_t batch_size_unrolled = batch_size / UNROLL_COUNT * UNROLL_COUNT;
-        for (; i < batch_size_unrolled; i += UNROLL_COUNT)
+        for (; i < start_offset + batch_size_unrolled; i += UNROLL_COUNT)
         {
             AggregateDataPtr places[UNROLL_COUNT];
             for (size_t j = 0; j < UNROLL_COUNT; ++j)
@@ -353,7 +353,7 @@ public:
                 static_cast<const Derived *>(this)->add(places[j] + place_offset, columns, i + j, arena);
         }
 
-        for (; i < batch_size; ++i)
+        for (; i < start_offset + batch_size; ++i)
         {
             AggregateDataPtr & place = map[key[i]];
             if (unlikely(!place))
@@ -538,7 +538,7 @@ public:
         /// Aggregate data into different lookup tables.
 
         size_t batch_size_unrolled = batch_size / UNROLL_COUNT * UNROLL_COUNT;
-        for (; i < batch_size_unrolled; i += UNROLL_COUNT)
+        for (; i < start_offset + batch_size_unrolled; i += UNROLL_COUNT)
         {
             for (size_t j = 0; j < UNROLL_COUNT; ++j)
             {
@@ -572,7 +572,7 @@ public:
 
         /// Process tails and add directly to the final destination.
 
-        for (; i < batch_size; ++i)
+        for (; i < start_offset + batch_size; ++i)
         {
             size_t k = key[i];
             AggregateDataPtr & place = map[k];

--- a/dbms/src/AggregateFunctions/IAggregateFunction.h
+++ b/dbms/src/AggregateFunctions/IAggregateFunction.h
@@ -514,15 +514,8 @@ public:
 
         if (func.allocatesMemoryInArena() || sizeof(Data) > 16 || func.sizeOfData() != sizeof(Data))
         {
-            IAggregateFunctionHelper<Derived>::addBatchLookupTable8(
-                start_offset,
-                batch_size,
-                map,
-                place_offset,
-                init,
-                key,
-                columns,
-                arena);
+            IAggregateFunctionHelper<
+                Derived>::addBatchLookupTable8(start_offset, batch_size, map, place_offset, init, key, columns, arena);
             return;
         }
 

--- a/dbms/src/Columns/ColumnsCommon.cpp
+++ b/dbms/src/Columns/ColumnsCommon.cpp
@@ -83,6 +83,16 @@ size_t countBytesInFilter(const UInt8 * filt, size_t sz)
     return CountBytesInFilter(filt, 0, sz);
 }
 
+size_t countBytesInFilter(const UInt8 * filt, size_t start, size_t sz)
+{
+    return CountBytesInFilter(filt, start, start + sz);
+}
+
+size_t countBytesInFilter(const IColumn::Filter & filt, size_t start, size_t sz)
+{
+    return CountBytesInFilter(filt.data(), start, start + sz);
+}
+
 size_t countBytesInFilter(const IColumn::Filter & filt)
 {
     return CountBytesInFilter(filt.data(), 0, filt.size());
@@ -130,6 +140,11 @@ static inline size_t CountBytesInFilterWithNull(
 size_t countBytesInFilterWithNull(const IColumn::Filter & filt, const UInt8 * null_map)
 {
     return CountBytesInFilterWithNull(filt, null_map, 0, filt.size());
+}
+
+size_t countBytesInFilterWithNull(const IColumn::Filter & filt, const UInt8 * null_map, size_t start, size_t sz)
+{
+    return CountBytesInFilterWithNull(filt, null_map, start, start + sz);
 }
 
 std::vector<size_t> countColumnsSizeInSelector(IColumn::ColumnIndex num_columns, const IColumn::Selector & selector)

--- a/dbms/src/Columns/ColumnsCommon.h
+++ b/dbms/src/Columns/ColumnsCommon.h
@@ -23,8 +23,11 @@ namespace DB
 {
 /// Counts how many bytes of `filt` are greater than zero.
 size_t countBytesInFilter(const UInt8 * filt, size_t sz);
+size_t countBytesInFilter(const UInt8 * filt, size_t start, size_t sz);
 size_t countBytesInFilter(const IColumn::Filter & filt);
+size_t countBytesInFilter(const IColumn::Filter & filt, size_t start, size_t sz);
 size_t countBytesInFilterWithNull(const IColumn::Filter & filt, const UInt8 * null_map);
+size_t countBytesInFilterWithNull(const IColumn::Filter & filt, const UInt8 * null_map, size_t start, size_t sz);
 
 /// Returns vector with num_columns elements. vector[i] is the count of i values in selector.
 /// Selector must contain values from 0 to num_columns - 1. NOTE: this is not checked.

--- a/dbms/src/DataStreams/ParallelAggregatingBlockInputStream.cpp
+++ b/dbms/src/DataStreams/ParallelAggregatingBlockInputStream.cpp
@@ -146,7 +146,6 @@ void ParallelAggregatingBlockInputStream::Handler::onBlock(Block & block, size_t
 {
     auto & data = *parent.many_data[thread_num];
     auto & agg_process_info = parent.threads_data[thread_num].agg_process_info;
-    RUNTIME_CHECK_MSG(agg_process_info.start_row == agg_process_info.end_row, "Previous block is not processed yet");
     agg_process_info.resetBlock(block);
     parent.aggregator.executeOnBlock(agg_process_info, data, thread_num);
     if (data.need_spill)
@@ -270,9 +269,6 @@ void ParallelAggregatingBlockInputStream::execute()
     {
         auto & data = *many_data[0];
         auto & agg_process_info = threads_data[0].agg_process_info;
-        RUNTIME_CHECK_MSG(
-            agg_process_info.start_row == agg_process_info.end_row,
-            "Previous block is not processed yet");
         agg_process_info.resetBlock(children.at(0)->getHeader());
         aggregator.executeOnBlock(agg_process_info, data, 0);
         if (data.need_spill)

--- a/dbms/src/DataStreams/ParallelAggregatingBlockInputStream.cpp
+++ b/dbms/src/DataStreams/ParallelAggregatingBlockInputStream.cpp
@@ -40,8 +40,6 @@ ParallelAggregatingBlockInputStream::ParallelAggregatingBlockInputStream(
     , final(final_)
     , max_buffered_bytes(max_buffered_bytes_)
     , temporary_data_merge_threads(temporary_data_merge_threads_)
-    , keys_size(params.keys_size)
-    , aggregates_size(params.aggregates_size)
     , handler(*this)
     , processor(inputs, additional_inputs_at_end, max_threads, handler, log)
 {
@@ -147,12 +145,10 @@ Block ParallelAggregatingBlockInputStream::readImpl()
 void ParallelAggregatingBlockInputStream::Handler::onBlock(Block & block, size_t thread_num)
 {
     auto & data = *parent.many_data[thread_num];
-    parent.aggregator.executeOnBlock(
-        block,
-        data,
-        parent.threads_data[thread_num].key_columns,
-        parent.threads_data[thread_num].aggregate_columns,
-        thread_num);
+    auto & agg_process_info = parent.threads_data[thread_num].agg_process_info;
+    RUNTIME_CHECK_MSG(agg_process_info.start_row == agg_process_info.end_row, "Previous block is not processed yet");
+    agg_process_info.resetBlock(block);
+    parent.aggregator.executeOnBlock(agg_process_info, data, thread_num);
     if (data.need_spill)
         parent.aggregator.spill(data, thread_num);
 
@@ -220,7 +216,7 @@ void ParallelAggregatingBlockInputStream::execute()
     exceptions.resize(max_threads);
 
     for (size_t i = 0; i < max_threads; ++i)
-        threads_data.emplace_back(keys_size, aggregates_size);
+        threads_data.emplace_back();
     aggregator.initThresholdByAggregatedDataVariantsSize(many_data.size());
 
     LOG_TRACE(log, "Aggregating");
@@ -273,12 +269,12 @@ void ParallelAggregatingBlockInputStream::execute()
     if (total_src_rows == 0 && params.keys_size == 0 && !params.empty_result_for_aggregation_by_empty_set)
     {
         auto & data = *many_data[0];
-        aggregator.executeOnBlock(
-            children.at(0)->getHeader(),
-            data,
-            threads_data[0].key_columns,
-            threads_data[0].aggregate_columns,
-            0);
+        auto & agg_process_info = threads_data[0].agg_process_info;
+        RUNTIME_CHECK_MSG(
+            agg_process_info.start_row == agg_process_info.end_row,
+            "Previous block is not processed yet");
+        agg_process_info.resetBlock(children.at(0)->getHeader());
+        aggregator.executeOnBlock(agg_process_info, data, 0);
         if (data.need_spill)
             aggregator.spill(data, 0);
     }

--- a/dbms/src/DataStreams/ParallelAggregatingBlockInputStream.h
+++ b/dbms/src/DataStreams/ParallelAggregatingBlockInputStream.h
@@ -69,9 +69,6 @@ private:
     Int64 max_buffered_bytes;
     size_t temporary_data_merge_threads;
 
-    size_t keys_size;
-    size_t aggregates_size;
-
     std::atomic<bool> executed{false};
 
     ManyAggregatedDataVariants many_data;
@@ -82,15 +79,7 @@ private:
     {
         size_t src_rows = 0;
         size_t src_bytes = 0;
-
-        ColumnRawPtrs key_columns;
-        Aggregator::AggregateColumns aggregate_columns;
-
-        ThreadData(size_t keys_size, size_t aggregates_size)
-        {
-            key_columns.resize(keys_size);
-            aggregate_columns.resize(aggregates_size);
-        }
+        Aggregator::AggProcessInfo agg_process_info{};
     };
 
     std::vector<ThreadData> threads_data;

--- a/dbms/src/Interpreters/Aggregator.cpp
+++ b/dbms/src/Interpreters/Aggregator.cpp
@@ -698,16 +698,7 @@ ALWAYS_INLINE void Aggregator::executeImplBatch(
     /// Add values to the aggregate functions.
     for (AggregateFunctionInstruction * inst = aggregate_instructions; inst->that; ++inst)
     {
-        if (inst->offsets)
-            inst->batch_that->addBatchArray(
-                rows,
-                places.get(),
-                inst->state_offset,
-                inst->batch_arguments,
-                inst->offsets,
-                aggregates_pool);
-        else
-            inst->batch_that->addBatch(rows, places.get(), inst->state_offset, inst->batch_arguments, aggregates_pool);
+        inst->batch_that->addBatch(rows, places.get(), inst->state_offset, inst->batch_arguments, aggregates_pool);
     }
 }
 
@@ -720,14 +711,7 @@ void NO_INLINE Aggregator::executeWithoutKeyImpl(
     /// Adding values
     for (AggregateFunctionInstruction * inst = aggregate_instructions; inst->that; ++inst)
     {
-        if (inst->offsets)
-            inst->batch_that->addBatchSinglePlace(
-                inst->offsets[static_cast<ssize_t>(rows - 1)],
-                res + inst->state_offset,
-                inst->batch_arguments,
-                arena);
-        else
-            inst->batch_that->addBatchSinglePlace(rows, res + inst->state_offset, inst->batch_arguments, arena);
+        inst->batch_that->addBatchSinglePlace(rows, res + inst->state_offset, inst->batch_arguments, arena);
     }
 }
 

--- a/dbms/src/Interpreters/Aggregator.cpp
+++ b/dbms/src/Interpreters/Aggregator.cpp
@@ -648,7 +648,8 @@ ALWAYS_INLINE void Aggregator::executeImplBatch(
     /// Optimization for special case when aggregating by 8bit key.
     if constexpr (std::is_same_v<Method, AggregatedDataVariants::AggregationMethod_key8>)
     {
-        for (AggregateFunctionInstruction * inst = agg_process_info.aggregate_functions_instructions.data(); inst->that; ++inst)
+        for (AggregateFunctionInstruction * inst = agg_process_info.aggregate_functions_instructions.data(); inst->that;
+             ++inst)
         {
             inst->batch_that->addBatchLookupTable8(
                 agg_process_info.start_row,
@@ -670,7 +671,8 @@ ALWAYS_INLINE void Aggregator::executeImplBatch(
 
     /// Generic case.
 
-    std::unique_ptr<AggregateDataPtr[]> places(new AggregateDataPtr[agg_process_info.end_row - agg_process_info.start_row]);
+    std::unique_ptr<AggregateDataPtr[]> places(
+        new AggregateDataPtr[agg_process_info.end_row - agg_process_info.start_row]);
 
     for (size_t i = agg_process_info.start_row; i < agg_process_info.end_row; ++i)
     {
@@ -696,22 +698,33 @@ ALWAYS_INLINE void Aggregator::executeImplBatch(
     }
 
     /// Add values to the aggregate functions.
-    for (AggregateFunctionInstruction * inst = agg_process_info.aggregate_functions_instructions.data(); inst->that; ++inst)
+    for (AggregateFunctionInstruction * inst = agg_process_info.aggregate_functions_instructions.data(); inst->that;
+         ++inst)
     {
-        inst->batch_that->addBatch(agg_process_info.start_row, agg_process_info.end_row - agg_process_info.start_row, places.get(), inst->state_offset, inst->batch_arguments, aggregates_pool);
+        inst->batch_that->addBatch(
+            agg_process_info.start_row,
+            agg_process_info.end_row - agg_process_info.start_row,
+            places.get(),
+            inst->state_offset,
+            inst->batch_arguments,
+            aggregates_pool);
     }
     agg_process_info.start_row = agg_process_info.end_row;
 }
 
-void NO_INLINE Aggregator::executeWithoutKeyImpl(
-    AggregatedDataWithoutKey & res,
-    AggProcessInfo & agg_process_info,
-    Arena * arena)
+void NO_INLINE
+Aggregator::executeWithoutKeyImpl(AggregatedDataWithoutKey & res, AggProcessInfo & agg_process_info, Arena * arena)
 {
     /// Adding values
-    for (AggregateFunctionInstruction * inst = agg_process_info.aggregate_functions_instructions.data(); inst->that; ++inst)
+    for (AggregateFunctionInstruction * inst = agg_process_info.aggregate_functions_instructions.data(); inst->that;
+         ++inst)
     {
-        inst->batch_that->addBatchSinglePlace(agg_process_info.start_row, agg_process_info.end_row - agg_process_info.start_row, res + inst->state_offset, inst->batch_arguments, arena);
+        inst->batch_that->addBatchSinglePlace(
+            agg_process_info.start_row,
+            agg_process_info.end_row - agg_process_info.start_row,
+            res + inst->state_offset,
+            inst->batch_arguments,
+            arena);
     }
     agg_process_info.start_row = agg_process_info.end_row;
 }
@@ -836,10 +849,7 @@ bool Aggregator::executeOnBlock(AggProcessInfo & agg_process_info, AggregatedDat
     /// For the case when there are no keys (all aggregate into one row).
     if (result.type == AggregatedDataVariants::Type::without_key)
     {
-        executeWithoutKeyImpl(
-            result.without_key,
-            agg_process_info,
-            result.aggregates_pool);
+        executeWithoutKeyImpl(result.without_key, agg_process_info, result.aggregates_pool);
     }
     else
     {

--- a/dbms/src/Interpreters/Aggregator.cpp
+++ b/dbms/src/Interpreters/Aggregator.cpp
@@ -771,8 +771,8 @@ void Aggregator::AggProcessInfo::prepareForAgg(Aggregator * aggregator)
     end_row = block.rows();
     input_columns = block.getColumns();
     materialized_columns.reserve(aggregator->params.keys_size);
-    key_columns.reserve(aggregator->params.keys_size);
-    aggregate_columns.reserve(aggregator->params.aggregates_size);
+    key_columns.resize(aggregator->params.keys_size);
+    aggregate_columns.resize(aggregator->params.aggregates_size);
 
     /** Constant columns are not supported directly during aggregation.
       * To make them work anyway, we materialize them.

--- a/dbms/src/Interpreters/Aggregator.h
+++ b/dbms/src/Interpreters/Aggregator.h
@@ -1146,6 +1146,7 @@ public:
         void prepareForAgg(Aggregator * aggregator);
         void resetBlock(const Block & block_)
         {
+            RUNTIME_CHECK_MSG(start_row == end_row, "Previous block is not processed yet");
             block = block_;
             start_row = 0;
             end_row = 0;

--- a/dbms/src/Interpreters/Aggregator.h
+++ b/dbms/src/Interpreters/Aggregator.h
@@ -1262,10 +1262,7 @@ protected:
         AggProcessInfo & agg_process_info) const;
 
     /// For case when there are no keys (all aggregate into one row).
-    static void executeWithoutKeyImpl(
-        AggregatedDataWithoutKey & res,
-        AggProcessInfo & agg_process_info,
-        Arena * arena);
+    static void executeWithoutKeyImpl(AggregatedDataWithoutKey & res, AggProcessInfo & agg_process_info, Arena * arena);
 
     template <typename Method>
     void spillImpl(AggregatedDataVariants & data_variants, Method & method, size_t thread_num);

--- a/dbms/src/Interpreters/Aggregator.h
+++ b/dbms/src/Interpreters/Aggregator.h
@@ -1149,6 +1149,7 @@ public:
             block = block_;
             start_row = 0;
             end_row = 0;
+            materialized_columns.clear();
             prepare_for_agg_done = false;
         }
     };

--- a/dbms/src/Interpreters/Aggregator.h
+++ b/dbms/src/Interpreters/Aggregator.h
@@ -1116,13 +1116,46 @@ public:
     using AggregateColumnsConstData = std::vector<const ColumnAggregateFunction::Container *>;
     using AggregateFunctionsPlainPtrs = std::vector<IAggregateFunction *>;
 
+    /** This array serves two purposes.
+      *
+      * Function arguments are collected side by side, and they do not need to be collected from different places. Also the array is made zero-terminated.
+      * The inner loop (for the case without_key) is almost twice as compact; performance gain of about 30%.
+      */
+    struct AggregateFunctionInstruction
+    {
+        const IAggregateFunction * that{};
+        IAggregateFunction::AddFunc func{};
+        size_t state_offset{};
+        const IColumn ** arguments{};
+        const IAggregateFunction * batch_that{};
+        const IColumn ** batch_arguments{};
+        const UInt64 * offsets{};
+    };
+
+    using AggregateFunctionInstructions = std::vector<AggregateFunctionInstruction>;
+    struct AggProcessInfo
+    {
+        Block block;
+        size_t start_row = 0;
+        size_t end_row = 0;
+        bool prepare_for_agg_done = false;
+        Columns materialized_columns;
+        Columns input_columns;
+        ColumnRawPtrs key_columns;
+        AggregateColumns aggregate_columns;
+        AggregateFunctionInstructions aggregate_functions_instructions;
+        void prepareForAgg(Aggregator * aggregator);
+        void resetBlock(const Block & block_)
+        {
+            block = block_;
+            start_row = 0;
+            end_row = 0;
+            prepare_for_agg_done = false;
+        }
+    };
+
     /// Process one block. Return false if the processing should be aborted.
-    bool executeOnBlock(
-        const Block & block,
-        AggregatedDataVariants & result,
-        ColumnRawPtrs & key_columns,
-        AggregateColumns & aggregate_columns, /// Passed to not create them anew for each block
-        size_t thread_num);
+    bool executeOnBlock(AggProcessInfo & agg_process_info, AggregatedDataVariants & result, size_t thread_num);
 
     /** Merge several aggregation data structures and output the MergingBucketsPtr used to merge.
       * Return nullptr if there are no non empty data_variant.
@@ -1170,24 +1203,6 @@ protected:
     Sizes key_sizes;
 
     AggregateFunctionsPlainPtrs aggregate_functions;
-
-    /** This array serves two purposes.
-      *
-      * Function arguments are collected side by side, and they do not need to be collected from different places. Also the array is made zero-terminated.
-      * The inner loop (for the case without_key) is almost twice as compact; performance gain of about 30%.
-      */
-    struct AggregateFunctionInstruction
-    {
-        const IAggregateFunction * that{};
-        IAggregateFunction::AddFunc func{};
-        size_t state_offset{};
-        const IColumn ** arguments{};
-        const IAggregateFunction * batch_that{};
-        const IColumn ** batch_arguments{};
-        const UInt64 * offsets{};
-    };
-
-    using AggregateFunctionInstructions = std::vector<AggregateFunctionInstruction>;
 
     Sizes offsets_of_aggregate_states; /// The offset to the n-th aggregate function in a row of aggregate functions.
     size_t total_size_of_aggregate_states = 0; /// The total size of the row from the aggregate functions.

--- a/dbms/src/Interpreters/Aggregator.h
+++ b/dbms/src/Interpreters/Aggregator.h
@@ -1129,7 +1129,6 @@ public:
         const IColumn ** arguments{};
         const IAggregateFunction * batch_that{};
         const IColumn ** batch_arguments{};
-        const UInt64 * offsets{};
     };
 
     using AggregateFunctionInstructions = std::vector<AggregateFunctionInstruction>;

--- a/dbms/src/Interpreters/Aggregator.h
+++ b/dbms/src/Interpreters/Aggregator.h
@@ -1249,24 +1249,20 @@ protected:
     void executeImpl(
         Method & method,
         Arena * aggregates_pool,
-        size_t rows,
-        ColumnRawPtrs & key_columns,
-        TiDB::TiDBCollators & collators,
-        AggregateFunctionInstruction * aggregate_instructions) const;
+        AggProcessInfo & agg_process_info,
+        TiDB::TiDBCollators & collators) const;
 
     template <typename Method>
     void executeImplBatch(
         Method & method,
         typename Method::State & state,
         Arena * aggregates_pool,
-        size_t rows,
-        AggregateFunctionInstruction * aggregate_instructions) const;
+        AggProcessInfo & agg_process_info) const;
 
     /// For case when there are no keys (all aggregate into one row).
     static void executeWithoutKeyImpl(
         AggregatedDataWithoutKey & res,
-        size_t rows,
-        AggregateFunctionInstruction * aggregate_instructions,
+        AggProcessInfo & agg_process_info,
         Arena * arena);
 
     template <typename Method>

--- a/dbms/src/Operators/AggregateContext.cpp
+++ b/dbms/src/Operators/AggregateContext.cpp
@@ -31,7 +31,7 @@ void AggregateContext::initBuild(
     threads_data.reserve(max_threads);
     for (size_t i = 0; i < max_threads; ++i)
     {
-        threads_data.emplace_back(std::make_unique<ThreadData>(params.keys_size, params.aggregates_size));
+        threads_data.emplace_back(std::make_unique<ThreadData>());
         many_data.emplace_back(std::make_shared<AggregatedDataVariants>());
     }
 
@@ -46,12 +46,10 @@ void AggregateContext::initBuild(
 void AggregateContext::buildOnBlock(size_t task_index, const Block & block)
 {
     assert(status.load() == AggStatus::build);
-    aggregator->executeOnBlock(
-        block,
-        *many_data[task_index],
-        threads_data[task_index]->key_columns,
-        threads_data[task_index]->aggregate_columns,
-        task_index);
+    auto & agg_process_info = threads_data[task_index]->agg_process_info;
+    RUNTIME_CHECK_MSG(agg_process_info.start_row == agg_process_info.end_row, "Previous block is not processed yet");
+    agg_process_info.resetBlock(block);
+    aggregator->executeOnBlock(agg_process_info, *many_data[task_index], task_index);
     threads_data[task_index]->src_bytes += block.bytes();
     threads_data[task_index]->src_rows += block.rows();
 }
@@ -137,12 +135,12 @@ void AggregateContext::initConvergentPrefix()
 
     if (total_src_rows == 0 && keys_size == 0 && !empty_result_for_aggregation_by_empty_set)
     {
-        aggregator->executeOnBlock(
-            this->getHeader(),
-            *many_data[0],
-            threads_data[0]->key_columns,
-            threads_data[0]->aggregate_columns,
-            0);
+        auto & agg_process_info = threads_data[0]->agg_process_info;
+        RUNTIME_CHECK_MSG(
+            agg_process_info.start_row == agg_process_info.end_row,
+            "Previous block is not processed yet");
+        agg_process_info.resetBlock(this->getHeader());
+        aggregator->executeOnBlock(agg_process_info, *many_data[0], 0);
         /// Since this won't consume a lot of memory,
         /// even if it triggers marking need spill due to a low threshold setting,
         /// it's still reasonable not to spill disk.

--- a/dbms/src/Operators/AggregateContext.cpp
+++ b/dbms/src/Operators/AggregateContext.cpp
@@ -47,7 +47,6 @@ void AggregateContext::buildOnBlock(size_t task_index, const Block & block)
 {
     assert(status.load() == AggStatus::build);
     auto & agg_process_info = threads_data[task_index]->agg_process_info;
-    RUNTIME_CHECK_MSG(agg_process_info.start_row == agg_process_info.end_row, "Previous block is not processed yet");
     agg_process_info.resetBlock(block);
     aggregator->executeOnBlock(agg_process_info, *many_data[task_index], task_index);
     threads_data[task_index]->src_bytes += block.bytes();
@@ -136,9 +135,6 @@ void AggregateContext::initConvergentPrefix()
     if (total_src_rows == 0 && keys_size == 0 && !empty_result_for_aggregation_by_empty_set)
     {
         auto & agg_process_info = threads_data[0]->agg_process_info;
-        RUNTIME_CHECK_MSG(
-            agg_process_info.start_row == agg_process_info.end_row,
-            "Previous block is not processed yet");
         agg_process_info.resetBlock(this->getHeader());
         aggregator->executeOnBlock(agg_process_info, *many_data[0], 0);
         /// Since this won't consume a lot of memory,

--- a/dbms/src/Operators/AggregateContext.h
+++ b/dbms/src/Operators/AggregateContext.h
@@ -27,14 +27,7 @@ struct ThreadData
     size_t src_rows = 0;
     size_t src_bytes = 0;
 
-    ColumnRawPtrs key_columns;
-    Aggregator::AggregateColumns aggregate_columns;
-
-    ThreadData(size_t keys_size, size_t aggregates_size)
-    {
-        key_columns.resize(keys_size);
-        aggregate_columns.resize(aggregates_size);
-    }
+    Aggregator::AggProcessInfo agg_process_info{};
 };
 
 /// Aggregated data shared between AggBuild and AggConvergent Pipeline.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #7738

Problem Summary:
Before this pr, `Aggregator::executeOnBlock` only support aggregate the whole input block once a time, after this pr, `Aggregator::executeOnBlock` support aggregate only part of the data from the input block.
Note this pr only supports aggregation on part of the input block in terms of form, the code logic is not changed, the real support will be on the next pr.
### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
