### PR TITLE
Fully support aggregate on part of a input block

### DIFF
--- a/dbms/src/Common/FailPoint.cpp
+++ b/dbms/src/Common/FailPoint.cpp
@@ -101,7 +101,8 @@ namespace DB
     M(skip_seek_before_read_dmfile)                          \
     M(exception_after_large_write_exceed)                    \
     M(proactive_flush_force_set_type)                        \
-    M(exception_when_fetch_disagg_pages)
+    M(exception_when_fetch_disagg_pages)                     \
+    M(force_agg_on_partial_block)
 
 #define APPLY_FOR_PAUSEABLE_FAILPOINTS_ONCE(M) \
     M(pause_with_alter_locks_acquired)         \

--- a/dbms/src/DataStreams/ParallelAggregatingBlockInputStream.cpp
+++ b/dbms/src/DataStreams/ParallelAggregatingBlockInputStream.cpp
@@ -152,7 +152,7 @@ void ParallelAggregatingBlockInputStream::Handler::onBlock(Block & block, size_t
         parent.aggregator.executeOnBlock(agg_process_info, data, thread_num);
         if (data.need_spill)
             parent.aggregator.spill(data, thread_num);
-    } while (agg_process_info.start_row < agg_process_info.end_row);
+    } while (!agg_process_info.allBlockDataHandled());
 
     parent.threads_data[thread_num].src_rows += block.rows();
     parent.threads_data[thread_num].src_bytes += block.bytes();
@@ -276,7 +276,7 @@ void ParallelAggregatingBlockInputStream::execute()
         aggregator.executeOnBlock(agg_process_info, data, 0);
         if (data.need_spill)
             aggregator.spill(data, 0);
-        assert(agg_process_info.start_row == agg_process_info.end_row);
+        assert(agg_process_info.allBlockDataHandled());
     }
 }
 

--- a/dbms/src/Flash/tests/gtest_aggregation_executor.cpp
+++ b/dbms/src/Flash/tests/gtest_aggregation_executor.cpp
@@ -237,7 +237,7 @@ public:
 };
 
 #define WRAP_FOR_AGG_PARTIAL_BLOCK_START                                              \
-    std::vector<bool> partial_blocks{false, true};                                    \
+    std::vector<bool> partial_blocks{true, false};                                    \
     for (auto partial_block : partial_blocks)                                         \
     {                                                                                 \
         if (partial_block)                                                            \

--- a/dbms/src/Flash/tests/gtest_aggregation_executor.cpp
+++ b/dbms/src/Flash/tests/gtest_aggregation_executor.cpp
@@ -20,6 +20,10 @@
 
 namespace DB
 {
+namespace FailPoints
+{
+extern const char force_agg_on_partial_block[];
+} // namespace FailPoints
 namespace tests
 {
 #define DT DecimalField<Decimal32>
@@ -232,6 +236,17 @@ public:
     ColumnWithUInt64 col_pr{1, 2, 0, 3290124, 968933, 3125, 31236, 4327, 80000};
 };
 
+#define WRAP_FOR_AGG_PARTIAL_BLOCK_START                                              \
+    std::vector<bool> partial_blocks{false, true};                                    \
+    for (auto partial_block : partial_blocks)                                         \
+    {                                                                                 \
+        if (partial_block)                                                            \
+            FailPointHelper::enableFailPoint(FailPoints::force_agg_on_partial_block); \
+        else                                                                          \
+            FailPointHelper::disableFailPoint(FailPoints::force_agg_on_partial_block);
+
+#define WRAP_FOR_AGG_PARTIAL_BLOCK_END }
+
 /// Guarantee the correctness of group by
 TEST_F(AggExecutorTestRunner, GroupBy)
 try
@@ -340,7 +355,9 @@ try
         for (size_t i = 0; i < test_num; ++i)
         {
             request = buildDAGRequest(std::make_pair(db_name, table_types), {}, group_by_exprs[i], projections[i]);
+            WRAP_FOR_AGG_PARTIAL_BLOCK_START
             executeAndAssertColumnsEqual(request, expect_cols[i]);
+            WRAP_FOR_AGG_PARTIAL_BLOCK_END
         }
     }
 
@@ -397,7 +414,9 @@ try
         for (size_t i = 0; i < test_num; ++i)
         {
             request = buildDAGRequest(std::make_pair(db_name, table_types), {}, group_by_exprs[i], projections[i]);
+            WRAP_FOR_AGG_PARTIAL_BLOCK_START
             executeAndAssertColumnsEqual(request, expect_cols[i]);
+            WRAP_FOR_AGG_PARTIAL_BLOCK_END
         }
     }
 
@@ -429,7 +448,9 @@ try
     for (size_t i = 0; i < test_num; ++i)
     {
         request = buildDAGRequest(std::make_pair(db_name, table_name), agg_funcs[i], group_by_exprs[i], projections[i]);
+        WRAP_FOR_AGG_PARTIAL_BLOCK_START
         executeAndAssertColumnsEqual(request, expect_cols[i]);
+        WRAP_FOR_AGG_PARTIAL_BLOCK_END
     }
 
     /// Min function tests
@@ -448,7 +469,9 @@ try
     for (size_t i = 0; i < test_num; ++i)
     {
         request = buildDAGRequest(std::make_pair(db_name, table_name), agg_funcs[i], group_by_exprs[i], projections[i]);
+        WRAP_FOR_AGG_PARTIAL_BLOCK_START
         executeAndAssertColumnsEqual(request, expect_cols[i]);
+        WRAP_FOR_AGG_PARTIAL_BLOCK_END
     }
 }
 CATCH
@@ -506,7 +529,9 @@ try
     {
         request
             = buildDAGRequest(std::make_pair(db_name, table_name), {agg_funcs[i]}, group_by_exprs[i], projections[i]);
+        WRAP_FOR_AGG_PARTIAL_BLOCK_START
         executeAndAssertColumnsEqual(request, expect_cols[i]);
+        WRAP_FOR_AGG_PARTIAL_BLOCK_END
     }
 }
 CATCH
@@ -574,7 +599,9 @@ try
                 {agg_func},
                 group_by_exprs[i],
                 projections[i]);
+            WRAP_FOR_AGG_PARTIAL_BLOCK_START
             executeAndAssertColumnsEqual(request, expect_cols[i]);
+            WRAP_FOR_AGG_PARTIAL_BLOCK_END
         }
     }
     {
@@ -586,7 +613,9 @@ try
                 {agg_func},
                 group_by_exprs[i],
                 projections[i]);
+            WRAP_FOR_AGG_PARTIAL_BLOCK_START
             executeAndAssertColumnsEqual(request, expect_cols[i]);
+            WRAP_FOR_AGG_PARTIAL_BLOCK_END
         }
     }
     for (auto collation_id : {0, static_cast<int>(TiDB::ITiDBCollator::BINARY)})
@@ -623,7 +652,9 @@ try
                 {agg_func},
                 group_by_exprs[i],
                 projections[i]);
+            WRAP_FOR_AGG_PARTIAL_BLOCK_START
             executeAndAssertColumnsEqual(request, expect_cols[i]);
+            WRAP_FOR_AGG_PARTIAL_BLOCK_END
         }
     }
 }
@@ -636,7 +667,9 @@ try
     executeAndAssertColumnsEqual(request, {{toNullableVec<String>({"banana"})}});
 
     request = context.scan("aggnull_test", "t1").aggregation({}, {col("s1")}).build(context);
+    WRAP_FOR_AGG_PARTIAL_BLOCK_START
     executeAndAssertColumnsEqual(request, {{toNullableVec<String>("s1", {{}, "banana"})}});
+    WRAP_FOR_AGG_PARTIAL_BLOCK_END
 }
 CATCH
 
@@ -648,7 +681,9 @@ try
         = {toNullableVec<Int64>({3}), toNullableVec<Int64>({1}), toVec<UInt64>({6})};
     auto test_single_function = [&](size_t index) {
         auto request = context.scan("test_db", "test_table").aggregation({functions[index]}, {}).build(context);
+        WRAP_FOR_AGG_PARTIAL_BLOCK_START
         executeAndAssertColumnsEqual(request, {functions_result[index]});
+        WRAP_FOR_AGG_PARTIAL_BLOCK_END
     };
     for (size_t i = 0; i < functions.size(); ++i)
         test_single_function(i);
@@ -669,7 +704,9 @@ try
                 results.push_back(functions_result[k]);
 
                 auto request = context.scan("test_db", "test_table").aggregation(funcs, {}).build(context);
+                WRAP_FOR_AGG_PARTIAL_BLOCK_START
                 executeAndAssertColumnsEqual(request, results);
+                WRAP_FOR_AGG_PARTIAL_BLOCK_END
 
                 funcs.pop_back();
                 results.pop_back();
@@ -705,7 +742,9 @@ try
                 context.context->setSetting(
                     "group_by_two_level_threshold",
                     Field(static_cast<UInt64>(two_level_threshold)));
+                WRAP_FOR_AGG_PARTIAL_BLOCK_START
                 executeAndAssertColumnsEqual(request, expect);
+                WRAP_FOR_AGG_PARTIAL_BLOCK_END
             }
         }
     }
@@ -736,6 +775,7 @@ try
                         "group_by_two_level_threshold",
                         Field(static_cast<UInt64>(two_level_threshold)));
                     context.context->setSetting("max_block_size", Field(static_cast<UInt64>(block_size)));
+                    WRAP_FOR_AGG_PARTIAL_BLOCK_START
                     auto blocks = getExecuteStreamsReturnBlocks(request, concurrency);
                     size_t actual_row = 0;
                     for (auto & block : blocks)
@@ -744,6 +784,7 @@ try
                         actual_row += block.rows();
                     }
                     ASSERT_EQ(actual_row, expect_rows[i]);
+                    WRAP_FOR_AGG_PARTIAL_BLOCK_END
                 }
             }
         }
@@ -857,6 +898,7 @@ try
                             "group_by_two_level_threshold",
                             Field(static_cast<UInt64>(two_level_threshold)));
                         context.context->setSetting("max_block_size", Field(static_cast<UInt64>(block_size)));
+                        WRAP_FOR_AGG_PARTIAL_BLOCK_START
                         auto blocks = getExecuteStreamsReturnBlocks(request, concurrency);
                         for (auto & block : blocks)
                         {
@@ -881,6 +923,7 @@ try
                                 vstackBlocks(std::move(blocks)).getColumnsWithTypeAndName(),
                                 false));
                         }
+                        WRAP_FOR_AGG_PARTIAL_BLOCK_END
                     }
                 }
             }
@@ -907,12 +950,20 @@ try
     executeAndAssertColumnsEqual(request, {});
 
     request = context.receive("empty_recv", 5).aggregation({Max(col("s1"))}, {col("s2")}, 5).build(context);
-    executeAndAssertColumnsEqual(request, {});
+    {
+        WRAP_FOR_AGG_PARTIAL_BLOCK_START
+        executeAndAssertColumnsEqual(request, {});
+        WRAP_FOR_AGG_PARTIAL_BLOCK_END
+    }
 
     request = context.scan("test_db", "empty_table")
                   .aggregation({Count(lit(Field(static_cast<UInt64>(1))))}, {})
                   .build(context);
-    executeAndAssertColumnsEqual(request, {toVec<UInt64>({0})});
+    {
+        WRAP_FOR_AGG_PARTIAL_BLOCK_START
+        executeAndAssertColumnsEqual(request, {toVec<UInt64>({0})});
+        WRAP_FOR_AGG_PARTIAL_BLOCK_END
+    }
 }
 CATCH
 
@@ -961,10 +1012,15 @@ try
     auto baseline = executeStreams(gen_request(1), 1);
     for (size_t exchange_concurrency : exchange_receiver_concurrency)
     {
+        WRAP_FOR_AGG_PARTIAL_BLOCK_START
         executeAndAssertColumnsEqual(gen_request(exchange_concurrency), baseline);
+        WRAP_FOR_AGG_PARTIAL_BLOCK_END
     }
 }
 CATCH
+
+#undef WRAP_FOR_AGG_PARTIAL_BLOCK_START
+#undef WRAP_FOR_AGG_PARTIAL_BLOCK_END
 
 } // namespace tests
 } // namespace DB

--- a/dbms/src/Flash/tests/gtest_spill_aggregation.cpp
+++ b/dbms/src/Flash/tests/gtest_spill_aggregation.cpp
@@ -44,7 +44,7 @@ public:
 #define WRAP_FOR_AGG_PARTIAL_BLOCK_END }
 
 #define WRAP_FOR_SPILL_TEST_BEGIN                  \
-    std::vector<bool> pipeline_bools{false, true}; \
+    std::vector<bool> pipeline_bools{true, false}; \
     for (auto enable_pipeline : pipeline_bools)    \
     {                                              \
         enablePipeline(enable_pipeline);

--- a/dbms/src/Flash/tests/gtest_spill_aggregation.cpp
+++ b/dbms/src/Flash/tests/gtest_spill_aggregation.cpp
@@ -33,7 +33,7 @@ public:
 };
 
 #define WRAP_FOR_AGG_PARTIAL_BLOCK_START                                              \
-    std::vector<bool> partial_blocks{false, true};                                    \
+    std::vector<bool> partial_blocks{true, false};                                    \
     for (auto partial_block : partial_blocks)                                         \
     {                                                                                 \
         if (partial_block)                                                            \
@@ -44,7 +44,7 @@ public:
 #define WRAP_FOR_AGG_PARTIAL_BLOCK_END }
 
 #define WRAP_FOR_SPILL_TEST_BEGIN                  \
-    std::vector<bool> pipeline_bools{true, false}; \
+    std::vector<bool> pipeline_bools{false, true}; \
     for (auto enable_pipeline : pipeline_bools)    \
     {                                              \
         enablePipeline(enable_pipeline);

--- a/dbms/src/Interpreters/Aggregator.cpp
+++ b/dbms/src/Interpreters/Aggregator.cpp
@@ -1080,7 +1080,7 @@ void Aggregator::execute(const BlockInputStreamPtr & stream, AggregatedDataVaria
             }
             if (result.need_spill)
                 spill(result, thread_num);
-        } while (agg_process_info.start_row < agg_process_info.end_row);
+        } while (!agg_process_info.allBlockDataHandled());
 
         if (should_stop)
             break;

--- a/dbms/src/Interpreters/Aggregator.cpp
+++ b/dbms/src/Interpreters/Aggregator.cpp
@@ -722,7 +722,7 @@ Aggregator::executeWithoutKeyImpl(AggregatedDataWithoutKey & res, AggProcessInfo
 {
     size_t agg_size = agg_process_info.end_row - agg_process_info.start_row;
     fiu_do_on(FailPoints::force_agg_on_partial_block, {
-        if (agg_size > 0)
+        if (agg_size > 0 && agg_process_info.start_row == 0)
             agg_size = std::max(agg_size / 2, 1);
     });
     /// Adding values

--- a/dbms/src/Interpreters/Aggregator.cpp
+++ b/dbms/src/Interpreters/Aggregator.cpp
@@ -1097,7 +1097,7 @@ void Aggregator::execute(const BlockInputStreamPtr & stream, AggregatedDataVaria
         executeOnBlock(agg_process_info, result, thread_num);
         if (result.need_spill)
             spill(result, thread_num);
-        assert(agg_process_info.start_row == agg_process_info.end_row);
+        assert(agg_process_info.allBlockDataHandled());
     }
 
     double elapsed_seconds = watch.elapsedSeconds();

--- a/dbms/src/Interpreters/Aggregator.cpp
+++ b/dbms/src/Interpreters/Aggregator.cpp
@@ -853,8 +853,6 @@ bool Aggregator::executeOnBlock(AggProcessInfo & agg_process_info, AggregatedDat
 
     /// We select one of the aggregation methods and call it.
 
-    /// todo support non-zero start_row
-    //assert(agg_process_info.start_row == 0 && agg_process_info.end_row == agg_process_info.block.rows());
     assert(agg_process_info.start_row <= agg_process_info.end_row);
     /// For the case when there are no keys (all aggregate into one row).
     if (result.type == AggregatedDataVariants::Type::without_key)

--- a/dbms/src/Interpreters/Aggregator.cpp
+++ b/dbms/src/Interpreters/Aggregator.cpp
@@ -1071,7 +1071,7 @@ void Aggregator::execute(const BlockInputStreamPtr & stream, AggregatedDataVaria
         bool should_stop = false;
         do
         {
-            if (is_cancelled())
+            if unlikely (is_cancelled())
                 return;
             if (!executeOnBlock(agg_process_info, result, thread_num))
             {

--- a/dbms/src/Interpreters/Aggregator.h
+++ b/dbms/src/Interpreters/Aggregator.h
@@ -1144,9 +1144,14 @@ public:
         AggregateColumns aggregate_columns;
         AggregateFunctionInstructions aggregate_functions_instructions;
         void prepareForAgg(Aggregator * aggregator);
+        bool allBlockDataHandled() const
+        {
+            assert(start_row <= end_row);
+            return start_row == end_row;
+        }
         void resetBlock(const Block & block_)
         {
-            RUNTIME_CHECK_MSG(start_row == end_row, "Previous block is not processed yet");
+            RUNTIME_CHECK_MSG(allBlockDataHandled(), "Previous block is not processed yet");
             block = block_;
             start_row = 0;
             end_row = 0;

--- a/dbms/src/Operators/AggregateBuildSinkOp.cpp
+++ b/dbms/src/Operators/AggregateBuildSinkOp.cpp
@@ -17,6 +17,17 @@
 
 namespace DB
 {
+OperatorStatus AggregateBuildSinkOp::prepareImpl()
+{
+    while (agg_context->hasLocalDataToBuild(index))
+    {
+        agg_context->buildOnLocalData(index);
+        if (agg_context->needSpill(index))
+            return OperatorStatus::IO_OUT;
+    }
+    return OperatorStatus::NEED_INPUT;
+}
+
 OperatorStatus AggregateBuildSinkOp::writeImpl(Block && block)
 {
     if (unlikely(!block))
@@ -30,8 +41,6 @@ OperatorStatus AggregateBuildSinkOp::writeImpl(Block && block)
         return OperatorStatus::FINISHED;
     }
     agg_context->buildOnBlock(index, block);
-    total_rows += block.rows();
-    block.clear();
     return agg_context->needSpill(index) ? OperatorStatus::IO_OUT : OperatorStatus::NEED_INPUT;
 }
 
@@ -43,7 +52,7 @@ OperatorStatus AggregateBuildSinkOp::executeIOImpl()
 
 void AggregateBuildSinkOp::operateSuffixImpl()
 {
-    LOG_DEBUG(log, "finish build with {} rows", total_rows);
+    LOG_DEBUG(log, "finish build with {} rows", agg_context->getTotalBuildRows(index));
 }
 
 } // namespace DB

--- a/dbms/src/Operators/AggregateBuildSinkOp.h
+++ b/dbms/src/Operators/AggregateBuildSinkOp.h
@@ -39,13 +39,14 @@ public:
 protected:
     void operateSuffixImpl() override;
 
+    OperatorStatus prepareImpl() override;
+
     OperatorStatus writeImpl(Block && block) override;
 
     OperatorStatus executeIOImpl() override;
 
 private:
     size_t index{};
-    uint64_t total_rows{};
     AggregateContextPtr agg_context;
 
     bool is_final_spill = false;

--- a/dbms/src/Operators/AggregateContext.cpp
+++ b/dbms/src/Operators/AggregateContext.cpp
@@ -43,14 +43,29 @@ void AggregateContext::initBuild(
     LOG_TRACE(log, "Aggregate Context inited");
 }
 
+void AggregateContext::buildOnLocalData(size_t task_index)
+{
+    auto & agg_process_info = threads_data[task_index]->agg_process_info;
+    aggregator->executeOnBlock(agg_process_info, *many_data[task_index], task_index);
+    if likely (agg_process_info.start_row == agg_process_info.end_row)
+    {
+        threads_data[task_index]->src_bytes += agg_process_info.block.bytes();
+        threads_data[task_index]->src_rows += agg_process_info.block.rows();
+        agg_process_info.block.clear();
+    }
+}
+
+bool AggregateContext::hasLocalDataToBuild(size_t task_index)
+{
+    return threads_data[task_index]->agg_process_info.start_row < threads_data[task_index]->agg_process_info.end_row;
+}
+
 void AggregateContext::buildOnBlock(size_t task_index, const Block & block)
 {
     assert(status.load() == AggStatus::build);
     auto & agg_process_info = threads_data[task_index]->agg_process_info;
     agg_process_info.resetBlock(block);
-    aggregator->executeOnBlock(agg_process_info, *many_data[task_index], task_index);
-    threads_data[task_index]->src_bytes += block.bytes();
-    threads_data[task_index]->src_rows += block.rows();
+    buildOnLocalData(task_index);
 }
 
 bool AggregateContext::hasSpilledData() const
@@ -141,6 +156,7 @@ void AggregateContext::initConvergentPrefix()
         /// even if it triggers marking need spill due to a low threshold setting,
         /// it's still reasonable not to spill disk.
         many_data[0]->need_spill = false;
+        assert(agg_process_info.start_row == agg_process_info.end_row);
         RUNTIME_CHECK(!aggregator->hasSpilledData());
     }
 }

--- a/dbms/src/Operators/AggregateContext.cpp
+++ b/dbms/src/Operators/AggregateContext.cpp
@@ -47,7 +47,7 @@ void AggregateContext::buildOnLocalData(size_t task_index)
 {
     auto & agg_process_info = threads_data[task_index]->agg_process_info;
     aggregator->executeOnBlock(agg_process_info, *many_data[task_index], task_index);
-    if likely (agg_process_info.start_row == agg_process_info.end_row)
+    if likely (agg_process_info.allBlockDataHandled())
     {
         threads_data[task_index]->src_bytes += agg_process_info.block.bytes();
         threads_data[task_index]->src_rows += agg_process_info.block.rows();
@@ -57,7 +57,7 @@ void AggregateContext::buildOnLocalData(size_t task_index)
 
 bool AggregateContext::hasLocalDataToBuild(size_t task_index)
 {
-    return threads_data[task_index]->agg_process_info.start_row < threads_data[task_index]->agg_process_info.end_row;
+    return !threads_data[task_index]->agg_process_info.allBlockDataHandled();
 }
 
 void AggregateContext::buildOnBlock(size_t task_index, const Block & block)
@@ -156,7 +156,7 @@ void AggregateContext::initConvergentPrefix()
         /// even if it triggers marking need spill due to a low threshold setting,
         /// it's still reasonable not to spill disk.
         many_data[0]->need_spill = false;
-        assert(agg_process_info.start_row == agg_process_info.end_row);
+        assert(agg_process_info.allBlockDataHandled());
         RUNTIME_CHECK(!aggregator->hasSpilledData());
     }
 }

--- a/dbms/src/Operators/AggregateContext.h
+++ b/dbms/src/Operators/AggregateContext.h
@@ -71,6 +71,12 @@ public:
 
     AggSpillContextPtr & getAggSpillContext() { return aggregator->getAggSpillContext(); }
 
+    bool hasLocalDataToBuild(size_t task_index);
+
+    void buildOnLocalData(size_t task_index);
+
+    size_t getTotalBuildRows(size_t task_index) { return threads_data[task_index]->src_rows; }
+
 private:
     std::unique_ptr<Aggregator> aggregator;
     bool keys_size = false;

--- a/dbms/src/Operators/Operator.cpp
+++ b/dbms/src/Operators/Operator.cpp
@@ -162,7 +162,7 @@ OperatorStatus SinkOp::prepare()
     profile_info.anchor();
     auto op_status = prepareImpl();
 #ifndef NDEBUG
-    assertOperatorStatus(op_status, {OperatorStatus::NEED_INPUT});
+    assertOperatorStatus(op_status, {OperatorStatus::NEED_INPUT, OperatorStatus::IO_OUT});
 #endif
     profile_info.update();
     FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::random_pipeline_model_operator_run_failpoint);

--- a/dbms/src/Operators/Operator.cpp
+++ b/dbms/src/Operators/Operator.cpp
@@ -162,7 +162,7 @@ OperatorStatus SinkOp::prepare()
     profile_info.anchor();
     auto op_status = prepareImpl();
 #ifndef NDEBUG
-    assertOperatorStatus(op_status, {OperatorStatus::NEED_INPUT, OperatorStatus::IO_OUT});
+    assertOperatorStatus(op_status, {OperatorStatus::NEED_INPUT});
 #endif
     profile_info.update();
     FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::random_pipeline_model_operator_run_failpoint);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #7738

Problem Summary:

### What is changed and how it works?
This pr is after #8056, and in the pr, aggregate part of the input block in `Aggregator` fully supported. However, although supported, this feature can only be triggered by failpoint.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
