### PR TITLE
Disagg: Fix hang when canceling non-owner

### DIFF
--- a/dbms/src/Storages/Transaction/RaftLogManager.cpp
+++ b/dbms/src/Storages/Transaction/RaftLogManager.cpp
@@ -37,7 +37,8 @@ bool RaftLogEagerGcTasks::updateHint(
     UInt64 applied_index,
     UInt64 threshold)
 {
-    if (applied_index < eager_truncated_index || applied_index - eager_truncated_index < threshold)
+    if (threshold == 0 //
+        || applied_index < eager_truncated_index || applied_index - eager_truncated_index < threshold)
         return false;
 
     // Try to register a task for eager remove RaftLog to reduce the memory overhead of UniPS

--- a/dbms/src/Storages/Transaction/RaftLogManager.h
+++ b/dbms/src/Storages/Transaction/RaftLogManager.h
@@ -43,6 +43,6 @@ private:
 // RegionID -> truncated index
 using RaftLogGcTasksRes = std::unordered_map<RegionID, UInt64>;
 
-RaftLogGcTasksRes executeRaftLogGcTasks(Context & global_ctx, RaftLogEagerGcTasks::Hints && hints);
+[[nodiscard]] RaftLogGcTasksRes executeRaftLogGcTasks(Context & global_ctx, RaftLogEagerGcTasks::Hints && hints);
 
 } // namespace DB

--- a/dbms/src/Storages/Transaction/tests/gtest_raft_log_manager.cpp
+++ b/dbms/src/Storages/Transaction/tests/gtest_raft_log_manager.cpp
@@ -1,0 +1,84 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Debug/dbgTools.h>
+#include <Storages/Transaction/tests/kvstore_helper.h>
+
+namespace DB::tests
+{
+
+TEST(RaftLogEagerGCTasksTest, Basic)
+try
+{
+    RaftLogEagerGcTasks tasks;
+
+    RegionID region_id = 1000;
+    // threshold == 0 always return false
+    ASSERT_FALSE(tasks.updateHint(region_id, /*eager_truncated_index=*/10, /*applied_index=*/10000, /*threshold=*/0));
+    ASSERT_FALSE(tasks.updateHint(region_id, /*eager_truncated_index=*/10000, /*applied_index=*/10, /*threshold=*/0));
+
+    ASSERT_FALSE(tasks.updateHint(region_id, /*eager_truncated_index=*/10000, /*applied_index=*/10, /*threshold=*/512));
+
+    {
+        // create new hints
+        ASSERT_TRUE(
+            tasks.updateHint(region_id, /*eager_truncated_index=*/10, /*applied_index=*/10000, /*threshold=*/512));
+        // the applied index advance, but not merged into the hints
+        ASSERT_FALSE(
+            tasks.updateHint(region_id, /*eager_truncated_index=*/10, /*applied_index=*/10000 + 10, /*threshold=*/512));
+        auto hints = tasks.getAndClearHints();
+        ASSERT_EQ(hints.size(), 1);
+        ASSERT_TRUE(hints.contains(region_id));
+        ASSERT_EQ(hints[region_id].applied_index, 10000);
+        ASSERT_EQ(hints[region_id].eager_truncate_index, 10);
+    }
+    {
+        auto hints = tasks.getAndClearHints();
+        ASSERT_TRUE(hints.empty());
+    }
+
+    {
+        // create new hints
+        ASSERT_TRUE(
+            tasks.updateHint(region_id, /*eager_truncated_index=*/10, /*applied_index=*/10000, /*threshold=*/512));
+        // the applied index advance, and merged into the hints
+        ASSERT_TRUE(
+            tasks.updateHint(region_id, /*eager_truncated_index=*/10, /*applied_index=*/10000 + 523, /*threshold=*/512));
+        // applied index rollback, just ignore
+        ASSERT_FALSE(
+            tasks.updateHint(region_id, /*eager_truncated_index=*/10, /*applied_index=*/10000 + 500, /*threshold=*/512));
+        auto hints = tasks.getAndClearHints();
+        ASSERT_EQ(hints.size(), 1);
+        ASSERT_TRUE(hints.contains(region_id));
+        ASSERT_EQ(hints[region_id].applied_index, 10000 + 523);
+        ASSERT_EQ(hints[region_id].eager_truncate_index, 10);
+    }
+
+    {
+        // create new hints
+        ASSERT_TRUE(
+            tasks.updateHint(region_id, /*eager_truncated_index=*/10, /*applied_index=*/10000, /*threshold=*/512));
+        // the applied index and truncated index advance, and merged into the hints
+        ASSERT_TRUE(
+            tasks.updateHint(region_id, /*eager_truncated_index=*/30, /*applied_index=*/10000 + 523, /*threshold=*/512));
+        auto hints = tasks.getAndClearHints();
+        ASSERT_EQ(hints.size(), 1);
+        ASSERT_TRUE(hints.contains(region_id));
+        ASSERT_EQ(hints[region_id].applied_index, 10000 + 523);
+        ASSERT_EQ(hints[region_id].eager_truncate_index, 10);
+    }
+}
+CATCH
+
+} // namespace DB::tests

--- a/dbms/src/Storages/Transaction/tests/gtest_raft_log_manager.cpp
+++ b/dbms/src/Storages/Transaction/tests/gtest_raft_log_manager.cpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <Debug/dbgTools.h>
-#include <Storages/Transaction/tests/kvstore_helper.h>
+#include <Storages/Transaction/RaftLogManager.h>
+#include <TestUtils/TiFlashTestBasic.h>
 
 namespace DB::tests
 {
@@ -54,10 +54,12 @@ try
             tasks.updateHint(region_id, /*eager_truncated_index=*/10, /*applied_index=*/10000, /*threshold=*/512));
         // the applied index advance, and merged into the hints
         ASSERT_TRUE(
-            tasks.updateHint(region_id, /*eager_truncated_index=*/10, /*applied_index=*/10000 + 523, /*threshold=*/512));
+            tasks
+                .updateHint(region_id, /*eager_truncated_index=*/10, /*applied_index=*/10000 + 523, /*threshold=*/512));
         // applied index rollback, just ignore
         ASSERT_FALSE(
-            tasks.updateHint(region_id, /*eager_truncated_index=*/10, /*applied_index=*/10000 + 500, /*threshold=*/512));
+            tasks
+                .updateHint(region_id, /*eager_truncated_index=*/10, /*applied_index=*/10000 + 500, /*threshold=*/512));
         auto hints = tasks.getAndClearHints();
         ASSERT_EQ(hints.size(), 1);
         ASSERT_TRUE(hints.contains(region_id));
@@ -71,7 +73,8 @@ try
             tasks.updateHint(region_id, /*eager_truncated_index=*/10, /*applied_index=*/10000, /*threshold=*/512));
         // the applied index and truncated index advance, and merged into the hints
         ASSERT_TRUE(
-            tasks.updateHint(region_id, /*eager_truncated_index=*/30, /*applied_index=*/10000 + 523, /*threshold=*/512));
+            tasks
+                .updateHint(region_id, /*eager_truncated_index=*/30, /*applied_index=*/10000 + 523, /*threshold=*/512));
         auto hints = tasks.getAndClearHints();
         ASSERT_EQ(hints.size(), 1);
         ASSERT_TRUE(hints.contains(region_id));

--- a/dbms/src/TiDB/Etcd/Client.cpp
+++ b/dbms/src/TiDB/Etcd/Client.cpp
@@ -186,6 +186,7 @@ grpc::Status Client::leaseRevoke(LeaseID lease_id)
 }
 
 std::tuple<v3electionpb::LeaderKey, grpc::Status> Client::campaign(
+    grpc::ClientContext * grpc_context,
     const String & name,
     const String & value,
     LeaseID lease_id)
@@ -195,12 +196,11 @@ std::tuple<v3electionpb::LeaderKey, grpc::Status> Client::campaign(
     req.set_value(value);
     req.set_lease(lease_id);
 
-    grpc::ClientContext context;
     // usually use `campaign` blocks until become leader or error happens,
     // don't set timeout.
 
     v3electionpb::CampaignResponse resp;
-    auto status = leaderClient()->election_stub->Campaign(&context, req, &resp);
+    auto status = leaderClient()->election_stub->Campaign(grpc_context, req, &resp);
     return {resp.leader(), status};
 }
 

--- a/dbms/src/TiDB/Etcd/Client.h
+++ b/dbms/src/TiDB/Etcd/Client.h
@@ -74,6 +74,7 @@ public:
     grpc::Status leaseRevoke(LeaseID lease_id);
 
     std::tuple<v3electionpb::LeaderKey, grpc::Status> campaign(
+        grpc::ClientContext * grpc_context,
         const String & name,
         const String & value,
         LeaseID lease_id);

--- a/dbms/src/TiDB/OwnerManager.h
+++ b/dbms/src/TiDB/OwnerManager.h
@@ -181,6 +181,7 @@ private:
     std::mutex mtx_camaign;
     State state = State::Init;
     std::condition_variable cv_camaign;
+    std::unique_ptr<grpc::ClientContext> campaing_ctx;
 
     // A thread for running camaign logic
     std::thread th_camaign;

--- a/dbms/src/TiDB/tests/gtest_owner_manager.cpp
+++ b/dbms/src/TiDB/tests/gtest_owner_manager.cpp
@@ -451,7 +451,7 @@ try
         EXPECT_EQ(owner_info.status, OwnerType::IsOwner) << magic_enum::enum_name(owner_info.status);
     });
 
-    auto th_non_owner = std::async([&]{
+    auto th_non_owner = std::async([&] {
         const String id = "owner_1";
 
         LOG_INFO(log, "waiting for owner0 elected");
@@ -463,7 +463,7 @@ try
         owner1->campaignOwner(); // this will block
     });
 
-    auto th_cancel_non_owner = std::async([&]{
+    auto th_cancel_non_owner = std::async([&] {
         while (!owner0_elected)
             ;
 

--- a/dbms/src/TiDB/tests/gtest_owner_manager.cpp
+++ b/dbms/src/TiDB/tests/gtest_owner_manager.cpp
@@ -28,6 +28,7 @@
 #include <chrono>
 #include <condition_variable>
 #include <ext/scope_guard.h>
+#include <future>
 #include <magic_enum.hpp>
 #include <memory>
 #include <mutex>
@@ -370,7 +371,6 @@ try
 }
 CATCH
 
-
 TEST_F(OwnerManagerTest, CreateEtcdSessionFail)
 try
 {
@@ -397,7 +397,7 @@ try
     auto owner0
         = std::static_pointer_cast<EtcdOwnerManager>(OwnerManager::createS3GCOwner(*ctx, id, etcd_client, test_ttl));
     auto owner_info = owner0->getOwnerID();
-    EXPECT_EQ(owner_info.status, OwnerType::NotOwner) << magic_enum::enum_name(owner_info.status);
+    EXPECT_EQ(owner_info.status, OwnerType::NoLeader) << magic_enum::enum_name(owner_info.status);
 
     FailPointHelper::enableFailPoint(FailPoints::force_fail_to_create_etcd_session);
 
@@ -405,6 +405,78 @@ try
 
     std::this_thread::sleep_for(5s); // wait bg task wake
     owner0->cancel();
+}
+CATCH
+
+TEST_F(OwnerManagerTest, CancelNonOwner)
+try
+{
+    auto etcd_endpoint = Poco::Environment::get("ETCD_ENDPOINT", "");
+    if (etcd_endpoint.empty())
+    {
+        const auto * t = ::testing::UnitTest::GetInstance()->current_test_info();
+        LOG_INFO(
+            log,
+            "{}.{} is skipped because env ETCD_ENDPOINT not set. "
+            "Run it with an etcd cluster using `ETCD_ENDPOINT=127.0.0.1:2379 ./dbms/gtests_dbms ...`",
+            t->test_case_name(),
+            t->name());
+        return;
+    }
+
+    using namespace std::chrono_literals;
+
+    auto ctx = TiFlashTestEnv::getContext();
+    pingcap::ClusterConfig config;
+    pingcap::pd::ClientPtr pd_client = std::make_shared<pingcap::pd::Client>(Strings{etcd_endpoint}, config);
+    auto etcd_client = DB::Etcd::Client::create(pd_client, config);
+
+    std::atomic<bool> owner0_elected = false;
+    std::shared_ptr<EtcdOwnerManager> owner0;
+    std::shared_ptr<EtcdOwnerManager> owner1;
+    auto th_owner = std::async([&]() {
+        const String id = "owner_0";
+        owner0 = std::static_pointer_cast<EtcdOwnerManager>(
+            OwnerManager::createS3GCOwner(*ctx, id, etcd_client, test_ttl));
+        auto owner_info = owner0->getOwnerID();
+        EXPECT_EQ(owner_info.status, OwnerType::NoLeader) << magic_enum::enum_name(owner_info.status);
+
+        owner0->setBeOwnerHook([&] { owner0_elected = true; });
+        owner0->campaignOwner();
+
+        while (!owner0_elected)
+            ;
+
+        owner_info = owner0->getOwnerID();
+        EXPECT_EQ(owner_info.status, OwnerType::IsOwner) << magic_enum::enum_name(owner_info.status);
+    });
+
+    auto th_non_owner = std::async([&]{
+        const String id = "owner_1";
+
+        LOG_INFO(log, "waiting for owner0 elected");
+        while (!owner0_elected)
+            ;
+
+        owner1 = std::static_pointer_cast<EtcdOwnerManager>(
+            OwnerManager::createS3GCOwner(*ctx, id, etcd_client, test_ttl));
+        owner1->campaignOwner(); // this will block
+    });
+
+    auto th_cancel_non_owner = std::async([&]{
+        while (!owner0_elected)
+            ;
+
+        LOG_INFO(log, "waiting for owner1 start campaign");
+        std::this_thread::sleep_for(3s);
+        LOG_INFO(log, "cancel owner1 start");
+        owner1->cancel(); // cancel should finished th_non_owner
+        LOG_INFO(log, "cancel owner1 done");
+    });
+
+    th_cancel_non_owner.wait();
+    th_non_owner.wait();
+    th_owner.wait();
 }
 CATCH
 

--- a/metrics/grafana/tiflash_summary.json
+++ b/metrics/grafana/tiflash_summary.json
@@ -52,7 +52,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1694151861721,
+  "iteration": 1694151861724,
   "links": [],
   "panels": [
     {
@@ -6857,6 +6857,121 @@
         {
           "aliasColors": {},
           "bars": false,
+          "cacheTimeout": null,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "The current processing number of  segments' background management",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 54
+          },
+          "hiddenSeries": false,
+          "id": 67,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.11",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "avg(tiflash_system_current_metric_DT_DeltaMerge{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance)",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "legendFormat": "delta_merge-{{instance}}",
+              "refId": "A"
+            },
+            {
+              "expr": "avg(tiflash_system_current_metric_DT_SegmentSplit{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance)",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "seg_split-{{instance}}",
+              "refId": "B"
+            },
+            {
+              "expr": "avg(tiflash_system_current_metric_DT_SegmentMerge{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance)",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "seg_merge-{{instance}}",
+              "refId": "C"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Current Data Management Tasks",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": 0,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
@@ -6870,7 +6985,7 @@
           "gridPos": {
             "h": 8,
             "w": 12,
-            "x": 0,
+            "x": 12,
             "y": 54
           },
           "hiddenSeries": false,
@@ -6962,6 +7077,106 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
+          "description": "The storage I/O limiter metrics.",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 62
+          },
+          "hiddenSeries": false,
+          "id": 84,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.11",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(tiflash_storage_io_limiter{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (type)",
+              "format": "time_series",
+              "instant": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{type}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "I/O Limiter",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": 0,
+              "format": "binBps",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
           "description": "I/O Limiter pending tasks.",
           "fieldConfig": {
             "defaults": {},
@@ -6973,7 +7188,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 54
+            "y": 62
           },
           "hiddenSeries": false,
           "id": 86,
@@ -7097,221 +7312,6 @@
             },
             {
               "format": "s",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "${DS_TEST-CLUSTER}",
-          "description": "The storage I/O limiter metrics.",
-          "fieldConfig": {
-            "defaults": {},
-            "overrides": []
-          },
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 62
-          },
-          "hiddenSeries": false,
-          "id": 84,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": true,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null as zero",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "7.5.11",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum(rate(tiflash_storage_io_limiter{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (type)",
-              "format": "time_series",
-              "instant": false,
-              "intervalFactor": 2,
-              "legendFormat": "{{type}}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "I/O Limiter",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "decimals": 0,
-              "format": "binBps",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "cacheTimeout": null,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "${DS_TEST-CLUSTER}",
-          "description": "The current processing number of  segments' background management",
-          "fieldConfig": {
-            "defaults": {},
-            "overrides": []
-          },
-          "fill": 0,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 62
-          },
-          "hiddenSeries": false,
-          "id": 67,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null as zero",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "7.5.11",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "avg(tiflash_system_current_metric_DT_DeltaMerge{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance)",
-              "format": "time_series",
-              "hide": false,
-              "intervalFactor": 1,
-              "legendFormat": "delta_merge-{{instance}}",
-              "refId": "A"
-            },
-            {
-              "expr": "avg(tiflash_system_current_metric_DT_SegmentSplit{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance)",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "seg_split-{{instance}}",
-              "refId": "B"
-            },
-            {
-              "expr": "avg(tiflash_system_current_metric_DT_SegmentMerge{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance)",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "seg_merge-{{instance}}",
-              "refId": "C"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Current Data Management Tasks",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "decimals": 0,
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "none",
               "label": null,
               "logBase": 1,
               "max": null,

--- a/metrics/grafana/tiflash_summary.json
+++ b/metrics/grafana/tiflash_summary.json
@@ -52,7 +52,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1694098045746,
+  "iteration": 1694151861721,
   "links": [],
   "panels": [
     {
@@ -1088,7 +1088,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 34
+            "y": 2
           },
           "hiddenSeries": false,
           "id": 141,
@@ -1200,7 +1200,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 34
+            "y": 2
           },
           "hiddenSeries": false,
           "id": 154,
@@ -1330,7 +1330,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 41
+            "y": 9
           },
           "hiddenSeries": false,
           "id": 145,
@@ -1460,7 +1460,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 41
+            "y": 9
           },
           "hiddenSeries": false,
           "id": 147,
@@ -1590,7 +1590,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 48
+            "y": 16
           },
           "hiddenSeries": false,
           "id": 155,
@@ -1720,7 +1720,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 48
+            "y": 16
           },
           "hiddenSeries": false,
           "id": 153,
@@ -1850,7 +1850,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 55
+            "y": 23
           },
           "hiddenSeries": false,
           "id": 151,
@@ -1980,7 +1980,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 55
+            "y": 23
           },
           "hiddenSeries": false,
           "id": 156,
@@ -2110,7 +2110,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 62
+            "y": 30
           },
           "hiddenSeries": false,
           "id": 149,
@@ -2240,7 +2240,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 62
+            "y": 30
           },
           "hiddenSeries": false,
           "id": 159,
@@ -2370,7 +2370,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 69
+            "y": 37
           },
           "hiddenSeries": false,
           "id": 161,
@@ -4167,7 +4167,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 36
+            "y": 4
           },
           "hiddenSeries": false,
           "id": 107,
@@ -4269,7 +4269,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 36
+            "y": 4
           },
           "hiddenSeries": false,
           "id": 109,
@@ -4389,7 +4389,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 44
+            "y": 12
           },
           "hiddenSeries": false,
           "id": 111,
@@ -4500,7 +4500,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 44
+            "y": 12
           },
           "hiddenSeries": false,
           "id": 113,
@@ -4611,7 +4611,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 52
+            "y": 20
           },
           "hiddenSeries": false,
           "id": 117,
@@ -4712,7 +4712,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 52
+            "y": 20
           },
           "hiddenSeries": false,
           "id": 115,
@@ -4846,7 +4846,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 37
+            "y": 5
           },
           "hiddenSeries": false,
           "id": 19,
@@ -4968,7 +4968,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 37
+            "y": 5
           },
           "hiddenSeries": false,
           "id": 18,
@@ -5066,7 +5066,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 44
+            "y": 12
           },
           "hiddenSeries": false,
           "id": 20,
@@ -5216,7 +5216,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 38
+            "y": 6
           },
           "hiddenSeries": false,
           "id": 41,
@@ -5329,7 +5329,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 38
+            "y": 6
           },
           "hiddenSeries": false,
           "id": 38,
@@ -5487,7 +5487,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 46
+            "y": 14
           },
           "hiddenSeries": false,
           "id": 40,
@@ -5587,7 +5587,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 54
+            "y": 22
           },
           "hiddenSeries": false,
           "id": 39,
@@ -5690,7 +5690,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 54
+            "y": 22
           },
           "hiddenSeries": false,
           "id": 42,
@@ -5794,7 +5794,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 59
+            "y": 27
           },
           "hiddenSeries": false,
           "id": 130,
@@ -5897,7 +5897,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 59
+            "y": 27
           },
           "hiddenSeries": false,
           "id": 131,
@@ -6001,7 +6001,7 @@
             "h": 7,
             "w": 8,
             "x": 0,
-            "y": 64
+            "y": 32
           },
           "hiddenSeries": false,
           "id": 50,
@@ -6135,7 +6135,7 @@
             "h": 7,
             "w": 8,
             "x": 8,
-            "y": 64
+            "y": 32
           },
           "hiddenSeries": false,
           "id": 22,
@@ -6249,7 +6249,7 @@
             "h": 7,
             "w": 8,
             "x": 16,
-            "y": 64
+            "y": 32
           },
           "hiddenSeries": false,
           "id": 52,
@@ -6366,7 +6366,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 71
+            "y": 39
           },
           "hiddenSeries": false,
           "id": 46,
@@ -6489,7 +6489,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 71
+            "y": 39
           },
           "hiddenSeries": false,
           "id": 47,
@@ -6613,7 +6613,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 78
+            "y": 46
           },
           "height": "",
           "hiddenSeries": false,
@@ -6743,7 +6743,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 78
+            "y": 46
           },
           "height": "",
           "hiddenSeries": false,
@@ -6860,25 +6860,25 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "The storage I/O limiter metrics.",
+          "description": "Errors of DeltaIndex",
           "fieldConfig": {
             "defaults": {},
             "overrides": []
           },
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 86
+            "y": 54
           },
           "hiddenSeries": false,
-          "id": 84,
+          "id": 237,
           "legend": {
             "alignAsTable": true,
             "avg": false,
-            "current": true,
+            "current": false,
             "max": true,
             "min": false,
             "rightSide": true,
@@ -6895,7 +6895,7 @@
           },
           "percentage": false,
           "pluginVersion": "7.5.11",
-          "pointradius": 2,
+          "pointradius": 5,
           "points": false,
           "renderer": "flot",
           "seriesOverrides": [],
@@ -6904,11 +6904,13 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(tiflash_storage_io_limiter{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (type)",
+              "exemplar": true,
+              "expr": "sum(rate(tiflash_system_profile_event_DTDeltaIndexError{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (instance)",
               "format": "time_series",
-              "instant": false,
-              "intervalFactor": 2,
-              "legendFormat": "{{type}}",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "DeltaIndexError-{{instance}}",
               "refId": "A"
             }
           ],
@@ -6916,7 +6918,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "I/O Limiter",
+          "title": "DeltaIndexError",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -6932,8 +6934,8 @@
           },
           "yaxes": [
             {
-              "decimals": 0,
-              "format": "binBps",
+              "decimals": null,
+              "format": "cps",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -6941,12 +6943,12 @@
               "show": true
             },
             {
-              "format": "short",
+              "format": "opm",
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
-              "show": true
+              "min": "0",
+              "show": false
             }
           ],
           "yaxis": {
@@ -6971,7 +6973,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 86
+            "y": 54
           },
           "hiddenSeries": false,
           "id": 86,
@@ -7113,6 +7115,221 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
+          "description": "The storage I/O limiter metrics.",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 62
+          },
+          "hiddenSeries": false,
+          "id": 84,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.11",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(tiflash_storage_io_limiter{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (type)",
+              "format": "time_series",
+              "instant": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{type}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "I/O Limiter",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": 0,
+              "format": "binBps",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "The current processing number of  segments' background management",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 62
+          },
+          "hiddenSeries": false,
+          "id": 67,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.11",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "avg(tiflash_system_current_metric_DT_DeltaMerge{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance)",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "legendFormat": "delta_merge-{{instance}}",
+              "refId": "A"
+            },
+            {
+              "expr": "avg(tiflash_system_current_metric_DT_SegmentSplit{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance)",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "seg_split-{{instance}}",
+              "refId": "B"
+            },
+            {
+              "expr": "avg(tiflash_system_current_metric_DT_SegmentMerge{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance)",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "seg_merge-{{instance}}",
+              "refId": "C"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Current Data Management Tasks",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": 0,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
           "description": "The information of read thread scheduling and data sharing cache hit ratio. Data sharing cache is purpose-built for OLAP workload that can reduce repeated data reads of concurrent table scanning.",
           "fieldConfig": {
             "defaults": {},
@@ -7124,7 +7341,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 94
+            "y": 70
           },
           "hiddenSeries": false,
           "id": 132,
@@ -7242,270 +7459,6 @@
         {
           "aliasColors": {},
           "bars": false,
-          "cacheTimeout": null,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "${DS_TEST-CLUSTER}",
-          "description": "The current processing number of  segments' background management",
-          "fieldConfig": {
-            "defaults": {},
-            "overrides": []
-          },
-          "fill": 0,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 94
-          },
-          "hiddenSeries": false,
-          "id": 67,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null as zero",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "7.5.11",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "avg(tiflash_system_current_metric_DT_DeltaMerge{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance)",
-              "format": "time_series",
-              "hide": false,
-              "intervalFactor": 1,
-              "legendFormat": "delta_merge-{{instance}}",
-              "refId": "A"
-            },
-            {
-              "expr": "avg(tiflash_system_current_metric_DT_SegmentSplit{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance)",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "seg_split-{{instance}}",
-              "refId": "B"
-            },
-            {
-              "expr": "avg(tiflash_system_current_metric_DT_SegmentMerge{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance)",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "seg_merge-{{instance}}",
-              "refId": "C"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Current Data Management Tasks",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "decimals": 0,
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "none",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "${DS_TEST-CLUSTER}",
-          "description": "cache misses or cache hits of mark_cache.\nBased on this infactor, we can check whether mark_cache is large enough",
-          "fieldConfig": {
-            "defaults": {},
-            "overrides": []
-          },
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 0,
-            "y": 102
-          },
-          "hiddenSeries": false,
-          "id": 169,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "7.5.11",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "max(tiflash_system_profile_event_MarkCacheMisses{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance)",
-              "interval": "",
-              "legendFormat": "mark cache misses",
-              "queryType": "randomWalk",
-              "refId": "A"
-            },
-            {
-              "exemplar": true,
-              "expr": "max(tiflash_system_profile_event_MarkCacheHits{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance)",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "mark cache hits",
-              "refId": "B"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Effectiveness of Mark Cache",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "transformations": [
-            {
-              "id": "calculateField",
-              "options": {
-                "alias": "mark cache count total",
-                "binary": {
-                  "left": "mark cache misses",
-                  "operator": "+",
-                  "reducer": "sum",
-                  "right": "mark cache hits"
-                },
-                "mode": "binary",
-                "reduce": {
-                  "reducer": "sum"
-                }
-              }
-            },
-            {
-              "id": "calculateField",
-              "options": {
-                "alias": "mark cache effectiveness",
-                "binary": {
-                  "left": "mark cache hits",
-                  "operator": "/",
-                  "reducer": "sum",
-                  "right": "mark cache count total"
-                },
-                "mode": "binary",
-                "reduce": {
-                  "reducer": "sum"
-                }
-              }
-            },
-            {
-              "id": "filterFieldsByName",
-              "options": {
-                "include": {
-                  "names": [
-                    "Time",
-                    "mark cache effectiveness"
-                  ]
-                }
-              }
-            }
-          ],
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "percentunit",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "percent",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
@@ -7517,10 +7470,10 @@
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
-            "h": 7,
+            "h": 8,
             "w": 12,
             "x": 12,
-            "y": 102
+            "y": 70
           },
           "hiddenSeries": false,
           "id": 88,
@@ -7708,42 +7661,39 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "Errors of DeltaIndex",
+          "description": "cache misses or cache hits of mark_cache.\nBased on this infactor, we can check whether mark_cache is large enough",
           "fieldConfig": {
             "defaults": {},
             "overrides": []
           },
-          "fill": 0,
+          "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 77
+            "y": 78
           },
           "hiddenSeries": false,
-          "id": 237,
+          "id": 169,
           "legend": {
-            "alignAsTable": true,
             "avg": false,
             "current": false,
-            "max": true,
+            "max": false,
             "min": false,
-            "rightSide": true,
             "show": true,
             "total": false,
-            "values": true
+            "values": false
           },
           "lines": true,
           "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null as zero",
+          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
           "percentage": false,
           "pluginVersion": "7.5.11",
-          "pointradius": 5,
+          "pointradius": 2,
           "points": false,
           "renderer": "flot",
           "seriesOverrides": [],
@@ -7753,25 +7703,76 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(rate(tiflash_system_profile_event_DTDeltaIndexError{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (instance)",
-              "format": "time_series",
+              "expr": "max(tiflash_system_profile_event_MarkCacheMisses{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance)",
+              "interval": "",
+              "legendFormat": "mark cache misses",
+              "queryType": "randomWalk",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "max(tiflash_system_profile_event_MarkCacheHits{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance)",
               "hide": false,
               "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "DeltaIndexError-{{instance}}",
-              "refId": "A"
+              "legendFormat": "mark cache hits",
+              "refId": "B"
             }
           ],
           "thresholds": [],
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "DeltaIndexError",
+          "title": "Effectiveness of Mark Cache",
           "tooltip": {
             "shared": true,
             "sort": 0,
             "value_type": "individual"
           },
+          "transformations": [
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "mark cache count total",
+                "binary": {
+                  "left": "mark cache misses",
+                  "operator": "+",
+                  "reducer": "sum",
+                  "right": "mark cache hits"
+                },
+                "mode": "binary",
+                "reduce": {
+                  "reducer": "sum"
+                }
+              }
+            },
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "mark cache effectiveness",
+                "binary": {
+                  "left": "mark cache hits",
+                  "operator": "/",
+                  "reducer": "sum",
+                  "right": "mark cache count total"
+                },
+                "mode": "binary",
+                "reduce": {
+                  "reducer": "sum"
+                }
+              }
+            },
+            {
+              "id": "filterFieldsByName",
+              "options": {
+                "include": {
+                  "names": [
+                    "Time",
+                    "mark cache effectiveness"
+                  ]
+                }
+              }
+            }
+          ],
           "type": "graph",
           "xaxis": {
             "buckets": null,
@@ -7782,20 +7783,19 @@
           },
           "yaxes": [
             {
-              "decimals": null,
-              "format": "cps",
+              "format": "percentunit",
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": "0",
+              "min": null,
               "show": true
             },
             {
-              "format": "opm",
+              "format": "percent",
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": "0",
+              "min": null,
               "show": false
             }
           ],
@@ -7821,7 +7821,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 109
+            "y": 78
           },
           "hiddenSeries": false,
           "id": 168,
@@ -7941,7 +7941,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 117
+            "y": 86
           },
           "hiddenSeries": false,
           "id": 238,
@@ -11473,7 +11473,7 @@
             "y": 72
           },
           "hiddenSeries": false,
-          "id": 238,
+          "id": 239,
           "legend": {
             "alignAsTable": true,
             "avg": false,
@@ -12542,7 +12542,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 176
+            "y": 11
           },
           "hiddenSeries": false,
           "id": 173,
@@ -12643,7 +12643,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 184
+            "y": 19
           },
           "hiddenSeries": false,
           "id": 187,
@@ -12771,7 +12771,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 184
+            "y": 19
           },
           "height": "",
           "hiddenSeries": false,
@@ -12890,7 +12890,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 192
+            "y": 27
           },
           "height": "",
           "hiddenSeries": false,
@@ -13000,7 +13000,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 192
+            "y": 27
           },
           "height": "",
           "hiddenSeries": false,
@@ -13113,7 +13113,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 200
+            "y": 35
           },
           "hiddenSeries": false,
           "id": 176,
@@ -13221,7 +13221,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 200
+            "y": 35
           },
           "hiddenSeries": false,
           "id": 175,
@@ -13348,7 +13348,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 208
+            "y": 43
           },
           "hiddenSeries": false,
           "id": 189,
@@ -13450,7 +13450,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 208
+            "y": 43
           },
           "hiddenSeries": false,
           "id": 191,
@@ -13550,7 +13550,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 216
+            "y": 51
           },
           "hiddenSeries": false,
           "id": 193,
@@ -13676,7 +13676,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 216
+            "y": 51
           },
           "hiddenSeries": false,
           "id": 195,
@@ -13787,7 +13787,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 224
+            "y": 59
           },
           "hiddenSeries": false,
           "id": 201,
@@ -13923,7 +13923,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 224
+            "y": 59
           },
           "hiddenSeries": false,
           "id": 233,
@@ -14039,7 +14039,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 232
+            "y": 67
           },
           "hiddenSeries": false,
           "id": 236,
@@ -14169,7 +14169,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 177
+            "y": 12
           },
           "hiddenSeries": false,
           "id": 178,
@@ -14287,7 +14287,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 177
+            "y": 12
           },
           "hiddenSeries": false,
           "id": 179,
@@ -14461,7 +14461,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 185
+            "y": 20
           },
           "hiddenSeries": false,
           "id": 182,
@@ -14579,7 +14579,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 185
+            "y": 20
           },
           "hiddenSeries": false,
           "id": 180,
@@ -14706,7 +14706,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 193
+            "y": 28
           },
           "hiddenSeries": false,
           "id": 185,
@@ -14833,7 +14833,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 193
+            "y": 28
           },
           "hiddenSeries": false,
           "id": 186,
@@ -14935,7 +14935,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 201
+            "y": 36
           },
           "hiddenSeries": false,
           "id": 188,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/8069

Problem Summary:

When deployed under disagg arch, the non S3 gc owner TiFlash wn may hang forever. It is because when `EtcdOwnerManager::cancelImpl` is called, `client->campaign` is still stuck on the RPC call, and `th_camaign.join()` may never get returned. 

### What is changed and how it works?

* Cancel the grpc context of `client->campaign` when `EtcdOwnerManager::cancelImpl` is called
* Add some unit test for RaftLogManager
* Fix the position of some grafana panels

Before this PR
![image](https://github.com/pingcap/tiflash/assets/4865550/56d86b97-4bf4-453f-a2a4-f784433d8ebe)

After this PR
![image](https://github.com/pingcap/tiflash/assets/4865550/313b03fd-770e-493a-875c-3a48e38bed58)

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
