### PR TITLE
Disagg: show the num of tables on Grafana

### DIFF
--- a/dbms/src/Common/CurrentMetrics.cpp
+++ b/dbms/src/Common/CurrentMetrics.cpp
@@ -67,6 +67,7 @@
     M(StoragePoolV2Only)                        \
     M(StoragePoolV3Only)                        \
     M(StoragePoolMixMode)                       \
+    M(StoragePoolUniPS)                         \
     M(RegionPersisterRunMode)                   \
     M(S3Requests)                               \
     M(GlobalStorageRunMode)                     \

--- a/dbms/src/Debug/dbgFuncMockRaftSnapshot.cpp
+++ b/dbms/src/Debug/dbgFuncMockRaftSnapshot.cpp
@@ -770,7 +770,7 @@ void MockRaftCommand::dbgFuncRegionSnapshotPreHandleDTFiles(
     }
 
     // set block size so that we can test for schema-sync while decoding dt files
-    FailPointHelper::enableFailPoint(FailPoints::force_set_sst_to_dtfile_block_size);
+    FailPointHelper::enableFailPoint(FailPoints::force_set_sst_to_dtfile_block_size, static_cast<size_t>(3));
     FailPointHelper::enableFailPoint(FailPoints::force_set_safepoint_when_decode_block);
 
     auto ingest_ids = kvstore->preHandleSnapshotToFiles(
@@ -876,7 +876,7 @@ void MockRaftCommand::dbgFuncRegionSnapshotPreHandleDTFilesWithHandles(
     }
 
     // set block size so that we can test for schema-sync while decoding dt files
-    FailPointHelper::enableFailPoint(FailPoints::force_set_sst_to_dtfile_block_size);
+    FailPointHelper::enableFailPoint(FailPoints::force_set_sst_to_dtfile_block_size, static_cast<size_t>(3));
     FailPointHelper::enableFailPoint(FailPoints::force_set_safepoint_when_decode_block);
 
     auto ingest_ids = kvstore->preHandleSnapshotToFiles(

--- a/dbms/src/Storages/DeltaMerge/StoragePool.h
+++ b/dbms/src/Storages/DeltaMerge/StoragePool.h
@@ -178,7 +178,7 @@ public:
 #ifndef DBMS_PUBLIC_GTEST
 private:
 #endif
-    bool doV2Gc(const Settings & settings);
+    bool doV2Gc(const Settings & settings) const;
 
     void forceTransformMetaV2toV3();
     void forceTransformDataV2toV3();

--- a/dbms/src/Storages/Page/V3/PageStorageImpl.cpp
+++ b/dbms/src/Storages/Page/V3/PageStorageImpl.cpp
@@ -32,17 +32,12 @@
 
 #include <mutex>
 
-namespace DB
-{
-namespace ErrorCodes
+namespace DB::ErrorCodes
 {
 extern const int NOT_IMPLEMENTED;
-} // namespace ErrorCodes
-namespace FailPoints
-{
-extern const char force_ps_wal_compact[];
-}
-namespace PS::V3
+} // namespace DB::ErrorCodes
+
+namespace DB::PS::V3
 {
 PageStorageImpl::PageStorageImpl(
     String name,
@@ -326,5 +321,4 @@ void PageStorageImpl::unregisterExternalPagesCallbacks(NamespaceID ns_id)
     page_directory->unregisterNamespace(ns_id);
 }
 
-} // namespace PS::V3
-} // namespace DB
+} // namespace DB::PS::V3

--- a/dbms/src/Storages/Page/V3/Universal/tests/gtest_checkpoint.cpp
+++ b/dbms/src/Storages/Page/V3/Universal/tests/gtest_checkpoint.cpp
@@ -39,11 +39,6 @@
 #include <limits>
 using namespace DB::S3::tests;
 
-namespace DB::FailPoints
-{
-extern const char force_ps_wal_compact[];
-} // namespace DB::FailPoints
-
 namespace DB::PS::universal::tests
 {
 

--- a/dbms/src/Storages/Transaction/ApplySnapshot.cpp
+++ b/dbms/src/Storages/Transaction/ApplySnapshot.cpp
@@ -349,7 +349,10 @@ std::vector<DM::ExternalDTFileInfo> KVStore::preHandleSSTsToDTFiles(
     size_t expected_block_size = DEFAULT_MERGE_BLOCK_SIZE;
 
     // Use failpoint to change the expected_block_size for some test cases
-    fiu_do_on(FailPoints::force_set_sst_to_dtfile_block_size, { expected_block_size = 3; });
+    fiu_do_on(FailPoints::force_set_sst_to_dtfile_block_size, {
+        if (auto v = FailPointHelper::getFailPointVal(FailPoints::force_set_sst_to_dtfile_block_size); v)
+            expected_block_size = std::any_cast<size_t>(v.value());
+    });
 
     Stopwatch watch;
     SCOPE_EXIT({

--- a/metrics/grafana/tiflash_summary.json
+++ b/metrics/grafana/tiflash_summary.json
@@ -52,7 +52,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1694151861724,
+  "iteration": 1694430080744,
   "links": [],
   "panels": [
     {
@@ -9492,6 +9492,7 @@
             "alignAsTable": true,
             "avg": false,
             "current": true,
+            "hideZero": true,
             "max": false,
             "min": false,
             "rightSide": true,
@@ -9525,7 +9526,7 @@
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{instance}}-OnlyV2",
+              "legendFormat": "{{instance}}-V2",
               "refId": "A",
               "step": 10
             },
@@ -9534,7 +9535,7 @@
               "expr": "sum(tiflash_system_current_metric_StoragePoolV3Only{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance)",
               "hide": false,
               "interval": "",
-              "legendFormat": "{{instance}}-OnlyV3",
+              "legendFormat": "{{instance}}-V3",
               "refId": "B"
             },
             {
@@ -9544,6 +9545,14 @@
               "interval": "",
               "legendFormat": "{{instance}}-MixMode",
               "refId": "C"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(tiflash_system_current_metric_StoragePoolUniPS{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{instance}}-UniPS",
+              "refId": "D"
             }
           ],
           "thresholds": [],


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/6882

Problem Summary: The number of DeltaMergeStore running on disagg-arch is not reported

### What is changed and how it works?

![image](https://github.com/pingcap/tiflash/assets/4865550/ceff33c2-5b31-4256-acfb-c9a99a836b07)


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
