### PR TITLE
support agg resize callback

### DIFF
--- a/dbms/src/Common/HashTable/TwoLevelHashTable.h
+++ b/dbms/src/Common/HashTable/TwoLevelHashTable.h
@@ -65,6 +65,12 @@ public:
     /// NOTE Bad for hash tables with more than 2^32 cells.
     static size_t getBucketFromHash(size_t hash_value) { return (hash_value >> (32 - BITS_FOR_BUCKET)) & MAX_BUCKET; }
 
+    void setResizeCallback(const ResizeCallback & resize_callback)
+    {
+        for (auto & impl : impls)
+            impl.setResizeCallback(resize_callback);
+    }
+
 protected:
     typename Impl::iterator beginOfNextNonEmptyBucket(size_t & bucket)
     {

--- a/dbms/src/Common/HashTable/TwoLevelStringHashTable.h
+++ b/dbms/src/Common/HashTable/TwoLevelStringHashTable.h
@@ -38,6 +38,12 @@ public:
         });
     }
 
+    void setResizeCallback(const ResizeCallback & resize_callback)
+    {
+        for (auto & impl : impls)
+            impl.setResizeCallback(resize_callback);
+    }
+
     size_t operator()(const Key & x) const { return hash(x); }
 
     /// NOTE Bad for hash tables with more than 2^32 cells.

--- a/dbms/src/Core/CachedSpillHandler.cpp
+++ b/dbms/src/Core/CachedSpillHandler.cpp
@@ -43,6 +43,8 @@ bool CachedSpillHandler::batchRead()
     {
         if unlikely (is_cancelled())
             return false;
+        if unlikely (block.rows() == 0)
+            continue;
         ret.push_back(std::move(block));
         current_return_size += ret.back().estimateBytesForSpill();
         if (bytes_threshold > 0 && current_return_size >= bytes_threshold)

--- a/dbms/src/Interpreters/Aggregator.cpp
+++ b/dbms/src/Interpreters/Aggregator.cpp
@@ -160,7 +160,7 @@ void AggregatedDataVariants::setResizeCallbackIfNeeded(size_t thread_num) const
         {
             auto resize_callback = [agg_spill_context, thread_num]() {
                 return !(
-                    agg_spill_context->supportAutoTriggerSpill()
+                    agg_spill_context->supportFurtherSpill()
                     && agg_spill_context->isThreadMarkedForAutoSpill(thread_num));
             };
 #define M(NAME)                                                                                         \

--- a/dbms/src/Interpreters/Aggregator.cpp
+++ b/dbms/src/Interpreters/Aggregator.cpp
@@ -159,7 +159,7 @@ void AggregatedDataVariants::setResizeCallbackIfNeeded(size_t thread_num) const
         if (agg_spill_context->isSpillEnabled() && agg_spill_context->isInAutoSpillMode())
         {
             auto resize_callback = [agg_spill_context, thread_num]() {
-                return !agg_spill_context->isThreadMarkedForAutoSpill(thread_num);
+                return !(agg_spill_context->supportAutoTriggerSpill() && agg_spill_context->isThreadMarkedForAutoSpill(thread_num));
             };
 #define M(NAME)                                                                                         \
     case AggregationMethodType(NAME):                                                                   \

--- a/dbms/src/Interpreters/Aggregator.h
+++ b/dbms/src/Interpreters/Aggregator.h
@@ -938,7 +938,7 @@ struct AggregatedDataVariants : private boost::noncopyable
 
     void convertToTwoLevel();
 
-    void setResizeCallbackIfNeeded(size_t thread_num);
+    void setResizeCallbackIfNeeded(size_t thread_num) const;
 
 #define APPLY_FOR_VARIANTS_TWO_LEVEL(M)               \
     M(key32_two_level)                                \

--- a/dbms/src/Interpreters/Aggregator.h
+++ b/dbms/src/Interpreters/Aggregator.h
@@ -938,6 +938,8 @@ struct AggregatedDataVariants : private boost::noncopyable
 
     void convertToTwoLevel();
 
+    void setResizeCallbackIfNeeded(size_t thread_num);
+
 #define APPLY_FOR_VARIANTS_TWO_LEVEL(M)               \
     M(key32_two_level)                                \
     M(key64_two_level)                                \

--- a/dbms/src/Interpreters/Aggregator.h
+++ b/dbms/src/Interpreters/Aggregator.h
@@ -131,6 +131,7 @@ struct AggregationMethodOneNumber
     /// To use one `Method` in different threads, use different `State`.
     using State = ColumnsHashing::
         HashMethodOneNumber<typename Data::value_type, Mapped, FieldType, consecutive_keys_optimization>;
+    using EmplaceResult = ColumnsHashing::columns_hashing_impl::EmplaceResultImpl<Mapped>;
 
     /// Shuffle key columns before `insertKeyIntoColumns` call if needed.
     std::optional<Sizes> shuffleKeyColumns(std::vector<IColumn *> &, const Sizes &) { return {}; }
@@ -166,6 +167,7 @@ struct AggregationMethodString
     {}
 
     using State = ColumnsHashing::HashMethodString<typename Data::value_type, Mapped>;
+    using EmplaceResult = ColumnsHashing::columns_hashing_impl::EmplaceResultImpl<Mapped>;
 
     std::optional<Sizes> shuffleKeyColumns(std::vector<IColumn *> &, const Sizes &) { return {}; }
 
@@ -198,6 +200,7 @@ struct AggregationMethodStringNoCache
 
     // Remove last zero byte.
     using State = ColumnsHashing::HashMethodString<typename Data::value_type, Mapped, true, false>;
+    using EmplaceResult = ColumnsHashing::columns_hashing_impl::EmplaceResultImpl<Mapped>;
 
     std::optional<Sizes> shuffleKeyColumns(std::vector<IColumn *> &, const Sizes &) { return {}; }
 
@@ -229,6 +232,7 @@ struct AggregationMethodOneKeyStringNoCache
     {}
 
     using State = ColumnsHashing::HashMethodStringBin<typename Data::value_type, Mapped, bin_padding>;
+    using EmplaceResult = ColumnsHashing::columns_hashing_impl::EmplaceResultImpl<Mapped>;
 
     std::optional<Sizes> shuffleKeyColumns(std::vector<IColumn *> &, const Sizes &) { return {}; }
 
@@ -262,6 +266,7 @@ struct AggregationMethodMultiStringNoCache
     {}
 
     using State = ColumnsHashing::HashMethodMultiString<typename Data::value_type, Mapped>;
+    using EmplaceResult = ColumnsHashing::columns_hashing_impl::EmplaceResultImpl<Mapped>;
 
     std::optional<Sizes> shuffleKeyColumns(std::vector<IColumn *> &, const Sizes &) { return {}; }
 
@@ -292,6 +297,7 @@ struct AggregationMethodFastPathTwoKeysNoCache
 
     using State
         = ColumnsHashing::HashMethodFastPathTwoKeysSerialized<Key1Desc, Key2Desc, typename Data::value_type, Mapped>;
+    using EmplaceResult = ColumnsHashing::columns_hashing_impl::EmplaceResultImpl<Mapped>;
 
     std::optional<Sizes> shuffleKeyColumns(std::vector<IColumn *> &, const Sizes &) { return {}; }
 
@@ -386,6 +392,7 @@ struct AggregationMethodFixedString
     {}
 
     using State = ColumnsHashing::HashMethodFixedString<typename Data::value_type, Mapped>;
+    using EmplaceResult = ColumnsHashing::columns_hashing_impl::EmplaceResultImpl<Mapped>;
 
     std::optional<Sizes> shuffleKeyColumns(std::vector<IColumn *> &, const Sizes &) { return {}; }
 
@@ -417,6 +424,7 @@ struct AggregationMethodFixedStringNoCache
     {}
 
     using State = ColumnsHashing::HashMethodFixedString<typename Data::value_type, Mapped, true, false>;
+    using EmplaceResult = ColumnsHashing::columns_hashing_impl::EmplaceResultImpl<Mapped>;
 
     std::optional<Sizes> shuffleKeyColumns(std::vector<IColumn *> &, const Sizes &) { return {}; }
 
@@ -451,6 +459,7 @@ struct AggregationMethodKeysFixed
 
     using State
         = ColumnsHashing::HashMethodKeysFixed<typename Data::value_type, Key, Mapped, has_nullable_keys, use_cache>;
+    using EmplaceResult = ColumnsHashing::columns_hashing_impl::EmplaceResultImpl<Mapped>;
 
     std::optional<Sizes> shuffleKeyColumns(std::vector<IColumn *> & key_columns, const Sizes & key_sizes)
     {
@@ -538,6 +547,7 @@ struct AggregationMethodSerialized
     {}
 
     using State = ColumnsHashing::HashMethodSerialized<typename Data::value_type, Mapped>;
+    using EmplaceResult = ColumnsHashing::columns_hashing_impl::EmplaceResultImpl<Mapped>;
 
     std::optional<Sizes> shuffleKeyColumns(std::vector<IColumn *> &, const Sizes &) { return {}; }
 
@@ -1267,6 +1277,14 @@ protected:
         typename Method::State & state,
         Arena * aggregates_pool,
         AggProcessInfo & agg_process_info) const;
+
+    template <typename Method>
+    std::optional<typename Method::EmplaceResult> emplaceKey(
+        Method & method,
+        typename Method::State & state,
+        size_t index,
+        Arena & aggregates_pool,
+        std::vector<std::string> & sort_key_containers) const;
 
     /// For case when there are no keys (all aggregate into one row).
     static void executeWithoutKeyImpl(AggregatedDataWithoutKey & res, AggProcessInfo & agg_process_info, Arena * arena);

--- a/dbms/src/Interpreters/JoinPartition.cpp
+++ b/dbms/src/Interpreters/JoinPartition.cpp
@@ -236,7 +236,9 @@ void JoinPartition::setResizeCallbackIfNeeded()
     if (hash_join_spill_context->isSpillEnabled() && hash_join_spill_context->isInAutoSpillMode())
     {
         auto resize_callback = [this]() {
-            return !(hash_join_spill_context->supportFurtherSpill() && hash_join_spill_context->isPartitionMarkedForAutoSpill(partition_index));
+            return !(
+                hash_join_spill_context->supportFurtherSpill()
+                && hash_join_spill_context->isPartitionMarkedForAutoSpill(partition_index));
         };
         assert(pool != nullptr);
         pool->setResizeCallback(resize_callback);

--- a/dbms/src/Interpreters/JoinPartition.cpp
+++ b/dbms/src/Interpreters/JoinPartition.cpp
@@ -236,7 +236,7 @@ void JoinPartition::setResizeCallbackIfNeeded()
     if (hash_join_spill_context->isSpillEnabled() && hash_join_spill_context->isInAutoSpillMode())
     {
         auto resize_callback = [this]() {
-            return !hash_join_spill_context->isPartitionMarkedForAutoSpill(partition_index);
+            return !(hash_join_spill_context->supportFurtherSpill() && hash_join_spill_context->isPartitionMarkedForAutoSpill(partition_index));
         };
         assert(pool != nullptr);
         pool->setResizeCallback(resize_callback);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #7738

Problem Summary:

### What is changed and how it works?
This pr set ResizeCallback for aggregation hash table, so when the hash table need resize in aggregation, it has the chance to check if current hash table is already maked to spill, if yes, it can simply give up resize and release the memory in time.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
   will add integration test in endless
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
