### PR TITLE
Disagg: Fix exception when query table with generated column(s)

### DIFF
--- a/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
@@ -1031,8 +1031,11 @@ DM::Remote::DisaggPhysicalTableReadSnapshotPtr DAGStorageInterpreter::buildLocal
                 RUNTIME_CHECK_MSG(
                     delta_merge_storage != nullptr,
                     "delta_merge_storage which cast from storage is null");
-                table_snap = delta_merge_storage
-                                 ->writeNodeBuildRemoteReadSnapshot(required_columns, query_info, context, max_streams);
+                table_snap = delta_merge_storage->writeNodeBuildRemoteReadSnapshot( //
+                    required_columns,
+                    query_info,
+                    context,
+                    max_streams);
             }
 
             injectFailPointForLocalRead(query_info);
@@ -1111,8 +1114,11 @@ DM::Remote::DisaggPhysicalTableReadSnapshotPtr DAGStorageInterpreter::buildLocal
                 RUNTIME_CHECK_MSG(
                     delta_merge_storage != nullptr,
                     "delta_merge_storage which cast from storage is null");
-                table_snap = delta_merge_storage
-                                 ->writeNodeBuildRemoteReadSnapshot(required_columns, query_info, context, max_streams);
+                table_snap = delta_merge_storage->writeNodeBuildRemoteReadSnapshot( //
+                    required_columns,
+                    query_info,
+                    context,
+                    max_streams);
             }
 
             injectFailPointForLocalRead(query_info);

--- a/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
@@ -1033,13 +1033,6 @@ DM::Remote::DisaggPhysicalTableReadSnapshotPtr DAGStorageInterpreter::buildLocal
                     "delta_merge_storage which cast from storage is null");
                 table_snap = delta_merge_storage
                                  ->writeNodeBuildRemoteReadSnapshot(required_columns, query_info, context, max_streams);
-                // TODO: could be shared on the logical table level
-                table_snap->output_field_types = std::make_shared<std::vector<tipb::FieldType>>();
-                *table_snap->output_field_types = collectOutputFieldTypes(*dag_context.dag_request);
-                RUNTIME_CHECK(
-                    table_snap->output_field_types->size() == table_snap->column_defines->size(),
-                    table_snap->output_field_types->size(),
-                    table_snap->column_defines->size());
             }
 
             injectFailPointForLocalRead(query_info);
@@ -1120,13 +1113,6 @@ DM::Remote::DisaggPhysicalTableReadSnapshotPtr DAGStorageInterpreter::buildLocal
                     "delta_merge_storage which cast from storage is null");
                 table_snap = delta_merge_storage
                                  ->writeNodeBuildRemoteReadSnapshot(required_columns, query_info, context, max_streams);
-                // TODO: could be shared on the logical table level
-                table_snap->output_field_types = std::make_shared<std::vector<tipb::FieldType>>();
-                *table_snap->output_field_types = collectOutputFieldTypes(*dag_context.dag_request);
-                RUNTIME_CHECK(
-                    table_snap->output_field_types->size() == table_snap->column_defines->size(),
-                    table_snap->output_field_types->size(),
-                    table_snap->column_defines->size());
             }
 
             injectFailPointForLocalRead(query_info);

--- a/dbms/src/Flash/Disaggregated/WNFetchPagesStreamWriter.cpp
+++ b/dbms/src/Flash/Disaggregated/WNFetchPagesStreamWriter.cpp
@@ -42,7 +42,6 @@ WNFetchPagesStreamWriterPtr WNFetchPagesStreamWriter::build(
     return std::unique_ptr<WNFetchPagesStreamWriter>(new WNFetchPagesStreamWriter(
         task.seg_task,
         task.column_defines,
-        task.output_field_types,
         read_page_ids,
         packet_limit_size));
 }

--- a/dbms/src/Flash/Disaggregated/WNFetchPagesStreamWriter.cpp
+++ b/dbms/src/Flash/Disaggregated/WNFetchPagesStreamWriter.cpp
@@ -39,11 +39,8 @@ WNFetchPagesStreamWriterPtr WNFetchPagesStreamWriter::build(
     const PageIdU64s & read_page_ids,
     UInt64 packet_limit_size)
 {
-    return std::unique_ptr<WNFetchPagesStreamWriter>(new WNFetchPagesStreamWriter(
-        task.seg_task,
-        task.column_defines,
-        read_page_ids,
-        packet_limit_size));
+    return std::unique_ptr<WNFetchPagesStreamWriter>(
+        new WNFetchPagesStreamWriter(task.seg_task, task.column_defines, read_page_ids, packet_limit_size));
 }
 
 std::pair<DM::RemotePb::RemotePage, size_t> WNFetchPagesStreamWriter::getPersistedRemotePage(UInt64 page_id)

--- a/dbms/src/Flash/Disaggregated/WNFetchPagesStreamWriter.h
+++ b/dbms/src/Flash/Disaggregated/WNFetchPagesStreamWriter.h
@@ -55,12 +55,10 @@ private:
     WNFetchPagesStreamWriter(
         DM::SegmentReadTaskPtr seg_task_,
         DM::ColumnDefinesPtr column_defines_,
-        std::shared_ptr<std::vector<tipb::FieldType>> result_field_types_,
         PageIdU64s read_page_ids,
         UInt64 packet_limit_size_)
         : seg_task(std::move(seg_task_))
         , column_defines(column_defines_)
-        , result_field_types(std::move(result_field_types_))
         , read_page_ids(std::move(read_page_ids))
         , packet_limit_size(packet_limit_size_)
         , log(Logger::get())
@@ -75,7 +73,6 @@ private:
     const DM::DisaggTaskId task_id;
     DM::SegmentReadTaskPtr seg_task;
     DM::ColumnDefinesPtr column_defines;
-    std::shared_ptr<std::vector<tipb::FieldType>> result_field_types;
     PageIdU64s read_page_ids;
     UInt64 packet_limit_size;
 

--- a/dbms/src/Storages/DeltaMerge/Remote/DisaggSnapshot.cpp
+++ b/dbms/src/Storages/DeltaMerge/Remote/DisaggSnapshot.cpp
@@ -45,9 +45,7 @@ SegmentPagesFetchTask DisaggReadSnapshot::popSegTask(TableID physical_table_id, 
             segment_id));
     }
 
-    auto task = SegmentPagesFetchTask::task(
-        seg_task,
-        table_iter->second->column_defines);
+    auto task = SegmentPagesFetchTask::task(seg_task, table_iter->second->column_defines);
     if (table_iter->second->empty())
     {
         table_snapshots.erase(table_iter);

--- a/dbms/src/Storages/DeltaMerge/Remote/DisaggSnapshot.cpp
+++ b/dbms/src/Storages/DeltaMerge/Remote/DisaggSnapshot.cpp
@@ -47,8 +47,7 @@ SegmentPagesFetchTask DisaggReadSnapshot::popSegTask(TableID physical_table_id, 
 
     auto task = SegmentPagesFetchTask::task(
         seg_task,
-        table_iter->second->column_defines,
-        table_iter->second->output_field_types);
+        table_iter->second->column_defines);
     if (table_iter->second->empty())
     {
         table_snapshots.erase(table_iter);

--- a/dbms/src/Storages/DeltaMerge/Remote/DisaggSnapshot.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/DisaggSnapshot.h
@@ -48,11 +48,9 @@ struct SegmentPagesFetchTask
 public:
     static SegmentPagesFetchTask error(String err_msg)
     {
-        return SegmentPagesFetchTask{nullptr, nullptr,std::move(err_msg)};
+        return SegmentPagesFetchTask{nullptr, nullptr, std::move(err_msg)};
     }
-    static SegmentPagesFetchTask task(
-        SegmentReadTaskPtr seg_task,
-        DM::ColumnDefinesPtr column_defines)
+    static SegmentPagesFetchTask task(SegmentReadTaskPtr seg_task, DM::ColumnDefinesPtr column_defines)
     {
         return SegmentPagesFetchTask{std::move(seg_task), std::move(column_defines), ""};
     }

--- a/dbms/src/Storages/DeltaMerge/Remote/DisaggSnapshot.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/DisaggSnapshot.h
@@ -40,7 +40,6 @@ struct SegmentPagesFetchTask
 {
     SegmentReadTaskPtr seg_task;
     DM::ColumnDefinesPtr column_defines;
-    std::shared_ptr<std::vector<tipb::FieldType>> output_field_types;
 
     String err_msg;
 
@@ -49,14 +48,13 @@ struct SegmentPagesFetchTask
 public:
     static SegmentPagesFetchTask error(String err_msg)
     {
-        return SegmentPagesFetchTask{nullptr, nullptr, nullptr, std::move(err_msg)};
+        return SegmentPagesFetchTask{nullptr, nullptr,std::move(err_msg)};
     }
     static SegmentPagesFetchTask task(
         SegmentReadTaskPtr seg_task,
-        DM::ColumnDefinesPtr column_defines,
-        std::shared_ptr<std::vector<tipb::FieldType>> output_field_types)
+        DM::ColumnDefinesPtr column_defines)
     {
-        return SegmentPagesFetchTask{std::move(seg_task), std::move(column_defines), std::move(output_field_types), ""};
+        return SegmentPagesFetchTask{std::move(seg_task), std::move(column_defines), ""};
     }
 };
 
@@ -116,7 +114,6 @@ public:
     // TODO: these members are the same in the logical table level,
     //       maybe we can reuse them to reduce memory consumption.
     DM::ColumnDefinesPtr column_defines;
-    std::shared_ptr<std::vector<tipb::FieldType>> output_field_types;
 
 private:
     mutable std::shared_mutex mtx;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/8090

Problem Summary: Deployed on a disagg arch cluster, when we execute queries on a table with generate column(s), the query will fail

### What is changed and how it works?

Because `DisaggPhysicalTableReadSnapshot:: output_field_types` is not used by any codes now. We just remove it and its checks.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  - Deploy a disagg cluster
```sql
CREATE TABLE `cached` (
  `cache_key` varchar(512) NOT NULL,
  `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
  `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
  `expires` int(11) DEFAULT '-1' COMMENT 'cache will expire after n seconds',
  `expired_at` datetime GENERATED ALWAYS AS (if(`expires` > 0, date_add(`updated_at`, interval `expires` second), date_add(`updated_at`, interval 99 year))) VIRTUAL,
  PRIMARY KEY (`cache_key`) /*T![clustered_index] CLUSTERED */,
  KEY `idx_ctc_on_created_at` (`created_at`)
)

insert into cached(cache_key,expires) values ('1', 3600)

alter table cached set tiflash replica 1
set session tidb_isolation_read_engines='tiflash'
select * from cached;
+-----------+---------------------+---------------------+---------+---------------------+
| cache_key | created_at          | updated_at          | expires | expired_at          |
+-----------+---------------------+---------------------+---------+---------------------+
| 1         | 2023-09-13 18:05:47 | 2023-09-13 18:05:47 | 3600    | 2023-09-13 19:05:47 |
+-----------+---------------------+---------------------+---------+---------------------+
```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
