### PR TITLE
Add metrics to monitor size of ongoing raft snapshots

### DIFF
--- a/dbms/src/Common/TiFlashMetrics.h
+++ b/dbms/src/Common/TiFlashMetrics.h
@@ -440,6 +440,12 @@ namespace DB
       "Bucketed histogram entry size",                                                                                              \
       Histogram,                                                                                                                    \
       F(type_normal, {{"type", "normal"}}, ExpBuckets{1, 2, 13}))                                                                   \
+    M(tiflash_raft_ongoing_snapshot_total_size,                                                                                     \
+      "Ongoing snapshot total size",                                                                                                \
+      Gauge,                                                                                                                        \
+      F(type_raft_snapshot, {{"type", "raft_snapshot"}}),                                                                           \
+      F(type_dt_on_disk, {{"type", "dt_on_disk"}}),                                                                                 \
+      F(type_dt_total, {{"type", "dt_total"}}))                                                                                     \
     /* required by DBaaS */                                                                                                         \
     M(tiflash_server_info,                                                                                                          \
       "Indicate the tiflash server info, and the value is the start timestamp (s).",                                                \

--- a/dbms/src/Common/TiFlashMetrics.h
+++ b/dbms/src/Common/TiFlashMetrics.h
@@ -440,7 +440,7 @@ namespace DB
       "Bucketed histogram entry size",                                                                                              \
       Histogram,                                                                                                                    \
       F(type_normal, {{"type", "normal"}}, ExpBuckets{1, 2, 13}))                                                                   \
-    M(tiflash_raft_ongoing_snapshot_total_bytes,                                                                                     \
+    M(tiflash_raft_ongoing_snapshot_total_bytes,                                                                                    \
       "Ongoing snapshot total size",                                                                                                \
       Gauge,                                                                                                                        \
       F(type_raft_snapshot, {{"type", "raft_snapshot"}}),                                                                           \

--- a/dbms/src/Common/TiFlashMetrics.h
+++ b/dbms/src/Common/TiFlashMetrics.h
@@ -440,7 +440,7 @@ namespace DB
       "Bucketed histogram entry size",                                                                                              \
       Histogram,                                                                                                                    \
       F(type_normal, {{"type", "normal"}}, ExpBuckets{1, 2, 13}))                                                                   \
-    M(tiflash_raft_ongoing_snapshot_total_size,                                                                                     \
+    M(tiflash_raft_ongoing_snapshot_total_bytes,                                                                                     \
       "Ongoing snapshot total size",                                                                                                \
       Gauge,                                                                                                                        \
       F(type_raft_snapshot, {{"type", "raft_snapshot"}}),                                                                           \

--- a/dbms/src/Common/TiFlashMetrics.h
+++ b/dbms/src/Common/TiFlashMetrics.h
@@ -377,8 +377,8 @@ namespace DB
       F(type_ingest_sst, {{"type", "ingest_sst"}}, ExpBuckets{0.05, 2, 10}),                                                        \
       F(type_ingest_sst_sst2dt, {{"type", "ingest_sst_sst2dt"}}, ExpBuckets{0.05, 2, 10}),                                          \
       F(type_ingest_sst_upload, {{"type", "ingest_sst_upload"}}, ExpBuckets{0.05, 2, 10}),                                          \
-      F(type_apply_snapshot_predecode, {{"type", "snapshot_predecode"}}, ExpBuckets{0.05, 2, 10}),                                  \
-      F(type_apply_snapshot_predecode_sst2dt, {{"type", "snapshot_predecode_sst2dt"}}, ExpBuckets{0.05, 2, 10}),                    \
+      F(type_apply_snapshot_predecode, {{"type", "snapshot_predecode"}}, ExpBuckets{0.05, 2, 15}),                                  \
+      F(type_apply_snapshot_predecode_sst2dt, {{"type", "snapshot_predecode_sst2dt"}}, ExpBuckets{0.05, 2, 15}),                    \
       F(type_apply_snapshot_predecode_upload, {{"type", "snapshot_predecode_upload"}}, ExpBuckets{0.05, 2, 10}),                    \
       F(type_apply_snapshot_flush, {{"type", "snapshot_flush"}}, ExpBuckets{0.05, 2, 10}))                                          \
     M(tiflash_raft_process_keys,                                                                                                    \
@@ -410,9 +410,9 @@ namespace DB
     M(tiflash_raft_raft_log_gap_count,                                                                                              \
       "Bucketed histogram raft index gap between applied and truncated index",                                                      \
       Histogram,                                                                                                                    \
-      F(type_applied_index, {{"type", "applied_index"}}, EqualWidthBuckets{0, 100, 10}),                                            \
+      F(type_applied_index, {{"type", "applied_index"}}, EqualWidthBuckets{0, 100, 15}),                                            \
       F(type_eager_gc_applied_index, {{"type", "eager_gc_applied_index"}}, EqualWidthBuckets{0, 100, 10}),                          \
-      F(type_unflushed_applied_index, {{"type", "unflushed_applied_index"}}, EqualWidthBuckets{0, 100, 10}))                        \
+      F(type_unflushed_applied_index, {{"type", "unflushed_applied_index"}}, EqualWidthBuckets{0, 100, 15}))                        \
     M(tiflash_raft_raft_events_count,                                                                                               \
       "Raft event counter",                                                                                                         \
       Counter,                                                                                                                      \

--- a/dbms/src/Debug/MockRaftStoreProxy.cpp
+++ b/dbms/src/Debug/MockRaftStoreProxy.cpp
@@ -976,9 +976,9 @@ RegionPtr MockRaftStoreProxy::snapshot(
         }
     }
     SSTViewVec snaps{ssts.data(), ssts.size()};
-    auto ingest_ids = kvs.preHandleSnapshotToFiles(new_kv_region, snaps, index, term, deadline_index, tmt);
+    auto prehandle_result = kvs.preHandleSnapshotToFiles(new_kv_region, snaps, index, term, deadline_index, tmt);
 
-    auto rg = RegionPtrWithSnapshotFiles{new_kv_region, std::move(ingest_ids)};
+    auto rg = RegionPtrWithSnapshotFiles{new_kv_region, std::move(prehandle_result.ingest_ids)};
     if (cancel_after_prehandle)
     {
         kvs.releasePreHandledSnapshot(rg, tmt);

--- a/dbms/src/Debug/dbgFuncMockRaftSnapshot.cpp
+++ b/dbms/src/Debug/dbgFuncMockRaftSnapshot.cpp
@@ -773,18 +773,18 @@ void MockRaftCommand::dbgFuncRegionSnapshotPreHandleDTFiles(
     FailPointHelper::enableFailPoint(FailPoints::force_set_sst_to_dtfile_block_size, static_cast<size_t>(3));
     FailPointHelper::enableFailPoint(FailPoints::force_set_safepoint_when_decode_block);
 
-    auto ingest_ids = kvstore->preHandleSnapshotToFiles(
+    auto prehandle_result = kvstore->preHandleSnapshotToFiles(
         new_region,
         SSTViewVec{sst_views.data(), sst_views.size()},
         index,
         MockTiKV::instance().getRaftTerm(region_id),
         std::nullopt,
         tmt);
-    GLOBAL_REGION_MAP.insertRegionSnap(region_name, {new_region, ingest_ids});
+    GLOBAL_REGION_MAP.insertRegionSnap(region_name, {new_region, prehandle_result.ingest_ids});
 
     FailPointHelper::disableFailPoint(FailPoints::force_set_safepoint_when_decode_block);
     {
-        output(fmt::format("Generate {} files for [region_id={}]", ingest_ids.size(), region_id));
+        output(fmt::format("Generate {} files for [region_id={}]", prehandle_result.ingest_ids.size(), region_id));
     }
 }
 
@@ -879,18 +879,18 @@ void MockRaftCommand::dbgFuncRegionSnapshotPreHandleDTFilesWithHandles(
     FailPointHelper::enableFailPoint(FailPoints::force_set_sst_to_dtfile_block_size, static_cast<size_t>(3));
     FailPointHelper::enableFailPoint(FailPoints::force_set_safepoint_when_decode_block);
 
-    auto ingest_ids = kvstore->preHandleSnapshotToFiles(
+    auto prehandle_result = kvstore->preHandleSnapshotToFiles(
         new_region,
         SSTViewVec{sst_views.data(), sst_views.size()},
         index,
         MockTiKV::instance().getRaftTerm(region_id),
         std::nullopt,
         tmt);
-    GLOBAL_REGION_MAP.insertRegionSnap(region_name, {new_region, ingest_ids});
+    GLOBAL_REGION_MAP.insertRegionSnap(region_name, {new_region, prehandle_result.ingest_ids});
 
     FailPointHelper::disableFailPoint(FailPoints::force_set_safepoint_when_decode_block);
     {
-        output(fmt::format("Generate {} files for [region_id={}]", ingest_ids.size(), region_id));
+        output(fmt::format("Generate {} files for [region_id={}]", prehandle_result.ingest_ids.size(), region_id));
     }
 }
 

--- a/dbms/src/Debug/dbgTools.cpp
+++ b/dbms/src/Debug/dbgTools.cpp
@@ -779,8 +779,8 @@ void handleApplySnapshot(
     TMTContext & tmt)
 {
     auto new_region = kvstore.genRegionPtr(std::move(region), peer_id, index, term);
-    auto external_files = kvstore.preHandleSnapshotToFiles(new_region, snaps, index, term, deadline_index, tmt);
-    kvstore.applyPreHandledSnapshot(RegionPtrWithSnapshotFiles{new_region, std::move(external_files)}, tmt);
+    auto prehandle_result = kvstore.preHandleSnapshotToFiles(new_region, snaps, index, term, deadline_index, tmt);
+    kvstore.applyPreHandledSnapshot(RegionPtrWithSnapshotFiles{new_region, std::move(prehandle_result.ingest_ids)}, tmt);
 }
 
 } // namespace RegionBench

--- a/dbms/src/Debug/dbgTools.cpp
+++ b/dbms/src/Debug/dbgTools.cpp
@@ -780,7 +780,9 @@ void handleApplySnapshot(
 {
     auto new_region = kvstore.genRegionPtr(std::move(region), peer_id, index, term);
     auto prehandle_result = kvstore.preHandleSnapshotToFiles(new_region, snaps, index, term, deadline_index, tmt);
-    kvstore.applyPreHandledSnapshot(RegionPtrWithSnapshotFiles{new_region, std::move(prehandle_result.ingest_ids)}, tmt);
+    kvstore.applyPreHandledSnapshot(
+        RegionPtrWithSnapshotFiles{new_region, std::move(prehandle_result.ingest_ids)},
+        tmt);
 }
 
 } // namespace RegionBench

--- a/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.cpp
@@ -241,7 +241,8 @@ void SSTFilesToBlockInputStream::loadCFDataFromSST(
         }
         LOG_DEBUG(
             log,
-            "Done loading all kvpairs from [CF={}] [offset={}] [proc_size={}] [write_cf_offset={}] [region_id={}] [snapshot_index={}]",
+            "Done loading all kvpairs from [CF={}] [offset={}] [proc_size={}] [write_cf_offset={}] [region_id={}] "
+            "[snapshot_index={}]",
             CFToName(cf),
             (*p_process_keys),
             (*p_process_keys_bytes),

--- a/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.cpp
@@ -241,7 +241,7 @@ void SSTFilesToBlockInputStream::loadCFDataFromSST(
         }
         LOG_DEBUG(
             log,
-            "Done loading all kvpairs, CF={} offset={} processed_size={} write_cf_offset={} region_id={} "
+            "Done loading all kvpairs, CF={} offset={} processed_bytes={} write_cf_offset={} region_id={} "
             "snapshot_index={}",
             CFToName(cf),
             (*p_process_keys),
@@ -261,7 +261,7 @@ void SSTFilesToBlockInputStream::loadCFDataFromSST(
         {
             LOG_DEBUG(
                 log,
-                "Done loading, CF={} offset={} processed_size={} write_cf_offset={} last_loaded_rowkey={} "
+                "Done loading, CF={} offset={} processed_bytes={} write_cf_offset={} last_loaded_rowkey={} "
                 "rowkey_to_be_included={} region_id={} snapshot_index={}",
                 CFToName(cf),
                 (*p_process_keys),

--- a/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.cpp
@@ -241,8 +241,8 @@ void SSTFilesToBlockInputStream::loadCFDataFromSST(
         }
         LOG_DEBUG(
             log,
-            "Done loading all kvpairs from [CF={}] [offset={}] [proc_size={}] [write_cf_offset={}] [region_id={}] "
-            "[snapshot_index={}]",
+            "Done loading all kvpairs, CF={} offset={} processed_size={} write_cf_offset={} region_id={} "
+            "snapshot_index={}",
             CFToName(cf),
             (*p_process_keys),
             (*p_process_keys_bytes),

--- a/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.cpp
@@ -130,9 +130,13 @@ void SSTFilesToBlockInputStream::readPrefix()
         this->region->id(),
         snapshot_index);
 
+    // Init stat info.
     process_keys.default_cf = 0;
     process_keys.write_cf = 0;
     process_keys.lock_cf = 0;
+    process_keys.default_cf_bytes = 0;
+    process_keys.write_cf_bytes = 0;
+    process_keys.lock_cf_bytes = 0;
 }
 
 void SSTFilesToBlockInputStream::readSuffix()
@@ -165,6 +169,7 @@ Block SSTFilesToBlockInputStream::read()
             BaseBuffView value = write_cf_reader->valueView();
             region->insert(ColumnFamilyType::Write, TiKVKey(key.data, key.len), TiKVValue(value.data, value.len));
             ++process_keys.write_cf;
+            process_keys.write_cf_bytes += (key.len + value.len);
             if (process_keys.write_cf % expected_size == 0)
             {
                 loaded_write_cf_key.assign(key.data, key.len);
@@ -202,17 +207,20 @@ void SSTFilesToBlockInputStream::loadCFDataFromSST(
 {
     SSTReader * reader;
     size_t * p_process_keys;
+    size_t * p_process_keys_bytes;
     DecodedTiKVKey * last_loaded_rowkey;
     if (cf == ColumnFamilyType::Default)
     {
         reader = default_cf_reader.get();
         p_process_keys = &process_keys.default_cf;
+        p_process_keys_bytes = &process_keys.default_cf_bytes;
         last_loaded_rowkey = &default_last_loaded_rowkey;
     }
     else if (cf == ColumnFamilyType::Lock)
     {
         reader = lock_cf_reader.get();
         p_process_keys = &process_keys.lock_cf;
+        p_process_keys_bytes = &process_keys.lock_cf_bytes;
         last_loaded_rowkey = &lock_last_loaded_rowkey;
     }
     else
@@ -229,12 +237,14 @@ void SSTFilesToBlockInputStream::loadCFDataFromSST(
             region->insert(cf, TiKVKey(key.data, key.len), TiKVValue(value.data, value.len), DupCheck::AllowSame);
             reader->next();
             (*p_process_keys) += 1;
+            (*p_process_keys_bytes) += (key.len + value.len);
         }
         LOG_DEBUG(
             log,
-            "Done loading all kvpairs from [CF={}] [offset={}] [write_cf_offset={}] [region_id={}] [snapshot_index={}]",
+            "Done loading all kvpairs from [CF={}] [offset={}] [proc_size={}] [write_cf_offset={}] [region_id={}] [snapshot_index={}]",
             CFToName(cf),
             (*p_process_keys),
+            (*p_process_keys_bytes),
             process_keys.write_cf,
             region->id(),
             snapshot_index);
@@ -250,10 +260,11 @@ void SSTFilesToBlockInputStream::loadCFDataFromSST(
         {
             LOG_DEBUG(
                 log,
-                "Done loading from [CF={}] [offset={}] [write_cf_offset={}] [last_loaded_rowkey={}] "
+                "Done loading from [CF={}] [offset={}] [proc_size={}] [write_cf_offset={}] [last_loaded_rowkey={}] "
                 "[rowkey_to_be_included={}] [region_id={}] [snapshot_index={}]",
                 CFToName(cf),
                 (*p_process_keys),
+                (*p_process_keys_bytes),
                 process_keys.write_cf,
                 Redact::keyToDebugString(last_loaded_rowkey->data(), last_loaded_rowkey->size()),
                 (rowkey_to_be_included
@@ -273,6 +284,7 @@ void SSTFilesToBlockInputStream::loadCFDataFromSST(
                 // TODO: use doInsert to avoid locking
                 region->insert(cf, TiKVKey(key.data, key.len), TiKVValue(value.data, value.len));
                 (*p_process_keys) += 1;
+                (*p_process_keys_bytes) += (key.len + value.len);
                 if (*p_process_keys == process_keys_offset_end)
                 {
                     *last_loaded_rowkey = RecordKVFormat::decodeTiKVKey(TiKVKey(key.data, key.len));

--- a/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.cpp
@@ -261,8 +261,8 @@ void SSTFilesToBlockInputStream::loadCFDataFromSST(
         {
             LOG_DEBUG(
                 log,
-                "Done loading from [CF={}] [offset={}] [proc_size={}] [write_cf_offset={}] [last_loaded_rowkey={}] "
-                "[rowkey_to_be_included={}] [region_id={}] [snapshot_index={}]",
+                "Done loading, CF={} offset={} processed_size={} write_cf_offset={} last_loaded_rowkey={} "
+                "rowkey_to_be_included={} region_id={} snapshot_index={}",
                 CFToName(cf),
                 (*p_process_keys),
                 (*p_process_keys_bytes),

--- a/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.h
@@ -81,10 +81,17 @@ public:
         size_t default_cf = 0;
         size_t write_cf = 0;
         size_t lock_cf = 0;
+        size_t default_cf_bytes = 0;
+        size_t write_cf_bytes = 0;
+        size_t lock_cf_bytes = 0;
 
         inline size_t total() const { return default_cf + write_cf + lock_cf; }
+        inline size_t total_bytes() const { return default_cf_bytes + write_cf_bytes + lock_cf_bytes; }
     };
 
+    const ProcessKeys & getProcessKeys() const {
+        return process_keys;
+    }
 private:
     void loadCFDataFromSST(ColumnFamilyType cf, const DecodedTiKVKey * rowkey_to_be_included);
 

--- a/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.h
@@ -81,8 +81,6 @@ public:
         size_t default_cf = 0;
         size_t write_cf = 0;
         size_t lock_cf = 0;
-        // These are bytes we actually read from sst reader.
-        // It doesn't includes rocksdb's space amplification.
         size_t default_cf_bytes = 0;
         size_t write_cf_bytes = 0;
         size_t lock_cf_bytes = 0;

--- a/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.h
@@ -89,9 +89,8 @@ public:
         inline size_t total_bytes() const { return default_cf_bytes + write_cf_bytes + lock_cf_bytes; }
     };
 
-    const ProcessKeys & getProcessKeys() const {
-        return process_keys;
-    }
+    const ProcessKeys & getProcessKeys() const { return process_keys; }
+
 private:
     void loadCFDataFromSST(ColumnFamilyType cf, const DecodedTiKVKey * rowkey_to_be_included);
 

--- a/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.h
@@ -81,6 +81,8 @@ public:
         size_t default_cf = 0;
         size_t write_cf = 0;
         size_t lock_cf = 0;
+        // These are bytes we actually read from sst reader.
+        // It doesn't includes rocksdb's space amplification.
         size_t default_cf_bytes = 0;
         size_t write_cf_bytes = 0;
         size_t lock_cf_bytes = 0;

--- a/dbms/src/Storages/DeltaMerge/SSTFilesToDTFilesOutputStream.h
+++ b/dbms/src/Storages/DeltaMerge/SSTFilesToDTFilesOutputStream.h
@@ -96,6 +96,9 @@ public:
 
     bool isAbort() const { return abort_flag->load(std::memory_order_seq_cst); }
 
+    size_t getTotalCommittedBytes() const { return total_committed_bytes; }
+    size_t getTotalBytesOnDisk() const { return total_bytes_on_disk; }
+
 private:
     /**
      * Generate a DMFilePtr and its DMFileBlockOutputStream.

--- a/dbms/src/Storages/KVStore/Decode/RegionDataRead.h
+++ b/dbms/src/Storages/KVStore/Decode/RegionDataRead.h
@@ -14,8 +14,8 @@
 
 #pragma once
 
-#include <Storages/KVStore/Decode/DecodedTiKVKeyValue.h>
 #include <Storages/DeltaMerge/ExternalDTFileInfo.h>
+#include <Storages/KVStore/Decode/DecodedTiKVKeyValue.h>
 
 #include <list>
 
@@ -26,9 +26,11 @@ using RegionDataReadInfo = std::tuple<RawTiDBPK, UInt8, Timestamp, std::shared_p
 
 using RegionDataReadInfoList = std::vector<RegionDataReadInfo>;
 
-struct PrehandleResult {
+struct PrehandleResult
+{
     std::vector<DM::ExternalDTFileInfo> ingest_ids;
-    struct Stats {
+    struct Stats
+    {
         size_t raft_snapshot_bytes;
         size_t dt_disk_bytes;
         size_t dt_total_bytes;

--- a/dbms/src/Storages/KVStore/Decode/RegionDataRead.h
+++ b/dbms/src/Storages/KVStore/Decode/RegionDataRead.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <Storages/KVStore/Decode/DecodedTiKVKeyValue.h>
+#include <Storages/DeltaMerge/ExternalDTFileInfo.h>
 
 #include <list>
 
@@ -25,4 +26,13 @@ using RegionDataReadInfo = std::tuple<RawTiDBPK, UInt8, Timestamp, std::shared_p
 
 using RegionDataReadInfoList = std::vector<RegionDataReadInfo>;
 
+struct PrehandleResult {
+    std::vector<DM::ExternalDTFileInfo> ingest_ids;
+    struct Stats {
+        size_t raft_snapshot_bytes;
+        size_t dt_disk_bytes;
+        size_t dt_total_bytes;
+    };
+    Stats stats;
+};
 } // namespace DB

--- a/dbms/src/Storages/KVStore/Decode/RegionDataRead.h
+++ b/dbms/src/Storages/KVStore/Decode/RegionDataRead.h
@@ -31,6 +31,8 @@ struct PrehandleResult
     std::vector<DM::ExternalDTFileInfo> ingest_ids;
     struct Stats
     {
+        // These are bytes we actually read from sst reader.
+        // It doesn't includes rocksdb's space amplification.
         size_t raft_snapshot_bytes;
         size_t dt_disk_bytes;
         size_t dt_total_bytes;

--- a/dbms/src/Storages/KVStore/FFI/ProxyFFI.cpp
+++ b/dbms/src/Storages/KVStore/FFI/ProxyFFI.cpp
@@ -629,11 +629,11 @@ struct PreHandledSnapshotWithFiles
     ~PreHandledSnapshotWithFiles()
     {
         CurrentMetrics::sub(CurrentMetrics::RaftNumSnapshotsPendingApply);
-        GET_METRIC(tiflash_raft_ongoing_snapshot_total_size, type_raft_snapshot)
+        GET_METRIC(tiflash_raft_ongoing_snapshot_total_bytes, type_raft_snapshot)
             .Decrement(prehandle_result.stats.raft_snapshot_bytes);
-        GET_METRIC(tiflash_raft_ongoing_snapshot_total_size, type_dt_on_disk)
+        GET_METRIC(tiflash_raft_ongoing_snapshot_total_bytes, type_dt_on_disk)
             .Decrement(prehandle_result.stats.dt_disk_bytes);
-        GET_METRIC(tiflash_raft_ongoing_snapshot_total_size, type_dt_total)
+        GET_METRIC(tiflash_raft_ongoing_snapshot_total_bytes, type_dt_total)
             .Decrement(prehandle_result.stats.dt_total_bytes);
     }
     PreHandledSnapshotWithFiles(const RegionPtr & region_, PrehandleResult && prehandle_result_)
@@ -641,11 +641,11 @@ struct PreHandledSnapshotWithFiles
         , prehandle_result(std::move(prehandle_result_))
     {
         CurrentMetrics::add(CurrentMetrics::RaftNumSnapshotsPendingApply);
-        GET_METRIC(tiflash_raft_ongoing_snapshot_total_size, type_raft_snapshot)
+        GET_METRIC(tiflash_raft_ongoing_snapshot_total_bytes, type_raft_snapshot)
             .Increment(prehandle_result.stats.raft_snapshot_bytes);
-        GET_METRIC(tiflash_raft_ongoing_snapshot_total_size, type_dt_on_disk)
+        GET_METRIC(tiflash_raft_ongoing_snapshot_total_bytes, type_dt_on_disk)
             .Increment(prehandle_result.stats.dt_disk_bytes);
-        GET_METRIC(tiflash_raft_ongoing_snapshot_total_size, type_dt_total)
+        GET_METRIC(tiflash_raft_ongoing_snapshot_total_bytes, type_dt_total)
             .Increment(prehandle_result.stats.dt_total_bytes);
     }
     RegionPtr region;

--- a/dbms/src/Storages/KVStore/FFI/ProxyFFI.cpp
+++ b/dbms/src/Storages/KVStore/FFI/ProxyFFI.cpp
@@ -627,14 +627,14 @@ RawRustPtrWrap::RawRustPtrWrap(RawRustPtrWrap && src)
 struct PreHandledSnapshotWithFiles
 {
     ~PreHandledSnapshotWithFiles() { CurrentMetrics::sub(CurrentMetrics::RaftNumSnapshotsPendingApply); }
-    PreHandledSnapshotWithFiles(const RegionPtr & region_, std::vector<DM::ExternalDTFileInfo> && external_files_)
+    PreHandledSnapshotWithFiles(const RegionPtr & region_, PrehandleResult && prehandle_result_)
         : region(region_)
-        , external_files(std::move(external_files_))
+        , prehandle_result(std::move(prehandle_result_))
     {
         CurrentMetrics::add(CurrentMetrics::RaftNumSnapshotsPendingApply);
     }
     RegionPtr region;
-    std::vector<DM::ExternalDTFileInfo> external_files; // The file_ids storing pre-handled files
+    PrehandleResult prehandle_result; // The file_ids storing pre-handled files
 };
 
 RawCppPtr PreHandleSnapshot(
@@ -663,8 +663,8 @@ RawCppPtr PreHandleSnapshot(
 
         // Pre-decode and save as DTFiles
         // TODO Forward deadline_index when TiKV supports.
-        auto ingest_ids = kvstore->preHandleSnapshotToFiles(new_region, snaps, index, term, std::nullopt, tmt);
-        auto * res = new PreHandledSnapshotWithFiles{new_region, std::move(ingest_ids)};
+        auto prehandle_result = kvstore->preHandleSnapshotToFiles(new_region, snaps, index, term, std::nullopt, tmt);
+        auto * res = new PreHandledSnapshotWithFiles{new_region, std::move(prehandle_result)};
         return GenRawCppPtr(res, RawCppPtrTypeImpl::PreHandledSnapshotWithFiles);
     }
     catch (...)
@@ -685,7 +685,7 @@ void ApplyPreHandledSnapshot(EngineStoreServerWrap * server, RawVoidPtr res, Raw
         {
             auto & kvstore = server->tmt->getKVStore();
             kvstore->applyPreHandledSnapshot(
-                RegionPtrWithSnapshotFiles{snap->region, std::move(snap->external_files)},
+                RegionPtrWithSnapshotFiles{snap->region, std::move(snap->prehandle_result.ingest_ids)},
                 *server->tmt);
         }
         catch (...)
@@ -719,7 +719,7 @@ void ReleasePreHandledSnapshot(EngineStoreServerWrap * server, RawVoidPtr res, R
     auto * snap = reinterpret_cast<PreHandledSnapshotWithFiles *>(res);
     try
     {
-        auto s = RegionPtrWithSnapshotFiles{snap->region, std::move(snap->external_files)};
+        auto s = RegionPtrWithSnapshotFiles{snap->region, std::move(snap->prehandle_result.ingest_ids)};
         auto & kvstore = server->tmt->getKVStore();
         kvstore->releasePreHandledSnapshot(s, *server->tmt);
     }

--- a/dbms/src/Storages/KVStore/KVStore.h
+++ b/dbms/src/Storages/KVStore/KVStore.h
@@ -171,7 +171,7 @@ public:
 
     // For Raftstore V2, there could be some orphan keys in the write column family being left to `new_region` after pre-handled.
     // All orphan write keys are asserted to be replayed before reaching `deadline_index`.
-    std::vector<DM::ExternalDTFileInfo> preHandleSnapshotToFiles(
+    PrehandleResult preHandleSnapshotToFiles(
         RegionPtr new_region,
         SSTViewVec,
         uint64_t index,
@@ -277,7 +277,7 @@ private:
     StoreMeta & getStore();
     const StoreMeta & getStore() const;
 
-    std::vector<DM::ExternalDTFileInfo> preHandleSSTsToDTFiles(
+    PrehandleResult preHandleSSTsToDTFiles(
         RegionPtr new_region,
         const SSTViewVec,
         uint64_t index,

--- a/dbms/src/Storages/KVStore/MultiRaft/ApplySnapshot.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/ApplySnapshot.cpp
@@ -210,6 +210,8 @@ void KVStore::onSnapshot(
                 }
                 else
                 {
+                    // It is only for debug usage now.
+                    static_assert(std::is_same_v<RegionPtrWrap, RegionPtrWithBlock>);
                     // Call `deleteRange` to delete data for range
                     dm_storage->deleteRange(new_key_range, context.getSettingsRef());
                 }
@@ -438,11 +440,10 @@ PrehandleResult KVStore::preHandleSSTsToDTFiles(
                 stream->cancel();
             }
             prehandle_result.ingest_ids = stream->outputFiles();
-            prehandle_result.stats = PrehandleResult::Stats {
+            prehandle_result.stats = PrehandleResult::Stats{
                 sst_stream->getProcessKeys().total_bytes(),
                 stream->getTotalCommittedBytes(),
-                stream->getTotalBytesOnDisk()
-            };
+                stream->getTotalBytesOnDisk()};
 
             (void)table_drop_lock; // the table should not be dropped during ingesting file
             break;
@@ -702,7 +703,8 @@ RegionPtr KVStore::handleIngestSSTByDTFile(
     PrehandleResult prehandle_result;
     try
     {
-        prehandle_result = preHandleSSTsToDTFiles(tmp_region, snaps, index, term, DM::FileConvertJobType::IngestSST, tmt);
+        prehandle_result
+            = preHandleSSTsToDTFiles(tmp_region, snaps, index, term, DM::FileConvertJobType::IngestSST, tmt);
     }
     catch (DB::Exception & e)
     {

--- a/dbms/src/Storages/KVStore/MultiRaft/ApplySnapshot.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/ApplySnapshot.cpp
@@ -441,9 +441,9 @@ PrehandleResult KVStore::preHandleSSTsToDTFiles(
             }
             prehandle_result.ingest_ids = stream->outputFiles();
             prehandle_result.stats = PrehandleResult::Stats{
-                sst_stream->getProcessKeys().total_bytes(),
-                stream->getTotalCommittedBytes(),
-                stream->getTotalBytesOnDisk()};
+                .raft_snapshot_bytes = sst_stream->getProcessKeys().total_bytes(),
+                .dt_disk_bytes = stream->getTotalBytesOnDisk(),
+                .dt_total_bytes = stream->getTotalCommittedBytes()};
 
             (void)table_drop_lock; // the table should not be dropped during ingesting file
             break;

--- a/dbms/src/Storages/KVStore/tests/gtest_kvstore.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_kvstore.cpp
@@ -1195,9 +1195,9 @@ try
                 RecordKVFormat::genKey(table_id, 50),
                 RecordKVFormat::genKey(table_id, 100),
                 kvs.getProxyHelper());
-            auto ingest_ids = kvs.preHandleSnapshotToFiles(region, {}, 9, 5, std::nullopt, ctx.getTMTContext());
+            auto prehandle_result = kvs.preHandleSnapshotToFiles(region, {}, 9, 5, std::nullopt, ctx.getTMTContext());
             kvs.checkAndApplyPreHandledSnapshot<RegionPtrWithSnapshotFiles>(
-                RegionPtrWithSnapshotFiles{region, std::move(ingest_ids)},
+                RegionPtrWithSnapshotFiles{region, std::move(prehandle_result.ingest_ids)},
                 ctx.getTMTContext());
             auto region_applied_22 = kvs.getRegion(22);
             ASSERT_NE(region_applied_22, nullptr);
@@ -1212,9 +1212,9 @@ try
                 RecordKVFormat::genKey(table_id, 50),
                 RecordKVFormat::genKey(table_id, 100),
                 kvs.getProxyHelper());
-            auto ingest_ids = kvs.preHandleSnapshotToFiles(region, {}, 9, 5, std::nullopt, ctx.getTMTContext());
+            auto prehandle_result = kvs.preHandleSnapshotToFiles(region, {}, 9, 5, std::nullopt, ctx.getTMTContext());
             kvs.checkAndApplyPreHandledSnapshot<RegionPtrWithSnapshotFiles>(
-                RegionPtrWithSnapshotFiles{region, std::move(ingest_ids)},
+                RegionPtrWithSnapshotFiles{region, std::move(prehandle_result.ingest_ids)},
                 ctx.getTMTContext()); // overlap, but not tombstone
             ASSERT_TRUE(false);
         }
@@ -1237,10 +1237,10 @@ try
                 RecordKVFormat::genKey(table_id, 100),
                 kvs.getProxyHelper());
             // preHandleSnapshotToFiles will assert proxy_ptr is not null.
-            auto ingest_ids = kvs.preHandleSnapshotToFiles(region, {}, 10, 5, std::nullopt, ctx.getTMTContext());
+            auto prehandle_result = kvs.preHandleSnapshotToFiles(region, {}, 10, 5, std::nullopt, ctx.getTMTContext());
             proxy_helper->proxy_ptr.inner = nullptr;
             kvs.checkAndApplyPreHandledSnapshot<RegionPtrWithSnapshotFiles>(
-                RegionPtrWithSnapshotFiles{region, std::move(ingest_ids)},
+                RegionPtrWithSnapshotFiles{region, std::move(prehandle_result.ingest_ids)},
                 ctx.getTMTContext());
             ASSERT_TRUE(false);
         }
@@ -1262,9 +1262,9 @@ try
             RecordKVFormat::genKey(table_id, 50),
             RecordKVFormat::genKey(table_id, 100),
             kvs.getProxyHelper());
-        auto ingest_files = kvs.preHandleSnapshotToFiles(region, {}, 10, 5, std::nullopt, ctx.getTMTContext());
+        auto prehandle_result = kvs.preHandleSnapshotToFiles(region, {}, 10, 5, std::nullopt, ctx.getTMTContext());
         kvs.checkAndApplyPreHandledSnapshot<RegionPtrWithSnapshotFiles>(
-            RegionPtrWithSnapshotFiles{region, std::move(ingest_files)},
+            RegionPtrWithSnapshotFiles{region, std::move(prehandle_result.ingest_ids)},
             ctx.getTMTContext()); // overlap, tombstone, remove previous one
 
         auto state = proxy_helper->getRegionLocalState(22);

--- a/metrics/grafana/tiflash_summary.json
+++ b/metrics/grafana/tiflash_summary.json
@@ -52,7 +52,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1694430080744,
+  "iteration": 1694697238872,
   "links": [],
   "panels": [
     {
@@ -11170,7 +11170,7 @@
             },
             {
               "exemplar": true,
-              "expr": "sum(delta(tiflash_raft_raft_log_gap_count_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", type=~\"unflushed_applied_index\"}[1m])) by (le, type)",
+              "expr": "sum(delta(tiflash_raft_raft_log_gap_count_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", type=~\"compact_index\"}[1m])) by (le, type)",
               "hide": false,
               "interval": "",
               "legendFormat": "{{le}}",
@@ -11299,7 +11299,7 @@
           "gridPos": {
             "h": 7,
             "w": 12,
-            "x": 6,
+            "x": 0,
             "y": 65
           },
           "heatmap": {},
@@ -11358,6 +11358,105 @@
           "yBucketBound": "upper",
           "yBucketNumber": null,
           "yBucketSize": null
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 65
+          },
+          "hiddenSeries": false,
+          "id": 249,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.11",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(rate(tiflash_raft_ongoing_snapshot_total_size{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[$__rate_interval])) by (type)",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "{{le}}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Ongoing raft snapshot",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "bytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
           "aliasColors": {},
@@ -16106,150 +16205,149 @@
         "y": 13
       },
       "id": 248,
-      "panels": [],
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Metas of resource group",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 14
+          },
+          "hiddenSeries": false,
+          "id": 246,
+          "legend": {
+            "alignAsTable": false,
+            "avg": true,
+            "current": true,
+            "hideEmpty": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.11",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "max(tiflash_resource_group{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=\"remaining_tokens\", instance=~\"$instance\"}) by (instance,resource_group)",
+              "interval": "",
+              "legendFormat": "{{instance}}-{{resource_group}}",
+              "queryType": "randomWalk",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "max(tiflash_resource_group{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=\"avg_speed\", instance=~\"$instance\"}) by (instance,resource_group)",
+              "hide": true,
+              "interval": "",
+              "legendFormat": "{{instance}}-{{resource_group}}",
+              "refId": "B"
+            },
+            {
+              "exemplar": true,
+              "expr": "max(tiflash_resource_group{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=\"total_consumption\", instance=~\"$instance\"}) by (instance,resource_group)",
+              "hide": true,
+              "interval": "",
+              "legendFormat": "{{instance}}-{{resource_group}}",
+              "refId": "C"
+            },
+            {
+              "exemplar": true,
+              "expr": "max(tiflash_resource_group{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=\"bucket_fill_rate\", instance=~\"$instance\"}) by (instance,resource_group)",
+              "hide": true,
+              "interval": "",
+              "legendFormat": "{{instance}}-{{resource_group}}",
+              "refId": "D"
+            },
+            {
+              "exemplar": true,
+              "expr": "max(tiflash_resource_group{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=\"bucket_capacity\", instance=~\"$instance\"}) by (instance,resource_group)",
+              "hide": true,
+              "interval": "",
+              "legendFormat": "{{instance}}-{{resource_group}}",
+              "refId": "E"
+            },
+            {
+              "exemplar": true,
+              "expr": "max(tiflash_resource_group{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=\"fetch_tokens_from_gac_count\", instance=~\"$instance\"}) by (instance,resource_group)",
+              "hide": true,
+              "interval": "",
+              "legendFormat": "{{instance}}-{{resource_group}}",
+              "refId": "F"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "TiFlash Resource Group",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
       "title": "TiFlash Resource Control",
       "type": "row"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "${DS_TEST-CLUSTER}",
-      "description": "Metas of resource group",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 14
-      },
-      "hiddenSeries": false,
-      "id": 246,
-      "legend": {
-        "alignAsTable": false,
-        "avg": true,
-        "current": true,
-        "hideEmpty": false,
-        "max": false,
-        "min": false,
-        "rightSide": true,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.5.11",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "max(tiflash_resource_group{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=\"remaining_tokens\", instance=~\"$instance\"}) by (instance,resource_group)",
-          "interval": "",
-          "legendFormat": "{{instance}}-{{resource_group}}",
-          "queryType": "randomWalk",
-          "refId": "A"
-        },
-        {
-          "exemplar": true,
-          "expr": "max(tiflash_resource_group{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=\"avg_speed\", instance=~\"$instance\"}) by (instance,resource_group)",
-          "hide": true,
-          "interval": "",
-          "legendFormat": "{{instance}}-{{resource_group}}",
-          "refId": "B"
-        },
-        {
-          "exemplar": true,
-          "expr": "max(tiflash_resource_group{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=\"total_consumption\", instance=~\"$instance\"}) by (instance,resource_group)",
-          "hide": true,
-          "interval": "",
-          "legendFormat": "{{instance}}-{{resource_group}}",
-          "refId": "C"
-        },
-        {
-          "exemplar": true,
-          "expr": "max(tiflash_resource_group{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=\"bucket_fill_rate\", instance=~\"$instance\"}) by (instance,resource_group)",
-          "hide": true,
-          "interval": "",
-          "legendFormat": "{{instance}}-{{resource_group}}",
-          "refId": "D"
-        },
-        {
-          "exemplar": true,
-          "expr": "max(tiflash_resource_group{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=\"bucket_capacity\", instance=~\"$instance\"}) by (instance,resource_group)",
-          "hide": true,
-          "interval": "",
-          "legendFormat": "{{instance}}-{{resource_group}}",
-          "refId": "E"
-        },
-        {
-          "exemplar": true,
-          "expr": "max(tiflash_resource_group{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=\"fetch_tokens_from_gac_count\", instance=~\"$instance\"}) by (instance,resource_group)",
-          "hide": true,
-          "interval": "",
-          "legendFormat": "{{instance}}-{{resource_group}}",
-          "refId": "F"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "TiFlash Resource Group",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:377",
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:378",
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
     }
   ],
   "refresh": "30s",

--- a/metrics/grafana/tiflash_summary.json
+++ b/metrics/grafana/tiflash_summary.json
@@ -11408,7 +11408,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(rate(tiflash_raft_ongoing_snapshot_total_size{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[$__rate_interval])) by (type)",
+              "expr": "sum(rate(tiflash_raft_ongoing_snapshot_total_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[$__rate_interval])) by (type)",
               "format": "time_series",
               "hide": false,
               "interval": "",

--- a/metrics/grafana/tiflash_summary.json
+++ b/metrics/grafana/tiflash_summary.json
@@ -11170,7 +11170,7 @@
             },
             {
               "exemplar": true,
-              "expr": "sum(delta(tiflash_raft_raft_log_gap_count_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", type=~\"compact_index\"}[1m])) by (le, type)",
+              "expr": "sum(delta(tiflash_raft_raft_log_gap_count_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", type=~\"unflushed_applied_index\"}[1m])) by (le, type)",
               "hide": false,
               "interval": "",
               "legendFormat": "{{le}}",


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #7777

Problem Summary:

1. change type_apply_snapshot_predecode and type_apply_snapshot_predecode_sst2dt from order 10 to order 15.
2. add a metric to observe all ongoing snapshot size on disk.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
