### PR TITLE
Fix MPPTask hang introduced by #8064

### DIFF
--- a/dbms/src/DataStreams/ParallelAggregatingBlockInputStream.cpp
+++ b/dbms/src/DataStreams/ParallelAggregatingBlockInputStream.cpp
@@ -218,7 +218,7 @@ void ParallelAggregatingBlockInputStream::execute()
     exceptions.resize(max_threads);
 
     for (size_t i = 0; i < max_threads; ++i)
-        threads_data.emplace_back();
+        threads_data.emplace_back(&aggregator);
     aggregator.initThresholdByAggregatedDataVariantsSize(many_data.size());
 
     LOG_TRACE(log, "Aggregating");

--- a/dbms/src/DataStreams/ParallelAggregatingBlockInputStream.h
+++ b/dbms/src/DataStreams/ParallelAggregatingBlockInputStream.h
@@ -79,7 +79,11 @@ private:
     {
         size_t src_rows = 0;
         size_t src_bytes = 0;
-        Aggregator::AggProcessInfo agg_process_info{};
+        Aggregator::AggProcessInfo agg_process_info;
+
+        ThreadData(Aggregator * aggregator)
+            : agg_process_info(aggregator)
+        {}
     };
 
     std::vector<ThreadData> threads_data;

--- a/dbms/src/Interpreters/Aggregator.cpp
+++ b/dbms/src/Interpreters/Aggregator.cpp
@@ -856,7 +856,7 @@ void Aggregator::prepareAggregateInstructions(
     }
 }
 
-void Aggregator::AggProcessInfo::prepareForAgg(Aggregator * aggregator)
+void Aggregator::AggProcessInfo::prepareForAgg()
 {
     if (prepare_for_agg_done)
         return;
@@ -909,7 +909,7 @@ bool Aggregator::executeOnBlock(AggProcessInfo & agg_process_info, AggregatedDat
         LOG_TRACE(log, "Aggregation method: `{}`", result.getMethodName());
     }
 
-    agg_process_info.prepareForAgg(this);
+    agg_process_info.prepareForAgg();
 
     if (is_cancelled())
         return true;
@@ -1137,7 +1137,7 @@ void Aggregator::execute(const BlockInputStreamPtr & stream, AggregatedDataVaria
 
     size_t src_rows = 0;
     size_t src_bytes = 0;
-    AggProcessInfo agg_process_info;
+    AggProcessInfo agg_process_info(this);
 
     /// Read all the data
     while (Block block = stream->read())

--- a/dbms/src/Interpreters/Aggregator.h
+++ b/dbms/src/Interpreters/Aggregator.h
@@ -1175,7 +1175,6 @@ public:
             block = block_;
             start_row = 0;
             end_row = 0;
-            aggregator = nullptr;
             materialized_columns.clear();
             prepare_for_agg_done = false;
         }

--- a/dbms/src/Operators/AggregateContext.cpp
+++ b/dbms/src/Operators/AggregateContext.cpp
@@ -27,17 +27,16 @@ void AggregateContext::initBuild(
     max_threads = max_threads_;
     empty_result_for_aggregation_by_empty_set = params.empty_result_for_aggregation_by_empty_set;
     keys_size = params.keys_size;
+    aggregator = std::make_unique<Aggregator>(params, log->identifier(), max_threads, register_operator_spill_context);
+    aggregator->setCancellationHook(is_cancelled);
+    aggregator->initThresholdByAggregatedDataVariantsSize(max_threads);
     many_data.reserve(max_threads);
     threads_data.reserve(max_threads);
     for (size_t i = 0; i < max_threads; ++i)
     {
-        threads_data.emplace_back(std::make_unique<ThreadData>());
+        threads_data.emplace_back(std::make_unique<ThreadData>(aggregator.get()));
         many_data.emplace_back(std::make_shared<AggregatedDataVariants>());
     }
-
-    aggregator = std::make_unique<Aggregator>(params, log->identifier(), max_threads, register_operator_spill_context);
-    aggregator->setCancellationHook(is_cancelled);
-    aggregator->initThresholdByAggregatedDataVariantsSize(many_data.size());
     status = AggStatus::build;
     build_watch.emplace();
     LOG_TRACE(log, "Aggregate Context inited");

--- a/dbms/src/Operators/AggregateContext.h
+++ b/dbms/src/Operators/AggregateContext.h
@@ -27,7 +27,10 @@ struct ThreadData
     size_t src_rows = 0;
     size_t src_bytes = 0;
 
-    Aggregator::AggProcessInfo agg_process_info{};
+    Aggregator::AggProcessInfo agg_process_info;
+    ThreadData(Aggregator * aggregator)
+        : agg_process_info(aggregator)
+    {}
 };
 
 /// Aggregated data shared between AggBuild and AggConvergent Pipeline.

--- a/tests/fullstack-test2/ddl/alter_partition_by.test
+++ b/tests/fullstack-test2/ddl/alter_partition_by.test
@@ -137,7 +137,7 @@ id	estRows	task	access object	operator info
 StreamAgg	1.00	root		funcs:count(Column#16)->Column#4
 └─IndexReader	1.00	root	partition:p0	index:StreamAgg
 └─StreamAgg	1.00	cop[tikv]		funcs:count(1)->Column#16
-└─IndexFullScan	16.00	cop[tikv]	table:t2, index:b(b)	keep order:false
+└─IndexFullScan	16.00	cop[tikv]	table:t2	keep order:false
 
 mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t2]) */ count(*) from test.t2 partition (p0);
 +----------+

--- a/tests/fullstack-test2/ddl/alter_partition_by.test
+++ b/tests/fullstack-test2/ddl/alter_partition_by.test
@@ -132,13 +132,6 @@ mysql> drop table test.t;
 mysql> alter table test.t2 partition by hash (a) partitions 3;
 mysql> analyze table test.t2;
 
-mysql> explain format='brief' select /*+ READ_FROM_STORAGE(TIFLASH[t2]) */ count(*) from test.t2 partition (p0);
-id	estRows	task	access object	operator info
-StreamAgg	1.00	root		funcs:count(Column#16)->Column#4
-└─IndexReader	1.00	root	partition:p0	index:StreamAgg
-└─StreamAgg	1.00	cop[tikv]		funcs:count(1)->Column#16
-└─IndexFullScan	16.00	cop[tikv]	table:t2	keep order:false
-
 mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t2]) */ count(*) from test.t2 partition (p0);
 +----------+
 | count(*) |


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #7738

Problem Summary:

### What is changed and how it works?
In #8064, it use a `while` loop to handle aggregate input block, like 
https://github.com/pingcap/tiflash/blob/f6e8ffa5b76768c307368e45f7e668f78c1a1e71/dbms/src/DataStreams/ParallelAggregatingBlockInputStream.cpp#L150-L155

while, unfortunately, both the while loop and `allBlockDataHandled()` does not aware that the agg is cancelled, so it may cause hang.
This pr makes `AggProcessInfo` aware the cancellation of current aggregator. 
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
