### PR TITLE
*: Fix max snapshot lifetime is now shown on Grafana

### DIFF
--- a/dbms/src/Interpreters/AsynchronousMetrics.cpp
+++ b/dbms/src/Interpreters/AsynchronousMetrics.cpp
@@ -30,6 +30,7 @@
 #include <Storages/KVStore/TMTContext.h>
 #include <Storages/MarkCache.h>
 #include <Storages/Page/FileUsage.h>
+#include <Storages/Page/PageConstants.h>
 #include <Storages/Page/PageStorage.h>
 #include <Storages/Page/V3/Universal/UniversalPageStorageService.h>
 #include <Storages/StorageDeltaMerge.h>
@@ -242,23 +243,60 @@ void AsynchronousMetrics::update()
                 {
                     if (auto store = dt_storage->getStoreIfInited(); store)
                     {
-                        auto stat = store->getStoreStats();
-                        calculateMax(
-                            max_dt_stable_oldest_snapshot_lifetime,
-                            stat.storage_stable_oldest_snapshot_lifetime);
-                        calculateMax(
-                            max_dt_delta_oldest_snapshot_lifetime,
-                            stat.storage_delta_oldest_snapshot_lifetime);
-                        calculateMax(max_dt_meta_oldest_snapshot_lifetime, stat.storage_meta_oldest_snapshot_lifetime);
+                        const auto stat = store->getStoreStats();
+                        if (context.getPageStorageRunMode() == PageStorageRunMode::ONLY_V2)
+                        {
+                            calculateMax(
+                                max_dt_stable_oldest_snapshot_lifetime,
+                                stat.storage_stable_oldest_snapshot_lifetime);
+                            calculateMax(
+                                max_dt_delta_oldest_snapshot_lifetime,
+                                stat.storage_delta_oldest_snapshot_lifetime);
+                            calculateMax(
+                                max_dt_meta_oldest_snapshot_lifetime,
+                                stat.storage_meta_oldest_snapshot_lifetime);
+                        }
                         calculateMax(max_dt_background_tasks_length, stat.background_tasks_length);
                     }
                 }
             }
         }
 
-        set("MaxDTStableOldestSnapshotLifetime", max_dt_stable_oldest_snapshot_lifetime);
-        set("MaxDTDeltaOldestSnapshotLifetime", max_dt_delta_oldest_snapshot_lifetime);
-        set("MaxDTMetaOldestSnapshotLifetime", max_dt_meta_oldest_snapshot_lifetime);
+        switch (context.getPageStorageRunMode())
+        {
+        case PageStorageRunMode::ONLY_V2:
+        {
+            set("MaxDTStableOldestSnapshotLifetime", max_dt_stable_oldest_snapshot_lifetime);
+            set("MaxDTDeltaOldestSnapshotLifetime", max_dt_delta_oldest_snapshot_lifetime);
+            set("MaxDTMetaOldestSnapshotLifetime", max_dt_meta_oldest_snapshot_lifetime);
+            break;
+        }
+        case PageStorageRunMode::ONLY_V3:
+        case PageStorageRunMode::MIX_MODE:
+        {
+            if (auto global_storage_pool = context.getGlobalStoragePool(); global_storage_pool)
+            {
+                const auto log_snap_stat = global_storage_pool->log_storage->getSnapshotsStat();
+                const auto meta_snap_stat = global_storage_pool->meta_storage->getSnapshotsStat();
+                const auto data_snap_stat = global_storage_pool->data_storage->getSnapshotsStat();
+                set("MaxDTDeltaOldestSnapshotLifetime", log_snap_stat.longest_living_seconds);
+                set("MaxDTMetaOldestSnapshotLifetime", meta_snap_stat.longest_living_seconds);
+                set("MaxDTStableOldestSnapshotLifetime", data_snap_stat.longest_living_seconds);
+            }
+            break;
+        }
+        case PageStorageRunMode::UNI_PS:
+        {
+            if (auto uni_ps = context.tryGetWriteNodePageStorage(); uni_ps != nullptr)
+            {
+                // Only set delta snapshot lifetime when UniPS is enabled
+                const auto snap_stat = uni_ps->getSnapshotsStat();
+                set("MaxDTDeltaOldestSnapshotLifetime", snap_stat.longest_living_seconds);
+            }
+            break;
+        }
+        }
+
         set("MaxDTBackgroundTasksLength", max_dt_background_tasks_length);
     }
 

--- a/dbms/src/Storages/KVStore/TMTContext.cpp
+++ b/dbms/src/Storages/KVStore/TMTContext.cpp
@@ -91,7 +91,7 @@ void checkLongLiveMPPTasks(const std::unordered_map<String, Stopwatch> & monitor
     }
 
     if (!log_info.empty())
-        LOG_INFO(log, log_info);
+        LOG_WARNING(log, log_info);
     GET_METRIC(tiflash_mpp_task_monitor, type_longest_live_time).Set(longest_live_time);
 }
 

--- a/tests/fullstack-test2/ddl/alter_partition_by.test
+++ b/tests/fullstack-test2/ddl/alter_partition_by.test
@@ -132,13 +132,6 @@ mysql> drop table test.t;
 mysql> alter table test.t2 partition by hash (a) partitions 3;
 mysql> analyze table test.t2;
 
-mysql> explain format='brief' select /*+ READ_FROM_STORAGE(TIFLASH[t2]) */ count(*) from test.t2 partition (p0);
-id	estRows	task	access object	operator info
-StreamAgg	1.00	root		funcs:count(Column#16)->Column#4
-└─TableReader	1.00	root	partition:p0	index:StreamAgg
-└─StreamAgg	1.00	cop[tikv]		funcs:count(1)->Column#16
-└─IndexFullScan	16.00	cop[tikv]	table:t2	keep order:false
-
 mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t2]) */ count(*) from test.t2 partition (p0);
 +----------+
 | count(*) |

--- a/tests/fullstack-test2/ddl/alter_partition_by.test
+++ b/tests/fullstack-test2/ddl/alter_partition_by.test
@@ -135,9 +135,9 @@ mysql> analyze table test.t2;
 mysql> explain format='brief' select /*+ READ_FROM_STORAGE(TIFLASH[t2]) */ count(*) from test.t2 partition (p0);
 id	estRows	task	access object	operator info
 StreamAgg	1.00	root		funcs:count(Column#16)->Column#4
-└─IndexReader	1.00	root	partition:p0	index:StreamAgg
+└─TableReader	1.00	root	partition:p0	index:StreamAgg
 └─StreamAgg	1.00	cop[tikv]		funcs:count(1)->Column#16
-└─IndexFullScan	16.00	cop[tikv]	table:t2, index:b(b)	keep order:false
+└─IndexFullScan	16.00	cop[tikv]	table:t2	keep order:false
 
 mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t2]) */ count(*) from test.t2 partition (p0);
 +----------+


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/7713

Problem Summary:

After https://github.com/pingcap/tiflash/pull/7706, when PS V3 or UniPS is enabled, the metrics of max snapshot lifetime is always reported to prometheus as 0.

### What is changed and how it works?

When PS V3 or UniPS is enabled, get and report the metrics in `AsynchronousMetrics::update`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  * Block the queries by using `DBGInvoke disable_fail_point(hang_in_execution)` through `tiflash client`
  * We can see that the max snapshot lifetime is reported normally on Grafana
![image](https://github.com/pingcap/tiflash/assets/4865550/a70588c5-8d81-4328-8347-77eaae2334f7)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
