### PR TITLE
Sort raft snapshot related utils into different modules

### DIFF
--- a/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/SSTFilesToBlockInputStream.h
@@ -125,6 +125,7 @@ private:
 
 // Bound the blocks read from SSTFilesToBlockInputStream by column `_tidb_rowid` and
 // do some calculation for the `DMFileWriter::BlockProperty` of read blocks.
+// Equals to PKSquashingBlockInputStream + DMVersionFilterBlockInputStream<COMPACT>
 class BoundedSSTFilesToBlockInputStream final
 {
 public:

--- a/dbms/src/Storages/KVStore/MultiRaft/ApplySnapshot.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/ApplySnapshot.cpp
@@ -16,21 +16,13 @@
 #include <Common/TiFlashMetrics.h>
 #include <Common/setThreadName.h>
 #include <Interpreters/Context.h>
-#include <Storages/DeltaMerge/SSTFilesToBlockInputStream.h>
-#include <Storages/DeltaMerge/SSTFilesToDTFilesOutputStream.h>
-#include <Storages/KVStore/Decode/PartitionStreams.h>
 #include <Storages/KVStore/Decode/RegionTable.h>
 #include <Storages/KVStore/FFI/ProxyFFI.h>
-#include <Storages/KVStore/FFI/SSTReader.h>
 #include <Storages/KVStore/KVStore.h>
 #include <Storages/KVStore/Region.h>
 #include <Storages/KVStore/TMTContext.h>
-#include <Storages/KVStore/TiKVHelpers/PDTiKVClient.h>
-#include <Storages/KVStore/Types.h>
 #include <Storages/StorageDeltaMerge.h>
 #include <Storages/StorageDeltaMergeHelpers.h>
-#include <TiDB/Schema/SchemaSyncer.h>
-#include <TiDB/Schema/TiDBSchemaManager.h>
 
 #include <ext/scope_guard.h>
 
@@ -38,7 +30,6 @@ namespace DB
 {
 namespace FailPoints
 {
-extern const char force_set_sst_to_dtfile_block_size[];
 extern const char pause_until_apply_raft_snapshot[];
 } // namespace FailPoints
 
@@ -46,7 +37,6 @@ namespace ErrorCodes
 {
 extern const int LOGICAL_ERROR;
 extern const int TABLE_IS_DROPPED;
-extern const int REGION_DATA_SCHEMA_UPDATED;
 } // namespace ErrorCodes
 
 template <typename RegionPtrWrap>
@@ -127,6 +117,7 @@ void KVStore::checkAndApplyPreHandledSnapshot(const RegionPtrWrap & new_region, 
     onSnapshot(new_region, old_region, old_applied_index, tmt);
 }
 
+// This function get tiflash replica count from schema.
 std::pair<UInt64, bool> getTiFlashReplicaSyncInfo(StorageDeltaMergePtr & dm_storage)
 {
     auto struct_lock = dm_storage->lockStructureForShare(getThreadNameAndID());
@@ -300,207 +291,6 @@ void KVStore::onSnapshot(
     prehandling_trace.deregisterTask(new_region->id());
 }
 
-PrehandleResult KVStore::preHandleSnapshotToFiles(
-    RegionPtr new_region,
-    const SSTViewVec snaps,
-    uint64_t index,
-    uint64_t term,
-    std::optional<uint64_t> deadline_index,
-    TMTContext & tmt)
-{
-    new_region->beforePrehandleSnapshot(new_region->id(), deadline_index);
-    PrehandleResult result;
-    try
-    {
-        SCOPE_EXIT({ new_region->afterPrehandleSnapshot(); });
-        result = preHandleSSTsToDTFiles( //
-            new_region,
-            snaps,
-            index,
-            term,
-            DM::FileConvertJobType::ApplySnapshot,
-            tmt);
-    }
-    catch (DB::Exception & e)
-    {
-        e.addMessage(
-            fmt::format("(while preHandleSnapshot region_id={}, index={}, term={})", new_region->id(), index, term));
-        e.rethrow();
-    }
-    return result;
-}
-
-/// `preHandleSSTsToDTFiles` read data from SSTFiles and generate DTFile(s) for commited data
-/// return the ids of DTFile(s), the uncommitted data will be inserted to `new_region`
-PrehandleResult KVStore::preHandleSSTsToDTFiles(
-    RegionPtr new_region,
-    const SSTViewVec snaps,
-    uint64_t index,
-    uint64_t term,
-    DM::FileConvertJobType job_type,
-    TMTContext & tmt)
-{
-    // if it's only a empty snapshot, we don't create the Storage object, but return directly.
-    if (snaps.len == 0)
-    {
-        return {};
-    }
-    auto context = tmt.getContext();
-    auto keyspace_id = new_region->getKeyspaceID();
-    bool force_decode = false;
-    size_t expected_block_size = DEFAULT_MERGE_BLOCK_SIZE;
-
-    // Use failpoint to change the expected_block_size for some test cases
-    fiu_do_on(FailPoints::force_set_sst_to_dtfile_block_size, {
-        if (auto v = FailPointHelper::getFailPointVal(FailPoints::force_set_sst_to_dtfile_block_size); v)
-            expected_block_size = std::any_cast<size_t>(v.value());
-    });
-
-    Stopwatch watch;
-    SCOPE_EXIT({
-        GET_METRIC(tiflash_raft_command_duration_seconds, type_apply_snapshot_predecode)
-            .Observe(watch.elapsedSeconds());
-    });
-
-    PrehandleResult prehandle_result;
-    TableID physical_table_id = InvalidTableID;
-
-    auto region_id = new_region->id();
-    auto prehandle_task = prehandling_trace.registerTask(region_id);
-    while (true)
-    {
-        // If any schema changes is detected during decoding SSTs to DTFiles, we need to cancel and recreate DTFiles with
-        // the latest schema. Or we will get trouble in `BoundedSSTFilesToBlockInputStream`.
-        std::shared_ptr<DM::SSTFilesToDTFilesOutputStream<DM::BoundedSSTFilesToBlockInputStreamPtr>> stream;
-        try
-        {
-            // Get storage schema atomically, will do schema sync if the storage does not exists.
-            // Will return the storage even if it is tombstone.
-            const auto [table_drop_lock, storage, schema_snap] = AtomicGetStorageSchema(new_region, tmt);
-            if (unlikely(storage == nullptr))
-            {
-                // The storage must be physically dropped, throw exception and do cleanup.
-                throw Exception("", ErrorCodes::TABLE_IS_DROPPED);
-            }
-
-            // Get a gc safe point for compacting
-            Timestamp gc_safepoint = 0;
-            if (auto pd_client = tmt.getPDClient(); !pd_client->isMock())
-            {
-                gc_safepoint = PDClientHelper::getGCSafePointWithRetry(
-                    pd_client,
-                    keyspace_id,
-                    /* ignore_cache= */ false,
-                    context.getSettingsRef().safe_point_update_interval_seconds);
-            }
-            physical_table_id = storage->getTableInfo().id;
-            auto log_prefix = fmt::format("keyspace={} table_id={}", keyspace_id, physical_table_id);
-
-            auto & global_settings = context.getGlobalContext().getSettingsRef();
-
-            // Read from SSTs and refine the boundary of blocks output to DTFiles
-            auto sst_stream = std::make_shared<DM::SSTFilesToBlockInputStream>(
-                log_prefix,
-                new_region,
-                index,
-                snaps,
-                proxy_helper,
-                schema_snap,
-                gc_safepoint,
-                force_decode,
-                tmt,
-                expected_block_size);
-            auto bounded_stream = std::make_shared<DM::BoundedSSTFilesToBlockInputStream>(
-                sst_stream,
-                ::DB::TiDBPkColumnID,
-                schema_snap);
-            stream = std::make_shared<DM::SSTFilesToDTFilesOutputStream<DM::BoundedSSTFilesToBlockInputStreamPtr>>(
-                log_prefix,
-                bounded_stream,
-                storage,
-                schema_snap,
-                job_type,
-                /* split_after_rows */ global_settings.dt_segment_limit_rows,
-                /* split_after_size */ global_settings.dt_segment_limit_size,
-                region_id,
-                prehandle_task,
-                context);
-
-            stream->writePrefix();
-            stream->write();
-            stream->writeSuffix();
-            if (stream->isAbort())
-            {
-                LOG_INFO(
-                    log,
-                    "Apply snapshot is aborted, cancelling. region_id={} term={} index={}",
-                    region_id,
-                    term,
-                    index);
-                stream->cancel();
-            }
-            prehandle_result.ingest_ids = stream->outputFiles();
-            prehandle_result.stats = PrehandleResult::Stats{
-                .raft_snapshot_bytes = sst_stream->getProcessKeys().total_bytes(),
-                .dt_disk_bytes = stream->getTotalBytesOnDisk(),
-                .dt_total_bytes = stream->getTotalCommittedBytes()};
-
-            (void)table_drop_lock; // the table should not be dropped during ingesting file
-            break;
-        }
-        catch (DB::Exception & e)
-        {
-            if (stream != nullptr)
-            {
-                // Remove all DMFiles.
-                stream->cancel();
-            }
-
-            if (e.code() == ErrorCodes::REGION_DATA_SCHEMA_UPDATED)
-            {
-                // The schema of decoding region data has been updated, need to clear and recreate another stream for writing DTFile(s)
-                new_region->clearAllData();
-
-                if (force_decode)
-                {
-                    // Can not decode data with `force_decode == true`, must be something wrong
-                    throw;
-                }
-
-                // Update schema and try to decode again
-                LOG_INFO(
-                    log,
-                    "Decoding Region snapshot data meet error, sync schema and try to decode again {} [error={}]",
-                    new_region->toString(true),
-                    e.displayText());
-                GET_METRIC(tiflash_schema_trigger_count, type_raft_decode).Increment();
-                tmt.getSchemaSyncerManager()->syncTableSchema(context, keyspace_id, physical_table_id);
-                // Next time should force_decode
-                force_decode = true;
-
-                continue;
-            }
-            else if (e.code() == ErrorCodes::TABLE_IS_DROPPED)
-            {
-                // We can ignore if storage is dropped.
-                LOG_INFO(
-                    log,
-                    "Pre-handle snapshot to DTFiles is ignored because the table is dropped {}",
-                    new_region->toString(true));
-                break;
-            }
-            else
-            {
-                // Other unrecoverable error, throw
-                e.addMessage(fmt::format("keyspace={} physical_table_id={}", keyspace_id, physical_table_id));
-                throw;
-            }
-        }
-    }
-
-    return prehandle_result;
-}
-
 template <typename RegionPtrWrap>
 void KVStore::applyPreHandledSnapshot(const RegionPtrWrap & new_region, TMTContext & tmt)
 {
@@ -534,225 +324,10 @@ template void KVStore::onSnapshot<RegionPtrWithSnapshotFiles>(
     UInt64,
     TMTContext &);
 
-template <>
-void KVStore::releasePreHandledSnapshot<RegionPtrWithSnapshotFiles>(
-    const RegionPtrWithSnapshotFiles & s,
-    TMTContext & tmt)
-{
-    auto & storages = tmt.getStorages();
-    auto keyspace_id = s.base->getKeyspaceID();
-    auto table_id = s.base->getMappedTableID();
-    auto storage = storages.get(keyspace_id, table_id);
-    if (storage->engineType() != TiDB::StorageEngine::DT)
-    {
-        return;
-    }
-    auto dm_storage = std::dynamic_pointer_cast<StorageDeltaMerge>(storage);
-    LOG_INFO(
-        log,
-        "Release prehandled snapshot, clean {} dmfiles, region_id={} keyspace={} table_id={}",
-        s.external_files.size(),
-        s.base->id(),
-        keyspace_id,
-        table_id);
-    auto & context = tmt.getContext();
-    dm_storage->cleanPreIngestFiles(s.external_files, context.getSettingsRef());
-}
-
-void KVStore::abortPreHandleSnapshot(UInt64 region_id, TMTContext & tmt)
-{
-    UNUSED(tmt);
-    auto cancel_flag = prehandling_trace.deregisterTask(region_id);
-    if (cancel_flag)
-    {
-        // The task is registered, set the cancel flag to true and the generated files
-        // will be clear later by `releasePreHandleSnapshot`
-        LOG_INFO(log, "Try cancel pre-handling from upper layer, region_id={}", region_id);
-        cancel_flag->store(true, std::memory_order_seq_cst);
-    }
-    else
-    {
-        // the task is not registered, continue
-        LOG_INFO(log, "Start cancel pre-handling from upper layer, region_id={}", region_id);
-    }
-}
-
-static const metapb::Peer & findPeer(const metapb::Region & region, UInt64 peer_id)
-{
-    for (const auto & peer : region.peers())
-    {
-        if (peer.id() == peer_id)
-        {
-            return peer;
-        }
-    }
-
-    throw Exception(
-        ErrorCodes::LOGICAL_ERROR,
-        "{}: peer not found in region, peer_id={} region_id={}",
-        __PRETTY_FUNCTION__,
-        peer_id,
-        region.id());
-}
-
-RegionPtr KVStore::genRegionPtr(metapb::Region && region, UInt64 peer_id, UInt64 index, UInt64 term)
-{
-    auto meta = ({
-        auto peer = findPeer(region, peer_id);
-        raft_serverpb::RaftApplyState apply_state;
-        {
-            apply_state.set_applied_index(index);
-            apply_state.mutable_truncated_state()->set_index(index);
-            apply_state.mutable_truncated_state()->set_term(term);
-        }
-        RegionMeta(std::move(peer), std::move(region), std::move(apply_state));
-    });
-
-    return std::make_shared<Region>(std::move(meta), proxy_helper);
-}
-
 void KVStore::handleIngestCheckpoint(RegionPtr region, CheckpointInfoPtr checkpoint_info, TMTContext & tmt)
 {
     applyPreHandledSnapshot(RegionPtrWithCheckpointInfo{region, checkpoint_info}, tmt);
 }
 
-EngineStoreApplyRes KVStore::handleIngestSST(
-    UInt64 region_id,
-    const SSTViewVec snaps,
-    UInt64 index,
-    UInt64 term,
-    TMTContext & tmt)
-{
-    auto region_task_lock = region_manager.genRegionTaskLock(region_id);
-
-    Stopwatch watch;
-    SCOPE_EXIT({ GET_METRIC(tiflash_raft_command_duration_seconds, type_ingest_sst).Observe(watch.elapsedSeconds()); });
-
-    const RegionPtr region = getRegion(region_id);
-    if (region == nullptr)
-    {
-        LOG_WARNING(
-            log,
-            "region not found, might be removed already, region_id={} term={} index={}",
-            region_id,
-            term,
-            index);
-        return EngineStoreApplyRes::NotFound;
-    }
-
-    const auto func_try_flush = [&]() {
-        if (!region->writeCFCount())
-            return;
-        try
-        {
-            tmt.getRegionTable().tryWriteBlockByRegionAndFlush(region);
-            tryFlushRegionCacheInStorage(tmt, *region, log);
-        }
-        catch (Exception & e)
-        {
-            // sst of write cf may be ingested first, exception may be raised because there is no matched data in default cf.
-            // ignore it.
-            LOG_DEBUG(log, "catch but ignore exception: {}", e.message());
-        }
-    };
-
-    {
-        // try to flush remain data in memory.
-        func_try_flush();
-        auto tmp_region = handleIngestSSTByDTFile(region, snaps, index, term, tmt);
-        // Merge data from tmp_region.
-        region->finishIngestSSTByDTFile(std::move(tmp_region), index, term);
-        // after `finishIngestSSTByDTFile`, try to flush committed data into storage
-        func_try_flush();
-    }
-
-    if (region->dataSize())
-    {
-        LOG_INFO(log, "{} with data {}, skip persist", region->toString(true), region->dataInfo());
-        return EngineStoreApplyRes::None;
-    }
-    else
-    {
-        // We always try to flush dm cache and region if possible for every IngestSST,
-        // in order to have the raft log truncated and sst deleted.
-        persistRegion(*region, &region_task_lock, PersistRegionReason::IngestSst, "");
-        return EngineStoreApplyRes::Persist;
-    }
-}
-
-RegionPtr KVStore::handleIngestSSTByDTFile(
-    const RegionPtr & region,
-    const SSTViewVec snaps,
-    UInt64 index,
-    UInt64 term,
-    TMTContext & tmt)
-{
-    if (index <= region->appliedIndex())
-        return nullptr;
-
-    // Create a tmp region to store uncommitted data
-    RegionPtr tmp_region;
-    {
-        auto meta_region = region->cloneMetaRegion();
-        auto meta_snap = region->dumpRegionMetaSnapshot();
-        auto peer_id = meta_snap.peer.id();
-        tmp_region = genRegionPtr(std::move(meta_region), peer_id, index, term);
-    }
-
-    // Decode the KV pairs in ingesting SST into DTFiles
-    PrehandleResult prehandle_result;
-    try
-    {
-        prehandle_result
-            = preHandleSSTsToDTFiles(tmp_region, snaps, index, term, DM::FileConvertJobType::IngestSST, tmt);
-    }
-    catch (DB::Exception & e)
-    {
-        e.addMessage(
-            fmt::format("(while handleIngestSST region_id={} index={} term={})", tmp_region->id(), index, term));
-        e.rethrow();
-    }
-
-    // If `external_files` is empty, ingest SST won't write delete_range for ingest region, it is safe to
-    // ignore the step of calling `ingestFiles`
-    if (!prehandle_result.ingest_ids.empty())
-    {
-        auto keyspace_id = region->getKeyspaceID();
-        auto table_id = region->getMappedTableID();
-        if (auto storage = tmt.getStorages().get(keyspace_id, table_id); storage)
-        {
-            // Ingest DTFiles into DeltaMerge storage
-            auto & context = tmt.getContext();
-            try
-            {
-                // Acquire `drop_lock` so that no other threads can drop the storage. `alter_lock` is not required.
-                auto table_lock = storage->lockForShare(getThreadNameAndID());
-                auto key_range = DM::RowKeyRange::fromRegionRange(
-                    region->getRange(),
-                    table_id,
-                    storage->isCommonHandle(),
-                    storage->getRowKeyColumnSize());
-                // Call `ingestFiles` to ingest external DTFiles.
-                // Note that ingest sst won't remove the data in the key range
-                auto dm_storage = std::dynamic_pointer_cast<StorageDeltaMerge>(storage);
-                dm_storage->ingestFiles( //
-                    key_range,
-                    prehandle_result.ingest_ids,
-                    /*clear_data_in_range=*/false,
-                    context.getSettingsRef());
-            }
-            catch (DB::Exception & e)
-            {
-                // We can ignore if storage is dropped.
-                if (e.code() == ErrorCodes::TABLE_IS_DROPPED)
-                    return nullptr;
-                else
-                    throw;
-            }
-        }
-    }
-
-    return tmp_region;
-}
 
 } // namespace DB

--- a/dbms/src/Storages/KVStore/MultiRaft/ApplySnapshot.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/ApplySnapshot.cpp
@@ -117,7 +117,7 @@ void KVStore::checkAndApplyPreHandledSnapshot(const RegionPtrWrap & new_region, 
     onSnapshot(new_region, old_region, old_applied_index, tmt);
 }
 
-// This function get tiflash replica count from schema.
+// This function get tiflash replica count from local schema.
 std::pair<UInt64, bool> getTiFlashReplicaSyncInfo(StorageDeltaMergePtr & dm_storage)
 {
     auto struct_lock = dm_storage->lockStructureForShare(getThreadNameAndID());

--- a/dbms/src/Storages/KVStore/MultiRaft/IngestSST.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/IngestSST.cpp
@@ -1,0 +1,201 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Common/FailPoint.h>
+#include <Common/TiFlashMetrics.h>
+#include <Common/setThreadName.h>
+#include <Interpreters/Context.h>
+#include <Storages/DeltaMerge/SSTFilesToDTFilesOutputStream.h>
+#include <Storages/KVStore/Decode/RegionTable.h>
+#include <Storages/KVStore/FFI/ProxyFFI.h>
+#include <Storages/KVStore/FFI/SSTReader.h>
+#include <Storages/KVStore/KVStore.h>
+#include <Storages/KVStore/Region.h>
+#include <Storages/KVStore/TMTContext.h>
+#include <Storages/StorageDeltaMerge.h>
+#include <Storages/StorageDeltaMergeHelpers.h>
+
+namespace DB
+{
+namespace ErrorCodes
+{
+extern const int TABLE_IS_DROPPED;
+} // namespace ErrorCodes
+
+EngineStoreApplyRes KVStore::handleIngestSST(
+    UInt64 region_id,
+    const SSTViewVec snaps,
+    UInt64 index,
+    UInt64 term,
+    TMTContext & tmt)
+{
+    auto region_task_lock = region_manager.genRegionTaskLock(region_id);
+
+    Stopwatch watch;
+    SCOPE_EXIT({ GET_METRIC(tiflash_raft_command_duration_seconds, type_ingest_sst).Observe(watch.elapsedSeconds()); });
+
+    const RegionPtr region = getRegion(region_id);
+    if (region == nullptr)
+    {
+        LOG_WARNING(
+            log,
+            "region not found, might be removed already, region_id={} term={} index={}",
+            region_id,
+            term,
+            index);
+        return EngineStoreApplyRes::NotFound;
+    }
+
+    const auto func_try_flush = [&]() {
+        if (!region->writeCFCount())
+            return;
+        try
+        {
+            tmt.getRegionTable().tryWriteBlockByRegionAndFlush(region);
+            tryFlushRegionCacheInStorage(tmt, *region, log);
+        }
+        catch (Exception & e)
+        {
+            // sst of write cf may be ingested first, exception may be raised because there is no matched data in default cf.
+            // ignore it.
+            LOG_DEBUG(log, "catch but ignore exception: {}", e.message());
+        }
+    };
+
+    {
+        // try to flush remain data in memory.
+        func_try_flush();
+        auto tmp_region = handleIngestSSTByDTFile(region, snaps, index, term, tmt);
+        // Merge data from tmp_region.
+        region->finishIngestSSTByDTFile(std::move(tmp_region), index, term);
+        // after `finishIngestSSTByDTFile`, try to flush committed data into storage
+        func_try_flush();
+    }
+
+    if (region->dataSize())
+    {
+        LOG_INFO(log, "{} with data {}, skip persist", region->toString(true), region->dataInfo());
+        return EngineStoreApplyRes::None;
+    }
+    else
+    {
+        // We always try to flush dm cache and region if possible for every IngestSST,
+        // in order to have the raft log truncated and sst deleted.
+        persistRegion(*region, &region_task_lock, PersistRegionReason::IngestSst, "");
+        return EngineStoreApplyRes::Persist;
+    }
+}
+
+RegionPtr KVStore::handleIngestSSTByDTFile(
+    const RegionPtr & region,
+    const SSTViewVec snaps,
+    UInt64 index,
+    UInt64 term,
+    TMTContext & tmt)
+{
+    if (index <= region->appliedIndex())
+        return nullptr;
+
+    // Create a tmp region to store uncommitted data
+    RegionPtr tmp_region;
+    {
+        auto meta_region = region->cloneMetaRegion();
+        auto meta_snap = region->dumpRegionMetaSnapshot();
+        auto peer_id = meta_snap.peer.id();
+        tmp_region = genRegionPtr(std::move(meta_region), peer_id, index, term);
+    }
+
+    // Decode the KV pairs in ingesting SST into DTFiles
+    PrehandleResult prehandle_result;
+    try
+    {
+        prehandle_result
+            = preHandleSSTsToDTFiles(tmp_region, snaps, index, term, DM::FileConvertJobType::IngestSST, tmt);
+    }
+    catch (DB::Exception & e)
+    {
+        e.addMessage(
+            fmt::format("(while handleIngestSST region_id={} index={} term={})", tmp_region->id(), index, term));
+        e.rethrow();
+    }
+
+    // If `external_files` is empty, ingest SST won't write delete_range for ingest region, it is safe to
+    // ignore the step of calling `ingestFiles`
+    if (!prehandle_result.ingest_ids.empty())
+    {
+        auto keyspace_id = region->getKeyspaceID();
+        auto table_id = region->getMappedTableID();
+        if (auto storage = tmt.getStorages().get(keyspace_id, table_id); storage)
+        {
+            // Ingest DTFiles into DeltaMerge storage
+            auto & context = tmt.getContext();
+            try
+            {
+                // Acquire `drop_lock` so that no other threads can drop the storage. `alter_lock` is not required.
+                auto table_lock = storage->lockForShare(getThreadNameAndID());
+                auto key_range = DM::RowKeyRange::fromRegionRange(
+                    region->getRange(),
+                    table_id,
+                    storage->isCommonHandle(),
+                    storage->getRowKeyColumnSize());
+                // Call `ingestFiles` to ingest external DTFiles.
+                // Note that ingest sst won't remove the data in the key range
+                auto dm_storage = std::dynamic_pointer_cast<StorageDeltaMerge>(storage);
+                dm_storage->ingestFiles( //
+                    key_range,
+                    prehandle_result.ingest_ids,
+                    /*clear_data_in_range=*/false,
+                    context.getSettingsRef());
+            }
+            catch (DB::Exception & e)
+            {
+                // We can ignore if storage is dropped.
+                if (e.code() == ErrorCodes::TABLE_IS_DROPPED)
+                    return nullptr;
+                else
+                    throw;
+            }
+        }
+    }
+
+    return tmp_region;
+}
+
+void Region::finishIngestSSTByDTFile(RegionPtr && temp_region, UInt64 index, UInt64 term)
+{
+    if (index <= appliedIndex())
+        return;
+
+    {
+        std::unique_lock<std::shared_mutex> lock(mutex);
+
+        if (temp_region)
+        {
+            // Merge the uncommitted data from `temp_region`.
+            // As we have taken the ownership of `temp_region`, so don't need to acquire lock on `temp_region.mutex`
+            data.mergeFrom(temp_region->data);
+        }
+
+        meta.setApplied(index, term);
+    }
+    LOG_INFO(
+        log,
+        "{} finish ingest sst by DTFile, write_cf_keys={} default_cf_keys={} lock_cf_keys={}",
+        this->toString(false),
+        data.write_cf.getSize(),
+        data.default_cf.getSize(),
+        data.lock_cf.getSize());
+    meta.notifyAll();
+}
+} // namespace DB

--- a/dbms/src/Storages/KVStore/MultiRaft/PrehandleSnapshot.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/PrehandleSnapshot.cpp
@@ -1,0 +1,315 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Common/FailPoint.h>
+#include <Common/TiFlashMetrics.h>
+#include <Interpreters/Context.h>
+#include <Storages/DeltaMerge/SSTFilesToBlockInputStream.h>
+#include <Storages/DeltaMerge/SSTFilesToDTFilesOutputStream.h>
+#include <Storages/KVStore/Decode/PartitionStreams.h>
+#include <Storages/KVStore/FFI/ProxyFFI.h>
+#include <Storages/KVStore/FFI/SSTReader.h>
+#include <Storages/KVStore/KVStore.h>
+#include <Storages/KVStore/Region.h>
+#include <Storages/KVStore/TMTContext.h>
+#include <Storages/KVStore/Types.h>
+#include <Storages/StorageDeltaMerge.h>
+#include <Storages/StorageDeltaMergeHelpers.h>
+#include <TiDB/Schema/SchemaSyncer.h>
+#include <TiDB/Schema/TiDBSchemaManager.h>
+
+namespace DB
+{
+namespace FailPoints
+{
+extern const char force_set_sst_to_dtfile_block_size[];
+} // namespace FailPoints
+
+namespace ErrorCodes
+{
+extern const int TABLE_IS_DROPPED;
+extern const int REGION_DATA_SCHEMA_UPDATED;
+} // namespace ErrorCodes
+
+// It is currently a wrapper for preHandleSSTsToDTFiles.
+PrehandleResult KVStore::preHandleSnapshotToFiles(
+    RegionPtr new_region,
+    const SSTViewVec snaps,
+    uint64_t index,
+    uint64_t term,
+    std::optional<uint64_t> deadline_index,
+    TMTContext & tmt)
+{
+    new_region->beforePrehandleSnapshot(new_region->id(), deadline_index);
+    PrehandleResult result;
+    try
+    {
+        SCOPE_EXIT({ new_region->afterPrehandleSnapshot(); });
+        result = preHandleSSTsToDTFiles( //
+            new_region,
+            snaps,
+            index,
+            term,
+            DM::FileConvertJobType::ApplySnapshot,
+            tmt);
+    }
+    catch (DB::Exception & e)
+    {
+        e.addMessage(
+            fmt::format("(while preHandleSnapshot region_id={}, index={}, term={})", new_region->id(), index, term));
+        e.rethrow();
+    }
+    return result;
+}
+
+/// `preHandleSSTsToDTFiles` read data from SSTFiles and generate DTFile(s) for commited data
+/// return the ids of DTFile(s), the uncommitted data will be inserted to `new_region`
+PrehandleResult KVStore::preHandleSSTsToDTFiles(
+    RegionPtr new_region,
+    const SSTViewVec snaps,
+    uint64_t index,
+    uint64_t term,
+    DM::FileConvertJobType job_type,
+    TMTContext & tmt)
+{
+    // if it's only a empty snapshot, we don't create the Storage object, but return directly.
+    if (snaps.len == 0)
+    {
+        return {};
+    }
+    auto context = tmt.getContext();
+    auto keyspace_id = new_region->getKeyspaceID();
+    bool force_decode = false;
+    size_t expected_block_size = DEFAULT_MERGE_BLOCK_SIZE;
+
+    // Use failpoint to change the expected_block_size for some test cases
+    fiu_do_on(FailPoints::force_set_sst_to_dtfile_block_size, {
+        if (auto v = FailPointHelper::getFailPointVal(FailPoints::force_set_sst_to_dtfile_block_size); v)
+            expected_block_size = std::any_cast<size_t>(v.value());
+    });
+
+    Stopwatch watch;
+    SCOPE_EXIT({
+        GET_METRIC(tiflash_raft_command_duration_seconds, type_apply_snapshot_predecode)
+            .Observe(watch.elapsedSeconds());
+    });
+
+    PrehandleResult prehandle_result;
+    TableID physical_table_id = InvalidTableID;
+
+    auto region_id = new_region->id();
+    auto prehandle_task = prehandling_trace.registerTask(region_id);
+    while (true)
+    {
+        // If any schema changes is detected during decoding SSTs to DTFiles, we need to cancel and recreate DTFiles with
+        // the latest schema. Or we will get trouble in `BoundedSSTFilesToBlockInputStream`.
+        std::shared_ptr<DM::SSTFilesToDTFilesOutputStream<DM::BoundedSSTFilesToBlockInputStreamPtr>> stream;
+        try
+        {
+            // Get storage schema atomically, will do schema sync if the storage does not exists.
+            // Will return the storage even if it is tombstone.
+            const auto [table_drop_lock, storage, schema_snap] = AtomicGetStorageSchema(new_region, tmt);
+            if (unlikely(storage == nullptr))
+            {
+                // The storage must be physically dropped, throw exception and do cleanup.
+                throw Exception("", ErrorCodes::TABLE_IS_DROPPED);
+            }
+
+            // Get a gc safe point for compacting
+            Timestamp gc_safepoint = 0;
+            if (auto pd_client = tmt.getPDClient(); !pd_client->isMock())
+            {
+                gc_safepoint = PDClientHelper::getGCSafePointWithRetry(
+                    pd_client,
+                    keyspace_id,
+                    /* ignore_cache= */ false,
+                    context.getSettingsRef().safe_point_update_interval_seconds);
+            }
+            physical_table_id = storage->getTableInfo().id;
+            auto log_prefix = fmt::format("keyspace={} table_id={}", keyspace_id, physical_table_id);
+
+            auto & global_settings = context.getGlobalContext().getSettingsRef();
+
+            // Read from SSTs and refine the boundary of blocks output to DTFiles
+            auto sst_stream = std::make_shared<DM::SSTFilesToBlockInputStream>(
+                log_prefix,
+                new_region,
+                index,
+                snaps,
+                proxy_helper,
+                schema_snap,
+                gc_safepoint,
+                force_decode,
+                tmt,
+                expected_block_size);
+            auto bounded_stream = std::make_shared<DM::BoundedSSTFilesToBlockInputStream>(
+                sst_stream,
+                ::DB::TiDBPkColumnID,
+                schema_snap);
+            stream = std::make_shared<DM::SSTFilesToDTFilesOutputStream<DM::BoundedSSTFilesToBlockInputStreamPtr>>(
+                log_prefix,
+                bounded_stream,
+                storage,
+                schema_snap,
+                job_type,
+                /* split_after_rows */ global_settings.dt_segment_limit_rows,
+                /* split_after_size */ global_settings.dt_segment_limit_size,
+                region_id,
+                prehandle_task,
+                context);
+
+            stream->writePrefix();
+            stream->write();
+            stream->writeSuffix();
+            if (stream->isAbort())
+            {
+                LOG_INFO(
+                    log,
+                    "Apply snapshot is aborted, cancelling. region_id={} term={} index={}",
+                    region_id,
+                    term,
+                    index);
+                stream->cancel();
+            }
+            prehandle_result.ingest_ids = stream->outputFiles();
+            prehandle_result.stats = PrehandleResult::Stats{
+                .raft_snapshot_bytes = sst_stream->getProcessKeys().total_bytes(),
+                .dt_disk_bytes = stream->getTotalBytesOnDisk(),
+                .dt_total_bytes = stream->getTotalCommittedBytes()};
+
+            (void)table_drop_lock; // the table should not be dropped during ingesting file
+            break;
+        }
+        catch (DB::Exception & e)
+        {
+            if (stream != nullptr)
+            {
+                // Remove all DMFiles.
+                stream->cancel();
+            }
+
+            if (e.code() == ErrorCodes::REGION_DATA_SCHEMA_UPDATED)
+            {
+                // The schema of decoding region data has been updated, need to clear and recreate another stream for writing DTFile(s)
+                new_region->clearAllData();
+
+                if (force_decode)
+                {
+                    // Can not decode data with `force_decode == true`, must be something wrong
+                    throw;
+                }
+
+                // Update schema and try to decode again
+                LOG_INFO(
+                    log,
+                    "Decoding Region snapshot data meet error, sync schema and try to decode again {} [error={}]",
+                    new_region->toString(true),
+                    e.displayText());
+                GET_METRIC(tiflash_schema_trigger_count, type_raft_decode).Increment();
+                tmt.getSchemaSyncerManager()->syncTableSchema(context, keyspace_id, physical_table_id);
+                // Next time should force_decode
+                force_decode = true;
+
+                continue;
+            }
+            else if (e.code() == ErrorCodes::TABLE_IS_DROPPED)
+            {
+                // We can ignore if storage is dropped.
+                LOG_INFO(
+                    log,
+                    "Pre-handle snapshot to DTFiles is ignored because the table is dropped {}",
+                    new_region->toString(true));
+                break;
+            }
+            else
+            {
+                // Other unrecoverable error, throw
+                e.addMessage(fmt::format("keyspace={} physical_table_id={}", keyspace_id, physical_table_id));
+                throw;
+            }
+        }
+    }
+
+    return prehandle_result;
+}
+
+template <>
+void KVStore::releasePreHandledSnapshot<RegionPtrWithSnapshotFiles>(
+    const RegionPtrWithSnapshotFiles & s,
+    TMTContext & tmt)
+{
+    auto & storages = tmt.getStorages();
+    auto keyspace_id = s.base->getKeyspaceID();
+    auto table_id = s.base->getMappedTableID();
+    auto storage = storages.get(keyspace_id, table_id);
+    if (storage->engineType() != TiDB::StorageEngine::DT)
+    {
+        return;
+    }
+    auto dm_storage = std::dynamic_pointer_cast<StorageDeltaMerge>(storage);
+    LOG_INFO(
+        log,
+        "Release prehandled snapshot, clean {} dmfiles, region_id={} keyspace={} table_id={}",
+        s.external_files.size(),
+        s.base->id(),
+        keyspace_id,
+        table_id);
+    auto & context = tmt.getContext();
+    dm_storage->cleanPreIngestFiles(s.external_files, context.getSettingsRef());
+}
+
+void KVStore::abortPreHandleSnapshot(UInt64 region_id, TMTContext & tmt)
+{
+    UNUSED(tmt);
+    auto cancel_flag = prehandling_trace.deregisterTask(region_id);
+    if (cancel_flag)
+    {
+        // The task is registered, set the cancel flag to true and the generated files
+        // will be clear later by `releasePreHandleSnapshot`
+        LOG_INFO(log, "Try cancel pre-handling from upper layer, region_id={}", region_id);
+        cancel_flag->store(true, std::memory_order_seq_cst);
+    }
+    else
+    {
+        // the task is not registered, continue
+        LOG_INFO(log, "Start cancel pre-handling from upper layer, region_id={}", region_id);
+    }
+}
+
+void Region::beforePrehandleSnapshot(uint64_t region_id, std::optional<uint64_t> deadline_index)
+{
+    if (getClusterRaftstoreVer() == RaftstoreVer::V2)
+    {
+        data.orphan_keys_info.snapshot_index = appliedIndex();
+        data.orphan_keys_info.pre_handling = true;
+        data.orphan_keys_info.deadline_index = deadline_index;
+        data.orphan_keys_info.region_id = region_id;
+    }
+}
+
+void Region::afterPrehandleSnapshot()
+{
+    if (getClusterRaftstoreVer() == RaftstoreVer::V2)
+    {
+        data.orphan_keys_info.pre_handling = false;
+        LOG_INFO(
+            log,
+            "After prehandle, remains orphan keys {} removed orphan keys {} [region_id={}]",
+            data.orphan_keys_info.remainedKeyCount(),
+            data.orphan_keys_info.removed_remained_keys.size(),
+            id());
+    }
+}
+
+} // namespace DB

--- a/dbms/src/Storages/KVStore/MultiRaft/PrehandleSnapshot.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/PrehandleSnapshot.cpp
@@ -244,6 +244,24 @@ PrehandleResult KVStore::preHandleSSTsToDTFiles(
     return prehandle_result;
 }
 
+void KVStore::abortPreHandleSnapshot(UInt64 region_id, TMTContext & tmt)
+{
+    UNUSED(tmt);
+    auto cancel_flag = prehandling_trace.deregisterTask(region_id);
+    if (cancel_flag)
+    {
+        // The task is registered, set the cancel flag to true and the generated files
+        // will be clear later by `releasePreHandleSnapshot`
+        LOG_INFO(log, "Try cancel pre-handling from upper layer, region_id={}", region_id);
+        cancel_flag->store(true, std::memory_order_seq_cst);
+    }
+    else
+    {
+        // the task is not registered, continue
+        LOG_INFO(log, "Start cancel pre-handling from upper layer, region_id={}", region_id);
+    }
+}
+
 template <>
 void KVStore::releasePreHandledSnapshot<RegionPtrWithSnapshotFiles>(
     const RegionPtrWithSnapshotFiles & s,
@@ -267,24 +285,6 @@ void KVStore::releasePreHandledSnapshot<RegionPtrWithSnapshotFiles>(
         table_id);
     auto & context = tmt.getContext();
     dm_storage->cleanPreIngestFiles(s.external_files, context.getSettingsRef());
-}
-
-void KVStore::abortPreHandleSnapshot(UInt64 region_id, TMTContext & tmt)
-{
-    UNUSED(tmt);
-    auto cancel_flag = prehandling_trace.deregisterTask(region_id);
-    if (cancel_flag)
-    {
-        // The task is registered, set the cancel flag to true and the generated files
-        // will be clear later by `releasePreHandleSnapshot`
-        LOG_INFO(log, "Try cancel pre-handling from upper layer, region_id={}", region_id);
-        cancel_flag->store(true, std::memory_order_seq_cst);
-    }
-    else
-    {
-        // the task is not registered, continue
-        LOG_INFO(log, "Start cancel pre-handling from upper layer, region_id={}", region_id);
-    }
 }
 
 void Region::beforePrehandleSnapshot(uint64_t region_id, std::optional<uint64_t> deadline_index)

--- a/dbms/src/Storages/KVStore/Region.cpp
+++ b/dbms/src/Storages/KVStore/Region.cpp
@@ -1045,6 +1045,7 @@ static const metapb::Peer & findPeer(const metapb::Region & region, UInt64 peer_
         region.id());
 }
 
+// Generate a temporary region pointer by the given meta
 RegionPtr KVStore::genRegionPtr(metapb::Region && region, UInt64 peer_id, UInt64 index, UInt64 term)
 {
     auto meta = ({


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #7777 ref #4646

Problem Summary:

The pr is:
1. as part of kvstore refactor
2. as part of parallel pre-handling single snapshot
3. remove some needless utils
4. move some raft-related utils into these modules

We've done the following in this pr:
1. an PrehandleSnapshot.cpp which is about how to generate column format files(DTFiles) from SST format(including a whole rocksdb instance) file
2. an IngestSST.cpp which is about how to ingest an sst file as part of data of a region.
5. an ApplySnapshot.cpp is about how to replace data in a certain key range. 

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
