### PR TITLE
Make delta_index_epoch monotonic increase.

### DIFF
--- a/dbms/src/Storages/DeltaMerge/Delta/DeltaValueSpace.cpp
+++ b/dbms/src/Storages/DeltaMerge/Delta/DeltaValueSpace.cpp
@@ -389,7 +389,7 @@ bool DeltaValueSpace::flush(DMContext & context)
 
             // Indicate that the index with old epoch should not be used anymore.
             // This is useful in disaggregated mode which will invalidate the delta index cache in RN.
-            delta_index_epoch = std::chrono::steady_clock::now().time_since_epoch().count();;
+            delta_index_epoch = std::chrono::steady_clock::now().time_since_epoch().count();
         }
 
         LOG_DEBUG(

--- a/dbms/src/Storages/DeltaMerge/Delta/DeltaValueSpace.cpp
+++ b/dbms/src/Storages/DeltaMerge/Delta/DeltaValueSpace.cpp
@@ -389,7 +389,7 @@ bool DeltaValueSpace::flush(DMContext & context)
 
             // Indicate that the index with old epoch should not be used anymore.
             // This is useful in disaggregated mode which will invalidate the delta index cache in RN.
-            delta_index_epoch += 1;
+            delta_index_epoch = std::chrono::steady_clock::now().time_since_epoch().count();;
         }
 
         LOG_DEBUG(

--- a/dbms/src/Storages/DeltaMerge/Delta/DeltaValueSpace.h
+++ b/dbms/src/Storages/DeltaMerge/Delta/DeltaValueSpace.h
@@ -94,7 +94,10 @@ private:
     std::atomic<size_t> last_try_place_delta_index_rows = 0;
 
     DeltaIndexPtr delta_index;
-    UInt64 delta_index_epoch = 0;
+    // `delta_index_epoch` is used in disaggregated mode by compute-nodes to identify if the delta_index has changed.
+    // To avoid persisting it, we use `std::chrono::steady_clock` to make it monotonic increase.
+    // Accuracy of `std::chrono::steady_clock` in Linux is nanosecond. This is much smaller than the interval between two flushes.
+    UInt64 delta_index_epoch = std::chrono::steady_clock::now().time_since_epoch().count();
 
     // Protects the operations in this instance.
     // It is a recursive_mutex because the lock may be also used by the parent segment as its update lock.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #7359 https://github.com/tidbcloud/tiflash-cse/issues/88

Problem Summary:
- `delta_index_epoch` is not persisted. It will fallback to zero if TiFlash (WN) restarts.
- This will result in inconsistent `delta_index_epoch` between WN and CN and lead to inconsistent delta index eventually.

### What is changed and how it works?
- `delta_index_epoch` is used in disaggregated mode by compute-nodes to identify if the delta_index has changed.
- To avoid persisting it, we use `std::chrono::steady_clock` to make it monotonic increase.
- Accuracy of `std::chrono::steady_clock` in Linux is nanosecond. This is much smaller than the interval between two flushes.


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
