### PR TITLE
No tracing memory usage of shared column data in MPPTask's memory tracker

### DIFF
--- a/dbms/src/Common/CurrentMetrics.cpp
+++ b/dbms/src/Common/CurrentMetrics.cpp
@@ -81,7 +81,8 @@
     M(PageCacheUsed)                            \
     M(ConnectionPoolSize)                       \
     M(MemoryTrackingQueryStorageTask)           \
-    M(MemoryTrackingFetchPages)
+    M(MemoryTrackingFetchPages)                 \
+    M(MemoryTrackingSharedColumnData)
 
 namespace CurrentMetrics
 {

--- a/dbms/src/Common/MemoryTracker.cpp
+++ b/dbms/src/Common/MemoryTracker.cpp
@@ -27,6 +27,7 @@ namespace CurrentMetrics
 {
 extern const Metric MemoryTrackingQueryStorageTask;
 extern const Metric MemoryTrackingFetchPages;
+extern const Metric MemoryTrackingSharedColumnData;
 } // namespace CurrentMetrics
 
 std::atomic<Int64> real_rss{0}, proc_num_threads{1}, baseline_of_query_mem_tracker{0};
@@ -76,7 +77,8 @@ static String storageMemoryUsageDetail()
     return fmt::format(
         "non-query: peak={}, amount={}; "
         "query-storage-task: peak={}, amount={}; "
-        "fetch-pages: peak={}, amount={}.",
+        "fetch-pages: peak={}, amount={};"
+        "shared-column-data: peak={}, amount={}.",
         root_of_non_query_mem_trackers ? formatReadableSizeWithBinarySuffix(root_of_non_query_mem_trackers->getPeak())
                                        : "0",
         root_of_non_query_mem_trackers ? formatReadableSizeWithBinarySuffix(root_of_non_query_mem_trackers->get())
@@ -88,7 +90,11 @@ static String storageMemoryUsageDetail()
             ? formatReadableSizeWithBinarySuffix(sub_root_of_query_storage_task_mem_trackers->get())
             : "0",
         fetch_pages_mem_tracker ? formatReadableSizeWithBinarySuffix(fetch_pages_mem_tracker->getPeak()) : "0",
-        fetch_pages_mem_tracker ? formatReadableSizeWithBinarySuffix(fetch_pages_mem_tracker->get()) : "0");
+        fetch_pages_mem_tracker ? formatReadableSizeWithBinarySuffix(fetch_pages_mem_tracker->get()) : "0",
+        shared_column_data_mem_tracker ? formatReadableSizeWithBinarySuffix(shared_column_data_mem_tracker->getPeak())
+                                       : "0",
+        shared_column_data_mem_tracker ? formatReadableSizeWithBinarySuffix(shared_column_data_mem_tracker->get())
+                                       : "0");
 }
 
 void MemoryTracker::logPeakMemoryUsage() const
@@ -285,6 +291,7 @@ std::shared_ptr<MemoryTracker> root_of_query_mem_trackers = MemoryTracker::creat
 
 std::shared_ptr<MemoryTracker> sub_root_of_query_storage_task_mem_trackers;
 std::shared_ptr<MemoryTracker> fetch_pages_mem_tracker;
+std::shared_ptr<MemoryTracker> shared_column_data_mem_tracker;
 
 void initStorageMemoryTracker(Int64 limit, Int64 larger_than_limit)
 {
@@ -302,6 +309,11 @@ void initStorageMemoryTracker(Int64 limit, Int64 larger_than_limit)
     fetch_pages_mem_tracker = MemoryTracker::create();
     fetch_pages_mem_tracker->setNext(sub_root_of_query_storage_task_mem_trackers.get());
     fetch_pages_mem_tracker->setAmountMetric(CurrentMetrics::MemoryTrackingFetchPages);
+
+    RUNTIME_CHECK(shared_column_data_mem_tracker == nullptr);
+    shared_column_data_mem_tracker = MemoryTracker::create();
+    shared_column_data_mem_tracker->setNext(sub_root_of_query_storage_task_mem_trackers.get());
+    shared_column_data_mem_tracker->setAmountMetric(CurrentMetrics::MemoryTrackingSharedColumnData);
 }
 
 namespace CurrentMemoryTracker

--- a/dbms/src/Common/MemoryTracker.cpp
+++ b/dbms/src/Common/MemoryTracker.cpp
@@ -77,7 +77,7 @@ static String storageMemoryUsageDetail()
     return fmt::format(
         "non-query: peak={}, amount={}; "
         "query-storage-task: peak={}, amount={}; "
-        "fetch-pages: peak={}, amount={};"
+        "fetch-pages: peak={}, amount={}; "
         "shared-column-data: peak={}, amount={}.",
         root_of_non_query_mem_trackers ? formatReadableSizeWithBinarySuffix(root_of_non_query_mem_trackers->getPeak())
                                        : "0",

--- a/dbms/src/Common/MemoryTracker.cpp
+++ b/dbms/src/Common/MemoryTracker.cpp
@@ -119,7 +119,8 @@ void MemoryTracker::alloc(Int64 size, bool check_memory_limit)
     if (!next.load(std::memory_order_relaxed))
     {
         CurrentMetrics::add(metric, size);
-        will_be += shared_column_data_mem_tracker->get(); // Add shared column data size to root tracker.
+        if (shared_column_data_mem_tracker)
+            will_be += shared_column_data_mem_tracker->get(); // Add shared column data size to root tracker.
     }
 
     if (check_memory_limit)

--- a/dbms/src/Common/MemoryTracker.cpp
+++ b/dbms/src/Common/MemoryTracker.cpp
@@ -117,7 +117,10 @@ void MemoryTracker::alloc(Int64 size, bool check_memory_limit)
     reportAmount();
 
     if (!next.load(std::memory_order_relaxed))
+    {
         CurrentMetrics::add(metric, size);
+        will_be += shared_column_data_mem_tracker->get(); // Add shared column data size to root tracker.
+    }
 
     if (check_memory_limit)
     {

--- a/dbms/src/Common/MemoryTracker.h
+++ b/dbms/src/Common/MemoryTracker.h
@@ -171,6 +171,7 @@ extern std::shared_ptr<MemoryTracker> root_of_query_mem_trackers;
 //                  |-- fetch_pages_mem_tracker
 extern std::shared_ptr<MemoryTracker> sub_root_of_query_storage_task_mem_trackers;
 extern std::shared_ptr<MemoryTracker> fetch_pages_mem_tracker;
+extern std::shared_ptr<MemoryTracker> shared_column_data_mem_tracker;
 
 void initStorageMemoryTracker(Int64 limit, Int64 larger_than_limit);
 

--- a/dbms/src/Common/PODArray.h
+++ b/dbms/src/Common/PODArray.h
@@ -111,7 +111,8 @@ protected:
 
     [[nodiscard]] __attribute__((always_inline)) std::optional<MemoryTrackerSetter> swicthMemoryTracker()
     {
-        return is_shared_memory ? std::make_optional<MemoryTrackerSetter>(true, shared_column_data_mem_tracker.get()) : std::nullopt;
+        return is_shared_memory ? std::make_optional<MemoryTrackerSetter>(true, shared_column_data_mem_tracker.get())
+                                : std::nullopt;
     }
 
     /// The amount of memory occupied by the num_elements of the elements.

--- a/dbms/src/Storages/DeltaMerge/File/DMFileReader.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileReader.cpp
@@ -14,6 +14,7 @@
 
 #include <Columns/ColumnsCommon.h>
 #include <Common/CurrentMetrics.h>
+#include <Common/MemoryTracker.h>
 #include <Common/Stopwatch.h>
 #include <Common/escapeForFileName.h>
 #include <DataTypes/IDataType.h>
@@ -809,8 +810,14 @@ void DMFileReader::readColumn(
     size_t read_rows,
     size_t skip_packs)
 {
+    bool has_concurrent_reader = DMFileReaderPool::instance().hasConcurrentReader(*this);
     if (!getCachedPacks(column_define.id, start_pack_id, pack_count, read_rows, column))
     {
+        // If there are concurrent read requests, this data is likely to be shared.
+        // So the allocation and deallocation of this data may not be in the same MemoryTracker.
+        // This can lead to inaccurate memory statistics of MemoryTracker.
+        // To solve this problem, we use a independent global memory tracker to trace the shared column data in ColumnSharingCacheMap.
+        MemoryTrackerSetter mem_tracker_guard(true, has_concurrent_reader ? nullptr : current_memory_tracker);
         auto data_type = dmfile->getColumnStat(column_define.id).type;
         auto col = data_type->createColumn();
         readFromDisk(column_define, col, start_pack_id, read_rows, skip_packs, last_read_from_cache[column_define.id]);
@@ -822,7 +829,7 @@ void DMFileReader::readColumn(
         last_read_from_cache[column_define.id] = true;
     }
 
-    if (col_data_cache != nullptr)
+    if (has_concurrent_reader && col_data_cache != nullptr)
     {
         DMFileReaderPool::instance().set(*this, column_define.id, start_pack_id, pack_count, column);
     }

--- a/dbms/src/Storages/DeltaMerge/File/DMFileReader.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileReader.cpp
@@ -817,7 +817,8 @@ void DMFileReader::readColumn(
         // So the allocation and deallocation of this data may not be in the same MemoryTracker.
         // This can lead to inaccurate memory statistics of MemoryTracker.
         // To solve this problem, we use a independent global memory tracker to trace the shared column data in ColumnSharingCacheMap.
-        MemoryTrackerSetter mem_tracker_guard(true, has_concurrent_reader ? nullptr : current_memory_tracker);
+        auto mem_tracker_guard
+            = has_concurrent_reader ? std::make_optional<MemoryTrackerSetter>(true, nullptr) : std::nullopt;
         auto data_type = dmfile->getColumnStat(column_define.id).type;
         auto col = data_type->createColumn();
         readFromDisk(column_define, col, start_pack_id, read_rows, skip_packs, last_read_from_cache[column_define.id]);

--- a/dbms/src/Storages/DeltaMerge/ReadThread/ColumnSharingCache.cpp
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/ColumnSharingCache.cpp
@@ -61,6 +61,14 @@ void DMFileReaderPool::set(DMFileReader & from_reader, int64_t col_id, size_t st
     }
 }
 
+// Check is there any concurrent DMFileReader with `from_reader`.
+bool DMFileReaderPool::hasConcurrentReader(DMFileReader & from_reader)
+{
+    std::lock_guard lock(mtx);
+    auto itr = readers.find(from_reader.path());
+    return itr != readers.end() && itr->second.size() >= 2;
+}
+
 DMFileReader * DMFileReaderPool::get(const std::string & name)
 {
     std::lock_guard lock(mtx);

--- a/dbms/src/Storages/DeltaMerge/ReadThread/ColumnSharingCache.h
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/ColumnSharingCache.h
@@ -53,6 +53,16 @@ public:
         auto & value = packs[start_pack_id];
         if (value.pack_count < pack_count)
         {
+            // Alloc/free memory usage in shared_column_data_mem_tracker every time although we just
+            // increase/decrease a reference count of a pointer. This is because check use count of `col_data`
+            // and alloc/free memory usage in shared_column_data_mem_tracker are not atomic.
+            // So, the actual memory usage is smaller than statics in shared_column_data_mem_tracker
+            // if `col_data` is sharing between more than two requests.
+            if (value.col_data != nullptr)
+            {
+                shared_column_data_mem_tracker->free(value.col_data->byteSize());
+            }
+            shared_column_data_mem_tracker->alloc(col_data->byteSize());
             value.pack_count = pack_count;
             value.col_data = col_data;
         }
@@ -102,6 +112,7 @@ public:
         {
             if (itr->first + itr->second.pack_count <= upper_start_pack_id)
             {
+                shared_column_data_mem_tracker->free(itr->second.col_data->byteSize());
                 itr = packs.erase(itr);
             }
             else
@@ -109,6 +120,12 @@ public:
                 break;
             }
         }
+    }
+
+    ~ColumnSharingCache()
+    {
+        // Deleta all.
+        del(std::numeric_limits<size_t>::max());
     }
 
 private:
@@ -230,6 +247,7 @@ public:
     void add(DMFileReader & reader);
     void del(DMFileReader & reader);
     void set(DMFileReader & from_reader, int64_t col_id, size_t start, size_t count, ColumnPtr & col);
+    bool hasConcurrentReader(DMFileReader & from_reader);
     // `get` is just for test.
     DMFileReader * get(const std::string & name);
 

--- a/dbms/src/TestUtils/TiFlashTestEnv.cpp
+++ b/dbms/src/TestUtils/TiFlashTestEnv.cpp
@@ -22,6 +22,7 @@
 #include <Poco/Logger.h>
 #include <Poco/PatternFormatter.h>
 #include <Server/RaftConfigParser.h>
+#include <Server/ServerInfo.h>
 #include <Storages/DeltaMerge/ColumnFile/ColumnFileSchema.h>
 #include <Storages/DeltaMerge/StoragePool.h>
 #include <Storages/KVStore/TMTContext.h>
@@ -171,6 +172,8 @@ void TiFlashTestEnv::addGlobalContext(
     global_context->getTMTContext().restore(path_pool);
 
     global_context->initializeSharedBlockSchemas(10000);
+
+    global_context->setServerInfo(ServerInfo{}); // Default server info.
 }
 
 ContextPtr TiFlashTestEnv::getContext()

--- a/dbms/src/TestUtils/TiFlashTestEnv.cpp
+++ b/dbms/src/TestUtils/TiFlashTestEnv.cpp
@@ -22,7 +22,6 @@
 #include <Poco/Logger.h>
 #include <Poco/PatternFormatter.h>
 #include <Server/RaftConfigParser.h>
-#include <Server/ServerInfo.h>
 #include <Storages/DeltaMerge/ColumnFile/ColumnFileSchema.h>
 #include <Storages/DeltaMerge/StoragePool.h>
 #include <Storages/KVStore/TMTContext.h>
@@ -172,8 +171,6 @@ void TiFlashTestEnv::addGlobalContext(
     global_context->getTMTContext().restore(path_pool);
 
     global_context->initializeSharedBlockSchemas(10000);
-
-    global_context->setServerInfo(ServerInfo{}); // Default server info.
 }
 
 ContextPtr TiFlashTestEnv::getContext()

--- a/dbms/src/TestUtils/gtests_dbms_main.cpp
+++ b/dbms/src/TestUtils/gtests_dbms_main.cpp
@@ -69,16 +69,11 @@ int main(int argc, char ** argv)
     DB::tests::TiFlashTestEnv::setupLogger("trace", std::cerr, enable_colors);
     auto run_mode = DB::PageStorageRunMode::ONLY_V3;
     DB::tests::TiFlashTestEnv::initializeGlobalContext(/*testdata_path*/ {}, run_mode);
-    const auto & settings = DB::tests::TiFlashTestEnv::getGlobalContext().getSettingsRef();
-    const auto & server_info = DB::tests::TiFlashTestEnv::getGlobalContext().getServerInfo();
-    RUNTIME_CHECK(server_info.has_value());
-    initStorageMemoryTracker(
-        settings.max_memory_usage_for_all_queries.getActualBytes(server_info->memory_info.capacity),
-        settings.bytes_that_rss_larger_than_limit);
+    DB::ServerInfo server_info;
     // `DMFileReaderPool` should be constructed before and destructed after `SegmentReaderPoolManager`.
     DB::DM::DMFileReaderPool::instance();
     DB::DM::SegmentReaderPoolManager::instance().init(
-        server_info->cpu_info.logical_cores,
+        server_info.cpu_info.logical_cores,
         DB::tests::TiFlashTestEnv::getGlobalContext().getSettingsRef().dt_read_thread_count_scale);
     DB::DM::SegmentReadTaskScheduler::instance();
 

--- a/dbms/src/TestUtils/gtests_dbms_main.cpp
+++ b/dbms/src/TestUtils/gtests_dbms_main.cpp
@@ -69,12 +69,16 @@ int main(int argc, char ** argv)
     DB::tests::TiFlashTestEnv::setupLogger("trace", std::cerr, enable_colors);
     auto run_mode = DB::PageStorageRunMode::ONLY_V3;
     DB::tests::TiFlashTestEnv::initializeGlobalContext(/*testdata_path*/ {}, run_mode);
-
-    DB::ServerInfo server_info;
+    const auto & settings = DB::tests::TiFlashTestEnv::getGlobalContext().getSettingsRef();
+    const auto & server_info = DB::tests::TiFlashTestEnv::getGlobalContext().getServerInfo();
+    RUNTIME_CHECK(server_info.has_value());
+    initStorageMemoryTracker(
+        settings.max_memory_usage_for_all_queries.getActualBytes(server_info->memory_info.capacity),
+        settings.bytes_that_rss_larger_than_limit);
     // `DMFileReaderPool` should be constructed before and destructed after `SegmentReaderPoolManager`.
     DB::DM::DMFileReaderPool::instance();
     DB::DM::SegmentReaderPoolManager::instance().init(
-        server_info.cpu_info.logical_cores,
+        server_info->cpu_info.logical_cores,
         DB::tests::TiFlashTestEnv::getGlobalContext().getSettingsRef().dt_read_thread_count_scale);
     DB::DM::SegmentReadTaskScheduler::instance();
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8128 

### What is changed and how it works?

- In `DMFileReader::readCoumn`, if there are some concurrent `DMFileReader` of the same file existing, this column data is likely to be shared, so disable memory tracing by setting `current_memory_tracker` to `nullptr`.
- Mark `PODArray` the underlying memory of column data to be `is_shared_memory` and use `shared_column_data_mem_tracker` to trace its memory.


Before this PR(from issue #8128)
```
[2023/09/21 09:08:37.087 +08:00] [DEBUG] [MemoryTracker.cpp:101] ["Peak memory usage (for query): 10.48 GiB."] [source=MemoryTracker] [thread_id=269]
[2023/09/21 09:08:37.090 +08:00] [DEBUG] [MemoryTracker.cpp:101] ["Peak memory usage (for query): 288.86 MiB."] [source=MemoryTracker] [thread_id=270]
[2023/09/21 09:08:37.090 +08:00] [DEBUG] [MemoryTracker.cpp:101] ["Peak memory usage (total): 988.18 MiB."] [source=MemoryTracker] [thread_id=270]
[2023/09/21 09:08:38.407 +08:00] [DEBUG] [MemoryTracker.cpp:101] ["Peak memory usage (for query): 8.28 GiB."] [source=MemoryTracker] [thread_id=275]
[2023/09/21 09:08:38.824 +08:00] [DEBUG] [MemoryTracker.cpp:101] ["Peak memory usage (for query): 244.48 MiB."] [source=MemoryTracker] [thread_id=277]
[2023/09/21 09:08:39.801 +08:00] [DEBUG] [MemoryTracker.cpp:101] ["Peak memory usage (for query): 3.79 GiB."] [source=MemoryTracker] [thread_id=280]
[2023/09/21 09:08:40.381 +08:00] [DEBUG] [MemoryTracker.cpp:101] ["Peak memory usage (for query): 288.98 MiB."] [source=MemoryTracker] [thread_id=283]
[2023/09/21 09:08:41.408 +08:00] [DEBUG] [MemoryTracker.cpp:101] ["Peak memory usage (for query): 2.69 GiB."] [source=MemoryTracker] [thread_id=286]
[2023/09/21 09:08:42.029 +08:00] [DEBUG] [MemoryTracker.cpp:101] ["Peak memory usage (for query): 397.90 MiB."] [source=MemoryTracker] [thread_id=289]
[2023/09/21 09:08:43.009 +08:00] [DEBUG] [MemoryTracker.cpp:101] ["Peak memory usage (for query): 4.41 GiB."] [source=MemoryTracker] [thread_id=292]
[2023/09/21 09:08:43.488 +08:00] [DEBUG] [MemoryTracker.cpp:101] ["Peak memory usage (for query): 435.62 MiB."] [source=MemoryTracker] [thread_id=295]
[2023/09/21 09:08:43.488 +08:00] [DEBUG] [MemoryTracker.cpp:101] ["Peak memory usage (total): 8.89 GiB."] [source=MemoryTracker] [thread_id=295]
```
After this PR:
```
[2023/09/22 17:20:49.967 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.04 GiB."] [source=MemoryTracker] [thread_id=3084]
[2023/09/22 17:20:53.023 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.60 GiB."] [source=MemoryTracker] [thread_id=3086]
[2023/09/22 17:20:53.132 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.07 GiB."] [source=MemoryTracker] [thread_id=3089]
[2023/09/22 17:20:56.188 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.21 GiB."] [source=MemoryTracker] [thread_id=3091]
[2023/09/22 17:20:56.298 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.02 GiB."] [source=MemoryTracker] [thread_id=3094]
[2023/09/22 17:20:59.324 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.43 GiB."] [source=MemoryTracker] [thread_id=3096]
[2023/09/22 17:20:59.440 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.03 GiB."] [source=MemoryTracker] [thread_id=3098]
[2023/09/22 17:21:02.469 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.28 GiB."] [source=MemoryTracker] [thread_id=3100]
[2023/09/22 17:21:02.564 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.03 GiB."] [source=MemoryTracker] [thread_id=3103]
[2023/09/22 17:21:05.894 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.38 GiB."] [source=MemoryTracker] [thread_id=3105]
[2023/09/22 17:21:05.991 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.01 GiB."] [source=MemoryTracker] [thread_id=3108]
[2023/09/22 17:21:09.070 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.69 GiB."] [source=MemoryTracker] [thread_id=3109]
[2023/09/22 17:21:09.187 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.30 GiB."] [source=MemoryTracker] [thread_id=3112]
[2023/09/22 17:21:12.246 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.25 GiB."] [source=MemoryTracker] [thread_id=3114]
[2023/09/22 17:21:12.361 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.11 GiB."] [source=MemoryTracker] [thread_id=3118]
[2023/09/22 17:21:15.412 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.30 GiB."] [source=MemoryTracker] [thread_id=3120]
[2023/09/22 17:21:15.569 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.04 GiB."] [source=MemoryTracker] [thread_id=3122]
[2023/09/22 17:21:18.653 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.33 GiB."] [source=MemoryTracker] [thread_id=3125]
[2023/09/22 17:21:18.769 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.71 GiB."] [source=MemoryTracker] [thread_id=3128]
[2023/09/22 17:21:21.845 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.28 GiB."] [source=MemoryTracker] [thread_id=3131]
[2023/09/22 17:21:21.988 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.08 GiB."] [source=MemoryTracker] [thread_id=3134]
[2023/09/22 17:21:25.001 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.35 GiB."] [source=MemoryTracker] [thread_id=3137]
[2023/09/22 17:21:25.135 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.05 GiB."] [source=MemoryTracker] [thread_id=3139]
[2023/09/22 17:21:28.144 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.22 GiB."] [source=MemoryTracker] [thread_id=3142]
[2023/09/22 17:21:28.286 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.12 GiB."] [source=MemoryTracker] [thread_id=3143]
[2023/09/22 17:21:31.336 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.20 GiB."] [source=MemoryTracker] [thread_id=3144]
[2023/09/22 17:21:31.454 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.32 GiB."] [source=MemoryTracker] [thread_id=3145]
[2023/09/22 17:21:34.535 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.28 GiB."] [source=MemoryTracker] [thread_id=3146]
[2023/09/22 17:21:34.650 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1023.65 MiB."] [source=MemoryTracker] [thread_id=3148]
[2023/09/22 17:21:37.665 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.31 GiB."] [source=MemoryTracker] [thread_id=3151]
[2023/09/22 17:21:37.799 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.09 GiB."] [source=MemoryTracker] [thread_id=3153]
[2023/09/22 17:21:40.931 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.28 GiB."] [source=MemoryTracker] [thread_id=3155]
[2023/09/22 17:21:41.051 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.20 GiB."] [source=MemoryTracker] [thread_id=3157]
[2023/09/22 17:21:44.169 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.24 GiB."] [source=MemoryTracker] [thread_id=3159]
[2023/09/22 17:21:44.294 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.10 GiB."] [source=MemoryTracker] [thread_id=3162]
[2023/09/22 17:21:47.329 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.25 GiB."] [source=MemoryTracker] [thread_id=3165]
[2023/09/22 17:21:47.441 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.12 GiB."] [source=MemoryTracker] [thread_id=3167]
[2023/09/22 17:21:50.481 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.53 GiB."] [source=MemoryTracker] [thread_id=3170]
[2023/09/22 17:21:50.657 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 998.26 MiB."] [source=MemoryTracker] [thread_id=3171]
[2023/09/22 17:21:53.689 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.67 GiB."] [source=MemoryTracker] [thread_id=3173]
[2023/09/22 17:21:53.801 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.88 GiB."] [source=MemoryTracker] [thread_id=3176]
[2023/09/22 17:21:56.932 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.36 GiB."] [source=MemoryTracker] [thread_id=3179]
[2023/09/22 17:21:57.026 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.06 GiB."] [source=MemoryTracker] [thread_id=3181]
[2023/09/22 17:22:00.085 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.62 GiB."] [source=MemoryTracker] [thread_id=3183]
[2023/09/22 17:22:00.210 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.13 GiB."] [source=MemoryTracker] [thread_id=3185]
[2023/09/22 17:22:03.338 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.35 GiB."] [source=MemoryTracker] [thread_id=3186]
[2023/09/22 17:22:03.421 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.06 GiB."] [source=MemoryTracker] [thread_id=3188]
[2023/09/22 17:22:06.471 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.48 GiB."] [source=MemoryTracker] [thread_id=3191]
[2023/09/22 17:22:06.589 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (for query): 1.05 GiB."] [source=MemoryTracker] [thread_id=3193]
[2023/09/22 17:22:06.589 +08:00] [DEBUG] [MemoryTracker.cpp:107] ["Peak memory usage (total): 3.86 GiB."] [source=MemoryTracker] [thread_id=3193]
```

- Maybe there are some global PODArray object that are not being traced before, about 12.4MiB.
![image](https://github.com/pingcap/tiflash/assets/6143402/f26347c1-0a9a-4aac-8b73-0d8658ff8d17)

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
