### PR TITLE
fix network error handling of LocalAdmissionController

### DIFF
--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/ResourceControlQueue.h
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/ResourceControlQueue.h
@@ -34,9 +34,7 @@ public:
         RUNTIME_CHECK_MSG(
             LocalAdmissionController::global_instance != nullptr,
             "LocalAdmissionController::global_instance has not been initialized yet.");
-        LocalAdmissionController::global_instance->registerRefillTokenCallback([&]() {
-            cv.notify_all();
-        });
+        LocalAdmissionController::global_instance->registerRefillTokenCallback([&]() { cv.notify_all(); });
     }
 
     ~ResourceControlQueue() override { LocalAdmissionController::global_instance->unregisterRefillTokenCallback(); }

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/ResourceControlQueue.h
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/ResourceControlQueue.h
@@ -35,7 +35,6 @@ public:
             LocalAdmissionController::global_instance != nullptr,
             "LocalAdmissionController::global_instance has not been initialized yet.");
         LocalAdmissionController::global_instance->registerRefillTokenCallback([&]() {
-            std::lock_guard lock(mu);
             cv.notify_all();
         });
     }

--- a/dbms/src/Flash/ResourceControl/LocalAdmissionController.cpp
+++ b/dbms/src/Flash/ResourceControl/LocalAdmissionController.cpp
@@ -324,10 +324,9 @@ std::vector<std::string> LocalAdmissionController::handleTokenBucketsResp(
         {
             LOG_ERROR(
                 log,
-                fmt::format(
-                    "expect resp.granted_r_u_tokens().size() is 1 or 0, but got {} for rg {}",
-                    one_resp.granted_r_u_tokens().size(),
-                    one_resp.resource_group_name()));
+                "expect resp.granted_r_u_tokens().size() is 1 or 0, but got {} for rg {}",
+                one_resp.granted_r_u_tokens().size(),
+                one_resp.resource_group_name());
             continue;
         }
 

--- a/dbms/src/Flash/ResourceControl/LocalAdmissionController.cpp
+++ b/dbms/src/Flash/ResourceControl/LocalAdmissionController.cpp
@@ -322,9 +322,12 @@ std::vector<std::string> LocalAdmissionController::handleTokenBucketsResp(
 
         if unlikely (one_resp.granted_r_u_tokens().size() != 1)
         {
-            LOG_ERROR(log, fmt::format(
-                "expect resp.granted_r_u_tokens().size() is 1 or 0, but got {} for rg {}",
-                one_resp.granted_r_u_tokens().size(), one_resp.resource_group_name()));
+            LOG_ERROR(
+                log,
+                fmt::format(
+                    "expect resp.granted_r_u_tokens().size() is 1 or 0, but got {} for rg {}",
+                    one_resp.granted_r_u_tokens().size(),
+                    one_resp.resource_group_name()));
             continue;
         }
 

--- a/dbms/src/Flash/ResourceControl/LocalAdmissionController.cpp
+++ b/dbms/src/Flash/ResourceControl/LocalAdmissionController.cpp
@@ -56,13 +56,13 @@ void LocalAdmissionController::startBackgroudJob()
     {
         try
         {
-            // If the unique_client_id cannot be successfully obtained from GAC for a long, then the behavior of resource control is:
+            // If the unique_client_id cannot be successfully obtained from GAC for a long time, then the behavior of resource control is:
             // when the resource group has consumed RU, all queries cannot be scheduled anymore.
             unique_client_id = etcd_client->acquireServerIDFromPD();
         }
         catch (...)
         {
-            // In case we got context timeout error.
+            // Needs to catch in case we got context timeout error.
             LOG_ERROR(
                 log,
                 "get unique_client_id from PD error: {}, resource control may not work properly, try again later",

--- a/dbms/src/Flash/ResourceControl/LocalAdmissionController.cpp
+++ b/dbms/src/Flash/ResourceControl/LocalAdmissionController.cpp
@@ -392,7 +392,7 @@ void LocalAdmissionController::watchGAC()
                 return;
 
             // Create new grpc_context for each reader/writer.
-            watch_gac_grpc_context = std::make_shared<grpc::ClientContext>();
+            watch_gac_grpc_context = std::make_unique<grpc::ClientContext>();
         }
     }
 }

--- a/dbms/src/Flash/ResourceControl/LocalAdmissionController.cpp
+++ b/dbms/src/Flash/ResourceControl/LocalAdmissionController.cpp
@@ -313,11 +313,13 @@ std::vector<std::string> LocalAdmissionController::handleTokenBucketsResp(
 
         handled_resource_group_names.emplace_back(one_resp.resource_group_name());
 
-        if unlikely (one_resp.granted_r_u_tokens().size() != 1)
+        // It's possible for one_resp.granted_r_u_tokens() to be empty
+        // when the acquire_token_req is only for report RU consumption.
+        if unlikely (!one_resp.granted_r_u_tokens().empty() && one_resp.granted_r_u_tokens().size() != 1)
         {
             handleBackgroundError(fmt::format(
-                "expect resp.granted_r_u_tokens().size() is 1, but got {}",
-                one_resp.granted_r_u_tokens().size()));
+                "expect resp.granted_r_u_tokens().size() is 1 or 0, but got {} for rg {}",
+                one_resp.granted_r_u_tokens().size(), one_resp.resource_group_name()));
             continue;
         }
         auto resource_group = findResourceGroup(one_resp.resource_group_name());

--- a/dbms/src/Flash/ResourceControl/LocalAdmissionController.h
+++ b/dbms/src/Flash/ResourceControl/LocalAdmissionController.h
@@ -385,7 +385,7 @@ public:
     LocalAdmissionController(::pingcap::kv::Cluster * cluster_, Etcd::ClientPtr etcd_client_)
         : cluster(cluster_)
         , etcd_client(etcd_client_)
-        , watch_gac_grpc_context(std::make_shared<grpc::ClientContext>())
+        , watch_gac_grpc_context(std::make_unique<grpc::ClientContext>())
     {
         background_threads.emplace_back([this] { this->startBackgroudJob(); });
         background_threads.emplace_back([this] { this->watchGAC(); });
@@ -582,7 +582,7 @@ private:
     ::pingcap::kv::Cluster * cluster = nullptr;
     uint64_t unique_client_id = 0;
     Etcd::ClientPtr etcd_client = nullptr;
-    std::shared_ptr<grpc::ClientContext> watch_gac_grpc_context = nullptr;
+    std::unique_ptr<grpc::ClientContext> watch_gac_grpc_context = nullptr;
     std::vector<std::thread> background_threads;
 
     std::function<void()> refill_token_callback;

--- a/dbms/src/Flash/ResourceControl/LocalAdmissionController.h
+++ b/dbms/src/Flash/ResourceControl/LocalAdmissionController.h
@@ -446,6 +446,9 @@ public:
 
     void registerRefillTokenCallback(const std::function<void()> & cb)
     {
+        // NOTE: Better not use lock inside refill_token_callback,
+        // because LAC needs to lock when calling refill_token_callback,
+        // which may introduce dead lock.
         std::lock_guard lock(mu);
         RUNTIME_CHECK_MSG(refill_token_callback == nullptr, "callback cannot be registered multiple times");
         refill_token_callback = cb;
@@ -516,8 +519,6 @@ private:
     }
 
     std::vector<std::string> handleTokenBucketsResp(const resource_manager::TokenBucketsResponse & resp);
-
-    void handleBackgroundError(const std::string & err_msg) const;
 
     static void checkGACRespValid(const resource_manager::ResourceGroup & new_group_pb);
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8074

Problem Summary: 
two problems:
1. Grpc needs new a client context for each new reader/writer, otherwise may crash.
2. Network between GAC and LAC may got network error(like timeout). Need to handle it more gracefully, otherwise tiflash will crash.

two enhancements:
1. Delete `handleBackgroundError()`, because it's just a dummy wrap of `LOG_ERROR`
2. Add lock when call `refill_token_callback` to avoid RCQ been destroied when calling `refill_token_callback`

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
1. start cluster with tiflash
3. continuously kill pd and check tiflash should not crash
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
