### PR TITLE
Fix potential hang if tidb cancel is lost

### DIFF
--- a/dbms/src/Flash/EstablishCall.cpp
+++ b/dbms/src/Flash/EstablishCall.cpp
@@ -50,6 +50,15 @@ EstablishCallData::EstablishCallData(
     service->RequestEstablishMPPConnection(&ctx, &request, &responder, cq, notify_cq, asGRPCKickTag());
 }
 
+EstablishCallData::EstablishCallData()
+    : service(nullptr)
+    , cq(nullptr)
+    , notify_cq(nullptr)
+    , is_shutdown(std::make_shared<std::atomic<bool>>(false))
+    , responder(&ctx)
+    , state(NEW_REQUEST)
+{}
+
 EstablishCallData::~EstablishCallData()
 {
     GET_METRIC(tiflash_object_count, type_count_of_establish_calldata).Decrement();

--- a/dbms/src/Flash/EstablishCall.h
+++ b/dbms/src/Flash/EstablishCall.h
@@ -54,6 +54,9 @@ public:
         grpc::ServerCompletionQueue * notify_cq,
         const std::shared_ptr<std::atomic<bool>> & is_shutdown);
 
+    /// for test
+    EstablishCallData();
+
     ~EstablishCallData() override;
 
     void execute(bool ok) override;

--- a/dbms/src/Flash/Mpp/MPPTask.cpp
+++ b/dbms/src/Flash/Mpp/MPPTask.cpp
@@ -124,7 +124,7 @@ MPPTaskMonitorHelper::~MPPTaskMonitorHelper()
     }
 }
 
-MPPTask::MPPTask(const mpp::TaskMeta & meta_, const ContextPtr & context_, bool for_test)
+MPPTask::MPPTask(const mpp::TaskMeta & meta_, const ContextPtr & context_)
     : meta(meta_)
     , id(meta)
     , context(context_)
@@ -136,12 +136,13 @@ MPPTask::MPPTask(const mpp::TaskMeta & meta_, const ContextPtr & context_, bool 
     assert(manager != nullptr);
     current_memory_tracker = nullptr;
     mpp_task_monitor_helper.initAndAddself(manager, id.toString());
-    if unlikely (for_test)
-    {
-        dag_context = std::make_unique<DAGContext>(100);
-        context->setDAGContext(dag_context.get());
-        schedule_entry.setNeededThreads(10);
-    }
+}
+
+void MPPTask::initForTest()
+{
+    dag_context = std::make_unique<DAGContext>(100);
+    context->setDAGContext(dag_context.get());
+    schedule_entry.setNeededThreads(10);
 }
 
 MPPTask::~MPPTask()

--- a/dbms/src/Flash/Mpp/MPPTask.cpp
+++ b/dbms/src/Flash/Mpp/MPPTask.cpp
@@ -124,7 +124,7 @@ MPPTaskMonitorHelper::~MPPTaskMonitorHelper()
     }
 }
 
-MPPTask::MPPTask(const mpp::TaskMeta & meta_, const ContextPtr & context_)
+MPPTask::MPPTask(const mpp::TaskMeta & meta_, const ContextPtr & context_, bool for_test)
     : meta(meta_)
     , id(meta)
     , context(context_)
@@ -136,6 +136,12 @@ MPPTask::MPPTask(const mpp::TaskMeta & meta_, const ContextPtr & context_)
     assert(manager != nullptr);
     current_memory_tracker = nullptr;
     mpp_task_monitor_helper.initAndAddself(manager, id.toString());
+    if unlikely (for_test)
+    {
+        dag_context = std::make_unique<DAGContext>(100);
+        context->setDAGContext(dag_context.get());
+        schedule_entry.setNeededThreads(10);
+    }
 }
 
 MPPTask::~MPPTask()

--- a/dbms/src/Flash/Mpp/MPPTask.cpp
+++ b/dbms/src/Flash/Mpp/MPPTask.cpp
@@ -361,7 +361,7 @@ MemoryTracker * MPPTask::getMemoryTracker() const
 
 void MPPTask::unregisterTask()
 {
-    auto [result, reason] = manager->unregisterTask(id);
+    auto [result, reason] = manager->unregisterTask(id, getErrString());
     if (result)
         LOG_DEBUG(log, "task unregistered");
     else

--- a/dbms/src/Flash/Mpp/MPPTask.h
+++ b/dbms/src/Flash/Mpp/MPPTask.h
@@ -101,7 +101,7 @@ public:
     ~MPPTask();
 
 private:
-    MPPTask(const mpp::TaskMeta & meta_, const ContextPtr & context_);
+    MPPTask(const mpp::TaskMeta & meta_, const ContextPtr & context_, bool for_test = false);
 
     void runImpl();
 

--- a/dbms/src/Flash/Mpp/MPPTask.h
+++ b/dbms/src/Flash/Mpp/MPPTask.h
@@ -79,6 +79,15 @@ public:
         return Ptr(new MPPTask(std::forward<Args>(args)...));
     }
 
+    /// Ensure all MPPTasks are allocated as std::shared_ptr
+    template <typename... Args>
+    static Ptr newTaskForTest(Args &&... args)
+    {
+        auto ret = Ptr(new MPPTask(std::forward<Args>(args)...));
+        ret->initForTest();
+        return ret;
+    }
+
     const MPPTaskId & getId() const { return id; }
 
     bool isRootMPPTask() const;
@@ -101,9 +110,11 @@ public:
     ~MPPTask();
 
 private:
-    MPPTask(const mpp::TaskMeta & meta_, const ContextPtr & context_, bool for_test = false);
+    MPPTask(const mpp::TaskMeta & meta_, const ContextPtr & context_);
 
     void runImpl();
+
+    void initForTest();
 
     void unregisterTask();
 

--- a/dbms/src/Flash/Mpp/MPPTaskManager.h
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.h
@@ -65,6 +65,7 @@ struct MPPGatherTaskSet
     }
     void cancelAlarmsBySenderTaskId(const MPPTaskId & task_id);
     bool hasMPPTask() const { return !task_map.empty(); }
+    bool hasAlarm() const { return !alarms.empty(); }
     template <typename F>
     void forEachMPPTask(F && f) const
     {
@@ -252,6 +253,9 @@ public:
     MPPQueryPtr getMPPQueryWithoutLock(const MPPQueryId & query_id);
 
     MPPQueryPtr getMPPQuery(const MPPQueryId & query_id);
+
+    /// for test
+    MPPQueryId getCurrentMinTSOQueryId(const String & resource_group_name);
 
 private:
     MPPQueryPtr addMPPQuery(

--- a/dbms/src/Flash/Mpp/MinTSOScheduler.cpp
+++ b/dbms/src/Flash/Mpp/MinTSOScheduler.cpp
@@ -175,6 +175,12 @@ void MinTSOScheduler::deleteQuery(
     }
 }
 
+MPPQueryId MinTSOScheduler::getCurrentMinTSOQueryId(const String & resource_group_name)
+{
+    auto & group_entry = getOrCreateGroupEntry(resource_group_name);
+    return group_entry.min_query_id;
+}
+
 /// NOTE: should not throw exceptions due to being called when destruction.
 void MinTSOScheduler::releaseThreadsThenSchedule(
     const String & resource_group_name,

--- a/dbms/src/Flash/Mpp/MinTSOScheduler.h
+++ b/dbms/src/Flash/Mpp/MinTSOScheduler.h
@@ -50,6 +50,8 @@ public:
         const String & resource_group_name,
         int needed_threads,
         MPPTaskManager & task_manager);
+    /// for test
+    MPPQueryId getCurrentMinTSOQueryId(const String & resource_group_name);
 
 private:
     bool scheduleImp(

--- a/dbms/src/Flash/Mpp/tests/gtest_mpp_task_manager.cpp
+++ b/dbms/src/Flash/Mpp/tests/gtest_mpp_task_manager.cpp
@@ -97,7 +97,7 @@ try
         mpp_task_manager->getCurrentMinTSOQueryId(gather_id.query_id.resource_group_name) == gather_id.query_id);
 
     /// unregister task should clean the related alarms
-    mpp_task_manager->unregisterTask(mpp_task_1->getId());
+    mpp_task_manager->unregisterTask(mpp_task_1->getId(), "");
     gather_task_set = mpp_task_manager->getGatherTaskSet(MPPGatherId(1, MPPQueryId(1, 1, 1, 1, "")));
     ASSERT_TRUE(gather_task_set.first->hasMPPTask());
     ASSERT_TRUE(!gather_task_set.first->hasAlarm());
@@ -113,7 +113,7 @@ try
     ASSERT_TRUE(find_tunnel_result.first == nullptr && !find_tunnel_result.second.empty());
 
     /// if all task is unregistered, min tso should be updated
-    mpp_task_manager->unregisterTask(mpp_task_2->getId());
+    mpp_task_manager->unregisterTask(mpp_task_2->getId(), "");
     gather_task_set = mpp_task_manager->getGatherTaskSet(MPPGatherId(1, MPPQueryId(1, 1, 1, 1, "")));
     ASSERT_TRUE(gather_task_set.first == nullptr);
     ASSERT_TRUE(

--- a/dbms/src/Flash/Mpp/tests/gtest_mpp_task_manager.cpp
+++ b/dbms/src/Flash/Mpp/tests/gtest_mpp_task_manager.cpp
@@ -85,8 +85,8 @@ try
         mpp_task_manager->getCurrentMinTSOQueryId(gather_id.query_id.resource_group_name) == MPPTaskId::Max_Query_Id);
 
     /// schedule task will put query_id to scheduler
-    auto mpp_task_1 = MPPTask::newTask(*sender_meta, context, true);
-    auto mpp_task_2 = MPPTask::newTask(*receiver_meta, context, true);
+    auto mpp_task_1 = MPPTask::newTaskForTest(*sender_meta, context);
+    auto mpp_task_2 = MPPTask::newTaskForTest(*receiver_meta, context);
     mpp_task_manager->registerTask(mpp_task_1.get());
     mpp_task_manager->tryToScheduleTask(mpp_task_1->getScheduleEntry());
     mpp_task_manager->registerTask(mpp_task_2.get());

--- a/dbms/src/Flash/Mpp/tests/gtest_mpp_task_manager.cpp
+++ b/dbms/src/Flash/Mpp/tests/gtest_mpp_task_manager.cpp
@@ -1,0 +1,125 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Flash/Coprocessor/DAGContext.h>
+#include <Flash/Mpp/MPPTaskManager.h>
+#include <Interpreters/Context.h>
+#include <Storages/KVStore/TMTContext.h>
+#include <TestUtils/TiFlashTestBasic.h>
+#include <TestUtils/TiFlashTestEnv.h>
+#include <gtest/gtest.h>
+
+#include "Server/RaftConfigParser.h"
+
+namespace DB
+{
+namespace tests
+{
+class TestMPPTaskManager : public testing::Test
+{
+public:
+    TestMPPTaskManager()
+    {
+        global_context = Context::createGlobal();
+        global_context->mockConfigLoaded();
+        TiFlashRaftConfig raft_config;
+        global_context->createTMTContext(raft_config, pingcap::ClusterConfig());
+    }
+    static void fillTaskMeta(mpp::TaskMeta * task_meta, Int64 task_id, MPPGatherId & gather_id)
+    {
+        task_meta->set_gather_id(gather_id.gather_id);
+        task_meta->set_task_id(task_id);
+        task_meta->set_local_query_id(gather_id.query_id.local_query_id);
+        task_meta->set_query_ts(gather_id.query_id.query_ts);
+        task_meta->set_server_id(gather_id.query_id.server_id);
+        task_meta->set_start_ts(gather_id.query_id.start_ts);
+        task_meta->set_resource_group_name(gather_id.query_id.resource_group_name);
+    }
+    ContextPtr createContextForTest()
+    {
+        auto context = std::make_shared<Context>(*global_context);
+        String query_id = "query_id_for_test";
+        context->setCurrentQueryId(query_id);
+        return context;
+    }
+
+protected:
+    std::unique_ptr<Context> global_context;
+};
+
+TEST_F(TestMPPTaskManager, testUnregisterMPPTask)
+try
+{
+    auto context = createContextForTest();
+
+    /// find async tunnel create alarm if task is not visible
+    EstablishCallData establish_call_data;
+    mpp::EstablishMPPConnectionRequest establish_req;
+    auto gather_id = MPPGatherId(1, MPPQueryId(1, 1, 1, 1, ""));
+    auto * receiver_meta = establish_req.mutable_receiver_meta();
+    fillTaskMeta(receiver_meta, 2, gather_id);
+    auto * sender_meta = establish_req.mutable_sender_meta();
+    fillTaskMeta(sender_meta, 1, gather_id);
+    auto mpp_task_manager = context->getTMTContext().getMPPTaskManager();
+    auto find_tunnel_result
+        = mpp_task_manager->findAsyncTunnel(&establish_req, &establish_call_data, nullptr, *context);
+    ASSERT_TRUE(find_tunnel_result.first == nullptr && find_tunnel_result.second.empty());
+
+    /// `findAsyncTunnel` will create GatherTaskSet
+    auto gather_task_set = mpp_task_manager->getGatherTaskSet(MPPGatherId(1, MPPQueryId(1, 1, 1, 1, "")));
+    ASSERT_TRUE(gather_task_set.first != nullptr);
+    ASSERT_TRUE(!gather_task_set.first->hasMPPTask());
+    ASSERT_TRUE(gather_task_set.first->hasAlarm());
+    ASSERT_TRUE(
+        mpp_task_manager->getCurrentMinTSOQueryId(gather_id.query_id.resource_group_name) == MPPTaskId::Max_Query_Id);
+
+    /// schedule task will put query_id to scheduler
+    auto mpp_task_1 = MPPTask::newTask(*sender_meta, context, true);
+    auto mpp_task_2 = MPPTask::newTask(*receiver_meta, context, true);
+    mpp_task_manager->registerTask(mpp_task_1.get());
+    mpp_task_manager->tryToScheduleTask(mpp_task_1->getScheduleEntry());
+    mpp_task_manager->registerTask(mpp_task_2.get());
+    mpp_task_manager->tryToScheduleTask(mpp_task_2->getScheduleEntry());
+    ASSERT_TRUE(gather_task_set.first->hasMPPTask());
+    ASSERT_TRUE(gather_task_set.first->hasAlarm());
+    ASSERT_TRUE(
+        mpp_task_manager->getCurrentMinTSOQueryId(gather_id.query_id.resource_group_name) == gather_id.query_id);
+
+    /// unregister task should clean the related alarms
+    mpp_task_manager->unregisterTask(mpp_task_1->getId());
+    gather_task_set = mpp_task_manager->getGatherTaskSet(MPPGatherId(1, MPPQueryId(1, 1, 1, 1, "")));
+    ASSERT_TRUE(gather_task_set.first->hasMPPTask());
+    ASSERT_TRUE(!gather_task_set.first->hasAlarm());
+
+    /// `findAsyncTunnel` should return error if target sender task is unregistered
+    EstablishCallData establish_call_data_1;
+    mpp::EstablishMPPConnectionRequest establish_req_1;
+    receiver_meta = establish_req_1.mutable_receiver_meta();
+    fillTaskMeta(receiver_meta, 3, gather_id);
+    sender_meta = establish_req_1.mutable_sender_meta();
+    fillTaskMeta(sender_meta, 1, gather_id);
+    find_tunnel_result = mpp_task_manager->findAsyncTunnel(&establish_req, &establish_call_data, nullptr, *context);
+    ASSERT_TRUE(find_tunnel_result.first == nullptr && !find_tunnel_result.second.empty());
+
+    /// if all task is unregistered, min tso should be updated
+    mpp_task_manager->unregisterTask(mpp_task_2->getId());
+    gather_task_set = mpp_task_manager->getGatherTaskSet(MPPGatherId(1, MPPQueryId(1, 1, 1, 1, "")));
+    ASSERT_TRUE(gather_task_set.first == nullptr);
+    ASSERT_TRUE(
+        mpp_task_manager->getCurrentMinTSOQueryId(gather_id.query_id.resource_group_name) == MPPTaskId::Max_Query_Id);
+}
+CATCH
+
+} // namespace tests
+} // namespace DB

--- a/dbms/src/Interpreters/Aggregator.cpp
+++ b/dbms/src/Interpreters/Aggregator.cpp
@@ -984,7 +984,8 @@ bool Aggregator::executeOnBlock(AggProcessInfo & agg_process_info, AggregatedDat
     /** Flush data to disk if too much RAM is consumed.
       */
     auto revocable_bytes = result.revocableBytes();
-    LOG_TRACE(log, "Revocable bytes after insert one block {}, thread {}", revocable_bytes, thread_num);
+    if (revocable_bytes > 20 * 1024 * 1024)
+        LOG_TRACE(log, "Revocable bytes after insert one block {}, thread {}", revocable_bytes, thread_num);
     if (agg_spill_context->updatePerThreadRevocableMemory(revocable_bytes, thread_num))
     {
         result.tryMarkNeedSpill();

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -613,12 +613,17 @@ void Join::insertFromBlock(const Block & block, size_t stream_index)
         }
         if (!hash_join_spill_context->isInAutoSpillMode())
             spillMostMemoryUsedPartitionIfNeed(stream_index);
-        LOG_DEBUG(
-            log,
-            fmt::format(
-                "all bytes used after one insert: {}, hash table and pool size: {}",
-                getTotalByteCount(),
-                getTotalHashTableAndPoolByteCount()));
+        if (log->is(Poco::Message::PRIO_DEBUG))
+        {
+            auto total_bytes = getTotalByteCount();
+            if (total_bytes > 100 * 1024 * 1024)
+                LOG_DEBUG(
+                    log,
+                    fmt::format(
+                        "all bytes used after one insert: {}, hash table and pool size: {}",
+                        getTotalByteCount(),
+                        getTotalHashTableAndPoolByteCount()));
+        }
     }
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6233

Problem Summary:

### What is changed and how it works?
In `MPPTaskManager::unregisterTask`
https://github.com/pingcap/tiflash/blob/9d4485f152f8fd11225018aec128a760141f6edb/dbms/src/Flash/Mpp/MPPTaskManager.cpp#L404-L407
it only remove `MPPGatherTaskSet` if current gather_set does not has mpp task && current gather_set does not have pending alarms. If there is any pending alarms, the gather_set will be kept in `MPPTaskManager`, thus also kept in `MinTSOScheduler`, if all the task are unregistered, the only way to remove gather_set from `MPPTaskManager` and `MinTSOScheduler` is from TiDB's cancel request, if the request is lost, the `MinTSOScheduler` may be work as expected since `min_tso` will not be updated.

In this pr, it tries to only keep "valid" alarms in gather_set by
* `MPPGatherTaskSet` keep a set of finished/failed task ids
* `MPPTaskManager::findAsyncTunnel` will return error directly if target send task is already finished or failed
* `MPPTaskManager::unregisterTask` will remove related `alarms` in `MPPGatherTaskSet`
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
