### PR TITLE
Reset current_memory_tracker when WNEstablishDisaggTaskHandler finished.

### DIFF
--- a/dbms/src/Flash/FlashService.cpp
+++ b/dbms/src/Flash/FlashService.cpp
@@ -908,6 +908,10 @@ grpc::Status FlashService::EstablishDisaggTask(
             [&handler, &request, &response, deadline = grpc_context->deadline()]() {
                 auto current = std::chrono::system_clock::now();
                 RUNTIME_CHECK(current < deadline, current, deadline);
+                // `handler` may set `current_memory_tracker` in various ways.
+                // Let's backup the original `current_memory_tracker` and reset it after task finished.
+                auto * current_memory_tracker_backup = current_memory_tracker;
+                SCOPE_EXIT({ current_memory_tracker = current_memory_tracker_backup; });
                 handler->prepare(request);
                 handler->execute(response);
             });


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8173

Problem Summary:

1. In `WNEstablishDisaggTaskHandler::execute`, a `ProcessListElement` object will be created and sets `current_memory_tracker` to its `memory_tracker` member in constructor. And `current_memory_tracker`  will be reset in the destructor of  `ProcessListElement`.

2. However, objects of `ProcessListElement` are created in threads of  `WNEstablishDisaggTaskPool`, but destructed in threads of GRPC because it will be destructed with object of  `WNEstablishDisaggTaskHandler` (`handler` -> `dag_context` -> `process_list_entry`).

3. This result in `current_memory_tracker` of threads of `WNEstablishDisaggTaskPool` is not reset after task finished and other tasks may continue to use this memory tracker, although it may have already been destructed.

### What is changed and how it works?

- Reset `current_memory_tracker` after tasks of `WNEstablishDisaggTaskPool` finished.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
