### PR TITLE
refine log for cop/batch cop

### DIFF
--- a/dbms/src/Flash/BatchCoprocessorHandler.cpp
+++ b/dbms/src/Flash/BatchCoprocessorHandler.cpp
@@ -37,12 +37,13 @@ extern const int NOT_IMPLEMENTED;
 BatchCoprocessorHandler::BatchCoprocessorHandler(
     CoprocessorContext & cop_context_,
     const coprocessor::BatchRequest * cop_request_,
-    ::grpc::ServerWriter<::coprocessor::BatchResponse> * writer_)
+    ::grpc::ServerWriter<::coprocessor::BatchResponse> * writer_,
+    const String & identifier)
     : cop_context(cop_context_)
     , cop_request(cop_request_)
     , writer(writer_)
     , resource_group_name(cop_request->context().resource_control_context().resource_group_name())
-    , log(Logger::get("BatchCoprocessorHandler, resource_group: " + resource_group_name))
+    , log(Logger::get(identifier))
 {}
 
 grpc::Status BatchCoprocessorHandler::execute()
@@ -83,7 +84,7 @@ grpc::Status BatchCoprocessorHandler::execute()
                 cop_context.db_context.getClientInfo().current_address.toString(),
                 DAGRequestKind::BatchCop,
                 resource_group_name,
-                Logger::get("BatchCoprocessorHandler, resource_group: " + resource_group_name));
+                Logger::get(log->identifier()));
             cop_context.db_context.setDAGContext(&dag_context);
 
             DAGDriver<DAGRequestKind::BatchCop> driver(

--- a/dbms/src/Flash/BatchCoprocessorHandler.h
+++ b/dbms/src/Flash/BatchCoprocessorHandler.h
@@ -32,7 +32,8 @@ public:
     BatchCoprocessorHandler(
         CoprocessorContext & cop_context_,
         const coprocessor::BatchRequest * cop_request_,
-        ::grpc::ServerWriter<::coprocessor::BatchResponse> * writer_);
+        ::grpc::ServerWriter<::coprocessor::BatchResponse> * writer_,
+        const String & identifier);
 
     grpc::Status execute();
 

--- a/dbms/src/Flash/Coprocessor/CoprocessorReader.h
+++ b/dbms/src/Flash/Coprocessor/CoprocessorReader.h
@@ -43,7 +43,6 @@ namespace pingcap
 {
 namespace common
 {
-
 template <typename T>
 class CopIterMPMCQueue : public IMPMCQueue<T>
 {
@@ -181,7 +180,8 @@ public:
         bool enable_cop_stream_,
         size_t queue_size,
         UInt64 cop_timeout,
-        const pingcap::kv::LabelFilter & tiflash_label_filter_)
+        const pingcap::kv::LabelFilter & tiflash_label_filter_,
+        const String & source_identifier)
         : schema(schema_)
         , has_enforce_encode_type(has_enforce_encode_type_)
         , concurrency(concurrency_)
@@ -191,7 +191,7 @@ public:
               std::move(tasks),
               cluster,
               concurrency_,
-              &Poco::Logger::get("pingcap/coprocessor"),
+              &Poco::Logger::get(fmt::format("{} pingcap/coprocessor", source_identifier)),
               cop_timeout,
               tiflash_label_filter_)
     {}

--- a/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
@@ -747,7 +747,8 @@ CoprocessorReaderPtr DAGStorageInterpreter::buildCoprocessorReader(const std::ve
         enable_cop_stream,
         queue_size,
         cop_timeout,
-        tiflash_label_filter);
+        tiflash_label_filter,
+        log->identifier());
     context.getDAGContext()->addCoprocessorReader(coprocessor_reader);
 
     return coprocessor_reader;

--- a/dbms/src/Flash/CoprocessorHandler.h
+++ b/dbms/src/Flash/CoprocessorHandler.h
@@ -64,11 +64,13 @@ public:
     CoprocessorHandler(
         CoprocessorContext & cop_context_,
         const coprocessor::Request * cop_request_,
-        coprocessor::Response * response_);
+        coprocessor::Response * response_,
+        const String & identifier);
     CoprocessorHandler(
         CoprocessorContext & cop_context_,
         const coprocessor::Request * cop_request_,
-        grpc::ServerWriter<coprocessor::Response> * cop_writer_);
+        grpc::ServerWriter<coprocessor::Response> * cop_writer_,
+        const String & identifier);
 
     grpc::Status execute();
 

--- a/dbms/src/Flash/FlashService.cpp
+++ b/dbms/src/Flash/FlashService.cpp
@@ -207,15 +207,19 @@ grpc::Status FlashService::Coprocessor(
 {
     CPUAffinityManager::getInstance().bindSelfGrpcThread();
     bool is_remote_read = getClientMetaVarWithDefault(grpc_context, "is_remote_read", "") == "true";
+    auto region_info = fmt::format(
+        "{{{}, {}, {}}}",
+        request->context().region_id(),
+        request->context().region_epoch().conf_ver(),
+        request->context().region_epoch().version());
     auto log_level = is_remote_read ? Poco::Message::PRIO_INFORMATION : Poco::Message::PRIO_DEBUG;
     LOG_IMPL(
         log,
         log_level,
-        "Handling coprocessor request, is_remote_read: {}, start ts: {}, region info: {}, region epoch: {}",
+        "Handling coprocessor request, is_remote_read: {}, start ts: {}, region info: {}",
         is_remote_read,
         request->start_ts(),
-        request->context().region_id(),
-        request->context().region_epoch().DebugString());
+        region_info);
 
     auto check_result = checkGrpcContext(grpc_context);
     if (!check_result.ok())
@@ -275,11 +279,10 @@ grpc::Status FlashService::Coprocessor(
         LOG_IMPL(
             log,
             log_level,
-            "Begin process cop request after wait {} ms, start ts: {}, region info: {}, region epoch: {}",
+            "Begin process cop request after wait {} ms, start ts: {}, region info: {}",
             wait_ms,
             request->start_ts(),
-            request->context().region_id(),
-            request->context().region_epoch().DebugString());
+            region_info);
         auto [db_context, status] = createDBContext(grpc_context);
         if (!status.ok())
         {
@@ -292,7 +295,13 @@ grpc::Status FlashService::Coprocessor(
                 GET_METRIC(tiflash_coprocessor_handling_request_count, type_remote_read_executing).Decrement();
         });
         CoprocessorContext cop_context(*db_context, request->context(), *grpc_context);
-        CoprocessorHandler<false> cop_handler(cop_context, request, response);
+        auto request_identifier = fmt::format(
+            "Coprocessor, is_remote_read: {}, start_ts: {}, region_info: {}, resource_group: {}",
+            is_remote_read,
+            request->start_ts(),
+            region_info,
+            request->context().resource_control_context().resource_group_name());
+        CoprocessorHandler<false> cop_handler(cop_context, request, response, request_identifier);
         return cop_handler.execute();
     });
 
@@ -330,7 +339,11 @@ grpc::Status FlashService::BatchCoprocessor(
             return status;
         }
         CoprocessorContext cop_context(*db_context, request->context(), *grpc_context);
-        BatchCoprocessorHandler cop_handler(cop_context, request, writer);
+        auto request_identifier = fmt::format(
+            "BatchCoprocessor, start_ts: {}, resource_group: {}",
+            request->start_ts(),
+            request->context().resource_control_context().resource_group_name());
+        BatchCoprocessorHandler cop_handler(cop_context, request, writer, request_identifier);
         return cop_handler.execute();
     });
 
@@ -345,15 +358,19 @@ grpc::Status FlashService::CoprocessorStream(
 {
     CPUAffinityManager::getInstance().bindSelfGrpcThread();
     bool is_remote_read = getClientMetaVarWithDefault(grpc_context, "is_remote_read", "") == "true";
+    auto region_info = fmt::format(
+        "{{{}, {}, {}}}",
+        request->context().region_id(),
+        request->context().region_epoch().conf_ver(),
+        request->context().region_epoch().version());
     auto log_level = is_remote_read ? Poco::Message::PRIO_INFORMATION : Poco::Message::PRIO_DEBUG;
     LOG_IMPL(
         log,
         log_level,
-        "Handling coprocessor stream request, is_remote_read: {}, start ts: {}, region info: {}, region epoch: {}",
+        "Handling coprocessor stream request, is_remote_read: {}, start ts: {}, region info: {}",
         is_remote_read,
         request->start_ts(),
-        request->context().region_id(),
-        request->context().region_epoch().DebugString());
+        region_info);
 
     auto check_result = checkGrpcContext(grpc_context);
     if (!check_result.ok())
@@ -419,11 +436,10 @@ grpc::Status FlashService::CoprocessorStream(
         LOG_IMPL(
             log,
             log_level,
-            "Begin process cop stream request after wait {} ms, start ts: {}, region info: {}, region epoch: {}",
+            "Begin process cop stream request after wait {} ms, start ts: {}, region info: {}",
             wait_ms,
             request->start_ts(),
-            request->context().region_id(),
-            request->context().region_epoch().DebugString());
+            region_info);
         auto [db_context, status] = createDBContext(grpc_context);
         if (!status.ok())
         {
@@ -436,7 +452,13 @@ grpc::Status FlashService::CoprocessorStream(
                 GET_METRIC(tiflash_coprocessor_handling_request_count, type_remote_read_executing).Decrement();
         });
         CoprocessorContext cop_context(*db_context, request->context(), *grpc_context);
-        CoprocessorHandler<true> cop_handler(cop_context, request, writer);
+        auto request_identifier = fmt::format(
+            "Coprocessor(stream), is_remote_read: {}, start_ts: {}, region_info: {}, resource_group: {}",
+            is_remote_read,
+            request->start_ts(),
+            region_info,
+            request->context().resource_control_context().resource_group_name());
+        CoprocessorHandler<true> cop_handler(cop_context, request, writer, request_identifier);
         return cop_handler.execute();
     });
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8181

Problem Summary:

### What is changed and how it works?
1. refine the log of cop/batch cop
2. refine the log inside client-c for remote read
3. update client-c to fix some minor bugs

Before this pr, the log for cop/batch cop is
```
[DEBUG] [PhysicalPlan.cpp:84] ["tidb table scan has runtime filter size:0"] [source=CoprocessorHandler(stream)] [thread_id=240]
```
The log for client-c remote read is
```
[INFO] [<unknown>] ["thread start."] [source=pingcap/coprocessor] [thread_id=250]
```
After this pr, these log will be 
```
[DEBUG] [PhysicalPlan.cpp:84] ["tidb table scan has runtime filter size:0"] [source="Coprocessor, is_remote_read: true, start_ts: 444859118261370884, region_info: {1125035, 2, 1088}, resource_group: default"] [thread_id=283]
[INFO] [<unknown>] ["thread start."] [source="MPP<gather_id:<gather_id:1, query_ts:1697002862090574000, local_query_id:26, server_id:1412, start_ts:444859118274478084, resource_group: default>,task_id:1> pingcap/coprocessor"] [thread_id=287]
```
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
