### PR TITLE
Add some debug info when meet duplicate key in parallel prehandling

### DIFF
--- a/dbms/src/Storages/DeltaMerge/Decode/SSTFilesToDTFilesOutputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/Decode/SSTFilesToDTFilesOutputStream.cpp
@@ -50,7 +50,7 @@ SSTFilesToDTFilesOutputStream<ChildStream>::SSTFilesToDTFilesOutputStream( //
     UInt64 split_after_rows_,
     UInt64 split_after_size_,
     UInt64 region_id_,
-    std::shared_ptr<std::atomic_bool> abort_flag_,
+    std::shared_ptr<PreHandlingTrace::Item> prehandle_task_,
     Context & context_)
     : child(std::move(child_))
     , storage(std::move(storage_))
@@ -59,7 +59,7 @@ SSTFilesToDTFilesOutputStream<ChildStream>::SSTFilesToDTFilesOutputStream( //
     , split_after_rows(split_after_rows_)
     , split_after_size(split_after_size_)
     , region_id(region_id_)
-    , abort_flag(abort_flag_)
+    , prehandle_task(prehandle_task_)
     , context(context_)
     , log(Logger::get(log_prefix_))
 {}
@@ -250,7 +250,7 @@ void SSTFilesToDTFilesOutputStream<ChildStream>::write()
     size_t cur_deleted_rows = 0;
     while (true)
     {
-        if (abort_flag->load(std::memory_order_seq_cst))
+        if (prehandle_task->abort_flag.load(std::memory_order_seq_cst))
         {
             break;
         }

--- a/dbms/src/Storages/DeltaMerge/Decode/SSTFilesToDTFilesOutputStream.h
+++ b/dbms/src/Storages/DeltaMerge/Decode/SSTFilesToDTFilesOutputStream.h
@@ -18,6 +18,7 @@
 #include <RaftStoreProxyFFI/ColumnFamily.h>
 #include <Storages/DeltaMerge/Decode/SSTFilesToBlockInputStream.h>
 #include <Storages/DeltaMerge/ExternalDTFileInfo.h>
+#include <Storages/KVStore/MultiRaft/PreHandlingTrace.h>
 #include <Storages/Page/PageDefinesBase.h>
 
 #include <memory>
@@ -78,7 +79,7 @@ public:
         UInt64 split_after_rows_,
         UInt64 split_after_size_,
         UInt64 region_id_,
-        std::shared_ptr<std::atomic_bool> abort_flag_,
+        std::shared_ptr<PreHandlingTrace::Item> prehandle_task_,
         Context & context);
     ~SSTFilesToDTFilesOutputStream();
 
@@ -94,7 +95,7 @@ public:
     // Try to cleanup the files in `ingest_files` quickly.
     void cancel();
 
-    bool isAbort() const { return abort_flag->load(std::memory_order_seq_cst); }
+    bool isAbort() const { return prehandle_task->abort_flag.load(std::memory_order_seq_cst); }
 
     size_t getTotalCommittedBytes() const { return total_committed_bytes; }
     size_t getTotalBytesOnDisk() const { return total_bytes_on_disk; }
@@ -122,7 +123,7 @@ private:
     const UInt64 split_after_rows;
     const UInt64 split_after_size;
     const UInt64 region_id;
-    std::shared_ptr<std::atomic_bool> abort_flag;
+    std::shared_ptr<PreHandlingTrace::Item> prehandle_task;
     Context & context;
     LoggerPtr log;
 

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_sst_files_stream.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_sst_files_stream.cpp
@@ -18,6 +18,7 @@
 #include <Storages/DeltaMerge/Decode/SSTFilesToDTFilesOutputStream.h>
 #include <Storages/DeltaMerge/DeltaMergeStore.h>
 #include <Storages/DeltaMerge/tests/DMTestEnv.h>
+#include <Storages/KVStore/KVStore.h>
 #include <Storages/KVStore/TMTContext.h>
 #include <Storages/KVStore/tests/region_helper.h>
 #include <Storages/PathPool.h>
@@ -181,7 +182,7 @@ try
     auto [schema_snapshot, unused] = storage->getSchemaSnapshotAndBlockForDecoding(table_lock, false);
 
     auto mock_stream = makeMockChild(prepareBlocks(100, 100, /*block_size=*/5));
-    auto abort_flag = std::make_shared<std::atomic_bool>(false);
+    auto prehandle_task = std::make_shared<PreHandlingTrace::Item>();
     auto stream = std::make_shared<DM::SSTFilesToDTFilesOutputStream<DM::MockSSTFilesToDTFilesOutputStreamChildPtr>>(
         /* log_prefix */ "",
         mock_stream,
@@ -191,7 +192,7 @@ try
         /* split_after_rows */ 0,
         /* split_after_size */ 0,
         0,
-        abort_flag,
+        prehandle_task,
         *db_context);
 
     stream->writePrefix();
@@ -211,7 +212,7 @@ try
     auto [schema_snapshot, unused] = storage->getSchemaSnapshotAndBlockForDecoding(table_lock, false);
 
     auto mock_stream = makeMockChild(prepareBlocks(50, 100, /*block_size=*/5));
-    auto abort_flag = std::make_shared<std::atomic_bool>(false);
+    auto prehandle_task = std::make_shared<PreHandlingTrace::Item>();
     auto stream = std::make_shared<DM::SSTFilesToDTFilesOutputStream<DM::MockSSTFilesToDTFilesOutputStreamChildPtr>>(
         /* log_prefix */ "",
         mock_stream,
@@ -221,7 +222,7 @@ try
         /* split_after_rows */ 0,
         /* split_after_size */ 0,
         0,
-        abort_flag,
+        prehandle_task,
         *db_context);
 
     stream->writePrefix();
@@ -243,7 +244,7 @@ try
     auto [schema_snapshot, unused] = storage->getSchemaSnapshotAndBlockForDecoding(table_lock, false);
 
     auto mock_stream = makeMockChild(prepareBlocks(50, 100, /*block_size=*/1000));
-    auto abort_flag = std::make_shared<std::atomic_bool>(false);
+    auto prehandle_task = std::make_shared<PreHandlingTrace::Item>();
     auto stream = std::make_shared<DM::SSTFilesToDTFilesOutputStream<DM::MockSSTFilesToDTFilesOutputStreamChildPtr>>(
         /* log_prefix */ "",
         mock_stream,
@@ -253,7 +254,7 @@ try
         /* split_after_rows */ 1,
         /* split_after_size */ 1,
         0,
-        abort_flag,
+        prehandle_task,
         *db_context);
 
     stream->writePrefix();
@@ -276,7 +277,7 @@ try
     auto [schema_snapshot, unused] = storage->getSchemaSnapshotAndBlockForDecoding(table_lock, false);
 
     auto mock_stream = makeMockChild(prepareBlocks(50, 100, /*block_size=*/1));
-    auto abort_flag = std::make_shared<std::atomic_bool>(false);
+    auto prehandle_task = std::make_shared<PreHandlingTrace::Item>();
     auto stream = std::make_shared<DM::SSTFilesToDTFilesOutputStream<DM::MockSSTFilesToDTFilesOutputStreamChildPtr>>(
         /* log_prefix */ "",
         mock_stream,
@@ -286,7 +287,7 @@ try
         /* split_after_rows */ 10,
         /* split_after_size */ 0,
         0,
-        abort_flag,
+        prehandle_task,
         *db_context);
 
     stream->writePrefix();
@@ -315,7 +316,7 @@ try
     auto [schema_snapshot, unused] = storage->getSchemaSnapshotAndBlockForDecoding(table_lock, false);
 
     auto mock_stream = makeMockChild(prepareBlocks(50, 100, /*block_size=*/20));
-    auto abort_flag = std::make_shared<std::atomic_bool>(false);
+    auto prehandle_task = std::make_shared<PreHandlingTrace::Item>();
     auto stream = std::make_shared<DM::SSTFilesToDTFilesOutputStream<DM::MockSSTFilesToDTFilesOutputStreamChildPtr>>(
         /* log_prefix */ "",
         mock_stream,
@@ -325,7 +326,7 @@ try
         /* split_after_rows */ 10,
         /* split_after_size */ 0,
         0,
-        abort_flag,
+        prehandle_task,
         *db_context);
 
     stream->writePrefix();
@@ -350,7 +351,7 @@ try
     auto [schema_snapshot, unused] = storage->getSchemaSnapshotAndBlockForDecoding(table_lock, false);
 
     auto mock_stream = makeMockChild(prepareBlocks(50, 100, /*block_size=*/20));
-    auto abort_flag = std::make_shared<std::atomic_bool>(false);
+    auto prehandle_task = std::make_shared<PreHandlingTrace::Item>();
     auto stream = std::make_shared<DM::SSTFilesToDTFilesOutputStream<DM::MockSSTFilesToDTFilesOutputStreamChildPtr>>(
         /* log_prefix */ "",
         mock_stream,
@@ -360,7 +361,7 @@ try
         /* split_after_rows */ 10000,
         /* split_after_size */ 0,
         0,
-        abort_flag,
+        prehandle_task,
         *db_context);
 
     stream->writePrefix();
@@ -385,7 +386,7 @@ try
     auto blocks2 = prepareBlocks(130, 150, /*block_size=*/10);
     blocks1.insert(blocks1.end(), blocks2.begin(), blocks2.end());
     auto mock_stream = makeMockChild(blocks1);
-    auto abort_flag = std::make_shared<std::atomic_bool>(false);
+    auto prehandle_task = std::make_shared<PreHandlingTrace::Item>();
 
     auto stream = std::make_shared<DM::SSTFilesToDTFilesOutputStream<DM::MockSSTFilesToDTFilesOutputStreamChildPtr>>(
         /* log_prefix */ "",
@@ -396,7 +397,7 @@ try
         /* split_after_rows */ 20,
         /* split_after_size */ 0,
         0,
-        abort_flag,
+        prehandle_task,
         *db_context);
 
     stream->writePrefix();
@@ -427,7 +428,7 @@ try
     auto blocks2 = prepareBlocks(0, 30, /*block_size=*/20);
     blocks1.insert(blocks1.end(), blocks2.begin(), blocks2.end());
     auto mock_stream = makeMockChild(blocks1);
-    auto abort_flag = std::make_shared<std::atomic_bool>(false);
+    auto prehandle_task = std::make_shared<PreHandlingTrace::Item>();
 
     auto stream = std::make_shared<DM::SSTFilesToDTFilesOutputStream<DM::MockSSTFilesToDTFilesOutputStreamChildPtr>>(
         /* log_prefix */ "",
@@ -438,7 +439,7 @@ try
         /* split_after_rows */ 20,
         /* split_after_size */ 0,
         0,
-        abort_flag,
+        prehandle_task,
         *db_context);
 
     EXPECT_THROW(
@@ -460,7 +461,7 @@ try
     auto [schema_snapshot, unused] = storage->getSchemaSnapshotAndBlockForDecoding(table_lock, false);
 
     auto mock_stream = makeMockChild(prepareBlocks(50, 100, /*block_size=*/1));
-    auto abort_flag = std::make_shared<std::atomic_bool>(false);
+    auto prehandle_task = std::make_shared<PreHandlingTrace::Item>();
     auto stream = std::make_shared<DM::SSTFilesToDTFilesOutputStream<DM::MockSSTFilesToDTFilesOutputStreamChildPtr>>(
         /* log_prefix */ "",
         mock_stream,
@@ -470,7 +471,7 @@ try
         /* split_after_rows */ 10,
         /* split_after_size */ 0,
         0,
-        abort_flag,
+        prehandle_task,
         *db_context);
 
     stream->writePrefix();
@@ -509,7 +510,7 @@ try
     auto [schema_snapshot, unused] = storage->getSchemaSnapshotAndBlockForDecoding(table_lock, false);
 
     auto mock_stream = makeMockChild(prepareBlocks(50, 100, /*block_size=*/1));
-    auto abort_flag = std::make_shared<std::atomic_bool>(false);
+    auto prehandle_task = std::make_shared<PreHandlingTrace::Item>();
     auto stream = std::make_shared<DM::SSTFilesToDTFilesOutputStream<DM::MockSSTFilesToDTFilesOutputStreamChildPtr>>(
         /* log_prefix */ "",
         mock_stream,
@@ -519,20 +520,20 @@ try
         /* split_after_rows */ 10,
         /* split_after_size */ 0,
         0,
-        abort_flag,
+        prehandle_task,
         *db_context);
 
     auto sp = SyncPointCtl::enableInScope("before_SSTFilesToDTFilesOutputStream::handle_one");
     stream->writePrefix();
     auto t = std::thread([&]() { stream->write(); });
     sp.waitAndPause();
-    abort_flag->store(true, std::memory_order_seq_cst);
+    prehandle_task->abort_flag.store(true, std::memory_order_seq_cst);
     sp.next();
     sp.disable();
     t.join();
     stream->writeSuffix();
     auto files = stream->outputFiles();
-    ASSERT_EQ(true, abort_flag->load(std::memory_order_seq_cst));
+    ASSERT_EQ(true, prehandle_task->abort_flag.load(std::memory_order_seq_cst));
     ASSERT_EQ(1, files.size());
     auto delegator = storage->getAndMaybeInitStore()->path_pool->getStableDiskDelegator();
     std::vector<std::string> fps;

--- a/dbms/src/Storages/KVStore/KVStore.h
+++ b/dbms/src/Storages/KVStore/KVStore.h
@@ -18,6 +18,7 @@
 #include <Storages/DeltaMerge/RowKeyRange.h>
 #include <Storages/KVStore/Decode/RegionDataRead.h>
 #include <Storages/KVStore/MultiRaft/Disagg/RaftLogManager.h>
+#include <Storages/KVStore/MultiRaft/PreHandlingTrace.h>
 #include <Storages/KVStore/MultiRaft/RegionManager.h>
 #include <Storages/KVStore/MultiRaft/RegionRangeKeys.h>
 #include <Storages/KVStore/StorageEngineType.h>
@@ -115,40 +116,6 @@ struct ProxyConfigSummary
 {
     bool valid = false;
     size_t snap_handle_pool_size = 0;
-};
-
-struct PreHandlingTrace : MutexLockWrap
-{
-    std::unordered_map<uint64_t, std::shared_ptr<std::atomic_bool>> tasks;
-
-    std::shared_ptr<std::atomic_bool> registerTask(uint64_t region_id)
-    {
-        // Automaticlly override the old one.
-        auto _ = genLockGuard();
-        auto b = std::make_shared<std::atomic_bool>(false);
-        tasks[region_id] = b;
-        return b;
-    }
-    std::shared_ptr<std::atomic_bool> deregisterTask(uint64_t region_id)
-    {
-        auto _ = genLockGuard();
-        auto it = tasks.find(region_id);
-        if (it != tasks.end())
-        {
-            auto b = it->second;
-            tasks.erase(it);
-            return b;
-        }
-        else
-        {
-            return nullptr;
-        }
-    }
-    bool hasTask(uint64_t region_id)
-    {
-        auto _ = genLockGuard();
-        return tasks.find(region_id) != tasks.end();
-    }
 };
 
 /// TODO: brief design document.

--- a/dbms/src/Storages/KVStore/KVStore.h
+++ b/dbms/src/Storages/KVStore/KVStore.h
@@ -117,6 +117,40 @@ struct ProxyConfigSummary
     size_t snap_handle_pool_size = 0;
 };
 
+struct PreHandlingTrace : MutexLockWrap
+{
+    std::unordered_map<uint64_t, std::shared_ptr<std::atomic_bool>> tasks;
+
+    std::shared_ptr<std::atomic_bool> registerTask(uint64_t region_id)
+    {
+        // Automaticlly override the old one.
+        auto _ = genLockGuard();
+        auto b = std::make_shared<std::atomic_bool>(false);
+        tasks[region_id] = b;
+        return b;
+    }
+    std::shared_ptr<std::atomic_bool> deregisterTask(uint64_t region_id)
+    {
+        auto _ = genLockGuard();
+        auto it = tasks.find(region_id);
+        if (it != tasks.end())
+        {
+            auto b = it->second;
+            tasks.erase(it);
+            return b;
+        }
+        else
+        {
+            return nullptr;
+        }
+    }
+    bool hasTask(uint64_t region_id)
+    {
+        auto _ = genLockGuard();
+        return tasks.find(region_id) != tasks.end();
+    }
+};
+
 /// TODO: brief design document.
 class KVStore final : private boost::noncopyable
 {
@@ -360,40 +394,6 @@ private:
 
     void releaseReadIndexWorkers();
     void handleDestroy(UInt64 region_id, TMTContext & tmt, const KVStoreTaskLock &);
-
-    struct PreHandlingTrace : MutexLockWrap
-    {
-        std::unordered_map<uint64_t, std::shared_ptr<std::atomic_bool>> tasks;
-
-        std::shared_ptr<std::atomic_bool> registerTask(uint64_t region_id)
-        {
-            // Automaticlly override the old one.
-            auto _ = genLockGuard();
-            auto b = std::make_shared<std::atomic_bool>(false);
-            tasks[region_id] = b;
-            return b;
-        }
-        std::shared_ptr<std::atomic_bool> deregisterTask(uint64_t region_id)
-        {
-            auto _ = genLockGuard();
-            auto it = tasks.find(region_id);
-            if (it != tasks.end())
-            {
-                auto b = it->second;
-                tasks.erase(it);
-                return b;
-            }
-            else
-            {
-                return nullptr;
-            }
-        }
-        bool hasTask(uint64_t region_id)
-        {
-            auto _ = genLockGuard();
-            return tasks.find(region_id) != tasks.end();
-        }
-    };
 
 #ifndef DBMS_PUBLIC_GTEST
 private:

--- a/dbms/src/Storages/KVStore/MultiRaft/PreHandlingTrace.h
+++ b/dbms/src/Storages/KVStore/MultiRaft/PreHandlingTrace.h
@@ -1,0 +1,65 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <Storages/KVStore/Utils.h>
+
+#include <atomic>
+#include <memory>
+#include <unordered_map>
+
+namespace DB
+{
+struct PreHandlingTrace : MutexLockWrap
+{
+    struct Item
+    {
+        Item()
+            : abort_flag(false)
+        {}
+        std::atomic_bool abort_flag;
+    };
+    std::unordered_map<uint64_t, std::shared_ptr<Item>> tasks;
+
+    std::shared_ptr<Item> registerTask(uint64_t region_id)
+    {
+        // Automaticlly override the old one.
+        auto _ = genLockGuard();
+        auto b = std::make_shared<Item>();
+        tasks[region_id] = b;
+        return b;
+    }
+    std::shared_ptr<Item> deregisterTask(uint64_t region_id)
+    {
+        auto _ = genLockGuard();
+        auto it = tasks.find(region_id);
+        if (it != tasks.end())
+        {
+            auto b = it->second;
+            tasks.erase(it);
+            return b;
+        }
+        else
+        {
+            return nullptr;
+        }
+    }
+    bool hasTask(uint64_t region_id)
+    {
+        auto _ = genLockGuard();
+        return tasks.find(region_id) != tasks.end();
+    }
+};
+} // namespace DB

--- a/dbms/src/Storages/KVStore/MultiRaft/RegionCFDataBase.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/RegionCFDataBase.cpp
@@ -202,6 +202,27 @@ RegionCFDataBase<Trait> & RegionCFDataBase<Trait>::operator=(RegionCFDataBase &&
 }
 
 template <typename Trait>
+std::string getTraitName()
+{
+    if constexpr (std::is_same_v<Trait, RegionWriteCFDataTrait>)
+    {
+        return "write";
+    }
+    else if constexpr (std::is_same_v<Trait, RegionDefaultCFDataTrait>)
+    {
+        return "default";
+    }
+    else if constexpr (std::is_same_v<Trait, RegionLockCFDataTrait>)
+    {
+        return "lock";
+    }
+    else
+    {
+        return "unknown";
+    }
+}
+
+template <typename Trait>
 size_t RegionCFDataBase<Trait>::mergeFrom(const RegionCFDataBase & ori_region_data)
 {
     size_t size_changed = 0;
@@ -214,7 +235,13 @@ size_t RegionCFDataBase<Trait>::mergeFrom(const RegionCFDataBase & ori_region_da
         size_changed += calcTiKVKeyValueSize(it->second);
         auto ok = tar_map.emplace(*it).second;
         if (!ok)
-            throw Exception(std::string(__PRETTY_FUNCTION__) + ": got duplicate key", ErrorCodes::LOGICAL_ERROR);
+            throw Exception(
+                ErrorCodes::LOGICAL_ERROR,
+                fmt::format(
+                    "{}: got duplicate key {}, cf={}",
+                    __PRETTY_FUNCTION__,
+                    getTiKVKey(it->second),
+                    getTraitName<Trait>()));
     }
 
     return size_changed;

--- a/dbms/src/Storages/KVStore/MultiRaft/RegionCFDataBase.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/RegionCFDataBase.cpp
@@ -237,11 +237,10 @@ size_t RegionCFDataBase<Trait>::mergeFrom(const RegionCFDataBase & ori_region_da
         if (!ok)
             throw Exception(
                 ErrorCodes::LOGICAL_ERROR,
-                fmt::format(
-                    "{}: got duplicate key {}, cf={}",
-                    __PRETTY_FUNCTION__,
-                    getTiKVKey(it->second),
-                    getTraitName<Trait>()));
+                "{}: got duplicate key {}, cf={}",
+                __PRETTY_FUNCTION__,
+                getTiKVKey(it->second),
+                getTraitName<Trait>());
     }
 
     return size_changed;

--- a/dbms/src/Storages/KVStore/MultiRaft/RegionCFDataBase.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/RegionCFDataBase.cpp
@@ -230,6 +230,7 @@ size_t RegionCFDataBase<Trait>::mergeFrom(const RegionCFDataBase & ori_region_da
     const auto & ori_map = ori_region_data.data;
     auto & tar_map = data;
 
+    size_t ori_key_count = ori_region_data.getSize();
     for (auto it = ori_map.begin(); it != ori_map.end(); it++)
     {
         size_changed += calcTiKVKeyValueSize(it->second);
@@ -237,10 +238,11 @@ size_t RegionCFDataBase<Trait>::mergeFrom(const RegionCFDataBase & ori_region_da
         if (!ok)
             throw Exception(
                 ErrorCodes::LOGICAL_ERROR,
-                "{}: got duplicate key {}, cf={}",
+                "{}: got duplicate key {}, cf={}, ori_key_count={}",
                 __PRETTY_FUNCTION__,
                 getTiKVKey(it->second),
-                getTraitName<Trait>());
+                getTraitName<Trait>(),
+                ori_key_count);
     }
 
     return size_changed;

--- a/dbms/src/Storages/KVStore/Region.cpp
+++ b/dbms/src/Storages/KVStore/Region.cpp
@@ -491,5 +491,6 @@ void Region::cleanApproxMemCacheInfo() const
 void Region::mergeDataFrom(const Region & other)
 {
     this->data.mergeFrom(other.data);
+    this->data.orphan_keys_info.mergeFrom(other.data.orphan_keys_info);
 }
 } // namespace DB


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8081

Problem Summary:

it is reported that in some case, there are duplicated keys when merge uncommitted region data.
Add some debug info to peek exactly which key is duplicated.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
