### PR TITLE
Fix potential hang when duplicated task registered.

### DIFF
--- a/dbms/src/Flash/Mpp/MPPTask.cpp
+++ b/dbms/src/Flash/Mpp/MPPTask.cpp
@@ -112,13 +112,12 @@ void MPPTaskMonitorHelper::initAndAddself(MPPTaskManager * manager_, const Strin
 {
     manager = manager_;
     task_unique_id = task_unique_id_;
-    manager->addMonitoredTask(task_unique_id);
-    initialized = true;
+    added_to_monitor = manager->addMonitoredTask(task_unique_id);
 }
 
 MPPTaskMonitorHelper::~MPPTaskMonitorHelper()
 {
-    if (initialized)
+    if (added_to_monitor)
     {
         manager->removeMonitoredTask(task_unique_id);
     }
@@ -361,11 +360,14 @@ MemoryTracker * MPPTask::getMemoryTracker() const
 
 void MPPTask::unregisterTask()
 {
-    auto [result, reason] = manager->unregisterTask(id, getErrString());
-    if (result)
-        LOG_DEBUG(log, "task unregistered");
-    else
-        LOG_WARNING(log, "task failed to unregister, reason: {}", reason);
+    if (is_registered)
+    {
+        auto [result, reason] = manager->unregisterTask(id, getErrString());
+        if (result)
+            LOG_DEBUG(log, "task unregistered");
+        else
+            LOG_WARNING(log, "task failed to unregister, reason: {}", reason);
+    }
 }
 
 void MPPTask::initQueryOperatorSpillContexts(

--- a/dbms/src/Flash/Mpp/MPPTask.h
+++ b/dbms/src/Flash/Mpp/MPPTask.h
@@ -62,7 +62,7 @@ public:
 private:
     MPPTaskManager * manager = nullptr;
     String task_unique_id;
-    bool initialized = false;
+    bool added_to_monitor = false;
 };
 
 class MPPTask
@@ -176,7 +176,7 @@ private:
     ContextPtr context;
 
     MPPTaskManager * manager;
-    std::atomic<bool> is_public{false};
+    std::atomic<bool> is_registered{false};
 
     MPPTaskScheduleEntry schedule_entry;
 

--- a/dbms/src/Flash/Mpp/tests/gtest_mpp_task_manager.cpp
+++ b/dbms/src/Flash/Mpp/tests/gtest_mpp_task_manager.cpp
@@ -124,21 +124,24 @@ CATCH
 TEST_F(TestMPPTaskManager, testDuplicateMPPTaskId)
 try
 {
+    MPPTaskPtr original_task;
     auto context = createContextForTest();
-    mpp::EstablishMPPConnectionRequest establish_req;
-    auto gather_id = MPPGatherId(1, MPPQueryId(1, 1, 1, 1, ""));
-    auto * sender_meta = establish_req.mutable_sender_meta();
-    fillTaskMeta(sender_meta, 1, gather_id);
     auto mpp_task_manager = context->getTMTContext().getMPPTaskManager();
-    auto mpp_task_1 = MPPTask::newTaskForTest(*sender_meta, context);
-    auto result = mpp_task_manager->registerTask(mpp_task_1.get());
-    ASSERT_TRUE(result.first);
-    auto mpp_task_2 = MPPTask::newTaskForTest(*sender_meta, context);
-    result = mpp_task_manager->registerTask(mpp_task_2.get());
-    ASSERT_FALSE(result.first);
-    mpp_task_2->handleError(result.second);
-    ASSERT_TRUE(mpp_task_manager->isTaskExists(mpp_task_1->getId()));
-    mpp_task_manager->getMPPTaskMonitor()->isInMonitor(mpp_task_1->getId().toString());
+    {
+        mpp::EstablishMPPConnectionRequest establish_req;
+        auto gather_id = MPPGatherId(1, MPPQueryId(1, 1, 1, 1, ""));
+        auto * sender_meta = establish_req.mutable_sender_meta();
+        fillTaskMeta(sender_meta, 1, gather_id);
+        original_task = MPPTask::newTaskForTest(*sender_meta, context);
+        auto result = mpp_task_manager->registerTask(original_task.get());
+        ASSERT_TRUE(result.first);
+        auto second_task = MPPTask::newTaskForTest(*sender_meta, context);
+        result = mpp_task_manager->registerTask(second_task.get());
+        ASSERT_FALSE(result.first);
+        second_task->handleError(result.second);
+    }
+    ASSERT_TRUE(mpp_task_manager->isTaskExists(original_task->getId()));
+    ASSERT_TRUE(mpp_task_manager->getMPPTaskMonitor()->isInMonitor(original_task->getId().toString()));
 }
 CATCH
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8192

Problem Summary:

### What is changed and how it works?
Only unregister and remove from mpp task monitor if the task is registered successfully.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
