### PR TITLE
*: Refine pageworkload output

### DIFF
--- a/dbms/src/Storages/Page/workload/HeavyMemoryCostInGC.h
+++ b/dbms/src/Storages/Page/workload/HeavyMemoryCostInGC.h
@@ -66,7 +66,7 @@ public:
     void onFailed() override
     {
         LOG_WARNING(
-            StressEnv::logger,
+            options.logger,
             "Memory Peak is {}, it should not bigger than {}",
             metrics_dumper->getMemoryPeak(),
             5 * 1024 * 1024);

--- a/dbms/src/Storages/Page/workload/HighValidBigFileGC.h
+++ b/dbms/src/Storages/Page/workload/HighValidBigFileGC.h
@@ -42,11 +42,11 @@ public:
 
     void run() override
     {
-        metrics_dumper = std::make_shared<PSMetricsDumper>(1);
+        metrics_dumper = std::make_shared<PSMetricsDumper>(1, options.logger);
         metrics_dumper->start();
 
         // For safe , setup timeout.
-        stress_time = std::make_shared<StressTimeout>(100);
+        stress_time = std::make_shared<StressTimeout>(100, options.logger);
         stress_time->start();
 
         // Generate 8G data in the same Pagefile
@@ -70,7 +70,7 @@ public:
             onDumpResult();
         }
 
-        LOG_INFO(StressEnv::logger, "Already generator an 8G page file");
+        LOG_INFO(options.logger, "Already generator an 8G page file");
 
         // Generate normal data in the same Pagefile
         {
@@ -115,7 +115,7 @@ public:
 
     void onFailed() override
     {
-        LOG_WARNING(StressEnv::logger, "GC time is {} , it should not bigger than {} ", gc_time_ms, 1 * 1000);
+        LOG_WARNING(options.logger, "GC time is {} , it should not bigger than {} ", gc_time_ms, 1 * 1000);
     }
 
 private:

--- a/dbms/src/Storages/Page/workload/MainEntry.cpp
+++ b/dbms/src/Storages/Page/workload/MainEntry.cpp
@@ -40,13 +40,14 @@ int StressWorkload::mainEntry(int argc, char ** argv)
     }
     try
     {
-        StressEnv::initGlobalLogger();
         auto env = StressEnv::parse(argc, argv);
         env.setup();
 
-        auto & mamager = PageWorkloadFactory::getInstance();
-        mamager.setEnv(env);
-        mamager.runWorkload();
+        auto & factory = PageWorkloadFactory::getInstance();
+        factory.setEnv(env);
+        factory.runWorkload();
+
+        SCOPE_EXIT({ factory.stopWorkload(); });
 
         return StressEnvStatus::getInstance().isSuccess();
     }

--- a/dbms/src/Storages/Page/workload/Normal.h
+++ b/dbms/src/Storages/Page/workload/Normal.h
@@ -46,7 +46,7 @@ public:
         {
             static constexpr PageIdU64 MAX_PAGE_ID_DEFAULT = 1000;
             initPages(MAX_PAGE_ID_DEFAULT);
-            LOG_INFO(StressEnv::logger, "All pages have been init.");
+            LOG_INFO(options.logger, "All pages have been init.");
         }
 
         RUNTIME_CHECK(options.avg_page_size > 1000);

--- a/dbms/src/Storages/Page/workload/PSBackground.cpp
+++ b/dbms/src/Storages/Page/workload/PSBackground.cpp
@@ -18,9 +18,27 @@
 #include <Storages/Page/workload/PSBackground.h>
 #include <fmt/format.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#include <Poco/JSON/Object.h>
+#pragma GCC diagnostic pop
 
 namespace DB::PS::tests
 {
+void PSMetricsDumper::addJSONSummaryTo(Poco::JSON::Object::Ptr & root) const
+{
+    for (const auto & m : metrics)
+    {
+        Poco::JSON::Object::Ptr metrics_obj = new Poco::JSON::Object();
+        metrics_obj->set("latest", m.second.lastest);
+        double avg = m.second.loop_times == 0 ? 0.0 : (1.0 * m.second.summary / m.second.loop_times);
+        metrics_obj->set("avg", avg);
+        metrics_obj->set("top", m.second.biggest);
+
+        root->set(m.second.name, metrics_obj);
+    }
+}
+
 void PSMetricsDumper::onTime(Poco::Timer & /*timer*/)
 {
     for (auto & metric : metrics)
@@ -33,7 +51,7 @@ void PSMetricsDumper::onTime(Poco::Timer & /*timer*/)
             info.lastest = lastest;
             info.summary += lastest;
             info.biggest = std::max(info.biggest, lastest);
-            LOG_INFO(StressEnv::logger, info.toString());
+            LOG_INFO(logger, info.toString());
         }
     }
 }
@@ -75,10 +93,10 @@ void PSSnapStatGetter::onTime(Poco::Timer & /*timer*/)
 {
     try
     {
-        LOG_INFO(StressEnv::logger, "Scanner start");
+        LOG_INFO(logger, "Scanner start");
         auto stat = ps->getSnapshotsStat();
         LOG_INFO(
-            StressEnv::logger,
+            logger,
             "Scanner get {} snapshots, longest lifetime: {:.3f}s longest from thread: {}, tracing_id: {}",
             stat.num_snapshots,
             stat.longest_living_seconds,
@@ -102,7 +120,7 @@ void PSSnapStatGetter::start()
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 void StressTimeout::onTime(Poco::Timer & /* t */)
 {
-    LOG_INFO(StressEnv::logger, "timeout.");
+    LOG_INFO(logger, "timeout.");
     StressEnvStatus::getInstance().setStat(STATUS_TIMEOUT);
 }
 

--- a/dbms/src/Storages/Page/workload/PSBackground.cpp
+++ b/dbms/src/Storages/Page/workload/PSBackground.cpp
@@ -30,7 +30,7 @@ void PSMetricsDumper::addJSONSummaryTo(Poco::JSON::Object::Ptr & root) const
     for (const auto & m : metrics)
     {
         Poco::JSON::Object::Ptr metrics_obj = new Poco::JSON::Object();
-        metrics_obj->set("latest", m.second.lastest);
+        metrics_obj->set("latest", m.second.latest);
         double avg = m.second.loop_times == 0 ? 0.0 : (1.0 * m.second.summary / m.second.loop_times);
         metrics_obj->set("avg", avg);
         metrics_obj->set("top", m.second.biggest);
@@ -43,14 +43,14 @@ void PSMetricsDumper::onTime(Poco::Timer & /*timer*/)
 {
     for (auto & metric : metrics)
     {
-        auto lastest = CurrentMetrics::get(metric.first);
-        if (likely(lastest != 0))
+        auto latest = CurrentMetrics::get(metric.first);
+        if (likely(latest != 0))
         {
             auto & info = metric.second;
             info.loop_times++;
-            info.lastest = lastest;
-            info.summary += lastest;
-            info.biggest = std::max(info.biggest, lastest);
+            info.latest = latest;
+            info.summary += latest;
+            info.biggest = std::max(info.biggest, latest);
             LOG_INFO(logger, info.toString());
         }
     }

--- a/dbms/src/Storages/Page/workload/PSBackground.h
+++ b/dbms/src/Storages/Page/workload/PSBackground.h
@@ -51,19 +51,6 @@ public:
 
     void addJSONSummaryTo(Poco::JSON::Object::Ptr & root) const;
 
-    String toString() const
-    {
-        String str;
-        for (const auto & metric : metrics)
-        {
-            if (likely(metric.second.loop_times != 0))
-            {
-                str += (metric.second.toString() + "\n");
-            }
-        }
-        return str;
-    }
-
     void start();
 
     void stop() { timer_status.stop(); }
@@ -83,7 +70,7 @@ private:
     {
         String name;
         UInt32 loop_times = 0;
-        UInt32 lastest = 0;
+        UInt32 latest = 0;
         UInt32 biggest = 0;
         UInt32 summary = 0;
 
@@ -92,7 +79,7 @@ private:
             return fmt::format(
                 "{} lastest used: {}, avg used: {}, top used: {}.",
                 name,
-                lastest,
+                latest,
                 loop_times == 0 ? 0 : (summary / loop_times),
                 biggest);
         }

--- a/dbms/src/Storages/Page/workload/PSRunnable.cpp
+++ b/dbms/src/Storages/Page/workload/PSRunnable.cpp
@@ -57,17 +57,13 @@ try
     }
     auto peak = current_memory_tracker->getPeak();
     current_memory_tracker = nullptr;
-    LOG_INFO(
-        StressEnv::logger,
-        "{} exit with peak memory usage: {}",
-        description(),
-        formatReadableSizeWithBinarySuffix(peak));
+    LOG_INFO(logger, "{} exit with peak memory usage: {}", description(), formatReadableSizeWithBinarySuffix(peak));
 }
 catch (...)
 {
     // stop the whole testing
     StressEnvStatus::getInstance().setStat(StressEnvStat::STATUS_EXCEPTION);
-    DB::tryLogCurrentException(StressEnv::logger);
+    DB::tryLogCurrentException(logger);
 }
 
 size_t PSRunnable::getBytesUsed() const
@@ -106,7 +102,7 @@ void PSWriter::setBufferSizeRange(size_t min, size_t max)
     buffer_size_max = max;
 
     if (buffer_size_max - buffer_size_min >= 4096)
-        LOG_WARNING(StressEnv::logger, "The result maybe not stable, min_size={} max_size={}", min, max);
+        LOG_WARNING(logger, "The result maybe not stable, min_size={} max_size={}", min, max);
 }
 
 void PSWriter::write(const RandomPageId & r)
@@ -123,7 +119,7 @@ void PSWriter::write(const RandomPageId & r)
     bytes_used += buff_ptr->buffer().size();
 
     // verbose logging for debug
-    // LOG_TRACE(StressEnv::logger, "write done, page_id={}, remove={}", r.page_id, r.page_id_to_remove);
+    // LOG_TRACE(logger, "write done, page_id={}, remove={}", r.page_id, r.page_id_to_remove);
 
     global_stat->commit(r);
 }
@@ -191,7 +187,7 @@ bool PSCommonWriter::runImpl()
     bytes_used += bytes_write;
 
     // verbose logging for debug
-    // LOG_TRACE(StressEnv::logger, "write done, page_id={}, remove={}", r.page_id, r.page_id_to_remove);
+    // LOG_TRACE(logger, "write done, page_id={}, remove={}", r.page_id, r.page_id_to_remove);
     global_stat->commit(r);
     bool keep_running = (batch_buffer_limit == 0 || bytes_used < batch_buffer_limit);
     return keep_running;
@@ -316,7 +312,7 @@ RandomPageId PSWindowWriter::genRandomPageId()
 
         auto page_id = global_stat->right_id_boundary++;
         if (page_id % 200 == 0)
-            LOG_INFO(StressEnv::logger, "Update boundary to [{}, {})", left_boundary, global_stat->right_id_boundary);
+            LOG_INFO(logger, "Update boundary to [{}, {})", left_boundary, global_stat->right_id_boundary);
         return page_id;
     }();
     return RandomPageId(page_id, ids_to_del);

--- a/dbms/src/Storages/Page/workload/PSRunnable.h
+++ b/dbms/src/Storages/Page/workload/PSRunnable.h
@@ -23,6 +23,10 @@ static constexpr PageIdU64 MAX_PAGE_ID_DEFAULT = 1000;
 class PSRunnable : public Poco::Runnable
 {
 public:
+    explicit PSRunnable(LoggerPtr log)
+        : logger(log)
+    {}
+
     void run() override;
 
     size_t getBytesUsed() const;
@@ -33,6 +37,8 @@ public:
 
     size_t bytes_used = 0;
     size_t pages_used = 0;
+
+    LoggerPtr logger;
 };
 
 // The random page id for adding and removing
@@ -72,8 +78,13 @@ struct GlobalStat
 class PSWriter : public PSRunnable
 {
 public:
-    PSWriter(const PSPtr & ps_, DB::UInt32 index_, const std::unique_ptr<GlobalStat> & global_stat_)
-        : ps(ps_)
+    PSWriter(
+        const PSPtr & ps_,
+        DB::UInt32 index_,
+        const std::unique_ptr<GlobalStat> & global_stat_,
+        const LoggerPtr & log)
+        : PSRunnable(log)
+        , ps(ps_)
         , index(index_)
         , global_stat(global_stat_)
     {
@@ -114,8 +125,12 @@ protected:
 class PSCommonWriter : public PSWriter
 {
 public:
-    PSCommonWriter(const PSPtr & ps_, DB::UInt32 index_, const std::unique_ptr<GlobalStat> & global_stat_)
-        : PSWriter(ps_, index_, global_stat_)
+    PSCommonWriter(
+        const PSPtr & ps_,
+        DB::UInt32 index_,
+        const std::unique_ptr<GlobalStat> & global_stat_,
+        const LoggerPtr & log)
+        : PSWriter(ps_, index_, global_stat_, log)
     {}
 
     DB::ReadBufferPtr getRandomData() override;
@@ -158,8 +173,12 @@ protected:
 class PSWindowWriter : public PSCommonWriter
 {
 public:
-    PSWindowWriter(const PSPtr & ps_, DB::UInt32 index_, const std::unique_ptr<GlobalStat> & global_stat_)
-        : PSCommonWriter(ps_, index_, global_stat_)
+    PSWindowWriter(
+        const PSPtr & ps_,
+        DB::UInt32 index_,
+        const std::unique_ptr<GlobalStat> & global_stat_,
+        const LoggerPtr & log)
+        : PSCommonWriter(ps_, index_, global_stat_, log)
     {}
 
     String description() override { return fmt::format("(Stress Test Window Writer {})", index); }
@@ -177,8 +196,12 @@ protected:
 class PSIncreaseWriter : public PSCommonWriter
 {
 public:
-    PSIncreaseWriter(const PSPtr & ps_, DB::UInt32 index_, const std::unique_ptr<GlobalStat> & global_stat_)
-        : PSCommonWriter(ps_, index_, global_stat_)
+    PSIncreaseWriter(
+        const PSPtr & ps_,
+        DB::UInt32 index_,
+        const std::unique_ptr<GlobalStat> & global_stat_,
+        const LoggerPtr & log)
+        : PSCommonWriter(ps_, index_, global_stat_, log)
     {}
 
     String description() override { return fmt::format("(Stress Test Increase Writer {})", index); }
@@ -198,8 +221,13 @@ protected:
 class PSReader : public PSRunnable
 {
 public:
-    PSReader(const PSPtr & ps_, DB::UInt32 index_, const std::unique_ptr<GlobalStat> & global_stat_)
-        : ps(ps_)
+    PSReader(
+        const PSPtr & ps_,
+        DB::UInt32 index_,
+        const std::unique_ptr<GlobalStat> & global_stat_,
+        const LoggerPtr & log)
+        : PSRunnable(log)
+        , ps(ps_)
         , index(index_)
         , global_stat(global_stat_)
     {
@@ -244,8 +272,12 @@ protected:
 class PSWindowReader : public PSReader
 {
 public:
-    PSWindowReader(const PSPtr & ps_, DB::UInt32 index_, const std::unique_ptr<GlobalStat> & global_stat_)
-        : PSReader(ps_, index_, global_stat_)
+    PSWindowReader(
+        const PSPtr & ps_,
+        DB::UInt32 index_,
+        const std::unique_ptr<GlobalStat> & global_stat_,
+        const LoggerPtr & log)
+        : PSReader(ps_, index_, global_stat_, log)
     {}
 
     void setNormalDistributionSigma(size_t sigma);
@@ -264,8 +296,12 @@ protected:
 class PSSnapshotReader : public PSReader
 {
 public:
-    PSSnapshotReader(const PSPtr & ps_, DB::UInt32 index_, const std::unique_ptr<GlobalStat> & global_stat_)
-        : PSReader(ps_, index_, global_stat_)
+    PSSnapshotReader(
+        const PSPtr & ps_,
+        DB::UInt32 index_,
+        const std::unique_ptr<GlobalStat> & global_stat_,
+        const LoggerPtr & log)
+        : PSReader(ps_, index_, global_stat_, log)
     {}
 
     bool runImpl() override;

--- a/dbms/src/Storages/Page/workload/PSStressEnv.h
+++ b/dbms/src/Storages/Page/workload/PSStressEnv.h
@@ -66,8 +66,6 @@ public:
 
 struct StressEnv
 {
-    static Poco::Logger * logger;
-
     size_t num_writers = 1;
     size_t num_readers = 4;
     bool init_pages = false;
@@ -115,10 +113,13 @@ struct StressEnv
         );
     }
 
-    static void initGlobalLogger();
+    LoggerPtr logger;
+
 
     static StressEnv parse(int argc, char ** argv);
 
     void setup();
+
+    static LoggerPtr buildLogger(bool enable_color);
 };
 } // namespace DB::PS::tests

--- a/dbms/src/Storages/Page/workload/PSWorkload.h
+++ b/dbms/src/Storages/Page/workload/PSWorkload.h
@@ -83,7 +83,7 @@ protected:
         writers.clear();
         for (size_t i = 0; i < nums_writers; ++i)
         {
-            auto writer = std::make_shared<T>(ps, i, runtime_stat);
+            auto writer = std::make_shared<T>(ps, i, runtime_stat, options.logger);
             if (writer_configure)
             {
                 writer_configure(writer);
@@ -99,7 +99,7 @@ protected:
         readers.clear();
         for (size_t i = 0; i < nums_readers; ++i)
         {
-            auto reader = std::make_shared<T>(ps, i, runtime_stat);
+            auto reader = std::make_shared<T>(ps, i, runtime_stat, options.logger);
             if (reader_configure)
             {
                 reader_configure(reader);
@@ -173,7 +173,7 @@ public:
 
     String toWorkloadSelctedString() const
     {
-        String debug_string = "Selected Workloads : ";
+        String debug_string = "Selected Workloads: ";
         for (const auto & it : funcs)
         {
             if (options.situation_mask & it.first)
@@ -197,11 +197,7 @@ public:
 
     void runWorkload();
 
-    void stopWorkload()
-    {
-        if (running_workload)
-            running_workload->stop();
-    }
+    void stopWorkload();
 
 private:
     StressEnv options;

--- a/dbms/src/Storages/Page/workload/PageStorageInMemoryCapacity.h
+++ b/dbms/src/Storages/Page/workload/PageStorageInMemoryCapacity.h
@@ -156,7 +156,7 @@ private:
         assert(page_writen != 0);
 
         LOG_INFO(
-            StressEnv::logger,
+            options.logger,
             "After gen: {} pages"
             "virtual memory used: {} MB,"
             "resident memory used: {} MB,"

--- a/dbms/src/Storages/Page/workload/ThousandsOfOffset.h
+++ b/dbms/src/Storages/Page/workload/ThousandsOfOffset.h
@@ -69,11 +69,11 @@ private:
         DB::PageStorageConfig config;
         initPageStorage(config, name());
 
-        metrics_dumper = std::make_shared<PSMetricsDumper>(1);
+        metrics_dumper = std::make_shared<PSMetricsDumper>(1, options.logger);
         metrics_dumper->start();
 
         {
-            stress_time = std::make_shared<StressTimeout>(30);
+            stress_time = std::make_shared<StressTimeout>(30, options.logger);
             stress_time->start();
 
             stop_watch.start();
@@ -96,7 +96,7 @@ private:
         }
 
         {
-            stress_time = std::make_shared<StressTimeout>(30);
+            stress_time = std::make_shared<StressTimeout>(30, options.logger);
             stress_time->start();
 
             stop_watch.start();
@@ -119,7 +119,7 @@ private:
         }
 
         {
-            stress_time = std::make_shared<StressTimeout>(30);
+            stress_time = std::make_shared<StressTimeout>(30, options.logger);
             stress_time->start();
 
             stop_watch.start();
@@ -142,7 +142,7 @@ private:
         }
 
         {
-            stress_time = std::make_shared<StressTimeout>(30);
+            stress_time = std::make_shared<StressTimeout>(30, options.logger);
             stress_time->start();
 
             stop_watch.start();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/6233

Problem Summary:
The previous output of `pageworkload` is hard to parse and run performance result comparsion

### What is changed and how it works?

* Add `--color false` for pageworkload to disable color fields in the output
* The performance summary is print into stdout and the running logging is print into stderr
* Use `JSON` as the performance output format

```
> ./dbms/src/Server/tiflash pageworkload -T 10 --color false > a.log 2> a.err.log
>  tail a.log
Workload summary: {"memory":{"avg":111674800,"latest":127928458,"top":127928458},"read":{"bytes_read":33,"pages":27123,"read_speed":"3.283"},"snapshots":{"avg":2017,"latest":3432,"top":3432},"write":{"bytes_written":4,"pages":2539,"write_speed":"0.493"}}
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
