### PR TITLE
runtime filter: fix timezone error in runtime filter

### DIFF
--- a/dbms/src/DataStreams/RuntimeFilter.cpp
+++ b/dbms/src/DataStreams/RuntimeFilter.cpp
@@ -55,7 +55,8 @@ void RuntimeFilter::setINValuesSet(const std::shared_ptr<Set> & in_values_set_)
     in_values_set = in_values_set_;
 }
 
-void RuntimeFilter::setTimezoneInfo(const TimezoneInfo & timezone_info_) {
+void RuntimeFilter::setTimezoneInfo(const TimezoneInfo & timezone_info_)
+{
     timezone_info = timezone_info_;
 }
 

--- a/dbms/src/DataStreams/RuntimeFilter.cpp
+++ b/dbms/src/DataStreams/RuntimeFilter.cpp
@@ -55,6 +55,10 @@ void RuntimeFilter::setINValuesSet(const std::shared_ptr<Set> & in_values_set_)
     in_values_set = in_values_set_;
 }
 
+void RuntimeFilter::setTimezoneInfo(const TimezoneInfo & timezone_info_) {
+    timezone_info = timezone_info_;
+}
+
 void RuntimeFilter::build()
 {
     if (!DM::FilterParser::isRSFilterSupportType(target_expr.field_type().tp()))
@@ -210,7 +214,8 @@ DM::RSOperatorPtr RuntimeFilter::parseToRSOperator(DM::ColumnDefines & columns_t
             rf_type,
             target_expr,
             columns_to_read,
-            in_values_set->getUniqueSetElements());
+            in_values_set->getUniqueSetElements(),
+            timezone_info);
     case tipb::MIN_MAX:
     case tipb::BLOOM_FILTER:
         // TODO

--- a/dbms/src/DataStreams/RuntimeFilter.h
+++ b/dbms/src/DataStreams/RuntimeFilter.h
@@ -61,6 +61,8 @@ public:
 
     void setINValuesSet(const std::shared_ptr<Set> & in_values_set_);
 
+    void setTimezoneInfo(const TimezoneInfo & timezone_info_);
+
     void build();
 
     void updateValues(const ColumnWithTypeAndName & values, const LoggerPtr & log);
@@ -85,6 +87,7 @@ private:
     tipb::Expr source_expr;
     tipb::Expr target_expr;
     const tipb::RuntimeFilterType rf_type;
+    TimezoneInfo timezone_info;
     // thread safe
     std::atomic<RuntimeFilterStatus> status = RuntimeFilterStatus::NOT_READY;
     // used for failed_reason thread safe

--- a/dbms/src/Flash/Coprocessor/DAGExpressionAnalyzer.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGExpressionAnalyzer.cpp
@@ -1375,6 +1375,7 @@ void DAGExpressionAnalyzer::appendRuntimeFilterProperties(RuntimeFilterPtr & run
         header.insert(ColumnWithTypeAndName(name_and_type.type->createColumn(), name_and_type.type, "_" + toString(1)));
         in_values_set->setHeader(header);
         runtime_filter->setINValuesSet(in_values_set);
+        runtime_filter->setTimezoneInfo(context.getTimezoneInfo());
         break;
     case tipb::MIN_MAX:
     case tipb::BLOOM_FILTER:

--- a/dbms/src/Storages/DeltaMerge/FilterParser/FilterParser.cpp
+++ b/dbms/src/Storages/DeltaMerge/FilterParser/FilterParser.cpp
@@ -391,15 +391,18 @@ RSOperatorPtr FilterParser::parseRFInExpr(
             return createUnsupported(target_expr.ShortDebugString(), "rf target expr is not column expr", false);
         auto column_define = cop::getColumnDefineForColumnExpr(target_expr, columns_to_read);
         auto attr = Attr{.col_name = column_define.name, .col_id = column_define.id, .type = column_define.type};
-        if (target_expr.field_type().tp() == TiDB::TypeTimestamp && !timezone_info.is_utc_timezone) {
+        if (target_expr.field_type().tp() == TiDB::TypeTimestamp && !timezone_info.is_utc_timezone)
+        {
             Fields values;
-            std::for_each(setElements.begin(), setElements.end(),[&](Field element) {
+            std::for_each(setElements.begin(), setElements.end(), [&](Field element) {
                 // convert literal value from timezone specified in cop request to UTC
                 cop::convertFieldWithTimezone(element, timezone_info);
                 values.push_back(element);
             });
             return createIn(attr, values);
-        } else {
+        }
+        else
+        {
             Fields values(setElements.begin(), setElements.end());
             return createIn(attr, values);
         }

--- a/dbms/src/Storages/DeltaMerge/FilterParser/FilterParser.cpp
+++ b/dbms/src/Storages/DeltaMerge/FilterParser/FilterParser.cpp
@@ -380,7 +380,8 @@ RSOperatorPtr FilterParser::parseRFInExpr(
     const tipb::RuntimeFilterType rf_type,
     const tipb::Expr & target_expr,
     const ColumnDefines & columns_to_read,
-    const std::set<Field> & setElements)
+    const std::set<Field> & setElements,
+    const TimezoneInfo & timezone_info)
 {
     switch (rf_type)
     {
@@ -390,9 +391,18 @@ RSOperatorPtr FilterParser::parseRFInExpr(
             return createUnsupported(target_expr.ShortDebugString(), "rf target expr is not column expr", false);
         auto column_define = cop::getColumnDefineForColumnExpr(target_expr, columns_to_read);
         auto attr = Attr{.col_name = column_define.name, .col_id = column_define.id, .type = column_define.type};
-        // FIXME: for timestamp literal, we should convert it to UTC timezone
-        Fields values(setElements.begin(), setElements.end());
-        return createIn(attr, values);
+        if (target_expr.field_type().tp() == TiDB::TypeTimestamp && !timezone_info.is_utc_timezone) {
+            Fields values;
+            std::for_each(setElements.begin(), setElements.end(),[&](Field element) {
+                // convert literal value from timezone specified in cop request to UTC
+                cop::convertFieldWithTimezone(element, timezone_info);
+                values.push_back(element);
+            });
+            return createIn(attr, values);
+        } else {
+            Fields values(setElements.begin(), setElements.end());
+            return createIn(attr, values);
+        }
     }
     case tipb::MIN_MAX:
     case tipb::BLOOM_FILTER:

--- a/dbms/src/Storages/DeltaMerge/FilterParser/FilterParser.cpp
+++ b/dbms/src/Storages/DeltaMerge/FilterParser/FilterParser.cpp
@@ -394,6 +394,7 @@ RSOperatorPtr FilterParser::parseRFInExpr(
         if (target_expr.field_type().tp() == TiDB::TypeTimestamp && !timezone_info.is_utc_timezone)
         {
             Fields values;
+            values.reserve(setElements.size());
             std::for_each(setElements.begin(), setElements.end(), [&](Field element) {
                 // convert literal value from timezone specified in cop request to UTC
                 cop::convertFieldWithTimezone(element, timezone_info);

--- a/dbms/src/Storages/DeltaMerge/FilterParser/FilterParser.h
+++ b/dbms/src/Storages/DeltaMerge/FilterParser/FilterParser.h
@@ -50,7 +50,8 @@ public:
         tipb::RuntimeFilterType rf_type,
         const tipb::Expr & target_expr,
         const ColumnDefines & columns_to_read,
-        const std::set<Field> & setElements);
+        const std::set<Field> & setElements,
+        const TimezoneInfo & timezone_info);
 
     static bool isRSFilterSupportType(Int32 field_type);
 

--- a/tests/fullstack-test/mpp/runtime_filter.test
+++ b/tests/fullstack-test/mpp/runtime_filter.test
@@ -34,11 +34,13 @@ mysql> drop table if exists test.t1_timestamp;
 mysql> create table test.t1_timestamp (k1 int, k2 timestamp);
 mysql> alter table test.t1_timestamp set tiflash replica 1;
 mysql> insert into t1_timestamp values (1, "2023-10-20 00:00:00");
+mysql> alter table t1_timestamp compact tiflash replica;
 
 mysql> drop table if exists test.t2_timestamp;
 mysql> create table test.t2_timestamp (k1 int, k2 timestamp);
 mysql> alter table test.t2_timestamp set tiflash replica 1;
 mysql> insert into t2_timestamp values (1, "2023-10-20 00:00:00");
+mysql> alter table t2_timestamp compact tiflash replica;
 
 func> wait_table test t1
 func> wait_table test t2

--- a/tests/fullstack-test/mpp/runtime_filter.test
+++ b/tests/fullstack-test/mpp/runtime_filter.test
@@ -33,12 +33,12 @@ mysql> insert into test.t2 values (4,null,null,null,null,null, null, null, null,
 mysql> drop table if exists test.t1_timestamp;
 mysql> create table test.t1_timestamp (k1 int, k2 timestamp);
 mysql> alter table test.t1_timestamp set tiflash replica 1;
-mysql> insert into t1_timestamp values (1, "2023-10-20 00:00:00");
+mysql> insert into t1_timestamp values (1, '2023-10-20 00:00:00');
 
 mysql> drop table if exists test.t2_timestamp;
 mysql> create table test.t2_timestamp (k1 int, k2 timestamp);
 mysql> alter table test.t2_timestamp set tiflash replica 1;
-mysql> insert into t2_timestamp values (1, "2023-10-20 00:00:00");
+mysql> insert into t2_timestamp values (1, '2023-10-20 00:00:00');
 
 func> wait_table test t1
 func> wait_table test t2

--- a/tests/fullstack-test/mpp/runtime_filter.test
+++ b/tests/fullstack-test/mpp/runtime_filter.test
@@ -34,18 +34,19 @@ mysql> drop table if exists test.t1_timestamp;
 mysql> create table test.t1_timestamp (k1 int, k2 timestamp);
 mysql> alter table test.t1_timestamp set tiflash replica 1;
 mysql> insert into t1_timestamp values (1, "2023-10-20 00:00:00");
-mysql> alter table t1_timestamp compact tiflash replica;
 
 mysql> drop table if exists test.t2_timestamp;
 mysql> create table test.t2_timestamp (k1 int, k2 timestamp);
 mysql> alter table test.t2_timestamp set tiflash replica 1;
 mysql> insert into t2_timestamp values (1, "2023-10-20 00:00:00");
-mysql> alter table t2_timestamp compact tiflash replica;
 
 func> wait_table test t1
 func> wait_table test t2
 func> wait_table test t1_timestamp
 func> wait_table test t2_timestamp
+
+mysql> alter table t1_timestamp compact tiflash replica;
+mysql> alter table t2_timestamp compact tiflash replica;
 
 # inner join
 mysql> set @@tidb_isolation_read_engines='tiflash'; set tidb_enforce_mpp = 1; set tidb_runtime_filter_mode="LOCAL"; select t1_tinyint, t2_tinyint from test.t1, test.t2 where t1.t1_tinyint=t2.t2_tinyint;

--- a/tests/fullstack-test/mpp/runtime_filter.test
+++ b/tests/fullstack-test/mpp/runtime_filter.test
@@ -33,20 +33,20 @@ mysql> insert into test.t2 values (4,null,null,null,null,null, null, null, null,
 mysql> drop table if exists test.t1_timestamp;
 mysql> create table test.t1_timestamp (k1 int, k2 timestamp);
 mysql> alter table test.t1_timestamp set tiflash replica 1;
-mysql> insert into t1_timestamp values (1, '2023-10-20 00:00:00');
+mysql> insert into test.t1_timestamp values (1, '2023-10-20 00:00:00');
 
 mysql> drop table if exists test.t2_timestamp;
 mysql> create table test.t2_timestamp (k1 int, k2 timestamp);
 mysql> alter table test.t2_timestamp set tiflash replica 1;
-mysql> insert into t2_timestamp values (1, '2023-10-20 00:00:00');
+mysql> insert into test.t2_timestamp values (1, '2023-10-20 00:00:00');
 
 func> wait_table test t1
 func> wait_table test t2
 func> wait_table test t1_timestamp
 func> wait_table test t2_timestamp
 
-mysql> alter table t1_timestamp compact tiflash replica;
-mysql> alter table t2_timestamp compact tiflash replica;
+mysql> alter table test.t1_timestamp compact tiflash replica;
+mysql> alter table test.t2_timestamp compact tiflash replica;
 
 # inner join
 mysql> set @@tidb_isolation_read_engines='tiflash'; set tidb_enforce_mpp = 1; set tidb_runtime_filter_mode="LOCAL"; select t1_tinyint, t2_tinyint from test.t1, test.t2 where t1.t1_tinyint=t2.t2_tinyint;

--- a/tests/fullstack-test/mpp/runtime_filter.test
+++ b/tests/fullstack-test/mpp/runtime_filter.test
@@ -30,8 +30,20 @@ mysql> insert into test.t2 values (2,3,3,3,3333333,3, 1, 3, 3.0, 3.00, 3.0);
 mysql> insert into test.t2 values (3,3,3,3,3333333,3, 1, 3, 3.0, 3.00, 3.0);
 mysql> insert into test.t2 values (4,null,null,null,null,null, null, null, null, null, null);
 
+mysql> drop table if exists test.t1_timestamp;
+mysql> create table test.t1_timestamp (k1 int, k2 timestamp);
+mysql> alter table test.t1_timestamp set tiflash replica 1;
+mysql> insert into t1_timestamp values (1, "2023-10-20 00:00:00");
+
+mysql> drop table if exists test.t2_timestamp;
+mysql> create table test.t2_timestamp (k1 int, k2 timestamp);
+mysql> alter table test.t2_timestamp set tiflash replica 1;
+mysql> insert into t2_timestamp values (1, "2023-10-20 00:00:00");
+
 func> wait_table test t1
 func> wait_table test t2
+func> wait_table test t1_timestamp
+func> wait_table test t2_timestamp
 
 # inner join
 mysql> set @@tidb_isolation_read_engines='tiflash'; set tidb_enforce_mpp = 1; set tidb_runtime_filter_mode="LOCAL"; select t1_tinyint, t2_tinyint from test.t1, test.t2 where t1.t1_tinyint=t2.t2_tinyint;
@@ -62,5 +74,15 @@ mysql> set @@tidb_isolation_read_engines='tiflash'; set tidb_enforce_mpp = 1; se
 |          1 |
 +------------+
 
+# test timestamp column type for issue #8222
+mysql> set @@tidb_isolation_read_engines='tiflash'; set tidb_enforce_mpp = 1; set tidb_runtime_filter_mode="LOCAL"; select * from test.t1_timestamp, test.t2_timestamp where t1_timestamp.k2=t2_timestamp.k2;
++------+---------------------+------+---------------------+
+| k1   | k2                  | k1   | k2                  |
++------+---------------------+------+---------------------+
+|    1 | 2023-10-20 00:00:00 |    1 | 2023-10-20 00:00:00 |
++------+---------------------+------+---------------------+
+
 mysql> drop table test.t1;
 mysql> drop table test.t2;
+mysql> drop table test.t1_timestamp;
+mysql> drop table test.t2_timestamp;


### PR DESCRIPTION
### What problem does this PR solve?

This pr fix #8222.
The rs operator which is parsed by filter should change the timezone to UTF when the column type is timestamp.

The tiflash storage layer store the timestamp type value using UTF. So all of literal include runtime filter values should be changed to UTF timezone.

Issue Number: close #8222

Problem Summary:

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
```
tiup playground --tiflash 1
use test;
create table t1(k1 int , k2 timestamp);
create table t2(k1 int, k2 timestamp);
alter table t1 set tiflash replica 1;
alter table t2 set tiflash replica 1;
set tidb_isolation_read_engines = "tiflash";
insert into t1 values (1, "2023-10-20 00:00:00");
insert into t2 values (1, "2023-10-20 00:00:00");
set tidb_runtime_filter_mode="LOCAL";
explain select * from t1, t2 where t1.k2=t2.k2; -- with runtime filter
mysql> select * from t1, t2 where t1.k2=t2.k2;
+------+---------------------+------+---------------------+
| k1   | k2                  | k1   | k2                  |
+------+---------------------+------+---------------------+
|    1 | 2023-10-20 00:00:00 |    1 | 2023-10-20 00:00:00 |
+------+---------------------+------+---------------------+
1 row in set (0.02 sec)
```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```

### Fix version
v7.5
