### PR TITLE
Reduce redundant calculation in join probe, optimize `mergeNullAndFilterResult`

### DIFF
--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -860,10 +860,15 @@ void Join::handleOtherConditions(
     auto & filter = filter_column->getData();
     mergeNullAndFilterResult(block, filter, non_equal_conditions.other_cond_name, false);
 
-    ColumnUInt8::Container row_filter(filter.size(), 0);
+    ColumnUInt8::Container row_filter(block.rows(), 0);
 
     if (isLeftOuterSemiFamily(kind))
     {
+        if (filter.size() != block.rows())
+        {
+            assert(filter.empty());
+            filter.assign(block.rows(), static_cast<UInt8>(1));
+        }
         const auto helper_pos = block.getPositionByName(match_helper_name);
 
         const auto * old_match_nullable
@@ -950,6 +955,7 @@ void Join::handleOtherConditions(
     /// otherwise, it will check other_eq_filter_from_in_column, if other_eq_filter_from_in_column return false, this row should
     /// be returned, if other_eq_filter_from_in_column return true or null this row should not be returned.
     mergeNullAndFilterResult(block, filter, non_equal_conditions.other_eq_cond_from_in_name, isAntiJoin(kind));
+    assert(block.rows() == filter.size());
 
     if ((isInnerJoin(kind) && original_strictness == ASTTableJoin::Strictness::All)
         || isNecessaryKindToUseRowFlaggedHashMap(kind))
@@ -1049,6 +1055,11 @@ void Join::handleOtherConditionsForOneProbeRow(Block & block, ProbeProcessInfo &
     UInt64 matched_row_count_in_current_block = 0;
     if (isLeftOuterSemiFamily(kind) && !non_equal_conditions.other_eq_cond_from_in_name.empty())
     {
+        if (filter.size() != block.rows())
+        {
+            assert(filter.empty());
+            filter.assign(block.rows(), static_cast<UInt8>(1));
+        }
         assert(probe_process_info.has_row_matched == false);
         ColumnPtr eq_in_column = block.getByName(non_equal_conditions.other_eq_cond_from_in_name).column;
         auto [eq_in_vec, eq_in_nullmap] = getDataAndNullMapVectorFromFilterColumn(eq_in_column);
@@ -1068,6 +1079,7 @@ void Join::handleOtherConditionsForOneProbeRow(Block & block, ProbeProcessInfo &
     else
     {
         mergeNullAndFilterResult(block, filter, non_equal_conditions.other_eq_cond_from_in_name, isAntiJoin(kind));
+        assert(filter.size() == block.rows());
         matched_row_count_in_current_block = countBytesInFilter(filter);
         probe_process_info.has_row_matched |= matched_row_count_in_current_block != 0;
     }

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -793,20 +793,45 @@ void mergeNullAndFilterResult(
     auto [filter_vec, nullmap_vec] = getDataAndNullMapVectorFromFilterColumn(current_filter_column);
     if (nullmap_vec != nullptr)
     {
-        for (size_t i = 0; i < nullmap_vec->size(); ++i)
+        if (filter_column.empty())
         {
-            if (filter_column[i] == 0)
-                continue;
-            if ((*nullmap_vec)[i])
-                filter_column[i] = null_as_true;
+            filter_column.insert(nullmap_vec->begin(), nullmap_vec->end());
+            if (null_as_true)
+            {
+                for (size_t i = 0; i < nullmap_vec->size(); ++i)
+                    filter_column[i] = filter_column[i] || (*filter_vec)[i];
+            }
             else
-                filter_column[i] = filter_column[i] && (*filter_vec)[i];
+            {
+                for (size_t i = 0; i < nullmap_vec->size(); ++i)
+                    filter_column[i] = !filter_column[i] && (*filter_vec)[i];
+            }
+        }
+        else
+        {
+            if (null_as_true)
+            {
+                for (size_t i = 0; i < nullmap_vec->size(); ++i)
+                    filter_column[i] = filter_column[i] && ((*nullmap_vec)[i] || (*filter_vec)[i]);
+            }
+            else
+            {
+                for (size_t i = 0; i < nullmap_vec->size(); ++i)
+                    filter_column[i] = filter_column[i] && (*nullmap_vec)[i] == 0 && (*filter_vec)[i];
+            }
         }
     }
     else
     {
-        for (size_t i = 0; i < filter_vec->size(); ++i)
-            filter_column[i] = filter_column[i] && (*filter_vec)[i];
+        if (filter_column.empty())
+        {
+            filter_column.insert(filter_vec->begin(), filter_vec->end());
+        }
+        else
+        {
+            for (size_t i = 0; i < filter_vec->size(); ++i)
+                filter_column[i] = filter_column[i] && (*filter_vec)[i];
+        }
     }
 }
 
@@ -833,7 +858,6 @@ void Join::handleOtherConditions(
 
     auto filter_column = ColumnUInt8::create();
     auto & filter = filter_column->getData();
-    filter.assign(block.rows(), static_cast<UInt8>(1));
     mergeNullAndFilterResult(block, filter, non_equal_conditions.other_cond_name, false);
 
     ColumnUInt8::Container row_filter(filter.size(), 0);
@@ -1021,7 +1045,6 @@ void Join::handleOtherConditionsForOneProbeRow(Block & block, ProbeProcessInfo &
     non_equal_conditions.other_cond_expr->execute(block);
     auto filter_column = ColumnUInt8::create();
     auto & filter = filter_column->getData();
-    filter.assign(block.rows(), static_cast<UInt8>(1));
     mergeNullAndFilterResult(block, filter, non_equal_conditions.other_cond_name, false);
     UInt64 matched_row_count_in_current_block = 0;
     if (isLeftOuterSemiFamily(kind) && !non_equal_conditions.other_eq_cond_from_in_name.empty())
@@ -1228,11 +1251,10 @@ Block Join::doJoinBlockHash(ProbeProcessInfo & probe_process_info) const
     auto & filter = probe_process_info.filter;
     auto & offsets_to_replicate = probe_process_info.offsets_to_replicate;
 
-    bool enable_spill_join = isEnableSpill();
     JoinBuildInfo join_build_info{
         enable_fine_grained_shuffle,
         fine_grained_shuffle_count,
-        enable_spill_join,
+        isEnableSpill(),
         hash_join_spill_context->isSpilled(),
         build_concurrency,
         restore_round};
@@ -1365,7 +1387,14 @@ Block Join::joinBlockHash(ProbeProcessInfo & probe_process_info) const
 {
     std::vector<Block> result_blocks;
     size_t result_rows = 0;
-    probe_process_info.prepareForHashProbe(key_names_left, non_equal_conditions.left_filter_column, kind, strictness);
+    bool need_compute_hash = enable_fine_grained_shuffle || (hash_join_spill_context->isSpillEnabled() && !hash_join_spill_context->isSpilled());
+    probe_process_info.prepareForHashProbe(key_names_left,
+                                           non_equal_conditions.left_filter_column,
+                                           kind,
+                                           strictness,
+                                           need_compute_hash,
+                                           collators,
+                                           restore_round);
     while (true)
     {
         auto block = doJoinBlockHash(probe_process_info);

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -1387,14 +1387,16 @@ Block Join::joinBlockHash(ProbeProcessInfo & probe_process_info) const
 {
     std::vector<Block> result_blocks;
     size_t result_rows = 0;
-    bool need_compute_hash = enable_fine_grained_shuffle || (hash_join_spill_context->isSpillEnabled() && !hash_join_spill_context->isSpilled());
-    probe_process_info.prepareForHashProbe(key_names_left,
-                                           non_equal_conditions.left_filter_column,
-                                           kind,
-                                           strictness,
-                                           need_compute_hash,
-                                           collators,
-                                           restore_round);
+    bool need_compute_hash = enable_fine_grained_shuffle
+        || (hash_join_spill_context->isSpillEnabled() && !hash_join_spill_context->isSpilled());
+    probe_process_info.prepareForHashProbe(
+        key_names_left,
+        non_equal_conditions.left_filter_column,
+        kind,
+        strictness,
+        need_compute_hash,
+        collators,
+        restore_round);
     while (true)
     {
         auto block = doJoinBlockHash(probe_process_info);

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -817,7 +817,7 @@ void mergeNullAndFilterResult(
             else
             {
                 for (size_t i = 0; i < nullmap_vec->size(); ++i)
-                    filter_column[i] = filter_column[i] && (*nullmap_vec)[i] == 0 && (*filter_vec)[i];
+                    filter_column[i] = filter_column[i] && !(*nullmap_vec)[i] && (*filter_vec)[i];
             }
         }
     }

--- a/dbms/src/Interpreters/Join.h
+++ b/dbms/src/Interpreters/Join.h
@@ -454,7 +454,7 @@ private:
     void insertFromBlockInternal(Block * stored_block, size_t stream_index);
 
     Block joinBlockHash(ProbeProcessInfo & probe_process_info) const;
-    Block doJoinBlockHash(ProbeProcessInfo & probe_process_info) const;
+    Block doJoinBlockHash(ProbeProcessInfo & probe_process_info, const JoinBuildInfo & join_build_info) const;
 
     Block joinBlockNullAware(ProbeProcessInfo & probe_process_info) const;
 

--- a/dbms/src/Interpreters/JoinPartition.cpp
+++ b/dbms/src/Interpreters/JoinPartition.cpp
@@ -1476,7 +1476,6 @@ void NO_INLINE probeBlockImplTypeCase(
     std::vector<std::string> sort_key_containers;
     sort_key_containers.resize(key_columns.size());
     Arena pool;
-    WeakHash32 build_hash(0); /// reproduce hash values according to build stage
     if (join_build_info.needVirtualDispatchForProbeBlock())
     {
         assert(!(join_build_info.restore_round > 0 && join_build_info.enable_fine_grained_shuffle));
@@ -1484,16 +1483,10 @@ void NO_INLINE probeBlockImplTypeCase(
         /// Note: 1. Not sure, if inconsistency will do happen in heterogeneous envs
         ///       2. Virtual column would take up a little more network bandwidth, might lead to poor performance if network was bottleneck
         /// Currently, the computation cost is tolerable, since it's a very simple crc32 hash algorithm, and heterogeneous envs support is not considered
-        computeDispatchHash(
-            rows,
-            key_columns,
-            collators,
-            sort_key_containers,
-            join_build_info.restore_round,
-            build_hash);
+        assert(probe_process_info.hash_data->getData().size() == rows);
     }
 
-    const auto & build_hash_data = build_hash.getData();
+    const auto & build_hash_data = probe_process_info.hash_data->getData();
     assert(probe_process_info.start_row < rows);
     size_t i;
     bool block_full = false;

--- a/dbms/src/Interpreters/JoinPartition.cpp
+++ b/dbms/src/Interpreters/JoinPartition.cpp
@@ -1479,10 +1479,6 @@ void NO_INLINE probeBlockImplTypeCase(
     if (join_build_info.needVirtualDispatchForProbeBlock())
     {
         assert(!(join_build_info.restore_round > 0 && join_build_info.enable_fine_grained_shuffle));
-        /// TODO: consider adding a virtual column in Sender side to avoid computing cost and potential inconsistency by heterogeneous envs(AMD64, ARM64)
-        /// Note: 1. Not sure, if inconsistency will do happen in heterogeneous envs
-        ///       2. Virtual column would take up a little more network bandwidth, might lead to poor performance if network was bottleneck
-        /// Currently, the computation cost is tolerable, since it's a very simple crc32 hash algorithm, and heterogeneous envs support is not considered
         assert(probe_process_info.hash_data->getData().size() == rows);
     }
 

--- a/dbms/src/Interpreters/ProbeProcessInfo.cpp
+++ b/dbms/src/Interpreters/ProbeProcessInfo.cpp
@@ -101,13 +101,7 @@ void ProbeProcessInfo::prepareForHashProbe(
     {
         std::vector<std::string> sort_key_containers;
         sort_key_containers.resize(key_columns.size());
-        computeDispatchHash(
-            block.rows(),
-            key_columns,
-            collators,
-            sort_key_containers,
-            restore_round,
-            *hash_data);
+        computeDispatchHash(block.rows(), key_columns, collators, sort_key_containers, restore_round, *hash_data);
     }
     prepare_for_probe_done = true;
 }

--- a/dbms/src/Interpreters/ProbeProcessInfo.cpp
+++ b/dbms/src/Interpreters/ProbeProcessInfo.cpp
@@ -38,6 +38,7 @@ void ProbeProcessInfo::resetBlock(Block && block_, size_t partition_index_)
     offsets_to_replicate.reset();
     key_columns.clear();
     materialized_columns.clear();
+    hash_data = nullptr;
     result_block_schema.clear();
     right_column_index.clear();
     right_rows_to_be_added_when_matched = 0;
@@ -53,7 +54,10 @@ void ProbeProcessInfo::prepareForHashProbe(
     const Names & key_names,
     const String & filter_column,
     ASTTableJoin::Kind kind,
-    ASTTableJoin::Strictness strictness)
+    ASTTableJoin::Strictness strictness,
+    bool need_compute_hash,
+    const TiDB::TiDBCollators & collators,
+    size_t restore_round)
 {
     if (prepare_for_probe_done)
         return;
@@ -91,6 +95,20 @@ void ProbeProcessInfo::prepareForHashProbe(
         filter = std::make_unique<IColumn::Filter>(block.rows());
     if (strictness == ASTTableJoin::Strictness::All)
         offsets_to_replicate = std::make_unique<IColumn::Offsets>(block.rows());
+
+    hash_data = std::make_unique<WeakHash32>(0);
+    if (need_compute_hash)
+    {
+        std::vector<std::string> sort_key_containers;
+        sort_key_containers.resize(key_columns.size());
+        computeDispatchHash(
+            block.rows(),
+            key_columns,
+            collators,
+            sort_key_containers,
+            restore_round,
+            *hash_data);
+    }
     prepare_for_probe_done = true;
 }
 

--- a/dbms/src/Interpreters/ProbeProcessInfo.h
+++ b/dbms/src/Interpreters/ProbeProcessInfo.h
@@ -51,6 +51,7 @@ struct ProbeProcessInfo
     /// for hash probe
     Columns materialized_columns;
     ColumnRawPtrs key_columns;
+    std::unique_ptr<WeakHash32> hash_data; /// reproduce hash values according to build stage
 
     /// for cross probe
     Block result_block_schema;
@@ -118,7 +119,10 @@ struct ProbeProcessInfo
         const Names & key_names,
         const String & filter_column,
         ASTTableJoin::Kind kind,
-        ASTTableJoin::Strictness strictness);
+        ASTTableJoin::Strictness strictness,
+        bool need_compute_hash,
+        const TiDB::TiDBCollators & collators,
+        size_t restore_round);
     void prepareForCrossProbe(
         const String & filter_column,
         ASTTableJoin::Kind kind,

--- a/dbms/src/Interpreters/ProbeProcessInfo.h
+++ b/dbms/src/Interpreters/ProbeProcessInfo.h
@@ -51,7 +51,11 @@ struct ProbeProcessInfo
     /// for hash probe
     Columns materialized_columns;
     ColumnRawPtrs key_columns;
-    std::unique_ptr<WeakHash32> hash_data; /// reproduce hash values according to build stage
+    /// TODO: consider adding a virtual column in Sender side to avoid computing cost and potential inconsistency by heterogeneous envs(AMD64, ARM64)
+    /// Note: 1. Not sure, if inconsistency will do happen in heterogeneous envs
+    ///       2. Virtual column would take up a little more network bandwidth, might lead to poor performance if network was bottleneck
+    /// Currently, the computation cost is tolerable, since it's a very simple crc32 hash algorithm, and heterogeneous envs support is not considered
+    std::unique_ptr<WeakHash32> hash_data; /// to reproduce hash values according to build stage
 
     /// for cross probe
     Block result_block_schema;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8294

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```
mysql> desc t;
+---------+---------+------+------+---------+-------+
| Field   | Type    | Null | Key  | Default | Extra |
+---------+---------+------+------+---------+-------+
| from_id | int(11) | YES  |      | NULL    |       |
| to_id   | int(11) | YES  |      | NULL    |       |
| value   | int(11) | YES  |      | NULL    |       |
+---------+---------+------+------+---------+-------+
mysql> select count(*) from t;
+----------+
| count(*) |
+----------+
|   393216 |
+----------+
mysql> select count(*), from_id, to_id, value from t group by from_id, to_id, value;
+----------+---------+-------+-------+
| count(*) | from_id | to_id | value |
+----------+---------+-------+-------+
|   131072 |       2 |     3 |     2 |
|   131072 |       3 |     4 |     3 |
|   131072 |       1 |     2 |     1 |
+----------+---------+-------+-------+
```
Before this pr(based on some other optimization)
```
mysql> select count(t1.value) from t t1 join t t2 on t1.from_id = t2.to_id and t1.value > t2.value;
+-----------------+                                  
| count(t1.value) |                                  
+-----------------+                                  
|     34359738368 |                                  
+-----------------+                                  
1 row in set (42.24 sec)
```
After this pr(based on the same optimization as above)
```
mysql> select count(t1.value) from t t1 join t t2 on t1.from_id = t2.to_id and t1.value > t2.value;
+-----------------+
| count(t1.value) |
+-----------------+
|     34359738368 |
+-----------------+
1 row in set (34.63 sec)
```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
