### PR TITLE
Remove useless member in DMFilePackFilter to save memory

### DIFF
--- a/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.h
@@ -30,6 +30,8 @@ class Logger;
 using LoggerPtr = std::shared_ptr<Logger>;
 namespace DM
 {
+inline static const size_t DMFILE_READ_ROWS_THRESHOLD = DEFAULT_MERGE_BLOCK_SIZE * 3;
+
 class DMFileBlockInputStream : public SkippableBlockInputStream
 {
 public:

--- a/dbms/src/Storages/DeltaMerge/File/DMFileReader.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileReader.h
@@ -34,7 +34,6 @@ namespace DM
 class RSOperator;
 using RSOperatorPtr = std::shared_ptr<RSOperator>;
 
-inline static const size_t DMFILE_READ_ROWS_THRESHOLD = DEFAULT_MERGE_BLOCK_SIZE * 3;
 
 class DMFileReader
 {

--- a/dbms/src/Storages/DeltaMerge/Filter/FilterHelper.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/FilterHelper.h
@@ -21,7 +21,7 @@
 namespace DB::DM
 {
 
-inline RSOperatorPtr toFilter(RowKeyRange & rowkey_range)
+inline RSOperatorPtr toFilter(const RowKeyRange & rowkey_range)
 {
     Attr handle_attr
         = {EXTRA_HANDLE_COLUMN_NAME,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6233 

Problem Summary:

### What is changed and how it works?

clear `param` after creating, and add `handle_index` and `version_index` to store necessary information.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
