### PR TITLE
fix: update git version for submodules

### DIFF
--- a/release-centos7-llvm/dockerfiles/misc/bake_llvm_base_aarch64.sh
+++ b/release-centos7-llvm/dockerfiles/misc/bake_llvm_base_aarch64.sh
@@ -44,6 +44,10 @@ function bake_llvm_base_aarch64() {
     install_openssl "1_1_1t"
     export OPENSSL_ROOT_DIR="/usr/local/opt/openssl"
 
+    # Git
+    source $SCRIPTPATH/install_git.sh
+    install_git "2.40.1"
+
     # Go
     source $SCRIPTPATH/install_go.sh
     install_go "1.20" "arm64"

--- a/release-centos7-llvm/dockerfiles/misc/bake_llvm_base_amd64.sh
+++ b/release-centos7-llvm/dockerfiles/misc/bake_llvm_base_amd64.sh
@@ -43,6 +43,10 @@ function bake_llvm_base_amd64() {
     install_openssl "1_1_1t"
     export OPENSSL_ROOT_DIR="/usr/local/opt/openssl"
 
+    # Git
+    source $SCRIPTPATH/install_git.sh
+    install_git "2.40.1"
+
     # Go
     source $SCRIPTPATH/install_go.sh
     install_go "1.20" "amd64"

--- a/release-centos7-llvm/dockerfiles/misc/install_ccache.sh
+++ b/release-centos7-llvm/dockerfiles/misc/install_ccache.sh
@@ -29,6 +29,7 @@ function install_ccache() {
       -DCMAKE_INSTALL_PREFIX="/usr/local" \
       -GNinja
     ninja && ninja install
+    mkdir -p /usr/lib64/ccache && ln -s `which ccache` /usr/lib64/ccache/clang &&  ln -s `which ccache` /usr/lib64/ccache/clang++
     cd ../..
     rm -rf "ccache-$1"
 }

--- a/release-centos7-llvm/dockerfiles/misc/install_git.sh
+++ b/release-centos7-llvm/dockerfiles/misc/install_git.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Copyright 2022 PingCAP, Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Install git for CI/CD.
+# Require: openssl
+
+function install_git() {
+    # $1: git version
+    wget -O git.tar.gz https://github.com/git/git/archive/refs/tags/v$1.tar.gz
+	tar -xzvf git.tar.gz --transform="s,^git-$1/,git/,1"
+    cd git
+	make configure
+	./configure --with-openssl $OPENSSL_ROOT_DIR --prefix /usr/local
+	make -j
+	make install
+	cd ..
+	rm -rf git git.tar.gz
+}

--- a/release-centos7-llvm/dockerfiles/misc/install_git.sh
+++ b/release-centos7-llvm/dockerfiles/misc/install_git.sh
@@ -19,12 +19,12 @@
 function install_git() {
     # $1: git version
     wget -O git.tar.gz https://github.com/git/git/archive/refs/tags/v$1.tar.gz
-	tar -xzvf git.tar.gz --transform="s,^git-$1/,git/,1"
-    cd git
-	make configure
-	./configure --with-openssl $OPENSSL_ROOT_DIR --prefix /usr/local
-	make -j
-	make install
-	cd ..
-	rm -rf git git.tar.gz
+    mkdir git && cd git
+    tar -xzvf ../git.tar.gz --strip-components=1
+    make configure
+    ./configure --with-openssl $OPENSSL_ROOT_DIR --prefix /usr/local
+    make -j
+    make install
+    cd ..
+    rm -rf git git.tar.gz
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8324

Problem Summary:
- git version is too old for recent tiflash repo
- easier ccache enabling dir

### What is changed and how it works?
- update git version for the tiflash building container 

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
