### PR TITLE
Support Clang Thread Safety Analysis

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,15 @@ if (ENABLE_TIME_TRACES)
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CLANG_TIME_TRACES_FLAGS}")
 endif ()
 
+option(ENABLE_TSA "Enable clang feature thread safety analysis " OFF)
+if (ENABLE_TSA)
+    set (CLANG_TSA_FLAGS "-Wthread-safety")
+    add_definitions(-D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS)
+    message (STATUS "Enable clang thread safety analysis flag: -Wthread-safety -D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS.")
+    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CLANG_TSA_FLAGS}")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CLANG_TSA_FLAGS}")
+endif ()
+
 # https://clang.llvm.org/docs/ThinLTO.html
 # Applies to clang only.
 option(ENABLE_THINLTO "Clang-specific link time optimization" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ if (ENABLE_TIME_TRACES)
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CLANG_TIME_TRACES_FLAGS}")
 endif ()
 
-option(ENABLE_TSA "Enable clang feature thread safety analysis " OFF)
+option(ENABLE_TSA "Enable clang feature thread safety analysis " ON)
 if (ENABLE_TSA)
     set (CLANG_TSA_FLAGS "-Wthread-safety")
     add_definitions(-D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS)

--- a/dbms/src/Debug/MockKVStore/MockProxyRegion.cpp
+++ b/dbms/src/Debug/MockKVStore/MockProxyRegion.cpp
@@ -29,19 +29,19 @@
 
 namespace DB
 {
-raft_serverpb::RegionLocalState MockProxyRegion::getState()
+raft_serverpb::RegionLocalState MockProxyRegion::getState() NO_THREAD_SAFETY_ANALYSIS
 {
     auto _ = genLockGuard();
     return state;
 }
 
-raft_serverpb::RaftApplyState MockProxyRegion::getApply()
+raft_serverpb::RaftApplyState MockProxyRegion::getApply() NO_THREAD_SAFETY_ANALYSIS
 {
     auto _ = genLockGuard();
     return apply;
 }
 
-void MockProxyRegion::updateAppliedIndex(uint64_t index, bool persist_at_once)
+void MockProxyRegion::updateAppliedIndex(uint64_t index, bool persist_at_once) NO_THREAD_SAFETY_ANALYSIS
 {
     auto l = genLockGuard();
     this->apply.set_applied_index(index);
@@ -51,7 +51,7 @@ void MockProxyRegion::updateAppliedIndex(uint64_t index, bool persist_at_once)
     }
 }
 
-void MockProxyRegion::persistAppliedIndex()
+void MockProxyRegion::persistAppliedIndex() NO_THREAD_SAFETY_ANALYSIS
 {
     auto _ = genLockGuard();
     this->persisted_apply = apply;
@@ -62,26 +62,26 @@ void MockProxyRegion::persistAppliedIndex(const std::lock_guard<Mutex> &)
     this->persisted_apply = apply;
 }
 
-uint64_t MockProxyRegion::getPersistedAppliedIndex()
+uint64_t MockProxyRegion::getPersistedAppliedIndex() NO_THREAD_SAFETY_ANALYSIS
 {
     // Assume persist after every advance for simplicity.
     auto _ = genLockGuard();
     return this->persisted_apply.applied_index();
 }
 
-uint64_t MockProxyRegion::getLatestAppliedIndex()
+uint64_t MockProxyRegion::getLatestAppliedIndex() NO_THREAD_SAFETY_ANALYSIS
 {
     auto _ = genLockGuard();
     return this->apply.applied_index();
 }
 
-uint64_t MockProxyRegion::getLatestCommitTerm()
+uint64_t MockProxyRegion::getLatestCommitTerm() NO_THREAD_SAFETY_ANALYSIS
 {
     auto _ = genLockGuard();
     return this->apply.commit_term();
 }
 
-uint64_t MockProxyRegion::getLatestCommitIndex()
+uint64_t MockProxyRegion::getLatestCommitIndex() NO_THREAD_SAFETY_ANALYSIS
 {
     auto _ = genLockGuard();
     return this->apply.commit_index();
@@ -96,19 +96,19 @@ void MockProxyRegion::tryUpdateTruncatedState(uint64_t index, uint64_t term)
     }
 }
 
-void MockProxyRegion::updateCommitIndex(uint64_t index)
+void MockProxyRegion::updateCommitIndex(uint64_t index) NO_THREAD_SAFETY_ANALYSIS
 {
     auto _ = genLockGuard();
     this->apply.set_commit_index(index);
 }
 
-void MockProxyRegion::setState(raft_serverpb::RegionLocalState s)
+void MockProxyRegion::setState(raft_serverpb::RegionLocalState s) NO_THREAD_SAFETY_ANALYSIS
 {
     auto _ = genLockGuard();
     this->state = s;
 }
 
-void MockProxyRegion::reload()
+void MockProxyRegion::reload() NO_THREAD_SAFETY_ANALYSIS
 {
     auto _ = genLockGuard();
     this->apply.set_applied_index(this->persisted_apply.applied_index());
@@ -126,7 +126,7 @@ MockProxyRegion::MockProxyRegion(uint64_t id_)
     state.mutable_region()->set_id(id);
 }
 
-UniversalWriteBatch MockProxyRegion::persistMeta()
+UniversalWriteBatch MockProxyRegion::persistMeta() NO_THREAD_SAFETY_ANALYSIS
 {
     auto _ = genLockGuard();
     auto wb = UniversalWriteBatch();
@@ -158,7 +158,7 @@ UniversalWriteBatch MockProxyRegion::persistMeta()
     return wb;
 }
 
-void MockProxyRegion::addPeer(uint64_t store_id, uint64_t peer_id, metapb::PeerRole role)
+void MockProxyRegion::addPeer(uint64_t store_id, uint64_t peer_id, metapb::PeerRole role) NO_THREAD_SAFETY_ANALYSIS
 {
     auto _ = genLockGuard();
     auto & peer = *state.mutable_region()->mutable_peers()->Add();

--- a/dbms/src/Debug/MockKVStore/MockRaftStoreProxy.cpp
+++ b/dbms/src/Debug/MockKVStore/MockRaftStoreProxy.cpp
@@ -65,7 +65,7 @@ TiFlashRaftProxyHelper MockRaftStoreProxy::SetRaftStoreProxyFFIHelper(RaftStoreP
     return res;
 }
 
-MockProxyRegionPtr MockRaftStoreProxy::getRegion(uint64_t id)
+MockProxyRegionPtr MockRaftStoreProxy::getRegion(uint64_t id) NO_THREAD_SAFETY_ANALYSIS
 {
     auto _ = genLockGuard();
     return doGetRegion(id);
@@ -80,7 +80,7 @@ MockProxyRegionPtr MockRaftStoreProxy::doGetRegion(uint64_t id)
     return nullptr;
 }
 
-MockReadIndexTask * MockRaftStoreProxy::makeReadIndexTask(kvrpcpb::ReadIndexRequest req)
+MockReadIndexTask * MockRaftStoreProxy::makeReadIndexTask(kvrpcpb::ReadIndexRequest req) NO_THREAD_SAFETY_ANALYSIS
 {
     auto _ = genLockGuard();
 
@@ -99,7 +99,7 @@ MockReadIndexTask * MockRaftStoreProxy::makeReadIndexTask(kvrpcpb::ReadIndexRequ
     return nullptr;
 }
 
-void MockRaftStoreProxy::init(size_t region_num)
+void MockRaftStoreProxy::init(size_t region_num) NO_THREAD_SAFETY_ANALYSIS
 {
     auto _ = genLockGuard();
     for (size_t i = 0; i < region_num; ++i)
@@ -117,13 +117,13 @@ std::unique_ptr<TiFlashRaftProxyHelper> MockRaftStoreProxy::generateProxyHelper(
     return proxy_helper;
 }
 
-size_t MockRaftStoreProxy::size() const
+size_t MockRaftStoreProxy::size() const NO_THREAD_SAFETY_ANALYSIS
 {
     auto _ = genLockGuard();
     return regions.size();
 }
 
-void MockRaftStoreProxy::testRunReadIndex(const std::atomic_bool & over)
+void MockRaftStoreProxy::testRunReadIndex(const std::atomic_bool & over) NO_THREAD_SAFETY_ANALYSIS
 {
     while (!over)
     {
@@ -135,7 +135,7 @@ void MockRaftStoreProxy::testRunReadIndex(const std::atomic_bool & over)
     }
 }
 
-void MockRaftStoreProxy::unsafeInvokeForTest(std::function<void(MockRaftStoreProxy &)> && cb)
+void MockRaftStoreProxy::unsafeInvokeForTest(std::function<void(MockRaftStoreProxy &)> && cb) NO_THREAD_SAFETY_ANALYSIS
 {
     auto _ = genLockGuard();
     cb(*this);
@@ -145,7 +145,7 @@ void MockRaftStoreProxy::bootstrapWithRegion(
     KVStore & kvs,
     TMTContext & tmt,
     UInt64 region_id,
-    std::optional<std::pair<std::string, std::string>> maybe_range)
+    std::optional<std::pair<std::string, std::string>> maybe_range) NO_THREAD_SAFETY_ANALYSIS
 {
     {
         auto _ = genLockGuard();
@@ -163,7 +163,7 @@ void MockRaftStoreProxy::debugAddRegions(
     KVStore & kvs,
     TMTContext & tmt,
     std::vector<UInt64> region_ids,
-    std::vector<std::pair<std::string, std::string>> && ranges)
+    std::vector<std::pair<std::string, std::string>> && ranges) NO_THREAD_SAFETY_ANALYSIS
 {
     UNUSED(tmt);
     int n = ranges.size();
@@ -673,13 +673,13 @@ std::pair<std::string, std::string> MockRaftStoreProxy::generateTiKVKeyValue(uin
     return std::make_pair(value_write, value_default);
 }
 
-void GCMonitor::add(RawObjType type, int64_t diff)
+void GCMonitor::add(RawObjType type, int64_t diff) NO_THREAD_SAFETY_ANALYSIS
 {
     auto _ = genLockGuard();
     data[type] += diff;
 }
 
-bool GCMonitor::checkClean()
+bool GCMonitor::checkClean() NO_THREAD_SAFETY_ANALYSIS
 {
     auto _ = genLockGuard();
     for (auto && d : data)
@@ -693,7 +693,7 @@ bool GCMonitor::checkClean()
     return true;
 }
 
-bool GCMonitor::empty()
+bool GCMonitor::empty() NO_THREAD_SAFETY_ANALYSIS
 {
     auto _ = genLockGuard();
     return data.empty();

--- a/dbms/src/Debug/MockKVStore/MockRaftStoreProxy.h
+++ b/dbms/src/Debug/MockKVStore/MockRaftStoreProxy.h
@@ -252,7 +252,7 @@ struct MockRaftStoreProxy : MutexLockWrap
     void reload();
     void replay(KVStore & kvs, TMTContext & tmt, uint64_t region_id, uint64_t to);
 
-    void clear()
+    void clear() NO_THREAD_SAFETY_ANALYSIS
     {
         auto _ = genLockGuard();
         regions.clear();

--- a/dbms/src/Debug/MockKVStore/MockReadIndex.cpp
+++ b/dbms/src/Debug/MockKVStore/MockReadIndex.cpp
@@ -94,6 +94,7 @@ kvrpcpb::ReadIndexRequest make_read_index_reqs(uint64_t region_id, uint64_t star
 }
 
 std::optional<kvrpcpb::ReadIndexResponse> RawMockReadIndexTask::poll(std::shared_ptr<MockAsyncNotifier> waker)
+    NO_THREAD_SAFETY_ANALYSIS
 {
     auto _ = genLockGuard();
 
@@ -119,7 +120,7 @@ std::optional<kvrpcpb::ReadIndexResponse> RawMockReadIndexTask::poll(std::shared
     return resp;
 }
 
-void RawMockReadIndexTask::update(bool lock, bool region_error)
+void RawMockReadIndexTask::update(bool lock, bool region_error) NO_THREAD_SAFETY_ANALYSIS
 {
     {
         auto _ = genLockGuard();

--- a/dbms/src/Flash/Disaggregated/S3LockService.cpp
+++ b/dbms/src/Flash/Disaggregated/S3LockService.cpp
@@ -176,7 +176,7 @@ bool S3LockService::tryAddLockImpl(
     const String & data_file_key,
     UInt64 lock_store_id,
     UInt64 lock_seq,
-    disaggregated::TryAddLockResponse * response)
+    disaggregated::TryAddLockResponse * response) NO_THREAD_SAFETY_ANALYSIS
 {
     GET_METRIC(tiflash_disaggregated_object_lock_request_count, type_lock).Increment();
     const S3FilenameView key_view = S3FilenameView::fromKey(data_file_key);

--- a/dbms/src/Flash/Disaggregated/S3LockService.h
+++ b/dbms/src/Flash/Disaggregated/S3LockService.h
@@ -74,9 +74,9 @@ private:
         std::mutex file_mutex;
         UInt32 ref_count = 0;
 
-        void lock() { file_mutex.lock(); }
+        void lock() NO_THREAD_SAFETY_ANALYSIS { file_mutex.lock(); }
 
-        void unlock() { file_mutex.unlock(); }
+        void unlock() NO_THREAD_SAFETY_ANALYSIS { file_mutex.unlock(); }
 
         // must be protected by the mutex on the whole map
         void addRefCount() { ++ref_count; }

--- a/dbms/src/Storages/DeltaMerge/ReadThread/MergedTask.h
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/MergedTask.h
@@ -153,7 +153,7 @@ public:
 
 private:
     std::mutex mtx;
-    std::list<MergedTaskPtr> merged_task_pool;
+    std::list<MergedTaskPtr> merged_task_pool GUARDED_BY(mtx);
     LoggerPtr log;
 };
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.h
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.h
@@ -65,7 +65,7 @@ private:
     SegmentReadTaskPools getPoolsUnlock(const std::vector<uint64_t> & pool_ids) EXCLUSIVE_LOCKS_REQUIRED(mtx);
 
     // To restrict the instantaneous concurrency of `add` and avoid `schedule` from always failing to acquire the lock.
-    std::mutex add_mtx;
+    std::mutex add_mtx ACQUIRED_BEFORE(mtx);
 
     std::mutex mtx;
     SegmentReadTaskPoolList read_pools GUARDED_BY(mtx);

--- a/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.h
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.h
@@ -43,35 +43,34 @@ public:
     DISALLOW_COPY_AND_MOVE(SegmentReadTaskScheduler);
 
     // Add SegmentReadTaskPool to `read_pools` and index segments into merging_segments.
-    void add(const SegmentReadTaskPoolPtr & pool);
+    void add(const SegmentReadTaskPoolPtr & pool) LOCKS_EXCLUDED(add_mtx, mtx);
 
     void pushMergedTask(const MergedTaskPtr & p) { merged_task_pool.push(p); }
 
 private:
     SegmentReadTaskScheduler();
 
-    // Choose segment to read.
-    // Returns <MergedTaskPtr, run_next_schedule_immediately>
-    std::pair<MergedTaskPtr, bool> scheduleMergedTask();
-
     void setStop();
     bool isStop() const;
-    bool schedule();
-    void schedLoop();
     bool needScheduleToRead(const SegmentReadTaskPoolPtr & pool);
-    SegmentReadTaskPools getPoolsUnlock(const std::vector<uint64_t> & pool_ids);
-    // <seg_id, pool_ids>
+
+    bool schedule() LOCKS_EXCLUDED(mtx);
+    void schedLoop() LOCKS_EXCLUDED(mtx);
+    // Choose segment to read, returns <MergedTaskPtr, run_next_schedule_immediately>.
+    std::pair<MergedTaskPtr, bool> scheduleMergedTask() EXCLUSIVE_LOCKS_REQUIRED(mtx);
+    SegmentReadTaskPoolPtr scheduleSegmentReadTaskPoolUnlock() EXCLUSIVE_LOCKS_REQUIRED(mtx);
+    // Returns <seg_id, pool_ids>.
     std::optional<std::pair<GlobalSegmentID, std::vector<UInt64>>> scheduleSegmentUnlock(
-        const SegmentReadTaskPoolPtr & pool);
-    SegmentReadTaskPoolPtr scheduleSegmentReadTaskPoolUnlock();
+        const SegmentReadTaskPoolPtr & pool) EXCLUSIVE_LOCKS_REQUIRED(mtx);
+    SegmentReadTaskPools getPoolsUnlock(const std::vector<uint64_t> & pool_ids) EXCLUSIVE_LOCKS_REQUIRED(mtx);
 
     // To restrict the instantaneous concurrency of `add` and avoid `schedule` from always failing to acquire the lock.
     std::mutex add_mtx;
-    std::mutex mtx;
-    SegmentReadTaskPoolList read_pools;
 
+    std::mutex mtx;
+    SegmentReadTaskPoolList read_pools GUARDED_BY(mtx);
     // GlobalSegmentID -> pool_ids
-    MergingSegments merging_segments;
+    MergingSegments merging_segments GUARDED_BY(mtx);
 
     MergedTaskPool merged_task_pool;
 

--- a/dbms/src/Storages/KVStore/KVStore.cpp
+++ b/dbms/src/Storages/KVStore/KVStore.cpp
@@ -153,7 +153,7 @@ RegionMap KVStore::getRegionsByRangeOverlap(const RegionRange & range) const
     return manage_lock.index.findByRangeOverlap(range);
 }
 
-RegionTaskLock RegionTaskCtrl::genRegionTaskLock(RegionID region_id) const
+RegionTaskLock RegionTaskCtrl::genRegionTaskLock(RegionID region_id) const NO_THREAD_SAFETY_ANALYSIS
 {
     RegionTaskElement * e = nullptr;
     {

--- a/dbms/src/Storages/KVStore/MultiRaft/PreHandlingTrace.h
+++ b/dbms/src/Storages/KVStore/MultiRaft/PreHandlingTrace.h
@@ -62,7 +62,7 @@ struct PreHandlingTrace : MutexLockWrap
     PreHandlingTrace()
         : log(Logger::get("PreHandlingTrace"))
     {}
-    std::shared_ptr<Item> registerTask(uint64_t region_id)
+    std::shared_ptr<Item> registerTask(uint64_t region_id) NO_THREAD_SAFETY_ANALYSIS
     {
         // Automaticlly override the old one.
         auto _ = genLockGuard();
@@ -70,7 +70,7 @@ struct PreHandlingTrace : MutexLockWrap
         tasks[region_id] = b;
         return b;
     }
-    std::shared_ptr<Item> deregisterTask(uint64_t region_id)
+    std::shared_ptr<Item> deregisterTask(uint64_t region_id) NO_THREAD_SAFETY_ANALYSIS
     {
         auto _ = genLockGuard();
         auto it = tasks.find(region_id);
@@ -85,7 +85,7 @@ struct PreHandlingTrace : MutexLockWrap
             return nullptr;
         }
     }
-    bool hasTask(uint64_t region_id)
+    bool hasTask(uint64_t region_id) NO_THREAD_SAFETY_ANALYSIS
     {
         auto _ = genLockGuard();
         return tasks.find(region_id) != tasks.end();

--- a/dbms/src/Storages/KVStore/Read/ReadIndexWorker.cpp
+++ b/dbms/src/Storages/KVStore/Read/ReadIndexWorker.cpp
@@ -65,7 +65,7 @@ AsyncNotifier::Status AsyncWaker::Notifier::blockedWaitUtil(const SteadyClock::t
     return res;
 }
 
-void AsyncWaker::Notifier::wake()
+void AsyncWaker::Notifier::wake() NO_THREAD_SAFETY_ANALYSIS
 {
     // if flag from false -> true, then wake up.
     // if flag from true -> true, do nothing.
@@ -275,17 +275,17 @@ struct ReadIndexNotifyCtrl : MutexLockWrap
 {
     using Data = std::deque<std::pair<RegionID, Timestamp>>;
 
-    bool empty() const
+    bool empty() const NO_THREAD_SAFETY_ANALYSIS
     {
         auto _ = genLockGuard();
         return data.empty();
     }
-    void add(RegionID id, Timestamp ts)
+    void add(RegionID id, Timestamp ts) NO_THREAD_SAFETY_ANALYSIS
     {
         auto _ = genLockGuard();
         data.emplace_back(id, ts);
     }
-    Data popAll()
+    Data popAll() NO_THREAD_SAFETY_ANALYSIS
     {
         auto _ = genLockGuard();
         return std::move(data);
@@ -327,7 +327,7 @@ std::atomic<std::chrono::milliseconds> ReadIndexWorker::max_read_index_task_time
     = std::chrono::milliseconds{8 * 1000};
 //std::atomic<size_t> ReadIndexWorker::max_read_index_history{8};
 
-void ReadIndexFuture::update(kvrpcpb::ReadIndexResponse resp)
+void ReadIndexFuture::update(kvrpcpb::ReadIndexResponse resp) NO_THREAD_SAFETY_ANALYSIS
 {
     auto _ = genLockGuard();
     if (finished)
@@ -346,6 +346,7 @@ void ReadIndexFuture::update(kvrpcpb::ReadIndexResponse resp)
 }
 
 std::optional<kvrpcpb::ReadIndexResponse> ReadIndexFuture::poll(const std::shared_ptr<AsyncNotifier> & notifier_) const
+    NO_THREAD_SAFETY_ANALYSIS
 {
     auto _ = genLockGuard();
     if (!finished)
@@ -485,7 +486,7 @@ void ReadIndexDataNode::doConsume(const TiFlashRaftProxyHelper & helper, Running
     }
 }
 
-void ReadIndexDataNode::consume(const TiFlashRaftProxyHelper & helper, Timestamp ts)
+void ReadIndexDataNode::consume(const TiFlashRaftProxyHelper & helper, Timestamp ts) NO_THREAD_SAFETY_ANALYSIS
 {
     auto _ = genLockGuard();
 
@@ -515,6 +516,7 @@ std::optional<ReadIndexTask> makeReadIndexTask(const TiFlashRaftProxyHelper & he
 }
 
 void ReadIndexDataNode::runOneRound(const TiFlashRaftProxyHelper & helper, const ReadIndexNotifyCtrlPtr & notify)
+    NO_THREAD_SAFETY_ANALYSIS
 {
     auto opt_waiting_tasks = this->waiting_tasks.popAll();
     if (!opt_waiting_tasks)
@@ -593,7 +595,7 @@ void ReadIndexDataNode::runOneRound(const TiFlashRaftProxyHelper & helper, const
     }
 }
 
-ReadIndexDataNode::~ReadIndexDataNode()
+ReadIndexDataNode::~ReadIndexDataNode() NO_THREAD_SAFETY_ANALYSIS
 {
     auto _ = genLockGuard();
 

--- a/dbms/src/Storages/KVStore/Read/ReadIndexWorker.h
+++ b/dbms/src/Storages/KVStore/Read/ReadIndexWorker.h
@@ -167,17 +167,17 @@ struct RegionNotifyMap : MutexLockWrap
 {
     using Data = std::unordered_set<RegionID>;
 
-    bool empty() const
+    bool empty() const NO_THREAD_SAFETY_ANALYSIS
     {
         auto _ = genLockGuard();
         return data.empty();
     }
-    void add(RegionID id)
+    void add(RegionID id) NO_THREAD_SAFETY_ANALYSIS
     {
         auto _ = genLockGuard();
         data.emplace(id);
     }
-    Data popAll()
+    Data popAll() NO_THREAD_SAFETY_ANALYSIS
     {
         auto _ = genLockGuard();
         return std::move(data);
@@ -229,13 +229,13 @@ struct ReadIndexDataNode : MutexLockWrap
     {
         using Data = std::deque<std::pair<Timestamp, ReadIndexFuturePtr>>;
 
-        void add(Timestamp ts, ReadIndexFuturePtr f)
+        void add(Timestamp ts, ReadIndexFuturePtr f) NO_THREAD_SAFETY_ANALYSIS
         {
             auto _ = genLockGuard();
             waiting_tasks.emplace_back(ts, std::move(f));
         }
 
-        std::optional<Data> popAll()
+        std::optional<Data> popAll() NO_THREAD_SAFETY_ANALYSIS
         {
             auto _ = genLockGuard();
             if (waiting_tasks.empty())
@@ -243,7 +243,7 @@ struct ReadIndexDataNode : MutexLockWrap
             return std::move(waiting_tasks);
         }
 
-        size_t size() const
+        size_t size() const NO_THREAD_SAFETY_ANALYSIS
         {
             auto _ = genLockGuard();
             return waiting_tasks.size();

--- a/dbms/src/Storages/KVStore/tests/gtest_read_index_worker.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_read_index_worker.cpp
@@ -194,7 +194,7 @@ size_t ReadIndexTest::computeCntUseHistoryTasks(ReadIndexWorkerManager & manager
     size_t cnt_use_history_tasks = 0;
     for (auto & worker : manager.workers)
     {
-        worker->data_map.invoke([&](std::unordered_map<RegionID, ReadIndexDataNodePtr> & d) {
+        worker->data_map.invoke([&](std::unordered_map<RegionID, ReadIndexDataNodePtr> & d) NO_THREAD_SAFETY_ANALYSIS {
             for (auto & x : d)
             {
                 auto _ = x.second->genLockGuard();

--- a/dbms/src/Storages/KVStore/tests/gtest_read_index_worker.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_read_index_worker.cpp
@@ -189,7 +189,7 @@ void ReadIndexTest::testError()
     ASSERT(GCMonitor::instance().checkClean());
     ASSERT(!GCMonitor::instance().empty());
 }
-size_t ReadIndexTest::computeCntUseHistoryTasks(ReadIndexWorkerManager & manager)
+size_t ReadIndexTest::computeCntUseHistoryTasks(ReadIndexWorkerManager & manager) NO_THREAD_SAFETY_ANALYSIS
 {
     size_t cnt_use_history_tasks = 0;
     for (auto & worker : manager.workers)
@@ -227,7 +227,7 @@ void ReadIndexTest::testBasic()
         // lock wrap
         struct TestMutexLockWrap : MutexLockWrap
         {
-            void test()
+            void test() NO_THREAD_SAFETY_ANALYSIS
             {
                 {
                     auto lock = genLockGuard();

--- a/dbms/src/Storages/Page/V3/Blob/BlobStat.cpp
+++ b/dbms/src/Storages/Page/V3/Blob/BlobStat.cpp
@@ -189,7 +189,7 @@ void BlobStats::eraseStat(BlobFileId blob_file_id, const std::lock_guard<std::mu
     eraseStat(std::move(stat), lock);
 }
 
-void BlobStats::setAllToReadOnly()
+void BlobStats::setAllToReadOnly() NO_THREAD_SAFETY_ANALYSIS
 {
     auto lock_stats = lock();
     for (const auto & [path, stats] : stats_map)
@@ -258,7 +258,7 @@ std::pair<BlobStats::BlobStatPtr, BlobFileId> BlobStats::chooseStat(
     return std::make_pair(nullptr, next_id);
 }
 
-BlobStats::BlobStatPtr BlobStats::blobIdToStat(BlobFileId file_id, bool ignore_not_exist)
+BlobStats::BlobStatPtr BlobStats::blobIdToStat(BlobFileId file_id, bool ignore_not_exist) NO_THREAD_SAFETY_ANALYSIS
 {
     auto guard = lock();
     for (const auto & [path, stats] : stats_map)

--- a/dbms/src/Storages/Page/V3/Blob/BlobStat.h
+++ b/dbms/src/Storages/Page/V3/Blob/BlobStat.h
@@ -156,7 +156,7 @@ public:
     BlobStatPtr blobIdToStat(BlobFileId file_id, bool ignore_not_exist = false);
 
     using StatsMap = std::map<String, std::list<BlobStatPtr>>;
-    StatsMap getStats() const
+    StatsMap getStats() const NO_THREAD_SAFETY_ANALYSIS
     {
         auto guard = lock();
         return stats_map;

--- a/dbms/src/Storages/Page/V3/BlobStore.cpp
+++ b/dbms/src/Storages/Page/V3/BlobStore.cpp
@@ -91,7 +91,7 @@ BlobStore<Trait>::BlobStore(
 {}
 
 template <typename Trait>
-void BlobStore<Trait>::registerPaths()
+void BlobStore<Trait>::registerPaths() NO_THREAD_SAFETY_ANALYSIS
 {
     for (const auto & path : delegator->listPaths())
     {
@@ -153,7 +153,7 @@ void BlobStore<Trait>::reloadConfig(const BlobConfig & rhs)
 }
 
 template <typename Trait>
-FileUsageStatistics BlobStore<Trait>::getFileUsageStatistics() const
+FileUsageStatistics BlobStore<Trait>::getFileUsageStatistics() const NO_THREAD_SAFETY_ANALYSIS
 {
     FileUsageStatistics usage;
 
@@ -667,7 +667,7 @@ void BlobStore<Trait>::freezeBlobFiles()
 }
 
 template <typename Trait>
-void BlobStore<Trait>::remove(const PageEntries & del_entries)
+void BlobStore<Trait>::remove(const PageEntries & del_entries) NO_THREAD_SAFETY_ANALYSIS
 {
     std::set<BlobFileId> blob_updated;
     for (const auto & entry : del_entries)
@@ -725,11 +725,12 @@ void BlobStore<Trait>::remove(const PageEntries & del_entries)
 
 template <typename Trait>
 std::pair<BlobFileId, BlobFileOffset> BlobStore<Trait>::getPosFromStats(size_t size, PageType page_type)
+    NO_THREAD_SAFETY_ANALYSIS
 {
     Stopwatch watch;
     BlobStatPtr stat;
 
-    auto lock_stat = [size, this, &stat, &page_type]() {
+    auto lock_stat = [size, this, &stat, &page_type]() NO_THREAD_SAFETY_ANALYSIS {
         auto lock_stats = blob_stats.lock();
         BlobFileId blob_file_id = INVALID_BLOBFILE_ID;
         std::tie(stat, blob_file_id) = blob_stats.chooseStat(size, page_type, lock_stats);
@@ -782,6 +783,7 @@ std::pair<BlobFileId, BlobFileOffset> BlobStore<Trait>::getPosFromStats(size_t s
 
 template <typename Trait>
 void BlobStore<Trait>::removePosFromStats(BlobFileId blob_id, BlobFileOffset offset, size_t size)
+    NO_THREAD_SAFETY_ANALYSIS
 {
     const auto & stat = blob_stats.blobIdToStat(blob_id);
     {
@@ -1165,7 +1167,7 @@ BlobFilePtr BlobStore<Trait>::read(
 
 
 template <typename Trait>
-typename BlobStore<Trait>::PageTypeAndBlobIds BlobStore<Trait>::getGCStats()
+typename BlobStore<Trait>::PageTypeAndBlobIds BlobStore<Trait>::getGCStats() NO_THREAD_SAFETY_ANALYSIS
 {
     // Get a copy of stats map to avoid the big lock on stats map
     const auto stats_list = blob_stats.getStats();

--- a/dbms/src/Storages/Page/V3/PageDirectory.cpp
+++ b/dbms/src/Storages/Page/V3/PageDirectory.cpp
@@ -77,6 +77,7 @@ namespace PS::V3
 
 template <typename Trait>
 void VersionedPageEntries<Trait>::createNewEntry(const PageVersion & ver, const PageEntryV3 & entry)
+    NO_THREAD_SAFETY_ANALYSIS
 {
     auto page_lock = acquireLock();
     if (type == EditRecordType::VAR_DELETE)
@@ -135,7 +136,7 @@ template <typename Trait>
 typename VersionedPageEntries<Trait>::PageId VersionedPageEntries<Trait>::createUpsertEntry(
     const PageVersion & ver,
     const PageEntryV3 & entry,
-    bool strict_check)
+    bool strict_check) NO_THREAD_SAFETY_ANALYSIS
 {
     auto page_lock = acquireLock();
 
@@ -232,7 +233,7 @@ typename VersionedPageEntries<Trait>::PageId VersionedPageEntries<Trait>::create
 template <typename Trait>
 std::shared_ptr<typename VersionedPageEntries<Trait>::PageId> VersionedPageEntries<Trait>::createNewExternal(
     const PageVersion & ver,
-    const PageEntryV3 & entry)
+    const PageEntryV3 & entry) NO_THREAD_SAFETY_ANALYSIS
 {
     auto page_lock = acquireLock();
     if (type == EditRecordType::VAR_DELETE)
@@ -288,7 +289,7 @@ std::shared_ptr<typename VersionedPageEntries<Trait>::PageId> VersionedPageEntri
 
 // Create a new delete version with version=`ver`.
 template <typename Trait>
-void VersionedPageEntries<Trait>::createDelete(const PageVersion & ver)
+void VersionedPageEntries<Trait>::createDelete(const PageVersion & ver) NO_THREAD_SAFETY_ANALYSIS
 {
     auto page_lock = acquireLock();
     if (type == EditRecordType::VAR_ENTRY)
@@ -323,6 +324,7 @@ void VersionedPageEntries<Trait>::createDelete(const PageVersion & ver)
 
 template <typename Trait>
 bool VersionedPageEntries<Trait>::updateLocalCacheForRemotePage(const PageVersion & ver, const PageEntryV3 & entry)
+    NO_THREAD_SAFETY_ANALYSIS
 {
     auto page_lock = acquireLock();
     if (type == EditRecordType::VAR_ENTRY)
@@ -353,6 +355,7 @@ bool VersionedPageEntries<Trait>::updateLocalCacheForRemotePage(const PageVersio
 // If create success, then return true, otherwise return false.
 template <typename Trait>
 bool VersionedPageEntries<Trait>::createNewRef(const PageVersion & ver, const PageId & ori_page_id_)
+    NO_THREAD_SAFETY_ANALYSIS
 {
     auto page_lock = acquireLock();
     if (type == EditRecordType::VAR_DELETE)
@@ -408,7 +411,7 @@ bool VersionedPageEntries<Trait>::createNewRef(const PageVersion & ver, const Pa
 
 template <typename Trait>
 std::shared_ptr<typename VersionedPageEntries<Trait>::PageId> VersionedPageEntries<Trait>::fromRestored(
-    const typename PageEntriesEdit::EditRecord & rec)
+    const typename PageEntriesEdit::EditRecord & rec) NO_THREAD_SAFETY_ANALYSIS
 {
     auto page_lock = acquireLock();
     switch (rec.type)
@@ -448,7 +451,7 @@ std::shared_ptr<typename VersionedPageEntries<Trait>::PageId> VersionedPageEntri
 
 template <typename Trait>
 std::tuple<ResolveResult, typename VersionedPageEntries<Trait>::PageId, PageVersion> VersionedPageEntries<
-    Trait>::resolveToPageId(UInt64 seq, bool ignore_delete, PageEntryV3 * entry)
+    Trait>::resolveToPageId(UInt64 seq, bool ignore_delete, PageEntryV3 * entry) NO_THREAD_SAFETY_ANALYSIS
 {
     auto page_lock = acquireLock();
     if (type == EditRecordType::VAR_ENTRY)
@@ -512,7 +515,7 @@ std::tuple<ResolveResult, typename VersionedPageEntries<Trait>::PageId, PageVers
 }
 
 template <typename Trait>
-std::optional<PageEntryV3> VersionedPageEntries<Trait>::getEntry(UInt64 seq) const
+std::optional<PageEntryV3> VersionedPageEntries<Trait>::getEntry(UInt64 seq) const NO_THREAD_SAFETY_ANALYSIS
 {
     auto page_lock = acquireLock();
     if (type == EditRecordType::VAR_ENTRY)
@@ -530,6 +533,7 @@ std::optional<PageEntryV3> VersionedPageEntries<Trait>::getEntry(UInt64 seq) con
 
 template <typename Trait>
 std::optional<PageEntryV3> VersionedPageEntries<Trait>::getLastEntry(std::optional<UInt64> seq) const
+    NO_THREAD_SAFETY_ANALYSIS
 {
     auto page_lock = acquireLock();
     if (type == EditRecordType::VAR_ENTRY)
@@ -549,6 +553,7 @@ std::optional<PageEntryV3> VersionedPageEntries<Trait>::getLastEntry(std::option
 
 template <typename Trait>
 void VersionedPageEntries<Trait>::copyCheckpointInfoFromEdit(const typename PageEntriesEdit::EditRecord & edit)
+    NO_THREAD_SAFETY_ANALYSIS
 {
     // We have a running PageStorage instance, and did a checkpoint dump. The checkpoint dump is encoded using
     // PageEntriesEdit. During the checkpoint dump, this function is invoked so that we can write back where
@@ -601,7 +606,7 @@ void VersionedPageEntries<Trait>::copyCheckpointInfoFromEdit(const typename Page
 // If this page id is marked as deleted or not created, it is "not visible".
 // Note that not visible does not means this id can be GC.
 template <typename Trait>
-bool VersionedPageEntries<Trait>::isVisible(UInt64 seq) const
+bool VersionedPageEntries<Trait>::isVisible(UInt64 seq) const NO_THREAD_SAFETY_ANALYSIS
 {
     auto page_lock = acquireLock();
     if (type == EditRecordType::VAR_DELETE)
@@ -636,6 +641,7 @@ bool VersionedPageEntries<Trait>::isVisible(UInt64 seq) const
 
 template <typename Trait>
 Int64 VersionedPageEntries<Trait>::incrRefCount(const PageVersion & target_ver, const PageVersion & ref_ver)
+    NO_THREAD_SAFETY_ANALYSIS
 {
     auto page_lock = acquireLock();
     if (type == EditRecordType::VAR_ENTRY)
@@ -687,7 +693,7 @@ PageSize VersionedPageEntries<Trait>::getEntriesByBlobIds(
     const std::unordered_set<BlobFileId> & blob_ids,
     const PageId & page_id,
     GcEntriesMap & blob_versioned_entries,
-    std::map<PageId, std::tuple<PageId, PageVersion>> & ref_ids_maybe_rewrite)
+    std::map<PageId, std::tuple<PageId, PageVersion>> & ref_ids_maybe_rewrite) NO_THREAD_SAFETY_ANALYSIS
 {
     // `blob_versioned_entries`:
     // blob_file_0, [<page_id_0, ver0, entry0>,
@@ -857,7 +863,7 @@ bool VersionedPageEntries<Trait>::derefAndClean(
     const typename Trait::PageId & page_id,
     const PageVersion & deref_ver,
     const Int64 deref_count,
-    PageEntriesV3 * entries_removed)
+    PageEntriesV3 * entries_removed) NO_THREAD_SAFETY_ANALYSIS
 {
     auto page_lock = acquireLock();
     if (type == EditRecordType::VAR_EXTERNAL)
@@ -913,6 +919,7 @@ bool VersionedPageEntries<Trait>::derefAndClean(
 
 template <typename Trait>
 void VersionedPageEntries<Trait>::collapseTo(const UInt64 seq, const PageId & page_id, PageEntriesEdit & edit)
+    NO_THREAD_SAFETY_ANALYSIS
 {
     auto page_lock = acquireLock();
     if (type == EditRecordType::VAR_REF)
@@ -2040,6 +2047,7 @@ size_t PageDirectory<Trait>::copyCheckpointInfoFromEdit(const PageEntriesEdit & 
 
 template <typename Trait>
 typename PageDirectory<Trait>::PageEntries PageDirectory<Trait>::gcInMemEntries(const InMemGCOption & options)
+    NO_THREAD_SAFETY_ANALYSIS
 {
     UInt64 lowest_seq = sequence.load();
 

--- a/dbms/src/Storages/Page/V3/PageDirectory.h
+++ b/dbms/src/Storages/Page/V3/PageDirectory.h
@@ -355,7 +355,7 @@ public:
 
     void collapseTo(UInt64 seq, const PageId & page_id, PageEntriesEdit & edit);
 
-    size_t size() const
+    size_t size() const NO_THREAD_SAFETY_ANALYSIS
     {
         auto lock = acquireLock();
         return entries.size();

--- a/dbms/src/Storages/Page/V3/tests/gtest_blob_stat.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_blob_stat.cpp
@@ -87,7 +87,7 @@ try
     ASSERT_EQ(file_id4, 30);
 
     {
-        const auto & lock = stats.lock();
+        std::lock_guard lock(stats.lock_stats);
         stats.createStatNotChecking(file_id1, config.file_limit_size, lock);
         stats.createStatNotChecking(file_id2, config.file_limit_size, lock);
         stats.createStatNotChecking(file_id3, config.file_limit_size, lock);
@@ -173,7 +173,7 @@ try
     BlobFileId file_id1 = 11;
 
     {
-        const auto & lock = stats.lock();
+        std::lock_guard lock(stats.lock_stats);
         stats.createStatNotChecking(file_id1, config.file_limit_size, lock);
     }
 
@@ -232,7 +232,7 @@ TEST_F(BlobStoreStatsTest, testStats)
     BlobFileId file_id1 = PageTypeUtils::nextFileID(PageType::Normal, file_id0);
     BlobFileId file_id2 = PageTypeUtils::nextFileID(PageType::Normal, file_id1);
     {
-        auto lock = stats.lock();
+        std::lock_guard lock(stats.lock_stats);
         stats.createStat(file_id1, config.file_limit_size, lock);
         stats.createStat(file_id2, config.file_limit_size, lock);
     }
@@ -371,7 +371,7 @@ TEST_F(BlobStoreStatsTest, testFullStats)
     BlobStats stats(logger, delegator, config);
 
     {
-        auto lock = stats.lock();
+        std::lock_guard lock(stats.lock_stats);
         BlobFileId file_id = 10;
         BlobStats::BlobStatPtr stat = stats.createStat(file_id, config.file_limit_size, lock);
         auto offset = stat->getPosFromStat(BLOBFILE_LIMIT_SIZE - 1, stat->lock());

--- a/dbms/src/Storages/Page/V3/tests/gtest_page_directory.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_page_directory.cpp
@@ -2763,7 +2763,7 @@ try
         auto config = BlobConfig{};
         BlobStats stats(log, delegator, config);
         {
-            const auto & lock = stats.lock();
+            std::lock_guard lock(stats.lock_stats);
             stats.createStatNotChecking(file_id1, BLOBFILE_LIMIT_SIZE, lock);
             stats.createStatNotChecking(file_id2, BLOBFILE_LIMIT_SIZE, lock);
         }

--- a/dbms/src/Storages/Page/V3/tests/gtest_versioned_entries.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_versioned_entries.cpp
@@ -67,7 +67,7 @@ class VersionedEntriesTest : public ::testing::Test
 {
 public:
     using DerefCounter = std::map<PageIdV3Internal, std::pair<PageVersion, Int64>>;
-    std::tuple<bool, PageEntriesV3, DerefCounter> runClean(UInt64 seq)
+    std::tuple<bool, PageEntriesV3, DerefCounter> runClean(UInt64 seq) NO_THREAD_SAFETY_ANALYSIS
     {
         DerefCounter deref_counter;
         PageEntriesV3 removed_entries;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6834, ref https://github.com/pingcap/tiflash/issues/6350

### What is changed and how it works?

- Clang Thread Safety Analysis is a C++ language extension which warns about potential race conditions in code. The analysis is completely static (i.e. compile-time); there is no run-time overhead. For more information, please check [https://clang.llvm.org/docs/ThreadSafetyAnalysis.html](https://clang.llvm.org/docs/ThreadSafetyAnalysis.html).
- Support Clang Thread Safety Analysis in TiFlash (`-DENABLE_TSA=ON`).
- Usage: 
```
cmake .. \
-DCMAKE_CXX_COMPILER=clang++ \
-DCMAKE_C_COMPILER=clang \
-DCMAKE_BUILD_TYPE=RELWITHDEBINFO \
-DENABLE_TSA=ON \
-GNinja
```

- Annotated `SegmentReadTaskScheduler` and `MergedTaskPool` with thread-safety-analysis attributes.
- The main problem of TiFlash's existing code is that the analyzer doesn't recognize move semantics and RVO, so it can't support code like below:
  - Disable with NO_THREAD_SAFETY_ANALYSIS.
```cpp
void func()
{
    auto lock = acquireLock();
    // ...
    // error: releasing mutex 'xxx' that was not held
}
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
