### PR TITLE
*: Upgrade fmtlib and print enum value explicitly

### DIFF
--- a/contrib/fmtlib-cmake/CMakeLists.txt
+++ b/contrib/fmtlib-cmake/CMakeLists.txt
@@ -1,4 +1,5 @@
 set (SRCS
+    ../fmtlib/src/fmt.cc
     ../fmtlib/src/format.cc
     ../fmtlib/src/os.cc
 
@@ -9,11 +10,11 @@ set (SRCS
     ../fmtlib/include/fmt/core.h
     ../fmtlib/include/fmt/format.h
     ../fmtlib/include/fmt/format-inl.h
-    ../fmtlib/include/fmt/locale.h
     ../fmtlib/include/fmt/os.h
     ../fmtlib/include/fmt/ostream.h
     ../fmtlib/include/fmt/printf.h
     ../fmtlib/include/fmt/ranges.h
+    ../fmtlib/include/fmt/std.h
     ../fmtlib/include/fmt/xchar.h
 )
 

--- a/contrib/fmtlib-cmake/CMakeLists.txt
+++ b/contrib/fmtlib-cmake/CMakeLists.txt
@@ -1,5 +1,4 @@
 set (SRCS
-    ../fmtlib/src/fmt.cc
     ../fmtlib/src/format.cc
     ../fmtlib/src/os.cc
 

--- a/dbms/src/DataStreams/RuntimeFilter.cpp
+++ b/dbms/src/DataStreams/RuntimeFilter.cpp
@@ -75,7 +75,7 @@ void RuntimeFilter::build()
         throw TiFlashException(
             Errors::Coprocessor::BadRequest,
             "The source expr {} of rf {} should be column ref",
-            source_expr.tp(),
+            tipb::ExprType_Name(source_expr.tp()),
             id);
     }
 }

--- a/dbms/src/Encryption/RateLimiter.h
+++ b/dbms/src/Encryption/RateLimiter.h
@@ -18,6 +18,7 @@
 #include <Common/nocopyable.h>
 #include <Server/StorageConfigParser.h>
 #include <fmt/core.h>
+#include <fmt/std.h>
 
 #include <atomic>
 #include <chrono>
@@ -62,7 +63,7 @@ struct ReadInfo
 
     std::string toString() const
     {
-        return fmt::format("fg_read_bytes {} bg_read_bytes {}", fg_read_bytes.load(), bg_read_bytes.load());
+        return fmt::format("fg_read_bytes {} bg_read_bytes {}", fg_read_bytes, bg_read_bytes);
     }
 };
 

--- a/dbms/src/Encryption/RateLimiter.h
+++ b/dbms/src/Encryption/RateLimiter.h
@@ -62,7 +62,7 @@ struct ReadInfo
 
     std::string toString() const
     {
-        return fmt::format("fg_read_bytes {} bg_read_bytes {}", fg_read_bytes, bg_read_bytes);
+        return fmt::format("fg_read_bytes {} bg_read_bytes {}", fg_read_bytes.load(), bg_read_bytes.load());
     }
 };
 

--- a/dbms/src/Flash/Coprocessor/DAGUtils.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGUtils.cpp
@@ -757,7 +757,7 @@ const String & getAggFunctionName(const tipb::Expr & expr)
         Errors::Coprocessor::Unimplemented,
         "{}(distinct={}) is not supported.",
         tipb::ExprType_Name(expr.tp()),
-        expr.has_distinct() ? "true" : "false");
+        expr.has_distinct());
 }
 
 const String & getWindowFunctionName(const tipb::Expr & expr)

--- a/dbms/src/Flash/Coprocessor/DAGUtils.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGUtils.cpp
@@ -803,7 +803,9 @@ String getExchangeTypeName(const tipb::ExchangeType & tp)
     case tipb::ExchangeType::Hash:
         return "Hash";
     default:
-        throw TiFlashException(fmt::format("Not supported Exchange type: {}", tp), Errors::Coprocessor::Internal);
+        throw TiFlashException(
+            fmt::format("Not supported Exchange type: {}", fmt::underlying(tp)),
+            Errors::Coprocessor::Internal);
     }
 }
 
@@ -826,7 +828,9 @@ String getJoinTypeName(const tipb::JoinType & tp)
     case tipb::JoinType::TypeSemiJoin:
         return "SemiJoin";
     default:
-        throw TiFlashException(fmt::format("Not supported Join type: {}", tp), Errors::Coprocessor::Internal);
+        throw TiFlashException(
+            fmt::format("Not supported Join type: {}", fmt::underlying(tp)),
+            Errors::Coprocessor::Internal);
     }
 }
 
@@ -838,7 +842,7 @@ String getJoinExecTypeName(const tipb::JoinExecType & tp)
         return "HashJoin";
     default:
         throw TiFlashException(
-            fmt::format("Not supported Join exectution type: {}", tp),
+            fmt::format("Not supported Join exectution type: {}", fmt::underlying(tp)),
             Errors::Coprocessor::Internal);
     }
 }

--- a/dbms/src/Flash/Coprocessor/DAGUtils.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGUtils.cpp
@@ -753,11 +753,11 @@ const String & getAggFunctionName(const tipb::Expr & expr)
             return it->second;
     }
 
-    const auto errmsg = fmt::format(
+    throw TiFlashException(
+        Errors::Coprocessor::Unimplemented,
         "{}(distinct={}) is not supported.",
         tipb::ExprType_Name(expr.tp()),
         expr.has_distinct() ? "true" : "false");
-    throw TiFlashException(errmsg, Errors::Coprocessor::Unimplemented);
 }
 
 const String & getWindowFunctionName(const tipb::Expr & expr)
@@ -766,8 +766,7 @@ const String & getWindowFunctionName(const tipb::Expr & expr)
     if (it != window_func_map.end())
         return it->second;
 
-    const auto errmsg = fmt::format("{} is not supported.", tipb::ExprType_Name(expr.tp()));
-    throw TiFlashException(errmsg, Errors::Coprocessor::Unimplemented);
+    throw TiFlashException(Errors::Coprocessor::Unimplemented, "{} is not supported.", tipb::ExprType_Name(expr.tp()));
 }
 
 
@@ -786,8 +785,9 @@ const String & getFunctionName(const tipb::Expr & expr)
         auto it = scalar_func_map.find(expr.sig());
         if (it == scalar_func_map.end())
             throw TiFlashException(
-                tipb::ScalarFuncSig_Name(expr.sig()) + " is not supported.",
-                Errors::Coprocessor::Unimplemented);
+                Errors::Coprocessor::Unimplemented,
+                "{} is not supported.",
+                tipb::ScalarFuncSig_Name(expr.sig()));
         return it->second;
     }
 }
@@ -803,9 +803,7 @@ String getExchangeTypeName(const tipb::ExchangeType & tp)
     case tipb::ExchangeType::Hash:
         return "Hash";
     default:
-        throw TiFlashException(
-            fmt::format("Not supported Exchange type: {}", fmt::underlying(tp)),
-            Errors::Coprocessor::Internal);
+        throw TiFlashException(Errors::Coprocessor::Internal, "Not supported Exchange type: {}", fmt::underlying(tp));
     }
 }
 
@@ -828,9 +826,7 @@ String getJoinTypeName(const tipb::JoinType & tp)
     case tipb::JoinType::TypeSemiJoin:
         return "SemiJoin";
     default:
-        throw TiFlashException(
-            fmt::format("Not supported Join type: {}", fmt::underlying(tp)),
-            Errors::Coprocessor::Internal);
+        throw TiFlashException(Errors::Coprocessor::Internal, "Not supported Join type: {}", fmt::underlying(tp));
     }
 }
 
@@ -842,8 +838,9 @@ String getJoinExecTypeName(const tipb::JoinExecType & tp)
         return "HashJoin";
     default:
         throw TiFlashException(
-            fmt::format("Not supported Join exectution type: {}", fmt::underlying(tp)),
-            Errors::Coprocessor::Internal);
+            Errors::Coprocessor::Internal,
+            "Not supported Join exectution type: {}",
+            fmt::underlying(tp));
     }
 }
 
@@ -886,7 +883,7 @@ String getFieldTypeName(Int32 tp)
     case TiDB::TypeString:
         return "String";
     default:
-        throw TiFlashException(fmt::format("Not supported field type: {}", tp), Errors::Coprocessor::Internal);
+        throw TiFlashException(Errors::Coprocessor::Internal, "Not supported field type: {}", tp);
     }
 }
 

--- a/dbms/src/Flash/Coprocessor/JoinInterpreterHelper.cpp
+++ b/dbms/src/Flash/Coprocessor/JoinInterpreterHelper.cpp
@@ -26,7 +26,6 @@
 #include <common/logger_useful.h>
 #include <fmt/format.h>
 
-#include <magic_enum.hpp>
 #include <unordered_map>
 
 namespace DB

--- a/dbms/src/Flash/Coprocessor/JoinInterpreterHelper.cpp
+++ b/dbms/src/Flash/Coprocessor/JoinInterpreterHelper.cpp
@@ -122,7 +122,7 @@ std::pair<ASTTableJoin::Kind, size_t> getJoinKindAndBuildSideIndex(
         throw TiFlashException(
             Errors::Coprocessor::BadRequest,
             "Unknown join type in dag request {} {}",
-            magic_enum::enum_name(tipb_join_type),
+            fmt::underlying(tipb_join_type),
             inner_index);
     return join_type_it->second;
 }

--- a/dbms/src/Flash/Coprocessor/JoinInterpreterHelper.cpp
+++ b/dbms/src/Flash/Coprocessor/JoinInterpreterHelper.cpp
@@ -26,6 +26,7 @@
 #include <common/logger_useful.h>
 #include <fmt/format.h>
 
+#include <magic_enum.hpp>
 #include <unordered_map>
 
 namespace DB
@@ -119,8 +120,10 @@ std::pair<ASTTableJoin::Kind, size_t> getJoinKindAndBuildSideIndex(
     auto join_type_it = join_type_map.find(std::make_pair(tipb_join_type, inner_index));
     if (unlikely(join_type_it == join_type_map.end()))
         throw TiFlashException(
-            fmt::format("Unknown join type in dag request {} {}", tipb_join_type, inner_index),
-            Errors::Coprocessor::BadRequest);
+            Errors::Coprocessor::BadRequest,
+            "Unknown join type in dag request {} {}",
+            magic_enum::enum_name(tipb_join_type),
+            inner_index);
     return join_type_it->second;
 }
 

--- a/dbms/src/Flash/Disaggregated/S3LockClient.cpp
+++ b/dbms/src/Flash/Disaggregated/S3LockClient.cpp
@@ -118,7 +118,11 @@ std::pair<bool, String> S3LockClient::makeCall(
                 throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "deadline exceed, " + tracing_log->identifier());
             }
             // retry
-            LOG_ERROR(tracing_log, "meets error, code={} msg={}", status.error_code(), status.error_message());
+            LOG_ERROR(
+                tracing_log,
+                "meets error, code={} msg={}",
+                magic_enum::enum_name(status.error_code()),
+                status.error_message());
             address = updateOwnerAddr(deadline, tracing_log);
         }
 

--- a/dbms/src/Flash/FlashService.cpp
+++ b/dbms/src/Flash/FlashService.cpp
@@ -300,7 +300,12 @@ grpc::Status FlashService::Coprocessor(
     };
     grpc::Status ret = cop_limiter->executeFor(std::move(exec_func), max_queued_duration_ms, std::move(timeout_func));
 
-    LOG_IMPL(log, log_level, "Handle coprocessor request done: {}, {}", ret.error_code(), ret.error_message());
+    LOG_IMPL(
+        log,
+        log_level,
+        "Handle coprocessor request done: {}, {}",
+        magic_enum::enum_name(ret.error_code()),
+        ret.error_message());
     return ret;
 }
 
@@ -342,7 +347,11 @@ grpc::Status FlashService::BatchCoprocessor(
         return cop_handler.execute();
     });
 
-    LOG_INFO(log, "Handle batch coprocessor request done: {}, {}", ret.error_code(), ret.error_message());
+    LOG_INFO(
+        log,
+        "Handle batch coprocessor request done: {}, {}",
+        magic_enum::enum_name(ret.error_code()),
+        ret.error_message());
     return ret;
 }
 
@@ -459,7 +468,12 @@ grpc::Status FlashService::CoprocessorStream(
     grpc::Status ret
         = cop_stream_limiter->executeFor(std::move(exec_func), max_queued_duration_ms, std::move(timeout_func));
 
-    LOG_IMPL(log, log_level, "Handle coprocessor stream request done: {}, {}", ret.error_code(), ret.error_message());
+    LOG_IMPL(
+        log,
+        log_level,
+        "Handle coprocessor stream request done: {}, {}",
+        magic_enum::enum_name(ret.error_code()),
+        ret.error_message());
     return ret;
 }
 

--- a/dbms/src/Flash/LogSearch.cpp
+++ b/dbms/src/Flash/LogSearch.cpp
@@ -18,6 +18,7 @@
 #include <boost_wrapper/string.h>
 
 #include <boost/algorithm/string/predicate.hpp>
+#include <magic_enum.hpp>
 
 namespace DB
 {
@@ -365,7 +366,11 @@ LogIterator::~LogIterator()
 {
     if (err_info.has_value())
     {
-        LOG_DEBUG(log, "LogIterator search end with error {} at line {}.", err_info->second, err_info->first);
+        LOG_DEBUG(
+            log,
+            "LogIterator search end with error {} at line {}.",
+            magic_enum::enum_name(err_info->second),
+            err_info->first);
     }
 }
 

--- a/dbms/src/Flash/Mpp/AsyncRequestHandler.h
+++ b/dbms/src/Flash/Mpp/AsyncRequestHandler.h
@@ -197,7 +197,7 @@ private:
             String done_msg = fmt::format("Exchange receiver meet error : {}", finish_status.error_message());
             String log_msg = fmt::format(
                 "Finish fail. err code: {}, err msg: {}, retry time {}",
-                finish_status.error_code(),
+                magic_enum::enum_name(finish_status.error_code()),
                 finish_status.error_message(),
                 retry_times);
             retryOrDone(std::move(done_msg), log_msg);

--- a/dbms/src/Flash/Mpp/ExchangeReceiver.cpp
+++ b/dbms/src/Flash/Mpp/ExchangeReceiver.cpp
@@ -173,7 +173,7 @@ public:
                 LOG_WARNING(
                     log,
                     "Finish fail. err code: {}, err msg: {}, retry time {}",
-                    finish_status.error_code(),
+                    magic_enum::enum_name(finish_status.error_code()),
                     finish_status.error_message(),
                     retry_times);
                 retryOrDone(fmt::format("Exchange receiver meet error : {}", finish_status.error_message()));
@@ -681,7 +681,7 @@ void ExchangeReceiverBase<RPCContext>::readLoop(const Request & req)
                 LOG_WARNING(
                     log,
                     "EstablishMPPConnectionRequest meets rpc fail. Err code = {}, err msg = {}, retriable = {}",
-                    status.error_code(),
+                    magic_enum::enum_name(status.error_code()),
                     status.error_message(),
                     retriable);
                 // if we have received some data, we should not retry.

--- a/dbms/src/Flash/Mpp/MppVersion.h
+++ b/dbms/src/Flash/Mpp/MppVersion.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <common/defines.h>
 #include <fmt/format.h>
 
 #include <string>
@@ -29,7 +30,7 @@ enum MppVersion : int64_t
     MppVersionMAX,
 };
 // Make MppVersion formatable by fmtlib
-auto format_as(MppVersion v)
+ALWAYS_INLINE inline auto format_as(MppVersion v)
 {
     return fmt::underlying(v);
 }
@@ -42,7 +43,7 @@ enum MPPDataPacketVersion : int64_t
     MPPDataPacketMAX,
 };
 // Make MPPDataPacketVersion formatable by fmtlib
-auto format_as(MPPDataPacketVersion v)
+ALWAYS_INLINE inline auto format_as(MPPDataPacketVersion v)
 {
     return fmt::underlying(v);
 }

--- a/dbms/src/Flash/Mpp/MppVersion.h
+++ b/dbms/src/Flash/Mpp/MppVersion.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <fmt/format.h>
+
 #include <string>
 
 namespace DB
@@ -26,6 +28,11 @@ enum MppVersion : int64_t
     //
     MppVersionMAX,
 };
+// Make MppVersion formatable by fmtlib
+auto format_as(MppVersion v)
+{
+    return fmt::underlying(v);
+}
 
 enum MPPDataPacketVersion : int64_t
 {
@@ -34,6 +41,11 @@ enum MPPDataPacketVersion : int64_t
     //
     MPPDataPacketMAX,
 };
+// Make MPPDataPacketVersion formatable by fmtlib
+auto format_as(MPPDataPacketVersion v)
+{
+    return fmt::underlying(v);
+}
 
 bool ReportStatusToCoordinator(int64_t mpp_version, const std::string & coordinator_address);
 bool ReportExecutionSummaryToCoordinator(int64_t mpp_version, bool report_execution_summary);

--- a/dbms/src/Flash/Planner/PhysicalPlan.cpp
+++ b/dbms/src/Flash/Planner/PhysicalPlan.cpp
@@ -232,7 +232,7 @@ void PhysicalPlan::build(const tipb::Executor * executor)
     }
     default:
         throw TiFlashException(
-            fmt::format("{} executor is not supported", executor->tp()),
+            fmt::format("{} executor is not supported", tipb::ExecType_Name(executor->tp())),
             Errors::Planner::Unimplemented);
     }
 }

--- a/dbms/src/Flash/Planner/PhysicalPlan.cpp
+++ b/dbms/src/Flash/Planner/PhysicalPlan.cpp
@@ -232,7 +232,7 @@ void PhysicalPlan::build(const tipb::Executor * executor)
     }
     default:
         throw TiFlashException(
-            fmt::format("{} executor is not supported", tipb::ExecType_Name(executor->tp())),
+            fmt::format("{} executor is not supported", fmt::underlying(executor->tp())),
             Errors::Planner::Unimplemented);
     }
 }

--- a/dbms/src/Flash/tests/gtest_collation.cpp
+++ b/dbms/src/Flash/tests/gtest_collation.cpp
@@ -233,7 +233,7 @@ std::queue<tipb::ExecType> ExecutorCollation::checkExecutorCollation(
             break; /// Do nothing
         default:
         {
-            auto exception_str = fmt::format("Unhandled executor {}", type);
+            auto exception_str = fmt::format("Unhandled executor {}", fmt::underlying(type));
             throw Exception(exception_str);
         }
         }
@@ -313,7 +313,7 @@ void ExecutorCollation::checkScalarFunctionCollation(std::shared_ptr<tipb::DAGRe
             break; /// Do nothing
         default:
         {
-            auto exception_str = fmt::format("Unhandled executor {}", type);
+            auto exception_str = fmt::format("Unhandled executor {}", fmt::underlying(type));
             throw Exception(exception_str);
         }
         }

--- a/dbms/src/Flash/tests/gtest_join_executor.cpp
+++ b/dbms/src/Flash/tests/gtest_join_executor.cpp
@@ -2291,7 +2291,7 @@ ColumnsWithTypeAndName genSemiJoinResult(
             r.column = r.column->filter(filter, -1);
     }
     else
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Semi join Type {} is not supported", type);
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Semi join Type {} is not supported", magic_enum::enum_name(type));
     return res;
 }
 } // namespace

--- a/dbms/src/Interpreters/SettingsCommon.h
+++ b/dbms/src/Interpreters/SettingsCommon.h
@@ -830,3 +830,39 @@ private:
 };
 
 } // namespace DB
+
+template <typename T>
+struct fmt::formatter<DB::SettingInt<T>>
+{
+    static constexpr auto parse(format_parse_context & ctx) { return ctx.begin(); }
+
+    template <typename FormatContext>
+    auto format(const DB::SettingInt<T> & s, FormatContext & ctx) const
+    {
+        return fmt::format_to(ctx.out(), "{}", s.get());
+    }
+};
+
+template <>
+struct fmt::formatter<DB::SettingFloat>
+{
+    static constexpr auto parse(format_parse_context & ctx) { return ctx.begin(); }
+
+    template <typename FormatContext>
+    auto format(const DB::SettingFloat & s, FormatContext & ctx) const
+    {
+        return fmt::format_to(ctx.out(), "{:.3f}", s.get());
+    }
+};
+
+template <>
+struct fmt::formatter<DB::SettingDouble>
+{
+    static constexpr auto parse(format_parse_context & ctx) { return ctx.begin(); }
+
+    template <typename FormatContext>
+    auto format(const DB::SettingDouble & s, FormatContext & ctx) const
+    {
+        return fmt::format_to(ctx.out(), "{:.3f}", s.get());
+    }
+};

--- a/dbms/src/Interpreters/SettingsCommon.h
+++ b/dbms/src/Interpreters/SettingsCommon.h
@@ -91,6 +91,12 @@ private:
     std::atomic<IntType> value;
 };
 
+// Make SettingInt formatable by fmtlib
+template <typename IntType>
+ALWAYS_INLINE inline auto format_as(SettingInt<IntType> s)
+{
+    return s.get();
+}
 
 using SettingUInt64 = SettingInt<UInt64>;
 using SettingInt64 = SettingInt<Int64>;
@@ -338,6 +344,12 @@ private:
     std::atomic<float> value;
 };
 
+// Make SettingFloat formatable by fmtlib
+ALWAYS_INLINE inline auto format_as(SettingFloat s)
+{
+    return s.get();
+}
+
 /// MemoryLimit can either be an UInt64 (means memory limit in bytes),
 /// or be a float-point number (means memory limit ratio of total RAM, from 0.0 to 1.0).
 /// 0 or 0.0 means unlimited.
@@ -438,6 +450,12 @@ public:
 private:
     std::atomic<double> value;
 };
+
+// Make SettingDouble formatable by fmtlib
+ALWAYS_INLINE inline auto format_as(SettingDouble s)
+{
+    return s.get();
+}
 
 enum class LoadBalancing
 {
@@ -830,39 +848,3 @@ private:
 };
 
 } // namespace DB
-
-template <typename T>
-struct fmt::formatter<DB::SettingInt<T>>
-{
-    static constexpr auto parse(format_parse_context & ctx) { return ctx.begin(); }
-
-    template <typename FormatContext>
-    auto format(const DB::SettingInt<T> & s, FormatContext & ctx) const
-    {
-        return fmt::format_to(ctx.out(), "{}", s.get());
-    }
-};
-
-template <>
-struct fmt::formatter<DB::SettingFloat>
-{
-    static constexpr auto parse(format_parse_context & ctx) { return ctx.begin(); }
-
-    template <typename FormatContext>
-    auto format(const DB::SettingFloat & s, FormatContext & ctx) const
-    {
-        return fmt::format_to(ctx.out(), "{:.3f}", s.get());
-    }
-};
-
-template <>
-struct fmt::formatter<DB::SettingDouble>
-{
-    static constexpr auto parse(format_parse_context & ctx) { return ctx.begin(); }
-
-    template <typename FormatContext>
-    auto format(const DB::SettingDouble & s, FormatContext & ctx) const
-    {
-        return fmt::format_to(ctx.out(), "{:.3f}", s.get());
-    }
-};

--- a/dbms/src/Interpreters/WindowDescription.cpp
+++ b/dbms/src/Interpreters/WindowDescription.cpp
@@ -48,7 +48,7 @@ WindowFrame::FrameType getFrameTypeFromTipb(const tipb::WindowFrameType & type)
     case tipb::WindowFrameType::Groups:
         return WindowFrame::FrameType::Groups;
     default:
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unknown frame type {}", magic_enum::enum_name(type));
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unknown frame type {}", fmt::underlying(type));
     }
 }
 

--- a/dbms/src/Interpreters/WindowDescription.cpp
+++ b/dbms/src/Interpreters/WindowDescription.cpp
@@ -48,7 +48,7 @@ WindowFrame::FrameType getFrameTypeFromTipb(const tipb::WindowFrameType & type)
     case tipb::WindowFrameType::Groups:
         return WindowFrame::FrameType::Groups;
     default:
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unknown frame type {}", type);
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unknown frame type {}", magic_enum::enum_name(type));
     }
 }
 

--- a/dbms/src/Server/MockComputeClient.h
+++ b/dbms/src/Server/MockComputeClient.h
@@ -42,7 +42,7 @@ public:
         {
             throw Exception(fmt::format(
                 "Meet error while dispatch mpp task, error code = {}, message = {}",
-                status.error_code(),
+                magic_enum::enum_name(status.error_code()),
                 status.error_message()));
         }
         if (response.has_error())
@@ -63,7 +63,7 @@ public:
         {
             throw Exception(fmt::format(
                 "Meet error while run coprocessor task, error code = {}, message = {}",
-                status.error_code(),
+                magic_enum::enum_name(status.error_code()),
                 status.error_message()));
         }
 

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -367,7 +367,7 @@ pingcap::ClusterConfig getClusterConfig(
         ca_path,
         cert_path,
         key_path,
-        config.api_version);
+        fmt::underlying(config.api_version));
     return config;
 }
 

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -1589,7 +1589,7 @@ bool DeltaMergeStore::checkSegmentUpdate(
             LOG_DEBUG(
                 log,
                 "Foreground flush cache in checkSegmentUpdate, thread={} segment={} input_type={}",
-                thread_type,
+                magic_enum::enum_name(thread_type),
                 segment->info(),
                 magic_enum::enum_name(input_type));
             segment->flushCache(*dm_context);

--- a/dbms/src/Storages/DeltaMerge/File/DMFile.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFile.cpp
@@ -820,11 +820,11 @@ void DMFile::initializeIndices()
         }
         catch (const std::invalid_argument & err)
         {
-            throw DB::Exception(fmt::format("invalid ColId: {} from file: {}", err.what(), data));
+            throw DB::Exception(fmt::format("invalid ColId: {} from file: {}", err.what(), data.toStringView()));
         }
         catch (const std::out_of_range & err)
         {
-            throw DB::Exception(fmt::format("invalid ColId: {} from file: {}", err.what(), data));
+            throw DB::Exception(fmt::format("invalid ColId: {} from file: {}", err.what(), data.toStringView()));
         }
     };
 

--- a/dbms/src/Storages/DeltaMerge/File/DMFile.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFile.cpp
@@ -820,11 +820,11 @@ void DMFile::initializeIndices()
         }
         catch (const std::invalid_argument & err)
         {
-            throw DB::Exception(fmt::format("invalid ColId: {} from file: {}", err.what(), data.toStringView()));
+            throw DB::Exception(fmt::format("invalid ColId: {} from file: {}", err.what(), data));
         }
         catch (const std::out_of_range & err)
         {
-            throw DB::Exception(fmt::format("invalid ColId: {} from file: {}", err.what(), data.toStringView()));
+            throw DB::Exception(fmt::format("invalid ColId: {} from file: {}", err.what(), data));
         }
     };
 

--- a/dbms/src/Storages/KVStore/Decode/RegionBlockReader.cpp
+++ b/dbms/src/Storages/KVStore/Decode/RegionBlockReader.cpp
@@ -90,7 +90,7 @@ bool RegionBlockReader::read(Block & block, const RegionDataReadInfoList & data_
             "schema_snapshot->column_defines is {}, "
             "decoding_snapshot_epoch is {}, "
             "block schema is {} ",
-            schema_snapshot->pk_type,
+            magic_enum::enum_name(schema_snapshot->pk_type),
             print_map(schema_snapshot->sorted_column_id_with_pos),
             print_column_defines(schema_snapshot->column_defines),
             schema_snapshot->decoding_schema_epoch,

--- a/dbms/src/Storages/KVStore/MultiRaft/RaftCommandsKVS.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/RaftCommandsKVS.cpp
@@ -29,8 +29,6 @@
 #include <Storages/StorageDeltaMergeHelpers.h>
 #include <common/likely.h>
 
-#include <magic_enum.hpp>
-
 namespace DB
 {
 

--- a/dbms/src/Storages/KVStore/MultiRaft/RaftCommandsKVS.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/RaftCommandsKVS.cpp
@@ -29,6 +29,8 @@
 #include <Storages/StorageDeltaMergeHelpers.h>
 #include <common/likely.h>
 
+#include <magic_enum.hpp>
+
 namespace DB
 {
 
@@ -135,7 +137,7 @@ EngineStoreApplyRes KVStore::handleUselessAdminRaftCmd(
             curr_region,
             &region_task_lock,
             PersistRegionReason::UselessAdminCommand,
-            fmt::format("{}", cmd_type).c_str());
+            raft_cmdpb::AdminCmdType_Name(cmd_type).c_str());
         return EngineStoreApplyRes::Persist;
     }
     return EngineStoreApplyRes::None;

--- a/dbms/src/Storages/KVStore/Read/ReadIndex.cpp
+++ b/dbms/src/Storages/KVStore/Read/ReadIndex.cpp
@@ -98,7 +98,7 @@ std::tuple<WaitIndexResult, double> Region::waitIndex(
                 toString(false),
                 index,
                 appliedIndex(),
-                peerState());
+                fmt::underlying(peerState()));
             return {wait_idx_res, elapsed_secs};
         }
         }

--- a/dbms/src/Storages/KVStore/Types.h
+++ b/dbms/src/Storages/KVStore/Types.h
@@ -45,15 +45,13 @@ using KeyspaceDatabaseID = std::pair<KeyspaceID, DatabaseID>;
 
 using ColumnID = Int64;
 
-enum : ColumnID
-{
-    // Prevent conflict with TiDB.
-    TiDBPkColumnID = -1,
-    ExtraTableIDColumnID = -3,
-    VersionColumnID = -1024,
-    DelMarkColumnID = -1025,
-    InvalidColumnID = -10000,
-};
+// Constants for column id, prevent conflict with TiDB.
+static constexpr Int64 TiDBPkColumnID = -1;
+static constexpr Int64 ExtraTableIDColumnID = -3;
+static constexpr Int64 VersionColumnID = -1024;
+static constexpr Int64 DelMarkColumnID = -1025;
+static constexpr Int64 InvalidColumnID = -10000;
+
 
 using HandleID = Int64;
 using Timestamp = UInt64;

--- a/dbms/src/Storages/KVStore/Types.h
+++ b/dbms/src/Storages/KVStore/Types.h
@@ -46,11 +46,11 @@ using KeyspaceDatabaseID = std::pair<KeyspaceID, DatabaseID>;
 using ColumnID = Int64;
 
 // Constants for column id, prevent conflict with TiDB.
-static constexpr Int64 TiDBPkColumnID = -1;
-static constexpr Int64 ExtraTableIDColumnID = -3;
-static constexpr Int64 VersionColumnID = -1024;
-static constexpr Int64 DelMarkColumnID = -1025;
-static constexpr Int64 InvalidColumnID = -10000;
+static constexpr ColumnID TiDBPkColumnID = -1;
+static constexpr ColumnID ExtraTableIDColumnID = -3;
+static constexpr ColumnID VersionColumnID = -1024;
+static constexpr ColumnID DelMarkColumnID = -1025;
+static constexpr ColumnID InvalidColumnID = -10000;
 
 
 using HandleID = Int64;

--- a/dbms/src/Storages/Page/Config.h
+++ b/dbms/src/Storages/Page/Config.h
@@ -138,15 +138,15 @@ struct PageStorageConfig
             "gc_min_legacy_num: {}, gc_max_expect_legacy: {}, gc_max_valid_rate_bound: {:.3f}, "
             "prob_do_gc_when_write_is_low: {}, "
             "open_file_max_idle_time: {}}}",
-            gc_min_files,
-            gc_min_bytes,
+            gc_min_files.toString(),
+            gc_min_bytes.toString(),
             gc_force_hardlink_rate.get(),
             gc_max_valid_rate.get(),
-            gc_min_legacy_num,
+            gc_min_legacy_num.toString(),
             gc_max_expect_legacy_files.get(),
             gc_max_valid_rate_bound.get(),
-            prob_do_gc_when_write_is_low,
-            open_file_max_idle_time);
+            prob_do_gc_when_write_is_low.toString(),
+            open_file_max_idle_time.toString());
     }
 
     String toDebugStringV3() const

--- a/dbms/src/Storages/Page/Config.h
+++ b/dbms/src/Storages/Page/Config.h
@@ -138,15 +138,15 @@ struct PageStorageConfig
             "gc_min_legacy_num: {}, gc_max_expect_legacy: {}, gc_max_valid_rate_bound: {:.3f}, "
             "prob_do_gc_when_write_is_low: {}, "
             "open_file_max_idle_time: {}}}",
-            gc_min_files.toString(),
-            gc_min_bytes.toString(),
+            gc_min_files,
+            gc_min_bytes,
             gc_force_hardlink_rate.get(),
             gc_max_valid_rate.get(),
-            gc_min_legacy_num.toString(),
+            gc_min_legacy_num,
             gc_max_expect_legacy_files.get(),
             gc_max_valid_rate_bound.get(),
-            prob_do_gc_when_write_is_low.toString(),
-            open_file_max_idle_time.toString());
+            prob_do_gc_when_write_is_low,
+            open_file_max_idle_time);
     }
 
     String toDebugStringV3() const

--- a/dbms/src/TestUtils/ExecutorSerializer.cpp
+++ b/dbms/src/TestUtils/ExecutorSerializer.cpp
@@ -262,7 +262,7 @@ void serializeWindow(const String & executor_id, const tipb::Window & window [[m
         {
             buf.fmtAppend(
                 "start<{}, {}, {}>",
-                window.frame().start().type(),
+                fmt::underlying(window.frame().start().type()),
                 window.frame().start().unbounded(),
                 window.frame().start().offset());
         }
@@ -270,7 +270,7 @@ void serializeWindow(const String & executor_id, const tipb::Window & window [[m
         {
             buf.fmtAppend(
                 ", end<{}, {}, {}>",
-                window.frame().end().type(),
+                fmt::underlying(window.frame().end().type()),
                 window.frame().end().unbounded(),
                 window.frame().end().offset());
         }

--- a/dbms/src/TestUtils/ExecutorSerializer.cpp
+++ b/dbms/src/TestUtils/ExecutorSerializer.cpp
@@ -262,7 +262,7 @@ void serializeWindow(const String & executor_id, const tipb::Window & window [[m
         {
             buf.fmtAppend(
                 "start<{}, {}, {}>",
-                fmt::underlying(window.frame().start().type()),
+                tipb::WindowBoundType_Name(window.frame().start().type()),
                 window.frame().start().unbounded(),
                 window.frame().start().offset());
         }
@@ -270,7 +270,7 @@ void serializeWindow(const String & executor_id, const tipb::Window & window [[m
         {
             buf.fmtAppend(
                 ", end<{}, {}, {}>",
-                fmt::underlying(window.frame().end().type()),
+                tipb::WindowBoundType_Name(window.frame().end().type()),
                 window.frame().end().unbounded(),
                 window.frame().end().offset());
         }

--- a/dbms/src/TestUtils/ExecutorTestUtils.cpp
+++ b/dbms/src/TestUtils/ExecutorTestUtils.cpp
@@ -26,6 +26,7 @@
 #include <TestUtils/ExecutorSerializer.h>
 #include <TestUtils/ExecutorTestUtils.h>
 #include <gtest/gtest.h>
+#include <gtest/internal/gtest-internal.h>
 
 #include <functional>
 
@@ -418,9 +419,18 @@ DB::ColumnsWithTypeAndName ExecutorTest::executeRawQuery(const String & query, s
     return executeStreams(query_tasks[0].dag_request, concurrency);
 }
 
-void ExecutorTest::dagRequestEqual(const String & expected_string, const std::shared_ptr<tipb::DAGRequest> & actual)
+::testing::AssertionResult ExecutorTest::dagRequestEqual(
+    const char * lhs_expr,
+    const char * rhs_expr,
+    const String & expected_string,
+    const std::shared_ptr<tipb::DAGRequest> & actual)
 {
-    ASSERT_EQ(Poco::trim(expected_string), Poco::trim(ExecutorSerializer().serialize(actual.get())));
+    auto trim_expected = Poco::trim(expected_string);
+    auto trim_actual = Poco::trim(ExecutorSerializer().serialize(actual.get()));
+
+    if (trim_expected == trim_actual)
+        return ::testing::AssertionSuccess();
+    return ::testing::internal::EqFailure(lhs_expr, rhs_expr, trim_expected, trim_actual, false);
 }
 
 } // namespace DB::tests

--- a/dbms/src/TestUtils/ExecutorTestUtils.h
+++ b/dbms/src/TestUtils/ExecutorTestUtils.h
@@ -115,7 +115,7 @@ public:
         case ExchangeReceiver:
             return "exchange_receiver_0";
         default:
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unknown Executor Source type {}", magic_enum::enum_name(type));
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unknown Executor Source type {}", fmt::underlying(type));
         }
     }
 

--- a/dbms/src/TestUtils/ExecutorTestUtils.h
+++ b/dbms/src/TestUtils/ExecutorTestUtils.h
@@ -115,7 +115,7 @@ public:
         case ExchangeReceiver:
             return "exchange_receiver_0";
         default:
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unknown Executor Source type {}", type);
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unknown Executor Source type {}", magic_enum::enum_name(type));
         }
     }
 

--- a/dbms/src/TestUtils/ExecutorTestUtils.h
+++ b/dbms/src/TestUtils/ExecutorTestUtils.h
@@ -71,7 +71,11 @@ public:
 
     void enablePipeline(bool is_enable) const;
 
-    static void dagRequestEqual(const String & expected_string, const std::shared_ptr<tipb::DAGRequest> & actual);
+    static ::testing::AssertionResult dagRequestEqual(
+        const char * lhs_expr,
+        const char * rhs_expr,
+        const String & expected_string,
+        const std::shared_ptr<tipb::DAGRequest> & actual);
 
     void executeInterpreter(
         const String & expected_string,
@@ -158,7 +162,7 @@ protected:
     std::unique_ptr<DAGContext> dag_context_ptr;
 };
 
-#define ASSERT_DAGREQUEST_EQAUL(str, request) dagRequestEqual((str), (request));
+#define ASSERT_DAGREQUEST_EQAUL(str, request) ASSERT_PRED_FORMAT2(ExecutorTest::dagRequestEqual, (str), (request));
 #define ASSERT_BLOCKINPUTSTREAM_EQAUL(str, request, concurrency) executeInterpreter((str), (request), (concurrency))
 
 // nullable type

--- a/dbms/src/TestUtils/tests/gtest_mock_executors.cpp
+++ b/dbms/src/TestUtils/tests/gtest_mock_executors.cpp
@@ -356,10 +356,11 @@ try
                        .window(RowNumber(), {"s1", true}, {"s2", false}, buildDefaultRowsFrame())
                        .build(context);
     {
-        String expected = "window_2 | partition_by: {(<1, String>, desc: false)}}, order_by: {(<0, String>, desc: "
-                          "true)}, func_desc: {row_number()}, frame: {start<2, false, 0>, end<2, false, 0>}\n"
-                          " sort_1 | isPartialSort: true, partition_by: {(<0, String>, desc: false)}\n"
-                          "  table_scan_0 | {<0, String>, <1, String>}\n";
+        String expected
+            = "window_2 | partition_by: {(<1, String>, desc: false)}}, order_by: {(<0, String>, desc: "
+              "true)}, func_desc: {row_number()}, frame: {start<CurrentRow, false, 0>, end<CurrentRow, false, 0>}\n"
+              " sort_1 | isPartialSort: true, partition_by: {(<0, String>, desc: false)}\n"
+              "  table_scan_0 | {<0, String>, <1, String>}\n";
         ASSERT_DAGREQUEST_EQAUL(expected, request);
     }
 
@@ -369,10 +370,11 @@ try
                   .window(RowNumber(), {"test_table.s1", true}, {"test_table.s2", false}, buildDefaultRowsFrame())
                   .build(context);
     {
-        String expected = "window_2 | partition_by: {(<1, String>, desc: false)}}, order_by: {(<0, String>, desc: "
-                          "true)}, func_desc: {row_number()}, frame: {start<2, false, 0>, end<2, false, 0>}\n"
-                          " sort_1 | isPartialSort: true, partition_by: {(<0, String>, desc: false)}\n"
-                          "  table_scan_0 | {<0, String>, <1, String>}\n";
+        String expected
+            = "window_2 | partition_by: {(<1, String>, desc: false)}}, order_by: {(<0, String>, desc: "
+              "true)}, func_desc: {row_number()}, frame: {start<CurrentRow, false, 0>, end<CurrentRow, false, 0>}\n"
+              " sort_1 | isPartialSort: true, partition_by: {(<0, String>, desc: false)}\n"
+              "  table_scan_0 | {<0, String>, <1, String>}\n";
         ASSERT_DAGREQUEST_EQAUL(expected, request);
     }
 }

--- a/dbms/src/TiDB/Decode/TypeMapping.cpp
+++ b/dbms/src/TiDB/Decode/TypeMapping.cpp
@@ -169,7 +169,7 @@ DataTypePtr TypeMapping::getDataType(const ColumnInfo & column_info)
         iter != type_map.end(),
         "Invalid type from column info, column_id={} tp={} flag={}",
         column_info.id,
-        column_info.tp,
+        fmt::underlying(column_info.tp),
         column_info.flag);
     return (iter->second)(column_info);
 }

--- a/dbms/src/TiDB/Etcd/Client.cpp
+++ b/dbms/src/TiDB/Etcd/Client.cpp
@@ -23,6 +23,8 @@
 #include <etcd/v3election.pb.h>
 #include <fmt/chrono.h>
 
+#include <magic_enum.hpp>
+
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -160,7 +162,11 @@ SessionPtr Client::createSession(grpc::ClientContext * grpc_context, Int64 ttl)
     const auto & [lease_id, status] = leaseGrant(ttl);
     if (!status.ok())
     {
-        LOG_ERROR(log, "etcd lease grant failed, code={} msg={}", status.error_code(), status.error_message());
+        LOG_ERROR(
+            log,
+            "etcd lease grant failed, code={} msg={}",
+            magic_enum::enum_name(status.error_code()),
+            status.error_message());
         return {};
     }
 
@@ -370,7 +376,11 @@ bool Session::keepAliveOne()
     if (!ok)
     {
         auto status = writer->Finish();
-        LOG_INFO(log, "keep alive write fail, code={} msg={}", status.error_code(), status.error_message());
+        LOG_INFO(
+            log,
+            "keep alive write fail, code={} msg={}",
+            magic_enum::enum_name(status.error_code()),
+            status.error_message());
         finished = true;
         return false;
     }
@@ -380,7 +390,11 @@ bool Session::keepAliveOne()
     if (!ok)
     {
         auto status = writer->Finish();
-        LOG_INFO(log, "keep alive read fail, code={} msg={}", status.error_code(), status.error_message());
+        LOG_INFO(
+            log,
+            "keep alive read fail, code={} msg={}",
+            magic_enum::enum_name(status.error_code()),
+            status.error_message());
         finished = true;
         return false;
     }

--- a/dbms/src/TiDB/OwnerManager.cpp
+++ b/dbms/src/TiDB/OwnerManager.cpp
@@ -266,7 +266,7 @@ void EtcdOwnerManager::camaignLoop(Etcd::SessionPtr session)
                     "failed to campaign, id={} lease={:x} code={} msg={}",
                     id,
                     lease_id,
-                    status.error_code(),
+                    magic_enum::enum_name(status.error_code()),
                     status.error_message());
                 static constexpr std::chrono::milliseconds CampaignRetryInterval(200);
                 std::this_thread::sleep_for(CampaignRetryInterval);
@@ -341,7 +341,7 @@ void EtcdOwnerManager::watchOwner(const String & owner_key, grpc::ClientContext 
         if (!ok)
         {
             auto s = rw->Finish();
-            LOG_DEBUG(log, "watch finish, code={} msg={}", s.error_code(), s.error_message());
+            LOG_DEBUG(log, "watch finish, code={} msg={}", magic_enum::enum_name(s.error_code()), s.error_message());
             return;
         }
 
@@ -372,7 +372,7 @@ void EtcdOwnerManager::watchOwner(const String & owner_key, grpc::ClientContext 
             }
         } // loop until key deleted or failed
         auto s = rw->Finish();
-        LOG_DEBUG(log, "watch finish, code={} msg={}", s.error_code(), s.error_message());
+        LOG_DEBUG(log, "watch finish, code={} msg={}", magic_enum::enum_name(s.error_code()), s.error_message());
     }
     catch (...)
     {
@@ -385,7 +385,11 @@ std::optional<String> EtcdOwnerManager::getOwnerKey(const String & expect_id)
     const auto & [kv, status] = client->leader(campaign_name);
     if (!status.ok())
     {
-        LOG_INFO(log, "failed to get leader, code={} msg={}", status.error_code(), status.error_message());
+        LOG_INFO(
+            log,
+            "failed to get leader, code={} msg={}",
+            magic_enum::enum_name(status.error_code()),
+            status.error_message());
         return std::nullopt;
     }
     // Check whether the owner id get from etcd is the same as this node
@@ -501,7 +505,7 @@ void EtcdOwnerManager::revokeEtcdSession(Etcd::LeaseID lease_id)
     // revoke the session lease
     // if revoke takes longer than the ttl, lease is expired anyway. it is safe to ignore error here.
     auto status = client->leaseRevoke(lease_id);
-    LOG_INFO(log, "revoke session, code={} msg={}", status.error_code(), status.error_message());
+    LOG_INFO(log, "revoke session, code={} msg={}", magic_enum::enum_name(status.error_code()), status.error_message());
 }
 
 OwnerInfo EtcdOwnerManager::getOwnerID()
@@ -519,7 +523,8 @@ OwnerInfo EtcdOwnerManager::getOwnerID()
     if (!status.ok())
         return OwnerInfo{
             .status = OwnerType::GrpcError,
-            .owner_id = fmt::format("code={} msg={}", status.error_code(), status.error_message()),
+            .owner_id
+            = fmt::format("code={} msg={}", magic_enum::enum_name(status.error_code()), status.error_message()),
         };
     if (val.empty())
         return OwnerInfo{

--- a/libs/libcommon/include/common/StringRef.h
+++ b/libs/libcommon/include/common/StringRef.h
@@ -70,6 +70,7 @@ struct StringRef
     constexpr StringRef() = default;
 
     std::string toString() const { return std::string(data, size); }
+    std::string_view toStringView() const { return std::string_view(data, size); }
 
     explicit operator std::string() const { return toString(); }
     constexpr explicit operator std::string_view() const { return {data, size}; }
@@ -251,3 +252,8 @@ inline void set(StringRef & x)
 
 
 std::ostream & operator<<(std::ostream & os, const StringRef & str);
+
+inline auto format_as(StringRef ref)
+{
+    return ref.toStringView();
+}

--- a/libs/libcommon/include/common/StringRef.h
+++ b/libs/libcommon/include/common/StringRef.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <city.h>
+#include <common/defines.h>
 #include <common/mem_utils.h>
 #include <common/mem_utils_opt.h>
 #include <common/types.h>
@@ -253,7 +254,7 @@ inline void set(StringRef & x)
 
 std::ostream & operator<<(std::ostream & os, const StringRef & str);
 
-inline auto format_as(StringRef ref)
+ALWAYS_INLINE inline auto format_as(StringRef ref)
 {
     return ref.toStringView();
 }

--- a/libs/libcommon/include/common/logger_useful.h
+++ b/libs/libcommon/include/common/logger_useful.h
@@ -20,6 +20,7 @@
 #include <fmt/compile.h>
 #include <fmt/format.h>
 #include <fmt/ranges.h>
+#include <fmt/std.h>
 
 #ifndef QUERY_PREVIEW_LENGTH
 #define QUERY_PREVIEW_LENGTH 160

--- a/libs/libcommon/src/tests/gtest_logger.cpp
+++ b/libs/libcommon/src/tests/gtest_logger.cpp
@@ -21,7 +21,9 @@
 #include <Poco/FormattingChannel.h>
 #include <Poco/Logger.h>
 #include <Poco/PatternFormatter.h>
+#include <common/StringRef.h>
 #include <common/logger_useful.h>
+#include <fmt/format.h>
 #include <gtest/gtest.h>
 
 #include <iomanip>
@@ -67,6 +69,14 @@ TEST_F(LoggerUsefulTest, Log)
     std::string msg_in_log;
     msg_in_log = "hello tiflash";
     LOG_DEBUG(log, msg_in_log);
+}
+
+TEST(FmtTest, StringRef)
+{
+    const char * str = "abcdefg\0\0\0\0";
+    ASSERT_EQ("abc", fmt::format("{}", StringRef(str, 3)));
+    ASSERT_EQ("abcdefg", fmt::format("{}", StringRef(str, 7)));
+    ASSERT_EQ(std::string_view("abcdefg\0", 8), fmt::format("{}", StringRef(str, 8)));
 }
 
 } // namespace tests


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/8331

Problem Summary:

The latest version of fmtlib disables implicit casts from `enum`/`enum class` to `int`, which leads to compile error. We must resolve those errors with `magic_enum::enum_name` to print out the enum nam or `fmt::underlying` to print out the int value.

Reference: https://github.com/fmtlib/fmt/issues/3671

An example of the compile error raised by upgraded fmtlib
```
...  -c x/tiflash-master/dbms/src/Flash/tests/gtest_collation.cpp
In file included from x/tiflash-master/dbms/src/Flash/tests/gtest_collation.cpp:16:
In file included from x/tiflash-master/dbms/src/TestUtils/ExecutorTestUtils.h:20:
In file included from x/tiflash-master/dbms/src/TestUtils/ExecutorSerializer.h:17:
In file included from x/tiflash-master/dbms/src/Common/FmtUtils.h:17:
In file included from x/tiflash-master/contrib/fmtlib-cmake/../fmtlib/include/fmt/compile.h:11:
In file included from x/tiflash-master/contrib/fmtlib-cmake/../fmtlib/include/fmt/format.h:49:
x/tiflash-master/contrib/fmtlib-cmake/../fmtlib/include/fmt/core.h:2548:45: error: implicit instantiation of undefined template 'fmt::detail::type_is_unformattable_for<tipb::ExecType, char>'
    type_is_unformattable_for<T, char_type> _;
                                            ^
x/tiflash-master/contrib/fmtlib-cmake/../fmtlib/include/fmt/core.h:2611:23: note: in instantiation of function template specialization 'fmt::detail::parse_format_specs<tipb::ExecType, fmt::detail::compile_parse_context<char>>' requested here
        parse_funcs_{&parse_format_specs<Args, parse_context_type>...} {}
                      ^
x/tiflash-master/contrib/fmtlib-cmake/../fmtlib/include/fmt/core.h:2740:47: note: in instantiation of member function 'fmt::detail::format_string_checker<char, tipb::ExecType>::format_string_checker' requested here
      detail::parse_format_string<true>(str_, checker(s));
                                              ^
x/tiflash-master/dbms/src/Flash/tests/gtest_collation.cpp:316:46: note: in instantiation of function template specialization 'fmt::basic_format_string<char, tipb::ExecType &>::basic_format_string<char[22], 0>' requested here
            auto exception_str = fmt::format("Unhandled executor {}", type);
                                             ^
x/tiflash-master/contrib/fmtlib-cmake/../fmtlib/include/fmt/core.h:1554:45: note: template is declared here
template <typename T, typename Char> struct type_is_unformattable_for;
```

### What is changed and how it works?

* Upgrade fmtlib to [v10.1.1](https://github.com/fmtlib/fmt/releases/tag/10.1.1)
* When we are sure the enum value has corresponding name, we use `magic_enum::enum_name` to cast it to string
* When we are not sure the enum value has corresponding name, we use `fmt::underlying` to cast it to int
  * for example, the enum type defined in kvproto/tipb
* For some classes, we implement a `format_as` function to make it printable by fmtlib
  * `MppVersion`/`MPPDataPacketVersion`/`StringRef`/`SettingInt`/`SettingFloat`/`SettingDouble`


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
