### PR TITLE
ddl: Fix potential data lost of `alter_partition_by`

### DIFF
--- a/dbms/src/TiDB/Schema/SchemaBuilder.cpp
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.cpp
@@ -462,6 +462,8 @@ void SchemaBuilder<Getter, NameMapper>::applyPartitionDiff(
 {
     const auto & local_table_info = storage->getTableInfo();
     // ALTER TABLE t PARTITION BY ... may turn a non-partition table into partition table
+    // with some partition ids in `partition.adding_definitions`/`partition.definitions`
+    // and `partition.dropping_definitions`. We need to create those partitions.
     if (!local_table_info.isLogicalPartitionTable())
     {
         LOG_INFO(

--- a/dbms/src/TiDB/Schema/SchemaBuilder.cpp
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.cpp
@@ -844,7 +844,7 @@ void SchemaBuilder<Getter, NameMapper>::applyDropSchema(const String & db_name)
     auto db = context.tryGetDatabase(db_name);
     if (db == nullptr)
     {
-        LOG_INFO(log, "Database {} does not exists", db_name);
+        LOG_INFO(log, "Database does not exist, db_name={}", db_name);
         return;
     }
 
@@ -1046,7 +1046,7 @@ void SchemaBuilder<Getter, NameMapper>::applyDropPhysicalTable(const String & db
     auto storage = tmt_context.getStorages().get(keyspace_id, table_id);
     if (storage == nullptr)
     {
-        LOG_DEBUG(log, "table {} does not exist.", table_id);
+        LOG_DEBUG(log, "table does not exist, table_id={}", table_id);
         return;
     }
     GET_METRIC(tiflash_schema_internal_ddl_count, type_drop_table).Increment();
@@ -1087,7 +1087,7 @@ void SchemaBuilder<Getter, NameMapper>::applyDropTable(DatabaseID database_id, T
     auto * storage = tmt_context.getStorages().get(keyspace_id, table_id).get();
     if (storage == nullptr)
     {
-        LOG_DEBUG(log, "table {} does not exist.", table_id);
+        LOG_DEBUG(log, "table does not exist, table_id={}", table_id);
         return;
     }
     const auto & table_info = storage->getTableInfo();

--- a/dbms/src/TiDB/Schema/SchemaBuilder.cpp
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.cpp
@@ -1094,12 +1094,12 @@ void SchemaBuilder<Getter, NameMapper>::applyDropTable(DatabaseID database_id, T
             if (TableID latest_logical_table_id = table_id_map.findTableIDInPartitionMap(part_def.id);
                 latest_logical_table_id == -1 || latest_logical_table_id != table_info.id)
             {
-                // The partition is managed by another logical table now, skip dropping this partition
-                // when dropping the old logical table
+                // The partition is managed by another logical table now (caused by `alter table X partition by ...`),
+                // skip dropping this partition when dropping the old logical table
                 LOG_INFO(
                     log,
                     "The partition is not managed by current logical table, skip, partition_table_id={} "
-                    "new_logical_table_id={} current_table_id={}",
+                    "new_logical_table_id={} current_logical_table_id={}",
                     part_def.id,
                     latest_logical_table_id,
                     table_info.id);

--- a/dbms/src/TiDB/Schema/SchemaBuilder.cpp
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.cpp
@@ -527,12 +527,6 @@ void SchemaBuilder<Getter, NameMapper>::applyPartitionDiff(
         }
     }
 
-    if (table_info->partition.new_table_id != DB::InvalidTableID)
-    {
-        // TODO: maybe we should create the new_logical_table here? But we don't know
-        //       the database_id of new_logical_table
-    }
-
     auto alter_lock = storage->lockForAlter(getThreadNameAndID());
     storage->alterSchemaChange(
         alter_lock,

--- a/dbms/src/TiDB/Schema/SchemaBuilder.cpp
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.cpp
@@ -252,14 +252,13 @@ void SchemaBuilder<Getter, NameMapper>::applyDiff(const SchemaDiff & diff)
         }
         else
         {
-            /// The new non-partitioned table will have a new id
-            // Create the new table. If the new table is a partition table,
-            // this will also overwrite the partition id mapping to the
-            // new logical table.
-            applyCreateTable(diff.schema_id, diff.table_id);
-            // try to renew the partition info for the new table
-            applyPartitionDiff(diff.schema_id, diff.table_id);
-            // drop the old table
+            // Create the new table.
+            // If the new table is a partition table, this will also overwrite
+            // the partition id mapping to the new logical table and renew the
+            // partition info.
+            applyPartitionAlter(diff.schema_id, diff.table_id);
+            // Drop the old table. if the previous partitions of the old table are
+            // not mapping to the old logical table now, they will not be removed.
             applyDropTable(diff.schema_id, diff.old_table_id);
         }
         break;
@@ -377,6 +376,51 @@ void SchemaBuilder<Getter, NameMapper>::applySetTiFlashReplica(DatabaseID databa
             }
         }
     }
+}
+
+template <typename Getter, typename NameMapper>
+void SchemaBuilder<Getter, NameMapper>::applyPartitionAlter(DatabaseID database_id, TableID table_id)
+{
+    auto table_info = getter.getTableInfo(database_id, table_id);
+    if (table_info == nullptr) // the database maybe dropped
+    {
+        LOG_DEBUG(log, "table is not exist in TiKV, may have been dropped, table_id={}", table_id);
+        return;
+    }
+
+    table_id_map.emplaceTableID(table_id, database_id);
+    LOG_DEBUG(log, "register table to table_id_map, database_id={} table_id={}", database_id, table_id);
+
+    if (!table_info->isLogicalPartitionTable())
+    {
+        return;
+    }
+
+    // If table is partition table, we will create the logical table here.
+    // Because we get the table_info, so we can ensure new_db_info will not be nullptr.
+    auto new_db_info = getter.getDatabase(database_id);
+    applyCreatePhysicalTable(new_db_info, table_info);
+
+    for (const auto & part_def : table_info->partition.definitions)
+    {
+        LOG_DEBUG(
+            log,
+            "register table to table_id_map for partition table, logical_table_id={} physical_table_id={}",
+            table_id,
+            part_def.id);
+        table_id_map.emplacePartitionTableID(part_def.id, table_id);
+    }
+
+    auto & tmt_context = context.getTMTContext();
+    auto storage = tmt_context.getStorages().get(keyspace_id, table_info->id);
+    if (storage == nullptr)
+    {
+        LOG_ERROR(log, "table is not exist in TiFlash, table_id={}", table_id);
+        return;
+    }
+
+    // Try to renew the partition info for the new table
+    applyPartitionDiff(new_db_info, table_info, storage);
 }
 
 template <typename Getter, typename NameMapper>

--- a/dbms/src/TiDB/Schema/SchemaBuilder.h
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.h
@@ -195,7 +195,7 @@ private:
 
     void applyCreateSchema(const TiDB::DBInfoPtr & db_info);
 
-    void applyCreatePhysicalTable(const TiDB::DBInfoPtr & db_info, const TiDB::TableInfoPtr & table_info);
+    void applyCreateStorageInstance(const TiDB::DBInfoPtr & db_info, const TiDB::TableInfoPtr & table_info);
 
     void applyDropTable(DatabaseID database_id, TableID table_id);
 

--- a/dbms/src/TiDB/Schema/SchemaBuilder.h
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.h
@@ -206,8 +206,6 @@ private:
     /// Parameter schema_name should be mapped.
     void applyDropPhysicalTable(const String & db_name, TableID table_id);
 
-    void applyPartitionAlter(DatabaseID database_id, TableID table_id);
-
     void applyPartitionDiff(DatabaseID database_id, TableID table_id);
     void applyPartitionDiff(
         const TiDB::DBInfoPtr & db_info,

--- a/dbms/src/TiDB/Schema/SchemaBuilder.h
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.h
@@ -206,8 +206,9 @@ private:
     /// Parameter schema_name should be mapped.
     void applyDropPhysicalTable(const String & db_name, TableID table_id);
 
-    void applyPartitionDiff(DatabaseID database_id, TableID table_id);
+    void applyPartitionAlter(DatabaseID database_id, TableID table_id);
 
+    void applyPartitionDiff(DatabaseID database_id, TableID table_id);
     void applyPartitionDiff(
         const TiDB::DBInfoPtr & db_info,
         const TiDB::TableInfoPtr & table_info,

--- a/dbms/src/TiDB/Schema/SchemaGetter.cpp
+++ b/dbms/src/TiDB/Schema/SchemaGetter.cpp
@@ -248,10 +248,10 @@ std::optional<SchemaDiff> SchemaGetter::getSchemaDiff(Int64 ver)
     String data = TxnStructure::get(snap, key);
     if (data.empty())
     {
-        LOG_WARNING(log, "The schema diff for version {}, key {} is empty.", ver, key);
+        LOG_WARNING(log, "The schema diff is empty, schema_version={} key={}", ver, key);
         return std::nullopt;
     }
-    LOG_DEBUG(log, "Get SchemaDiff from TiKV: {}", data); // TODO: turn it into trace level
+    LOG_TRACE(log, "Get SchemaDiff from TiKV, schema_version={} data={}", ver, data);
     SchemaDiff diff;
     diff.deserialize(data);
     return diff;
@@ -275,7 +275,7 @@ TiDB::DBInfoPtr SchemaGetter::getDatabase(DatabaseID db_id)
     if (json.empty())
         return nullptr;
 
-    LOG_DEBUG(log, "Get DB Info from TiKV : " + json);
+    LOG_DEBUG(log, "Get DB Info from TiKV: {}", json);
     auto db_info = std::make_shared<TiDB::DBInfo>(json, keyspace_id);
     return db_info;
 }
@@ -285,25 +285,26 @@ TiDB::TableInfoPtr SchemaGetter::getTableInfo(DatabaseID db_id, TableID table_id
     String db_key = getDBKey(db_id);
     if (!checkDBExists(db_key))
     {
-        LOG_ERROR(log, "The database {} does not exist.", db_id);
+        LOG_ERROR(log, "The database does not exist, database_id={}", db_id);
         return nullptr;
     }
     String table_key = getTableKey(table_id);
     String table_info_json = TxnStructure::hGet(snap, db_key, table_key);
     if (table_info_json.empty())
     {
-        LOG_WARNING(log, "The table {} is dropped in TiKV, try to get the latest table_info", table_id);
+        LOG_WARNING(log, "The table is dropped in TiKV, try to get the latest table_info, table_id={}", table_id);
         table_info_json = TxnStructure::mvccGet(snap, db_key, table_key);
         if (table_info_json.empty())
         {
             LOG_ERROR(
                 log,
-                "The table {} is dropped in TiKV, and the latest table_info is still empty, it should by gc",
+                "The table is dropped in TiKV, and the latest table_info is still empty, it should be GCed, "
+                "table_id={}",
                 table_id);
             return nullptr;
         }
     }
-    LOG_DEBUG(log, "Get Table Info from TiKV : " + table_info_json);
+    LOG_DEBUG(log, "Get Table Info from TiKV: {}", table_info_json);
     TiDB::TableInfoPtr table_info = std::make_shared<TiDB::TableInfo>(table_info_json, keyspace_id);
 
     return table_info;
@@ -319,26 +320,26 @@ std::tuple<TiDB::DBInfoPtr, TiDB::TableInfoPtr> SchemaGetter::getDatabaseAndTabl
     if (db_json.empty())
         return std::make_tuple(nullptr, nullptr);
 
-    LOG_DEBUG(log, "Get DB Info from TiKV : " + db_json);
+    LOG_DEBUG(log, "Get DB Info from TiKV: {}", db_json);
     auto db_info = std::make_shared<TiDB::DBInfo>(db_json, keyspace_id);
 
     String table_key = getTableKey(table_id);
     String table_info_json = TxnStructure::hGet(snap, db_key, table_key);
     if (table_info_json.empty())
     {
-        LOG_WARNING(log, "The table {} is dropped in TiKV, try to get the latest table_info", table_id);
+        LOG_WARNING(log, "The table is dropped in TiKV, try to get the latest table_info, table_id={}", table_id);
         table_info_json = TxnStructure::mvccGet(snap, db_key, table_key);
         if (table_info_json.empty())
         {
             LOG_ERROR(
                 log,
-                "The table {} is dropped in TiKV, and the latest table_info is still empty, it should by gc",
+                "The table is dropped in TiKV, and the latest table_info is still empty, it should be GCed, "
+                "table_id={}",
                 table_id);
             return std::make_tuple(db_info, nullptr);
-            ;
         }
     }
-    LOG_DEBUG(log, "Get Table Info from TiKV : " + table_info_json);
+    LOG_DEBUG(log, "Get Table Info from TiKV: {}", table_info_json);
     TiDB::TableInfoPtr table_info = std::make_shared<TiDB::TableInfo>(table_info_json, keyspace_id);
 
     return std::make_tuple(db_info, table_info);

--- a/dbms/src/TiDB/Schema/SchemaGetter.cpp
+++ b/dbms/src/TiDB/Schema/SchemaGetter.cpp
@@ -251,6 +251,7 @@ std::optional<SchemaDiff> SchemaGetter::getSchemaDiff(Int64 ver)
         LOG_WARNING(log, "The schema diff for version {}, key {} is empty.", ver, key);
         return std::nullopt;
     }
+    LOG_DEBUG(log, "Get SchemaDiff from TiKV: {}", data); // TODO: turn it into trace level
     SchemaDiff diff;
     diff.deserialize(data);
     return diff;

--- a/dbms/src/TiDB/Schema/TiDB.cpp
+++ b/dbms/src/TiDB/Schema/TiDB.cpp
@@ -540,6 +540,10 @@ try
         part_id_set.emplace(definition.id);
     }
 
+    /// Treat `adding_definitions` and `dropping_definitions` as the normal `definitions`
+    /// in TiFlash. Because TiFlash need to create the physical IStorage instance
+    /// to handle the data on those partitions during DDL.
+
     auto add_defs_json = json->getArray("adding_definitions");
     if (!add_defs_json.isNull())
     {
@@ -569,6 +573,8 @@ try
     }
 
     num = json->getValue<UInt64>("num");
+
+    new_table_id = json->getValue<UInt64>("new_table_id");
 }
 catch (const Poco::Exception & e)
 {
@@ -851,8 +857,6 @@ TableInfo::TableInfo(const String & table_info_json, KeyspaceID keyspace_id_)
 String TableInfo::serialize() const
 try
 {
-    std::stringstream buf;
-
     Poco::JSON::Object::Ptr json = new Poco::JSON::Object();
     json->set("id", id);
     json->set("keyspace_id", keyspace_id);
@@ -867,8 +871,8 @@ try
         auto col_obj = col_info.getJSONObject();
         cols_arr->add(col_obj);
     }
-
     json->set("cols", cols_arr);
+
     Poco::JSON::Array::Ptr index_arr = new Poco::JSON::Array();
     for (const auto & index_info : index_infos)
     {
@@ -904,8 +908,8 @@ try
 
     json->set("tiflash_replica", replica_info.getJSONObject());
 
+    std::stringstream buf;
     json->stringify(buf);
-
     return buf.str();
 }
 catch (const Poco::Exception & e)

--- a/dbms/src/TiDB/Schema/TiDB.cpp
+++ b/dbms/src/TiDB/Schema/TiDB.cpp
@@ -574,7 +574,10 @@ try
 
     num = json->getValue<UInt64>("num");
 
-    new_table_id = json->getValue<UInt64>("new_table_id");
+    if (json->has("new_table_id"))
+    {
+        new_table_id = json->getValue<UInt64>("new_table_id");
+    }
 }
 catch (const Poco::Exception & e)
 {

--- a/dbms/src/TiDB/Schema/TiDB.cpp
+++ b/dbms/src/TiDB/Schema/TiDB.cpp
@@ -573,11 +573,6 @@ try
     }
 
     num = json->getValue<UInt64>("num");
-
-    if (json->has("new_table_id"))
-    {
-        new_table_id = json->getValue<UInt64>("new_table_id");
-    }
 }
 catch (const Poco::Exception & e)
 {

--- a/dbms/src/TiDB/Schema/TiDB.h
+++ b/dbms/src/TiDB/Schema/TiDB.h
@@ -266,8 +266,6 @@ struct PartitionInfo
     bool enable = false;
     std::vector<PartitionDefinition> definitions;
     UInt64 num = 0;
-
-    TableID new_table_id = DB::InvalidTableID;
 };
 
 struct DBInfo

--- a/dbms/src/TiDB/Schema/TiDB.h
+++ b/dbms/src/TiDB/Schema/TiDB.h
@@ -266,6 +266,8 @@ struct PartitionInfo
     bool enable = false;
     std::vector<PartitionDefinition> definitions;
     UInt64 num = 0;
+
+    TableID new_table_id = DB::InvalidTableID;
 };
 
 struct DBInfo

--- a/tests/fullstack-test2/ddl/alter_partition_by.test
+++ b/tests/fullstack-test2/ddl/alter_partition_by.test
@@ -28,7 +28,7 @@ mysql> insert into test.t select a+1000000,a+1000000,-(a+1000000) from test.t;
 
 func> wait_table test t
 
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ * from test.t order by a;
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t order by a;
 +---------+---------+----------+
 | a       | b       | c        |
 +---------+---------+----------+
@@ -56,7 +56,7 @@ mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ * from test.t order by a;
 │ test          │ t         │
 └───────────────┴───────────┘
 
-mysql> select /*+ READ_FROM_STORAGE(TIKV[t]) */ count(*) from test.t partition (p0);
+mysql> set session tidb_isolation_read_engines='tikv'; select count(*) from test.t partition (p0);
 +----------+
 | count(*) |
 +----------+
@@ -64,7 +64,7 @@ mysql> select /*+ READ_FROM_STORAGE(TIKV[t]) */ count(*) from test.t partition (
 +----------+
 
 mysql> show warnings;
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partition (p0);
+mysql> set session tidb_isolation_read_engines='tiflash'; select count(*) from test.t partition (p0);
 +----------+
 | count(*) |
 +----------+
@@ -72,14 +72,14 @@ mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partitio
 +----------+
 
 mysql> show warnings;
-mysql> select /*+ READ_FROM_STORAGE(TIKV[t]) */ count(*) from test.t partition (p1M);
+mysql> set session tidb_isolation_read_engines='tikv'; select count(*) from test.t partition (p1M);
 +----------+
 | count(*) |
 +----------+
 |        8 |
 +----------+
 
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partition (p1M);
+mysql> set session tidb_isolation_read_engines='tiflash'; select count(*) from test.t partition (p1M);
 +----------+
 | count(*) |
 +----------+
@@ -90,7 +90,7 @@ mysql> show warnings;
 
 mysql> alter table test.t partition by range (a) (partition p0 values less than (500000), partition p500k values less than (1000000), partition p1M values less than (2000000));
 
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partition (p0);
+mysql> set session tidb_isolation_read_engines='tiflash'; select count(*) from test.t partition (p0);
 +----------+
 | count(*) |
 +----------+
@@ -99,7 +99,7 @@ mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partitio
 
 mysql> show warnings;
 
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partition (p500k);
+mysql> set session tidb_isolation_read_engines='tiflash'; select count(*) from test.t partition (p500k);
 +----------+
 | count(*) |
 +----------+
@@ -108,14 +108,14 @@ mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partitio
 
 mysql> show warnings;
 
-mysql> select /*+ READ_FROM_STORAGE(TIKV[t]) */ count(*) from test.t partition (p0);
+mysql> set session tidb_isolation_read_engines='tikv'; select count(*) from test.t partition (p0);
 +----------+
 | count(*) |
 +----------+
 |        4 |
 +----------+
 
-mysql> select /*+ READ_FROM_STORAGE(TIKV[t]) */ count(*) from test.t partition (p500k);
+mysql> set session tidb_isolation_read_engines='tikv'; select count(*) from test.t partition (p500k);
 +----------+
 | count(*) |
 +----------+
@@ -124,14 +124,14 @@ mysql> select /*+ READ_FROM_STORAGE(TIKV[t]) */ count(*) from test.t partition (
 
 mysql> show warnings;
 
-mysql> select /*+ READ_FROM_STORAGE(TIKV[t]) */ count(*) from test.t partition (p1M);
+mysql> set session tidb_isolation_read_engines='tikv'; select count(*) from test.t partition (p1M);
 +----------+
 | count(*) |
 +----------+
 |        8 |
 +----------+
 
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partition (p1M);
+mysql> set session tidb_isolation_read_engines='tiflash'; select count(*) from test.t partition (p1M);
 +----------+
 | count(*) |
 +----------+
@@ -144,7 +144,7 @@ mysql> alter table test.t2 set tiflash replica 1;
 mysql> insert into test.t2 select * from test.t;
 func> wait_table test t2
 
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t2]) */ * from test.t2 order by a;
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t2 order by a;
 +---------+---------+----------+
 | a       | b       | c        |
 +---------+---------+----------+
@@ -168,6 +168,7 @@ mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t2]) */ * from test.t2 order by a;
 
 mysql> drop table test.t;
 
+# check the t2 is created in TiFlash
 >> select tidb_database,tidb_name from system.tables where tidb_database = 'test' and tidb_name = 't2' and is_tombstone = 0
 ┌─tidb_database─┬─tidb_name─┐
 │ test          │ t2        │
@@ -176,7 +177,7 @@ mysql> drop table test.t;
 mysql> alter table test.t2 partition by hash (a) partitions 3;
 mysql> analyze table test.t2;
 
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t2]) */ count(*) from test.t2 partition (p0);
+mysql> set session tidb_isolation_read_engines='tiflash'; select count(*) from test.t2 partition (p0);
 +----------+
 | count(*) |
 +----------+
@@ -185,7 +186,7 @@ mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t2]) */ count(*) from test.t2 partit
 
 mysql> show warnings;
 
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t2]) */ count(*) from test.t2 partition (p1);
+mysql> set session tidb_isolation_read_engines='tiflash'; select count(*) from test.t2 partition (p1);
 +----------+
 | count(*) |
 +----------+
@@ -194,14 +195,14 @@ mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t2]) */ count(*) from test.t2 partit
 
 mysql> show warnings;
 
-mysql> select /*+ READ_FROM_STORAGE(TIKV[t2]) */ count(*) from test.t2 partition (p0);
+mysql> set session tidb_isolation_read_engines='tikv'; select count(*) from test.t2 partition (p0);
 +----------+
 | count(*) |
 +----------+
 |        5 |
 +----------+
 
-mysql> select /*+ READ_FROM_STORAGE(TIKV[t2]) */ count(*) from test.t2 partition (p1);
+mysql> set session tidb_isolation_read_engines='tikv'; select count(*) from test.t2 partition (p1);
 +----------+
 | count(*) |
 +----------+
@@ -211,14 +212,14 @@ mysql> select /*+ READ_FROM_STORAGE(TIKV[t2]) */ count(*) from test.t2 partition
 mysql> show warnings;
 
 
-mysql> select /*+ READ_FROM_STORAGE(TIKV[t2]) */ count(*) from test.t2 partition (p2);
+mysql> set session tidb_isolation_read_engines='tikv'; select count(*) from test.t2 partition (p2);
 +----------+
 | count(*) |
 +----------+
 |        5 |
 +----------+
 
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t2]) */ count(*) from test.t2 partition (p2);
+mysql> set session tidb_isolation_read_engines='tiflash'; select count(*) from test.t2 partition (p2);
 +----------+
 | count(*) |
 +----------+

--- a/tests/fullstack-test2/ddl/alter_partition_by.test
+++ b/tests/fullstack-test2/ddl/alter_partition_by.test
@@ -143,6 +143,7 @@ mysql> create table test.t2 (a int primary key, b varchar(255), c int, key (b), 
 mysql> alter table test.t2 set tiflash replica 1;
 mysql> insert into test.t2 select * from test.t;
 func> wait_table test t2
+mysql> drop table test.t;
 
 mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t2 order by a;
 +---------+---------+----------+
@@ -166,8 +167,6 @@ mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t2 
 | 1500004 | 1500004 | -1500004 |
 +---------+---------+----------+
 
-mysql> drop table test.t;
-
 # check the t2 is created in TiFlash
 >> select tidb_database,tidb_name from system.tables where tidb_database = 'test' and tidb_name = 't2' and is_tombstone = 0
 ┌─tidb_database─┬─tidb_name─┐
@@ -176,6 +175,9 @@ mysql> drop table test.t;
 
 mysql> alter table test.t2 partition by hash (a) partitions 3;
 mysql> analyze table test.t2;
+
+#TODO this is just a workaround, the tidb return before waitting tiflash replica available for the new partitions
+SLEEP 10
 
 mysql> set session tidb_isolation_read_engines='tiflash'; select count(*) from test.t2 partition (p0);
 +----------+

--- a/tests/fullstack-test2/ddl/alter_partition_by.test
+++ b/tests/fullstack-test2/ddl/alter_partition_by.test
@@ -176,9 +176,6 @@ mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t2 
 mysql> alter table test.t2 partition by hash (a) partitions 3;
 mysql> analyze table test.t2;
 
-#TODO this is just a workaround, the tidb return before waitting tiflash replica available for the new partitions
-SLEEP 10
-
 mysql> set session tidb_isolation_read_engines='tiflash'; select count(*) from test.t2 partition (p0);
 +----------+
 | count(*) |

--- a/tests/fullstack-test2/ddl/remove_partitioning.test
+++ b/tests/fullstack-test2/ddl/remove_partitioning.test
@@ -28,13 +28,35 @@ mysql> insert into test.t select a+1000000,a+1000000,-(a+1000000) from test.t;
 
 func> wait_table test t
 
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t;
++---------+---------+----------+
+| a       | b       | c        |
++---------+---------+----------+
+|       1 | 1       |       -1 |
+|       2 | 2       |       -2 |
+|       3 | 3       |       -3 |
+|       4 | 4       |       -4 |
+|  500001 | 500001  |  -500001 |
+|  500002 | 500002  |  -500002 |
+|  500003 | 500003  |  -500003 |
+|  500004 | 500004  |  -500004 |
+| 1000001 | 1000001 | -1000001 |
+| 1000002 | 1000002 | -1000002 |
+| 1000003 | 1000003 | -1000003 |
+| 1000004 | 1000004 | -1000004 |
+| 1500001 | 1500001 | -1500001 |
+| 1500002 | 1500002 | -1500002 |
+| 1500003 | 1500003 | -1500003 |
+| 1500004 | 1500004 | -1500004 |
++---------+---------+----------+
+
 # check table info in tiflash
 >> select tidb_database,tidb_name from system.tables where tidb_database = 'test' and tidb_name = 't' and is_tombstone = 0
 ┌─tidb_database─┬─tidb_name─┐
 │ test          │ t         │
 └───────────────┴───────────┘
 
-mysql> select /*+ READ_FROM_STORAGE(TIKV[t]) */ count(*) from test.t partition (p0);
+mysql> set session tidb_isolation_read_engines='tikv'; select count(*) from test.t partition (p0);
 +----------+
 | count(*) |
 +----------+
@@ -42,7 +64,7 @@ mysql> select /*+ READ_FROM_STORAGE(TIKV[t]) */ count(*) from test.t partition (
 +----------+
 
 mysql> show warnings;
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partition (p0);
+mysql> set session tidb_isolation_read_engines='tiflash'; select count(*) from test.t partition (p0);
 +----------+
 | count(*) |
 +----------+
@@ -50,14 +72,14 @@ mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partitio
 +----------+
 
 mysql> show warnings;
-mysql> select /*+ READ_FROM_STORAGE(TIKV[t]) */ count(*) from test.t partition (p1M);
+mysql> set session tidb_isolation_read_engines='tikv'; select count(*) from test.t partition (p1M);
 +----------+
 | count(*) |
 +----------+
 |        8 |
 +----------+
 
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partition (p1M);
+mysql> set session tidb_isolation_read_engines='tiflash'; select count(*) from test.t partition (p1M);
 +----------+
 | count(*) |
 +----------+
@@ -68,7 +90,7 @@ mysql> show warnings;
 
 mysql> alter table test.t remove partitioning;
 
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t;
+mysql> set session tidb_isolation_read_engines='tiflash'; select count(*) from test.t;
 +----------+
 | count(*) |
 +----------+
@@ -77,7 +99,7 @@ mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t;
 
 mysql> show warnings;
 
-mysql> select /*+ READ_FROM_STORAGE(TIKV[t]) */ count(*) from test.t;
+mysql> set session tidb_isolation_read_engines='tikv'; select count(*) from test.t;
 +----------+
 | count(*) |
 +----------+

--- a/tests/fullstack-test2/ddl/reorganize_partition.test
+++ b/tests/fullstack-test2/ddl/reorganize_partition.test
@@ -34,7 +34,7 @@ func> wait_table test t
 │ test          │ t         │
 └───────────────┴───────────┘
 
-mysql> select /*+ READ_FROM_STORAGE(TIKV[t]) */ count(*) from test.t partition (p0);
+mysql> set session tidb_isolation_read_engines='tikv'; select count(*) from test.t partition (p0);
 +----------+
 | count(*) |
 +----------+
@@ -42,7 +42,7 @@ mysql> select /*+ READ_FROM_STORAGE(TIKV[t]) */ count(*) from test.t partition (
 +----------+
 
 mysql> show warnings;
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partition (p0);
+mysql> set session tidb_isolation_read_engines='tiflash'; select count(*) from test.t partition (p0);
 +----------+
 | count(*) |
 +----------+
@@ -50,14 +50,14 @@ mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partitio
 +----------+
 
 mysql> show warnings;
-mysql> select /*+ READ_FROM_STORAGE(TIKV[t]) */ count(*) from test.t partition (p1M);
+mysql> set session tidb_isolation_read_engines='tikv'; select count(*) from test.t partition (p1M);
 +----------+
 | count(*) |
 +----------+
 |        8 |
 +----------+
 
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partition (p1M);
+mysql> set session tidb_isolation_read_engines='tiflash'; select count(*) from test.t partition (p1M);
 +----------+
 | count(*) |
 +----------+
@@ -68,7 +68,7 @@ mysql> show warnings;
 
 mysql> alter table test.t reorganize partition p0 INTO (partition p0 values less than (500000), partition p500k values less than (1000000));
 
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partition (p0);
+mysql> set session tidb_isolation_read_engines='tiflash'; select count(*) from test.t partition (p0);
 +----------+
 | count(*) |
 +----------+
@@ -77,7 +77,7 @@ mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partitio
 
 mysql> show warnings;
 
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partition (p500k);
+mysql> set session tidb_isolation_read_engines='tiflash'; select count(*) from test.t partition (p500k);
 +----------+
 | count(*) |
 +----------+
@@ -86,14 +86,14 @@ mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partitio
 
 mysql> show warnings;
 
-mysql> select /*+ READ_FROM_STORAGE(TIKV[t]) */ count(*) from test.t partition (p0);
+mysql> set session tidb_isolation_read_engines='tikv'; select count(*) from test.t partition (p0);
 +----------+
 | count(*) |
 +----------+
 |        4 |
 +----------+
 
-mysql> select /*+ READ_FROM_STORAGE(TIKV[t]) */ count(*) from test.t partition (p500k);
+mysql> set session tidb_isolation_read_engines='tikv'; select count(*) from test.t partition (p500k);
 +----------+
 | count(*) |
 +----------+
@@ -102,14 +102,14 @@ mysql> select /*+ READ_FROM_STORAGE(TIKV[t]) */ count(*) from test.t partition (
 
 mysql> show warnings;
 
-mysql> select /*+ READ_FROM_STORAGE(TIKV[t]) */ count(*) from test.t partition (p1M);
+mysql> set session tidb_isolation_read_engines='tikv'; select count(*) from test.t partition (p1M);
 +----------+
 | count(*) |
 +----------+
 |        8 |
 +----------+
 
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partition (p1M);
+mysql> set session tidb_isolation_read_engines='tiflash'; select count(*) from test.t partition (p1M);
 +----------+
 | count(*) |
 +----------+
@@ -147,14 +147,14 @@ mysql> alter table test.t1 reorganize partition p1 INTO (partition p1 values les
 # make write cmd take effect
 >> DBGInvoke __disable_fail_point(pause_before_apply_raft_cmd)
 
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[test.t1]) */ * from test.t1 partition (p1);
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t1 partition (p1);
 +----+------+----+
 | id | name |  c |
 +----+------+----+
 | 60 | cba  |NULL|
 +----+------+----+
 
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[test.t1]) */ * from test.t1 partition (p2);
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t1 partition (p2);
 +----+------+----+
 | id | name |  c |
 +----+------+----+


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/8206

Problem Summary: 

Introduced by https://github.com/pingcap/tiflash/pull/7822

When executing `alter table xxx partition by ...` to turn a non-partition table into partition table, there could be a chance that tiflash see a non-partition table turn into a partition table (using the same table_id). But it would be skipped by the previous implementation
https://github.com/pingcap/tiflash/blob/b092db0b8f0bede1867b3cebfececad619adfdb7/dbms/src/TiDB/Schema/SchemaBuilder.cpp#L407-L423

And then tiflash mistaken drop the old table along with all its partitions, but actually those partition are now attached to a new logical table. This leads to data lost after `alter table xxx partition ...

### What is changed and how it works?

* Use tidb_isolation_read_engines instead of hint in test cases
* Allow turning a non-partition table into partition table
* When applying SchemaDiff for alter partition, we first create the new table and override the partition id mapping before dropping the old table

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
