### PR TITLE
*: Fix time step backward for `Stopwatch::elapsedFromLastTime`

### DIFF
--- a/dbms/src/Common/Stopwatch.h
+++ b/dbms/src/Common/Stopwatch.h
@@ -30,7 +30,7 @@ inline UInt64 clock_gettime_ns(clockid_t clock_type = CLOCK_MONOTONIC)
     {
     };
     clock_gettime(clock_type, &ts);
-    return UInt64(ts.tv_sec * 1000000000ULL + ts.tv_nsec);
+    return static_cast<UInt64>(ts.tv_sec * 1000000000ULL + ts.tv_nsec);
 }
 
 /// Sometimes monotonic clock may not be monotonic (due to bug in kernel?).
@@ -64,14 +64,14 @@ public:
 
     void start()
     {
-        start_ns = nanoseconds();
+        start_ns = nanosecondsWithBound(start_ns);
         last_ns = start_ns;
         is_running = true;
     }
 
     void stop()
     {
-        stop_ns = nanoseconds();
+        stop_ns = nanosecondsWithBound(start_ns);
         is_running = false;
     }
 
@@ -82,14 +82,16 @@ public:
         last_ns = 0;
         is_running = false;
     }
+
     void restart() { start(); }
-    UInt64 elapsed() const { return is_running ? nanoseconds() - start_ns : stop_ns - start_ns; }
+
+    UInt64 elapsed() const { return is_running ? nanosecondsWithBound(start_ns) - start_ns : stop_ns - start_ns; }
     UInt64 elapsedMilliseconds() const { return elapsed() / 1000000UL; }
     double elapsedSeconds() const { return static_cast<double>(elapsed()) / 1000000000ULL; }
 
     UInt64 elapsedFromLastTime()
     {
-        const auto now_ns = nanoseconds();
+        const auto now_ns = nanosecondsWithBound(last_ns);
         if (is_running)
         {
             auto rc = now_ns - last_ns;
@@ -100,7 +102,7 @@ public:
         {
             return stop_ns - last_ns;
         }
-    };
+    }
 
     UInt64 elapsedMillisecondsFromLastTime() { return elapsedFromLastTime() / 1000000UL; }
     double elapsedSecondsFromLastTime() { return static_cast<double>(elapsedFromLastTime()) / 1000000000ULL; }
@@ -109,10 +111,12 @@ private:
     UInt64 start_ns = 0;
     UInt64 stop_ns = 0;
     UInt64 last_ns = 0;
-    clockid_t clock_type;
+    const clockid_t clock_type;
     bool is_running = false;
 
-    UInt64 nanoseconds() const { return clock_gettime_ns_adjusted(start_ns, clock_type); }
+    // Get current nano seconds, ensuring the return value is not
+    // less than `lower_bound`.
+    UInt64 nanosecondsWithBound(UInt64 lower_bound) const { return clock_gettime_ns_adjusted(lower_bound, clock_type); }
 };
 
 

--- a/dbms/src/Common/Stopwatch.h
+++ b/dbms/src/Common/Stopwatch.h
@@ -111,7 +111,7 @@ private:
     UInt64 start_ns = 0;
     UInt64 stop_ns = 0;
     UInt64 last_ns = 0;
-    const clockid_t clock_type;
+    clockid_t clock_type;
     bool is_running = false;
 
     // Get current nano seconds, ensuring the return value is not


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/8336

Problem Summary:

### What is changed and how it works?

Use `nanosecondsWithBound` to ensure the return value is not less than `last_ns` in `elapsedFromLastTime`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
