### PR TITLE
Try to fix unstable unittests.

### DIFF
--- a/dbms/src/TestUtils/FunctionTestUtils.cpp
+++ b/dbms/src/TestUtils/FunctionTestUtils.cpp
@@ -342,7 +342,7 @@ ColumnWithTypeAndName executeFunction(
     for (size_t i = 0; i < columns.size(); ++i)
         argument_column_numbers.push_back(i);
 
-    /// Replace `std::random_device` with `std::chrono::system_clock` here to avoid 
+    /// Replace `std::random_device` with `std::chrono::system_clock` here to avoid
     /// exceptions like 'random_device failed to open /dev/urandom: Operation not permitted'.
     /// The reason of exceptions is unknown, but the probability of its occurrence in unittests
     /// TestDateTimeDayMonthYear.dayMonthYearTest is not low.

--- a/dbms/src/TestUtils/FunctionTestUtils.cpp
+++ b/dbms/src/TestUtils/FunctionTestUtils.cpp
@@ -342,10 +342,13 @@ ColumnWithTypeAndName executeFunction(
     for (size_t i = 0; i < columns.size(); ++i)
         argument_column_numbers.push_back(i);
 
+    /// Replace `std::random_device` with `std::chrono::system_clock` here to avoid 
+    /// exceptions like 'random_device failed to open /dev/urandom: Operation not permitted'.
+    /// The reason of exceptions is unknown, but the probability of its occurrence in unittests
+    /// TestDateTimeDayMonthYear.dayMonthYearTest is not low.
+    /// Since this function is just used for testing, using current timestamp as a random seed is not a problem.
+    std::mt19937 g(std::chrono::system_clock::to_time_t(std::chrono::system_clock::now()));
     /// shuffle input columns to assure function correctly use physical offsets instead of logical offsets
-    std::random_device rd;
-    std::mt19937 g(rd());
-
     std::shuffle(argument_column_numbers.begin(), argument_column_numbers.end(), g);
     const auto columns_reordered = toColumnsReordered(columns, argument_column_numbers);
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6233

Problem Summary: 

Unittests TestDateTimeDayMonthYear.dayMonthYearTest is unstable, due to "std::exception. Code: 1001, type: std::__1::system_error, e.what() = random_device failed to open /dev/urandom: Operation not permitted".

![image](https://github.com/pingcap/tiflash/assets/6143402/4991474e-228e-47d2-9852-f235e62f1ad4)
### What is changed and how it works?

- Replace `std::random_device` with `std::chrono::system_clock` here to avoid exceptions like 'random_device failed to open /dev/urandom: Operation not permitted'.
- The reason of exceptions is unknown, but the probability of its occurrence in unittests TestDateTimeDayMonthYear.dayMonthYearTest is not low.
- Since this function is just used for testing, using current timestamp as a random seed is not a problem.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
