### PR TITLE
ddl: Fix potential data lost of `alter_partition_by` (release-7.5)

### DIFF
--- a/dbms/src/TiDB/Schema/SchemaBuilder.cpp
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.cpp
@@ -252,9 +252,14 @@ void SchemaBuilder<Getter, NameMapper>::applyDiff(const SchemaDiff & diff)
         }
         else
         {
-            /// The new non-partitioned table will have a new id
+            // Create the new table.
+            // If the new table is a partition table, this will also overwrite
+            // the partition id mapping to the new logical table and renew the
+            // partition info.
+            applyPartitionAlter(diff.schema_id, diff.table_id);
+            // Drop the old table. if the previous partitions of the old table are
+            // not mapping to the old logical table now, they will not be removed.
             applyDropTable(diff.schema_id, diff.old_table_id);
-            applyCreateTable(diff.schema_id, diff.table_id);
         }
         break;
     }
@@ -374,6 +379,51 @@ void SchemaBuilder<Getter, NameMapper>::applySetTiFlashReplica(DatabaseID databa
 }
 
 template <typename Getter, typename NameMapper>
+void SchemaBuilder<Getter, NameMapper>::applyPartitionAlter(DatabaseID database_id, TableID table_id)
+{
+    auto table_info = getter.getTableInfo(database_id, table_id);
+    if (table_info == nullptr) // the database maybe dropped
+    {
+        LOG_DEBUG(log, "table is not exist in TiKV, may have been dropped, table_id={}", table_id);
+        return;
+    }
+
+    table_id_map.emplaceTableID(table_id, database_id);
+    LOG_DEBUG(log, "register table to table_id_map, database_id={} table_id={}", database_id, table_id);
+
+    if (!table_info->isLogicalPartitionTable())
+    {
+        return;
+    }
+
+    // If table is partition table, we will create the logical table here.
+    // Because we get the table_info, so we can ensure new_db_info will not be nullptr.
+    auto new_db_info = getter.getDatabase(database_id);
+    applyCreatePhysicalTable(new_db_info, table_info);
+
+    for (const auto & part_def : table_info->partition.definitions)
+    {
+        LOG_DEBUG(
+            log,
+            "register table to table_id_map for partition table, logical_table_id={} physical_table_id={}",
+            table_id,
+            part_def.id);
+        table_id_map.emplacePartitionTableID(part_def.id, table_id);
+    }
+
+    auto & tmt_context = context.getTMTContext();
+    auto storage = tmt_context.getStorages().get(keyspace_id, table_info->id);
+    if (storage == nullptr)
+    {
+        LOG_ERROR(log, "table is not exist in TiFlash, table_id={}", table_id);
+        return;
+    }
+
+    // Try to renew the partition info for the new table
+    applyPartitionDiff(new_db_info, table_info, storage);
+}
+
+template <typename Getter, typename NameMapper>
 void SchemaBuilder<Getter, NameMapper>::applyPartitionDiff(DatabaseID database_id, TableID table_id)
 {
     auto [db_info, table_info] = getter.getDatabaseAndTableInfo(database_id, table_id);
@@ -410,34 +460,30 @@ void SchemaBuilder<Getter, NameMapper>::applyPartitionDiff(
     const TableInfoPtr & table_info,
     const ManageableStoragePtr & storage)
 {
-    const auto & orig_table_info = storage->getTableInfo();
-    if (!orig_table_info.isLogicalPartitionTable())
+    const auto & local_table_info = storage->getTableInfo();
+    // ALTER TABLE t PARTITION BY ... may turn a non-partition table into partition table
+    // with some partition ids in `partition.adding_definitions`/`partition.definitions`
+    // and `partition.dropping_definitions`. We need to create those partitions.
+    if (!local_table_info.isLogicalPartitionTable())
     {
-        LOG_ERROR(
+        LOG_INFO(
             log,
-            "old table in TiFlash not partition table {} with database_id={}, table_id={}",
-            name_mapper.debugCanonicalName(*db_info, orig_table_info),
+            "Altering non-partition table to be a partition table {} with database_id={}, table_id={}",
+            name_mapper.debugCanonicalName(*db_info, local_table_info),
             db_info->id,
-            orig_table_info.id);
-        return;
+            local_table_info.id);
     }
 
-    const auto & orig_defs = orig_table_info.partition.definitions;
+    const auto & local_defs = local_table_info.partition.definitions;
     const auto & new_defs = table_info->partition.definitions;
 
-    std::unordered_set<TableID> orig_part_id_set, new_part_id_set;
-    std::vector<String> orig_part_ids, new_part_ids;
-    std::for_each(orig_defs.begin(), orig_defs.end(), [&orig_part_id_set, &orig_part_ids](const auto & def) {
-        orig_part_id_set.emplace(def.id);
-        orig_part_ids.emplace_back(std::to_string(def.id));
+    std::unordered_set<TableID> local_part_id_set, new_part_id_set;
+    std::for_each(local_defs.begin(), local_defs.end(), [&local_part_id_set](const auto & def) {
+        local_part_id_set.emplace(def.id);
     });
-    std::for_each(new_defs.begin(), new_defs.end(), [&new_part_id_set, &new_part_ids](const auto & def) {
+    std::for_each(new_defs.begin(), new_defs.end(), [&new_part_id_set](const auto & def) {
         new_part_id_set.emplace(def.id);
-        new_part_ids.emplace_back(std::to_string(def.id));
     });
-
-    auto orig_part_ids_str = boost::algorithm::join(orig_part_ids, ", ");
-    auto new_part_ids_str = boost::algorithm::join(new_part_ids, ", ");
 
     LOG_INFO(
         log,
@@ -445,35 +491,39 @@ void SchemaBuilder<Getter, NameMapper>::applyPartitionDiff(
         name_mapper.debugCanonicalName(*db_info, *table_info),
         db_info->id,
         table_info->id,
-        orig_part_ids_str,
-        new_part_ids_str);
+        local_part_id_set,
+        new_part_id_set);
 
-    if (orig_part_id_set == new_part_id_set)
+    if (local_part_id_set == new_part_id_set)
     {
         LOG_INFO(
             log,
-            "No partition changes {} with database_id={}, table_id={}",
+            "No partition changes, paritions_size={} {} with database_id={}, table_id={}",
             name_mapper.debugCanonicalName(*db_info, *table_info),
+            new_part_id_set.size(),
             db_info->id,
             table_info->id);
         return;
     }
 
-    auto updated_table_info = orig_table_info;
+    // Copy the local table info and update fileds on the copy
+    auto updated_table_info = local_table_info;
+    updated_table_info.is_partition_table = true;
+    updated_table_info.belonging_table_id = table_info->belonging_table_id;
     updated_table_info.partition = table_info->partition;
 
     /// Apply changes to physical tables.
-    for (const auto & orig_def : orig_defs)
+    for (const auto & local_def : local_defs)
     {
-        if (new_part_id_set.count(orig_def.id) == 0)
+        if (!new_part_id_set.contains(local_def.id))
         {
-            applyDropPhysicalTable(name_mapper.mapDatabaseName(*db_info), orig_def.id);
+            applyDropPhysicalTable(name_mapper.mapDatabaseName(*db_info), local_def.id);
         }
     }
 
     for (const auto & new_def : new_defs)
     {
-        if (orig_part_id_set.count(new_def.id) == 0)
+        if (!local_part_id_set.contains(new_def.id))
         {
             table_id_map.emplacePartitionTableID(new_def.id, updated_table_info.id);
         }
@@ -790,7 +840,7 @@ void SchemaBuilder<Getter, NameMapper>::applyDropSchema(const String & db_name)
     auto db = context.tryGetDatabase(db_name);
     if (db == nullptr)
     {
-        LOG_INFO(log, "Database {} does not exists", db_name);
+        LOG_INFO(log, "Database does not exist, db_name={}", db_name);
         return;
     }
 
@@ -992,7 +1042,7 @@ void SchemaBuilder<Getter, NameMapper>::applyDropPhysicalTable(const String & db
     auto storage = tmt_context.getStorages().get(keyspace_id, table_id);
     if (storage == nullptr)
     {
-        LOG_DEBUG(log, "table {} does not exist.", table_id);
+        LOG_DEBUG(log, "table does not exist, table_id={}", table_id);
         return;
     }
     GET_METRIC(tiflash_schema_internal_ddl_count, type_drop_table).Increment();
@@ -1033,7 +1083,7 @@ void SchemaBuilder<Getter, NameMapper>::applyDropTable(DatabaseID database_id, T
     auto * storage = tmt_context.getStorages().get(keyspace_id, table_id).get();
     if (storage == nullptr)
     {
-        LOG_DEBUG(log, "table {} does not exist.", table_id);
+        LOG_DEBUG(log, "table does not exist, table_id={}", table_id);
         return;
     }
     const auto & table_info = storage->getTableInfo();
@@ -1041,6 +1091,21 @@ void SchemaBuilder<Getter, NameMapper>::applyDropTable(DatabaseID database_id, T
     {
         for (const auto & part_def : table_info.partition.definitions)
         {
+            if (TableID latest_logical_table_id = table_id_map.findTableIDInPartitionMap(part_def.id);
+                latest_logical_table_id == -1 || latest_logical_table_id != table_info.id)
+            {
+                // The partition is managed by another logical table now (caused by `alter table X partition by ...`),
+                // skip dropping this partition when dropping the old logical table
+                LOG_INFO(
+                    log,
+                    "The partition is not managed by current logical table, skip, partition_table_id={} "
+                    "new_logical_table_id={} current_logical_table_id={}",
+                    part_def.id,
+                    latest_logical_table_id,
+                    table_info.id);
+                continue;
+            }
+
             applyDropPhysicalTable(name_mapper.mapDatabaseName(database_id, keyspace_id), part_def.id);
         }
     }

--- a/dbms/src/TiDB/Schema/SchemaBuilder.h
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.h
@@ -195,7 +195,7 @@ private:
 
     void applyCreateSchema(const TiDB::DBInfoPtr & db_info);
 
-    void applyCreatePhysicalTable(const TiDB::DBInfoPtr & db_info, const TiDB::TableInfoPtr & table_info);
+    void applyCreateStorageInstance(const TiDB::DBInfoPtr & db_info, const TiDB::TableInfoPtr & table_info);
 
     void applyDropTable(DatabaseID database_id, TableID table_id);
 

--- a/dbms/src/TiDB/Schema/SchemaBuilder.h
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.h
@@ -206,8 +206,6 @@ private:
     /// Parameter schema_name should be mapped.
     void applyDropPhysicalTable(const String & db_name, TableID table_id);
 
-    void applyPartitionAlter(DatabaseID database_id, TableID table_id);
-
     void applyPartitionDiff(DatabaseID database_id, TableID table_id);
     void applyPartitionDiff(
         const TiDB::DBInfoPtr & db_info,

--- a/dbms/src/TiDB/Schema/SchemaBuilder.h
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.h
@@ -206,8 +206,9 @@ private:
     /// Parameter schema_name should be mapped.
     void applyDropPhysicalTable(const String & db_name, TableID table_id);
 
-    void applyPartitionDiff(DatabaseID database_id, TableID table_id);
+    void applyPartitionAlter(DatabaseID database_id, TableID table_id);
 
+    void applyPartitionDiff(DatabaseID database_id, TableID table_id);
     void applyPartitionDiff(
         const TiDB::DBInfoPtr & db_info,
         const TiDB::TableInfoPtr & table_info,

--- a/dbms/src/TiDB/Schema/TiDB.cpp
+++ b/dbms/src/TiDB/Schema/TiDB.cpp
@@ -540,6 +540,10 @@ try
         part_id_set.emplace(definition.id);
     }
 
+    /// Treat `adding_definitions` and `dropping_definitions` as the normal `definitions`
+    /// in TiFlash. Because TiFlash need to create the physical IStorage instance
+    /// to handle the data on those partitions during DDL.
+
     auto add_defs_json = json->getArray("adding_definitions");
     if (!add_defs_json.isNull())
     {
@@ -851,8 +855,6 @@ TableInfo::TableInfo(const String & table_info_json, KeyspaceID keyspace_id_)
 String TableInfo::serialize() const
 try
 {
-    std::stringstream buf;
-
     Poco::JSON::Object::Ptr json = new Poco::JSON::Object();
     json->set("id", id);
     json->set("keyspace_id", keyspace_id);
@@ -867,8 +869,8 @@ try
         auto col_obj = col_info.getJSONObject();
         cols_arr->add(col_obj);
     }
-
     json->set("cols", cols_arr);
+
     Poco::JSON::Array::Ptr index_arr = new Poco::JSON::Array();
     for (const auto & index_info : index_infos)
     {
@@ -904,8 +906,8 @@ try
 
     json->set("tiflash_replica", replica_info.getJSONObject());
 
+    std::stringstream buf;
     json->stringify(buf);
-
     return buf.str();
 }
 catch (const Poco::Exception & e)

--- a/tests/fullstack-test2/ddl/alter_partition_by.test
+++ b/tests/fullstack-test2/ddl/alter_partition_by.test
@@ -28,7 +28,7 @@ mysql> insert into test.t select a+1000000,a+1000000,-(a+1000000) from test.t;
 
 func> wait_table test t
 
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ * from test.t order by a;
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t order by a;
 +---------+---------+----------+
 | a       | b       | c        |
 +---------+---------+----------+
@@ -56,7 +56,7 @@ mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ * from test.t order by a;
 │ test          │ t         │
 └───────────────┴───────────┘
 
-mysql> select /*+ READ_FROM_STORAGE(TIKV[t]) */ count(*) from test.t partition (p0);
+mysql> set session tidb_isolation_read_engines='tikv'; select count(*) from test.t partition (p0);
 +----------+
 | count(*) |
 +----------+
@@ -64,7 +64,7 @@ mysql> select /*+ READ_FROM_STORAGE(TIKV[t]) */ count(*) from test.t partition (
 +----------+
 
 mysql> show warnings;
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partition (p0);
+mysql> set session tidb_isolation_read_engines='tiflash'; select count(*) from test.t partition (p0);
 +----------+
 | count(*) |
 +----------+
@@ -72,14 +72,14 @@ mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partitio
 +----------+
 
 mysql> show warnings;
-mysql> select /*+ READ_FROM_STORAGE(TIKV[t]) */ count(*) from test.t partition (p1M);
+mysql> set session tidb_isolation_read_engines='tikv'; select count(*) from test.t partition (p1M);
 +----------+
 | count(*) |
 +----------+
 |        8 |
 +----------+
 
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partition (p1M);
+mysql> set session tidb_isolation_read_engines='tiflash'; select count(*) from test.t partition (p1M);
 +----------+
 | count(*) |
 +----------+
@@ -90,7 +90,7 @@ mysql> show warnings;
 
 mysql> alter table test.t partition by range (a) (partition p0 values less than (500000), partition p500k values less than (1000000), partition p1M values less than (2000000));
 
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partition (p0);
+mysql> set session tidb_isolation_read_engines='tiflash'; select count(*) from test.t partition (p0);
 +----------+
 | count(*) |
 +----------+
@@ -99,7 +99,7 @@ mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partitio
 
 mysql> show warnings;
 
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partition (p500k);
+mysql> set session tidb_isolation_read_engines='tiflash'; select count(*) from test.t partition (p500k);
 +----------+
 | count(*) |
 +----------+
@@ -108,14 +108,14 @@ mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partitio
 
 mysql> show warnings;
 
-mysql> select /*+ READ_FROM_STORAGE(TIKV[t]) */ count(*) from test.t partition (p0);
+mysql> set session tidb_isolation_read_engines='tikv'; select count(*) from test.t partition (p0);
 +----------+
 | count(*) |
 +----------+
 |        4 |
 +----------+
 
-mysql> select /*+ READ_FROM_STORAGE(TIKV[t]) */ count(*) from test.t partition (p500k);
+mysql> set session tidb_isolation_read_engines='tikv'; select count(*) from test.t partition (p500k);
 +----------+
 | count(*) |
 +----------+
@@ -124,14 +124,14 @@ mysql> select /*+ READ_FROM_STORAGE(TIKV[t]) */ count(*) from test.t partition (
 
 mysql> show warnings;
 
-mysql> select /*+ READ_FROM_STORAGE(TIKV[t]) */ count(*) from test.t partition (p1M);
+mysql> set session tidb_isolation_read_engines='tikv'; select count(*) from test.t partition (p1M);
 +----------+
 | count(*) |
 +----------+
 |        8 |
 +----------+
 
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partition (p1M);
+mysql> set session tidb_isolation_read_engines='tiflash'; select count(*) from test.t partition (p1M);
 +----------+
 | count(*) |
 +----------+
@@ -143,8 +143,9 @@ mysql> create table test.t2 (a int primary key, b varchar(255), c int, key (b), 
 mysql> alter table test.t2 set tiflash replica 1;
 mysql> insert into test.t2 select * from test.t;
 func> wait_table test t2
+mysql> drop table test.t;
 
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t2]) */ * from test.t2 order by a;
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t2 order by a;
 +---------+---------+----------+
 | a       | b       | c        |
 +---------+---------+----------+
@@ -166,8 +167,7 @@ mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t2]) */ * from test.t2 order by a;
 | 1500004 | 1500004 | -1500004 |
 +---------+---------+----------+
 
-mysql> drop table test.t;
-
+# check the t2 is created in TiFlash
 >> select tidb_database,tidb_name from system.tables where tidb_database = 'test' and tidb_name = 't2' and is_tombstone = 0
 ┌─tidb_database─┬─tidb_name─┐
 │ test          │ t2        │
@@ -176,7 +176,7 @@ mysql> drop table test.t;
 mysql> alter table test.t2 partition by hash (a) partitions 3;
 mysql> analyze table test.t2;
 
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t2]) */ count(*) from test.t2 partition (p0);
+mysql> set session tidb_isolation_read_engines='tiflash'; select count(*) from test.t2 partition (p0);
 +----------+
 | count(*) |
 +----------+
@@ -185,7 +185,7 @@ mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t2]) */ count(*) from test.t2 partit
 
 mysql> show warnings;
 
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t2]) */ count(*) from test.t2 partition (p1);
+mysql> set session tidb_isolation_read_engines='tiflash'; select count(*) from test.t2 partition (p1);
 +----------+
 | count(*) |
 +----------+
@@ -194,14 +194,14 @@ mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t2]) */ count(*) from test.t2 partit
 
 mysql> show warnings;
 
-mysql> select /*+ READ_FROM_STORAGE(TIKV[t2]) */ count(*) from test.t2 partition (p0);
+mysql> set session tidb_isolation_read_engines='tikv'; select count(*) from test.t2 partition (p0);
 +----------+
 | count(*) |
 +----------+
 |        5 |
 +----------+
 
-mysql> select /*+ READ_FROM_STORAGE(TIKV[t2]) */ count(*) from test.t2 partition (p1);
+mysql> set session tidb_isolation_read_engines='tikv'; select count(*) from test.t2 partition (p1);
 +----------+
 | count(*) |
 +----------+
@@ -211,14 +211,14 @@ mysql> select /*+ READ_FROM_STORAGE(TIKV[t2]) */ count(*) from test.t2 partition
 mysql> show warnings;
 
 
-mysql> select /*+ READ_FROM_STORAGE(TIKV[t2]) */ count(*) from test.t2 partition (p2);
+mysql> set session tidb_isolation_read_engines='tikv'; select count(*) from test.t2 partition (p2);
 +----------+
 | count(*) |
 +----------+
 |        5 |
 +----------+
 
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t2]) */ count(*) from test.t2 partition (p2);
+mysql> set session tidb_isolation_read_engines='tiflash'; select count(*) from test.t2 partition (p2);
 +----------+
 | count(*) |
 +----------+

--- a/tests/fullstack-test2/ddl/remove_partitioning.test
+++ b/tests/fullstack-test2/ddl/remove_partitioning.test
@@ -28,13 +28,35 @@ mysql> insert into test.t select a+1000000,a+1000000,-(a+1000000) from test.t;
 
 func> wait_table test t
 
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t;
++---------+---------+----------+
+| a       | b       | c        |
++---------+---------+----------+
+|       1 | 1       |       -1 |
+|       2 | 2       |       -2 |
+|       3 | 3       |       -3 |
+|       4 | 4       |       -4 |
+|  500001 | 500001  |  -500001 |
+|  500002 | 500002  |  -500002 |
+|  500003 | 500003  |  -500003 |
+|  500004 | 500004  |  -500004 |
+| 1000001 | 1000001 | -1000001 |
+| 1000002 | 1000002 | -1000002 |
+| 1000003 | 1000003 | -1000003 |
+| 1000004 | 1000004 | -1000004 |
+| 1500001 | 1500001 | -1500001 |
+| 1500002 | 1500002 | -1500002 |
+| 1500003 | 1500003 | -1500003 |
+| 1500004 | 1500004 | -1500004 |
++---------+---------+----------+
+
 # check table info in tiflash
 >> select tidb_database,tidb_name from system.tables where tidb_database = 'test' and tidb_name = 't' and is_tombstone = 0
 ┌─tidb_database─┬─tidb_name─┐
 │ test          │ t         │
 └───────────────┴───────────┘
 
-mysql> select /*+ READ_FROM_STORAGE(TIKV[t]) */ count(*) from test.t partition (p0);
+mysql> set session tidb_isolation_read_engines='tikv'; select count(*) from test.t partition (p0);
 +----------+
 | count(*) |
 +----------+
@@ -42,7 +64,7 @@ mysql> select /*+ READ_FROM_STORAGE(TIKV[t]) */ count(*) from test.t partition (
 +----------+
 
 mysql> show warnings;
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partition (p0);
+mysql> set session tidb_isolation_read_engines='tiflash'; select count(*) from test.t partition (p0);
 +----------+
 | count(*) |
 +----------+
@@ -50,14 +72,14 @@ mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partitio
 +----------+
 
 mysql> show warnings;
-mysql> select /*+ READ_FROM_STORAGE(TIKV[t]) */ count(*) from test.t partition (p1M);
+mysql> set session tidb_isolation_read_engines='tikv'; select count(*) from test.t partition (p1M);
 +----------+
 | count(*) |
 +----------+
 |        8 |
 +----------+
 
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partition (p1M);
+mysql> set session tidb_isolation_read_engines='tiflash'; select count(*) from test.t partition (p1M);
 +----------+
 | count(*) |
 +----------+
@@ -68,7 +90,7 @@ mysql> show warnings;
 
 mysql> alter table test.t remove partitioning;
 
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t;
+mysql> set session tidb_isolation_read_engines='tiflash'; select count(*) from test.t;
 +----------+
 | count(*) |
 +----------+
@@ -77,7 +99,7 @@ mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t;
 
 mysql> show warnings;
 
-mysql> select /*+ READ_FROM_STORAGE(TIKV[t]) */ count(*) from test.t;
+mysql> set session tidb_isolation_read_engines='tikv'; select count(*) from test.t;
 +----------+
 | count(*) |
 +----------+

--- a/tests/fullstack-test2/ddl/reorganize_partition.test
+++ b/tests/fullstack-test2/ddl/reorganize_partition.test
@@ -34,7 +34,7 @@ func> wait_table test t
 │ test          │ t         │
 └───────────────┴───────────┘
 
-mysql> select /*+ READ_FROM_STORAGE(TIKV[t]) */ count(*) from test.t partition (p0);
+mysql> set session tidb_isolation_read_engines='tikv'; select count(*) from test.t partition (p0);
 +----------+
 | count(*) |
 +----------+
@@ -42,7 +42,7 @@ mysql> select /*+ READ_FROM_STORAGE(TIKV[t]) */ count(*) from test.t partition (
 +----------+
 
 mysql> show warnings;
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partition (p0);
+mysql> set session tidb_isolation_read_engines='tiflash'; select count(*) from test.t partition (p0);
 +----------+
 | count(*) |
 +----------+
@@ -50,14 +50,14 @@ mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partitio
 +----------+
 
 mysql> show warnings;
-mysql> select /*+ READ_FROM_STORAGE(TIKV[t]) */ count(*) from test.t partition (p1M);
+mysql> set session tidb_isolation_read_engines='tikv'; select count(*) from test.t partition (p1M);
 +----------+
 | count(*) |
 +----------+
 |        8 |
 +----------+
 
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partition (p1M);
+mysql> set session tidb_isolation_read_engines='tiflash'; select count(*) from test.t partition (p1M);
 +----------+
 | count(*) |
 +----------+
@@ -68,7 +68,7 @@ mysql> show warnings;
 
 mysql> alter table test.t reorganize partition p0 INTO (partition p0 values less than (500000), partition p500k values less than (1000000));
 
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partition (p0);
+mysql> set session tidb_isolation_read_engines='tiflash'; select count(*) from test.t partition (p0);
 +----------+
 | count(*) |
 +----------+
@@ -77,7 +77,7 @@ mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partitio
 
 mysql> show warnings;
 
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partition (p500k);
+mysql> set session tidb_isolation_read_engines='tiflash'; select count(*) from test.t partition (p500k);
 +----------+
 | count(*) |
 +----------+
@@ -86,14 +86,14 @@ mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partitio
 
 mysql> show warnings;
 
-mysql> select /*+ READ_FROM_STORAGE(TIKV[t]) */ count(*) from test.t partition (p0);
+mysql> set session tidb_isolation_read_engines='tikv'; select count(*) from test.t partition (p0);
 +----------+
 | count(*) |
 +----------+
 |        4 |
 +----------+
 
-mysql> select /*+ READ_FROM_STORAGE(TIKV[t]) */ count(*) from test.t partition (p500k);
+mysql> set session tidb_isolation_read_engines='tikv'; select count(*) from test.t partition (p500k);
 +----------+
 | count(*) |
 +----------+
@@ -102,14 +102,14 @@ mysql> select /*+ READ_FROM_STORAGE(TIKV[t]) */ count(*) from test.t partition (
 
 mysql> show warnings;
 
-mysql> select /*+ READ_FROM_STORAGE(TIKV[t]) */ count(*) from test.t partition (p1M);
+mysql> set session tidb_isolation_read_engines='tikv'; select count(*) from test.t partition (p1M);
 +----------+
 | count(*) |
 +----------+
 |        8 |
 +----------+
 
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[t]) */ count(*) from test.t partition (p1M);
+mysql> set session tidb_isolation_read_engines='tiflash'; select count(*) from test.t partition (p1M);
 +----------+
 | count(*) |
 +----------+
@@ -147,14 +147,14 @@ mysql> alter table test.t1 reorganize partition p1 INTO (partition p1 values les
 # make write cmd take effect
 >> DBGInvoke __disable_fail_point(pause_before_apply_raft_cmd)
 
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[test.t1]) */ * from test.t1 partition (p1);
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t1 partition (p1);
 +----+------+----+
 | id | name |  c |
 +----+------+----+
 | 60 | cba  |NULL|
 +----+------+----+
 
-mysql> select /*+ READ_FROM_STORAGE(TIFLASH[test.t1]) */ * from test.t1 partition (p2);
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t1 partition (p2);
 +----+------+----+
 | id | name |  c |
 +----+------+----+


### PR DESCRIPTION
cherry-pick of https://github.com/pingcap/tiflash/pull/8337

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/8206

Problem Summary: 

Introduced by https://github.com/pingcap/tiflash/pull/7822

When executing `alter table xxx partition by ...` to turn a non-partition table into partition table, there could be a chance that tiflash see a non-partition table turn into a partition table (using the same table_id). But it would be skipped by the previous implementation
https://github.com/pingcap/tiflash/blob/b092db0b8f0bede1867b3cebfececad619adfdb7/dbms/src/TiDB/Schema/SchemaBuilder.cpp#L407-L423

And then tiflash mistaken drop the old table along with all its partitions, but actually those partition are now attached to a new logical table. This leads to data lost after `alter table xxx partition ...

### What is changed and how it works?

* Use tidb_isolation_read_engines instead of hint in test cases
* Allow turning a non-partition table into partition table
* When applying SchemaDiff for alter partition, we first create the new table and override the partition id mapping before dropping the old table

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
