### PR TITLE
add read bytes ru in disagg mode for resource control

### DIFF
--- a/dbms/src/Storages/StorageDisaggregatedRemote.cpp
+++ b/dbms/src/Storages/StorageDisaggregatedRemote.cpp
@@ -126,8 +126,9 @@ DM::SegmentReadTasks StorageDisaggregated::buildReadTaskWithBackoff(const Contex
 {
     using namespace pingcap;
 
-    auto scan_context = std::make_shared<DM::ScanContext>();
-    context.getDAGContext()->scan_context_map[table_scan.getTableScanExecutorID()] = scan_context;
+    auto * dag_context = context.getDAGContext();
+    auto scan_context = std::make_shared<DM::ScanContext>(dag_context->getResourceGroupName());
+    dag_context->scan_context_map[table_scan.getTableScanExecutorID()] = scan_context;
 
     DM::SegmentReadTasks read_task;
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8358

Problem Summary:
storage read bytes ru has added for coupled tiflash, should also add it for disagg mode.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)

check the following image, after add read bytes ru for disagg mode , we can see ru usage is very different.
![hyLuHcbDMO](https://github.com/tidbcloud/tiflash-cse/assets/7493273/6ed1800c-62fd-4ade-84f6-66089b6bb813)

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
