### PR TITLE
ddl: Fix zero safepoint make schema gc run repeatly

### DIFF
--- a/dbms/src/TiDB/Schema/SchemaSyncService.cpp
+++ b/dbms/src/TiDB/Schema/SchemaSyncService.cpp
@@ -208,7 +208,7 @@ bool SchemaSyncService::gc(Timestamp gc_safepoint, KeyspaceID keyspace_id)
     if (gc_safepoint == 0)
         return false;
     // the gc safepoint is not changed since last schema gc run, skip it
-    if (last_gc_safepoint != std::nullopt && gc_safepoint == *last_gc_safepoint)
+    if (last_gc_safepoint.has_value() && gc_safepoint == *last_gc_safepoint)
         return false;
 
     auto keyspace_log = log->getChild(fmt::format("keyspace={}", keyspace_id));

--- a/dbms/src/TiDB/Schema/SchemaSyncService.h
+++ b/dbms/src/TiDB/Schema/SchemaSyncService.h
@@ -61,10 +61,9 @@ private:
 
     friend void dbgFuncGcSchemas(Context &, const ASTs &, DBGInvokerPrinter);
 
-    static constexpr Timestamp INVALID_GC_SAFEPOINT = -1;
     struct KeyspaceGCContext
     {
-        Timestamp last_gc_safepoint = INVALID_GC_SAFEPOINT;
+        Timestamp last_gc_safepoint = 0;
     };
 
     BackgroundProcessingPool & background_pool;

--- a/dbms/src/TiDB/Schema/SchemaSyncService.h
+++ b/dbms/src/TiDB/Schema/SchemaSyncService.h
@@ -59,9 +59,10 @@ private:
 
     friend void dbgFuncGcSchemas(Context &, const ASTs &, DBGInvokerPrinter);
 
+    static constexpr Timestamp INVALID_GC_SAFEPOINT = -1;
     struct KeyspaceGCContext
     {
-        Timestamp last_gc_safepoint = 0;
+        Timestamp last_gc_safepoint = INVALID_GC_SAFEPOINT;
     };
 
     BackgroundProcessingPool & background_pool;

--- a/dbms/src/TiDB/Schema/SchemaSyncService.h
+++ b/dbms/src/TiDB/Schema/SchemaSyncService.h
@@ -45,13 +45,15 @@ public:
 
     bool gc(Timestamp gc_safepoint, KeyspaceID keyspace_id);
 
+    void shutdown();
+
 private:
     bool syncSchemas(KeyspaceID keyspace_id);
 
     void addKeyspaceGCTasks();
     void removeKeyspaceGCTasks();
 
-    Timestamp lastGcSafePoint(KeyspaceID keyspace_id) const;
+    std::optional<Timestamp> lastGcSafePoint(KeyspaceID keyspace_id) const;
     void updateLastGcSafepoint(KeyspaceID keyspace_id, Timestamp gc_safepoint);
 
 private:


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/8356

Problem Summary:

After a new tidb cluster deployed, there is an interval that PD will return gc safepoint with 0
```
>  tiup ctl:nightly pd -u [10.2.12.81:6540](http://10.2.12.81:6540/) -i
Starting component `ctl`: /DATA/disk1/ra_common/.tiup/components/ctl/v7.6.0-alpha-nightly-20231112/ctl pd -u [10.2.12.81:6540](http://10.2.12.81:6540/) -i
» service-gc-safepoint
{
  "service_gc_safe_points": [
    {
      "service_id": "gc_worker",
      "expired_at": 9223372036854775807,
      "safe_point": 445603590956646400
    }
  ],
  "gc_safe_point": 0 <-- tiflash use this value
}
```

This will lead to `SchemaSyncService::gc` running repeatedly. This results in lots of useless logging and getting gc safepoint from pd frequently.

### What is changed and how it works?

* If tiflash receives a gc safepoint == 0 from PD, it skips the schema gc task
* Refine some logging for adding/removing schema task for keyspace

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
