### PR TITLE
Set log level to FATAL on FFI boundary on exception

### DIFF
--- a/dbms/src/Common/Exception.cpp
+++ b/dbms/src/Common/Exception.cpp
@@ -67,28 +67,43 @@ void tryLogCurrentException(const char * log_name, const std::string & start_of_
     tryLogCurrentException(&Poco::Logger::get(log_name), start_of_message);
 }
 
-#define TRY_LOG_CURRENT_EXCEPTION(logger, start_of_message) \
-    try                                                     \
-    {                                                       \
-        LOG_ERROR(                                          \
-            (logger),                                       \
-            "{}{}{}",                                       \
-            (start_of_message),                             \
-            ((start_of_message).empty() ? "" : ": "),       \
-            getCurrentExceptionMessage(true));              \
-    }                                                       \
-    catch (...)                                             \
-    {                                                       \
-    }
+void tryLogCurrentFatalException(const char * log_name, const std::string & start_of_message)
+{
+    tryLogCurrentFatalException(&Poco::Logger::get(log_name), start_of_message);
+}
+
+#define TRY_LOG_CURRENT_EXCEPTION(logger, prio, start_of_message) \
+    try                                                           \
+    {                                                             \
+        LOG_IMPL(                                                 \
+            (logger),                                             \
+            prio,                                                 \
+            "{}{}{}",                                             \
+            (start_of_message),                                   \
+            ((start_of_message).empty() ? "" : ": "),             \
+            getCurrentExceptionMessage(true));                    \
+    }                                                             \
+    catch (...)                                                   \
+    {}
 
 void tryLogCurrentException(const LoggerPtr & logger, const std::string & start_of_message)
 {
-    TRY_LOG_CURRENT_EXCEPTION(logger, start_of_message);
+    TRY_LOG_CURRENT_EXCEPTION(logger, Poco::Message::PRIO_ERROR, start_of_message);
 }
 
 void tryLogCurrentException(Poco::Logger * logger, const std::string & start_of_message)
 {
-    TRY_LOG_CURRENT_EXCEPTION(logger, start_of_message);
+    TRY_LOG_CURRENT_EXCEPTION(logger, Poco::Message::PRIO_ERROR, start_of_message);
+}
+
+void tryLogCurrentFatalException(const LoggerPtr & logger, const std::string & start_of_message)
+{
+    TRY_LOG_CURRENT_EXCEPTION(logger, Poco::Message::PRIO_FATAL, start_of_message);
+}
+
+void tryLogCurrentFatalException(Poco::Logger * logger, const std::string & start_of_message)
+{
+    TRY_LOG_CURRENT_EXCEPTION(logger, Poco::Message::PRIO_FATAL, start_of_message);
 }
 
 #undef TRY_LOG_CURRENT_EXCEPTION
@@ -117,8 +132,7 @@ std::string getCurrentExceptionMessage(bool with_stacktrace, bool check_embedded
                 e.what());
         }
         catch (...)
-        {
-        }
+        {}
     }
     catch (const std::exception & e)
     {
@@ -137,8 +151,7 @@ std::string getCurrentExceptionMessage(bool with_stacktrace, bool check_embedded
                 e.what());
         }
         catch (...)
-        {
-        }
+        {}
     }
     catch (...)
     {
@@ -153,8 +166,7 @@ std::string getCurrentExceptionMessage(bool with_stacktrace, bool check_embedded
             buffer.fmtAppend("Unknown exception. Code: {}, type: {}", ErrorCodes::UNKNOWN_EXCEPTION, name);
         }
         catch (...)
-        {
-        }
+        {}
     }
 
     return buffer.toString();
@@ -217,8 +229,7 @@ std::string getExceptionMessage(const Exception & e, bool with_stacktrace, bool 
             buffer.append(", Stack trace:\n\n").append(e.getStackTrace().toString());
     }
     catch (...)
-    {
-    }
+    {}
 
     return buffer.toString();
 }

--- a/dbms/src/Common/Exception.h
+++ b/dbms/src/Common/Exception.h
@@ -121,6 +121,10 @@ void tryLogCurrentException(const char * log_name, const std::string & start_of_
 void tryLogCurrentException(const LoggerPtr & logger, const std::string & start_of_message = "");
 void tryLogCurrentException(Poco::Logger * logger, const std::string & start_of_message = "");
 
+void tryLogCurrentFatalException(const char * log_name, const std::string & start_of_message = "");
+void tryLogCurrentFatalException(const LoggerPtr & logger, const std::string & start_of_message = "");
+void tryLogCurrentFatalException(Poco::Logger * logger, const std::string & start_of_message = "");
+
 /** Prints current exception in canonical format.
  * with_stacktrace - prints stack trace for DB::Exception.
  * check_embedded_stacktrace - if DB::Exception has embedded stacktrace then

--- a/dbms/src/Storages/KVStore/FFI/ProxyFFI.cpp
+++ b/dbms/src/Storages/KVStore/FFI/ProxyFFI.cpp
@@ -99,7 +99,7 @@ EngineStoreApplyRes HandleWriteRaftCmd(const EngineStoreServerWrap * server, Wri
     }
     catch (...)
     {
-        tryLogCurrentException(__PRETTY_FUNCTION__);
+        tryLogCurrentFatalException(__PRETTY_FUNCTION__);
         exit(-1);
     }
 }
@@ -127,7 +127,7 @@ EngineStoreApplyRes HandleAdminRaftCmd(
     }
     catch (...)
     {
-        tryLogCurrentException(__PRETTY_FUNCTION__);
+        tryLogCurrentFatalException(__PRETTY_FUNCTION__);
         exit(-1);
     }
 }
@@ -141,7 +141,7 @@ uint8_t NeedFlushData(EngineStoreServerWrap * server, uint64_t region_id)
     }
     catch (...)
     {
-        tryLogCurrentException(__PRETTY_FUNCTION__);
+        tryLogCurrentFatalException(__PRETTY_FUNCTION__);
         exit(-1);
     }
 }
@@ -170,7 +170,7 @@ uint8_t TryFlushData(
     }
     catch (...)
     {
-        tryLogCurrentException(__PRETTY_FUNCTION__);
+        tryLogCurrentFatalException(__PRETTY_FUNCTION__);
         exit(-1);
     }
 }
@@ -186,7 +186,7 @@ RawCppPtr CreateWriteBatch(const EngineStoreServerWrap * dummy)
     }
     catch (...)
     {
-        tryLogCurrentException(__PRETTY_FUNCTION__);
+        tryLogCurrentFatalException(__PRETTY_FUNCTION__);
         exit(-1);
     }
 }
@@ -205,7 +205,7 @@ void WriteBatchPutPage(RawVoidPtr ptr, BaseBuffView page_id, BaseBuffView value)
     }
     catch (...)
     {
-        tryLogCurrentException(__PRETTY_FUNCTION__);
+        tryLogCurrentFatalException(__PRETTY_FUNCTION__);
         exit(-1);
     }
 }
@@ -220,7 +220,7 @@ void WriteBatchDelPage(RawVoidPtr ptr, BaseBuffView page_id)
     }
     catch (...)
     {
-        tryLogCurrentException(__PRETTY_FUNCTION__);
+        tryLogCurrentFatalException(__PRETTY_FUNCTION__);
         exit(-1);
     }
 }
@@ -234,7 +234,7 @@ uint64_t GetWriteBatchSize(RawVoidPtr ptr)
     }
     catch (...)
     {
-        tryLogCurrentException(__PRETTY_FUNCTION__);
+        tryLogCurrentFatalException(__PRETTY_FUNCTION__);
         exit(-1);
     }
 }
@@ -248,7 +248,7 @@ uint8_t IsWriteBatchEmpty(RawVoidPtr ptr)
     }
     catch (...)
     {
-        tryLogCurrentException(__PRETTY_FUNCTION__);
+        tryLogCurrentFatalException(__PRETTY_FUNCTION__);
         exit(-1);
     }
 }
@@ -263,7 +263,7 @@ void HandleMergeWriteBatch(RawVoidPtr lhs, RawVoidPtr rhs)
     }
     catch (...)
     {
-        tryLogCurrentException(__PRETTY_FUNCTION__);
+        tryLogCurrentFatalException(__PRETTY_FUNCTION__);
         exit(-1);
     }
 }
@@ -277,7 +277,7 @@ void HandleClearWriteBatch(RawVoidPtr ptr)
     }
     catch (...)
     {
-        tryLogCurrentException(__PRETTY_FUNCTION__);
+        tryLogCurrentFatalException(__PRETTY_FUNCTION__);
         exit(-1);
     }
 }
@@ -294,7 +294,7 @@ void HandleConsumeWriteBatch(const EngineStoreServerWrap * server, RawVoidPtr pt
     }
     catch (...)
     {
-        tryLogCurrentException(__PRETTY_FUNCTION__);
+        tryLogCurrentFatalException(__PRETTY_FUNCTION__);
         exit(-1);
     }
 }
@@ -328,7 +328,7 @@ CppStrWithView HandleReadPage(const EngineStoreServerWrap * server, BaseBuffView
     }
     catch (...)
     {
-        tryLogCurrentException(__PRETTY_FUNCTION__);
+        tryLogCurrentFatalException(__PRETTY_FUNCTION__);
         exit(-1);
     }
 }
@@ -374,7 +374,7 @@ RawCppPtrCarr HandleScanPage(const EngineStoreServerWrap * server, BaseBuffView 
     }
     catch (...)
     {
-        tryLogCurrentException(__PRETTY_FUNCTION__);
+        tryLogCurrentFatalException(__PRETTY_FUNCTION__);
         exit(-1);
     }
 }
@@ -409,7 +409,7 @@ CppStrWithView HandleGetLowerBound(const EngineStoreServerWrap * server, BaseBuf
     }
     catch (...)
     {
-        tryLogCurrentException(__PRETTY_FUNCTION__);
+        tryLogCurrentFatalException(__PRETTY_FUNCTION__);
         exit(-1);
     }
 }
@@ -423,7 +423,7 @@ uint8_t IsPSEmpty(const EngineStoreServerWrap * server)
     }
     catch (...)
     {
-        tryLogCurrentException(__PRETTY_FUNCTION__);
+        tryLogCurrentFatalException(__PRETTY_FUNCTION__);
         exit(-1);
     }
 }
@@ -437,7 +437,7 @@ void HandlePurgePageStorage(const EngineStoreServerWrap * server)
     }
     catch (...)
     {
-        tryLogCurrentException(__PRETTY_FUNCTION__);
+        tryLogCurrentFatalException(__PRETTY_FUNCTION__);
         exit(-1);
     }
 }
@@ -467,7 +467,7 @@ void HandleDestroy(EngineStoreServerWrap * server, uint64_t region_id)
     }
     catch (...)
     {
-        tryLogCurrentException(__PRETTY_FUNCTION__);
+        tryLogCurrentFatalException(__PRETTY_FUNCTION__);
         exit(-1);
     }
 }
@@ -481,7 +481,7 @@ EngineStoreApplyRes HandleIngestSST(EngineStoreServerWrap * server, SSTViewVec s
     }
     catch (...)
     {
-        tryLogCurrentException(__PRETTY_FUNCTION__);
+        tryLogCurrentFatalException(__PRETTY_FUNCTION__);
         exit(-1);
     }
 }
@@ -498,7 +498,7 @@ StoreStats HandleComputeStoreStats(EngineStoreServerWrap * server)
     }
     catch (...)
     {
-        tryLogCurrentException(__PRETTY_FUNCTION__);
+        tryLogCurrentFatalException(__PRETTY_FUNCTION__);
     }
     return res;
 }
@@ -675,7 +675,7 @@ RawCppPtr PreHandleSnapshot(
     }
     catch (...)
     {
-        tryLogCurrentException(__PRETTY_FUNCTION__);
+        tryLogCurrentFatalException(__PRETTY_FUNCTION__);
         exit(-1);
     }
 }
@@ -701,29 +701,37 @@ void ApplyPreHandledSnapshot(EngineStoreServerWrap * server, RawVoidPtr res, Raw
         }
         catch (...)
         {
-            tryLogCurrentException(__PRETTY_FUNCTION__);
+            tryLogCurrentFatalException(__PRETTY_FUNCTION__);
             exit(-1);
         }
         break;
     }
     default:
-        LOG_ERROR(&Poco::Logger::get(__FUNCTION__), "unknown type {}", type);
+        LOG_FATAL(&Poco::Logger::get(__FUNCTION__), "unknown type {}", type);
         exit(-1);
     }
 }
 
 void AbortPreHandledSnapshot(EngineStoreServerWrap * server, uint64_t region_id, uint64_t peer_id)
 {
-    UNUSED(peer_id);
-    auto & kvstore = server->tmt->getKVStore();
-    kvstore->abortPreHandleSnapshot(region_id, *server->tmt);
+    try
+    {
+        UNUSED(peer_id);
+        auto & kvstore = server->tmt->getKVStore();
+        kvstore->abortPreHandleSnapshot(region_id, *server->tmt);
+    }
+    catch (...)
+    {
+        tryLogCurrentFatalException(__PRETTY_FUNCTION__);
+        exit(-1);
+    }
 }
 
 void ReleasePreHandledSnapshot(EngineStoreServerWrap * server, RawVoidPtr res, RawCppPtrType type)
 {
     if (static_cast<RawCppPtrTypeImpl>(type) != RawCppPtrTypeImpl::PreHandledSnapshotWithFiles)
     {
-        LOG_ERROR(&Poco::Logger::get(__FUNCTION__), "unknown type {}", type);
+        LOG_FATAL(&Poco::Logger::get(__FUNCTION__), "unknown type {}", type);
         exit(-1);
     }
 
@@ -736,7 +744,7 @@ void ReleasePreHandledSnapshot(EngineStoreServerWrap * server, RawVoidPtr res, R
     }
     catch (...)
     {
-        tryLogCurrentException(__PRETTY_FUNCTION__);
+        tryLogCurrentFatalException(__PRETTY_FUNCTION__);
         exit(-1);
     }
 }
@@ -763,7 +771,7 @@ void GcRawCppPtr(RawVoidPtr ptr, RawCppPtrType type)
             delete reinterpret_cast<Page *>(ptr);
             break;
         default:
-            LOG_ERROR(&Poco::Logger::get(__FUNCTION__), "unknown type {}", type);
+            LOG_FATAL(&Poco::Logger::get(__FUNCTION__), "unknown type {}", type);
             exit(-1);
         }
     }
@@ -787,7 +795,7 @@ void GcRawCppPtrCArr(RawVoidPtr ptr, RawCppPtrType type, uint64_t len)
             break;
         }
         default:
-            LOG_ERROR(&Poco::Logger::get(__FUNCTION__), "unknown type arr {}", type);
+            LOG_FATAL(&Poco::Logger::get(__FUNCTION__), "unknown type arr {}", type);
             exit(-1);
         }
     }
@@ -818,7 +826,7 @@ void GcSpecialRawCppPtr(void * ptr, uint64_t hint_size, SpecialCppPtrType type)
             break;
         }
         default:
-            LOG_ERROR(
+            LOG_FATAL(
                 &Poco::Logger::get(__FUNCTION__),
                 "unknown type {}",
                 static_cast<std::underlying_type_t<SpecialCppPtrType>>(type));
@@ -952,7 +960,7 @@ void HandleSafeTSUpdate(
     }
     catch (...)
     {
-        tryLogCurrentException(__PRETTY_FUNCTION__);
+        tryLogCurrentFatalException(__PRETTY_FUNCTION__);
         exit(-1);
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #8365

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
