### PR TITLE
Check RU in read thread of Storage.

### DIFF
--- a/dbms/src/Common/TiFlashMetrics.h
+++ b/dbms/src/Common/TiFlashMetrics.h
@@ -536,6 +536,7 @@ namespace DB
       F(type_sche_no_slot, {"type", "sche_no_slot"}),                                                                               \
       F(type_sche_no_ru, {"type", "sche_no_ru"}),                                                                                   \
       F(type_sche_no_segment, {"type", "sche_no_segment"}),                                                                         \
+      F(type_sche_active_segment_limit, {"type", "sche_active_segment_limit"}),                                                     \
       F(type_sche_from_cache, {"type", "sche_from_cache"}),                                                                         \
       F(type_sche_new_task, {"type", "sche_new_task"}),                                                                             \
       F(type_ru_exhausted, {"type", "ru_exhausted"}),                                                                               \

--- a/dbms/src/Common/TiFlashMetrics.h
+++ b/dbms/src/Common/TiFlashMetrics.h
@@ -534,6 +534,7 @@ namespace DB
       Counter,                                                                                                                      \
       F(type_sche_no_pool, {"type", "sche_no_pool"}),                                                                               \
       F(type_sche_no_slot, {"type", "sche_no_slot"}),                                                                               \
+      F(type_sche_no_ru, {"type", "sche_no_ru"}),                                                                                   \
       F(type_sche_no_segment, {"type", "sche_no_segment"}),                                                                         \
       F(type_sche_from_cache, {"type", "sche_from_cache"}),                                                                         \
       F(type_sche_new_task, {"type", "sche_new_task"}),                                                                             \

--- a/dbms/src/Common/TiFlashMetrics.h
+++ b/dbms/src/Common/TiFlashMetrics.h
@@ -538,6 +538,7 @@ namespace DB
       F(type_sche_no_segment, {"type", "sche_no_segment"}),                                                                         \
       F(type_sche_from_cache, {"type", "sche_from_cache"}),                                                                         \
       F(type_sche_new_task, {"type", "sche_new_task"}),                                                                             \
+      F(type_ru_exhausted, {"type", "ru_exhausted"}),                                                                               \
       F(type_add_cache_succ, {"type", "add_cache_succ"}),                                                                           \
       F(type_add_cache_stale, {"type", "add_cache_stale"}),                                                                         \
       F(type_get_cache_miss, {"type", "get_cache_miss"}),                                                                           \

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -1568,10 +1568,8 @@ int Server::main(const std::vector<std::string> & /*args*/)
     if (init_pipeline_and_lac)
     {
 #ifdef DBMS_PUBLIC_GTEST
-        LOG_INFO(log, "Create MockLocalAdmissionController");
         LocalAdmissionController::global_instance = std::make_unique<MockLocalAdmissionController>();
 #else
-        LOG_INFO(log, "Create LocalAdmissionController");
         LocalAdmissionController::global_instance
             = std::make_unique<LocalAdmissionController>(tmt_context.getKVCluster(), tmt_context.getEtcdClient());
 #endif

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -1568,8 +1568,10 @@ int Server::main(const std::vector<std::string> & /*args*/)
     if (init_pipeline_and_lac)
     {
 #ifdef DBMS_PUBLIC_GTEST
+        LOG_INFO(log, "Create MockLocalAdmissionController");
         LocalAdmissionController::global_instance = std::make_unique<MockLocalAdmissionController>();
 #else
+        LOG_INFO(log, "Create LocalAdmissionController");
         LocalAdmissionController::global_instance
             = std::make_unique<LocalAdmissionController>(tmt_context.getKVCluster(), tmt_context.getEtcdClient());
 #endif

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSetReader.cpp
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSetReader.cpp
@@ -191,7 +191,8 @@ size_t ColumnFileSetReader::readRows(
     for (const auto & col : output_columns)
         delta_bytes += col->byteSize();
 
-    lac_bytes_collector.collect(delta_bytes);
+    if (row_ids == nullptr)
+        lac_bytes_collector.collect(delta_bytes);
     if (likely(context.scan_context))
         context.scan_context->total_user_read_bytes += delta_bytes;
 

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSetReader.cpp
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSetReader.cpp
@@ -131,6 +131,14 @@ Block ColumnFileSetReader::readPKVersion(size_t offset, size_t limit)
     return block;
 }
 
+static Int64 columnsSize(MutableColumns & columns)
+{
+    Int64 bytes = 0;
+    for (const auto & col : columns)
+        bytes += col->byteSize();
+    return bytes;
+}
+
 size_t ColumnFileSetReader::readRows(
     MutableColumns & output_columns,
     size_t offset,
@@ -156,6 +164,7 @@ size_t ColumnFileSetReader::readRows(
     if (end == start)
         return 0;
 
+    auto bytes_before_read = columnsSize(output_columns);
     auto [start_file_index, rows_start_in_start_file] = locatePosByAccumulation(column_file_rows_end, start);
     auto [end_file_index, rows_end_in_end_file] = locatePosByAccumulation(column_file_rows_end, end);
 
@@ -187,14 +196,13 @@ size_t ColumnFileSetReader::readRows(
         }
     }
 
-    UInt64 delta_bytes = 0;
-    for (const auto & col : output_columns)
-        delta_bytes += col->byteSize();
-
-    if (row_ids == nullptr)
-        lac_bytes_collector.collect(delta_bytes);
-    if (likely(context.scan_context))
-        context.scan_context->total_user_read_bytes += delta_bytes;
+    if (auto delta_bytes = columnsSize(output_columns) - bytes_before_read; delta_bytes > 0)
+    {
+        if (row_ids == nullptr)
+            lac_bytes_collector.collect(delta_bytes);
+        if (likely(context.scan_context))
+            context.scan_context->total_user_read_bytes += delta_bytes;
+    }
 
     return actual_read;
 }

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -958,7 +958,8 @@ BlockInputStreams DeltaMergeStore::readRaw(
         after_segment_read,
         req_info,
         enable_read_thread,
-        final_num_stream);
+        final_num_stream,
+        dm_context->scan_context->resource_group_name);
 
     BlockInputStreams res;
     for (size_t i = 0; i < final_num_stream; ++i)
@@ -1061,7 +1062,8 @@ void DeltaMergeStore::readRaw(
         after_segment_read,
         req_info,
         enable_read_thread,
-        final_num_stream);
+        final_num_stream,
+        dm_context->scan_context->resource_group_name);
 
     if (enable_read_thread)
     {
@@ -1193,7 +1195,8 @@ BlockInputStreams DeltaMergeStore::read(
         after_segment_read,
         log_tracing_id,
         enable_read_thread,
-        final_num_stream);
+        final_num_stream,
+        dm_context->scan_context->resource_group_name);
 
     BlockInputStreams res;
     for (size_t i = 0; i < final_num_stream; ++i)
@@ -1297,7 +1300,8 @@ void DeltaMergeStore::read(
         after_segment_read,
         log_tracing_id,
         enable_read_thread,
-        final_num_stream);
+        final_num_stream,
+        dm_context->scan_context->resource_group_name);
     const auto & columns_after_cast = filter && filter->extra_cast ? *filter->columns_after_cast : columns_to_read;
 
     if (enable_read_thread)

--- a/dbms/src/Storages/DeltaMerge/ReadThread/MergedTask.cpp
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/MergedTask.cpp
@@ -47,6 +47,10 @@ void MergedTask::initOnce()
             setStreamFinished(cur_idx);
             continue;
         }
+        if (pool->isRUExhausted())
+        {
+            continue;
+        }
         stream = pool->buildInputStream(task);
         fiu_do_on(FailPoints::exception_in_merged_task_init, {
             throw Exception("Fail point exception_in_merged_task_init is triggered.", ErrorCodes::FAIL_POINT_ERROR);
@@ -77,6 +81,11 @@ int MergedTask::readOneBlock()
         if (pool->getFreeBlockSlots() <= 0 || pool->isRUExhausted())
         {
             continue;
+        }
+
+        if (stream == nullptr)
+        {
+            stream = pool->buildInputStream(task);
         }
 
         if (pool->readOneBlock(stream, task))

--- a/dbms/src/Storages/DeltaMerge/ReadThread/MergedTask.cpp
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/MergedTask.cpp
@@ -74,7 +74,7 @@ int MergedTask::readOneBlock()
             continue;
         }
 
-        if (pool->getFreeBlockSlots() <= 0)
+        if (pool->getFreeBlockSlots() <= 0 || pool->isRUExhausted())
         {
             continue;
         }

--- a/dbms/src/Storages/DeltaMerge/ReadThread/MergedTask.cpp
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/MergedTask.cpp
@@ -47,6 +47,10 @@ void MergedTask::initOnce()
             setStreamFinished(cur_idx);
             continue;
         }
+        //if (pool->isRUExhausted())
+        //{
+            //continue;
+        //}
         stream = pool->buildInputStream(task);
         fiu_do_on(FailPoints::exception_in_merged_task_init, {
             throw Exception("Fail point exception_in_merged_task_init is triggered.", ErrorCodes::FAIL_POINT_ERROR);
@@ -77,6 +81,11 @@ int MergedTask::readOneBlock()
         if (pool->getFreeBlockSlots() <= 0 || pool->isRUExhausted())
         {
             continue;
+        }
+
+        if (stream == nullptr)
+        {
+            stream = pool->buildInputStream(task);
         }
 
         if (pool->readOneBlock(stream, task))

--- a/dbms/src/Storages/DeltaMerge/ReadThread/MergedTask.cpp
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/MergedTask.cpp
@@ -47,10 +47,6 @@ void MergedTask::initOnce()
             setStreamFinished(cur_idx);
             continue;
         }
-        //if (pool->isRUExhausted())
-        //{
-            //continue;
-        //}
         stream = pool->buildInputStream(task);
         fiu_do_on(FailPoints::exception_in_merged_task_init, {
             throw Exception("Fail point exception_in_merged_task_init is triggered.", ErrorCodes::FAIL_POINT_ERROR);
@@ -81,11 +77,6 @@ int MergedTask::readOneBlock()
         if (pool->getFreeBlockSlots() <= 0 || pool->isRUExhausted())
         {
             continue;
-        }
-
-        if (stream == nullptr)
-        {
-            stream = pool->buildInputStream(task);
         }
 
         if (pool->readOneBlock(stream, task))

--- a/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.cpp
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.cpp
@@ -122,6 +122,7 @@ SegmentReadTaskPools SegmentReadTaskScheduler::getPoolsUnlock(const std::vector<
 bool SegmentReadTaskScheduler::needScheduleToRead(const SegmentReadTaskPoolPtr & pool)
 {
     return pool->getFreeBlockSlots() > 0 && // Block queue is not full and
+        !pool->isRUExhausted() && // RU is not exhausted and
         (merged_task_pool.has(pool->pool_id) || // can schedule a segment from MergedTaskPool or
          pool->getFreeActiveSegments() > 0); // schedule a new segment.
 }

--- a/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.cpp
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.cpp
@@ -132,7 +132,7 @@ bool SegmentReadTaskScheduler::needScheduleToRead(const SegmentReadTaskPoolPtr &
         GET_METRIC(tiflash_storage_read_thread_counter, type_sche_no_ru).Increment();
         return false;
     }
-    
+
     // No segment to be scheduled.
     if (!merged_task_pool.has(pool->pool_id) && pool->getFreeActiveSegments() <= 0)
     {

--- a/dbms/src/Storages/DeltaMerge/Segment.h
+++ b/dbms/src/Storages/DeltaMerge/Segment.h
@@ -69,6 +69,13 @@ struct SegmentSnapshot : private boost::noncopyable
     UInt64 getRows() const { return delta->getRows() + stable->getRows(); }
 
     bool isForUpdate() const { return delta->isForUpdate(); }
+
+    UInt64 estimatedBytesOfInternalColumns() const
+    {
+        // TODO: how about cluster index?
+        // handle + version + flag
+        return (sizeof(Int64) + sizeof(UInt64) + sizeof(UInt8)) * getRows();
+    }
 };
 
 /// A segment contains many rows of a table. A table is split into segments by consecutive ranges.

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.cpp
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.cpp
@@ -120,7 +120,8 @@ SegmentReadTaskPool::SegmentReadTaskPool(
     AfterSegmentRead after_segment_read_,
     const String & tracing_id,
     bool enable_read_thread_,
-    Int64 num_streams_)
+    Int64 num_streams_,
+    const String & res_group_name_)
     : pool_id(nextPoolId())
     , mem_tracker(current_memory_tracker == nullptr ? nullptr : current_memory_tracker->shared_from_this())
     , extra_table_id_index(extra_table_id_index_)
@@ -141,6 +142,7 @@ SegmentReadTaskPool::SegmentReadTaskPool(
     // Limiting the minimum number of reading segments to 2 is to avoid, as much as possible,
     // situations where the computation may be faster and the storage layer may not be able to keep up.
     , active_segment_limit(std::max(num_streams_, 2))
+    , res_group_name(res_group_name_)
 {
     if (tasks_wrapper.empty())
     {
@@ -272,6 +274,7 @@ void SegmentReadTaskPool::pushBlock(Block && block)
 {
     blk_stat.push(block);
     global_blk_stat.push(block);
+    read_bytes_after_last_check += block.bytes();
     q.push(std::move(block), nullptr);
 }
 
@@ -318,6 +321,55 @@ void SegmentReadTaskPool::setException(const DB::Exception & e)
         exception_happened.store(true, std::memory_order_relaxed);
         q.finish();
     }
+}
+
+static Int64 currentMS()
+{
+    return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())
+        .count();
+}
+
+static bool checkIsRUExhausted(const String & res_group_name)
+{
+    auto priority = LocalAdmissionController::global_instance->getPriority(res_group_name);
+    if (unlikely(!priority.has_value()))
+    {
+        return false;
+    }
+    return LocalAdmissionController::isRUExhausted(*priority);
+}
+
+bool SegmentReadTaskPool::isRUExhausted()
+{
+    if (unlikely(res_group_name.empty() || LocalAdmissionController::global_instance == nullptr))
+    {
+        return false;
+    }
+
+    // To reduce lock contention in resource control,
+    // check if RU is exhuasted every `bytes_of_one_hundred_ru` or every `100ms`.
+
+    // Fast path.
+    Int64 ms = currentMS();
+    if (read_bytes_after_last_check < bytes_of_one_hundred_ru || ms - last_time_check_ru < check_ru_interval_ms)
+    {
+        return ru_is_exhausted; // Return result of last time.
+    }
+
+    std::lock_guard lock(ru_mu);
+    // If last thread has check is ru exhausted, use the result of last thread.
+    // Attention: `read_bytes_after_last_check` can be written concurrently in `pushBlock`.
+    ms = currentMS();
+    if (read_bytes_after_last_check < bytes_of_one_hundred_ru || ms - last_time_check_ru < check_ru_interval_ms)
+    {
+        return ru_is_exhausted; // Return result of last time.
+    }
+
+    // Check and reset everything.
+    read_bytes_after_last_check = 0;
+    ru_is_exhausted = checkIsRUExhausted(res_group_name);
+    last_time_check_ru = currentMS();
+    return ru_is_exhausted;
 }
 
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.cpp
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.cpp
@@ -351,7 +351,7 @@ bool SegmentReadTaskPool::isRUExhausted()
 
     // Fast path.
     Int64 ms = currentMS();
-    if (read_bytes_after_last_check < bytes_of_one_hundred_ru || ms - last_time_check_ru < check_ru_interval_ms)
+    if (read_bytes_after_last_check < bytes_of_one_hundred_ru && ms - last_time_check_ru < check_ru_interval_ms)
     {
         return ru_is_exhausted; // Return result of last time.
     }
@@ -360,7 +360,7 @@ bool SegmentReadTaskPool::isRUExhausted()
     // If last thread has check is ru exhausted, use the result of last thread.
     // Attention: `read_bytes_after_last_check` can be written concurrently in `pushBlock`.
     ms = currentMS();
-    if (read_bytes_after_last_check < bytes_of_one_hundred_ru || ms - last_time_check_ru < check_ru_interval_ms)
+    if (read_bytes_after_last_check < bytes_of_one_hundred_ru && ms - last_time_check_ru < check_ru_interval_ms)
     {
         return ru_is_exhausted; // Return result of last time.
     }

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.cpp
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.cpp
@@ -308,6 +308,12 @@ Int64 SegmentReadTaskPool::getFreeActiveSegmentsUnlock() const
     return active_segment_limit - static_cast<Int64>(active_segment_ids.size());
 }
 
+Int64 SegmentReadTaskPool::getPendingSegmentCount() const
+{
+    std::lock_guard lock(mutex);
+    return tasks_wrapper.getTasks().size();
+}
+
 bool SegmentReadTaskPool::exceptionHappened() const
 {
     return exception_happened.load(std::memory_order_relaxed);

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.cpp
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.cpp
@@ -378,7 +378,7 @@ bool SegmentReadTaskPool::isRUExhaustedImpl()
     // Check and reset everything.
     read_bytes_after_last_check = 0;
     ru_is_exhausted = checkIsRUExhausted(res_group_name);
-    last_time_check_ru = currentMS();
+    last_time_check_ru = ms;
     return ru_is_exhausted;
 }
 

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.cpp
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.cpp
@@ -89,6 +89,11 @@ BlockInputStreamPtr SegmentReadTaskPool::buildInputStream(SegmentReadTaskPtr & t
 
     MemoryTrackerSetter setter(true, mem_tracker.get());
 
+    if (likely(read_mode == ReadMode::Bitmap && !res_group_name.empty()))
+    {
+        auto bytes = t->read_snapshot->estimatedBytesOfInternalColumns();
+        LocalAdmissionController::global_instance->consumeResource(res_group_name, bytesToRU(bytes), 0);
+    }
     t->initInputStream(
         columns_to_read,
         max_version,

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.cpp
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.cpp
@@ -341,6 +341,16 @@ static bool checkIsRUExhausted(const String & res_group_name)
 
 bool SegmentReadTaskPool::isRUExhausted()
 {
+    auto res = isRUExhaustedImpl();
+    if (res)
+    {
+        GET_METRIC(tiflash_storage_read_thread_counter, type_ru_exhausted).Increment();
+    }
+    return res;
+}
+
+bool SegmentReadTaskPool::isRUExhaustedImpl()
+{
     if (unlikely(res_group_name.empty() || LocalAdmissionController::global_instance == nullptr))
     {
         return false;

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.h
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.h
@@ -215,6 +215,8 @@ private:
     void finishSegment(const SegmentReadTaskPtr & seg);
     void pushBlock(Block && block);
 
+    bool isRUExhaustedImpl();
+
     const int extra_table_id_index;
     ColumnDefines columns_to_read;
     PushDownFilterPtr filter;

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.h
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.h
@@ -179,6 +179,7 @@ public:
     Int64 decreaseUnorderedInputStreamRefCount();
     Int64 getFreeBlockSlots() const;
     Int64 getFreeActiveSegments() const;
+    Int64 getPendingSegmentCount() const;
     bool valid() const;
     void setException(const DB::Exception & e);
 

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.h
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.h
@@ -132,7 +132,8 @@ public:
         AfterSegmentRead after_segment_read_,
         const String & tracing_id,
         bool enable_read_thread_,
-        Int64 num_streams_);
+        Int64 num_streams_,
+        const String & res_group_name_);
 
     ~SegmentReadTaskPool()
     {
@@ -206,6 +207,8 @@ public:
         }
     }
 
+    bool isRUExhausted();
+
 private:
     Int64 getFreeActiveSegmentsUnlock() const;
     bool exceptionHappened() const;
@@ -240,9 +243,16 @@ private:
     const Int64 block_slot_limit;
     const Int64 active_segment_limit;
 
+    const String res_group_name;
+    std::mutex ru_mu;
+    std::atomic<Int64> last_time_check_ru = 0;
+    std::atomic<bool> ru_is_exhausted = false;
+    std::atomic<UInt64> read_bytes_after_last_check = 0;
+
     inline static std::atomic<uint64_t> pool_id_gen{1};
     inline static BlockStat global_blk_stat;
     static uint64_t nextPoolId() { return pool_id_gen.fetch_add(1, std::memory_order_relaxed); }
+    inline static constexpr Int64 check_ru_interval_ms = 100;
 };
 
 using SegmentReadTaskPoolPtr = std::shared_ptr<SegmentReadTaskPool>;

--- a/dbms/src/Storages/DeltaMerge/SkippableBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/SkippableBlockInputStream.h
@@ -221,7 +221,10 @@ private:
         if (likely(scan_context != nullptr))
         {
             scan_context->total_user_read_bytes += bytes;
-            lac_bytes_collector.collect(bytes);
+            if constexpr (!need_row_id)
+            {
+                lac_bytes_collector.collect(bytes);
+            }
         }
     }
     BlockInputStreams::iterator current_stream;

--- a/dbms/src/Storages/StorageDisaggregatedRemote.cpp
+++ b/dbms/src/Storages/StorageDisaggregatedRemote.cpp
@@ -537,7 +537,8 @@ std::variant<DM::Remote::RNWorkersPtr, DM::SegmentReadTaskPoolPtr> StorageDisagg
             /*after_segment_read*/ [](const DM::DMContextPtr &, const DM::SegmentPtr &) {},
             executor_id,
             /*enable_read_thread*/ true,
-            num_streams);
+            num_streams,
+            context.getDAGContext()->getResourceGroupName());
     }
     else
     {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8362

### What is changed and how it works?

1. Check whether RU is exhausted in `MergedTask`. If RU is exhausted, yield this task.
2. Check whether RU is exhausted is `SegmentReadTaskScheduler`. If RU is exhausted, don't schedule this `SegmentReadTaskPool`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
