### PR TITLE
Fix resource control when read-thread-pool is disabled.

### DIFF
--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSetReader.cpp
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSetReader.cpp
@@ -198,6 +198,10 @@ size_t ColumnFileSetReader::readRows(
 
     if (auto delta_bytes = columnsSize(output_columns) - bytes_before_read; delta_bytes > 0)
     {
+        // When `row_ids` is not null, it read for building MVCC bitmap filter.
+        // Before building MVCC bitmap filter, we performa a calculation of
+        // how many bytes will be read and then consuming it in advance.
+        // So, there is no need to count the amount of data read for building MVCC bitmap here.
         if (row_ids == nullptr)
             lac_bytes_collector.collect(delta_bytes);
         if (likely(context.scan_context))

--- a/dbms/src/Storages/DeltaMerge/Segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/Segment.cpp
@@ -2740,6 +2740,11 @@ BitmapFilterPtr Segment::buildBitmapFilterNormal(
     size_t expected_block_size)
 {
     Stopwatch sw_total;
+    if (const auto & res_group_name = dm_context.scan_context->resource_group_name; !res_group_name.empty())
+    {
+        auto bytes = segment_snap->estimatedBytesOfInternalColumns();
+        LocalAdmissionController::global_instance->consumeResource(res_group_name, bytesToRU(bytes), 0);
+    }
     ColumnDefines columns_to_read{
         getExtraHandleColumnDefine(is_common_handle),
     };

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.cpp
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.cpp
@@ -89,11 +89,6 @@ BlockInputStreamPtr SegmentReadTaskPool::buildInputStream(SegmentReadTaskPtr & t
 
     MemoryTrackerSetter setter(true, mem_tracker.get());
 
-    if (likely(read_mode == ReadMode::Bitmap && !res_group_name.empty()))
-    {
-        auto bytes = t->read_snapshot->estimatedBytesOfInternalColumns();
-        LocalAdmissionController::global_instance->consumeResource(res_group_name, bytesToRU(bytes), 0);
-    }
     t->initInputStream(
         columns_to_read,
         max_version,

--- a/dbms/src/Storages/DeltaMerge/SkippableBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/SkippableBlockInputStream.h
@@ -225,6 +225,10 @@ private:
             {
                 lac_bytes_collector.collect(bytes);
             }
+            // When `need_row_id` is true, it read for building MVCC bitmap filter.
+            // Before building MVCC bitmap filter, we performa a calculation of
+            // how many bytes will be read and then consuming it in advance.
+            // So, there is no need to count the amount of data read for building MVCC bitmap here.
         }
     }
     BlockInputStreams::iterator current_stream;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #8362

Problem Summary:

- Before building MVCC bitmap filter, we perform a calculation of how many bytes will be read and then consuming it in advance(#8369).
- However, this logic is added in `SegmentReadTaskPool` so it only work when read-thread-pool is enabled.
- In serverless, read-thread-pool is not supported.

### What is changed and how it works?

- Move the logic of calculating and consuming data that read for building MVCC bitmap filter into `buildBitmapFilterNormal`. 

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
