### PR TITLE
Don't log too many useless information in log

### DIFF
--- a/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.cpp
@@ -301,7 +301,7 @@ void DAGQueryBlockInterpreter::handleJoin(
     const Settings & settings = context.getSettingsRef();
     SpillConfig build_spill_config(
         context.getTemporaryPath(),
-        fmt::format("{}_hash_join_0_build", log->identifier()),
+        fmt::format("{}_0_build", log->identifier()),
         settings.max_cached_data_bytes_in_spiller,
         settings.max_spilled_rows_per_file,
         settings.max_spilled_bytes_per_file,
@@ -310,7 +310,7 @@ void DAGQueryBlockInterpreter::handleJoin(
         settings.max_block_size);
     SpillConfig probe_spill_config(
         context.getTemporaryPath(),
-        fmt::format("{}_hash_join_0_probe", log->identifier()),
+        fmt::format("{}_0_probe", log->identifier()),
         settings.max_cached_data_bytes_in_spiller,
         settings.max_spilled_rows_per_file,
         settings.max_spilled_bytes_per_file,
@@ -499,7 +499,7 @@ void DAGQueryBlockInterpreter::executeAggregation(
     AggregationInterpreterHelper::fillArgColumnNumbers(aggregate_descriptions, before_agg_header);
     SpillConfig spill_config(
         context.getTemporaryPath(),
-        fmt::format("{}_aggregation", log->identifier()),
+        log->identifier(),
         settings.max_cached_data_bytes_in_spiller,
         settings.max_spilled_rows_per_file,
         settings.max_spilled_bytes_per_file,

--- a/dbms/src/Flash/Coprocessor/InterpreterUtils.cpp
+++ b/dbms/src/Flash/Coprocessor/InterpreterUtils.cpp
@@ -207,7 +207,7 @@ void orderStreams(
                 getAverageThreshold(settings.max_bytes_before_external_sort, pipeline.streams.size()),
                 SpillConfig(
                     context.getTemporaryPath(),
-                    fmt::format("{}_sort", log->identifier()),
+                    log->identifier(),
                     settings.max_cached_data_bytes_in_spiller,
                     settings.max_spilled_rows_per_file,
                     settings.max_spilled_bytes_per_file,
@@ -239,7 +239,7 @@ void orderStreams(
             // todo use identifier_executor_id as the spill id
             SpillConfig(
                 context.getTemporaryPath(),
-                fmt::format("{}_sort", log->identifier()),
+                log->identifier(),
                 settings.max_cached_data_bytes_in_spiller,
                 settings.max_spilled_rows_per_file,
                 settings.max_spilled_bytes_per_file,
@@ -295,7 +295,7 @@ void executeLocalSort(
             fine_grained_spill_context = std::make_shared<FineGrainedOperatorSpillContext>("sort", log);
         SpillConfig spill_config{
             context.getTemporaryPath(),
-            fmt::format("{}_sort", log->identifier()),
+            log->identifier(),
             settings.max_cached_data_bytes_in_spiller,
             settings.max_spilled_rows_per_file,
             settings.max_spilled_bytes_per_file,
@@ -353,7 +353,7 @@ void executeFinalSort(
 
         SpillConfig spill_config{
             context.getTemporaryPath(),
-            fmt::format("{}_sort", log->identifier()),
+            log->identifier(),
             settings.max_cached_data_bytes_in_spiller,
             settings.max_spilled_rows_per_file,
             settings.max_spilled_bytes_per_file,

--- a/dbms/src/Flash/Mpp/MPPTaskId.cpp
+++ b/dbms/src/Flash/Mpp/MPPTaskId.cpp
@@ -107,8 +107,7 @@ String MPPTaskId::toString() const
 const MPPTaskId MPPTaskId::unknown_mpp_task_id = MPPTaskId{};
 
 constexpr UInt64 MAX_UINT64 = std::numeric_limits<UInt64>::max();
-const MPPQueryId MPPTaskId::Max_Query_Id
-    = MPPQueryId(MAX_UINT64, MAX_UINT64, MAX_UINT64, MAX_UINT64, "", MAX_UINT64, "");
+const MPPQueryId MPPTaskId::Max_Query_Id = MPPQueryId(MAX_UINT64, MAX_UINT64, MAX_UINT64, MAX_UINT64, "", 0, "");
 
 bool operator==(const MPPTaskId & lid, const MPPTaskId & rid)
 {

--- a/dbms/src/Flash/Mpp/MPPTaskId.cpp
+++ b/dbms/src/Flash/Mpp/MPPTaskId.cpp
@@ -101,7 +101,7 @@ size_t MPPGatherIdHash::operator()(MPPGatherId const & mpp_gather_id) const noex
 String MPPTaskId::toString() const
 {
     return isUnknown() ? "MPP<gather_id:N/A,task_id:N/A>"
-                       : fmt::format("MPP<gather_id:{},task_id:{}>", gather_id.toString(), task_id);
+                       : fmt::format("MPP<{},task_id:{}>", gather_id.toString(), task_id);
 }
 
 const MPPTaskId MPPTaskId::unknown_mpp_task_id = MPPTaskId{};

--- a/dbms/src/Flash/Mpp/MPPTaskId.h
+++ b/dbms/src/Flash/Mpp/MPPTaskId.h
@@ -109,7 +109,7 @@ struct MPPGatherId
     String toString() const
     {
         return fmt::format(
-            "<gather_id:{}, query_ts:{}, local_query_id:{}, server_id:{}, start_ts:{}>",
+            "gather_id:{}, query_ts:{}, local_query_id:{}, server_id:{}, start_ts:{}",
             gather_id,
             query_id.query_ts,
             query_id.local_query_id,

--- a/dbms/src/Flash/Mpp/MPPTaskId.h
+++ b/dbms/src/Flash/Mpp/MPPTaskId.h
@@ -64,15 +64,11 @@ struct MPPQueryId
     String toString() const
     {
         return fmt::format(
-            "<query_ts:{}, local_query_id:{}, server_id:{}, start_ts:{}, resource_group: {}, conn_id: {}, conn_alias: "
-            "{}>",
+            "<query_ts:{}, local_query_id:{}, server_id:{}, start_ts:{}>",
             query_ts,
             local_query_id,
             server_id,
-            start_ts,
-            resource_group_name,
-            connection_id,
-            connection_alias);
+            start_ts);
     }
 };
 
@@ -113,16 +109,12 @@ struct MPPGatherId
     String toString() const
     {
         return fmt::format(
-            "<gather_id:{}, query_ts:{}, local_query_id:{}, server_id:{}, start_ts:{}, resource_group: {}, conn_id: "
-            "{}, conn_alias: {}>",
+            "<gather_id:{}, query_ts:{}, local_query_id:{}, server_id:{}, start_ts:{}>",
             gather_id,
             query_id.query_ts,
             query_id.local_query_id,
             query_id.server_id,
-            query_id.start_ts,
-            query_id.resource_group_name,
-            query_id.connection_id,
-            query_id.connection_alias);
+            query_id.start_ts);
     }
     bool hasMeaningfulGatherId() const { return gather_id > 0; }
     bool operator==(const MPPGatherId & rid) const;

--- a/dbms/src/Flash/Mpp/MPPTaskManager.cpp
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.cpp
@@ -147,7 +147,7 @@ std::pair<MPPTunnelPtr, String> MPPTaskManager::findAsyncTunnel(
     if (!error_msg.empty())
     {
         /// if the gather is aborted, return the error message
-        LOG_WARNING(log, "{}: Gather {} is aborted, all its tasks are invalid.", req_info, id.gather_id.toString());
+        LOG_WARNING(log, "{}: Gather <{}> is aborted, all its tasks are invalid.", req_info, id.gather_id.toString());
         /// meet error
         return {nullptr, error_msg};
     }
@@ -229,7 +229,11 @@ std::pair<MPPTunnelPtr, String> MPPTaskManager::findTunnelWithTimeout(
         if (!error_msg.empty())
         {
             /// if the gather is aborted, return true to stop waiting timeout.
-            LOG_WARNING(log, "{}: Gather {} is aborted, all its tasks are invalid.", req_info, id.gather_id.toString());
+            LOG_WARNING(
+                log,
+                "{}: Gather <{}> is aborted, all its tasks are invalid.",
+                req_info,
+                id.gather_id.toString());
             cancelled = true;
             error_message = error_msg;
             return true;

--- a/dbms/src/Flash/Planner/PhysicalPlanNode.cpp
+++ b/dbms/src/Flash/Planner/PhysicalPlanNode.cpp
@@ -30,8 +30,9 @@ PhysicalPlanNode::PhysicalPlanNode(
     const PlanType & type_,
     const NamesAndTypes & schema_,
     const FineGrainedShuffle & fine_grained_shuffle_,
-    const String & req_id)
+    const String & req_id_)
     : executor_id(executor_id_)
+    , req_id(req_id_)
     , type(type_)
     , schema(schema_)
     , fine_grained_shuffle(fine_grained_shuffle_)

--- a/dbms/src/Flash/Planner/PhysicalPlanNode.h
+++ b/dbms/src/Flash/Planner/PhysicalPlanNode.h
@@ -116,6 +116,7 @@ protected:
     void recordProfileStreams(DAGPipeline & pipeline, const Context & context);
 
     String executor_id;
+    String req_id;
     PlanType type;
     NamesAndTypes schema;
 

--- a/dbms/src/Flash/Planner/Plans/PhysicalAggregation.cpp
+++ b/dbms/src/Flash/Planner/Plans/PhysicalAggregation.cpp
@@ -100,7 +100,7 @@ void PhysicalAggregation::buildBlockInputStreamImpl(DAGPipeline & pipeline, Cont
     AggregationInterpreterHelper::fillArgColumnNumbers(aggregate_descriptions, before_agg_header);
     SpillConfig spill_config(
         context.getTemporaryPath(),
-        fmt::format("{}_aggregation", log->identifier()),
+        log->identifier(),
         context.getSettingsRef().max_cached_data_bytes_in_spiller,
         context.getSettingsRef().max_spilled_rows_per_file,
         context.getSettingsRef().max_spilled_bytes_per_file,
@@ -216,7 +216,7 @@ void PhysicalAggregation::buildPipelineExecGroupImpl(
     AggregationInterpreterHelper::fillArgColumnNumbers(aggregate_descriptions, before_agg_header);
     SpillConfig spill_config(
         context.getTemporaryPath(),
-        fmt::format("{}_aggregation", log->identifier()),
+        log->identifier(),
         context.getSettingsRef().max_cached_data_bytes_in_spiller,
         context.getSettingsRef().max_spilled_rows_per_file,
         context.getSettingsRef().max_spilled_bytes_per_file,
@@ -264,7 +264,7 @@ void PhysicalAggregation::buildPipeline(
         auto agg_build = std::make_shared<PhysicalAggregationBuild>(
             executor_id,
             schema,
-            log->identifier(),
+            req_id,
             child,
             before_agg_actions,
             aggregation_keys,
@@ -281,7 +281,7 @@ void PhysicalAggregation::buildPipeline(
         auto agg_convergent = std::make_shared<PhysicalAggregationConvergent>(
             executor_id,
             schema,
-            log->identifier(),
+            req_id,
             aggregate_context,
             expr_after_agg);
         builder.addPlanNode(agg_convergent);

--- a/dbms/src/Flash/Planner/Plans/PhysicalAggregationBuild.cpp
+++ b/dbms/src/Flash/Planner/Plans/PhysicalAggregationBuild.cpp
@@ -40,7 +40,7 @@ void PhysicalAggregationBuild::buildPipelineExecGroupImpl(
     AggregationInterpreterHelper::fillArgColumnNumbers(aggregate_descriptions, before_agg_header);
     SpillConfig spill_config(
         context.getTemporaryPath(),
-        fmt::format("{}_aggregation", log->identifier()),
+        log->identifier(),
         context.getSettingsRef().max_cached_data_bytes_in_spiller,
         context.getSettingsRef().max_spilled_rows_per_file,
         context.getSettingsRef().max_spilled_bytes_per_file,

--- a/dbms/src/Flash/Planner/Plans/PhysicalJoin.cpp
+++ b/dbms/src/Flash/Planner/Plans/PhysicalJoin.cpp
@@ -305,7 +305,7 @@ void PhysicalJoin::buildPipeline(PipelineBuilder & builder, Context & context, P
         executor_id,
         build()->getSchema(),
         fine_grained_shuffle,
-        log->identifier(),
+        req_id,
         build(),
         join_ptr,
         build_side_prepare_actions);
@@ -319,7 +319,7 @@ void PhysicalJoin::buildPipeline(PipelineBuilder & builder, Context & context, P
     auto join_probe = std::make_shared<PhysicalJoinProbe>(
         executor_id,
         schema,
-        log->identifier(),
+        req_id,
         probe(),
         join_ptr,
         probe_side_prepare_actions);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8399

Problem Summary:

### What is changed and how it works?
1. for `resource_group/conn_id/conn_alias`, only log it once at the begining of each request
2. remove some redundant information in each executor's log identifier

Before this pr, the spill file name in `AggregationBuild` is
```
tmp_MPP_gather_id__gather_id_1__query_ts_1700522319105637023__local_query_id_13__server_id_1453__start_ts_445781716263239681__resource_group__default__conn_id__3047162128__conn_alias____task_id_5__Aggregation_HashAgg_80_AggregationBuild_HashAgg_80_aggregation_partition_0_1749
``` 
After this pr, the spill file name will be
```
tmp_MPP_gather_id_1__query_ts_1700522319105637023__local_query_id_13__server_id_1453__start_ts_445781716263239681_task_id_5__AggregationBuild_HashAgg_80_partition_0_1749
```
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
