### PR TITLE
Rename some names of DB::DM::Remote::Serializer.

### DIFF
--- a/dbms/src/Flash/Disaggregated/WNEstablishDisaggTaskHandler.cpp
+++ b/dbms/src/Flash/Disaggregated/WNEstablishDisaggTaskHandler.cpp
@@ -101,7 +101,8 @@ void WNEstablishDisaggTaskHandler::execute(disaggregated::EstablishDisaggTaskRes
 
     using DM::Remote::Serializer;
     snap->iterateTableSnapshots([&](const DM::Remote::DisaggPhysicalTableReadSnapshotPtr & snap) {
-        response->add_tables(Serializer::serializeTo(snap, task_id, mem_tracker_wrapper).SerializeAsString());
+        response->add_tables(
+            Serializer::serializePhysicalTable(snap, task_id, mem_tracker_wrapper).SerializeAsString());
     });
 }
 

--- a/dbms/src/Storages/DeltaMerge/Remote/Serializer.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/Serializer.h
@@ -56,14 +56,21 @@ namespace DB::DM::Remote
 {
 struct Serializer
 {
-    static RemotePb::RemotePhysicalTable serializeTo(
+public:
+    static RemotePb::RemotePhysicalTable serializePhysicalTable(
         const DisaggPhysicalTableReadSnapshotPtr & snap,
         const DisaggTaskId & task_id,
         MemTrackerWrapper & mem_tracker_wrapper);
 
-    /// segment snapshot ///
+    static SegmentSnapshotPtr deserializeSegment(
+        const DMContext & dm_context,
+        StoreID remote_store_id,
+        KeyspaceID keyspace_id,
+        TableID table_id,
+        const RemotePb::RemoteSegment & proto);
 
-    static RemotePb::RemoteSegment serializeTo(
+private:
+    static RemotePb::RemoteSegment serializeSegment(
         const SegmentSnapshotPtr & snap,
         PageIdU64 segment_id,
         UInt64 segment_epoch,
@@ -71,19 +78,9 @@ struct Serializer
         const RowKeyRanges & read_ranges,
         MemTrackerWrapper & mem_tracker_wrapper);
 
-    static SegmentSnapshotPtr deserializeSegmentSnapshotFrom(
-        const DMContext & dm_context,
-        StoreID remote_store_id,
-        KeyspaceID keyspace_id,
-        TableID table_id,
-        const RemotePb::RemoteSegment & proto);
-
-    /// column file set ///
-
-    static google::protobuf::RepeatedPtrField<RemotePb::ColumnFileRemote> serializeTo(
+    static google::protobuf::RepeatedPtrField<RemotePb::ColumnFileRemote> serializeColumnFileSet(
         const ColumnFileSetSnapshotPtr & snap,
         MemTrackerWrapper & mem_tracker_wrapper);
-
     /// Note: This function always build a snapshot over nop data provider. In order to read from this snapshot,
     /// you must explicitly assign a proper data provider.
     static ColumnFileSetSnapshotPtr deserializeColumnFileSet(
@@ -91,20 +88,18 @@ struct Serializer
         const Remote::IDataStorePtr & data_store,
         const RowKeyRange & segment_range);
 
-    /// column file ///
-
-    static RemotePb::ColumnFileRemote serializeTo(const ColumnFileInMemory & cf_in_mem);
+    static RemotePb::ColumnFileRemote serializeCFInMemory(const ColumnFileInMemory & cf_in_mem);
     static ColumnFileInMemoryPtr deserializeCFInMemory(const RemotePb::ColumnFileInMemory & proto);
 
-    static RemotePb::ColumnFileRemote serializeTo(
+    static RemotePb::ColumnFileRemote serializeCFTiny(
         const ColumnFileTiny & cf_tiny,
         IColumnFileDataProviderPtr data_provider);
     static ColumnFileTinyPtr deserializeCFTiny(const RemotePb::ColumnFileTiny & proto);
 
-    static RemotePb::ColumnFileRemote serializeTo(const ColumnFileDeleteRange & cf_delete_range);
+    static RemotePb::ColumnFileRemote serializeCFDeleteRange(const ColumnFileDeleteRange & cf_delete_range);
     static ColumnFileDeleteRangePtr deserializeCFDeleteRange(const RemotePb::ColumnFileDeleteRange & proto);
 
-    static RemotePb::ColumnFileRemote serializeTo(const ColumnFileBig & cf_big);
+    static RemotePb::ColumnFileRemote serializeCFBig(const ColumnFileBig & cf_big);
     static ColumnFileBigPtr deserializeCFBig(
         const RemotePb::ColumnFileBig & proto,
         const Remote::IDataStorePtr & data_store,

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTask.cpp
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTask.cpp
@@ -100,12 +100,8 @@ SegmentReadTask::SegmentReadTask(
         nullptr,
         nullptr);
 
-    read_snapshot = Remote::Serializer::deserializeSegmentSnapshotFrom(
-        *dm_context,
-        store_id,
-        keyspace_id,
-        physical_table_id,
-        proto);
+    read_snapshot
+        = Remote::Serializer::deserializeSegment(*dm_context, store_id, keyspace_id, physical_table_id, proto);
 
     ranges.reserve(proto.read_key_ranges_size());
     for (const auto & read_key_range : proto.read_key_ranges())

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_read_task.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_read_task.cpp
@@ -186,7 +186,7 @@ try
     snap->column_defines = std::make_shared<ColumnDefines>(store->getTableColumns());
 
     MemTrackerWrapper mem_tracker_wrapper(nullptr);
-    auto remote_table_pb = Remote::Serializer::serializeTo(snap, /*task_id*/ {}, mem_tracker_wrapper);
+    auto remote_table_pb = Remote::Serializer::serializePhysicalTable(snap, /*task_id*/ {}, mem_tracker_wrapper);
 
     ASSERT_GT(remote_table_pb.segments_size(), 0);
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6834

Problem Summary: 

- The name `serializeTo` is too generalization and there are too many overload functions with this name.

### What is changed and how it works?

- Change `serializeTo` to `serializeXXX`, XXX is the object type to be serialized.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
