### PR TITLE
ddl: Fix broken TableIDMapping lead to data loss or crashes (release-7.5)

### DIFF
--- a/dbms/src/Debug/MockSchemaGetter.h
+++ b/dbms/src/Debug/MockSchemaGetter.h
@@ -34,7 +34,7 @@ struct MockSchemaGetter
 
     static bool checkSchemaDiffExists(Int64 version) { return MockTiDB::instance().checkSchemaDiffExists(version); }
 
-    static TiDB::TableInfoPtr getTableInfo(DatabaseID, TableID table_id)
+    static TiDB::TableInfoPtr getTableInfo(DatabaseID, TableID table_id, [[maybe_unused]] bool try_mvcc = true)
     {
         return MockTiDB::instance().getTableInfoByID(table_id);
     }

--- a/dbms/src/Encryption/tests/gtest_rate_limiter.cpp
+++ b/dbms/src/Encryption/tests/gtest_rate_limiter.cpp
@@ -71,8 +71,10 @@ TEST(WriteLimiterTest, Rate)
         // hint: the range [0.8, 1.25] is copied from rocksdb,
         // if tests fail, try to enlarge this range.
         // enlarge the range to [0.75, 1.30]
-        EXPECT_GE(actual_rate / target, 0.75);
-        EXPECT_LE(actual_rate / target, 1.30);
+        EXPECT_GE(actual_rate / target, 0.75)
+            << fmt::format("actual_rate={} target={} elapsed={:.3f}s", actual_rate, target, elapsed);
+        EXPECT_LE(actual_rate / target, 1.30)
+            << fmt::format("actual_rate={} target={} elapsed={:.3f}s", actual_rate, target, elapsed);
     }
 }
 

--- a/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
@@ -1339,7 +1339,11 @@ std::unordered_map<TableID, DAGStorageInterpreter::StorageWithStructureLock> DAG
         if (!table_store)
         {
             if (schema_synced)
-                throw TiFlashException(fmt::format("Table {} doesn't exist.", table_id), Errors::Table::NotExists);
+                throw TiFlashException(
+                    Errors::Table::NotExists,
+                    "Table doesn't exist, keyspace={} table_id={}",
+                    keyspace_id,
+                    table_id);
             else
                 return {{}, {}};
         }

--- a/dbms/src/TiDB/Schema/SchemaBuilder.cpp
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Common/Exception.h>
 #include <Common/FailPoint.h>
 #include <Common/FmtUtils.h>
 #include <Common/TiFlashException.h>
@@ -719,7 +720,10 @@ void SchemaBuilder<Getter, NameMapper>::applyRenameLogicalTable(
             auto part_storage = tmt_context.getStorages().get(keyspace_id, part_def.id);
             if (part_storage == nullptr)
             {
-                LOG_ERROR(log, "table is not exist in TiFlash, physical_table_id={}", part_def.id);
+                LOG_ERROR(
+                    log,
+                    "table is not exist in TiFlash, applyRenamePhysicalTable is ignored, physical_table_id={}",
+                    part_def.id);
                 return;
             }
             auto part_table_info = new_table_info->producePartitionTableInfo(part_def.id, name_mapper);
@@ -1379,7 +1383,7 @@ void SchemaBuilder<Getter, NameMapper>::syncAllSchema()
         if (created_db_set.count(it->first) == 0 && !isReservedDatabase(context, it->first))
         {
             applyDropSchema(it->first);
-            LOG_DEBUG(log, "DB {} dropped during sync all schemas", it->first);
+            LOG_INFO(log, "Database {} dropped during sync all schemas", it->first);
         }
     }
 

--- a/dbms/src/TiDB/Schema/SchemaBuilder.cpp
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.cpp
@@ -477,7 +477,7 @@ void SchemaBuilder<Getter, NameMapper>::applySetTiFlashReplica(DatabaseID databa
     auto [db_info, table_info] = getter.getDatabaseAndTableInfo(database_id, table_id);
     if (unlikely(table_info == nullptr))
     {
-        LOG_ERROR(log, "table is not exist in TiKV, applySetTiFlashReplica is ignored, table_id={}", table_id);
+        LOG_WARNING(log, "table is not exist in TiKV, applySetTiFlashReplica is ignored, table_id={}", table_id);
         return;
     }
 
@@ -633,8 +633,8 @@ void SchemaBuilder<Getter, NameMapper>::applyPartitionDiff(
         LOG_INFO(
             log,
             "No partition changes, paritions_size={} {} with database_id={}, table_id={}",
-            name_mapper.debugCanonicalName(*db_info, *table_info),
             new_part_id_set.size(),
+            name_mapper.debugCanonicalName(*db_info, *table_info),
             db_info->id,
             table_info->id);
         return;
@@ -697,7 +697,7 @@ void SchemaBuilder<Getter, NameMapper>::applyRenameTable(DatabaseID database_id,
     auto storage = tmt_context.getStorages().get(keyspace_id, table_id);
     if (storage == nullptr)
     {
-        LOG_ERROR(log, "table is not exist in TiFlash, applyRenameTable is ignored, table_id={}", table_id);
+        LOG_WARNING(log, "table is not exist in TiFlash, applyRenameTable is ignored, table_id={}", table_id);
         return;
     }
 

--- a/dbms/src/TiDB/Schema/SchemaBuilder.h
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.h
@@ -183,7 +183,7 @@ struct SchemaBuilder
 
     void dropAllSchema();
 
-    void applyTable(DatabaseID database_id, TableID logical_table_id, TableID physical_table_id);
+    bool applyTable(DatabaseID database_id, TableID logical_table_id, TableID physical_table_id);
 
 private:
     void applyDropSchema(DatabaseID schema_id);

--- a/dbms/src/TiDB/Schema/SchemaBuilder.h
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.h
@@ -23,80 +23,48 @@ namespace DB
 /// TableIDMap use to store the mapping between table_id -> database_id and partition_id -> logical_table_id
 struct TableIDMap
 {
-    LoggerPtr & log;
-    std::shared_mutex shared_mutex_for_table_id_map;
-    std::unordered_map<DB::TableID, DB::DatabaseID> table_id_to_database_id;
-    std::unordered_map<DB::TableID, DB::TableID> partition_id_to_logical_id;
-
-    explicit TableIDMap(LoggerPtr & log_)
+    explicit TableIDMap(const LoggerPtr & log_)
         : log(log_)
     {}
 
     void erase(DB::TableID table_id)
     {
-        std::unique_lock lock(shared_mutex_for_table_id_map);
+        std::unique_lock lock(mtx_id_mapping);
         table_id_to_database_id.erase(table_id);
         partition_id_to_logical_id.erase(table_id);
     }
 
     void clear()
     {
-        std::unique_lock lock(shared_mutex_for_table_id_map);
+        std::unique_lock lock(mtx_id_mapping);
         table_id_to_database_id.clear();
         partition_id_to_logical_id.clear();
     }
 
     void emplaceTableID(TableID table_id, DatabaseID database_id)
     {
-        std::unique_lock lock(shared_mutex_for_table_id_map);
-        if (table_id_to_database_id.find(table_id) != table_id_to_database_id.end())
-        {
-            LOG_WARNING(log, "table {} is already exists in table_id_to_database_id ", table_id);
-            table_id_to_database_id[table_id] = database_id;
-        }
-        else
-            table_id_to_database_id.emplace(table_id, database_id);
+        std::unique_lock lock(mtx_id_mapping);
+        doEmplaceTableID(table_id, database_id, "", lock);
     }
 
     void emplacePartitionTableID(TableID partition_id, TableID table_id)
     {
-        std::unique_lock lock(shared_mutex_for_table_id_map);
-        if (partition_id_to_logical_id.find(partition_id) != partition_id_to_logical_id.end())
-        {
-            LOG_WARNING(log, "partition id {} is already exists in partition_id_to_logical_id ", partition_id);
-            partition_id_to_logical_id[partition_id] = table_id;
-        }
-        else
-            partition_id_to_logical_id.emplace(partition_id, table_id);
+        std::unique_lock lock(mtx_id_mapping);
+        doEmplacePartitionTableID(partition_id, table_id, "", lock);
     }
 
-    void eraseTableIDOrLogError(TableID table_id)
-    {
-        std::unique_lock lock(shared_mutex_for_table_id_map);
-        if (table_id_to_database_id.find(table_id) != table_id_to_database_id.end())
-            table_id_to_database_id.erase(table_id);
-        else
-            LOG_ERROR(log, "table_id {} not in table_id_to_database_id", table_id);
-    }
+    void exchangeTablePartition(
+        DatabaseID non_partition_database_id,
+        TableID non_partition_table_id,
+        DatabaseID partition_database_id,
+        TableID partition_logical_table_id,
+        TableID partition_physical_table_id);
 
-    void erasePartitionTableIDOrLogError(TableID table_id)
+    std::vector<TableID> findTablesByDatabaseID(DatabaseID database_id) const
     {
-        std::unique_lock lock(shared_mutex_for_table_id_map);
-        if (partition_id_to_logical_id.find(table_id) != partition_id_to_logical_id.end())
-        {
-            partition_id_to_logical_id.erase(table_id);
-        }
-        else
-        {
-            LOG_ERROR(log, "table_id {} not in partition_id_to_logical_id", table_id);
-        }
-    }
-
-    std::vector<TableID> findTablesByDatabaseID(DatabaseID database_id)
-    {
-        std::shared_lock lock(shared_mutex_for_table_id_map);
+        std::shared_lock lock(mtx_id_mapping);
         std::vector<TableID> tables;
-        for (auto & table_id : table_id_to_database_id)
+        for (const auto & table_id : table_id_to_database_id)
         {
             if (table_id.second == database_id)
             {
@@ -106,24 +74,24 @@ struct TableIDMap
         return tables;
     }
 
-    bool tableIDInTwoMaps(TableID table_id)
+    bool tableIDInTwoMaps(TableID table_id) const
     {
-        std::shared_lock<std::shared_mutex> lock(shared_mutex_for_table_id_map);
+        std::shared_lock<std::shared_mutex> lock(mtx_id_mapping);
         return !(
             table_id_to_database_id.find(table_id) == table_id_to_database_id.end()
             && partition_id_to_logical_id.find(table_id) == partition_id_to_logical_id.end());
     }
 
-    bool tableIDInDatabaseIdMap(TableID table_id)
+    bool tableIDInDatabaseIdMap(TableID table_id) const
     {
-        std::shared_lock<std::shared_mutex> lock(shared_mutex_for_table_id_map);
+        std::shared_lock<std::shared_mutex> lock(mtx_id_mapping);
         return !(table_id_to_database_id.find(table_id) == table_id_to_database_id.end());
     }
 
     // if not find，than return -1
-    DatabaseID findTableIDInDatabaseMap(TableID table_id)
+    DatabaseID findTableIDInDatabaseMap(TableID table_id) const
     {
-        std::shared_lock<std::shared_mutex> lock(shared_mutex_for_table_id_map);
+        std::shared_lock<std::shared_mutex> lock(mtx_id_mapping);
         auto database_iter = table_id_to_database_id.find(table_id);
         if (database_iter == table_id_to_database_id.end())
             return -1;
@@ -132,15 +100,35 @@ struct TableIDMap
     }
 
     // if not find，than return -1
-    TableID findTableIDInPartitionMap(TableID partition_id)
+    TableID findTableIDInPartitionMap(TableID partition_id) const
     {
-        std::shared_lock<std::shared_mutex> lock(shared_mutex_for_table_id_map);
+        std::shared_lock<std::shared_mutex> lock(mtx_id_mapping);
         auto logical_table_iter = partition_id_to_logical_id.find(partition_id);
         if (logical_table_iter == partition_id_to_logical_id.end())
             return -1;
 
         return logical_table_iter->second;
     }
+
+    std::tuple<bool, DatabaseID, TableID> findDatabaseIDAndLogicalTableID(TableID physical_table_id) const;
+
+private:
+    void doEmplaceTableID(
+        TableID table_id,
+        DatabaseID database_id,
+        std::string_view log_prefix,
+        const std::unique_lock<std::shared_mutex> &);
+    void doEmplacePartitionTableID(
+        TableID partition_id,
+        TableID table_id,
+        std::string_view log_prefix,
+        const std::unique_lock<std::shared_mutex> &);
+
+private:
+    LoggerPtr log;
+    mutable std::shared_mutex mtx_id_mapping;
+    std::unordered_map<DB::TableID, DB::DatabaseID> table_id_to_database_id;
+    std::unordered_map<DB::TableID, DB::TableID> partition_id_to_logical_id;
 };
 
 template <typename Getter, typename NameMapper>

--- a/dbms/src/TiDB/Schema/SchemaGetter.cpp
+++ b/dbms/src/TiDB/Schema/SchemaGetter.cpp
@@ -275,7 +275,7 @@ TiDB::DBInfoPtr SchemaGetter::getDatabase(DatabaseID db_id)
     if (json.empty())
         return nullptr;
 
-    LOG_DEBUG(log, "Get DB Info from TiKV: {}", json);
+    LOG_DEBUG(log, "Get DB Info from TiKV, database_id={} {}", db_id, json);
     auto db_info = std::make_shared<TiDB::DBInfo>(json, keyspace_id);
     return db_info;
 }
@@ -304,7 +304,7 @@ TiDB::TableInfoPtr SchemaGetter::getTableInfo(DatabaseID db_id, TableID table_id
             return nullptr;
         }
     }
-    LOG_DEBUG(log, "Get Table Info from TiKV: {}", table_info_json);
+    LOG_DEBUG(log, "Get Table Info from TiKV, table_id={} {}", table_id, table_info_json);
     TiDB::TableInfoPtr table_info = std::make_shared<TiDB::TableInfo>(table_info_json, keyspace_id);
 
     return table_info;
@@ -339,7 +339,7 @@ std::tuple<TiDB::DBInfoPtr, TiDB::TableInfoPtr> SchemaGetter::getDatabaseAndTabl
             return std::make_tuple(db_info, nullptr);
         }
     }
-    LOG_DEBUG(log, "Get Table Info from TiKV: {}", table_info_json);
+    LOG_DEBUG(log, "Get Table Info from TiKV, table_id={} {}", table_id, table_info_json);
     TiDB::TableInfoPtr table_info = std::make_shared<TiDB::TableInfo>(table_info_json, keyspace_id);
 
     return std::make_tuple(db_info, table_info);

--- a/dbms/src/TiDB/Schema/SchemaGetter.h
+++ b/dbms/src/TiDB/Schema/SchemaGetter.h
@@ -164,7 +164,12 @@ struct SchemaGetter
 
     TiDB::DBInfoPtr getDatabase(DatabaseID db_id);
 
-    TiDB::TableInfoPtr getTableInfo(DatabaseID db_id, TableID table_id);
+    TiDB::TableInfoPtr getTableInfo(DatabaseID db_id, TableID table_id, bool try_mvcc = true)
+    {
+        if (try_mvcc)
+            return getTableInfoImpl</*mvcc_get*/ true>(db_id, table_id);
+        return getTableInfoImpl</*mvcc_get*/ false>(db_id, table_id);
+    }
 
     std::tuple<TiDB::DBInfoPtr, TiDB::TableInfoPtr> getDatabaseAndTableInfo(DatabaseID db_id, TableID table_id);
 
@@ -173,6 +178,10 @@ struct SchemaGetter
     std::vector<TiDB::TableInfoPtr> listTables(DatabaseID db_id);
 
     KeyspaceID getKeyspaceID() const { return keyspace_id; }
+
+private:
+    template <bool mvcc_get>
+    TiDB::TableInfoPtr getTableInfoImpl(DatabaseID db_id, TableID table_id);
 };
 
 } // namespace DB

--- a/dbms/src/TiDB/Schema/TiDB.cpp
+++ b/dbms/src/TiDB/Schema/TiDB.cpp
@@ -29,6 +29,7 @@
 #include <TiDB/Schema/TiDB.h>
 #include <common/logger_useful.h>
 
+#include <algorithm>
 #include <cmath>
 
 namespace DB

--- a/dbms/src/TiDB/Schema/TiDBSchemaSyncer.cpp
+++ b/dbms/src/TiDB/Schema/TiDBSchemaSyncer.cpp
@@ -184,8 +184,8 @@ std::tuple<bool, String> TiDBSchemaSyncer<mock_getter, mock_mapper>::trySyncTabl
 {
     // Get logical_table_id and database_id by physical_table_id.
     // If the table is a partition table, logical_table_id != physical_table_id, otherwise, logical_table_id == physical_table_id;
-    auto [find, database_id, logical_table_id] = findDatabaseIDAndTableID(physical_table_id);
-    if (!find)
+    auto [found, database_id, logical_table_id] = findDatabaseIDAndTableID(physical_table_id);
+    if (!found)
     {
         String message = fmt::format(
             "Can not find related database_id and logical_table_id from table_id_map, {}."

--- a/dbms/src/TiDB/Schema/TiDBSchemaSyncer.cpp
+++ b/dbms/src/TiDB/Schema/TiDBSchemaSyncer.cpp
@@ -24,12 +24,16 @@ namespace DB
 template <bool mock_getter, bool mock_mapper>
 bool TiDBSchemaSyncer<mock_getter, mock_mapper>::syncSchemas(Context & context)
 {
+    auto getter = createSchemaGetter(keyspace_id);
+    return syncSchemasByGetter(context, getter);
+}
+
+template <bool mock_getter, bool mock_mapper>
+bool TiDBSchemaSyncer<mock_getter, mock_mapper>::syncSchemasByGetter(Context & context, Getter & getter)
+{
     std::lock_guard<std::mutex> lock(mutex_for_sync_schema);
 
     GET_METRIC(tiflash_sync_schema_applying).Increment();
-
-    auto getter = createSchemaGetter(keyspace_id);
-    const Int64 version = getter.getVersion();
 
     Stopwatch watch;
     SCOPE_EXIT({
@@ -37,6 +41,7 @@ bool TiDBSchemaSyncer<mock_getter, mock_mapper>::syncSchemas(Context & context)
         GET_METRIC(tiflash_sync_schema_applying).Decrement();
     });
 
+    const Int64 version = getter.getVersion();
     if (version == SchemaGetter::SchemaVersionNotExist)
     {
         // Tables and databases are already tombstoned and waiting for GC.
@@ -162,7 +167,7 @@ std::tuple<bool, DatabaseID, TableID> TiDBSchemaSyncer<mock_getter, mock_mapper>
             database_id = table_id_map.findTableIDInDatabaseMap(logical_table_id);
     }
 
-    if (database_id != -1 and logical_table_id != -1)
+    if (database_id != -1 && logical_table_id != -1)
     {
         return std::make_tuple(true, database_id, logical_table_id);
     }
@@ -170,9 +175,45 @@ std::tuple<bool, DatabaseID, TableID> TiDBSchemaSyncer<mock_getter, mock_mapper>
     return std::make_tuple(false, 0, 0);
 }
 
+template <bool mock_getter, bool mock_mapper>
+std::tuple<bool, String> TiDBSchemaSyncer<mock_getter, mock_mapper>::trySyncTableSchema(
+    Context & context,
+    TableID physical_table_id,
+    Getter & getter,
+    const char * next_action)
+{
+    // Get logical_table_id and database_id by physical_table_id.
+    // If the table is a partition table, logical_table_id != physical_table_id, otherwise, logical_table_id == physical_table_id;
+    auto [find, database_id, logical_table_id] = findDatabaseIDAndTableID(physical_table_id);
+    if (!find)
+    {
+        String message = fmt::format(
+            "Can not find related database_id and logical_table_id from table_id_map, {}."
+            " physical_table_id={}",
+            next_action,
+            physical_table_id);
+        return {true, message};
+    }
 
-/// we don't need a lock at the beginning of syncTableSchema,
-/// we will catch the AlterLock for storage later.
+    // Try to fetch the latest table info from TiKV.
+    // If the table schema apply is failed, then we need to update the table-id-mapping
+    // and retry.
+    SchemaBuilder<Getter, NameMapper> builder(getter, context, databases, table_id_map, shared_mutex_for_databases);
+    if (!builder.applyTable(database_id, logical_table_id, physical_table_id))
+    {
+        String message = fmt::format(
+            "Can not apply table schema because the table_id_map is not up-to-date, {}."
+            " physical_table_id={} database_id={} logical_table_id={}",
+            next_action,
+            physical_table_id,
+            database_id,
+            logical_table_id);
+        return {true, message};
+    }
+    // apply is done successfully
+    return {false, ""};
+}
+
 template <bool mock_getter, bool mock_mapper>
 bool TiDBSchemaSyncer<mock_getter, mock_mapper>::syncTableSchema(Context & context, TableID physical_table_id)
 {
@@ -182,36 +223,34 @@ bool TiDBSchemaSyncer<mock_getter, mock_mapper>::syncTableSchema(Context & conte
             .Observe(watch.elapsedSeconds());
     });
 
-    LOG_INFO(log, "Start sync table schema, table_id={}", physical_table_id);
-    auto getter = createSchemaGetter(keyspace_id);
+    LOG_INFO(log, "Sync table schema begin, table_id={}", physical_table_id);
+    auto getter = createSchemaGetter(keyspace_id); // use the same tso for getting schema
 
-    // get logical_table_id and database_id based on physical_table_id,
-    // if the table is a partition table, logical_table_id != physical_table_id, otherwise, logical_table_id = physical_table_id;
-    auto [find, database_id, logical_table_id] = findDatabaseIDAndTableID(physical_table_id);
-    if (!find)
+    /// Note that we don't need a lock at the beginning of syncTableSchema.
+    /// The AlterLock for storage will be acquired in `SchemaBuilder::applyTable`.
+    auto [need_update_id_mapping, message]
+        = trySyncTableSchema(context, physical_table_id, getter, "try to syncSchemas");
+    if (!need_update_id_mapping)
     {
-        LOG_WARNING(
-            log,
-            "Can't find related database_id and logical_table_id from table_id_map, try to syncSchemas. "
-            "physical_table_id={}",
-            physical_table_id);
-        GET_METRIC(tiflash_schema_trigger_count, type_sync_table_schema).Increment();
-        syncSchemas(context);
-        std::tie(find, database_id, logical_table_id) = findDatabaseIDAndTableID(physical_table_id);
-        if (!find)
-        {
-            LOG_ERROR(
-                log,
-                "Still can't find related database_id and logical_table_id from table_id_map, physical_table_id={}",
-                physical_table_id);
-            return false;
-        }
+        LOG_INFO(log, "Sync table schema end, table_id={}", physical_table_id);
+        return true;
     }
 
-    SchemaBuilder<Getter, NameMapper> builder(getter, context, databases, table_id_map, shared_mutex_for_databases);
-    builder.applyTable(database_id, logical_table_id, physical_table_id);
+    LOG_WARNING(log, message);
+    GET_METRIC(tiflash_schema_trigger_count, type_sync_table_schema).Increment();
+    // Notice: must use the same getter
+    syncSchemasByGetter(context, getter);
+    std::tie(need_update_id_mapping, message)
+        = trySyncTableSchema(context, physical_table_id, getter, "sync table schema fail");
+    if (likely(!need_update_id_mapping))
+    {
+        LOG_INFO(log, "Sync table schema end after syncSchemas, table_id={}", physical_table_id);
+        return true;
+    }
 
-    return true;
+    // Still fail, maybe some unknown bugs?
+    LOG_ERROR(log, message);
+    return false;
 }
 
 template class TiDBSchemaSyncer<false, false>;

--- a/dbms/src/TiDB/Schema/TiDBSchemaSyncer.h
+++ b/dbms/src/TiDB/Schema/TiDBSchemaSyncer.h
@@ -105,6 +105,9 @@ private:
     Int64 syncSchemaDiffs(Context & context, Getter & getter, Int64 latest_version);
     Int64 syncAllSchemas(Context & context, Getter & getter, Int64 version);
 
+    bool syncSchemasByGetter(Context & context, Getter &getter);
+    std::tuple<bool, String> trySyncTableSchema(Context & context, TableID physical_table_id, Getter & getter, const char * next_action);
+
     TiDB::DBInfoPtr getDBInfoByName(const String & database_name) override
     {
         std::shared_lock<std::shared_mutex> lock(shared_mutex_for_databases);

--- a/dbms/src/TiDB/Schema/TiDBSchemaSyncer.h
+++ b/dbms/src/TiDB/Schema/TiDBSchemaSyncer.h
@@ -105,8 +105,12 @@ private:
     Int64 syncSchemaDiffs(Context & context, Getter & getter, Int64 latest_version);
     Int64 syncAllSchemas(Context & context, Getter & getter, Int64 version);
 
-    bool syncSchemasByGetter(Context & context, Getter &getter);
-    std::tuple<bool, String> trySyncTableSchema(Context & context, TableID physical_table_id, Getter & getter, const char * next_action);
+    bool syncSchemasByGetter(Context & context, Getter & getter);
+    std::tuple<bool, String> trySyncTableSchema(
+        Context & context,
+        TableID physical_table_id,
+        Getter & getter,
+        const char * next_action);
 
     TiDB::DBInfoPtr getDBInfoByName(const String & database_name) override
     {

--- a/dbms/src/TiDB/Schema/tests/gtest_table_id_map.cpp
+++ b/dbms/src/TiDB/Schema/tests/gtest_table_id_map.cpp
@@ -1,0 +1,166 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Storages/KVStore/Types.h>
+#include <TestUtils/TiFlashTestBasic.h>
+#include <TiDB/Schema/SchemaBuilder.h>
+#include <gtest/gtest.h>
+#include <gtest/internal/gtest-internal.h>
+
+namespace DB::tests
+{
+::testing::AssertionResult isSameMapping(
+    const char * lhs_expr,
+    const char * rhs_expr,
+    std::tuple<bool, DatabaseID, TableID> lhs,
+    std::tuple<bool, DatabaseID, TableID> rhs)
+{
+    if (std::get<0>(lhs) == std::get<0>(rhs))
+        return ::testing::AssertionSuccess();
+    return ::testing::internal::EqFailure(
+        lhs_expr,
+        rhs_expr,
+        fmt::format("<found={} db_id={} tbl_id={}>", std::get<0>(lhs), std::get<1>(lhs), std::get<2>(lhs)),
+        fmt::format("<found={} db_id={} tbl_id={}>", std::get<0>(rhs), std::get<1>(rhs), std::get<2>(rhs)),
+        false);
+}
+
+#define ASSERT_MAPPING_EQ(val1, val2) ASSERT_PRED_FORMAT2(isSameMapping, val1, val2)
+
+class TableIDMapTest : public ::testing::Test
+{
+public:
+    TableIDMapTest()
+        : log(Logger::get())
+    {}
+
+
+protected:
+    LoggerPtr log;
+};
+
+TEST_F(TableIDMapTest, Basic)
+{
+    TableIDMap mapping(log);
+
+    // partition table
+    TableID partition_logical_table_id = 100;
+    mapping.emplaceTableID(partition_logical_table_id, 2);
+    mapping.emplacePartitionTableID(101, 100);
+    mapping.emplacePartitionTableID(102, 100);
+    mapping.emplacePartitionTableID(103, 100);
+    // non-partition table
+    TableID non_partition_table_id = 200;
+    mapping.emplaceTableID(non_partition_table_id, 2);
+
+    ASSERT_EQ(mapping.findTableIDInDatabaseMap(partition_logical_table_id), 2);
+    ASSERT_EQ(mapping.findTableIDInPartitionMap(101), partition_logical_table_id);
+    ASSERT_EQ(mapping.findTableIDInDatabaseMap(101), -1);
+    ASSERT_EQ(mapping.findTableIDInPartitionMap(non_partition_table_id), -1);
+    ASSERT_EQ(mapping.findTableIDInDatabaseMap(non_partition_table_id), 2);
+
+    ASSERT_MAPPING_EQ(std::make_tuple(true, 2, 100), mapping.findDatabaseIDAndLogicalTableID(100));
+    ASSERT_MAPPING_EQ(std::make_tuple(true, 2, 100), mapping.findDatabaseIDAndLogicalTableID(101));
+    ASSERT_MAPPING_EQ(std::make_tuple(true, 2, 100), mapping.findDatabaseIDAndLogicalTableID(102));
+    ASSERT_MAPPING_EQ(std::make_tuple(true, 2, 100), mapping.findDatabaseIDAndLogicalTableID(103));
+    ASSERT_MAPPING_EQ(std::make_tuple(true, 2, 200), mapping.findDatabaseIDAndLogicalTableID(200));
+
+    // non exist
+    ASSERT_MAPPING_EQ(std::make_tuple(false, 0, 0), mapping.findDatabaseIDAndLogicalTableID(900));
+    // broken state, physical_table_id -> logical_table_id, but no logical_table_id -> database_id
+    mapping.emplacePartitionTableID(901, 900);
+    ASSERT_MAPPING_EQ(std::make_tuple(false, 0, 0), mapping.findDatabaseIDAndLogicalTableID(901));
+}
+
+TEST_F(TableIDMapTest, ExchangePartition)
+{
+    TableIDMap mapping(log);
+
+    /// Prepare
+    // partition table
+    TableID partition_logical_table_id = 100;
+    mapping.emplaceTableID(partition_logical_table_id, 2);
+    mapping.emplacePartitionTableID(101, 100);
+    mapping.emplacePartitionTableID(102, 100);
+    mapping.emplacePartitionTableID(103, 100);
+    // non-partition table
+    TableID non_partition_table_id = 200;
+    mapping.emplaceTableID(non_partition_table_id, 2);
+    ASSERT_EQ(mapping.findTableIDInDatabaseMap(partition_logical_table_id), 2);
+    ASSERT_EQ(mapping.findTableIDInPartitionMap(101), partition_logical_table_id);
+    ASSERT_EQ(mapping.findTableIDInDatabaseMap(101), -1);
+    ASSERT_EQ(mapping.findTableIDInPartitionMap(non_partition_table_id), -1);
+    ASSERT_EQ(mapping.findTableIDInDatabaseMap(non_partition_table_id), 2);
+    ASSERT_MAPPING_EQ(std::make_tuple(true, 2, 100), mapping.findDatabaseIDAndLogicalTableID(100));
+    ASSERT_MAPPING_EQ(std::make_tuple(true, 2, 100), mapping.findDatabaseIDAndLogicalTableID(101));
+    ASSERT_MAPPING_EQ(std::make_tuple(true, 2, 100), mapping.findDatabaseIDAndLogicalTableID(102));
+    ASSERT_MAPPING_EQ(std::make_tuple(true, 2, 100), mapping.findDatabaseIDAndLogicalTableID(103));
+    ASSERT_MAPPING_EQ(std::make_tuple(true, 2, 200), mapping.findDatabaseIDAndLogicalTableID(200));
+
+    // exchange
+    mapping.exchangeTablePartition(2, non_partition_table_id, 2, partition_logical_table_id, 101);
+
+    ASSERT_EQ(mapping.findTableIDInDatabaseMap(partition_logical_table_id), 2);
+    ASSERT_EQ(mapping.findTableIDInPartitionMap(101), -1);
+    ASSERT_EQ(mapping.findTableIDInDatabaseMap(101), 2);
+    ASSERT_EQ(mapping.findTableIDInPartitionMap(non_partition_table_id), partition_logical_table_id);
+    ASSERT_EQ(mapping.findTableIDInDatabaseMap(non_partition_table_id), -1);
+    ASSERT_MAPPING_EQ(std::make_tuple(true, 2, 100), mapping.findDatabaseIDAndLogicalTableID(100));
+    ASSERT_MAPPING_EQ(std::make_tuple(true, 2, 101), mapping.findDatabaseIDAndLogicalTableID(101)); // changed
+    ASSERT_MAPPING_EQ(std::make_tuple(true, 2, 100), mapping.findDatabaseIDAndLogicalTableID(102));
+    ASSERT_MAPPING_EQ(std::make_tuple(true, 2, 100), mapping.findDatabaseIDAndLogicalTableID(103));
+    ASSERT_MAPPING_EQ(std::make_tuple(true, 2, 100), mapping.findDatabaseIDAndLogicalTableID(200)); // changed
+}
+
+TEST_F(TableIDMapTest, ExchangePartitionCrossDatabase)
+{
+    TableIDMap mapping(log);
+
+    /// Prepare
+    // partition table
+    TableID partition_logical_table_id = 100;
+    mapping.emplaceTableID(partition_logical_table_id, 2);
+    mapping.emplacePartitionTableID(101, 100);
+    mapping.emplacePartitionTableID(102, 100);
+    mapping.emplacePartitionTableID(103, 100);
+    // non-partition table
+    TableID non_partition_table_id = 200;
+    mapping.emplaceTableID(non_partition_table_id, 7);
+    ASSERT_EQ(mapping.findTableIDInDatabaseMap(partition_logical_table_id), 2);
+    ASSERT_EQ(mapping.findTableIDInPartitionMap(101), partition_logical_table_id);
+    ASSERT_EQ(mapping.findTableIDInDatabaseMap(101), -1);
+    ASSERT_EQ(mapping.findTableIDInPartitionMap(non_partition_table_id), -1);
+    ASSERT_EQ(mapping.findTableIDInDatabaseMap(non_partition_table_id), 7);
+    ASSERT_MAPPING_EQ(std::make_tuple(true, 2, 100), mapping.findDatabaseIDAndLogicalTableID(100));
+    ASSERT_MAPPING_EQ(std::make_tuple(true, 2, 100), mapping.findDatabaseIDAndLogicalTableID(101));
+    ASSERT_MAPPING_EQ(std::make_tuple(true, 2, 100), mapping.findDatabaseIDAndLogicalTableID(102));
+    ASSERT_MAPPING_EQ(std::make_tuple(true, 2, 100), mapping.findDatabaseIDAndLogicalTableID(103));
+    ASSERT_MAPPING_EQ(std::make_tuple(true, 7, 200), mapping.findDatabaseIDAndLogicalTableID(200));
+
+    // exchange
+    mapping.exchangeTablePartition(7, non_partition_table_id, 2, partition_logical_table_id, 101);
+
+    ASSERT_EQ(mapping.findTableIDInDatabaseMap(partition_logical_table_id), 2);
+    ASSERT_EQ(mapping.findTableIDInPartitionMap(101), -1);
+    ASSERT_EQ(mapping.findTableIDInDatabaseMap(101), 7);
+    ASSERT_EQ(mapping.findTableIDInPartitionMap(non_partition_table_id), partition_logical_table_id);
+    ASSERT_EQ(mapping.findTableIDInDatabaseMap(non_partition_table_id), -1);
+    ASSERT_MAPPING_EQ(std::make_tuple(true, 2, 100), mapping.findDatabaseIDAndLogicalTableID(100));
+    ASSERT_MAPPING_EQ(std::make_tuple(true, 7, 101), mapping.findDatabaseIDAndLogicalTableID(101)); // changed
+    ASSERT_MAPPING_EQ(std::make_tuple(true, 2, 100), mapping.findDatabaseIDAndLogicalTableID(102));
+    ASSERT_MAPPING_EQ(std::make_tuple(true, 2, 100), mapping.findDatabaseIDAndLogicalTableID(103));
+    ASSERT_MAPPING_EQ(std::make_tuple(true, 2, 100), mapping.findDatabaseIDAndLogicalTableID(200)); // changed
+}
+
+} // namespace DB::tests

--- a/tests/fullstack-test2/ddl/alter_exchange_partition.test
+++ b/tests/fullstack-test2/ddl/alter_exchange_partition.test
@@ -83,6 +83,105 @@ mysql> set session tidb_isolation_read_engines='tiflash'; select * from test_new
 mysql> alter table test.e drop column c1;
 >> DBGInvoke __refresh_table_schema(test, e)
 
+# cleanup
+mysql> drop table if exists test.e;
+mysql> drop table if exists test.e2;
+mysql> drop table if exists test_new.e2;
+mysql> drop database if exists test_new;
+
+# case 11, create non-partition table and execute exchagne partition immediately
+mysql> create table test.e(id INT NOT NULL,fname VARCHAR(30),lname VARCHAR(30)) PARTITION BY RANGE (id) ( PARTITION p0 VALUES LESS THAN (50),PARTITION p1 VALUES LESS THAN (100),PARTITION p2 VALUES LESS THAN (150), PARTITION p3 VALUES LESS THAN (MAXVALUE));
+mysql> insert into test.e values (1, 'a', 'b'),(108, 'a', 'b');
+# sync the partition table to tiflash
+>> DBGInvoke __refresh_schemas()
+
+mysql> create table test.e2(id int not null,fname varchar(30),lname varchar(30));
+>> DBGInvoke __refresh_schemas()
+mysql> insert into test.e2 values (2, 'a', 'b');
+mysql> set @@tidb_enable_exchange_partition=1; alter table test.e exchange partition p0 with table test.e2
+
+mysql> alter table test.e set tiflash replica 1;
+mysql> alter table test.e2 set tiflash replica 1;
+func> wait_table test e e2
+>> DBGInvoke __refresh_schemas()
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.e order by id;
++-----+-------+-------+
+| id  | fname | lname |
++-----+-------+-------+
+|   2 | a     | b     |
+| 108 | a     | b     |
++-----+-------+-------+
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.e2 order by id;
++-----+-------+-------+
+| id  | fname | lname |
++-----+-------+-------+
+|   1 | a     | b     |
++-----+-------+-------+
+
+# ensure the swap out table is not mark as tombstone
+>> DBGInvoke __enable_schema_sync_service('true')
+>> DBGInvoke __gc_schemas(18446744073709551615)
+>> DBGInvoke __enable_schema_sync_service('false')
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.e order by id;
++-----+-------+-------+
+| id  | fname | lname |
++-----+-------+-------+
+|   2 | a     | b     |
+| 108 | a     | b     |
++-----+-------+-------+
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.e2 order by id;
++-----+-------+-------+
+| id  | fname | lname |
++-----+-------+-------+
+|   1 | a     | b     |
++-----+-------+-------+
+
+# case 12, create partition table, non-partition table and execute exchagne partition immediately
+mysql> drop table if exists test.e
+mysql> drop table if exists test.e2
+mysql> create table test.e(id INT NOT NULL,fname VARCHAR(30),lname VARCHAR(30)) PARTITION BY RANGE (id) ( PARTITION p0 VALUES LESS THAN (50),PARTITION p1 VALUES LESS THAN (100),PARTITION p2 VALUES LESS THAN (150), PARTITION p3 VALUES LESS THAN (MAXVALUE));
+mysql> insert into test.e values (1, 'a', 'b'),(108, 'a', 'b');
+mysql> create table test.e2(id int not null,fname varchar(30),lname varchar(30));
+mysql> insert into test.e2 values (2, 'a', 'b');
+mysql> set @@tidb_enable_exchange_partition=1; alter table test.e exchange partition p0 with table test.e2
+
+mysql> alter table test.e set tiflash replica 1;
+mysql> alter table test.e2 set tiflash replica 1;
+func> wait_table test e e2
+# tiflash the final result
+>> DBGInvoke __refresh_schemas()
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.e order by id;
++-----+-------+-------+
+| id  | fname | lname |
++-----+-------+-------+
+|   2 | a     | b     |
+| 108 | a     | b     |
++-----+-------+-------+
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.e2 order by id;
++-----+-------+-------+
+| id  | fname | lname |
++-----+-------+-------+
+|   1 | a     | b     |
++-----+-------+-------+
+# ensure the swap out table is not mark as tombstone
+>> DBGInvoke __enable_schema_sync_service('true')
+>> DBGInvoke __gc_schemas(18446744073709551615)
+>> DBGInvoke __enable_schema_sync_service('false')
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.e order by id;
++-----+-------+-------+
+| id  | fname | lname |
++-----+-------+-------+
+|   2 | a     | b     |
+| 108 | a     | b     |
++-----+-------+-------+
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.e2 order by id;
++-----+-------+-------+
+| id  | fname | lname |
++-----+-------+-------+
+|   1 | a     | b     |
++-----+-------+-------+
+
+# cleanup
 mysql> drop table if exists test.e;
 mysql> drop table if exists test.e2;
 mysql> drop table if exists test_new.e2;

--- a/tests/fullstack-test2/ddl/rename_table_across_databases.test
+++ b/tests/fullstack-test2/ddl/rename_table_across_databases.test
@@ -63,3 +63,45 @@ mysql> set session tidb_isolation_read_engines='tiflash'; select * from test_new
 mysql> drop table if exists test.t;
 mysql> drop table if exists test_new.t2;
 mysql> drop database if exists test_new;
+
+# rename table across database case 2
+mysql> create database if not exists test
+mysql> create database if not exists test_new
+# (required) stop regular schema sync
+=> DBGInvoke __enable_schema_sync_service('false')
+
+mysql> create table test.t(a int, b int);
+mysql> insert into test.t values (1, 1); insert into test.t values (1, 2);
+# (required) sync table id mapping to tiflash
+=> DBGInvoke __refresh_schemas()
+mysql> rename table test.t to test_new.t2;
+mysql> alter table test_new.t2 set tiflash replica 1;
+# new snapshot sync to tiflash, but the table id mapping is not updated
+func> wait_table test_new t2
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test_new.t2;
++------+------+
+| a    | b    |
++------+------+
+|    1 |    1 |
+|    1 |    2 |
++------+------+
+
+mysql> drop table if exists test.t;
+mysql> drop table if exists test_new.t2;
+mysql> drop database if exists test_new;
+
+# (required) create a new table and sync to tiflash, check whether it can apply
+mysql> drop table if exists test.t3;
+mysql> create table test.t3(c int, d int);
+mysql> insert into test.t3 values (3,3),(3,4);
+mysql> alter table test.t3 set tiflash replica 1;
+func> wait_table test t3
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t3;
++------+------+
+| c    | d    |
++------+------+
+|    3 |    3 |
+|    3 |    4 |
++------+------+
+
+mysql> drop table if exists test.t3;


### PR DESCRIPTION
manual cherry-pick of https://github.com/pingcap/tiflash/pull/8402

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/8398

Problem Summary:

The main problem is when we want to create a Storage instance

* `TiDBSchemaSyncer::syncTableSchema` first check whether we can find the TableID mapping in memory
* If we can find the TableID mapping, then `SchemaBuilder::applyTable` will fetch the table info from TiKV and try to create the table

https://github.com/pingcap/tiflash/blob/5ba01c04abc057f376eb71c8598cab65bc711460/dbms/src/TiDB/Schema/TiDBSchemaSyncer.cpp#L174-L215

https://github.com/pingcap/tiflash/blob/5ba01c04abc057f376eb71c8598cab65bc711460/dbms/src/TiDB/Schema/SchemaBuilder.cpp#L1203-L1213

However, even if we can find the TableID from the TableID mapping, we can not ensure its freshness. There could be some DDLs has changed the TableID mapping when we really want to create a Storage instance, this could lead to incorrect TableInfo fetched from TiKV. For example:
* Rename table to a new database
* `ALTER TABLE ... EXCHANGE PARTITION` that will make a partition to be a non-partition table

### What is changed and how it works?

commit: https://github.com/pingcap/tiflash/pull/8403/commits/76ee7091183730416bdd8b218b19c4da0349e289
- Iet `SchemaBuilder::applyTable` can detect the wrong TableID mapping and return false
  - Get the table info without `MVCC GET`, so that if a table has been renamed to a new database or dropped, we can return false
  - If we can not produce the table info by the logical_table_id, it is possible some partitions DDLs have been executed, return false
  - Only return true if we create the Storage instance by the latest table info or has applied the latest table info to the existing Storage instance
- Iet `TiDBSchemaSyncer:: syncTableSchema` try to sync the table schema to refresh the TableID mapping when need
  - First check the table id mapping and then try to call `SchemaBuilder::applyTable`
  - If something wrong happens in the first step, then try to sync the TiFlash instance schema using the same TiKV snapshot (same `SchemaGetter`). This will ensure the freshness of TableIDMapping
  - Then try to check the table id mapping and call `SchemaBuilder::applyTable` again with the same TiKV snapshot, it should OK for all cases now
- `SchemaBuilder:: applyRenameTable`
  - Will update the TableID -> DatabaseID mapping even if the Storage instance is not exist

commit: https://github.com/pingcap/tiflash/pull/8402/commits/babdf5588dbd7ac2cda9bee211905b859ae21f84
* Make `exchange partition` to be an atomic function `TableIDMap::exchangeTablePartition`
* `TableIDMap::emplaceTableID`/`TableIDMap::emplacePartitionTableID` check whether the old value is the same as new value before logging a warning message

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix a data inconsistency issue after `ALTER TABLE ... EXCHANGE PARTITION`
```
