### PR TITLE
*: Fix invalid memory access when shutting down

### DIFF
--- a/dbms/src/Common/MemoryTracker.cpp
+++ b/dbms/src/Common/MemoryTracker.cpp
@@ -39,7 +39,7 @@ MemoryTracker::~MemoryTracker()
     if (is_global_root)
         return;
 
-    if (peak)
+    if (peak && log_peak_memory_usage_in_destructor)
     {
         try
         {
@@ -305,19 +305,23 @@ void initStorageMemoryTracker(Int64 limit, Int64 larger_than_limit)
         "Storage task memory limit={}, larger_than_limit={}",
         formatReadableSizeWithBinarySuffix(limit),
         formatReadableSizeWithBinarySuffix(larger_than_limit));
+
+    // When these (static) mem tracker are reset, it means the process is shutdown and the logging system is stopped.
+    // Do not log down the usage info in dctor of them.
+    bool log_in_destructor = false;
     RUNTIME_CHECK(sub_root_of_query_storage_task_mem_trackers == nullptr);
-    sub_root_of_query_storage_task_mem_trackers = MemoryTracker::create(limit);
+    sub_root_of_query_storage_task_mem_trackers = MemoryTracker::create(limit, nullptr, log_in_destructor);
     sub_root_of_query_storage_task_mem_trackers->setBytesThatRssLargerThanLimit(larger_than_limit);
     sub_root_of_query_storage_task_mem_trackers->setAmountMetric(CurrentMetrics::MemoryTrackingQueryStorageTask);
 
     RUNTIME_CHECK(fetch_pages_mem_tracker == nullptr);
-    fetch_pages_mem_tracker = MemoryTracker::create();
-    fetch_pages_mem_tracker->setNext(sub_root_of_query_storage_task_mem_trackers.get());
+    fetch_pages_mem_tracker
+        = MemoryTracker::create(0, sub_root_of_query_storage_task_mem_trackers.get(), log_in_destructor);
     fetch_pages_mem_tracker->setAmountMetric(CurrentMetrics::MemoryTrackingFetchPages);
 
     RUNTIME_CHECK(shared_column_data_mem_tracker == nullptr);
-    shared_column_data_mem_tracker = MemoryTracker::create();
-    shared_column_data_mem_tracker->setNext(sub_root_of_query_storage_task_mem_trackers.get());
+    shared_column_data_mem_tracker
+        = MemoryTracker::create(0, sub_root_of_query_storage_task_mem_trackers.get(), log_in_destructor);
     shared_column_data_mem_tracker->setAmountMetric(CurrentMetrics::MemoryTrackingSharedColumnData);
 }
 

--- a/dbms/src/Common/MemoryTracker.h
+++ b/dbms/src/Common/MemoryTracker.h
@@ -18,6 +18,7 @@
 #include <common/types.h>
 
 #include <atomic>
+#include <boost/noncopyable.hpp>
 
 extern std::atomic<Int64> real_rss, proc_num_threads, baseline_of_query_mem_tracker;
 extern std::atomic<UInt64> proc_virt_size;
@@ -66,7 +67,6 @@ class MemoryTracker : public std::enable_shared_from_this<MemoryTracker>
     std::atomic<const char *> description = nullptr;
 
     /// Make constructors private to ensure all objects of this class is created by `MemoryTracker::create`.
-    MemoryTracker() = default;
     explicit MemoryTracker(Int64 limit_)
         : limit(limit_)
     {}
@@ -186,8 +186,6 @@ void realloc(Int64 old_size, Int64 new_size);
 void free(Int64 size);
 } // namespace CurrentMemoryTracker
 
-
-#include <boost/noncopyable.hpp>
 
 struct TemporarilyDisableMemoryTracker : private boost::noncopyable
 {

--- a/dbms/src/Common/MemoryTracker.h
+++ b/dbms/src/Common/MemoryTracker.h
@@ -85,7 +85,7 @@ public:
         MemoryTracker * parent = nullptr,
         bool log_peak_memory_usage_in_destructor = true)
     {
-        std::shared_ptr<MemoryTracker> p = std::shared_ptr<MemoryTracker>(new MemoryTracker(limit));
+        auto p = std::shared_ptr<MemoryTracker>(new MemoryTracker(limit));
         p->setParent(parent);
         p->log_peak_memory_usage_in_destructor = log_peak_memory_usage_in_destructor;
         return p;

--- a/dbms/src/Common/tests/gtest_memtracker.cpp
+++ b/dbms/src/Common/tests/gtest_memtracker.cpp
@@ -39,8 +39,7 @@ TEST_F(MemTrackerTest, testRootAndChild)
 try
 {
     auto root_mem_tracker = MemoryTracker::create();
-    auto child_mem_tracker = MemoryTracker::create(512);
-    child_mem_tracker->setNext(root_mem_tracker.get());
+    auto child_mem_tracker = MemoryTracker::create(512, root_mem_tracker.get());
     // alloc 500
     child_mem_tracker->alloc(500);
     ASSERT_EQ(500, child_mem_tracker->get());
@@ -71,10 +70,8 @@ TEST_F(MemTrackerTest, testRootAndMultipleChild)
 try
 {
     auto root = MemoryTracker::create(512); // limit 512
-    auto child1 = MemoryTracker::create(512); // limit 512
-    auto child2 = MemoryTracker::create(512); // limit 512
-    child1->setNext(root.get());
-    child2->setNext(root.get());
+    auto child1 = MemoryTracker::create(512, root.get()); // limit 512
+    auto child2 = MemoryTracker::create(512, root.get()); // limit 512
     // alloc 500 on child1
     child1->alloc(500);
     ASSERT_EQ(500, child1->get());

--- a/dbms/src/Interpreters/ProcessList.cpp
+++ b/dbms/src/Interpreters/ProcessList.cpp
@@ -172,7 +172,7 @@ ProcessList::EntryPtr ProcessList::insert(
             user_process_list.user_memory_tracker->setOrRaiseLimit(
                 settings.max_memory_usage_for_user.getActualBytes(total_memory));
             user_process_list.user_memory_tracker->setDescription("(for user)");
-            current_memory_tracker->setNext(user_process_list.user_memory_tracker.get());
+            current_memory_tracker->setParent(user_process_list.user_memory_tracker.get());
 
             /// Track memory usage for all simultaneously running queries.
             /// You should specify this value in configuration for default profile,
@@ -183,7 +183,7 @@ ProcessList::EntryPtr ProcessList::insert(
             total_memory_tracker->setBytesThatRssLargerThanLimit(settings.bytes_that_rss_larger_than_limit);
             total_memory_tracker->setDescription("(total)");
             total_memory_tracker->setAccuracyDiffForTest(settings.memory_tracker_accuracy_diff_for_test);
-            user_process_list.user_memory_tracker->setNext(total_memory_tracker.get());
+            user_process_list.user_memory_tracker->setParent(total_memory_tracker.get());
         }
 
         if (!total_network_throttler && settings.max_network_bandwidth_for_all_users)

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -1713,8 +1713,6 @@ int Server::main(const std::vector<std::string> & /*args*/)
                     store_id,
                     store_ident->store_id());
             }
-            throw Exception("Mock exception thrown");
-
             if (global_context->getSharedContextDisagg()->isDisaggregatedComputeMode())
             {
                 // compute node do not need to handle read index

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -1713,6 +1713,8 @@ int Server::main(const std::vector<std::string> & /*args*/)
                     store_id,
                     store_ident->store_id());
             }
+            throw Exception("Mock exception thrown");
+
             if (global_context->getSharedContextDisagg()->isDisaggregatedComputeMode())
             {
                 // compute node do not need to handle read index

--- a/dbms/src/Storages/BackgroundProcessingPool.cpp
+++ b/dbms/src/Storages/BackgroundProcessingPool.cpp
@@ -213,8 +213,7 @@ void BackgroundProcessingPool::threadFunction(size_t thread_idx) noexcept
     }
 
     // set up the thread local memory tracker
-    auto memory_tracker = MemoryTracker::create();
-    memory_tracker->setNext(root_of_non_query_mem_trackers.get());
+    auto memory_tracker = MemoryTracker::create(0, root_of_non_query_mem_trackers.get());
     memory_tracker->setMetric(CurrentMetrics::MemoryTrackingInBackgroundProcessingPool);
     current_memory_tracker = memory_tracker.get();
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/8408

Problem Summary:

There is an invalid memory access. This is because the logging system is already closed

![image](https://github.com/pingcap/tiflash/assets/4865550/4f761383-294d-4f25-a31b-c54ff15e3bb0)
![image](https://github.com/pingcap/tiflash/assets/4865550/dc6b9226-dbe0-44ce-83ea-88bc483c9c3b)

### What is changed and how it works?

When `sub_root_of_query_storage_task_mem_trackers` and its children are destructoring, it means the process is shutting down and the logging system is stopped.

Suppress the logging of these memory trackers.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  - Add a line after store_idnet is got to mock an exception thrown and tiflash stopped `throw Exception("Mock exception thrown");`
https://github.com/pingcap/tiflash/blob/3d3a5f14d51a55c636223e1ac9c9038e082ebb62/dbms/src/Server/Server.cpp#L1707-L1716
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
