### PR TITLE
Fixed the issue that `updateStatistics` was not called for `mlfq` in `resource group queue`

### DIFF
--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/ResourceControlQueue.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/ResourceControlQueue.cpp
@@ -147,7 +147,10 @@ bool ResourceControlQueue<NestedTaskQueueType>::take(TaskPtr & task)
 }
 
 template <typename NestedTaskQueueType>
-void ResourceControlQueue<NestedTaskQueueType>::updateStatistics(const TaskPtr & task, ExecTaskStatus exec_task_status, UInt64 inc_value)
+void ResourceControlQueue<NestedTaskQueueType>::updateStatistics(
+    const TaskPtr & task,
+    ExecTaskStatus exec_task_status,
+    UInt64 inc_value)
 {
     assert(task);
     auto ru = cpuTimeToRU(inc_value);

--- a/dbms/src/Flash/Pipeline/Schedule/TaskQueues/ResourceControlQueue.h
+++ b/dbms/src/Flash/Pipeline/Schedule/TaskQueues/ResourceControlQueue.h
@@ -45,7 +45,7 @@ public:
 
     bool take(TaskPtr & task) override;
 
-    void updateStatistics(const TaskPtr & task, ExecTaskStatus, UInt64 inc_value) override;
+    void updateStatistics(const TaskPtr & task, ExecTaskStatus exec_task_status, UInt64 inc_value) override;
 
     bool empty() const override;
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8415

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fixed the issue that updateStatistics was not called for mlfq in resource group queue.
```
