### PR TITLE
fix asan fail for `cast_decimal_as_json` and `cast_time_as_json`

### DIFF
--- a/dbms/src/Functions/FunctionsJson.h
+++ b/dbms/src/Functions/FunctionsJson.h
@@ -787,11 +787,12 @@ private:
         JsonBinary::JsonBinaryWriteBuffer write_buffer(data_to, reserve_size);
         for (size_t i = 0; i < column_from->size(); ++i)
         {
-            const auto & field = (*column_from)[i].template safeGet<DecimalField<FromType>>();
+            auto & field = (*column_from)[i].template safeGet<DecimalField<FromType>>();
             // same as https://github.com/pingcap/tidb/blob/90628349860718bb84c94fe7dc1e1f9bd9da4348/pkg/expression/builtin_cast.go#L854-L865
             // https://github.com/pingcap/tidb/issues/48796
             // TODO `select json_type(cast(1111.11 as json))` should return `DECIMAL`, we return `DOUBLE` now.
-            JsonBinary::appendNumber(write_buffer, static_cast<Float64>(field));
+            auto float64_val = static_cast<Float64>(field);
+            JsonBinary::appendNumber(write_buffer, float64_val);
             writeChar(0, write_buffer);
             offsets_to[i] = write_buffer.count();
         }

--- a/dbms/src/Functions/FunctionsJson.h
+++ b/dbms/src/Functions/FunctionsJson.h
@@ -787,12 +787,12 @@ private:
         JsonBinary::JsonBinaryWriteBuffer write_buffer(data_to, reserve_size);
         for (size_t i = 0; i < column_from->size(); ++i)
         {
-            auto & field = (*column_from)[i].template safeGet<DecimalField<FromType>>();
             // same as https://github.com/pingcap/tidb/blob/90628349860718bb84c94fe7dc1e1f9bd9da4348/pkg/expression/builtin_cast.go#L854-L865
             // https://github.com/pingcap/tidb/issues/48796
             // TODO `select json_type(cast(1111.11 as json))` should return `DECIMAL`, we return `DOUBLE` now.
-            auto float64_val = static_cast<Float64>(field);
-            JsonBinary::appendNumber(write_buffer, float64_val);
+            JsonBinary::appendNumber(
+                write_buffer,
+                static_cast<Float64>((*column_from)[i].template safeGet<DecimalField<FromType>>()));
             writeChar(0, write_buffer);
             offsets_to[i] = write_buffer.count();
         }

--- a/dbms/src/Functions/tests/gtest_cast_as_json.cpp
+++ b/dbms/src/Functions/tests/gtest_cast_as_json.cpp
@@ -197,28 +197,28 @@ try
     using DecimalField256 = DecimalField<Decimal256>;
 
     /// Decimal32
-    executeAndAssert<Decimal32>(func_name, DecimalField32(1011, 1), "101.1");
-    executeAndAssert<Decimal32>(func_name, DecimalField32(-1011, 1), "-101.1");
-    executeAndAssert<Decimal32>(func_name, DecimalField32(9999, 1), "999.9");
-    executeAndAssert<Decimal32>(func_name, DecimalField32(-9999, 1), "-999.9");
+    executeAndAssert(func_name, DecimalField32(1011, 1), "101.1");
+    executeAndAssert(func_name, DecimalField32(-1011, 1), "-101.1");
+    executeAndAssert(func_name, DecimalField32(9999, 1), "999.9");
+    executeAndAssert(func_name, DecimalField32(-9999, 1), "-999.9");
 
-    /// Decimal64
-    executeAndAssert<Decimal64>(func_name, DecimalField64(1011, 1), "101.1");
-    executeAndAssert<Decimal64>(func_name, DecimalField64(-1011, 1), "-101.1");
-    executeAndAssert<Decimal64>(func_name, DecimalField64(9999, 1), "999.9");
-    executeAndAssert<Decimal64>(func_name, DecimalField64(-9999, 1), "-999.9");
+    // Decimal64
+    executeAndAssert(func_name, DecimalField64(1011, 1), "101.1");
+    executeAndAssert(func_name, DecimalField64(-1011, 1), "-101.1");
+    executeAndAssert(func_name, DecimalField64(9999, 1), "999.9");
+    executeAndAssert(func_name, DecimalField64(-9999, 1), "-999.9");
 
     /// Decimal128
-    executeAndAssert<Decimal128>(func_name, DecimalField128(1011, 1), "101.1");
-    executeAndAssert<Decimal128>(func_name, DecimalField128(-1011, 1), "-101.1");
-    executeAndAssert<Decimal128>(func_name, DecimalField128(9999, 1), "999.9");
-    executeAndAssert<Decimal128>(func_name, DecimalField128(-9999, 1), "-999.9");
+    executeAndAssert(func_name, DecimalField128(1011, 1), "101.1");
+    executeAndAssert(func_name, DecimalField128(-1011, 1), "-101.1");
+    executeAndAssert(func_name, DecimalField128(9999, 1), "999.9");
+    executeAndAssert(func_name, DecimalField128(-9999, 1), "-999.9");
 
     /// Decimal256
-    executeAndAssert<Decimal256>(func_name, DecimalField256(static_cast<Int256>(1011), 1), "101.1");
-    executeAndAssert<Decimal256>(func_name, DecimalField256(static_cast<Int256>(-1011), 1), "-101.1");
-    executeAndAssert<Decimal256>(func_name, DecimalField256(static_cast<Int256>(9999), 1), "999.9");
-    executeAndAssert<Decimal256>(func_name, DecimalField256(static_cast<Int256>(-9999), 1), "-999.9");
+    executeAndAssert(func_name, DecimalField256(static_cast<Int256>(1011), 1), "101.1");
+    executeAndAssert(func_name, DecimalField256(static_cast<Int256>(-1011), 1), "-101.1");
+    executeAndAssert(func_name, DecimalField256(static_cast<Int256>(9999), 1), "999.9");
+    executeAndAssert(func_name, DecimalField256(static_cast<Int256>(-9999), 1), "-999.9");
 }
 CATCH
 

--- a/dbms/src/Functions/tests/gtest_cast_as_json.cpp
+++ b/dbms/src/Functions/tests/gtest_cast_as_json.cpp
@@ -322,20 +322,20 @@ try
     static auto const date_type_ptr = std::make_shared<DataTypeMyDate>();
 
     // DataTypeMyDateTime
+    // Only raw function test is tested, so input_tidb_tp is always nullptr and only the case of TiDB::TypeTimestamp is tested here.
     {
         auto data_col_ptr
             = createColumn<DataTypeMyDateTime::FieldType>(
                   {MyDateTime(2023, 1, 2, 3, 4, 5, 6).toPackedUInt(), MyDateTime(0, 0, 0, 0, 0, 0, 0).toPackedUInt()})
                   .column;
         ColumnWithTypeAndName input(data_col_ptr, datetime_type_ptr, "");
-        auto res = executeFunctionWithCast("cast_time_as_json", {input});
+        auto res = executeFunctionWithCast<true>("cast_time_as_json", {input});
         auto expect
             = createColumn<Nullable<String>>({"\"2023-01-02 03:04:05.000006\"", "\"0000-00-00 00:00:00.000000\""});
         ASSERT_COLUMN_EQ(expect, res);
     }
 
     // DataTypeMyDate
-    // Only raw function test is tested, so input_tidb_tp is always nullptr and only the case of TiDB::TypeTimestamp is tested here.
     {
         auto data_col_ptr = createColumn<DataTypeMyDate::FieldType>(
                                 {MyDate(2023, 12, 31).toPackedUInt(), MyDate(0, 0, 0).toPackedUInt()})

--- a/dbms/src/Functions/tests/gtest_cast_as_json.cpp
+++ b/dbms/src/Functions/tests/gtest_cast_as_json.cpp
@@ -202,7 +202,7 @@ try
     executeAndAssert(func_name, DecimalField32(9999, 1), "999.9");
     executeAndAssert(func_name, DecimalField32(-9999, 1), "-999.9");
 
-    // Decimal64
+    /// Decimal64
     executeAndAssert(func_name, DecimalField64(1011, 1), "101.1");
     executeAndAssert(func_name, DecimalField64(-1011, 1), "-101.1");
     executeAndAssert(func_name, DecimalField64(9999, 1), "999.9");


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8427

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
