### PR TITLE
Disagg: Fix the problem of missing remote page id in MemTableSet.

### DIFF
--- a/dbms/src/Storages/DeltaMerge/SegmentReadTask.cpp
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTask.cpp
@@ -110,23 +110,31 @@ SegmentReadTask::SegmentReadTask(
         ranges.push_back(RowKeyRange::deserialize(rb));
     }
 
-    const auto & cfs = read_snapshot->delta->getPersistedFileSetSnapshot()->getColumnFiles();
     std::vector<UInt64> remote_page_ids;
     std::vector<size_t> remote_page_sizes;
-    remote_page_ids.reserve(cfs.size());
-    remote_page_sizes.reserve(cfs.size());
+    {
+        // The number of ColumnFileTiny of MemTableSet is unknown, but there is a very high probability that it is zero.
+        // So ignoring the number of ColumnFileTiny of MemTableSet is better than always adding all the number of ColumnFile of MemTableSet when reserving.
+        const auto & cfs = read_snapshot->delta->getPersistedFileSetSnapshot()->getColumnFiles();
+        remote_page_ids.reserve(cfs.size());
+        remote_page_sizes.reserve(cfs.size());
+    }
     auto extract_remote_pages = [&remote_page_ids, &remote_page_sizes](const ColumnFiles & cfs) {
+        UInt64 count = 0;
         for (const auto & cf : cfs)
         {
             if (auto * tiny = cf->tryToTinyFile(); tiny)
             {
                 remote_page_ids.emplace_back(tiny->getDataPageId());
                 remote_page_sizes.emplace_back(tiny->getDataPageSize());
+                ++count;
             }
         }
+        return count;
     };
-    extract_remote_pages(read_snapshot->delta->getMemTableSetSnapshot()->getColumnFiles());
-    extract_remote_pages(read_snapshot->delta->getPersistedFileSetSnapshot()->getColumnFiles());
+    auto memory_page_count = extract_remote_pages(read_snapshot->delta->getMemTableSetSnapshot()->getColumnFiles());
+    auto persisted_page_count
+        = extract_remote_pages(read_snapshot->delta->getPersistedFileSetSnapshot()->getColumnFiles());
 
     extra_remote_info.emplace(ExtraRemoteSegmentInfo{
         .store_address = store_address,
@@ -137,9 +145,12 @@ SegmentReadTask::SegmentReadTask(
 
     LOG_DEBUG(
         read_snapshot->log,
-        "memtable_cfs_count={} persisted_cfs_count={} remote_page_ids={} delta_index={} store_address={}",
+        "memory_cfs_count={} memory_page_count={} persisted_cfs_count={} persisted_page_count={} remote_page_ids={} "
+        "delta_index={} store_address={}",
         read_snapshot->delta->getMemTableSetSnapshot()->getColumnFileCount(),
-        cfs.size(),
+        memory_page_count,
+        read_snapshot->delta->getPersistedFileSetSnapshot()->getColumnFileCount(),
+        persisted_page_count,
         extra_remote_info->remote_page_ids,
         read_snapshot->delta->getSharedDeltaIndex()->toString(),
         store_address);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8436

### What is changed and how it works?

1. Extract page id from MemTableSet.
2. Initialize data provider of MemTableSet.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
