### PR TITLE
Storages: Fix memory leak when copying DeltaTree failed.

### DIFF
--- a/dbms/src/Common/FailPoint.cpp
+++ b/dbms/src/Common/FailPoint.cpp
@@ -106,7 +106,8 @@ namespace DB
     M(cop_send_failure)                                      \
     M(force_set_parallel_prehandle_threshold)                \
     M(force_raise_prehandle_exception)                       \
-    M(force_agg_on_partial_block)
+    M(force_agg_on_partial_block)                            \
+    M(delta_tree_create_node_fail)
 
 #define APPLY_FOR_PAUSEABLE_FAILPOINTS_ONCE(M) \
     M(pause_with_alter_locks_acquired)         \

--- a/dbms/src/Storages/DeltaMerge/DeltaTree.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaTree.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <Common/FailPoint.h>
 #include <Common/TargetSpecific.h>
 #include <Core/Types.h>
 #include <IO/WriteHelpers.h>
@@ -21,12 +22,21 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <ext/scope_guard.h>
 #include <memory>
 #include <queue>
 
-namespace DB
+namespace DB::FailPoints
 {
-namespace DM
+extern const char delta_tree_create_node_fail[];
+}
+
+namespace DB::ErrorCodes
+{
+extern const int FAIL_POINT_ERROR;
+};
+
+namespace DB::DM
 {
 struct DTMutation;
 template <size_t M, size_t F, size_t S>
@@ -817,7 +827,7 @@ private:
     size_t num_deletes = 0;
     size_t num_entries = 0;
 
-    Allocator * allocator = nullptr;
+    std::unique_ptr<Allocator> allocator;
     size_t bytes = 0;
 
 public:
@@ -901,6 +911,11 @@ private:
     template <typename T>
     T * createNode()
     {
+        fiu_do_on(FailPoints::delta_tree_create_node_fail, {
+            static int num_call = 0;
+            if (num_call++ % 100 == 90)
+                throw Exception("Failpoint delta_tree_create_node_fail is triggered", ErrorCodes::FAIL_POINT_ERROR);
+        });
         T * n = reinterpret_cast<T *>(allocator->alloc(sizeof(T)));
         new (n) T();
 
@@ -915,7 +930,7 @@ private:
         constexpr bool is_leaf = std::is_same<Leaf, T>::value;
         if constexpr (!is_leaf)
         {
-            InternPtr intern = static_cast<InternPtr>(node);
+            auto intern = static_cast<InternPtr>(node);
             if (intern->count)
             {
                 if (isLeaf(intern->children[0]))
@@ -931,7 +946,7 @@ private:
 
     void init(const ValueSpacePtr & insert_value_space_)
     {
-        allocator = new Allocator();
+        allocator = std::make_unique<Allocator>();
 
         insert_value_space = insert_value_space_;
 
@@ -983,8 +998,6 @@ public:
             else
                 freeTree<Intern>(static_cast<InternPtr>(root));
         }
-
-        delete allocator;
     }
 
     void checkAll() const
@@ -1043,8 +1056,25 @@ DT_CLASS::DeltaTree(const DT_CLASS::Self & o)
     , num_inserts(o.num_inserts)
     , num_deletes(o.num_deletes)
     , num_entries(o.num_entries)
-    , allocator(new Allocator())
+    , allocator(std::make_unique<Allocator>())
 {
+    // If exception is thrown before clear copying_nodes, all nodes will be destroyed.
+    std::vector<NodePtr> copying_nodes;
+    auto destroy_copying_nodes = [&]() {
+        for (auto * node : copying_nodes)
+        {
+            if (isLeaf(node))
+            {
+                freeNode<Leaf>(static_cast<LeafPtr>(node));
+            }
+            else
+            {
+                freeNode<Intern>(static_cast<InternPtr>(node));
+            }
+        }
+    };
+    SCOPE_EXIT({ destroy_copying_nodes(); });
+
     NodePtr my_root;
     if (isLeaf(o.root))
         my_root = new (createNode<Leaf>()) Leaf(*as(Leaf, o.root));
@@ -1053,6 +1083,7 @@ DT_CLASS::DeltaTree(const DT_CLASS::Self & o)
 
     std::queue<NodePtr> nodes;
     nodes.push(my_root);
+    copying_nodes.push_back(my_root);
 
     LeafPtr first_leaf = nullptr;
     LeafPtr last_leaf = nullptr;
@@ -1084,6 +1115,7 @@ DT_CLASS::DeltaTree(const DT_CLASS::Self & o)
                 {
                     auto child = new (createNode<Leaf>()) Leaf(*as(Leaf, intern->children[i]));
                     nodes.push(child);
+                    copying_nodes.push_back(child);
                     intern->children[i] = child;
 
                     child->parent = intern;
@@ -1095,6 +1127,7 @@ DT_CLASS::DeltaTree(const DT_CLASS::Self & o)
                 {
                     auto child = new (createNode<Intern>()) Intern(*as(Intern, intern->children[i]));
                     nodes.push(child);
+                    copying_nodes.push_back(child);
                     intern->children[i] = child;
 
                     child->parent = intern;
@@ -1103,6 +1136,7 @@ DT_CLASS::DeltaTree(const DT_CLASS::Self & o)
         }
     }
 
+    copying_nodes.clear();
     this->root = my_root;
     this->left_leaf = first_leaf;
     this->right_leaf = last_leaf;
@@ -1495,5 +1529,4 @@ typename DT_CLASS::InternPtr DT_CLASS::afterNodeUpdated(T * node)
 #undef DT_TEMPLATE
 #undef DT_CLASS
 
-} // namespace DM
-} // namespace DB
+} // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_tree.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_tree.cpp
@@ -15,14 +15,11 @@
 #include <Storages/DeltaMerge/DeltaMergeDefines.h>
 #include <Storages/DeltaMerge/DeltaTree.h>
 #include <Storages/DeltaMerge/Tuple.h>
-#include <gtest/gtest.h>
+#include <TestUtils/TiFlashTestBasic.h>
 
-namespace DB
+namespace DB::DM::tests
 {
-namespace DM
-{
-namespace tests
-{
+
 #define print(M) std::cout << "" #M ": " << M << std::endl
 
 class FakeValueSpace;
@@ -62,7 +59,23 @@ using FakeValueSpacePtr = std::shared_ptr<FakeValueSpace>;
 class DeltaTree_test : public ::testing::Test
 {
 protected:
-    FakeDeltaTree tree;
+    void SetUp() override
+    {
+        CurrentMemoryTracker::disableThreshold();
+        memory_tracker = MemoryTracker::create();
+        memory_tracker_setter.emplace(true, memory_tracker.get());
+        ASSERT_EQ(current_memory_tracker->get(), 0);
+
+        fake_tree = std::make_unique<FakeDeltaTree>();
+        ASSERT_EQ(fake_tree->getBytes(), sizeof(FakeDeltaTree::Leaf));
+        ASSERT_EQ(current_memory_tracker->get(), sizeof(FakeDeltaTree::Leaf));
+    }
+
+    void TearDown() override { DB::FailPointHelper::disableFailPoint(DB::FailPoints::delta_tree_create_node_fail); }
+
+    std::unique_ptr<FakeDeltaTree> fake_tree;
+    MemoryTrackerPtr memory_tracker;
+    std::optional<MemoryTrackerSetter> memory_tracker_setter;
 };
 
 void printTree(const FakeDeltaTree & tree)
@@ -79,7 +92,7 @@ void printTree(const FakeDeltaTree & tree)
 
 std::string treeToString(const FakeDeltaTree & tree)
 {
-    std::string result = "";
+    std::string result;
     std::string temp;
     for (auto it = tree.begin(), end = tree.end(); it != end; ++it)
     {
@@ -117,6 +130,7 @@ TEST_F(DeltaTree_test, PrintSize)
 
 TEST_F(DeltaTree_test, Insert)
 {
+    auto & tree = *fake_tree;
     // insert 100 items
     for (int i = 0; i < 100; ++i)
     {
@@ -199,6 +213,7 @@ TEST_F(DeltaTree_test, Insert)
 
 TEST_F(DeltaTree_test, DeleteAfterInsert)
 {
+    auto & tree = *fake_tree;
     int batch_num = 100;
 
     std::string expectedResult;
@@ -261,6 +276,7 @@ TEST_F(DeltaTree_test, DeleteAfterInsert)
 
 TEST_F(DeltaTree_test, Delete1)
 {
+    auto & tree = *fake_tree;
     int batch_num = 100;
 
     // delete stable from begin to end with merge
@@ -276,6 +292,7 @@ TEST_F(DeltaTree_test, Delete1)
 
 TEST_F(DeltaTree_test, Delete2)
 {
+    auto & tree = *fake_tree;
     int batch_num = 100;
 
     std::string expectedResult;
@@ -298,6 +315,7 @@ TEST_F(DeltaTree_test, Delete2)
 
 TEST_F(DeltaTree_test, InsertSkipDelete)
 {
+    auto & tree = *fake_tree;
     int batch_num = 100;
     tree.addDelete(0);
     std::string expectedResult = "(0|0|DEL|1|0),";
@@ -317,6 +335,36 @@ TEST_F(DeltaTree_test, InsertSkipDelete)
     checkCopy(tree);
 }
 
-} // namespace tests
-} // namespace DM
-} // namespace DB
+
+TEST_F(DeltaTree_test, CreateNodeFailInCopyCtor)
+try
+{
+    auto & tree = *fake_tree;
+    // Create a tree for copy
+    for (int i = 0; i < 1000; ++i)
+    {
+        tree.addInsert(i, i);
+    }
+    auto mem_usage_old = current_memory_tracker->get();
+    ASSERT_EQ(mem_usage_old, tree.getBytes());
+
+    DB::FailPointHelper::enableFailPoint(DB::FailPoints::delta_tree_create_node_fail);
+    try
+    {
+        // Must throw DB::Exception
+        FakeDeltaTree copy(tree);
+    }
+    catch (const Exception & e)
+    {
+        // Catch, check and return directly
+        ASSERT_EQ(e.code(), ErrorCodes::FAIL_POINT_ERROR);
+        ASSERT_EQ(e.message(), String("Failpoint delta_tree_create_node_fail is triggered"));
+        auto mem_usage_current = current_memory_tracker->get();
+        ASSERT_EQ(mem_usage_current, mem_usage_old);
+        return;
+    }
+    FAIL() << "Should not come here";
+}
+CATCH
+
+} // namespace DB::DM::tests


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8447

### What is changed and how it works?

Collect all new nodes when copying DeltaTree object and destroy them if exception happened.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix a memory leak issue when queries reach the memory limit
```
