### PR TITLE
ddl: Fix unstable FLASHBACK DATABASE test (release-6.5)

### DIFF
--- a/tests/fullstack-test2/ddl/flashback_database.test
+++ b/tests/fullstack-test2/ddl/flashback_database.test
@@ -33,6 +33,7 @@ mysql> alter table d1.t3 add column b int;
 mysql> insert into d1.t3 values(2,2);
 mysql> alter table d1.t4 add column b int;
 
+=> DBGInvoke __refresh_schemas()
 mysql> drop database d1;
 
 mysql> flashback database d1 to d1_new


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/8450

Problem Summary:

```
mysql> alter table d1.t3 add column b int;
mysql> insert into d1.t3 values(2,2);
mysql> alter table d1.t4 add column b int;
-- drop immediately after adding new columns
mysql> drop database d1;
mysql> flashback database d1 to d1_new
```

If database is dropped before tiflash apply the `add column` DDLs, then tiflash can not know the latest table info because it has been "dropped"

### What is changed and how it works?

Add a schema sync on tiflash before executing `drop database`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
