### PR TITLE
Support only null type for json_extract

### DIFF
--- a/dbms/src/Functions/tests/gtest_json_extract.cpp
+++ b/dbms/src/Functions/tests/gtest_json_extract.cpp
@@ -137,6 +137,14 @@ try
     expect_null_vec = {1, 1, 1};
     checkResult(res.column, expect_null_vec, expect_string_vec);
 
+    /// only null
+    auto const_null_only_col = createOnlyNullColumnConst(3);
+    res = executeFunction(func_name, {const_null_only_col, path_col});
+    ASSERT_TRUE(res.column->size() == 3);
+    expect_string_vec = {"", "", ""};
+    expect_null_vec = {1, 1, 1};
+    checkResult(res.column, expect_null_vec, expect_string_vec);
+
     /// ColumnVector(non-null)
     auto non_null_str_col = ColumnString::create();
     non_null_str_col->insertData(reinterpret_cast<const char *>(bj2), sizeof(bj2) / sizeof(UInt8));

--- a/dbms/src/Functions/tests/gtest_json_extract.cpp
+++ b/dbms/src/Functions/tests/gtest_json_extract.cpp
@@ -137,7 +137,7 @@ try
     expect_null_vec = {1, 1, 1};
     checkResult(res.column, expect_null_vec, expect_string_vec);
 
-    /// only null
+    /// JsonBinary only null
     auto const_null_only_col = createOnlyNullColumnConst(3);
     res = executeFunction(func_name, {const_null_only_col, path_col});
     ASSERT_TRUE(res.column->size() == 3);
@@ -156,6 +156,13 @@ try
     ASSERT_TRUE(res.column->size() == 3);
     expect_string_vec = {"3", "3", "[2, 3]"};
     expect_null_vec = {0, 0, 0};
+    checkResult(res.column, expect_null_vec, expect_string_vec);
+
+    /// One of Paths is only null
+    res = executeFunction(func_name, {non_null_input_col, non_null_path_col, const_null_only_col});
+    ASSERT_TRUE(res.column->size() == 3);
+    expect_string_vec = {"", "", ""};
+    expect_null_vec = {1, 1, 1};
     checkResult(res.column, expect_null_vec, expect_string_vec);
 
     /// ColumnConst(non-null)

--- a/tests/fullstack-test/expr/json_extract.test
+++ b/tests/fullstack-test/expr/json_extract.test
@@ -47,4 +47,18 @@ mysql> set tidb_enforce_mpp=1; select json_extract(d, '\$[0]', '\$[1]', '\$[2].a
 | [1, 2, "b"] |
 +-------------+
 
+mysql> set tidb_enforce_mpp=1; select json_extract(NULL, '\$[0]', '\$[1]', '\$[2].a') as col_a from test.t #NO_UNESCAPE
++-------+
+| col_a |
++-------+
+| NULL  |
++-------+
+
+mysql> set tidb_enforce_mpp=1; select json_extract(d, '\$[0]', NULL, '\$[2].a') as col_a from test.t #NO_UNESCAPE
++-------+
+| col_a |
++-------+
+| NULL  |
++-------+
+
 mysql> drop table if exists test.t


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8486

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
