### PR TITLE
Storages: fix segmentfault when `fetchPages` failed.

### DIFF
--- a/dbms/src/Storages/DeltaMerge/SegmentReadTask.cpp
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTask.cpp
@@ -509,7 +509,7 @@ void SegmentReadTask::checkMemTableSetReady() const
     {
         if (auto * in_mem_cf = cf->tryToInMemoryFile(); in_mem_cf)
         {
-            RUNTIME_CHECK(in_mem_cf->getCache() != nullptr);
+            RUNTIME_CHECK_MSG(in_mem_cf->getCache() != nullptr, "Fail to fetch MemTableSet from {}", *this);
         }
     }
 }

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTask.cpp
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTask.cpp
@@ -564,7 +564,7 @@ void SegmentReadTask::doFetchPages(const disaggregated::FetchDisaggPagesRequest 
     });
 
     doFetchPagesImpl(
-        [&stream_resp](disaggregated::PagesPacket & packet) {
+        [&stream_resp, this](disaggregated::PagesPacket & packet) {
             if (stream_resp->Read(&packet))
             {
                 return true;
@@ -575,7 +575,8 @@ void SegmentReadTask::doFetchPages(const disaggregated::FetchDisaggPagesRequest 
                 stream_resp.reset(); // Reset to avoid calling `Finish()` repeatedly.
                 RUNTIME_CHECK_MSG(
                     status.ok(),
-                    "status={} message={}",
+                    "Failed to fetch all pages from {}, status={}, message={}",
+                    *this,
                     static_cast<int>(status.error_code()),
                     status.error_message());
                 return false;

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTask.h
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTask.h
@@ -133,6 +133,7 @@ public:
         std::unordered_set<UInt64> remaining_pages_to_fetch);
     void checkMemTableSet(const ColumnFileSetSnapshotPtr & mem_table_snap) const;
     bool needFetchMemTableSet() const;
+    void checkMemTableSetReady() const;
 
     void initColumnFileDataProvider(const Remote::RNLocalPageCacheGuardPtr & pages_guard);
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8515

Problem Summary:
When network partitioned, CN fetches pages and memtableset from WN will fail. However, we forgot to check the status of grpc after response stream returns false, and the function `FetchPages()` may think that the pages fetching was successful (but actually not).

Before [PR8430](https://github.com/pingcap/tiflash/pull/8430), [some](https://github.com/pingcap/tiflash/blob/master/dbms/src/Storages/DeltaMerge/SegmentReadTask.cpp#L674-L678)[ condition checks](https://github.com/pingcap/tiflash/blob/master/dbms/src/Storages/DeltaMerge/SegmentReadTask.cpp#L674-L678) will discover these anomalies, and throw exceptions. In the case that all pages are cached, this condition check takes no effect. 

In [PR8430](https://github.com/pingcap/tiflash/pull/8430), `FetchPages()` needs to fetch `MemTableSet` too. If grpc fails, the data of `MemTableSet` is empty (pointer of cache is nullptr), and causes segmentfault when reading data.

### What is changed and how it works?

- We need to call `Finish()` and check the status of grpc after response stream returns false.
- For safety, check if the data of `ColumnFileInMemory` is ready after fetching pages.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
    - Run queries and restart WN, check server status of CNs.
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
