### PR TITLE
Update tsan suppressions to ignore protobuf DebugString and ShortDebugString

### DIFF
--- a/tests/sanitize/tsan.suppression
+++ b/tests/sanitize/tsan.suppression
@@ -1,6 +1,7 @@
 race:dbms/src/Common/TiFlashMetrics.h
 race:DB::Context::setCancelTest
 race:DB::getCurrentExceptionMessage
-race:google::protobuf::internal::AssignDescriptors
+race:google::protobuf::Message::DebugString
+race:google::protobuf::Message::ShortDebugString
 race:fiu_fail
 race:dbms/src/DataStreams/BlockStreamProfileInfo.h


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #8285

Problem Summary:
In PR #8499, try add AssignDescriptors to tsan suppression to ignore false positive warnings. However, the tool fails to recognize and ignore some cases(write code is protected by call_once):
![gRUZHBl5IB](https://github.com/pingcap/tiflash/assets/12403562/ce390628-44c6-47b2-b8cf-8759a0db0976)

![8mz1Eue6r7](https://github.com/pingcap/tiflash/assets/12403562/a54e2151-e624-4806-b6d2-1504edf00d1c)
### What is changed and how it works?
Ignore high level functions: DebugString and ShortDebugString

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
