### PR TITLE
Disagg: Fix infinite retries on owner election

### DIFF
--- a/dbms/src/Common/FailPoint.cpp
+++ b/dbms/src/Common/FailPoint.cpp
@@ -65,6 +65,7 @@ namespace DB
     M(force_ps_wal_compact)                                       \
     M(pause_before_full_gc_prepare)                               \
     M(force_owner_mgr_state)                                      \
+    M(force_owner_mgr_campaign_failed)                            \
     M(exception_during_spill)                                     \
     M(force_fail_to_create_etcd_session)                          \
     M(force_remote_read_for_batch_cop_once)                       \

--- a/dbms/src/TiDB/Etcd/Client.cpp
+++ b/dbms/src/TiDB/Etcd/Client.cpp
@@ -402,7 +402,14 @@ bool Session::keepAliveOne()
     // the lease is not valid anymore
     if (resp.ttl() <= 0)
     {
-        LOG_DEBUG(log, "keep alive fail, ttl={}", resp.ttl());
+        auto status = writer->Finish();
+        LOG_INFO(
+            log,
+            "keep alive fail, ttl={}, code={} msg={}",
+            resp.ttl(),
+            magic_enum::enum_name(status.error_code()),
+            status.error_message());
+        finished = true;
         return false;
     }
     lease_deadline = next_timepoint + std::chrono::seconds(resp.ttl());

--- a/dbms/src/TiDB/OwnerManager.cpp
+++ b/dbms/src/TiDB/OwnerManager.cpp
@@ -51,6 +51,7 @@ namespace DB
 namespace FailPoints
 {
 extern const char force_owner_mgr_state[];
+extern const char force_owner_mgr_campaign_failed[];
 extern const char force_fail_to_create_etcd_session[];
 } // namespace FailPoints
 
@@ -227,10 +228,10 @@ std::pair<bool, Etcd::SessionPtr> EtcdOwnerManager::runNextCampaign(Etcd::Sessio
 void EtcdOwnerManager::tryChangeState(State coming_state)
 {
     std::unique_lock lk(mtx_camaign);
-    // The campaign is stopping, it will cause
-    // - leader key deleted in watch thread
-    // - etcd lease expired in keepalive task
-    // Do not overwrite `CancelByStop` because the next campaign is expected to be stopped.
+    // When the campaign is stopping, it will cause
+    // - leader key deleted in watch thread => try set state to `CancelByKeyDeleted`
+    // - etcd lease expired in keepalive task => try set state to `CancelByLeaseInvalid`
+    // Do not let those actually overwrite `CancelByStop` because the next campaign is expected to be stopped.
     if (state != State::CancelByStop)
     {
         // ok to set the state
@@ -258,6 +259,10 @@ void EtcdOwnerManager::camaignLoop(Etcd::SessionPtr session)
                 campaing_ctx = std::make_unique<grpc::ClientContext>();
             }
             auto && [new_leader, status] = client->campaign(campaing_ctx.get(), campaign_name, id, lease_id);
+            fiu_do_on(FailPoints::force_owner_mgr_campaign_failed, {
+                status = grpc::Status(grpc::StatusCode::UNKNOWN, "<mock error> etcdserver: requested lease not found");
+                LOG_WARNING(log, "force_owner_mgr_campaign_failed enabled, return failed grpc::Status");
+            });
             if (!status.ok())
             {
                 // if error, continue next campaign
@@ -268,6 +273,9 @@ void EtcdOwnerManager::camaignLoop(Etcd::SessionPtr session)
                     lease_id,
                     magic_enum::enum_name(status.error_code()),
                     status.error_message());
+                // The error is possible cause by lease invalid, create a new etcd
+                // session next round.
+                tryChangeState(State::CancelByLeaseInvalid);
                 static constexpr std::chrono::milliseconds CampaignRetryInterval(200);
                 std::this_thread::sleep_for(CampaignRetryInterval);
                 continue;
@@ -372,7 +380,7 @@ void EtcdOwnerManager::watchOwner(const String & owner_key, grpc::ClientContext 
             }
         } // loop until key deleted or failed
         auto s = rw->Finish();
-        LOG_DEBUG(log, "watch finish, code={} msg={}", magic_enum::enum_name(s.error_code()), s.error_message());
+        LOG_INFO(log, "watch finish, code={} msg={}", magic_enum::enum_name(s.error_code()), s.error_message());
     }
     catch (...)
     {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/8519

Problem Summary:

When the campaign loop is break by watch key deleted, and etcd session expired. The campaign loop still keep trying with the old session.
```
[2023/12/01 05:07:43.325 +00:00] [INFO] [OwnerManager.cpp:368] ["watch failed, owner key is deleted"] [source="owner_id=0.0.0.0:3930"] [thread_id=1233]Show context
[2023/12/01 05:08:08.199 +00:00] [WARN] [OwnerManager.cpp:304] ["is not the owner"] [source="owner_id=0.0.0.0:3930"] [thread_id=1203]
[2023/12/01 05:08:08.201 +00:00] [INFO] [OwnerManager.cpp:270] ["failed to campaign, id=0.0.0.0:3930 lease=73928bb2367fd5e9 code=2 msg=etcdserver: requested lease not found"] [source="owner_id=0.0.0.0:3930"] [thread_id=1203]
[2023/12/01 05:08:08.403 +00:00] [INFO] [OwnerManager.cpp:270] ["failed to campaign, id=0.0.0.0:3930 lease=73928bb2367fd5e9 code=2 msg=etcdserver: requested lease not found"] [source="owner_id=0.0.0.0:3930"] [thread_id=1203]
[2023/12/01 05:08:08.605 +00:00] [INFO] [OwnerManager.cpp:270] ["failed to campaign, id=0.0.0.0:3930 lease=73928bb2367fd5e9 code=2 msg=etcdserver: requested lease not found"] [source="owner_id=0.0.0.0:3930"] [thread_id=1203]
```

### What is changed and how it works?

When campaign meet error, try to create a new etcd session and retry.

also update poco to fix compile error under clang-17

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
