### PR TITLE
ddl: Fix corner case of `FLASHBACK DATABASE`

### DIFF
--- a/dbms/src/Common/FailPoint.cpp
+++ b/dbms/src/Common/FailPoint.cpp
@@ -131,6 +131,7 @@ namespace DB
     M(pause_when_altering_dt_store)       \
     M(pause_after_copr_streams_acquired)  \
     M(pause_query_init)                   \
+    M(pause_before_prehandle_snapshot)    \
     M(pause_before_prehandle_subtask)     \
     M(pause_before_wn_establish_task)     \
     M(pause_passive_flush_before_persist_region)

--- a/dbms/src/Debug/MockSchemaGetter.h
+++ b/dbms/src/Debug/MockSchemaGetter.h
@@ -44,11 +44,6 @@ struct MockSchemaGetter
         return {getTableInfo(db_id, table_id), false};
     }
 
-    static std::tuple<TiDB::DBInfoPtr, TiDB::TableInfoPtr> getDatabaseAndTableInfo(DatabaseID db_id, TableID table_id)
-    {
-        return std::make_tuple(getDatabase(db_id), getTableInfo(db_id, table_id));
-    }
-
     static std::vector<TiDB::DBInfoPtr> listDBs()
     {
         std::vector<TiDB::DBInfoPtr> res;

--- a/dbms/src/Storages/KVStore/MultiRaft/PrehandleSnapshot.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/PrehandleSnapshot.cpp
@@ -263,6 +263,7 @@ PrehandleResult KVStore::preHandleSnapshotToFiles(
             DM::FileConvertJobType::ApplySnapshot,
             tmt);
         result.stats.start_time = start_time;
+        return result;
     }
     catch (DB::Exception & e)
     {

--- a/dbms/src/Storages/KVStore/MultiRaft/PrehandleSnapshot.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/PrehandleSnapshot.cpp
@@ -46,6 +46,7 @@ namespace FailPoints
 extern const char force_set_sst_to_dtfile_block_size[];
 extern const char force_set_parallel_prehandle_threshold[];
 extern const char force_raise_prehandle_exception[];
+extern const char pause_before_prehandle_snapshot[];
 extern const char pause_before_prehandle_subtask[];
 } // namespace FailPoints
 
@@ -242,7 +243,9 @@ PrehandleResult KVStore::preHandleSnapshotToFiles(
 {
     new_region->beforePrehandleSnapshot(new_region->id(), deadline_index);
     ongoing_prehandle_task_count.fetch_add(1);
-    PrehandleResult result;
+
+    FAIL_POINT_PAUSE(FailPoints::pause_before_prehandle_snapshot);
+
     uint64_t start_time
         = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())
               .count();
@@ -252,7 +255,7 @@ PrehandleResult KVStore::preHandleSnapshotToFiles(
             auto ongoing = ongoing_prehandle_task_count.fetch_sub(1) - 1;
             new_region->afterPrehandleSnapshot(ongoing);
         });
-        result = preHandleSSTsToDTFiles( //
+        PrehandleResult result = preHandleSSTsToDTFiles( //
             new_region,
             snaps,
             index,
@@ -267,7 +270,8 @@ PrehandleResult KVStore::preHandleSnapshotToFiles(
             fmt::format("(while preHandleSnapshot region_id={}, index={}, term={})", new_region->id(), index, term));
         e.rethrow();
     }
-    return result;
+
+    return PrehandleResult{};
 }
 
 size_t KVStore::getMaxParallelPrehandleSize() const

--- a/dbms/src/TiDB/Schema/SchemaBuilder.cpp
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.cpp
@@ -175,8 +175,8 @@ void SchemaBuilder<Getter, NameMapper>::applyExchangeTablePartition(const Schema
             {
                 LOG_INFO(
                     log,
-                    "ExchangeTablePartition: non_partition_table instance is not created in TiFlash, rename is"
-                    " ignored, table_id={}",
+                    "ExchangeTablePartition: non_partition_table instance is not created in TiFlash"
+                    ", rename is ignored, table_id={}",
                     non_partition_table_id);
                 break;
             }

--- a/dbms/src/TiDB/Schema/SchemaBuilder.h
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.h
@@ -81,30 +81,34 @@ private:
     void applyDropPhysicalTable(const String & db_name, TableID table_id);
 
     void applyRecoverTable(DatabaseID database_id, TiDB::TableID table_id);
-    void applyRecoverLogicalTable(const TiDB::DBInfoPtr & db_info, const TiDB::TableInfoPtr & table_info);
+    void applyRecoverLogicalTable(DatabaseID database_id, const TiDB::TableInfoPtr & table_info);
     bool tryRecoverPhysicalTable(DatabaseID database_id, const TiDB::TableInfoPtr & table_info);
 
     void applyPartitionDiff(DatabaseID database_id, TableID table_id);
     void applyPartitionDiffOnLogicalTable(
-        const TiDB::DBInfoPtr & db_info,
+        DatabaseID database_id,
         const TiDB::TableInfoPtr & table_info,
         const ManageableStoragePtr & storage);
 
     void applyRenameTable(DatabaseID database_id, TiDB::TableID table_id);
 
     void applyRenameLogicalTable(
-        const TiDB::DBInfoPtr & new_db_info,
+        DatabaseID new_database_id,
+        const String & new_database_display_name,
         const TiDB::TableInfoPtr & new_table_info,
         const ManageableStoragePtr & storage);
 
     void applyRenamePhysicalTable(
-        const TiDB::DBInfoPtr & new_db_info,
+        DatabaseID new_database_id,
+        const String & new_database_display_name,
         const TiDB::TableInfo & new_table_info,
         const ManageableStoragePtr & storage);
 
     void applySetTiFlashReplica(DatabaseID database_id, TableID table_id);
 
     void applyExchangeTablePartition(const SchemaDiff & diff);
+
+    String tryGetDatabaseDisplayNameFromLocal(DatabaseID database_id);
 };
 
 } // namespace DB

--- a/dbms/src/TiDB/Schema/SchemaBuilder.h
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.h
@@ -74,10 +74,7 @@ private:
     void applyRecoverDatabase(DatabaseID database_id);
 
     void applyCreateTable(DatabaseID database_id, TableID table_id);
-    void applyCreateStorageInstance(
-        const TiDB::DBInfoPtr & db_info,
-        const TiDB::TableInfoPtr & table_info,
-        bool is_tombstone);
+    void applyCreateStorageInstance(DatabaseID database_id, const TiDB::TableInfoPtr & table_info, bool is_tombstone);
 
     void applyDropTable(DatabaseID database_id, TableID table_id);
     /// Parameter schema_name should be mapped.
@@ -85,7 +82,7 @@ private:
 
     void applyRecoverTable(DatabaseID database_id, TiDB::TableID table_id);
     void applyRecoverLogicalTable(const TiDB::DBInfoPtr & db_info, const TiDB::TableInfoPtr & table_info);
-    bool tryRecoverPhysicalTable(const TiDB::DBInfoPtr & db_info, const TiDB::TableInfoPtr & table_info);
+    bool tryRecoverPhysicalTable(DatabaseID database_id, const TiDB::TableInfoPtr & table_info);
 
     void applyPartitionDiff(DatabaseID database_id, TableID table_id);
     void applyPartitionDiffOnLogicalTable(

--- a/dbms/src/TiDB/Schema/SchemaGetter.h
+++ b/dbms/src/TiDB/Schema/SchemaGetter.h
@@ -177,8 +177,6 @@ struct SchemaGetter
         return getTableInfoImpl</*mvcc_get*/ true>(db_id, table_id);
     }
 
-    std::tuple<TiDB::DBInfoPtr, TiDB::TableInfoPtr> getDatabaseAndTableInfo(DatabaseID db_id, TableID table_id);
-
     std::vector<TiDB::DBInfoPtr> listDBs();
 
     std::vector<TiDB::TableInfoPtr> listTables(DatabaseID db_id);

--- a/dbms/src/TiDB/tests/gtest_table_info.cpp
+++ b/dbms/src/TiDB/tests/gtest_table_info.cpp
@@ -33,10 +33,11 @@ namespace DB
 {
 
 String createTableStmt(
-    const DBInfo & db_info,
+    KeyspaceID keyspace_id,
+    DatabaseID database_id,
     const TableInfo & table_info,
     const SchemaNameMapper & name_mapper,
-    const UInt64 tombstone,
+    UInt64 tombstone,
     const LoggerPtr & log);
 
 namespace tests
@@ -151,7 +152,13 @@ struct StmtCase
         // generate create statement with db_info and table_info
         auto verify_stmt = [&](TiDB::StorageEngine engine_type) {
             table_info.engine_type = engine_type;
-            String stmt = createTableStmt(db_info, table_info, MockSchemaNameMapper(), tombstone, Logger::get());
+            String stmt = createTableStmt(
+                db_info.keyspace_id,
+                db_info.id,
+                table_info,
+                MockSchemaNameMapper(),
+                tombstone,
+                Logger::get());
             EXPECT_EQ(stmt, create_stmt_dm) << "Table info create statement mismatch:\n" + stmt + "\n" + create_stmt_dm;
 
             json1 = extractTableInfoFromCreateStatement(stmt, table_info.name);

--- a/tests/fullstack-test2/ddl/flashback/flashback_database.test
+++ b/tests/fullstack-test2/ddl/flashback/flashback_database.test
@@ -97,6 +97,7 @@ func> wait_table d1 t1
 mysql> alter table d1.t1 add column b int;
 
 >> DBGInvoke __enable_fail_point(pause_before_apply_raft_cmd)
+>> DBGInvoke __enable_fail_point(pause_before_prehandle_snapshot)
 
 # exactly write until fail point "pause_before_apply_raft_cmd" to be disable
 mysql> insert into d1.t1 values(2,2);
@@ -107,6 +108,7 @@ mysql> drop database d1;
 
 # make write cmd take effect
 >> DBGInvoke __disable_fail_point(pause_before_apply_raft_cmd)
+>> DBGInvoke __disable_fail_point(pause_before_prehandle_snapshot)
 
 # the `t1` is still mark as tombstone
 >> select tidb_database,tidb_name,is_tombstone,tidb_table_id from system.tables where is_tombstone = 0 and tidb_database = 'd1' and tidb_name='t1';
@@ -145,15 +147,18 @@ mysql> create table d1.t2(id INT NOT NULL,name VARCHAR(30)) PARTITION BY RANGE (
 mysql> insert into d1.t2 values(1, 'abc'),(2, 'cde'),(53, 'efg');
 
 >> DBGInvoke __enable_fail_point(pause_before_apply_raft_cmd)
+>> DBGInvoke __enable_fail_point(pause_before_prehandle_snapshot)
 mysql> alter table d1.t2 set tiflash replica 1;
 mysql> alter table d1.t2 add column b int;
 
 mysql> drop database d1;
 
+SLEEP 5
 => DBGInvoke __refresh_schemas()
 
 # make write cmd take effect
 >> DBGInvoke __disable_fail_point(pause_before_apply_raft_cmd)
+>> DBGInvoke __disable_fail_point(pause_before_prehandle_snapshot)
 
 # check the row is written to the storage or not
 mysql> flashback database d1 to d1_new

--- a/tests/fullstack-test2/ddl/flashback/flashback_database.test
+++ b/tests/fullstack-test2/ddl/flashback/flashback_database.test
@@ -153,7 +153,6 @@ mysql> alter table d1.t2 add column b int;
 
 mysql> drop database d1;
 
-SLEEP 5
 => DBGInvoke __refresh_schemas()
 
 # make write cmd take effect


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/8506

Problem Summary:

If the Region snapshot arrived TiFlash after the database has been dropped, then we can not successfully create the Storage instance because we can not fetch it from TiKV. And also `DatabaseInfo` can not be fetch by "mvcc get".
https://github.com/pingcap/tiflash/blob/a46271dd7db654ec0ab59f77915706863bf91e0b/dbms/src/TiDB/Schema/SchemaBuilder.cpp#L1454-L1465

### What is changed and how it works?

To successfully create a Storage instance (`applyCreateStorageInstance`), we don't need the `DatabaseInfo`, a `DatabaseID` is sufficient. We are rewriting methods in `SchemaBuilder` to replace the methods with `DatabaseInfo` by `DatabaseID`. So that we can create those Storage instances and decode the Raft logs or snapshots after a database is dropped and the data can be "flashback" later.
What's more, avoiding fetching the `DatabaseInfo` from TiKV can speed up syncing schema.

For those methods that need the `DatabaseInfo` to get the database name in TiDB to rename tables, we fetch the `DatabaseInfo` from the local cache because the `applyDiff` that calls those methods should be applied before the "drop database" SchemaDiff.

Add a failpoint to pause pre-handling snapshot for testing.


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
