### PR TITLE
Revert "Refine cancel for read thread stream (#8511)"

### DIFF
--- a/dbms/src/Storages/DeltaMerge/ReadThread/UnorderedInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/UnorderedInputStream.h
@@ -46,9 +46,11 @@ public:
         LOG_DEBUG(log, "Created, pool_id={} ref_no={}", task_pool->pool_id, ref_no);
     }
 
-    void cancel(bool /*kill*/) override { decreaseRefCount(true); }
-
-    ~UnorderedInputStream() override { decreaseRefCount(false); }
+    ~UnorderedInputStream() override
+    {
+        task_pool->decreaseUnorderedInputStreamRefCount();
+        LOG_DEBUG(log, "Destroy, pool_id={} ref_no={}", task_pool->pool_id, ref_no);
+    }
 
     String getName() const override { return NAME; }
 
@@ -65,16 +67,6 @@ public:
     }
 
 protected:
-    void decreaseRefCount(bool is_cancel)
-    {
-        bool ori = false;
-        if (is_stopped.compare_exchange_strong(ori, true))
-        {
-            task_pool->decreaseUnorderedInputStreamRefCount();
-            LOG_DEBUG(log, "{}, pool_id={} ref_no={}", is_cancel ? "Cancel" : "Destroy", task_pool->pool_id, ref_no);
-        }
-    }
-
     Block readImpl() override
     {
         FilterPtr filter_ignored;
@@ -154,7 +146,5 @@ private:
     // runtime filter
     std::vector<RuntimeFilterPtr> runtime_filter_list;
     int max_wait_time_ms;
-
-    std::atomic_bool is_stopped = false;
 };
 } // namespace DB::DM


### PR DESCRIPTION
This reverts commit adf85696270f864c0317526919b37fbdfe5a6417.

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/8539

Problem Summary:
See https://github.com/pingcap/tiflash/issues/8539

### What is changed and how it works?
#8511 introduced an issue that `WorkQueue<Block>` in `SegmentReadTaskPool` may not finish forever. Revert this PR to fix this issue for safety and simplicity.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
