### PR TITLE
Storages: fix MemoryTracker may release before MemoryTrackerSetter destructed

### DIFF
--- a/dbms/src/Storages/DeltaMerge/ReadThread/MergedTask.h
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/MergedTask.h
@@ -38,10 +38,14 @@ struct MergedUnit
     {
         if (!isFinished())
         {
-            // For updating memory statistics of `MemoryTracker`.
-            MemoryTrackerSetter setter(true, pool->mem_tracker.get());
-            task = nullptr;
-            stream = nullptr;
+            {
+                // For updating memory statistics of `MemoryTracker`.
+                MemoryTrackerSetter setter(true, pool->mem_tracker.get());
+                task = nullptr;
+                stream = nullptr;
+            }
+            // `SegmentReadTaskScheduler` will release `pool` if there is no other component/thread hold it.
+            // So `pool` should release after `setter` destructed because it holds a raw pointer of `mem_tracker`.
             pool = nullptr;
             return true;
         }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8551

### What is changed and how it works?

See commnets in code.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
