### PR TITLE
Disagg: Fix infinite retries on owner election (#8534)

### DIFF
--- a/dbms/src/Common/FailPoint.cpp
+++ b/dbms/src/Common/FailPoint.cpp
@@ -65,6 +65,7 @@ namespace DB
     M(force_ps_wal_compact)                                       \
     M(pause_before_full_gc_prepare)                               \
     M(force_owner_mgr_state)                                      \
+    M(force_owner_mgr_campaign_failed)                            \
     M(exception_during_spill)                                     \
     M(force_fail_to_create_etcd_session)                          \
     M(force_remote_read_for_batch_cop_once)                       \

--- a/dbms/src/Storages/KVStore/Region.cpp
+++ b/dbms/src/Storages/KVStore/Region.cpp
@@ -199,8 +199,8 @@ RegionPtr Region::deserialize(ReadBuffer & buf, const TiFlashRaftProxyHelper * p
         throw Exception(
             ErrorCodes::UNKNOWN_FORMAT_VERSION,
             "{}: unexpected version: {}, expected: {}",
-            binary_version,
             __PRETTY_FUNCTION__,
+            binary_version,
             CURRENT_VERSION);
     }
 

--- a/dbms/src/TiDB/Etcd/Client.cpp
+++ b/dbms/src/TiDB/Etcd/Client.cpp
@@ -393,7 +393,7 @@ bool Session::keepAliveOne()
             log,
             "keep alive fail, ttl={}, code={} msg={}",
             resp.ttl(),
-            magic_enum::enum_name(status.error_code()),
+            status.error_code(),
             status.error_message());
         finished = true;
         return false;

--- a/dbms/src/TiDB/Etcd/Client.cpp
+++ b/dbms/src/TiDB/Etcd/Client.cpp
@@ -388,7 +388,14 @@ bool Session::keepAliveOne()
     // the lease is not valid anymore
     if (resp.ttl() <= 0)
     {
-        LOG_DEBUG(log, "keep alive fail, ttl={}", resp.ttl());
+        auto status = writer->Finish();
+        LOG_INFO(
+            log,
+            "keep alive fail, ttl={}, code={} msg={}",
+            resp.ttl(),
+            magic_enum::enum_name(status.error_code()),
+            status.error_message());
+        finished = true;
         return false;
     }
     lease_deadline = next_timepoint + std::chrono::seconds(resp.ttl());


### PR DESCRIPTION
manual cherry-pick of https://github.com/pingcap/tiflash/pull/8534

* * *

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/8519

Problem Summary:

When the campaign loop is break by watch key deleted, and etcd session expired. The campaign loop still keep trying with the old session.
```
[2023/12/01 05:07:43.325 +00:00] [INFO] [OwnerManager.cpp:368] ["watch failed, owner key is deleted"] [source="owner_id=0.0.0.0:3930"] [thread_id=1233]Show context
[2023/12/01 05:08:08.199 +00:00] [WARN] [OwnerManager.cpp:304] ["is not the owner"] [source="owner_id=0.0.0.0:3930"] [thread_id=1203]
[2023/12/01 05:08:08.201 +00:00] [INFO] [OwnerManager.cpp:270] ["failed to campaign, id=0.0.0.0:3930 lease=73928bb2367fd5e9 code=2 msg=etcdserver: requested lease not found"] [source="owner_id=0.0.0.0:3930"] [thread_id=1203]
[2023/12/01 05:08:08.403 +00:00] [INFO] [OwnerManager.cpp:270] ["failed to campaign, id=0.0.0.0:3930 lease=73928bb2367fd5e9 code=2 msg=etcdserver: requested lease not found"] [source="owner_id=0.0.0.0:3930"] [thread_id=1203]
[2023/12/01 05:08:08.605 +00:00] [INFO] [OwnerManager.cpp:270] ["failed to campaign, id=0.0.0.0:3930 lease=73928bb2367fd5e9 code=2 msg=etcdserver: requested lease not found"] [source="owner_id=0.0.0.0:3930"] [thread_id=1203]
```

### What is changed and how it works?

When campaign meet error, try to create a new etcd session and retry.

also update poco to fix compile error under clang-17

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
