### PR TITLE
KVStore: Reduce lock contention in `RegionPersister::doPersist`

### DIFF
--- a/dbms/src/Common/FailPoint.cpp
+++ b/dbms/src/Common/FailPoint.cpp
@@ -133,6 +133,7 @@ namespace DB
     M(pause_query_init)                   \
     M(pause_before_prehandle_snapshot)    \
     M(pause_before_prehandle_subtask)     \
+    M(pause_when_persist_region)          \
     M(pause_before_wn_establish_task)     \
     M(pause_passive_flush_before_persist_region)
 

--- a/dbms/src/Common/FailPoint.cpp
+++ b/dbms/src/Common/FailPoint.cpp
@@ -162,6 +162,7 @@ namespace DB
     M(random_pipeline_model_execute_prefix_failpoint)        \
     M(random_pipeline_model_execute_suffix_failpoint)        \
     M(random_spill_to_disk_failpoint)                        \
+    M(random_region_persister_latency_failpoint)             \
     M(random_restore_from_disk_failpoint)                    \
     M(random_exception_when_connect_local_tunnel)            \
     M(random_exception_when_construct_async_request_handler) \

--- a/dbms/src/Server/tests/gtest_server_config.cpp
+++ b/dbms/src/Server/tests/gtest_server_config.cpp
@@ -378,8 +378,7 @@ dt_page_gc_low_write_prob = 0.2
         return;
     }
     auto & global_path_pool = global_ctx.getPathPool();
-    RegionManager region_manager;
-    RegionPersister persister(global_ctx, region_manager);
+    RegionPersister persister(global_ctx);
     persister.restore(global_path_pool, nullptr, PageStorageConfig{});
 
     auto verify_persister_reload_config = [&global_ctx](RegionPersister & persister) {

--- a/dbms/src/Storages/KVStore/Decode/RegionTable.h
+++ b/dbms/src/Storages/KVStore/Decode/RegionTable.h
@@ -17,6 +17,7 @@
 #include <Common/nocopyable.h>
 #include <Core/Block.h>
 #include <Core/Names.h>
+#include <Interpreters/Context_fwd.h>
 #include <Storages/DeltaMerge/ExternalDTFileInfo.h>
 #include <Storages/DeltaMerge/RowKeyRange.h>
 #include <Storages/KVStore/Decode/RegionDataRead.h>
@@ -41,7 +42,6 @@ struct TableInfo;
 namespace DB
 {
 struct ColumnsDescription;
-class Context;
 class IStorage;
 using StoragePtr = std::shared_ptr<IStorage>;
 class TMTContext;

--- a/dbms/src/Storages/KVStore/KVStore.cpp
+++ b/dbms/src/Storages/KVStore/KVStore.cpp
@@ -55,9 +55,8 @@ extern const char force_not_clean_fap_on_destroy[];
 
 KVStore::KVStore(Context & context)
     : region_persister(
-        context.getSharedContextDisagg()->isDisaggregatedComputeMode()
-            ? nullptr
-            : std::make_unique<RegionPersister>(context, region_manager))
+        context.getSharedContextDisagg()->isDisaggregatedComputeMode() ? nullptr
+                                                                       : std::make_unique<RegionPersister>(context))
     , raft_cmd_res(std::make_unique<RaftCommandResult>())
     , log(Logger::get())
     , region_compact_log_min_rows(40 * 1024)
@@ -375,7 +374,7 @@ void KVStore::setRegionCompactLogConfig(UInt64 rows, UInt64 bytes, UInt64 gap, U
 
 void KVStore::persistRegion(
     const Region & region,
-    std::optional<const RegionTaskLock *> region_task_lock,
+    const RegionTaskLock & region_task_lock,
     PersistRegionReason reason,
     const char * extra_msg) const
 {
@@ -383,25 +382,17 @@ void KVStore::persistRegion(
         region_persister,
         "try access to region_persister without initialization, stack={}",
         StackTrace().toString());
-    if (region_task_lock.has_value())
-    {
-        auto reason_id = magic_enum::enum_underlying(reason);
-        std::string caller = fmt::format("{} {}", PersistRegionReasonMap[reason_id], extra_msg);
-        LOG_INFO(
-            log,
-            "Start to persist {}, cache size: {} bytes for `{}`",
-            region.getDebugString(),
-            region.dataSize(),
-            caller);
-        region_persister->persist(region, *region_task_lock.value());
-        LOG_DEBUG(log, "Persist {} done", region.toString(false));
-    }
-    else
-    {
-        LOG_INFO(log, "Try to persist {}", region.toString(false));
-        region_persister->persist(region);
-        LOG_INFO(log, "After persisted {}, cache {} bytes", region.toString(false), region.dataSize());
-    }
+
+    auto reason_id = magic_enum::enum_underlying(reason);
+    std::string caller = fmt::format("{} {}", PersistRegionReasonMap[reason_id], extra_msg);
+    LOG_INFO(
+        log,
+        "Start to persist {}, cache size: {} bytes for `{}`",
+        region.getDebugString(),
+        region.dataSize(),
+        caller);
+    region_persister->persist(region, region_task_lock);
+    LOG_DEBUG(log, "Persist {} done, cache size: {} bytes", region.toString(false), region.dataSize());
 
     switch (reason)
     {
@@ -611,7 +602,7 @@ bool KVStore::forceFlushRegionDataImpl(
     }
 
     // flush cache in storage level is done, persist the region info
-    persistRegion(curr_region, &region_task_lock, PersistRegionReason::Flush, "");
+    persistRegion(curr_region, region_task_lock, PersistRegionReason::Flush, "");
     // CompactLog will be done in proxy soon, we advance the eager truncate index in TiFlash
     curr_region.updateRaftLogEagerIndex(index);
     curr_region.cleanApproxMemCacheInfo();

--- a/dbms/src/Storages/KVStore/KVStore.h
+++ b/dbms/src/Storages/KVStore/KVStore.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <Interpreters/Context_fwd.h>
 #include <Storages/DeltaMerge/DeltaMergeInterfaces.h>
 #include <Storages/DeltaMerge/RowKeyRange.h>
 #include <Storages/KVStore/Decode/RegionDataRead.h>
@@ -32,7 +33,6 @@ struct TableInfo;
 }
 namespace DB
 {
-class Context;
 namespace RegionBench
 {
 extern void concurrentBatchInsert(const TiDB::TableInfo &, Int64, Int64, Int64, UInt64, UInt64, Context &);
@@ -357,7 +357,7 @@ private:
 
     void persistRegion(
         const Region & region,
-        std::optional<const RegionTaskLock *> region_task_lock,
+        const RegionTaskLock & region_task_lock,
         PersistRegionReason reason,
         const char * extra_msg) const;
 

--- a/dbms/src/Storages/KVStore/MultiRaft/ApplySnapshot.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/ApplySnapshot.cpp
@@ -81,7 +81,7 @@ void KVStore::checkAndApplyPreHandledSnapshot(const RegionPtrWrap & new_region, 
             old_region->setStateApplying();
             tmt.getRegionTable().tryWriteBlockByRegion(old_region);
             tryFlushRegionCacheInStorage(tmt, *old_region, log);
-            persistRegion(*old_region, &region_lock, PersistRegionReason::ApplySnapshotPrevRegion, "");
+            persistRegion(*old_region, region_lock, PersistRegionReason::ApplySnapshotPrevRegion, "");
         }
     }
 
@@ -303,7 +303,7 @@ void KVStore::onSnapshot(
         }
 
         GET_METRIC(tiflash_raft_write_flow_bytes, type_snapshot_uncommitted).Observe(new_region->dataSize());
-        persistRegion(*new_region, &region_lock, PersistRegionReason::ApplySnapshotCurRegion, "");
+        persistRegion(*new_region, region_lock, PersistRegionReason::ApplySnapshotCurRegion, "");
 
         tmt.getRegionTable().shrinkRegionRange(*new_region);
     }

--- a/dbms/src/Storages/KVStore/MultiRaft/IngestSST.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/IngestSST.cpp
@@ -92,7 +92,7 @@ EngineStoreApplyRes KVStore::handleIngestSST(
     {
         // We always try to flush dm cache and region if possible for every IngestSST,
         // in order to have the raft log truncated and sst deleted.
-        persistRegion(*region, &region_task_lock, PersistRegionReason::IngestSst, "");
+        persistRegion(*region, region_task_lock, PersistRegionReason::IngestSst, "");
         return EngineStoreApplyRes::Persist;
     }
 }

--- a/dbms/src/Storages/KVStore/MultiRaft/RaftCommandsKVS.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/RaftCommandsKVS.cpp
@@ -73,7 +73,7 @@ EngineStoreApplyRes KVStore::handleWriteRaftCmdInner(
             /// We should execute eager RaftLog GC, persist the Region in both TiFlash and proxy
             // Persist RegionMeta on the storage engine
             tryFlushRegionCacheInStorage(tmt, *region, Logger::get());
-            persistRegion(*region, &region_persist_lock, PersistRegionReason::EagerRaftGc, "");
+            persistRegion(*region, region_persist_lock, PersistRegionReason::EagerRaftGc, "");
             // return "Persist" to proxy for persisting the RegionMeta
             apply_res = EngineStoreApplyRes::Persist;
         }
@@ -133,7 +133,7 @@ EngineStoreApplyRes KVStore::handleUselessAdminRaftCmd(
         tryFlushRegionCacheInStorage(tmt, curr_region, log);
         persistRegion(
             curr_region,
-            &region_task_lock,
+            region_task_lock,
             PersistRegionReason::UselessAdminCommand,
             raft_cmdpb::AdminCmdType_Name(cmd_type).c_str());
         return EngineStoreApplyRes::Persist;
@@ -236,7 +236,7 @@ EngineStoreApplyRes KVStore::handleAdminRaftCmd(
 
         const auto persist_and_sync = [&](const Region & region) {
             tryFlushRegionCacheInStorage(tmt, region, log);
-            persistRegion(region, &region_task_lock, PersistRegionReason::AdminCommand, "");
+            persistRegion(region, region_task_lock, PersistRegionReason::AdminCommand, "");
         };
 
         const auto handle_batch_split = [&](Regions & split_regions) {

--- a/dbms/src/Storages/KVStore/MultiRaft/RegionPersister.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/RegionPersister.cpp
@@ -103,8 +103,6 @@ void RegionPersister::doPersist(
 {
     auto & [region_id, buffer, region_size, applied_index] = region_write_buffer;
 
-    std::lock_guard lock(mutex);
-
     auto entry = page_reader->getPageEntry(region_id);
     if (entry.isValid() && entry.tag > applied_index)
         return;

--- a/dbms/src/Storages/KVStore/MultiRaft/RegionPersister.h
+++ b/dbms/src/Storages/KVStore/MultiRaft/RegionPersister.h
@@ -84,7 +84,6 @@ private:
 
     NamespaceID ns_id = KVSTORE_NAMESPACE_ID;
     const RegionManager & region_manager;
-    std::mutex mutex;
     LoggerPtr log;
 };
 } // namespace DB

--- a/dbms/src/Storages/KVStore/MultiRaft/RegionPersister.h
+++ b/dbms/src/Storages/KVStore/MultiRaft/RegionPersister.h
@@ -77,7 +77,7 @@ private:
     PageWriterPtr page_writer;
     PageReaderPtr page_reader;
 
-    NamespaceID ns_id = KVSTORE_NAMESPACE_ID;
+    const NamespaceID ns_id = KVSTORE_NAMESPACE_ID;
     LoggerPtr log;
 };
 } // namespace DB

--- a/dbms/src/Storages/KVStore/MultiRaft/RegionPersister.h
+++ b/dbms/src/Storages/KVStore/MultiRaft/RegionPersister.h
@@ -16,16 +16,14 @@
 
 #include <Common/Logger.h>
 #include <IO/MemoryReadWriteBuffer.h>
+#include <Interpreters/Context_fwd.h>
 #include <Storages/KVStore/Types.h>
 #include <Storages/Page/FileUsage.h>
 #include <Storages/Page/PageStorage.h>
 #include <Storages/Page/V3/Universal/UniversalPageIdFormatImpl.h>
-#include <Storages/Page/WriteBatchImpl.h>
 
 namespace DB
 {
-class Context;
-
 class PathPool;
 class Region;
 using RegionPtr = std::shared_ptr<Region>;
@@ -39,10 +37,9 @@ struct TiFlashRaftProxyHelper;
 class RegionPersister final : private boost::noncopyable
 {
 public:
-    RegionPersister(Context & global_context_, const RegionManager & region_manager_);
+    explicit RegionPersister(Context & global_context_);
 
     void drop(RegionID region_id, const RegionTaskLock &);
-    void persist(const Region & region);
     void persist(const Region & region, const RegionTaskLock & lock);
     RegionMap restore(
         PathPool & path_pool,
@@ -62,9 +59,7 @@ private:
     void forceTransformKVStoreV2toV3();
 
     void doPersist(RegionCacheWriteElement & region_write_buffer, const RegionTaskLock & lock, const Region & region);
-    void doPersist(const Region & region, const RegionTaskLock * lock);
 
-private:
     inline std::variant<String, NamespaceID> getWriteBatchPrefix() const
     {
         switch (run_mode)
@@ -83,7 +78,6 @@ private:
     PageReaderPtr page_reader;
 
     NamespaceID ns_id = KVSTORE_NAMESPACE_ID;
-    const RegionManager & region_manager;
     LoggerPtr log;
 };
 } // namespace DB

--- a/dbms/src/Storages/KVStore/TMTContext.h
+++ b/dbms/src/Storages/KVStore/TMTContext.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <Interpreters/Context_fwd.h>
 #include <Poco/Util/AbstractConfiguration.h>
 #include <Storages/GCManager.h>
 #include <Storages/KVStore/Decode/RegionTable.h>
@@ -23,8 +24,6 @@
 
 namespace DB
 {
-class Context;
-
 class PathPool;
 
 class KVStore;

--- a/dbms/src/Storages/KVStore/tests/gtest_region_persister.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_region_persister.cpp
@@ -15,6 +15,7 @@
 #include <Common/FailPoint.h>
 #include <Common/Logger.h>
 #include <Common/Stopwatch.h>
+#include <Common/SyncPoint/Ctl.h>
 #include <IO/ReadBufferFromFile.h>
 #include <IO/WriteBufferFromFile.h>
 #include <Interpreters/Context.h>
@@ -32,12 +33,14 @@
 #include <common/types.h>
 
 #include <ext/scope_guard.h>
+#include <future>
 
 namespace DB
 {
 namespace FailPoints
 {
 extern const char force_region_persist_version[];
+extern const char pause_when_persist_region[];
 } // namespace FailPoints
 
 namespace tests
@@ -298,6 +301,75 @@ protected:
     std::unique_ptr<PathPool> mocked_path_pool;
     LoggerPtr log;
 };
+
+TEST_P(RegionPersisterTest, Concurrency)
+try
+{
+    RegionManager region_manager;
+
+    auto ctx = TiFlashTestEnv::getGlobalContext();
+
+    RegionMap regions;
+    const TableID table_id = 100;
+
+    PageStorageConfig config;
+    config.file_roll_size = 128 * MB;
+
+    UInt64 diff = 0;
+    RegionPersister persister(ctx);
+    persister.restore(*mocked_path_pool, nullptr, config);
+
+    // Persist region by region
+    const RegionID region_100 = 100;
+    FailPointHelper::enableFailPoint(FailPoints::pause_when_persist_region, region_100);
+    SCOPE_EXIT({ FailPointHelper::disableFailPoint(FailPoints::pause_when_persist_region); });
+
+    auto sp_persist_region_100 = SyncPointCtl::enableInScope("before_RegionPersister::persist_write_done");
+    auto th_persist_region_100 = std::async([&]() {
+        auto region_task_lock = region_manager.genRegionTaskLock(region_100);
+
+        auto region = std::make_shared<Region>(createRegionMeta(region_100, table_id));
+        TiKVKey key = RecordKVFormat::genKey(table_id, region_100, diff++);
+        region->insert(ColumnFamilyType::Default, TiKVKey::copyFrom(key), TiKVValue("value1"));
+        region->insert(ColumnFamilyType::Write, TiKVKey::copyFrom(key), RecordKVFormat::encodeWriteCfValue('P', 0));
+        region->insert(
+            ColumnFamilyType::Lock,
+            TiKVKey::copyFrom(key),
+            RecordKVFormat::encodeLockCfValue('P', "", 0, 0));
+
+        persister.persist(*region, region_task_lock);
+
+        regions.emplace(region->id(), region);
+    });
+    LOG_INFO(log, "paused before persisting region 100");
+    sp_persist_region_100.waitAndPause();
+
+    LOG_INFO(log, "before persisting region 101");
+    const RegionID region_101 = 101;
+    {
+        auto region_task_lock = region_manager.genRegionTaskLock(region_101);
+
+        auto region = std::make_shared<Region>(createRegionMeta(region_101, table_id));
+        TiKVKey key = RecordKVFormat::genKey(table_id, region_101, diff++);
+        region->insert(ColumnFamilyType::Default, TiKVKey::copyFrom(key), TiKVValue("value1"));
+        region->insert(ColumnFamilyType::Write, TiKVKey::copyFrom(key), RecordKVFormat::encodeWriteCfValue('P', 0));
+        region->insert(
+            ColumnFamilyType::Lock,
+            TiKVKey::copyFrom(key),
+            RecordKVFormat::encodeLockCfValue('P', "", 0, 0));
+
+        persister.persist(*region, region_task_lock);
+
+        regions.emplace(region->id(), region);
+    }
+    LOG_INFO(log, "after persisting region 101");
+
+    sp_persist_region_100.next();
+    th_persist_region_100.get();
+
+    LOG_INFO(log, "finished");
+}
+CATCH
 
 TEST_P(RegionPersisterTest, persister)
 try

--- a/dbms/src/Storages/KVStore/tests/kvstore_helper.h
+++ b/dbms/src/Storages/KVStore/tests/kvstore_helper.h
@@ -166,7 +166,8 @@ protected:
     {
         if (auto region = kvs.getRegion(region_id); region)
         {
-            kvs.persistRegion(*region, std::nullopt, PersistRegionReason::Debug, "");
+            auto region_task_lock = kvs.region_manager.genRegionTaskLock(region_id);
+            kvs.persistRegion(*region, region_task_lock, PersistRegionReason::Debug, "");
         }
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/8583

Problem Summary:

https://github.com/pingcap/tiflash/blob/5980908e68629f40c2191ae2d100f41d554dce44/dbms/src/Storages/KVStore/MultiRaft/RegionPersister.cpp#L99-L125

`RegionPersister::doPersist` acquires a lock and calls `PageStorage::write` with the lock. This means when we're persisting Region meta, all other threads can not do the persistence for other Region meta. Which is not reasonable.

### What is changed and how it works?

There is a `region_task_lock` to ensure that only one thread could call `RegionPersister::doPersist` at the same time. And `PageStorage` support multi-thread reading and writing for different page_id. There is no need to acquire another lock in `RegionPersister::doPersist` that could slowdown the raft apply process

And also remove calling `KVStore::persistRegion` with a null `region_task_lock`. So we can simplify codes and remove the member `RegionPersister:: RegionManager`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Reduce the impact of disk performance jitter on write throughput
```
