### PR TITLE
*: Reduce logging from `UnorderedInputStream`

### DIFF
--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -1049,7 +1049,7 @@ BlockInputStreams DeltaMergeStore::read(const Context & db_context,
         }
         res.push_back(stream);
     }
-    LOG_DEBUG(tracing_logger, "Read create stream done");
+    LOG_INFO(tracing_logger, "Read create stream done, pool_id={} num_streams={}", read_task_pool->poolId(), final_num_stream);
 
     return res;
 }

--- a/dbms/src/Storages/DeltaMerge/ReadThread/UnorderedInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/UnorderedInputStream.h
@@ -52,13 +52,14 @@ public:
             header.insert(extra_table_id_index, col);
         }
         ref_no = task_pool->increaseUnorderedInputStreamRefCount();
-        LOG_INFO(log, "Created, pool_id={} ref_no={}", task_pool->poolId(), ref_no);
     }
 
     ~UnorderedInputStream() override
     {
-        task_pool->decreaseUnorderedInputStreamRefCount();
-        LOG_INFO(log, "Destroy, pool_id={} ref_no={}", task_pool->poolId(), ref_no);
+        if (const auto rc_before_decr = task_pool->decreaseUnorderedInputStreamRefCount(); rc_before_decr == 1)
+        {
+            LOG_INFO(log, "All unordered input streams are finished, pool_id={} last_stream_ref_no={}", task_pool->poolId(), ref_no);
+        }
     }
 
     String getName() const override { return NAME; }

--- a/dbms/src/Storages/Page/V3/BlobStore.cpp
+++ b/dbms/src/Storages/Page/V3/BlobStore.cpp
@@ -980,11 +980,6 @@ std::vector<BlobFileId> BlobStore::getGCStats()
                 // TODO: avoid always truncate on empty BlobFile
                 RUNTIME_CHECK_MSG(stat->sm_valid_size == 0, "Current blob is empty, but valid size is not 0. [blob_id={}] [valid_size={}] [valid_rate={}]", stat->id, stat->sm_valid_size, stat->sm_valid_rate);
 
-                if (stat->sm_total_size == 0)
-                {
-                    continue;
-                }
-
                 // If current blob empty, the size of in disk blob may not empty
                 // So we need truncate current blob, and let it be reused.
                 auto blobfile = getBlobFile(stat->id);

--- a/dbms/src/Storages/Page/V3/BlobStore.cpp
+++ b/dbms/src/Storages/Page/V3/BlobStore.cpp
@@ -972,7 +972,7 @@ std::vector<BlobFileId> BlobStore::getGCStats()
             auto lock = stat->lock();
             auto right_margin = stat->smap->getUsedBoundary();
 
-            // Truncate the file by its right margin. If the file has no context, just skip
+            // Truncate the file by its right margin. If the file has no data, just skip
             if (right_margin == 0)
             {
                 // Note `stat->sm_total_size` isn't strictly the same as the actual size of underlying BlobFile after restart tiflash,

--- a/dbms/src/Storages/Page/V3/BlobStore.cpp
+++ b/dbms/src/Storages/Page/V3/BlobStore.cpp
@@ -972,13 +972,18 @@ std::vector<BlobFileId> BlobStore::getGCStats()
             auto lock = stat->lock();
             auto right_margin = stat->smap->getUsedBoundary();
 
-            // Avoid divide by zero
+            // Truncate the file by its right margin. If the file has no context, just skip
             if (right_margin == 0)
             {
                 // Note `stat->sm_total_size` isn't strictly the same as the actual size of underlying BlobFile after restart tiflash,
                 // because some entry may be deleted but the actual disk space is not reclaimed in previous run.
                 // TODO: avoid always truncate on empty BlobFile
                 RUNTIME_CHECK_MSG(stat->sm_valid_size == 0, "Current blob is empty, but valid size is not 0. [blob_id={}] [valid_size={}] [valid_rate={}]", stat->id, stat->sm_valid_size, stat->sm_valid_rate);
+
+                if (stat->sm_total_size == 0)
+                {
+                    continue;
+                }
 
                 // If current blob empty, the size of in disk blob may not empty
                 // So we need truncate current blob, and let it be reused.
@@ -990,6 +995,7 @@ std::vector<BlobFileId> BlobStore::getGCStats()
                 continue;
             }
 
+            assert(right_margin > 0); // Avoid divide by zero
             stat->sm_valid_rate = stat->sm_valid_size * 1.0 / right_margin;
 
             if (stat->sm_valid_rate > 1.0)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/8563

Problem Summary:

### What is changed and how it works?

* Log down the pool_id and num_stream once for one TableScan
* Avoid calling `BlobFile::truncate` repeatly when its data size is zero

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
