### PR TITLE
*: Add mvcc input bytes and num columns read to logging

### DIFF
--- a/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
@@ -322,7 +322,9 @@ void DAGStorageInterpreter::executeImpl(DAGPipeline & pipeline)
 {
     if (!mvcc_query_info->regions_query_info.empty())
     {
-        dagContext().scan_context_map[table_scan.getTableScanExecutorID()] = std::make_shared<DM::ScanContext>();
+        auto scan_context = std::make_shared<DM::ScanContext>();
+        scan_context->num_columns = required_columns.size();
+        dagContext().scan_context_map[table_scan.getTableScanExecutorID()] = scan_context;
         buildLocalStreams(pipeline, settings.max_block_size);
     }
 

--- a/dbms/src/Storages/DeltaMerge/DMVersionFilterBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/DMVersionFilterBlockInputStream.cpp
@@ -67,6 +67,7 @@ Block DMVersionFilterBlockInputStream<MODE>::read(FilterPtr & res_filter, bool r
             if (scan_context)
             {
                 scan_context->mvcc_input_rows += rows;
+                scan_context->mvcc_input_bytes += cur_raw_block.bytes();
                 scan_context->mvcc_output_rows += rows;
             }
 
@@ -390,7 +391,9 @@ Block DMVersionFilterBlockInputStream<MODE>::read(FilterPtr & res_filter, bool r
         if (scan_context)
         {
             scan_context->mvcc_input_rows += rows;
+            scan_context->mvcc_input_bytes += cur_raw_block.bytes();
             scan_context->mvcc_output_rows += passed_rows;
+            // When `return_filter != nullptr`, the output bytes is not accurate
         }
 
         // This block is empty after filter, continue to process next block

--- a/dbms/src/Storages/DeltaMerge/DMVersionFilterBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/DMVersionFilterBlockInputStream.cpp
@@ -392,7 +392,7 @@ Block DMVersionFilterBlockInputStream<MODE>::read(FilterPtr & res_filter, bool r
         {
             scan_context->mvcc_input_rows += rows;
             scan_context->mvcc_input_bytes += cur_raw_block.bytes();
-            scan_context->mvcc_output_rows += passed_rows;
+            scan_context->mvcc_output_rows += passed_count;
             // When `return_filter != nullptr`, the output bytes is not accurate
         }
 

--- a/dbms/src/Storages/DeltaMerge/ScanContext.cpp
+++ b/dbms/src/Storages/DeltaMerge/ScanContext.cpp
@@ -31,6 +31,7 @@ String ScanContext::toJson() const
 
     json->set("num_segments", num_segments.load());
     json->set("num_read_tasks", num_read_tasks.load());
+    json->set("num_columns", num_columns.load());
 
     json->set("delta_rows", delta_rows.load());
     json->set("delta_bytes", delta_bytes.load());

--- a/dbms/src/Storages/DeltaMerge/ScanContext.cpp
+++ b/dbms/src/Storages/DeltaMerge/ScanContext.cpp
@@ -36,6 +36,7 @@ String ScanContext::toJson() const
     json->set("delta_bytes", delta_bytes.load());
 
     json->set("mvcc_input_rows", mvcc_input_rows.load());
+    json->set("mvcc_input_bytes", mvcc_input_bytes.load());
     json->set("mvcc_output_rows", mvcc_output_rows.load());
 
     std::stringstream buf;

--- a/dbms/src/Storages/DeltaMerge/ScanContext.h
+++ b/dbms/src/Storages/DeltaMerge/ScanContext.h
@@ -56,6 +56,7 @@ public:
 
     // mvcc input rows, output rows
     std::atomic<uint64_t> mvcc_input_rows{0};
+    std::atomic<uint64_t> mvcc_input_bytes{0};
     std::atomic<uint64_t> mvcc_output_rows{0};
 
     // TODO: mode, filter
@@ -104,6 +105,7 @@ public:
         delta_bytes += other.delta_bytes;
 
         mvcc_input_rows += other.mvcc_input_rows;
+        mvcc_input_bytes += other.mvcc_input_bytes;
         mvcc_output_rows += other.mvcc_output_rows;
     }
 

--- a/dbms/src/Storages/DeltaMerge/ScanContext.h
+++ b/dbms/src/Storages/DeltaMerge/ScanContext.h
@@ -49,6 +49,7 @@ public:
     // num segments, num tasks
     std::atomic<uint64_t> num_segments{0};
     std::atomic<uint64_t> num_read_tasks{0};
+    std::atomic<uint64_t> num_columns{0};
 
     // delta rows, bytes
     std::atomic<uint64_t> delta_rows{0};
@@ -100,6 +101,7 @@ public:
 
         num_segments += other.num_segments;
         num_read_tasks += other.num_read_tasks;
+        // num_columns should not sum
 
         delta_rows += other.delta_rows;
         delta_bytes += other.delta_bytes;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/8563

Problem Summary:

### What is changed and how it works?

Add mvcc input bytes and num columns about TableScan to `MPPTaskStatistics::logTracingJson`

### Check List

Run the following queries on ch-benchmark 1500, the mvcc input rows is the same. But the query time elapsed, mvcc input bytes, are quite different.

```
time_elapsed num_columns_scan mvcc_input_rows outbound_rows mvcc_input_bytes outbound_bytes
    2.081s      4               464139510       334475782       18565580400     10233415852
    2.307s      4               464139510       334475782       18565580400     10233415852
    4.252s      5               464139510       334475782       34346323740     25361074068
    4.978s      9               464139510       334475782       41772555900     32479972052
```

```
select   ol_number,
         sum(ol_quantity) as sum_qty,
         sum(ol_amount) as sum_amount,
         avg(ol_quantity) as avg_qty,
         avg(ol_amount) as avg_amount,
         count(*) as count_order
from     order_line
where    ol_delivery_d > '2007-01-02 00:00:00.000000'
group by ol_number order by ol_number;

select   ol_number,
         sum(ol_quantity) as sum_qty,
         sum(ol_amount) as sum_amount,
         avg(ol_quantity) as avg_qty,
         avg(ol_amount) as avg_amount,
         min(ol_delivery_d) as min_deliver_d,
         max(ol_delivery_d) as min_deliver_d,
         count(*) as count_order
from     order_line
where    ol_delivery_d > '2007-01-02 00:00:00.000000'
group by ol_number order by ol_number;

select   ol_number,
         sum(ol_quantity) as sum_qty,
         sum(ol_amount) as sum_amount,
         avg(ol_quantity) as avg_qty,
         avg(ol_amount) as avg_amount,
         min(ol_delivery_d) as min_deliver_d,
         max(ol_delivery_d) as min_deliver_d,
         sum(length(ol_dist_info)),
         count(*) as count_order
from     order_line
where    ol_delivery_d > '2007-01-02 00:00:00.000000'
group by ol_number order by ol_number;

select   ol_number,
         sum(ol_quantity) as sum_qty,
         sum(ol_amount) as sum_amount,
         avg(ol_quantity) as avg_qty,
         avg(ol_amount) as avg_amount,
         min(ol_delivery_d) as min_deliver_d,
         max(ol_delivery_d) as min_deliver_d,
         sum(length(ol_dist_info)),
         sum(ol_i_id),max(ol_o_id),max(ol_d_id),max(ol_w_id),sum(ol_number),
         count(*) as count_order
from     order_line
where    ol_delivery_d > '2007-01-02 00:00:00.000000'
group by ol_number order by ol_number;
```


<details>
<summary>The JSON output</summary>

```
{"query_tso":446602298295844865,"task_id":1,"is_root":false,"sender_executor_id":"ExchangeSender_51","executors":[{"id":"ExchangeSender_51","type":"ExchangeSender","children":["HashAgg_47"],"outbound_rows":15,"outbound_blocks":256,"outbound_bytes":1440,"execution_time_ns":2002997168,"partition_num":1,"sender_target_task_ids":[2],"exchange_type":"Hash","connection_details":[{"tunnel_id":"tunnel1+2","sender_target_task_id":2,"sender_target_host":"10.2.12.81:9540","is_local":true,"packets":16,"bytes":13565}]},{"id":"HashAgg_47","type":"Agg","children":["Projection_57"],"outbound_rows":15,"outbound_blocks":256,"outbound_bytes":1440,"execution_time_ns":2002997168},{"id":"Projection_57","type":"Projection","children":["Selection_36"],"outbound_rows":334475782,"outbound_blocks":7440,"outbound_bytes":7692942986,"execution_time_ns":1721997574},{"id":"Selection_36","type":"Selection","children":["TableFullScan_35"],"outbound_rows":334475782,"outbound_blocks":7440,"outbound_bytes":7692942986,"execution_time_ns":1678997630},{"id":"TableFullScan_35","type":"TableScan","children":[],"outbound_rows":444931124,"outbound_blocks":7441,"outbound_bytes":10233415852,"execution_time_ns":1525997844,"connection_details":[{"is_local":true,"packets":0,"bytes":10233415852},{"is_local":false,"packets":0,"bytes":0}],"scan_details":{"create_inputstream_time":"4377ms","create_snapshot_time":"0ms","delta_bytes":1857917470,"delta_rows":19557026,"dmfile_read_time":"12878ms","dmfile_scan_rows":469209513,"dmfile_skip_rows":48308989,"mvcc_input_bytes":18565580400,"mvcc_input_rows":464139510,"mvcc_output_rows":444931124,"num_columns":4,"num_read_tasks":602,"num_segments":602}}],"host":"10.2.12.81:9540","task_init_timestamp":1703652566175346000,"task_start_timestamp":1703652566223758000,"task_end_timestamp":1703652568227284000,"compile_start_timestamp":1703652566186284000,"compile_end_timestamp":1703652566223724000,"read_wait_index_start_timestamp":1703652566196499000,"read_wait_index_end_timestamp":1703652566214200000,"local_input_bytes":10233415852,"remote_input_bytes":0,"output_bytes":1440,"status":"FINISHED","error_message":"","working_time":0,"memory_peak":1295620212}

{"query_tso":446602298846347265,"task_id":1,"is_root":false,"sender_executor_id":"ExchangeSender_51","executors":[{"id":"ExchangeSender_51","type":"ExchangeSender","children":["HashAgg_47"],"outbound_rows":15,"outbound_blocks":256,"outbound_bytes":1710,"execution_time_ns":2272996786,"partition_num":1,"sender_target_task_ids":[2],"exchange_type":"Hash","connection_details":[{"tunnel_id":"tunnel1+2","sender_target_task_id":2,"sender_target_host":"10.2.12.81:9540","is_local":true,"packets":16,"bytes":15994}]},{"id":"HashAgg_47","type":"Agg","children":["Projection_57"],"outbound_rows":15,"outbound_blocks":256,"outbound_bytes":1710,"execution_time_ns":2272996786},{"id":"Projection_57","type":"Projection","children":["Selection_36"],"outbound_rows":334475782,"outbound_blocks":7440,"outbound_bytes":10703225024,"execution_time_ns":1572997775},{"id":"Selection_36","type":"Selection","children":["TableFullScan_35"],"outbound_rows":334475782,"outbound_blocks":7440,"outbound_bytes":7692942986,"execution_time_ns":1543997816},{"id":"TableFullScan_35","type":"TableScan","children":[],"outbound_rows":444931124,"outbound_blocks":7441,"outbound_bytes":10233415852,"execution_time_ns":1365998065,"connection_details":[{"is_local":true,"packets":0,"bytes":10233415852},{"is_local":false,"packets":0,"bytes":0}],"scan_details":{"create_inputstream_time":"535ms","create_snapshot_time":"0ms","delta_bytes":1857917470,"delta_rows":19557026,"dmfile_read_time":"10209ms","dmfile_scan_rows":444640988,"dmfile_skip_rows":26964985,"mvcc_input_bytes":18565580400,"mvcc_input_rows":464139510,"mvcc_output_rows":444931124,"num_columns":4,"num_read_tasks":602,"num_segments":602}}],"host":"10.2.12.81:9540","task_init_timestamp":1703652568243687000,"task_start_timestamp":1703652568262410000,"task_end_timestamp":1703652570535667000,"compile_start_timestamp":1703652568244537000,"compile_end_timestamp":1703652568262393000,"read_wait_index_start_timestamp":1703652568245493000,"read_wait_index_end_timestamp":1703652568256545000,"local_input_bytes":10233415852,"remote_input_bytes":0,"output_bytes":1710,"status":"FINISHED","error_message":"","working_time":0,"memory_peak":1362048465}

{"query_tso":446602299449278465,"task_id":1,"is_root":false,"sender_executor_id":"ExchangeSender_51","executors":[{"id":"ExchangeSender_51","type":"ExchangeSender","children":["HashAgg_47"],"outbound_rows":15,"outbound_blocks":256,"outbound_bytes":1965,"execution_time_ns":4194994070,"partition_num":1,"sender_target_task_ids":[2],"exchange_type":"Hash","connection_details":[{"tunnel_id":"tunnel1+2","sender_target_task_id":2,"sender_target_host":"10.2.12.81:9540","is_local":true,"packets":16,"bytes":19235}]},{"id":"HashAgg_47","type":"Agg","children":["Projection_57"],"outbound_rows":15,"outbound_blocks":256,"outbound_bytes":1965,"execution_time_ns":4194994070},{"id":"Projection_57","type":"Projection","children":["Selection_36"],"outbound_rows":334475782,"outbound_blocks":7440,"outbound_bytes":16389313318,"execution_time_ns":3213995454},{"id":"Selection_36","type":"Selection","children":["TableFullScan_35"],"outbound_rows":334475782,"outbound_blocks":7440,"outbound_bytes":19065119574,"execution_time_ns":2401996600},{"id":"TableFullScan_35","type":"TableScan","children":[],"outbound_rows":444931124,"outbound_blocks":7441,"outbound_bytes":25361074068,"execution_time_ns":2082997057,"connection_details":[{"is_local":true,"packets":0,"bytes":25361074068},{"is_local":false,"packets":0,"bytes":0}],"scan_details":{"create_inputstream_time":"1088ms","create_snapshot_time":"0ms","delta_bytes":1857917470,"delta_rows":19557026,"dmfile_read_time":"33331ms","dmfile_scan_rows":444640988,"dmfile_skip_rows":26964985,"mvcc_input_bytes":34346323740,"mvcc_input_rows":464139510,"mvcc_output_rows":444931124,"num_columns":5,"num_read_tasks":602,"num_segments":602}}],"host":"10.2.12.81:9540","task_init_timestamp":1703652570551852000,"task_start_timestamp":1703652570589057000,"task_end_timestamp":1703652574785044000,"compile_start_timestamp":1703652570552809000,"compile_end_timestamp":1703652570589019000,"read_wait_index_start_timestamp":1703652570554243000,"read_wait_index_end_timestamp":1703652570576467000,"local_input_bytes":25361074068,"remote_input_bytes":0,"output_bytes":1965,"status":"FINISHED","error_message":"","working_time":0,"memory_peak":2345570843}

{"query_tso":446602300563390465,"task_id":1,"is_root":false,"sender_executor_id":"ExchangeSender_51","executors":[{"id":"ExchangeSender_51","type":"ExchangeSender","children":["HashAgg_47"],"outbound_rows":15,"outbound_blocks":256,"outbound_bytes":2700,"execution_time_ns":4930993029,"partition_num":1,"sender_target_task_ids":[2],"exchange_type":"Hash","connection_details":[{"tunnel_id":"tunnel1+2","sender_target_task_id":2,"sender_target_host":"10.2.12.81:9540","is_local":true,"packets":16,"bytes":28550}]},{"id":"HashAgg_47","type":"Agg","children":["Projection_57"],"outbound_rows":15,"outbound_blocks":256,"outbound_bytes":2655,"execution_time_ns":4930993029},{"id":"Projection_57","type":"Projection","children":["Selection_36"],"outbound_rows":334475782,"outbound_blocks":7440,"outbound_bytes":26423586778,"execution_time_ns":3740994704},{"id":"Selection_36","type":"Selection","children":["TableFullScan_35"],"outbound_rows":334475782,"outbound_blocks":7440,"outbound_bytes":24416732086,"execution_time_ns":2770996077},{"id":"TableFullScan_35","type":"TableScan","children":[],"outbound_rows":444931124,"outbound_blocks":7441,"outbound_bytes":32479972052,"execution_time_ns":2272996778,"connection_details":[{"is_local":true,"packets":0,"bytes":32479972052},{"is_local":false,"packets":0,"bytes":0}],"scan_details":{"create_inputstream_time":"1736ms","create_snapshot_time":"0ms","delta_bytes":1857917470,"delta_rows":19557026,"dmfile_read_time":"40633ms","dmfile_scan_rows":444640988,"dmfile_skip_rows":26964985,"mvcc_input_bytes":41772555900,"mvcc_input_rows":464139510,"mvcc_output_rows":444931124,"num_columns":9,"num_read_tasks":602,"num_segments":602}}],"host":"10.2.12.81:9540","task_init_timestamp":1703652574806750000,"task_start_timestamp":1703652574828116000,"task_end_timestamp":1703652579759446000,"compile_start_timestamp":1703652574808286000,"compile_end_timestamp":1703652574828088000,"read_wait_index_start_timestamp":1703652574809698000,"read_wait_index_end_timestamp":1703652574817890000,"local_input_bytes":32479972052,"remote_input_bytes":0,"output_bytes":2700,"status":"FINISHED","error_message":"","working_time":0,"memory_peak":2859102384}
```
</details>

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  - See the queries and result above
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
