### PR TITLE
*: Add table scan details logging; change default logging level to "info"

### DIFF
--- a/dbms/src/DataStreams/TiRemoteBlockInputStream.h
+++ b/dbms/src/DataStreams/TiRemoteBlockInputStream.h
@@ -23,7 +23,6 @@
 #include <Flash/Coprocessor/RemoteExecutionSummary.h>
 #include <Flash/Mpp/ExchangeReceiver.h>
 #include <Flash/Statistics/ConnectionProfileInfo.h>
-#include <Storages/DeltaMerge/ScanContext.h>
 #include <common/logger_useful.h>
 
 #include <chrono>

--- a/dbms/src/Flash/Coprocessor/DAGContext.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGContext.cpp
@@ -20,6 +20,7 @@
 #include <Flash/Mpp/ExchangeReceiver.h>
 #include <Flash/Statistics/transformProfiles.h>
 #include <Flash/Statistics/traverseExecutors.h>
+#include <Storages/DeltaMerge/ScanContext.h>
 #include <Storages/KVStore/TMTContext.h>
 #include <kvproto/disaggregated.pb.h>
 #include <tipb/executor.pb.h>
@@ -473,7 +474,7 @@ RU DAGContext::getReadRU() const
     for (const auto & [id, sc] : scan_context_map)
     {
         (void)id; // Disable unused variable warnning.
-        read_bytes += sc->total_user_read_bytes;
+        read_bytes += sc->user_read_bytes;
     }
     return bytesToRU(read_bytes);
 }

--- a/dbms/src/Flash/Coprocessor/DAGContext.h
+++ b/dbms/src/Flash/Coprocessor/DAGContext.h
@@ -39,7 +39,7 @@
 #include <Operators/OperatorProfileInfo.h>
 #include <Parsers/makeDummyQuery.h>
 #include <Storages/DeltaMerge/Remote/DisaggTaskId.h>
-#include <Storages/DeltaMerge/ScanContext.h>
+#include <Storages/DeltaMerge/ScanContext_fwd.h>
 #include <TiDB/Schema/TiDB.h>
 namespace DB
 {

--- a/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
@@ -642,6 +642,7 @@ void DAGStorageInterpreter::prepare()
     storage_for_logical_table = storages_with_structure_lock[logical_table_id].storage;
 
     std::tie(required_columns, may_need_add_cast_column) = getColumnsForTableScan();
+    scan_context->num_columns = required_columns.size();
 }
 
 void DAGStorageInterpreter::executeCastAfterTableScan(

--- a/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
@@ -634,7 +634,7 @@ void DAGStorageInterpreter::prepare()
         learner_read_snapshot = doBatchCopLearnerRead();
     else
         learner_read_snapshot = doCopLearnerRead();
-    scan_context->total_learner_read_ns += watch.elapsed();
+    scan_context->learner_read_ns += watch.elapsed();
 
     // Acquire read lock on `alter lock` and build the requested inputstreams
     storages_with_structure_lock = getAndLockStorages(context.getSettingsRef().schema_version);

--- a/dbms/src/Flash/Coprocessor/ExecutionSummary.cpp
+++ b/dbms/src/Flash/Coprocessor/ExecutionSummary.cpp
@@ -14,9 +14,14 @@
 
 #include <Flash/Coprocessor/ExecutionSummary.h>
 #include <Flash/Statistics/BaseRuntimeStatistics.h>
+#include <Storages/DeltaMerge/ScanContext.h>
 
 namespace DB
 {
+ExecutionSummary::ExecutionSummary()
+    : scan_context(std::make_shared<DM::ScanContext>())
+{}
+
 void ExecutionSummary::merge(const ExecutionSummary & other)
 {
     time_processed_ns = std::max(time_processed_ns, other.time_processed_ns);

--- a/dbms/src/Flash/Coprocessor/ExecutionSummary.h
+++ b/dbms/src/Flash/Coprocessor/ExecutionSummary.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include <Storages/DeltaMerge/ScanContext.h>
+#include <Storages/DeltaMerge/ScanContext_fwd.h>
 #include <common/types.h>
 #include <tipb/select.pb.h>
 

--- a/dbms/src/Flash/Coprocessor/ExecutionSummary.h
+++ b/dbms/src/Flash/Coprocessor/ExecutionSummary.h
@@ -32,9 +32,9 @@ struct ExecutionSummary
     UInt64 num_iterations = 0;
     UInt64 concurrency = 0;
 
-    DM::ScanContextPtr scan_context = std::make_shared<DB::DM::ScanContext>();
+    DM::ScanContextPtr scan_context;
 
-    ExecutionSummary() = default;
+    ExecutionSummary();
 
     void merge(const ExecutionSummary & other);
     void merge(const tipb::ExecutorExecutionSummary & other);

--- a/dbms/src/Flash/Coprocessor/tests/gtest_ti_remote_block_inputstream.cpp
+++ b/dbms/src/Flash/Coprocessor/tests/gtest_ti_remote_block_inputstream.cpp
@@ -78,7 +78,7 @@ struct MockWriter
         summary.scan_context->total_dmfile_skipped_rows = 15000;
         summary.scan_context->total_dmfile_rough_set_index_check_time_ns = 10;
         summary.scan_context->total_dmfile_read_time_ns = 200;
-        summary.scan_context->total_create_snapshot_time_ns = 5;
+        summary.scan_context->create_snapshot_time_ns = 5;
         summary.scan_context->total_local_region_num = 10;
         summary.scan_context->total_remote_region_num = 5;
         return summary;

--- a/dbms/src/Flash/Statistics/ExecutionSummaryHelper.cpp
+++ b/dbms/src/Flash/Statistics/ExecutionSummaryHelper.cpp
@@ -14,6 +14,7 @@
 
 #include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Statistics/ExecutionSummaryHelper.h>
+#include <Storages/DeltaMerge/ScanContext.h>
 
 namespace DB
 {

--- a/dbms/src/Flash/Statistics/ExecutorStatisticsCollector.cpp
+++ b/dbms/src/Flash/Statistics/ExecutorStatisticsCollector.cpp
@@ -24,6 +24,7 @@
 #include <Flash/Statistics/JoinImpl.h>
 #include <Flash/Statistics/TableScanImpl.h>
 #include <Flash/Statistics/traverseExecutors.h>
+#include <Storages/DeltaMerge/ScanContext.h>
 
 namespace DB
 {

--- a/dbms/src/Flash/Statistics/ExecutorStatisticsCollector.h
+++ b/dbms/src/Flash/Statistics/ExecutorStatisticsCollector.h
@@ -16,7 +16,7 @@
 
 #include <Common/Exception.h>
 #include <Flash/Statistics/ExecutorStatisticsBase.h>
-#include <Storages/DeltaMerge/ScanContext.h>
+#include <Storages/DeltaMerge/ScanContext_fwd.h>
 #include <tipb/executor.pb.h>
 #include <tipb/select.pb.h>
 

--- a/dbms/src/Flash/Statistics/TableScanImpl.cpp
+++ b/dbms/src/Flash/Statistics/TableScanImpl.cpp
@@ -26,14 +26,13 @@ String TableScanDetail::toJson() const
 
 void TableScanStatistics::appendExtraJson(FmtBuffer & fmt_buffer) const
 {
-    DM::ScanContextPtr scan_context;
-    if (auto it = dag_context.scan_context_map.find(executor_id); it != dag_context.scan_context_map.end())
-        scan_context = it->second;
+    auto scan_ctx_it = dag_context.scan_context_map.find(executor_id);
     fmt_buffer.fmtAppend(
         R"("connection_details":[{},{}],"scan_details":{})",
         local_table_scan_detail.toJson(),
         remote_table_scan_detail.toJson(),
-        scan_context ? scan_context->toJson() : "{}" // empty json object for nullptr
+        scan_ctx_it != dag_context.scan_context_map.end() ? scan_ctx_it->second->toJson()
+                                                          : "{}" // empty json object for nullptr
     );
 }
 

--- a/dbms/src/Flash/Statistics/TableScanImpl.cpp
+++ b/dbms/src/Flash/Statistics/TableScanImpl.cpp
@@ -25,10 +25,15 @@ String TableScanDetail::toJson() const
 
 void TableScanStatistics::appendExtraJson(FmtBuffer & fmt_buffer) const
 {
+    DM::ScanContextPtr scan_context;
+    if (auto it = dag_context.scan_context_map.find(executor_id); it != dag_context.scan_context_map.end())
+        scan_context = it->second;
     fmt_buffer.fmtAppend(
-        R"("connection_details":[{},{}])",
+        R"("connection_details":[{},{}],"scan_details":{})",
         local_table_scan_detail.toJson(),
-        remote_table_scan_detail.toJson());
+        remote_table_scan_detail.toJson(),
+        scan_context ? scan_context->toJson() : "{}" // empty json object for nullptr
+    );
 }
 
 void TableScanStatistics::updateTableScanDetail(const std::vector<ConnectionProfileInfo> & connection_profile_infos)

--- a/dbms/src/Flash/Statistics/TableScanImpl.cpp
+++ b/dbms/src/Flash/Statistics/TableScanImpl.cpp
@@ -15,6 +15,7 @@
 #include <DataStreams/TiRemoteBlockInputStream.h>
 #include <Flash/Statistics/TableScanImpl.h>
 #include <Interpreters/Join.h>
+#include <Storages/DeltaMerge/ScanContext.h>
 
 namespace DB
 {

--- a/dbms/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterSelectQuery.cpp
@@ -37,7 +37,6 @@
 #include <DataStreams/UnionBlockInputStream.h>
 #include <DataStreams/copyData.h>
 #include <Encryption/FileProvider.h>
-#include <Flash/Coprocessor/DAGQueryInfo.h>
 #include <Interpreters/ExpressionAnalyzer.h>
 #include <Interpreters/InterpreterSelectQuery.h>
 #include <Interpreters/InterpreterSelectWithUnionQuery.h>

--- a/dbms/src/Operators/UnorderedSourceOp.h
+++ b/dbms/src/Operators/UnorderedSourceOp.h
@@ -45,13 +45,18 @@ public:
     {
         setHeader(AddExtraTableIDColumnTransformAction::buildHeader(columns_to_read_, extra_table_id_index_));
         ref_no = task_pool->increaseUnorderedInputStreamRefCount();
-        LOG_DEBUG(log, "Created, pool_id={} ref_no={}", task_pool->pool_id, ref_no);
     }
 
     ~UnorderedSourceOp() override
     {
-        task_pool->decreaseUnorderedInputStreamRefCount();
-        LOG_DEBUG(log, "Destroy, pool_id={} ref_no={}", task_pool->pool_id, ref_no);
+        if (const auto rc_before_decr = task_pool->decreaseUnorderedInputStreamRefCount(); rc_before_decr == 1)
+        {
+            LOG_INFO(
+                log,
+                "All unordered input streams are finished, pool_id={} last_stream_ref_no={}",
+                task_pool->pool_id,
+                ref_no);
+        }
     }
 
     String getName() const override { return "UnorderedSourceOp"; }

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSetReader.cpp
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSetReader.cpp
@@ -201,7 +201,7 @@ size_t ColumnFileSetReader::readRows(
         if (row_ids == nullptr)
             lac_bytes_collector.collect(delta_bytes);
         if (likely(context.scan_context))
-            context.scan_context->total_user_read_bytes += delta_bytes;
+            context.scan_context->user_read_bytes += delta_bytes;
     }
 
     return actual_read;

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSetReader.h
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSetReader.h
@@ -16,6 +16,7 @@
 
 #include <Storages/DeltaMerge/ColumnFile/ColumnFileSetSnapshot.h>
 #include <Storages/DeltaMerge/DMContext.h>
+#include <Storages/DeltaMerge/ScanContext.h>
 #include <Storages/DeltaMerge/SkippableBlockInputStream.h>
 
 namespace DB

--- a/dbms/src/Storages/DeltaMerge/DMVersionFilterBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/DMVersionFilterBlockInputStream.cpp
@@ -64,6 +64,12 @@ Block DMVersionFilterBlockInputStream<MODE>::read(FilterPtr & res_filter, bool r
 
             total_rows += rows;
             passed_rows += rows;
+            if (scan_context)
+            {
+                scan_context->mvcc_input_rows += rows;
+                scan_context->mvcc_input_bytes += cur_raw_block.bytes();
+                scan_context->mvcc_output_rows += rows;
+            }
 
             initNextBlock();
 
@@ -399,6 +405,12 @@ Block DMVersionFilterBlockInputStream<MODE>::read(FilterPtr & res_filter, bool r
         ++total_blocks;
         total_rows += rows;
         passed_rows += passed_count;
+        if (scan_context)
+        {
+            scan_context->mvcc_input_rows += rows;
+            scan_context->mvcc_input_bytes += cur_raw_block.bytes();
+            scan_context->mvcc_output_rows += passed_count;
+        }
 
         // This block is empty after filter, continue to process next block
         if (passed_count == 0)

--- a/dbms/src/Storages/DeltaMerge/DMVersionFilterBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/DMVersionFilterBlockInputStream.h
@@ -21,6 +21,7 @@
 #include <DataStreams/SelectionByColumnIdTransformAction.h>
 #include <Storages/DeltaMerge/DeltaMergeHelpers.h>
 #include <Storages/DeltaMerge/RowKeyRange.h>
+#include <Storages/DeltaMerge/ScanContext.h>
 #include <common/logger_useful.h>
 
 namespace DB
@@ -49,11 +50,13 @@ public:
         const ColumnDefines & read_columns,
         UInt64 version_limit_,
         bool is_common_handle_,
-        const String & tracing_id = "")
+        const String & tracing_id = "",
+        const ScanContextPtr & scan_context_ = nullptr)
         : version_limit(version_limit_)
         , is_common_handle(is_common_handle_)
         , header(toEmptyBlock(read_columns))
         , select_by_colid_action(input->getHeader(), header)
+        , scan_context(scan_context_)
         , log(Logger::get((MODE == DM_VERSION_FILTER_MODE_MVCC ? MVCC_FILTER_NAME : COMPACT_FILTER_NAME), tracing_id))
     {
         children.push_back(input);
@@ -269,6 +272,8 @@ private:
     size_t deleted_rows = 0;
 
     SelectionByColumnIdTransformAction select_by_colid_action;
+
+    const ScanContextPtr scan_context;
 
     const LoggerPtr log;
 };

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -1236,7 +1236,11 @@ BlockInputStreams DeltaMergeStore::read(
         }
         res.push_back(stream);
     }
-    LOG_DEBUG(tracing_logger, "Read create stream done");
+    LOG_INFO(
+        tracing_logger,
+        "Read create stream done, pool_id={} num_streams={}",
+        read_task_pool->pool_id,
+        final_num_stream);
 
     return res;
 }
@@ -1351,7 +1355,11 @@ void DeltaMergeStore::read(
         });
     }
 
-    LOG_DEBUG(tracing_logger, "Read create PipelineExec done");
+    LOG_INFO(
+        tracing_logger,
+        "Read create PipelineExec done, pool_id={} num_streams={}",
+        read_task_pool->pool_id,
+        final_num_stream);
 }
 
 Remote::DisaggPhysicalTableReadSnapshotPtr DeltaMergeStore::writeNodeBuildRemoteReadSnapshot(

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -1203,7 +1203,7 @@ BlockInputStreams DeltaMergeStore::read(
         enable_read_thread,
         final_num_stream,
         dm_context->scan_context->resource_group_name);
-    scan_context->read_mode = read_mode;
+    dm_context->scan_context->read_mode = read_mode;
 
     BlockInputStreams res;
     for (size_t i = 0; i < final_num_stream; ++i)
@@ -1313,7 +1313,7 @@ void DeltaMergeStore::read(
         enable_read_thread,
         final_num_stream,
         dm_context->scan_context->resource_group_name);
-    scan_context->read_mode = read_mode;
+    dm_context->scan_context->read_mode = read_mode;
 
     const auto & columns_after_cast = filter && filter->extra_cast ? *filter->columns_after_cast : columns_to_read;
     if (enable_read_thread)
@@ -1387,7 +1387,7 @@ Remote::DisaggPhysicalTableReadSnapshotPtr DeltaMergeStore::writeNodeBuildRemote
         read_segments,
         /* try_split_task */ false);
     GET_METRIC(tiflash_disaggregated_read_tasks_count).Increment(tasks.size());
-    LOG_DEBUG(tracing_logger, "Read create segment snapshot done");
+    LOG_INFO(tracing_logger, "Read create segment snapshot done");
 
     return std::make_unique<Remote::DisaggPhysicalTableReadSnapshot>(
         KeyspaceTableID{keyspace_id, physical_table_id},

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -1204,6 +1204,7 @@ BlockInputStreams DeltaMergeStore::read(
         enable_read_thread,
         final_num_stream,
         dm_context->scan_context->resource_group_name);
+    scan_context->read_mode = read_mode;
 
     BlockInputStreams res;
     for (size_t i = 0; i < final_num_stream; ++i)
@@ -1313,8 +1314,9 @@ void DeltaMergeStore::read(
         enable_read_thread,
         final_num_stream,
         dm_context->scan_context->resource_group_name);
-    const auto & columns_after_cast = filter && filter->extra_cast ? *filter->columns_after_cast : columns_to_read;
+    scan_context->read_mode = read_mode;
 
+    const auto & columns_after_cast = filter && filter->extra_cast ? *filter->columns_after_cast : columns_to_read;
     if (enable_read_thread)
     {
         for (size_t i = 0; i < final_num_stream; ++i)

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
@@ -757,8 +757,7 @@ private:
         const RowKeyRanges & sorted_ranges,
         size_t expected_tasks_count = 1,
         const SegmentIdSet & read_segments = {},
-        bool try_split_task = true,
-        const ScanContextPtr & scan_context = nullptr);
+        bool try_split_task = true);
 
 private:
     /**

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
@@ -757,7 +757,8 @@ private:
         const RowKeyRanges & sorted_ranges,
         size_t expected_tasks_count = 1,
         const SegmentIdSet & read_segments = {},
-        bool try_split_task = true);
+        bool try_split_task = true,
+        const ScanContextPtr & scan_context = nullptr);
 
 private:
     /**

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
@@ -29,7 +29,7 @@
 #include <Storages/DeltaMerge/Filter/PushDownFilter.h>
 #include <Storages/DeltaMerge/Remote/DisaggSnapshot_fwd.h>
 #include <Storages/DeltaMerge/RowKeyRange.h>
-#include <Storages/DeltaMerge/ScanContext.h>
+#include <Storages/DeltaMerge/ScanContext_fwd.h>
 #include <Storages/DeltaMerge/SegmentReadTaskPool.h>
 #include <Storages/KVStore/Decode/DecodingStorageSchemaSnapshot.h>
 #include <Storages/KVStore/MultiRaft/Disagg/CheckpointIngestInfo.h>

--- a/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.h
@@ -19,7 +19,7 @@
 #include <Storages/DeltaMerge/File/DMFileReader.h>
 #include <Storages/DeltaMerge/ReadThread/SegmentReader.h>
 #include <Storages/DeltaMerge/RowKeyRange.h>
-#include <Storages/DeltaMerge/ScanContext.h>
+#include <Storages/DeltaMerge/ScanContext_fwd.h>
 #include <Storages/DeltaMerge/SkippableBlockInputStream.h>
 
 

--- a/dbms/src/Storages/DeltaMerge/File/DMFileReader.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileReader.cpp
@@ -404,6 +404,7 @@ size_t DMFileReader::skipNextBlock()
     if (likely(read_rows > 0))
         use_packs[next_pack_id - 1] = false;
 
+    scan_context->late_materialization_skip_rows += read_rows;
     return read_rows;
 }
 
@@ -438,6 +439,7 @@ Block DMFileReader::readWithFilter(const IColumn::Filter & filter)
             auto skip = std::distance(begin, it);
             while (next_pack_id_cp < use_packs.size() && skip >= pack_stats[next_pack_id_cp].rows)
             {
+                scan_context->late_materialization_skip_rows += pack_stats[next_pack_id_cp].rows;
                 use_packs[next_pack_id_cp] = false;
                 skip -= pack_stats[next_pack_id_cp].rows;
                 read_rows += pack_stats[next_pack_id_cp].rows;

--- a/dbms/src/Storages/DeltaMerge/File/DMFileReader.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileReader.h
@@ -23,7 +23,7 @@
 #include <Storages/DeltaMerge/File/DMFilePackFilter.h>
 #include <Storages/DeltaMerge/ReadThread/ColumnSharingCache.h>
 #include <Storages/DeltaMerge/RowKeyRange.h>
-#include <Storages/DeltaMerge/ScanContext.h>
+#include <Storages/DeltaMerge/ScanContext_fwd.h>
 #include <Storages/MarkCache.h>
 
 namespace DB

--- a/dbms/src/Storages/DeltaMerge/File/DMFileReader.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileReader.h
@@ -98,6 +98,8 @@ public:
     /// Return false if it is the end of stream.
     bool getSkippedRows(size_t & skip_rows);
 
+    /// NOTE: skipNextBlock and readWithFilter are only used by late materialization.
+
     /// Skip the packs to read next
     /// Return the number of rows skipped.
     /// Return 0 if it is the end of file.

--- a/dbms/src/Storages/DeltaMerge/LateMaterializationBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/LateMaterializationBlockInputStream.cpp
@@ -31,8 +31,8 @@ LateMaterializationBlockInputStream::LateMaterializationBlockInputStream(
     const String & req_id_)
     : header(toEmptyBlock(columns_to_read))
     , filter_column_name(filter_column_name_)
-    , filter_column_stream(filter_column_stream_)
-    , rest_column_stream(rest_column_stream_)
+    , filter_column_stream(std::move(filter_column_stream_))
+    , rest_column_stream(std::move(rest_column_stream_))
     , bitmap_filter(bitmap_filter_)
     , log(Logger::get(NAME, req_id_))
 {}

--- a/dbms/src/Storages/DeltaMerge/LateMaterializationBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/LateMaterializationBlockInputStream.cpp
@@ -17,7 +17,6 @@
 #include <Storages/DeltaMerge/LateMaterializationBlockInputStream.h>
 #include <Storages/DeltaMerge/ReadUtil.h>
 
-#include <algorithm>
 
 namespace DB::DM
 {
@@ -28,14 +27,12 @@ LateMaterializationBlockInputStream::LateMaterializationBlockInputStream(
     BlockInputStreamPtr filter_column_stream_,
     SkippableBlockInputStreamPtr rest_column_stream_,
     const BitmapFilterPtr & bitmap_filter_,
-    const String & req_id_,
-    const ScanContextPtr & scan_context_)
+    const String & req_id_)
     : header(toEmptyBlock(columns_to_read))
     , filter_column_name(filter_column_name_)
     , filter_column_stream(std::move(filter_column_stream_))
     , rest_column_stream(std::move(rest_column_stream_))
     , bitmap_filter(bitmap_filter_)
-    , scan_context(scan_context_)
     , log(Logger::get(NAME, req_id_))
 {}
 
@@ -77,7 +74,6 @@ Block LateMaterializationBlockInputStream::readImpl()
                     col.column = col.column->filter(col_filter, passed_count);
                 }
             }
-            // No need to change scan_context->late_materialize_skip_rows
             return hstackBlocks({std::move(filter_column_block), std::move(rest_column_block)}, header);
         }
 
@@ -101,13 +97,11 @@ Block LateMaterializationBlockInputStream::readImpl()
                     filter_column_block.startOffset(),
                     filter_column_block.rows());
             }
-            scan_context->late_materialize_skip_rows += rows;
         }
         else
         {
             Block rest_column_block;
             auto filter_out_count = rows - passed_count;
-            scan_context->late_materialize_skip_rows += filter_out_count;
             if (filter_out_count >= DEFAULT_MERGE_BLOCK_SIZE * 2)
             {
                 // When DEFAULT_MERGE_BLOCK_SIZE < row_left < DEFAULT_MERGE_BLOCK_SIZE * 2,

--- a/dbms/src/Storages/DeltaMerge/LateMaterializationBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/LateMaterializationBlockInputStream.h
@@ -39,7 +39,8 @@ public:
         BlockInputStreamPtr filter_column_stream_,
         SkippableBlockInputStreamPtr rest_column_stream_,
         const BitmapFilterPtr & bitmap_filter_,
-        const String & req_id_);
+        const String & req_id_,
+        const ScanContextPtr & scan_context_);
 
     String getName() const override { return NAME; }
 
@@ -59,6 +60,8 @@ private:
     SkippableBlockInputStreamPtr rest_column_stream;
     // The MVCC-bitmap.
     BitmapFilterPtr bitmap_filter;
+
+    ScanContextPtr scan_context;
 
     const LoggerPtr log;
 };

--- a/dbms/src/Storages/DeltaMerge/LateMaterializationBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/LateMaterializationBlockInputStream.h
@@ -39,8 +39,7 @@ public:
         BlockInputStreamPtr filter_column_stream_,
         SkippableBlockInputStreamPtr rest_column_stream_,
         const BitmapFilterPtr & bitmap_filter_,
-        const String & req_id_,
-        const ScanContextPtr & scan_context_);
+        const String & req_id_);
 
     String getName() const override { return NAME; }
 
@@ -60,8 +59,6 @@ private:
     SkippableBlockInputStreamPtr rest_column_stream;
     // The MVCC-bitmap.
     BitmapFilterPtr bitmap_filter;
-
-    ScanContextPtr scan_context;
 
     const LoggerPtr log;
 };

--- a/dbms/src/Storages/DeltaMerge/ReadMode.h
+++ b/dbms/src/Storages/DeltaMerge/ReadMode.h
@@ -1,0 +1,42 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace DB::DM
+{
+
+enum class ReadMode
+{
+    /**
+     * Read in normal mode. Data is ordered by PK, and only the most recent version is returned.
+     */
+    Normal,
+
+    /**
+     * Read in fast mode. Data is not sort merged, and all versions are returned. However, deleted records (del_mark=1)
+     * will be still filtered out.
+     */
+    Fast,
+
+    /**
+     * Read in raw mode, for example, for statements like `SELRAW *`. In raw mode, data is not sort merged and all versions
+     * are just returned.
+     */
+    Raw,
+
+    Bitmap,
+};
+
+} // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.cpp
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.cpp
@@ -45,7 +45,7 @@ void SegmentReadTaskScheduler::add(const SegmentReadTaskPoolPtr & pool, const Lo
     {
         merging_segments[seg_id].push_back(pool->pool_id);
     }
-    LOG_DEBUG(
+    LOG_INFO(
         req_log,
         "Added, pool_id={} block_slots={} segment_count={} pool_count={} cost={:.3f}us do_add_cost={:.3f}us", //
         pool->pool_id,

--- a/dbms/src/Storages/DeltaMerge/ReadThread/UnorderedInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/UnorderedInputStream.h
@@ -43,13 +43,18 @@ public:
         , max_wait_time_ms(max_wait_time_ms_)
     {
         ref_no = task_pool->increaseUnorderedInputStreamRefCount();
-        LOG_DEBUG(log, "Created, pool_id={} ref_no={}", task_pool->pool_id, ref_no);
     }
 
     ~UnorderedInputStream() override
     {
-        task_pool->decreaseUnorderedInputStreamRefCount();
-        LOG_DEBUG(log, "Destroy, pool_id={} ref_no={}", task_pool->pool_id, ref_no);
+        if (const auto rc_before_decr = task_pool->decreaseUnorderedInputStreamRefCount(); rc_before_decr == 1)
+        {
+            LOG_INFO(
+                log,
+                "All unordered input streams are finished, pool_id={} last_stream_ref_no={}",
+                task_pool->pool_id,
+                ref_no);
+        }
     }
 
     String getName() const override { return NAME; }

--- a/dbms/src/Storages/DeltaMerge/Remote/RNLocalPageCache.cpp
+++ b/dbms/src/Storages/DeltaMerge/Remote/RNLocalPageCache.cpp
@@ -392,11 +392,11 @@ RNLocalPageCache::OccupySpaceResult RNLocalPageCache::occupySpace(
         // to the storage.
         if (const auto & page_entry = storage->getEntry(keys[i], snapshot); page_entry.isValid())
         {
-            scan_context->total_disagg_read_cache_hit_size += page_sizes[i];
+            scan_context->disagg_read_cache_hit_size += page_sizes[i];
             continue;
         }
         missing_ids.push_back(pages[i]);
-        scan_context->total_disagg_read_cache_miss_size += page_sizes[i];
+        scan_context->disagg_read_cache_miss_size += page_sizes[i];
     }
     GET_METRIC(tiflash_storage_remote_cache, type_page_miss).Increment(missing_ids.size());
     GET_METRIC(tiflash_storage_remote_cache, type_page_hit).Increment(pages.size() - missing_ids.size());

--- a/dbms/src/Storages/DeltaMerge/Remote/RNLocalPageCache.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/RNLocalPageCache.h
@@ -18,7 +18,7 @@
 #include <Interpreters/Context_fwd.h>
 #include <Storages/DeltaMerge/Remote/ObjectId.h>
 #include <Storages/DeltaMerge/Remote/RNLocalPageCache_fwd.h>
-#include <Storages/DeltaMerge/ScanContext.h>
+#include <Storages/DeltaMerge/ScanContext_fwd.h>
 #include <Storages/KVStore/Types.h>
 #include <Storages/Page/Page.h>
 #include <Storages/Page/PageStorage_fwd.h>

--- a/dbms/src/Storages/DeltaMerge/RowKeyOrderedBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/RowKeyOrderedBlockInputStream.h
@@ -36,8 +36,8 @@ public:
         size_t stable_rows_,
         const String & req_id_)
         : header(toEmptyBlock(columns_to_read_))
-        , stable(stable_)
-        , delta(delta_)
+        , stable(std::move(stable_))
+        , delta(std::move(delta_))
         , stable_rows(stable_rows_)
         , log(Logger::get(NAME, req_id_))
     {}

--- a/dbms/src/Storages/DeltaMerge/ScanContext.cpp
+++ b/dbms/src/Storages/DeltaMerge/ScanContext.cpp
@@ -29,14 +29,11 @@ String ScanContext::toJson() const
     json->set("dmfile_scan_rows", total_dmfile_scanned_rows.load());
     json->set("dmfile_skip_rows", total_dmfile_skipped_rows.load());
     json->set("dmfile_read_time", fmt::format("{:.3f}ms", total_dmfile_read_time_ns.load() / NS_TO_MS_SCALE));
-    json->set("create_snapshot_time", fmt::format("{:.3f}ms", create_snapshot_time_ns.load() / NS_TO_MS_SCALE));
-    json->set("create_stream_time", fmt::format("{:.3f}ms", create_inputstream_time_ns.load() / NS_TO_MS_SCALE));
 
     json->set("remote_region_num", total_remote_region_num.load());
     json->set("local_region_num", total_remote_region_num.load());
 
     json->set("read_bytes", user_read_bytes.load());
-    json->set("learner_read_time", fmt::format("{:.3f}ms", learner_read_ns.load() / NS_TO_MS_SCALE));
 
     json->set("disagg_cache_hit_size", disagg_read_cache_hit_size.load());
     json->set("disagg_cache_miss_size", disagg_read_cache_miss_size.load());
@@ -48,15 +45,19 @@ String ScanContext::toJson() const
     json->set("delta_rows", delta_rows.load());
     json->set("delta_bytes", delta_bytes.load());
 
-    json->set("mvcc_input_rows", mvcc_input_rows.load());
-    json->set("mvcc_input_bytes", mvcc_input_bytes.load());
-    json->set("mvcc_skip_rows", mvcc_input_rows.load() - mvcc_output_rows.load());
-
     // Note we must wrap the result of `magic_enum::enum_name` with `String`,
     // or Poco can not turn it into JSON correctly and crash
     json->set("read_mode", String(magic_enum::enum_name(read_mode)));
-    json->set("build_bitmap_time", fmt::format("{:.3f}ms", build_bitmap_time_ns.load() / NS_TO_MS_SCALE));
+
+    json->set("mvcc_input_rows", mvcc_input_rows.load());
+    json->set("mvcc_input_bytes", mvcc_input_bytes.load());
+    json->set("mvcc_skip_rows", mvcc_input_rows.load() - mvcc_output_rows.load());
     json->set("late_materialization_skip_rows", late_materialization_skip_rows.load());
+
+    json->set("learner_read_time", fmt::format("{:.3f}ms", learner_read_ns.load() / NS_TO_MS_SCALE));
+    json->set("create_snapshot_time", fmt::format("{:.3f}ms", create_snapshot_time_ns.load() / NS_TO_MS_SCALE));
+    json->set("create_stream_time", fmt::format("{:.3f}ms", create_inputstream_time_ns.load() / NS_TO_MS_SCALE));
+    json->set("build_bitmap_time", fmt::format("{:.3f}ms", build_bitmap_time_ns.load() / NS_TO_MS_SCALE));
 
     std::stringstream buf;
     json->stringify(buf);

--- a/dbms/src/Storages/DeltaMerge/ScanContext.cpp
+++ b/dbms/src/Storages/DeltaMerge/ScanContext.cpp
@@ -28,7 +28,9 @@ String ScanContext::toJson() const
     json->set("dmfile_skip_rows", total_dmfile_skipped_rows.load());
     json->set("dmfile_read_time", fmt::format("{:.3f}ms", total_dmfile_read_time_ns.load() / NS_TO_MS_SCALE));
     json->set("create_snapshot_time", fmt::format("{:.3f}ms", total_create_snapshot_time_ns.load() / NS_TO_MS_SCALE));
-    json->set("create_inputstream_time", fmt::format("{:.3f}ms", total_create_inputstream_time_ns.load() / NS_TO_MS_SCALE));
+    json->set(
+        "create_inputstream_time",
+        fmt::format("{:.3f}ms", total_create_inputstream_time_ns.load() / NS_TO_MS_SCALE));
 
     json->set("remote_region_num", total_remote_region_num.load());
     json->set("local_region_num", total_remote_region_num.load());

--- a/dbms/src/Storages/DeltaMerge/ScanContext.cpp
+++ b/dbms/src/Storages/DeltaMerge/ScanContext.cpp
@@ -18,6 +18,8 @@
 #pragma GCC diagnostic pop
 #include <Storages/DeltaMerge/ScanContext.h>
 
+#include <magic_enum.hpp>
+
 namespace DB::DM
 {
 String ScanContext::toJson() const
@@ -27,17 +29,17 @@ String ScanContext::toJson() const
     json->set("dmfile_scan_rows", total_dmfile_scanned_rows.load());
     json->set("dmfile_skip_rows", total_dmfile_skipped_rows.load());
     json->set("dmfile_read_time", fmt::format("{:.3f}ms", total_dmfile_read_time_ns.load() / NS_TO_MS_SCALE));
-    json->set("create_snapshot_time", fmt::format("{:.3f}ms", total_create_snapshot_time_ns.load() / NS_TO_MS_SCALE));
-    json->set("create_stream_time", fmt::format("{:.3f}ms", total_create_inputstream_time_ns.load() / NS_TO_MS_SCALE));
+    json->set("create_snapshot_time", fmt::format("{:.3f}ms", create_snapshot_time_ns.load() / NS_TO_MS_SCALE));
+    json->set("create_stream_time", fmt::format("{:.3f}ms", create_inputstream_time_ns.load() / NS_TO_MS_SCALE));
 
     json->set("remote_region_num", total_remote_region_num.load());
     json->set("local_region_num", total_remote_region_num.load());
 
-    json->set("outbound_bytes", total_user_read_bytes.load()); // FIXME: is it duplicated?
-    json->set("learner_read_time", fmt::format("{:.3f}ms", total_learner_read_ns.load() / NS_TO_MS_SCALE));
+    json->set("read_bytes", user_read_bytes.load());
+    json->set("learner_read_time", fmt::format("{:.3f}ms", learner_read_ns.load() / NS_TO_MS_SCALE));
 
-    json->set("disagg_cache_hit_size", total_disagg_read_cache_hit_size.load());
-    json->set("disagg_cache_miss_size", total_disagg_read_cache_miss_size.load());
+    json->set("disagg_cache_hit_size", disagg_read_cache_hit_size.load());
+    json->set("disagg_cache_miss_size", disagg_read_cache_miss_size.load());
 
     json->set("num_segments", num_segments.load());
     json->set("num_read_tasks", num_read_tasks.load());
@@ -48,7 +50,13 @@ String ScanContext::toJson() const
 
     json->set("mvcc_input_rows", mvcc_input_rows.load());
     json->set("mvcc_input_bytes", mvcc_input_bytes.load());
-    json->set("mvcc_output_rows", mvcc_output_rows.load());
+    json->set("mvcc_skip_rows", mvcc_input_rows.load() - mvcc_output_rows.load());
+
+    // Note we must wrap the result of `magic_enum::enum_name` with `String`,
+    // or Poco can not turn it into JSON correctly and crash
+    json->set("read_mode", String(magic_enum::enum_name(read_mode)));
+    json->set("build_bitmap_time", fmt::format("{:.3f}ms", build_bitmap_time_ns.load() / NS_TO_MS_SCALE));
+    json->set("late_materialize_skip_rows", late_materialize_skip_rows.load());
 
     std::stringstream buf;
     json->stringify(buf);

--- a/dbms/src/Storages/DeltaMerge/ScanContext.cpp
+++ b/dbms/src/Storages/DeltaMerge/ScanContext.cpp
@@ -28,9 +28,7 @@ String ScanContext::toJson() const
     json->set("dmfile_skip_rows", total_dmfile_skipped_rows.load());
     json->set("dmfile_read_time", fmt::format("{:.3f}ms", total_dmfile_read_time_ns.load() / NS_TO_MS_SCALE));
     json->set("create_snapshot_time", fmt::format("{:.3f}ms", total_create_snapshot_time_ns.load() / NS_TO_MS_SCALE));
-    json->set(
-        "create_inputstream_time",
-        fmt::format("{:.3f}ms", total_create_inputstream_time_ns.load() / NS_TO_MS_SCALE));
+    json->set("create_stream_time", fmt::format("{:.3f}ms", total_create_inputstream_time_ns.load() / NS_TO_MS_SCALE));
 
     json->set("remote_region_num", total_remote_region_num.load());
     json->set("local_region_num", total_remote_region_num.load());

--- a/dbms/src/Storages/DeltaMerge/ScanContext.cpp
+++ b/dbms/src/Storages/DeltaMerge/ScanContext.cpp
@@ -1,0 +1,57 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#include <Poco/JSON/Object.h>
+#pragma GCC diagnostic pop
+#include <Storages/DeltaMerge/ScanContext.h>
+
+namespace DB::DM
+{
+String ScanContext::toJson() const
+{
+    static constexpr double NS_TO_MS_SCALE = 1'000'000.0;
+    Poco::JSON::Object::Ptr json = new Poco::JSON::Object();
+    json->set("dmfile_scan_rows", total_dmfile_scanned_rows.load());
+    json->set("dmfile_skip_rows", total_dmfile_skipped_rows.load());
+    json->set("dmfile_read_time", fmt::format("{:.3f}ms", total_dmfile_read_time_ns.load() / NS_TO_MS_SCALE));
+    json->set("create_snapshot_time", fmt::format("{:.3f}ms", total_create_snapshot_time_ns.load() / NS_TO_MS_SCALE));
+    json->set("create_inputstream_time", fmt::format("{:.3f}ms", total_create_inputstream_time_ns.load() / NS_TO_MS_SCALE));
+
+    json->set("remote_region_num", total_remote_region_num.load());
+    json->set("local_region_num", total_remote_region_num.load());
+
+    json->set("outbound_bytes", total_user_read_bytes.load()); // FIXME: is it duplicated?
+    json->set("learner_read_time", fmt::format("{:.3f}ms", total_learner_read_ns.load() / NS_TO_MS_SCALE));
+
+    json->set("disagg_cache_hit_size", total_disagg_read_cache_hit_size.load());
+    json->set("disagg_cache_miss_size", total_disagg_read_cache_miss_size.load());
+
+    json->set("num_segments", num_segments.load());
+    json->set("num_read_tasks", num_read_tasks.load());
+    json->set("num_columns", num_columns.load());
+
+    json->set("delta_rows", delta_rows.load());
+    json->set("delta_bytes", delta_bytes.load());
+
+    json->set("mvcc_input_rows", mvcc_input_rows.load());
+    json->set("mvcc_input_bytes", mvcc_input_bytes.load());
+    json->set("mvcc_output_rows", mvcc_output_rows.load());
+
+    std::stringstream buf;
+    json->stringify(buf);
+    return buf.str();
+}
+} // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/ScanContext.cpp
+++ b/dbms/src/Storages/DeltaMerge/ScanContext.cpp
@@ -56,7 +56,6 @@ String ScanContext::toJson() const
 
     json->set("learner_read_time", fmt::format("{:.3f}ms", learner_read_ns.load() / NS_TO_MS_SCALE));
     json->set("create_snapshot_time", fmt::format("{:.3f}ms", create_snapshot_time_ns.load() / NS_TO_MS_SCALE));
-    json->set("create_stream_time", fmt::format("{:.3f}ms", create_inputstream_time_ns.load() / NS_TO_MS_SCALE));
     json->set("build_bitmap_time", fmt::format("{:.3f}ms", build_bitmap_time_ns.load() / NS_TO_MS_SCALE));
 
     std::stringstream buf;

--- a/dbms/src/Storages/DeltaMerge/ScanContext.cpp
+++ b/dbms/src/Storages/DeltaMerge/ScanContext.cpp
@@ -56,7 +56,7 @@ String ScanContext::toJson() const
     // or Poco can not turn it into JSON correctly and crash
     json->set("read_mode", String(magic_enum::enum_name(read_mode)));
     json->set("build_bitmap_time", fmt::format("{:.3f}ms", build_bitmap_time_ns.load() / NS_TO_MS_SCALE));
-    json->set("late_materialize_skip_rows", late_materialize_skip_rows.load());
+    json->set("late_materialization_skip_rows", late_materialization_skip_rows.load());
 
     std::stringstream buf;
     json->stringify(buf);

--- a/dbms/src/Storages/DeltaMerge/ScanContext.h
+++ b/dbms/src/Storages/DeltaMerge/ScanContext.h
@@ -64,13 +64,20 @@ public:
     std::atomic<uint64_t> delta_rows{0};
     std::atomic<uint64_t> delta_bytes{0};
 
+    ReadMode read_mode = ReadMode::Normal;
+
+    // - read_mode == Normal, apply mvcc to all read blocks
+    // - read_mode == Bitmap, it will apply mvcc to get the bitmap
+    //   then skip rows according to the mvcc bitmap and push down filter
+    //   for other columns
+    // - read_mode == Fast, bypass the mvcc
     // mvcc input rows, output rows
     std::atomic<uint64_t> mvcc_input_rows{0};
     std::atomic<uint64_t> mvcc_input_bytes{0};
     std::atomic<uint64_t> mvcc_output_rows{0};
+    std::atomic<uint64_t> late_materialization_skip_rows{0};
 
     // TODO: filter
-    ReadMode read_mode = ReadMode::Normal;
     // Learner read
     std::atomic<uint64_t> learner_read_ns{0};
     // Create snapshot from PageStorage
@@ -80,7 +87,6 @@ public:
     std::atomic<uint64_t> create_inputstream_time_ns{0};
     // Building bitmap
     std::atomic<uint64_t> build_bitmap_time_ns{0};
-    std::atomic<uint64_t> late_materialization_skip_rows{0};
 
     const String resource_group_name;
 

--- a/dbms/src/Storages/DeltaMerge/ScanContext.h
+++ b/dbms/src/Storages/DeltaMerge/ScanContext.h
@@ -82,9 +82,6 @@ public:
     std::atomic<uint64_t> learner_read_ns{0};
     // Create snapshot from PageStorage
     std::atomic<uint64_t> create_snapshot_time_ns{0};
-    // Create inputstream and updating DeltaIndex
-    // When read_mode == Bitmap, it include the time of building bitmap
-    std::atomic<uint64_t> create_inputstream_time_ns{0};
     // Building bitmap
     std::atomic<uint64_t> build_bitmap_time_ns{0};
 
@@ -142,7 +139,6 @@ public:
         total_dmfile_rough_set_index_check_time_ns += other.total_dmfile_rough_set_index_check_time_ns;
         total_dmfile_read_time_ns += other.total_dmfile_read_time_ns;
         create_snapshot_time_ns += other.create_snapshot_time_ns;
-        create_inputstream_time_ns += other.create_inputstream_time_ns;
 
         total_local_region_num += other.total_local_region_num;
         total_remote_region_num += other.total_remote_region_num;

--- a/dbms/src/Storages/DeltaMerge/ScanContext.h
+++ b/dbms/src/Storages/DeltaMerge/ScanContext.h
@@ -75,6 +75,7 @@ public:
     ReadMode read_mode = ReadMode::Normal;
     // TODO: Building bitmap cost
     std::atomic<uint64_t> build_bitmap_time_ns{0};
+    std::atomic<uint64_t> late_materialize_skip_rows{0};
 
     explicit ScanContext(const String & name = "")
         : resource_group_name(name)

--- a/dbms/src/Storages/DeltaMerge/ScanContext.h
+++ b/dbms/src/Storages/DeltaMerge/ScanContext.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <Storages/DeltaMerge/ReadMode.h>
+#include <Storages/DeltaMerge/ScanContext_fwd.h>
 #include <common/types.h>
 #include <fmt/format.h>
 #include <sys/types.h>
@@ -69,7 +71,9 @@ public:
     std::atomic<uint64_t> mvcc_input_bytes{0};
     std::atomic<uint64_t> mvcc_output_rows{0};
 
-    // TODO: mode, filter
+    // TODO: filter
+    ReadMode read_mode = ReadMode::Normal;
+    // TODO: Building bitmap cost
 
     explicit ScanContext(const String & name = "")
         : resource_group_name(name)
@@ -165,7 +169,5 @@ public:
 
     const String resource_group_name;
 };
-
-using ScanContextPtr = std::shared_ptr<ScanContext>;
 
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/ScanContext.h
+++ b/dbms/src/Storages/DeltaMerge/ScanContext.h
@@ -45,6 +45,7 @@ public:
     std::atomic<uint64_t> total_dmfile_rough_set_index_check_time_ns{0};
     std::atomic<uint64_t> total_dmfile_read_time_ns{0};
     std::atomic<uint64_t> total_create_snapshot_time_ns{0};
+    std::atomic<uint64_t> total_create_inputstream_time_ns{0};
 
     std::atomic<uint64_t> total_remote_region_num{0};
     std::atomic<uint64_t> total_local_region_num{0};
@@ -54,6 +55,21 @@ public:
     std::atomic<uint64_t> total_disagg_read_cache_hit_size{0};
     std::atomic<uint64_t> total_disagg_read_cache_miss_size{0};
 
+    // num segments, num tasks
+    std::atomic<uint64_t> num_segments{0};
+    std::atomic<uint64_t> num_read_tasks{0};
+    std::atomic<uint64_t> num_columns{0};
+
+    // delta rows, bytes
+    std::atomic<uint64_t> delta_rows{0};
+    std::atomic<uint64_t> delta_bytes{0};
+
+    // mvcc input rows, output rows
+    std::atomic<uint64_t> mvcc_input_rows{0};
+    std::atomic<uint64_t> mvcc_input_bytes{0};
+    std::atomic<uint64_t> mvcc_output_rows{0};
+
+    // TODO: mode, filter
 
     explicit ScanContext(const String & name = "")
         : resource_group_name(name)
@@ -107,12 +123,25 @@ public:
         total_dmfile_rough_set_index_check_time_ns += other.total_dmfile_rough_set_index_check_time_ns;
         total_dmfile_read_time_ns += other.total_dmfile_read_time_ns;
         total_create_snapshot_time_ns += other.total_create_snapshot_time_ns;
+        total_create_inputstream_time_ns += other.total_create_inputstream_time_ns;
+
         total_local_region_num += other.total_local_region_num;
         total_remote_region_num += other.total_remote_region_num;
         total_user_read_bytes += other.total_user_read_bytes;
         total_learner_read_ns += other.total_learner_read_ns;
         total_disagg_read_cache_hit_size += other.total_disagg_read_cache_hit_size;
         total_disagg_read_cache_miss_size += other.total_disagg_read_cache_miss_size;
+
+        num_segments += other.num_segments;
+        num_read_tasks += other.num_read_tasks;
+        // num_columns should not sum
+
+        delta_rows += other.delta_rows;
+        delta_bytes += other.delta_bytes;
+
+        mvcc_input_rows += other.mvcc_input_rows;
+        mvcc_input_bytes += other.mvcc_input_bytes;
+        mvcc_output_rows += other.mvcc_output_rows;
     }
 
     void merge(const tipb::TiFlashScanContext & other)
@@ -131,6 +160,8 @@ public:
         total_disagg_read_cache_hit_size += other.total_disagg_read_cache_hit_size();
         total_disagg_read_cache_miss_size += other.total_disagg_read_cache_miss_size();
     }
+
+    String toJson() const;
 
     const String resource_group_name;
 };

--- a/dbms/src/Storages/DeltaMerge/ScanContext.h
+++ b/dbms/src/Storages/DeltaMerge/ScanContext.h
@@ -74,6 +74,7 @@ public:
     // TODO: filter
     ReadMode read_mode = ReadMode::Normal;
     // TODO: Building bitmap cost
+    std::atomic<uint64_t> build_bitmap_time_ns{0};
 
     explicit ScanContext(const String & name = "")
         : resource_group_name(name)

--- a/dbms/src/Storages/DeltaMerge/ScanContext.h
+++ b/dbms/src/Storages/DeltaMerge/ScanContext.h
@@ -80,7 +80,7 @@ public:
     std::atomic<uint64_t> create_inputstream_time_ns{0};
     // Building bitmap
     std::atomic<uint64_t> build_bitmap_time_ns{0};
-    std::atomic<uint64_t> late_materialize_skip_rows{0};
+    std::atomic<uint64_t> late_materialization_skip_rows{0};
 
     const String resource_group_name;
 

--- a/dbms/src/Storages/DeltaMerge/ScanContext_fwd.h
+++ b/dbms/src/Storages/DeltaMerge/ScanContext_fwd.h
@@ -1,0 +1,23 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+
+namespace DB::DM
+{
+class ScanContext;
+using ScanContextPtr = std::shared_ptr<ScanContext>;
+} // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/Segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/Segment.cpp
@@ -3168,8 +3168,7 @@ BlockInputStreamPtr Segment::getLateMaterializationStream(
         filter_column_stream,
         rest_column_stream,
         bitmap_filter,
-        dm_context.tracing_id,
-        dm_context.scan_context);
+        dm_context.tracing_id);
 }
 
 RowKeyRanges Segment::shrinkRowKeyRanges(const RowKeyRanges & read_ranges) const

--- a/dbms/src/Storages/DeltaMerge/Segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/Segment.cpp
@@ -792,9 +792,6 @@ BlockInputStreamPtr Segment::getInputStream(
     UInt64 max_version,
     size_t expected_block_size)
 {
-    Stopwatch watch;
-    SCOPE_EXIT({ dm_context.scan_context->create_inputstream_time_ns += watch.elapsed(); });
-
     auto clipped_block_rows = clipBlockRows( //
         dm_context.global_context,
         expected_block_size,

--- a/dbms/src/Storages/DeltaMerge/Segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/Segment.cpp
@@ -768,7 +768,7 @@ SegmentSnapshotPtr Segment::createSnapshot(const DMContext & dm_context, bool fo
     const
 {
     Stopwatch watch;
-    SCOPE_EXIT({ dm_context.scan_context->total_create_snapshot_time_ns += watch.elapsed(); });
+    SCOPE_EXIT({ dm_context.scan_context->create_snapshot_time_ns += watch.elapsed(); });
     auto delta_snap = delta->createSnapshot(dm_context, for_update, metric);
     auto stable_snap = stable->createSnapshot();
     if (!delta_snap || !stable_snap)
@@ -793,7 +793,7 @@ BlockInputStreamPtr Segment::getInputStream(
     size_t expected_block_size)
 {
     Stopwatch watch;
-    SCOPE_EXIT({ dm_context.scan_context->total_create_inputstream_time_ns += watch.elapsed(); });
+    SCOPE_EXIT({ dm_context.scan_context->create_inputstream_time_ns += watch.elapsed(); });
 
     auto clipped_block_rows = clipBlockRows( //
         dm_context.global_context,

--- a/dbms/src/Storages/DeltaMerge/Segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/Segment.cpp
@@ -2777,6 +2777,7 @@ BitmapFilterPtr Segment::buildBitmapFilterNormal(
     ColumnDefines columns_to_read{
         getExtraHandleColumnDefine(is_common_handle),
     };
+    // Generate the bitmap according to the MVCC filter result
     auto stream = getInputStreamModeNormal(
         dm_context,
         columns_to_read,
@@ -2786,11 +2787,12 @@ BitmapFilterPtr Segment::buildBitmapFilterNormal(
         max_version,
         expected_block_size,
         /*need_row_id*/ true);
+    // `total_rows` is the rows read for building bitmap
     auto total_rows = segment_snap->delta->getRows() + segment_snap->stable->getDMFilesRows();
     auto bitmap_filter = std::make_shared<BitmapFilter>(total_rows, /*default_value*/ false);
     bitmap_filter->set(stream);
     bitmap_filter->runOptimize();
-    LOG_DEBUG(
+    LOG_INFO(
         segment_snap->log,
         "buildBitmapFilterNormal total_rows={} cost={}ms",
         total_rows,

--- a/dbms/src/Storages/DeltaMerge/Segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/Segment.cpp
@@ -3168,7 +3168,8 @@ BlockInputStreamPtr Segment::getLateMaterializationStream(
         filter_column_stream,
         rest_column_stream,
         bitmap_filter,
-        dm_context.tracing_id);
+        dm_context.tracing_id,
+        dm_context.scan_context);
 }
 
 RowKeyRanges Segment::shrinkRowKeyRanges(const RowKeyRanges & read_ranges) const

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTask.h
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTask.h
@@ -168,6 +168,17 @@ struct fmt::formatter<DB::DM::SegmentReadTask>
     template <typename FormatContext>
     auto format(const DB::DM::SegmentReadTask & t, FormatContext & ctx) const
     {
+        if (t.dm_context->keyspace_id == DB::NullspaceID)
+        {
+            return fmt::format_to(
+                ctx.out(),
+                "s{}_t{}_{}_{}_{}",
+                t.store_id,
+                t.dm_context->physical_table_id,
+                t.segment->segmentId(),
+                t.segment->segmentEpoch(),
+                t.read_snapshot->delta->getDeltaIndexEpoch());
+        }
         return fmt::format_to(
             ctx.out(),
             "s{}_ks{}_t{}_{}_{}_{}",

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.h
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.h
@@ -16,6 +16,7 @@
 #include <Common/MemoryTrackerSetter.h>
 #include <Storages/DeltaMerge/DMContext_fwd.h>
 #include <Storages/DeltaMerge/Filter/PushDownFilter.h>
+#include <Storages/DeltaMerge/ReadMode.h>
 #include <Storages/DeltaMerge/ReadThread/WorkQueue.h>
 #include <Storages/DeltaMerge/SegmentReadTask.h>
 
@@ -71,28 +72,6 @@ private:
     std::atomic<Int64> total_count;
     std::atomic<Int64> total_bytes;
     std::atomic<Int64> total_rows;
-};
-
-enum class ReadMode
-{
-    /**
-     * Read in normal mode. Data is ordered by PK, and only the most recent version is returned.
-     */
-    Normal,
-
-    /**
-     * Read in fast mode. Data is not sort merged, and all versions are returned. However, deleted records (del_mark=1)
-     * will be still filtered out.
-     */
-    Fast,
-
-    /**
-     * Read in raw mode, for example, for statements like `SELRAW *`. In raw mode, data is not sort merged and all versions
-     * are just returned.
-     */
-    Raw,
-
-    Bitmap,
 };
 
 // If `enable_read_thread_` is true, `SegmentReadTasksWrapper` use `std::unordered_map` to index `SegmentReadTask` by segment id,

--- a/dbms/src/Storages/DeltaMerge/SkippableBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/SkippableBlockInputStream.h
@@ -221,7 +221,7 @@ private:
     {
         if (likely(scan_context != nullptr))
         {
-            scan_context->total_user_read_bytes += bytes;
+            scan_context->user_read_bytes += bytes;
             if constexpr (!need_row_id)
             {
                 lac_bytes_collector.collect(bytes);

--- a/dbms/src/Storages/DeltaMerge/SkippableBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/SkippableBlockInputStream.h
@@ -20,6 +20,7 @@
 #include <Flash/ResourceControl/LocalAdmissionController.h>
 #include <Storages/DeltaMerge/DeltaMergeDefines.h>
 #include <Storages/DeltaMerge/DeltaMergeHelpers.h>
+#include <Storages/DeltaMerge/ScanContext.h>
 
 namespace DB
 {

--- a/dbms/src/Storages/Page/V3/BlobStore.cpp
+++ b/dbms/src/Storages/Page/V3/BlobStore.cpp
@@ -1231,6 +1231,7 @@ typename BlobStore<Trait>::PageTypeAndBlobIds BlobStore<Trait>::getGCStats() NO_
                 continue;
             }
 
+            assert(right_boundary > 0); // Avoid divide by zero
             stat->sm_valid_rate = stat->sm_valid_size * 1.0 / right_boundary;
 
             if (stat->sm_valid_rate > 1.0)

--- a/dbms/src/Storages/S3/S3RandomAccessFile.cpp
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.cpp
@@ -236,11 +236,11 @@ inline static RandomAccessFilePtr createFromNormalFile(
     if (file != nullptr)
     {
         if (scan_context.has_value())
-            scan_context.value()->total_disagg_read_cache_hit_size += filesize.value();
+            scan_context.value()->disagg_read_cache_hit_size += filesize.value();
         return file;
     }
     if (scan_context.has_value())
-        scan_context.value()->total_disagg_read_cache_miss_size += filesize.value();
+        scan_context.value()->disagg_read_cache_miss_size += filesize.value();
     auto & ins = S3::ClientFactory::instance();
     return std::make_shared<S3RandomAccessFile>(ins.sharedTiFlashClient(), remote_fname);
 }

--- a/dbms/src/Storages/S3/S3RandomAccessFile.cpp
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.cpp
@@ -18,6 +18,7 @@
 #include <Common/StringUtils/StringUtils.h>
 #include <Common/TiFlashMetrics.h>
 #include <Encryption/RandomAccessFile.h>
+#include <Storages/DeltaMerge/ScanContext.h>
 #include <Storages/S3/FileCache.h>
 #include <Storages/S3/MemoryRandomAccessFile.h>
 #include <Storages/S3/S3Common.h>

--- a/dbms/src/Storages/S3/S3RandomAccessFile.h
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.h
@@ -18,7 +18,7 @@
 #include <Common/Logger.h>
 #include <Encryption/RandomAccessFile.h>
 #include <Storages/DeltaMerge/File/MergedFile.h>
-#include <Storages/DeltaMerge/ScanContext.h>
+#include <Storages/DeltaMerge/ScanContext_fwd.h>
 #include <aws/s3/model/GetObjectResult.h>
 #include <common/types.h>
 

--- a/dbms/src/Storages/StorageDeltaMerge.h
+++ b/dbms/src/Storages/StorageDeltaMerge.h
@@ -25,7 +25,7 @@
 #include <Storages/DeltaMerge/DeltaMergeStore.h>
 #include <Storages/DeltaMerge/Filter/PushDownFilter.h>
 #include <Storages/DeltaMerge/Remote/DisaggSnapshot_fwd.h>
-#include <Storages/DeltaMerge/ScanContext.h>
+#include <Storages/DeltaMerge/ScanContext_fwd.h>
 #include <Storages/IManageableStorage.h>
 #include <Storages/IStorage.h>
 #include <Storages/KVStore/Decode/DecodingStorageSchemaSnapshot.h>

--- a/libs/libdaemon/src/BaseDaemon.cpp
+++ b/libs/libdaemon/src/BaseDaemon.cpp
@@ -758,7 +758,7 @@ void BaseDaemon::buildLoggers(Poco::Util::AbstractConfiguration & config)
     // Split log, error log and tracing log.
     Poco::AutoPtr<Poco::ReloadableSplitterChannel> split = new Poco::ReloadableSplitterChannel;
 
-    auto log_level = normalize(config.getString("logger.level", "debug"));
+    auto log_level = normalize(config.getString("logger.level", "info"));
     const auto log_path = config.getString("logger.log", "");
     if (!log_path.empty())
     {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/8563

Problem Summary:

### What is changed and how it works?

* Change the default log level to "INFO"
* Adjust some logging about `SegmentReadTaskScheduler` `UnorderedInputStream`
* Add more details about TableScan
  * num columns, segments, tasks involve
  * delta layer stats
  * mvcc filter stats
  * late materialize filter stats

### Check List

Tests <!-- At least one of them must be included. -->

chbenchmark 1500

```
-- with late materialization
set tidb_opt_enable_late_materialization=1;
explain analyze select   ol_number,          sum(ol_quantity) as sum_qty,          sum(ol_amount) as sum_amount,          avg(ol_quantity) as avg_qty,          avg(ol_amount) as avg_amount,          min(ol_delivery_d) as min_deliver_d,          max(ol_delivery_d) as min_deliver_d,          sum(length(ol_dist_info)),          sum(ol_i_id),max(ol_o_id),max(ol_d_id),max(ol_w_id),sum(ol_number),          count(*) as count_order from     order_line where    ol_delivery_d > '2007-01-02 00:00:00.000000' group by ol_number order by ol_number;
+--------------------------------------+--------------+-----------+--------------+------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+---------+
| id                                   | estRows      | actRows   | task         | access object    | execution info                                                                                                                                                                                       | operator info                                                                                                                                                                                                                                                                                                                                  | memory    | disk    |
+--------------------------------------+--------------+-----------+--------------+------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+---------+
| Sort_6                               | 10.67        | 15        | root         |                  | time:3.23s, loops:2, RU:0.000000                                                                                                                                                                                       | chbenchmark.order_line.ol_number                                                                                                                                                                                                                                                                                                                                  | 12.5 KB   | 0 Bytes |
| └─TableReader_54                     | 10.67        | 15        | root         |                  | time:3.23s, loops:2, cop_task: {num: 14, max: 0s, min: 0s, avg: 0s, p95: 0s, copr_cache_hit_ratio: 0.00}                                                                                                                                                                                       | MppVersion: 2, data:ExchangeSender_53                                                                                                                                                                                                                                                                                                                                  | 923 Bytes | N/A     |
|   └─ExchangeSender_53                | 10.67        | 15        | mpp[tiflash] |                  | tiflash_task:{time:3.21s, loops:13, threads:36}                                                                                                                                                                                       | ExchangeType: PassThrough                                                                                                                                                                                                                                                                                                                                  | N/A       | N/A     |
|     └─Projection_9                   | 10.67        | 15        | mpp[tiflash] |                  | tiflash_task:{time:3.21s, loops:13, threads:36}                                                                                                                                                                                       | chbenchmark.order_line.ol_number, Column#12, Column#13, Column#14, Column#15, Column#16, Column#17, Column#18, Column#19, Column#20, Column#21, Column#22, Column#23, Column#24                                                                                                                                                                                                                                                                                                                                  | N/A       | N/A     |
|       └─Projection_49                | 10.67        | 15        | mpp[tiflash] |                  | tiflash_task:{time:3.21s, loops:13, threads:36}                                                                                                                                                                                       | Column#12, Column#13, div(Column#14, cast(case(eq(Column#79, 0), 1, Column#79), decimal(20,0) BINARY))->Column#14, div(Column#15, cast(case(eq(Column#80, 0), 1, Column#80), decimal(20,0) BINARY))->Column#15, Column#16, Column#17, Column#18, Column#19, Column#20, Column#21, Column#22, Column#23, Column#24, chbenchmark.order_line.ol_number                                                                                                                                                                  | N/A       | N/A     |
|         └─HashAgg_50                 | 10.67        | 15        | mpp[tiflash] |                  | tiflash_task:{time:3.21s, loops:13, threads:36}                                                                                                                                                                                       | group by:chbenchmark.order_line.ol_number, funcs:sum(Column#81)->Column#12, funcs:sum(Column#82)->Column#13, funcs:sum(Column#83)->Column#79, funcs:sum(Column#84)->Column#14, funcs:sum(Column#85)->Column#80, funcs:sum(Column#86)->Column#15, funcs:min(Column#87)->Column#16, funcs:max(Column#88)->Column#17, funcs:sum(Column#89)->Column#18, funcs:sum(Column#90)->Column#19, funcs:max(Column#91)->Column#20, funcs:max(Column#92)->Column#21, funcs:max(Column#93)->Column#22, funcs:sum(Column#94)->Col... | N/A       | N/A     |
|           └─ExchangeReceiver_52      | 10.67        | 15        | mpp[tiflash] |                  | tiflash_task:{time:3.21s, loops:13, threads:36}                                                                                                                                                                                       | stream_count: 36                                                                                                                                                                                                                                                                                                                                  | N/A       | N/A     |
|             └─ExchangeSender_51      | 10.67        | 15        | mpp[tiflash] |                  | tiflash_task:{time:3.21s, loops:1, threads:1}                                                                                                                                                                                       | ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: chbenchmark.order_line.ol_number, collate: binary], stream_count: 36                                                                                                                                                                                                                                                                                                                                  | N/A       | N/A     |
|               └─HashAgg_47           | 10.67        | 15        | mpp[tiflash] |                  | tiflash_task:{time:3.21s, loops:1, threads:1}                                                                                                                                                                                       | group by:Column#111, funcs:sum(Column#97)->Column#81, funcs:sum(Column#98)->Column#82, funcs:count(Column#99)->Column#83, funcs:sum(Column#100)->Column#84, funcs:count(Column#101)->Column#85, funcs:sum(Column#102)->Column#86, funcs:min(Column#103)->Column#87, funcs:max(Column#104)->Column#88, funcs:sum(Column#105)->Column#89, funcs:sum(Column#106)->Column#90, funcs:max(Column#107)->Column#91, funcs:max(Column#108)->Column#92, funcs:max(Column#109)->Column#93, funcs:sum(Column#110)->Column#94,... | N/A       | N/A     |
|                 └─Projection_57      | 320161490.84 | 321641463 | mpp[tiflash] |                  | tiflash_task:{time:2.69s, loops:11994, threads:72}                                                                                                                                                                                       | cast(chbenchmark.order_line.ol_quantity, decimal(10,0) BINARY)->Column#97, chbenchmark.order_line.ol_amount->Column#98, chbenchmark.order_line.ol_quantity->Column#99, cast(chbenchmark.order_line.ol_quantity, decimal(10,0) BINARY)->Column#100, chbenchmark.order_line.ol_amount->Column#101, chbenchmark.order_line.ol_amount->Column#102, chbenchmark.order_line.ol_delivery_d->Column#103, chbenchmark.order_line.ol_delivery_d->Column#104, cast(length(chbenchmark.order_line.ol_dist_info), decimal(20,0... | N/A       | N/A     |
|                   └─TableFullScan_35 | 320161490.84 | 321641463 | mpp[tiflash] | table:order_line | tiflash_task:{time:2.18s, loops:11994, threads:72}, tiflash_scan:{dtfile:{total_scanned_packs:234864, total_skipped_packs:9668, total_scanned_rows:1916326703, total_skipped_rows:78937719, total_rs_index_check_time: 634ms, total_read_time: 63607ms, total_disagg_read_cache_hit_size: 0, total_disagg_read_cache_miss_size: 0}, total_create_snapshot_time: 3ms, total_local_region_num: 589, total_remote_region_num: 0, total_learner_read_time: 12ms} | pushed down filter:gt(chbenchmark.order_line.ol_delivery_d, 2007-01-02 00:00:00.000000), keep order:false                                                                                                                                                                                                                                                                                                                                                                                                            | N/A       | N/A     |
+--------------------------------------+--------------+-----------+--------------+------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+---------+

[2023/12/29 00:40:41.829 +08:00] [INFO] [MPPTaskStatistics.cpp:138] ["{\"query_tso\":446636133861556226,\"task_id\":1,\"is_root\":false,\"sender_executor_id\":\"ExchangeSender_51\",\"executors\":[{\"id\":\"ExchangeSender_51\",\"type\":\"ExchangeSender\",\"children\":[\"HashAgg_47\"],\"outbound_rows\":15,\"outbound_blocks\":1,\"outbound_bytes\":2700,\"outbound_allocated_bytes\":6054,\"concurrency\":1,\"execution_time_ns\":3183997226,\"partition_num\":1,\"sender_target_task_ids\":[2],\"exchange_type\":\"Hash\",\"connection_details\":[{\"tunnel_id\":\"tunnel1+2\",\"sender_target_task_id\":2,\"sender_target_host\":\"10.2.12.81:9520\",\"is_local\":true,\"packets\":1,\"bytes\":26377}]},{\"id\":\"HashAgg_47\",\"type\":\"Agg\",\"children\":[\"Projection_57\"],\"outbound_rows\":15,\"outbound_blocks\":1,\"outbound_bytes\":2625,\"outbound_allocated_bytes\":5824,\"concurrency\":1,\"execution_time_ns\":3181997228},{\"id\":\"Projection_57\",\"type\":\"Projection\",\"children\":[\"TableFullScan_35\"],\"outbound_rows\":321641463,\"outbound_blocks\":11994,\"outbound_bytes\":24766392651,\"outbound_allocated_bytes\":28815589970,\"concurrency\":72,\"execution_time_ns\":2661997681},{\"id\":\"TableFullScan_35\",\"type\":\"TableScan\",\"children\":[],\"outbound_rows\":321641463,\"outbound_blocks\":11994,\"outbound_bytes\":23479826799,\"outbound_allocated_bytes\":32900678464,\"concurrency\":72,\"execution_time_ns\":2156998119,\"connection_details\":[{\"is_local\":true,\"packets\":0,\"bytes\":23479826799},{\"is_local\":false,\"packets\":0,\"bytes\":0}],\"scan_details\":{\"build_bitmap_time\":\"107084.878ms\",\"create_snapshot_time\":\"3.113ms\",\"create_stream_time\":\"129335.426ms\",\"delta_bytes\":638315925,\"delta_rows\":6719115,\"disagg_cache_hit_size\":0,\"disagg_cache_miss_size\":0,\"dmfile_read_time\":\"63607.359ms\",\"dmfile_scan_rows\":1916326703,\"dmfile_skip_rows\":78937719,\"late_materialization_skip_rows\":12677929,\"learner_read_time\":\"12.917ms\",\"local_region_num\":0,\"mvcc_input_bytes\":7888726886,\"mvcc_input_rows\":464042758,\"mvcc_skip_rows\":6653709,\"num_columns\":9,\"num_read_tasks\":587,\"num_segments\":587,\"read_bytes\":42982171024,\"read_mode\":\"Bitmap\",\"remote_region_num\":0}}],\"host\":\"10.2.12.81:9520\",\"task_init_timestamp\":1703781638606437000,\"task_start_timestamp\":1703781638647501000,\"task_end_timestamp\":1703781641829349000,\"compile_start_timestamp\":1703781638620016000,\"compile_end_timestamp\":1703781638647441000,\"read_wait_index_start_timestamp\":1703781638622464000,\"read_wait_index_end_timestamp\":1703781638634583000,\"local_input_bytes\":23479826799,\"remote_input_bytes\":0,\"output_bytes\":0,\"status\":\"FINISHED\",\"error_message\":\"\",\"cpu_ru\":28697.666666666668,\"read_ru\":655855.8811035156,\"memory_peak\":2061153151}"] [source="mpp_task_tracing MPP<gather_id:1, query_ts:1703781638601123926, local_query_id:503, server_id:374, start_ts:446636133861556226,task_id:1>"] [thread_id=594]
	   {
		"id": "TableFullScan_35",
		"type": "TableScan",
		"children": [],
		"outbound_rows": 321641463,
		"outbound_blocks": 11994,
		"outbound_bytes": 23479826799,
		"outbound_allocated_bytes": 32900678464,
		"concurrency": 72,
		"execution_time_ns": 2156998119,
		"connection_details": [{
			"is_local": true,
			"packets": 0,
			"bytes": 23479826799
		}, {
			"is_local": false,
			"packets": 0,
			"bytes": 0
		}],
		"scan_details": {
			"build_bitmap_time": "107084.878ms",
			"create_snapshot_time": "3.113ms",
			"delta_bytes": 638315925,
			"delta_rows": 6719115,
			"disagg_cache_hit_size": 0,
			"disagg_cache_miss_size": 0,
			"dmfile_read_time": "63607.359ms",
			"dmfile_scan_rows": 1916326703,
			"dmfile_skip_rows": 78937719,
			"late_materialization_skip_rows": 12677929,
			"learner_read_time": "12.917ms",
			"local_region_num": 0,
			"mvcc_input_bytes": 7888726886,
			"mvcc_input_rows": 464042758,
			"mvcc_skip_rows": 6653709,
			"num_columns": 9,
			"num_read_tasks": 587,
			"num_segments": 587,
			"read_bytes": 42982171024,
			"read_mode": "Bitmap",
			"remote_region_num": 0
		}
	}],
```
```
-- no late materialization
set tidb_opt_enable_late_materialization=0;
explain analyze select   ol_number,          sum(ol_quantity) as sum_qty,          sum(ol_amount) as sum_amount,          avg(ol_quantity) as avg_qty,          avg(ol_amount) as avg_amount,          min(ol_delivery_d) as min_deliver_d,          max(ol_delivery_d) as min_deliver_d,          sum(length(ol_dist_info)),          sum(ol_i_id),max(ol_o_id),max(ol_d_id),max(ol_w_id),sum(ol_number),          count(*) as count_order from     order_line where    ol_delivery_d > '2007-01-02 00:00:00.000000' group by ol_number order by ol_number;

+----------------------------------------+--------------+-----------+--------------+------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+---------+
| id                                     | estRows      | actRows   | task         | access object    | execution info                                                                                                                                                                                                                                                                                                                                                                                                                                   | operator info                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | memory    | disk    |
+----------------------------------------+--------------+-----------+--------------+------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+---------+
| Sort_6                                 | 10.67        | 15        | root         |                  | time:3.07s, loops:2, RU:0.000000                                                                                                                                                                                                                                                                                                                                                                                                                 | chbenchmark.order_line.ol_number                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | 12.5 KB   | 0 Bytes |
| └─TableReader_54                       | 10.67        | 15        | root         |                  | time:3.07s, loops:2, cop_task: {num: 14, max: 0s, min: 0s, avg: 0s, p95: 0s, copr_cache_hit_ratio: 0.00}                                                                                                                                                                                                                                                                                                                                         | MppVersion: 2, data:ExchangeSender_53                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | 923 Bytes | N/A     |
|   └─ExchangeSender_53                  | 10.67        | 15        | mpp[tiflash] |                  | tiflash_task:{time:3.07s, loops:13, threads:36}                                                                                                                                                                                                                                                                                                                                                                                                  | ExchangeType: PassThrough                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | N/A       | N/A     |
|     └─Projection_9                     | 10.67        | 15        | mpp[tiflash] |                  | tiflash_task:{time:3.07s, loops:13, threads:36}                                                                                                                                                                                                                                                                                                                                                                                                  | chbenchmark.order_line.ol_number, Column#12, Column#13, Column#14, Column#15, Column#16, Column#17, Column#18, Column#19, Column#20, Column#21, Column#22, Column#23, Column#24                                                                                                                                                                                                                                                                                                                                      | N/A       | N/A     |
|       └─Projection_49                  | 10.67        | 15        | mpp[tiflash] |                  | tiflash_task:{time:3.07s, loops:13, threads:36}                                                                                                                                                                                                                                                                                                                                                                                                  | Column#12, Column#13, div(Column#14, cast(case(eq(Column#79, 0), 1, Column#79), decimal(20,0) BINARY))->Column#14, div(Column#15, cast(case(eq(Column#80, 0), 1, Column#80), decimal(20,0) BINARY))->Column#15, Column#16, Column#17, Column#18, Column#19, Column#20, Column#21, Column#22, Column#23, Column#24, chbenchmark.order_line.ol_number                                                                                                                                                                  | N/A       | N/A     |
|         └─HashAgg_50                   | 10.67        | 15        | mpp[tiflash] |                  | tiflash_task:{time:3.07s, loops:13, threads:36}                                                                                                                                                                                                                                                                                                                                                                                                  | group by:chbenchmark.order_line.ol_number, funcs:sum(Column#81)->Column#12, funcs:sum(Column#82)->Column#13, funcs:sum(Column#83)->Column#79, funcs:sum(Column#84)->Column#14, funcs:sum(Column#85)->Column#80, funcs:sum(Column#86)->Column#15, funcs:min(Column#87)->Column#16, funcs:max(Column#88)->Column#17, funcs:sum(Column#89)->Column#18, funcs:sum(Column#90)->Column#19, funcs:max(Column#91)->Column#20, funcs:max(Column#92)->Column#21, funcs:max(Column#93)->Column#22, funcs:sum(Column#94)->Col... | N/A       | N/A     |
|           └─ExchangeReceiver_52        | 10.67        | 15        | mpp[tiflash] |                  | tiflash_task:{time:3.07s, loops:13, threads:36}                                                                                                                                                                                                                                                                                                                                                                                                  | stream_count: 36                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | N/A       | N/A     |
|             └─ExchangeSender_51        | 10.67        | 15        | mpp[tiflash] |                  | tiflash_task:{time:3.07s, loops:1, threads:1}                                                                                                                                                                                                                                                                                                                                                                                                    | ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: chbenchmark.order_line.ol_number, collate: binary], stream_count: 36                                                                                                                                                                                                                                                                                                                                                                               | N/A       | N/A     |
|               └─HashAgg_47             | 10.67        | 15        | mpp[tiflash] |                  | tiflash_task:{time:3.06s, loops:1, threads:1}                                                                                                                                                                                                                                                                                                                                                                                                    | group by:Column#111, funcs:sum(Column#97)->Column#81, funcs:sum(Column#98)->Column#82, funcs:count(Column#99)->Column#83, funcs:sum(Column#100)->Column#84, funcs:count(Column#101)->Column#85, funcs:sum(Column#102)->Column#86, funcs:min(Column#103)->Column#87, funcs:max(Column#104)->Column#88, funcs:sum(Column#105)->Column#89, funcs:sum(Column#106)->Column#90, funcs:max(Column#107)->Column#91, funcs:max(Column#108)->Column#92, funcs:max(Column#109)->Column#93, funcs:sum(Column#110)->Column#94,... | N/A       | N/A     |
|                 └─Projection_57        | 320161490.84 | 321641463 | mpp[tiflash] |                  | tiflash_task:{time:2.36s, loops:11994, threads:72}                                                                                                                                                                                                                                                                                                                                                                                               | cast(chbenchmark.order_line.ol_quantity, decimal(10,0) BINARY)->Column#97, chbenchmark.order_line.ol_amount->Column#98, chbenchmark.order_line.ol_quantity->Column#99, cast(chbenchmark.order_line.ol_quantity, decimal(10,0) BINARY)->Column#100, chbenchmark.order_line.ol_amount->Column#101, chbenchmark.order_line.ol_amount->Column#102, chbenchmark.order_line.ol_delivery_d->Column#103, chbenchmark.order_line.ol_delivery_d->Column#104, cast(length(chbenchmark.order_line.ol_dist_info), decimal(20,0... | N/A       | N/A     |
|                   └─Selection_36       | 320161490.84 | 321641463 | mpp[tiflash] |                  | tiflash_task:{time:1.78s, loops:11994, threads:72}                                                                                                                                                                                                                                                                                                                                                                                               | gt(chbenchmark.order_line.ol_delivery_d, 2007-01-02 00:00:00.000000)                                                                                                                                                                                                                                                                                                                                                                                                                                                 | N/A       | N/A     |
|                     └─TableFullScan_35 | 457389049.00 | 457389049 | mpp[tiflash] | table:order_line | tiflash_task:{time:1.39s, loops:12141, threads:72}, tiflash_scan:{dtfile:{total_scanned_packs:112250, total_skipped_packs:0, total_scanned_rows:914676276, total_skipped_rows:0, total_rs_index_check_time: 323ms, total_read_time: 61540ms, total_disagg_read_cache_hit_size: 0, total_disagg_read_cache_miss_size: 0}, total_create_snapshot_time: 2ms, total_local_region_num: 589, total_remote_region_num: 0, total_learner_read_time: 8ms} | keep order:false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | N/A       | N/A     |
+----------------------------------------+--------------+-----------+--------------+------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+---------+
7362:[2023/12/29 00:42:11.133 +08:00] [INFO] [MPPTaskStatistics.cpp:138] ["{\"query_tso\":446636157310599171,\"task_id\":1,\"is_root\":false,\"sender_executor_id\":\"ExchangeSender_51\",\"executors\":[{\"id\":\"ExchangeSender_51\",\"type\":\"ExchangeSender\",\"children\":[\"HashAgg_47\"],\"outbound_rows\":15,\"outbound_blocks\":1,\"outbound_bytes\":2700,\"outbound_allocated_bytes\":6054,\"concurrency\":1,\"execution_time_ns\":3048001958,\"partition_num\":1,\"sender_target_task_ids\":[2],\"exchange_type\":\"Hash\",\"connection_details\":[{\"tunnel_id\":\"tunnel1+2\",\"sender_target_task_id\":2,\"sender_target_host\":\"10.2.12.81:9520\",\"is_local\":true,\"packets\":1,\"bytes\":26377}]},{\"id\":\"HashAgg_47\",\"type\":\"Agg\",\"children\":[\"Projection_57\"],\"outbound_rows\":15,\"outbound_blocks\":1,\"outbound_bytes\":2625,\"outbound_allocated_bytes\":5824,\"concurrency\":1,\"execution_time_ns\":3044001956},{\"id\":\"Projection_57\",\"type\":\"Projection\",\"children\":[\"Selection_36\"],\"outbound_rows\":321641463,\"outbound_blocks\":11994,\"outbound_bytes\":24766392651,\"outbound_allocated_bytes\":28815589970,\"concurrency\":72,\"execution_time_ns\":2342001509},{\"id\":\"Selection_36\",\"type\":\"Selection\",\"children\":[\"TableFullScan_35\"],\"outbound_rows\":321641463,\"outbound_blocks\":11994,\"outbound_bytes\":23479826799,\"outbound_allocated_bytes\":32900678464,\"concurrency\":72,\"execution_time_ns\":1759001131},{\"id\":\"TableFullScan_35\",\"type\":\"TableScan\",\"children\":[],\"outbound_rows\":457389049,\"outbound_blocks\":12141,\"outbound_bytes\":33389400577,\"outbound_allocated_bytes\":42645066688,\"concurrency\":72,\"execution_time_ns\":1370000883,\"connection_details\":[{\"is_local\":true,\"packets\":0,\"bytes\":33389400577},{\"is_local\":false,\"packets\":0,\"bytes\":0}],\"scan_details\":{\"build_bitmap_time\":\"67339.978ms\",\"create_snapshot_time\":\"2.140ms\",\"create_stream_time\":\"96911.415ms\",\"delta_bytes\":638315925,\"delta_rows\":6719115,\"disagg_cache_hit_size\":0,\"disagg_cache_miss_size\":0,\"dmfile_read_time\":\"61540.283ms\",\"dmfile_scan_rows\":914676276,\"dmfile_skip_rows\":0,\"late_materialization_skip_rows\":0,\"learner_read_time\":\"8.935ms\",\"local_region_num\":0,\"mvcc_input_bytes\":7888726886,\"mvcc_input_rows\":464042758,\"mvcc_skip_rows\":6653709,\"num_columns\":9,\"num_read_tasks\":587,\"num_segments\":587,\"read_bytes\":41274410960,\"read_mode\":\"Bitmap\",\"remote_region_num\":0}}],\"host\":\"10.2.12.81:9520\",\"task_init_timestamp\":1703781728070933000,\"task_start_timestamp\":1703781728089125000,\"task_end_timestamp\":1703781731133684000,\"compile_start_timestamp\":1703781728072014000,\"compile_end_timestamp\":1703781728089094000,\"read_wait_index_start_timestamp\":1703781728073876000,\"read_wait_index_end_timestamp\":1703781728082239000,\"local_input_bytes\":33389400577,\"remote_input_bytes\":0,\"output_bytes\":0,\"status\":\"FINISHED\",\"error_message\":\"\",\"cpu_ru\":44555,\"read_ru\":629797.5305175781,\"memory_peak\":2517584929}"] [source="mpp_task_tracing MPP<gather_id:1, query_ts:1703781728067568358, local_query_id:504, server_id:374, start_ts:446636157310599171,task_id:1>"] [thread_id=602]
        {
		"id": "TableFullScan_35",
		"type": "TableScan",
		"children": [],
		"outbound_rows": 457389049,
		"outbound_blocks": 12141,
		"outbound_bytes": 33389400577,
		"outbound_allocated_bytes": 42645066688,
		"concurrency": 72,
		"execution_time_ns": 1370000883,
		"connection_details": [{
			"is_local": true,
			"packets": 0,
			"bytes": 33389400577
		}, {
			"is_local": false,
			"packets": 0,
			"bytes": 0
		}],
		"scan_details": {
			"build_bitmap_time": "67339.978ms",
			"create_snapshot_time": "2.140ms",
			"delta_bytes": 638315925,
			"delta_rows": 6719115,
			"disagg_cache_hit_size": 0,
			"disagg_cache_miss_size": 0,
			"dmfile_read_time": "61540.283ms",
			"dmfile_scan_rows": 914676276,
			"dmfile_skip_rows": 0,
			"late_materialization_skip_rows": 0,
			"learner_read_time": "8.935ms",
			"local_region_num": 0,
			"mvcc_input_bytes": 7888726886,
			"mvcc_input_rows": 464042758,
			"mvcc_skip_rows": 6653709,
			"num_columns": 9,
			"num_read_tasks": 587,
			"num_segments": 587,
			"read_bytes": 41274410960,
			"read_mode": "Bitmap",
			"remote_region_num": 0
		}
	}],
```
```
-- no bitmap and late materialization
set tidb_opt_enable_late_materialization=0;
explain analyze select   ol_number,          sum(ol_quantity) as sum_qty,          sum(ol_amount) as sum_amount,          avg(ol_quantity) as avg_qty,          avg(ol_amount) as avg_amount,          min(ol_delivery_d) as min_deliver_d,          max(ol_delivery_d) as min_deliver_d,          sum(length(ol_dist_info)),          sum                               -> (ol_i_id),max(ol_o_id),max(ol_d_id),max(ol_w_id),sum(ol_number),          count(*) as count_order from     order_line where    ol_delivery_d > '2007-01-02 00:00:00.000000' group by ol_number order by ol_number;
+----------------------------------------+--------------+-----------+--------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+---------+
| id                                     | estRows      | actRows   | task         | access object    | execution info                                                                                                                                                                                                                                                                                                                                                                                                                                 | operator info                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | memory    | disk    |
+----------------------------------------+--------------+-----------+--------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+---------+
| Sort_6                                 | 10.67        | 15        | root         |                  | time:3.38s, loops:2, RU:0.000000                                                                                                                                                                                                                                                                                                                                                                                                               | chbenchmark.order_line.ol_number                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | 12.5 KB   | 0 Bytes |
| └─TableReader_54                       | 10.67        | 15        | root         |                  | time:3.38s, loops:2, cop_task: {num: 14, max: 0s, min: 0s, avg: 0s, p95: 0s, copr_cache_hit_ratio: 0.00}                                                                                                                                                                                                                                                                                                                                       | MppVersion: 2, data:ExchangeSender_53                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | 923 Bytes | N/A     |
|   └─ExchangeSender_53                  | 10.67        | 15        | mpp[tiflash] |                  | tiflash_task:{time:3.38s, loops:13, threads:36}                                                                                                                                                                                                                                                                                                                                                                                                | ExchangeType: PassThrough                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | N/A       | N/A     |
|     └─Projection_9                     | 10.67        | 15        | mpp[tiflash] |                  | tiflash_task:{time:3.38s, loops:13, threads:36}                                                                                                                                                                                                                                                                                                                                                                                                | chbenchmark.order_line.ol_number, Column#12, Column#13, Column#14, Column#15, Column#16, Column#17, Column#18, Column#19, Column#20, Column#21, Column#22, Column#23, Column#24                                                                                                                                                                                                                                                                                                                                      | N/A       | N/A     |
|       └─Projection_49                  | 10.67        | 15        | mpp[tiflash] |                  | tiflash_task:{time:3.38s, loops:13, threads:36}                                                                                                                                                                                                                                                                                                                                                                                                | Column#12, Column#13, div(Column#14, cast(case(eq(Column#79, 0), 1, Column#79), decimal(20,0) BINARY))->Column#14, div(Column#15, cast(case(eq(Column#80, 0), 1, Column#80), decimal(20,0) BINARY))->Column#15, Column#16, Column#17, Column#18, Column#19, Column#20, Column#21, Column#22, Column#23, Column#24, chbenchmark.order_line.ol_number                                                                                                                                                                  | N/A       | N/A     |
|         └─HashAgg_50                   | 10.67        | 15        | mpp[tiflash] |                  | tiflash_task:{time:3.38s, loops:13, threads:36}                                                                                                                                                                                                                                                                                                                                                                                                | group by:chbenchmark.order_line.ol_number, funcs:sum(Column#81)->Column#12, funcs:sum(Column#82)->Column#13, funcs:sum(Column#83)->Column#79, funcs:sum(Column#84)->Column#14, funcs:sum(Column#85)->Column#80, funcs:sum(Column#86)->Column#15, funcs:min(Column#87)->Column#16, funcs:max(Column#88)->Column#17, funcs:sum(Column#89)->Column#18, funcs:sum(Column#90)->Column#19, funcs:max(Column#91)->Column#20, funcs:max(Column#92)->Column#21, funcs:max(Column#93)->Column#22, funcs:sum(Column#94)->Col... | N/A       | N/A     |
|           └─ExchangeReceiver_52        | 10.67        | 15        | mpp[tiflash] |                  | tiflash_task:{time:3.38s, loops:13, threads:36}                                                                                                                                                                                                                                                                                                                                                                                                | stream_count: 36                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | N/A       | N/A     |
|             └─ExchangeSender_51        | 10.67        | 15        | mpp[tiflash] |                  | tiflash_task:{time:3.38s, loops:1, threads:1}                                                                                                                                                                                                                                                                                                                                                                                                  | ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: chbenchmark.order_line.ol_number, collate: binary], stream_count: 36                                                                                                                                                                                                                                                                                                                                                                               | N/A       | N/A     |
|               └─HashAgg_47             | 10.67        | 15        | mpp[tiflash] |                  | tiflash_task:{time:3.38s, loops:1, threads:1}                                                                                                                                                                                                                                                                                                                                                                                                  | group by:Column#111, funcs:sum(Column#97)->Column#81, funcs:sum(Column#98)->Column#82, funcs:count(Column#99)->Column#83, funcs:sum(Column#100)->Column#84, funcs:count(Column#101)->Column#85, funcs:sum(Column#102)->Column#86, funcs:min(Column#103)->Column#87, funcs:max(Column#104)->Column#88, funcs:sum(Column#105)->Column#89, funcs:sum(Column#106)->Column#90, funcs:max(Column#107)->Column#91, funcs:max(Column#108)->Column#92, funcs:max(Column#109)->Column#93, funcs:sum(Column#110)->Column#94,... | N/A       | N/A     |
|                 └─Projection_57        | 320161490.84 | 321641463 | mpp[tiflash] |                  | tiflash_task:{time:2.48s, loops:7247, threads:72}                                                                                                                                                                                                                                                                                                                                                                                              | cast(chbenchmark.order_line.ol_quantity, decimal(10,0) BINARY)->Column#97, chbenchmark.order_line.ol_amount->Column#98, chbenchmark.order_line.ol_quantity->Column#99, cast(chbenchmark.order_line.ol_quantity, decimal(10,0) BINARY)->Column#100, chbenchmark.order_line.ol_amount->Column#101, chbenchmark.order_line.ol_amount->Column#102, chbenchmark.order_line.ol_delivery_d->Column#103, chbenchmark.order_line.ol_delivery_d->Column#104, cast(length(chbenchmark.order_line.ol_dist_info), decimal(20,0... | N/A       | N/A     |
|                   └─Selection_36       | 320161490.84 | 321641463 | mpp[tiflash] |                  | tiflash_task:{time:1.78s, loops:7247, threads:72}                                                                                                                                                                                                                                                                                                                                                                                              | gt(chbenchmark.order_line.ol_delivery_d, 2007-01-02 00:00:00.000000)                                                                                                                                                                                                                                                                                                                                                                                                                                                 | N/A       | N/A     |
|                     └─TableFullScan_35 | 457389049.00 | 457389049 | mpp[tiflash] | table:order_line | tiflash_task:{time:1.27s, loops:7381, threads:72}, tiflash_scan:{dtfile:{total_scanned_packs:56125, total_skipped_packs:0, total_scanned_rows:457338138, total_skipped_rows:0, total_rs_index_check_time: 35ms, total_read_time: 74543ms, total_disagg_read_cache_hit_size: 0, total_disagg_read_cache_miss_size: 0}, total_create_snapshot_time: 3ms, total_local_region_num: 589, total_remote_region_num: 0, total_learner_read_time: 17ms} | keep order:false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | N/A       | N/A     |
+----------------------------------------+--------------+-----------+--------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+---------+
5016:[2023/12/29 01:13:46.861 +08:00] [INFO] [MPPTaskStatistics.cpp:138] ["{\"query_tso\":446636654191181826,\"task_id\":1,\"is_root\":false,\"sender_executor_id\":\"ExchangeSender_51\",\"executors\":[{\"id\":\"ExchangeSender_51\",\"type\":\"ExchangeSender\",\"children\":[\"HashAgg_47\"],\"outbound_rows\":15,\"outbound_blocks\":1,\"outbound_bytes\":2700,\"outbound_allocated_bytes\":6054,\"concurrency\":1,\"execution_time_ns\":3351993264,\"partition_num\":1,\"sender_target_task_ids\":[2],\"exchange_type\":\"Hash\",\"connection_details\":[{\"tunnel_id\":\"tunnel1+2\",\"sender_target_task_id\":2,\"sender_target_host\":\"10.2.12.81:9520\",\"is_local\":true,\"packets\":1,\"bytes\":26377}]},{\"id\":\"HashAgg_47\",\"type\":\"Agg\",\"children\":[\"Projection_57\"],\"outbound_rows\":15,\"outbound_blocks\":1,\"outbound_bytes\":2625,\"outbound_allocated_bytes\":5824,\"concurrency\":1,\"execution_time_ns\":3347993272},{\"id\":\"Projection_57\",\"type\":\"Projection\",\"children\":[\"Selection_36\"],\"outbound_rows\":321641463,\"outbound_blocks\":7247,\"outbound_bytes\":24766392651,\"outbound_allocated_bytes\":29046976104,\"concurrency\":72,\"execution_time_ns\":2456995062},{\"id\":\"Selection_36\",\"type\":\"Selection\",\"children\":[\"TableFullScan_35\"],\"outbound_rows\":321641463,\"outbound_blocks\":7247,\"outbound_bytes\":23479826799,\"outbound_allocated_bytes\":34766573184,\"concurrency\":72,\"execution_time_ns\":1756996468},{\"id\":\"TableFullScan_35\",\"type\":\"TableScan\",\"children\":[],\"outbound_rows\":457389049,\"outbound_blocks\":7381,\"outbound_bytes\":33389400577,\"outbound_allocated_bytes\":53921185792,\"concurrency\":72,\"execution_time_ns\":1239997509,\"connection_details\":[{\"is_local\":true,\"packets\":0,\"bytes\":33389400577},{\"is_local\":false,\"packets\":0,\"bytes\":0}],\"scan_details\":{\"build_bitmap_time\":\"0.000ms\",\"create_snapshot_time\":\"3.129ms\",\"create_stream_time\":\"11363.734ms\",\"delta_bytes\":638315925,\"delta_rows\":6719115,\"disagg_cache_hit_size\":0,\"disagg_cache_miss_size\":0,\"dmfile_read_time\":\"74543.014ms\",\"dmfile_scan_rows\":457338138,\"dmfile_skip_rows\":0,\"late_materialization_skip_rows\":0,\"learner_read_time\":\"17.675ms\",\"local_region_num\":0,\"mvcc_input_bytes\":41763848220,\"mvcc_input_rows\":464042758,\"mvcc_skip_rows\":6653709,\"num_columns\":9,\"num_read_tasks\":587,\"num_segments\":587,\"read_bytes\":41763848220,\"read_mode\":\"Normal\",\"remote_region_num\":0}}],\"host\":\"10.2.12.81:9520\",\"task_init_timestamp\":1703783623484337000,\"task_start_timestamp\":1703783623513080000,\"task_end_timestamp\":1703783626861578000,\"compile_start_timestamp\":1703783623485328000,\"compile_end_timestamp\":1703783623513046000,\"read_wait_index_start_timestamp\":1703783623487125000,\"read_wait_index_end_timestamp\":1703783623504283000,\"local_input_bytes\":33389400577,\"remote_input_bytes\":0,\"output_bytes\":0,\"status\":\"FINISHED\",\"error_message\":\"\",\"cpu_ru\":54400.666666666664,\"read_ru\":637265.7504272461,\"memory_peak\":6078342192}"] [source="mpp_task_tracing MPP<gather_id:1, query_ts:1703783623480873181, local_query_id:508, server_id:374, start_ts:446636654191181826,task_id:1>"] [thread_id=619]
	  {
		"id": "TableFullScan_35",
		"type": "TableScan",
		"children": [],
		"outbound_rows": 457389049,
		"outbound_blocks": 7381,
		"outbound_bytes": 33389400577,
		"outbound_allocated_bytes": 53921185792,
		"concurrency": 72,
		"execution_time_ns": 1239997509,
		"connection_details": [{
			"is_local": true,
			"packets": 0,
			"bytes": 33389400577
		}, {
			"is_local": false,
			"packets": 0,
			"bytes": 0
		}],
		"scan_details": {
			"build_bitmap_time": "0.000ms",
			"create_snapshot_time": "3.129ms",
			"delta_bytes": 638315925,
			"delta_rows": 6719115,
			"disagg_cache_hit_size": 0,
			"disagg_cache_miss_size": 0,
			"dmfile_read_time": "74543.014ms",
			"dmfile_scan_rows": 457338138,
			"dmfile_skip_rows": 0,
			"late_materialization_skip_rows": 0,
			"learner_read_time": "17.675ms",
			"local_region_num": 0,
			"mvcc_input_bytes": 41763848220,
			"mvcc_input_rows": 464042758,
			"mvcc_skip_rows": 6653709,
			"num_columns": 9,
			"num_read_tasks": 587,
			"num_segments": 587,
			"read_bytes": 41763848220,
			"read_mode": "Normal",
			"remote_region_num": 0
		}
	}]
```

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Change the default log level to "INFO"
```
