### PR TITLE
tests: Fix some issue found by ASAN

### DIFF
--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_storage_delta_merge.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_storage_delta_merge.cpp
@@ -124,12 +124,17 @@ try
         ctx->getSettingsRef().resolve_locks,
         std::numeric_limits<UInt64>::max(),
         scan_context);
+    // these field should live long enough because `DAGQueryInfo` only
+    // keep a ref on them
+    const google::protobuf::RepeatedPtrField<tipb::Expr> filters{};
     const google::protobuf::RepeatedPtrField<tipb::Expr> pushed_down_filters{};
+    ColumnInfos source_columns{};
+    const std::vector<int> runtime_filter_ids;
     query_info.dag_query = std::make_unique<DAGQueryInfo>(
-        google::protobuf::RepeatedPtrField<tipb::Expr>(),
+        filters,
         pushed_down_filters, // Not care now
-        std::vector<TiDB::ColumnInfo>{}, // Not care now
-        std::vector<int>{},
+        source_columns, // Not care now
+        runtime_filter_ids,
         0,
         ctx->getTimezoneInfo());
     BlockInputStreams ins = storage->read(column_names, query_info, *ctx, stage2, 8192, 1);
@@ -674,12 +679,17 @@ try
         ctx->getSettingsRef().resolve_locks,
         std::numeric_limits<UInt64>::max(),
         scan_context);
+    // these field should live long enough because `DAGQueryInfo` only
+    // keep a ref on them
+    const google::protobuf::RepeatedPtrField<tipb::Expr> filters{};
     const google::protobuf::RepeatedPtrField<tipb::Expr> pushed_down_filters{};
+    ColumnInfos source_columns{};
+    const std::vector<int> runtime_filter_ids;
     query_info.dag_query = std::make_unique<DAGQueryInfo>(
-        google::protobuf::RepeatedPtrField<tipb::Expr>(),
+        filters,
         pushed_down_filters, // Not care now
-        std::vector<TiDB::ColumnInfo>{}, // Not care now
-        std::vector<int>{},
+        source_columns, // Not care now
+        runtime_filter_ids,
         0,
         ctx->getTimezoneInfo());
     Names read_columns = {"col1", EXTRA_TABLE_ID_COLUMN_NAME, "col2"};
@@ -786,12 +796,17 @@ try
             ctx->getSettingsRef().resolve_locks,
             std::numeric_limits<UInt64>::max(),
             scan_context);
+        // these field should live long enough because `DAGQueryInfo` only
+        // keep a ref on them
+        const google::protobuf::RepeatedPtrField<tipb::Expr> filters{};
         const google::protobuf::RepeatedPtrField<tipb::Expr> pushed_down_filters{};
+        ColumnInfos source_columns{};
+        const std::vector<int> runtime_filter_ids;
         query_info.dag_query = std::make_unique<DAGQueryInfo>(
-            google::protobuf::RepeatedPtrField<tipb::Expr>(),
+            filters,
             pushed_down_filters, // Not care now
-            std::vector<TiDB::ColumnInfo>{}, // Not care now
-            std::vector<int>{},
+            source_columns, // Not care now
+            runtime_filter_ids,
             0,
             ctx->getTimezoneInfo());
         Names read_columns = {"col1", EXTRA_TABLE_ID_COLUMN_NAME, "col2"};

--- a/dbms/src/Storages/S3/MockS3Client.cpp
+++ b/dbms/src/Storages/S3/MockS3Client.cpp
@@ -94,7 +94,8 @@ Model::GetObjectOutcome MockS3Client::GetObject(const Model::GetObjectRequest & 
     }
     auto size = right - left + 1;
     Model::GetObjectResult result;
-    auto * ss = new std::stringstream(itr_obj->second.substr(left, size));
+    auto * ss = Aws::New<Aws::StringStream>("MockS3Client");
+    *ss << itr_obj->second.substr(left, size);
     result.ReplaceBody(ss);
     result.SetContentLength(size);
     return result;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/6233

Problem Summary:
```
==395555==ERROR: AddressSanitizer: alloc-dealloc-mismatch (operator new vs free) on 0x6120006196c0
    #0 0x4cebc92 in free /llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:111:3
    #1 0x213fefda in std::__1::enable_if<std::is_polymorphic<std::__1::basic_iostream<char, std::__1::char_traits<char> > >::value, void>::type Aws::Delete<std::__1::basic_iostream<char, std::__1::char_traits<char> > >(std::__1::basic_iostream<char, std::__1::char_traits<char> >*) /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/contrib/aws/src/aws-cpp-sdk-core/include/aws/core/utils/memory/AWSMemory.h:120:9
    #2 0x213fefda in Aws::Utils::Stream::ResponseStream::ReleaseStream() /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/contrib/aws/src/aws-cpp-sdk-core/source/utils/stream/ResponseStream.cpp:83:9
    #3 0x213fefda in Aws::Utils::Stream::ResponseStream::~ResponseStream() /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/contrib/aws/src/aws-cpp-sdk-core/source/utils/stream/ResponseStream.cpp:75:5
    #4 0x1f3024a1 in DB::S3::S3RandomAccessFile::~S3RandomAccessFile() /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/dbms/src/Storages/S3/S3RandomAccessFile.h:44:7
...
0x6120006196c0 is located 0 bytes inside of 280-byte region [0x6120006196c0,0x6120006197d8)
allocated by thread T0 here:
    #0 0x4d1dd4d in operator new(unsigned long) /llvm-project/compiler-rt/lib/asan/asan_new_delete.cpp:95:3
    #1 0x1f2788bb in DB::S3::tests::MockS3Client::GetObject(Aws::S3::Model::GetObjectRequest const&) const /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/dbms/src/Storages/S3/MockS3Client.cpp:97:17
...
```
```
==411659==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7ffddf704c98 at pc 0x00001b40bfe6 bp 0x7ffddf703990 sp 0x7ffddf703988
READ of size 4 at 0x7ffddf704c98 thread T0
    #0 0x1b40bfe5 in google::protobuf::internal::RepeatedPtrFieldBase::size() const /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/contrib/protobuf/src/google/protobuf/repeated_ptr_field.h:850:56
    #1 0x1b40bfe5 in google::protobuf::RepeatedPtrField<tipb::Expr>::size() const /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/contrib/protobuf/src/google/protobuf/repeated_ptr_field.h:1323:32
    #2 0x1b40bfe5 in DB::DM::FilterParser::parseDAGQuery(DB::DAGQueryInfo const&, std::__1::vector<DB::DM::ColumnDefine, std::__1::allocator<DB::DM::ColumnDefine> > const&, std::__1::function<DB::DM::Attr (long)>&&, std::__1::shared_ptr<DB::Logger> const&) /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/dbms/src/Storages/DeltaMerge/FilterParser/FilterParser.cpp:348:39
    #3 0x1f168ed4 in DB::StorageDeltaMerge::buildRSOperator(std::__1::unique_ptr<DB::DAGQueryInfo, std::__1::default_delete<DB::DAGQueryInfo> > const&, std::__1::vector<DB::DM::ColumnDefine, std::__1::allocator<DB::DM::ColumnDefine> > const&, DB::Context const&, std::__1::shared_ptr<DB::Logger> const&) /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/dbms/src/Storages/StorageDeltaMerge.cpp:755:15
    #4 0x1f170911 in DB::StorageDeltaMerge::parsePushDownFilter(DB::SelectQueryInfo const&, std::__1::vector<DB::DM::ColumnDefine, std::__1::allocator<DB::DM::ColumnDefine> > const&, DB::Context const&, std::__1::shared_ptr<DB::Logger> const&) /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/dbms/src/Storages/StorageDeltaMerge.cpp:905:43
    #5 0x1f171249 in DB::StorageDeltaMerge::read(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&, DB::SelectQueryInfo const&, DB::Context const&, DB::QueryProcessingStage::Enum&, unsigned long, unsigned int) /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/dbms/src/Storages/StorageDeltaMerge.cpp:970:19
    #6 0xbc1421d in DB::DM::tests::StorageDeltaMergeTest_RestoreAfterClearData_Test::TestBody()::$_3::operator()() const /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/dbms/src/Storages/DeltaMerge/tests/gtest_dm_storage_delta_merge.cpp:798:42
    #7 0xbc0abdc in DB::DM::tests::StorageDeltaMergeTest_RestoreAfterClearData_Test::TestBody() /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/dbms/src/Storages/DeltaMerge/tests/gtest_dm_storage_delta_merge.cpp:815:9
...
Address 0x7ffddf704c98 is located in stack of thread T0 at offset 344 in frame
    #0 0xbc133ff in DB::DM::tests::StorageDeltaMergeTest_RestoreAfterClearData_Test::TestBody()::$_3::operator()() const /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/dbms/src/Storages/DeltaMerge/tests/gtest_dm_storage_delta_merge.cpp:780

```
### What is changed and how it works?

* Use `Aws::New` instead of `new` in `MockS3Client::GetObject`
* Define local variables instead of temp instance created in `StorageDeltaMergeTest` tests

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
