### PR TITLE
fix In ScalarFunc in RoughSetFilter

### DIFF
--- a/dbms/src/Storages/DeltaMerge/FilterParser/FilterParser.cpp
+++ b/dbms/src/Storages/DeltaMerge/FilterParser/FilterParser.cpp
@@ -178,6 +178,12 @@ inline RSOperatorPtr parseTiCompareExpr( //
             }
             values.push_back(value);
         }
+        else
+        {
+            return createUnsupported(
+                expr.ShortDebugString(),
+                fmt::format("Unknown child type: {}", tipb::ExprType_Name(child.tp())));
+        }
     }
 
     // At least one ColumnRef and one Literal

--- a/dbms/src/Storages/DeltaMerge/FilterParser/FilterParser.cpp
+++ b/dbms/src/Storages/DeltaMerge/FilterParser/FilterParser.cpp
@@ -180,6 +180,8 @@ inline RSOperatorPtr parseTiCompareExpr( //
         }
         else
         {
+            // Any other type of child is not supported, like: ScalarFunc.
+            // case like `cast(a as signed) > 1`, `a in (0, cast(a as signed))` is not supported.
             return createUnsupported(
                 expr.ShortDebugString(),
                 fmt::format("Unknown child type: {}", tipb::ExprType_Name(child.tp())));
@@ -196,7 +198,7 @@ inline RSOperatorPtr parseTiCompareExpr( //
         return createUnsupported(
             expr.ShortDebugString(),
             fmt::format("Multiple Literal in compare expression is not supported, size: {}", values.size()));
-    // For In type, the first child must be ColumnRef, nested column like `cast(a as signed)` is not supported.
+    // For In type, the first child must be ColumnRef
     if (column_expr_child_idx != 0 && filter_type == FilterParser::RSFilterType::In)
         return createUnsupported(expr.ShortDebugString(), "the first child of In expression must be ColumnRef");
 

--- a/tests/fullstack-test/expr/in_expression.test
+++ b/tests/fullstack-test/expr/in_expression.test
@@ -224,3 +224,18 @@ mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t w
 |  981 |
 +------+
 mysql> drop table test.t;
+
+mysql> create table test.t (a int, b int);
+mysql> insert into test.t values (10,30), (50, 60);
+mysql> alter table test.t set tiflash replica 1;
+func> wait_table test t
+
+mysql> alter table test.t compact tiflash replica;
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where not a not in (0, cast(+ a as signed));
++------+------+
+| a    | b    |
++------+------+
+|   10 |   30 |
+|   50 |   60 |
++------+------+
+mysql> drop table test.t;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8631

Problem Summary:

### What is changed and how it works?

reject all children which are not `ColumnRef` or `Literal`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix the wrong result when executing queries with a filter like `ColumnRef in (Literal, Func...)`
```
