### PR TITLE
Fix hash join crash

### DIFF
--- a/dbms/src/Flash/tests/gtest_join_executor.cpp
+++ b/dbms/src/Flash/tests/gtest_join_executor.cpp
@@ -1802,6 +1802,25 @@ try
 }
 CATCH
 
+TEST_F(JoinExecutorTestRunner, LeftJoinAggWithOtherCondition)
+try
+{
+    auto request_column
+        = context.scan("test_db", "l_table")
+              .join(
+                  context.scan("test_db", "r_table"),
+                  tipb::JoinType::TypeLeftOuterJoin,
+                  {col("join_c")},
+                  {},
+                  {},
+                  {And(lt(col("l_table.s"), col("r_table.s")), eq(col("l_table.join_c"), col("r_table.join_c")))},
+                  {})
+              .aggregation({Count(lit(static_cast<UInt64>(1)))}, {})
+              .build(context);
+    ASSERT_COLUMNS_EQ_UR(genScalarCountResults(2), executeStreams(request_column, 2));
+}
+CATCH
+
 TEST_F(JoinExecutorTestRunner, JoinWithExchangeReceiver)
 try
 {

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -2650,12 +2650,12 @@ void Join::finalize(const Names & parent_require)
     /// nullaware/semi join will reuse the input columns so need to let finalize keep the input columns
     if (non_equal_conditions.null_aware_eq_cond_expr != nullptr)
     {
-        /// todo don't keep input columns for non-semi/non-nullaware join
         non_equal_conditions.null_aware_eq_cond_expr->finalize(updated_require, true);
         updated_require = non_equal_conditions.null_aware_eq_cond_expr->getRequiredColumns();
     }
     if (non_equal_conditions.other_cond_expr != nullptr)
     {
+        /// todo don't keep input columns for non-semi/non-nullaware join
         non_equal_conditions.other_cond_expr->finalize(updated_require, true);
         updated_require = non_equal_conditions.other_cond_expr->getRequiredColumns();
     }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8633

Problem Summary:

### What is changed and how it works?
The root cause is in `Join::finalize`, it may add some `REMOVE_COLUMN` action in `other_cond_expr` if it is not semi or nullaware join:
https://github.com/pingcap/tiflash/blob/ce42814e493e62731172774d783c294c76de3afe/dbms/src/Interpreters/Join.cpp#L2654
 however, for function `handleOtherCondition()`,  https://github.com/pingcap/tiflash/blob/ce42814e493e62731172774d783c294c76de3afe/dbms/src/Interpreters/Join.cpp#L850-L854
`right_table_columns` is a index based on previous block, of there is `REMOVE_COLUMN` action in `other_cond_expr`, the index will become invalid.

This pr disable generating `REMOVE_COLUMN` during `Join::finalize`. It is possible that refine the code in `handleOtherCondition` so it does not depends on the index based `right_table_columns`, but I would like to do it in a standalone pr later since there is no too much time before a new release.  
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
