### PR TITLE
refine handleOtherConditions in join

### DIFF
--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -844,10 +844,7 @@ void applyNullToNotMatchedRows(Block & block, const Block & right_columns, const
         {
             auto full_column
                 = column.column->isColumnConst() ? column.column->convertToFullColumnIfConst() : column.column;
-            if (!full_column->isColumnNullable())
-            {
-                throw Exception("Should not reach here, the right table column for left join must be nullable");
-            }
+            RUNTIME_CHECK_MSG(full_column->isColumnNullable(), "the right table column for left join must be nullable");
             auto current_column = full_column;
             auto result_column = (*std::move(current_column)).mutate();
             static_cast<ColumnNullable &>(*result_column).applyNegatedNullMap(filter_column);

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -887,8 +887,7 @@ void Join::handleOtherConditions(Block & block, IColumn::Filter * anti_filter, I
         {
             auto & col_name = input_block.getByPosition(i).name;
             if ((!flag_mapped_entry_helper_name.empty() && col_name == flag_mapped_entry_helper_name)
-                || output_column_names_set_after_finalize.find(col_name)
-                    != output_column_names_set_after_finalize.end())
+                || output_column_names_set_after_finalize.contains(col_name))
                 ++i;
             else
                 input_block.erase(i);
@@ -902,10 +901,8 @@ void Join::handleOtherConditions(Block & block, IColumn::Filter * anti_filter, I
             assert(filter.empty());
             filter.assign(block_rows, static_cast<UInt8>(1));
         }
-        auto helper_pos = block.getPositionByName(match_helper_name);
-
         const auto * old_match_nullable
-            = checkAndGetColumn<ColumnNullable>(block.safeGetByPosition(helper_pos).column.get());
+            = checkAndGetColumn<ColumnNullable>(block.getByName(match_helper_name).column.get());
         const auto & old_match_vec
             = static_cast<const ColumnVector<Int8> *>(old_match_nullable->getNestedColumnPtr().get())->getData();
 
@@ -976,7 +973,7 @@ void Join::handleOtherConditions(Block & block, IColumn::Filter * anti_filter, I
         }
 
         erase_useless_column(block);
-        helper_pos = block.getPositionByName(match_helper_name);
+        auto helper_pos = block.getPositionByName(match_helper_name);
         for (size_t i = 0; i < block.columns(); ++i)
             if (i != helper_pos)
                 block.getByPosition(i).column = block.getByPosition(i).column->filter(row_filter, -1);
@@ -1080,8 +1077,7 @@ void Join::handleOtherConditionsForOneProbeRow(Block & block, ProbeProcessInfo &
         {
             auto & col_name = input_block.getByPosition(i).name;
             if ((!flag_mapped_entry_helper_name.empty() && col_name == flag_mapped_entry_helper_name)
-                || output_column_names_set_after_finalize.find(col_name)
-                    != output_column_names_set_after_finalize.end())
+                || output_column_names_set_after_finalize.contains(col_name))
                 ++i;
             else
                 input_block.erase(i);

--- a/dbms/src/Interpreters/Join.h
+++ b/dbms/src/Interpreters/Join.h
@@ -481,11 +481,7 @@ private:
       *
       * @param block
       */
-    void handleOtherConditions(
-        Block & block,
-        IColumn::Filter * filter,
-        IColumn::Offsets * offsets_to_replicate,
-        const std::vector<size_t> & right_table_column) const;
+    void handleOtherConditions(Block & block, IColumn::Filter * filter, IColumn::Offsets * offsets_to_replicate) const;
 
     void handleOtherConditionsForOneProbeRow(Block & block, ProbeProcessInfo & probe_process_info) const;
 

--- a/dbms/src/Interpreters/ProbeProcessInfo.cpp
+++ b/dbms/src/Interpreters/ProbeProcessInfo.cpp
@@ -160,9 +160,6 @@ void ProbeProcessInfo::prepareForCrossProbe(
                 cross_join_data->right_column_index_in_right_block.push_back(i);
             }
         }
-        auto offset = cross_join_data->left_column_index_in_left_block.size();
-        for (size_t i = 0; i < cross_join_data->right_column_index_in_right_block.size(); ++i)
-            cross_join_data->right_column_index_in_result_block.push_back(offset + i);
     }
     if (cross_join_data->cross_probe_mode == CrossProbeMode::SHALLOW_COPY_RIGHT_BLOCK && null_map != nullptr)
         cross_join_data->row_num_filtered_by_left_condition = countBytesInFilter(*null_map);

--- a/dbms/src/Interpreters/ProbeProcessInfo.h
+++ b/dbms/src/Interpreters/ProbeProcessInfo.h
@@ -48,7 +48,6 @@ struct HashJoinProbeProcessData
 struct CrossJoinProbeProcessData
 {
     Block result_block_schema;
-    std::vector<size_t> right_column_index_in_result_block;
     std::vector<size_t> right_column_index_in_right_block;
     std::vector<size_t> left_column_index_in_left_block;
     size_t right_rows_to_be_added_when_matched = 0;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #8633

Problem Summary:

### What is changed and how it works?
Refine `Join::handleOtherConditions` so it does not rely on index based `right_table_columns`
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
