### PR TITLE
PageStorage: Optimize the critical region when removing a BlobFile from disk

### DIFF
--- a/dbms/src/Storages/Page/V3/BlobStore.cpp
+++ b/dbms/src/Storages/Page/V3/BlobStore.cpp
@@ -800,17 +800,25 @@ void BlobStore<Trait>::removePosFromStats(BlobFileId blob_id, BlobFileOffset off
         auto lock_stats = blob_stats.lock();
         blob_stats.eraseStat(std::move(stat), lock_stats);
     }
+
+    BlobFilePtr blob_file_to_removed;
     {
-        // Remove the blob file from disk and memory
+        // Remove the blob file from memory
+        // If the blob_id does not exist, the blob_file is never
+        // opened for read/write. It is safe to ignore it.
         std::lock_guard files_gurad(mtx_blob_files);
         if (auto iter = blob_files.find(blob_id); iter != blob_files.end())
         {
-            auto blob_file = iter->second;
-            blob_file->remove();
+            blob_file_to_removed = iter->second;
             blob_files.erase(iter);
         }
-        // If the blob_id does not exist, the blob_file is never
-        // opened for read/write. It is safe to ignore it.
+    }
+
+    // Removing the BlobFile from disk could cost several tens of ms,
+    // do it without locking
+    if (blob_file_to_removed)
+    {
+        blob_file_to_removed->remove();
     }
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/8650

Problem Summary:

When all page data in a BlobFile gets removed in the GC thread, `removePosFromStats` will remove the BlobFile from disk. However, it holds a lock on `mtx_blob_files` when removing the file from disk. If `BlobStore::write` happens to write a page data to a new BlobFile, `BlobStore::getBlobFile` will be blocked by the GC thread.

According to local tests, removing a BlobFile takes tens of milliseconds. Thus introducing performance jitter.

https://github.com/pingcap/tiflash/blob/63eb295f0664ec4251907f00f335976225ddf337/dbms/src/Storages/Page/V3/BlobStore.cpp#L803-L814

https://github.com/pingcap/tiflash/blob/63eb295f0664ec4251907f00f335976225ddf337/dbms/src/Storages/Page/V3/BlobStore.cpp#L632-L636

https://github.com/pingcap/tiflash/blob/63eb295f0664ec4251907f00f335976225ddf337/dbms/src/Storages/Page/V3/BlobStore.cpp#L1494-L1503

### What is changed and how it works?

Keep a pointer within the lock on `mtx_blob_files`, and remove the blob file from disk without the lock

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Reduce the effect of background GC tasks on foreground read/write tasks
```
