### PR TITLE
Storages: Don't merge SegmentReadTasks when data sharing is disabled

### DIFF
--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -1376,6 +1376,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
             global_context->getTMTContext().reloadConfig(*config);
             global_context->getIORateLimiter().updateConfig(*config);
             global_context->reloadDeltaTreeConfig(*config);
+            DM::SegmentReadTaskScheduler::instance().updateConfig(global_context->getSettingsRef());
             if (FileCache::instance() != nullptr)
             {
                 FileCache::instance()->updateConfig(global_context->getSettingsRef());
@@ -1494,7 +1495,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
     DM::SegmentReaderPoolManager::instance().init(
         server_info.cpu_info.logical_cores,
         settings.dt_read_thread_count_scale);
-    DM::SegmentReadTaskScheduler::instance();
+    DM::SegmentReadTaskScheduler::instance().updateConfig(global_context->getSettingsRef());
 
     auto schema_cache_size = config().getInt("schema_cache_size", 10000);
     global_context->initializeSharedBlockSchemas(schema_cache_size);

--- a/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.h
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.h
@@ -44,6 +44,8 @@ public:
 
     void pushMergedTask(const MergedTaskPtr & p) { merged_task_pool.push(p); }
 
+    void updateConfig(const Settings & settings);
+
 #ifndef DBMS_PUBLIC_GTEST
 private:
 #else
@@ -86,12 +88,14 @@ public:
 
     MergedTaskPool merged_task_pool;
 
-    std::atomic<bool> stop;
+    std::atomic<bool> stop{false};
     std::thread sched_thread;
 
     LoggerPtr log;
 
     // To count how many threads are waitting to add tasks.
     std::atomic<Int64> add_waittings{0};
+
+    bool enable_data_sharing{true};
 };
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.h
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.h
@@ -89,13 +89,12 @@ public:
     MergedTaskPool merged_task_pool;
 
     std::atomic<bool> stop{false};
+    bool enable_data_sharing{true};
     std::thread sched_thread;
 
     LoggerPtr log;
 
     // To count how many threads are waitting to add tasks.
     std::atomic<Int64> add_waittings{0};
-
-    bool enable_data_sharing{true};
 };
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.h
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.h
@@ -152,7 +152,10 @@ public:
     void popBlock(Block & block);
     bool tryPopBlock(Block & block);
 
-    MergingSegments::iterator scheduleSegment(MergingSegments & segments, uint64_t expected_merge_count);
+    MergingSegments::iterator scheduleSegment(
+        MergingSegments & segments,
+        UInt64 expected_merge_count,
+        bool enable_data_sharing);
 
     Int64 increaseUnorderedInputStreamRefCount();
     Int64 decreaseUnorderedInputStreamRefCount();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #8564

Problem Summary:

- In PR #8567, we disable data sharing when `dt_max_sharing_column_bytes_for_all <= 0`. 
- However, `SegmentReadTaskScheduler` will still try to merge `SegmentReadTask` when `dt_max_sharing_column_bytes_for_all <= 0`, although these SegmentReadTasks would not sharing data.

### What is changed and how it works?

- Don't merge SegmentReadTasks when data sharing is disabled.


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
