### PR TITLE
Storage: Fix max-id being mis-reused cause data corruption after changing tiflash replica number

### DIFF
--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -63,6 +63,7 @@
 #include <Storages/KVStore/BackgroundService.h>
 #include <Storages/KVStore/TMTContext.h>
 #include <Storages/MarkCache.h>
+#include <Storages/Page/PageConstants.h>
 #include <Storages/Page/V3/PageStorageImpl.h>
 #include <Storages/Page/V3/Universal/UniversalPageStorageService.h>
 #include <Storages/PathCapacityMetrics.h>
@@ -77,8 +78,6 @@
 #include <pcg_random.hpp>
 #include <set>
 #include <unordered_map>
-
-#include "Storages/Page/PageConstants.h"
 
 
 namespace ProfileEvents

--- a/dbms/src/Interpreters/Context.h
+++ b/dbms/src/Interpreters/Context.h
@@ -110,6 +110,8 @@ class DeltaIndexManager;
 class GlobalStoragePool;
 class SharedBlockSchemas;
 using GlobalStoragePoolPtr = std::shared_ptr<GlobalStoragePool>;
+class GlobalPageIdAllocator;
+using GlobalPageIdAllocatorPtr = std::shared_ptr<GlobalPageIdAllocator>;
 } // namespace DM
 
 /// (database name, table name)
@@ -444,6 +446,10 @@ public:
     void initializePageStorageMode(const PathPool & path_pool, UInt64 storage_page_format_version);
     void setPageStorageRunMode(PageStorageRunMode run_mode) const;
     PageStorageRunMode getPageStorageRunMode() const;
+
+    bool initializeGlobalPageIdAllocator();
+    DM::GlobalPageIdAllocatorPtr getGlobalPageIdAllocator() const;
+
     bool initializeGlobalStoragePoolIfNeed(const PathPool & path_pool);
     DM::GlobalStoragePoolPtr getGlobalStoragePool() const;
 

--- a/dbms/src/Server/DTTool/DTTool.h
+++ b/dbms/src/Server/DTTool/DTTool.h
@@ -113,6 +113,7 @@ class ImitativeEnv
             global_context->getPathCapacity(),
             global_context->getFileProvider());
         TiFlashRaftConfig raft_config;
+        global_context->initializeGlobalPageIdAllocator();
         global_context->initializeGlobalStoragePoolIfNeed(global_context->getPathPool());
         raft_config.ignore_databases = {"default", "system"};
         raft_config.engine = TiDB::StorageEngine::DT;

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -1297,6 +1297,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
         settings.bytes_that_rss_larger_than_limit);
 
     /// PageStorage run mode has been determined above
+    global_context->initializeGlobalPageIdAllocator();
     if (!global_context->getSharedContextDisagg()->isDisaggregatedComputeMode())
     {
         global_context->initializeGlobalStoragePoolIfNeed(global_context->getPathPool());

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -261,14 +261,16 @@ DeltaMergeStore::DeltaMergeStore(
     try
     {
         page_storage_run_mode = storage_pool->restore(); // restore from disk
+        // If there is meta of `DELTA_MERGE_FIRST_SEGMENT_ID`, restore all segments
+        // If there is no `DELTA_MERGE_FIRST_SEGMENT_ID`, the first segment will be created by `createFirstSegment` later
         if (const auto first_segment_entry = storage_pool->metaReader()->getPageEntry(DELTA_MERGE_FIRST_SEGMENT_ID);
             first_segment_entry.isValid())
         {
+            // Restore all existing segments
             auto segment_id = DELTA_MERGE_FIRST_SEGMENT_ID;
-
-            // parallel restore segment to speed up
             if (thread_pool)
             {
+                // parallel restore segment to speed up
                 auto wait_group = thread_pool->waitGroup();
                 auto segment_ids = Segment::getAllSegmentIds(*dm_context, segment_id);
                 for (auto & segment_id : segment_ids)
@@ -286,6 +288,7 @@ DeltaMergeStore::DeltaMergeStore(
             }
             else
             {
+                // restore segment one by one
                 while (segment_id != 0)
                 {
                     auto segment = Segment::restoreSegment(log, *dm_context, segment_id);
@@ -2129,9 +2132,10 @@ std::pair<SegmentPtr, bool> DeltaMergeStore::getSegmentByStartKey(
         if (create_if_empty && is_empty)
         {
             auto dm_context = newDMContext(global_context, global_context.getSettingsRef());
-            auto page_storage_run_mode = storage_pool->getPageStorageRunMode();
-            createFirstSegment(*dm_context, page_storage_run_mode);
+            createFirstSegment(*dm_context);
         }
+        // The first segment may be created in this thread or another thread,
+        // try again to get the new created segment.
     } while (create_if_empty && is_empty);
 
     if (throw_if_notfound)
@@ -2147,7 +2151,7 @@ std::pair<SegmentPtr, bool> DeltaMergeStore::getSegmentByStartKey(
     }
 }
 
-void DeltaMergeStore::createFirstSegment(DM::DMContext & dm_context, PageStorageRunMode page_storage_run_mode)
+void DeltaMergeStore::createFirstSegment(DM::DMContext & dm_context)
 {
     std::unique_lock lock(read_write_mutex);
     if (!segments.empty())
@@ -2155,22 +2159,10 @@ void DeltaMergeStore::createFirstSegment(DM::DMContext & dm_context, PageStorage
         return;
     }
 
-    auto segment_id = storage_pool->newMetaPageId();
-    if (segment_id != DELTA_MERGE_FIRST_SEGMENT_ID)
-    {
-        RUNTIME_CHECK_MSG(
-            page_storage_run_mode != PageStorageRunMode::ONLY_V2,
-            "The first segment id should be {}, but get {}, run_mode={}",
-            DELTA_MERGE_FIRST_SEGMENT_ID,
-            segment_id,
-            magic_enum::enum_name(page_storage_run_mode));
-
-        // In ONLY_V3 or MIX_MODE, If create a new DeltaMergeStore
-        // Should used fixed DELTA_MERGE_FIRST_SEGMENT_ID to create first segment
-        segment_id = DELTA_MERGE_FIRST_SEGMENT_ID;
-    }
+    const auto segment_id = DELTA_MERGE_FIRST_SEGMENT_ID;
     LOG_INFO(log, "creating the first segment with segment_id={}", segment_id);
 
+    // newSegment will also commit the segment meta to PageStorage
     auto first_segment = Segment::newSegment( //
         log,
         dm_context,

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
@@ -788,7 +788,7 @@ public:
         const RowKeyValueRef & start_key,
         bool create_if_empty,
         bool throw_if_notfound);
-    void createFirstSegment(DM::DMContext & dm_context, PageStorageRunMode page_storage_run_mode);
+    void createFirstSegment(DM::DMContext & dm_context);
 
     Context & global_context;
     std::shared_ptr<StoragePathPool> path_pool;

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalBg.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalBg.cpp
@@ -272,7 +272,7 @@ void DeltaMergeStore::setUpBackgroundTask(const DMContextPtr & dm_context)
     // that callbacks is called after the `DeltaMergeStore` shutdown or dropped,
     // we must make the callbacks safe.
     ExternalPageCallbacks callbacks;
-    callbacks.prefix = storage_pool->getNamespaceID();
+    callbacks.prefix = storage_pool->getTableID();
     if (auto data_store = dm_context->global_context.getSharedContextDisagg()->remote_data_store; !data_store)
     {
         callbacks.scanner

--- a/dbms/src/Storages/DeltaMerge/StoragePool/GlobalPageIdAllocator.cpp
+++ b/dbms/src/Storages/DeltaMerge/StoragePool/GlobalPageIdAllocator.cpp
@@ -1,0 +1,45 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Common/Logger.h>
+#include <Common/SyncPoint/SyncPoint.h>
+#include <Storages/DeltaMerge/StoragePool/GlobalPageIdAllocator.h>
+#include <Storages/Page/PageDefinesBase.h>
+#include <common/logger_useful.h>
+
+#include <atomic>
+
+namespace DB::DM
+{
+
+void GlobalPageIdAllocator::raiseTargetByLowerBound(std::atomic<PageIdU64> & target, PageIdU64 lower_bound)
+{
+    PageIdU64 old_value = target.load();
+    while (true)
+    {
+        // already satisfied the lower_bound, done.
+        if (old_value >= lower_bound)
+            break;
+        SYNC_FOR("before_GlobalPageIdAllocator::raiseLowerBoundCAS_1");
+        // try raise to the lower_bound
+        if (target.compare_exchange_strong(old_value, lower_bound))
+        {
+            // raise success, done.
+            break;
+        }
+        // else the `old_value` is updated, try again
+    }
+}
+
+} // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/StoragePool/GlobalPageIdAllocator.h
+++ b/dbms/src/Storages/DeltaMerge/StoragePool/GlobalPageIdAllocator.h
@@ -1,0 +1,68 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <Storages/KVStore/Types.h>
+#include <Storages/Page/PageStorage_fwd.h>
+
+#include <atomic>
+
+namespace DB::DM
+{
+
+class GlobalPageIdAllocator : private boost::noncopyable
+{
+public:
+    GlobalPageIdAllocator() = default;
+
+    void raiseDataPageIdLowerBound(PageIdU64 lower_bound) { raiseTargetByLowerBound(max_data_page_id, lower_bound); }
+    void raiseLogPageIdLowerBound(PageIdU64 lower_bound) { raiseTargetByLowerBound(max_log_page_id, lower_bound); }
+    void raiseMetaPageIdLowerBound(PageIdU64 lower_bound) { raiseTargetByLowerBound(max_meta_page_id, lower_bound); }
+
+    PageIdU64 newDataPageIdForDTFile() { return ++max_data_page_id; }
+    PageIdU64 newLogPageId() { return ++max_log_page_id; }
+    PageIdU64 newMetaPageId() { return ++max_meta_page_id; }
+
+    std::tuple<PageIdU64, PageIdU64, PageIdU64> getCurrentIds() const
+    {
+        return std::make_tuple(max_log_page_id.load(), max_data_page_id.load(), max_meta_page_id.load());
+    }
+
+private:
+    static void raiseTargetByLowerBound(std::atomic<PageIdU64> & target, PageIdU64 lower_bound)
+    {
+        PageIdU64 old_value = target.load();
+        while (true)
+        {
+            // already satisfied the lower_bound, done.
+            if (old_value > lower_bound)
+                break;
+            // try raise to the lower_bound
+            if (target.compare_exchange_strong(old_value, lower_bound))
+            {
+                // raise success, done.
+                break;
+            }
+            // else the `old_value` is updated, try again
+        }
+    }
+
+private:
+    std::atomic<PageIdU64> max_log_page_id = 0;
+    std::atomic<PageIdU64> max_data_page_id = 0;
+    std::atomic<PageIdU64> max_meta_page_id = 0;
+};
+
+} // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/StoragePool/GlobalPageIdAllocator.h
+++ b/dbms/src/Storages/DeltaMerge/StoragePool/GlobalPageIdAllocator.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <Storages/KVStore/Types.h>
+#include <Storages/Page/PageDefinesBase.h>
 #include <Storages/Page/PageStorage_fwd.h>
 
 #include <atomic>
@@ -41,23 +42,7 @@ public:
     }
 
 private:
-    static void raiseTargetByLowerBound(std::atomic<PageIdU64> & target, PageIdU64 lower_bound)
-    {
-        PageIdU64 old_value = target.load();
-        while (true)
-        {
-            // already satisfied the lower_bound, done.
-            if (old_value > lower_bound)
-                break;
-            // try raise to the lower_bound
-            if (target.compare_exchange_strong(old_value, lower_bound))
-            {
-                // raise success, done.
-                break;
-            }
-            // else the `old_value` is updated, try again
-        }
-    }
+    static void raiseTargetByLowerBound(std::atomic<PageIdU64> & target, PageIdU64 lower_bound);
 
 private:
     std::atomic<PageIdU64> max_log_page_id = 0;

--- a/dbms/src/Storages/DeltaMerge/StoragePool/GlobalPageIdAllocator.h
+++ b/dbms/src/Storages/DeltaMerge/StoragePool/GlobalPageIdAllocator.h
@@ -62,7 +62,8 @@ private:
 private:
     std::atomic<PageIdU64> max_log_page_id = 0;
     std::atomic<PageIdU64> max_data_page_id = 0;
-    std::atomic<PageIdU64> max_meta_page_id = 0;
+    // The meta_page_id == 1 is reserved for first segment in each physical table
+    std::atomic<PageIdU64> max_meta_page_id = 1;
 };
 
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/StoragePool/GlobalStoragePool.cpp
+++ b/dbms/src/Storages/DeltaMerge/StoragePool/GlobalStoragePool.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <Interpreters/Context.h>
+#include <Storages/DeltaMerge/StoragePool/GlobalPageIdAllocator.h>
 #include <Storages/DeltaMerge/StoragePool/GlobalStoragePool.h>
 #include <Storages/DeltaMerge/StoragePool/StoragePoolConfig.h>
 #include <Storages/Page/Page.h>

--- a/dbms/src/Storages/DeltaMerge/StoragePool/StoragePool.h
+++ b/dbms/src/Storages/DeltaMerge/StoragePool/StoragePool.h
@@ -53,9 +53,18 @@ public:
     StoragePool(
         Context & global_ctx,
         KeyspaceID keyspace_id_,
-        NamespaceID ns_id_,
+        NamespaceID table_id_,
         StoragePathPool & storage_path_pool_,
-        const String & name = "");
+        const String & name);
+    
+    // For test
+    StoragePool(
+        Context & global_ctx,
+        KeyspaceID keyspace_id_,
+        NamespaceID table_id_,
+        StoragePathPool & storage_path_pool_,
+        GlobalPageIdAllocatorPtr page_id_allocator_,
+        const String & name);
 
     PageStorageRunMode restore();
 
@@ -63,7 +72,7 @@ public:
 
     KeyspaceID getKeyspaceID() const { return keyspace_id; }
 
-    NamespaceID getNamespaceID() const { return ns_id; }
+    NamespaceID getTableID() const { return table_id; }
 
     PageStorageRunMode getPageStorageRunMode() const { return run_mode; }
 
@@ -149,11 +158,8 @@ private:
     LoggerPtr logger;
 
     PageStorageRunMode run_mode;
-
     const KeyspaceID keyspace_id;
-
-    // whether the three storage instance is owned by this StoragePool
-    const NamespaceID ns_id;
+    const NamespaceID table_id;
 
     StoragePathPool & storage_path_pool;
 

--- a/dbms/src/Storages/DeltaMerge/StoragePool/StoragePool.h
+++ b/dbms/src/Storages/DeltaMerge/StoragePool/StoragePool.h
@@ -56,7 +56,7 @@ public:
         NamespaceID table_id_,
         StoragePathPool & storage_path_pool_,
         const String & name);
-    
+
     // For test
     StoragePool(
         Context & global_ctx,

--- a/dbms/src/Storages/DeltaMerge/StoragePool/StoragePool.h
+++ b/dbms/src/Storages/DeltaMerge/StoragePool/StoragePool.h
@@ -16,6 +16,8 @@
 
 #include <Common/CurrentMetrics.h>
 #include <Common/Logger.h>
+#include <Interpreters/Context_fwd.h>
+#include <Interpreters/Settings_fwd.h>
 #include <Storages/BackgroundProcessingPool.h>
 #include <Storages/DeltaMerge/StoragePool/StoragePool_fwd.h>
 #include <Storages/KVStore/Types.h>
@@ -32,8 +34,6 @@ using WriteLimiterPtr = std::shared_ptr<WriteLimiter>;
 class ReadLimiter;
 using ReadLimiterPtr = std::shared_ptr<ReadLimiter>;
 
-struct Settings;
-class Context;
 class StoragePathPool;
 class PathPool;
 class StableDiskDelegator;

--- a/dbms/src/Storages/DeltaMerge/StoragePool/StoragePool.h
+++ b/dbms/src/Storages/DeltaMerge/StoragePool/StoragePool.h
@@ -131,9 +131,9 @@ public:
     // StoragePool will assign the max_log_page_id/max_meta_page_id/max_data_page_id by the global max id
     // regardless of ns_id while being restored. This causes the ids in a table to not be continuously incremented.
 
-    PageIdU64 newDataPageIdForDTFile(StableDiskDelegator & delegator, const char * who);
-    PageIdU64 newLogPageId() { return ++max_log_page_id; }
-    PageIdU64 newMetaPageId() { return ++max_meta_page_id; }
+    PageIdU64 newDataPageIdForDTFile(StableDiskDelegator & delegator, const char * who) const;
+    PageIdU64 newLogPageId() const;
+    PageIdU64 newMetaPageId() const;
 
 #ifndef DBMS_PUBLIC_GTEST
 private:
@@ -181,9 +181,7 @@ private:
 
     Context & global_context;
 
-    std::atomic<PageIdU64> max_log_page_id = 0;
-    std::atomic<PageIdU64> max_data_page_id = 0;
-    std::atomic<PageIdU64> max_meta_page_id = 0;
+    GlobalPageIdAllocatorPtr global_id_allocator;
 
     BackgroundProcessingPool::TaskHandle gc_handle = nullptr;
 

--- a/dbms/src/Storages/DeltaMerge/StoragePool/StoragePool_fwd.h
+++ b/dbms/src/Storages/DeltaMerge/StoragePool/StoragePool_fwd.h
@@ -18,6 +18,8 @@
 
 namespace DB::DM
 {
+class GlobalPageIdAllocator;
+using GlobalPageIdAllocatorPtr = std::shared_ptr<GlobalPageIdAllocator>;
 
 class StoragePool;
 using StoragePoolPtr = std::shared_ptr<StoragePool>;

--- a/dbms/src/Storages/DeltaMerge/WriteBatchesImpl.h
+++ b/dbms/src/Storages/DeltaMerge/WriteBatchesImpl.h
@@ -46,7 +46,7 @@ struct WriteBatches : private boost::noncopyable
 
     explicit WriteBatches(StoragePool & storage_pool_, const WriteLimiterPtr & write_limiter_ = nullptr)
         : keyspace_id(storage_pool_.getKeyspaceID())
-        , ns_id(storage_pool_.getNamespaceID())
+        , ns_id(storage_pool_.getTableID())
         , run_mode(storage_pool_.getPageStorageRunMode())
         , log(run_mode, keyspace_id, StorageType::Log, ns_id)
         , data(run_mode, keyspace_id, StorageType::Data, ns_id)

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment.cpp
@@ -79,13 +79,20 @@ public:
     }
 
 protected:
-    SegmentPtr buildFirstSegment(const ColumnDefinesPtr & pre_define_columns = {}, DB::Settings && db_settings = DB::Settings())
+    SegmentPtr buildFirstSegment(
+        const ColumnDefinesPtr & pre_define_columns = {},
+        DB::Settings && db_settings = DB::Settings())
     {
         TiFlashStorageTestBasic::reload(std::move(db_settings));
         storage_path_pool = std::make_shared<StoragePathPool>(db_context->getPathPool().withTable("test", "t1", false));
         page_id_allocator = std::make_shared<GlobalPageIdAllocator>();
-        storage_pool
-            = std::make_shared<StoragePool>(*db_context, NullspaceID, /*ns_id*/ 100, *storage_path_pool, page_id_allocator, "test.t1");
+        storage_pool = std::make_shared<StoragePool>(
+            *db_context,
+            NullspaceID,
+            /*ns_id*/ 100,
+            *storage_path_pool,
+            page_id_allocator,
+            "test.t1");
         storage_pool->restore();
         ColumnDefinesPtr cols = (!pre_define_columns) ? DMTestEnv::getDefaultColumns() : pre_define_columns;
         setColumns(cols);

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment.cpp
@@ -20,6 +20,8 @@
 #include <Storages/DeltaMerge/DeltaMergeStore.h>
 #include <Storages/DeltaMerge/File/DMFileBlockOutputStream.h>
 #include <Storages/DeltaMerge/Segment.h>
+#include <Storages/DeltaMerge/Segment_fwd.h>
+#include <Storages/DeltaMerge/StoragePool/GlobalPageIdAllocator.h>
 #include <Storages/DeltaMerge/StoragePool/StoragePool.h>
 #include <Storages/DeltaMerge/WriteBatchesImpl.h>
 #include <Storages/DeltaMerge/tests/DMTestEnv.h>
@@ -35,6 +37,7 @@
 #include <ctime>
 #include <future>
 #include <memory>
+
 
 namespace CurrentMetrics
 {
@@ -71,17 +74,18 @@ public:
         TiFlashStorageTestBasic::SetUp();
         table_columns = std::make_shared<ColumnDefines>();
 
-        segment = reload();
+        segment = buildFirstSegment();
         ASSERT_EQ(segment->segmentId(), DELTA_MERGE_FIRST_SEGMENT_ID);
     }
 
 protected:
-    SegmentPtr reload(const ColumnDefinesPtr & pre_define_columns = {}, DB::Settings && db_settings = DB::Settings())
+    SegmentPtr buildFirstSegment(const ColumnDefinesPtr & pre_define_columns = {}, DB::Settings && db_settings = DB::Settings())
     {
         TiFlashStorageTestBasic::reload(std::move(db_settings));
         storage_path_pool = std::make_shared<StoragePathPool>(db_context->getPathPool().withTable("test", "t1", false));
+        page_id_allocator = std::make_shared<GlobalPageIdAllocator>();
         storage_pool
-            = std::make_shared<StoragePool>(*db_context, NullspaceID, /*ns_id*/ 100, *storage_path_pool, "test.t1");
+            = std::make_shared<StoragePool>(*db_context, NullspaceID, /*ns_id*/ 100, *storage_path_pool, page_id_allocator, "test.t1");
         storage_pool->restore();
         ColumnDefinesPtr cols = (!pre_define_columns) ? DMTestEnv::getDefaultColumns() : pre_define_columns;
         setColumns(cols);
@@ -91,7 +95,7 @@ protected:
             *dm_context,
             table_columns,
             RowKeyRange::newAll(false, 1),
-            storage_pool->newMetaPageId(),
+            DELTA_MERGE_FIRST_SEGMENT_ID,
             0);
     }
 
@@ -118,6 +122,7 @@ protected:
 
 protected:
     /// all these var lives as ref in dm_context
+    GlobalPageIdAllocatorPtr page_id_allocator;
     std::shared_ptr<StoragePathPool> storage_path_pool;
     std::shared_ptr<StoragePool> storage_pool;
     ColumnDefinesPtr table_columns;
@@ -436,7 +441,7 @@ try
     Settings my_settings;
     const auto enable_relevant_place = GetParam();
     my_settings.dt_enable_relevant_place = enable_relevant_place;
-    this->reload({}, std::move(my_settings));
+    this->buildFirstSegment({}, std::move(my_settings));
 
     const size_t num_rows_write = 300;
     {
@@ -990,7 +995,7 @@ try
     settings.dt_segment_limit_rows = 11;
     settings.dt_segment_delta_limit_rows = 7;
 
-    segment = reload(DMTestEnv::getDefaultColumns(), std::move(settings));
+    segment = buildFirstSegment(DMTestEnv::getDefaultColumns(), std::move(settings));
 
     size_t num_batches_written = 0;
     const size_t num_rows_per_write = 5;
@@ -1306,7 +1311,7 @@ try
         auto columns_before_ddl = DMTestEnv::getDefaultColumns();
         columns_before_ddl->emplace_back(column_i8_before_ddl);
         DB::Settings db_settings;
-        segment = reload(columns_before_ddl, std::move(db_settings));
+        segment = buildFirstSegment(columns_before_ddl, std::move(db_settings));
 
         /// write to segment
         Block block = DMTestEnv::prepareSimpleWriteBlock(0, num_rows_write, false);
@@ -1431,7 +1436,7 @@ try
         auto columns_before_ddl = DMTestEnv::getDefaultColumns();
         // Not cache any rows
         DB::Settings db_settings;
-        segment = reload(columns_before_ddl, std::move(db_settings));
+        segment = buildFirstSegment(columns_before_ddl, std::move(db_settings));
     }
 
     const size_t num_rows_write = 100;
@@ -1551,7 +1556,7 @@ try
     Settings settings = dmContext().global_context.getSettings();
     settings.dt_segment_stable_pack_rows = 10;
 
-    segment = reload(DMTestEnv::getDefaultColumns(), std::move(settings));
+    segment = buildFirstSegment(DMTestEnv::getDefaultColumns(), std::move(settings));
 
     const size_t num_rows_write_every_round = 100;
     const size_t write_round = 3;
@@ -1592,7 +1597,7 @@ try
     Settings settings = dmContext().global_context.getSettings();
     settings.dt_segment_stable_pack_rows = 10;
 
-    segment = reload(DMTestEnv::getDefaultColumns(), std::move(settings));
+    segment = buildFirstSegment(DMTestEnv::getDefaultColumns(), std::move(settings));
 
     const size_t num_rows_write_every_round = 100;
     const size_t write_round = 3;

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment_common_handle.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment_common_handle.cpp
@@ -16,6 +16,8 @@
 #include <Storages/DeltaMerge/DMContext.h>
 #include <Storages/DeltaMerge/DeltaMergeStore.h>
 #include <Storages/DeltaMerge/Segment.h>
+#include <Storages/DeltaMerge/Segment_fwd.h>
+#include <Storages/DeltaMerge/StoragePool/GlobalPageIdAllocator.h>
 #include <Storages/DeltaMerge/StoragePool/StoragePool.h>
 #include <Storages/DeltaMerge/tests/DMTestEnv.h>
 #include <Storages/PathPool.h>
@@ -44,40 +46,46 @@ public:
     void SetUp() override
     {
         TiFlashStorageTestBasic::SetUp();
-        table_columns_ = std::make_shared<ColumnDefines>();
+        table_columns = std::make_shared<ColumnDefines>();
 
-        segment = reload();
+        segment = buildFirstSegment();
         ASSERT_EQ(segment->segmentId(), DELTA_MERGE_FIRST_SEGMENT_ID);
     }
 
 protected:
-    SegmentPtr reload(ColumnDefinesPtr cols = {}, DB::Settings && db_settings = DB::Settings())
+    SegmentPtr buildFirstSegment(ColumnDefinesPtr cols = {}, DB::Settings && db_settings = DB::Settings())
     {
         TiFlashStorageTestBasic::reload(std::move(db_settings));
         path_pool = std::make_shared<StoragePathPool>(db_context->getPathPool().withTable("test", "t", false));
-        storage_pool = std::make_shared<StoragePool>(*db_context, NullspaceID, /*table_id*/ 100, *path_pool, "test.t1");
+        page_id_allocator = std::make_shared<GlobalPageIdAllocator>();
+        storage_pool = std::make_shared<StoragePool>(
+            *db_context,
+            NullspaceID,
+            /*table_id*/ 100,
+            *path_pool,
+            page_id_allocator,
+            "test.t1");
         storage_pool->restore();
         if (!cols)
             cols = DMTestEnv::getDefaultColumns(
                 is_common_handle ? DMTestEnv::PkType::CommonHandle : DMTestEnv::PkType::HiddenTiDBRowID);
         setColumns(cols);
 
-        auto segment_id = storage_pool->newMetaPageId();
         return Segment::newSegment(
             Logger::get(),
-            *dm_context_,
-            table_columns_,
+            *dm_context,
+            table_columns,
             RowKeyRange::newAll(is_common_handle, rowkey_column_size),
-            segment_id,
+            DELTA_MERGE_FIRST_SEGMENT_ID,
             0);
     }
 
     // setColumns should update dm_context at the same time
     void setColumns(const ColumnDefinesPtr & columns)
     {
-        *table_columns_ = *columns;
+        *table_columns = *columns;
 
-        dm_context_ = DMContext::createUnique(
+        dm_context = DMContext::createUnique(
             *db_context,
             path_pool,
             storage_pool,
@@ -89,18 +97,19 @@ protected:
             db_context->getSettingsRef());
     }
 
-    const ColumnDefinesPtr & tableColumns() const { return table_columns_; }
+    const ColumnDefinesPtr & tableColumns() const { return table_columns; }
 
-    DMContext & dmContext() { return *dm_context_; }
+    DMContext & dmContext() { return *dm_context; }
 
 private:
     /// all these var lives as ref in dm_context
+    GlobalPageIdAllocatorPtr page_id_allocator;
     std::shared_ptr<StoragePathPool> path_pool;
     std::shared_ptr<StoragePool> storage_pool;
-    ColumnDefinesPtr table_columns_;
+    ColumnDefinesPtr table_columns;
     DM::DeltaMergeStore::Settings settings;
     /// dm_context
-    std::unique_ptr<DMContext> dm_context_;
+    std::unique_ptr<DMContext> dm_context;
 
 protected:
     // the segment we are going to test
@@ -306,13 +315,13 @@ try
 }
 CATCH
 
-class SegmentDeletion_Common_Handle_test
+class SegmentDeletionCommonHandleTest
     : public SegmentCommonHandleTest
     , public testing::WithParamInterface<std::tuple<bool, bool>>
 {
 };
 
-TEST_P(SegmentDeletion_Common_Handle_test, DeleteDataInDelta)
+TEST_P(SegmentDeletionCommonHandleTest, DeleteDataInDelta)
 try
 {
     const size_t num_rows_write = 100;
@@ -382,7 +391,7 @@ try
 }
 CATCH
 
-TEST_P(SegmentDeletion_Common_Handle_test, DeleteDataInStable)
+TEST_P(SegmentDeletionCommonHandleTest, DeleteDataInStable)
 try
 {
     const size_t num_rows_write = 100;
@@ -460,7 +469,7 @@ try
 }
 CATCH
 
-TEST_P(SegmentDeletion_Common_Handle_test, DeleteDataInStableAndDelta)
+TEST_P(SegmentDeletionCommonHandleTest, DeleteDataInStableAndDelta)
 try
 {
     const size_t num_rows_write = 100;
@@ -550,7 +559,7 @@ CATCH
 
 INSTANTIATE_TEST_CASE_P(
     WhetherReadOrMergeDeltaBeforeDeleteRange,
-    SegmentDeletion_Common_Handle_test,
+    SegmentDeletionCommonHandleTest,
     testing::Combine(testing::Bool(), testing::Bool()));
 
 TEST_F(SegmentCommonHandleTest, DeleteRead)
@@ -929,7 +938,7 @@ try
     settings.dt_segment_limit_rows = 11;
     settings.dt_segment_delta_limit_rows = 7;
 
-    segment = reload(DMTestEnv::getDefaultColumns(DMTestEnv::PkType::CommonHandle), std::move(settings));
+    segment = buildFirstSegment(DMTestEnv::getDefaultColumns(DMTestEnv::PkType::CommonHandle), std::move(settings));
 
     size_t num_batches_written = 0;
     const size_t num_rows_per_write = 5;

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment_s3.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment_s3.cpp
@@ -18,6 +18,8 @@
 #include <Storages/DeltaMerge/DMContext.h>
 #include <Storages/DeltaMerge/DeltaMergeStore.h>
 #include <Storages/DeltaMerge/Segment.h>
+#include <Storages/DeltaMerge/Segment_fwd.h>
+#include <Storages/DeltaMerge/StoragePool/GlobalPageIdAllocator.h>
 #include <Storages/DeltaMerge/StoragePool/StoragePool.h>
 #include <Storages/DeltaMerge/WriteBatchesImpl.h>
 #include <Storages/DeltaMerge/tests/DMTestEnv.h>
@@ -96,7 +98,7 @@ public:
             kvstore->setStore(meta_store);
         }
 
-        segment = reload();
+        segment = buildFirstSegment();
         ASSERT_EQ(segment->segmentId(), DELTA_MERGE_FIRST_SEGMENT_ID);
     }
 
@@ -118,11 +120,20 @@ public:
     }
 
 protected:
-    SegmentPtr reload(const ColumnDefinesPtr & pre_define_columns = {}, DB::Settings && db_settings = DB::Settings())
+    SegmentPtr buildFirstSegment(
+        const ColumnDefinesPtr & pre_define_columns = {},
+        DB::Settings && db_settings = DB::Settings())
     {
         TiFlashStorageTestBasic::reload(std::move(db_settings));
         storage_path_pool = std::make_shared<StoragePathPool>(db_context->getPathPool().withTable("test", "t1", false));
-        storage_pool = std::make_shared<StoragePool>(*db_context, NullspaceID, ns_id, *storage_path_pool, "test.t1");
+        page_id_allocator = std::make_shared<GlobalPageIdAllocator>();
+        storage_pool = std::make_shared<StoragePool>(
+            *db_context,
+            NullspaceID,
+            ns_id,
+            *storage_path_pool,
+            page_id_allocator,
+            "test.t1");
         storage_pool->restore();
         ColumnDefinesPtr cols = (!pre_define_columns) ? DMTestEnv::getDefaultColumns() : pre_define_columns;
         setColumns(cols);
@@ -132,7 +143,7 @@ protected:
             *dm_context,
             table_columns,
             RowKeyRange::newAll(false, 1),
-            storage_pool->newMetaPageId(),
+            DELTA_MERGE_FIRST_SEGMENT_ID,
             0);
     }
 
@@ -159,6 +170,7 @@ protected:
 
 protected:
     /// all these var lives as ref in dm_context
+    GlobalPageIdAllocatorPtr page_id_allocator;
     std::shared_ptr<StoragePathPool> storage_path_pool;
     std::shared_ptr<StoragePool> storage_pool;
     ColumnDefinesPtr table_columns;

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_storage_delta_merge.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_storage_delta_merge.cpp
@@ -763,6 +763,7 @@ try
         table_info.pk_is_handle = false;
 
         // max page id is only updated at restart, so we need recreate page v3 before recreate table
+        ctx->getGlobalContext().initializeGlobalPageIdAllocator();
         ctx->getGlobalContext().initializeGlobalStoragePoolIfNeed(ctx->getPathPool());
         storage = StorageDeltaMerge::create(
             "TiFlash",

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_global_page_id_allocator.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_global_page_id_allocator.cpp
@@ -1,0 +1,104 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Common/SyncPoint/Ctl.h>
+#include <Interpreters/Context.h>
+#include <Storages/DeltaMerge/StoragePool/GlobalPageIdAllocator.h>
+#include <Storages/DeltaMerge/tests/DMTestEnv.h>
+#include <TestUtils/TiFlashTestBasic.h>
+
+#include <future>
+
+namespace DB::DM::tests
+{
+
+TEST(GlobalPageIdAllocatorTest, Normal)
+{
+    GlobalPageIdAllocator allocator;
+
+    // Note the meta page id is allocated begin with 2
+    // 1 is reserved for `DELTA_MERGE_FIRST_SEGMENT_ID` for each
+    // physical table
+    EXPECT_EQ(allocator.newMetaPageId(), 2);
+    EXPECT_EQ(allocator.newMetaPageId(), 3);
+    EXPECT_EQ(allocator.newMetaPageId(), 4);
+    allocator.raiseMetaPageIdLowerBound(1024);
+    EXPECT_EQ(allocator.newMetaPageId(), 1025);
+    EXPECT_EQ(allocator.newMetaPageId(), 1026);
+    EXPECT_EQ(allocator.newMetaPageId(), 1027);
+
+    EXPECT_EQ(allocator.newLogPageId(), 1);
+    EXPECT_EQ(allocator.newLogPageId(), 2);
+    EXPECT_EQ(allocator.newLogPageId(), 3);
+    allocator.raiseLogPageIdLowerBound(65536);
+    EXPECT_EQ(allocator.newLogPageId(), 65537);
+    EXPECT_EQ(allocator.newLogPageId(), 65538);
+
+    EXPECT_EQ(allocator.newDataPageIdForDTFile(), 1);
+    EXPECT_EQ(allocator.newDataPageIdForDTFile(), 2);
+    EXPECT_EQ(allocator.newDataPageIdForDTFile(), 3);
+    allocator.raiseDataPageIdLowerBound(114);
+    EXPECT_EQ(allocator.newDataPageIdForDTFile(), 115);
+    EXPECT_EQ(allocator.newDataPageIdForDTFile(), 116);
+}
+
+TEST(GlobalPageIdAllocatorTest, IdChangedBeforeRaiseLowerBound)
+{
+    GlobalPageIdAllocator allocator;
+
+    EXPECT_EQ(allocator.newLogPageId(), 1);
+    EXPECT_EQ(allocator.newLogPageId(), 2);
+    EXPECT_EQ(allocator.newLogPageId(), 3);
+
+    auto sp_raise_bound = SyncPointCtl::enableInScope("before_GlobalPageIdAllocator::raiseLowerBoundCAS_1");
+    auto th_raise_lower_bound = std::async([&]() {
+        allocator.raiseLogPageIdLowerBound(1024);
+        EXPECT_EQ(allocator.newLogPageId(), 1025);
+    });
+
+    sp_raise_bound.waitAndPause();
+    EXPECT_EQ(allocator.newLogPageId(), 4);
+    sp_raise_bound.next();
+    EXPECT_EQ(allocator.newLogPageId(), 5);
+
+    // use `disable` instead of `next` to break the loop inside `raiseTargetByLowerBound`
+    sp_raise_bound.disable();
+    th_raise_lower_bound.get();
+    EXPECT_EQ(allocator.newLogPageId(), 1026);
+}
+
+TEST(GlobalPageIdAllocatorTest, IdRaisedBeforeRaiseLowerBound)
+{
+    GlobalPageIdAllocator allocator;
+
+    EXPECT_EQ(allocator.newLogPageId(), 1);
+    EXPECT_EQ(allocator.newLogPageId(), 2);
+    EXPECT_EQ(allocator.newLogPageId(), 3);
+
+    auto sp_raise_bound = SyncPointCtl::enableInScope("before_GlobalPageIdAllocator::raiseLowerBoundCAS_1");
+    auto th_raise_lower_bound_1 = std::async([&]() { allocator.raiseLogPageIdLowerBound(1024); });
+    auto th_raise_lower_bound_2 = std::async([&]() { allocator.raiseLogPageIdLowerBound(3000); });
+
+    sp_raise_bound.waitAndPause();
+
+    // use `disable` instead of `next` to break the loop inside `raiseTargetByLowerBound`
+    sp_raise_bound.disable();
+
+    th_raise_lower_bound_2.get();
+    EXPECT_EQ(allocator.newLogPageId(), 3001);
+    th_raise_lower_bound_1.get();
+    EXPECT_EQ(allocator.newLogPageId(), 3002);
+}
+
+} // namespace DB::DM::tests

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_test_basic.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_test_basic.cpp
@@ -832,12 +832,13 @@ SegmentPtr SegmentTestBasic::reload(
                                                   : pre_define_columns;
     setColumns(cols);
 
+    // Always return the first segment
     return Segment::newSegment(
         Logger::get(),
         *dm_context,
         table_columns,
         RowKeyRange::newAll(is_common_handle, 1),
-        storage_pool->newMetaPageId(),
+        DELTA_MERGE_FIRST_SEGMENT_ID,
         0);
 }
 

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_test_basic.h
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_test_basic.h
@@ -138,8 +138,6 @@ protected:
     // <name, number_of_success_runs>
     std::map<std::string, size_t> operation_statistics;
 
-    SegmentPtr reload(bool is_common_handle, const ColumnDefinesPtr & pre_define_columns, DB::Settings && db_settings);
-
     // setColumns should update dm_context at the same time
     void setColumns(const ColumnDefinesPtr & columns);
 
@@ -153,6 +151,9 @@ protected:
     std::unique_ptr<DMContext> createDMContext();
 
     std::pair<SegmentPtr, SegmentSnapshotPtr> getSegmentForRead(PageIdU64 segment_id);
+
+private:
+    SegmentPtr reload(bool is_common_handle, const ColumnDefinesPtr & pre_define_columns, DB::Settings && db_settings);
 
 protected:
     inline static constexpr PageIdU64 NAMESPACE_ID = 100;

--- a/dbms/src/Storages/DeltaMerge/workload/DTWorkload.cpp
+++ b/dbms/src/Storages/DeltaMerge/workload/DTWorkload.cpp
@@ -56,6 +56,7 @@ DTWorkload::DTWorkload(
     key_gen = KeyGenerator::create(opts_);
     ts_gen = std::make_unique<TimestampGenerator>();
     // max page id is only updated at restart, so we need recreate page v3 before recreate table
+    context->initializeGlobalPageIdAllocator();
     context->initializeGlobalStoragePoolIfNeed(context->getPathPool());
     Stopwatch sw;
     store = std::make_unique<DeltaMergeStore>(

--- a/dbms/src/Storages/DeltaMerge/workload/MainEntry.cpp
+++ b/dbms/src/Storages/DeltaMerge/workload/MainEntry.cpp
@@ -236,6 +236,7 @@ void run(WorkloadOptions & opts, ContextPtr context)
     std::vector<Statistics> stats;
     try
     {
+        context->initializeGlobalPageIdAllocator();
         // HandleTable is a unordered_map that stores handle->timestamp for data verified.
         auto handle_table = createHandleTable(opts);
         // Table Schema

--- a/dbms/src/Storages/Page/V3/PageDirectoryFactory.h
+++ b/dbms/src/Storages/Page/V3/PageDirectoryFactory.h
@@ -67,7 +67,8 @@ public:
         const String & storage_name,
         FileProviderPtr & file_provider,
         PSDiskDelegatorPtr & delegator,
-        PageEntriesEdit & edit);
+        PageEntriesEdit & edit,
+        UInt64 filter_seq = 0);
 
     // just for test
     PageDirectoryFactory<Trait> & setBlobStats(BlobStats & blob_stats_)
@@ -83,6 +84,7 @@ private:
         const PageDirectoryPtr & dir,
         const typename PageEntriesEdit::EditRecord & r,
         bool strict_check);
+    static void updateMaxIdByRecord(const PageDirectoryPtr & dir, const typename PageEntriesEdit::EditRecord & r);
 
     void restoreBlobStats(const PageDirectoryPtr & dir);
 

--- a/dbms/src/Storages/Page/V3/tests/gtest_page_directory.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_page_directory.cpp
@@ -34,6 +34,7 @@
 #include <TestUtils/TiFlashStorageTestBasic.h>
 #include <TestUtils/TiFlashTestBasic.h>
 #include <TestUtils/TiFlashTestEnv.h>
+#include <common/UInt128.h>
 #include <common/logger_useful.h>
 #include <common/types.h>
 #include <fmt/format.h>
@@ -1296,6 +1297,31 @@ try
         auto normal_id = getNormalPageIdU64(restored_dir, 353, snap);
         EXPECT_EQ(normal_id, 352);
     }
+}
+CATCH
+
+TEST_F(PageDirectoryTest, RestoreWithIdempotentRef)
+try
+{
+    auto provider = DB::tests::TiFlashTestEnv::getDefaultFileProvider();
+    auto path = getTemporaryPath();
+    PSDiskDelegatorPtr delegator = std::make_shared<DB::tests::MockDiskDelegatorSingle>(path);
+    PageDirectoryFactory<u128::FactoryTrait> factory;
+
+    // Generate an edit with idempotent REF operation
+    const UInt64 filter_seq = 1000;
+    u128::PageEntriesEdit edit;
+    edit.appendRecord({.type = EditRecordType::UPSERT, .page_id = UInt128(10000), .version = PageVersion(53, 1)});
+    edit.appendRecord(
+        {.type = EditRecordType::REF,
+         .page_id = UInt128(90000),
+         .ori_page_id = UInt128(1),
+         .version = PageVersion(51)});
+    edit.appendRecord({.type = EditRecordType::UPSERT, .page_id = UInt128(1), .version = PageVersion(52, 1)});
+    edit.appendRecord({.type = EditRecordType::PUT, .page_id = UInt128(5), .version = PageVersion(1001)});
+
+    auto d = factory.createFromEditForTest(getCurrentTestName(), provider, delegator, edit, filter_seq);
+    EXPECT_EQ(d->getMaxIdAfterRestart(), 90000);
 }
 CATCH
 

--- a/dbms/src/TestUtils/TiFlashTestEnv.cpp
+++ b/dbms/src/TestUtils/TiFlashTestEnv.cpp
@@ -155,6 +155,7 @@ void TiFlashTestEnv::addGlobalContext(
         global_context->getFileProvider());
 
     global_context->setPageStorageRunMode(ps_run_mode);
+    global_context->initializeGlobalPageIdAllocator();
     global_context->initializeGlobalStoragePoolIfNeed(global_context->getPathPool());
     global_context->initializeWriteNodePageStorageIfNeed(global_context->getPathPool());
     LOG_INFO(Logger::get(), "Storage mode : {}", static_cast<UInt8>(global_context->getPageStorageRunMode()));
@@ -194,6 +195,7 @@ ContextPtr TiFlashTestEnv::getContext(const DB::Settings & settings, Strings tes
     context.setPath(root_path);
     auto paths = getPathPool(testdata_path);
     context.setPathPool(paths.first, paths.second, Strings{}, context.getPathCapacity(), context.getFileProvider());
+    global_contexts[0]->initializeGlobalPageIdAllocator();
     global_contexts[0]->initializeGlobalStoragePoolIfNeed(context.getPathPool());
     global_contexts[0]->tryReleaseWriteNodePageStorageForTest();
     global_contexts[0]->initializeWriteNodePageStorageIfNeed(context.getPathPool());


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/8695

Problem Summary: As the issue describe: https://github.com/pingcap/tiflash/issues/8695#issuecomment-1895280095

### What is changed and how it works?

Introduce a `GlobalPageIdAllocator` to avoid a page_id from being reused in one physical_table_id scope. Specifically,

* Introduced a `GlobalPageIdAllocator` to allocate page_id for segment_id, delta-layer and stable-layer for all IStorage instances instead of each `StoragePool` allocate the page_id for its own IStorage instance independently
* Each IStorage instance restored from disk, it will first try raise the lower bound of the `GlobalPageIdAllocator`. After that, a table won't be able to reuse the allocated id
* If an IStorage instance being physically removed (cause by setting tiflash replica to 0) and re-create again, it will still allocated the page_id from `GlobalPageIdAllocator`, so no page_id will be reused too.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```
Load tpc-ds 50
Set tiflash replica 1 for database tpcds50 and wait for all tables progress == 1
Set tiflash replica 0 and wait for gc
Set tiflash replica 1 and wait for all tables progress == 1
Run queries on tpcds 50 through tiflash
```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix the issue that the tiflash replica data may be corrupted after setting the tiflash replica to 0 and add it back later
```
