### PR TITLE
DDL: Add the reason why storage instance is created or dropped

### DIFF
--- a/dbms/src/Storages/KVStore/MultiRaft/RegionData.h
+++ b/dbms/src/Storages/KVStore/MultiRaft/RegionData.h
@@ -79,7 +79,7 @@ public:
     const RegionDefaultCFData & defaultCF() const;
     const RegionLockCFData & lockCF() const;
 
-    RegionData() {}
+    RegionData() = default;
 
     RegionData(RegionData && data);
     RegionData & operator=(RegionData &&);

--- a/dbms/src/TiDB/Schema/SchemaBuilder.cpp
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.cpp
@@ -49,6 +49,7 @@
 #include <boost/algorithm/string/join.hpp>
 #include <magic_enum.hpp>
 #include <mutex>
+#include <string_view>
 #include <tuple>
 
 namespace DB
@@ -292,13 +293,13 @@ void SchemaBuilder<Getter, NameMapper>::applyDiff(const SchemaDiff & diff)
     case SchemaActionType::DropTable:
     case SchemaActionType::DropView:
     {
-        applyDropTable(diff.schema_id, diff.table_id);
+        applyDropTable(diff.schema_id, diff.table_id, magic_enum::enum_name(diff.type));
         break;
     }
     case SchemaActionType::TruncateTable:
     {
         applyCreateTable(diff.schema_id, diff.table_id);
-        applyDropTable(diff.schema_id, diff.old_table_id);
+        applyDropTable(diff.schema_id, diff.old_table_id, magic_enum::enum_name(diff.type));
         break;
     }
     case SchemaActionType::RenameTable:
@@ -330,7 +331,7 @@ void SchemaBuilder<Getter, NameMapper>::applyDiff(const SchemaDiff & diff)
             applyCreateTable(diff.schema_id, diff.table_id);
             // Drop the old table. if the previous partitions of the old table are
             // not mapping to the old logical table now, they will not be removed.
-            applyDropTable(diff.schema_id, diff.old_table_id);
+            applyDropTable(diff.schema_id, diff.old_table_id, magic_enum::enum_name(diff.type));
         }
         break;
     }
@@ -376,7 +377,7 @@ void SchemaBuilder<Getter, NameMapper>::applySetTiFlashReplica(DatabaseID databa
     auto & tmt_context = context.getTMTContext();
     if (table_info->replica_info.count == 0)
     {
-        // if set 0, drop table in TiFlash
+        // Replicat number is to 0, mark the table as tombstone in TiFlash
         auto storage = tmt_context.getStorages().get(keyspace_id, table_info->id);
         if (unlikely(storage == nullptr))
         {
@@ -387,12 +388,12 @@ void SchemaBuilder<Getter, NameMapper>::applySetTiFlashReplica(DatabaseID databa
             return;
         }
 
-        applyDropTable(database_id, table_id);
+        applyDropTable(database_id, table_id, "SetTiFlashReplicaToZero");
         return;
     }
 
     assert(table_info->replica_info.count != 0);
-    // Replica info is set to non-zero, create the storage if not exists.
+    // Replica number is set to non-zero, create the storage if not exists.
     auto storage = tmt_context.getStorages().get(keyspace_id, table_info->id);
     if (storage == nullptr)
     {
@@ -577,11 +578,12 @@ void SchemaBuilder<Getter, NameMapper>::applyPartitionDiffOnLogicalTable(
     updated_table_info.partition = table_info->partition;
 
     /// Apply changes to physical tables.
+    auto reason = fmt::format("ApplyPartitionDiff-logical_table_id={}", local_table_info.id);
     for (const auto & local_def : local_defs)
     {
         if (!new_part_id_set.contains(local_def.id))
         {
-            applyDropPhysicalTable(name_mapper.mapDatabaseName(database_id, keyspace_id), local_def.id);
+            applyDropPhysicalTable(name_mapper.mapDatabaseName(database_id, keyspace_id), local_def.id, reason);
         }
     }
 
@@ -953,9 +955,10 @@ void SchemaBuilder<Getter, NameMapper>::applyDropDatabase(DatabaseID database_id
     // `DatabaseInfo` from TiKV.
     {
         //TODO: it seems may need a lot time, maybe we can do it in a background thread
+        auto reason = fmt::format("DropDatabase-database_id={}", database_id);
         auto table_ids = table_id_map.findTablesByDatabaseID(database_id);
         for (auto table_id : table_ids)
-            applyDropTable(database_id, table_id);
+            applyDropTable(database_id, table_id, reason);
     }
 
     applyDropDatabaseByName(name_mapper.mapDatabaseName(database_id, keyspace_id));
@@ -1168,23 +1171,31 @@ void SchemaBuilder<Getter, NameMapper>::applyCreateStorageInstance(
 
 
 template <typename Getter, typename NameMapper>
-void SchemaBuilder<Getter, NameMapper>::applyDropPhysicalTable(const String & db_name, TableID table_id)
+void SchemaBuilder<Getter, NameMapper>::applyDropPhysicalTable(
+    const String & db_name,
+    TableID table_id,
+    std::string_view source)
 {
     auto & tmt_context = context.getTMTContext();
     auto storage = tmt_context.getStorages().get(keyspace_id, table_id);
     if (storage == nullptr)
     {
-        LOG_INFO(log, "Storage instance does not exist, applyDropPhysicalTable is ignored, table_id={}", table_id);
+        LOG_INFO(
+            log,
+            "Storage instance does not exist, applyDropPhysicalTable is ignored, table_id={} source={}",
+            table_id,
+            source);
         return;
     }
 
     GET_METRIC(tiflash_schema_internal_ddl_count, type_drop_table).Increment();
     LOG_INFO(
         log,
-        "Tombstone table {}.{} begin, table_id={}",
+        "Tombstone table {}.{} begin, table_id={} source={}",
         db_name,
         name_mapper.debugTableName(storage->getTableInfo()),
-        table_id);
+        table_id,
+        source);
 
     const UInt64 tombstone_ts = tmt_context.getPDClient()->getTS();
     // TODO:try to optimize alterCommands
@@ -1204,15 +1215,19 @@ void SchemaBuilder<Getter, NameMapper>::applyDropPhysicalTable(const String & db
     storage->updateTombstone(alter_lock, commands, db_name, storage->getTableInfo(), name_mapper, context);
     LOG_INFO(
         log,
-        "Tombstone table {}.{} end, table_id={} tombstone={}",
+        "Tombstone table {}.{} end, table_id={} tombstone={} source={}",
         db_name,
         name_mapper.debugTableName(storage->getTableInfo()),
         table_id,
-        tombstone_ts);
+        tombstone_ts,
+        source);
 }
 
 template <typename Getter, typename NameMapper>
-void SchemaBuilder<Getter, NameMapper>::applyDropTable(DatabaseID database_id, TableID table_id)
+void SchemaBuilder<Getter, NameMapper>::applyDropTable(
+    DatabaseID database_id,
+    TableID table_id,
+    std::string_view source)
 {
     auto & tmt_context = context.getTMTContext();
     auto storage = tmt_context.getStorages().get(keyspace_id, table_id);
@@ -1241,13 +1256,13 @@ void SchemaBuilder<Getter, NameMapper>::applyDropTable(DatabaseID database_id, T
                 continue;
             }
 
-            applyDropPhysicalTable(name_mapper.mapDatabaseName(database_id, keyspace_id), part_def.id);
+            applyDropPhysicalTable(name_mapper.mapDatabaseName(database_id, keyspace_id), part_def.id, source);
         }
     }
 
     // Drop logical table at last, only logical table drop will be treated as "complete".
     // Intermediate failure will hide the logical table drop so that schema syncing when restart will re-drop all (despite some physical tables may have dropped).
-    applyDropPhysicalTable(name_mapper.mapDatabaseName(database_id, keyspace_id), table_info.id);
+    applyDropPhysicalTable(name_mapper.mapDatabaseName(database_id, keyspace_id), table_info.id, source);
 }
 
 /// syncAllSchema will be called when a new keyspace is created or we meet diff->regenerate_schema_map = true.
@@ -1354,7 +1369,7 @@ void SchemaBuilder<Getter, NameMapper>::syncAllSchema()
 
         if (!table_id_map.tableIDInTwoMaps(table_info.id))
         {
-            applyDropPhysicalTable(it->second->getDatabaseName(), table_info.id);
+            applyDropPhysicalTable(it->second->getDatabaseName(), table_info.id, "SyncAllSchema");
             LOG_INFO(
                 log,
                 "Table {}.{} dropped during sync all schemas, table_id={}",
@@ -1525,7 +1540,7 @@ void SchemaBuilder<Getter, NameMapper>::dropAllSchema()
         {
             continue;
         }
-        applyDropPhysicalTable(storage.second->getDatabaseName(), table_info.id);
+        applyDropPhysicalTable(storage.second->getDatabaseName(), table_info.id, "DropAllSchema");
         LOG_INFO(
             log,
             "Table {}.{} dropped during drop all schemas, table_id={}",

--- a/dbms/src/TiDB/Schema/SchemaBuilder.cpp
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.cpp
@@ -70,7 +70,7 @@ template <typename Getter, typename NameMapper>
 void SchemaBuilder<Getter, NameMapper>::applyCreateTable(
     DatabaseID database_id,
     TableID table_id,
-    std::string_view source)
+    std::string_view action)
 {
     TableInfoPtr table_info;
     bool get_by_mvcc = false;
@@ -80,20 +80,20 @@ void SchemaBuilder<Getter, NameMapper>::applyCreateTable(
         LOG_INFO(
             log,
             "table is not exist in TiKV, may have been dropped, applyCreateTable is ignored, database_id={} "
-            "table_id={} source={}",
+            "table_id={} action={}",
             database_id,
             table_id,
-            source);
+            action);
         return;
     }
 
     table_id_map.emplaceTableID(table_id, database_id);
     LOG_DEBUG(
         log,
-        "register table to table_id_map, database_id={} table_id={} source={}",
+        "register table to table_id_map, database_id={} table_id={} action={}",
         database_id,
         table_id,
-        source);
+        action);
 
     // non partition table, done
     if (!table_info->isLogicalPartitionTable())
@@ -105,7 +105,7 @@ void SchemaBuilder<Getter, NameMapper>::applyCreateTable(
     // here (and store the table info to local).
     // Because `applyPartitionDiffOnLogicalTable` need the logical table for comparing
     // the latest partitioning and the local partitioning in table info to apply the changes.
-    applyCreateStorageInstance(database_id, table_info, get_by_mvcc, source);
+    applyCreateStorageInstance(database_id, table_info, get_by_mvcc, action);
 
     // Register the partition_id -> logical_table_id mapping
     for (const auto & part_def : table_info->partition.definitions)
@@ -113,11 +113,11 @@ void SchemaBuilder<Getter, NameMapper>::applyCreateTable(
         LOG_DEBUG(
             log,
             "register table to table_id_map for partition table, database_id={} logical_table_id={} "
-            "physical_table_id={} source={}",
+            "physical_table_id={} action={}",
             database_id,
             table_id,
             part_def.id,
-            source);
+            action);
         table_id_map.emplacePartitionTableID(part_def.id, table_id);
     }
 }
@@ -1092,18 +1092,18 @@ void SchemaBuilder<Getter, NameMapper>::applyCreateStorageInstance(
     const DatabaseID database_id,
     const TableInfoPtr & table_info,
     bool is_tombstone,
-    std::string_view source)
+    std::string_view action)
 {
     assert(table_info != nullptr);
 
     GET_METRIC(tiflash_schema_internal_ddl_count, type_create_table).Increment();
     LOG_INFO(
         log,
-        "Create table {} begin, database_id={}, table_id={} source={}",
+        "Create table {} begin, database_id={}, table_id={} action={}",
         name_mapper.debugCanonicalName(*table_info, database_id, keyspace_id),
         database_id,
         table_info->id,
-        source);
+        action);
 
     /// Try to recover the existing storage instance
     if (tryRecoverPhysicalTable(database_id, table_info))
@@ -1148,9 +1148,10 @@ void SchemaBuilder<Getter, NameMapper>::applyCreateStorageInstance(
         LOG_WARNING(
             log,
             "database instance is not exist (applyCreateStorageInstance), may has been dropped, create a database with "
-            "fake DatabaseInfo for it, database_id={} database_name={}",
+            "fake DatabaseInfo for it, database_id={} database_name={} action={}",
             database_id,
-            database_mapped_name);
+            database_mapped_name,
+            action);
         // The database is dropped in TiKV and we can not fetch it. Generate a fake
         // DatabaseInfo for it. It is OK because the DatabaseInfo will be updated
         // when the database is `FLASHBACK`.
@@ -1178,11 +1179,11 @@ void SchemaBuilder<Getter, NameMapper>::applyCreateStorageInstance(
     interpreter.execute();
     LOG_INFO(
         log,
-        "Creat table {} end, database_id={} table_id={} source={}",
+        "Creat table {} end, database_id={} table_id={} action={}",
         name_mapper.debugCanonicalName(*table_info, database_id, keyspace_id),
         database_id,
         table_info->id,
-        source);
+        action);
 }
 
 
@@ -1190,7 +1191,7 @@ template <typename Getter, typename NameMapper>
 void SchemaBuilder<Getter, NameMapper>::applyDropPhysicalTable(
     const String & db_name,
     TableID table_id,
-    std::string_view source)
+    std::string_view action)
 {
     auto & tmt_context = context.getTMTContext();
     auto storage = tmt_context.getStorages().get(keyspace_id, table_id);
@@ -1198,20 +1199,20 @@ void SchemaBuilder<Getter, NameMapper>::applyDropPhysicalTable(
     {
         LOG_INFO(
             log,
-            "Storage instance does not exist, applyDropPhysicalTable is ignored, table_id={} source={}",
+            "Storage instance does not exist, applyDropPhysicalTable is ignored, table_id={} action={}",
             table_id,
-            source);
+            action);
         return;
     }
 
     GET_METRIC(tiflash_schema_internal_ddl_count, type_drop_table).Increment();
     LOG_INFO(
         log,
-        "Tombstone table {}.{} begin, table_id={} source={}",
+        "Tombstone table {}.{} begin, table_id={} action={}",
         db_name,
         name_mapper.debugTableName(storage->getTableInfo()),
         table_id,
-        source);
+        action);
 
     const UInt64 tombstone_ts = tmt_context.getPDClient()->getTS();
     // TODO:try to optimize alterCommands
@@ -1231,25 +1232,29 @@ void SchemaBuilder<Getter, NameMapper>::applyDropPhysicalTable(
     storage->updateTombstone(alter_lock, commands, db_name, storage->getTableInfo(), name_mapper, context);
     LOG_INFO(
         log,
-        "Tombstone table {}.{} end, table_id={} tombstone={} source={}",
+        "Tombstone table {}.{} end, table_id={} tombstone={} action={}",
         db_name,
         name_mapper.debugTableName(storage->getTableInfo()),
         table_id,
         tombstone_ts,
-        source);
+        action);
 }
 
 template <typename Getter, typename NameMapper>
 void SchemaBuilder<Getter, NameMapper>::applyDropTable(
     DatabaseID database_id,
     TableID table_id,
-    std::string_view source)
+    std::string_view action)
 {
     auto & tmt_context = context.getTMTContext();
     auto storage = tmt_context.getStorages().get(keyspace_id, table_id);
     if (storage == nullptr)
     {
-        LOG_INFO(log, "Storage instance does not exist, applyDropTable is ignored, table_id={}", table_id);
+        LOG_INFO(
+            log,
+            "Storage instance does not exist, applyDropTable is ignored, table_id={} action={}",
+            table_id,
+            action);
         return;
     }
     const auto & table_info = storage->getTableInfo();
@@ -1265,20 +1270,21 @@ void SchemaBuilder<Getter, NameMapper>::applyDropTable(
                 LOG_INFO(
                     log,
                     "The partition is not managed by current logical table, skip, partition_table_id={} "
-                    "new_logical_table_id={} current_logical_table_id={}",
+                    "new_logical_table_id={} current_logical_table_id={} action={}",
                     part_def.id,
                     latest_logical_table_id,
-                    table_info.id);
+                    table_info.id,
+                    action);
                 continue;
             }
 
-            applyDropPhysicalTable(name_mapper.mapDatabaseName(database_id, keyspace_id), part_def.id, source);
+            applyDropPhysicalTable(name_mapper.mapDatabaseName(database_id, keyspace_id), part_def.id, action);
         }
     }
 
     // Drop logical table at last, only logical table drop will be treated as "complete".
     // Intermediate failure will hide the logical table drop so that schema syncing when restart will re-drop all (despite some physical tables may have dropped).
-    applyDropPhysicalTable(name_mapper.mapDatabaseName(database_id, keyspace_id), table_info.id, source);
+    applyDropPhysicalTable(name_mapper.mapDatabaseName(database_id, keyspace_id), table_info.id, action);
 }
 
 /// syncAllSchema will be called when a new keyspace is created or we meet diff->regenerate_schema_map = true.

--- a/dbms/src/TiDB/Schema/SchemaBuilder.h
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.h
@@ -73,8 +73,12 @@ private:
 
     void applyRecoverDatabase(DatabaseID database_id);
 
-    void applyCreateTable(DatabaseID database_id, TableID table_id);
-    void applyCreateStorageInstance(DatabaseID database_id, const TiDB::TableInfoPtr & table_info, bool is_tombstone);
+    void applyCreateTable(DatabaseID database_id, TableID table_id, std::string_view source);
+    void applyCreateStorageInstance(
+        DatabaseID database_id,
+        const TiDB::TableInfoPtr & table_info,
+        bool is_tombstone,
+        std::string_view source);
 
     void applyDropTable(DatabaseID database_id, TableID table_id, std::string_view source);
     /// Parameter schema_name should be mapped.

--- a/dbms/src/TiDB/Schema/SchemaBuilder.h
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.h
@@ -15,13 +15,15 @@
 #pragma once
 
 #include <Interpreters/Context_fwd.h>
-#include <Storages/KVStore/TMTStorages.h>
+#include <Storages/KVStore/Types.h>
 #include <TiDB/Schema/DatabaseInfoCache.h>
 #include <TiDB/Schema/SchemaGetter.h>
 #include <TiDB/Schema/TableIDMap.h>
 
 namespace DB
 {
+class IManageableStorage;
+using ManageableStoragePtr = std::shared_ptr<IManageableStorage>;
 
 template <typename Getter, typename NameMapper>
 struct SchemaBuilder
@@ -73,16 +75,16 @@ private:
 
     void applyRecoverDatabase(DatabaseID database_id);
 
-    void applyCreateTable(DatabaseID database_id, TableID table_id, std::string_view source);
+    void applyCreateTable(DatabaseID database_id, TableID table_id, std::string_view action);
     void applyCreateStorageInstance(
         DatabaseID database_id,
         const TiDB::TableInfoPtr & table_info,
         bool is_tombstone,
-        std::string_view source);
+        std::string_view action);
 
-    void applyDropTable(DatabaseID database_id, TableID table_id, std::string_view source);
+    void applyDropTable(DatabaseID database_id, TableID table_id, std::string_view action);
     /// Parameter schema_name should be mapped.
-    void applyDropPhysicalTable(const String & db_name, TableID table_id, std::string_view source);
+    void applyDropPhysicalTable(const String & db_name, TableID table_id, std::string_view action);
 
     void applyRecoverTable(DatabaseID database_id, TiDB::TableID table_id);
     void applyRecoverLogicalTable(DatabaseID database_id, const TiDB::TableInfoPtr & table_info);

--- a/dbms/src/TiDB/Schema/SchemaBuilder.h
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.h
@@ -76,9 +76,9 @@ private:
     void applyCreateTable(DatabaseID database_id, TableID table_id);
     void applyCreateStorageInstance(DatabaseID database_id, const TiDB::TableInfoPtr & table_info, bool is_tombstone);
 
-    void applyDropTable(DatabaseID database_id, TableID table_id);
+    void applyDropTable(DatabaseID database_id, TableID table_id, std::string_view source);
     /// Parameter schema_name should be mapped.
-    void applyDropPhysicalTable(const String & db_name, TableID table_id);
+    void applyDropPhysicalTable(const String & db_name, TableID table_id, std::string_view source);
 
     void applyRecoverTable(DatabaseID database_id, TiDB::TableID table_id);
     void applyRecoverLogicalTable(DatabaseID database_id, const TiDB::TableInfoPtr & table_info);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/8695

Problem Summary:

### What is changed and how it works?

A storage instance may be created or dropped other than `CreateTable` and `DropTable` schema diff. Add the reason why storage instance is created or dropped to logging.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
