### PR TITLE
ddl: Fix NULL value in non-nullable column (release-6.5)

### DIFF
--- a/dbms/src/Storages/Transaction/RowCodec.cpp
+++ b/dbms/src/Storages/Transaction/RowCodec.cpp
@@ -480,17 +480,26 @@ bool appendRowV2ToBlockImpl(
                 {
                     if (!force_decode)
                     {
+                        // Detect `NULL` column value in a non-nullable column in the schema, let upper level try to sync the schema.
                         return false;
                     }
                     else
                     {
-                        throw Exception("Detected invalid null when decoding data of column " + column_info.name + " with column type " + raw_column->getName(),
-                                        ErrorCodes::LOGICAL_ERROR);
+                        // If user turn a nullable column (with default value) to a non-nullable column. There could exists some rows
+                        // with `NULL` values inside the SST files. Or some key-values encoded with old schema come after the schema
+                        // change is applied in TiFlash because of network issue.
+                        // If the column_id exists in null_column_ids, it means the column has default value but filled with NULL.
+                        // Just filled with default value for these old schema rows.
+                        raw_column->insert(column_info.defaultValueToField());
+                        idx_null++;
                     }
                 }
-                // ColumnNullable::insertDefault just insert a null value
-                raw_column->insertDefault();
-                idx_null++;
+                else
+                {
+                    // ColumnNullable::insertDefault just insert a null value
+                    raw_column->insertDefault();
+                    idx_null++;
+                }
             }
             else
             {

--- a/dbms/src/Storages/Transaction/RowCodec.cpp
+++ b/dbms/src/Storages/Transaction/RowCodec.cpp
@@ -610,19 +610,25 @@ bool appendRowV1ToBlock(
             }
             if (datum.invalidNull(column_info))
             {
-                // Null value with non-null type detected, fatal if force_decode is true,
-                // as schema being newer and with invalid null shouldn't happen.
-                // Otherwise return false to outer, outer should sync schema and try again.
-                if (force_decode)
+                if (!force_decode)
                 {
-                    throw Exception("Detected invalid null when decoding data " + std::to_string(unflattened.get<UInt64>())
-                                        + " of column " + column_info.name + " with type " + raw_column->getName(),
-                                    ErrorCodes::LOGICAL_ERROR);
+                    // Detect `NULL` column value in a non-nullable column in the schema, let upper level try to sync the schema.
+                    return false;
                 }
-
-                return false;
+                else
+                {
+                    // If user turn a nullable column (with default value) to a non-nullable column. There could exists some rows
+                    // with `NULL` values inside the SST files. Or some key-values encoded with old schema come after the schema
+                    // change is applied in TiFlash because of network issue.
+                    // If the column_id exists in null_column_ids, it means the column has default value but filled with NULL.
+                    // Just filled with default value for these old schema rows.
+                    raw_column->insert(column_info.defaultValueToField());
+                }
             }
-            raw_column->insert(unflattened);
+            else
+            {
+                raw_column->insert(unflattened);
+            }
             decoded_field_iter++;
             column_ids_iter++;
             block_column_pos++;

--- a/dbms/src/Storages/Transaction/tests/gtest_region_block_reader.cpp
+++ b/dbms/src/Storages/Transaction/tests/gtest_region_block_reader.cpp
@@ -50,6 +50,7 @@ protected:
 
     RegionDataReadInfoList data_list_read;
     std::unordered_map<ColumnID, Field> fields_map;
+    std::unordered_set<ColumnID> invalid_null_column_ids;
 
     LoggerPtr logger;
 
@@ -173,7 +174,17 @@ protected:
                 else
                 {
                     if (fields_map.count(column_element.column_id) > 0)
-                        ASSERT_FIELD_EQ((*column_element.column)[row], fields_map.at(column_element.column_id)) << gen_error_log();
+                    {
+                        if (!invalid_null_column_ids.contains(column_element.column_id))
+                        {
+                            ASSERT_FIELD_EQ((*column_element.column)[row], fields_map.at(column_element.column_id))
+                                << gen_error_log();
+                        }
+                        else
+                        {
+                            ASSERT_FIELD_EQ((*column_element.column)[row], UInt64(0));
+                        }
+                    }
                     else
                         LOG_INFO(logger, "ignore value check for new added column, id={}, name={}", column_element.column_id, column_element.name);
                 }
@@ -401,11 +412,12 @@ try
     encodeColumns(table_info, fields, RowEncodeVersion::RowV2);
 
     auto new_table_info = getTableInfoFieldsForInvalidNULLTest({EXTRA_HANDLE_COLUMN_ID}, false);
+    invalid_null_column_ids.emplace(11);
     ASSERT_TRUE(new_table_info.getColumnInfo(11).hasNotNullFlag()); // col 11 is not null
 
     auto new_decoding_schema = getDecodingStorageSchemaSnapshot(new_table_info);
     ASSERT_FALSE(decodeAndCheckColumns(new_decoding_schema, false));
-    ASSERT_ANY_THROW(decodeAndCheckColumns(new_decoding_schema, true));
+    ASSERT_TRUE(decodeAndCheckColumns(new_decoding_schema, true));
 }
 CATCH
 
@@ -413,10 +425,14 @@ TEST_F(RegionBlockReaderTest, InvalidNULLRowV1)
 {
     auto [table_info, fields] = getNormalTableInfoFields({EXTRA_HANDLE_COLUMN_ID}, false);
     encodeColumns(table_info, fields, RowEncodeVersion::RowV1);
+
     auto new_table_info = getTableInfoFieldsForInvalidNULLTest({EXTRA_HANDLE_COLUMN_ID}, false);
+    invalid_null_column_ids.emplace(11);
+    ASSERT_TRUE(new_table_info.getColumnInfo(11).hasNotNullFlag()); // col 11 is not null
+
     auto new_decoding_schema = getDecodingStorageSchemaSnapshot(new_table_info);
     ASSERT_FALSE(decodeAndCheckColumns(new_decoding_schema, false));
-    ASSERT_ANY_THROW(decodeAndCheckColumns(new_decoding_schema, true));
+    ASSERT_TRUE(decodeAndCheckColumns(new_decoding_schema, true));
 }
 
 

--- a/dbms/src/Storages/Transaction/tests/gtest_region_block_reader.cpp
+++ b/dbms/src/Storages/Transaction/tests/gtest_region_block_reader.cpp
@@ -175,7 +175,7 @@ protected:
                 {
                     if (fields_map.count(column_element.column_id) > 0)
                     {
-                        if (!invalid_null_column_ids.contains(column_element.column_id))
+                        if (!invalid_null_column_ids.count(column_element.column_id) > 0)
                         {
                             ASSERT_FIELD_EQ((*column_element.column)[row], fields_map.at(column_element.column_id))
                                 << gen_error_log();

--- a/dbms/src/Storages/Transaction/tests/gtest_region_block_reader.cpp
+++ b/dbms/src/Storages/Transaction/tests/gtest_region_block_reader.cpp
@@ -175,7 +175,7 @@ protected:
                 {
                     if (fields_map.count(column_element.column_id) > 0)
                     {
-                        if (!invalid_null_column_ids.count(column_element.column_id) > 0)
+                        if (invalid_null_column_ids.count(column_element.column_id) == 0)
                         {
                             ASSERT_FIELD_EQ((*column_element.column)[row], fields_map.at(column_element.column_id))
                                 << gen_error_log();

--- a/tests/fullstack-test2/ddl/alter_column_nullable.test
+++ b/tests/fullstack-test2/ddl/alter_column_nullable.test
@@ -128,6 +128,7 @@ mysql> select * from test.alt2 order by a;
 +------+---+----+
 # Send snapshot to TiFlash
 mysql> alter table test.alt2 set tiflash replica 1;
+func> wait_table test alt2
 mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.alt2 order by a;
 +------+---+----+
 | a    | b | c  |

--- a/tests/fullstack-test2/ddl/alter_column_nullable.test
+++ b/tests/fullstack-test2/ddl/alter_column_nullable.test
@@ -91,3 +91,55 @@ mysql> select * from test.a1
 +----+-----+------+
 
 mysql> drop table if exists test.a1
+
+##########
+# From nullable to not null, then add tiflash replica
+mysql> drop table if exists test.alt2;
+mysql> create table test.alt2 (a int, b DECIMAL(20) NULL default 1.0, c int NOT NULL);
+mysql> insert into test.alt2(a,b,c) values (1,NULL,1),(2,NULL,2),(3,NULL,3),(4,NULL,4);
+mysql> insert into test.alt2(a,b,c) values (11,0.1,11),(12,0.2,12),(13,0.3,13),(14,0.4,14);
+mysql> update test.alt2 set b = 0 where b is null;
+mysql> select * from test.alt2 order by a;
++------+------+----+
+| a    | b    | c  |
++------+------+----+
+|    1 |    0 |  1 |
+|    2 |    0 |  2 |
+|    3 |    0 |  3 |
+|    4 |    0 |  4 |
+|   11 |    0 | 11 |
+|   12 |    0 | 12 |
+|   13 |    0 | 13 |
+|   14 |    0 | 14 |
++------+------+----+
+mysql> alter table test.alt2 modify column b DECIMAL(20) NOT NULL;
+mysql> select * from test.alt2 order by a;
++------+---+----+
+| a    | b | c  |
++------+---+----+
+|    1 | 0 |  1 |
+|    2 | 0 |  2 |
+|    3 | 0 |  3 |
+|    4 | 0 |  4 |
+|   11 | 0 | 11 |
+|   12 | 0 | 12 |
+|   13 | 0 | 13 |
+|   14 | 0 | 14 |
++------+---+----+
+# Send snapshot to TiFlash
+mysql> alter table test.alt2 set tiflash replica 1;
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.alt2 order by a;
++------+---+----+
+| a    | b | c  |
++------+---+----+
+|    1 | 0 |  1 |
+|    2 | 0 |  2 |
+|    3 | 0 |  3 |
+|    4 | 0 |  4 |
+|   11 | 0 | 11 |
+|   12 | 0 | 12 |
+|   13 | 0 | 13 |
+|   14 | 0 | 14 |
++------+---+----+
+
+mysql> drop table if exists test.alt2


### PR DESCRIPTION
cherry-pick of https://github.com/pingcap/tiflash/pull/8722

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/8419

Problem Summary: As the issue described. https://github.com/pingcap/tiflash/issues/8419#issuecomment-1898320057

When the column is defined with default value, the column id exists in non-nullable-column-ids:
https://github.com/pingcap/tidb/blob/90fc8148a29ee77708628b6c6984d51b7e9f8cc3/pkg/table/tables/tables.go#L525-L528

There is a function for fixing similar cases, but it only handle the case for "missing column". And those column defined with default value is not consider as "missing column"
https://github.com/pingcap/tiflash/blob/752a2800e7b61b6ad8570faa7e1dfd7c7269b424/dbms/src/TiDB/Decode/RowCodec.cpp#L387-L423

### What is changed and how it works?

When tiflash meets such `NULL` datum value in non-nullable column when force_decode==true, just fill with the default value.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix the issue that executing the `ALTER TABLE ... MODIFY COLUMN ... NOT NULL` that turn a nullable column to not nullable cause panic
```
