### PR TITLE
Storages: add unit-tests of duplicated handle and version.

### DIFF
--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store.cpp
@@ -19,6 +19,7 @@
 #include <DataTypes/DataTypeMyDateTime.h>
 #include <Interpreters/Context.h>
 #include <Storages/DeltaMerge/DeltaMergeDefines.h>
+#include <Storages/DeltaMerge/DeltaMergeHelpers.h>
 #include <Storages/DeltaMerge/DeltaMergeStore.h>
 #include <Storages/DeltaMerge/Filter/RSOperator.h>
 #include <Storages/DeltaMerge/PKSquashingBlockInputStream.h>
@@ -1557,6 +1558,187 @@ try
 }
 CATCH
 
+TEST_P(DeltaMergeStoreRWTest, IngestDupHandleVersion)
+try
+{
+    setStorageFormat(5); // Some old formats does not support ingest DMFiles.
+
+    // Add a column for extra value.
+    const String value_col_name = "value";
+    const ColId value_col_id = 2;
+    const auto value_col_type = DataTypeFactory::instance().get("UInt64");
+    auto table_column_defines = DMTestEnv::getDefaultColumns();
+    table_column_defines->emplace_back(value_col_id, value_col_name, value_col_type);
+    store = reload(table_column_defines);
+
+    auto create_block = [&](UInt64 beg, UInt64 end, UInt64 value) {
+        constexpr UInt64 ts = 1; // Always use the same ts.
+        auto block = DMTestEnv::prepareSimpleWriteBlock(beg, end, false, ts);
+        block.insert(createColumn<UInt64>(std::vector<UInt64>(end - beg + 1, value), value_col_name, value_col_id));
+        return block;
+    };
+
+    auto read_all_data = [&]() {
+        auto stream = store->read(
+            *db_context,
+            db_context->getSettingsRef(),
+            store->getTableColumns(),
+            {RowKeyRange::newAll(store->isCommonHandle(), store->getRowKeyColumnSize())},
+            /* num_streams= */ 1,
+            /* max_version= */ std::numeric_limits<UInt64>::max(),
+            EMPTY_FILTER,
+            std::vector<RuntimeFilterPtr>{},
+            /* rf_max_wait_time_ms= */ 0,
+            TRACING_NAME,
+            /* keep_order= */ false,
+            /* is_fast_scan= */ false,
+            DEFAULT_BLOCK_SIZE)[0];
+        std::unordered_map<Int64, UInt64> data;
+        for (;;)
+        {
+            auto block = stream->read();
+            if (!block)
+            {
+                break;
+            }
+            const auto & handle = *toColumnVectorDataPtr<Int64>(block.getByName(EXTRA_HANDLE_COLUMN_NAME).column);
+            const auto & value = *toColumnVectorDataPtr<UInt64>(block.getByName(value_col_name).column);
+            for (size_t i = 0; i < block.rows(); i++)
+            {
+                data[handle[i]] = value[i];
+            }
+        }
+        return data;
+    };
+
+    std::unordered_map<Int64, UInt64> expect_result;
+
+    auto update_expect_result = [&](Int64 beg, Int64 end, UInt64 value) {
+        for (auto i = beg; i < end; i++)
+        {
+            expect_result[i] = value;
+        }
+    };
+
+    auto verify = [&](bool flush) {
+        if (flush)
+        {
+            store->flushCache(*db_context, RowKeyRange::newAll(store->isCommonHandle(), store->getRowKeyColumnSize()));
+        }
+        auto handle_to_value = read_all_data();
+        ASSERT_EQ(handle_to_value.size(), expect_result.size());
+        for (const auto & [handle, value] : handle_to_value)
+        {
+            auto itr = expect_result.find(handle);
+            ASSERT_NE(itr, expect_result.end());
+            ASSERT_EQ(value, itr->second);
+        }
+    };
+
+    auto create_dmfile = [&](UInt64 beg, UInt64 end, UInt64 value) {
+        auto dm_context = store->newDMContext(*db_context, db_context->getSettingsRef());
+        return genDMFile(*dm_context, create_block(beg, end, value));
+    };
+
+    // Write [0, 128) with value 1
+    {
+        auto block = create_block(0, 128, 1);
+        store->write(*db_context, db_context->getSettingsRef(), block);
+        update_expect_result(0, 128, 1);
+        verify(false);
+        verify(true);
+    }
+
+    // Write [0, 1) with value 2
+    {
+        auto block = create_block(0, 1, 2);
+        store->write(*db_context, db_context->getSettingsRef(), block);
+        update_expect_result(0, 1, 2);
+        verify(false);
+        verify(true);
+    }
+
+    // Write [127, 128) with value 3
+    {
+        auto block = create_block(127, 128, 3);
+        store->write(*db_context, db_context->getSettingsRef(), block);
+        update_expect_result(127, 128, 3);
+        verify(false);
+        verify(true);
+    }
+
+    // Write [64, 65) with value 4
+    {
+        auto block = create_block(64, 65, 4);
+        store->write(*db_context, db_context->getSettingsRef(), block);
+        update_expect_result(64, 65, 4);
+        verify(false);
+        verify(true);
+    }
+
+    // Write [0, 128) with value 5
+    {
+        auto block = create_block(0, 128, 5);
+        store->write(*db_context, db_context->getSettingsRef(), block);
+        update_expect_result(0, 128, 5);
+        verify(false);
+        verify(true);
+    }
+
+    {
+        auto r = store->mergeDeltaAll(*db_context);
+        ASSERT_TRUE(r);
+        verify(false);
+    }
+
+    // Ingest [0, 64) with value 6
+    {
+        auto [range, dmfiles] = create_dmfile(0, 64, 6);
+        auto dm_context = store->newDMContext(*db_context, db_context->getSettingsRef());
+        store->ingestFiles(dm_context, range, dmfiles, /*clear_data_in_range*/ true);
+        update_expect_result(0, 64, 6);
+        verify(false);
+    }
+
+    // Ingest [32, 64) with value 7
+    {
+        auto [range, dmfiles] = create_dmfile(32, 64, 7);
+        auto dm_context = store->newDMContext(*db_context, db_context->getSettingsRef());
+        store->ingestFiles(dm_context, range, dmfiles, /*clear_data_in_range*/ true);
+        update_expect_result(32, 64, 7);
+        verify(false);
+    }
+
+    // Ingest [48, 96) with value 8
+    {
+        auto [range, dmfiles] = create_dmfile(48, 96, 8);
+        auto dm_context = store->newDMContext(*db_context, db_context->getSettingsRef());
+        store->ingestFiles(dm_context, range, dmfiles, /*clear_data_in_range*/ true);
+        update_expect_result(48, 96, 8);
+        verify(false);
+    }
+
+    // Ingest [30, 60) with value 9 and Ingest [40, 90) with value 10
+    {
+        auto [range1, dmfiles1] = create_dmfile(30, 60, 9);
+        auto dm_context = store->newDMContext(*db_context, db_context->getSettingsRef());
+        store->ingestFiles(dm_context, range1, dmfiles1, /*clear_data_in_range*/ true);
+        update_expect_result(30, 60, 9);
+
+        auto [range2, dmfiles2] = create_dmfile(40, 90, 10);
+        store->ingestFiles(dm_context, range2, dmfiles2, /*clear_data_in_range*/ true);
+        update_expect_result(40, 90, 10);
+
+        verify(false);
+    }
+
+    {
+        auto r = store->mergeDeltaAll(*db_context);
+        ASSERT_TRUE(r);
+        verify(false);
+    }
+}
+CATCH
 
 TEST_P(DeltaMergeStoreRWTest, Split)
 try


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #8736 

### What is changed and how it works?

Verifing DeltaIndex will use new records to overwrite old records for records with the same key and commit_ts.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
