### PR TITLE
Storages: Refine comparator of row key to operator<=>

### DIFF
--- a/dbms/src/Storages/DeltaMerge/DMVersionFilterBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/DMVersionFilterBlockInputStream.cpp
@@ -107,10 +107,8 @@ Block DMVersionFilterBlockInputStream<MODE>::read(FilterPtr & res_filter, bool r
                 size_t next_handle_pos = handle_pos + 1;
                 for (size_t i = 0; i < batch_rows; ++i)
                 {
-                    (*filter_pos) |= compare(
-                                         rowkey_column->getRowKeyValue(handle_pos),
-                                         rowkey_column->getRowKeyValue(next_handle_pos))
-                        != 0;
+                    (*filter_pos)
+                        |= rowkey_column->getRowKeyValue(handle_pos) != rowkey_column->getRowKeyValue(next_handle_pos);
                     ++filter_pos;
                     ++handle_pos;
                     ++next_handle_pos;
@@ -151,10 +149,8 @@ Block DMVersionFilterBlockInputStream<MODE>::read(FilterPtr & res_filter, bool r
                 size_t next_handle_pos = handle_pos + 1;
                 for (size_t i = 0; i < batch_rows; ++i)
                 {
-                    (*filter_pos) = compare(
-                                        rowkey_column->getRowKeyValue(handle_pos),
-                                        rowkey_column->getRowKeyValue(next_handle_pos))
-                        != 0;
+                    (*filter_pos)
+                        = rowkey_column->getRowKeyValue(handle_pos) != rowkey_column->getRowKeyValue(next_handle_pos);
                     ++filter_pos;
                     ++handle_pos;
                     ++next_handle_pos;
@@ -207,10 +203,8 @@ Block DMVersionFilterBlockInputStream<MODE>::read(FilterPtr & res_filter, bool r
                 size_t next_handle_pos = handle_pos + 1;
                 for (size_t i = 0; i < batch_rows; ++i)
                 {
-                    (*effective_pos) = compare(
-                                           rowkey_column->getRowKeyValue(handle_pos),
-                                           rowkey_column->getRowKeyValue(next_handle_pos))
-                        != 0;
+                    (*effective_pos)
+                        = rowkey_column->getRowKeyValue(handle_pos) != rowkey_column->getRowKeyValue(next_handle_pos);
                     ++effective_pos;
                     ++handle_pos;
                     ++next_handle_pos;
@@ -238,10 +232,8 @@ Block DMVersionFilterBlockInputStream<MODE>::read(FilterPtr & res_filter, bool r
                 size_t next_handle_pos = handle_pos + 1;
                 for (size_t i = 0; i < batch_rows; ++i)
                 {
-                    (*not_clean_pos) = compare(
-                                           rowkey_column->getRowKeyValue(handle_pos),
-                                           rowkey_column->getRowKeyValue(next_handle_pos))
-                        == 0;
+                    (*not_clean_pos)
+                        = rowkey_column->getRowKeyValue(handle_pos) == rowkey_column->getRowKeyValue(next_handle_pos);
                     ++not_clean_pos;
                     ++handle_pos;
                     ++next_handle_pos;
@@ -372,15 +364,15 @@ Block DMVersionFilterBlockInputStream<MODE>::read(FilterPtr & res_filter, bool r
                 if constexpr (MODE == DM_VERSION_FILTER_MODE_MVCC)
                 {
                     filter[rows - 1] = !deleted && cur_version <= version_limit
-                        && (compare(cur_handle, next_handle) != 0 || next_version > version_limit);
+                        && (cur_handle != next_handle || next_version > version_limit);
                 }
                 else if (MODE == DM_VERSION_FILTER_MODE_COMPACT)
                 {
                     filter[rows - 1] = cur_version >= version_limit
-                        || ((compare(cur_handle, next_handle) != 0 || next_version > version_limit) && !deleted);
-                    not_clean[rows - 1] = filter[rows - 1] && (compare(cur_handle, next_handle) == 0 || deleted);
+                        || ((cur_handle != next_handle || next_version > version_limit) && !deleted);
+                    not_clean[rows - 1] = filter[rows - 1] && (cur_handle == next_handle || deleted);
                     is_deleted[rows - 1] = filter[rows - 1] && deleted;
-                    effective[rows - 1] = filter[rows - 1] && (compare(cur_handle, next_handle) != 0);
+                    effective[rows - 1] = filter[rows - 1] && (cur_handle != next_handle);
                     if (filter[rows - 1])
                         gc_hint_version = std::min(
                             gc_hint_version,

--- a/dbms/src/Storages/DeltaMerge/DMVersionFilterBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/DMVersionFilterBlockInputStream.h
@@ -116,15 +116,15 @@ private:
         if constexpr (MODE == DM_VERSION_FILTER_MODE_MVCC)
         {
             filter[i] = !deleted && cur_version <= version_limit
-                && (compare(cur_handle, next_handle) != 0 || next_version > version_limit);
+                && (cur_handle != next_handle || next_version > version_limit);
         }
         else if constexpr (MODE == DM_VERSION_FILTER_MODE_COMPACT)
         {
             filter[i] = cur_version >= version_limit
-                || ((compare(cur_handle, next_handle) != 0 || next_version > version_limit) && !deleted);
-            not_clean[i] = filter[i] && (compare(cur_handle, next_handle) == 0 || deleted);
+                || ((cur_handle != next_handle || next_version > version_limit) && !deleted);
+            not_clean[i] = filter[i] && (cur_handle == next_handle || deleted);
             is_deleted[i] = filter[i] && deleted;
-            effective[i] = filter[i] && (compare(cur_handle, next_handle) != 0);
+            effective[i] = filter[i] && (cur_handle != next_handle);
             if (filter[i])
                 gc_hint_version = std::min(
                     gc_hint_version,
@@ -190,12 +190,12 @@ private:
         // update status variable for next row if need
         if (next_handle_valid)
         {
-            if (compare(cur_handle, next_handle) != 0)
+            if (cur_handle != next_handle)
             {
                 is_first_oldest_version = true;
                 is_second_oldest_version = false;
             }
-            else if (is_first_oldest_version && (compare(cur_handle, next_handle) == 0))
+            else if (is_first_oldest_version && cur_handle == next_handle)
             {
                 is_first_oldest_version = false;
                 is_second_oldest_version = true;

--- a/dbms/src/Storages/DeltaMerge/Decode/SSTFilesToDTFilesOutputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/Decode/SSTFilesToDTFilesOutputStream.cpp
@@ -395,7 +395,7 @@ void SSTFilesToDTFilesOutputStream<ChildStream>::updateRangeFromNonEmptyBlock(Bl
 
     // Note: The underlying stream ensures that one row key will not fall into two blocks (when there are multiple versions).
     // So we will never have overlapped range.
-    RUNTIME_CHECK(compare(block_start, block_end.toRowKeyValueRef()) < 0);
+    RUNTIME_CHECK(block_start < block_end.toRowKeyValueRef());
 
     if (!current_file_range.has_value())
     {
@@ -407,7 +407,7 @@ void SSTFilesToDTFilesOutputStream<ChildStream>::updateRangeFromNonEmptyBlock(Bl
     }
     else
     {
-        RUNTIME_CHECK(compare(block_start, current_file_range->getStart()) > 0);
+        RUNTIME_CHECK(block_start > current_file_range->getStart());
         current_file_range->setEnd(block_end);
     }
     RUNTIME_CHECK(!current_file_range->none());

--- a/dbms/src/Storages/DeltaMerge/DeltaMerge.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaMerge.h
@@ -230,8 +230,9 @@ private:
             {
                 auto rowkey_value = rowkey_column.getRowKeyValue(i);
                 auto version = version_column[i];
-                int cmp_result = rowkey_value <=> last_value_ref;
-                if (cmp_result < 0 || (cmp_result == 0 && version < last_version))
+                auto cmp_result = rowkey_value <=> last_value_ref;
+                if (cmp_result == std::strong_ordering::less
+                    || (cmp_result == std::strong_ordering::equal && version < last_version))
                 {
                     ProfileEvents::increment(ProfileEvents::DTDeltaIndexError);
                     LOG_ERROR(

--- a/dbms/src/Storages/DeltaMerge/DeltaMerge.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaMerge.h
@@ -230,7 +230,7 @@ private:
             {
                 auto rowkey_value = rowkey_column.getRowKeyValue(i);
                 auto version = version_column[i];
-                int cmp_result = compare(rowkey_value, last_value_ref);
+                int cmp_result = rowkey_value <=> last_value_ref;
                 if (cmp_result < 0 || (cmp_result == 0 && version < last_version))
                 {
                     ProfileEvents::increment(ProfileEvents::DTDeltaIndexError);

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -1810,7 +1810,7 @@ void DeltaMergeStore::check(const Context & /*db_context*/)
 
             throw Exception(fmt::format("Segment [{}] is expected to have id [{}]", segment_id, next_segment_id));
         }
-        if (compare(last_end.data, last_end.size, range.getStart().data, range.getStart().size) != 0)
+        if (last_end != range.getStart())
             throw Exception(fmt::format(
                 "Segment [{}:{}] is expected to have the same start edge value like the end edge value in {}",
                 segment_id,

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_Ingest.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore_Ingest.cpp
@@ -285,7 +285,7 @@ Segments DeltaMergeStore::ingestDTFilesUsingSplit(
             if (succeeded)
             {
                 updated_segments.insert(segment);
-                RUNTIME_CHECK(compare(delete_range.getEnd(), remaining_delete_range.getStart()) >= 0);
+                RUNTIME_CHECK(delete_range.getEnd() >= remaining_delete_range.getStart());
                 remaining_delete_range.setStart(delete_range.end); // We always move forward
             }
             else
@@ -402,7 +402,7 @@ Segments DeltaMergeStore::ingestDTFilesUsingSplit(
             {
                 updated_segments.insert(segment);
                 // We have ingested (DTFileRange ∪ ThisSegmentRange), let's try with next overlapped segment.
-                RUNTIME_CHECK(compare(segment_ingest_range.getEnd(), file_ingest_range.getStart()) > 0);
+                RUNTIME_CHECK(segment_ingest_range.getEnd() > file_ingest_range.getStart());
                 file_ingest_range.setStart(segment_ingest_range.end);
             }
             else
@@ -436,16 +436,16 @@ bool DeltaMergeStore::ingestDTFileIntoSegmentUsingSplit(
     // The ingest_range must fall in segment's range.
     RUNTIME_CHECK(!ingest_range.none(), ingest_range.toDebugString());
     RUNTIME_CHECK(
-        compare(segment_range.getStart(), ingest_range.getStart()) <= 0,
+        segment_range.getStart() <= ingest_range.getStart(),
         segment_range.toDebugString(),
         ingest_range.toDebugString());
     RUNTIME_CHECK(
-        compare(segment_range.getEnd(), ingest_range.getEnd()) >= 0,
+        segment_range.getEnd() >= ingest_range.getEnd(),
         segment_range.toDebugString(),
         ingest_range.toDebugString());
 
-    const bool is_start_matching = (compare(segment_range.getStart(), ingest_range.getStart()) == 0);
-    const bool is_end_matching = (compare(segment_range.getEnd(), ingest_range.getEnd()) == 0);
+    const bool is_start_matching = segment_range.getStart() == ingest_range.getStart();
+    const bool is_end_matching = segment_range.getEnd() == ingest_range.getEnd();
 
     if (is_start_matching && is_end_matching)
     {
@@ -605,7 +605,7 @@ UInt64 DeltaMergeStore::ingestFiles(
         {
             RUNTIME_CHECK(!ext_file.range.none(), ext_file.toString());
             RUNTIME_CHECK(
-                compare(last_end.toRowKeyValueRef(), ext_file.range.getStart()) <= 0,
+                last_end.toRowKeyValueRef() <= ext_file.range.getStart(),
                 last_end.toDebugString(),
                 ext_file.toString());
             last_end = ext_file.range.end;
@@ -617,8 +617,7 @@ UInt64 DeltaMergeStore::ingestFiles(
             for (const auto & ext_file : external_files)
             {
                 RUNTIME_CHECK_MSG(
-                    compare(range.getStart(), ext_file.range.getStart()) <= 0
-                        && compare(range.getEnd(), ext_file.range.getEnd()) >= 0,
+                    range.getStart() <= ext_file.range.getStart() && range.getEnd() >= ext_file.range.getEnd(),
                     "Detected illegal region boundary: range={} file_range={} keyspace={} table_id={}. "
                     "TiFlash will exit to prevent data inconsistency. "
                     "If you accept data inconsistency and want to continue the service, "
@@ -877,7 +876,7 @@ std::vector<SegmentPtr> DeltaMergeStore::ingestSegmentsUsingSplit(
             if (succeeded)
             {
                 updated_segments.insert(segment);
-                RUNTIME_CHECK(compare(delete_range.getEnd(), remaining_delete_range.getStart()) >= 0);
+                RUNTIME_CHECK(delete_range.getEnd() >= remaining_delete_range.getStart());
                 remaining_delete_range.setStart(delete_range.end); // We always move forward
             }
             else
@@ -986,7 +985,7 @@ std::vector<SegmentPtr> DeltaMergeStore::ingestSegmentsUsingSplit(
             {
                 updated_segments.insert(segment);
                 // We have ingested (DTFileRange ∪ ThisSegmentRange), let's try with next overlapped segment.
-                RUNTIME_CHECK(compare(segment_ingest_range.getEnd(), file_ingest_range.getStart()) > 0);
+                RUNTIME_CHECK(segment_ingest_range.getEnd() > file_ingest_range.getStart());
                 file_ingest_range.setStart(segment_ingest_range.end);
             }
             else
@@ -1016,16 +1015,16 @@ bool DeltaMergeStore::ingestSegmentDataIntoSegmentUsingSplit(
     // The ingest_range must fall in segment's range.
     RUNTIME_CHECK(!ingest_range.none(), ingest_range.toDebugString());
     RUNTIME_CHECK(
-        compare(segment_range.getStart(), ingest_range.getStart()) <= 0,
+        segment_range.getStart() <= ingest_range.getStart(),
         segment_range.toDebugString(),
         ingest_range.toDebugString());
     RUNTIME_CHECK(
-        compare(segment_range.getEnd(), ingest_range.getEnd()) >= 0,
+        segment_range.getEnd() >= ingest_range.getEnd(),
         segment_range.toDebugString(),
         ingest_range.toDebugString());
 
-    const bool is_start_matching = (compare(segment_range.getStart(), ingest_range.getStart()) == 0);
-    const bool is_end_matching = (compare(segment_range.getEnd(), ingest_range.getEnd()) == 0);
+    const bool is_start_matching = segment_range.getStart() == ingest_range.getStart();
+    const bool is_end_matching = segment_range.getEnd() == ingest_range.getEnd();
 
     if (is_start_matching && is_end_matching)
     {

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalSegment.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalSegment.cpp
@@ -597,7 +597,7 @@ SegmentPtr DeltaMergeStore::segmentIngestData(
             new_segment = apply_result;
 
             RUNTIME_CHECK(
-                compare(segment->getRowKeyRange().getEnd(), new_segment->getRowKeyRange().getEnd()) == 0,
+                segment->getRowKeyRange().getEnd() == new_segment->getRowKeyRange().getEnd(),
                 segment->info(),
                 new_segment->info());
             RUNTIME_CHECK(segment->segmentId() == new_segment->segmentId(), segment->info(), new_segment->info());
@@ -672,7 +672,7 @@ SegmentPtr DeltaMergeStore::segmentDangerouslyReplaceDataFromCheckpoint(
             column_file_persisteds);
 
         RUNTIME_CHECK(
-            compare(segment->getRowKeyRange().getEnd(), new_segment->getRowKeyRange().getEnd()) == 0,
+            segment->getRowKeyRange().getEnd() == new_segment->getRowKeyRange().getEnd(),
             segment->info(),
             new_segment->info());
         RUNTIME_CHECK(segment->segmentId() == new_segment->segmentId(), segment->info(), new_segment->info());

--- a/dbms/src/Storages/DeltaMerge/PKSquashingBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/PKSquashingBlockInputStream.h
@@ -151,7 +151,7 @@ private:
         for (/* */; cut_offset < next_col->size(); ++cut_offset)
         {
             const auto next_pk = next_rowkey_column.getRowKeyValue(cut_offset);
-            if (compare(next_pk, last_curr_pk) != 0)
+            if (next_pk != last_curr_pk)
             {
                 if constexpr (DM_RUN_CHECK)
                 {

--- a/dbms/src/Storages/DeltaMerge/RowKeyRange.h
+++ b/dbms/src/Storages/DeltaMerge/RowKeyRange.h
@@ -326,7 +326,7 @@ inline auto operator<=>(const RowKeyValue & a, const RowKeyValue & b)
 
 inline bool operator==(const RowKeyValue & a, const RowKeyValue & b)
 {
-    return (a <=> b) == std::strong_ordering::equal;
+    return a.is_common_handle == b.is_common_handle && (*a.value) == (*b.value) && a.int_value == b.int_value;
 }
 
 struct RowKeyColumnContainer

--- a/dbms/src/Storages/DeltaMerge/RowKeyRange.h
+++ b/dbms/src/Storages/DeltaMerge/RowKeyRange.h
@@ -316,9 +316,12 @@ inline bool operator!=(const RowKeyValueRef & a, const RowKeyValueRef & b)
     return (a <=> b) != std::strong_ordering::equal;
 }
 
-inline std::strong_ordering operator<=>(const RowKeyValue & a, const RowKeyValue & b)
+// For compare `RowKeyValue`, do not use operator<=> of `RowKeyValueRef`.
+// Because `is_common_handle` of `a` and `b` may not match.
+inline auto operator<=>(const RowKeyValue & a, const RowKeyValue & b)
 {
-    return a.toRowKeyValueRef() <=> b.toRowKeyValueRef();
+    // Seems std::string::operator<=> is not support in clang-15.
+    return compare(a.value->data(), a.value->size(), b.value->data(), b.value->size());
 }
 
 inline bool operator==(const RowKeyValue & a, const RowKeyValue & b)

--- a/dbms/src/Storages/DeltaMerge/Segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/Segment.cpp
@@ -766,10 +766,7 @@ SegmentPtr Segment::ingestDataForTest(DMContext & dm_context, const DMFilePtr & 
     auto new_segment = applyIngestData(segment_lock, dm_context, data_file, ii);
     if (new_segment.get() != this)
     {
-        RUNTIME_CHECK(
-            compare(getRowKeyRange().getEnd(), new_segment->getRowKeyRange().getEnd()) == 0,
-            info(),
-            new_segment->info());
+        RUNTIME_CHECK(getRowKeyRange().getEnd() == new_segment->getRowKeyRange().getEnd(), info(), new_segment->info());
         RUNTIME_CHECK(segmentId() == new_segment->segmentId(), info(), new_segment->info());
     }
 
@@ -1630,8 +1627,7 @@ std::optional<RowKeyValue> Segment::getSplitPointSlow(
 
 bool isSplitPointValid(const RowKeyRange & segment_range, const RowKeyValueRef & split_point)
 {
-    return segment_range.check(split_point) && //
-        compare(split_point, segment_range.getStart()) != 0;
+    return segment_range.check(split_point) && split_point != segment_range.getStart();
 }
 
 std::optional<Segment::SplitInfo> Segment::prepareSplit(
@@ -2077,7 +2073,7 @@ StableValueSpacePtr Segment::prepareMerge(
     for (size_t i = 1; i < ordered_segments.size(); i++)
     {
         RUNTIME_CHECK(
-            compare(ordered_segments[i - 1]->rowkey_range.getEnd(), ordered_segments[i]->rowkey_range.getStart()) == 0,
+            ordered_segments[i - 1]->rowkey_range.getEnd() == ordered_segments[i]->rowkey_range.getStart(),
             i,
             ordered_segments[i - 1]->info(),
             ordered_segments[i]->info());
@@ -2644,7 +2640,7 @@ bool Segment::placeUpsert(
     RowKeyValueRef range_start = relevant_range.getStart();
 
     auto place_handle_range = skippable_place
-        ? RowKeyRange::startFrom(max(first_rowkey, range_start), is_common_handle, rowkey_column_size)
+        ? RowKeyRange::startFrom(std::max(first_rowkey, range_start), is_common_handle, rowkey_column_size)
         : RowKeyRange::newAll(is_common_handle, rowkey_column_size);
 
     auto compacted_index = update_delta_tree.getCompactedEntries();

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_simple_pk_test_basic.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_simple_pk_test_basic.cpp
@@ -92,7 +92,7 @@ void SimplePKTestBasic::ensureSegmentBreakpoints(const std::vector<Int64> & brea
         {
             auto [segment, is_empty] = store->getSegmentByStartKey(bp_key.toRowKeyValueRef(), true, true);
             // The segment is already break at the boundary
-            if (compare(segment->getRowKeyRange().getStart(), bp_key.toRowKeyValueRef()) == 0)
+            if (segment->getRowKeyRange().getStart() == bp_key.toRowKeyValueRef())
                 break;
             auto split_mode = use_logical_split ? DeltaMergeStore::SegmentSplitMode::Logical
                                                 : DeltaMergeStore::SegmentSplitMode::Physical;

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_key_range.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_key_range.cpp
@@ -107,7 +107,7 @@ TEST(RowKey, ToNextKeyIntHandle)
 
     {
         const auto expected_next_int = RowKeyValue::fromHandle(21);
-        EXPECT_EQ(0, compare(next.toRowKeyValueRef(), expected_next_int.toRowKeyValueRef()));
+        EXPECT_EQ(next.toRowKeyValueRef(), expected_next_int.toRowKeyValueRef());
     }
     {
         const auto range_keys
@@ -117,7 +117,7 @@ TEST(RowKey, ToNextKeyIntHandle)
             /* table_id */ 1,
             /* is_common_handle */ false,
             /* row_key_column_size */ 1);
-        EXPECT_EQ(0, compare(next.toRowKeyValueRef(), range.getEnd()));
+        EXPECT_EQ(next.toRowKeyValueRef(), range.getEnd());
     }
     // Note: {20,00} will be regarded as Key=21 in RowKeyRange::fromRegionRange.
     {
@@ -131,7 +131,7 @@ TEST(RowKey, ToNextKeyIntHandle)
             /* table_id */ 1,
             /* is_common_handle */ false,
             /* row_key_column_size */ 1);
-        EXPECT_EQ(0, compare(next.toRowKeyValueRef(), range.getEnd()));
+        EXPECT_EQ(next.toRowKeyValueRef(), range.getEnd());
     }
 }
 
@@ -144,7 +144,7 @@ TEST(RowKey, ToNextKeyCommonHandle)
     EXPECT_EQ("CCAB00", next.toDebugString());
 
     const auto my_next = RowKeyValue(/* is_common_handle */ true, std::make_shared<String>("\xcc\xab\x00"s), 0);
-    EXPECT_EQ(0, compare(my_next.toRowKeyValueRef(), next.toRowKeyValueRef()));
+    EXPECT_EQ(my_next.toRowKeyValueRef(), next.toRowKeyValueRef());
 }
 
 TEST(RowKey, NextIntHandleCompare)
@@ -152,17 +152,17 @@ TEST(RowKey, NextIntHandleCompare)
     auto int_max = RowKeyValue::INT_HANDLE_MAX_KEY;
     auto int_max_i64 = RowKeyValue::fromHandle(Handle(std::numeric_limits<HandleID>::max()));
 
-    EXPECT_EQ(1, compare(int_max.toRowKeyValueRef(), int_max_i64.toRowKeyValueRef()));
+    EXPECT_GT(int_max.toRowKeyValueRef(), int_max_i64.toRowKeyValueRef());
 
     auto int_max_i64_pnext = int_max_i64.toPrefixNext();
     EXPECT_EQ(int_max, int_max_i64_pnext);
-    EXPECT_EQ(0, compare(int_max.toRowKeyValueRef(), int_max_i64_pnext.toRowKeyValueRef()));
-    EXPECT_EQ(0, compare(int_max_i64_pnext.toRowKeyValueRef(), int_max.toRowKeyValueRef()));
+    EXPECT_EQ(int_max.toRowKeyValueRef(), int_max_i64_pnext.toRowKeyValueRef());
+    EXPECT_EQ(int_max_i64_pnext.toRowKeyValueRef(), int_max.toRowKeyValueRef());
 
     auto int_max_i64_next = int_max_i64.toNext();
     EXPECT_EQ(int_max, int_max_i64_next);
-    EXPECT_EQ(0, compare(int_max.toRowKeyValueRef(), int_max_i64_next.toRowKeyValueRef()));
-    EXPECT_EQ(0, compare(int_max_i64_next.toRowKeyValueRef(), int_max.toRowKeyValueRef()));
+    EXPECT_EQ(int_max.toRowKeyValueRef(), int_max_i64_next.toRowKeyValueRef());
+    EXPECT_EQ(int_max_i64_next.toRowKeyValueRef(), int_max.toRowKeyValueRef());
 }
 
 TEST(RowKey, NextIntHandleMinMax)
@@ -171,11 +171,11 @@ TEST(RowKey, NextIntHandleMinMax)
     auto v0_next = v0.toNext();
     auto v1 = RowKeyValue::fromHandle(Handle(1178401));
 
-    EXPECT_EQ(v0, min(v0, v1));
-    EXPECT_EQ(v0, min(v0, v0_next));
+    EXPECT_EQ(v0, std::min(v0, v1));
+    EXPECT_EQ(v0, std::min(v0, v0_next));
 
-    EXPECT_EQ(v1, max(v0, v1));
-    EXPECT_EQ(v1, max(v0, v0_next));
+    EXPECT_EQ(v1, std::max(v0, v1));
+    EXPECT_EQ(v1, std::max(v0, v0_next));
 }
 
 } // namespace tests

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_test_randomized.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_test_randomized.cpp
@@ -383,7 +383,7 @@ protected:
                 auto next_segment = segments[next_segment_id];
                 RUNTIME_CHECK(next_segment->segmentId() == next_segment_id, next_segment->info(), next_segment_id);
                 RUNTIME_CHECK(
-                    compare(last_segment->getRowKeyRange().getEnd(), next_segment->getRowKeyRange().getStart()) == 0,
+                    last_segment->getRowKeyRange().getEnd() == next_segment->getRowKeyRange().getStart(),
                     last_segment->info(),
                     next_segment->info());
                 segments_id.push_back(next_segment_id);

--- a/dbms/src/Storages/KVStore/MultiRaft/Disagg/FastAddPeerCache.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/Disagg/FastAddPeerCache.cpp
@@ -57,7 +57,7 @@ UInt64 EndToSegmentId::getSegmentIdContainingKey(std::unique_lock<std::mutex> & 
         end_to_segment_id.end(),
         key,
         [](const DM::RowKeyValue & key1, const std::pair<DM::RowKeyValue, UInt64> & element2) {
-            return compare(key1.toRowKeyValueRef(), element2.first.toRowKeyValueRef()) < 0;
+            return key1.toRowKeyValueRef() < element2.first.toRowKeyValueRef();
         });
     RUNTIME_CHECK(
         iter != end_to_segment_id.end(),


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6233

### What is changed and how it works?

- Updating the comparsion code of RowKeyValueRef/RowKeyValue with operators that makes code more readable. 
- Rename comparator of `RowKeyValueRef` from `compare` to `operator<=>`, so that we can use operators >, <, >=, <= directly.
- Simply wrap `operator==` and `operator!=` with `operator<=>` because complier does not generate these functions when `operator<=>` if not default.
- Remove some unused overload operators.
- Refine comparator of `RowKeyValue`. Make it use the same comparator with `RowKeyValueRef`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
