### PR TITLE
Fix decimal to real asan stack-use-after-scope error

### DIFF
--- a/dbms/src/Functions/FunctionsTiDBConversion.h
+++ b/dbms/src/Functions/FunctionsTiDBConversion.h
@@ -774,7 +774,7 @@ struct TiDBConvertToFloat
 
             for (size_t i = 0; i < size; ++i)
             {
-		auto raw_field = (*col_from)[i];
+                auto raw_field = (*col_from)[i];
                 const auto & field = raw_field.template safeGet<DecimalField<FromFieldType>>();
                 vec_to[i] = toFloat(field);
             }

--- a/dbms/src/Functions/FunctionsTiDBConversion.h
+++ b/dbms/src/Functions/FunctionsTiDBConversion.h
@@ -744,6 +744,7 @@ struct TiDBConvertToFloat
         return produceTargetFloat64(f, need_truncate, shift, max_f, context);
     }
 
+    NO_SANITIZE_ADDRESS	    
     static void execute(
         Block & block,
         const ColumnNumbers & arguments,
@@ -774,7 +775,7 @@ struct TiDBConvertToFloat
 
             for (size_t i = 0; i < size; ++i)
             {
-                auto & field = (*col_from)[i].template safeGet<DecimalField<FromFieldType>>();
+                const auto & field = (*col_from)[i].template safeGet<DecimalField<FromFieldType>>();
                 vec_to[i] = toFloat(field);
             }
         }

--- a/dbms/src/Functions/FunctionsTiDBConversion.h
+++ b/dbms/src/Functions/FunctionsTiDBConversion.h
@@ -744,7 +744,6 @@ struct TiDBConvertToFloat
         return produceTargetFloat64(f, need_truncate, shift, max_f, context);
     }
 
-    NO_SANITIZE_ADDRESS	    
     static void execute(
         Block & block,
         const ColumnNumbers & arguments,
@@ -775,7 +774,8 @@ struct TiDBConvertToFloat
 
             for (size_t i = 0; i < size; ++i)
             {
-                const auto & field = (*col_from)[i].template safeGet<DecimalField<FromFieldType>>();
+		auto raw_field = (*col_from)[i];
+                const auto & field = raw_field.template safeGet<DecimalField<FromFieldType>>();
                 vec_to[i] = toFloat(field);
             }
         }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #8285

Problem Summary:
https://github.com/pingcap/tiflash/blob/82a13c4da1a93ef872e553ff31ab140916c79a78/dbms/src/Functions/FunctionsTiDBConversion.h#L777C1-L778C44
The local variable field is a reference to temporary object col_from[i], and its scope is limited to that statement. It's suspicious here. 
Asan error:
https://github.com/pingcap/tiflash/issues/8285#issuecomment-1958520854

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
