### PR TITLE
ddl: Fix database drop by accident when meet `regenerate_schema_map` flag

### DIFF
--- a/dbms/src/Debug/DBGInvoker.cpp
+++ b/dbms/src/Debug/DBGInvoker.cpp
@@ -91,6 +91,7 @@ DBGInvoker::DBGInvoker()
     regSchemalessFunc("refresh_table_schema", dbgFuncRefreshTableSchema);
     regSchemalessFunc("refresh_mapped_table_schema", dbgFuncRefreshMappedTableSchema);
     regSchemalessFunc("skip_schema_version", dbgFuncSkipSchemaVersion);
+    regSchemalessFunc("regenerate_schema_map", dbgFuncRegrenationSchemaMap);
 
     regSchemalessFunc("region_split", MockRaftCommand::dbgFuncRegionBatchSplit);
     regSchemalessFunc("region_prepare_merge", MockRaftCommand::dbgFuncPrepareMerge);

--- a/dbms/src/Debug/MockTiDB.cpp
+++ b/dbms/src/Debug/MockTiDB.cpp
@@ -743,6 +743,18 @@ void MockTiDB::truncateTable(const String & database_name, const String & table_
     version_diff[version] = diff;
 }
 
+Int64 MockTiDB::regenerateSchemaMap()
+{
+    std::lock_guard lock(tables_mutex);
+
+    SchemaDiff diff;
+    diff.regenerate_schema_map = true;
+    diff.version = version + 1;
+    version++;
+    version_diff[version] = diff;
+    return version;
+}
+
 TablePtr MockTiDB::getTableByName(const String & database_name, const String & table_name)
 {
     std::lock_guard lock(tables_mutex);

--- a/dbms/src/Debug/MockTiDB.cpp
+++ b/dbms/src/Debug/MockTiDB.cpp
@@ -748,6 +748,7 @@ Int64 MockTiDB::regenerateSchemaMap()
     std::lock_guard lock(tables_mutex);
 
     SchemaDiff diff;
+    diff.type = SchemaActionType::None;
     diff.regenerate_schema_map = true;
     diff.version = version + 1;
     version++;

--- a/dbms/src/Debug/MockTiDB.h
+++ b/dbms/src/Debug/MockTiDB.h
@@ -144,6 +144,8 @@ public:
     // Return the schema_version with empty SchemaDiff
     Int64 skipSchemaVersion() { return ++version; }
 
+    Int64 regenerateSchemaMap();
+
     TablePtr getTableByName(const String & database_name, const String & table_name);
 
     TiDB::TableInfoPtr getTableInfoByID(TableID table_id);

--- a/dbms/src/Debug/dbgFuncSchema.cpp
+++ b/dbms/src/Debug/dbgFuncSchema.cpp
@@ -242,4 +242,16 @@ void dbgFuncSkipSchemaVersion(Context &, const ASTs &, DBGInvoker::Printer outpu
     output(fmt::format("Generate an empty schema diff with schema_version={}", empty_schema_version));
 }
 
+void dbgFuncRegrenationSchemaMap(Context &, const ASTs &, DBGInvoker::Printer output)
+{
+    auto regen_schema_version = MockTiDB::instance().regenerateSchemaMap();
+    LOG_WARNING(
+        Logger::get(),
+        "Generate a schema diff with regenerate_schema_map == true, schema_version={}",
+        regen_schema_version);
+    output(fmt::format(
+        "Generate a empty schema diff with regenerate_schema_map == true, schema_version={}",
+        regen_schema_version));
+}
+
 } // namespace DB

--- a/dbms/src/Debug/dbgFuncSchema.h
+++ b/dbms/src/Debug/dbgFuncSchema.h
@@ -62,4 +62,9 @@ void dbgFuncIsTombstone(Context & context, const ASTs & args, DBGInvoker::Printe
 // Usage:
 //   ./storage-client.sh "DBGInvoke skip_schema_version()"
 void dbgFuncSkipSchemaVersion(Context & context, const ASTs & args, DBGInvoker::Printer output);
+
+// Mock that special DDL generate a SchemaDiff with regenerate_schema_map == true.
+// Usage:
+//   ./storage-client.sh "DBGInvoke regenerate_schema_map()"
+void dbgFuncRegrenationSchemaMap(Context & context, const ASTs & args, DBGInvoker::Printer output);
 } // namespace DB

--- a/dbms/src/TiDB/Schema/SchemaBuilder.cpp
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.cpp
@@ -1326,7 +1326,6 @@ public:
 /// syncAllSchema will be called when
 /// - a new keyspace is created
 /// - meet diff->regenerate_schema_map = true
-/// - exception thrown in applyDiff
 /// Thus, we should not assume all the map is empty during syncAllSchema.
 template <typename Getter, typename NameMapper>
 void SchemaBuilder<Getter, NameMapper>::syncAllSchema()

--- a/dbms/src/TiDB/Schema/SchemaBuilder.cpp
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.cpp
@@ -52,6 +52,7 @@
 #include <mutex>
 #include <string_view>
 #include <tuple>
+#include <unordered_set>
 
 namespace DB
 {
@@ -1304,6 +1305,24 @@ void SchemaBuilder<Getter, NameMapper>::applyDropTable(
     applyDropPhysicalTable(name_mapper.mapDatabaseName(database_id, keyspace_id), table_info.id, action);
 }
 
+class SyncedDatabaseSet
+{
+private:
+    std::unordered_set<String> nameset;
+    std::mutex mtx;
+
+public:
+    // Thread-safe emplace
+    void emplace(const String & name)
+    {
+        std::unique_lock lock(mtx);
+        nameset.emplace(name);
+    }
+
+    // Non thread-safe check.
+    bool nonThreadSafeContains(const String & name) const { return nameset.contains(name); }
+};
+
 /// syncAllSchema will be called when
 /// - a new keyspace is created
 /// - meet diff->regenerate_schema_map = true
@@ -1323,11 +1342,14 @@ void SchemaBuilder<Getter, NameMapper>::syncAllSchema()
         = ThreadPool(default_num_threads, default_num_threads / 2, default_num_threads * 2);
     auto sync_all_schema_wait_group = sync_all_schema_thread_pool.waitGroup();
 
-    std::mutex created_db_set_mutex;
-    std::unordered_set<String> created_db_set;
+    SyncedDatabaseSet latest_db_nameset;
     for (const auto & db_info : all_db_info)
     {
-        auto task = [this, db_info, &created_db_set, &created_db_set_mutex] {
+        auto task = [this, db_info, &latest_db_nameset] {
+            // Insert into nameset no matter it already present in local or not.
+            // Otherwise "drop all unmapped databases" result in unexpected data dropped.
+            latest_db_nameset.emplace(name_mapper.mapDatabaseName(*db_info));
+
             do
             {
                 if (databases.exists(db_info->id))
@@ -1335,11 +1357,6 @@ void SchemaBuilder<Getter, NameMapper>::syncAllSchema()
                     break;
                 }
                 applyCreateDatabaseByInfo(db_info);
-                {
-                    std::unique_lock<std::mutex> created_db_set_lock(created_db_set_mutex);
-                    created_db_set.emplace(name_mapper.mapDatabaseName(*db_info));
-                }
-
                 LOG_INFO(
                     log,
                     "Database {} created during sync all schemas, database_id={}",
@@ -1430,7 +1447,7 @@ void SchemaBuilder<Getter, NameMapper>::syncAllSchema()
         {
             continue;
         }
-        if (created_db_set.count(it->first) == 0 && !isReservedDatabase(context, it->first))
+        if (!latest_db_nameset.nonThreadSafeContains(it->first) && !isReservedDatabase(context, it->first))
         {
             applyDropDatabaseByName(it->first);
             LOG_INFO(log, "Database {} dropped during sync all schemas", it->first);

--- a/dbms/src/TiDB/Schema/SchemaBuilder.cpp
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.cpp
@@ -1304,7 +1304,10 @@ void SchemaBuilder<Getter, NameMapper>::applyDropTable(
     applyDropPhysicalTable(name_mapper.mapDatabaseName(database_id, keyspace_id), table_info.id, action);
 }
 
-/// syncAllSchema will be called when a new keyspace is created or we meet diff->regenerate_schema_map = true.
+/// syncAllSchema will be called when
+/// - a new keyspace is created
+/// - meet diff->regenerate_schema_map = true
+/// - exception thrown in applyDiff
 /// Thus, we should not assume all the map is empty during syncAllSchema.
 template <typename Getter, typename NameMapper>
 void SchemaBuilder<Getter, NameMapper>::syncAllSchema()

--- a/dbms/src/TiDB/Schema/TiDBSchemaSyncer.cpp
+++ b/dbms/src/TiDB/Schema/TiDBSchemaSyncer.cpp
@@ -177,7 +177,11 @@ Int64 TiDBSchemaSyncer<mock_getter, mock_mapper>::syncSchemaDiffsImpl(
         {
             // `FLASHBACK CLUSTER` is executed, return `SchemaGetter::SchemaVersionNotExist`.
             // The caller should let TiFlash reload schema info from TiKV.
-            LOG_INFO(log, "Meets a schema diff with regenerate_schema_map flag, schema_version={}", cur_apply_version);
+            LOG_INFO(
+                log,
+                "Meets a schema diff with regenerate_schema_map flag, schema_version={} diff_type={}",
+                cur_apply_version,
+                static_cast<Int32>(diff->type));
             return SchemaGetter::SchemaVersionNotExist;
         }
 

--- a/dbms/src/TiDB/Schema/TiDBSchemaSyncer.cpp
+++ b/dbms/src/TiDB/Schema/TiDBSchemaSyncer.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <Common/Stopwatch.h>
-#include <Common/TiFlashException.h>
 #include <Common/TiFlashMetrics.h>
 #include <Storages/KVStore/TiKVHelpers/PDTiKVClient.h>
 #include <TiDB/Schema/SchemaBuilder.h>
@@ -94,20 +93,26 @@ bool TiDBSchemaSyncer<mock_getter, mock_mapper>::syncSchemasByGetter(Context & c
         if (cur_version <= 0)
         {
             // first load all db and tables
-            Int64 version_after_load_all = syncAllSchemas(context, getter, version);
-            cur_version = version_after_load_all;
+            cur_version = syncAllSchemas(context, getter, version);
         }
         else
         {
-            Int64 version_after_load_diff = syncSchemaDiffs(context, getter, version);
-            if (version_after_load_diff == SchemaGetter::SchemaVersionNotExist)
+            // After the feature concurrent DDL, TiDB does `update schema version` before `set schema diff`, and they are done in separate transactions.
+            // So TiFlash may see a schema version X but no schema diff X, meaning that the transaction of schema diff X has not been committed or has
+            // been aborted.
+            // However, TiDB makes sure that if we get a schema version X, then the schema diff X-1 must exist. Otherwise the transaction of schema diff
+            // X-1 is aborted and we can safely ignore it.
+            // Since TiDB can not make sure the schema diff of the latest schema version X is not empty, under this situation we should set the `cur_version`
+            // to X-1 and try to fetch the schema diff X next time.
+            const Int64 version_after_load_diff = syncSchemaDiffs(context, getter, version);
+            if (likely(version_after_load_diff != SchemaGetter::SchemaVersionNotExist))
             {
-                // when diff->regenerate_schema_map == true, or excpetion thrown, we use syncAllSchemas to reload all schemas
-                cur_version = syncAllSchemas(context, getter, version);
+                cur_version = version_after_load_diff;
             }
             else
             {
-                cur_version = version_after_load_diff;
+                // when diff->regenerate_schema_map == true, we use syncAllSchemas to reload all schemas
+                cur_version = syncAllSchemas(context, getter, version);
             }
         }
     }
@@ -120,13 +125,6 @@ bool TiDBSchemaSyncer<mock_getter, mock_mapper>::syncSchemasByGetter(Context & c
     return true;
 }
 
-// After the feature concurrent DDL, TiDB does `update schema version` before `set schema diff`, and they are done in separate transactions.
-// So TiFlash may see a schema version X but no schema diff X, meaning that the transaction of schema diff X has not been committed or has
-// been aborted.
-// However, TiDB makes sure that if we get a schema version X, then the schema diff X-1 must exist. Otherwise the transaction of schema diff
-// X-1 is aborted and we can safely ignore it.
-// Since TiDB can not make sure the schema diff of the latest schema version X is not empty, under this situation we should set the `cur_version`
-// to X-1 and try to fetch the schema diff X next time.
 template <bool mock_getter, bool mock_mapper>
 Int64 TiDBSchemaSyncer<mock_getter, mock_mapper>::syncSchemaDiffs(
     Context & context,

--- a/dbms/src/TiDB/Schema/TiDBSchemaSyncer.h
+++ b/dbms/src/TiDB/Schema/TiDBSchemaSyncer.h
@@ -81,7 +81,6 @@ public:
 
 private:
     Int64 syncSchemaDiffs(Context & context, Getter & getter, Int64 latest_version);
-    Int64 syncSchemaDiffsImpl(Context & context, Getter & getter, Int64 latest_version);
     Int64 syncAllSchemas(Context & context, Getter & getter, Int64 version);
 
     bool syncSchemasByGetter(Context & context, Getter & getter);

--- a/dbms/src/TiDB/Schema/TiDBSchemaSyncer.h
+++ b/dbms/src/TiDB/Schema/TiDBSchemaSyncer.h
@@ -81,6 +81,7 @@ public:
 
 private:
     Int64 syncSchemaDiffs(Context & context, Getter & getter, Int64 latest_version);
+    Int64 syncSchemaDiffsImpl(Context & context, Getter & getter, Int64 latest_version);
     Int64 syncAllSchemas(Context & context, Getter & getter, Int64 version);
 
     bool syncSchemasByGetter(Context & context, Getter & getter);

--- a/tests/delta-merge-test/raft/schema/concurrent_ddl_conflict.test
+++ b/tests/delta-merge-test/raft/schema/concurrent_ddl_conflict.test
@@ -32,6 +32,18 @@
 │ test1 │     1 │ 65536 │
 └───────┴───────┴───────┘
 
+# Meet SchemaDiff with regenerate_schema_map
+=> DBGInvoke __regenerate_schema_map()
+# Try gc tombstone storages
+=> DBGInvoke __refresh_schemas()
+>> DBGInvoke __enable_schema_sync_service('true')
+>> DBGInvoke __gc_schemas(18446744073709551615, 'true')
+# Check the storage is not dropped
+>> DBGInvoke query_mapped('select col_1,col_2,col_3 from \$d.\$t', default, test)
+┌─col_1─┬─col_2─┬─col_3─┐
+│ test1 │     1 │ 65536 │
+└───────┴───────┴───────┘
+
 # Clean up.
 => DBGInvoke __drop_tidb_table(default, test)
 => DBGInvoke __refresh_schemas()


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/8777

Problem Summary:

Normally, after users executed DDL statements, the TiDB server will generate some "SchemaDiff" to indicate what happens. And TiFlash will follow the "SchemaDiff" to figure out what DDL operations need to be executed.
But when there are special DDL `FLASHBACK CLUSTER TO` or `br restore point` (which generate `regenerate_schema_map == true`), TiFlash will try to list all existing databases and tables in the cluster and enter `syncAllSchema` to check all existing databases and tables one by one and execute proper DDL on them.

However, in the DDL framwork refactor since v7.2(https://github.com/pingcap/tiflash/pull/7437), there is a mistake in the implementation. In the following codes, only newly created database that does not exist in TiFlash local are put in `created_db_set`. In line 1383, if the database is not existed in `created_db_set`, then the database will be marked as tombstone unexpectedly. And after the gc_safepoint advance, the data on TiFlash replica get physically removed unexpectedly. :(

https://github.com/pingcap/tiflash/blob/fe6621befaefdfd03a6fa5c10318b7e6583fa3d2/dbms/src/TiDB/Schema/SchemaBuilder.cpp#L1269-L1391

Though `syncAllSchema` will also run right after TiFlash restarts, but at that time, the `DatabaseInfoCache` is empty, so it do not trigger this bug.

### What is changed and how it works?

Add the database name to set no matter the database is already present locally or not

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix the issue that TiFlash replica data dropped unexpectedly after PITR restore or `FLASHBACK CLUSTER TO` is executed
```
