### PR TITLE
ddl: Fix an issue where a query may throw an error during a remote read and the precision of a duration data type is changed (release-6.5)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -66,7 +66,6 @@ ContinuationIndentWidth: 4
 DerivePointerAlignment: false
 DisableFormat:   false
 ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
-IndentWidth:     4
 IndentWrappedFunctionNames: false
 MacroBlockBegin: ''
 MacroBlockEnd:   ''

--- a/dbms/src/DataStreams/NativeBlockInputStream.cpp
+++ b/dbms/src/DataStreams/NativeBlockInputStream.cpp
@@ -155,9 +155,9 @@ Block NativeBlockInputStream::readImpl()
     }
 
     if (header)
-        CodecUtils::checkColumnSize(header.columns(), columns);
+        CodecUtils::checkColumnSize("NativeBlockInputStream", header.columns(), columns);
     else if (!output_names.empty())
-        CodecUtils::checkColumnSize(output_names.size(), columns);
+        CodecUtils::checkColumnSize("NativeBlockInputStream", output_names.size(), columns);
 
     for (size_t i = 0; i < columns; ++i)
     {
@@ -184,7 +184,7 @@ Block NativeBlockInputStream::readImpl()
         readBinary(type_name, istr);
         if (header)
         {
-            CodecUtils::checkDataTypeName(i, header_datatypes[i].name, type_name);
+            CodecUtils::checkDataTypeName("NativeBlockInputStream", i, header_datatypes[i].name, type_name);
             column.type = header_datatypes[i].type;
         }
         else

--- a/dbms/src/Encryption/tests/gtest_rate_limiter.cpp
+++ b/dbms/src/Encryption/tests/gtest_rate_limiter.cpp
@@ -70,8 +70,10 @@ TEST(WriteLimiterTest, Rate)
         // make sure that 0.8 * target <= actual_rate <= 1.25 * target
         // hint: the range [0.8, 1.25] is copied from rocksdb,
         // if tests fail, try to enlarge this range.
-        EXPECT_GE(actual_rate / target, 0.80);
-        EXPECT_LE(actual_rate / target, 1.25);
+        EXPECT_GE(actual_rate / target, 0.80)
+            << fmt::format("actual_rate={} target={} elapsed={:.3f}s", actual_rate, target, elapsed);
+        EXPECT_LE(actual_rate / target, 1.30)
+            << fmt::format("actual_rate={} target={} elapsed={:.3f}s", actual_rate, target, elapsed);
     }
 }
 

--- a/dbms/src/Flash/Coprocessor/CHBlockChunkCodec.cpp
+++ b/dbms/src/Flash/Coprocessor/CHBlockChunkCodec.cpp
@@ -188,9 +188,9 @@ void CHBlockChunkCodec::readBlockMeta(ReadBuffer & istr, size_t & columns, size_
     readVarUInt(rows, istr);
 
     if (header)
-        CodecUtils::checkColumnSize(header.columns(), columns);
+        CodecUtils::checkColumnSize("CHBlockChunkCodec", header.columns(), columns);
     else if (!output_names.empty())
-        CodecUtils::checkColumnSize(output_names.size(), columns);
+        CodecUtils::checkColumnSize("CHBlockChunkCodec", output_names.size(), columns);
 }
 
 void CHBlockChunkCodec::readColumnMeta(size_t i, ReadBuffer & istr, ColumnWithTypeAndName & column)
@@ -208,7 +208,7 @@ void CHBlockChunkCodec::readColumnMeta(size_t i, ReadBuffer & istr, ColumnWithTy
     const DataTypeFactory & data_type_factory = DataTypeFactory::instance();
     if (header)
     {
-        CodecUtils::checkDataTypeName(i, header_datatypes[i].name, type_name);
+        CodecUtils::checkDataTypeName("CHBlockChunkCodec", i, header_datatypes[i].name, type_name);
         column.type = header_datatypes[i].type;
     }
     else

--- a/dbms/src/Flash/Coprocessor/CodecUtils.cpp
+++ b/dbms/src/Flash/Coprocessor/CodecUtils.cpp
@@ -25,20 +25,21 @@ extern const int LOGICAL_ERROR;
 
 namespace CodecUtils
 {
-void checkColumnSize(size_t expected, size_t actual)
+void checkColumnSize(const String & identifier, size_t expected, size_t actual)
 {
     if unlikely (expected != actual)
         throw Exception(
-            fmt::format("NativeBlockInputStream schema mismatch, expected {}, actual {}.", expected, actual),
+            fmt::format("{} schema size mismatch, expected {}, actual {}.", identifier, expected, actual),
             ErrorCodes::LOGICAL_ERROR);
 }
 
-void checkDataTypeName(size_t column_index, const String & expected, const String & actual)
+void checkDataTypeName(const String & identifier, size_t column_index, const String & expected, const String & actual)
 {
     if unlikely (expected != actual)
         throw Exception(
             fmt::format(
-                "NativeBlockInputStream schema mismatch at column {}, expected {}, actual {}",
+                "{} schema mismatch at column {}, expected {}, actual {}",
+                identifier,
                 column_index,
                 expected,
                 actual),

--- a/dbms/src/Flash/Coprocessor/CodecUtils.h
+++ b/dbms/src/Flash/Coprocessor/CodecUtils.h
@@ -32,7 +32,7 @@ struct DataTypeWithTypeName
     String name;
 };
 
-void checkColumnSize(size_t expected, size_t actual);
-void checkDataTypeName(size_t column_index, const String & expected, const String & actual);
+void checkColumnSize(const String & identifier, size_t expected, size_t actual);
+void checkDataTypeName(const String & identifier, size_t column_index, const String & expected, const String & actual);
 } // namespace CodecUtils
 } // namespace DB

--- a/dbms/src/TiDB/Schema/SchemaBuilder.cpp
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.cpp
@@ -141,9 +141,9 @@ bool typeDiffers(const TiDB::ColumnInfo & a, const TiDB::ColumnInfo & b)
     {
         return a.flen != b.flen || a.decimal != b.decimal;
     }
-    else if (a.tp == TiDB::TypeDatetime || a.tp == TiDB::TypeDate || a.tp == TiDB::TypeTimestamp)
+    else if (a.tp == TiDB::TypeDatetime || a.tp == TiDB::TypeDate || a.tp == TiDB::TypeTimestamp || a.tp == TiDB::TypeTime)
     {
-        // detect fsp changed in MyDateTime/MyTime
+        // detect fsp changed in MyDateTime/MyTime/MyDuration (`Datetime`/`TIMESTAMP`/`TIME` in TiDB)
         return a.flen != b.flen || a.decimal != b.decimal;
     }
     return false;

--- a/tests/_env.sh
+++ b/tests/_env.sh
@@ -42,7 +42,7 @@ export storage_db="default"
 export tidb_server="127.0.0.1"
 
 # TiDB port
-export tidb_port="4000"
+export tidb_port="${tidb_port:-4000}"
 
 # TiDB status port
 export tidb_status_port="10080"
@@ -54,8 +54,7 @@ export tidb_db="test"
 export tidb_table="t"
 
 # Whether run scripts with verbose output
-export verbose="false"
-# export verbose="true"
+export verbose="${verbose:-"false"}"
 
 # Setup running env vars
 #source ../../_vars.sh

--- a/tests/fullstack-test/issues/issue_8601.test
+++ b/tests/fullstack-test/issues/issue_8601.test
@@ -1,0 +1,72 @@
+# Copyright 2024 PingCAP, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Preparation.
+=> DBGInvoke __init_fail_point()
+=> DBGInvoke __enable_schema_sync_service('false')
+
+mysql> drop table if exists test.t;
+mysql> create table if not exists test.t(a time(4));
+
+mysql> insert into test.t values('700:10:10.123456');
+mysql> insert into test.t values('-700:10:10.123456');
+mysql> alter table test.t set tiflash replica 1;
+func> wait_table test t
+
+## time(4) to time(6)
+mysql> alter table test.t modify column a time(6);
+
+mysql> use test; set tidb_enforce_mpp=1; set tidb_isolation_read_engines='tiflash'; select a from test.t;
++-------------------+
+| a                 |
++-------------------+
+| 700:10:10.123500  |
+| -700:10:10.123500 |
++-------------------+
+
+=> DBGInvoke __enable_fail_point(force_remote_read_for_batch_cop)
+mysql> use test; set tidb_enforce_mpp=1; set tidb_isolation_read_engines='tiflash'; select a from test.t;
++-------------------+
+| a                 |
++-------------------+
+| 700:10:10.123500  |
+| -700:10:10.123500 |
++-------------------+
+=> DBGInvoke __disable_fail_point(force_remote_read_for_batch_cop)
+
+## time(6) to time(2)
+mysql> alter table test.t modify column a time(2);
+
+mysql> use test; set tidb_enforce_mpp=1; set tidb_isolation_read_engines='tiflash'; select a from test.t;
++---------------+
+| a             |
++---------------+
+| 700:10:10.12  |
+| -700:10:10.12 |
++---------------+
+
+=> DBGInvoke __enable_fail_point(force_remote_read_for_batch_cop)
+mysql> use test; set tidb_enforce_mpp=1; set tidb_isolation_read_engines='tiflash'; select a from test.t;
++---------------+
+| a             |
++---------------+
+| 700:10:10.12  |
+| -700:10:10.12 |
++---------------+
+=> DBGInvoke __disable_fail_point(force_remote_read_for_batch_cop)
+
+# Clean up.
+mysql> drop table if exists test.t
+
+=> DBGInvoke __enable_schema_sync_service('true')


### PR DESCRIPTION
This is an manual fix of #8671 in release-7.1

### What problem does this PR solve?

Issue Number: close #8601

Problem Summary:

### What is changed and how it works?

see https://github.com/pingcap/tiflash/issues/8601#issuecomment-1878393488. The different in release-7.1 and earlier branches is because the fsp change of `time` column type is ignored

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix an issue where a query may throw an error during a remote read and the precision of a duration data type is changed.
```
