### PR TITLE
Fix jemalloc build on Mac

### DIFF
--- a/contrib/jemalloc-cmake/include/jemalloc/internal/jemalloc_preamble.h
+++ b/contrib/jemalloc-cmake/include/jemalloc/internal/jemalloc_preamble.h
@@ -1,8 +1,8 @@
 #ifndef JEMALLOC_PREAMBLE_H
 #define JEMALLOC_PREAMBLE_H
 
-#include "jemalloc/internal/jemalloc_internal_decls.h"
 #include "jemalloc_internal_defs.h"
+#include "jemalloc/internal/jemalloc_internal_decls.h"
 
 #if defined(JEMALLOC_UTRACE) || defined(JEMALLOC_UTRACE_LABEL)
 #include <sys/ktrace.h>

--- a/libs/libcommon/cmake/find_jemalloc.cmake
+++ b/libs/libcommon/cmake/find_jemalloc.cmake
@@ -12,17 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Only enable under linux
-if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-    set(ENABLE_JEMALLOC_DEFAULT 1)
-elseif(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
-    set(ENABLE_JEMALLOC_DEFAULT 0)
-elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    set(ENABLE_JEMALLOC_DEFAULT 0)
-endif()
-
-option (ENABLE_JEMALLOC "Set to TRUE to use jemalloc" ${ENABLE_JEMALLOC_DEFAULT})
-# TODO: Make ENABLE_JEMALLOC_PROF default value to ${ENABLE_JEMALLOC_DEFAULT} after https://github.com/pingcap/tics/issues/3236 get fixed.
+option (ENABLE_JEMALLOC "Set to TRUE to use jemalloc" ON)
+# TODO: Make ENABLE_JEMALLOC_PROF default value to ON after https://github.com/pingcap/tics/issues/3236 get fixed.
 option (ENABLE_JEMALLOC_PROF "Set to ON to enable jemalloc profiling" OFF)
 option (USE_INTERNAL_JEMALLOC_LIBRARY "Set to FALSE to use system jemalloc library instead of bundled" ${NOT_UNBUNDLED})
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8824

Problem Summary:

See #8824.

### What is changed and how it works?

It turns out to be a simple include order issue in the provided jemalloc header:
https://github.com/pingcap/tiflash/blob/ee0fc2270c9d5f60090f77dc9df75d58104d275d/contrib/jemalloc-cmake/include/jemalloc/internal/jemalloc_preamble.h#L4-L5

Switching the order passed the build.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
