### PR TITLE
Disable 3rd party allocators for sanitizer builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,8 +53,8 @@ message (STATUS "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
 
 # ASan - build type with address sanitizer
 # UBSan - build type with undefined behaviour sanitizer
-# TSan is not supported due to false positive errors in libstdc++ and necessity to rebuild libstdc++ with TSan
-set (CMAKE_CONFIGURATION_TYPES "RelWithDebInfo;Debug;Release;MinSizeRel;ASan;UBSan" CACHE STRING "" FORCE)
+# TSan - build type with thread sanitizer
+set (CMAKE_CONFIGURATION_TYPES "RelWithDebInfo;Debug;Release;MinSizeRel;ASan;UBSan;TSan" CACHE STRING "" FORCE)
 
 if (NOT MSVC)
     set (COMMON_WARNING_FLAGS "${COMMON_WARNING_FLAGS} -Wall")    # -Werror is also added inside directories with our own code.

--- a/libs/libcommon/cmake/find_jemalloc.cmake
+++ b/libs/libcommon/cmake/find_jemalloc.cmake
@@ -17,6 +17,11 @@ option (ENABLE_JEMALLOC "Set to TRUE to use jemalloc" ON)
 option (ENABLE_JEMALLOC_PROF "Set to ON to enable jemalloc profiling" OFF)
 option (USE_INTERNAL_JEMALLOC_LIBRARY "Set to FALSE to use system jemalloc library instead of bundled" ${NOT_UNBUNDLED})
 
+if (ENABLE_JEMALLOC AND (CMAKE_BUILD_TYPE_UC STREQUAL "ASAN" OR CMAKE_BUILD_TYPE_UC STREQUAL "UBSAN" OR CMAKE_BUILD_TYPE_UC STREQUAL "TSAN"))
+    message (WARNING "ENABLE_JEMALLOC is set to OFF implicitly: jemalloc doesn't work with ${CMAKE_BUILD_TYPE_UC}")
+    set (ENABLE_JEMALLOC OFF)
+endif ()
+
 if (ENABLE_JEMALLOC)
     if (USE_INTERNAL_JEMALLOC_LIBRARY)
         set (JEMALLOC_LIBRARIES "jemalloc")

--- a/libs/libcommon/cmake/find_mimalloc.cmake
+++ b/libs/libcommon/cmake/find_mimalloc.cmake
@@ -14,6 +14,11 @@
 
 option (ENABLE_MIMALLOC "Set to ON to use mimalloc" OFF)
 
+if (ENABLE_MIMALLOC AND (CMAKE_BUILD_TYPE_UC STREQUAL "ASAN" OR CMAKE_BUILD_TYPE_UC STREQUAL "UBSAN" OR CMAKE_BUILD_TYPE_UC STREQUAL "TSAN"))
+    message (WARNING "ENABLE_MIMALLOC is set to OFF implicitly: mimalloc doesn't work with ${CMAKE_BUILD_TYPE_UC}")
+    set (ENABLE_MIMALLOC OFF)
+endif ()
+
 if (ENABLE_MIMALLOC)
     set (MIMALLOC_LIBRARIES "mimalloc-obj")
     set (USE_MIMALLOC 1)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8859

Problem Summary:

### What is changed and how it works?

Detect sanitizer for jemalloc and mimalloc, and disable themselves if any sanitizer is found.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
