### PR TITLE
*: more forward decl

### DIFF
--- a/dbms/src/Debug/MockStorage.cpp
+++ b/dbms/src/Debug/MockStorage.cpp
@@ -25,6 +25,7 @@
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTInsertQuery.h>
 #include <Parsers/ASTSelectQuery.h>
+#include <Storages/DeltaMerge/ScanContext.h>
 #include <Storages/RegionQueryInfo.h>
 #include <Storages/StorageDeltaMerge.h>
 

--- a/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.h
+++ b/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.h
@@ -20,7 +20,6 @@
 #include <Flash/Coprocessor/DAGStorageInterpreter.h>
 #include <Flash/Coprocessor/TiDBTableScan.h>
 #include <Interpreters/AggregateDescription.h>
-#include <Interpreters/Context.h>
 #include <Interpreters/Context_fwd.h>
 #include <Interpreters/ExpressionActions.h>
 #include <Storages/TableLockHolder.h>

--- a/dbms/src/Flash/Disaggregated/WNFetchPagesStreamWriter.cpp
+++ b/dbms/src/Flash/Disaggregated/WNFetchPagesStreamWriter.cpp
@@ -18,6 +18,7 @@
 #include <Flash/Coprocessor/CHBlockChunkCodec.h>
 #include <Flash/Disaggregated/WNFetchPagesStreamWriter.h>
 #include <Flash/Mpp/TrackedMppDataPacket.h>
+#include <Interpreters/Settings.h>
 #include <Interpreters/SharedContexts/Disagg.h>
 #include <Storages/DeltaMerge/ColumnFile/ColumnFileDataProvider.h>
 #include <Storages/DeltaMerge/Delta/DeltaValueSpace.h>
@@ -149,5 +150,17 @@ void WNFetchPagesStreamWriter::syncWrite()
         send_pages_ns / 1000000);
 }
 
+WNFetchPagesStreamWriter::WNFetchPagesStreamWriter(
+    std::function<void(const disaggregated::PagesPacket &)> && sync_write_,
+    DM::SegmentReadTaskPtr seg_task_,
+    PageIdU64s read_page_ids_,
+    const Settings & settings_)
+    : sync_write(std::move(sync_write_))
+    , seg_task(std::move(seg_task_))
+    , read_page_ids(std::move(read_page_ids_))
+    , packet_limit_size(settings_.dt_fetch_pages_packet_limit_size)
+    , enable_fetch_memtableset(settings_.dt_enable_fetch_memtableset)
+    , mem_tracker_wrapper(fetch_pages_mem_tracker.get())
+{}
 
 } // namespace DB

--- a/dbms/src/Flash/Disaggregated/WNFetchPagesStreamWriter.h
+++ b/dbms/src/Flash/Disaggregated/WNFetchPagesStreamWriter.h
@@ -31,6 +31,9 @@
 
 namespace DB
 {
+
+struct Settings;
+
 using SyncPagePacketWriter = grpc::ServerWriter<disaggregated::PagesPacket>;
 
 class WNFetchPagesStreamWriter;
@@ -48,14 +51,7 @@ public:
         std::function<void(const disaggregated::PagesPacket &)> && sync_write_,
         DM::SegmentReadTaskPtr seg_task_,
         PageIdU64s read_page_ids_,
-        const Settings & settings_)
-        : sync_write(std::move(sync_write_))
-        , seg_task(std::move(seg_task_))
-        , read_page_ids(std::move(read_page_ids_))
-        , packet_limit_size(settings_.dt_fetch_pages_packet_limit_size)
-        , enable_fetch_memtableset(settings_.dt_enable_fetch_memtableset)
-        , mem_tracker_wrapper(fetch_pages_mem_tracker.get())
-    {}
+        const Settings & settings_);
 
     void syncWrite();
 

--- a/dbms/src/Operators/DMSegmentThreadSourceOp.cpp
+++ b/dbms/src/Operators/DMSegmentThreadSourceOp.cpp
@@ -15,6 +15,7 @@
 #include <Common/FailPoint.h>
 #include <Interpreters/Context.h>
 #include <Operators/DMSegmentThreadSourceOp.h>
+#include <Storages/DeltaMerge/DMContext.h>
 
 namespace DB
 {

--- a/dbms/src/Server/DTTool/DTToolBench.cpp
+++ b/dbms/src/Server/DTTool/DTToolBench.cpp
@@ -25,6 +25,7 @@
 #include <Storages/DeltaMerge/File/DMFile.h>
 #include <Storages/DeltaMerge/File/DMFileBlockInputStream.h>
 #include <Storages/DeltaMerge/File/DMFileBlockOutputStream.h>
+#include <Storages/DeltaMerge/ScanContext.h>
 #include <Storages/DeltaMerge/StoragePool/StoragePool.h>
 #include <Storages/FormatVersion.h>
 #include <Storages/KVStore/TMTContext.h>

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -77,6 +77,7 @@
 #include <Storages/DeltaMerge/ReadThread/ColumnSharingCache.h>
 #include <Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.h>
 #include <Storages/DeltaMerge/ReadThread/SegmentReader.h>
+#include <Storages/DeltaMerge/ScanContext.h>
 #include <Storages/FormatVersion.h>
 #include <Storages/IManageableStorage.h>
 #include <Storages/KVStore/FFI/FileEncryption.h>

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSetReader.cpp
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSetReader.cpp
@@ -19,6 +19,7 @@
 #include <Storages/DeltaMerge/ColumnFile/ColumnFileSetReader.h>
 #include <Storages/DeltaMerge/ColumnFile/ColumnFileTiny.h>
 #include <Storages/DeltaMerge/DMContext.h>
+#include <Storages/DeltaMerge/ScanContext.h>
 
 namespace DB
 {
@@ -79,6 +80,11 @@ std::pair<size_t, size_t> findColumnFile(const ColumnFiles & column_files, size_
 
     return {column_file_index, 0};
 }
+
+ColumnFileSetReader::ColumnFileSetReader(const DMContext & context_)
+    : context(context_)
+    , lac_bytes_collector(context_.scan_context ? context_.scan_context->resource_group_name : "")
+{}
 
 ColumnFileSetReader::ColumnFileSetReader(
     const DMContext & context_,
@@ -340,6 +346,7 @@ bool ColumnFileSetReader::shouldPlace(
 
     return false;
 }
+
 
 } // namespace DM
 } // namespace DB

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSetReader.h
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSetReader.h
@@ -15,8 +15,7 @@
 #pragma once
 
 #include <Storages/DeltaMerge/ColumnFile/ColumnFileSetSnapshot.h>
-#include <Storages/DeltaMerge/DMContext.h>
-#include <Storages/DeltaMerge/ScanContext.h>
+#include <Storages/DeltaMerge/DMContext_fwd.h>
 #include <Storages/DeltaMerge/SkippableBlockInputStream.h>
 
 namespace DB
@@ -45,10 +44,7 @@ private:
     LACBytesCollector lac_bytes_collector;
 
 private:
-    explicit ColumnFileSetReader(const DMContext & context_)
-        : context(context_)
-        , lac_bytes_collector(context_.scan_context ? context_.scan_context->resource_group_name : "")
-    {}
+    explicit ColumnFileSetReader(const DMContext & context_);
 
     Block readPKVersion(size_t offset, size_t limit);
 

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileTiny.cpp
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileTiny.cpp
@@ -405,5 +405,21 @@ ColumnFileReaderPtr ColumnFileTinyReader::createNewReader(const ColumnDefinesPtr
     return std::make_shared<ColumnFileTinyReader>(tiny_file, data_provider, new_col_defs, cols_data_cache);
 }
 
+ColumnFileTiny::ColumnFileTiny(
+    const ColumnFileSchemaPtr & schema_,
+    UInt64 rows_,
+    UInt64 bytes_,
+    PageIdU64 data_page_id_,
+    const DMContext & dm_context,
+    const CachePtr & cache_)
+    : schema(schema_)
+    , rows(rows_)
+    , bytes(bytes_)
+    , data_page_id(data_page_id_)
+    , keyspace_id(dm_context.keyspace_id)
+    , file_provider(dm_context.global_context.getFileProvider())
+    , cache(cache_)
+{}
+
 } // namespace DM
 } // namespace DB

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileTiny.h
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileTiny.h
@@ -14,10 +14,11 @@
 
 #pragma once
 
+#include <IO/FileProvider/FileProvider_fwd.h>
 #include <Storages/DeltaMerge/ColumnFile/ColumnFile.h>
 #include <Storages/DeltaMerge/ColumnFile/ColumnFilePersisted.h>
 #include <Storages/DeltaMerge/ColumnFile/ColumnFileSchema.h>
-#include <Storages/DeltaMerge/DMContext.h>
+#include <Storages/DeltaMerge/DMContext_fwd.h>
 #include <Storages/DeltaMerge/Remote/Serializer_fwd.h>
 #include <Storages/Page/PageStorage_fwd.h>
 
@@ -87,15 +88,7 @@ public:
         UInt64 bytes_,
         PageIdU64 data_page_id_,
         const DMContext & dm_context,
-        const CachePtr & cache_ = nullptr)
-        : schema(schema_)
-        , rows(rows_)
-        , bytes(bytes_)
-        , data_page_id(data_page_id_)
-        , keyspace_id(dm_context.keyspace_id)
-        , file_provider(dm_context.global_context.getFileProvider())
-        , cache(cache_)
-    {}
+        const CachePtr & cache_ = nullptr);
 
     Type getType() const override { return Type::TINY_FILE; }
 

--- a/dbms/src/Storages/DeltaMerge/DMContext.cpp
+++ b/dbms/src/Storages/DeltaMerge/DMContext.cpp
@@ -14,16 +14,58 @@
 
 #include <Interpreters/Context.h>
 #include <Storages/DeltaMerge/DMContext.h>
+#include <Storages/DeltaMerge/ScanContext.h>
 
 namespace DB::DM
 {
+
 WriteLimiterPtr DMContext::getWriteLimiter() const
 {
     return global_context.getWriteLimiter();
 }
+
 ReadLimiterPtr DMContext::getReadLimiter() const
 {
     return global_context.getReadLimiter();
 }
+
+DMContext::DMContext(
+    const Context & session_context_,
+    const StoragePathPoolPtr & path_pool_,
+    const StoragePoolPtr & storage_pool_,
+    const DB::Timestamp min_version_,
+    KeyspaceID keyspace_id_,
+    TableID physical_table_id_,
+    bool is_common_handle_,
+    size_t rowkey_column_size_,
+    const DB::Settings & settings,
+    const ScanContextPtr & scan_context_,
+    const String & tracing_id_)
+    : global_context(session_context_.getGlobalContext()) // always save the global context
+    , path_pool(path_pool_)
+    , storage_pool(storage_pool_)
+    , min_version(min_version_)
+    , keyspace_id(keyspace_id_)
+    , physical_table_id(physical_table_id_)
+    , is_common_handle(is_common_handle_)
+    , rowkey_column_size(rowkey_column_size_)
+    , segment_limit_rows(settings.dt_segment_limit_rows)
+    , segment_limit_bytes(settings.dt_segment_limit_size)
+    , segment_force_split_bytes(settings.dt_segment_force_split_size)
+    , delta_limit_rows(settings.dt_segment_delta_limit_rows)
+    , delta_limit_bytes(settings.dt_segment_delta_limit_size)
+    , delta_cache_limit_rows(settings.dt_segment_delta_cache_limit_rows)
+    , delta_cache_limit_bytes(settings.dt_segment_delta_cache_limit_size)
+    , delta_small_column_file_rows(settings.dt_segment_delta_small_column_file_rows)
+    , delta_small_column_file_bytes(settings.dt_segment_delta_small_column_file_size)
+    , stable_pack_rows(settings.dt_segment_stable_pack_rows)
+    , enable_logical_split(settings.dt_enable_logical_split)
+    , read_delta_only(settings.dt_read_delta_only)
+    , read_stable_only(settings.dt_read_stable_only)
+    , enable_relevant_place(settings.dt_enable_relevant_place)
+    , enable_skippable_place(settings.dt_enable_skippable_place)
+    , tracing_id(tracing_id_)
+    , scan_context(scan_context_ ? scan_context_ : std::make_shared<ScanContext>())
+{}
 
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/DMContext.h
+++ b/dbms/src/Storages/DeltaMerge/DMContext.h
@@ -16,20 +16,25 @@
 
 #include <Common/Logger.h>
 #include <Core/Types.h>
-#include <Interpreters/Context.h>
+#include <Interpreters/Context_fwd.h>
 #include <Interpreters/Settings.h>
 #include <Storages/DeltaMerge/DMChecksumConfig.h>
 #include <Storages/DeltaMerge/DMContext_fwd.h>
 #include <Storages/DeltaMerge/DeltaMergeDefines.h>
-#include <Storages/DeltaMerge/ScanContext.h>
+#include <Storages/DeltaMerge/ScanContext_fwd.h>
 
 #include <memory>
 
 namespace DB
 {
+
 class StoragePathPool;
 using StoragePathPoolPtr = std::shared_ptr<StoragePathPool>;
 
+class WriteLimiter;
+using WriteLimiterPtr = std::shared_ptr<WriteLimiter>;
+class ReadLimiter;
+using ReadLimiterPtr = std::shared_ptr<ReadLimiter>;
 
 namespace DM
 {
@@ -161,33 +166,7 @@ private:
         size_t rowkey_column_size_,
         const DB::Settings & settings,
         const ScanContextPtr & scan_context_ = nullptr,
-        const String & tracing_id_ = "")
-        : global_context(session_context_.getGlobalContext()) // always save the global context
-        , path_pool(path_pool_)
-        , storage_pool(storage_pool_)
-        , min_version(min_version_)
-        , keyspace_id(keyspace_id_)
-        , physical_table_id(physical_table_id_)
-        , is_common_handle(is_common_handle_)
-        , rowkey_column_size(rowkey_column_size_)
-        , segment_limit_rows(settings.dt_segment_limit_rows)
-        , segment_limit_bytes(settings.dt_segment_limit_size)
-        , segment_force_split_bytes(settings.dt_segment_force_split_size)
-        , delta_limit_rows(settings.dt_segment_delta_limit_rows)
-        , delta_limit_bytes(settings.dt_segment_delta_limit_size)
-        , delta_cache_limit_rows(settings.dt_segment_delta_cache_limit_rows)
-        , delta_cache_limit_bytes(settings.dt_segment_delta_cache_limit_size)
-        , delta_small_column_file_rows(settings.dt_segment_delta_small_column_file_rows)
-        , delta_small_column_file_bytes(settings.dt_segment_delta_small_column_file_size)
-        , stable_pack_rows(settings.dt_segment_stable_pack_rows)
-        , enable_logical_split(settings.dt_enable_logical_split)
-        , read_delta_only(settings.dt_read_delta_only)
-        , read_stable_only(settings.dt_read_stable_only)
-        , enable_relevant_place(settings.dt_enable_relevant_place)
-        , enable_skippable_place(settings.dt_enable_skippable_place)
-        , tracing_id(tracing_id_)
-        , scan_context(scan_context_ ? scan_context_ : std::make_shared<ScanContext>())
-    {}
+        const String & tracing_id_ = "");
 };
 
 } // namespace DM

--- a/dbms/src/Storages/DeltaMerge/DMSegmentThreadInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/DMSegmentThreadInputStream.h
@@ -17,7 +17,7 @@
 #include <Common/FailPoint.h>
 #include <DataStreams/IProfilingBlockInputStream.h>
 #include <Interpreters/Context.h>
-#include <Storages/DeltaMerge/DMContext.h>
+#include <Storages/DeltaMerge/DMContext_fwd.h>
 #include <Storages/DeltaMerge/Segment.h>
 #include <Storages/DeltaMerge/SegmentReadTaskPool.h>
 

--- a/dbms/src/Storages/DeltaMerge/DMVersionFilterBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/DMVersionFilterBlockInputStream.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <Storages/DeltaMerge/DMVersionFilterBlockInputStream.h>
+#include <Storages/DeltaMerge/ScanContext.h>
 
 namespace ProfileEvents
 {

--- a/dbms/src/Storages/DeltaMerge/DMVersionFilterBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/DMVersionFilterBlockInputStream.h
@@ -21,7 +21,7 @@
 #include <DataStreams/SelectionByColumnIdTransformAction.h>
 #include <Storages/DeltaMerge/DeltaMergeHelpers.h>
 #include <Storages/DeltaMerge/RowKeyRange.h>
-#include <Storages/DeltaMerge/ScanContext.h>
+#include <Storages/DeltaMerge/ScanContext_fwd.h>
 #include <common/logger_useful.h>
 
 namespace DB

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -42,6 +42,7 @@
 #include <Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.h>
 #include <Storages/DeltaMerge/ReadThread/UnorderedInputStream.h>
 #include <Storages/DeltaMerge/Remote/DisaggSnapshot.h>
+#include <Storages/DeltaMerge/ScanContext.h>
 #include <Storages/DeltaMerge/SchemaUpdate.h>
 #include <Storages/DeltaMerge/Segment.h>
 #include <Storages/DeltaMerge/SegmentReadTaskPool.h>

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
@@ -44,6 +44,8 @@
 namespace DB
 {
 
+struct Settings;
+
 class Logger;
 using LoggerPtr = std::shared_ptr<Logger>;
 struct CheckpointInfo;
@@ -762,7 +764,7 @@ private:
      * This may be called from multiple threads, e.g. at the foreground write moment, or in background threads.
      * A `thread_type` should be specified indicating the type of the thread calling this function.
      * Depend on the thread type, the "update" to do may be varied.
-     * 
+     *
      * It returns a bool which indicates whether a flush of KVStore is recommended.
      */
     bool checkSegmentUpdate(

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_Ingest.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore_Ingest.cpp
@@ -16,6 +16,7 @@
 #include <Common/TiFlashMetrics.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/SharedContexts/Disagg.h>
+#include <Storages/DeltaMerge/DMContext.h>
 #include <Storages/DeltaMerge/DeltaMergeStore.h>
 #include <Storages/DeltaMerge/ExternalDTFileInfo.h>
 #include <Storages/DeltaMerge/File/DMFile.h>

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalBg.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalBg.cpp
@@ -17,6 +17,7 @@
 #include <Common/TiFlashMetrics.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/SharedContexts/Disagg.h>
+#include <Storages/DeltaMerge/DMContext.h>
 #include <Storages/DeltaMerge/DeltaMergeStore.h>
 #include <Storages/DeltaMerge/GCOptions.h>
 #include <Storages/DeltaMerge/Segment.h>

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalSegment.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalSegment.cpp
@@ -14,6 +14,7 @@
 
 #include <Common/SyncPoint/SyncPoint.h>
 #include <Common/TiFlashMetrics.h>
+#include <Storages/DeltaMerge/DMContext.h>
 #include <Storages/DeltaMerge/DeltaMergeStore.h>
 #include <Storages/DeltaMerge/Segment.h>
 #include <Storages/DeltaMerge/WriteBatchesImpl.h>

--- a/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.h
@@ -158,14 +158,8 @@ public:
 private:
     // These methods are called by the ctor
 
-    DMFileBlockInputStreamBuilder & setFromSettings(const Settings & settings)
-    {
-        enable_column_cache = settings.dt_enable_stable_column_cache;
-        max_read_buffer_size = settings.max_read_buffer_size;
-        max_sharing_column_bytes_for_all = settings.dt_max_sharing_column_bytes_for_all;
-        max_sharing_column_count = settings.dt_max_sharing_column_count;
-        return *this;
-    }
+    DMFileBlockInputStreamBuilder & setFromSettings(const Settings & settings);
+
     DMFileBlockInputStreamBuilder & setCaches(
         const MarkCachePtr & mark_cache_,
         const MinMaxIndexCachePtr & index_cache_)
@@ -211,22 +205,9 @@ private:
  * @param cols The columns to read. Empty means read all columns.
  * @return A shared pointer of an input stream
  */
-inline DMFileBlockInputStreamPtr createSimpleBlockInputStream(
+DMFileBlockInputStreamPtr createSimpleBlockInputStream(
     const DB::Context & context,
     const DMFilePtr & file,
-    ColumnDefines cols = {})
-{
-    // disable clean read is needed, since we just want to read all data from the file, and we do not know about the column handle
-    // enable read_one_pack_every_time_ is needed to preserve same block structure as the original file
-    DMFileBlockInputStreamBuilder builder(context);
-    if (cols.empty())
-    {
-        // turn into read all columns from file
-        cols = file->getColumnDefines();
-    }
-    return builder.setRowsThreshold(DMFILE_READ_ROWS_THRESHOLD)
-        .onlyReadOnePackEveryTime()
-        .build(file, cols, DB::DM::RowKeyRanges{}, std::make_shared<ScanContext>());
-}
+    ColumnDefines cols = {});
 
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter.cpp
@@ -1,0 +1,239 @@
+
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Storages/DeltaMerge/File/DMFilePackFilter.h>
+#include <Storages/DeltaMerge/ScanContext.h>
+
+namespace DB::DM
+{
+
+void DMFilePackFilter::init()
+{
+    size_t pack_count = dmfile->getPacks();
+    auto read_all_packs = (rowkey_ranges.size() == 1 && rowkey_ranges[0].all()) || rowkey_ranges.empty();
+    if (!read_all_packs)
+    {
+        tryLoadIndex(EXTRA_HANDLE_COLUMN_ID);
+        std::vector<RSOperatorPtr> handle_filters;
+        for (auto & rowkey_range : rowkey_ranges)
+            handle_filters.emplace_back(toFilter(rowkey_range));
+        for (size_t i = 0; i < pack_count; ++i)
+        {
+            handle_res[i] = RSResult::None;
+        }
+        for (auto & handle_filter : handle_filters)
+        {
+            auto res = handle_filter->roughCheck(0, pack_count, param);
+            std::transform(
+                handle_res.begin(),
+                handle_res.end(),
+                res.begin(),
+                handle_res.begin(),
+                [](RSResult a, RSResult b) { return a || b; });
+        }
+    }
+
+    ProfileEvents::increment(ProfileEvents::DMFileFilterNoFilter, pack_count);
+
+    size_t after_pk = 0;
+    size_t after_read_packs = 0;
+    size_t after_filter = 0;
+
+    /// Check packs by handle_res
+    for (size_t i = 0; i < pack_count; ++i)
+    {
+        use_packs[i] = handle_res[i] != None;
+    }
+
+    for (auto u : use_packs)
+        after_pk += u;
+
+    /// Check packs by read_packs
+    if (read_packs)
+    {
+        for (size_t i = 0; i < pack_count; ++i)
+        {
+            use_packs[i] = (static_cast<bool>(use_packs[i])) && read_packs->contains(i);
+        }
+    }
+
+    for (auto u : use_packs)
+        after_read_packs += u;
+    ProfileEvents::increment(ProfileEvents::DMFileFilterAftPKAndPackSet, after_read_packs);
+
+
+    /// Check packs by filter in where clause
+    if (filter)
+    {
+        // Load index based on filter.
+        ColIds ids = filter->getColumnIDs();
+        for (const auto & id : ids)
+        {
+            tryLoadIndex(id);
+        }
+
+        Stopwatch watch;
+        const auto check_results = filter->roughCheck(0, pack_count, param);
+        std::transform(
+            use_packs.begin(),
+            use_packs.end(),
+            check_results.begin(),
+            use_packs.begin(),
+            [](UInt8 a, RSResult b) { return (static_cast<bool>(a)) && (b != None); });
+        scan_context->total_dmfile_rough_set_index_check_time_ns += watch.elapsed();
+    }
+
+    for (auto u : use_packs)
+        after_filter += u;
+    ProfileEvents::increment(ProfileEvents::DMFileFilterAftRoughSet, after_filter);
+
+    Float64 filter_rate = 0.0;
+    if (after_read_packs != 0)
+    {
+        filter_rate = (after_read_packs - after_filter) * 100.0 / after_read_packs;
+        GET_METRIC(tiflash_storage_rough_set_filter_rate, type_dtfile_pack).Observe(filter_rate);
+    }
+    LOG_DEBUG(
+        log,
+        "RSFilter exclude rate: {:.2f}, after_pk: {}, after_read_packs: {}, after_filter: {}, handle_ranges: {}"
+        ", read_packs: {}, pack_count: {}",
+        ((after_read_packs == 0) ? std::numeric_limits<double>::quiet_NaN() : filter_rate),
+        after_pk,
+        after_read_packs,
+        after_filter,
+        toDebugString(rowkey_ranges),
+        ((read_packs == nullptr) ? 0 : read_packs->size()),
+        pack_count);
+}
+
+void DMFilePackFilter::loadIndex(
+    ColumnIndexes & indexes,
+    const DMFilePtr & dmfile,
+    const FileProviderPtr & file_provider,
+    const MinMaxIndexCachePtr & index_cache,
+    bool set_cache_if_miss,
+    ColId col_id,
+    const ReadLimiterPtr & read_limiter,
+    const ScanContextPtr & scan_context)
+{
+    const auto & type = dmfile->getColumnStat(col_id).type;
+    const auto file_name_base = DMFile::getFileNameBase(col_id);
+
+    auto load = [&]() {
+        auto index_file_size = dmfile->colIndexSize(col_id);
+        if (index_file_size == 0)
+            return std::make_shared<MinMaxIndex>(*type);
+        auto index_guard = S3::S3RandomAccessFile::setReadFileInfo({
+            .size = dmfile->getReadFileSize(col_id, dmfile->colIndexFileName(file_name_base)),
+            .scan_context = scan_context,
+        });
+        if (!dmfile->configuration) // v1
+        {
+            auto index_buf = ReadBufferFromRandomAccessFileBuilder::build(
+                file_provider,
+                dmfile->colIndexPath(file_name_base),
+                dmfile->encryptionIndexPath(file_name_base),
+                std::min(static_cast<size_t>(DBMS_DEFAULT_BUFFER_SIZE), index_file_size),
+                read_limiter);
+            return MinMaxIndex::read(*type, index_buf, index_file_size);
+        }
+        else if (dmfile->useMetaV2()) // v3
+        {
+            auto info = dmfile->merged_sub_file_infos.find(dmfile->colIndexFileName(file_name_base));
+            if (info == dmfile->merged_sub_file_infos.end())
+            {
+                throw Exception(
+                    fmt::format("Unknown index file {}", dmfile->colIndexPath(file_name_base)),
+                    ErrorCodes::LOGICAL_ERROR);
+            }
+
+            auto file_path = dmfile->mergedPath(info->second.number);
+            auto encryp_path = dmfile->encryptionMergedPath(info->second.number);
+            auto offset = info->second.offset;
+            auto data_size = info->second.size;
+
+            auto buffer = ReadBufferFromRandomAccessFileBuilder::build(
+                file_provider,
+                file_path,
+                encryp_path,
+                dmfile->getConfiguration()->getChecksumFrameLength(),
+                read_limiter);
+            buffer.seek(offset);
+
+            String raw_data;
+            raw_data.resize(data_size);
+
+            buffer.read(reinterpret_cast<char *>(raw_data.data()), data_size);
+
+            auto buf = ChecksumReadBufferBuilder::build(
+                std::move(raw_data),
+                dmfile->colDataPath(file_name_base),
+                dmfile->getConfiguration()->getChecksumFrameLength(),
+                dmfile->configuration->getChecksumAlgorithm(),
+                dmfile->configuration->getChecksumFrameLength());
+
+            auto header_size = dmfile->configuration->getChecksumHeaderLength();
+            auto frame_total_size = dmfile->configuration->getChecksumFrameLength() + header_size;
+            auto frame_count = index_file_size / frame_total_size + (index_file_size % frame_total_size != 0);
+
+            return MinMaxIndex::read(*type, *buf, index_file_size - header_size * frame_count);
+        }
+        else
+        { // v2
+            auto index_buf = ChecksumReadBufferBuilder::build(
+                file_provider,
+                dmfile->colIndexPath(file_name_base),
+                dmfile->encryptionIndexPath(file_name_base),
+                index_file_size,
+                read_limiter,
+                dmfile->configuration->getChecksumAlgorithm(),
+                dmfile->configuration->getChecksumFrameLength());
+            auto header_size = dmfile->configuration->getChecksumHeaderLength();
+            auto frame_total_size = dmfile->configuration->getChecksumFrameLength() + header_size;
+            auto frame_count = index_file_size / frame_total_size + (index_file_size % frame_total_size != 0);
+            return MinMaxIndex::read(*type, *index_buf, index_file_size - header_size * frame_count);
+        }
+    };
+    MinMaxIndexPtr minmax_index;
+    if (index_cache && set_cache_if_miss)
+    {
+        minmax_index = index_cache->getOrSet(dmfile->colIndexCacheKey(file_name_base), load);
+    }
+    else
+    {
+        // try load from the cache first
+        if (index_cache)
+            minmax_index = index_cache->get(dmfile->colIndexCacheKey(file_name_base));
+        if (minmax_index == nullptr)
+            minmax_index = load();
+    }
+    indexes.emplace(col_id, RSIndex(type, minmax_index));
+}
+
+void DMFilePackFilter::tryLoadIndex(const ColId col_id)
+{
+    if (param.indexes.count(col_id))
+        return;
+
+    if (!dmfile->isColIndexExist(col_id))
+        return;
+
+    Stopwatch watch;
+    loadIndex(param.indexes, dmfile, file_provider, index_cache, set_cache_if_miss, col_id, read_limiter, scan_context);
+
+    scan_context->total_dmfile_rough_set_index_check_time_ns += watch.elapsed();
+}
+
+} // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter.h
@@ -19,10 +19,11 @@
 #include <Common/TiFlashMetrics.h>
 #include <IO/FileProvider/ChecksumReadBufferBuilder.h>
 #include <Storages/DeltaMerge/File/DMFile.h>
+#include <Storages/DeltaMerge/File/DMFilePackFilter_fwd.h>
 #include <Storages/DeltaMerge/Filter/FilterHelper.h>
 #include <Storages/DeltaMerge/Filter/RSOperator.h>
 #include <Storages/DeltaMerge/RowKeyRange.h>
-#include <Storages/DeltaMerge/ScanContext.h>
+#include <Storages/DeltaMerge/ScanContext_fwd.h>
 #include <Storages/S3/S3Common.h>
 
 namespace ProfileEvents
@@ -36,9 +37,6 @@ namespace DB
 {
 namespace DM
 {
-using IdSet = std::set<UInt64>;
-using IdSetPtr = std::shared_ptr<IdSet>;
-
 class DMFilePackFilter
 {
 public:
@@ -141,104 +139,7 @@ private:
         , read_limiter(read_limiter_)
     {}
 
-    void init()
-    {
-        size_t pack_count = dmfile->getPacks();
-        auto read_all_packs = (rowkey_ranges.size() == 1 && rowkey_ranges[0].all()) || rowkey_ranges.empty();
-        if (!read_all_packs)
-        {
-            tryLoadIndex(EXTRA_HANDLE_COLUMN_ID);
-            std::vector<RSOperatorPtr> handle_filters;
-            for (auto & rowkey_range : rowkey_ranges)
-                handle_filters.emplace_back(toFilter(rowkey_range));
-            for (size_t i = 0; i < pack_count; ++i)
-            {
-                handle_res[i] = RSResult::None;
-            }
-            for (auto & handle_filter : handle_filters)
-            {
-                auto res = handle_filter->roughCheck(0, pack_count, param);
-                std::transform(
-                    handle_res.begin(),
-                    handle_res.end(),
-                    res.begin(),
-                    handle_res.begin(),
-                    [](RSResult a, RSResult b) { return a || b; });
-            }
-        }
-
-        ProfileEvents::increment(ProfileEvents::DMFileFilterNoFilter, pack_count);
-
-        size_t after_pk = 0;
-        size_t after_read_packs = 0;
-        size_t after_filter = 0;
-
-        /// Check packs by handle_res
-        for (size_t i = 0; i < pack_count; ++i)
-        {
-            use_packs[i] = handle_res[i] != None;
-        }
-
-        for (auto u : use_packs)
-            after_pk += u;
-
-        /// Check packs by read_packs
-        if (read_packs)
-        {
-            for (size_t i = 0; i < pack_count; ++i)
-            {
-                use_packs[i] = (static_cast<bool>(use_packs[i])) && read_packs->contains(i);
-            }
-        }
-
-        for (auto u : use_packs)
-            after_read_packs += u;
-        ProfileEvents::increment(ProfileEvents::DMFileFilterAftPKAndPackSet, after_read_packs);
-
-
-        /// Check packs by filter in where clause
-        if (filter)
-        {
-            // Load index based on filter.
-            ColIds ids = filter->getColumnIDs();
-            for (const auto & id : ids)
-            {
-                tryLoadIndex(id);
-            }
-
-            Stopwatch watch;
-            const auto check_results = filter->roughCheck(0, pack_count, param);
-            std::transform(
-                use_packs.begin(),
-                use_packs.end(),
-                check_results.begin(),
-                use_packs.begin(),
-                [](UInt8 a, RSResult b) { return (static_cast<bool>(a)) && (b != None); });
-            scan_context->total_dmfile_rough_set_index_check_time_ns += watch.elapsed();
-        }
-
-        for (auto u : use_packs)
-            after_filter += u;
-        ProfileEvents::increment(ProfileEvents::DMFileFilterAftRoughSet, after_filter);
-
-        Float64 filter_rate = 0.0;
-        if (after_read_packs != 0)
-        {
-            filter_rate = (after_read_packs - after_filter) * 100.0 / after_read_packs;
-            GET_METRIC(tiflash_storage_rough_set_filter_rate, type_dtfile_pack).Observe(filter_rate);
-        }
-        LOG_DEBUG(
-            log,
-            "RSFilter exclude rate: {:.2f}, after_pk: {}, after_read_packs: {}, after_filter: {}, handle_ranges: {}"
-            ", read_packs: {}, pack_count: {}",
-            ((after_read_packs == 0) ? std::numeric_limits<double>::quiet_NaN() : filter_rate),
-            after_pk,
-            after_read_packs,
-            after_filter,
-            toDebugString(rowkey_ranges),
-            ((read_packs == nullptr) ? 0 : read_packs->size()),
-            pack_count);
-    }
+    void init();
 
     static void loadIndex(
         ColumnIndexes & indexes,
@@ -248,123 +149,9 @@ private:
         bool set_cache_if_miss,
         ColId col_id,
         const ReadLimiterPtr & read_limiter,
-        const ScanContextPtr & scan_context)
-    {
-        const auto & type = dmfile->getColumnStat(col_id).type;
-        const auto file_name_base = DMFile::getFileNameBase(col_id);
+        const ScanContextPtr & scan_context);
 
-        auto load = [&]() {
-            auto index_file_size = dmfile->colIndexSize(col_id);
-            if (index_file_size == 0)
-                return std::make_shared<MinMaxIndex>(*type);
-            auto index_guard = S3::S3RandomAccessFile::setReadFileInfo({
-                .size = dmfile->getReadFileSize(col_id, dmfile->colIndexFileName(file_name_base)),
-                .scan_context = scan_context,
-            });
-            if (!dmfile->configuration) // v1
-            {
-                auto index_buf = ReadBufferFromRandomAccessFileBuilder::build(
-                    file_provider,
-                    dmfile->colIndexPath(file_name_base),
-                    dmfile->encryptionIndexPath(file_name_base),
-                    std::min(static_cast<size_t>(DBMS_DEFAULT_BUFFER_SIZE), index_file_size),
-                    read_limiter);
-                return MinMaxIndex::read(*type, index_buf, index_file_size);
-            }
-            else if (dmfile->useMetaV2()) // v3
-            {
-                auto info = dmfile->merged_sub_file_infos.find(dmfile->colIndexFileName(file_name_base));
-                if (info == dmfile->merged_sub_file_infos.end())
-                {
-                    throw Exception(
-                        fmt::format("Unknown index file {}", dmfile->colIndexPath(file_name_base)),
-                        ErrorCodes::LOGICAL_ERROR);
-                }
-
-                auto file_path = dmfile->mergedPath(info->second.number);
-                auto encryp_path = dmfile->encryptionMergedPath(info->second.number);
-                auto offset = info->second.offset;
-                auto data_size = info->second.size;
-
-                auto buffer = ReadBufferFromRandomAccessFileBuilder::build(
-                    file_provider,
-                    file_path,
-                    encryp_path,
-                    dmfile->getConfiguration()->getChecksumFrameLength(),
-                    read_limiter);
-                buffer.seek(offset);
-
-                String raw_data;
-                raw_data.resize(data_size);
-
-                buffer.read(reinterpret_cast<char *>(raw_data.data()), data_size);
-
-                auto buf = ChecksumReadBufferBuilder::build(
-                    std::move(raw_data),
-                    dmfile->colDataPath(file_name_base),
-                    dmfile->getConfiguration()->getChecksumFrameLength(),
-                    dmfile->configuration->getChecksumAlgorithm(),
-                    dmfile->configuration->getChecksumFrameLength());
-
-                auto header_size = dmfile->configuration->getChecksumHeaderLength();
-                auto frame_total_size = dmfile->configuration->getChecksumFrameLength() + header_size;
-                auto frame_count = index_file_size / frame_total_size + (index_file_size % frame_total_size != 0);
-
-                return MinMaxIndex::read(*type, *buf, index_file_size - header_size * frame_count);
-            }
-            else
-            { // v2
-                auto index_buf = ChecksumReadBufferBuilder::build(
-                    file_provider,
-                    dmfile->colIndexPath(file_name_base),
-                    dmfile->encryptionIndexPath(file_name_base),
-                    index_file_size,
-                    read_limiter,
-                    dmfile->configuration->getChecksumAlgorithm(),
-                    dmfile->configuration->getChecksumFrameLength());
-                auto header_size = dmfile->configuration->getChecksumHeaderLength();
-                auto frame_total_size = dmfile->configuration->getChecksumFrameLength() + header_size;
-                auto frame_count = index_file_size / frame_total_size + (index_file_size % frame_total_size != 0);
-                return MinMaxIndex::read(*type, *index_buf, index_file_size - header_size * frame_count);
-            }
-        };
-        MinMaxIndexPtr minmax_index;
-        if (index_cache && set_cache_if_miss)
-        {
-            minmax_index = index_cache->getOrSet(dmfile->colIndexCacheKey(file_name_base), load);
-        }
-        else
-        {
-            // try load from the cache first
-            if (index_cache)
-                minmax_index = index_cache->get(dmfile->colIndexCacheKey(file_name_base));
-            if (minmax_index == nullptr)
-                minmax_index = load();
-        }
-        indexes.emplace(col_id, RSIndex(type, minmax_index));
-    }
-
-    void tryLoadIndex(const ColId col_id)
-    {
-        if (param.indexes.count(col_id))
-            return;
-
-        if (!dmfile->isColIndexExist(col_id))
-            return;
-
-        Stopwatch watch;
-        loadIndex(
-            param.indexes,
-            dmfile,
-            file_provider,
-            index_cache,
-            set_cache_if_miss,
-            col_id,
-            read_limiter,
-            scan_context);
-
-        scan_context->total_dmfile_rough_set_index_check_time_ns += watch.elapsed();
-    }
+    void tryLoadIndex(const ColId col_id);
 
 private:
     DMFilePtr dmfile;

--- a/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter_fwd.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter_fwd.h
@@ -1,0 +1,27 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <common/types.h>
+
+namespace DB::DM
+{
+
+using IdSet = std::set<UInt64>;
+using IdSetPtr = std::shared_ptr<IdSet>;
+
+class DMFilePackFilter;
+
+} // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/File/DMFileReader.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileReader.h
@@ -20,6 +20,7 @@
 #include <Storages/DeltaMerge/File/ColumnStream.h>
 #include <Storages/DeltaMerge/File/DMFile.h>
 #include <Storages/DeltaMerge/File/DMFilePackFilter.h>
+#include <Storages/DeltaMerge/ReadMode.h>
 #include <Storages/DeltaMerge/ReadThread/ColumnSharingCache.h>
 #include <Storages/DeltaMerge/RowKeyRange.h>
 #include <Storages/DeltaMerge/ScanContext_fwd.h>

--- a/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.cpp
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.cpp
@@ -11,7 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #include <Common/setThreadName.h>
+#include <Interpreters/Settings.h>
 #include <Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.h>
 #include <Storages/DeltaMerge/ReadThread/SegmentReader.h>
 #include <Storages/DeltaMerge/Segment.h>

--- a/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.h
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.h
@@ -16,6 +16,11 @@
 #include <Storages/DeltaMerge/ReadThread/MergedTask.h>
 #include <Storages/DeltaMerge/SegmentReadTaskPool.h>
 
+namespace DB
+{
+struct Settings;
+}
+
 namespace DB::DM
 {
 

--- a/dbms/src/Storages/DeltaMerge/Remote/RNLocalPageCache.cpp
+++ b/dbms/src/Storages/DeltaMerge/Remote/RNLocalPageCache.cpp
@@ -19,6 +19,7 @@
 #include <Interpreters/Context.h>
 #include <Storages/DeltaMerge/DeltaMergeStore.h>
 #include <Storages/DeltaMerge/Remote/RNLocalPageCache.h>
+#include <Storages/DeltaMerge/ScanContext.h>
 #include <Storages/Page/V3/Universal/UniversalPageStorage.h>
 #include <Storages/Page/V3/Universal/UniversalWriteBatchImpl.h>
 

--- a/dbms/src/Storages/DeltaMerge/Remote/RNWorkerPrepareStreams.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/RNWorkerPrepareStreams.h
@@ -16,6 +16,7 @@
 
 #include <Common/ThreadedWorker.h>
 #include <Interpreters/Context.h>
+#include <Storages/DeltaMerge/DMContext.h>
 #include <Storages/DeltaMerge/Filter/PushDownFilter.h>
 #include <Storages/DeltaMerge/SegmentReadTask.h>
 

--- a/dbms/src/Storages/DeltaMerge/Segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/Segment.cpp
@@ -43,6 +43,7 @@
 #include <Storages/DeltaMerge/Remote/ObjectId.h>
 #include <Storages/DeltaMerge/Remote/RNDeltaIndexCache.h>
 #include <Storages/DeltaMerge/RowKeyOrderedBlockInputStream.h>
+#include <Storages/DeltaMerge/ScanContext.h>
 #include <Storages/DeltaMerge/Segment.h>
 #include <Storages/DeltaMerge/SegmentReadTaskPool.h>
 #include <Storages/DeltaMerge/Segment_fwd.h>

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTask.cpp
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTask.cpp
@@ -735,4 +735,37 @@ void SegmentReadTask::doFetchPagesImpl(
         wait_write_page_ns / 1000000);
 }
 
+String SegmentReadTask::string() const
+{
+    if (dm_context->keyspace_id == DB::NullspaceID)
+    {
+        return fmt::format(
+            "s{}_t{}_{}_{}_{}",
+            store_id,
+            dm_context->physical_table_id,
+            segment->segmentId(),
+            segment->segmentEpoch(),
+            read_snapshot->delta->getDeltaIndexEpoch());
+    }
+    return fmt::format(
+        "s{}_ks{}_t{}_{}_{}_{}",
+        store_id,
+        dm_context->keyspace_id,
+        dm_context->physical_table_id,
+        segment->segmentId(),
+        segment->segmentEpoch(),
+        read_snapshot->delta->getDeltaIndexEpoch());
+}
+
+GlobalSegmentID SegmentReadTask::getGlobalSegmentID() const
+{
+    return GlobalSegmentID{
+        .store_id = store_id,
+        .keyspace_id = dm_context->keyspace_id,
+        .physical_table_id = dm_context->physical_table_id,
+        .segment_id = segment->segmentId(),
+        .segment_epoch = segment->segmentEpoch(),
+    };
+}
+
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTask.cpp
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTask.cpp
@@ -735,7 +735,7 @@ void SegmentReadTask::doFetchPagesImpl(
         wait_write_page_ns / 1000000);
 }
 
-String SegmentReadTask::string() const
+String SegmentReadTask::toString() const
 {
     if (dm_context->keyspace_id == DB::NullspaceID)
     {

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTask.h
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTask.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include <Storages/DeltaMerge/DMContext.h>
+#include <Storages/DeltaMerge/DMContext_fwd.h>
 #include <Storages/DeltaMerge/Remote/DisaggTaskId.h>
 #include <Storages/DeltaMerge/Remote/Proto/remote.pb.h>
 #include <Storages/DeltaMerge/Remote/RNLocalPageCache.h>
@@ -82,16 +82,7 @@ public:
 
     ~SegmentReadTask();
 
-    GlobalSegmentID getGlobalSegmentID() const
-    {
-        return GlobalSegmentID{
-            .store_id = store_id,
-            .keyspace_id = dm_context->keyspace_id,
-            .physical_table_id = dm_context->physical_table_id,
-            .segment_id = segment->segmentId(),
-            .segment_epoch = segment->segmentEpoch(),
-        };
-    }
+    GlobalSegmentID getGlobalSegmentID() const;
 
     void addRange(const RowKeyRange & range);
 
@@ -114,6 +105,8 @@ public:
         RUNTIME_CHECK(input_stream != nullptr);
         return input_stream;
     }
+
+    String string() const;
 
 #ifndef DBMS_PUBLIC_GTEST
 private:
@@ -168,27 +161,8 @@ struct fmt::formatter<DB::DM::SegmentReadTask>
     template <typename FormatContext>
     auto format(const DB::DM::SegmentReadTask & t, FormatContext & ctx) const
     {
-        if (t.dm_context->keyspace_id == DB::NullspaceID)
-        {
-            return fmt::format_to(
-                ctx.out(),
-                "s{}_t{}_{}_{}_{}",
-                t.store_id,
-                t.dm_context->physical_table_id,
-                t.segment->segmentId(),
-                t.segment->segmentEpoch(),
-                t.read_snapshot->delta->getDeltaIndexEpoch());
-        }
-        return fmt::format_to(
-            ctx.out(),
-            "s{}_ks{}_t{}_{}_{}_{}",
-            t.store_id,
-            t.dm_context->keyspace_id,
-            t.dm_context->physical_table_id,
-            t.segment->segmentId(),
-            t.segment->segmentEpoch(),
-            t.read_snapshot->delta->getDeltaIndexEpoch());
-    }
+        return fmt::format_to(ctx.out(), "{}", t.string());
+    };
 };
 
 template <>

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTask.h
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTask.h
@@ -106,7 +106,7 @@ public:
         return input_stream;
     }
 
-    String string() const;
+    String toString() const;
 
 #ifndef DBMS_PUBLIC_GTEST
 private:
@@ -161,7 +161,7 @@ struct fmt::formatter<DB::DM::SegmentReadTask>
     template <typename FormatContext>
     auto format(const DB::DM::SegmentReadTask & t, FormatContext & ctx) const
     {
-        return fmt::format_to(ctx.out(), "{}", t.string());
+        return fmt::format_to(ctx.out(), "{}", t.toString());
     };
 };
 

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.cpp
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.cpp
@@ -15,6 +15,7 @@
 #include <Common/FailPoint.h>
 #include <DataStreams/AddExtraTableIDColumnInputStream.h>
 #include <Interpreters/Context.h>
+#include <Storages/DeltaMerge/DMContext.h>
 #include <Storages/DeltaMerge/SegmentReadTaskPool.h>
 
 #include <magic_enum.hpp>

--- a/dbms/src/Storages/DeltaMerge/SkippableBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/SkippableBlockInputStream.cpp
@@ -1,0 +1,183 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Storages/DeltaMerge/ScanContext.h>
+#include <Storages/DeltaMerge/SkippableBlockInputStream.h>
+
+namespace DB::DM
+{
+
+template <bool need_row_id>
+ConcatSkippableBlockInputStream<need_row_id>::ConcatSkippableBlockInputStream(
+    SkippableBlockInputStreams inputs_,
+    const ScanContextPtr & scan_context_)
+    : rows(inputs_.size(), 0)
+    , precede_stream_rows(0)
+    , scan_context(scan_context_)
+    , lac_bytes_collector(scan_context_ ? scan_context_->resource_group_name : "")
+{
+    children.insert(children.end(), inputs_.begin(), inputs_.end());
+    current_stream = children.begin();
+}
+
+template <bool need_row_id>
+ConcatSkippableBlockInputStream<need_row_id>::ConcatSkippableBlockInputStream(
+    SkippableBlockInputStreams inputs_,
+    std::vector<size_t> && rows_,
+    const ScanContextPtr & scan_context_)
+    : rows(std::move(rows_))
+    , precede_stream_rows(0)
+    , scan_context(scan_context_)
+    , lac_bytes_collector(scan_context_ ? scan_context_->resource_group_name : "")
+{
+    children.insert(children.end(), inputs_.begin(), inputs_.end());
+    current_stream = children.begin();
+}
+
+template <bool need_row_id>
+bool ConcatSkippableBlockInputStream<need_row_id>::getSkippedRows(size_t & skip_rows)
+{
+    skip_rows = 0;
+    while (current_stream != children.end())
+    {
+        auto * skippable_stream = dynamic_cast<SkippableBlockInputStream *>((*current_stream).get());
+
+        size_t skip;
+        bool has_next_block = skippable_stream->getSkippedRows(skip);
+        skip_rows += skip;
+
+        if (has_next_block)
+        {
+            return true;
+        }
+        else
+        {
+            (*current_stream)->readSuffix();
+            precede_stream_rows += rows[current_stream - children.begin()];
+            ++current_stream;
+        }
+    }
+
+    return false;
+}
+
+template <bool need_row_id>
+size_t ConcatSkippableBlockInputStream<need_row_id>::skipNextBlock()
+{
+    while (current_stream != children.end())
+    {
+        auto * skippable_stream = dynamic_cast<SkippableBlockInputStream *>((*current_stream).get());
+
+        size_t skipped_rows = skippable_stream->skipNextBlock();
+
+        if (skipped_rows > 0)
+        {
+            return skipped_rows;
+        }
+        else
+        {
+            (*current_stream)->readSuffix();
+            precede_stream_rows += rows[current_stream - children.begin()];
+            ++current_stream;
+        }
+    }
+    return 0;
+}
+
+template <bool need_row_id>
+Block ConcatSkippableBlockInputStream<need_row_id>::readWithFilter(const IColumn::Filter & filter)
+{
+    Block res;
+
+    while (current_stream != children.end())
+    {
+        auto * skippable_stream = dynamic_cast<SkippableBlockInputStream *>((*current_stream).get());
+        res = skippable_stream->readWithFilter(filter);
+
+        if (res)
+        {
+            res.setStartOffset(res.startOffset() + precede_stream_rows);
+            addReadBytes(res.bytes());
+            break;
+        }
+        else
+        {
+            (*current_stream)->readSuffix();
+            precede_stream_rows += rows[current_stream - children.begin()];
+            ++current_stream;
+        }
+    }
+    return res;
+}
+
+template <bool need_row_id>
+Block ConcatSkippableBlockInputStream<need_row_id>::read()
+{
+    Block res;
+
+    while (current_stream != children.end())
+    {
+        res = (*current_stream)->read();
+
+        if (res)
+        {
+            res.setStartOffset(res.startOffset() + precede_stream_rows);
+            if constexpr (need_row_id)
+            {
+                res.setSegmentRowIdCol(createSegmentRowIdCol(res.startOffset(), res.rows()));
+            }
+            addReadBytes(res.bytes());
+            break;
+        }
+        else
+        {
+            (*current_stream)->readSuffix();
+            precede_stream_rows += rows[current_stream - children.begin()];
+            ++current_stream;
+        }
+    }
+
+    return res;
+}
+
+template <bool need_row_id>
+ColumnPtr ConcatSkippableBlockInputStream<need_row_id>::createSegmentRowIdCol(UInt64 start, UInt64 limit)
+{
+    auto seg_row_id_col = ColumnUInt32::create();
+    ColumnUInt32::Container & res = seg_row_id_col->getData();
+    res.resize(limit);
+    for (UInt64 i = 0; i < limit; ++i)
+    {
+        res[i] = i + start;
+    }
+    return seg_row_id_col;
+}
+
+template <bool need_row_id>
+void ConcatSkippableBlockInputStream<need_row_id>::addReadBytes(UInt64 bytes)
+{
+    if (likely(scan_context != nullptr))
+    {
+        scan_context->user_read_bytes += bytes;
+        if constexpr (!need_row_id)
+        {
+            lac_bytes_collector.collect(bytes);
+        }
+    }
+}
+
+template class ConcatSkippableBlockInputStream<false>;
+template class ConcatSkippableBlockInputStream<true>;
+
+} // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/SkippableBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/SkippableBlockInputStream.h
@@ -20,7 +20,7 @@
 #include <Flash/ResourceControl/LocalAdmissionController.h>
 #include <Storages/DeltaMerge/DeltaMergeDefines.h>
 #include <Storages/DeltaMerge/DeltaMergeHelpers.h>
-#include <Storages/DeltaMerge/ScanContext.h>
+#include <Storages/DeltaMerge/ScanContext_fwd.h>
 
 namespace DB
 {
@@ -76,158 +76,30 @@ template <bool need_row_id = false>
 class ConcatSkippableBlockInputStream : public SkippableBlockInputStream
 {
 public:
-    ConcatSkippableBlockInputStream(SkippableBlockInputStreams inputs_, const ScanContextPtr & scan_context_)
-        : rows(inputs_.size(), 0)
-        , precede_stream_rows(0)
-        , scan_context(scan_context_)
-        , lac_bytes_collector(scan_context_ ? scan_context_->resource_group_name : "")
-    {
-        children.insert(children.end(), inputs_.begin(), inputs_.end());
-        current_stream = children.begin();
-    }
+    ConcatSkippableBlockInputStream(SkippableBlockInputStreams inputs_, const ScanContextPtr & scan_context_);
 
     ConcatSkippableBlockInputStream(
         SkippableBlockInputStreams inputs_,
         std::vector<size_t> && rows_,
-        const ScanContextPtr & scan_context_)
-        : rows(std::move(rows_))
-        , precede_stream_rows(0)
-        , scan_context(scan_context_)
-        , lac_bytes_collector(scan_context_ ? scan_context_->resource_group_name : "")
-    {
-        children.insert(children.end(), inputs_.begin(), inputs_.end());
-        current_stream = children.begin();
-    }
+        const ScanContextPtr & scan_context_);
 
     String getName() const override { return "ConcatSkippable"; }
 
     Block getHeader() const override { return children.at(0)->getHeader(); }
 
-    bool getSkippedRows(size_t & skip_rows) override
-    {
-        skip_rows = 0;
-        while (current_stream != children.end())
-        {
-            auto * skippable_stream = dynamic_cast<SkippableBlockInputStream *>((*current_stream).get());
+    bool getSkippedRows(size_t & skip_rows) override;
 
-            size_t skip;
-            bool has_next_block = skippable_stream->getSkippedRows(skip);
-            skip_rows += skip;
+    size_t skipNextBlock() override;
 
-            if (has_next_block)
-            {
-                return true;
-            }
-            else
-            {
-                (*current_stream)->readSuffix();
-                precede_stream_rows += rows[current_stream - children.begin()];
-                ++current_stream;
-            }
-        }
+    Block readWithFilter(const IColumn::Filter & filter) override;
 
-        return false;
-    }
-
-    size_t skipNextBlock() override
-    {
-        while (current_stream != children.end())
-        {
-            auto * skippable_stream = dynamic_cast<SkippableBlockInputStream *>((*current_stream).get());
-
-            size_t skipped_rows = skippable_stream->skipNextBlock();
-
-            if (skipped_rows > 0)
-            {
-                return skipped_rows;
-            }
-            else
-            {
-                (*current_stream)->readSuffix();
-                precede_stream_rows += rows[current_stream - children.begin()];
-                ++current_stream;
-            }
-        }
-        return 0;
-    }
-
-    Block readWithFilter(const IColumn::Filter & filter) override
-    {
-        Block res;
-
-        while (current_stream != children.end())
-        {
-            auto * skippable_stream = dynamic_cast<SkippableBlockInputStream *>((*current_stream).get());
-            res = skippable_stream->readWithFilter(filter);
-
-            if (res)
-            {
-                res.setStartOffset(res.startOffset() + precede_stream_rows);
-                addReadBytes(res.bytes());
-                break;
-            }
-            else
-            {
-                (*current_stream)->readSuffix();
-                precede_stream_rows += rows[current_stream - children.begin()];
-                ++current_stream;
-            }
-        }
-        return res;
-    }
-
-    Block read() override
-    {
-        Block res;
-
-        while (current_stream != children.end())
-        {
-            res = (*current_stream)->read();
-
-            if (res)
-            {
-                res.setStartOffset(res.startOffset() + precede_stream_rows);
-                if constexpr (need_row_id)
-                {
-                    res.setSegmentRowIdCol(createSegmentRowIdCol(res.startOffset(), res.rows()));
-                }
-                addReadBytes(res.bytes());
-                break;
-            }
-            else
-            {
-                (*current_stream)->readSuffix();
-                precede_stream_rows += rows[current_stream - children.begin()];
-                ++current_stream;
-            }
-        }
-
-        return res;
-    }
+    Block read() override;
 
 private:
-    ColumnPtr createSegmentRowIdCol(UInt64 start, UInt64 limit)
-    {
-        auto seg_row_id_col = ColumnUInt32::create();
-        ColumnUInt32::Container & res = seg_row_id_col->getData();
-        res.resize(limit);
-        for (UInt64 i = 0; i < limit; ++i)
-        {
-            res[i] = i + start;
-        }
-        return seg_row_id_col;
-    }
-    void addReadBytes(UInt64 bytes)
-    {
-        if (likely(scan_context != nullptr))
-        {
-            scan_context->user_read_bytes += bytes;
-            if constexpr (!need_row_id)
-            {
-                lac_bytes_collector.collect(bytes);
-            }
-        }
-    }
+    ColumnPtr createSegmentRowIdCol(UInt64 start, UInt64 limit);
+
+    void addReadBytes(UInt64 bytes);
+
     BlockInputStreams::iterator current_stream;
     std::vector<size_t> rows;
     size_t precede_stream_rows;

--- a/dbms/src/Storages/DeltaMerge/StableValueSpace.h
+++ b/dbms/src/Storages/DeltaMerge/StableValueSpace.h
@@ -16,8 +16,7 @@
 
 #include <Storages/DeltaMerge/DMContext_fwd.h>
 #include <Storages/DeltaMerge/File/ColumnCache.h>
-#include <Storages/DeltaMerge/File/DMFilePackFilter.h>
-#include <Storages/DeltaMerge/File/DMFileReader.h>
+#include <Storages/DeltaMerge/File/DMFilePackFilter_fwd.h>
 #include <Storages/DeltaMerge/File/DMFile_fwd.h>
 #include <Storages/DeltaMerge/Index/RSResult.h>
 #include <Storages/DeltaMerge/RowKeyRange.h>

--- a/dbms/src/Storages/DeltaMerge/tests/MultiSegmentTestUtil.h
+++ b/dbms/src/Storages/DeltaMerge/tests/MultiSegmentTestUtil.h
@@ -17,7 +17,6 @@
 
 #include <Common/FailPoint.h>
 #include <Interpreters/Context.h>
-#include <Interpreters/Context_fwd.h>
 #include <Storages/DeltaMerge/DMContext.h>
 #include <Storages/DeltaMerge/DeltaMergeDefines.h>
 #include <Storages/DeltaMerge/DeltaMergeStore.h>

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store.cpp
@@ -25,6 +25,7 @@
 #include <Storages/DeltaMerge/PKSquashingBlockInputStream.h>
 #include <Storages/DeltaMerge/ReadThread/UnorderedInputStream.h>
 #include <Storages/DeltaMerge/RowKeyRange.h>
+#include <Storages/DeltaMerge/ScanContext.h>
 #include <Storages/DeltaMerge/StoragePool/GlobalStoragePool.h>
 #include <Storages/DeltaMerge/StoragePool/StoragePool.h>
 #include <Storages/DeltaMerge/tests/DMTestEnv.h>

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_fast_add_peer.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_fast_add_peer.cpp
@@ -17,6 +17,7 @@
 #include <DataStreams/BlocksListBlockInputStream.h>
 #include <DataStreams/OneBlockInputStream.h>
 #include <Flash/Disaggregated/MockS3LockClient.h>
+#include <Interpreters/Context.h>
 #include <Interpreters/SharedContexts/Disagg.h>
 #include <Storages/DeltaMerge/DMContext.h>
 #include <Storages/DeltaMerge/DeltaMergeStore.h>

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_file.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_file.cpp
@@ -24,6 +24,7 @@
 #include <Storages/DeltaMerge/File/DMFileBlockOutputStream.h>
 #include <Storages/DeltaMerge/File/DMFileWriter.h>
 #include <Storages/DeltaMerge/RowKeyRange.h>
+#include <Storages/DeltaMerge/ScanContext.h>
 #include <Storages/DeltaMerge/StoragePool/StoragePool.h>
 #include <Storages/DeltaMerge/tests/DMTestEnv.h>
 #include <Storages/FormatVersion.h>

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_read_task.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_read_task.cpp
@@ -20,6 +20,7 @@
 #include <Storages/DeltaMerge/Remote/DataStore/DataStoreMock.h>
 #include <Storages/DeltaMerge/Remote/DisaggSnapshot.h>
 #include <Storages/DeltaMerge/Remote/Serializer.h>
+#include <Storages/DeltaMerge/ScanContext.h>
 #include <Storages/DeltaMerge/SegmentReadTask.h>
 #include <Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_test_basic.h>
 #include <Storages/DeltaMerge/tests/gtest_segment_test_basic.h>

--- a/dbms/src/Storages/KVStore/MultiRaft/Disagg/CheckpointIngestInfo.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/Disagg/CheckpointIngestInfo.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Interpreters/Context.h>
+#include <Storages/DeltaMerge/DMContext.h>
 #include <Storages/DeltaMerge/DeltaMergeStore.h>
 #include <Storages/DeltaMerge/Segment.h>
 #include <Storages/DeltaMerge/WriteBatchesImpl.h>

--- a/dbms/src/Storages/S3/tests/gtest_s3file.cpp
+++ b/dbms/src/Storages/S3/tests/gtest_s3file.cpp
@@ -25,6 +25,7 @@
 #include <Storages/DeltaMerge/File/DMFileBlockOutputStream.h>
 #include <Storages/DeltaMerge/File/DMFileWriter.h>
 #include <Storages/DeltaMerge/Remote/DataStore/DataStoreS3.h>
+#include <Storages/DeltaMerge/ScanContext.h>
 #include <Storages/DeltaMerge/tests/DMTestEnv.h>
 #include <Storages/Page/V3/CheckpointFile/CPDataFileStat.h>
 #include <Storages/Page/V3/CheckpointFile/CheckpointFiles.h>

--- a/dbms/src/Storages/StorageDisaggregatedRemote.cpp
+++ b/dbms/src/Storages/StorageDisaggregatedRemote.cpp
@@ -42,6 +42,7 @@
 #include <Storages/DeltaMerge/Remote/RNSegmentInputStream.h>
 #include <Storages/DeltaMerge/Remote/RNSegmentSourceOp.h>
 #include <Storages/DeltaMerge/Remote/RNWorkers.h>
+#include <Storages/DeltaMerge/ScanContext.h>
 #include <Storages/KVStore/Decode/DecodingStorageSchemaSnapshot.h>
 #include <Storages/KVStore/TMTContext.h>
 #include <Storages/KVStore/Types.h>


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/7000

Problem Summary:

### What is changed and how it works?

Reduce the usage of these imports in headers by using forward decl as more as possible:

- Context.h
- DMContext.h
- ScanContext.h

Some class implementations were developed in .h files. They are now moved to .cpp files so that only forward decl is needed in .h files.

Before this PR, when introducing a new field to ScanContext, 140 files need to be recompiled. After this PR, only 35 will be re-compiled.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
