### PR TITLE
logging: Fix `local_region_num` in MPPTaskStatistics logging

### DIFF
--- a/dbms/src/Storages/DeltaMerge/ScanContext.cpp
+++ b/dbms/src/Storages/DeltaMerge/ScanContext.cpp
@@ -31,7 +31,7 @@ String ScanContext::toJson() const
     json->set("dmfile_read_time", fmt::format("{:.3f}ms", total_dmfile_read_time_ns.load() / NS_TO_MS_SCALE));
 
     json->set("remote_region_num", total_remote_region_num.load());
-    json->set("local_region_num", total_remote_region_num.load());
+    json->set("local_region_num", total_local_region_num.load());
 
     json->set("read_bytes", user_read_bytes.load());
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/8895

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix the wrong number of `local_region_num` shown in logging
```
