### PR TITLE
do not mark spill if there is no data to spill in auto spill mode

### DIFF
--- a/dbms/src/Interpreters/AggSpillContext.cpp
+++ b/dbms/src/Interpreters/AggSpillContext.cpp
@@ -52,6 +52,9 @@ bool AggSpillContext::updatePerThreadRevocableMemory(Int64 new_value, size_t thr
     if (!in_spillable_stage || !isSpillEnabled())
         return false;
     per_thread_revocable_memories[thread_num] = new_value;
+    if (new_value == 0)
+        // new_value == 0 means no agg data to spill
+        return false;
     if (auto_spill_mode)
     {
         AutoSpillStatus old_value = AutoSpillStatus::NEED_AUTO_SPILL;
@@ -97,6 +100,9 @@ Int64 AggSpillContext::triggerSpillImpl(Int64 expected_released_memories)
     for (; checked_thread < per_thread_revocable_memories.size(); ++checked_thread)
     {
         AutoSpillStatus old_value = AutoSpillStatus::NO_NEED_AUTO_SPILL;
+        if (per_thread_revocable_memories[checked_thread] == 0)
+            // meaningless to trigger spill if there is no data
+            continue;
         if (per_thread_auto_spill_status[checked_thread].compare_exchange_strong(
                 old_value,
                 AutoSpillStatus::NEED_AUTO_SPILL))
@@ -146,7 +152,7 @@ void AggSpillContext::finishOneSpill(size_t thread_num)
 
 bool AggSpillContext::markThreadForAutoSpill(size_t thread_num)
 {
-    if (in_spillable_stage && isSpillEnabled())
+    if (in_spillable_stage && isSpillEnabled() && per_thread_revocable_memories[thread_num] > 0)
     {
         auto old_value = AutoSpillStatus::NO_NEED_AUTO_SPILL;
         return per_thread_auto_spill_status[thread_num].compare_exchange_strong(

--- a/dbms/src/Interpreters/AggSpillContext.cpp
+++ b/dbms/src/Interpreters/AggSpillContext.cpp
@@ -100,8 +100,7 @@ Int64 AggSpillContext::triggerSpillImpl(Int64 expected_released_memories)
     for (; checked_thread < per_thread_revocable_memories.size(); ++checked_thread)
     {
         AutoSpillStatus old_value = AutoSpillStatus::NO_NEED_AUTO_SPILL;
-        if (per_thread_revocable_memories[checked_thread] == 0)
-            // meaningless to trigger spill if there is no data
+        if (per_thread_revocable_memories[checked_thread] <= MIN_SPILL_THRESHOLD)
             continue;
         if (per_thread_auto_spill_status[checked_thread].compare_exchange_strong(
                 old_value,

--- a/dbms/src/Interpreters/AggSpillContext.cpp
+++ b/dbms/src/Interpreters/AggSpillContext.cpp
@@ -100,7 +100,7 @@ Int64 AggSpillContext::triggerSpillImpl(Int64 expected_released_memories)
     for (; checked_thread < per_thread_revocable_memories.size(); ++checked_thread)
     {
         AutoSpillStatus old_value = AutoSpillStatus::NO_NEED_AUTO_SPILL;
-        if (per_thread_revocable_memories[checked_thread] <= MIN_SPILL_THRESHOLD)
+        if (per_thread_revocable_memories[checked_thread] < MIN_SPILL_THRESHOLD)
             continue;
         if (per_thread_auto_spill_status[checked_thread].compare_exchange_strong(
                 old_value,

--- a/dbms/src/Interpreters/Aggregator.cpp
+++ b/dbms/src/Interpreters/Aggregator.cpp
@@ -997,6 +997,7 @@ bool Aggregator::executeOnBlock(AggProcessInfo & agg_process_info, AggregatedDat
         LOG_TRACE(log, "Revocable bytes after insert one block {}, thread {}", revocable_bytes, thread_num);
     if (agg_spill_context->updatePerThreadRevocableMemory(revocable_bytes, thread_num))
     {
+        assert(!result.empty());
         result.tryMarkNeedSpill();
     }
 

--- a/dbms/src/Interpreters/Aggregator.cpp
+++ b/dbms/src/Interpreters/Aggregator.cpp
@@ -1332,7 +1332,7 @@ inline void Aggregator::insertAggregatesIntoColumns(
     for (size_t destroy_i = 0; destroy_i < params.aggregates_size; ++destroy_i)
     {
         /// If ownership was not transferred to ColumnAggregateFunction.
-        if (!(destroy_i < insert_i && aggregate_functions[destroy_i]->isState()))
+        if (destroy_i >= insert_i || !aggregate_functions[destroy_i]->isState()))
             aggregate_functions[destroy_i]->destroy(mapped + offsets_of_aggregate_states[destroy_i]);
     }
 

--- a/dbms/src/Interpreters/Aggregator.cpp
+++ b/dbms/src/Interpreters/Aggregator.cpp
@@ -1332,7 +1332,7 @@ inline void Aggregator::insertAggregatesIntoColumns(
     for (size_t destroy_i = 0; destroy_i < params.aggregates_size; ++destroy_i)
     {
         /// If ownership was not transferred to ColumnAggregateFunction.
-        if (destroy_i >= insert_i || !aggregate_functions[destroy_i]->isState()))
+        if (destroy_i >= insert_i || !aggregate_functions[destroy_i]->isState())
             aggregate_functions[destroy_i]->destroy(mapped + offsets_of_aggregate_states[destroy_i]);
     }
 

--- a/dbms/src/Interpreters/HashJoinSpillContext.cpp
+++ b/dbms/src/Interpreters/HashJoinSpillContext.cpp
@@ -246,7 +246,7 @@ Int64 HashJoinSpillContext::triggerSpillImpl(Int64 expected_released_memories)
         });
     for (const auto & pair : partition_index_to_revocable_memories)
     {
-        if (pair.second.second <= 0)
+        if (pair.second.second <= MIN_SPILL_THRESHOLD)
             continue;
         if (!in_build_stage && !isPartitionSpilled(pair.first))
             /// no new partition spill is allowed if not in build stage

--- a/dbms/src/Interpreters/HashJoinSpillContext.cpp
+++ b/dbms/src/Interpreters/HashJoinSpillContext.cpp
@@ -246,7 +246,7 @@ Int64 HashJoinSpillContext::triggerSpillImpl(Int64 expected_released_memories)
         });
     for (const auto & pair : partition_index_to_revocable_memories)
     {
-        if (pair.second.second <= MIN_SPILL_THRESHOLD)
+        if (pair.second.second < MIN_SPILL_THRESHOLD)
             continue;
         if (!in_build_stage && !isPartitionSpilled(pair.first))
             /// no new partition spill is allowed if not in build stage

--- a/dbms/src/Interpreters/HashJoinSpillContext.cpp
+++ b/dbms/src/Interpreters/HashJoinSpillContext.cpp
@@ -129,6 +129,8 @@ bool HashJoinSpillContext::updatePartitionRevocableMemory(size_t partition_id, I
         return false;
     bool is_spilled = (*partition_is_spilled)[partition_id];
     (*partition_revocable_memories)[partition_id] = new_value;
+    if (new_value == 0)
+        return false;
     if (operator_spill_threshold > 0)
     {
         auto force_spill = is_spilled && operator_spill_threshold > 0

--- a/dbms/src/Interpreters/SortSpillContext.cpp
+++ b/dbms/src/Interpreters/SortSpillContext.cpp
@@ -71,7 +71,7 @@ bool SortSpillContext::updateRevocableMemory(Int64 new_value)
 
 Int64 SortSpillContext::triggerSpillImpl(DB::Int64 expected_released_memories)
 {
-    if (revocable_memory > 0)
+    if (revocable_memory > MIN_SPILL_THRESHOLD)
     {
         AutoSpillStatus old_value = AutoSpillStatus::NO_NEED_AUTO_SPILL;
         auto_spill_status.compare_exchange_strong(old_value, AutoSpillStatus::NEED_AUTO_SPILL);

--- a/dbms/src/Interpreters/SortSpillContext.cpp
+++ b/dbms/src/Interpreters/SortSpillContext.cpp
@@ -71,7 +71,7 @@ bool SortSpillContext::updateRevocableMemory(Int64 new_value)
 
 Int64 SortSpillContext::triggerSpillImpl(DB::Int64 expected_released_memories)
 {
-    if (revocable_memory > MIN_SPILL_THRESHOLD)
+    if (revocable_memory >= MIN_SPILL_THRESHOLD)
     {
         AutoSpillStatus old_value = AutoSpillStatus::NO_NEED_AUTO_SPILL;
         auto_spill_status.compare_exchange_strong(old_value, AutoSpillStatus::NEED_AUTO_SPILL);

--- a/dbms/src/Operators/AggregateContext.cpp
+++ b/dbms/src/Operators/AggregateContext.cpp
@@ -60,6 +60,7 @@ bool AggregateContext::isTaskMarkedForSpill(size_t task_index)
         return true;
     if (getAggSpillContext()->updatePerThreadRevocableMemory(many_data[task_index]->revocableBytes(), task_index))
     {
+        assert(!many_data[task_index]->empty());
         return many_data[task_index]->tryMarkNeedSpill();
     }
     return false;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8905

Problem Summary:

### What is changed and how it works?
Don't mark spill if there is not data to spill in auto spill mode
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
