### PR TITLE
ddl: Do not succee the last_gc_safepoint when physically dropping table is skipped

### DIFF
--- a/dbms/src/TiDB/Schema/SchemaSyncService.cpp
+++ b/dbms/src/TiDB/Schema/SchemaSyncService.cpp
@@ -304,6 +304,7 @@ bool SchemaSyncService::gcImpl(Timestamp gc_safepoint, KeyspaceID keyspace_id, b
                     storage->getTombstone(),
                     gc_safepoint,
                     canonical_name);
+                succeeded = false; // dropping this table is skipped, do not succee the `last_gc_safepoint`
                 continue;
             }
             else
@@ -343,7 +344,7 @@ bool SchemaSyncService::gcImpl(Timestamp gc_safepoint, KeyspaceID keyspace_id, b
         }
         catch (DB::Exception & e)
         {
-            succeeded = false;
+            succeeded = false; // dropping this table is skipped, do not succee the `last_gc_safepoint`
             String err_msg;
             // Maybe a read lock of a table is held for a long time, just ignore it this round.
             if (e.code() == ErrorCodes::DEADLOCK_AVOIDED)
@@ -397,7 +398,7 @@ bool SchemaSyncService::gcImpl(Timestamp gc_safepoint, KeyspaceID keyspace_id, b
         }
         catch (DB::Exception & e)
         {
-            succeeded = false;
+            succeeded = false; // dropping this database is skipped, do not succee the `last_gc_safepoint`
             String err_msg;
             if (e.code() == ErrorCodes::DEADLOCK_AVOIDED)
                 err_msg = "locking attempt has timed out!"; // ignore verbose stack for this error


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/8911

Problem Summary:
In https://github.com/pingcap/tiflash/pull/8721, we introduce a rule that: "if the regions of a given table is not totally removed from TiFlash, skip physically dropping it". However, it does not set the succeeded = false, so after all it will update the last_gc_safepoint.
When the whole cluster has few write commands, the gc_safepoint may not change. It make that the physically dropping only run after the gc_safepoint is changed again. Which will slow down the data disk reclaim.

### What is changed and how it works?

* If physically dropping a table is skipped by regions are not totally removed, set `succeeded = false`
* Then the `last_gc_safepoint` will not get updated
* And after `ddl_sync_interval_seconds` passed, `SchemaSyncService::gc` will run again even if the `gc_safepoint` on PD side is not changed

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
