### PR TITLE
*: Fix compile error

### DIFF
--- a/dbms/src/Flash/ResourceControl/MockLocalAdmissionController.h
+++ b/dbms/src/Flash/ResourceControl/MockLocalAdmissionController.h
@@ -70,7 +70,7 @@ public:
         return {get_priority_func(name)};
     }
     void warmupResourceGroupInfoCache(const std::string &) {}
-    uint64_t estWaitDuraMS(const std::string &) { return 100; }
+    static uint64_t estWaitDuraMS(const std::string &) { return 100; }
 
     void registerRefillTokenCallback(const std::function<void()> & cb)
     {
@@ -84,6 +84,8 @@ public:
         RUNTIME_CHECK_MSG(refill_token_callback != nullptr, "callback cannot be nullptr before unregistering");
         refill_token_callback = nullptr;
     }
+
+    void safeStop() { stop(); }
 
     void stop()
     {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/8860

Problem Summary:

```
>  ninja gtests_dbms tiflash -j32                                                                                                                                                                               2024-04-12 18:03:07
[0/2] Re-checking globbed directories...
[41/44] Building CXX object dbms/src/Server/CMakeFiles/tiflash-server-lib.dir/Server.cpp.o
FAILED: dbms/src/Server/CMakeFiles/tiflash-server-lib.dir/Server.cpp.o 
/DATA/disk1/ra_common/tiflash-env-15/sysroot/bin/ccache /DATA/disk1/ra_common/tiflash-env-15/sysroot/bin/clang++ -DAWS_SDK_VERSION_MAJOR=1 -DAWS_SDK_VERSION_MINOR=11 -DAWS_SDK_VERSION_PATCH=186 -DBOOST_BIND_GLOBAL_PLACEHOLDERS -DBOOST_NO_CXX98_FUNCTION_BASE -DBOOST_SYSTEM_NO_DEPRECATED -DCARES_STATICLIB -DDBMS_PUBLIC_GTEST -DFIU_ENABLE -DLZ4_DISABLE_DEPRECATE_WARNINGS=1 -DLZ4_FAST_DEC_LOOP=1 -DMULTIPLE_CONTEXT_GTEST -DPOCO_STATIC -DPOCO_UNBUNDLED_ZLIB -DSIMDJSON_THREADS_ENABLED=1 -DSTACK_LINE_READER_BUFFER_SIZE=1024 -DTIFLASH_COMPILER_VPCLMULQDQ_SUPPORT=1 -DTIFLASH_ENABLE_AVX512_SUPPORT=1 -DTIFLASH_ENABLE_AVX_SUPPORT=1 -DTIFLASH_SOURCE_PREFIX=\"/DATA/disk1/jaysonhuang/tiflash-master\" -D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS -I/DATA/disk1/jaysonhuang/tiflash-master/dbms/src -I/DATA/disk1/jaysonhuang/tiflash-master/libs/libdaemon/include -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/GmSSL/include -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/double-conversion -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/boost -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/xxHash -I/DATA/disk1/jaysonhuang/tiflash-master/cmake-build-debug/dbms/src -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/libpcg-random/include -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/libcityhash/include -I/DATA/disk1/jaysonhuang/tiflash-master/libs/libcommon/include -I/DATA/disk1/jaysonhuang/tiflash-master/cmake-build-debug/libs/libcommon/include -I/DATA/disk1/jaysonhuang/tiflash-master/libs/libpocoext/include -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/poco/Data/include -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/poco/Foundation/include -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/zlib-ng -I/DATA/disk1/jaysonhuang/tiflash-master/cmake-build-debug/contrib/zlib-ng -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/poco/Util/include -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/poco/XML/include -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/poco/JSON/include -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/poco/Net/include -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/cctz/include -I/DATA/disk1/jaysonhuang/tiflash-master/cmake-build-debug/contrib/jemalloc-cmake/include -I/DATA/disk1/jaysonhuang/tiflash-master/cmake-build-debug/contrib/jemalloc-cmake/include/jemalloc -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/jemalloc/include -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/jemalloc-cmake/include -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/cpu_features/include -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/libcpuid/include -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/lz4/lib -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/zstd/lib -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/client-c/third_party/libfiu/libfiu -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/prometheus-cpp/core/include -I/DATA/disk1/jaysonhuang/tiflash-master/cmake-build-debug/contrib/prometheus-cpp-cmake/core/include -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/prometheus-cpp/push/include -I/DATA/disk1/jaysonhuang/tiflash-master/cmake-build-debug/contrib/prometheus-cpp-cmake/push/include -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/prometheus-cpp/pull/include -I/DATA/disk1/jaysonhuang/tiflash-master/cmake-build-debug/contrib/prometheus-cpp-cmake/pull/include -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/cpptoml -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/magic_enum/include -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/simdjson/include -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/poco/NetSSL_OpenSSL/include -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/poco/Crypto/include -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/xxHash/cmake_unofficial/.. -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/tiflash-proxy/raftstore-proxy/ffi/src -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/libbtrie/include -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/abseil-cpp -I/DATA/disk1/jaysonhuang/tiflash-master/cmake-build-debug/contrib/etcd -I/DATA/disk1/jaysonhuang/tiflash-master/cmake-build-debug/contrib/etcd/etcd -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/grpc/include -I/DATA/disk1/jaysonhuang/tiflash-master/cmake-build-debug/contrib/kvproto/cpp -I/DATA/disk1/jaysonhuang/tiflash-master/cmake-build-debug/contrib/kvproto/cpp/kvproto -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/client-c/include -I/DATA/disk1/jaysonhuang/tiflash-master/cmake-build-debug/contrib/grpc/third_party/cares/cares -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/grpc/third_party/cares/cares -I/DATA/disk1/jaysonhuang/tiflash-master/cmake-build-debug/contrib/tipb/cpp -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/libunwind/include -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/libdivide -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/libmetrohash/src -I/DATA/disk1/jaysonhuang/tiflash-master/contrib/libfarmhash -isystem /DATA/disk1/jaysonhuang/tiflash-master/libs/libprocess_metrics/include -isystem /DATA/disk1/jaysonhuang/tiflash-master/contrib/fmtlib-cmake/../fmtlib/include -isystem /DATA/disk1/jaysonhuang/tiflash-master/libs/libsymbolization/include -isystem /DATA/disk1/jaysonhuang/tiflash-master/contrib/re2 -isystem /DATA/disk1/jaysonhuang/tiflash-master/cmake-build-debug/contrib/re2-cmake -isystem /DATA/disk1/jaysonhuang/tiflash-master/contrib/boringssl/include -isystem /DATA/disk1/jaysonhuang/tiflash-master/contrib/aws/src/aws-cpp-sdk-core/include -isystem /DATA/disk1/jaysonhuang/tiflash-master/cmake-build-debug/contrib/aws-cmake/include -isystem /DATA/disk1/jaysonhuang/tiflash-master/contrib/aws/generated/src/aws-cpp-sdk-s3/include -isystem /DATA/disk1/jaysonhuang/tiflash-master/contrib/aws/generated/src/aws-cpp-sdk-sts/include -isystem /DATA/disk1/jaysonhuang/tiflash-master/contrib/aws-c-auth/include -isystem /DATA/disk1/jaysonhuang/tiflash-master/contrib/aws-c-common/include -isystem /DATA/disk1/jaysonhuang/tiflash-master/contrib/aws-c-io/include -isystem /DATA/disk1/jaysonhuang/tiflash-master/contrib/aws-crt-cpp/include -isystem /DATA/disk1/jaysonhuang/tiflash-master/contrib/aws-c-mqtt/include -isystem /DATA/disk1/jaysonhuang/tiflash-master/contrib/aws-c-sdkutils/include -isystem /DATA/disk1/jaysonhuang/tiflash-master/contrib/protobuf/src -Wthread-safety  -pipe -mssse3 -msse4.1 -msse4.2 -mpclmul -mpopcnt  -fno-omit-frame-pointer  -Wall -Wno-unused-command-line-argument  -Wnon-virtual-dtor  -stdlib=libc++ -Wextra -Werror -g -g3 -ggdb3 -O0 -fverbose-asm -fno-inline  -D_LIBCPP_DEBUG=0 -fPIC -DDUMMY_BACKTRACE -std=gnu++20 -MD -MT dbms/src/Server/CMakeFiles/tiflash-server-lib.dir/Server.cpp.o -MF dbms/src/Server/CMakeFiles/tiflash-server-lib.dir/Server.cpp.o.d -o dbms/src/Server/CMakeFiles/tiflash-server-lib.dir/Server.cpp.o -c /DATA/disk1/jaysonhuang/tiflash-master/dbms/src/Server/Server.cpp
/DATA/disk1/jaysonhuang/tiflash-master/dbms/src/Server/Server.cpp:1789:60: error: no member named 'safeStop' in 'DB::MockLocalAdmissionController'
                LocalAdmissionController::global_instance->safeStop();
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
/DATA/disk1/jaysonhuang/tiflash-master/libs/libcommon/include/ext/scope_guard.h:46:50: note: expanded from macro 'SCOPE_EXIT'
#define SCOPE_EXIT(...) SCOPE_EXIT_FWD(__LINE__, __VA_ARGS__)
                                                 ^~~~~~~~~~~
/DATA/disk1/jaysonhuang/tiflash-master/libs/libcommon/include/ext/scope_guard.h:45:53: note: expanded from macro 'SCOPE_EXIT_FWD'
#define SCOPE_EXIT_FWD(n, ...) SCOPE_EXIT_CONCAT(n, __VA_ARGS__)
                                                    ^~~~~~~~~~~
/DATA/disk1/jaysonhuang/tiflash-master/libs/libcommon/include/ext/scope_guard.h:44:90: note: expanded from macro 'SCOPE_EXIT_CONCAT'
#define SCOPE_EXIT_CONCAT(n, ...) const auto scope_exit##n = ext::make_scope_guard([&] { __VA_ARGS__; })
                                                                                         ^~~~~~~~~~~
/DATA/disk1/jaysonhuang/tiflash-master/dbms/src/Server/Server.cpp:1812:60: error: no member named 'safeStop' in 'DB::MockLocalAdmissionController'
                LocalAdmissionController::global_instance->safeStop();
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
/DATA/disk1/jaysonhuang/tiflash-master/libs/libcommon/include/ext/scope_guard.h:46:50: note: expanded from macro 'SCOPE_EXIT'
#define SCOPE_EXIT(...) SCOPE_EXIT_FWD(__LINE__, __VA_ARGS__)
                                                 ^~~~~~~~~~~
/DATA/disk1/jaysonhuang/tiflash-master/libs/libcommon/include/ext/scope_guard.h:45:53: note: expanded from macro 'SCOPE_EXIT_FWD'
#define SCOPE_EXIT_FWD(n, ...) SCOPE_EXIT_CONCAT(n, __VA_ARGS__)
                                                    ^~~~~~~~~~~
/DATA/disk1/jaysonhuang/tiflash-master/libs/libcommon/include/ext/scope_guard.h:44:90: note: expanded from macro 'SCOPE_EXIT_CONCAT'
#define SCOPE_EXIT_CONCAT(n, ...) const auto scope_exit##n = ext::make_scope_guard([&] { __VA_ARGS__; })
```

### What is changed and how it works?

Fix compile error introduced by https://github.com/pingcap/tiflash/pull/8942

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
