### PR TITLE
ddl: Fix logging cause by non-dropped table

### DIFF
--- a/dbms/src/TiDB/Schema/SchemaSyncService.cpp
+++ b/dbms/src/TiDB/Schema/SchemaSyncService.cpp
@@ -408,7 +408,8 @@ bool SchemaSyncService::gcImpl(Timestamp gc_safepoint, KeyspaceID keyspace_id, b
         }
     }
 
-    // TODO: Optimize it after `BackgroundProcessingPool` can 
+    // TODO: Optimize it after `BackgroundProcessingPool` can the task return how many seconds to sleep
+    //       before next round.
     if (succeeded)
     {
         updateLastGcSafepoint(keyspace_id, gc_safepoint);

--- a/dbms/src/TiDB/Schema/SchemaSyncService.cpp
+++ b/dbms/src/TiDB/Schema/SchemaSyncService.cpp
@@ -408,6 +408,7 @@ bool SchemaSyncService::gcImpl(Timestamp gc_safepoint, KeyspaceID keyspace_id, b
         }
     }
 
+    // TODO: Optimize it after `BackgroundProcessingPool` can 
     if (succeeded)
     {
         updateLastGcSafepoint(keyspace_id, gc_safepoint);
@@ -417,6 +418,11 @@ bool SchemaSyncService::gcImpl(Timestamp gc_safepoint, KeyspaceID keyspace_id, b
             num_tables_removed,
             num_databases_removed,
             gc_safepoint);
+        // This round of GC could run for a long time. Run immediately to check whether
+        // the latest gc_safepoint has been updated in PD.
+        // - gc_safepoint is not updated, it will be skipped because gc_safepoint == last_gc_safepoint
+        // - gc_safepoint is updated, run again immediately to cleanup other dropped data
+        return true;
     }
     else
     {
@@ -426,9 +432,10 @@ bool SchemaSyncService::gcImpl(Timestamp gc_safepoint, KeyspaceID keyspace_id, b
             "Schema GC meet error, will try again later, last_safepoint={} safepoint={}",
             last_gc_safepoint,
             gc_safepoint);
+        // Return false to let it run again after `ddl_sync_interval_seconds` even if the gc_safepoint
+        // on PD is not updated.
+        return false;
     }
-
-    return true;
 }
 
 } // namespace DB

--- a/dbms/src/TiDB/Schema/SchemaSyncService.h
+++ b/dbms/src/TiDB/Schema/SchemaSyncService.h
@@ -28,7 +28,8 @@ namespace DB
 namespace tests
 {
 class RegionKVStoreTest;
-}
+class SchemaSyncTest;
+} // namespace tests
 class Logger;
 using LoggerPtr = std::shared_ptr<Logger>;
 
@@ -65,6 +66,7 @@ private:
 
     friend void dbgFuncGcSchemas(Context &, const ASTs &, DBGInvokerPrinter);
     friend class tests::RegionKVStoreTest;
+    friend class tests::SchemaSyncTest;
 
     struct KeyspaceGCContext
     {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/8911

Problem Summary:

After https://github.com/pingcap/tiflash/pull/8910, if some tables are not able to be dropped, `SchemaSyncService::gcImpl` will run again with the same gc_safepoint.
But in this path, `SchemaSyncService::gcImpl` always return true. So if there are some tables can not be dropped for some bugs, then this function will run again and again and print lots of loggings.

### What is changed and how it works?

if `succeeded == false`, then let `SchemaSyncService::gcImpl` run again after `ddl_sync_interval_seconds`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
