### PR TITLE
Storages: Remove some `DBMS_PUBLIC_GTEST` hacks

### DIFF
--- a/dbms/src/Storages/DeltaMerge/ReadThread/MergedTask.h
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/MergedTask.h
@@ -18,6 +18,11 @@
 
 namespace DB::DM
 {
+namespace tests
+{
+class SegmentReadTasksPoolTest;
+}
+
 struct MergedUnit
 {
     MergedUnit(const SegmentReadTaskPoolPtr & pool_, const SegmentReadTaskPtr & task_)
@@ -127,11 +132,7 @@ public:
         }
     }
 
-#ifndef DBMS_PUBLIC_GTEST
 private:
-#else
-public:
-#endif
     void initOnce();
     int readOneBlock();
     void setUnitFinish(int i) { finished_count += units[i].setFinish(); }
@@ -143,6 +144,8 @@ public:
     size_t finished_count;
     Stopwatch sw;
     inline static std::atomic<int64_t> passive_merged_segments{0};
+
+    friend class tests::SegmentReadTasksPoolTest;
 };
 
 using MergedTaskPtr = std::shared_ptr<MergedTask>;

--- a/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.h
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.h
@@ -23,7 +23,10 @@ struct Settings;
 
 namespace DB::DM
 {
-
+namespace tests
+{
+class SegmentReadTasksPoolTest;
+}
 // `SegmentReadTaskScheduler` is a global singleton. All `SegmentReadTaskPool` will be added to it and be scheduled by it.
 // 1. `UnorderedInputStream`/`UnorderedSourceOps` will call `SegmentReadTaskScheduler::add` to add a `SegmentReadTaskPool`
 // object to the `read_pools` list and index segments information into `merging_segments`.
@@ -51,11 +54,7 @@ public:
 
     void updateConfig(const Settings & settings);
 
-#ifndef DBMS_PUBLIC_GTEST
 private:
-#else
-public:
-#endif
     // `run_sched_thread` is used for test.
     explicit SegmentReadTaskScheduler(bool run_sched_thread = true);
 
@@ -101,5 +100,7 @@ public:
 
     // To count how many threads are waitting to add tasks.
     std::atomic<Int64> add_waittings{0};
+
+    friend class tests::SegmentReadTasksPoolTest;
 };
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.h
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.h
@@ -23,7 +23,10 @@
 
 namespace DB::DM
 {
-
+namespace tests
+{
+class SegmentReadTasksPoolTest;
+}
 using AfterSegmentRead = std::function<void(const DMContextPtr &, const SegmentPtr &)>;
 
 class BlockStat
@@ -199,11 +202,7 @@ public:
 
     const LoggerPtr & getLogger() const { return log; }
 
-#ifndef DBMS_PUBLIC_GTEST
 private:
-#else
-public:
-#endif
     Int64 getFreeActiveSegmentsUnlock() const;
     bool exceptionHappened() const;
     void finishSegment(const SegmentReadTaskPtr & seg);
@@ -249,6 +248,8 @@ public:
     inline static BlockStat global_blk_stat;
     static uint64_t nextPoolId() { return pool_id_gen.fetch_add(1, std::memory_order_relaxed); }
     inline static constexpr Int64 check_ru_interval_ms = 100;
+
+    friend class tests::SegmentReadTasksPoolTest;
 };
 
 using SegmentReadTaskPoolPtr = std::shared_ptr<SegmentReadTaskPool>;

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_read_task_pool.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_read_task_pool.cpp
@@ -107,75 +107,11 @@ protected:
             /*res_group_name_*/ String{});
     }
 
-    inline static const std::vector<PageIdU64> test_seg_ids{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
-};
 
-TEST_F(SegmentReadTasksPoolTest, UnorderedWrapper)
-{
-    SegmentReadTasksWrapper tasks_wrapper(true, createSegmentReadTasks(test_seg_ids));
-
-    bool exception_happened = false;
-    try
+    void schedulerBasic()
     {
-        tasks_wrapper.nextTask();
-    }
-    catch (const Exception & e)
-    {
-        exception_happened = true;
-    }
-    ASSERT_TRUE(exception_happened);
+        SegmentReadTaskScheduler scheduler{false};
 
-    ASSERT_FALSE(tasks_wrapper.empty());
-    const auto & tasks = tasks_wrapper.getTasks();
-    ASSERT_EQ(tasks.size(), test_seg_ids.size());
-
-    std::random_device rd;
-    std::mt19937 g(rd());
-    std::vector<PageIdU64> v = test_seg_ids;
-    std::shuffle(v.begin(), v.end(), g);
-    for (PageIdU64 seg_id : v)
-    {
-        auto global_seg_id = createGlobalSegmentID(seg_id);
-        auto task = tasks_wrapper.getTask(global_seg_id);
-        ASSERT_NE(task, nullptr);
-        ASSERT_EQ(task->segment->segmentId(), seg_id);
-        task = tasks_wrapper.getTask(global_seg_id);
-        ASSERT_EQ(task, nullptr);
-    }
-    ASSERT_TRUE(tasks_wrapper.empty());
-}
-
-TEST_F(SegmentReadTasksPoolTest, OrderedWrapper)
-{
-    SegmentReadTasksWrapper tasks_wrapper(false, createSegmentReadTasks(test_seg_ids));
-
-    bool exception_happened = false;
-    try
-    {
-        tasks_wrapper.getTasks();
-    }
-    catch (const Exception & e)
-    {
-        exception_happened = true;
-    }
-    ASSERT_TRUE(exception_happened);
-
-    ASSERT_FALSE(tasks_wrapper.empty());
-
-    for (PageIdU64 seg_id : test_seg_ids)
-    {
-        auto task = tasks_wrapper.nextTask();
-        ASSERT_EQ(task->segment->segmentId(), seg_id);
-    }
-    ASSERT_TRUE(tasks_wrapper.empty());
-    ASSERT_EQ(tasks_wrapper.nextTask(), nullptr);
-}
-
-TEST_F(SegmentReadTasksPoolTest, SchedulerBasic)
-{
-    SegmentReadTaskScheduler scheduler{false};
-
-    {
         // Create and add pool.
         auto pool = createSegmentReadTaskPool(test_seg_ids);
         pool->increaseUnorderedInputStreamRefCount();
@@ -254,6 +190,74 @@ TEST_F(SegmentReadTasksPoolTest, SchedulerBasic)
             ASSERT_FALSE(pool->valid());
         }
     }
+
+    inline static const std::vector<PageIdU64> test_seg_ids{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+};
+
+TEST_F(SegmentReadTasksPoolTest, UnorderedWrapper)
+{
+    SegmentReadTasksWrapper tasks_wrapper(true, createSegmentReadTasks(test_seg_ids));
+
+    bool exception_happened = false;
+    try
+    {
+        tasks_wrapper.nextTask();
+    }
+    catch (const Exception & e)
+    {
+        exception_happened = true;
+    }
+    ASSERT_TRUE(exception_happened);
+
+    ASSERT_FALSE(tasks_wrapper.empty());
+    const auto & tasks = tasks_wrapper.getTasks();
+    ASSERT_EQ(tasks.size(), test_seg_ids.size());
+
+    std::random_device rd;
+    std::mt19937 g(rd());
+    std::vector<PageIdU64> v = test_seg_ids;
+    std::shuffle(v.begin(), v.end(), g);
+    for (PageIdU64 seg_id : v)
+    {
+        auto global_seg_id = createGlobalSegmentID(seg_id);
+        auto task = tasks_wrapper.getTask(global_seg_id);
+        ASSERT_NE(task, nullptr);
+        ASSERT_EQ(task->segment->segmentId(), seg_id);
+        task = tasks_wrapper.getTask(global_seg_id);
+        ASSERT_EQ(task, nullptr);
+    }
+    ASSERT_TRUE(tasks_wrapper.empty());
+}
+
+TEST_F(SegmentReadTasksPoolTest, OrderedWrapper)
+{
+    SegmentReadTasksWrapper tasks_wrapper(false, createSegmentReadTasks(test_seg_ids));
+
+    bool exception_happened = false;
+    try
+    {
+        tasks_wrapper.getTasks();
+    }
+    catch (const Exception & e)
+    {
+        exception_happened = true;
+    }
+    ASSERT_TRUE(exception_happened);
+
+    ASSERT_FALSE(tasks_wrapper.empty());
+
+    for (PageIdU64 seg_id : test_seg_ids)
+    {
+        auto task = tasks_wrapper.nextTask();
+        ASSERT_EQ(task->segment->segmentId(), seg_id);
+    }
+    ASSERT_TRUE(tasks_wrapper.empty());
+    ASSERT_EQ(tasks_wrapper.nextTask(), nullptr);
+}
+
+TEST_F(SegmentReadTasksPoolTest, SchedulerBasic)
+{
+    schedulerBasic();
 }
 
 } // namespace DB::DM::tests


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6233

### What is changed and how it works?

- Avoid using the macro `DBMS_PUBLIC_GTEST` by declaring friend class and move some test functions in the TestFixture class.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
