### PR TITLE
tests: Fix unstable schema test

### DIFF
--- a/dbms/src/TiDB/Schema/TiDBSchemaManager.h
+++ b/dbms/src/TiDB/Schema/TiDBSchemaManager.h
@@ -133,7 +133,7 @@ private:
             return iter->second;
         }
         auto syncer = createSchemaSyncer(keyspace_id);
-        schema_syncers[keyspace_id] = syncer;
+        schema_syncers[keyspace_id] = syncer; // register to the syncers
         return syncer;
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/8968, close https://github.com/pingcap/tiflash/issues/8911

Problem Summary:
https://github.com/pingcap/tiflash/pull/8955 introduced a check on the cache gc_safepoint is not updated, but the background task of DDL sync make the ut unstable

### What is changed and how it works?

* Disable the background task when `profiles.default.ddl_sync_interval_seconds == 0`
* Refine the code in `TiDBSchemaManager.h` with comments on locking `schema_syncers_mutex`
* Refine the code in `SchemaSyncTest` to use temporary instance instead of the instance in `global_context`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
