### PR TITLE
KVStore: Temporarily disable reusing read index history

### DIFF
--- a/dbms/src/Storages/KVStore/Read/ReadIndexDataNode.cpp
+++ b/dbms/src/Storages/KVStore/Read/ReadIndexDataNode.cpp
@@ -72,9 +72,9 @@ void ReadIndexDataNode::runOneRound(const TiFlashRaftProxyHelper & helper, const
             waiting_tasks.size(),
             running_tasks.size());
 
-        // start-ts `0` will be used to only get the latest index, do not use history
         // According to https://github.com/pingcap/tiflash/issues/8845, a txn with larger commit_ts could have smaller raft log index.
         // Thus the optimization is not safe. We temporarily disable this feature until we find a correct way.
+        // start-ts `0` will be used to only get the latest index, do not use history
         if (false) // NOLINT
         {
             TEST_LOG_FMT("find history_tasks resp {}", history_success_tasks->second.ShortDebugString());

--- a/dbms/src/Storages/KVStore/Read/ReadIndexDataNode.cpp
+++ b/dbms/src/Storages/KVStore/Read/ReadIndexDataNode.cpp
@@ -73,7 +73,9 @@ void ReadIndexDataNode::runOneRound(const TiFlashRaftProxyHelper & helper, const
             running_tasks.size());
 
         // start-ts `0` will be used to only get the latest index, do not use history
-        if (history_success_tasks && history_success_tasks->first >= max_ts && max_ts)
+        // According to https://github.com/pingcap/tiflash/issues/8845, a txn with larger commit_ts could have smaller raft log index.
+        // Thus the optimization is not safe. We temporarily disable this feature until we find a correct way.
+        if (false) // NOLINT
         {
             TEST_LOG_FMT("find history_tasks resp {}", history_success_tasks->second.ShortDebugString());
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8845

Problem Summary:

According to #8845, we have to temporarily disable this mechanism before we find a way to address the current problem.

After this pr, we will expect more read index request being handled and processed by both TiFlash and TiKV. There could be some performance regressions, due to:
1. More requests may heavy the burden of TiKV and TiFlash.
2. Some single read index request could potentially processed slower, because it can't reuse history anymore.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
