### PR TITLE
WIP: Storages: Add some stats of table scanning

### DIFF
--- a/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.cpp
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.cpp
@@ -56,6 +56,9 @@ void SegmentReadTaskScheduler::add(const SegmentReadTaskPoolPtr & pool)
     {
         merging_segments[seg_id].push_back(pool->pool_id);
     }
+
+    pool->startTableScanning();
+
     LOG_INFO(
         pool->getLogger(),
         "Added, pool_id={} block_slots={} segment_count={} pool_count={} cost={:.3f}us do_add_cost={:.3f}us", //


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #8864

Problem Summary:

The time of table scanning in explain analyze is not the real working time of the scanning operator.

This PR add some stats of table scanning and print them in the log to help debugging some performance issues.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
