### PR TITLE
Storages: Use template to replace macro in RSOperator

### DIFF
--- a/dbms/src/Storages/DeltaMerge/Filter/Equal.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/Equal.h
@@ -31,9 +31,7 @@ public:
 
     RSResults roughCheck(size_t start_pack, size_t pack_count, const RSCheckParam & param) override
     {
-        RSResults results(pack_count, RSResult::Some);
-        GET_RSINDEX_FROM_PARAM_NOT_FOUND_RETURN_DIRECTLY(param, attr, rsindex, results);
-        return rsindex.minmax->checkCmp<RoughCheck::CheckEqual>(start_pack, pack_count, value, rsindex.type);
+        return minMaxCheckCmp<RoughCheck::CheckEqual>(start_pack, pack_count, param, attr, value);
     }
 };
 

--- a/dbms/src/Storages/DeltaMerge/Filter/Greater.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/Greater.h
@@ -31,9 +31,7 @@ public:
 
     RSResults roughCheck(size_t start_pack, size_t pack_count, const RSCheckParam & param) override
     {
-        RSResults results(pack_count, RSResult::Some);
-        GET_RSINDEX_FROM_PARAM_NOT_FOUND_RETURN_DIRECTLY(param, attr, rsindex, results);
-        return rsindex.minmax->checkCmp<RoughCheck::CheckGreater>(start_pack, pack_count, value, rsindex.type);
+        return minMaxCheckCmp<RoughCheck::CheckGreater>(start_pack, pack_count, param, attr, value);
     }
 };
 

--- a/dbms/src/Storages/DeltaMerge/Filter/GreaterEqual.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/GreaterEqual.h
@@ -31,9 +31,7 @@ public:
 
     RSResults roughCheck(size_t start_pack, size_t pack_count, const RSCheckParam & param) override
     {
-        RSResults results(pack_count, RSResult::Some);
-        GET_RSINDEX_FROM_PARAM_NOT_FOUND_RETURN_DIRECTLY(param, attr, rsindex, results);
-        return rsindex.minmax->checkCmp<RoughCheck::CheckGreaterEqual>(start_pack, pack_count, value, rsindex.type);
+        return minMaxCheckCmp<RoughCheck::CheckGreaterEqual>(start_pack, pack_count, param, attr, value);
     }
 };
 

--- a/dbms/src/Storages/DeltaMerge/Filter/In.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/In.h
@@ -55,9 +55,9 @@ public:
         // So return none directly.
         if (values.empty())
             return RSResults(pack_count, RSResult::None);
-        RSResults results(pack_count, RSResult::Some);
-        GET_RSINDEX_FROM_PARAM_NOT_FOUND_RETURN_DIRECTLY(param, attr, rsindex, results);
-        return rsindex.minmax->checkIn(start_pack, pack_count, values, rsindex.type);
+        auto rs_index = getRSIndex(param, attr);
+        return rs_index ? rs_index->minmax->checkIn(start_pack, pack_count, values, rs_index->type)
+                        : RSResults(pack_count, RSResult::Some);
     }
 };
 

--- a/dbms/src/Storages/DeltaMerge/Filter/IsNull.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/IsNull.h
@@ -36,9 +36,8 @@ public:
 
     RSResults roughCheck(size_t start_pack, size_t pack_count, const RSCheckParam & param) override
     {
-        RSResults results(pack_count, RSResult::Some);
-        GET_RSINDEX_FROM_PARAM_NOT_FOUND_RETURN_DIRECTLY(param, attr, rsindex, results);
-        return rsindex.minmax->checkIsNull(start_pack, pack_count);
+        auto rs_index = getRSIndex(param, attr);
+        return rs_index ? rs_index->minmax->checkIsNull(start_pack, pack_count) : RSResults(pack_count, RSResult::Some);
     }
 };
 

--- a/dbms/src/Storages/DeltaMerge/Filter/Less.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/Less.h
@@ -31,9 +31,7 @@ public:
 
     RSResults roughCheck(size_t start_pack, size_t pack_count, const RSCheckParam & param) override
     {
-        RSResults results(pack_count, RSResult::Some);
-        GET_RSINDEX_FROM_PARAM_NOT_FOUND_RETURN_DIRECTLY(param, attr, rsindex, results);
-        results = rsindex.minmax->checkCmp<RoughCheck::CheckGreaterEqual>(start_pack, pack_count, value, rsindex.type);
+        auto results = minMaxCheckCmp<RoughCheck::CheckGreaterEqual>(start_pack, pack_count, param, attr, value);
         std::transform(results.begin(), results.end(), results.begin(), [](RSResult result) { return !result; });
         return results;
     }

--- a/dbms/src/Storages/DeltaMerge/Filter/LessEqual.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/LessEqual.h
@@ -31,9 +31,7 @@ public:
 
     RSResults roughCheck(size_t start_pack, size_t pack_count, const RSCheckParam & param) override
     {
-        RSResults results(pack_count, RSResult::Some);
-        GET_RSINDEX_FROM_PARAM_NOT_FOUND_RETURN_DIRECTLY(param, attr, rsindex, results);
-        results = rsindex.minmax->checkCmp<RoughCheck::CheckGreater>(start_pack, pack_count, value, rsindex.type);
+        auto results = minMaxCheckCmp<RoughCheck::CheckGreater>(start_pack, pack_count, param, attr, value);
         std::transform(results.begin(), results.end(), results.begin(), [](const auto result) { return !result; });
         return results;
     }

--- a/dbms/src/Storages/DeltaMerge/Filter/NotEqual.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/NotEqual.h
@@ -31,9 +31,7 @@ public:
 
     RSResults roughCheck(size_t start_pack, size_t pack_count, const RSCheckParam & param) override
     {
-        RSResults results(pack_count, RSResult::Some);
-        GET_RSINDEX_FROM_PARAM_NOT_FOUND_RETURN_DIRECTLY(param, attr, rsindex, results);
-        results = rsindex.minmax->checkCmp<RoughCheck::CheckEqual>(start_pack, pack_count, value, rsindex.type);
+        auto results = minMaxCheckCmp<RoughCheck::CheckEqual>(start_pack, pack_count, param, attr, value);
         std::transform(results.begin(), results.end(), results.begin(), [](RSResult result) { return !result; });
         return results;
     }

--- a/dbms/src/Storages/DeltaMerge/Filter/PushDownFilter.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/PushDownFilter.h
@@ -24,7 +24,7 @@ class PushDownFilter;
 using PushDownFilterPtr = std::shared_ptr<PushDownFilter>;
 inline static const PushDownFilterPtr EMPTY_FILTER{};
 
-class PushDownFilter : public std::enable_shared_from_this<PushDownFilter>
+class PushDownFilter
 {
 public:
     PushDownFilter(


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6233

Problem Summary:

### What is changed and how it works?

1. Use template function to replace macro `GET_RSINDEX_FROM_PARAM_NOT_FOUND_RETURN_DIRECTLY`.
2. Remove inherit from `enable_shared_from_this` in `RSOperator` and `PushDownFilter` since `shared_from_this` is not used.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
