### PR TITLE
ddl: Fix exchange partition across databases (release-7.1)

### DIFF
--- a/dbms/src/Common/FailPoint.cpp
+++ b/dbms/src/Common/FailPoint.cpp
@@ -101,6 +101,7 @@ namespace DB
     M(force_use_dmfile_format_v3)                            \
     M(force_set_mocked_s3_object_mtime)                      \
     M(force_stop_background_checkpoint_upload)               \
+    M(force_schema_sync_too_old_schema)                      \
     M(skip_seek_before_read_dmfile)                          \
     M(exception_after_large_write_exceed)                    \
     M(delta_tree_create_node_fail)

--- a/dbms/src/Storages/StorageDeltaMerge.cpp
+++ b/dbms/src/Storages/StorageDeltaMerge.cpp
@@ -1333,7 +1333,7 @@ inline OptionTableInfoConstRef getTableInfoForCreateStatement(
 
 void StorageDeltaMerge::alterImpl(
     const AlterCommands & commands,
-    const String & database_name,
+    const String & database_name_,
     const String & table_name_,
     const OptionTableInfoConstRef table_info,
     const Context & context)
@@ -1440,7 +1440,7 @@ try
     // after update `new_columns` and store's table columns, we need to update create table statement,
     // so that we can restore table next time.
     updateDeltaMergeTableCreateStatement(
-        database_name,
+        database_name_,
         table_name_,
         pk_desc,
         getColumns(),

--- a/dbms/src/Storages/StorageDeltaMerge.h
+++ b/dbms/src/Storages/StorageDeltaMerge.h
@@ -217,8 +217,8 @@ private:
 
     void alterImpl(
         const AlterCommands & commands,
-        const String & database_name,
-        const String & table_name,
+        const String & database_name_,
+        const String & table_name_,
         DB::DM::OptionTableInfoConstRef table_info_,
         const Context & context);
 

--- a/dbms/src/TiDB/Schema/SchemaBuilder.cpp
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.cpp
@@ -693,6 +693,7 @@ void SchemaBuilder<Getter, NameMapper>::applyPartitionDiff(const TiDB::DBInfoPtr
             if (!new_part_id_set.contains(orig_def.id))
             {
                 const auto part_table_name = name_mapper.mapTableNameByID(updated_table_info.keyspace_id, orig_def.id);
+                // When `tryLoadSchemaDiffs` fails, we may run into `SchemaBuilder::syncAllSchem` -> `applyPartitionDiff` without `applyExchangeTablePartition`
                 // The physical table maybe `EXCHANGE` to another database, try to find the partition from all database
                 auto part_db_info = tryFindDatabaseByPartitionTable(db_info, part_table_name);
                 applyDropPhysicalTable(name_mapper.mapDatabaseName(*part_db_info), orig_def.id);
@@ -706,7 +707,8 @@ void SchemaBuilder<Getter, NameMapper>::applyPartitionDiff(const TiDB::DBInfoPtr
         {
             auto part_table_info = updated_table_info.producePartitionTableInfo(new_def.id, name_mapper);
             const auto part_table_name = name_mapper.mapTableName(*part_table_info);
-                // The physical table maybe `EXCHANGE` from another database, try to find the partition from all database
+            // When `tryLoadSchemaDiffs` fails, we may run into `SchemaBuilder::syncAllSchem` -> `applyPartitionDiff` without `applyExchangeTablePartition`
+            // The physical table maybe `EXCHANGE` from another database, try to find the partition from all database
             auto part_db_info = tryFindDatabaseByPartitionTable(db_info, part_table_name);
             applyCreatePhysicalTable(part_db_info, part_table_info);
         }

--- a/dbms/src/TiDB/Schema/SchemaBuilder.cpp
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.cpp
@@ -693,6 +693,7 @@ void SchemaBuilder<Getter, NameMapper>::applyPartitionDiff(const TiDB::DBInfoPtr
             if (!new_part_id_set.contains(orig_def.id))
             {
                 const auto part_table_name = name_mapper.mapTableNameByID(updated_table_info.keyspace_id, orig_def.id);
+                // The physical table maybe `EXCHANGE` to another database, try to find the partition from all database
                 auto part_db_info = tryFindDatabaseByPartitionTable(db_info, part_table_name);
                 applyDropPhysicalTable(name_mapper.mapDatabaseName(*part_db_info), orig_def.id);
             }
@@ -705,6 +706,7 @@ void SchemaBuilder<Getter, NameMapper>::applyPartitionDiff(const TiDB::DBInfoPtr
         {
             auto part_table_info = updated_table_info.producePartitionTableInfo(new_def.id, name_mapper);
             const auto part_table_name = name_mapper.mapTableName(*part_table_info);
+                // The physical table maybe `EXCHANGE` from another database, try to find the partition from all database
             auto part_db_info = tryFindDatabaseByPartitionTable(db_info, part_table_name);
             applyCreatePhysicalTable(part_db_info, part_table_info);
         }

--- a/dbms/src/TiDB/Schema/SchemaBuilder.h
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.h
@@ -79,6 +79,7 @@ private:
     void applyPartitionDiff(const TiDB::DBInfoPtr & db_info, TableID table_id);
 
     void applyPartitionDiff(const TiDB::DBInfoPtr & db_info, const TiDB::TableInfoPtr & table_info, const ManageableStoragePtr & storage, bool drop_part_if_not_exist);
+    TiDB::DBInfoPtr tryFindDatabaseByPartitionTable(const TiDB::DBInfoPtr & db_info, const String & part_table_name);
 
     void applyAlterTable(const TiDB::DBInfoPtr & db_info, TableID table_id);
 

--- a/dbms/src/TiDB/Schema/SchemaNameMapper.h
+++ b/dbms/src/TiDB/Schema/SchemaNameMapper.h
@@ -79,6 +79,11 @@ struct SchemaNameMapper
         auto table_name = fmt::format("{}{}", TABLE_PREFIX, table_info.id);
         return map2Keyspace(table_info.keyspace_id, table_name);
     }
+    virtual String mapTableNameByID(const KeyspaceID keyspace, const TiDB::TableID table_id) const
+    {
+        auto table_name = fmt::format("{}{}", TABLE_PREFIX, table_id);
+        return map2Keyspace(keyspace, table_name);
+    }
     virtual String displayTableName(const TiDB::TableInfo & table_info) const
     {
         return map2Keyspace(table_info.keyspace_id, table_info.name);

--- a/dbms/src/TiDB/Schema/TiDBSchemaSyncer.h
+++ b/dbms/src/TiDB/Schema/TiDBSchemaSyncer.h
@@ -33,6 +33,10 @@ namespace ErrorCodes
 {
 extern const int FAIL_POINT_ERROR;
 };
+namespace FailPoints
+{
+extern const char force_schema_sync_too_old_schema[];
+}
 
 using SchemaVerMap = std::unordered_map<KeyspaceID, Int64>;
 
@@ -60,7 +64,13 @@ struct TiDBSchemaSyncer : public SchemaSyncer
         , log(Logger::get())
     {}
 
-    bool isTooOldSchema(Int64 cur_ver, Int64 new_version) { return cur_ver == 0 || new_version - cur_ver > maxNumberOfDiffs; }
+    bool isTooOldSchema(Int64 cur_ver, Int64 new_version)
+    {
+        fiu_do_on(FailPoints::force_schema_sync_too_old_schema, {
+            return true;
+        });
+        return cur_ver == 0 || new_version - cur_ver > maxNumberOfDiffs;
+    }
 
     Getter createSchemaGetter(KeyspaceID keyspace_id)
     {

--- a/tests/fullstack-test2/ddl/alter_exchange_partition.test
+++ b/tests/fullstack-test2/ddl/alter_exchange_partition.test
@@ -370,3 +370,56 @@ mysql> drop table if exists test.e2;
 mysql> drop table if exists test_new.e2;
 mysql> drop database if exists test_new;
 >> DBGInvoke __enable_schema_sync_service('true')
+
+mysql> create table test.e(id INT NOT NULL,fname VARCHAR(30),lname VARCHAR(30)) PARTITION BY RANGE (id) ( PARTITION p0 VALUES LESS THAN (50),PARTITION p1 VALUES LESS THAN (100),PARTITION p2 VALUES LESS THAN (150), PARTITION p3 VALUES LESS THAN (MAXVALUE));
+mysql> alter table test.e set tiflash replica 1;
+
+mysql> create table test.e2(id int not null, fname varchar(30), lname varchar(30));
+mysql> alter table test.e2 set tiflash replica 1;
+
+mysql> create database test_new;
+mysql> create table test_new.e2(id int not null, fname varchar(30), lname varchar(30));
+mysql> alter table test_new.e2 set tiflash replica 1;
+
+func> wait_table test e e2
+func> wait_table test_new e2
+
+mysql> insert into test.e values (1, 'a', 'b'),(108, 'a', 'b');
+mysql> insert into test.e2 values (2, 'a', 'b');
+mysql> insert into test_new.e2 values (3, 'a', 'b');
+
+# disable schema sync service
+>> DBGInvoke __enable_schema_sync_service('false')
+>> DBGInvoke __refresh_schemas()
+
+# case 13, exchagne partition across databases, syncAllSchema without applying the diff
+>> DBGInvoke __enable_fail_point(force_schema_sync_too_old_schema)
+mysql> set @@tidb_enable_exchange_partition=1; alter table test.e exchange partition p0 with table test_new.e2
+>> DBGInvoke __enable_fail_point(exception_after_step_1_in_exchange_partition)
+>> DBGInvoke __refresh_schemas()
+mysql> alter table test.e add column c1 int;
+>> DBGInvoke __refresh_schemas()
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.e order by id;
++-----+-------+-------+------+
+| id  | fname | lname | c1   |
++-----+-------+-------+------+
+|   3 | a     | b     | NULL |
+| 108 | a     | b     | NULL |
++-----+-------+-------+------+
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test_new.e2;
++----+-------+-------+
+| id | fname | lname |
++----+-------+-------+
+|  1 | a     | b     |
++----+-------+-------+
+mysql> alter table test.e drop column c1;
+>> DBGInvoke __refresh_schemas()
+
+>> DBGInvoke __disable_fail_point(force_schema_sync_too_old_schema)
+
+# cleanup
+mysql> drop table if exists test.e;
+mysql> drop table if exists test.e2;
+mysql> drop table if exists test_new.e2;
+mysql> drop database if exists test_new;
+>> DBGInvoke __enable_schema_sync_service('true')


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/7296

Problem Summary:
When `tryLoadSchemaDiffs` fails, we may run into `SchemaBuilder::syncAllSchem` -> `applyPartitionDiff` without `applyExchangeTablePartition`
The physical table maybe `EXCHANGE` to another database, we need to try to find the partition from all database rather than just using the database of the target partitioned table

### What is changed and how it works?

try to find the partition from all database rather than just using the database of the target partitioned table

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix the issue that TiFlash may fail to finish schema sync after executing `ALTER TABLE ... EXCHANGE PARTITION` across databases
```
