### PR TITLE
Storages: Fix cloning delta index when there are duplicated tuples (release-8.1) (#9000)

### DIFF
--- a/dbms/src/Storages/DeltaMerge/Delta/DeltaValueSpace.h
+++ b/dbms/src/Storages/DeltaMerge/Delta/DeltaValueSpace.h
@@ -473,7 +473,8 @@ public:
 
     bool shouldPlace(
         const DMContext & context,
-        DeltaIndexPtr my_delta_index,
+        size_t placed_rows,
+        size_t placed_delete_ranges,
         const RowKeyRange & segment_range,
         const RowKeyRange & relevant_range,
         UInt64 max_version);

--- a/dbms/src/Storages/DeltaMerge/Delta/Snapshot.cpp
+++ b/dbms/src/Storages/DeltaMerge/Delta/Snapshot.cpp
@@ -121,15 +121,15 @@ size_t DeltaValueReader::readRows(
     //
     // So here, we should filter out those out-of-range rows.
 
-    auto mem_table_rows_offset = delta_snap->getMemTableSetRowsOffset();
-    auto total_delta_rows = delta_snap->getRows();
+    const auto mem_table_rows_offset = delta_snap->getMemTableSetRowsOffset();
+    const auto total_delta_rows = delta_snap->getRows();
 
-    auto persisted_files_start = std::min(offset, mem_table_rows_offset);
-    auto persisted_files_end = std::min(offset + limit, mem_table_rows_offset);
-    auto mem_table_start = offset <= mem_table_rows_offset
+    const auto persisted_files_start = std::min(offset, mem_table_rows_offset);
+    const auto persisted_files_end = std::min(offset + limit, mem_table_rows_offset);
+    const auto mem_table_start = offset <= mem_table_rows_offset
         ? 0
         : std::min(offset - mem_table_rows_offset, total_delta_rows - mem_table_rows_offset);
-    auto mem_table_end = offset + limit <= mem_table_rows_offset
+    const auto mem_table_end = offset + limit <= mem_table_rows_offset
         ? 0
         : std::min(offset + limit - mem_table_rows_offset, total_delta_rows - mem_table_rows_offset);
 
@@ -147,8 +147,12 @@ size_t DeltaValueReader::readRows(
     }
     if (mem_table_start < mem_table_end)
     {
-        actual_read += mem_table_reader
-                           ->readRows(output_cols, mem_table_start, mem_table_end - mem_table_start, range, row_ids);
+        actual_read += mem_table_reader->readRows( //
+            output_cols,
+            mem_table_start,
+            mem_table_end - mem_table_start,
+            range,
+            row_ids);
     }
 
     if (row_ids != nullptr)
@@ -213,14 +217,13 @@ BlockOrDeletes DeltaValueReader::getPlaceItems(
 
 bool DeltaValueReader::shouldPlace(
     const DMContext & context,
-    DeltaIndexPtr my_delta_index,
+    const size_t placed_rows,
+    const size_t placed_delete_ranges,
     const RowKeyRange & segment_range_,
     const RowKeyRange & relevant_range,
     UInt64 max_version)
 {
-    auto [placed_rows, placed_delete_ranges] = my_delta_index->getPlacedStatus();
-
-    // Already placed.
+    // The placed_rows, placed_delete_range already contains the data in delta_snap
     if (placed_rows >= delta_snap->getRows() && placed_delete_ranges == delta_snap->getDeletes())
         return false;
 

--- a/dbms/src/Storages/DeltaMerge/DeltaIndex.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaIndex.h
@@ -86,17 +86,17 @@ private:
         }
     }
 
-    DeltaIndexPtr tryCloneInner(size_t placed_deletes_limit, const Updates * updates = nullptr)
+    DeltaIndexPtr tryCloneInner(size_t rows_limit, size_t placed_deletes_limit, const Updates * updates = nullptr)
     {
         DeltaTreePtr delta_tree_copy;
         size_t placed_rows_copy = 0;
         size_t placed_deletes_copy = 0;
-        // Make sure the delta index do not place more deletes than `placed_deletes_limit`.
-        // Because delete ranges can break MVCC view.
         {
             std::scoped_lock lock(mutex);
-            // Safe to reuse the copy of the existing DeltaIndex
-            if (placed_deletes <= placed_deletes_limit)
+            // Make sure the MVCC view will not be broken by the mismatch of delta index and snapshot:
+            // - First, make sure the delta index do not place more deletes than `placed_deletes_limit`.
+            // - Second, make sure the snapshot includes all duplicated tuples in the delta index.
+            if (placed_deletes <= placed_deletes_limit && delta_tree->maxDupTupleID() < static_cast<Int64>(rows_limit))
             {
                 delta_tree_copy = delta_tree;
                 placed_rows_copy = placed_rows;
@@ -195,8 +195,9 @@ public:
     {
         std::scoped_lock lock(mutex);
 
-        if ((maybe_advanced.placed_rows >= placed_rows && maybe_advanced.placed_deletes >= placed_deletes)
-            && !(maybe_advanced.placed_rows == placed_rows && maybe_advanced.placed_deletes == placed_deletes))
+        if ((maybe_advanced.placed_rows >= placed_rows && maybe_advanced.placed_deletes >= placed_deletes) // advance
+            // not excatly the same
+            && (maybe_advanced.placed_rows != placed_rows || maybe_advanced.placed_deletes != placed_deletes))
         {
             delta_tree = maybe_advanced.delta_tree;
             placed_rows = maybe_advanced.placed_rows;
@@ -206,14 +207,17 @@ public:
         return false;
     }
 
-    DeltaIndexPtr tryClone(size_t /*rows*/, size_t deletes) { return tryCloneInner(deletes); }
+    /**
+     * Try to get a clone of current instance.
+     * Return an empty DeltaIndex if `deletes < this->placed_deletes` because the advanced delta-index will break
+     * the MVCC view.
+     */
+    DeltaIndexPtr tryClone(size_t rows, size_t deletes) { return tryCloneInner(rows, deletes); }
 
     DeltaIndexPtr cloneWithUpdates(const Updates & updates)
     {
-        if (unlikely(updates.empty()))
-            throw Exception("Unexpected empty updates");
-
-        return tryCloneInner(updates.front().delete_ranges_offset, &updates);
+        RUNTIME_CHECK_MSG(!updates.empty(), "Unexpected empty updates");
+        return tryCloneInner(updates.front().rows_offset, updates.front().delete_ranges_offset, &updates);
     }
 
     const std::optional<Remote::RNDeltaIndexCache::CacheKey> & getRNCacheKey() const { return rn_cache_key; }

--- a/dbms/src/Storages/DeltaMerge/DeltaIndex.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaIndex.h
@@ -209,8 +209,10 @@ public:
 
     /**
      * Try to get a clone of current instance.
-     * Return an empty DeltaIndex if `deletes < this->placed_deletes` because the advanced delta-index will break
-     * the MVCC view.
+     * Return an empty DeltaIndex if
+     * - `deletes < this->placed_deletes`
+     * - `rows <= this->delta_tree->maxDupTupleID()`
+     * because the advanced delta-index will break the MVCC view.
      */
     DeltaIndexPtr tryClone(size_t rows, size_t deletes) { return tryCloneInner(rows, deletes); }
 

--- a/dbms/src/Storages/DeltaMerge/DeltaPlace.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaPlace.h
@@ -262,7 +262,10 @@ bool placeInsert(
             tuple_id = delta_value_space_offset + (offset + i);
 
         if (dup)
+        {
             delta_tree.addDelete(rid);
+            delta_tree.setMaxDupTupleID(tuple_id);
+        }
         delta_tree.addInsert(rid, tuple_id);
     }
 

--- a/dbms/src/Storages/DeltaMerge/DeltaTree.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaTree.h
@@ -825,6 +825,7 @@ private:
     size_t num_inserts = 0;
     size_t num_deletes = 0;
     size_t num_entries = 0;
+    Int64 max_dup_tuple_id = -1;
 
     std::unique_ptr<Allocator> allocator;
     size_t bytes = 0;
@@ -1039,6 +1040,8 @@ public:
     size_t numEntries() const { return num_entries; }
     size_t numInserts() const { return num_inserts; }
     size_t numDeletes() const { return num_deletes; }
+    Int64 maxDupTupleID() const { return max_dup_tuple_id; }
+    void setMaxDupTupleID(Int64 tuple_id) { max_dup_tuple_id = std::max(tuple_id, max_dup_tuple_id); }
 
     void addDelete(UInt64 rid);
     void addInsert(UInt64 rid, UInt64 tuple_id);
@@ -1055,6 +1058,7 @@ DT_CLASS::DeltaTree(const DT_CLASS::Self & o)
     , num_inserts(o.num_inserts)
     , num_deletes(o.num_deletes)
     , num_entries(o.num_entries)
+    , max_dup_tuple_id(o.max_dup_tuple_id)
     , allocator(std::make_unique<Allocator>())
 {
     // If exception is thrown before clear copying_nodes, all nodes will be destroyed.

--- a/dbms/src/Storages/DeltaMerge/ReadThread/UnorderedInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/UnorderedInputStream.h
@@ -22,6 +22,10 @@
 
 namespace DB::DM
 {
+namespace tests
+{
+class DeltaMergeStoreRWTest;
+}
 class UnorderedInputStream : public IProfilingBlockInputStream
 {
     static constexpr auto NAME = "UnorderedInputStream";
@@ -151,5 +155,7 @@ private:
     // runtime filter
     std::vector<RuntimeFilterPtr> runtime_filter_list;
     int max_wait_time_ms;
+
+    friend class tests::DeltaMergeStoreRWTest;
 };
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/Segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/Segment.cpp
@@ -2536,7 +2536,8 @@ std::pair<DeltaIndexPtr, bool> Segment::ensurePlace(
 {
     const auto & stable_snap = segment_snap->stable;
     auto delta_snap = delta_reader->getDeltaSnap();
-    // Clone a new delta index.
+    // Try to clone from the sahred delta index, if it fails to reuse the shared delta index,
+    // it will return an empty delta index and we should place it in the following branch.
     auto my_delta_index = delta_snap->getSharedDeltaIndex()->tryClone(delta_snap->getRows(), delta_snap->getDeletes());
     auto my_delta_tree = my_delta_index->getDeltaTree();
 
@@ -2552,8 +2553,17 @@ std::pair<DeltaIndexPtr, bool> Segment::ensurePlace(
     auto [my_placed_rows, my_placed_deletes] = my_delta_index->getPlacedStatus();
 
     // Let's do a fast check, determine whether we need to do place or not.
-    if (!delta_reader->shouldPlace(dm_context, my_delta_index, rowkey_range, relevant_range, max_version))
+    if (!delta_reader->shouldPlace( //
+            dm_context,
+            my_placed_rows,
+            my_placed_deletes,
+            rowkey_range,
+            relevant_range,
+            max_version))
+    {
+        // We can reuse the shared-delta-index
         return {my_delta_index, false};
+    }
 
     CurrentMetrics::Increment cur_dm_segments{CurrentMetrics::DT_PlaceIndexUpdate};
     GET_METRIC(tiflash_storage_subtask_count, type_place_index_update).Increment();

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store.cpp
@@ -41,6 +41,7 @@
 #include <algorithm>
 #include <future>
 #include <iterator>
+#include <memory>
 #include <random>
 
 namespace DB
@@ -3701,6 +3702,188 @@ try
 }
 CATCH
 
+
+void DeltaMergeStoreRWTest::dupHandleVersionAndDeltaIndexAdvancedThanSnapshot()
+{
+    auto table_column_defines = DMTestEnv::getDefaultColumns();
+    store = reload(table_column_defines);
+
+    auto create_block = [&](UInt64 beg, UInt64 end, UInt64 ts) {
+        auto block = DMTestEnv::prepareSimpleWriteBlock(beg, end, false, ts);
+        block.checkNumberOfRows();
+        return block;
+    };
+
+    auto write_block = [&](UInt64 beg, UInt64 end, UInt64 ts) {
+        auto block = create_block(beg, end, ts);
+        store->write(*db_context, db_context->getSettingsRef(), block);
+    };
+
+    auto create_stream = [&]() {
+        return store->read(
+            *db_context,
+            db_context->getSettingsRef(),
+            store->getTableColumns(),
+            {RowKeyRange::newAll(store->isCommonHandle(), store->getRowKeyColumnSize())},
+            /* num_streams= */ 1,
+            /* start_ts= */ std::numeric_limits<UInt64>::max(),
+            EMPTY_FILTER,
+            std::vector<RuntimeFilterPtr>{},
+            /* rf_max_wait_time_ms= */ 0,
+            TRACING_NAME,
+            /* keep_order= */ false,
+            /* is_fast_scan= */ false,
+            DEFAULT_BLOCK_SIZE)[0];
+    };
+
+    auto count_rows = [](BlockInputStreamPtr stream) {
+        std::size_t count = 0;
+        stream->readPrefix();
+        for (;;)
+        {
+            auto block = stream->read();
+            if (!block)
+            {
+                break;
+            }
+            count += block.rows();
+        }
+        stream->readSuffix();
+        return count;
+    };
+
+    auto get_seg_read_task = [&](BlockInputStreamPtr stream) {
+        auto unordered_stream = std::dynamic_pointer_cast<UnorderedInputStream>(stream);
+        const auto & tasks = unordered_stream->task_pool->getTasks();
+        RUNTIME_CHECK(tasks.size() == 1, tasks.size());
+        return tasks.begin()->second;
+    };
+
+    auto clone_delta_index = [](SegmentReadTaskPtr seg_read_task) {
+        auto delta_snap = seg_read_task->read_snapshot->delta;
+        return delta_snap->getSharedDeltaIndex()->tryClone(delta_snap->getRows(), delta_snap->getDeletes());
+    };
+
+    auto check_delta_index
+        = [](DeltaIndexPtr delta_index, size_t expect_rows, size_t expect_deletes, Int64 expect_max_dup_tuple_id) {
+              auto [placed_rows, placed_deletes] = delta_index->getPlacedStatus();
+              ASSERT_EQ(placed_rows, expect_rows);
+              ASSERT_EQ(placed_deletes, expect_deletes);
+              ASSERT_EQ(delta_index->getDeltaTree()->maxDupTupleID(), expect_max_dup_tuple_id);
+          };
+
+    auto ensure_place = [&](SegmentReadTaskPtr seg_read_task) {
+        auto pk_ver_col_defs = std::make_shared<ColumnDefines>(
+            ColumnDefines{getExtraHandleColumnDefine(dm_context->is_common_handle), getVersionColumnDefine()});
+        auto delta_reader = std::make_shared<DeltaValueReader>(
+            *dm_context,
+            seg_read_task->read_snapshot->delta,
+            pk_ver_col_defs,
+            RowKeyRange::newAll(store->isCommonHandle(), store->getRowKeyColumnSize()),
+            ReadTag::MVCC);
+        return seg_read_task->segment->ensurePlace(
+            *dm_context,
+            seg_read_task->read_snapshot,
+            delta_reader,
+            {RowKeyRange::newAll(store->isCommonHandle(), store->getRowKeyColumnSize())},
+            std::numeric_limits<UInt64>::max());
+    };
+
+    // Write [0, 128) with ts 1 for initializing stable.
+    write_block(0, 128, 1);
+    store->mergeDeltaAll(*db_context);
+
+    // Write [50, 60) with ts 2 for initializing delta.
+    write_block(50, 60, 2);
+
+    // Scan table normally.
+    {
+        auto stream = create_stream();
+        auto count = count_rows(stream);
+        ASSERT_EQ(count, 128);
+    }
+
+    // The snapshot does not include all the duplicated tuples of the delta index.
+    // This snapshot should rebuild delta index for itself.
+    // https://github.com/pingcap/tiflash/issues/8845
+    {
+        // Create snapshot but not place index
+        auto stream1 = create_stream();
+
+        // !!!Duplicated!!!: Write [50, 60) with ts 2
+        write_block(50, 60, 2);
+
+        // Place index with newest data.
+        auto stream2 = create_stream();
+        auto count2 = count_rows(stream2);
+        ASSERT_EQ(count2, 128);
+
+        // stream1 should not resue delta index of stream2
+
+        // Check cloning delta index
+        {
+            auto seg_read_task = get_seg_read_task(stream1);
+
+            // Shared delta index has been placed to the newest by `count_rows(stream2)`.
+            auto shared_delta_index = seg_read_task->read_snapshot->delta->getSharedDeltaIndex();
+            check_delta_index(shared_delta_index, 20, 0, 19);
+
+            // Cannot clone delta index because it contains duplicated records in the gap of snapshot and the shared delta index.
+            auto cloned_delta_index = clone_delta_index(seg_read_task);
+            check_delta_index(cloned_delta_index, 0, 0, -1);
+        }
+        // Check scanning result of stream1
+        auto count1 = count_rows(stream1);
+        ASSERT_EQ(count1, count2);
+    }
+
+    // Make sure shared delta index can be reused by new snapshot
+    {
+        auto stream = create_stream();
+        auto seg_read_task = get_seg_read_task(stream);
+        auto cloned_delta_index = clone_delta_index(seg_read_task);
+        check_delta_index(cloned_delta_index, 20, 0, 19);
+    }
+
+    // The snapshot includes all the duplicated tuples of the delta index.
+    // Delta index can be reused safely.
+    {
+        write_block(70, 80, 2);
+        auto stream = create_stream();
+        auto seg_read_task = get_seg_read_task(stream);
+        auto shared_delta_index = seg_read_task->read_snapshot->delta->getSharedDeltaIndex();
+        check_delta_index(shared_delta_index, 20, 0, 19);
+        auto cloned_delta_index = clone_delta_index(seg_read_task);
+        check_delta_index(cloned_delta_index, 20, 0, 19);
+        auto [placed_delta_index, fully_indexed] = ensure_place(seg_read_task);
+        ASSERT_TRUE(fully_indexed);
+        check_delta_index(placed_delta_index, 30, 0, 19);
+        auto count = count_rows(stream);
+        ASSERT_EQ(count, 128);
+    }
+
+    {
+        write_block(75, 85, 2);
+        auto stream = create_stream();
+        auto seg_read_task = get_seg_read_task(stream);
+        auto shared_delta_index = seg_read_task->read_snapshot->delta->getSharedDeltaIndex();
+        check_delta_index(shared_delta_index, 30, 0, 19);
+        auto cloned_delta_index = clone_delta_index(seg_read_task);
+        check_delta_index(cloned_delta_index, 30, 0, 19);
+        auto [placed_delta_index, fully_indexed] = ensure_place(seg_read_task);
+        ASSERT_TRUE(fully_indexed);
+        check_delta_index(placed_delta_index, 40, 0, 34);
+        auto count = count_rows(stream);
+        ASSERT_EQ(count, 128);
+    }
+}
+
+TEST_P(DeltaMergeStoreRWTest, DupHandleVersionAndDeltaIndexAdvancedThanSnapshot)
+try
+{
+    dupHandleVersionAndDeltaIndexAdvancedThanSnapshot();
+}
+CATCH
 
 } // namespace tests
 } // namespace DM

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_test_basic.h
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_test_basic.h
@@ -162,6 +162,7 @@ public:
     {
         TiFlashStorageTestBasic::SetUp();
         store = reload();
+        dm_context = store->newDMContext(*db_context, db_context->getSettingsRef());
     }
 
     DeltaMergeStorePtr reload(
@@ -223,8 +224,11 @@ public:
 protected:
     TestMode mode;
     DeltaMergeStorePtr store;
+    DMContextPtr dm_context;
 
     constexpr static const char * TRACING_NAME = "DeltaMergeStoreRWTest";
+
+    void dupHandleVersionAndDeltaIndexAdvancedThanSnapshot();
 };
 } // namespace tests
 } // namespace DM

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_value_space.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_value_space.cpp
@@ -717,15 +717,18 @@ TEST_F(DeltaValueSpaceTest, ShouldPlace)
             table_columns,
             RowKeyRange::newAll(false, 1),
             ReadTag::Internal);
+        auto [placed_rows, placed_deletes] = snapshot->getSharedDeltaIndex()->getPlacedStatus();
         ASSERT_TRUE(reader->shouldPlace(
             dmContext(),
-            snapshot->getSharedDeltaIndex(),
+            placed_rows,
+            placed_deletes,
             RowKeyRange::newAll(false, 1),
             RowKeyRange::fromHandleRange(HandleRange(0, 100)),
             tso + 1));
         ASSERT_FALSE(reader->shouldPlace(
             dmContext(),
-            snapshot->getSharedDeltaIndex(),
+            placed_rows,
+            placed_deletes,
             RowKeyRange::newAll(false, 1),
             RowKeyRange::fromHandleRange(HandleRange(0, 100)),
             tso - 1));
@@ -739,15 +742,18 @@ TEST_F(DeltaValueSpaceTest, ShouldPlace)
             table_columns,
             RowKeyRange::newAll(false, 1),
             ReadTag::Internal);
+        auto [placed_rows, placed_deletes] = snapshot->getSharedDeltaIndex()->getPlacedStatus();
         ASSERT_TRUE(reader->shouldPlace(
             dmContext(),
-            snapshot->getSharedDeltaIndex(),
+            placed_rows,
+            placed_deletes,
             RowKeyRange::newAll(false, 1),
             RowKeyRange::fromHandleRange(HandleRange(0, 100)),
             tso + 1));
         ASSERT_FALSE(reader->shouldPlace(
             dmContext(),
-            snapshot->getSharedDeltaIndex(),
+            placed_rows,
+            placed_deletes,
             RowKeyRange::newAll(false, 1),
             RowKeyRange::fromHandleRange(HandleRange(0, 100)),
             tso - 1));

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment.cpp
@@ -19,6 +19,8 @@
 #include <Storages/DeltaMerge/DMContext.h>
 #include <Storages/DeltaMerge/DeltaMergeStore.h>
 #include <Storages/DeltaMerge/File/DMFileBlockOutputStream.h>
+#include <Storages/DeltaMerge/Range.h>
+#include <Storages/DeltaMerge/RowKeyRange.h>
 #include <Storages/DeltaMerge/Segment.h>
 #include <Storages/DeltaMerge/Segment_fwd.h>
 #include <Storages/DeltaMerge/StoragePool/GlobalPageIdAllocator.h>
@@ -49,9 +51,7 @@ extern const Metric DT_SnapshotOfDeltaMerge;
 extern const Metric DT_SnapshotOfPlaceIndex;
 } // namespace CurrentMetrics
 
-namespace DB
-{
-namespace DM
+namespace DB::DM
 {
 extern DMFilePtr writeIntoNewDMFile(
     DMContext & dm_context, //
@@ -59,7 +59,9 @@ extern DMFilePtr writeIntoNewDMFile(
     const BlockInputStreamPtr & input_stream,
     UInt64 file_id,
     const String & parent_path);
-namespace tests
+}
+
+namespace DB::DM::tests
 {
 class SegmentTest : public DB::base::TiFlashStorageTestBasic
 {
@@ -431,6 +433,211 @@ try
             std::numeric_limits<UInt64>::max(),
             DEFAULT_BLOCK_SIZE);
         ASSERT_INPUTSTREAM_NROWS(in, 100);
+    }
+}
+CATCH
+
+TEST_F(SegmentTest, ReadWithMoreAdvacedDeltaIndex2)
+try
+{
+    auto write_rows = [&](size_t offset, size_t rows) {
+        Block block = DMTestEnv::prepareSimpleWriteBlock(offset, offset + rows, false);
+        // write to segment
+        segment->write(dmContext(), block);
+    };
+
+    // Thread A
+    write_rows(0, 100);
+    ASSERT_INPUTSTREAM_NROWS(
+        segment->getInputStreamModeNormal(dmContext(), *tableColumns(), {RowKeyRange::newAll(false, 1)}),
+        100);
+    auto snap = segment->createSnapshot(dmContext(), false, CurrentMetrics::DT_SnapshotOfRead);
+
+    {
+        // check segment
+        segment->check(dmContext(), "test");
+    }
+
+    // Thread B
+    write_rows(0, 100);
+    ASSERT_INPUTSTREAM_NROWS(
+        segment->getInputStreamModeNormal(dmContext(), *tableColumns(), {RowKeyRange::newAll(false, 1)}),
+        100);
+
+    // Thread A
+    {
+        auto in = segment->getInputStreamModeNormal(
+            dmContext(),
+            *tableColumns(),
+            snap,
+            {RowKeyRange::newAll(false, 1)},
+            {},
+            std::numeric_limits<UInt64>::max(),
+            DEFAULT_BLOCK_SIZE);
+        ASSERT_INPUTSTREAM_NROWS(in, 100);
+    }
+}
+CATCH
+
+TEST_F(SegmentTest, ReadWithMoreAdvacedDeltaIndexWithDeleteRange01)
+try
+{
+    auto write_rows = [&](size_t offset, size_t rows) {
+        Block block = DMTestEnv::prepareSimpleWriteBlock(offset, offset + rows, false);
+        // write to segment
+        segment->write(dmContext(), block);
+    };
+
+    // Thread A write [0, 100) && [100, 200)
+    write_rows(0, 100);
+    write_rows(100, 100);
+    ASSERT_INPUTSTREAM_NROWS(
+        segment->getInputStreamModeNormal(dmContext(), *tableColumns(), {RowKeyRange::newAll(false, 1)}),
+        200);
+    // check segment
+    segment->check(dmContext(), "test");
+    auto snap_a = segment->createSnapshot(dmContext(), false, CurrentMetrics::DT_SnapshotOfRead);
+
+    // Thread B delete range [0, 50)
+    RowKeyRange range = RowKeyRange::fromHandleRange(HandleRange(0, 50));
+    segment->write(dmContext(), range);
+    LOG_INFO(Logger::get(), "Thread B read");
+    ASSERT_INPUTSTREAM_NROWS(
+        segment->getInputStreamModeNormal(dmContext(), *tableColumns(), {RowKeyRange::newAll(false, 1)}),
+        150);
+
+    {
+        // tryClone will return an empty delta-index because `shared_delta_index.placed_deletes != delta->getDeletes()`
+        auto my_delta_index
+            = snap_a->delta->getSharedDeltaIndex()->tryClone(snap_a->delta->getRows(), snap_a->delta->getDeletes());
+        auto [my_placed_rows, my_placed_deletes] = my_delta_index->getPlacedStatus();
+        ASSERT_EQ(my_placed_rows, 0);
+        ASSERT_EQ(my_placed_deletes, 0);
+    }
+
+    // Thread A read [0, 200)
+    {
+        LOG_INFO(Logger::get(), "Thread A read with snap_a");
+        auto in = segment->getInputStreamModeNormal(
+            dmContext(),
+            *tableColumns(),
+            snap_a,
+            {RowKeyRange::newAll(false, 1)},
+            {},
+            std::numeric_limits<UInt64>::max(),
+            DEFAULT_BLOCK_SIZE);
+        ASSERT_INPUTSTREAM_NROWS(in, 200);
+    }
+}
+CATCH
+
+
+TEST_F(SegmentTest, ReadWithMoreAdvacedDeltaIndexWithDeleteRange02)
+try
+{
+    auto write_rows = [&](size_t offset, size_t rows) {
+        Block block = DMTestEnv::prepareSimpleWriteBlock(offset, offset + rows, false);
+        // write to segment
+        segment->write(dmContext(), block);
+    };
+
+    // Thread A write [0, 100)
+    write_rows(0, 100);
+    ASSERT_INPUTSTREAM_NROWS(
+        segment->getInputStreamModeNormal(dmContext(), *tableColumns(), {RowKeyRange::newAll(false, 1)}),
+        100);
+    // check segment
+    segment->check(dmContext(), "test");
+    auto snap_a = segment->createSnapshot(dmContext(), false, CurrentMetrics::DT_SnapshotOfRead);
+
+    // Thread B write [100, 200) && delete range [0, 50)
+    write_rows(100, 100);
+    RowKeyRange range = RowKeyRange::fromHandleRange(HandleRange(0, 50));
+    segment->write(dmContext(), range);
+    LOG_INFO(Logger::get(), "Thread B read");
+    ASSERT_INPUTSTREAM_NROWS(
+        segment->getInputStreamModeNormal(dmContext(), *tableColumns(), {RowKeyRange::newAll(false, 1)}),
+        150);
+
+    // Thread A
+    {
+        LOG_INFO(Logger::get(), "Thread A read with snap_a");
+        auto in = segment->getInputStreamModeNormal(
+            dmContext(),
+            *tableColumns(),
+            snap_a,
+            {RowKeyRange::newAll(false, 1)},
+            {},
+            std::numeric_limits<UInt64>::max(),
+            DEFAULT_BLOCK_SIZE);
+        ASSERT_INPUTSTREAM_NROWS(in, 100);
+    }
+}
+CATCH
+
+TEST_F(SegmentTest, ReadWithMoreAdvacedDeltaIndexComplicated)
+try
+{
+    // Test the case that reading rows with an advance DeltaIndex
+    size_t offset = 0;
+    auto write_rows = [&](size_t rows, bool flush) {
+        Block block = DMTestEnv::prepareSimpleWriteBlock(offset, offset + rows, false);
+        offset += rows;
+        // write to segment
+        segment->write(dmContext(), block, flush);
+    };
+
+    // Thread C
+    write_rows(100, false);
+    write_rows(100, false);
+    ASSERT_INPUTSTREAM_NROWS(
+        segment->getInputStreamModeNormal(dmContext(), *tableColumns(), {RowKeyRange::newAll(false, 1)}),
+        200);
+    auto snap_c = segment->createSnapshot(dmContext(), false, CurrentMetrics::DT_SnapshotOfRead);
+    segment->check(dmContext(), "test");
+
+    // Thread A write 100 rows to persisted_files and 100 rows to mem_tables
+    write_rows(100, true);
+    write_rows(100, false);
+    ASSERT_INPUTSTREAM_NROWS(
+        segment->getInputStreamModeNormal(dmContext(), *tableColumns(), {RowKeyRange::newAll(false, 1)}),
+        400);
+    auto snap_a = segment->createSnapshot(dmContext(), false, CurrentMetrics::DT_SnapshotOfRead);
+    segment->check(dmContext(), "test");
+
+    // Thread B write 100 rows to mem_tables
+    write_rows(100, false);
+    LOG_INFO(Logger::get(), "Thread B read");
+    ASSERT_INPUTSTREAM_NROWS(
+        segment->getInputStreamModeNormal(dmContext(), *tableColumns(), {RowKeyRange::newAll(false, 1)}),
+        500);
+    segment->check(dmContext(), "test");
+
+    // Thread A
+    {
+        LOG_INFO(Logger::get(), "Thread A read with snap_a");
+        auto in = segment->getInputStreamModeNormal(
+            dmContext(),
+            *tableColumns(),
+            snap_a,
+            {RowKeyRange::newAll(false, 1)},
+            {},
+            std::numeric_limits<UInt64>::max(),
+            DEFAULT_BLOCK_SIZE);
+        ASSERT_INPUTSTREAM_NROWS(in, 400);
+    }
+    // Thread C
+    {
+        LOG_INFO(Logger::get(), "Thread C read with snap_c");
+        auto in = segment->getInputStreamModeNormal(
+            dmContext(),
+            *tableColumns(),
+            snap_c,
+            {RowKeyRange::newAll(false, 1)},
+            {},
+            std::numeric_limits<UInt64>::max(),
+            DEFAULT_BLOCK_SIZE);
+        ASSERT_INPUTSTREAM_NROWS(in, 200);
     }
 }
 CATCH
@@ -1747,6 +1954,4 @@ try
 }
 CATCH
 
-} // namespace tests
-} // namespace DM
-} // namespace DB
+} // namespace DB::DM::tests


### PR DESCRIPTION
cherry-pick of https://github.com/pingcap/tiflash/pull/9000 to release-8.1
* * *

### What problem does this PR solve?

Issue Number: close #8845

### What is changed and how it works?

1. Add a `max_dup_tuple_id` in `DeltaTree.h`.
2. Record the max duplucated tuple id in `DeltaPlace.h`.
3. Make sure the snapshot includes all duplicated tuples in the delta index when cloning the delta index in `DeltaIndex.h`.


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix the potential issue that tiflash returns transient inconsistent results under high concurrent read
```
