### PR TITLE
Add agg final spill event if have spill data

### DIFF
--- a/dbms/src/Common/FailPoint.cpp
+++ b/dbms/src/Common/FailPoint.cpp
@@ -113,7 +113,8 @@ namespace DB
     M(force_fap_worker_throw)                                \
     M(delta_tree_create_node_fail)                           \
     M(disable_flush_cache)                                   \
-    M(force_agg_two_level_hash_table_before_merge)
+    M(force_agg_two_level_hash_table_before_merge)           \
+    M(force_thread_0_no_agg_spill)
 
 #define APPLY_FOR_PAUSEABLE_FAILPOINTS_ONCE(M) \
     M(pause_with_alter_locks_acquired)         \

--- a/dbms/src/Flash/Pipeline/Schedule/Events/AggregateFinalConvertEvent.h
+++ b/dbms/src/Flash/Pipeline/Schedule/Events/AggregateFinalConvertEvent.h
@@ -30,10 +30,12 @@ public:
         const String & req_id,
         AggregateContextPtr agg_context_,
         std::vector<size_t> && indexes_,
+        bool need_final_spill_,
         OperatorProfileInfos && profile_infos_)
         : Event(exec_context_, req_id)
         , agg_context(std::move(agg_context_))
         , indexes(std::move(indexes_))
+        , need_final_spill(need_final_spill_)
         , profile_infos(std::move(profile_infos_))
     {
         assert(agg_context);
@@ -49,6 +51,7 @@ protected:
 private:
     AggregateContextPtr agg_context;
     std::vector<size_t> indexes;
+    bool need_final_spill;
 
     OperatorProfileInfos profile_infos;
 };

--- a/dbms/src/Flash/Planner/Plans/PhysicalAggregationBuild.cpp
+++ b/dbms/src/Flash/Planner/Plans/PhysicalAggregationBuild.cpp
@@ -103,7 +103,7 @@ EventPtr PhysicalAggregationBuild::doSinkComplete(PipelineExecutorContext & exec
 
     if (aggregate_context->isConvertibleToTwoLevel())
     {
-        bool need_convert_to_two_level = aggregate_context->hasAtLeastOneTwoLevel();
+        bool need_convert_to_two_level = need_final_spill || aggregate_context->hasAtLeastOneTwoLevel();
         fiu_do_on(FailPoints::force_agg_two_level_hash_table_before_merge, { need_convert_to_two_level = true; });
         if (need_convert_to_two_level)
         {

--- a/dbms/src/Flash/Planner/Plans/PhysicalAggregationBuild.cpp
+++ b/dbms/src/Flash/Planner/Plans/PhysicalAggregationBuild.cpp
@@ -88,17 +88,46 @@ EventPtr PhysicalAggregationBuild::doSinkComplete(PipelineExecutorContext & exec
     SCOPE_EXIT({ aggregate_context.reset(); });
 
     aggregate_context->getAggSpillContext()->finishSpillableStage();
-    bool need_final_spill = false;
-    for (size_t i = 0; i < aggregate_context->getBuildConcurrency(); ++i)
+    bool need_final_spill = aggregate_context->hasSpilledData();
+    if (!need_final_spill)
     {
-        if (aggregate_context->getAggSpillContext()->isThreadMarkedForAutoSpill(i))
+        for (size_t i = 0; i < aggregate_context->getBuildConcurrency(); ++i)
         {
-            need_final_spill = true;
-            break;
+            if (aggregate_context->getAggSpillContext()->isThreadMarkedForAutoSpill(i))
+            {
+                need_final_spill = true;
+                break;
+            }
         }
     }
 
-    if (aggregate_context->hasSpilledData() || need_final_spill)
+    if (aggregate_context->isConvertibleToTwoLevel())
+    {
+        bool need_convert_to_two_level = aggregate_context->hasAtLeastOneTwoLevel();
+        fiu_do_on(FailPoints::force_agg_two_level_hash_table_before_merge, { need_convert_to_two_level = true; });
+        if (need_convert_to_two_level)
+        {
+            std::vector<size_t> indexes;
+            for (size_t index = 0; index < aggregate_context->getBuildConcurrency(); ++index)
+            {
+                if (!aggregate_context->isTwoLevelOrEmpty(index))
+                    indexes.push_back(index);
+            }
+            if (!indexes.empty())
+            {
+                auto final_convert_event = std::make_shared<AggregateFinalConvertEvent>(
+                    exec_context,
+                    log->identifier(),
+                    aggregate_context,
+                    std::move(indexes),
+                    need_final_spill,
+                    std::move(profile_infos));
+                return final_convert_event;
+            }
+        }
+    }
+
+    if (need_final_spill)
     {
         /// Currently, the aggregation spill algorithm requires all bucket data to be spilled,
         /// so a new event is added here to execute the final spill.
@@ -122,31 +151,6 @@ EventPtr PhysicalAggregationBuild::doSinkComplete(PipelineExecutorContext & exec
                 std::move(indexes),
                 std::move(profile_infos));
             return final_spill_event;
-        }
-    }
-
-    if (!aggregate_context->hasSpilledData() && aggregate_context->isConvertibleToTwoLevel())
-    {
-        bool has_two_level = aggregate_context->hasAtLeastOneTwoLevel();
-        fiu_do_on(FailPoints::force_agg_two_level_hash_table_before_merge, { has_two_level = true; });
-        if (has_two_level)
-        {
-            std::vector<size_t> indexes;
-            for (size_t index = 0; index < aggregate_context->getBuildConcurrency(); ++index)
-            {
-                if (!aggregate_context->isTwoLevelOrEmpty(index))
-                    indexes.push_back(index);
-            }
-            if (!indexes.empty())
-            {
-                auto final_convert_event = std::make_shared<AggregateFinalConvertEvent>(
-                    exec_context,
-                    log->identifier(),
-                    aggregate_context,
-                    std::move(indexes),
-                    std::move(profile_infos));
-                return final_convert_event;
-            }
         }
     }
 

--- a/dbms/src/Flash/Planner/Plans/PhysicalAggregationBuild.cpp
+++ b/dbms/src/Flash/Planner/Plans/PhysicalAggregationBuild.cpp
@@ -98,7 +98,7 @@ EventPtr PhysicalAggregationBuild::doSinkComplete(PipelineExecutorContext & exec
         }
     }
 
-    if (need_final_spill)
+    if (aggregate_context->hasSpilledData() || need_final_spill)
     {
         /// Currently, the aggregation spill algorithm requires all bucket data to be spilled,
         /// so a new event is added here to execute the final spill.

--- a/dbms/src/Flash/tests/gtest_spill_aggregation.cpp
+++ b/dbms/src/Flash/tests/gtest_spill_aggregation.cpp
@@ -48,15 +48,15 @@ public:
 
 #define WRAP_FOR_AGG_PARTIAL_BLOCK_END }
 
-#define WRAP_FOR_AGG_THREAD0_NO_SPILL_START                                            \
-    for (auto thread0_no_spill : {true, false})                                        \
+#define WRAP_FOR_AGG_THREAD_0_NO_SPILL_START                                           \
+    for (auto thread_0_no_spill : {true, false})                                       \
     {                                                                                  \
-        if (thread0_no_spill)                                                          \
+        if (thread_0_no_spill)                                                         \
             FailPointHelper::enableFailPoint(FailPoints::force_thread_0_no_agg_spill); \
         else                                                                           \
             FailPointHelper::disableFailPoint(FailPoints::force_thread_0_no_agg_spill);
 
-#define WRAP_FOR_AGG_THREAD0_NO_SPILL_END }
+#define WRAP_FOR_AGG_THREAD_0_NO_SPILL_END }
 
 
 #define WRAP_FOR_SPILL_TEST_BEGIN                  \
@@ -115,9 +115,11 @@ try
     /// don't use `executeAndAssertColumnsEqual` since it takes too long to run
     /// test single thread aggregation
     WRAP_FOR_AGG_PARTIAL_BLOCK_START
+    WRAP_FOR_AGG_THREAD_0_NO_SPILL_START
     ASSERT_COLUMNS_EQ_UR(ref_columns, executeStreams(request, 1));
     /// test parallel aggregation
     ASSERT_COLUMNS_EQ_UR(ref_columns, executeStreams(request, original_max_streams));
+    WRAP_FOR_AGG_THREAD_0_NO_SPILL_END
     WRAP_FOR_AGG_PARTIAL_BLOCK_END
     /// enable spill and use small max_cached_data_bytes_in_spiller
     context.context->setSetting("max_cached_data_bytes_in_spiller", Field(static_cast<UInt64>(total_data_size / 200)));
@@ -261,7 +263,7 @@ try
                     context.context->setSetting("max_block_size", Field(static_cast<UInt64>(max_block_size)));
                     WRAP_FOR_SPILL_TEST_BEGIN
                     WRAP_FOR_AGG_PARTIAL_BLOCK_START
-                    WRAP_FOR_AGG_THREAD0_NO_SPILL_START
+                    WRAP_FOR_AGG_THREAD_0_NO_SPILL_START
                     auto blocks = getExecuteStreamsReturnBlocks(request, concurrency);
                     for (auto & block : blocks)
                     {
@@ -286,7 +288,7 @@ try
                             vstackBlocks(std::move(blocks)).getColumnsWithTypeAndName(),
                             false));
                     }
-                    WRAP_FOR_AGG_THREAD0_NO_SPILL_END
+                    WRAP_FOR_AGG_THREAD_0_NO_SPILL_END
                     WRAP_FOR_AGG_PARTIAL_BLOCK_END
                     WRAP_FOR_SPILL_TEST_END
                 }
@@ -416,7 +418,7 @@ try
                     context.context->setSetting("max_block_size", Field(static_cast<UInt64>(max_block_size)));
                     WRAP_FOR_SPILL_TEST_BEGIN
                     WRAP_FOR_AGG_PARTIAL_BLOCK_START
-                    WRAP_FOR_AGG_THREAD0_NO_SPILL_START
+                    WRAP_FOR_AGG_THREAD_0_NO_SPILL_START
                     auto blocks = getExecuteStreamsReturnBlocks(request, concurrency);
                     for (auto & block : blocks)
                     {
@@ -441,7 +443,7 @@ try
                             vstackBlocks(std::move(blocks)).getColumnsWithTypeAndName(),
                             false));
                     }
-                    WRAP_FOR_AGG_THREAD0_NO_SPILL_END
+                    WRAP_FOR_AGG_THREAD_0_NO_SPILL_END
                     WRAP_FOR_AGG_PARTIAL_BLOCK_END
                     WRAP_FOR_SPILL_TEST_END
                 }

--- a/dbms/src/Flash/tests/gtest_spill_aggregation.cpp
+++ b/dbms/src/Flash/tests/gtest_spill_aggregation.cpp
@@ -22,6 +22,7 @@ namespace DB
 namespace FailPoints
 {
 extern const char force_agg_on_partial_block[];
+extern const char force_thread_0_no_agg_spill[];
 } // namespace FailPoints
 
 namespace tests
@@ -46,6 +47,17 @@ public:
             FailPointHelper::disableFailPoint(FailPoints::force_agg_on_partial_block);
 
 #define WRAP_FOR_AGG_PARTIAL_BLOCK_END }
+
+#define WRAP_FOR_AGG_THREAD0_NO_SPILL_START                                            \
+    for (auto thread0_no_spill : {true, false})                                        \
+    {                                                                                  \
+        if (thread0_no_spill)                                                          \
+            FailPointHelper::enableFailPoint(FailPoints::force_thread_0_no_agg_spill); \
+        else                                                                           \
+            FailPointHelper::disableFailPoint(FailPoints::force_thread_0_no_agg_spill);
+
+#define WRAP_FOR_AGG_THREAD0_NO_SPILL_END }
+
 
 #define WRAP_FOR_SPILL_TEST_BEGIN                  \
     std::vector<bool> pipeline_bools{false, true}; \
@@ -249,6 +261,7 @@ try
                     context.context->setSetting("max_block_size", Field(static_cast<UInt64>(max_block_size)));
                     WRAP_FOR_SPILL_TEST_BEGIN
                     WRAP_FOR_AGG_PARTIAL_BLOCK_START
+                    WRAP_FOR_AGG_THREAD0_NO_SPILL_START
                     auto blocks = getExecuteStreamsReturnBlocks(request, concurrency);
                     for (auto & block : blocks)
                     {
@@ -273,6 +286,7 @@ try
                             vstackBlocks(std::move(blocks)).getColumnsWithTypeAndName(),
                             false));
                     }
+                    WRAP_FOR_AGG_THREAD0_NO_SPILL_END
                     WRAP_FOR_AGG_PARTIAL_BLOCK_END
                     WRAP_FOR_SPILL_TEST_END
                 }
@@ -402,6 +416,7 @@ try
                     context.context->setSetting("max_block_size", Field(static_cast<UInt64>(max_block_size)));
                     WRAP_FOR_SPILL_TEST_BEGIN
                     WRAP_FOR_AGG_PARTIAL_BLOCK_START
+                    WRAP_FOR_AGG_THREAD0_NO_SPILL_START
                     auto blocks = getExecuteStreamsReturnBlocks(request, concurrency);
                     for (auto & block : blocks)
                     {
@@ -426,6 +441,7 @@ try
                             vstackBlocks(std::move(blocks)).getColumnsWithTypeAndName(),
                             false));
                     }
+                    WRAP_FOR_AGG_THREAD0_NO_SPILL_END
                     WRAP_FOR_AGG_PARTIAL_BLOCK_END
                     WRAP_FOR_SPILL_TEST_END
                 }

--- a/dbms/src/Interpreters/AggSpillContext.cpp
+++ b/dbms/src/Interpreters/AggSpillContext.cpp
@@ -21,6 +21,7 @@ namespace DB
 namespace FailPoints
 {
 extern const char random_marked_for_auto_spill[];
+extern const char force_thread_0_no_agg_spill[];
 } // namespace FailPoints
 
 AggSpillContext::AggSpillContext(
@@ -55,6 +56,12 @@ bool AggSpillContext::updatePerThreadRevocableMemory(Int64 new_value, size_t thr
     if (new_value == 0)
         // new_value == 0 means no agg data to spill
         return false;
+    fiu_do_on(FailPoints::force_thread_0_no_agg_spill, {
+        if (thread_num == 0)
+        {
+            return false;
+        }
+    });
     if (auto_spill_mode)
     {
         AutoSpillStatus old_value = AutoSpillStatus::NEED_AUTO_SPILL;

--- a/dbms/src/Interpreters/Aggregator.cpp
+++ b/dbms/src/Interpreters/Aggregator.cpp
@@ -78,6 +78,7 @@ bool AggregatedDataVariants::tryMarkNeedSpill()
         /// Data can only be flushed to disk if a two-level aggregation is supported.
         if (!isConvertibleToTwoLevel())
             return false;
+        convertToTwoLevel();
     }
     need_spill = true;
     return true;
@@ -1027,11 +1028,6 @@ void Aggregator::spill(AggregatedDataVariants & data_variants, size_t thread_num
 {
     assert(data_variants.need_spill);
     agg_spill_context->markSpilled();
-    if unlikely (!data_variants.isTwoLevel())
-    {
-        assert(isConvertibleToTwoLevel());
-        data_variants.convertToTwoLevel();
-    }
     /// Flush only two-level data and possibly overflow data.
 #define M(NAME)                                                                                                     \
     case AggregationMethodType(NAME):                                                                               \

--- a/dbms/src/Interpreters/Aggregator.cpp
+++ b/dbms/src/Interpreters/Aggregator.cpp
@@ -78,7 +78,6 @@ bool AggregatedDataVariants::tryMarkNeedSpill()
         /// Data can only be flushed to disk if a two-level aggregation is supported.
         if (!isConvertibleToTwoLevel())
             return false;
-        convertToTwoLevel();
     }
     need_spill = true;
     return true;
@@ -1028,6 +1027,11 @@ void Aggregator::spill(AggregatedDataVariants & data_variants, size_t thread_num
 {
     assert(data_variants.need_spill);
     agg_spill_context->markSpilled();
+    if unlikely (!data_variants.isTwoLevel())
+    {
+        assert(isConvertibleToTwoLevel());
+        data_variants.convertToTwoLevel();
+    }
     /// Flush only two-level data and possibly overflow data.
 #define M(NAME)                                                                                                     \
     case AggregationMethodType(NAME):                                                                               \


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/9022

Problem Summary:
See https://github.com/pingcap/tiflash/issues/9022.

### What is changed and how it works?
1. Add agg final spill event if have spill data
2. Parallelize converting when spill is triggered by inserting `AggregateFinalConvertEvent` first.

Add a unit test to test this bug. For the original code, the test will fail due to wrong result.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
