### PR TITLE
Storages: Refine SegmentReadTaskScheduler::add to reduce lock contention

### DIFF
--- a/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.cpp
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.cpp
@@ -40,15 +40,13 @@ SegmentReadTaskScheduler::~SegmentReadTaskScheduler()
 
 void SegmentReadTaskScheduler::add(const SegmentReadTaskPoolPtr & pool)
 {
+    std::lock_guard lock(add_mtx);
+    submitPendingPool(pool);
+}
+
+void SegmentReadTaskScheduler::addPool(const SegmentReadTaskPoolPtr & pool)
+{
     assert(pool != nullptr);
-    Stopwatch sw_add;
-    // `add_lock` is only used in this function to make all threads calling `add` to execute serially.
-    std::lock_guard add_lock(add_mtx);
-    add_waittings.fetch_add(1, std::memory_order_relaxed);
-    // `lock` is used to protect data.
-    std::lock_guard lock(mtx);
-    add_waittings.fetch_sub(1, std::memory_order_relaxed);
-    Stopwatch sw_do_add;
     read_pools.emplace(pool->pool_id, pool);
 
     const auto & tasks = pool->getTasks();
@@ -56,15 +54,48 @@ void SegmentReadTaskScheduler::add(const SegmentReadTaskPoolPtr & pool)
     {
         merging_segments[seg_id].push_back(pool->pool_id);
     }
+}
+
+void SegmentReadTaskScheduler::addPools(const SegmentReadTaskPools & pools)
+{
+    for (const auto & pool : pools)
+    {
+        addPool(pool);
+    }
+    LOG_INFO(log, "Added, pool_ids={}, pool_count={}", pools, read_pools.size());
+}
+
+void SegmentReadTaskScheduler::submitPendingPool(SegmentReadTaskPoolPtr pool)
+{
+    assert(pool != nullptr);
+    if (pool->getPendingSegmentCount() <= 0)
+    {
+        LOG_INFO(pool->getLogger(), "Ignored for no segment to read, pool_id={}", pool->pool_id);
+        return;
+    }
+    Stopwatch sw;
+    std::lock_guard lock(pending_mtx);
+    pending_pools.push_back(pool);
     LOG_INFO(
         pool->getLogger(),
-        "Added, pool_id={} block_slots={} segment_count={} pool_count={} cost={:.3f}us do_add_cost={:.3f}us", //
+        "Submitted, pool_id={} segment_count={} pending_pools={} cost={}ns",
         pool->pool_id,
-        pool->getFreeBlockSlots(),
-        tasks.size(),
-        read_pools.size(),
-        sw_add.elapsed() / 1000.0,
-        sw_do_add.elapsed() / 1000.0);
+        pool->getPendingSegmentCount(),
+        pending_pools.size(),
+        sw.elapsed());
+}
+
+void SegmentReadTaskScheduler::reapPendingPools()
+{
+    SegmentReadTaskPools pools;
+    {
+        std::lock_guard lock(pending_mtx);
+        pools.swap(pending_pools);
+    }
+    if (!pools.empty())
+    {
+        addPools(pools);
+    }
 }
 
 MergedTaskPtr SegmentReadTaskScheduler::scheduleMergedTask(SegmentReadTaskPoolPtr & pool)
@@ -243,11 +274,7 @@ std::tuple<UInt64, UInt64, UInt64> SegmentReadTaskScheduler::scheduleOneRound()
 
 bool SegmentReadTaskScheduler::schedule()
 {
-    Stopwatch sw_sched_total;
-    std::lock_guard lock(mtx);
-    Stopwatch sw_do_sched;
-
-    auto pool_count = read_pools.size();
+    Stopwatch sw_sched;
     UInt64 erased_pool_count = 0;
     UInt64 sched_null_count = 0;
     UInt64 sched_succ_count = 0;
@@ -256,36 +283,30 @@ bool SegmentReadTaskScheduler::schedule()
     do
     {
         ++sched_round;
+        reapPendingPools();
         auto [erase, null, succ] = scheduleOneRound();
         erased_pool_count += erase;
         sched_null_count += null;
         sched_succ_count += succ;
 
         can_sched_more_tasks = succ > 0 && !read_pools.empty();
-        // If no thread is waitting to add tasks and there are some tasks to be scheduled, run scheduling again.
-        // Avoid releasing and acquiring `mtx` repeatly.
-        // This is common when query concurrency is low, but individual queries are heavy.
-    } while (add_waittings.load(std::memory_order_relaxed) <= 0 && can_sched_more_tasks);
+    } while (can_sched_more_tasks);
 
     if (read_pools.empty())
     {
         GET_METRIC(tiflash_storage_read_thread_counter, type_sche_no_pool).Increment();
     }
 
-    auto total_ms = sw_sched_total.elapsedMilliseconds();
-    if (total_ms >= 100)
+    if (auto total_ms = sw_sched.elapsedMilliseconds(); total_ms >= 100)
     {
         LOG_INFO(
             log,
-            "schedule sched_round={} pool_count={} erased_pool_count={} sched_null_count={} sched_succ_count={} "
-            "cost={}ms do_sched_cost={}ms",
+            "schedule sched_round={} erased_pool_count={} sched_null_count={} sched_succ_count={} cost={}ms",
             sched_round,
-            pool_count,
             erased_pool_count,
             sched_null_count,
             sched_succ_count,
-            total_ms,
-            sw_do_sched.elapsedMilliseconds());
+            total_ms);
     }
     return can_sched_more_tasks;
 }

--- a/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.cpp
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.cpp
@@ -40,6 +40,7 @@ SegmentReadTaskScheduler::~SegmentReadTaskScheduler()
 
 void SegmentReadTaskScheduler::add(const SegmentReadTaskPoolPtr & pool)
 {
+    // To avoid schedule from always failing to acquire the pending_mtx.
     std::lock_guard lock(add_mtx);
     submitPendingPool(pool);
 }

--- a/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.cpp
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.cpp
@@ -94,7 +94,11 @@ void SegmentReadTaskScheduler::reapPendingPools()
     }
     if (!pools.empty())
     {
-        addPools(pools);
+        for (const auto & pool : pools)
+        {
+            addPool(pool);
+        }
+        LOG_INFO(log, "Added, pool_ids={}, pool_count={}", pools, read_pools.size());
     }
 }
 

--- a/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.cpp
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.cpp
@@ -56,15 +56,6 @@ void SegmentReadTaskScheduler::addPool(const SegmentReadTaskPoolPtr & pool)
     }
 }
 
-void SegmentReadTaskScheduler::addPools(const SegmentReadTaskPools & pools)
-{
-    for (const auto & pool : pools)
-    {
-        addPool(pool);
-    }
-    LOG_INFO(log, "Added, pool_ids={}, pool_count={}", pools, read_pools.size());
-}
-
 void SegmentReadTaskScheduler::submitPendingPool(SegmentReadTaskPoolPtr pool)
 {
     assert(pool != nullptr);

--- a/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.h
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.h
@@ -84,7 +84,6 @@ private:
     void submitPendingPool(SegmentReadTaskPoolPtr pool);
     void reapPendingPools();
     void addPool(const SegmentReadTaskPoolPtr & pool);
-    void addPools(const SegmentReadTaskPools & pools);
 
     // To restrict the instantaneous concurrency of `add` and avoid `schedule` from always failing to acquire the lock.
     std::mutex add_mtx;

--- a/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.h
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.h
@@ -27,14 +27,14 @@ namespace tests
 {
 class SegmentReadTasksPoolTest;
 }
-// `SegmentReadTaskScheduler` is a global singleton. All `SegmentReadTaskPool` will be added to it and be scheduled by it.
-// 1. `UnorderedInputStream`/`UnorderedSourceOps` will call `SegmentReadTaskScheduler::add` to add a `SegmentReadTaskPool`
-// object to the `read_pools` list and index segments information into `merging_segments`.
-// 2. A schedule-thread will scheduling read tasks:
-//   a. It scans the `read_pools` list and check if `SegmentReadTaskPool` need be scheduled.
-//   b. Chooses a `SegmentReadTask` of the `SegmentReadTaskPool`, if other `SegmentReadTaskPool` will read the same
-//      `SegmentReadTask`, pop them, and build a `MergedTask`.
-//   c. Sends the MergedTask to read threads(SegmentReader).
+// SegmentReadTaskScheduler is a global singleton. All SegmentReadTaskPool objects will be added to it and be scheduled by it.
+// - Threads of computational layer will call SegmentReadTaskScheduler::add to add a SegmentReadTaskPool object to the `pending_pools`.
+// - Call path: UnorderedInputStream/UnorderedSourceOps -> SegmentReadTaskScheduler::add -> SegmentReadTaskScheduler::submitPendingPool
+//
+// - `sched_thread` will scheduling read tasks.
+// - Call path: schedLoop -> schedule -> reapPendingPools -> scheduleOneRound
+// - reapPeningPools will swap the `pending_pools` and add these pools to `read_pools` and `merging_segments`.
+// - scheduleOneRound will scan `read_pools` and choose segments to read.
 class SegmentReadTaskScheduler
 {
 public:
@@ -89,6 +89,7 @@ private:
     // To restrict the instantaneous concurrency of `add` and avoid `schedule` from always failing to acquire the lock.
     std::mutex add_mtx;
 
+    // `read_pools` and `merging_segment` are only accessed by `sched_thread`.
     // pool_id -> pool
     std::unordered_map<UInt64, SegmentReadTaskPoolPtr> read_pools;
     // GlobalSegmentID -> pool_ids

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.h
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.h
@@ -256,3 +256,15 @@ using SegmentReadTaskPoolPtr = std::shared_ptr<SegmentReadTaskPool>;
 using SegmentReadTaskPools = std::vector<SegmentReadTaskPoolPtr>;
 
 } // namespace DB::DM
+
+template <>
+struct fmt::formatter<DB::DM::SegmentReadTaskPoolPtr>
+{
+    static constexpr auto parse(format_parse_context & ctx) { return ctx.begin(); }
+
+    template <typename FormatContext>
+    auto format(const DB::DM::SegmentReadTaskPoolPtr & pool, FormatContext & ctx) const
+    {
+        return fmt::format_to(ctx.out(), "{}", pool->pool_id);
+    }
+};

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_read_task_pool.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_read_task_pool.cpp
@@ -123,13 +123,11 @@ protected:
         std::vector<MergedTaskPtr> merged_tasks;
         for (int i = 0; i < active_segment_limits; ++i)
         {
-            std::lock_guard lock(scheduler.mtx);
             auto merged_task = scheduler.scheduleMergedTask(pool);
             ASSERT_NE(merged_task, nullptr);
             merged_tasks.push_back(merged_task);
         }
         {
-            std::lock_guard lock(scheduler.mtx);
             ASSERT_EQ(scheduler.scheduleMergedTask(pool), nullptr);
         }
 
@@ -173,7 +171,6 @@ protected:
 
             for (;;)
             {
-                std::lock_guard lock(scheduler.mtx);
                 auto merged_task = scheduler.scheduleMergedTask(pool);
                 if (merged_task == nullptr)
                 {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9024

### What is changed and how it works?

- Add `pending_pools`: pools from computational layer will be added to `pending_pools` and can return immediately.
- `sched_thread` will reap `pending_pools` before calling `scheduleOneRound`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  - Run queries without any exceptions. 
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
