### PR TITLE
Storages: Fix max_dup_tuple_id in DeltaTree::swap

### DIFF
--- a/dbms/src/Storages/DeltaMerge/DeltaTree.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaTree.h
@@ -959,19 +959,10 @@ public:
     explicit DeltaTree(const ValueSpacePtr & insert_value_space_) { init(insert_value_space_); }
     DeltaTree(const Self & o);
 
-    DeltaTree & operator=(const Self & o)
-    {
-        Self tmp(o);
-        this->swap(tmp);
-        return *this;
-    }
+    DeltaTree & operator=(const Self & o) = delete;
+    DeltaTree & operator=(Self && o) = delete;
 
-    DeltaTree & operator=(Self && o) noexcept
-    {
-        this->swap(o);
-        return *this;
-    }
-
+    // `swap` is for test cases only.
     void swap(Self & other)
     {
         std::swap(root, other.root);
@@ -983,6 +974,7 @@ public:
         std::swap(num_inserts, other.num_inserts);
         std::swap(num_deletes, other.num_deletes);
         std::swap(num_entries, other.num_entries);
+        std::swap(max_dup_tuple_id, other.max_dup_tuple_id);
 
         std::swap(allocator, allocator);
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #8845

### What is changed and how it works?

- `DeltaTree::swap` need to swap `max_dup_tuple_id`. **Luckily, `DeltaTree::swap` is only used in tests**.
- Delete `DeltaTree::operator=` because it is not used.


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
