### PR TITLE
*: Fix too long thread name make TSAN failed to run

### DIFF
--- a/dbms/src/Storages/KVStore/FFI/JointThreadAllocInfo.cpp
+++ b/dbms/src/Storages/KVStore/FFI/JointThreadAllocInfo.cpp
@@ -27,7 +27,7 @@ namespace DB
 JointThreadInfoJeallocMap::JointThreadInfoJeallocMap()
 {
     monitoring_thread = new std::thread([&]() {
-        setThreadName("ThreadMemoryTracer");
+        setThreadName("ThdMemTrace");
         while (true)
         {
             using namespace std::chrono_literals;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/9043

Problem Summary:

As the issue describe
 
### What is changed and how it works?

Shorten the thread name to be within const char[15]

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
