### PR TITLE
*: Use static to avoid thread-wise memtrace lifetime problem

### DIFF
--- a/dbms/src/Interpreters/Context.h
+++ b/dbms/src/Interpreters/Context.h
@@ -100,7 +100,7 @@ using MockMPPServerInfo = DB::tests::MockMPPServerInfo;
 class TiFlashSecurityConfig;
 using TiFlashSecurityConfigPtr = std::shared_ptr<TiFlashSecurityConfig>;
 class MockStorage;
-struct JointThreadInfoJeallocMap;
+class JointThreadInfoJeallocMap;
 using JointThreadInfoJeallocMapPtr = std::shared_ptr<JointThreadInfoJeallocMap>;
 
 enum class PageStorageRunMode : UInt8;

--- a/dbms/src/Storages/KVStore/FFI/JointThreadAllocInfo.h
+++ b/dbms/src/Storages/KVStore/FFI/JointThreadAllocInfo.h
@@ -20,6 +20,11 @@
 namespace DB
 {
 
+namespace tests
+{
+class RegionKVStoreTest;
+} // namespace tests
+
 enum class ReportThreadAllocateInfoType : uint64_t;
 struct ReportThreadAllocateInfoBatch;
 
@@ -65,29 +70,40 @@ struct ThreadInfoJealloc
 ///   One must guarantee that the thread must exist before `Remove`.
 /// - Directly report by reportThreadAllocBatch
 ///   The call will immedialy update the alloc info of the specified thread.
-struct JointThreadInfoJeallocMap
+class JointThreadInfoJeallocMap
 {
+public:
     JointThreadInfoJeallocMap();
     ~JointThreadInfoJeallocMap();
-    /// Called by a bg thread as a routine work.
-    void recordThreadAllocInfoForKVStore();
-    void recordThreadAllocInfo();
+    // Stop the periodic c
     void stopThreadAllocInfo();
 
     /// For those everlasting threads, we can directly access their allocatedp/allocatedp.
     void reportThreadAllocInfoForKVStore(std::string_view, ReportThreadAllocateInfoType type, uint64_t value);
     /// For those threads with shorter life, we can only update in their call chain.
+    /// Note that this function rely on `TiFlashMetrics::instance` is alive
     static void reportThreadAllocBatchForKVStore(std::string_view, ReportThreadAllocateInfoBatch data);
 
-    mutable std::shared_mutex memory_allocation_mut;
-    std::unordered_map<std::string, ThreadInfoJealloc> kvstore_map;
+
+    friend class tests::RegionKVStoreTest;
 
 private:
+    /// Be called periodicly to submit the alloc info to TiFlashMetrics
+    /// Note that this function rely on `TiFlashMetrics::instance` is alive
+    void recordThreadAllocInfo();
+    void recordThreadAllocInfoForKVStore();
+
+    /// Note that this function rely on `TiFlashMetrics::instance` is alive
     void reportThreadAllocInfoImpl(
         std::unordered_map<std::string, ThreadInfoJealloc> &,
         std::string_view,
         ReportThreadAllocateInfoType type,
         uint64_t value);
+
+private:
+    mutable std::shared_mutex memory_allocation_mut;
+    std::unordered_map<std::string, ThreadInfoJealloc> kvstore_map;
+
     bool is_terminated{false};
     mutable std::mutex monitoring_mut;
     std::condition_variable monitoring_cv;

--- a/dbms/src/Storages/KVStore/FFI/ProxyFFI.cpp
+++ b/dbms/src/Storages/KVStore/FFI/ProxyFFI.cpp
@@ -1061,6 +1061,8 @@ void ReportThreadAllocateBatch(
     {
         UNUSED(server);
         UNUSED(tid);
+        // Note: We need to ensure the following code must be accessiable when
+        // tiflash process is shutting down
         KVStore::reportThreadAllocBatch(buffToStrView(name), data);
     }
     catch (...)

--- a/dbms/src/Storages/KVStore/FFI/ProxyFFI.cpp
+++ b/dbms/src/Storages/KVStore/FFI/ProxyFFI.cpp
@@ -1059,10 +1059,9 @@ void ReportThreadAllocateBatch(
 {
     try
     {
+        UNUSED(server);
         UNUSED(tid);
-        if (!server || !server->tmt || !server->tmt->getKVStore())
-            return;
-        server->tmt->getKVStore()->reportThreadAllocBatch(buffToStrView(name), data);
+        KVStore::reportThreadAllocBatch(buffToStrView(name), data);
     }
     catch (...)
     {

--- a/dbms/src/Storages/KVStore/KVStore.cpp
+++ b/dbms/src/Storages/KVStore/KVStore.cpp
@@ -497,7 +497,7 @@ void KVStore::reportThreadAllocInfo(std::string_view v, ReportThreadAllocateInfo
 
 void KVStore::reportThreadAllocBatch(std::string_view v, ReportThreadAllocateInfoBatch data)
 {
-    joint_memory_allocation_map->reportThreadAllocBatchForKVStore(v, data);
+    JointThreadInfoJeallocMap::reportThreadAllocBatchForKVStore(v, data);
 }
 
 } // namespace DB

--- a/dbms/src/Storages/KVStore/KVStore.h
+++ b/dbms/src/Storages/KVStore/KVStore.h
@@ -149,7 +149,7 @@ public:
     // Proxy will validate and refit the config items from the toml file.
     const ProxyConfigSummary & getProxyConfigSummay() const { return proxy_config_summary; }
     void reportThreadAllocInfo(std::string_view, ReportThreadAllocateInfoType type, uint64_t value);
-    void reportThreadAllocBatch(std::string_view, ReportThreadAllocateInfoBatch data);
+    static void reportThreadAllocBatch(std::string_view, ReportThreadAllocateInfoBatch data);
     JointThreadInfoJeallocMapPtr getJointThreadInfoJeallocMap() const { return joint_memory_allocation_map; }
 
 public: // Region Management

--- a/dbms/src/Storages/KVStore/tests/gtest_new_kvstore.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_new_kvstore.cpp
@@ -914,7 +914,7 @@ try
     auto & tiflash_metrics = TiFlashMetrics::instance();
     ASSERT_EQ(tiflash_metrics.getProxyThreadMemory(TiFlashMetrics::MemoryAllocType::Alloc, "test1"), 1);
     ASSERT_EQ(tiflash_metrics.getProxyThreadMemory(TiFlashMetrics::MemoryAllocType::Dealloc, "test1"), 2);
-    std::string namee = "";
+    std::string namee;
     kvs.reportThreadAllocBatch(
         std::string_view(namee.data(), namee.size()),
         ReportThreadAllocateInfoBatch{.alloc = 1, .dealloc = 2});
@@ -924,12 +924,12 @@ try
         std::string name1 = "test11-1";
         kvs.reportThreadAllocInfo(std::string_view(name1.data(), name1.size()), ReportThreadAllocateInfoType::Reset, 0);
         uint64_t mock = 999;
-        uint64_t alloc_ptr = reinterpret_cast<uint64_t>(&mock);
+        auto alloc_ptr = reinterpret_cast<uint64_t>(&mock);
         kvs.reportThreadAllocInfo(
             std::string_view(name1.data(), name1.size()),
             ReportThreadAllocateInfoType::AllocPtr,
             alloc_ptr);
-        kvs.joint_memory_allocation_map->recordThreadAllocInfoForKVStore();
+        recordThreadAllocInfoForKVStore(kvs.getJointThreadInfoJeallocMap());
         ASSERT_EQ(tiflash_metrics.getProxyThreadMemory(TiFlashMetrics::MemoryAllocType::Alloc, "test11"), 0);
 
         // recordThreadAllocInfoForKVStore can't override if not all alloc/dealloc are provided.
@@ -942,19 +942,19 @@ try
             std::string_view(name2.data(), name2.size()),
             ReportThreadAllocateInfoType::AllocPtr,
             alloc_ptr);
-        kvs.joint_memory_allocation_map->recordThreadAllocInfoForKVStore();
+        recordThreadAllocInfoForKVStore(kvs.getJointThreadInfoJeallocMap());
         ASSERT_EQ(tiflash_metrics.getProxyThreadMemory(TiFlashMetrics::MemoryAllocType::Alloc, "ReadIndexWkr"), 111);
         ASSERT_EQ(tiflash_metrics.getProxyThreadMemory(TiFlashMetrics::MemoryAllocType::Dealloc, "ReadIndexWkr"), 222);
 
         // recordThreadAllocInfoForKVStore will override if all alloc/dealloc are both provided,
         // because the infomation from pointer is always the newest.
         uint64_t mock2 = 998;
-        uint64_t dealloc_ptr = reinterpret_cast<uint64_t>(&mock2);
+        auto dealloc_ptr = reinterpret_cast<uint64_t>(&mock2);
         kvs.reportThreadAllocInfo(
             std::string_view(name2.data(), name2.size()),
             ReportThreadAllocateInfoType::DeallocPtr,
             dealloc_ptr);
-        kvs.joint_memory_allocation_map->recordThreadAllocInfoForKVStore();
+        recordThreadAllocInfoForKVStore(kvs.getJointThreadInfoJeallocMap());
         ASSERT_EQ(tiflash_metrics.getProxyThreadMemory(TiFlashMetrics::MemoryAllocType::Alloc, "ReadIndexWkr"), 999);
         ASSERT_EQ(tiflash_metrics.getProxyThreadMemory(TiFlashMetrics::MemoryAllocType::Dealloc, "ReadIndexWkr"), 998);
         kvs.reportThreadAllocInfo(
@@ -967,7 +967,7 @@ try
         kvs.reportThreadAllocBatch(
             std::string_view(name2.data(), name2.size()),
             ReportThreadAllocateInfoBatch{.alloc = 111, .dealloc = 222});
-        kvs.joint_memory_allocation_map->recordThreadAllocInfoForKVStore();
+        recordThreadAllocInfoForKVStore(kvs.getJointThreadInfoJeallocMap());
         ASSERT_EQ(tiflash_metrics.getProxyThreadMemory(TiFlashMetrics::MemoryAllocType::Alloc, "ReadIndexWkr"), 111);
         ASSERT_EQ(tiflash_metrics.getProxyThreadMemory(TiFlashMetrics::MemoryAllocType::Dealloc, "ReadIndexWkr"), 222);
     });

--- a/dbms/src/Storages/KVStore/tests/gtest_new_kvstore.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_new_kvstore.cpp
@@ -162,7 +162,7 @@ try
         auto expected = str_key.dataSize() + str_lock_value.size();
         ASSERT_EQ(root_of_kvstore_mem_trackers->get(), expected);
         auto str_key2 = RecordKVFormat::genKey(table_id, 20, 111);
-        std::string short_value('a', 100);
+        std::string short_value(97, 'a');
         auto str_lock_value2
             = RecordKVFormat::encodeLockCfValue(RecordKVFormat::CFModifyFlag::PutFlag, "PK", 20, 111, &short_value)
                   .toString();

--- a/dbms/src/Storages/KVStore/tests/region_kvstore_test.h
+++ b/dbms/src/Storages/KVStore/tests/region_kvstore_test.h
@@ -35,6 +35,11 @@ public:
     }
 
     static void dropTable(Context & ctx, TableID table_id);
+
+    static void recordThreadAllocInfoForKVStore(const JointThreadInfoJeallocMapPtr & m)
+    {
+        m->recordThreadAllocInfoForKVStore();
+    }
 };
 
 inline void validateSSTGeneration(


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9038

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
