### PR TITLE
tests: Disable some tests when jemalloc is not enabled

### DIFF
--- a/dbms/src/Storages/KVStore/FFI/JointThreadAllocInfo.cpp
+++ b/dbms/src/Storages/KVStore/FFI/JointThreadAllocInfo.cpp
@@ -149,7 +149,7 @@ void JointThreadInfoJeallocMap::recordThreadAllocInfoForProxy()
         {
             auto agg_thread_name = getThreadNameAggPrefix(k, '-');
             // Some thread may have shorter lifetime, we can't use this timed task here to upgrade.
-            if (PROXY_RECORD_WHITE_LIST_THREAD_PREFIX.contains(agg_thread_name) && v.has_ptr())
+            if (PROXY_RECORD_WHITE_LIST_THREAD_PREFIX.contains(agg_thread_name) && v.hasPtr())
             {
                 agg_allocate[agg_thread_name] += v.allocated();
                 agg_deallocate[agg_thread_name] += v.deallocated();
@@ -243,20 +243,20 @@ void JointThreadInfoJeallocMap::recordThreadAllocInfoForStorage()
     {
         auto agg_thread_name = getThreadNameAggPrefix(k, v.aggregate_delimer);
         // Some thread may have shorter lifetime, we can't use this timed task here to upgrade.
-        if (v.has_ptr())
+        if (v.hasPtr())
         {
             agg_allocate[agg_thread_name] += v.allocated();
             agg_deallocate[agg_thread_name] += v.deallocated();
         }
     }
+
+    auto & tiflash_metrics = TiFlashMetrics::instance();
     for (const auto & [k, v] : agg_allocate)
     {
-        auto & tiflash_metrics = TiFlashMetrics::instance();
         tiflash_metrics.setStorageThreadMemory(TiFlashMetrics::MemoryAllocType::Alloc, k, v);
     }
     for (const auto & [k, v] : agg_deallocate)
     {
-        auto & tiflash_metrics = TiFlashMetrics::instance();
         tiflash_metrics.setStorageThreadMemory(TiFlashMetrics::MemoryAllocType::Dealloc, k, v);
     }
 }

--- a/dbms/src/Storages/KVStore/FFI/JointThreadAllocInfo.cpp
+++ b/dbms/src/Storages/KVStore/FFI/JointThreadAllocInfo.cpp
@@ -157,7 +157,6 @@ void JointThreadInfoJeallocMap::recordThreadAllocInfoForProxy()
         }
     }
 
-    // TODO: maybe we should move the following code to `recordThreadAllocInfo`
     auto & tiflash_metrics = TiFlashMetrics::instance();
     for (const auto & [k, v] : agg_allocate)
     {
@@ -236,17 +235,20 @@ void JointThreadInfoJeallocMap::reportThreadAllocInfoForStorage(
 
 void JointThreadInfoJeallocMap::recordThreadAllocInfoForStorage()
 {
-    std::shared_lock l(memory_allocation_mut);
     std::unordered_map<std::string, uint64_t> agg_allocate;
     std::unordered_map<std::string, uint64_t> agg_deallocate;
-    for (const auto & [k, v] : storage_map)
+
     {
-        auto agg_thread_name = getThreadNameAggPrefix(k, v.aggregate_delimer);
-        // Some thread may have shorter lifetime, we can't use this timed task here to upgrade.
-        if (v.hasPtr())
+        std::shared_lock l(memory_allocation_mut);
+        for (const auto & [k, v] : storage_map)
         {
-            agg_allocate[agg_thread_name] += v.allocated();
-            agg_deallocate[agg_thread_name] += v.deallocated();
+            auto agg_thread_name = getThreadNameAggPrefix(k, v.aggregate_delimer);
+            // Some thread may have shorter lifetime, we can't use this timed task here to upgrade.
+            if (v.hasPtr())
+            {
+                agg_allocate[agg_thread_name] += v.allocated();
+                agg_deallocate[agg_thread_name] += v.deallocated();
+            }
         }
     }
 

--- a/dbms/src/Storages/KVStore/FFI/JointThreadAllocInfo.h
+++ b/dbms/src/Storages/KVStore/FFI/JointThreadAllocInfo.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <shared_mutex>
+#include <thread>
 #include <unordered_map>
 
 namespace DB
@@ -30,14 +31,14 @@ struct ReportThreadAllocateInfoBatch;
 
 struct ThreadInfoJealloc
 {
-    ThreadInfoJealloc(char aggregate_delimer_)
+    explicit ThreadInfoJealloc(char aggregate_delimer_)
         : aggregate_delimer(aggregate_delimer_)
     {}
     char aggregate_delimer = '-';
     uint64_t allocated_ptr{0};
     uint64_t deallocated_ptr{0};
 
-    bool has_ptr() const { return allocated_ptr != 0 && deallocated_ptr != 0; }
+    bool hasPtr() const { return allocated_ptr != 0 && deallocated_ptr != 0; }
 
     uint64_t allocated() const
     {

--- a/dbms/src/Storages/KVStore/tests/gtest_new_kvstore.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_new_kvstore.cpp
@@ -1065,16 +1065,16 @@ try
         char * a = new char[888888];
         std::thread t1([&]() {
             auto [allocated, deallocated] = JointThreadInfoJeallocMap::getPtrs();
-            ASSERT(allocated != nullptr);
+            ASSERT_TRUE(allocated != nullptr);
             ASSERT_EQ(*allocated, 0);
-            ASSERT(deallocated != nullptr);
+            ASSERT_TRUE(deallocated != nullptr);
             ASSERT_EQ(*deallocated, 0);
         });
         t1.join();
         auto [allocated, deallocated] = JointThreadInfoJeallocMap::getPtrs();
-        ASSERT(allocated != nullptr);
+        ASSERT_TRUE(allocated != nullptr);
         ASSERT_GE(*allocated, 888888);
-        ASSERT(deallocated != nullptr);
+        ASSERT_TRUE(deallocated != nullptr);
         delete[] a;
     });
     t2.join();

--- a/dbms/src/Storages/KVStore/tests/gtest_raftstore_v2.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_raftstore_v2.cpp
@@ -956,7 +956,7 @@ try
         while (kvs.getOngoingPrehandleTaskCount() != 3)
         {
             loop += 1;
-            ASSERT(loop < 30);
+            ASSERT_TRUE(loop < 30);
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
         }
         ASSERT_EQ(kvs.prehandling_trace.ongoing_prehandle_subtask_count.load(), 3);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/9090, ref https://github.com/pingcap/tiflash/issues/8835

Problem Summary:
Introduced by https://github.com/pingcap/tiflash/pull/9064, some tests that require jemalloc does not work well when tiflash is not compiled with jemalloc. For example, when compiled under `ASAN`/`TSAN`

https://github.com/pingcap/tiflash/blob/7cb240c9e86ff4cecdeb7cba40a373556f7f4738/libs/libcommon/cmake/find_jemalloc.cmake#L20-L23

### What is changed and how it works?

* Disable `FFIJemallocTest.JemallocThread` and `RegionKVStoreTest.StorageBgPool` when jemalloc is not enabled
* Refine the method of `ThreadInfoJealloc`

```commit-message
Disable some tests when jemalloc is not enabled
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```
cmake .. -GNinja -DCMAKE_BUILD_TYPE=TSAN -DENABLE_TESTS=ON
ninja gtests_dbms tiflash -j32

./dbms/gtests_dbms --gtest_filter='*StorageBgPool*'
```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
