### PR TITLE
tests: Fix MPPTask-Moniter may live longer than TiFlashMetrics

### DIFF
--- a/dbms/src/Flash/Mpp/MPPTaskManager.cpp
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.cpp
@@ -91,9 +91,17 @@ MPPTaskManager::MPPTaskManager(MPPTaskSchedulerPtr scheduler_)
 
 MPPTaskManager::~MPPTaskManager()
 {
-    std::lock_guard lock(monitor->mu);
-    monitor->is_shutdown = true;
-    monitor->cv.notify_all();
+    shutdown();
+}
+
+void MPPTaskManager::shutdown()
+{
+    if (monitor)
+    {
+        std::lock_guard lock(monitor->mu);
+        monitor->is_shutdown = true;
+        monitor->cv.notify_all();
+    }
 }
 
 MPPQueryPtr MPPTaskManager::addMPPQuery(

--- a/dbms/src/Flash/Mpp/MPPTaskManager.h
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.h
@@ -225,6 +225,8 @@ public:
 
     ~MPPTaskManager();
 
+    void shutdown();
+
     std::shared_ptr<MPPTaskMonitor> getMPPTaskMonitor() const { return monitor; }
 
     bool addMonitoredTask(const String & task_unique_id) { return monitor->addMonitoredTask(task_unique_id); }

--- a/tests/sanitize/tsan.suppression
+++ b/tests/sanitize/tsan.suppression
@@ -5,3 +5,5 @@ race:google::protobuf::Message::DebugString
 race:google::protobuf::Message::ShortDebugString
 race:fiu_fail
 race:dbms/src/DataStreams/BlockStreamProfileInfo.h
+race:StackTrace::toString
+race:DB::SyncPointCtl::sync


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/9092, close https://github.com/pingcap/tiflash/issues/9097

Problem Summary:

For #9092

TMTContext will start a thread "MPPTask-Moniter" for running `checkLongLiveMPPTasks`.
https://github.com/pingcap/tiflash/blob/38ab3f912220b94962043bde7cc341017d569994/dbms/src/Storages/KVStore/TMTContext.cpp#L121-L126

When the TiFlash is shutting down, the thread is not explicitly stopped. And the thread may live longer than the TiFlashMetrics instance. If the TiFlashMetrics instance is released before `checkLongLiveMPPTasks` run, then `checkLongLiveMPPTasks` will access to a random address and cause use-after-free data race when shutting down.

For #9097
Seems the race is reported in `backtrace-rs`, there is nothing we can do in tiflash code, just ignore

### What is changed and how it works?

For #9092
In `TMTContext::shutdown`, set the `MPPTaskMonitor->is_shutdown = true`. So the thread is expected to be stopped after TMTContext::shutdown is called and before `TiFlashMetrics` is release. And when `monitor->is_shutdown == true`, the thread don't report the metircs to `TiFlashMetrics`

For #9097
Add `race:StackTrace::toString, race:DB::SyncPointCtl::sync` to tsan.suppression. And they will be ignored when running with `TSAN_OPTIONS="suppressions=/tests/sanitize/tsan.suppression" ./dbms/gtests_dbms --gtest_filter=...`

```commit-message

```


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```
cmake .. -GNinja -DCMAKE_BUILD_TYPE=TSAN -DENABLE_TESTS=ON
ninja gtests_dbms tiflash -j32

./dbms/gtests_dbms
```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
