### PR TITLE
*: Fix compile error under macos

### DIFF
--- a/dbms/src/Common/MemoryAllocTrace.cpp
+++ b/dbms/src/Common/MemoryAllocTrace.cpp
@@ -25,10 +25,10 @@ std::tuple<uint64_t *, uint64_t *> getAllocDeallocPtr()
 {
 #if USE_JEMALLOC
     uint64_t * ptr1 = nullptr;
-    uint64_t size1 = sizeof ptr1;
+    size_t size1 = sizeof(ptr1);
     je_mallctl("thread.allocatedp", reinterpret_cast<void *>(&ptr1), &size1, nullptr, 0);
     uint64_t * ptr2 = nullptr;
-    uint64_t size2 = sizeof ptr2;
+    size_t size2 = sizeof(ptr2);
     je_mallctl("thread.deallocatedp", reinterpret_cast<void *>(&ptr2), &size2, nullptr, 0);
     return std::make_tuple(ptr1, ptr2);
 #else


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:

Introduce by https://github.com/pingcap/tiflash/pull/9064

The signature of `je_mallctl` is
```
int mallctl(	const char *name,
 	void *oldp,
 	size_t *oldlenp,
 	void *newp,
 	size_t newlen);
```

But we pass a `uint64_t *` for `oldlenp` and `newlen`.

'uint64_t' is 'unsigned long long ' while 'size_t' is 'unsigned long' under MacOS, that cause the following compile error

```
/Users/pingcap/workspace/bp-tiflash-release-darwin-arm64-dnmfl-build-binaries/source/tiflash/dbms/src/Common/MemoryAllocTrace.cpp:32:5: error: no matching function for call to 'je_mallctl'
    je_mallctl("thread.deallocatedp", reinterpret_cast<void *>(&ptr2), &size2, nullptr, 0);
    ^~~~~~~~~~
/Users/pingcap/workspace/bp-tiflash-release-darwin-arm64-dnmfl-build-binaries/source/tiflash/release-darwin/build-release/contrib/jemalloc-cmake/include/jemalloc/jemalloc_rename.h:11:20: note: expanded from macro 'je_mallctl'
#define je_mallctl je_mallctl
                   ^~~~~~~~~~
/Users/pingcap/workspace/bp-tiflash-release-darwin-arm64-dnmfl-build-binaries/source/tiflash/contrib/jemalloc-cmake/include/jemalloc/jemalloc_protos.h:53:38: note: candidate function not viable: no known conversion from 'uint64_t *' (aka 'unsigned long long *') to 'size_t *' (aka 'unsigned long *') for 3rd argument
JEMALLOC_EXPORT int JEMALLOC_NOTHROW je_mallctl(const char * name,
                                     ^
/Users/pingcap/workspace/bp-tiflash-release-darwin-arm64-dnmfl-build-binaries/source/tiflash/release-darwin/build-release/contrib/jemalloc-cmake/include/jemalloc/jemalloc_rename.h:11:20: note: expanded from macro 'je_mallctl'
#define je_mallctl je_mallctl
```

### What is changed and how it works?

Change the type from `uint64_t` to `size_t` for 3rd param of `je_mallctl`

```commit-message
Fix compile error under macos
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
