### PR TITLE
KVStore: Add comments and refine logging about WaitCheckRegionReady

### DIFF
--- a/dbms/src/Storages/DeltaMerge/Decode/SSTFilesToBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/Decode/SSTFilesToBlockInputStream.cpp
@@ -284,11 +284,11 @@ void SSTFilesToBlockInputStream::loadCFDataFromSST(
             (*p_process_keys_bytes) += (key.len + value.len);
             reader->next();
         }
-        auto sec = sw.elapsedMilliseconds();
+        const auto sec = sw.elapsedSeconds();
         LOG_DEBUG(
             log,
             "Done loading all kvpairs, CF={} offset={} processed_bytes={} write_cf_offset={} region_id={} split_id={} "
-            "snapshot_index={} elapsed_sec={} speed={}",
+            "snapshot_index={} elapsed_sec={:.3f} speed={}",
             CFToName(cf),
             (*p_process_keys),
             (*p_process_keys_bytes),
@@ -308,11 +308,11 @@ void SSTFilesToBlockInputStream::loadCFDataFromSST(
         // We keep an assumption that rowkeys are memory-comparable and they are asc sorted in the SST file
         if (!last_loaded_rowkey->empty() && *last_loaded_rowkey > *rowkey_to_be_included)
         {
-            auto sec = sw.elapsedMilliseconds();
+            const auto sec = sw.elapsedSeconds();
             LOG_DEBUG(
                 log,
                 "Done loading, CF={} offset={} processed_bytes={} write_cf_offset={} last_loaded_rowkey={} "
-                "rowkey_to_be_included={} region_id={} snapshot_index={} elapsed_sec={} speed={}",
+                "rowkey_to_be_included={} region_id={} snapshot_index={} elapsed_sec={:.3f} speed={}",
                 CFToName(cf),
                 (*p_process_keys),
                 (*p_process_keys_bytes),

--- a/dbms/src/Storages/DeltaMerge/Decode/SSTFilesToBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/Decode/SSTFilesToBlockInputStream.cpp
@@ -379,7 +379,7 @@ Block SSTFilesToBlockInputStream::readCommitedBlock()
                 log,
                 "Got error while reading region committed cache: {}. Stop decoding rows into DTFiles and keep "
                 "uncommitted data in region."
-                "region_id: {}, applied_index: {}, version: {}, conf_version {}, start_key: {}, end_key: {}",
+                "region_id={} applied_index={} version={} conf_version={} start_key={}, end_key={}",
                 e.displayText(),
                 region->id(),
                 region->appliedIndex(),
@@ -434,7 +434,7 @@ bool SSTFilesToBlockInputStream::maybeSkipBySoftLimit(ColumnFamilyType cf, SSTRe
             // or it is already seeked.
             LOG_TRACE(
                 log,
-                "Re-Seek backward is forbidden, start_limit {} current {}, cf={}, split_id={}, region_id={}",
+                "Re-Seek backward is forbidden, start_limit={} current={} cf={} split_id={} region_id={}",
                 soft_limit.value().raw_start.toDebugString(),
                 Redact::keyToDebugString(key.data, key.len),
                 magic_enum::enum_name(cf),
@@ -460,7 +460,7 @@ bool SSTFilesToBlockInputStream::maybeSkipBySoftLimit(ColumnFamilyType cf, SSTRe
         {
             RUNTIME_CHECK_MSG(
                 current_truncated_ts > start_limit,
-                "current pk decreases as reader advances, start_raw {} start_pk {} current {}, cf={}, split_id={}, "
+                "current pk decreases as reader advances, start_raw={} start_pk={} current={} cf={} split_id={} "
                 "region_id={}",
                 soft_limit.value().raw_start.toDebugString(),
                 start_limit.value().toDebugString(),
@@ -470,7 +470,7 @@ bool SSTFilesToBlockInputStream::maybeSkipBySoftLimit(ColumnFamilyType cf, SSTRe
                 region->id());
             LOG_INFO(
                 log,
-                "Re-Seek after start_raw {} start_pk {} to {}, current_pk = {}, cf={}, split_id={}, region_id={}",
+                "Re-Seek after start_raw={} start_pk={} to {}, current_pk={} cf={} split_id={} region_id={}",
                 soft_limit.value().raw_start.toDebugString(),
                 start_limit.value().toDebugString(),
                 tikv_key.toDebugString(),
@@ -485,7 +485,7 @@ bool SSTFilesToBlockInputStream::maybeSkipBySoftLimit(ColumnFamilyType cf, SSTRe
     // `start_limit` is the last pk of the sst file.
     LOG_INFO(
         log,
-        "Re-Seek to the last key of write cf start_raw {} start_pk {}, cf={}, split_id={}, region_id={}",
+        "Re-Seek to the last key of write cf start_raw={} start_pk={} cf={} split_id={} region_id={}",
         soft_limit.value().raw_start.toDebugString(),
         start_limit.value().toDebugString(),
         magic_enum::enum_name(cf),
@@ -510,7 +510,7 @@ bool SSTFilesToBlockInputStream::maybeStopBySoftLimit(ColumnFamilyType cf, SSTRe
     {
         LOG_INFO(
             log,
-            "Reach end for split {} current {} pk {} end_limit {}, cf={} split_id={} region_id={}",
+            "Reach end for split={} current={} pk={} end_limit={} cf={} split_id={} region_id={}",
             sl.toDebugString(),
             tikv_key.toDebugString(),
             current_truncated_ts.toDebugString(),

--- a/dbms/src/Storages/DeltaMerge/Decode/SSTFilesToBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/Decode/SSTFilesToBlockInputStream.cpp
@@ -379,7 +379,7 @@ Block SSTFilesToBlockInputStream::readCommitedBlock()
                 log,
                 "Got error while reading region committed cache: {}. Stop decoding rows into DTFiles and keep "
                 "uncommitted data in region."
-                "region_id={} applied_index={} version={} conf_version={} start_key={}, end_key={}",
+                "region_id={} applied_index={} version={} conf_version={} start_key={} end_key={}",
                 e.displayText(),
                 region->id(),
                 region->appliedIndex(),

--- a/dbms/src/Storages/KVStore/KVStore.h
+++ b/dbms/src/Storages/KVStore/KVStore.h
@@ -429,6 +429,6 @@ class KVStoreTaskLock : private boost::noncopyable
 };
 
 void WaitCheckRegionReady(const TMTContext &, KVStore & kvstore, const std::atomic_size_t & terminate_signals_counter);
-void WaitCheckRegionReady(const TMTContext &, KVStore & kvstore, const std::atomic_size_t &, double, double, double);
+void WaitCheckRegionReadyImpl(const TMTContext &, KVStore & kvstore, const std::atomic_size_t &, double, double, double);
 
 } // namespace DB

--- a/dbms/src/Storages/KVStore/KVStore.h
+++ b/dbms/src/Storages/KVStore/KVStore.h
@@ -429,6 +429,12 @@ class KVStoreTaskLock : private boost::noncopyable
 };
 
 void WaitCheckRegionReady(const TMTContext &, KVStore & kvstore, const std::atomic_size_t & terminate_signals_counter);
-void WaitCheckRegionReadyImpl(const TMTContext &, KVStore & kvstore, const std::atomic_size_t &, double, double, double);
+void WaitCheckRegionReadyImpl(
+    const TMTContext &,
+    KVStore & kvstore,
+    const std::atomic_size_t &,
+    double,
+    double,
+    double);
 
 } // namespace DB

--- a/dbms/src/Storages/KVStore/Read/ReadIndex.cpp
+++ b/dbms/src/Storages/KVStore/Read/ReadIndex.cpp
@@ -139,7 +139,7 @@ void WaitCheckRegionReadyImpl(
 
     LOG_INFO(
         log,
-        "start to check regions ready, min-wait-tick {}s, max-wait-tick {}s, wait-region-ready-timeout {:.3f}s",
+        "start to check regions ready, min_wait_tick={:.3f}s max_wait_tick={:.3f}s wait_region_ready_timeout={:.3f}s",
         wait_tick_time,
         max_wait_tick_time,
         get_wait_region_ready_timeout_sec);
@@ -299,7 +299,7 @@ void WaitCheckRegionReadyImpl(
     LOG_IMPL(
         log,
         log_level,
-        "finish to check regions, time cost {:.3f}s tot_regions={}",
+        "finish to check regions, time_cost={:.3f}s tot_regions={}",
         total_elapse,
         total_regions_cnt);
 }
@@ -310,6 +310,7 @@ void WaitCheckRegionReady(
     const std::atomic_size_t & terminate_signals_counter)
 {
     // wait interval to check region ready, not recommended to modify only if for tesing
+    // TODO: Move this hidden config to TMTContext
     auto wait_region_ready_tick = tmt.getContext().getConfigRef().getUInt64("flash.wait_region_ready_tick", 0);
     auto wait_region_ready_timeout_sec = static_cast<double>(tmt.waitRegionReadyTimeout());
     const double max_wait_tick_time = 0 == wait_region_ready_tick ? 20.0 : wait_region_ready_timeout_sec;

--- a/dbms/src/Storages/KVStore/Region.cpp
+++ b/dbms/src/Storages/KVStore/Region.cpp
@@ -22,6 +22,7 @@
 #include <Storages/KVStore/KVStore.h>
 #include <Storages/KVStore/Region.h>
 #include <Storages/KVStore/TMTContext.h>
+#include <Storages/KVStore/Types.h>
 #include <common/logger_useful.h>
 
 #include <ext/scope_guard.h>
@@ -131,10 +132,10 @@ std::string Region::getDebugString() const
 {
     const auto & meta_snap = meta.dumpRegionMetaSnapshot();
     return fmt::format(
-        "[region_id={} index={} keyspace={} table_id={} ver={} conf_ver={} state={} peer={} range={}]",
+        "[region_id={} index={} {}table_id={} ver={} conf_ver={} state={} peer={} range={}]",
         id(),
         meta.appliedIndex(),
-        keyspace_id,
+        ((keyspace_id == NullspaceID) ? "" : fmt::format("keyspace={} ", keyspace_id)),
         mapped_table_id,
         meta_snap.ver,
         meta_snap.conf_ver,

--- a/dbms/src/Storages/KVStore/Region.cpp
+++ b/dbms/src/Storages/KVStore/Region.cpp
@@ -131,9 +131,10 @@ std::string Region::getDebugString() const
 {
     const auto & meta_snap = meta.dumpRegionMetaSnapshot();
     return fmt::format(
-        "[region_id={} index={} table_id={} ver={} conf_ver={} state={} peer={} range={}]",
+        "[region_id={} index={} keyspace={} table_id={} ver={} conf_ver={} state={} peer={} range={}]",
         id(),
         meta.appliedIndex(),
+        keyspace_id,
         mapped_table_id,
         meta_snap.ver,
         meta_snap.conf_ver,

--- a/dbms/src/Storages/KVStore/tests/gtest_kvstore.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_kvstore.cpp
@@ -133,7 +133,7 @@ TEST_F(RegionKVStoreOldTest, ReadIndex)
             const std::atomic_size_t terminate_signals_counter{};
             std::thread t([&]() {
                 notifier.wake();
-                WaitCheckRegionReady(ctx.getTMTContext(), kvs, terminate_signals_counter, 1 / 1000.0, 20, 20 * 60);
+                WaitCheckRegionReadyImpl(ctx.getTMTContext(), kvs, terminate_signals_counter, 1 / 1000.0, 20, 20 * 60);
             });
             SCOPE_EXIT({
                 t.join();
@@ -162,7 +162,7 @@ TEST_F(RegionKVStoreOldTest, ReadIndex)
             const std::atomic_size_t terminate_signals_counter{};
             std::thread t([&]() {
                 notifier.wake();
-                WaitCheckRegionReady(
+                WaitCheckRegionReadyImpl(
                     ctx.getTMTContext(),
                     kvs,
                     terminate_signals_counter,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/6233

Problem Summary:

### What is changed and how it works?

```commit-message

```

* Log the logging as warning level when `WaitCheckRegionReadyImpl ` take more than 60 seconds
* Add `keyspace` to `Region::getDebugString`
* Add some comments
* Fix the time unit is wrong in logging introduced by https://github.com/pingcap/tiflash/pull/9155

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
