### PR TITLE
*: update minimum cmake version to 3.23

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required (VERSION 3.21)
+cmake_minimum_required (VERSION 3.23)
 
 project (TiFlash LANGUAGES C CXX ASM)
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ And the following operating systems:
 
 The following packages are required:
 
-- CMake 3.21.0+
-- Clang 17.0.0+ under Linux or AppleClang 15.0.0+ under MacOS
+- CMake 3.23.0+
+- Clang 17.0.0+ under Linux or AppleClang 14.0.0+ under MacOS
 - Rust
 - Python 3.0+
 - Ninja-Build or GNU Make


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8898, close #7193

Problem Summary:

cmake need to be upgrade to 3.23 at least for building under mac os with clang 14.0.0

### What is changed and how it works?

```commit-message
update minimum cmake version to 3.23
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
