### PR TITLE
Add debug log info to locate random fmt exception

### DIFF
--- a/dbms/src/Flash/Planner/PhysicalPlan.cpp
+++ b/dbms/src/Flash/Planner/PhysicalPlan.cpp
@@ -322,9 +322,12 @@ PipelinePtr PhysicalPlan::toPipeline(PipelineExecutorContext & exec_context, Con
 {
     RUNTIME_CHECK(root_node);
     PipelineBuilder builder{log->identifier()};
+    LOG_DEBUG(log, "Before buildPipeline");
     root_node->buildPipeline(builder, context, exec_context);
+    LOG_DEBUG(log, "After buildPipeline");
     root_node.reset();
     auto pipeline = builder.build();
+    LOG_DEBUG(log, "Before dump pipeline dag");
     LOG_DEBUG(log, "build pipeline dag: \n{}", pipeline->toTreeString());
     return pipeline;
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #9087

Problem Summary:

### What is changed and how it works?
Last logged info is: https://github.com/pingcap/tiflash/blob/f6071b34ea1ab60f2484b2af50fd0eef82a5c233/dbms/src/Flash/Planner/PhysicalPlan.cpp#L302
Thus pipeline dag log is not logged. Add more debug info to locate the actual place. 

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
