### PR TITLE
Adjust sanitizer sleep time for cancelMPPGather

### DIFF
--- a/dbms/src/Flash/tests/gtest_compute_server.cpp
+++ b/dbms/src/Flash/tests/gtest_compute_server.cpp
@@ -1119,7 +1119,7 @@ try
         single_gather_properties.gather_id = 1;
         addOneGather(running_queries, gather_ids, single_gather_properties);
         using namespace std::literals::chrono_literals;
-        ADAPTIVE_SLEEP(4s, 8s);
+        ADAPTIVE_SLEEP(4s, 16s);
         /// 6 gathers, but two query
         ASSERT_TRUE(
             TiFlashMetrics::instance()


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #8285

Problem Summary:

### What is changed and how it works?

```commit-message
In #9194, sleep time is changed to 8s in sanitizer mode. However, the case still failed occasionally. So change to a larger time span. 
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
