### PR TITLE
*: Add binaryDir to CMakePresets.json

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,7 +2,7 @@
   "version": 3,
   "cmakeMinimumRequired": {
     "major": 3,
-    "minor": 21,
+    "minor": 23,
     "patch": 0
   },
   "configurePresets": [
@@ -72,7 +72,8 @@
         "tests-on"
       ],
       "displayName": "Development: DEBUG build with tests enabled",
-      "cacheVariables": {}
+      "cacheVariables": {},
+      "binaryDir": "${sourceDir}/cmake-build-debug"
     },
     {
         "name": "dev-coverage",
@@ -83,7 +84,8 @@
         "displayName": "Development: DEBUG build with tests and code coverage enabled",
         "cacheVariables": {
             "TEST_LLVM_COVERAGE": "ON"
-        }
+        },
+        "binaryDir": "${sourceDir}/cmake-build-coverage"
     },
     {
       "name": "release",
@@ -92,7 +94,8 @@
         "tests-off"
       ],
       "displayName": "Release: RELWITHDEBINFO build without tests enabled",
-      "cacheVariables": {}
+      "cacheVariables": {},
+      "binaryDir": "${sourceDir}/cmake-build-release"
     },
     {
       "name": "asan",
@@ -101,7 +104,8 @@
         "tests-on"
       ],
       "displayName": "AddressSanitizer: ASAN build with tests enabled",
-      "cacheVariables": {}
+      "cacheVariables": {},
+      "binaryDir": "${sourceDir}/cmake-build-asan"
     },
     {
       "name": "tsan",
@@ -110,7 +114,8 @@
         "tests-on"
       ],
       "displayName": "ThreadSanitizer: TSAN build with tests enabled",
-      "cacheVariables": {}
+      "cacheVariables": {},
+      "binaryDir": "${sourceDir}/cmake-build-tsan"
     },
     {
       "name": "benchmarks",
@@ -119,7 +124,8 @@
         "tests-on"
       ],
       "displayName": "Benchmarks: RELEASE build with benchmarks enabled",
-      "cacheVariables": {}
+      "cacheVariables": {},
+      "binaryDir": "${sourceDir}/cmake-build-release"
     }
   ]
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8826

Problem Summary:

### What is changed and how it works?

```commit-message

```

```shell
> ls cmake-build-coverage
ls: cannot access 'cmake-build-coverage': No such file or directory
> cmake --list-presets
Available configure presets:

  "dev"          - Development: DEBUG build with tests enabled
  "dev-coverage" - Development: DEBUG build with tests and code coverage enabled
  "release"      - Release: RELWITHDEBINFO build without tests enabled
  "asan"         - AddressSanitizer: ASAN build with tests enabled
  "tsan"         - ThreadSanitizer: TSAN build with tests enabled
  "benchmarks"   - Benchmarks: RELEASE build with benchmarks enabled
> cmake --preset=dev-coverage
Preset CMake variables:

  CMAKE_BUILD_TYPE="DEBUG"
  ENABLE_TESTS="ON"
  TEST_LLVM_COVERAGE="ON"
...

> ls cmake-build-coverage
build.ninja  CMakeCache.txt  CMakeFiles  cmake_install.cmake  compile_commands.json  contrib  CPackConfig.cmake  CPackSourceConfig.cmake  CTestTestfile.cmake  dbms  gens  include_directories.txt  libs
> 
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
