### PR TITLE
tests: Add ut for parsing lock value

### DIFF
--- a/dbms/src/Storages/KVStore/tests/gtest_tikv_keyvalue.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_tikv_keyvalue.cpp
@@ -451,7 +451,6 @@ TEST(TiKVKeyValueTest, PortedTests)
             ASSERT_EQ(*tidb_pk, pk);
         }
     }
-
 }
 
 TEST(TiKVKeyValueTest, ParseLockValue)

--- a/dbms/src/Storages/KVStore/tests/gtest_tikv_keyvalue.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_tikv_keyvalue.cpp
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <IO/VarInt.h>
 #include <Storages/KVStore/Decode/TiKVHelper.h>
 #include <Storages/KVStore/Decode/TiKVRange.h>
 #include <Storages/KVStore/Region.h>
+#include <Storages/KVStore/TiKVHelpers/TiKVRecordFormat.h>
 #include <Storages/KVStore/tests/region_helper.h>
 #include <TestUtils/TiFlashTestBasic.h>
 
@@ -68,6 +70,13 @@ TiKVValue encode_lock_cf_value(
         res.write(RecordKVFormat::LAST_CHANGE_PREFIX);
         RecordKVFormat::encodeUInt64(12345678, res);
         TiKV::writeVarUInt(87654321, res);
+    }
+    {
+        res.write(RecordKVFormat::TXN_SOURCE_PREFIX_FOR_LOCK);
+        TiKV::writeVarUInt(876543, res);
+    }
+    {
+        res.write(RecordKVFormat::PESSIMISTIC_LOCK_WITH_CONFLICT_PREFIX);
     }
     return TiKVValue(res.releaseStr());
 }
@@ -442,7 +451,49 @@ TEST(TiKVKeyValueTest, PortedTests)
             ASSERT_EQ(*tidb_pk, pk);
         }
     }
+
 }
+
+TEST(TiKVKeyValueTest, ParseLockValue)
+try
+{
+    // prepare
+    std::string shor_value = "value";
+    auto lock_for_update_ts = 7777, txn_size = 1;
+    const std::vector<std::string> & async_commit = {"s1", "s2"};
+    const std::vector<uint64_t> & rollback = {3, 4};
+    auto lock_value = encode_lock_cf_value(
+        Region::DelFlag,
+        "primary key",
+        421321,
+        std::numeric_limits<UInt64>::max(),
+        &shor_value,
+        66666,
+        lock_for_update_ts,
+        txn_size,
+        async_commit,
+        rollback);
+
+    // parse
+    auto ori_key = std::make_shared<const TiKVKey>(RecordKVFormat::genKey(1, 88888));
+    auto lock = RecordKVFormat::DecodedLockCFValue(ori_key, std::make_shared<TiKVValue>(std::move(lock_value)));
+
+    // check the parsed result
+    {
+        auto & lock_info = lock;
+        ASSERT_TRUE(kvrpcpb::Op::Del == lock_info.lock_type);
+        ASSERT_TRUE("primary key" == lock_info.primary_lock);
+        ASSERT_TRUE(421321 == lock_info.lock_version);
+        ASSERT_TRUE(std::numeric_limits<UInt64>::max() == lock_info.lock_ttl);
+        ASSERT_TRUE(66666 == lock_info.min_commit_ts);
+        ASSERT_TRUE(ori_key == lock_info.key);
+        ASSERT_EQ(lock_for_update_ts, lock_info.lock_for_update_ts);
+        ASSERT_EQ(txn_size, lock_info.txn_size);
+
+        ASSERT_EQ(true, lock_info.use_async_commit);
+    }
+}
+CATCH
 
 TEST(TiKVKeyValueTest, Redact)
 try


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/7563

Problem Summary: Add ut for parsing lock value

### What is changed and how it works?

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
