### PR TITLE
ddl: Skip updating the tombstone_ts if the table is already tombstone (release-7.1)

### DIFF
--- a/dbms/src/TiDB/Schema/SchemaBuilder.cpp
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.cpp
@@ -687,6 +687,7 @@ void SchemaBuilder<Getter, NameMapper>::applyPartitionDiffOnLogicalTable(const T
     updated_table_info.partition = table_info->partition;
 
     /// Apply changes to physical tables.
+    auto reason = fmt::format("ApplyPartitionDiff-logical_table_id={}", orig_table_info.id);
     if (drop_part_if_not_exist)
     {
         for (const auto & orig_def : orig_defs)
@@ -697,7 +698,7 @@ void SchemaBuilder<Getter, NameMapper>::applyPartitionDiffOnLogicalTable(const T
                 // When `tryLoadSchemaDiffs` fails, we may run into `SchemaBuilder::syncAllSchema` -> `applyPartitionDiffOnLogicalTable` without `applyExchangeTablePartition`
                 // The physical table maybe `EXCHANGE` to another database, try to find the partition from all database
                 auto part_db_info = tryFindDatabaseByPartitionTable(db_info, part_table_name);
-                applyDropPhysicalTable(name_mapper.mapDatabaseName(*part_db_info), orig_def.id, /*must_update_tombstone*/ false, "exchange partition");
+                applyDropPhysicalTable(name_mapper.mapDatabaseName(*part_db_info), orig_def.id, /*must_update_tombstone*/ false, reason);
             }
         }
     }

--- a/dbms/src/TiDB/Schema/SchemaBuilder.cpp
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.cpp
@@ -1537,6 +1537,7 @@ void SchemaBuilder<Getter, NameMapper>::dropAllSchema()
 
     auto & tmt_context = context.getTMTContext();
 
+    const String action = "DropAllSchema";
     /// Drop all tables.
     auto storage_map = tmt_context.getStorages().getAllStorage();
     for (const auto & storage : storage_map)
@@ -1546,7 +1547,7 @@ void SchemaBuilder<Getter, NameMapper>::dropAllSchema()
         {
             continue;
         }
-        applyDropPhysicalTable(storage.second->getDatabaseName(), table_info.id);
+        applyDropPhysicalTable(storage.second->getDatabaseName(), table_info.id, /*must_update_tombstone*/ false, action);
         LOG_DEBUG(log, "Table {}.{} dropped during drop all schemas", storage.second->getDatabaseName(), name_mapper.debugTableName(table_info));
     }
 

--- a/dbms/src/TiDB/Schema/SchemaBuilder.cpp
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.cpp
@@ -697,7 +697,7 @@ void SchemaBuilder<Getter, NameMapper>::applyPartitionDiffOnLogicalTable(const T
                 // When `tryLoadSchemaDiffs` fails, we may run into `SchemaBuilder::syncAllSchema` -> `applyPartitionDiffOnLogicalTable` without `applyExchangeTablePartition`
                 // The physical table maybe `EXCHANGE` to another database, try to find the partition from all database
                 auto part_db_info = tryFindDatabaseByPartitionTable(db_info, part_table_name);
-                applyDropPhysicalTable(name_mapper.mapDatabaseName(*part_db_info), orig_def.id, "exchange partition");
+                applyDropPhysicalTable(name_mapper.mapDatabaseName(*part_db_info), orig_def.id, /*must_must_must_update_tombstone*/ false, "exchange partition");
             }
         }
     }
@@ -1287,7 +1287,7 @@ void SchemaBuilder<Getter, NameMapper>::applyCreateLogicalTable(const TiDB::DBIn
 }
 
 template <typename Getter, typename NameMapper>
-void SchemaBuilder<Getter, NameMapper>::applyDropPhysicalTable(const String & db_name, TableID table_id, std::string_view action)
+void SchemaBuilder<Getter, NameMapper>::applyDropPhysicalTable(const String & db_name, TableID table_id, bool must_update_tombstone, std::string_view action)
 {
     auto & tmt_context = context.getTMTContext();
     auto storage = tmt_context.getStorages().get(keyspace_id, table_id);
@@ -1297,11 +1297,15 @@ void SchemaBuilder<Getter, NameMapper>::applyDropPhysicalTable(const String & db
         return;
     }
 
-    // Skip updating the tombstone_ts if the table is already tombstone.
-    if (auto tombstone_ts = storage->getTombstone(); tombstone_ts != 0)
+    if (!must_update_tombstone)
     {
-        LOG_INFO(log, "Tombstone table {}.{} has been done before, action={} tombstone={}", db_name, name_mapper.debugTableName(storage->getTableInfo()), action, tombstone_ts);
-        return;
+        // When must_update_tombstone == false, we can try to skip updating
+        // the tombstone_ts if the table is already tombstone.
+        if (auto tombstone_ts = storage->getTombstone(); tombstone_ts != 0)
+        {
+            LOG_INFO(log, "Tombstone table {}.{} has been done before, action={} tombstone={}", db_name, name_mapper.debugTableName(storage->getTableInfo()), action, tombstone_ts);
+            return;
+        }
     }
 
     GET_METRIC(tiflash_schema_internal_ddl_count, type_drop_table).Increment();
@@ -1339,13 +1343,13 @@ void SchemaBuilder<Getter, NameMapper>::applyDropTable(const DBInfoPtr & db_info
     {
         for (const auto & part_def : table_info.partition.definitions)
         {
-            applyDropPhysicalTable(name_mapper.mapDatabaseName(*db_info), part_def.id, action);
+            applyDropPhysicalTable(name_mapper.mapDatabaseName(*db_info), part_def.id, /*must_update_tombstone*/ true, action);
         }
     }
 
     // Drop logical table at last, only logical table drop will be treated as "complete".
     // Intermediate failure will hide the logical table drop so that schema syncing when restart will re-drop all (despite some physical tables may have dropped).
-    applyDropPhysicalTable(name_mapper.mapDatabaseName(*db_info), table_info.id, action);
+    applyDropPhysicalTable(name_mapper.mapDatabaseName(*db_info), table_info.id, /*must_update_tombstone*/ true, action);
 }
 
 template <typename Getter, typename NameMapper>
@@ -1502,7 +1506,7 @@ void SchemaBuilder<Getter, NameMapper>::syncAllSchema()
         }
         if (table_set.count(table_info.id) == 0)
         {
-            applyDropPhysicalTable(it->second->getDatabaseName(), table_info.id, "SyncAllSchema");
+            applyDropPhysicalTable(it->second->getDatabaseName(), table_info.id, /*must_update_tombstone*/ false, "SyncAllSchema");
             LOG_INFO(log, "Table {}.{} dropped during sync all schemas", it->second->getDatabaseName(), name_mapper.debugTableName(table_info));
         }
     }

--- a/dbms/src/TiDB/Schema/SchemaBuilder.cpp
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.cpp
@@ -1285,8 +1285,16 @@ void SchemaBuilder<Getter, NameMapper>::applyDropPhysicalTable(const String & db
         LOG_DEBUG(log, "table {} does not exist.", table_id);
         return;
     }
+
+    // Skip updating the tombstone_ts if the table is already tombstone.
+    if (auto tombstone_ts = storage->getTombstone(); tombstone_ts != 0)
+    {
+        LOG_INFO(log, "Tombstone table {}.{} has been done before, tombstone={}", db_name, name_mapper.debugTableName(storage->getTableInfo()), tombstone_ts);
+        return;
+    }
+
     GET_METRIC(tiflash_schema_internal_ddl_count, type_drop_table).Increment();
-    LOG_INFO(log, "Tombstoning table {}.{}", db_name, name_mapper.debugTableName(storage->getTableInfo()));
+    LOG_INFO(log, "Tombstone table {}.{} begin", db_name, name_mapper.debugTableName(storage->getTableInfo()));
     const UInt64 tombstone_ts = PDClientHelper::getTSO(tmt_context.getPDClient(), PDClientHelper::get_tso_maxtime);
     AlterCommands commands;
     {
@@ -1302,7 +1310,7 @@ void SchemaBuilder<Getter, NameMapper>::applyDropPhysicalTable(const String & db
     }
     auto alter_lock = storage->lockForAlter(getThreadNameAndID());
     storage->alterFromTiDB(alter_lock, commands, db_name, storage->getTableInfo(), name_mapper, context);
-    LOG_INFO(log, "Tombstoned table {}.{}, tombstone={}", db_name, name_mapper.debugTableName(storage->getTableInfo()), tombstone_ts);
+    LOG_INFO(log, "Tombstone table {}.{} end, tombstone={}", db_name, name_mapper.debugTableName(storage->getTableInfo()), tombstone_ts);
 }
 
 template <typename Getter, typename NameMapper>

--- a/dbms/src/TiDB/Schema/SchemaBuilder.cpp
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.cpp
@@ -490,7 +490,7 @@ void SchemaBuilder<Getter, NameMapper>::applyDiff(const SchemaDiff & diff)
             auto db_info = getter.getDatabase(opt.schema_id);
             if (db_info == nullptr)
                 throw TiFlashException("miss database: " + std::to_string(diff.schema_id), Errors::DDL::StaleSchema);
-            applyRenameTable(db_info, opt.table_id);
+            applyRenameTable(db_info, opt.table_id, "RenameTables");
         }
         return;
     }
@@ -542,7 +542,7 @@ void SchemaBuilder<Getter, NameMapper>::applyDiff(const SchemaDiff & diff)
     }
     case SchemaActionType::RenameTable:
     {
-        applyRenameTable(db_info, diff.table_id);
+        applyRenameTable(db_info, diff.table_id, "RenameTable");
         break;
     }
     case SchemaActionType::AddTablePartition:
@@ -580,7 +580,8 @@ void SchemaBuilder<Getter, NameMapper>::applyDiff(const SchemaDiff & diff)
 
     if (old_table_id)
     {
-        applyDropTable(db_info, old_table_id);
+        String action = fmt::format("{}", magic_enum::enum_name(diff.type));
+        applyDropTable(db_info, old_table_id, action);
     }
 
     if (new_table_id)
@@ -595,11 +596,11 @@ void SchemaBuilder<Getter, NameMapper>::applyPartitionDiff(const TiDB::DBInfoPtr
     auto table_info = getter.getTableInfo(db_info->id, table_id);
     if (table_info == nullptr)
     {
-        throw TiFlashException(fmt::format("miss old table id in TiKV {}", table_id), Errors::DDL::StaleSchema);
+        throw TiFlashException(fmt::format("miss old table id in TiKV when applyPartitionDiff, table_id={}", table_id), Errors::DDL::StaleSchema);
     }
     if (!table_info->isLogicalPartitionTable())
     {
-        throw TiFlashException(fmt::format("new table in TiKV not partition table {}", name_mapper.debugCanonicalName(*db_info, *table_info)),
+        throw TiFlashException(fmt::format("new table in TiKV not partition table when applyPartitionDiff, {}", name_mapper.debugCanonicalName(*db_info, *table_info)),
                                Errors::DDL::TableTypeNotMatch);
     }
 
@@ -607,10 +608,10 @@ void SchemaBuilder<Getter, NameMapper>::applyPartitionDiff(const TiDB::DBInfoPtr
     auto storage = tmt_context.getStorages().get(keyspace_id, table_info->id);
     if (storage == nullptr)
     {
-        throw TiFlashException(fmt::format("miss table in TiFlash {}", table_id), Errors::DDL::MissingTable);
+        throw TiFlashException(fmt::format("miss table in TiFlash when applyPartitionDiff, table_id={}", table_id), Errors::DDL::MissingTable);
     }
 
-    applyPartitionDiff(db_info, table_info, storage, /*drop_part_if_not_exist*/ true);
+    applyPartitionDiffOnLogicalTable(db_info, table_info, storage, /*drop_part_if_not_exist*/ true);
 }
 
 template <typename Getter, typename NameMapper>
@@ -644,7 +645,7 @@ TiDB::DBInfoPtr SchemaBuilder<Getter, NameMapper>::tryFindDatabaseByPartitionTab
 }
 
 template <typename Getter, typename NameMapper>
-void SchemaBuilder<Getter, NameMapper>::applyPartitionDiff(const TiDB::DBInfoPtr & db_info, const TableInfoPtr & table_info, const ManageableStoragePtr & storage, bool drop_part_if_not_exist)
+void SchemaBuilder<Getter, NameMapper>::applyPartitionDiffOnLogicalTable(const TiDB::DBInfoPtr & db_info, const TableInfoPtr & table_info, const ManageableStoragePtr & storage, bool drop_part_if_not_exist)
 {
     const auto & orig_table_info = storage->getTableInfo();
     if (!orig_table_info.isLogicalPartitionTable())
@@ -693,10 +694,10 @@ void SchemaBuilder<Getter, NameMapper>::applyPartitionDiff(const TiDB::DBInfoPtr
             if (!new_part_id_set.contains(orig_def.id))
             {
                 const auto part_table_name = name_mapper.mapTableNameByID(updated_table_info.keyspace_id, orig_def.id);
-                // When `tryLoadSchemaDiffs` fails, we may run into `SchemaBuilder::syncAllSchem` -> `applyPartitionDiff` without `applyExchangeTablePartition`
+                // When `tryLoadSchemaDiffs` fails, we may run into `SchemaBuilder::syncAllSchema` -> `applyPartitionDiffOnLogicalTable` without `applyExchangeTablePartition`
                 // The physical table maybe `EXCHANGE` to another database, try to find the partition from all database
                 auto part_db_info = tryFindDatabaseByPartitionTable(db_info, part_table_name);
-                applyDropPhysicalTable(name_mapper.mapDatabaseName(*part_db_info), orig_def.id);
+                applyDropPhysicalTable(name_mapper.mapDatabaseName(*part_db_info), orig_def.id, "exchange partition");
             }
         }
     }
@@ -707,7 +708,7 @@ void SchemaBuilder<Getter, NameMapper>::applyPartitionDiff(const TiDB::DBInfoPtr
         {
             auto part_table_info = updated_table_info.producePartitionTableInfo(new_def.id, name_mapper);
             const auto part_table_name = name_mapper.mapTableName(*part_table_info);
-            // When `tryLoadSchemaDiffs` fails, we may run into `SchemaBuilder::syncAllSchem` -> `applyPartitionDiff` without `applyExchangeTablePartition`
+            // When `tryLoadSchemaDiffs` fails, we may run into `SchemaBuilder::syncAllSchema` -> `applyPartitionDiffOnLogicalTable` without `applyExchangeTablePartition`
             // The physical table maybe `EXCHANGE` from another database, try to find the partition from all database
             auto part_db_info = tryFindDatabaseByPartitionTable(db_info, part_table_name);
             applyCreatePhysicalTable(part_db_info, part_table_info);
@@ -722,31 +723,32 @@ void SchemaBuilder<Getter, NameMapper>::applyPartitionDiff(const TiDB::DBInfoPtr
 }
 
 template <typename Getter, typename NameMapper>
-void SchemaBuilder<Getter, NameMapper>::applyRenameTable(const DBInfoPtr & new_db_info, TableID table_id)
+void SchemaBuilder<Getter, NameMapper>::applyRenameTable(const DBInfoPtr & new_db_info, TableID table_id, std::string_view action)
 {
     auto new_table_info = getter.getTableInfo(new_db_info->id, table_id);
     if (new_table_info == nullptr)
     {
-        throw TiFlashException(fmt::format("miss table id in TiKV {}", table_id), Errors::DDL::StaleSchema);
+        throw TiFlashException(fmt::format("miss table id in TiKV when renameTable, table_id={} action={}", table_id, action), Errors::DDL::StaleSchema);
     }
 
     auto & tmt_context = context.getTMTContext();
     auto storage = tmt_context.getStorages().get(keyspace_id, table_id);
     if (storage == nullptr)
     {
-        throw TiFlashException(fmt::format("miss table id in TiFlash {}", table_id), Errors::DDL::MissingTable);
+        throw TiFlashException(fmt::format("miss table id in TiFlash when renameTable, table_id={} action={}", table_id, action), Errors::DDL::MissingTable);
     }
 
-    applyRenameLogicalTable(new_db_info, new_table_info, storage);
+    applyRenameLogicalTable(new_db_info, new_table_info, storage, action);
 }
 
 template <typename Getter, typename NameMapper>
 void SchemaBuilder<Getter, NameMapper>::applyRenameLogicalTable(
     const DBInfoPtr & new_db_info,
     const TableInfoPtr & new_table_info,
-    const ManageableStoragePtr & storage)
+    const ManageableStoragePtr & storage,
+    std::string_view action)
 {
-    applyRenamePhysicalTable(new_db_info, *new_table_info, storage);
+    applyRenamePhysicalTable(new_db_info, *new_table_info, storage, action);
 
     if (new_table_info->isLogicalPartitionTable())
     {
@@ -756,10 +758,16 @@ void SchemaBuilder<Getter, NameMapper>::applyRenameLogicalTable(
             auto part_storage = tmt_context.getStorages().get(keyspace_id, part_def.id);
             if (part_storage == nullptr)
             {
-                throw Exception(fmt::format("miss old table id in Flash {}", part_def.id));
+                throw Exception( //
+                    ErrorCodes::LOGICAL_ERROR,
+                    "Storage instance is not exist in TiFlash, the partition is not created yet in this TiFlash instance, "
+                    "physical_table_id={} logical_table_id={} action={}",
+                    part_def.id,
+                    new_table_info->id,
+                    action);
             }
             auto part_table_info = new_table_info->producePartitionTableInfo(part_def.id, name_mapper);
-            applyRenamePhysicalTable(new_db_info, *part_table_info, part_storage);
+            applyRenamePhysicalTable(new_db_info, *part_table_info, part_storage, action);
         }
     }
 }
@@ -768,7 +776,8 @@ template <typename Getter, typename NameMapper>
 void SchemaBuilder<Getter, NameMapper>::applyRenamePhysicalTable(
     const DBInfoPtr & new_db_info,
     const TableInfo & new_table_info,
-    const ManageableStoragePtr & storage)
+    const ManageableStoragePtr & storage,
+    std::string_view action)
 {
     const auto old_mapped_db_name = storage->getDatabaseName();
     const auto new_mapped_db_name = name_mapper.mapDatabaseName(*new_db_info);
@@ -776,7 +785,7 @@ void SchemaBuilder<Getter, NameMapper>::applyRenamePhysicalTable(
     const auto new_display_table_name = name_mapper.displayTableName(new_table_info);
     if (old_mapped_db_name == new_mapped_db_name && old_display_table_name == new_display_table_name)
     {
-        LOG_DEBUG(log, "Table {} name identical, not renaming.", name_mapper.debugCanonicalName(*new_db_info, new_table_info));
+        LOG_DEBUG(log, "Table {} name identical, not renaming, action={}", name_mapper.debugCanonicalName(*new_db_info, new_table_info), action);
         return;
     }
 
@@ -784,11 +793,12 @@ void SchemaBuilder<Getter, NameMapper>::applyRenamePhysicalTable(
     GET_METRIC(tiflash_schema_internal_ddl_count, type_rename_column).Increment();
     LOG_INFO(
         log,
-        "Renaming table {}.{} (display name: {}) to {}.",
+        "Renaming table {}.{} (display name: {}) to {}, action={}",
         old_mapped_db_name,
         old_mapped_tbl_name,
         old_display_table_name,
-        name_mapper.debugCanonicalName(*new_db_info, new_table_info));
+        name_mapper.debugCanonicalName(*new_db_info, new_table_info),
+        action);
 
     // Note that rename will update table info in table create statement by modifying original table info
     // with "tidb_display.table" instead of using new_table_info directly, so that other changes
@@ -804,11 +814,12 @@ void SchemaBuilder<Getter, NameMapper>::applyRenamePhysicalTable(
 
     LOG_INFO(
         log,
-        "Renamed table {}.{} (display name: {}) to {}",
+        "Renamed table {}.{} (display name: {}) to {}, action={}",
         old_mapped_db_name,
         old_mapped_tbl_name,
         old_display_table_name,
-        name_mapper.debugCanonicalName(*new_db_info, new_table_info));
+        name_mapper.debugCanonicalName(*new_db_info, new_table_info),
+        action);
 }
 
 template <typename Getter, typename NameMapper>
@@ -877,7 +888,7 @@ void SchemaBuilder<Getter, NameMapper>::applyExchangeTablePartition(const Schema
     // once it became a partition.
     // But this method will skip dropping partition id that is not exist in the new table_info,
     // because the physical table could be changed into a normal table without dropping.
-    applyPartitionDiff(pt_db_info, table_info, storage, /*drop_part_if_not_exist*/ false);
+    applyPartitionDiffOnLogicalTable(pt_db_info, table_info, storage, /*drop_part_if_not_exist*/ false);
     FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::exception_after_step_1_in_exchange_partition);
 
     /// step 2 change non partition table to a partition of the partition table
@@ -903,7 +914,7 @@ void SchemaBuilder<Getter, NameMapper>::applyExchangeTablePartition(const Schema
     FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::exception_before_step_2_rename_in_exchange_partition);
 
     if (npt_db_info->id != pt_db_info->id)
-        applyRenamePhysicalTable(pt_db_info, orig_table_info, storage);
+        applyRenamePhysicalTable(pt_db_info, orig_table_info, storage, "exchange partition");
     FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::exception_after_step_2_in_exchange_partition);
 
     /// step 3 change partition of the partition table to non partition table
@@ -935,9 +946,9 @@ void SchemaBuilder<Getter, NameMapper>::applyExchangeTablePartition(const Schema
     FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::exception_before_step_3_rename_in_exchange_partition);
 
     if (npt_db_info->id != pt_db_info->id)
-        applyRenamePhysicalTable(npt_db_info, orig_table_info, storage);
+        applyRenamePhysicalTable(npt_db_info, orig_table_info, storage, "exchange partition");
     FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::exception_after_step_3_in_exchange_partition);
-    LOG_INFO(log, "Execute exchange partition done, npt_table_id={} npt_database_id={} pt_table_id={} pt_partition_id={}  pt_database_id={}", npt_table_id, npt_database_id, pt_table_id, pt_partition_id, pt_database_id);
+    LOG_INFO(log, "Execute exchange partition done, npt_table_id={} npt_database_id={} pt_table_id={} pt_partition_id={} pt_database_id={}", npt_table_id, npt_database_id, pt_table_id, pt_partition_id, pt_database_id);
 }
 
 template <typename Getter, typename NameMapper>
@@ -1033,11 +1044,11 @@ template <typename Getter, typename NameMapper>
 void SchemaBuilder<Getter, NameMapper>::applyDropSchema(const String & db_name)
 {
     GET_METRIC(tiflash_schema_internal_ddl_count, type_drop_db).Increment();
-    LOG_INFO(log, "Tombstoning database {}", db_name);
+    LOG_INFO(log, "Tombstone database begin, db_name={}", db_name);
     auto db = context.tryGetDatabase(db_name);
     if (db == nullptr)
     {
-        LOG_INFO(log, "Database {} does not exists", db_name);
+        LOG_INFO(log, "Database does not exists, db_name={}", db_name);
         return;
     }
 
@@ -1054,7 +1065,7 @@ void SchemaBuilder<Getter, NameMapper>::applyDropSchema(const String & db_name)
     auto tombstone = PDClientHelper::getTSO(tmt_context.getPDClient(), PDClientHelper::get_tso_maxtime);
     db->alterTombstone(context, tombstone, /*new_db_info*/ nullptr); // keep the old db_info
 
-    LOG_INFO(log, "Tombstoned database {}, tombstone={}", db_name, tombstone);
+    LOG_INFO(log, "Tombstone database end, db_name={} tombstone={}", db_name, tombstone);
 }
 
 template <typename Getter, typename NameMapper>
@@ -1276,25 +1287,25 @@ void SchemaBuilder<Getter, NameMapper>::applyCreateLogicalTable(const TiDB::DBIn
 }
 
 template <typename Getter, typename NameMapper>
-void SchemaBuilder<Getter, NameMapper>::applyDropPhysicalTable(const String & db_name, TableID table_id)
+void SchemaBuilder<Getter, NameMapper>::applyDropPhysicalTable(const String & db_name, TableID table_id, std::string_view action)
 {
     auto & tmt_context = context.getTMTContext();
     auto storage = tmt_context.getStorages().get(keyspace_id, table_id);
     if (storage == nullptr)
     {
-        LOG_DEBUG(log, "table {} does not exist.", table_id);
+        LOG_DEBUG(log, "table does not exist, table_id={} action={}", table_id, action);
         return;
     }
 
     // Skip updating the tombstone_ts if the table is already tombstone.
     if (auto tombstone_ts = storage->getTombstone(); tombstone_ts != 0)
     {
-        LOG_INFO(log, "Tombstone table {}.{} has been done before, tombstone={}", db_name, name_mapper.debugTableName(storage->getTableInfo()), tombstone_ts);
+        LOG_INFO(log, "Tombstone table {}.{} has been done before, action={} tombstone={}", db_name, name_mapper.debugTableName(storage->getTableInfo()), action, tombstone_ts);
         return;
     }
 
     GET_METRIC(tiflash_schema_internal_ddl_count, type_drop_table).Increment();
-    LOG_INFO(log, "Tombstone table {}.{} begin", db_name, name_mapper.debugTableName(storage->getTableInfo()));
+    LOG_INFO(log, "Tombstone table {}.{} begin, action={}", db_name, name_mapper.debugTableName(storage->getTableInfo()), action);
     const UInt64 tombstone_ts = PDClientHelper::getTSO(tmt_context.getPDClient(), PDClientHelper::get_tso_maxtime);
     AlterCommands commands;
     {
@@ -1310,11 +1321,11 @@ void SchemaBuilder<Getter, NameMapper>::applyDropPhysicalTable(const String & db
     }
     auto alter_lock = storage->lockForAlter(getThreadNameAndID());
     storage->alterFromTiDB(alter_lock, commands, db_name, storage->getTableInfo(), name_mapper, context);
-    LOG_INFO(log, "Tombstone table {}.{} end, tombstone={}", db_name, name_mapper.debugTableName(storage->getTableInfo()), tombstone_ts);
+    LOG_INFO(log, "Tombstone table {}.{} end, action={} tombstone={}", db_name, name_mapper.debugTableName(storage->getTableInfo()), action, tombstone_ts);
 }
 
 template <typename Getter, typename NameMapper>
-void SchemaBuilder<Getter, NameMapper>::applyDropTable(const DBInfoPtr & db_info, TableID table_id)
+void SchemaBuilder<Getter, NameMapper>::applyDropTable(const DBInfoPtr & db_info, TableID table_id, std::string_view action)
 {
     auto & tmt_context = context.getTMTContext();
     auto * storage = tmt_context.getStorages().get(keyspace_id, table_id).get();
@@ -1328,13 +1339,13 @@ void SchemaBuilder<Getter, NameMapper>::applyDropTable(const DBInfoPtr & db_info
     {
         for (const auto & part_def : table_info.partition.definitions)
         {
-            applyDropPhysicalTable(name_mapper.mapDatabaseName(*db_info), part_def.id);
+            applyDropPhysicalTable(name_mapper.mapDatabaseName(*db_info), part_def.id, action);
         }
     }
 
     // Drop logical table at last, only logical table drop will be treated as "complete".
     // Intermediate failure will hide the logical table drop so that schema syncing when restart will re-drop all (despite some physical tables may have dropped).
-    applyDropPhysicalTable(name_mapper.mapDatabaseName(*db_info), table_info.id);
+    applyDropPhysicalTable(name_mapper.mapDatabaseName(*db_info), table_info.id, action);
 }
 
 template <typename Getter, typename NameMapper>
@@ -1467,10 +1478,10 @@ void SchemaBuilder<Getter, NameMapper>::syncAllSchema()
             if (table->isLogicalPartitionTable())
             {
                 /// Apply partition diff if needed.
-                applyPartitionDiff(db, table, storage, /*drop_part_if_not_exist*/ true);
+                applyPartitionDiffOnLogicalTable(db, table, storage, /*drop_part_if_not_exist*/ true);
             }
             /// Rename if needed.
-            applyRenameLogicalTable(db, table, storage);
+            applyRenameLogicalTable(db, table, storage, "SyncAllSchema");
             /// Update replica info if needed.
             applySetTiFlashReplicaOnLogicalTable(db, table, storage);
             /// Alter if needed.
@@ -1491,7 +1502,7 @@ void SchemaBuilder<Getter, NameMapper>::syncAllSchema()
         }
         if (table_set.count(table_info.id) == 0)
         {
-            applyDropPhysicalTable(it->second->getDatabaseName(), table_info.id);
+            applyDropPhysicalTable(it->second->getDatabaseName(), table_info.id, "SyncAllSchema");
             LOG_INFO(log, "Table {}.{} dropped during sync all schemas", it->second->getDatabaseName(), name_mapper.debugTableName(table_info));
         }
     }

--- a/dbms/src/TiDB/Schema/SchemaBuilder.h
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.h
@@ -71,14 +71,14 @@ private:
 
     void applyCreatePhysicalTable(const TiDB::DBInfoPtr & db_info, const TiDB::TableInfoPtr & table_info);
 
-    void applyDropTable(const TiDB::DBInfoPtr & db_info, TableID table_id);
+    void applyDropTable(const TiDB::DBInfoPtr & db_info, TableID table_id, std::string_view action);
 
     /// Parameter schema_name should be mapped.
-    void applyDropPhysicalTable(const String & db_name, TableID table_id);
+    void applyDropPhysicalTable(const String & db_name, TableID table_id, std::string_view action);
 
     void applyPartitionDiff(const TiDB::DBInfoPtr & db_info, TableID table_id);
 
-    void applyPartitionDiff(const TiDB::DBInfoPtr & db_info, const TiDB::TableInfoPtr & table_info, const ManageableStoragePtr & storage, bool drop_part_if_not_exist);
+    void applyPartitionDiffOnLogicalTable(const TiDB::DBInfoPtr & db_info, const TiDB::TableInfoPtr & table_info, const ManageableStoragePtr & storage, bool drop_part_if_not_exist);
     TiDB::DBInfoPtr tryFindDatabaseByPartitionTable(const TiDB::DBInfoPtr & db_info, const String & part_table_name);
 
     void applyAlterTable(const TiDB::DBInfoPtr & db_info, TableID table_id);
@@ -87,11 +87,11 @@ private:
 
     void applyAlterPhysicalTable(const TiDB::DBInfoPtr & db_info, const TiDB::TableInfoPtr & table_info, const ManageableStoragePtr & storage);
 
-    void applyRenameTable(const TiDB::DBInfoPtr & new_db_info, TiDB::TableID table_id);
+    void applyRenameTable(const TiDB::DBInfoPtr & new_db_info, TiDB::TableID table_id, std::string_view action);
 
-    void applyRenameLogicalTable(const TiDB::DBInfoPtr & new_db_info, const TiDB::TableInfoPtr & new_table_info, const ManageableStoragePtr & storage);
+    void applyRenameLogicalTable(const TiDB::DBInfoPtr & new_db_info, const TiDB::TableInfoPtr & new_table_info, const ManageableStoragePtr & storage, std::string_view action);
 
-    void applyRenamePhysicalTable(const TiDB::DBInfoPtr & new_db_info, const TiDB::TableInfo & new_table_info, const ManageableStoragePtr & storage);
+    void applyRenamePhysicalTable(const TiDB::DBInfoPtr & new_db_info, const TiDB::TableInfo & new_table_info, const ManageableStoragePtr & storage, std::string_view action);
 
     void applyExchangeTablePartition(const SchemaDiff & diff);
 

--- a/dbms/src/TiDB/Schema/SchemaBuilder.h
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.h
@@ -74,7 +74,7 @@ private:
     void applyDropTable(const TiDB::DBInfoPtr & db_info, TableID table_id, std::string_view action);
 
     /// Parameter schema_name should be mapped.
-    void applyDropPhysicalTable(const String & db_name, TableID table_id, std::string_view action);
+    void applyDropPhysicalTable(const String & db_name, TableID table_id, bool must_update_tombstone, std::string_view action);
 
     void applyPartitionDiff(const TiDB::DBInfoPtr & db_info, TableID table_id);
 

--- a/dbms/src/TiDB/Schema/tests/gtest_schema_sync.cpp
+++ b/dbms/src/TiDB/Schema/tests/gtest_schema_sync.cpp
@@ -37,6 +37,7 @@ namespace DB
 namespace FailPoints
 {
 extern const char exception_before_rename_table_old_meta_removed[];
+extern const char force_schema_sync_too_old_schema[];
 extern const char force_context_path[];
 } // namespace FailPoints
 namespace tests
@@ -340,6 +341,111 @@ try
     refreshSchema();
     auto part1_tbl = mustGetSyncedTable(part1_id);
     ASSERT_EQ(part1_tbl->isTombstone(), true);
+}
+CATCH
+
+TEST_F(SchemaSyncTest, DropTableTombstoneTSCase1)
+try
+{
+    // tiflash/issues/9227
+    auto pd_client = global_ctx.getTMTContext().getPDClient();
+
+    const String db_name = "mock_db";
+    const String tbl_name = "mock_part_tbl";
+
+    auto cols = ColumnsDescription({
+        {"col_1", typeFromString("String")},
+        {"col_2", typeFromString("Int64")},
+    });
+
+    /*auto db_id =*/MockTiDB::instance().newDataBase(db_name);
+    auto logical_table_id = MockTiDB::instance().newTable(db_name, tbl_name, cols, pd_client->getTS(), "", "dt");
+
+    refreshSchema();
+    {
+        auto storage = mustGetSyncedTable(logical_table_id);
+        ASSERT_EQ(storage->getTombstone(), 0);
+    }
+
+    // drop the table
+    LOG_INFO(Logger::get(), "mock drop table at tidb");
+    MockTiDB::instance().dropTable(global_ctx, db_name, tbl_name, /*drop_regions*/ true);
+    refreshSchema();
+    UInt64 tombstone_ts_before_sync_all = 0;
+    {
+        // the table should mark as tombstone != 0
+        auto storage = mustGetSyncedTable(logical_table_id);
+        tombstone_ts_before_sync_all = storage->getTombstone();
+        ASSERT_NE(tombstone_ts_before_sync_all, 0);
+    }
+    LOG_INFO(Logger::get(), "mock drop table at tidb done");
+
+    LOG_INFO(Logger::get(), "mock tiflash sync all schema");
+    FailPointHelper::enableFailPoint(FailPoints::force_schema_sync_too_old_schema);
+    SCOPE_EXIT({
+        FailPointHelper::disableFailPoint(FailPoints::force_schema_sync_too_old_schema);
+    });
+    MockTiDB::instance().newDataBase(db_name + "_copy");
+    refreshSchema();
+    {
+        // the table should mark as tombstone != 0
+        auto storage = mustGetSyncedTable(logical_table_id);
+        ASSERT_NE(storage->getTombstone(), 0);
+        // the tombstone_ts should not changed
+        ASSERT_EQ(storage->getTombstone(), tombstone_ts_before_sync_all);
+    }
+}
+CATCH
+
+TEST_F(SchemaSyncTest, DropTableTombstoneTSCase2)
+try
+{
+    // tiflash/issues/9227
+    auto pd_client = global_ctx.getTMTContext().getPDClient();
+
+    const String db_name = "mock_db";
+    const String tbl_name = "mock_part_tbl";
+
+    auto cols = ColumnsDescription({
+        {"col_1", typeFromString("String")},
+        {"col_2", typeFromString("Int64")},
+    });
+
+    /*auto db_id =*/MockTiDB::instance().newDataBase(db_name);
+    auto logical_table_id = MockTiDB::instance().newTable(db_name, tbl_name, cols, pd_client->getTS(), "", "dt");
+
+    refreshSchema();
+    {
+        auto storage = mustGetSyncedTable(logical_table_id);
+        ASSERT_EQ(storage->getTombstone(), 0);
+    }
+
+    // drop the table during sync all schema
+    LOG_INFO(Logger::get(), "mock tiflash sync all schema");
+    MockTiDB::instance().dropTable(global_ctx, db_name, tbl_name, /*drop_regions*/ true);
+    FailPointHelper::enableFailPoint(FailPoints::force_schema_sync_too_old_schema);
+    SCOPE_EXIT({
+        FailPointHelper::disableFailPoint(FailPoints::force_schema_sync_too_old_schema);
+    });
+    refreshSchema();
+    UInt64 tombstone_ts_by_sync_all = 0;
+    {
+        // the table should mark as tombstone != 0
+        auto storage = mustGetSyncedTable(logical_table_id);
+        tombstone_ts_by_sync_all = storage->getTombstone();
+        ASSERT_NE(tombstone_ts_by_sync_all, 0);
+    }
+
+    // trigger sync all schema again, the tombstone_ts should not change
+    MockTiDB::instance().newDataBase(db_name + "_copy");
+    refreshSchema();
+    {
+        // the table should mark as tombstone != 0
+        auto storage = mustGetSyncedTable(logical_table_id);
+        ASSERT_NE(storage->getTombstone(), 0);
+        // the tombstone_ts should not changed
+        ASSERT_EQ(storage->getTombstone(), tombstone_ts_by_sync_all);
+    }
 }
 CATCH
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/9227

Problem Summary: https://github.com/pingcap/tiflash/issues/9227#issuecomment-2225065052
In `SchemaBuilder::syncAllSchema`, each table that does not exists in tikv but still in the tiflash instance. TiFlash will execute `applyDropPhysicalTable` for each table, wich will update the "tombstone_ts" of the table in its ".sql" file.
Even if the table is already "tombstone", the function will update the "tombstone_ts" by a newer tso from PD. This make the IStorage instance still exist even after the gc_safepoint is exceed than the drop timepoint + gc_lifetime.
https://github.com/pingcap/tiflash/blob/28a2314dd36fc1e990b9d8a3a6aec89ba8a220b8/dbms/src/TiDB/Schema/SchemaBuilder.cpp#L1437-L1451
https://github.com/pingcap/tiflash/blob/28a2314dd36fc1e990b9d8a3a6aec89ba8a220b8/dbms/src/TiDB/Schema/SchemaBuilder.cpp#L1240-L1268

### What is changed and how it works?

```commit-message

```

Skip updating the tombstone_ts if the table is already tombstone. So even if the "syncAllSchema" is called repeatedly, the dropped IStorage instance can be physically removed from TiFlash instances correctly. And the time spend on "syncAllSchema" won't become longer and longer.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
Run the following test scripts. It will make tiflash run into sync all schema frequently.
```
>  cat test.sh
set -x

for (( i=0 ; i<1000 ; i++ )); do
echo "running with i=${i}"
mycli -h 10.2.12.81 -P 8042 -u root -D test -e 'CREATE TABLE if not exists test_range_1 (id INT,name VARCHAR(20)) PARTITION BY RANGE (id) (PARTITION p0 VALUES LESS THAN (10),PARTITION p1 VALUES LESS THAN (20),PARTITION p2 VALUES LESS THAN (30),PARTITION p3 VALUES LESS THAN (40),PARTITION p4 VALUES LESS THAN (50));'

mycli -h 10.2.12.81 -P 8042 -u root -D test -e 'CREATE TABLE if not exists test_swap_1 (id INT,name VARCHAR(20));'
mycli -h 10.2.12.81 -P 8042 -u root -D test -e 'ALTER TABLE test_range_1 EXCHANGE PARTITION p0 WITH TABLE test_swap_1;'
mycli -h 10.2.12.81 -P 8042 -u root -D test -e 'DROP TABLE test_swap_1;'
done
```

In the v6.5.10 version, after that script ran, 
```
## At the beginning, sync all schema taks about 38ms
[2024/09/02 14:53:02.454 +08:00] [INFO] [TiDBSchemaSyncer.h:124] ["Start to sync schemas. current version is: 589 and try to sync schema version to: 600"] [thread_id=85]
[2024/09/02 14:53:02.455 +08:00] [DEBUG] [TiDBSchemaSyncer.h:181] ["Try load schema diffs."] [thread_id=85]
[2024/09/02 14:53:02.457 +08:00] [DEBUG] [TiDBSchemaSyncer.h:192] ["End load schema diffs with total 11 entries."] [thread_id=85]
[2024/09/02 14:53:02.460 +08:00] [WARN] [TiDBSchemaSyncer.h:236] ["apply diff meets exception : DB::TiFlashException: miss partition table in TiKV, may have been dropped, physical_table_id=446 \n stack is \n       0x1779921\tDB::TiFlashException::TiFlashException(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::TiFlashError const&) [tiflash+24615201]\n                \tdbms/src/Common/TiFlashException.h:250\n       0x6cac991\tDB::SchemaBuilder<DB::SchemaGetter, DB::SchemaNameMapper>::applyExchangeTablePartition(DB::SchemaDiff const&) [tiflash+113953169]\n                \tdbms/src/TiDB/Schema/SchemaBuilder.cpp:908\n       0x6ca9123\tDB::SchemaBuilder<DB::SchemaGetter, DB::SchemaNameMapper>::applyDiff(DB::SchemaDiff const&) [tiflash+113938723]\n                \tdbms/src/TiDB/Schema/SchemaBuilder.cpp:551\n       0x6bf165b\tDB::TiDBSchemaSyncer<false, false>::syncSchemas(DB::Context&) [tiflash+113186395]\n                \tdbms/src/TiDB/Schema/TiDBSchemaSyncer.h:139\n       0x6cf1ff4\tstd::__1::__function::__func<DB::SchemaSyncService::SchemaSyncService(DB::Context&)::$_0, std::__1::allocator<DB::SchemaSyncService::SchemaSyncService(DB::Context&)::$_0>, bool ()>::operator()() [tiflash+114237428]\n                \t/usr/local/bin/../include/c++/v1/__functional/function.h:345\n       0x68e7fbc\tvoid* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, DB::BackgroundProcessingPool::BackgroundProcessingPool(int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >)::$_1> >(void*) [tiflash+110002108]\n                \t/usr/local/bin/../include/c++/v1/thread:291\n  0x7f415ae7d802\tstart_thread [libc.so.6+653314]\n  0x7f415ae1d450\tclone3 [libc.so.6+259152]"] [thread_id=85]
[2024/09/02 14:53:02.492 +08:00] [INFO] [TiDBSchemaSyncer.h:146] ["End sync schema, version has been updated to 600"] [thread_id=85]

## the last sync all schema takes about 300ms (to update about 429 tables)
238043:[2024/09/02 15:29:05.265 +08:00] [INFO] [TiDBSchemaSyncer.h:124] ["Start to sync schemas. current version is: 6576 and try to sync schema version to: 6606"] [thread_id=84]
238044:[2024/09/02 15:29:05.265 +08:00] [DEBUG] [TiDBSchemaSyncer.h:181] ["Try load schema diffs."] [thread_id=84]
238045:[2024/09/02 15:29:05.270 +08:00] [DEBUG] [TiDBSchemaSyncer.h:192] ["End load schema diffs with total 30 entries."] [thread_id=84]
238065:[2024/09/02 15:29:05.274 +08:00] [WARN] [TiDBSchemaSyncer.h:236] ["apply diff meets exception : DB::TiFlashException: miss table in TiFlash, npt_table_id=4444 : test(2).test_range_1(83) \n stack is \n       0x1779921\tDB::TiFlashException::TiFlashException(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::TiFlashError const&) [tiflash+24615201]\n                \tdbms/src/Common/TiFlashException.h:250\n       0x6cac822\tDB::SchemaBuilder<DB::SchemaGetter, DB::SchemaNameMapper>::applyExchangeTablePartition(DB::SchemaDiff const&) [tiflash+113952802]\n                \tdbms/src/TiDB/Schema/SchemaBuilder.cpp:880\n       0x6ca9123\tDB::SchemaBuilder<DB::SchemaGetter, DB::SchemaNameMapper>::applyDiff(DB::SchemaDiff const&) [tiflash+113938723]\n                \tdbms/src/TiDB/Schema/SchemaBuilder.cpp:551\n       0x6bf165b\tDB::TiDBSchemaSyncer<false, false>::syncSchemas(DB::Context&) [tiflash+113186395]\n                \tdbms/src/TiDB/Schema/TiDBSchemaSyncer.h:139\n       0x6cf1ff4\tstd::__1::__function::__func<DB::SchemaSyncService::SchemaSyncService(DB::Context&)::$_0, std::__1::allocator<DB::SchemaSyncService::SchemaSyncService(DB::Context&)::$_0>, bool ()>::operator()() [tiflash+114237428]\n                \t/usr/local/bin/../include/c++/v1/__functional/function.h:345\n       0x68e7fbc\tvoid* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, DB::BackgroundProcessingPool::BackgroundProcessingPool(int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >)::$_1> >(void*) [tiflash+110002108]\n                \t/usr/local/bin/../include/c++/v1/thread:291\n  0x7f415ae7d802\tstart_thread [libc.so.6+653314]\n  0x7f415ae1d450\tclone3 [libc.so.6+259152]"] [thread_id=84]
239987:[2024/09/02 15:29:05.565 +08:00] [INFO] [TiDBSchemaSyncer.h:146] ["End sync schema, version has been updated to 6606"] [thread_id=84]

## And the same table_id is being tombstone again and again
>  rg 'Tombstoned table db_2.t_94\(94\)' clusters/tiflash-5040/log/tiflash.log                                                                                                                                                                                                                                                                        2024-09-02 16:51:01
1309:[2024/09/02 14:46:29.519 +08:00] [INFO] [SchemaBuilder.cpp:1298] ["Tombstoned table db_2.t_94(94), tombstone=452266449829888006"] [thread_id=91]
1570:[2024/09/02 14:46:40.143 +08:00] [INFO] [SchemaBuilder.cpp:1298] ["Tombstoned table db_2.t_94(94), tombstone=452266452608614402"] [thread_id=92]
...
236355:[2024/09/02 15:28:54.154 +08:00] [INFO] [SchemaBuilder.cpp:1298] ["Tombstoned table db_2.t_94(94), tombstone=452267116894617606"] [thread_id=81]
238316:[2024/09/02 15:29:05.296 +08:00] [INFO] [SchemaBuilder.cpp:1298] ["Tombstoned table db_2.t_94(94), tombstone=452267119804416006"] [thread_id=84]
```


```
## At the beginning, sync all schema taks about 32ms
[2024/09/02 16:47:01.052 +08:00] [INFO] [TiDBSchemaSyncer.h:124] ["Start to sync schemas. current version is: 6626 and try to sync schema version to: 6658"] [thread_id=83]
[2024/09/02 16:47:01.052 +08:00] [DEBUG] [TiDBSchemaSyncer.h:181] ["Try load schema diffs."] [thread_id=83]
[2024/09/02 16:47:01.058 +08:00] [DEBUG] [TiDBSchemaSyncer.h:192] ["End load schema diffs with total 32 entries."] [thread_id=83]
[2024/09/02 16:47:01.061 +08:00] [WARN] [TiDBSchemaSyncer.h:236] ["apply diff meets exception : DB::TiFlashException: miss partition table in TiKV, may have been dropped, physical_table_id=4472 \n stack is \n       0x1752003\tStackTrace::StackTrace() [tiflash+24453123]\n                \tdbms/src/Common/StackTrace.cpp:23\n       0x177a67b\tDB::TiFlashException::TiFlashException(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::TiFlashError const&) [tiflash+24618619]\n                \tdbms/src/Common/TiFlashException.h:250\n       0x6c7aaa1\tDB::SchemaBuilder<DB::SchemaGetter, DB::SchemaNameMapper>::applyExchangeTablePartition(DB::SchemaDiff const&) [tiflash+113748641]\n                \tdbms/src/TiDB/Schema/SchemaBuilder.cpp:923\n       0x6c7790f\tDB::SchemaBuilder<DB::SchemaGetter, DB::SchemaNameMapper>::applyDiff(DB::SchemaDiff const&) [tiflash+113735951]\n                \tdbms/src/TiDB/Schema/SchemaBuilder.cpp:551\n       0x6bb98fb\tDB::TiDBSchemaSyncer<false, false>::tryLoadSchemaDiffs(DB::SchemaGetter&, long, DB::Context&) [tiflash+112957691]\n                \tdbms/src/TiDB/Schema/TiDBSchemaSyncer.h:227\n       0x6bb8a85\tDB::TiDBSchemaSyncer<false, false>::syncSchemas(DB::Context&) [tiflash+112953989]\n                \tdbms/src/TiDB/Schema/TiDBSchemaSyncer.h:139\n       0x6cb1a3e\tstd::__1::__function::__func<DB::SchemaSyncService::SchemaSyncService(DB::Context&)::$_0, std::__1::allocator<DB::SchemaSyncService::SchemaSyncService(DB::Context&)::$_0>, bool ()>::operator()() [tiflash+113973822]\n                \t/DATA/disk1/ra_common/tiflash-env-13/sysroot/bin/../include/c++/v1/__functional/function.h:345\n       0x6895d5f\tDB::BackgroundProcessingPool::threadFunction(unsigned long) [tiflash+109665631]\n                \tdbms/src/Storages/BackgroundProcessingPool.cpp:226\n       0x6896655\tvoid* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, DB::BackgroundProcessingPool::BackgroundProcessingPool(int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >)::$_1> >(void*) [tiflash+109667925]\n                \t/DATA/disk1/ra_common/tiflash-env-13/sysroot/bin/../include/c++/v1/thread:291\n  0x7f3b92a52802\tstart_thread [libc.so.6+653314]\n  0x7f3b929f2450\tclone3 [libc.so.6+259152]"] [thread_id=83]
[2024/09/02 16:47:01.084 +08:00] [INFO] [TiDBSchemaSyncer.h:146] ["End sync schema, version has been updated to 6658"] [thread_id=83]

## the last sync all schema takes about 38ms
[2024/09/02 17:22:10.555 +08:00] [INFO] [TiDBSchemaSyncer.h:124] ["Start to sync schemas. current version is: 12585 and try to sync schema version to: 12606"] [thread_id=95]
[2024/09/02 17:22:10.555 +08:00] [DEBUG] [TiDBSchemaSyncer.h:181] ["Try load schema diffs."] [thread_id=95]
[2024/09/02 17:22:10.560 +08:00] [DEBUG] [TiDBSchemaSyncer.h:192] ["End load schema diffs with total 21 entries."] [thread_id=95]
[2024/09/02 17:22:10.566 +08:00] [WARN] [TiDBSchemaSyncer.h:236] ["apply diff meets exception : DB::TiFlashException: miss table in TiFlash, npt_table_id=8452 : test(2).test_range_1(83) \n stack is \n       0x1752003\tStackTrace::StackTrace() [tiflash+24453123]\n                \tdbms/src/Common/StackTrace.cpp:23\n       0x177a67b\tDB::TiFlashException::TiFlashException(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::TiFlashError const&) [tiflash+24618619]\n                \tdbms/src/Common/TiFlashException.h:250\n       0x6c7a9a3\tDB::SchemaBuilder<DB::SchemaGetter, DB::SchemaNameMapper>::applyExchangeTablePartition(DB::SchemaDiff const&) [tiflash+113748387]\n                \tdbms/src/TiDB/Schema/SchemaBuilder.cpp:895\n       0x6c7790f\tDB::SchemaBuilder<DB::SchemaGetter, DB::SchemaNameMapper>::applyDiff(DB::SchemaDiff const&) [tiflash+113735951]\n                \tdbms/src/TiDB/Schema/SchemaBuilder.cpp:551\n       0x6bb98fb\tDB::TiDBSchemaSyncer<false, false>::tryLoadSchemaDiffs(DB::SchemaGetter&, long, DB::Context&) [tiflash+112957691]\n                \tdbms/src/TiDB/Schema/TiDBSchemaSyncer.h:227\n       0x6bb8a85\tDB::TiDBSchemaSyncer<false, false>::syncSchemas(DB::Context&) [tiflash+112953989]\n                \tdbms/src/TiDB/Schema/TiDBSchemaSyncer.h:139\n       0x6cb1a3e\tstd::__1::__function::__func<DB::SchemaSyncService::SchemaSyncService(DB::Context&)::$_0, std::__1::allocator<DB::SchemaSyncService::SchemaSyncService(DB::Context&)::$_0>, bool ()>::operator()() [tiflash+113973822]\n                \t/DATA/disk1/ra_common/tiflash-env-13/sysroot/bin/../include/c++/v1/__functional/function.h:345\n       0x6895d5f\tDB::BackgroundProcessingPool::threadFunction(unsigned long) [tiflash+109665631]\n                \tdbms/src/Storages/BackgroundProcessingPool.cpp:226\n       0x6896655\tvoid* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, DB::BackgroundProcessingPool::BackgroundProcessingPool(int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >)::$_1> >(void*) [tiflash+109667925]\n                \t/DATA/disk1/ra_common/tiflash-env-13/sysroot/bin/../include/c++/v1/thread:291\n  0x7f3b92a52802\tstart_thread [libc.so.6+653314]\n  0x7f3b929f2450\tclone3 [libc.so.6+259152]"] [thread_id=95]
[2024/09/02 17:22:10.593 +08:00] [INFO] [TiDBSchemaSyncer.h:146] ["End sync schema, version has been updated to 12606"] [thread_id=95]

## The same table_id only be dropped once
[2024/09/02 16:46:50.264 +08:00] [INFO] [SchemaBuilder.cpp:1343] ["Tombstone table db_2.t_4460(4460) begin, action=SyncAllSchema"] [thread_id=86]
[2024/09/02 16:46:50.264 +08:00] [INFO] [StorageDeltaMerge.cpp:115] ["updateTableColumnInfo: TableName t_4460 ordinary columns format version: 1\n3 columns:\n`id` Nullable(Int32)\n`name` Nullable(String)\n`_tidb_rowid` Int64\n materialized columns format version: 1\n2 columns:\n`_INTERNAL_VERSION` UInt64\n`_INTERNAL_DELMARK` UInt8\n"] [source=db_2.t_4460] [thr
ead_id=86]
[2024/09/02 16:46:50.265 +08:00] [INFO] [SchemaBuilder.cpp:1359] ["Tombstone table db_2.t_4460(4460) end, action=SyncAllSchema tombstone=452268342706176001"] [thread_id=86]
[2024/09/02 16:46:50.265 +08:00] [INFO] [SchemaBuilder.cpp:1542] ["Table db_2.t_4460(4460) dropped during sync all schemas"] [thread_id=86]
[2024/09/02 16:47:01.084 +08:00] [INFO] [SchemaBuilder.cpp:1337] ["Tombstone table db_2.t_4460(4460) has been done before, action=SyncAllSchema tombstone=452268342706176001"] [thread_id=83]
[2024/09/02 16:47:01.084 +08:00] [INFO] [SchemaBuilder.cpp:1542] ["Table db_2.t_4460(4460) dropped during sync all schemas"] [thread_id=83]
[2024/09/02 16:47:12.040 +08:00] [INFO] [SchemaBuilder.cpp:1337] ["Tombstone table db_2.t_4460(4460) has been done before, action=SyncAllSchema tombstone=452268342706176001"] [thread_id=84]
...
```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix an issue that rapidly executes `DROP TABLE` after other DDL operations on the same table for a long time, could potentially lead to a significant slowdown in TiFlash schema synchronization.
```
