### PR TITLE
security: Allow empty security config for disabling tls

### DIFF
--- a/dbms/src/Common/TiFlashSecurity.h
+++ b/dbms/src/Common/TiFlashSecurity.h
@@ -41,8 +41,6 @@ extern const int INVALID_CONFIG_PARAMETER;
 class TiFlashSecurityConfig : public ConfigObject
 {
 public:
-    TiFlashSecurityConfig() = default;
-
     explicit TiFlashSecurityConfig(const LoggerPtr & log_)
         : log(log_)
     {}
@@ -54,12 +52,6 @@ public:
             update(config);
             inited = true;
         }
-    }
-
-    void setLog(const LoggerPtr & log_)
-    {
-        std::unique_lock lock(mu);
-        log = log_;
     }
 
     bool hasTlsConfig()
@@ -358,8 +350,10 @@ private:
     String key_path;
 
     FilesChangesTracker cert_files;
-    RedactMode redact_info_log = RedactMode::Disable;
     std::set<String> allowed_common_names;
+
+    RedactMode redact_info_log = RedactMode::Disable;
+
     bool has_tls_config = false;
     bool has_security = false;
     bool inited = false;

--- a/dbms/src/Common/TiFlashSecurity.h
+++ b/dbms/src/Common/TiFlashSecurity.h
@@ -272,17 +272,17 @@ private:
         String new_key_path;
         if (config.has("security.ca_path"))
         {
-            new_ca_path = config.getString("security.ca_path");
+            new_ca_path = Poco::trim(config.getString("security.ca_path"));
             miss_ca_path = new_ca_path.empty();
         }
         if (config.has("security.cert_path"))
         {
-            new_cert_path = config.getString("security.cert_path");
+            new_cert_path = Poco::trim(config.getString("security.cert_path"));
             miss_cert_path = new_cert_path.empty();
         }
         if (config.has("security.key_path"))
         {
-            new_key_path = config.getString("security.key_path");
+            new_key_path = Poco::trim(config.getString("security.key_path"));
             miss_key_path = new_key_path.empty();
         }
 

--- a/dbms/src/Common/TiFlashSecurity.h
+++ b/dbms/src/Common/TiFlashSecurity.h
@@ -88,31 +88,7 @@ public:
     bool update(Poco::Util::AbstractConfiguration & config)
     {
         std::unique_lock lock(mu);
-        if (config.has("security"))
-        {
-            if (inited && !has_security)
-            {
-                LOG_WARNING(log, "Can't add security config online");
-                return false;
-            }
-            has_security = true;
-
-            bool cert_file_updated = updateCertPath(config);
-
-            if (config.has("security.cert_allowed_cn") && has_tls_config)
-            {
-                String verify_cns = config.getString("security.cert_allowed_cn");
-                allowed_common_names = parseAllowedCN(verify_cns);
-            }
-
-            // Mostly options name are combined with "_", keep this style
-            if (config.has("security.redact_info_log"))
-            {
-                redact_info_log = parseRedactLog(config.getString("security.redact_info_log"));
-            }
-            return cert_file_updated;
-        }
-        else
+        if (!config.has("security"))
         {
             if (inited && has_security)
             {
@@ -122,8 +98,31 @@ public:
             {
                 LOG_INFO(log, "security config is not set");
             }
+            return false;
         }
-        return false;
+
+        assert(config.has("security"));
+        if (inited && !has_security)
+        {
+            LOG_WARNING(log, "Can't add security config online");
+            return false;
+        }
+        has_security = true;
+
+        bool cert_file_updated = updateCertPath(config);
+
+        if (config.has("security.cert_allowed_cn") && has_tls_config)
+        {
+            String verify_cns = config.getString("security.cert_allowed_cn");
+            allowed_common_names = parseAllowedCN(verify_cns);
+        }
+
+        // Mostly options name are combined with "_", keep this style
+        if (config.has("security.redact_info_log"))
+        {
+            redact_info_log = parseRedactLog(config.getString("security.redact_info_log"));
+        }
+        return cert_file_updated;
     }
 
     static RedactMode parseRedactLog(const String & config_str)

--- a/dbms/src/Common/TiFlashSecurity.h
+++ b/dbms/src/Common/TiFlashSecurity.h
@@ -273,17 +273,17 @@ private:
         if (config.has("security.ca_path"))
         {
             new_ca_path = config.getString("security.ca_path");
-            miss_ca_path = false;
+            miss_ca_path = new_ca_path.empty();
         }
         if (config.has("security.cert_path"))
         {
             new_cert_path = config.getString("security.cert_path");
-            miss_cert_path = false;
+            miss_cert_path = new_cert_path.empty();
         }
         if (config.has("security.key_path"))
         {
             new_key_path = config.getString("security.key_path");
-            miss_key_path = false;
+            miss_key_path = new_key_path.empty();
         }
 
         if (miss_ca_path && miss_cert_path && miss_key_path)

--- a/dbms/src/Common/tests/gtest_tiflash_security.cpp
+++ b/dbms/src/Common/tests/gtest_tiflash_security.cpp
@@ -85,7 +85,7 @@ TEST(TiFlashSecurityTest, EmptyConfig)
     String test =
         R"(
 [security]
-ca_path=""
+ca_path="  "
 cert_path=""
 key_path=""
         )";

--- a/dbms/src/Common/tests/gtest_tiflash_security.cpp
+++ b/dbms/src/Common/tests/gtest_tiflash_security.cpp
@@ -76,6 +76,24 @@ cert_allowed_cn="tidb"
     ASSERT_EQ((int)new_tiflash_config.allowedCommonNames().count("tidb"), 0);
 }
 
+TEST(TiFlashSecurityTest, EmptyConfig)
+{
+    TiFlashSecurityConfig tiflash_config;
+    const auto log = Logger::get();
+    tiflash_config.setLog(log);
+
+    String test =
+        R"(
+[security]
+ca_path=""
+cert_path=""
+key_path=""
+        )";
+    auto new_config = loadConfigFromString(test);
+    tiflash_config.update(*new_config);
+    ASSERT_FALSE(tiflash_config.hasTlsConfig());
+}
+
 TEST(TiFlashSecurityTest, RedactLogConfig)
 {
     for (const auto & [input, expect] : std::vector<std::pair<String, RedactMode>>{

--- a/dbms/src/Common/tests/gtest_tiflash_security.cpp
+++ b/dbms/src/Common/tests/gtest_tiflash_security.cpp
@@ -125,6 +125,15 @@ key_path="")",
 ca_path=""
 cert_path=""
 key_path="security/key.pem")",
+             R"([security]
+ca_path=""
+cert_path="security/cert.pem"
+key_path="security/key.pem")",
+             // comment out
+             R"([security]
+ca_path="security/ca.pem"
+#cert_path="security/cert.pem"
+key_path="security/key.pem")",
          })
     {
         TiFlashSecurityConfig tiflash_config(log);

--- a/dbms/src/Common/tests/gtest_tiflash_security.cpp
+++ b/dbms/src/Common/tests/gtest_tiflash_security.cpp
@@ -75,7 +75,7 @@ cert_allowed_cn="tidb"
         auto new_tiflash_config = TiFlashSecurityConfig(log);
         new_tiflash_config.init(*new_config);
         ASSERT_FALSE(new_tiflash_config.hasTlsConfig());
-        // allowed common names is ignore when tls is not enabled
+        // allowed common names is ignored when tls is not enabled
         ASSERT_EQ(new_tiflash_config.allowedCommonNames().count("tidb"), 0);
     }
 }
@@ -98,10 +98,11 @@ cert_path=""
 key_path="")",
          })
     {
+        SCOPED_TRACE(fmt::format("case: {}", c));
         TiFlashSecurityConfig tiflash_config(log);
         auto new_config = loadConfigFromString(c);
         tiflash_config.init(*new_config);
-        ASSERT_FALSE(tiflash_config.hasTlsConfig()) << fmt::format("case: {}", c);
+        ASSERT_FALSE(tiflash_config.hasTlsConfig());
     }
 }
 CATCH
@@ -136,19 +137,20 @@ ca_path="security/ca.pem"
 key_path="security/key.pem")",
          })
     {
+        SCOPED_TRACE(fmt::format("case: {}", c));
         TiFlashSecurityConfig tiflash_config(log);
         auto new_config = loadConfigFromString(c);
         try
         {
             tiflash_config.init(*new_config);
-            ASSERT_FALSE(true) << fmt::format("should raise exception, case: {}", c);
+            ASSERT_FALSE(true) << "should raise exception";
         }
         catch (Exception & e)
         {
-            // has_tls remain false when exception raise
-            ASSERT_FALSE(tiflash_config.hasTlsConfig()) << fmt::format("case: {}", c);
+            // has_tls remains false when an exception raise
+            ASSERT_FALSE(tiflash_config.hasTlsConfig());
             // the error code must be INVALID_CONFIG_PARAMETER
-            ASSERT_EQ(e.code(), ErrorCodes::INVALID_CONFIG_PARAMETER) << fmt::format("case: {}", c);
+            ASSERT_EQ(e.code(), ErrorCodes::INVALID_CONFIG_PARAMETER);
         }
     }
 }

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -1404,9 +1404,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
             }
             {
                 // update TiFlashSecurity and related config in client for ssl certificate reload.
-                bool updated
-                    = global_context->getSecurityConfig()->update(*config); // Whether the cert path or file is updated.
-                if (updated)
+                if (bool updated = global_context->getSecurityConfig()->update(*config); updated)
                 {
                     auto raft_config = TiFlashRaftConfig::parseSettings(*config, log);
                     auto cluster_config

--- a/dbms/src/Storages/DeltaMerge/DeltaTree.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaTree.h
@@ -174,8 +174,8 @@ struct DTLeaf
 
     static inline bool overflow(size_t count) { return count > M * S; }
     static inline bool underflow(size_t count) { return count < M; }
-    inline bool legal() { return !overflow(count) && !underflow(count); }
-    inline std::string state() { return overflow(count) ? "overflow" : (underflow(count) ? "underflow" : "legal"); }
+    inline bool legal() const { return !overflow(count) && !underflow(count); }
+    inline String state() const { return overflow(count) ? "overflow" : (underflow(count) ? "underflow" : "legal"); }
 
     /// shift entries from pos with n steps.
     inline void shiftEntries(size_t pos, int n)
@@ -371,8 +371,8 @@ struct DTIntern
 
     static inline bool overflow(size_t count) { return count > F * S; }
     static inline bool underflow(size_t count) { return count < F; }
-    inline bool legal() { return !overflow(count) && !underflow(count); }
-    inline std::string state() { return overflow(count) ? "overflow" : (underflow(count) ? "underflow" : "legal"); }
+    inline bool legal() const { return !overflow(count) && !underflow(count); }
+    inline String state() const { return overflow(count) ? "overflow" : (underflow(count) ? "underflow" : "legal"); }
 
     /// shift entries from pos with n steps.
     inline void shiftEntries(size_t child_pos, int n)

--- a/dbms/src/Storages/DeltaMerge/DeltaTree.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaTree.h
@@ -174,8 +174,8 @@ struct DTLeaf
 
     static inline bool overflow(size_t count) { return count > M * S; }
     static inline bool underflow(size_t count) { return count < M; }
-    inline bool legal() const { return !overflow(count) && !underflow(count); }
-    inline String state() const { return overflow(count) ? "overflow" : (underflow(count) ? "underflow" : "legal"); }
+    inline bool legal() { return !overflow(count) && !underflow(count); }
+    inline std::string state() { return overflow(count) ? "overflow" : (underflow(count) ? "underflow" : "legal"); }
 
     /// shift entries from pos with n steps.
     inline void shiftEntries(size_t pos, int n)
@@ -371,8 +371,8 @@ struct DTIntern
 
     static inline bool overflow(size_t count) { return count > F * S; }
     static inline bool underflow(size_t count) { return count < F; }
-    inline bool legal() const { return !overflow(count) && !underflow(count); }
-    inline String state() const { return overflow(count) ? "overflow" : (underflow(count) ? "underflow" : "legal"); }
+    inline bool legal() { return !overflow(count) && !underflow(count); }
+    inline std::string state() { return overflow(count) ? "overflow" : (underflow(count) ? "underflow" : "legal"); }
 
     /// shift entries from pos with n steps.
     inline void shiftEntries(size_t child_pos, int n)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/9235

Problem Summary:

TiFlash fails to start with following configs
```
        [security]
          ca_path = ""
          cert_path = ""
          key_path = ""
```

### What is changed and how it works?

If any of the `security.ca_path`/`security.cert_path`/`security.key_path` is empty, treat it as missing.
And if all of the three config are not exist or empty strings, TLS is disabled in tiflash.

```commit-message
security: allow empty `security.ca_path`/`security.cert_path`/`security.key_path`
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix a bug that empty SSL config strings will enable TLS for tiflash
```
