### PR TITLE
tests: Limit the segments to be merged under tsan to suppress deadlock

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,9 @@ ninja gtests_libcommon
 There are known false positives reported from leak sanitizer (which is included in address sanitizer). To suppress these errors, set the following environment variables before running the executables:
 
 ```shell
-LSAN_OPTIONS=suppressions=test/sanitize/asan.suppression
+LSAN_OPTIONS="suppressions=tests/sanitize/asan.suppression" ./dbms/gtests_dbms ...
+# or
+TSAN_OPTIONS="suppressions=tests/sanitize/tsan.suppression" ./dbms/gtests_dbms ...
 ```
 
 ## Run Integration Tests

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
@@ -505,7 +505,7 @@ public:
      *   It is ensured that there are at least 2 elements in the returned vector.
      * When there is no mergeable segment, the returned vector will be empty.
      */
-    std::vector<SegmentPtr> getMergeableSegments(const DMContextPtr & context, const SegmentPtr & baseSegment);
+    std::vector<SegmentPtr> getMergeableSegments(const DMContextPtr & context, const SegmentPtr & base_segment);
 
     /// Apply schema change on `table_columns`
     void applySchemaChanges(TableInfo & table_info);

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalBg.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalBg.cpp
@@ -345,6 +345,12 @@ std::vector<SegmentPtr> DeltaMergeStore::getMergeableSegments(
             const auto this_bytes = this_seg->getEstimatedBytes();
             if (accumulated_rows + this_rows >= max_total_rows || accumulated_bytes + this_bytes >= max_total_bytes)
                 break;
+#if defined(THREAD_SANITIZER)
+            // Limit the segments to be merge less than 30, or thread sanitizer will fail
+            // https://github.com/pingcap/tiflash/issues/9257
+            if (results.size() > 30)
+                break;
+#endif
             results.emplace_back(this_seg);
             accumulated_rows += this_rows;
             accumulated_bytes += this_bytes;

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalBg.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalBg.cpp
@@ -312,10 +312,10 @@ void DeltaMergeStore::setUpBackgroundTask(const DMContextPtr & dm_context)
 
 std::vector<SegmentPtr> DeltaMergeStore::getMergeableSegments(
     const DMContextPtr & context,
-    const SegmentPtr & baseSegment)
+    const SegmentPtr & base_segment)
 {
     // Last segment cannot be merged.
-    if (baseSegment->getRowKeyRange().isEndInfinite())
+    if (base_segment->getRowKeyRange().isEndInfinite())
         return {};
 
     // We only merge small segments into a larger one.
@@ -329,15 +329,15 @@ std::vector<SegmentPtr> DeltaMergeStore::getMergeableSegments(
     {
         std::shared_lock lock(read_write_mutex);
 
-        if (!isSegmentValid(lock, baseSegment))
+        if (!isSegmentValid(lock, base_segment))
             return {};
 
         results.reserve(4); // In most cases we will only find <= 4 segments to merge.
-        results.emplace_back(baseSegment);
-        auto accumulated_rows = baseSegment->getEstimatedRows();
-        auto accumulated_bytes = baseSegment->getEstimatedBytes();
+        results.emplace_back(base_segment);
+        auto accumulated_rows = base_segment->getEstimatedRows();
+        auto accumulated_bytes = base_segment->getEstimatedBytes();
 
-        auto it = segments.upper_bound(baseSegment->getRowKeyRange().getEnd());
+        auto it = segments.upper_bound(base_segment->getRowKeyRange().getEnd());
         while (it != segments.end())
         {
             const auto & this_seg = it->second;
@@ -346,7 +346,7 @@ std::vector<SegmentPtr> DeltaMergeStore::getMergeableSegments(
             if (accumulated_rows + this_rows >= max_total_rows || accumulated_bytes + this_bytes >= max_total_bytes)
                 break;
 #if defined(THREAD_SANITIZER)
-            // Limit the segments to be merge less than 30, or thread sanitizer will fail
+            // Limit the segments to be merged less than 30, or thread sanitizer will fail
             // https://github.com/pingcap/tiflash/issues/9257
             if (results.size() > 30)
                 break;

--- a/tests/sanitize/tsan.suppression
+++ b/tests/sanitize/tsan.suppression
@@ -7,3 +7,4 @@ race:fiu_fail
 race:dbms/src/DataStreams/BlockStreamProfileInfo.h
 race:StackTrace::toString
 race:DB::SyncPointCtl::sync
+race:XXH3_hashLong_64b_withSeed_selection


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/9257

Problem Summary:

The TSAN will failed when one thread hold locks larger than 64. `StoreIngestTest.ConcurrentIngestAndWrite` will try to do "segmentMerge" on many segments (more than 500), causing this problem.

> The code in question is in lib/sanitizer_common/sanitizer_deadlock_detector.h
It limits the number of simultaneously held locks in a given thread to an arbitrary large number 64.
If you hold 65 locks in one thread at once, this will fail.

### What is changed and how it works?

```commit-message

```

* Limit the segments to be merged under tsan
* Suppress a data race on xxh3

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
