### PR TITLE
Storages: Fix obtaining incorrect column information when there are virtual columns in the query (release-8.1)

### DIFF
--- a/dbms/src/DataStreams/RuntimeFilter.cpp
+++ b/dbms/src/DataStreams/RuntimeFilter.cpp
@@ -206,7 +206,14 @@ bool RuntimeFilter::updateStatus(RuntimeFilterStatus status_, const std::string 
     return true;
 }
 
-DM::RSOperatorPtr RuntimeFilter::parseToRSOperator(DM::ColumnDefines & columns_to_read)
+void RuntimeFilter::setTargetAttr(
+    const DM::ColumnInfos & scan_column_infos,
+    const DM::ColumnDefines & table_column_defines)
+{
+    target_attr = DM::FilterParser::createAttr(target_expr, scan_column_infos, table_column_defines);
+}
+
+DM::RSOperatorPtr RuntimeFilter::parseToRSOperator()
 {
     switch (rf_type)
     {
@@ -216,7 +223,7 @@ DM::RSOperatorPtr RuntimeFilter::parseToRSOperator(DM::ColumnDefines & columns_t
         return DM::FilterParser::parseRFInExpr(
             rf_type,
             target_expr,
-            columns_to_read,
+            target_attr,
             in_values_set->getUniqueSetElements(),
             timezone_info);
     case tipb::MIN_MAX:

--- a/dbms/src/DataStreams/RuntimeFilter.h
+++ b/dbms/src/DataStreams/RuntimeFilter.h
@@ -16,6 +16,7 @@
 
 #include <Columns/IColumn.h>
 #include <Interpreters/Set.h>
+#include <Storages/DeltaMerge/ColumnDefine_fwd.h>
 #include <Storages/DeltaMerge/DeltaMergeDefines.h>
 #include <Storages/DeltaMerge/Filter/RSOperator.h>
 #include <tipb/executor.pb.h>
@@ -47,7 +48,7 @@ public:
         }
         source_expr = rf_pb.source_expr_list().Get(0);
         target_expr = rf_pb.target_expr_list().Get(0);
-    };
+    }
 
     std::string getSourceColumnName() const;
 
@@ -77,7 +78,8 @@ public:
 
     bool await(int64_t ms_remaining);
 
-    DM::RSOperatorPtr parseToRSOperator(DM::ColumnDefines & columns_to_read);
+    void setTargetAttr(const DM::ColumnInfos & scan_column_infos, const DM::ColumnDefines & table_column_defines);
+    DM::RSOperatorPtr parseToRSOperator();
 
     const int id;
 
@@ -86,6 +88,7 @@ private:
 
     tipb::Expr source_expr;
     tipb::Expr target_expr;
+    std::optional<DM::Attr> target_attr;
     const tipb::RuntimeFilterType rf_type;
     TimezoneInfo timezone_info;
     // thread safe

--- a/dbms/src/Debug/MockStorage.cpp
+++ b/dbms/src/Debug/MockStorage.cpp
@@ -200,10 +200,11 @@ BlockInputStreamPtr MockStorage::getStreamFromDeltaMerge(
     if (filter_conditions && filter_conditions->hasValue())
     {
         auto analyzer = std::make_unique<DAGExpressionAnalyzer>(names_and_types_map_for_delta_merge[table_id], context);
+        auto scan_column_infos = mockColumnInfosToTiDBColumnInfos(table_schema_for_delta_merge[table_id]);
         query_info.dag_query = std::make_unique<DAGQueryInfo>(
             filter_conditions->conditions,
             empty_pushed_down_filters, // Not care now
-            mockColumnInfosToTiDBColumnInfos(table_schema_for_delta_merge[table_id]),
+            scan_column_infos,
             runtime_filter_ids,
             rf_max_wait_time_ms,
             context.getTimezoneInfo());
@@ -227,10 +228,11 @@ BlockInputStreamPtr MockStorage::getStreamFromDeltaMerge(
     else
     {
         static const google::protobuf::RepeatedPtrField<tipb::Expr> empty_filters{};
+        auto scan_column_infos = mockColumnInfosToTiDBColumnInfos(table_schema_for_delta_merge[table_id]);
         query_info.dag_query = std::make_unique<DAGQueryInfo>(
             empty_filters,
             empty_pushed_down_filters, // Not care now
-            mockColumnInfosToTiDBColumnInfos(table_schema_for_delta_merge[table_id]),
+            scan_column_infos,
             runtime_filter_ids,
             rf_max_wait_time_ms,
             context.getTimezoneInfo());
@@ -257,10 +259,11 @@ void MockStorage::buildExecFromDeltaMerge(
     if (filter_conditions && filter_conditions->hasValue())
     {
         auto analyzer = std::make_unique<DAGExpressionAnalyzer>(names_and_types_map_for_delta_merge[table_id], context);
+        auto scan_column_infos = mockColumnInfosToTiDBColumnInfos(table_schema_for_delta_merge[table_id]);
         query_info.dag_query = std::make_unique<DAGQueryInfo>(
             filter_conditions->conditions,
             empty_pushed_down_filters, // Not care now
-            mockColumnInfosToTiDBColumnInfos(table_schema_for_delta_merge[table_id]),
+            scan_column_infos,
             runtime_filter_ids,
             rf_max_wait_time_ms,
             context.getTimezoneInfo());
@@ -289,10 +292,11 @@ void MockStorage::buildExecFromDeltaMerge(
     else
     {
         static const google::protobuf::RepeatedPtrField<tipb::Expr> empty_filters{};
+        auto scan_column_infos = mockColumnInfosToTiDBColumnInfos(table_schema_for_delta_merge[table_id]);
         query_info.dag_query = std::make_unique<DAGQueryInfo>(
             empty_filters,
             empty_pushed_down_filters, // Not care now
-            mockColumnInfosToTiDBColumnInfos(table_schema_for_delta_merge[table_id]),
+            scan_column_infos,
             runtime_filter_ids,
             rf_max_wait_time_ms,
             context.getTimezoneInfo());
@@ -574,6 +578,11 @@ TableInfo MockStorage::getTableInfo(const String & name)
 TableInfo MockStorage::getTableInfoForDeltaMerge(const String & name)
 {
     return table_infos_for_delta_merge[name];
+}
+
+DM::ColumnDefines MockStorage::getStoreColumnDefines(Int64 table_id)
+{
+    return storage_delta_merge_map[table_id]->getStoreColumnDefines();
 }
 
 ColumnInfos mockColumnInfosToTiDBColumnInfos(const MockColumnInfoVec & mock_column_infos)

--- a/dbms/src/Debug/MockStorage.h
+++ b/dbms/src/Debug/MockStorage.h
@@ -19,6 +19,7 @@
 #include <Flash/Coprocessor/TiDBTableScan.h>
 #include <Flash/Pipeline/Exec/PipelineExecBuilder.h>
 #include <Operators/Operator.h>
+#include <Storages/DeltaMerge/ColumnDefine_fwd.h>
 #include <TiDB/Schema/TiDB.h>
 #include <common/types.h>
 
@@ -145,6 +146,7 @@ public:
 
     TableInfo getTableInfo(const String & name);
     TableInfo getTableInfoForDeltaMerge(const String & name);
+    DM::ColumnDefines getStoreColumnDefines(Int64 table_id);
 
     size_t getTableScanConcurrencyHint(const TiDBTableScan & table_scan);
 

--- a/dbms/src/Flash/Pipeline/Schedule/Tasks/RFWaitTask.h
+++ b/dbms/src/Flash/Pipeline/Schedule/Tasks/RFWaitTask.h
@@ -68,7 +68,7 @@ public:
     {
         for (const RuntimeFilterPtr & rf : ready_rf_list)
         {
-            auto rs_operator = rf->parseToRSOperator(task_pool->getColumnToRead());
+            auto rs_operator = rf->parseToRSOperator();
             task_pool->appendRSOperator(rs_operator);
         }
         DM::SegmentReadTaskScheduler::instance().add(task_pool);

--- a/dbms/src/Flash/Planner/Plans/PhysicalMockTableScan.h
+++ b/dbms/src/Flash/Planner/Plans/PhysicalMockTableScan.h
@@ -16,6 +16,7 @@
 
 #include <DataStreams/IBlockInputStream.h>
 #include <Flash/Coprocessor/FilterConditions.h>
+#include <Flash/Coprocessor/RuntimeFilterMgr.h>
 #include <Flash/Coprocessor/TiDBTableScan.h>
 #include <Flash/Planner/Plans/PhysicalLeaf.h>
 #include <tipb/executor.pb.h>
@@ -69,6 +70,8 @@ private:
         size_t) override;
 
     void buildRuntimeFilterInLocalStream(Context & context);
+
+    RuntimeFilteList getRuntimeFilterList(Context & context);
 
 private:
     FilterConditions filter_conditions;

--- a/dbms/src/Storages/DeltaMerge/ColumnDefine_fwd.h
+++ b/dbms/src/Storages/DeltaMerge/ColumnDefine_fwd.h
@@ -20,10 +20,17 @@
 #include <unordered_map>
 #include <vector>
 
+namespace TiDB
+{
+struct ColumnInfo;
+}
+
 namespace DB::DM
 {
 struct ColumnDefine;
 using ColumnDefines = std::vector<ColumnDefine>;
 using ColumnDefinesPtr = std::shared_ptr<ColumnDefines>;
 using ColumnDefineMap = std::unordered_map<DB::ColumnID, ColumnDefine>;
+
+using ColumnInfos = std::vector<TiDB::ColumnInfo>;
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/FilterParser/FilterParser.cpp
+++ b/dbms/src/Storages/DeltaMerge/FilterParser/FilterParser.cpp
@@ -270,7 +270,7 @@ RSOperatorPtr parseTiExpr(
                 break;
             }
             if (const auto & child = expr.children(0); likely(isFunctionExpr(child)))
-                return createNot(parseTiExpr(child, columns_to_read, creator, timezone_info, log));
+                return createNot(parseTiExpr(child, scan_column_infos, creator, timezone_info, log));
             reason = "child of logical not is not function";
             break;
         }
@@ -385,7 +385,7 @@ RSOperatorPtr FilterParser::parseRFInExpr(
     {
         if (!isColumnExpr(target_expr) || !target_attr)
         {
-            return createUnsupported(target_expr.ShortDebugString(), "rf target expr is not column expr", false);
+            return createUnsupported(target_expr.ShortDebugString(), "rf target expr is not column expr");
         }
         const auto & attr = *target_attr;
         if (target_expr.field_type().tp() == TiDB::TypeTimestamp && !timezone_info.is_utc_timezone)

--- a/dbms/src/Storages/DeltaMerge/FilterParser/FilterParser.h
+++ b/dbms/src/Storages/DeltaMerge/FilterParser/FilterParser.h
@@ -41,7 +41,7 @@ public:
     using AttrCreatorByColumnID = std::function<Attr(const DB::ColumnID)>;
     static RSOperatorPtr parseDAGQuery(
         const DAGQueryInfo & dag_info,
-        const ColumnDefines & columns_to_read,
+        const ColumnInfos & scan_column_infos,
         AttrCreatorByColumnID && creator,
         const LoggerPtr & log);
 
@@ -49,9 +49,14 @@ public:
     static RSOperatorPtr parseRFInExpr(
         tipb::RuntimeFilterType rf_type,
         const tipb::Expr & target_expr,
-        const ColumnDefines & columns_to_read,
+        const std::optional<Attr> & target_attr,
         const std::set<Field> & setElements,
         const TimezoneInfo & timezone_info);
+
+    static std::optional<Attr> createAttr(
+        const tipb::Expr & expr,
+        const ColumnInfos & scan_column_infos,
+        const ColumnDefines & table_column_defines);
 
     static bool isRSFilterSupportType(Int32 field_type);
 

--- a/dbms/src/Storages/DeltaMerge/ReadThread/UnorderedInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/UnorderedInputStream.cpp
@@ -43,7 +43,7 @@ void UnorderedInputStream::pushDownReadyRFList(std::vector<RuntimeFilterPtr> rea
 {
     for (const RuntimeFilterPtr & rf : readyRFList)
     {
-        auto rs_operator = rf->parseToRSOperator(task_pool->getColumnToRead());
+        auto rs_operator = rf->parseToRSOperator();
         task_pool->appendRSOperator(rs_operator);
     }
 }

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_minmax_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_minmax_index.cpp
@@ -2254,7 +2254,7 @@ try
         return Attr{.col_name = "", .col_id = column_id, .type = DataTypePtr{}};
     };
     const auto op
-        = DB::DM::FilterParser::parseDAGQuery(*dag_query, columns_to_read, create_attr_by_column_id, Logger::get());
+        = DB::DM::FilterParser::parseDAGQuery(*dag_query, column_infos, create_attr_by_column_id, Logger::get());
     ASSERT_EQ(
         op->toDebugString(),
         "{\"op\":\"and\",\"children\":[{\"op\":\"in\",\"col\":\"b\",\"value\":\"[\"1\",\"2\"]},{\"op\":\"unsupported\","

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_minmax_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_minmax_index.cpp
@@ -2232,10 +2232,15 @@ try
     const ColumnDefines columns_to_read
         = {ColumnDefine{1, "a", std::make_shared<DataTypeInt64>()},
            ColumnDefine{2, "b", std::make_shared<DataTypeInt64>()}};
+    // Only need id of ColumnInfo
+    TiDB::ColumnInfo a, b;
+    a.id = 1;
+    b.id = 2;
+    ColumnInfos column_infos = {a, b};
     auto dag_query = std::make_unique<DAGQueryInfo>(
         filters,
         pushed_down_filters, // Not care now
-        std::vector<TiDB::ColumnInfo>{}, // Not care now
+        column_infos,
         std::vector<int>{},
         0,
         context->getTimezoneInfo());

--- a/dbms/src/Storages/StorageDeltaMerge.cpp
+++ b/dbms/src/Storages/StorageDeltaMerge.cpp
@@ -730,7 +730,6 @@ DM::RowKeyRanges StorageDeltaMerge::parseMvccQueryInfo(
 
 DM::RSOperatorPtr StorageDeltaMerge::buildRSOperator(
     const std::unique_ptr<DAGQueryInfo> & dag_query,
-    const ColumnDefines & columns_to_read,
     const Context & context,
     const LoggerPtr & tracing_logger)
 {
@@ -751,8 +750,11 @@ DM::RSOperatorPtr StorageDeltaMerge::buildRSOperator(
             // Maybe throw an exception? Or check if `type` is nullptr before creating filter?
             return Attr{.col_name = "", .col_id = column_id, .type = DataTypePtr{}};
         };
-        rs_operator
-            = FilterParser::parseDAGQuery(*dag_query, columns_to_read, std::move(create_attr_by_column_id), log);
+        rs_operator = FilterParser::parseDAGQuery(
+            *dag_query,
+            dag_query->source_columns,
+            std::move(create_attr_by_column_id),
+            log);
         if (likely(rs_operator != DM::EMPTY_RS_OPERATOR))
             LOG_DEBUG(tracing_logger, "Rough set filter: {}", rs_operator->toDebugString());
     }
@@ -838,10 +840,14 @@ DM::PushDownFilterPtr StorageDeltaMerge::buildPushDownFilter(
         has_cast)
     {
         NamesWithAliases project_cols;
-        for (size_t i = 0; i < columns_to_read.size(); ++i)
+        for (size_t i = 0; i < table_scan_column_info.size(); ++i)
         {
-            if (filter_col_id_set.contains(columns_to_read[i].id))
-                project_cols.emplace_back(casted_columns[i], columns_to_read[i].name);
+            if (filter_col_id_set.contains(table_scan_column_info[i].id))
+            {
+                auto it = columns_to_read_map.find(table_scan_column_info[i].id);
+                RUNTIME_CHECK(it != columns_to_read_map.end(), table_scan_column_info[i].id);
+                project_cols.emplace_back(casted_columns[i], it->second.name);
+            }
         }
         actions->add(ExpressionAction::project(project_cols));
 
@@ -902,7 +908,7 @@ DM::PushDownFilterPtr StorageDeltaMerge::parsePushDownFilter(
         return EMPTY_FILTER;
 
     // build rough set operator
-    const DM::RSOperatorPtr rs_operator = buildRSOperator(dag_query, columns_to_read, context, tracing_logger);
+    const DM::RSOperatorPtr rs_operator = buildRSOperator(dag_query, context, tracing_logger);
     // build push down filter
     const auto & columns_to_read_info = dag_query->source_columns;
     const auto & pushed_down_filters = dag_query->pushed_down_filters;
@@ -1011,6 +1017,11 @@ RuntimeFilteList StorageDeltaMerge::parseRuntimeFilterList(
     auto runtime_filter_list = db_context.getDAGContext()->runtime_filter_mgr.getLocalRuntimeFilterByIds(
         query_info.dag_query->runtime_filter_ids);
     LOG_DEBUG(log, "build runtime filter in local stream, list size:{}", runtime_filter_list.size());
+    const ColumnDefines & table_column_defines = getStoreColumnDefines();
+    for (auto & rf : runtime_filter_list)
+    {
+        rf->setTargetAttr(query_info.dag_query->source_columns, table_column_defines);
+    }
     return runtime_filter_list;
 }
 

--- a/dbms/src/Storages/StorageDeltaMerge.h
+++ b/dbms/src/Storages/StorageDeltaMerge.h
@@ -40,6 +40,8 @@ struct CheckpointInfo;
 using CheckpointInfoPtr = std::shared_ptr<CheckpointInfo>;
 struct CheckpointIngestInfo;
 using CheckpointIngestInfoPtr = std::shared_ptr<CheckpointIngestInfo>;
+class MockStorage;
+
 namespace DM
 {
 struct RowKeyRange;
@@ -254,7 +256,6 @@ private:
 
     DM::RSOperatorPtr buildRSOperator(
         const std::unique_ptr<DAGQueryInfo> & dag_query,
-        const DM::ColumnDefines & columns_to_read,
         const Context & context,
         const LoggerPtr & tracing_logger);
     /// Get filters from query to construct rough set operation and push down filters.
@@ -330,6 +331,8 @@ private:
     Context & global_context;
 
     LoggerPtr log;
+
+    friend class MockStorage;
 };
 
 

--- a/dbms/src/Storages/StorageDisaggregatedRemote.cpp
+++ b/dbms/src/Storages/StorageDisaggregatedRemote.cpp
@@ -509,8 +509,11 @@ DM::RSOperatorPtr StorageDisaggregated::buildRSOperator(
             return DM::Attr{.col_name = iter->name, .col_id = iter->id, .type = iter->type};
         return DM::Attr{.col_name = "", .col_id = column_id, .type = DataTypePtr{}};
     };
-    auto rs_operator
-        = DM::FilterParser::parseDAGQuery(*dag_query, *columns_to_read, std::move(create_attr_by_column_id), log);
+    auto rs_operator = DM::FilterParser::parseDAGQuery(
+        *dag_query,
+        table_scan.getColumns(),
+        std::move(create_attr_by_column_id),
+        log);
     if (likely(rs_operator != DM::EMPTY_RS_OPERATOR))
         LOG_DEBUG(log, "Rough set filter: {}", rs_operator->toDebugString());
     return rs_operator;

--- a/dbms/src/Storages/tests/gtest_filter_parser.cpp
+++ b/dbms/src/Storages/tests/gtest_filter_parser.cpp
@@ -119,7 +119,7 @@ DM::RSOperatorPtr FilterParserTest::generateRsOperator(
         return DM::Attr{.col_name = "", .col_id = column_id, .type = DataTypePtr{}};
     };
 
-    return DM::FilterParser::parseDAGQuery(*dag_query, columns_to_read, std::move(create_attr_by_column_id), log);
+    return DM::FilterParser::parseDAGQuery(*dag_query, table_info.columns, std::move(create_attr_by_column_id), log);
 }
 
 // Test cases for col and literal

--- a/dbms/src/Storages/tests/gtests_parse_push_down_filter.cpp
+++ b/dbms/src/Storages/tests/gtests_parse_push_down_filter.cpp
@@ -113,7 +113,7 @@ DM::PushDownFilterPtr ParsePushDownFilterTest::generatePushDownFilter(
     };
 
     auto rs_operator
-        = DM::FilterParser::parseDAGQuery(*dag_query, columns_to_read, std::move(create_attr_by_column_id), log);
+        = DM::FilterParser::parseDAGQuery(*dag_query, table_info.columns, std::move(create_attr_by_column_id), log);
     auto push_down_filter = StorageDeltaMerge::buildPushDownFilter(
         rs_operator,
         table_info.columns,

--- a/dbms/src/TiDB/Schema/TiDB.h
+++ b/dbms/src/TiDB/Schema/TiDB.h
@@ -433,3 +433,13 @@ std::vector<ColumnInfo> toTiDBColumnInfos(
     const ::google::protobuf::RepeatedPtrField<tipb::ColumnInfo> & tipb_column_infos);
 
 } // namespace TiDB
+
+template <>
+struct fmt::formatter<TiDB::ColumnInfo>
+{
+    template <typename FormatContext>
+    auto format(const TiDB::ColumnInfo & ci, FormatContext & ctx) const -> decltype(ctx.out())
+    {
+        return fmt::format_to(ctx.out(), "{}", ci.id);
+    }
+};

--- a/tests/fullstack-test/expr/generated_columns.test
+++ b/tests/fullstack-test/expr/generated_columns.test
@@ -1,0 +1,98 @@
+# Copyright 2024 PingCAP, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+mysql> drop table if exists test.t;
+mysql> create table if not exists test.t(a int);
+mysql> alter table test.t add column b int as (a+1) virtual;
+mysql> alter table test.t add column c int;
+mysql> alter table test.t add column d int as (c+1) virtual;
+mysql> alter table test.t add column e int;
+
+mysql> insert into test.t(a, c, e) values(1, 10, 100), (2, 20, 200), (3, 30, 300), (4, 40, 400), (5, 50, 500), (6, 60, 600), (7, 70, 700), (8, 80, 800), (9, 90, 900);
+
+mysql> alter table test.t set tiflash replica 1;
+
+func> wait_table test t
+
+mysql> set tidb_isolation_read_engines='tiflash'; select a, b, c, d, e from test.t where c = 10;
++------+------+------+------+------+
+| a    | b    | c    | d    | e    |
++------+------+------+------+------+
+|    1 |    2 |   10 |   11 |  100 |
++------+------+------+------+------+
+
+mysql> set tidb_isolation_read_engines='tiflash'; select a, b, c, d, e from test.t where c = 20;
++------+------+------+------+------+
+| a    | b    | c    | d    | e    |
++------+------+------+------+------+
+|    2 |    3 |   20 |   21 |  200 |
++------+------+------+------+------+
+
+mysql> set tidb_isolation_read_engines='tiflash'; select a, b, c, d, e from test.t where c = 30;
++------+------+------+------+------+
+| a    | b    | c    | d    | e    |
++------+------+------+------+------+
+|    3 |    4 |   30 |   31 |  300 |
++------+------+------+------+------+
+
+mysql> set tidb_isolation_read_engines='tiflash'; select a, b, c, d, e from test.t where c = 40;
++------+------+------+------+------+
+| a    | b    | c    | d    | e    |
++------+------+------+------+------+
+|    4 |    5 |   40 |   41 |  400 |
++------+------+------+------+------+
+
+mysql> set tidb_isolation_read_engines='tiflash'; select a, b, c, d, e from test.t where c = 50;
++------+------+------+------+------+
+| a    | b    | c    | d    | e    |
++------+------+------+------+------+
+|    5 |    6 |   50 |   51 |  500 |
++------+------+------+------+------+
+
+mysql> set tidb_isolation_read_engines='tiflash'; select a, b, c, d, e from test.t where c = 60;
++------+------+------+------+------+
+| a    | b    | c    | d    | e    |
++------+------+------+------+------+
+|    6 |    7 |   60 |   61 |  600 |
++------+------+------+------+------+
+
+mysql> set tidb_isolation_read_engines='tiflash'; select a, b, c, d, e from test.t where c = 70;
++------+------+------+------+------+
+| a    | b    | c    | d    | e    |
++------+------+------+------+------+
+|    7 |    8 |   70 |   71 |  700 |
++------+------+------+------+------+
+
+mysql> set tidb_isolation_read_engines='tiflash'; select a, b, c, d, e from test.t where c = 80;
++------+------+------+------+------+
+| a    | b    | c    | d    | e    |
++------+------+------+------+------+
+|    8 |    9 |   80 |   81 |  800 |
++------+------+------+------+------+
+
+mysql> set tidb_isolation_read_engines='tiflash'; select a, b, c, d, e from test.t where c = 80;
++------+------+------+------+------+
+| a    | b    | c    | d    | e    |
++------+------+------+------+------+
+|    8 |    9 |   80 |   81 |  800 |
++------+------+------+------+------+
+
+mysql> set tidb_isolation_read_engines='tiflash'; select a, b, c, d, e from test.t where c = 90;
++------+------+------+------+------+
+| a    | b    | c    | d    | e    |
++------+------+------+------+------+
+|    9 |   10 |   90 |   91 |  900 |
++------+------+------+------+------+
+
+mysql> drop table test.t;

--- a/tests/fullstack-test/expr/generated_columns2.test
+++ b/tests/fullstack-test/expr/generated_columns2.test
@@ -1,0 +1,49 @@
+# Copyright 2024 PingCAP, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+mysql> drop table if exists test.t;
+mysql> create table if not exists test.t(a int);
+mysql> alter table test.t add column b int as (a+1) virtual;
+mysql> alter table test.t add column c int;
+mysql> alter table test.t add column d int as (c+1) virtual;
+mysql> alter table test.t add column t time(6);
+
+mysql> insert into test.t(a, c, t) values(1, 2, '000:10:10.123456'), (3, 4, '001:10:10.123456'), (5, 6, '002:10:10.123456');
+mysql> insert into test.t(a, c, t) select a, c, t + 0.001 from test.t;
+mysql> insert into test.t(a, c, t) select a, c, t + 0.002 from test.t;
+mysql> insert into test.t(a, c, t) select a, c, t + 0.004 from test.t;
+mysql> insert into test.t(a, c, t) select a, c, t + 0.008 from test.t;
+mysql> insert into test.t(a, c, t) select a, c, t + 0.016 from test.t;
+mysql> insert into test.t(a, c, t) select a, c, t + 0.032 from test.t;
+mysql> insert into test.t(a, c, t) select a, c, t + 0.064 from test.t;
+mysql> insert into test.t(a, c, t) select a, c, t + 0.128 from test.t;
+mysql> insert into test.t(a, c, t) select a, c, t + 0.256 from test.t;
+mysql> insert into test.t(a, c, t) select a, c, t + 0.512 from test.t;
+mysql> insert into test.t(a, c, t) select a, c, t + 1.024 from test.t;
+mysql> insert into test.t(a, c, t) select a, c, t + 2.048 from test.t;
+
+mysql> alter table test.t set tiflash replica 1;
+
+func> wait_table test t
+
+mysql> analyze table test.t;
+
+mysql> set tidb_isolation_read_engines='tiflash'; select a, b, c, d, hour(t) from test.t where t = '000:10:10.123456';
++------+------+------+------+---------+
+| a    | b    | c    | d    | hour(t) |
++------+------+------+------+---------+
+|    1 |    2 |    2 |    3 |       0 |
++------+------+------+------+---------+
+
+mysql> drop table test.t;

--- a/tests/fullstack-test/expr/runtime_filter.test
+++ b/tests/fullstack-test/expr/runtime_filter.test
@@ -1,0 +1,46 @@
+# Copyright 2024 PingCAP, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+mysql> drop table if exists test.t;
+mysql> create table if not exists test.t(a int);
+mysql> alter table test.t add column b int as (a+1) virtual;
+mysql> alter table test.t add column c int;
+mysql> alter table test.t add column d int as (c+1) virtual;
+mysql> alter table test.t add column e int;
+mysql> insert into test.t(a, c, e) values(1, 10, 100), (2, 20, 200), (3, 30, 300), (4, 40, 400), (5, 50, 500), (6, 60, 600), (7, 70, 700), (8, 80, 800), (9, 90, 900);
+mysql> alter table test.t set tiflash replica 1;
+
+mysql> drop table if exists test.t2;
+mysql> create table if not exists test.t2(f int);
+mysql> insert into test.t2 values(10);
+mysql> alter table test.t2 set tiflash replica 1;
+
+func> wait_table test t
+func> wait_table test t2
+
+mysql> set tidb_runtime_filter_mode="LOCAL"; set tidb_isolation_read_engines='tiflash'; select /*+ HASH_JOIN_BUILD(test.t2) */ a, c, e from test.t t, test.t2 t2 where t.c = t2.f;
++------+------+------+
+| a    | c    | e    |
++------+------+------+
+|    1 |   10 |  100 |
++------+------+------+
+
+mysql> set tidb_runtime_filter_mode="LOCAL"; set tidb_isolation_read_engines='tiflash'; select /*+ HASH_JOIN_BUILD(test.t2) */ a, b, c, d, e from test.t t, test.t2 t2 where t.c = t2.f;
++------+------+------+------+------+
+| a    | b    | c    | d    | e    |
++------+------+------+------+------+
+|    1 |    2 |   10 |   11 |  100 |
++------+------+------+------+------+
+
+mysql> drop table test.t;


### PR DESCRIPTION
This is an manual cherry-pick of #9189

### What problem does this PR solve?

Issue Number: close #9188

Problem Summary:
When parsing some column expressions, it may need  to use column index to obtain column information, but since virtual columns are filtered out before being sent to the storage layer, the original columns and the columns for storage to read are 
inconsistency.

### What is changed and how it works?

```commit-message
1. Use the original columns  in `query_info.dag_query` instead of `columns_to_read` when building `RSOperator`.
2. For runtime filters, creating the `DM::Attr` object in `StorageDeltaMerge::read`, so it doesn't need to rely on `column_to_read`.
```
3. Currently, if a query contains virtual columns, hash join will not be pushed down to TiFlash. So in fact, runtime filters will not occur when a query contains virtual columns. But in order to keep the relevant codes consistent, make them not rely on `columns_to_read`, the way that runtime filters creating `DM::Attr` object is modified.


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix obtaining incorrect column information when there are virtual columns in the query.
```
