### PR TITLE
*: Support generating adhoc heap profiling in svg format

### DIFF
--- a/dbms/src/Storages/KVStore/tests/gtest_async_tasks.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_async_tasks.cpp
@@ -254,7 +254,7 @@ try
     auto async_tasks = std::make_unique<TestAsyncTasks>(1, 1, 2);
 
     int total = 5;
-    int max_steps = 10;
+    int max_steps = 15;
     int current_step = 0;
     std::vector<char> f(total, false);
     std::vector<char> s(total, false);

--- a/dbms/src/Storages/Page/V3/Universal/tests/gtest_universal_page_storage.cpp
+++ b/dbms/src/Storages/Page/V3/Universal/tests/gtest_universal_page_storage.cpp
@@ -619,6 +619,50 @@ TEST(UniPageStorageIdTest, UniversalWriteBatchMemory)
         ASSERT_EQ(PageStorageMemorySummary::universal_write_count.load(), 1);
     }
     ASSERT_EQ(PageStorageMemorySummary::universal_write_count.load(), 0);
+    {
+        UniversalWriteBatch wb;
+        wb.putPage(
+            UniversalPageIdFormat::toFullPageId(prefix, 0),
+            tag,
+            std::make_shared<ReadBufferFromMemory>(c_buff, buf_sz),
+            buf_sz);
+        UniversalWriteBatch wb2;
+        wb2.merge(wb);
+        ASSERT_EQ(PageStorageMemorySummary::universal_write_count.load(), 2);
+    }
+    {
+        UniversalWriteBatch wb;
+        wb.putPage(
+            UniversalPageIdFormat::toFullPageId(prefix, 0),
+            tag,
+            std::make_shared<ReadBufferFromMemory>(c_buff, buf_sz),
+            buf_sz);
+        wb.clear();
+        ASSERT_EQ(PageStorageMemorySummary::universal_write_count.load(), 0);
+    }
+    {
+        UniversalWriteBatch wb;
+        wb.putPage(
+            UniversalPageIdFormat::toFullPageId(prefix, 0),
+            tag,
+            std::make_shared<ReadBufferFromMemory>(c_buff, buf_sz),
+            buf_sz);
+        ASSERT_EQ(PageStorageMemorySummary::universal_write_count.load(), 1);
+        UniversalWriteBatch wb2;
+        wb.putPage(
+            UniversalPageIdFormat::toFullPageId(prefix, 1),
+            tag,
+            std::make_shared<ReadBufferFromMemory>(c_buff, buf_sz),
+            buf_sz);
+        wb.putPage(
+            UniversalPageIdFormat::toFullPageId(prefix, 2),
+            tag,
+            std::make_shared<ReadBufferFromMemory>(c_buff, buf_sz),
+            buf_sz);
+        ASSERT_EQ(PageStorageMemorySummary::universal_write_count.load(), 3);
+        wb.swap(wb2);
+        ASSERT_EQ(PageStorageMemorySummary::universal_write_count.load(), 3);
+    }
 }
 
 } // namespace PS::universal::tests


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #9241 close #9250

Problem Summary:

### What is changed and how it works?

```commit-message
Support generating adhoc heap profiling in svg format
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Support generating adhoc heap profiling in svg format
支持生成即席的 heap profiling 的 svg 图
```
