### PR TITLE
coprocessor: Refactor encoding `TiDBColumn`

### DIFF
--- a/dbms/src/Columns/ColumnArray.cpp
+++ b/dbms/src/Columns/ColumnArray.cpp
@@ -1110,6 +1110,11 @@ void ColumnArray::insertFromDatumData(const char * data, size_t length)
     insertData(data, precise_data_size);
 }
 
+std::pair<UInt32, StringRef> ColumnArray::getElementRef(size_t element_idx) const
+{
+    return {static_cast<UInt32>(sizeAt(element_idx)), getDataAt(element_idx)};
+}
+
 size_t ColumnArray::encodeIntoDatumData(size_t element_idx, WriteBuffer & writer) const
 {
     RUNTIME_CHECK(boost::endian::order::native == boost::endian::order::little);

--- a/dbms/src/Columns/ColumnArray.cpp
+++ b/dbms/src/Columns/ColumnArray.cpp
@@ -1115,25 +1115,4 @@ std::pair<UInt32, StringRef> ColumnArray::getElementRef(size_t element_idx) cons
     return {static_cast<UInt32>(sizeAt(element_idx)), getDataAt(element_idx)};
 }
 
-size_t ColumnArray::encodeIntoDatumData(size_t element_idx, WriteBuffer & writer) const
-{
-    RUNTIME_CHECK(boost::endian::order::native == boost::endian::order::little);
-
-    RUNTIME_CHECK(checkAndGetColumn<ColumnVector<Float32>>(&getData()));
-    RUNTIME_CHECK(getData().isFixedAndContiguous());
-
-    auto n = static_cast<UInt32>(sizeAt(element_idx));
-
-    writeIntBinary(n, writer);
-    size_t encoded_size = sizeof(UInt32);
-
-    auto data = getDataAt(element_idx);
-    RUNTIME_CHECK(data.size == n * sizeof(Float32));
-    writer.write(data.data, data.size);
-    encoded_size += data.size;
-
-    return encoded_size;
-}
-
-
 } // namespace DB

--- a/dbms/src/Columns/ColumnArray.h
+++ b/dbms/src/Columns/ColumnArray.h
@@ -174,7 +174,6 @@ public:
 
     void insertFromDatumData(const char * data, size_t length) override;
 
-    size_t encodeIntoDatumData(size_t element_idx, WriteBuffer & writer) const;
     std::pair<UInt32, StringRef> getElementRef(size_t element_idx) const;
 
 private:

--- a/dbms/src/Columns/ColumnArray.h
+++ b/dbms/src/Columns/ColumnArray.h
@@ -175,6 +175,7 @@ public:
     void insertFromDatumData(const char * data, size_t length) override;
 
     size_t encodeIntoDatumData(size_t element_idx, WriteBuffer & writer) const;
+    std::pair<UInt32, StringRef> getElementRef(size_t element_idx) const;
 
 private:
     ColumnPtr data;

--- a/dbms/src/Flash/Coprocessor/ArrowColCodec.cpp
+++ b/dbms/src/Flash/Coprocessor/ArrowColCodec.cpp
@@ -305,8 +305,6 @@ void flashArrayFloat32ColToArrowCol(
     const IColumn * nested_col = getNestedCol(flash_col_untyped);
     const auto * flash_col = checkAndGetColumn<ColumnArray>(nested_col);
 
-    RUNTIME_CHECK(boost::endian::order::native == boost::endian::order::little);
-
     RUNTIME_CHECK(checkAndGetColumn<ColumnVector<Float32>>(&flash_col->getData()));
     RUNTIME_CHECK(flash_col->getData().isFixedAndContiguous());
 

--- a/dbms/src/Flash/Coprocessor/TiDBChunk.cpp
+++ b/dbms/src/Flash/Coprocessor/TiDBChunk.cpp
@@ -31,7 +31,7 @@ namespace DB
 {
 TiDBChunk::TiDBChunk(const std::vector<tipb::FieldType> & field_types)
 {
-    for (auto & type : field_types)
+    for (const auto & type : field_types)
     {
         columns.emplace_back(getFieldLengthForArrowEncode(type.tp()));
     }

--- a/dbms/src/Flash/Coprocessor/TiDBColumn.cpp
+++ b/dbms/src/Flash/Coprocessor/TiDBColumn.cpp
@@ -123,7 +123,7 @@ void TiDBColumn::append(const TiDBEnum & ti_enum)
 
 void TiDBColumn::appendVectorF32(UInt32 num_elem, StringRef elem_bytes)
 {
-    writeIntBinary(num_elem, *data);
+    encodeLittleEndian<UInt32>(num_elem, *data);
     size_t encoded_size = sizeof(UInt32);
 
     RUNTIME_CHECK(elem_bytes.size == num_elem * sizeof(Float32));

--- a/dbms/src/Flash/Coprocessor/TiDBColumn.h
+++ b/dbms/src/Flash/Coprocessor/TiDBColumn.h
@@ -41,19 +41,19 @@ public:
     void append(const TiDBDecimal & decimal);
     void append(const TiDBBit & bit);
     void append(const TiDBEnum & ti_enum);
+    void appendVectorF32(UInt32 num_elem, StringRef elem_bytes);
     void encodeColumn(WriteBuffer & ss);
     void clear();
 
-    // FIXME: expose for ColumnArray::encodeIntoDatumData, find a better way to implement it.
-    void finishAppendVar(UInt32 size);
-    // WriteBufferFromOwnString is not moveable.
-    std::unique_ptr<WriteBufferFromOwnString> data;
-
 private:
+    void finishAppendVar(UInt32 size);
     void finishAppendFixed();
     bool isFixed() const { return fixed_size != VAR_SIZE; }
 
     void appendNullBitMap(bool value);
+
+    // WriteBufferFromOwnString is not moveable.
+    std::unique_ptr<WriteBufferFromOwnString> data;
 
     UInt32 length;
     UInt32 null_cnt;

--- a/dbms/src/Flash/Coprocessor/tests/gtest_streaming_writer.cpp
+++ b/dbms/src/Flash/Coprocessor/tests/gtest_streaming_writer.cpp
@@ -41,7 +41,7 @@ protected:
     }
 
 public:
-    TestStreamingWriter() {}
+    TestStreamingWriter() = default;
 
     // Return 10 Int64 column.
     static std::vector<tipb::FieldType> makeFields()
@@ -93,7 +93,7 @@ struct MockStreamWriter
     {}
 
     void write(tipb::SelectResponse & response) { checker(response); }
-    bool isWritable() const { throw Exception("Unsupport async write"); }
+    static bool isWritable() { throw Exception("Unsupport async write"); }
 
 private:
     MockStreamWriterChecker checker;

--- a/dbms/src/TiDB/Schema/TiDB.h
+++ b/dbms/src/TiDB/Schema/TiDB.h
@@ -56,6 +56,7 @@ using DB::Timestamp;
 // Column types.
 // In format:
 // TiDB type, int value, codec flag, CH type.
+// The int value is defined in pingcap/tidb pkg/parser/mysql/type.go
 #ifdef M
 #error "Please undefine macro M first."
 #endif


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/9032

Problem Summary:

`TiDBColumn::data` and `TiDBColumn::finishAppendVar` should not be exposed as public

### What is changed and how it works?

```commit-message

```

* Add `TiDBColumn::appendVectorF32` and `ColumnArray::getElementRef` to replace the origin implementation
* Use `encodeLittleEndian` in `TiDBColumn::appendVectorF32` instead of exception checking

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
