### PR TITLE
Use secure versions of memset and strncpy in libtrie and libcpuid

### DIFF
--- a/contrib/libbtrie/src/btrie.c
+++ b/contrib/libbtrie/src/btrie.c
@@ -46,7 +46,7 @@ btrie_create()
     tree->free  = NULL;
     tree->start = NULL;
     tree->size  = 0;
-    memset_s(tree->pools, 0, sizeof(btrie_t *) * BTRIE_MAX_PAGES);
+    memset_s(tree->pools, sizeof(char *) * BTRIE_MAX_PAGES, 0, sizeof(btrie_t *) * BTRIE_MAX_PAGES);
     tree->len = 0;
 
     tree->root = btrie_alloc(tree);

--- a/contrib/libbtrie/src/btrie.c
+++ b/contrib/libbtrie/src/btrie.c
@@ -46,7 +46,7 @@ btrie_create()
     tree->free  = NULL;
     tree->start = NULL;
     tree->size  = 0;
-    memset(tree->pools, 0, sizeof(btrie_t *) * BTRIE_MAX_PAGES);
+    memset_s(tree->pools, 0, sizeof(btrie_t *) * BTRIE_MAX_PAGES);
     tree->len = 0;
 
     tree->root = btrie_alloc(tree);

--- a/contrib/libcpuid/include/cpuid/cpuid_main.c
+++ b/contrib/libcpuid/include/cpuid/cpuid_main.c
@@ -285,7 +285,7 @@ static int cpuid_basic_identify(struct cpu_raw_data_t* raw, struct cpu_id_t* dat
 		brandstr[48] = 0;
 		i = 0;
 		while (brandstr[i] == ' ') i++;
-		strncpy_s(data->brand_str, brandstr + i, sizeof(data->brand_str));
+		strncpy_s(data->brand_str, BRAND_STR_MAX, brandstr + i, sizeof(data->brand_str));
 		data->brand_str[48] = 0;
 	}
 	load_features_common(raw, data);

--- a/contrib/libcpuid/include/cpuid/cpuid_main.c
+++ b/contrib/libcpuid/include/cpuid/cpuid_main.c
@@ -285,7 +285,7 @@ static int cpuid_basic_identify(struct cpu_raw_data_t* raw, struct cpu_id_t* dat
 		brandstr[48] = 0;
 		i = 0;
 		while (brandstr[i] == ' ') i++;
-		strncpy(data->brand_str, brandstr + i, sizeof(data->brand_str));
+		strncpy_s(data->brand_str, brandstr + i, sizeof(data->brand_str));
 		data->brand_str[48] = 0;
 	}
 	load_features_common(raw, data);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9280

Problem Summary: see #9280.

### What is changed and how it works?

```commit-message

Replace the usages of `memset` and `strncpy` with their secure versions.

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Replace the usages of `memset` and `strncpy` with their secure versions.
```
