### PR TITLE
PageStorage: Fix empty page cause TiFlash failed to start

### DIFF
--- a/dbms/src/Common/UniThreadPool.h
+++ b/dbms/src/Common/UniThreadPool.h
@@ -29,7 +29,6 @@
 #include <memory>
 #include <mutex>
 #include <optional>
-#include <queue>
 #include <thread>
 
 namespace DB

--- a/dbms/src/Storages/Page/V3/Blob/BlobStat.cpp
+++ b/dbms/src/Storages/Page/V3/Blob/BlobStat.cpp
@@ -216,8 +216,6 @@ std::pair<BlobStats::BlobStatPtr, BlobFileId> BlobStats::chooseStat(
     PageType page_type,
     const std::lock_guard<std::mutex> &)
 {
-    BlobStatPtr stat_ptr = nullptr;
-
     // No stats exist
     if (stats_map.empty())
     {
@@ -301,6 +299,12 @@ BlobStats::StatsMap BlobStats::getStats() const NO_THREAD_SAFETY_ANALYSIS
 
 BlobFileOffset BlobStats::BlobStat::getPosFromStat(size_t buf_size, const std::unique_lock<std::mutex> &)
 {
+    // A shortcut for empty page. All empty pages will be stored
+    // at the beginning of the BlobFile. It should not affects the
+    // sm_max_caps or other fields by adding these empty pages.
+    if (unlikely(buf_size == 0))
+        return 0;
+
     BlobFileOffset offset = 0;
     UInt64 max_cap = 0;
     bool expansion = true;

--- a/dbms/src/Storages/Page/V3/Blob/BlobStat.cpp
+++ b/dbms/src/Storages/Page/V3/Blob/BlobStat.cpp
@@ -15,6 +15,7 @@
 #include <Common/ProfileEvents.h>
 #include <Storages/Page/V3/Blob/BlobFile.h>
 #include <Storages/Page/V3/Blob/BlobStat.h>
+#include <Storages/Page/V3/PageDefines.h>
 #include <Storages/PathPool.h>
 #include <boost_wrapper/string_split.h>
 #include <common/logger_useful.h>

--- a/dbms/src/Storages/Page/V3/BlobStore.cpp
+++ b/dbms/src/Storages/Page/V3/BlobStore.cpp
@@ -729,6 +729,7 @@ std::pair<BlobFileId, BlobFileOffset> BlobStore<Trait>::getPosFromStats(size_t s
     Stopwatch watch;
     BlobStatPtr stat;
 
+    // TODO: make this lambda as a function of BlobStats to simplify code
     auto lock_stat = [size, this, &stat, &page_type]() NO_THREAD_SAFETY_ANALYSIS {
         auto lock_stats = blob_stats.lock();
         BlobFileId blob_file_id = INVALID_BLOBFILE_ID;

--- a/dbms/src/Storages/Page/V3/BlobStore.cpp
+++ b/dbms/src/Storages/Page/V3/BlobStore.cpp
@@ -1012,7 +1012,6 @@ typename BlobStore<Trait>::PageMap BlobStore<Trait>::read(
         for (const auto & [page_id_v3, entry] : entries)
         {
             // Unexpected behavior but do no harm
-            LOG_INFO(log, "Read entry without entry size, page_id={} entry={}", page_id_v3, entry);
             Page page(Trait::PageIdTrait::getU64ID(page_id_v3));
             page.data = std::string_view(nullptr, 0);
             page_map.emplace(Trait::PageIdTrait::getPageMapKey(page_id_v3), page);
@@ -1100,7 +1099,6 @@ Page BlobStore<Trait>::read(const PageIdAndEntry & id_entry, const ReadLimiterPt
     if (buf_size == 0)
     {
         // Unexpected behavior but do no harm
-        LOG_INFO(log, "Read entry without entry size, page_id={} entry={}", page_id_v3, entry);
         Page page(Trait::PageIdTrait::getU64ID(page_id_v3));
         page.data = std::string_view(nullptr, 0);
         return page;

--- a/dbms/src/Storages/Page/V3/BlobStore.cpp
+++ b/dbms/src/Storages/Page/V3/BlobStore.cpp
@@ -36,7 +36,6 @@
 #include <fiu.h>
 
 #include <ext/scope_guard.h>
-#include <iterator>
 #include <magic_enum.hpp>
 #include <unordered_map>
 
@@ -1014,6 +1013,7 @@ typename BlobStore<Trait>::PageMap BlobStore<Trait>::read(
             // Unexpected behavior but do no harm
             LOG_INFO(log, "Read entry without entry size, page_id={} entry={}", page_id_v3, entry);
             Page page(Trait::PageIdTrait::getU64ID(page_id_v3));
+            page.data = std::string_view(nullptr, 0);
             page_map.emplace(Trait::PageIdTrait::getPageMapKey(page_id_v3), page);
         }
         return page_map;
@@ -1101,6 +1101,7 @@ Page BlobStore<Trait>::read(const PageIdAndEntry & id_entry, const ReadLimiterPt
         // Unexpected behavior but do no harm
         LOG_INFO(log, "Read entry without entry size, page_id={} entry={}", page_id_v3, entry);
         Page page(Trait::PageIdTrait::getU64ID(page_id_v3));
+        page.data = std::string_view(nullptr, 0);
         return page;
     }
 

--- a/dbms/src/Storages/Page/V3/BlobStore.cpp
+++ b/dbms/src/Storages/Page/V3/BlobStore.cpp
@@ -918,8 +918,7 @@ typename BlobStore<Trait>::PageMap BlobStore<Trait>::read(FieldReadInfos & to_re
             // TODO: Continuously fields can read by one system call.
             const auto [beg_offset, end_offset] = entry.getFieldOffsets(field_index);
             const auto size_to_read = end_offset - beg_offset;
-            auto blob_file
-                = read(page_id_v3, entry.file_id, entry.offset + beg_offset, write_offset, size_to_read, read_limiter);
+            read(page_id_v3, entry.file_id, entry.offset + beg_offset, write_offset, size_to_read, read_limiter);
             fields_offset_in_page.emplace(field_index, read_size_this_entry);
 
             if constexpr (BLOBSTORE_CHECKSUM_ON_READ)
@@ -935,15 +934,14 @@ typename BlobStore<Trait>::PageMap BlobStore<Trait>::read(FieldReadInfos & to_re
                         "Reading with fields meet checksum not match "
                         "page_id={} expected=0x{:X} actual=0x{:X} "
                         "field_index={} field_offset={} field_size={} "
-                        "entry={} file={}",
+                        "entry={}",
                         page_id_v3,
                         expect_checksum,
                         field_checksum,
                         field_index,
                         beg_offset,
                         size_to_read,
-                        entry,
-                        blob_file->getPath());
+                        entry);
                 }
             }
 
@@ -1028,7 +1026,7 @@ typename BlobStore<Trait>::PageMap BlobStore<Trait>::read(
     PageMap page_map;
     for (const auto & [page_id_v3, entry] : entries)
     {
-        auto blob_file = read(page_id_v3, entry.file_id, entry.offset, pos, entry.size, read_limiter);
+        read(page_id_v3, entry.file_id, entry.offset, pos, entry.size, read_limiter);
 
         if constexpr (BLOBSTORE_CHECKSUM_ON_READ)
         {
@@ -1040,12 +1038,11 @@ typename BlobStore<Trait>::PageMap BlobStore<Trait>::read(
                 throw Exception(
                     ErrorCodes::CHECKSUM_DOESNT_MATCH,
                     "Reading with entries meet checksum not match page_id={} expected=0x{:X} actual=0x{:X} "
-                    "entry={} file={}",
+                    "entry={}",
                     page_id_v3,
                     entry.checksum,
                     checksum,
-                    entry,
-                    blob_file->getPath());
+                    entry);
             }
         }
 
@@ -1110,7 +1107,7 @@ Page BlobStore<Trait>::read(const PageIdAndEntry & id_entry, const ReadLimiterPt
     char * data_buf = static_cast<char *>(alloc(buf_size));
     MemHolder mem_holder = createMemHolder(data_buf, [&, buf_size](char * p) { free(p, buf_size); });
 
-    auto blob_file = read(page_id_v3, entry.file_id, entry.offset, data_buf, buf_size, read_limiter);
+    read(page_id_v3, entry.file_id, entry.offset, data_buf, buf_size, read_limiter);
     if constexpr (BLOBSTORE_CHECKSUM_ON_READ)
     {
         ChecksumClass digest;
@@ -1119,15 +1116,13 @@ Page BlobStore<Trait>::read(const PageIdAndEntry & id_entry, const ReadLimiterPt
         if (unlikely(entry.size != 0 && checksum != entry.checksum))
         {
             throw Exception(
-                fmt::format(
-                    "Reading with entries meet checksum not match [page_id={}] [expected=0x{:X}] [actual=0x{:X}] "
-                    "[entry={}] [file={}]",
-                    page_id_v3,
-                    entry.checksum,
-                    checksum,
-                    entry,
-                    blob_file->getPath()),
-                ErrorCodes::CHECKSUM_DOESNT_MATCH);
+                ErrorCodes::CHECKSUM_DOESNT_MATCH,
+                "Reading with entries meet checksum not match page_id={} expected=0x{:X} actual=0x{:X} "
+                "entry={}",
+                page_id_v3,
+                entry.checksum,
+                checksum,
+                entry);
         }
     }
 
@@ -1146,7 +1141,7 @@ Page BlobStore<Trait>::read(const PageIdAndEntry & id_entry, const ReadLimiterPt
 }
 
 template <typename Trait>
-BlobFilePtr BlobStore<Trait>::read(
+void BlobStore<Trait>::read(
     const typename BlobStore<Trait>::PageId & page_id_v3,
     BlobFileId blob_id,
     BlobFileOffset offset,
@@ -1156,6 +1151,12 @@ BlobFilePtr BlobStore<Trait>::read(
     bool background)
 {
     GET_METRIC(tiflash_storage_page_command_count, type_read_blob).Increment();
+
+    // A shortcut to avoid unnecessary locks / system call when "reading an empty page"
+    // Reading an empty page should not create a BlobFile if it has already removed.
+    if (unlikely(size == 0))
+        return;
+
     assert(buffers != nullptr);
     BlobFilePtr blob_file = getBlobFile(blob_id);
     try
@@ -1174,7 +1175,6 @@ BlobFilePtr BlobStore<Trait>::read(
             background));
         e.rethrow();
     }
-    return blob_file;
 }
 
 

--- a/dbms/src/Storages/Page/V3/BlobStore.h
+++ b/dbms/src/Storages/Page/V3/BlobStore.h
@@ -126,7 +126,7 @@ private:
         PageType page_type,
         const WriteLimiterPtr & write_limiter = nullptr);
 
-    BlobFilePtr read(
+    void read(
         const PageId & page_id_v3,
         BlobFileId blob_id,
         BlobFileOffset offset,

--- a/dbms/src/Storages/Page/V3/PageEntry.h
+++ b/dbms/src/Storages/Page/V3/PageEntry.h
@@ -51,7 +51,7 @@ public:
     OptionalCheckpointInfo checkpoint_info;
 
     // The offset to the beginning of specify field.
-    PageFieldOffsetChecksums field_offsets{};
+    PageFieldOffsetChecksums field_offsets;
 
 public:
     PageSize getTotalSize() const { return size + padded_size; }
@@ -60,54 +60,48 @@ public:
 
     size_t getFieldSize(size_t index) const
     {
-        if (unlikely(index >= field_offsets.size()))
-            throw Exception(
-                fmt::format(
-                    "Try to getFieldData of PageEntry [blob_id={}] with invalid [index={}] [fields size={}]",
-                    file_id,
-                    index,
-                    field_offsets.size()),
-                ErrorCodes::LOGICAL_ERROR);
-        else if (index == field_offsets.size() - 1)
+        RUNTIME_CHECK_MSG(
+            index < field_offsets.size(),
+            "Try to getFieldData of PageEntry [blob_id={}] with invalid [index={}] [fields size={}]",
+            file_id,
+            index,
+            field_offsets.size());
+        if (index != field_offsets.size() - 1)
         {
-            if (checkpoint_info.has_value() && checkpoint_info.is_local_data_reclaimed)
-            {
-                // entry.size is not reliable under this case, use the size_in_file in checkpoint_info instead
-                return checkpoint_info.data_location.size_in_file - field_offsets.back().first;
-            }
-            else
-            {
-                return size - field_offsets.back().first;
-            }
+            return field_offsets[index + 1].first - field_offsets[index].first;
+        }
+        if (checkpoint_info.has_value() && checkpoint_info.is_local_data_reclaimed)
+        {
+            // entry.size is not reliable under this case, use the size_in_file in checkpoint_info instead
+            return checkpoint_info.data_location.size_in_file - field_offsets.back().first;
         }
         else
-            return field_offsets[index + 1].first - field_offsets[index].first;
+        {
+            return size - field_offsets.back().first;
+        }
     }
 
     // Return field{index} offsets: [begin, end) of page data.
     std::pair<size_t, size_t> getFieldOffsets(size_t index) const
     {
-        if (unlikely(index >= field_offsets.size()))
-            throw Exception(
-                fmt::format(
-                    "Try to getFieldOffsets with invalid index [index={}] [fields_size={}]",
-                    index,
-                    field_offsets.size()),
-                ErrorCodes::LOGICAL_ERROR);
-        else if (index == field_offsets.size() - 1)
+        RUNTIME_CHECK_MSG(
+            index < field_offsets.size(),
+            "Try to getFieldOffsets with invalid index [index={}] [fields_size={}]",
+            index,
+            field_offsets.size());
+        if (index != field_offsets.size() - 1)
         {
-            if (checkpoint_info.has_value() && checkpoint_info.is_local_data_reclaimed)
-            {
-                // entry.size is not reliable under this case, use the size_in_file in checkpoint_info instead
-                return {field_offsets.back().first, checkpoint_info.data_location.size_in_file};
-            }
-            else
-            {
-                return {field_offsets.back().first, size};
-            }
+            return {field_offsets[index].first, field_offsets[index + 1].first};
+        }
+        if (checkpoint_info.has_value() && checkpoint_info.is_local_data_reclaimed)
+        {
+            // entry.size is not reliable under this case, use the size_in_file in checkpoint_info instead
+            return {field_offsets.back().first, checkpoint_info.data_location.size_in_file};
         }
         else
-            return {field_offsets[index].first, field_offsets[index + 1].first};
+        {
+            return {field_offsets.back().first, size};
+        }
     }
 };
 using PageEntriesV3 = std::vector<PageEntryV3>;

--- a/dbms/src/Storages/Page/V3/spacemap/SpaceMap.cpp
+++ b/dbms/src/Storages/Page/V3/spacemap/SpaceMap.cpp
@@ -17,9 +17,6 @@
 #include <Storages/Page/V3/spacemap/SpaceMap.h>
 #include <Storages/Page/V3/spacemap/SpaceMapSTDMap.h>
 #include <common/likely.h>
-#include <limits.h>
-#include <stdio.h>
-#include <stdlib.h>
 
 namespace DB
 {
@@ -52,14 +49,17 @@ SpaceMapPtr SpaceMap::createSpaceMap(SpaceMapType type, UInt64 start, UInt64 end
     return smap;
 }
 
-bool SpaceMap::checkSpace(UInt64 offset, size_t size) const
+bool SpaceMap::isInvalidRange(UInt64 offset, size_t size) const
 {
-    return (offset < start) || (offset > end) || (offset + size - 1 > end);
+    return (offset < start)
+        || (offset > end)
+        // check whether it can be changed to `(offset + size > end)`
+        || ((size != 0) && (offset + size - 1 > end));
 }
 
 bool SpaceMap::markFree(UInt64 offset, size_t length)
 {
-    if (checkSpace(offset, length))
+    if (isInvalidRange(offset, length))
     {
         throw Exception(
             fmt::format(
@@ -75,7 +75,7 @@ bool SpaceMap::markFree(UInt64 offset, size_t length)
 
 bool SpaceMap::markUsed(UInt64 offset, size_t length)
 {
-    if (checkSpace(offset, length))
+    if (isInvalidRange(offset, length))
     {
         throw Exception(
             fmt::format(
@@ -91,7 +91,7 @@ bool SpaceMap::markUsed(UInt64 offset, size_t length)
 
 bool SpaceMap::isMarkUsed(UInt64 offset, size_t length)
 {
-    if (checkSpace(offset, length))
+    if (isInvalidRange(offset, length))
     {
         throw Exception(
             fmt::format(

--- a/dbms/src/Storages/Page/V3/spacemap/SpaceMap.h
+++ b/dbms/src/Storages/Page/V3/spacemap/SpaceMap.h
@@ -145,7 +145,7 @@ protected:
 
 private:
     /* Check the range */
-    bool checkSpace(UInt64 offset, size_t size) const;
+    bool isInvalidRange(UInt64 offset, size_t size) const;
 
 #ifndef DBMS_PUBLIC_GTEST
 protected:

--- a/dbms/src/Storages/Page/V3/spacemap/SpaceMap.h
+++ b/dbms/src/Storages/Page/V3/spacemap/SpaceMap.h
@@ -82,7 +82,7 @@ public:
      * If such span is found.
      * It will mark that span to be used and also return a hint of the max capacity available in this SpaceMap. 
      * 
-     * return value is <insert_offset, max_cap>:
+     * return value is <insert_offset, max_cap, is_expansion>:
      *  insert_offset: start offset for the inserted space
      *  max_cap: A hint of the largest available space this SpaceMap can hold. 
      *  is_expansion: Whether it is an expansion span

--- a/dbms/src/Storages/Page/V3/spacemap/SpaceMapSTDMap.h
+++ b/dbms/src/Storages/Page/V3/spacemap/SpaceMapSTDMap.h
@@ -153,6 +153,11 @@ protected:
 
     bool markUsedImpl(UInt64 offset, size_t length) override
     {
+        // An empty data, we can simply consider it is stored and return true
+        // Do not let it split the space into smaller pieces.
+        if (length == 0)
+            return true;
+
         auto it = MapUtils::findLessEQ(free_map, offset); // first free block <= `offset`
         if (it == free_map.end())
         {
@@ -255,20 +260,19 @@ protected:
 
     bool markFreeImpl(UInt64 offset, size_t length) override
     {
-        auto it = free_map.find(offset);
+        // for an empty blob, no new free block is created, just skip
+        if (length == 0)
+        {
+            return true;
+        }
 
         /**
          * already unmarked.
          * The `offset` won't be mid of free space.
          * Because we alloc space from left to right.
          */
+        auto it = free_map.find(offset);
         if (it != free_map.end())
-        {
-            return true;
-        }
-
-        // for an empty blob, no new free block is created, just skip
-        if (length == 0)
         {
             return true;
         }

--- a/dbms/src/Storages/Page/V3/spacemap/SpaceMapSTDMap.h
+++ b/dbms/src/Storages/Page/V3/spacemap/SpaceMapSTDMap.h
@@ -20,6 +20,7 @@
 
 #include <ext/shared_ptr_helper.h>
 #include <map>
+#include <tuple>
 
 namespace DB
 {
@@ -222,8 +223,15 @@ protected:
         return true;
     }
 
+    // return value is <insert_offset, max_cap, is_expansion>
     std::tuple<UInt64, UInt64, bool> searchInsertOffset(size_t size) override
     {
+        if (unlikely(size == 0))
+        {
+            // The returned `max_cap` is 0 under this case, user should not use it.
+            return std::make_tuple(0, 0, false);
+        }
+
         if (unlikely(free_map.empty()))
         {
             LOG_ERROR(Logger::get(), "Current space map is full");

--- a/dbms/src/Storages/Page/V3/tests/gtest_blob_stat.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_blob_stat.cpp
@@ -391,13 +391,20 @@ TEST_F(BlobStoreStatsTest, StatWithEmptyBlob)
     ASSERT_EQ(offset, 0);
 
     offset = stat->getPosFromStat(0, stat->lock()); // empty
-    ASSERT_EQ(offset, 10);
+    ASSERT_EQ(offset, 0); // empty page always "stored" to the beginning of the space
+    offset = stat->getPosFromStat(0, stat->lock()); // empty
+    ASSERT_EQ(offset, 0); // empty page always "stored" to the beginning of the space
+    offset = stat->getPosFromStat(0, stat->lock()); // empty
+    ASSERT_EQ(offset, 0); // empty page always "stored" to the beginning of the space
 
     offset = stat->getPosFromStat(20, stat->lock());
     ASSERT_EQ(offset, 10);
 
     offset = stat->getPosFromStat(100, stat->lock());
     ASSERT_EQ(offset, 30);
+
+    offset = stat->getPosFromStat(0, stat->lock()); // empty
+    ASSERT_EQ(offset, 0); // empty page always "stored" to the beginning of the space
 
     ASSERT_EQ(stat->sm_total_size, 10 + 20 + 100);
     ASSERT_EQ(stat->sm_valid_size, 10 + 20 + 100);
@@ -419,9 +426,8 @@ TEST_F(BlobStoreStatsTest, testFullStats)
     BlobStats stats(logger, delegator, config);
 
     {
-        std::lock_guard lock(stats.lock_stats);
         BlobFileId file_id = 10;
-        BlobStats::BlobStatPtr stat = stats.createStat(file_id, config.file_limit_size, lock);
+        BlobStats::BlobStatPtr stat = stats.createStat(file_id, config.file_limit_size, stats.lock());
         auto offset = stat->getPosFromStat(BLOBFILE_LIMIT_SIZE - 1, stat->lock());
         ASSERT_EQ(offset, 0);
         stats.cur_max_id = file_id;

--- a/dbms/src/Storages/Page/V3/tests/gtest_blob_stat.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_blob_stat.cpp
@@ -165,7 +165,7 @@ try
 }
 CATCH
 
-TEST_F(BlobStoreStatsTest, RestoreWithEmptyPage)
+TEST_F(BlobStoreStatsTest, RestoreWithEmptyPageSamePosition)
 try
 {
     BlobStats stats(logger, delegator, config);
@@ -216,6 +216,54 @@ try
     auto stat = stats.blobIdToStat(file_id1);
     EXPECT_EQ(stat->sm_total_size, 2048 + 512);
     EXPECT_EQ(stat->sm_valid_size, 1024 + 512);
+
+    EXPECT_ANY_THROW({ stats.createStat(file_id1, config.file_limit_size, stats.lock()); });
+}
+CATCH
+
+TEST_F(BlobStoreStatsTest, RestoreWithEmptyPageSplitSpace)
+try
+{
+    BlobStats stats(logger, delegator, config);
+
+    BlobFileId file_id1 = 11;
+
+    {
+        std::lock_guard lock(stats.lock_stats);
+        stats.createStatNotChecking(file_id1, config.file_limit_size, lock);
+    }
+
+    {
+        // an entry at offset=0x15376, size=0
+        stats.restoreByEntry(PageEntryV3{
+            .file_id = file_id1,
+            .size = 0,
+            .padded_size = 0,
+            .tag = 0,
+            .offset = 0x15376,
+            .checksum = 0x4567,
+        });
+        // an entry at offset=0x15373, size=15. offset+size > 0x15376, but should be able to insert
+        stats.restoreByEntry(PageEntryV3{
+            .file_id = file_id1,
+            .size = 15,
+            .padded_size = 0,
+            .tag = 0,
+            .offset = 0x15373,
+            .checksum = 0x4567,
+        });
+        stats.restore();
+    }
+
+    auto stats_copy = stats.getStats();
+
+    ASSERT_EQ(stats_copy.size(), std::min(getTotalStatsNum(stats_copy), path_num));
+    ASSERT_EQ(getTotalStatsNum(stats_copy), 1);
+    EXPECT_EQ(stats.cur_max_id, file_id1);
+
+    auto stat = stats.blobIdToStat(file_id1);
+    EXPECT_EQ(stat->sm_total_size, 0x15373 + 15);
+    EXPECT_EQ(stat->sm_valid_size, 15);
 
     EXPECT_ANY_THROW({ stats.createStat(file_id1, config.file_limit_size, stats.lock()); });
 }

--- a/dbms/src/Storages/Page/V3/tests/gtest_blob_store.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_blob_store.cpp
@@ -31,9 +31,12 @@
 #include <TestUtils/TiFlashStorageTestBasic.h>
 #include <TestUtils/TiFlashTestBasic.h>
 
+#include <ext/scope_guard.h>
+
 namespace DB::FailPoints
 {
 extern const char exception_after_large_write_exceed[];
+extern const char force_pick_all_blobs_to_full_gc[];
 } // namespace DB::FailPoints
 
 namespace DB::PS::V3::tests
@@ -1645,7 +1648,7 @@ try
         page_type_and_config);
 
     {
-        size_t size_500 = 500;
+        const size_t size_500 = 500;
         char c_buff[size_500];
 
         WriteBatch wb;
@@ -1656,10 +1659,63 @@ try
         const auto & gc_info = blob_store.getGCStats();
         ASSERT_TRUE(gc_info.empty());
 
+        // only one blob_file for the large write
         ASSERT_EQ(getTotalStatsNum(blob_store.blob_stats.getStats()), 1);
         const auto & records = edit.getRecords();
         ASSERT_EQ(records.size(), 1);
         blob_store.removeEntries({records[0].entry});
+        ASSERT_EQ(getTotalStatsNum(blob_store.blob_stats.getStats()), 0);
+    }
+}
+CATCH
+
+TEST_F(BlobStoreTest, ReadEmptyPageAfterAllValidEntriesRmoved)
+try
+{
+    const auto file_provider = DB::tests::TiFlashTestEnv::getMockFileProvider();
+
+    BlobConfig config_with_small_file_limit_size;
+    config_with_small_file_limit_size.file_limit_size = 400;
+    auto blob_store = BlobStore(
+        getCurrentTestName(),
+        file_provider,
+        delegator,
+        config_with_small_file_limit_size,
+        page_type_and_config);
+
+    {
+        const size_t size_500 = 500;
+        char c_buff[size_500];
+
+        WriteBatch wb;
+        ReadBufferPtr buff = std::make_shared<ReadBufferFromMemory>(c_buff, size_500);
+        wb.putPage(50, /* tag */ 0, buff, size_500);
+        wb.putPage(51, 0, std::make_shared<ReadBufferFromMemory>(c_buff, 0), 0);
+        wb.putPage(52, 0, std::make_shared<ReadBufferFromMemory>(c_buff, 20), 20);
+        wb.putPage(53, 0, std::make_shared<ReadBufferFromMemory>(c_buff, 0), 0);
+        PageEntriesEdit edit = blob_store.write(std::move(wb));
+
+        // make the blob_file to be READ_ONLY
+        FailPointHelper::enableFailPoint(FailPoints::force_pick_all_blobs_to_full_gc);
+        SCOPE_EXIT({ FailPointHelper::disableFailPoint(FailPoints::force_pick_all_blobs_to_full_gc); });
+        const auto & gc_info = blob_store.getGCStats();
+        ASSERT_FALSE(gc_info.empty());
+
+        // one blob_file for the large write, another for the other pages
+        ASSERT_EQ(getTotalStatsNum(blob_store.blob_stats.getStats()), 2);
+        const auto & records = edit.getRecords();
+        ASSERT_EQ(records.size(), 4);
+        // remove the non-empty entries
+        blob_store.removeEntries({records[0].entry, records[2].entry});
+
+        /// try to read the empty pages after the blob_file get removed, no exception should happen
+        // read-1-entry
+        blob_store.read(PageIDAndEntryV3(51, records[1].entry), nullptr);
+        blob_store.read(PageIDAndEntryV3(53, records[3].entry), nullptr);
+        // read multiple entry
+        PageIDAndEntriesV3 entries{PageIDAndEntryV3(51, records[1].entry), PageIDAndEntryV3(53, records[3].entry)};
+        blob_store.read(entries, nullptr);
+
         ASSERT_EQ(getTotalStatsNum(blob_store.blob_stats.getStats()), 0);
     }
 }

--- a/dbms/src/Storages/Page/V3/tests/gtest_page_storage.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_page_storage.cpp
@@ -1950,6 +1950,7 @@ try
     }
 
     FailPointHelper::enableFailPoint(FailPoints::force_pick_all_blobs_to_full_gc);
+    SCOPE_EXIT({ FailPointHelper::disableFailPoint(FailPoints::force_pick_all_blobs_to_full_gc); });
     auto done_full_gc = page_storage->gc();
     EXPECT_TRUE(done_full_gc);
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/9282

Problem Summary:

By dumping the entries from PageStorage WAL, we can locate that two entries cause this issue:
```
[PageDirectoryFactory.cpp:225] ["{type:VAR_ENT, page_id:0x020102000000009CA4430A08, ori_id:0x.0, version:108969363.0, entry:PageEntry{file: 551, offset: 0x15376, size: 0, checksum: 0x0, tag: 0, field_offsets: [], checkpoint_info: invalid}, being_ref_count:1}"] [thread_id=1]
[PageDirectoryFactory.cpp:225] ["{type:PUT    , page_id:0x020102000000018204A17C03, ori_id:0x.0, version:127726467.0, entry:PageEntry{file: 551, offset: 0x15373, size: 15, checksum: 0x12D46C1C0D5B51FE, tag: 0, field_offsets: [], checkpoint_info: invalid}, being_ref_count:1}"] [thread_id=1]
```

The first entry is a page with data.size == 0, placed at blob_id=551, offset=0x15376. And later another page is placed at blob_id=551, offset=0x15373 with data.size == 15.
The first page split the free block into smaller pieces free blocks.
The second page will cover the place of the first page. And our code can not handle this situation with "empty page data".

### What is changed and how it works?

* For handling the existing empty pages, we won't let it split the free block into small pieces:
  * when `STDMapSpaceMap::markUsedImpl` accept a block of `length == 0`, it will directly return true instead of splitting the free block into smaller pieces.
* For newly created empty pages, we store them at the front of BlobFile to avoid further issues:
  * `BlobStats::BlobStat::getPosFromStat` and `STDMapSpaceMap::searchInsertOffset` accepts a block of `length == 0`, it will return `insert_offset == 0`, which we can "store the empty pages" at the front of the BlobFile for newly created empty pages.
* In `BlobStore::read(...)`, we ensure that reading empty pages won't cause NPE or other unexpected exceptions

```commit-message
PageStorage: Fix empty page cause TiFlash failed to start
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix an issue that TiFlash write node may fail to restart under disaggregated arch
```
