### PR TITLE
*: add workflow in CMakePresets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -179,13 +179,13 @@
     },
     {
       "name": "tsan",
-      "displayName": "Build dbms ThreadSanitizer tests",
+      "displayName": "Build dbms Thread Sanitizer tests",
       "configurePreset": "tsan",
       "targets": ["gtests_dbms"]
     },
     {
       "name": "tsan-all",
-      "displayName": "Build all ThreadSanitizer tests",
+      "displayName": "Build all Thread Sanitizer tests",
       "configurePreset": "tsan",
       "targets": ["gtests_dbms, gtests_libdaemon, gtests_libcommon"]
     },
@@ -283,7 +283,7 @@
     },
     {
       "name": "tsan-tests",
-      "displayName": "Build dbms ThreadSanitizer tests workflow",
+      "displayName": "Build dbms Thread Sanitizer tests workflow",
       "steps": [
         {
           "type": "configure",
@@ -297,7 +297,7 @@
     },
     {
       "name": "tsan-tests-all",
-      "displayName": "Build all ThreadSanitizer tests workflow",
+      "displayName": "Build all Thread Sanitizer tests workflow",
       "steps": [
         {
           "type": "configure",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 6,
   "cmakeMinimumRequired": {
     "major": 3,
     "minor": 23,
@@ -126,6 +126,202 @@
       "displayName": "Benchmarks: RELEASE build with benchmarks enabled",
       "cacheVariables": {},
       "binaryDir": "${sourceDir}/cmake-build-release"
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "dev",
+      "displayName": "Build tiflash binary with debug info and tests enabled",
+      "configurePreset": "dev",
+      "targets": ["tiflash"]
+    },
+    {
+      "name": "unit-tests",
+      "displayName": "Build dbms unit tests",
+      "configurePreset": "dev",
+      "targets": ["gtests_dbms"]
+    },
+    {
+      "name": "unit-tests-all",
+      "displayName": "Build all unit tests",
+      "configurePreset": "dev",
+      "targets": ["gtests_dbms, gtests_libdaemon, gtests_libcommon"]
+    },
+    {
+      "name": "dev-coverage",
+      "displayName": "Build dbms unit tests with code coverage",
+      "configurePreset": "dev-coverage",
+      "targets": ["gtests_dbms"]
+    },
+    {
+      "name": "dev-coverage-all",
+      "displayName": "Build all unit tests with code coverage",
+      "configurePreset": "dev-coverage",
+      "targets": ["gtests_dbms, gtests_libdaemon, gtests_libcommon"]
+    },
+    {
+      "name": "release",
+      "displayName": "Build tiflash binary without debug info",
+      "configurePreset": "release",
+      "targets": ["tiflash"]
+    },
+    {
+      "name": "asan",
+      "displayName": "Build dbms Address Sanitizer tests",
+      "configurePreset": "asan",
+      "targets": ["gtests_dbms"]
+    },
+    {
+      "name": "asan-all",
+      "displayName": "Build all Address Sanitizer tests",
+      "configurePreset": "asan",
+      "targets": ["gtests_dbms, gtests_libdaemon, gtests_libcommon"]
+    },
+    {
+      "name": "tsan",
+      "displayName": "Build dbms ThreadSanitizer tests",
+      "configurePreset": "tsan",
+      "targets": ["gtests_dbms"]
+    },
+    {
+      "name": "tsan-all",
+      "displayName": "Build all ThreadSanitizer tests",
+      "configurePreset": "tsan",
+      "targets": ["gtests_dbms, gtests_libdaemon, gtests_libcommon"]
+    },
+    {
+      "name": "benchmarks",
+      "displayName": "Build benchmarks",
+      "configurePreset": "benchmarks",
+      "targets": ["bench_dbms"]
+    }
+  ],
+  "workflowPresets": [
+    {
+      "name": "dev",
+      "displayName": "Build debug binary workflow",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "dev"
+        },
+        {
+          "type": "build",
+          "name": "dev"
+        }
+      ]
+    },
+    {
+      "name": "unit-tests",
+      "displayName": "Build dbms unit tests workflow",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "dev"
+        },
+        {
+          "type": "build",
+          "name": "unit-tests"
+        }
+      ]
+    },
+    {
+      "name": "unit-tests-all",
+      "displayName": "Build all unit tests workflow",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "dev"
+        },
+        {
+          "type": "build",
+          "name": "unit-tests-all"
+        }
+      ]
+    },
+    {
+      "name": "benchmarks",
+      "displayName": "Build benchmarks workflow",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "benchmarks"
+        },
+        {
+          "type": "build",
+          "name": "benchmarks"
+        }
+      ]
+    },
+    {
+      "name": "asan-tests",
+      "displayName": "Build dbms Address Sanitizer tests workflow",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "asan"
+        },
+        {
+          "type": "build",
+          "name": "asan"
+        }
+      ]
+    },
+    {
+      "name": "asan-tests-all",
+      "displayName": "Build all Address Sanitizer tests workflow",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "asan"
+        },
+        {
+          "type": "build",
+          "name": "asan-all"
+        }
+      ]
+    },
+    {
+      "name": "tsan-tests",
+      "displayName": "Build dbms ThreadSanitizer tests workflow",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "tsan"
+        },
+        {
+          "type": "build",
+          "name": "tsan"
+        }
+      ]
+    },
+    {
+      "name": "tsan-tests-all",
+      "displayName": "Build all ThreadSanitizer tests workflow",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "tsan"
+        },
+        {
+          "type": "build",
+          "name": "tsan-all"
+        }
+      ]
+    },
+    {
+      "name": "release",
+      "displayName": "Build release binary workflow",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "release"
+        },
+        {
+          "type": "build",
+          "name": "release"
+        }
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -149,21 +149,14 @@ To build TiFlash for development:
 
 ```shell
 # In the TiFlash repository root:
-mkdir cmake-build-debug  # The directory name can be customized
-cd cmake-build-debug
-
-cmake .. -GNinja -DCMAKE_BUILD_TYPE=DEBUG
-
-ninja tiflash
+cmake --workflow --preset dev
 ```
 
 Note: In Linux, usually you need to explicitly specify to use LLVM.
 
 ```shell
-# In cmake-build-debug directory:
-cmake .. -GNinja -DCMAKE_BUILD_TYPE=DEBUG \
-  -DCMAKE_C_COMPILER=/usr/bin/clang-17 \
-  -DCMAKE_CXX_COMPILER=/usr/bin/clang++-17
+export CC="/usr/bin/clang-17"
+export CXX="/usr/bin/clang++-17"
 ```
 
 In MacOS, if you install llvm clang, you need to explicitly specify to use llvm clang.
@@ -177,7 +170,12 @@ export CXX="/opt/homebrew/opt/llvm/bin/clang++"
 
 Or use `CMAKE_C_COMPILER` and `CMAKE_CXX_COMPILER` to specify the compiler, like this:
 ```shell
+mkdir cmake-build-debug
+cd cmake-build-debug
+
 cmake .. -GNinja -DCMAKE_BUILD_TYPE=DEBUG -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++
+
+ninja tiflash
 ```
 
 After building, you can get TiFlash binary in `dbms/src/Server/tiflash` in the `cmake-build-debug` directory.
@@ -270,11 +268,8 @@ cmake .. -GNinja -DCMAKE_BUILD_TYPE=DEBUG -DFOO=BAR
 Unit tests are automatically enabled in debug profile. To build these unit tests:
 
 ```shell
-cd cmake-build-debug
-cmake .. -GNinja -DCMAKE_BUILD_TYPE=DEBUG
-ninja gtests_dbms       # Most TiFlash unit tests
-ninja gtests_libdaemon  # Settings related tests
-ninja gtests_libcommon
+# In the TiFlash repository root:
+cmake --workflow --preset unit-tests-all
 ```
 
 Then, to run these unit tests:
@@ -296,12 +291,7 @@ To build unit test executables with sanitizer enabled:
 
 ```shell
 # In the TiFlash repository root:
-mkdir cmake-build-sanitizer
-cd cmake-build-sanitizer
-cmake .. -GNinja -DENABLE_TESTS=ON -DCMAKE_BUILD_TYPE=ASan # or TSan
-ninja gtests_dbms
-ninja gtests_libdaemon
-ninja gtests_libcommon
+cmake --workflow --preset asan-tests-all # or tsan-tests-all
 ```
 
 There are known false positives reported from leak sanitizer (which is included in address sanitizer). To suppress these errors, set the following environment variables before running the executables:
@@ -359,10 +349,7 @@ To build micro benchmark tests, you need release profile and tests enabled:
 
 ```shell
 # In the TiFlash repository root:
-mkdir cmake-build-release
-cd cmake-build-release
-cmake .. -GNinja -DCMAKE_BUILD_TYPE=RELEASE -DENABLE_TESTS=ON
-ninja bench_dbms
+cmake --workflow --preset benchmarks
 ```
 
 Then, to run these micro benchmarks:


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6233

Problem Summary:

### What is changed and how it works?

```commit-message
*: add workflow in CMakePresets
```

```shell
$ cmake --list-presets        
Available configure presets:

  "dev"          - Development: DEBUG build with tests enabled
  "dev-coverage" - Development: DEBUG build with tests and code coverage enabled
  "release"      - Release: RELWITHDEBINFO build without tests enabled
  "asan"         - AddressSanitizer: ASAN build with tests enabled
  "tsan"         - ThreadSanitizer: TSAN build with tests enabled
  "benchmarks"   - Benchmarks: RELEASE build with benchmarks enabled

$ cmake --build --list-presets
Available build presets:

  "dev"              - Build tiflash binary with debug info and tests enabled
  "unit-tests"       - Build dbms unit tests
  "unit-tests-all"   - Build all unit tests
  "dev-coverage"     - Build dbms unit tests with code coverage
  "dev-coverage-all" - Build all unit tests with code coverage
  "release"          - Build tiflash binary without debug info
  "asan"             - Build dbms Address Sanitizer tests
  "asan-all"         - Build all Address Sanitizer tests
  "tsan"             - Build dbms ThreadSanitizer tests
  "tsan-all"         - Build all ThreadSanitizer tests
  "benchmarks"       - Build benchmarks

$ cmake --workflow --list-presets
Available workflow presets:

  "dev"            - Build debug binary workflow
  "unit-tests"     - Build dbms unit tests workflow
  "unit-tests-all" - Build all unit tests workflow
  "benchmarks"     - Build benchmarks workflow
  "asan-tests"     - Build dbms Address Sanitizer tests workflow
  "asan-tests-all" - Build all Address Sanitizer tests workflow
  "tsan-tests"     - Build dbms ThreadSanitizer tests workflow
  "tsan-tests-all" - Build all ThreadSanitizer tests workflow
  "release"        - Build release binary workflow

$ cmake --workflow --preset benchmarks
Executing workflow step 1 of 2: configure preset "benchmarks"

Preset CMake variables:

  CMAKE_BUILD_TYPE="RELEASE"
  ENABLE_TESTS="ON"

-- Using compiler:
...
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
