### PR TITLE
fix mac build

### DIFF
--- a/dbms/src/Interpreters/Aggregator.h
+++ b/dbms/src/Interpreters/Aggregator.h
@@ -1316,7 +1316,7 @@ public:
 
         bool only_lookup = false;
         size_t hit_row_cnt = 0;
-        std::vector<size_t> not_found_rows;
+        std::vector<UInt64> not_found_rows;
 
         void prepareForAgg();
         bool allBlockDataHandled() const


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9306

Problem Summary:
```
2024-08-09T16:38:58.501736078+08:00 /Users/pingcap/workspace/bp-tiflash-release-darwin-amd64-m7wlv-build-binaries/source/tiflash/dbms/src/Operators/AutoPassThroughHashAggContext.cpp:64:45: note: in instantiation of function template specialization 'std::make_shared<std::vector<unsigned long long>, std::vector<unsigned long>, void>' requested here
2024-08-09T16:38:58.501738228+08:00             new_block.info.selective = std::make_shared<std::vector<UInt64>>(std::move(pass_through_rows));
2024-08-09T16:38:58.501740465+08:00                                             ^
2024-08-09T16:38:58.501742711+08:00 /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/__memory/construct_at.h:35:16: note: candidate template ignored: substitution failure [with _Tp = std::vector<unsigned long long>, _Args = <std::vector<unsigned long>>]: no matching constructor for initialization of 'std::vector<unsigned long long>'
2024-08-09T16:38:58.501745103+08:00 constexpr _Tp* construct_at(_Tp* __location, _Args&& ...__args) {
2024-08-09T16:38:58.501747467+08:00                ^
2024-08-09T16:38:58.501749818+08:00 1 error generated.
2024-08-09T16:38:58.505245979+08:00 make[3]: *** [dbms/CMakeFiles/dbms.dir/src/Operators/AutoPassThroughHashAggContext.cpp.o] Error 1
```

### What is changed and how it works?

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
