### PR TITLE
tests: Fix unstable unit-tests

### DIFF
--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_read_task.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_read_task.cpp
@@ -206,7 +206,7 @@ public:
             /*store_address*/ "127.0.0.1",
             store->keyspace_id,
             store->physical_table_id);
-    };
+    }
 
     void initReadNodePageCacheIfUninitialized()
     {
@@ -353,7 +353,7 @@ public:
             sub_files_cn.serializeToBuffer(wb_cn);
             ASSERT_EQ(wb_wn.str(), wb_cn.str());
         }
-    };
+    }
 
 
     void basicMemTableSet()
@@ -678,6 +678,8 @@ try
         store->flushCache(*db_context, RowKeyRange::newAll(store->isCommonHandle(), store->getRowKeyColumnSize()));
     }
 
+    auto fp_guard = disableFlushCache();
+
     // cf mem
     {
         auto block = DMTestEnv::prepareSimpleWriteBlock(0, 128, false);
@@ -817,6 +819,7 @@ try
     auto table_column_defines = DMTestEnv::getDefaultColumns();
     store = reload(table_column_defines);
 
+    auto fp_guard = disableFlushCache();
     {
         auto block = DMTestEnv::prepareSimpleWriteBlock(
             0,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9309

Problem Summary:

Background tasks may flush `MemTableSet` of delta before snapshot is created. 


### What is changed and how it works?

```commit-message
Disable `flushCache` in some unit-tests. 
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
