### PR TITLE
Compression: Support enabling lightweight compression

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,2 +1,4 @@
 CompileFlags:
-  Add: -ferror-limit=0
+  Add:
+    - -ferror-limit=0
+    - -Wno-vla-cxx-extension

--- a/dbms/src/Common/TiFlashMetrics.h
+++ b/dbms/src/Common/TiFlashMetrics.h
@@ -867,7 +867,24 @@ static_assert(RAFT_REGION_BIG_WRITE_THRES * 4 < RAFT_REGION_BIG_WRITE_MAX, "Inva
     M(tiflash_read_thread_internal_us,                                                                                              \
       "Durations of read thread internal components",                                                                               \
       Histogram,                                                                                                                    \
-      F(type_block_queue_pop_latency, {{"type", "block_queue_pop_latency"}}, ExpBuckets{1, 2, 20}))
+      F(type_block_queue_pop_latency, {{"type", "block_queue_pop_latency"}}, ExpBuckets{1, 2, 20}))                                 \
+    M(tiflash_storage_pack_compression_algorithm_count,                                                                             \
+      "The count of the compression algorithm used by each data part",                                                              \
+      Counter,                                                                                                                      \
+      F(type_constant, {"type", "constant"}),                                                                                       \
+      F(type_constant_delta, {"type", "constant_delta"}),                                                                           \
+      F(type_runlength, {"type", "runlength"}),                                                                                     \
+      F(type_for, {"type", "for"}),                                                                                                 \
+      F(type_delta_for, {"type", "delta_for"}),                                                                                     \
+      F(type_lz4, {"type", "lz4"}),                                                                                                 \
+      F(type_delta_lz4, {"type", "delta_lz4"}))                                                                                     \
+    M(tiflash_storage_pack_compression_bytes,                                                                                       \
+      "The uncompression/compression bytes of lz4 and lightweight",                                                                 \
+      Counter,                                                                                                                      \
+      F(type_lz4_compressed_bytes, {"type", "lz4_compressed_bytes"}),                                                               \
+      F(type_lz4_uncompressed_bytes, {"type", "lz4_uncompressed_bytes"}),                                                           \
+      F(type_lightweight_compressed_bytes, {"type", "lightweight_compressed_bytes"}),                                               \
+      F(type_lightweight_uncompressed_bytes, {"type", "lightweight_uncompressed_bytes"}))
 
 
 /// Buckets with boundaries [start * base^0, start * base^1, ..., start * base^(size-1)]

--- a/dbms/src/Common/TiFlashMetrics.h
+++ b/dbms/src/Common/TiFlashMetrics.h
@@ -876,8 +876,7 @@ static_assert(RAFT_REGION_BIG_WRITE_THRES * 4 < RAFT_REGION_BIG_WRITE_MAX, "Inva
       F(type_runlength, {"type", "runlength"}),                                                                                     \
       F(type_for, {"type", "for"}),                                                                                                 \
       F(type_delta_for, {"type", "delta_for"}),                                                                                     \
-      F(type_lz4, {"type", "lz4"}),                                                                                                 \
-      F(type_delta_lz4, {"type", "delta_lz4"}))                                                                                     \
+      F(type_lz4, {"type", "lz4"}))                                                                                                 \
     M(tiflash_storage_pack_compression_bytes,                                                                                       \
       "The uncompression/compression bytes of lz4 and lightweight",                                                                 \
       Counter,                                                                                                                      \

--- a/dbms/src/Common/TiFlashMetrics.h
+++ b/dbms/src/Common/TiFlashMetrics.h
@@ -885,7 +885,7 @@ static_assert(RAFT_REGION_BIG_WRITE_THRES * 4 < RAFT_REGION_BIG_WRITE_MAX, "Inva
       F(type_lz4_uncompressed_bytes, {"type", "lz4_uncompressed_bytes"}),                                                           \
       F(type_lightweight_compressed_bytes, {"type", "lightweight_compressed_bytes"}),                                               \
       F(type_lightweight_uncompressed_bytes, {"type", "lightweight_uncompressed_bytes"}))
-      
+
 
 /// Buckets with boundaries [start * base^0, start * base^1, ..., start * base^(size-1)]
 struct ExpBuckets

--- a/dbms/src/DataStreams/MergeSortingBlockInputStream.cpp
+++ b/dbms/src/DataStreams/MergeSortingBlockInputStream.cpp
@@ -20,7 +20,6 @@
 #include <DataStreams/SortHelper.h>
 #include <DataStreams/copyData.h>
 #include <IO/Buffer/WriteBufferFromFile.h>
-#include <IO/Compression/CompressedWriteBuffer.h>
 #include <common/logger_useful.h>
 
 namespace DB

--- a/dbms/src/IO/Compression/CompressionCodecDeflateQpl.h
+++ b/dbms/src/IO/Compression/CompressionCodecDeflateQpl.h
@@ -103,8 +103,6 @@ public:
     UInt8 getMethodByte() const override;
     bool isCompression() const override { return true; }
 
-    bool isCompression() const override { return true; }
-
 protected:
     UInt32 doCompressData(const char * source, UInt32 source_size, char * dest) const override;
     void doDecompressData(const char * source, UInt32 source_size, char * dest, UInt32 uncompressed_size)

--- a/dbms/src/IO/Compression/CompressionCodecDeflateQpl.h
+++ b/dbms/src/IO/Compression/CompressionCodecDeflateQpl.h
@@ -103,6 +103,8 @@ public:
     UInt8 getMethodByte() const override;
     bool isCompression() const override { return true; }
 
+    bool isCompression() const override { return true; }
+
 protected:
     UInt32 doCompressData(const char * source, UInt32 source_size, char * dest) const override;
     void doDecompressData(const char * source, UInt32 source_size, char * dest, UInt32 uncompressed_size)

--- a/dbms/src/IO/Compression/CompressionCodecDeltaFOR.cpp
+++ b/dbms/src/IO/Compression/CompressionCodecDeltaFOR.cpp
@@ -17,7 +17,6 @@
 #include <IO/Compression/CompressionCodecDeltaFOR.h>
 #include <IO/Compression/CompressionCodecFOR.h>
 #include <IO/Compression/CompressionInfo.h>
-#include <IO/Compression/CompressionSettings.h>
 #include <IO/Compression/EncodingUtil.h>
 #include <common/likely.h>
 
@@ -60,15 +59,13 @@ UInt32 compressData(const char * source, UInt32 source_size, char * dest)
     if unlikely (source_size % bytes_size != 0)
         throw Exception(ErrorCodes::CANNOT_DECOMPRESS, "source size {} is not aligned to {}", source_size, bytes_size);
     const auto count = source_size / bytes_size;
-    DB::Compression::deltaEncoding<T>(reinterpret_cast<const T *>(source), count, reinterpret_cast<T *>(dest));
     if (unlikely(count == 1))
         return bytes_size;
-    // Cast deltas to signed type to better compress negative values.
-    // For example, if we have a sequence of UInt8 values [3, 2, 1, 0], the deltas will be [3, -1, -1, -1]
-    // If we compress them as UInt8, we will get [3, 255, 255, 255], which is not optimal.
     using TS = typename std::make_signed<T>::type;
-    auto for_size = DB::CompressionCodecFOR::compressData<TS>(
-        reinterpret_cast<TS *>(dest + bytes_size),
+    // view source as signed integers so that delta will be smaller
+    DB::Compression::deltaEncoding<TS>(reinterpret_cast<const TS *>(source), count, reinterpret_cast<TS *>(dest));
+    auto for_size = DB::CompressionCodecFOR::compressData<T>(
+        reinterpret_cast<T *>(dest + bytes_size),
         source_size - bytes_size,
         dest + bytes_size);
     return bytes_size + for_size;

--- a/dbms/src/IO/Compression/CompressionCodecFOR.cpp
+++ b/dbms/src/IO/Compression/CompressionCodecFOR.cpp
@@ -16,7 +16,6 @@
 #include <Common/Exception.h>
 #include <IO/Compression/CompressionCodecFOR.h>
 #include <IO/Compression/CompressionInfo.h>
-#include <IO/Compression/CompressionSettings.h>
 #include <IO/Compression/EncodingUtil.h>
 #include <common/likely.h>
 
@@ -60,9 +59,11 @@ UInt32 CompressionCodecFOR::compressData(const T * source, UInt32 source_size, c
     if unlikely (count == 0)
         throw Exception(ErrorCodes::CANNOT_COMPRESS, "Cannot compress empty data");
     std::vector<T> values(source, source + count);
-    T frame_of_reference = *std::min_element(values.cbegin(), values.cend());
-    UInt8 width = DB::Compression::FOREncodingWidth(values, frame_of_reference);
-    return DB::Compression::FOREncoding<T, std::is_signed_v<T>>(values, frame_of_reference, width, dest);
+    auto minmax = std::minmax_element(values.cbegin(), values.cend());
+    T frame_of_reference = *minmax.first;
+    T max_value = *minmax.second;
+    UInt8 width = BitpackingPrimitives::minimumBitWidth<T>(max_value - frame_of_reference);
+    return DB::Compression::FOREncoding(values.data(), values.size(), frame_of_reference, width, dest);
 }
 
 UInt32 CompressionCodecFOR::doCompressData(const char * source, UInt32 source_size, char * dest) const

--- a/dbms/src/IO/Compression/CompressionCodecFactory.cpp
+++ b/dbms/src/IO/Compression/CompressionCodecFactory.cpp
@@ -77,7 +77,6 @@ template CompressionCodecPtr CompressionCodecFactory::getStaticCodec<Compression
 template CompressionCodecPtr CompressionCodecFactory::getStaticCodec<CompressionCodecRunLength>(
     const CompressionSetting & setting);
 
-
 template <>
 CompressionCodecPtr CompressionCodecFactory::getStaticCodec<CompressionCodecLZ4>(const CompressionSetting & setting)
 {
@@ -154,7 +153,6 @@ CompressionCodecPtr CompressionCodecFactory::getStaticCodec<CompressionCodecDefl
 }
 #endif
 
-
 template <bool IS_COMPRESS>
 CompressionCodecPtr CompressionCodecFactory::create(const CompressionSetting & setting)
 {
@@ -192,7 +190,7 @@ CompressionCodecPtr CompressionCodecFactory::create(const CompressionSetting & s
     switch (setting.method_byte)
     {
     case CompressionMethodByte::Lightweight:
-        return std::make_unique<CompressionCodecLightweight>(setting.data_type);
+        return std::make_unique<CompressionCodecLightweight>(setting.data_type, setting.level);
     case CompressionMethodByte::DeltaFOR:
         return getStaticCodec<CompressionCodecDeltaFOR>(setting);
     case CompressionMethodByte::RunLength:

--- a/dbms/src/IO/Compression/CompressionCodecFactory.cpp
+++ b/dbms/src/IO/Compression/CompressionCodecFactory.cpp
@@ -25,6 +25,8 @@
 #include <magic_enum.hpp>
 #include <shared_mutex>
 
+#include "IO/Compression/CompressionMethod.h"
+
 #if USE_QPL
 #include <IO/Compression/CompressionCodecDeflateQpl.h>
 #endif
@@ -180,7 +182,13 @@ CompressionCodecPtr CompressionCodecFactory::create(const CompressionSetting & s
         if (!isInteger(setting.data_type))
         {
             if (setting.method_byte == CompressionMethodByte::Lightweight)
+            {
+                // Use LZ4 codec for non-integral types
+                // TODO: maybe we can use zstd?
+                auto method = CompressionMethod::LZ4;
+                CompressionSetting setting(method, CompressionSetting::getDefaultLevel(method));
                 return getStaticCodec<CompressionCodecLZ4>(setting);
+            }
             else
                 return nullptr;
         }

--- a/dbms/src/IO/Compression/CompressionCodecFactory.cpp
+++ b/dbms/src/IO/Compression/CompressionCodecFactory.cpp
@@ -25,7 +25,6 @@
 #include <magic_enum.hpp>
 #include <shared_mutex>
 
-#include "IO/Compression/CompressionMethod.h"
 
 #if USE_QPL
 #include <IO/Compression/CompressionCodecDeflateQpl.h>

--- a/dbms/src/IO/Compression/CompressionCodecLZ4.cpp
+++ b/dbms/src/IO/Compression/CompressionCodecLZ4.cpp
@@ -25,8 +25,6 @@ namespace ErrorCodes
 {
 extern const int CANNOT_COMPRESS;
 extern const int CANNOT_DECOMPRESS;
-extern const int ILLEGAL_SYNTAX_FOR_CODEC_TYPE;
-extern const int ILLEGAL_CODEC_PARAMETER;
 } // namespace ErrorCodes
 
 CompressionCodecLZ4::CompressionCodecLZ4(int level_)

--- a/dbms/src/IO/Compression/CompressionCodecLZ4.cpp
+++ b/dbms/src/IO/Compression/CompressionCodecLZ4.cpp
@@ -72,10 +72,4 @@ CompressionCodecLZ4HC::CompressionCodecLZ4HC(int level_)
     : CompressionCodecLZ4(level_)
 {}
 
-
-CompressionCodecPtr getCompressionCodecLZ4(int level)
-{
-    return std::make_unique<CompressionCodecLZ4HC>(level);
-}
-
 } // namespace DB

--- a/dbms/src/IO/Compression/CompressionCodecLZ4.h
+++ b/dbms/src/IO/Compression/CompressionCodecLZ4.h
@@ -19,9 +19,14 @@
 namespace DB
 {
 
+class CompressionCodecFactory;
+
 class CompressionCodecLZ4 : public ICompressionCodec
 {
 public:
+    // The official document says that the compression ratio of LZ4 is 2.1, https://github.com/lz4/lz4
+    static constexpr size_t ESTIMATE_INTEGER_COMPRESSION_RATIO = 4;
+
     explicit CompressionCodecLZ4(int level_);
 
     UInt8 getMethodByte() const override;
@@ -39,6 +44,7 @@ private:
 
 protected:
     const int level;
+    friend class CompressionCodecFactory;
 };
 
 

--- a/dbms/src/IO/Compression/CompressionCodecLZ4.h
+++ b/dbms/src/IO/Compression/CompressionCodecLZ4.h
@@ -25,7 +25,7 @@ class CompressionCodecLZ4 : public ICompressionCodec
 {
 public:
     // The official document says that the compression ratio of LZ4 is 2.1, https://github.com/lz4/lz4
-    static constexpr size_t ESTIMATE_INTEGER_COMPRESSION_RATIO = 4;
+    static constexpr size_t ESTIMATE_INTEGER_COMPRESSION_RATIO = 3;
 
     explicit CompressionCodecLZ4(int level_);
 

--- a/dbms/src/IO/Compression/CompressionCodecLightweight.cpp
+++ b/dbms/src/IO/Compression/CompressionCodecLightweight.cpp
@@ -23,7 +23,6 @@
 namespace DB
 {
 
-// TODO: metrics
 
 namespace ErrorCodes
 {
@@ -31,8 +30,9 @@ extern const int CANNOT_COMPRESS;
 extern const int CANNOT_DECOMPRESS;
 } // namespace ErrorCodes
 
-CompressionCodecLightweight::CompressionCodecLightweight(CompressionDataType data_type_)
-    : data_type(data_type_)
+CompressionCodecLightweight::CompressionCodecLightweight(CompressionDataType data_type_, int level_)
+    : ctx(level_)
+    , data_type(data_type_)
 {}
 
 UInt8 CompressionCodecLightweight::getMethodByte() const
@@ -44,12 +44,6 @@ UInt32 CompressionCodecLightweight::getMaxCompressedDataSize(UInt32 uncompressed
 {
     // 1 byte for bytes_size, 1 byte for mode, and the rest for compressed data
     return 1 + 1 + LZ4_COMPRESSBOUND(uncompressed_size);
-}
-
-CompressionCodecLightweight::~CompressionCodecLightweight()
-{
-    if (ctx.isCompression())
-        LOG_INFO(Logger::get(), "lightweight codec: {}", ctx.toDebugString());
 }
 
 UInt32 CompressionCodecLightweight::doCompressData(const char * source, UInt32 source_size, char * dest) const

--- a/dbms/src/IO/Compression/CompressionCodecLightweight.h
+++ b/dbms/src/IO/Compression/CompressionCodecLightweight.h
@@ -61,7 +61,6 @@ private:
         FOR = 4, // Frame of Reference encoding
         DeltaFOR = 5, // delta encoding and then FOR encoding
         LZ4 = 6, // the above modes are not suitable, use LZ4 instead
-        DeltaLZ4 = 7, // delta encoding and then LZ4
     };
 
     // Constant or ConstantDelta
@@ -79,21 +78,14 @@ private:
     template <std::integral T>
     struct DeltaFORState
     {
-        using TS = typename std::make_signed_t<T>;
         std::vector<T> deltas;
-        TS min_delta_value;
+        T min_delta_value;
         UInt8 bit_width;
-    };
-
-    template <std::integral T>
-    struct DeltaLZ4State
-    {
-        std::vector<T> deltas;
     };
 
     // State is a union of different states for different modes
     template <std::integral T>
-    using IntegerState = std::variant<ConstantState<T>, FORState<T>, DeltaFORState<T>, DeltaLZ4State<T>>;
+    using IntegerState = std::variant<ConstantState<T>, FORState<T>, DeltaFORState<T>>;
 
     class IntegerCompressContext
     {
@@ -130,7 +122,6 @@ private:
         bool used_constant_delta = false;
         bool used_delta_for = false;
         bool used_rle = false;
-        bool used_delta_lz4 = false;
     };
 
     template <std::integral T>

--- a/dbms/src/IO/Compression/CompressionCodecLightweight.h
+++ b/dbms/src/IO/Compression/CompressionCodecLightweight.h
@@ -34,13 +34,13 @@ namespace DB
 class CompressionCodecLightweight : public ICompressionCodec
 {
 public:
-    explicit CompressionCodecLightweight(CompressionDataType data_type_);
+    explicit CompressionCodecLightweight(CompressionDataType data_type_, int level_);
 
     UInt8 getMethodByte() const override;
 
-    bool isCompression() const override { return true; }
+    ~CompressionCodecLightweight() override = default;
 
-    ~CompressionCodecLightweight() override;
+    bool isCompression() const override { return true; }
 
 protected:
     UInt32 doCompressData(const char * source, UInt32 source_size, char * dest) const override;
@@ -55,22 +55,20 @@ private:
     enum class IntegerMode : UInt8
     {
         Invalid = 0,
-        CONSTANT = 1, // all values are the same
-        CONSTANT_DELTA = 2, // the difference between two adjacent values is the same
-        RunLength = 3, // run-length encoding
+        Constant = 1, // all values are the same
+        ConstantDelta = 2, // the difference between two adjacent values is the same
+        RunLength = 3, // the same value appears multiple times
         FOR = 4, // Frame of Reference encoding
-        DELTA_FOR = 5, // delta encoding and then FOR encoding
+        DeltaFOR = 5, // delta encoding and then FOR encoding
         LZ4 = 6, // the above modes are not suitable, use LZ4 instead
+        DeltaLZ4 = 7, // delta encoding and then LZ4
     };
 
     // Constant or ConstantDelta
-    template <typename T>
+    template <std::integral T>
     using ConstantState = T;
 
-    template <typename T>
-    using RunLengthState = std::vector<std::pair<T, UInt8>>;
-
-    template <typename T>
+    template <std::integral T>
     struct FORState
     {
         std::vector<T> values;
@@ -78,63 +76,67 @@ private:
         UInt8 bit_width;
     };
 
-    template <typename T>
+    template <std::integral T>
     struct DeltaFORState
     {
         using TS = typename std::make_signed_t<T>;
-        std::vector<TS> deltas;
+        std::vector<T> deltas;
         TS min_delta_value;
         UInt8 bit_width;
     };
 
+    template <std::integral T>
+    struct DeltaLZ4State
+    {
+        std::vector<T> deltas;
+    };
+
     // State is a union of different states for different modes
-    template <typename T>
-    using IntegerState = std::variant<ConstantState<T>, RunLengthState<T>, FORState<T>, DeltaFORState<T>>;
+    template <std::integral T>
+    using IntegerState = std::variant<ConstantState<T>, FORState<T>, DeltaFORState<T>, DeltaLZ4State<T>>;
 
     class IntegerCompressContext
     {
     public:
-        IntegerCompressContext() = default;
+        explicit IntegerCompressContext(int round_count_)
+            : round_count(round_count_)
+        {}
 
-        template <typename T>
+        template <std::integral T>
         void analyze(std::span<const T> & values, IntegerState<T> & state);
 
         void update(size_t uncompressed_size, size_t compressed_size);
-
-        String toDebugString() const;
-        bool isCompression() const { return lz4_counter > 0 || lw_counter > 0; }
 
         IntegerMode mode = IntegerMode::LZ4;
 
     private:
         bool needAnalyze() const;
+
+        template <std::integral T>
         bool needAnalyzeDelta() const;
+
+        template <std::integral T>
+        static constexpr bool needAnalyzeFOR();
+
         bool needAnalyzeRunLength() const;
 
-    private:
-        // The threshold for the number of blocks to decide whether need to analyze.
-        // For example:
-        // If lz4 is used more than COUNT_THRESHOLD times and the compression ratio is better than lightweight codec, do not analyze anymore.
-        static constexpr size_t COUNT_THRESHOLD = 5;
-        // Assume that the compression ratio of LZ4 is 3.0
-        // The official document says that the compression ratio of LZ4 is 2.1, https://github.com/lz4/lz4
-        static constexpr size_t ESRTIMATE_LZ4_COMPRESSION_RATIO = 3;
+        void resetIfNeed();
 
-        size_t lw_uncompressed_size = 0;
-        size_t lw_compressed_size = 0;
-        size_t lw_counter = 0;
-        size_t lz4_uncompressed_size = 0;
-        size_t lz4_compressed_size = 0;
-        size_t lz4_counter = 0;
-        size_t constant_delta_counter = 0;
-        size_t delta_for_counter = 0;
-        size_t rle_counter = 0;
+    private:
+        // Every round_count blocks as a round, decide whether to analyze the mode.
+        const int round_count;
+        int compress_count = 0;
+        bool used_lz4 = false;
+        bool used_constant_delta = false;
+        bool used_delta_for = false;
+        bool used_rle = false;
+        bool used_delta_lz4 = false;
     };
 
-    template <typename T>
+    template <std::integral T>
     size_t compressDataForInteger(const char * source, UInt32 source_size, char * dest) const;
 
-    template <typename T>
+    template <std::integral T>
     void decompressDataForInteger(const char * source, UInt32 source_size, char * dest, UInt32 output_size) const;
 
     /// Non-integer data

--- a/dbms/src/IO/Compression/CompressionCodecRunLength.cpp
+++ b/dbms/src/IO/Compression/CompressionCodecRunLength.cpp
@@ -53,23 +53,11 @@ UInt32 compressDataForInteger(const char * source, UInt32 source_size, char * de
     constexpr auto bytes_size = sizeof(T);
     if unlikely (source_size % bytes_size != 0)
         throw Exception(ErrorCodes::CANNOT_DECOMPRESS, "source size {} is not aligned to {}", source_size, bytes_size);
-    const char * source_end = source + source_size;
-    DB::Compression::RunLengthPairs<T> rle_vec;
-    rle_vec.reserve(source_size / bytes_size);
-    for (const auto * src = source; src < source_end; src += bytes_size)
-    {
-        T value = unalignedLoad<T>(src);
-        // If the value is different from the previous one or the counter is at the maximum value (255 + 1 = 0),
-        // we need to start a new run.
-        // Otherwise, we can just increment the counter.
-        if (rle_vec.empty() || rle_vec.back().first != value
-            || rle_vec.back().second == std::numeric_limits<UInt8>::max())
-            rle_vec.emplace_back(value, 1);
-        else
-            ++rle_vec.back().second;
-    }
 
-    return DB::Compression::runLengthEncoding<T>(rle_vec, dest);
+    const auto * typed_source = reinterpret_cast<const T *>(source);
+    const auto source_count = source_size / bytes_size;
+
+    return DB::Compression::runLengthEncoding<T>(typed_source, source_count, dest);
 }
 } // namespace
 

--- a/dbms/src/IO/Compression/CompressionCodecZSTD.h
+++ b/dbms/src/IO/Compression/CompressionCodecZSTD.h
@@ -19,6 +19,9 @@
 namespace DB
 {
 
+class CompressionCodecFactory;
+
+
 class CompressionCodecZSTD : public ICompressionCodec
 {
 public:
@@ -38,6 +41,7 @@ protected:
 
 private:
     const int level;
+    friend class CompressionCodecFactory;
 };
 
 } // namespace DB

--- a/dbms/src/IO/Compression/CompressionSettings.cpp
+++ b/dbms/src/IO/Compression/CompressionSettings.cpp
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "CompressionSettings.h"
-
 #include <Common/config.h>
+#include <IO/Compression/CompressionSettings.h>
 #include <Interpreters/Settings.h>
 #include <lz4hc.h>
+
+#include <magic_enum.hpp>
+
 
 namespace DB
 {
@@ -48,9 +50,40 @@ int CompressionSetting::getDefaultLevel(CompressionMethod method)
     case CompressionMethod::QPL:
         return 1;
 #endif
+    case CompressionMethod::Lightweight:
+        return 3;
     default:
         return -1;
     }
 }
+
+template <typename T>
+CompressionSetting CompressionSetting::create(T method, int level, const IDataType & type)
+{
+    // Nullable type will be treated as Unknown
+    CompressionSetting setting(method);
+    if (type.isValueRepresentedByInteger())
+    {
+        auto data_type = magic_enum::enum_cast<CompressionDataType>(type.getSizeOfValueInMemory());
+        if (data_type.has_value())
+            setting.data_type = data_type.value();
+        else
+            setting.data_type = CompressionDataType::Unknown;
+    }
+    else if (type.isFloatingPoint() && type.getSizeOfValueInMemory() == 4)
+        setting.data_type = CompressionDataType::Float32;
+    else if (type.isFloatingPoint() && type.getSizeOfValueInMemory() == 8)
+        setting.data_type = CompressionDataType::Float64;
+    // TODO: support String
+    // else if (type.isStringOrFixedString())
+    //     setting.data_type = CompressionDataType::String;
+    else
+        setting.data_type = CompressionDataType::Unknown;
+    setting.level = level;
+    return setting;
+}
+
+template CompressionSetting CompressionSetting::create(CompressionMethod method, int level, const IDataType & type);
+template CompressionSetting CompressionSetting::create(CompressionMethodByte method, int level, const IDataType & type);
 
 } // namespace DB

--- a/dbms/src/IO/Compression/CompressionSettings.cpp
+++ b/dbms/src/IO/Compression/CompressionSettings.cpp
@@ -65,10 +65,7 @@ CompressionSetting CompressionSetting::create(T method, int level, const IDataTy
     if (type.isValueRepresentedByInteger())
     {
         auto data_type = magic_enum::enum_cast<CompressionDataType>(type.getSizeOfValueInMemory());
-        if (data_type.has_value())
-            setting.data_type = data_type.value();
-        else
-            setting.data_type = CompressionDataType::Unknown;
+        setting.data_type = data_type ? *data_type : CompressionDataType::Unknown;
     }
     else if (type.isFloatingPoint() && type.getSizeOfValueInMemory() == 4)
         setting.data_type = CompressionDataType::Float32;

--- a/dbms/src/IO/Compression/CompressionSettings.h
+++ b/dbms/src/IO/Compression/CompressionSettings.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <DataTypes/IDataType.h>
 #include <IO/Compression/CompressionInfo.h>
 #include <IO/Compression/CompressionMethod.h>
 #include <common/types.h>
@@ -48,9 +49,12 @@ const std::unordered_map<CompressionMethodByte, CompressionMethod> method_map = 
 struct CompressionSetting
 {
     CompressionMethod method;
-    CompressionMethodByte method_byte;
     int level;
+    // The type of data to be compressed.
+    // It may be used to determine the codec to use.
     CompressionDataType data_type = CompressionDataType::Unknown;
+    // Always use method_byte to determine the codec to use except for LZ4HC codec
+    CompressionMethodByte method_byte;
 
     CompressionSetting()
         : CompressionSetting(CompressionMethod::LZ4)
@@ -58,23 +62,26 @@ struct CompressionSetting
 
     explicit CompressionSetting(CompressionMethod method_)
         : method(method_)
-        , method_byte(method_byte_map[static_cast<size_t>(method_)])
         , level(getDefaultLevel(method))
+        , method_byte(method_byte_map[static_cast<size_t>(method_)])
     {}
 
     explicit CompressionSetting(CompressionMethodByte method_byte_)
         : method(method_map.at(method_byte_))
-        , method_byte(method_byte_)
         , level(getDefaultLevel(method))
+        , method_byte(method_byte_)
     {}
 
     CompressionSetting(CompressionMethod method_, int level_)
         : method(method_)
-        , method_byte(method_byte_map[static_cast<size_t>(method_)])
         , level(level_)
+        , method_byte(method_byte_map[static_cast<size_t>(method_)])
     {}
 
     explicit CompressionSetting(const Settings & settings);
+
+    template <typename T>
+    static CompressionSetting create(T method, int level, const IDataType & type);
 
     static int getDefaultLevel(CompressionMethod method);
 };

--- a/dbms/src/IO/Compression/EncodingUtil.cpp
+++ b/dbms/src/IO/Compression/EncodingUtil.cpp
@@ -30,62 +30,60 @@ char * writeSameValueMultipleTime(T value, UInt32 count, char * dest)
     {
         memset(dest, value, count);
         dest += count;
+        return dest;
     }
-    else
-    {
-        UInt32 j = 0;
+    UInt32 j = 0;
 #if defined(__AVX2__)
-        // avx2
-        while (j + sizeof(__m256i) / sizeof(T) <= count)
+    // avx2
+    while (j + sizeof(__m256i) / sizeof(T) <= count)
+    {
+        if constexpr (sizeof(T) == 2)
         {
-            if constexpr (sizeof(T) == 2)
-            {
-                auto value_avx2 = _mm256_set1_epi16(value);
-                _mm256_storeu_si256(reinterpret_cast<__m256i *>(dest), value_avx2);
-            }
-            else if constexpr (sizeof(T) == 4)
-            {
-                auto value_avx2 = _mm256_set1_epi32(value);
-                _mm256_storeu_si256(reinterpret_cast<__m256i *>(dest), value_avx2);
-            }
-            else if constexpr (sizeof(T) == 8)
-            {
-                auto value_avx2 = _mm256_set1_epi64x(value);
-                _mm256_storeu_si256(reinterpret_cast<__m256i *>(dest), value_avx2);
-            }
-            j += sizeof(__m256i) / sizeof(T);
-            dest += sizeof(__m256i);
+            auto value_avx2 = _mm256_set1_epi16(value);
+            _mm256_storeu_si256(reinterpret_cast<__m256i *>(dest), value_avx2);
         }
+        else if constexpr (sizeof(T) == 4)
+        {
+            auto value_avx2 = _mm256_set1_epi32(value);
+            _mm256_storeu_si256(reinterpret_cast<__m256i *>(dest), value_avx2);
+        }
+        else if constexpr (sizeof(T) == 8)
+        {
+            auto value_avx2 = _mm256_set1_epi64x(value);
+            _mm256_storeu_si256(reinterpret_cast<__m256i *>(dest), value_avx2);
+        }
+        j += sizeof(__m256i) / sizeof(T);
+        dest += sizeof(__m256i);
+    }
 #endif
 #if defined(__SSE2__)
-        // sse
-        while (j + sizeof(__m128i) / sizeof(T) <= count)
+    // sse
+    while (j + sizeof(__m128i) / sizeof(T) <= count)
+    {
+        if constexpr (sizeof(T) == 2)
         {
-            if constexpr (sizeof(T) == 2)
-            {
-                auto value_sse = _mm_set1_epi16(value);
-                _mm_storeu_si128(reinterpret_cast<__m128i *>(dest), value_sse);
-            }
-            else if constexpr (sizeof(T) == 4)
-            {
-                auto value_sse = _mm_set1_epi32(value);
-                _mm_storeu_si128(reinterpret_cast<__m128i *>(dest), value_sse);
-            }
-            else if constexpr (sizeof(T) == 8)
-            {
-                auto value_sse = _mm_set1_epi64x(value);
-                _mm_storeu_si128(reinterpret_cast<__m128i *>(dest), value_sse);
-            }
-            j += sizeof(__m128i) / sizeof(T);
-            dest += sizeof(__m128i);
+            auto value_sse = _mm_set1_epi16(value);
+            _mm_storeu_si128(reinterpret_cast<__m128i *>(dest), value_sse);
         }
+        else if constexpr (sizeof(T) == 4)
+        {
+            auto value_sse = _mm_set1_epi32(value);
+            _mm_storeu_si128(reinterpret_cast<__m128i *>(dest), value_sse);
+        }
+        else if constexpr (sizeof(T) == 8)
+        {
+            auto value_sse = _mm_set1_epi64x(value);
+            _mm_storeu_si128(reinterpret_cast<__m128i *>(dest), value_sse);
+        }
+        j += sizeof(__m128i) / sizeof(T);
+        dest += sizeof(__m128i);
+    }
 #endif
-        // scalar
-        for (; j < count; ++j)
-        {
-            unalignedStore<T>(dest, value);
-            dest += sizeof(T);
-        }
+    // scalar
+    for (; j < count; ++j)
+    {
+        unalignedStore<T>(dest, value);
+        dest += sizeof(T);
     }
     return dest;
 }

--- a/dbms/src/IO/Compression/EncodingUtil.cpp
+++ b/dbms/src/IO/Compression/EncodingUtil.cpp
@@ -22,6 +22,147 @@ namespace DB::Compression
 {
 
 template <std::integral T>
+char * writeSameValueMultipleTime(T value, UInt32 count, char * dest)
+{
+    if (unlikely(count == 0))
+        return dest;
+    if constexpr (sizeof(T) == 1)
+    {
+        memset(dest, value, count);
+        dest += count;
+    }
+    else
+    {
+        UInt32 j = 0;
+#if defined(__AVX2__)
+        // avx2
+        while (j + sizeof(__m256i) / sizeof(T) <= count)
+        {
+            if constexpr (sizeof(T) == 2)
+            {
+                auto value_avx2 = _mm256_set1_epi16(value);
+                _mm256_storeu_si256(reinterpret_cast<__m256i *>(dest), value_avx2);
+            }
+            else if constexpr (sizeof(T) == 4)
+            {
+                auto value_avx2 = _mm256_set1_epi32(value);
+                _mm256_storeu_si256(reinterpret_cast<__m256i *>(dest), value_avx2);
+            }
+            else if constexpr (sizeof(T) == 8)
+            {
+                auto value_avx2 = _mm256_set1_epi64x(value);
+                _mm256_storeu_si256(reinterpret_cast<__m256i *>(dest), value_avx2);
+            }
+            j += sizeof(__m256i) / sizeof(T);
+            dest += sizeof(__m256i);
+        }
+#endif
+#if defined(__SSE2__)
+        // sse
+        while (j + sizeof(__m128i) / sizeof(T) <= count)
+        {
+            if constexpr (sizeof(T) == 2)
+            {
+                auto value_sse = _mm_set1_epi16(value);
+                _mm_storeu_si128(reinterpret_cast<__m128i *>(dest), value_sse);
+            }
+            else if constexpr (sizeof(T) == 4)
+            {
+                auto value_sse = _mm_set1_epi32(value);
+                _mm_storeu_si128(reinterpret_cast<__m128i *>(dest), value_sse);
+            }
+            else if constexpr (sizeof(T) == 8)
+            {
+                auto value_sse = _mm_set1_epi64x(value);
+                _mm_storeu_si128(reinterpret_cast<__m128i *>(dest), value_sse);
+            }
+            j += sizeof(__m128i) / sizeof(T);
+            dest += sizeof(__m128i);
+        }
+#endif
+        // scalar
+        for (; j < count; ++j)
+        {
+            unalignedStore<T>(dest, value);
+            dest += sizeof(T);
+        }
+    }
+    return dest;
+}
+
+template char * writeSameValueMultipleTime<UInt8>(UInt8, UInt32, char *);
+template char * writeSameValueMultipleTime<UInt16>(UInt16, UInt32, char *);
+template char * writeSameValueMultipleTime<UInt32>(UInt32, UInt32, char *);
+template char * writeSameValueMultipleTime<UInt64>(UInt64, UInt32, char *);
+
+/// Constant encoding
+
+template <std::integral T>
+void constantDecoding(const char * src, UInt32 source_size, char * dest, UInt32 dest_size)
+{
+    if (unlikely(source_size < sizeof(T)))
+        throw Exception(
+            ErrorCodes::CANNOT_DECOMPRESS,
+            "Cannot use Constant decoding, data size {} is too small",
+            source_size);
+
+    T constant = unalignedLoad<T>(src);
+    writeSameValueMultipleTime<T>(constant, dest_size / sizeof(T), dest);
+}
+
+template void constantDecoding<UInt8>(const char *, UInt32, char *, UInt32);
+template void constantDecoding<UInt16>(const char *, UInt32, char *, UInt32);
+template void constantDecoding<UInt32>(const char *, UInt32, char *, UInt32);
+template void constantDecoding<UInt64>(const char *, UInt32, char *, UInt32);
+
+/// ConstantDelta encoding
+
+template <std::integral T>
+void constantDeltaDecoding(const char * src, UInt32 source_size, char * dest, UInt32 dest_size)
+{
+    if (unlikely(source_size < sizeof(T) + sizeof(T)))
+        throw Exception(
+            ErrorCodes::CANNOT_DECOMPRESS,
+            "Cannot use ConstantDelta decoding, data size {} is too small",
+            source_size);
+
+    T first_value = unalignedLoad<T>(src);
+    T constant_delta = unalignedLoad<T>(src + sizeof(T));
+    for (size_t i = 0; i < dest_size / sizeof(T); ++i)
+    {
+        unalignedStore<T>(dest, first_value);
+        first_value += constant_delta;
+        dest += sizeof(T);
+    }
+}
+
+template void constantDeltaDecoding<UInt8>(const char *, UInt32, char *, UInt32);
+template void constantDeltaDecoding<UInt16>(const char *, UInt32, char *, UInt32);
+template void constantDeltaDecoding<UInt32>(const char *, UInt32, char *, UInt32);
+template void constantDeltaDecoding<UInt64>(const char *, UInt32, char *, UInt32);
+
+/// Delta encoding
+
+template <std::integral T>
+void deltaEncoding(const T * source, UInt32 count, T * dest)
+{
+    T prev = 0;
+    for (UInt32 i = 0; i < count; ++i)
+    {
+        T curr = source[i];
+        dest[i] = curr - prev;
+        prev = curr;
+    }
+}
+
+template void deltaEncoding<Int8>(const Int8 *, UInt32, Int8 *);
+template void deltaEncoding<Int16>(const Int16 *, UInt32, Int16 *);
+template void deltaEncoding<Int32>(const Int32 *, UInt32, Int32 *);
+template void deltaEncoding<Int64>(const Int64 *, UInt32, Int64 *);
+
+/// Delta + FrameOfReference encoding
+
+template <std::integral T>
 void applyFrameOfReference(T * dst, T frame_of_reference, UInt32 count)
 {
     if (frame_of_reference == 0)
@@ -76,37 +217,41 @@ void subtractFrameOfReference(T * dst, T frame_of_reference, UInt32 count)
     if (frame_of_reference == 0)
         return;
 
+    using TU = std::make_unsigned_t<T>;
+    auto * unsigned_dst = reinterpret_cast<TU *>(dst);
+    auto unsigned_frame_of_reference = static_cast<TU>(frame_of_reference);
+
     UInt32 i = 0;
 #if defined(__AVX2__)
     UInt32 aligned_count = count - count % (sizeof(__m256i) / sizeof(T));
     for (; i < aligned_count; i += (sizeof(__m256i) / sizeof(T)))
     {
         // Load the data using SIMD
-        __m256i value = _mm256_loadu_si256(reinterpret_cast<__m256i *>(dst + i));
+        __m256i value = _mm256_loadu_si256(reinterpret_cast<__m256i *>(unsigned_dst + i));
         // Perform vectorized addition
         if constexpr (sizeof(T) == 1)
         {
-            value = _mm256_sub_epi8(value, _mm256_set1_epi8(frame_of_reference));
+            value = _mm256_sub_epi8(value, _mm256_set1_epi8(unsigned_frame_of_reference));
         }
         else if constexpr (sizeof(T) == 2)
         {
-            value = _mm256_sub_epi16(value, _mm256_set1_epi16(frame_of_reference));
+            value = _mm256_sub_epi16(value, _mm256_set1_epi16(unsigned_frame_of_reference));
         }
         else if constexpr (sizeof(T) == 4)
         {
-            value = _mm256_sub_epi32(value, _mm256_set1_epi32(frame_of_reference));
+            value = _mm256_sub_epi32(value, _mm256_set1_epi32(unsigned_frame_of_reference));
         }
         else if constexpr (sizeof(T) == 8)
         {
-            value = _mm256_sub_epi64(value, _mm256_set1_epi64x(frame_of_reference));
+            value = _mm256_sub_epi64(value, _mm256_set1_epi64x(unsigned_frame_of_reference));
         }
         // Store the result back to memory
-        _mm256_storeu_si256(reinterpret_cast<__m256i *>(dst + i), value);
+        _mm256_storeu_si256(reinterpret_cast<__m256i *>(unsigned_dst + i), value);
     }
 #endif
     for (; i < count; ++i)
     {
-        dst[i] -= frame_of_reference;
+        unsigned_dst[i] -= unsigned_frame_of_reference;
     }
 }
 
@@ -120,41 +265,13 @@ template void subtractFrameOfReference<UInt32>(UInt32 *, UInt32, UInt32);
 template void subtractFrameOfReference<UInt64>(UInt64 *, UInt64, UInt32);
 
 template <std::integral T>
-UInt8 FOREncodingWidth(std::vector<T> & values, T frame_of_reference)
-{
-    assert(!values.empty()); // caller must ensure input is not empty
-
-    if constexpr (std::is_signed_v<T>)
-    {
-        // For signed types, after subtracting frame of reference, the range of values is not always [0, max_value - min_value].
-        // For example, we have a sequence of Int8 values [-128, 1, 127], after subtracting frame of reference -128, the values are [0, -127, -1].
-        // The minimum bit width required to store the values is 8 rather than the width of `max_value - min_value = -1`.
-        // So we need to calculate the minimum bit width of the values after subtracting frame of reference.
-        subtractFrameOfReference<T>(values.data(), frame_of_reference, values.size());
-        auto [min_value, max_value] = std::minmax_element(values.cbegin(), values.cend());
-        return BitpackingPrimitives::minimumBitWidth<T>(*min_value, *max_value);
-    }
-    else
-    {
-        T max_value = *std::max_element(values.cbegin(), values.cend());
-        return BitpackingPrimitives::minimumBitWidth<T>(max_value - frame_of_reference);
-    }
-}
-
-template UInt8 FOREncodingWidth<Int8>(std::vector<Int8> &, Int8);
-template UInt8 FOREncodingWidth<Int16>(std::vector<Int16> &, Int16);
-template UInt8 FOREncodingWidth<Int32>(std::vector<Int32> &, Int32);
-template UInt8 FOREncodingWidth<Int64>(std::vector<Int64> &, Int64);
-template UInt8 FOREncodingWidth<UInt8>(std::vector<UInt8> &, UInt8);
-template UInt8 FOREncodingWidth<UInt16>(std::vector<UInt16> &, UInt16);
-template UInt8 FOREncodingWidth<UInt32>(std::vector<UInt32> &, UInt32);
-template UInt8 FOREncodingWidth<UInt64>(std::vector<UInt64> &, UInt64);
-
-template <std::integral T>
 void deltaDecoding(const char * source, UInt32 source_size, char * dest)
 {
     ordinaryDeltaDecoding<T>(source, source_size, dest);
 }
+
+template void deltaDecoding<Int8>(const char *, UInt32, char *);
+template void deltaDecoding<Int16>(const char *, UInt32, char *);
 
 #if defined(__AVX2__)
 
@@ -164,11 +281,11 @@ void deltaDecoding(const char * source, UInt32 source_size, char * dest)
  */
 
 template <>
-void deltaDecoding<UInt32>(const char * __restrict__ raw_source, UInt32 raw_source_size, char * __restrict__ raw_dest)
+void deltaDecoding<Int32>(const char * raw_source, UInt32 raw_source_size, char * raw_dest)
 {
-    const auto * source = reinterpret_cast<const UInt32 *>(raw_source);
-    auto source_size = raw_source_size / sizeof(UInt32);
-    auto * dest = reinterpret_cast<UInt32 *>(raw_dest);
+    const auto * source = reinterpret_cast<const Int32 *>(raw_source);
+    auto source_size = raw_source_size / sizeof(Int32);
+    auto * dest = reinterpret_cast<Int32 *>(raw_dest);
     __m128i prev = _mm_setzero_si128();
     size_t i = 0;
     for (; i < source_size / 4; i++)
@@ -179,7 +296,7 @@ void deltaDecoding<UInt32>(const char * __restrict__ raw_source, UInt32 raw_sour
         prev = _mm_add_epi32(tmp2, _mm_shuffle_epi32(prev, 0xff));
         _mm_storeu_si128(reinterpret_cast<__m128i *>(dest) + i, prev);
     }
-    uint32_t lastprev = _mm_extract_epi32(prev, 3);
+    Int32 lastprev = _mm_extract_epi32(prev, 3);
     for (i = 4 * i; i < source_size; ++i)
     {
         lastprev = lastprev + source[i];
@@ -188,11 +305,11 @@ void deltaDecoding<UInt32>(const char * __restrict__ raw_source, UInt32 raw_sour
 }
 
 template <>
-void deltaDecoding<UInt64>(const char * __restrict__ raw_source, UInt32 raw_source_size, char * __restrict__ raw_dest)
+void deltaDecoding<Int64>(const char * raw_source, UInt32 raw_source_size, char * raw_dest)
 {
-    const auto * source = reinterpret_cast<const UInt64 *>(raw_source);
-    auto source_size = raw_source_size / sizeof(UInt64);
-    auto * dest = reinterpret_cast<UInt64 *>(raw_dest);
+    const auto * source = reinterpret_cast<const Int64 *>(raw_source);
+    auto source_size = raw_source_size / sizeof(Int64);
+    auto * dest = reinterpret_cast<Int64 *>(raw_dest);
     // AVX2 does not support shffule across 128-bit lanes, so we need to use permute.
     __m256i prev = _mm256_setzero_si256();
     __m256i zero = _mm256_setzero_si256();
@@ -213,13 +330,18 @@ void deltaDecoding<UInt64>(const char * __restrict__ raw_source, UInt32 raw_sour
         // prev = {prev[3], prev[3], prev[3], prev[3]}
         prev = _mm256_permute4x64_epi64(prev, 0b11111111);
     }
-    UInt64 lastprev = _mm256_extract_epi64(prev, 3);
+    Int64 lastprev = _mm256_extract_epi64(prev, 3);
     for (i = 4 * i; i < source_size; ++i)
     {
         lastprev += source[i];
         dest[i] = lastprev;
     }
 }
+
+#else
+
+template void deltaDecoding<Int32>(const char *, UInt32, char *);
+template void deltaDecoding<Int64>(const char *, UInt32, char *);
 
 #endif
 
@@ -254,12 +376,12 @@ void deltaFORDecoding<UInt32>(const char * src, UInt32 source_size, char * dest,
     memset(tmp_buffer, 0, required_size);
     // copy the first value to the temporary buffer
     memcpy(tmp_buffer, src, TYPE_BYTE_SIZE);
-    FORDecoding<Int32>(
+    FORDecoding<UInt32>(
         src + TYPE_BYTE_SIZE,
         source_size - TYPE_BYTE_SIZE,
         tmp_buffer + TYPE_BYTE_SIZE,
         required_size - TYPE_BYTE_SIZE);
-    deltaDecoding<UInt32>(reinterpret_cast<const char *>(tmp_buffer), dest_size, dest);
+    deltaDecoding<Int32>(tmp_buffer, dest_size, dest);
 }
 
 template <>
@@ -282,13 +404,111 @@ void deltaFORDecoding<UInt64>(const char * src, UInt32 source_size, char * dest,
     memset(tmp_buffer, 0, required_size);
     // copy the first value to the temporary buffer
     memcpy(tmp_buffer, src, TYPE_BYTE_SIZE);
-    FORDecoding<Int64>(
+    FORDecoding<UInt64>(
         src + TYPE_BYTE_SIZE,
         source_size - TYPE_BYTE_SIZE,
         tmp_buffer + TYPE_BYTE_SIZE,
         required_size - TYPE_BYTE_SIZE);
-    deltaDecoding<UInt64>(reinterpret_cast<const char *>(tmp_buffer), dest_size, dest);
+    deltaDecoding<Int64>(tmp_buffer, dest_size, dest);
 }
 
+/// Run-length encoding
+
+template <std::integral T>
+size_t runLengthEncodedApproximateSize(const T * source, UInt32 source_size)
+{
+    T prev_value = source[0];
+    size_t pair_count = 1;
+
+    for (UInt32 i = 1; i < source_size; ++i)
+    {
+        T value = source[i];
+        if (prev_value != value)
+        {
+            ++pair_count;
+            prev_value = value;
+        }
+    }
+    return pair_count * RunLengthPairLength<T>;
+}
+
+template size_t runLengthEncodedApproximateSize<UInt8>(const UInt8 *, UInt32);
+template size_t runLengthEncodedApproximateSize<UInt16>(const UInt16 *, UInt32);
+template size_t runLengthEncodedApproximateSize<UInt32>(const UInt32 *, UInt32);
+template size_t runLengthEncodedApproximateSize<UInt64>(const UInt64 *, UInt32);
+
+template <std::integral T>
+size_t runLengthEncoding(const T * source, UInt32 source_size, char * dest)
+{
+    T prev_value = source[0];
+    memcpy(dest, source, sizeof(T));
+    dest += sizeof(T);
+
+    std::vector<UInt8> counts;
+    counts.reserve(source_size);
+    UInt8 count = 1;
+
+    for (UInt32 i = 1; i < source_size; ++i)
+    {
+        T value = source[i];
+        if (prev_value == value && count < std::numeric_limits<UInt8>::max())
+        {
+            ++count;
+        }
+        else
+        {
+            counts.push_back(count);
+            unalignedStore<T>(dest, value);
+            dest += sizeof(T);
+            prev_value = value;
+            count = 1;
+        }
+    }
+    counts.push_back(count);
+
+    memcpy(dest, counts.data(), counts.size());
+    return counts.size() * RunLengthPairLength<T>;
+}
+
+template size_t runLengthEncoding<UInt8>(const UInt8 *, UInt32, char *);
+template size_t runLengthEncoding<UInt16>(const UInt16 *, UInt32, char *);
+template size_t runLengthEncoding<UInt32>(const UInt32 *, UInt32, char *);
+template size_t runLengthEncoding<UInt64>(const UInt64 *, UInt32, char *);
+
+template <std::integral T>
+void runLengthDecoding(const char * src, UInt32 source_size, char * dest, UInt32 dest_size)
+{
+    if (unlikely(source_size % RunLengthPairLength<T> != 0))
+        throw Exception(
+            ErrorCodes::CANNOT_DECOMPRESS,
+            "Cannot use RunLength decoding, data size {} is not aligned to {}",
+            source_size,
+            RunLengthPairLength<T>);
+
+    const auto pair_count = source_size / RunLengthPairLength<T>;
+    const char * count_src = src + pair_count * sizeof(T);
+
+    const char * dest_end = dest + dest_size;
+    for (UInt32 i = 0; i < pair_count; ++i)
+    {
+        T value = unalignedLoad<T>(src);
+        src += sizeof(T);
+        auto count = unalignedLoad<UInt8>(count_src);
+        count_src += sizeof(UInt8);
+        if (unlikely(dest + count * sizeof(T) > dest_end))
+            throw Exception(
+                ErrorCodes::CANNOT_DECOMPRESS,
+                "Cannot use RunLength decoding, data is too large, value={}, count={} elem_byte={}",
+                value,
+                count,
+                sizeof(T));
+        dest = writeSameValueMultipleTime(value, count, dest);
+    }
+}
+
+template void runLengthDecoding<UInt8>(const char *, UInt32, char *, UInt32);
+template void runLengthDecoding<UInt16>(const char *, UInt32, char *, UInt32);
+template void runLengthDecoding<UInt32>(const char *, UInt32, char *, UInt32);
+template void runLengthDecoding<UInt64>(const char *, UInt32, char *, UInt32);
 
 } // namespace DB::Compression

--- a/dbms/src/IO/Compression/EncodingUtil.h
+++ b/dbms/src/IO/Compression/EncodingUtil.h
@@ -75,6 +75,7 @@ static constexpr size_t RunLengthPairLength = sizeof(T) + sizeof(UInt8);
 template <std::integral T>
 size_t runLengthEncodedApproximateSize(const T * source, UInt32 source_size);
 
+// After run-length encoding, the values stored in `dest` are:
 // [val1, val2, val3, ..., valn, cnt1, cnt2, ..., cntn]
 template <std::integral T>
 size_t runLengthEncoding(const T * source, UInt32 source_size, char * dest);

--- a/dbms/src/IO/Compression/EncodingUtil.h
+++ b/dbms/src/IO/Compression/EncodingUtil.h
@@ -147,6 +147,14 @@ void FORDecoding(const char * src, UInt32 source_size, char * dest, UInt32 dest_
     applyFrameOfReference(reinterpret_cast<T *>(dest), frame_of_reference, count);
 }
 
+/// ZigZag encoding
+
+template <std::integral T>
+void zigZagEncoding(const T * source, UInt32 count, T * dest);
+
+template <std::integral T>
+void zigZagDecoding(const T * source, UInt32 count, T * dest);
+
 /// Delta encoding
 
 template <std::integral T>
@@ -183,8 +191,12 @@ void ordinaryDeltaFORDecoding(const char * src, UInt32 source_size, char * dest,
     memcpy(dest, src, sizeof(T));
     if (unlikely(source_size == sizeof(T)))
         return;
-    // decode deltas
+    // FOR decode deltas
     FORDecoding<T>(src + sizeof(T), source_size - sizeof(T), dest + sizeof(T), dest_size - sizeof(T));
+    // ZigZag decode deltas
+    auto * deltas = reinterpret_cast<T *>(dest + sizeof(T));
+    zigZagDecoding<T>(deltas, (dest_size - sizeof(T)) / sizeof(T), deltas);
+    // delta decode
     using TS = typename std::make_signed<T>::type;
     ordinaryDeltaDecoding<TS>(dest, dest_size, dest);
 }

--- a/dbms/src/IO/Compression/EncodingUtil.h
+++ b/dbms/src/IO/Compression/EncodingUtil.h
@@ -19,9 +19,9 @@
 #include <common/types.h>
 #include <common/unaligned.h>
 
-#if defined(__AVX2__)
-#include <immintrin.h>
-#endif
+#include <cstring>
+#include <vector>
+
 
 namespace DB::ErrorCodes
 {
@@ -32,36 +32,25 @@ extern const int CANNOT_DECOMPRESS;
 namespace DB::Compression
 {
 
+template <std::integral T>
+char * writeSameValueMultipleTime(T value, UInt32 count, char * dest);
+
 /// Constant encoding
 
 template <std::integral T>
-size_t constantEncoding(T constant, char * dest)
+inline size_t constantEncoding(T constant, char * dest)
 {
     unalignedStore<T>(dest, constant);
     return sizeof(T);
 }
 
 template <std::integral T>
-void constantDecoding(const char * src, UInt32 source_size, char * dest, UInt32 dest_size)
-{
-    if (unlikely(source_size < sizeof(T)))
-        throw Exception(
-            ErrorCodes::CANNOT_DECOMPRESS,
-            "Cannot use Constant decoding, data size {} is too small",
-            source_size);
-
-    T constant = unalignedLoad<T>(src);
-    for (size_t i = 0; i < dest_size / sizeof(T); ++i)
-    {
-        unalignedStore<T>(dest, constant);
-        dest += sizeof(T);
-    }
-}
+void constantDecoding(const char * src, UInt32 source_size, char * dest, UInt32 dest_size);
 
 /// Constant delta encoding
 
 template <std::integral T>
-size_t constantDeltaEncoding(T first_value, T constant_delta, char * dest)
+inline size_t constantDeltaEncoding(T first_value, T constant_delta, char * dest)
 {
     unalignedStore<T>(dest, first_value);
     dest += sizeof(T);
@@ -70,23 +59,7 @@ size_t constantDeltaEncoding(T first_value, T constant_delta, char * dest)
 }
 
 template <std::integral T>
-void constantDeltaDecoding(const char * src, UInt32 source_size, char * dest, UInt32 dest_size)
-{
-    if (unlikely(source_size < sizeof(T) + sizeof(T)))
-        throw Exception(
-            ErrorCodes::CANNOT_DECOMPRESS,
-            "Cannot use ConstantDelta decoding, data size {} is too small",
-            source_size);
-
-    T first_value = unalignedLoad<T>(src);
-    T constant_delta = unalignedLoad<T>(src + sizeof(T));
-    for (size_t i = 0; i < dest_size / sizeof(T); ++i)
-    {
-        unalignedStore<T>(dest, first_value);
-        first_value += constant_delta;
-        dest += sizeof(T);
-    }
-}
+void constantDeltaDecoding(const char * src, UInt32 source_size, char * dest, UInt32 dest_size);
 
 /// Run-length encoding
 
@@ -98,63 +71,16 @@ using RunLengthPairs = std::vector<RunLengthPair<T>>;
 template <std::integral T>
 static constexpr size_t RunLengthPairLength = sizeof(T) + sizeof(UInt8);
 
+// Return the approximate size of the run-length encoded data. The actual size may be larger.
 template <std::integral T>
-size_t runLengthPairsByteSize(const RunLengthPairs<T> & rle)
-{
-    return rle.size() * RunLengthPairLength<T>;
-}
+size_t runLengthEncodedApproximateSize(const T * source, UInt32 source_size);
+
+// [val1, val2, val3, ..., valn, cnt1, cnt2, ..., cntn]
+template <std::integral T>
+size_t runLengthEncoding(const T * source, UInt32 source_size, char * dest);
 
 template <std::integral T>
-size_t runLengthEncoding(const RunLengthPairs<T> & rle, char * dest)
-{
-    for (const auto & [value, count] : rle)
-    {
-        unalignedStore<T>(dest, value);
-        dest += sizeof(T);
-        unalignedStore<UInt8>(dest, count);
-        dest += sizeof(UInt8);
-    }
-    return rle.size() * RunLengthPairLength<T>;
-}
-
-template <std::integral T>
-void runLengthDecoding(const char * src, UInt32 source_size, char * dest, UInt32 dest_size)
-{
-    if (unlikely(source_size % RunLengthPairLength<T> != 0))
-        throw Exception(
-            ErrorCodes::CANNOT_DECOMPRESS,
-            "Cannot use RunLength decoding, data size {} is not aligned to {}",
-            source_size,
-            RunLengthPairLength<T>);
-
-    const char * dest_end = dest + dest_size;
-    for (UInt32 i = 0; i < source_size / RunLengthPairLength<T>; ++i)
-    {
-        T value = unalignedLoad<T>(src);
-        src += sizeof(T);
-        auto count = unalignedLoad<UInt8>(src);
-        src += sizeof(UInt8);
-        if (unlikely(dest + count * sizeof(T) > dest_end))
-            throw Exception(
-                ErrorCodes::CANNOT_DECOMPRESS,
-                "Cannot use RunLength decoding, data is too large, count={} elem_byte={}",
-                count,
-                sizeof(T));
-        if constexpr (std::is_same_v<T, UInt8> || std::is_same_v<T, Int8>)
-        {
-            memset(dest, value, count);
-            dest += count * sizeof(T);
-        }
-        else
-        {
-            for (UInt32 j = 0; j < count; ++j)
-            {
-                unalignedStore<T>(dest, value);
-                dest += sizeof(T);
-            }
-        }
-    }
-}
+void runLengthDecoding(const char * src, UInt32 source_size, char * dest, UInt32 dest_size);
 
 /// Frame of Reference encoding
 
@@ -162,15 +88,11 @@ template <std::integral T>
 void subtractFrameOfReference(T * dst, T frame_of_reference, UInt32 count);
 
 template <std::integral T>
-UInt8 FOREncodingWidth(std::vector<T> & values, T frame_of_reference);
-
-template <std::integral T, bool skip_subtract_frame_of_reference = false>
-size_t FOREncoding(std::vector<T> & values, T frame_of_reference, UInt8 width, char * dest)
+size_t FOREncoding(T * values, UInt32 count, T frame_of_reference, UInt8 width, char * dest)
 {
-    assert(!values.empty()); // caller must ensure input is not empty
+    assert(count != 0); // caller must ensure input is not empty
 
-    if constexpr (!skip_subtract_frame_of_reference)
-        subtractFrameOfReference(values.data(), frame_of_reference, values.size());
+    subtractFrameOfReference(values, frame_of_reference, count);
     // store frame of reference
     unalignedStore<T>(dest, frame_of_reference);
     dest += sizeof(T);
@@ -180,9 +102,9 @@ size_t FOREncoding(std::vector<T> & values, T frame_of_reference, UInt8 width, c
     // if width == 0, skip bitpacking
     if (width == 0)
         return sizeof(T) + sizeof(UInt8);
-    auto required_size = BitpackingPrimitives::getRequiredSize(values.size(), width);
+    auto required_size = BitpackingPrimitives::getRequiredSize(count, width);
     // after applying frame of reference, all values are bigger than 0.
-    BitpackingPrimitives::packBuffer(reinterpret_cast<unsigned char *>(dest), values.data(), values.size(), width);
+    BitpackingPrimitives::packBuffer(reinterpret_cast<unsigned char *>(dest), values, count, width);
     return sizeof(T) + sizeof(UInt8) + required_size;
 }
 
@@ -228,16 +150,7 @@ void FORDecoding(const char * src, UInt32 source_size, char * dest, UInt32 dest_
 /// Delta encoding
 
 template <std::integral T>
-void deltaEncoding(const T * source, UInt32 count, T * dest)
-{
-    T prev = 0;
-    for (UInt32 i = 0; i < count; ++i)
-    {
-        T curr = source[i];
-        dest[i] = curr - prev;
-        prev = curr;
-    }
-}
+void deltaEncoding(const T * source, UInt32 count, T * dest);
 
 template <std::integral T>
 void ordinaryDeltaDecoding(const char * source, UInt32 source_size, char * dest)
@@ -266,14 +179,14 @@ void ordinaryDeltaFORDecoding(const char * src, UInt32 source_size, char * dest,
     assert(source_size >= sizeof(T));
     assert(dest_size >= sizeof(T));
 
-    using TS = typename std::make_signed_t<T>;
     // copy first value to dest
     memcpy(dest, src, sizeof(T));
     if (unlikely(source_size == sizeof(T)))
         return;
     // decode deltas
-    FORDecoding<TS>(src + sizeof(T), source_size - sizeof(T), dest + sizeof(T), dest_size - sizeof(T));
-    ordinaryDeltaDecoding<T>(dest, dest_size, dest);
+    FORDecoding<T>(src + sizeof(T), source_size - sizeof(T), dest + sizeof(T), dest_size - sizeof(T));
+    using TS = typename std::make_signed<T>::type;
+    ordinaryDeltaDecoding<TS>(dest, dest_size, dest);
 }
 
 template <std::integral T>

--- a/dbms/src/IO/Compression/tests/bench_codec.cpp
+++ b/dbms/src/IO/Compression/tests/bench_codec.cpp
@@ -272,4 +272,45 @@ static void multipleRead(benchmark::State & state)
 BENCH_MULTIPLE_WRITE(CodecMultipleWrite)
 BENCH_MULTIPLE_READ(CodecMultipleRead)
 
+BENCH_SINGLE_READ_METHOD_GENERATOR_TYPE(
+    RunLengthReadUInt8,
+    CompressionMethodByte::RunLength,
+    tests::RepeatGenerator<UInt8>(0),
+    UInt8)
+BENCH_SINGLE_READ_METHOD_GENERATOR_TYPE(
+    RunLengthReadUInt16,
+    CompressionMethodByte::RunLength,
+    tests::RepeatGenerator<UInt16>(0),
+    UInt16)
+BENCH_SINGLE_READ_METHOD_GENERATOR_TYPE(
+    RunLengthReadUInt32,
+    CompressionMethodByte::RunLength,
+    tests::RepeatGenerator<UInt32>(0),
+    UInt32)
+BENCH_SINGLE_READ_METHOD_GENERATOR_TYPE(
+    RunLengthReadUInt64,
+    CompressionMethodByte::RunLength,
+    tests::RepeatGenerator<UInt64>(0),
+    UInt64)
+BENCH_SINGLE_WRITE_METHOD_GENERATOR_TYPE(
+    RunLengthWriteUInt8,
+    CompressionMethodByte::RunLength,
+    tests::RepeatGenerator<UInt8>(0),
+    UInt8)
+BENCH_SINGLE_WRITE_METHOD_GENERATOR_TYPE(
+    RunLengthWriteUInt16,
+    CompressionMethodByte::RunLength,
+    tests::RepeatGenerator<UInt16>(0),
+    UInt16)
+BENCH_SINGLE_WRITE_METHOD_GENERATOR_TYPE(
+    RunLengthWriteUInt32,
+    CompressionMethodByte::RunLength,
+    tests::RepeatGenerator<UInt32>(0),
+    UInt32)
+BENCH_SINGLE_WRITE_METHOD_GENERATOR_TYPE(
+    RunLengthWriteUInt64,
+    CompressionMethodByte::RunLength,
+    tests::RepeatGenerator<UInt64>(0),
+    UInt64)
+
 } // namespace DB::bench

--- a/dbms/src/IO/Compression/tests/gtest_codec_compression.cpp
+++ b/dbms/src/IO/Compression/tests/gtest_codec_compression.cpp
@@ -390,7 +390,6 @@ INSTANTIATE_TEST_CASE_P(
             generateSeq<UInt32>(G(RandomGenerator<UInt32>(0, 0, 1000'000'000))),
             generateSeq<UInt64>(G(RandomGenerator<UInt64>(0, 0, 1000'000'000))))));
 
-
 INSTANTIATE_TEST_CASE_P(
     RepeatInt,
     CodecTest,

--- a/dbms/src/Interpreters/Settings.h
+++ b/dbms/src/Interpreters/Settings.h
@@ -214,8 +214,8 @@ struct Settings
     /* Checksum and compressions */ \
     M(SettingUInt64, dt_checksum_frame_size, DBMS_DEFAULT_BUFFER_SIZE, "Frame size for delta tree stable storage")                                                                                                                      \
     M(SettingChecksumAlgorithm, dt_checksum_algorithm, ChecksumAlgo::XXH3, "Checksum algorithm for delta tree stable storage")                                                                                                          \
-    M(SettingCompressionMethod, dt_compression_method, CompressionMethod::LZ4, "The method of data compression when writing.")                                                                                                          \
-    M(SettingInt64, dt_compression_level, 1, "The compression level.")                                                                                                                                                                  \
+    M(SettingCompressionMethod, dt_compression_method, CompressionMethod::Lightweight, "The method of data compression when writing.")                                                                                                  \
+    M(SettingInt64, dt_compression_level, 3, "The compression level.")                                                                                                                                                                  \
     M(SettingUInt64, min_compress_block_size, DEFAULT_MIN_COMPRESS_BLOCK_SIZE, "The actual size of the block to compress, if the uncompressed data less than max_compress_block_size is no less than this value "                       \
                                                                                "and no less than the volume of data for one mark.")                                                                                                     \
     M(SettingUInt64, max_compress_block_size, DEFAULT_MAX_COMPRESS_BLOCK_SIZE, "The maximum size of blocks of uncompressed data before compressing for writing to a table.")                                                            \

--- a/dbms/src/Interpreters/Settings.h
+++ b/dbms/src/Interpreters/Settings.h
@@ -214,8 +214,8 @@ struct Settings
     /* Checksum and compressions */ \
     M(SettingUInt64, dt_checksum_frame_size, DBMS_DEFAULT_BUFFER_SIZE, "Frame size for delta tree stable storage")                                                                                                                      \
     M(SettingChecksumAlgorithm, dt_checksum_algorithm, ChecksumAlgo::XXH3, "Checksum algorithm for delta tree stable storage")                                                                                                          \
-    M(SettingCompressionMethod, dt_compression_method, CompressionMethod::Lightweight, "The method of data compression when writing.")                                                                                                  \
-    M(SettingInt64, dt_compression_level, 3, "The compression level.")                                                                                                                                                                  \
+    M(SettingCompressionMethod, dt_compression_method, CompressionMethod::LZ4, "The method of data compression when writing.")                                                                                                          \
+    M(SettingInt64, dt_compression_level, 1, "The compression level.")                                                                                                                                                                  \
     M(SettingUInt64, min_compress_block_size, DEFAULT_MIN_COMPRESS_BLOCK_SIZE, "The actual size of the block to compress, if the uncompressed data less than max_compress_block_size is no less than this value "                       \
                                                                                "and no less than the volume of data for one mark.")                                                                                                     \
     M(SettingUInt64, max_compress_block_size, DEFAULT_MAX_COMPRESS_BLOCK_SIZE, "The maximum size of blocks of uncompressed data before compressing for writing to a table.")                                                            \

--- a/dbms/src/Interpreters/SettingsCommon.h
+++ b/dbms/src/Interpreters/SettingsCommon.h
@@ -726,8 +726,7 @@ public:
 
         if (value < CompressionMethod::LZ4 || value > compression_method_last)
             throw Exception("Unknown compression method", ErrorCodes::UNKNOWN_COMPRESSION_METHOD);
-#if USE_QPL
-#else
+#if !USE_QPL
         if (unlikely(value == CompressionMethod::QPL))
             throw Exception("Unknown compression method", ErrorCodes::UNKNOWN_COMPRESSION_METHOD);
 #endif

--- a/dbms/src/Interpreters/SettingsCommon.h
+++ b/dbms/src/Interpreters/SettingsCommon.h
@@ -56,12 +56,12 @@ struct SettingInt
 public:
     bool changed = false;
 
-    SettingInt(IntType x = 0)
+    SettingInt(IntType x = 0) // NOLINT(google-explicit-constructor)
         : value(x)
     {}
     SettingInt(const SettingInt & setting);
 
-    operator IntType() const { return value.load(); }
+    operator IntType() const { return value.load(); } // NOLINT(google-explicit-constructor)
     SettingInt & operator=(IntType x)
     {
         set(x);
@@ -113,12 +113,12 @@ public:
     bool is_auto;
     bool changed = false;
 
-    SettingMaxThreads(UInt64 x = 0)
+    SettingMaxThreads(UInt64 x = 0) // NOLINT(google-explicit-constructor)
         : is_auto(x == 0)
         , value(x ? x : getAutoValue())
     {}
 
-    operator UInt64() const { return value; }
+    operator UInt64() const { return value; } // NOLINT(google-explicit-constructor)
     SettingMaxThreads & operator=(UInt64 x)
     {
         set(x);
@@ -187,11 +187,11 @@ struct SettingSeconds
 public:
     bool changed = false;
 
-    SettingSeconds(UInt64 seconds = 0)
+    SettingSeconds(UInt64 seconds = 0) // NOLINT(google-explicit-constructor)
         : value(seconds, 0)
     {}
 
-    operator Poco::Timespan() const { return value; }
+    operator Poco::Timespan() const { return value; } // NOLINT(google-explicit-constructor)
     SettingSeconds & operator=(const Poco::Timespan & x)
     {
         set(x);
@@ -235,11 +235,11 @@ struct SettingMilliseconds
 public:
     bool changed = false;
 
-    SettingMilliseconds(UInt64 milliseconds = 0)
+    SettingMilliseconds(UInt64 milliseconds = 0) // NOLINT(google-explicit-constructor)
         : value(milliseconds * 1000)
     {}
 
-    operator Poco::Timespan() const { return value; }
+    operator Poco::Timespan() const { return value; } // NOLINT(google-explicit-constructor)
     SettingMilliseconds & operator=(const Poco::Timespan & x)
     {
         set(x);
@@ -283,11 +283,11 @@ struct SettingFloat
 public:
     bool changed = false;
 
-    SettingFloat(float x = 0)
+    SettingFloat(float x = 0) // NOLINT(google-explicit-constructor)
         : value(x)
     {}
     SettingFloat(const SettingFloat & setting) { value.store(setting.value.load()); }
-    operator float() const { return value.load(); }
+    operator float() const { return value.load(); } // NOLINT(google-explicit-constructor)
     SettingFloat & operator=(float x)
     {
         set(x);
@@ -390,11 +390,11 @@ struct SettingDouble
 public:
     bool changed = false;
 
-    SettingDouble(double x = 0)
+    SettingDouble(double x = 0) // NOLINT(google-explicit-constructor)
         : value(x)
     {}
     SettingDouble(const SettingDouble & setting) { value.store(setting.value.load()); }
-    operator double() const { return value.load(); }
+    operator double() const { return value.load(); } // NOLINT(google-explicit-constructor)
     SettingDouble & operator=(double x)
     {
         set(x);
@@ -473,11 +473,11 @@ struct SettingLoadBalancing
 public:
     bool changed = false;
 
-    SettingLoadBalancing(LoadBalancing x)
+    explicit SettingLoadBalancing(LoadBalancing x)
         : value(x)
     {}
 
-    operator LoadBalancing() const { return value; }
+    operator LoadBalancing() const { return value; } // NOLINT(google-explicit-constructor)
     SettingLoadBalancing & operator=(LoadBalancing x)
     {
         set(x);
@@ -537,11 +537,11 @@ struct SettingOverflowMode
 public:
     bool changed = false;
 
-    SettingOverflowMode(OverflowMode x = OverflowMode::THROW)
+    explicit SettingOverflowMode(OverflowMode x = OverflowMode::THROW)
         : value(x)
     {}
 
-    operator OverflowMode() const { return value; }
+    operator OverflowMode() const { return value; } // NOLINT(google-explicit-constructor)
     SettingOverflowMode & operator=(OverflowMode x)
     {
         set(x);
@@ -602,7 +602,7 @@ struct SettingChecksumAlgorithm
 public:
     bool changed = false;
 
-    SettingChecksumAlgorithm(ChecksumAlgo x = ChecksumAlgo::XXH3) // NOLINT(google-explicit-constructor)
+    explicit SettingChecksumAlgorithm(ChecksumAlgo x = ChecksumAlgo::XXH3)
         : value(x)
     {}
 
@@ -678,11 +678,11 @@ struct SettingCompressionMethod
 public:
     bool changed = false;
 
-    SettingCompressionMethod(CompressionMethod x = CompressionMethod::LZ4)
+    explicit SettingCompressionMethod(CompressionMethod x = CompressionMethod::LZ4)
         : value(x)
     {}
 
-    operator CompressionMethod() const { return value; }
+    operator CompressionMethod() const { return value; } // NOLINT(google-explicit-constructor)
     SettingCompressionMethod & operator=(CompressionMethod x)
     {
         set(x);
@@ -701,28 +701,36 @@ public:
 #if USE_QPL
         if (lower_str == "qpl")
             return CompressionMethod::QPL;
+#endif
+        if (lower_str == "none")
+            return CompressionMethod::NONE;
+        if (lower_str == "lightweight")
+            return CompressionMethod::Lightweight;
+#if USE_QPL
         throw Exception(
-            "Unknown compression method: '" + s + "', must be one of 'lz4', 'lz4hc', 'zstd', 'qpl'",
-            ErrorCodes::UNKNOWN_COMPRESSION_METHOD);
+            ErrorCodes::UNKNOWN_COMPRESSION_METHOD,
+            "Unknown compression method: '{}', must be one of 'lz4', 'lz4hc', 'zstd', 'qpl', 'none', 'lightweight'",
+            s);
 #else
         throw Exception(
-            "Unknown compression method: '" + s + "', must be one of 'lz4', 'lz4hc', 'zstd'",
-            ErrorCodes::UNKNOWN_COMPRESSION_METHOD);
+            ErrorCodes::UNKNOWN_COMPRESSION_METHOD,
+            "Unknown compression method: '{}', must be one of 'lz4', 'lz4hc', 'zstd', 'none', 'lightweight'",
+            s);
 #endif
     }
 
     String toString() const
     {
-#if USE_QPL
-        const char * strings[] = {nullptr, "lz4", "lz4hc", "zstd", "qpl"};
-        auto compression_method_last = CompressionMethod::QPL;
-#else
-        const char * strings[] = {nullptr, "lz4", "lz4hc", "zstd"};
-        auto compression_method_last = CompressionMethod::ZSTD;
-#endif
+        const char * strings[] = {nullptr, "lz4", "lz4hc", "zstd", "qpl", "none", "lightweight"};
+        auto compression_method_last = CompressionMethod::Lightweight;
 
         if (value < CompressionMethod::LZ4 || value > compression_method_last)
             throw Exception("Unknown compression method", ErrorCodes::UNKNOWN_COMPRESSION_METHOD);
+#if USE_QPL
+#else
+        if (unlikely(value == CompressionMethod::QPL))
+            throw Exception("Unknown compression method", ErrorCodes::UNKNOWN_COMPRESSION_METHOD);
+#endif
 
         return strings[static_cast<size_t>(value)];
     }
@@ -757,11 +765,11 @@ struct SettingTaskQueueType
 public:
     bool changed = false;
 
-    SettingTaskQueueType(TaskQueueType x = TaskQueueType::DEFAULT)
+    explicit SettingTaskQueueType(TaskQueueType x = TaskQueueType::DEFAULT)
         : value(x)
     {}
 
-    operator TaskQueueType() const { return value; }
+    operator TaskQueueType() const { return value; } // NOLINT(google-explicit-constructor)
     SettingTaskQueueType & operator=(TaskQueueType x)
     {
         set(x);
@@ -811,11 +819,11 @@ struct SettingString
 public:
     bool changed = false;
 
-    SettingString(const String & x = String{})
+    explicit SettingString(const String & x = String{})
         : value(x)
     {}
 
-    operator String() const { return value; }
+    operator String() const { return value; } // NOLINT(google-explicit-constructor)
     SettingString & operator=(const String & x)
     {
         set(x);

--- a/dbms/src/Server/tests/gtest_server_config.cpp
+++ b/dbms/src/Server/tests/gtest_server_config.cpp
@@ -287,6 +287,16 @@ dt_compression_level = 1
 [profiles.default]
 dt_compression_method = "LZ4"
 dt_compression_level = 1
+        )",
+        R"(
+[profiles]
+[profiles.default]
+dt_compression_method = "Lightweight"
+        )",
+        R"(
+[profiles]
+[profiles.default]
+dt_compression_method = "lightweight"
         )"};
 
     auto & global_ctx = TiFlashTestEnv::getGlobalContext();
@@ -345,6 +355,14 @@ dt_compression_level = 1
         {
             ASSERT_EQ(global_ctx.getSettingsRef().dt_compression_method, CompressionMethod::LZ4);
             ASSERT_EQ(global_ctx.getSettingsRef().dt_compression_level, 1);
+        }
+        if (i == 6)
+        {
+            ASSERT_EQ(global_ctx.getSettingsRef().dt_compression_method, CompressionMethod::Lightweight);
+        }
+        if (i == 7)
+        {
+            ASSERT_EQ(global_ctx.getSettingsRef().dt_compression_method, CompressionMethod::Lightweight);
         }
     }
     global_ctx.setSettings(origin_settings);

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFilePersisted.cpp
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFilePersisted.cpp
@@ -101,26 +101,18 @@ void serializeColumn(
     CompressionMethod compression_method,
     Int64 compression_level)
 {
-    std::unique_ptr<CompressedWriteBuffer<>> compressed;
-    if (compression_method == CompressionMethod::Lightweight)
-    {
-        // Do not use lightweight compression in ColumnFile whose write performance is the bottleneck.
-        compressed = std::make_unique<CompressedWriteBuffer<>>(buf, CompressionSettings(CompressionMethod::LZ4));
-    }
-    else
-    {
-        compressed = std::make_unique<CompressedWriteBuffer<>>(
-            buf,
-            CompressionSettings(compression_method, compression_level));
-    }
+    auto settings = compression_method == CompressionMethod::Lightweight
+        ? CompressionSettings(CompressionMethod::LZ4)
+        : CompressionSettings(compression_method, compression_level);
+    CompressedWriteBuffer compressed(buf, settings);
     type->serializeBinaryBulkWithMultipleStreams(
         column,
-        [&](const IDataType::SubstreamPath &) { return compressed.get(); },
+        [&](const IDataType::SubstreamPath &) { return &compressed; },
         offset,
         limit,
         true,
         {});
-    compressed->next();
+    compressed.next();
 }
 
 void deserializeColumn(IColumn & column, const DataTypePtr & type, std::string_view data_buf, size_t rows)

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFilePersisted.cpp
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFilePersisted.cpp
@@ -101,6 +101,7 @@ void serializeColumn(
     CompressionMethod compression_method,
     Int64 compression_level)
 {
+    // Do not use lightweight compression in ColumnFile whose write performance is the bottleneck.
     auto settings = compression_method == CompressionMethod::Lightweight
         ? CompressionSettings(CompressionMethod::LZ4)
         : CompressionSettings(compression_method, compression_level);

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_file.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_file.cpp
@@ -174,10 +174,10 @@ public:
     }
 
 protected:
-    std::unique_ptr<DMContext> dm_context{};
+    std::unique_ptr<DMContext> dm_context;
     /// all these var live as ref in dm_context
-    std::shared_ptr<StoragePathPool> path_pool{};
-    std::shared_ptr<StoragePool> storage_pool{};
+    std::shared_ptr<StoragePathPool> path_pool;
+    std::shared_ptr<StoragePool> storage_pool;
     ColumnDefinesPtr table_columns;
     DeltaMergeStore::Settings settings;
 
@@ -415,9 +415,8 @@ try
                 files.insert(itr.name());
             }
         }
-        ASSERT_EQ(files.size(), 3); // handle data / col data and merged file
+        ASSERT_EQ(files.size(), 2); // col data and merged file
         ASSERT(files.find("0.merged") != files.end());
-        ASSERT(files.find("%2D1.dat") != files.end());
         ASSERT(files.find("1.dat") != files.end());
     }
 
@@ -636,11 +635,13 @@ try
     const size_t num_rows_write = 128;
 
     DMFileBlockOutputStream::BlockProperty block_property1{
+        .not_clean_rows = 0,
         .deleted_rows = 1,
         .effective_num_rows = 1,
         .gc_hint_version = 1,
     };
     DMFileBlockOutputStream::BlockProperty block_property2{
+        .not_clean_rows = 0,
         .deleted_rows = 2,
         .effective_num_rows = 2,
         .gc_hint_version = 2,
@@ -733,16 +734,19 @@ try
     const size_t num_rows_write = 8192;
 
     DMFileBlockOutputStream::BlockProperty block_property1{
+        .not_clean_rows = 0,
         .deleted_rows = 1,
         .effective_num_rows = 1,
         .gc_hint_version = 1,
     };
     DMFileBlockOutputStream::BlockProperty block_property2{
+        .not_clean_rows = 0,
         .deleted_rows = 2,
         .effective_num_rows = 2,
         .gc_hint_version = 2,
     };
     DMFileBlockOutputStream::BlockProperty block_property3{
+        .not_clean_rows = 0,
         .deleted_rows = 3,
         .effective_num_rows = 3,
         .gc_hint_version = 3,
@@ -1046,16 +1050,19 @@ try
     const size_t num_rows_write = 8192;
 
     DMFileBlockOutputStream::BlockProperty block_property1{
+        .not_clean_rows = 0,
         .deleted_rows = 1,
         .effective_num_rows = 1,
         .gc_hint_version = 1,
     };
     DMFileBlockOutputStream::BlockProperty block_property2{
+        .not_clean_rows = 0,
         .deleted_rows = 2,
         .effective_num_rows = 2,
         .gc_hint_version = 2,
     };
     DMFileBlockOutputStream::BlockProperty block_property3{
+        .not_clean_rows = 0,
         .deleted_rows = 3,
         .effective_num_rows = 3,
         .gc_hint_version = 3,
@@ -1139,16 +1146,19 @@ try
     const size_t num_rows_write = 1024;
 
     DMFileBlockOutputStream::BlockProperty block_property1{
+        .not_clean_rows = 0,
         .deleted_rows = 1,
         .effective_num_rows = 1,
         .gc_hint_version = 1,
     };
     DMFileBlockOutputStream::BlockProperty block_property2{
+        .not_clean_rows = 0,
         .deleted_rows = 2,
         .effective_num_rows = 2,
         .gc_hint_version = 2,
     };
     DMFileBlockOutputStream::BlockProperty block_property3{
+        .not_clean_rows = 0,
         .deleted_rows = 3,
         .effective_num_rows = 3,
         .gc_hint_version = 3,
@@ -1981,10 +1991,10 @@ public:
 
 private:
     String path;
-    std::unique_ptr<DMContext> dm_context{};
+    std::unique_ptr<DMContext> dm_context;
     /// all these var live as ref in dm_context
-    std::shared_ptr<StoragePathPool> path_pool{};
-    std::shared_ptr<StoragePool> storage_pool{};
+    std::shared_ptr<StoragePathPool> path_pool;
+    std::shared_ptr<StoragePool> storage_pool;
     ColumnDefinesPtr table_columns;
     DeltaMergeStore::Settings settings;
 

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_file.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_file.cpp
@@ -413,8 +413,9 @@ try
                 files.insert(itr.name());
             }
         }
-        ASSERT_EQ(files.size(), 2); // col data and merged file
+        ASSERT_EQ(files.size(), 3); // handle, col data and merged file
         ASSERT(files.find("0.merged") != files.end());
+        ASSERT(files.find("%2D1.dat") != files.end());
         ASSERT(files.find("1.dat") != files.end());
     }
 

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_file.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_file.cpp
@@ -363,7 +363,6 @@ try
 CATCH
 
 // test multiple data  into v3, and read it
-// check there are only index and mrk and null.data in merged
 TEST_F(DMFileMetaV2Test, CheckDMFileV3WithMultiData)
 try
 {
@@ -386,7 +385,6 @@ try
 
         ASSERT_EQ(dm_file->getPackProperties().property_size(), 1);
     }
-
 
     {
         // Test read

--- a/metrics/grafana/tiflash_summary.json
+++ b/metrics/grafana/tiflash_summary.json
@@ -8571,8 +8571,8 @@
           "gridPos": {
             "h": 8,
             "w": 12,
-            "x": 0,
-            "y": 165
+            "x": 12,
+            "y": 117
           },
           "hiddenSeries": false,
           "id": 292,
@@ -9336,211 +9336,211 @@
           }
         },
         {
-          "type": "graph",
-          "title": "Compression Algorithm Count",
-          "gridPos": {
-            "x": 0,
-            "y": 110,
-            "w": 12,
-            "h": 8
-          },
-          "id": 23763571993,
-          "targets": [
-            {
-              "expr": "sum(rate(tiflash_storage_pack_compression_algorithm_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (type)",
-              "legendFormat": "{{type}}",
-              "interval": "",
-              "exemplar": true,
-              "refId": "A",
-              "queryType": "randomWalk",
-              "hide": false
-            }
-          ],
-          "options": {
-            "alertThreshold": true
-          },
-          "fieldConfig": {
-            "defaults": {},
-            "overrides": []
-          },
-          "pluginVersion": "7.5.17",
-          "renderer": "flot",
-          "yaxes": [
-            {
-              "label": null,
-              "show": true,
-              "logBase": 1,
-              "min": null,
-              "max": null,
-              "format": "short",
-              "$$hashKey": "object:304"
-            },
-            {
-              "label": null,
-              "show": true,
-              "logBase": 1,
-              "min": null,
-              "max": null,
-              "format": "short",
-              "$$hashKey": "object:305"
-            }
-          ],
-          "xaxis": {
-            "show": true,
-            "mode": "time",
-            "name": null,
-            "values": [],
-            "buckets": null
-          },
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          },
-          "lines": true,
-          "fill": 1,
-          "linewidth": 1,
-          "dashLength": 10,
-          "spaceLength": 10,
-          "pointradius": 2,
-          "legend": {
-            "show": true,
-            "values": true,
-            "min": false,
-            "max": false,
-            "current": true,
-            "total": true,
-            "avg": false,
-            "alignAsTable": true,
-            "rightSide": true
-          },
-          "nullPointMode": "null",
-          "tooltip": {
-            "value_type": "individual",
-            "shared": true,
-            "sort": 0
-          },
           "aliasColors": {},
-          "seriesOverrides": [],
-          "thresholds": [],
-          "timeRegions": [],
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
           "description": "The count of the compression algorithm used by each data part",
-          "fillGradient": 0,
-          "dashes": false,
-          "hiddenSeries": false,
-          "points": false,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "steppedLine": false,
-          "timeFrom": null,
-          "timeShift": null
-        },
-        {
-          "type": "graph",
-          "title": "Compression Ratio",
-          "gridPos": {
-            "x": 0,
-            "y": 109,
-            "w": 12,
-            "h": 8
-          },
-          "id": 23763571994,
-          "targets": [
-            {
-              "expr": "sum(rate(tiflash_storage_pack_compression_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", type=~\"lz4_uncompressed_bytes\"}[1m]))/sum(rate(tiflash_storage_pack_compression_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", type=~\"lz4_compressed_bytes\"}[1m]))",
-              "legendFormat": "lz4",
-              "interval": "",
-              "exemplar": true,
-              "refId": "A",
-              "queryType": "randomWalk"
-            },
-            {
-              "expr": "sum(rate(tiflash_storage_pack_compression_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", type=~\"lightweight_uncompressed_bytes\"}[1m]))/sum(rate(tiflash_storage_pack_compression_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", type=~\"lightweight_compressed_bytes\"}[1m]))",
-              "legendFormat": "lightweight",
-              "interval": "",
-              "exemplar": true,
-              "refId": "B",
-              "hide": false
-            }
-          ],
-          "options": {
-            "alertThreshold": true
-          },
-          "datasource": "${DS_TEST-CLUSTER}",
           "fieldConfig": {
             "defaults": {},
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 117
+          },
+          "hiddenSeries": false,
+          "id": 293,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": true,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
           "renderer": "flot",
-          "yaxes": [
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
             {
-              "label": null,
-              "show": true,
-              "logBase": 1,
-              "min": null,
-              "max": null,
-              "format": "short"
-            },
-            {
-              "label": null,
-              "show": true,
-              "logBase": 1,
-              "min": null,
-              "max": null,
-              "format": "short"
+              "exemplar": true,
+              "expr": "sum(rate(tiflash_storage_pack_compression_algorithm_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (type)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{type}}",
+              "queryType": "randomWalk",
+              "refId": "A"
             }
           ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Compression Algorithm Count",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
           "xaxis": {
-            "show": true,
+            "buckets": null,
             "mode": "time",
             "name": null,
-            "values": [],
-            "buckets": null
+            "show": true,
+            "values": []
           },
+          "yaxes": [
+            {
+              "$$hashKey": "object:304",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:305",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
           "yaxis": {
             "align": false,
             "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "The compression ratio of different compression algorithm",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 109
+          },
+          "hiddenSeries": false,
+          "id": 294,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
           },
           "lines": true,
-          "fill": 1,
           "linewidth": 1,
-          "dashLength": 10,
-          "spaceLength": 10,
-          "pointradius": 2,
-          "legend": {
-            "show": true,
-            "values": true,
-            "min": false,
-            "max": false,
-            "current": true,
-            "total": false,
-            "avg": true,
-            "alignAsTable": true,
-            "rightSide": true
-          },
           "nullPointMode": "null",
-          "tooltip": {
-            "value_type": "individual",
-            "shared": true,
-            "sort": 0
+          "options": {
+            "alertThreshold": true
           },
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "thresholds": [],
-          "timeRegions": [],
-          "fillGradient": 0,
-          "dashes": false,
-          "hiddenSeries": false,
-          "points": false,
-          "bars": false,
-          "stack": false,
           "percentage": false,
+          "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
           "steppedLine": false,
-          "description": "The compression ratio of different compression algorithm",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(rate(tiflash_storage_pack_compression_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", type=~\"lz4_uncompressed_bytes\"}[1m]))/sum(rate(tiflash_storage_pack_compression_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", type=~\"lz4_compressed_bytes\"}[1m]))",
+              "interval": "",
+              "legendFormat": "lz4",
+              "queryType": "randomWalk",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(rate(tiflash_storage_pack_compression_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", type=~\"lightweight_uncompressed_bytes\"}[1m]))/sum(rate(tiflash_storage_pack_compression_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", type=~\"lightweight_compressed_bytes\"}[1m]))",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "lightweight",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
           "timeFrom": null,
-          "timeShift": null
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Compression Ratio",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         }
       ],
       "repeat": null,

--- a/metrics/grafana/tiflash_summary.json
+++ b/metrics/grafana/tiflash_summary.json
@@ -8413,10 +8413,7 @@
               "id": "filterFieldsByName",
               "options": {
                 "include": {
-                  "names": [
-                    "Time",
-                    "mark cache effectiveness"
-                  ]
+                  "names": ["Time", "mark cache effectiveness"]
                 }
               }
             }
@@ -9337,6 +9334,213 @@
             "align": false,
             "alignLevel": null
           }
+        },
+        {
+          "type": "graph",
+          "title": "Compression Algorithm Count",
+          "gridPos": {
+            "x": 0,
+            "y": 110,
+            "w": 12,
+            "h": 8
+          },
+          "id": 23763571993,
+          "targets": [
+            {
+              "expr": "sum(rate(tiflash_storage_pack_compression_algorithm_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (type)",
+              "legendFormat": "{{type}}",
+              "interval": "",
+              "exemplar": true,
+              "refId": "A",
+              "queryType": "randomWalk",
+              "hide": false
+            }
+          ],
+          "options": {
+            "alertThreshold": true
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "pluginVersion": "7.5.17",
+          "renderer": "flot",
+          "yaxes": [
+            {
+              "label": null,
+              "show": true,
+              "logBase": 1,
+              "min": null,
+              "max": null,
+              "format": "short",
+              "$$hashKey": "object:304"
+            },
+            {
+              "label": null,
+              "show": true,
+              "logBase": 1,
+              "min": null,
+              "max": null,
+              "format": "short",
+              "$$hashKey": "object:305"
+            }
+          ],
+          "xaxis": {
+            "show": true,
+            "mode": "time",
+            "name": null,
+            "values": [],
+            "buckets": null
+          },
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          },
+          "lines": true,
+          "fill": 1,
+          "linewidth": 1,
+          "dashLength": 10,
+          "spaceLength": 10,
+          "pointradius": 2,
+          "legend": {
+            "show": true,
+            "values": true,
+            "min": false,
+            "max": false,
+            "current": true,
+            "total": true,
+            "avg": false,
+            "alignAsTable": true,
+            "rightSide": true
+          },
+          "nullPointMode": "null",
+          "tooltip": {
+            "value_type": "individual",
+            "shared": true,
+            "sort": 0
+          },
+          "aliasColors": {},
+          "seriesOverrides": [],
+          "thresholds": [],
+          "timeRegions": [],
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "The count of the compression algorithm used by each data part",
+          "fillGradient": 0,
+          "dashes": false,
+          "hiddenSeries": false,
+          "points": false,
+          "bars": false,
+          "stack": false,
+          "percentage": false,
+          "steppedLine": false,
+          "timeFrom": null,
+          "timeShift": null
+        },
+        {
+          "type": "graph",
+          "title": "Compression Ratio",
+          "gridPos": {
+            "x": 0,
+            "y": 109,
+            "w": 12,
+            "h": 8
+          },
+          "id": 23763571994,
+          "targets": [
+            {
+              "expr": "sum(rate(tiflash_storage_pack_compression_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", type=~\"lz4_uncompressed_bytes\"}[1m]))/sum(rate(tiflash_storage_pack_compression_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", type=~\"lz4_compressed_bytes\"}[1m]))",
+              "legendFormat": "lz4",
+              "interval": "",
+              "exemplar": true,
+              "refId": "A",
+              "queryType": "randomWalk"
+            },
+            {
+              "expr": "sum(rate(tiflash_storage_pack_compression_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", type=~\"lightweight_uncompressed_bytes\"}[1m]))/sum(rate(tiflash_storage_pack_compression_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", type=~\"lightweight_compressed_bytes\"}[1m]))",
+              "legendFormat": "lightweight",
+              "interval": "",
+              "exemplar": true,
+              "refId": "B",
+              "hide": false
+            }
+          ],
+          "options": {
+            "alertThreshold": true
+          },
+          "datasource": "${DS_TEST-CLUSTER}",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "pluginVersion": "7.5.17",
+          "renderer": "flot",
+          "yaxes": [
+            {
+              "label": null,
+              "show": true,
+              "logBase": 1,
+              "min": null,
+              "max": null,
+              "format": "short"
+            },
+            {
+              "label": null,
+              "show": true,
+              "logBase": 1,
+              "min": null,
+              "max": null,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true,
+            "mode": "time",
+            "name": null,
+            "values": [],
+            "buckets": null
+          },
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          },
+          "lines": true,
+          "fill": 1,
+          "linewidth": 1,
+          "dashLength": 10,
+          "spaceLength": 10,
+          "pointradius": 2,
+          "legend": {
+            "show": true,
+            "values": true,
+            "min": false,
+            "max": false,
+            "current": true,
+            "total": false,
+            "avg": true,
+            "alignAsTable": true,
+            "rightSide": true
+          },
+          "nullPointMode": "null",
+          "tooltip": {
+            "value_type": "individual",
+            "shared": true,
+            "sort": 0
+          },
+          "aliasColors": {},
+          "seriesOverrides": [],
+          "thresholds": [],
+          "timeRegions": [],
+          "fillGradient": 0,
+          "dashes": false,
+          "hiddenSeries": false,
+          "points": false,
+          "bars": false,
+          "stack": false,
+          "percentage": false,
+          "steppedLine": false,
+          "description": "The compression ratio of different compression algorithm",
+          "timeFrom": null,
+          "timeShift": null
         }
       ],
       "repeat": null,
@@ -19681,17 +19885,7 @@
       "2h",
       "1d"
     ],
-    "time_options": [
-      "5m",
-      "15m",
-      "1h",
-      "6h",
-      "12h",
-      "24h",
-      "2d",
-      "7d",
-      "30d"
-    ]
+    "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
   },
   "timezone": "",
   "title": "Test-Cluster-TiFlash-Summary",

--- a/tests/docker/config/tiflash_dt_lightweight_compression.toml
+++ b/tests/docker/config/tiflash_dt_lightweight_compression.toml
@@ -1,0 +1,53 @@
+# Copyright 2024 PingCAP, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+tmp_path = "/tmp/tiflash/data/tmp"
+
+path = "/tmp/tiflash/data/db"
+capacity = "10737418240"
+
+mark_cache_size = 5368709120
+minmax_index_cache_size = 5368709120
+tcp_port = 9000
+http_port = 8123
+
+[flash]
+tidb_status_addr = "tidb0:10080"
+service_addr = "0.0.0.0:3930"
+[flash.flash_cluster]
+update_rule_interval = 5
+[flash.proxy]
+addr = "0.0.0.0:20170"
+advertise-addr = "tiflash0:20170"
+data-dir = "/data"
+config = "/proxy.toml"
+log-file = "/log/proxy.log"
+engine-addr = "tiflash0:3930"
+status-addr = "0.0.0.0:20181"
+advertise-status-addr = "tiflash0:20181"
+
+[logger]
+count = 10
+errorlog = "/tmp/tiflash/log/error.log"
+size = "1000M"
+log = "/tmp/tiflash/log/server.log"
+level = "trace"
+
+[raft]
+pd_addr = "pd0:2379"
+ignore_databases = "system,default"
+
+[profiles]
+[profiles.default]
+dt_compression_method = "Lightweight"

--- a/tests/docker/config/tiflash_dt_lightweight_compression.toml
+++ b/tests/docker/config/tiflash_dt_lightweight_compression.toml
@@ -51,3 +51,4 @@ ignore_databases = "system,default"
 [profiles]
 [profiles.default]
 dt_compression_method = "Lightweight"
+dt_compression_level = 3

--- a/tests/docker/config/tiflash_dt_lightweight_compression.toml
+++ b/tests/docker/config/tiflash_dt_lightweight_compression.toml
@@ -20,13 +20,9 @@ capacity = "10737418240"
 mark_cache_size = 5368709120
 minmax_index_cache_size = 5368709120
 tcp_port = 9000
-http_port = 8123
 
 [flash]
-tidb_status_addr = "tidb0:10080"
 service_addr = "0.0.0.0:3930"
-[flash.flash_cluster]
-update_rule_interval = 5
 [flash.proxy]
 addr = "0.0.0.0:20170"
 advertise-addr = "tiflash0:20170"

--- a/tests/docker/tiflash-dt-lightweight-compression.yaml
+++ b/tests/docker/tiflash-dt-lightweight-compression.yaml
@@ -1,0 +1,43 @@
+# Copyright 2024 PingCAP, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: '2.3'
+
+services:
+  # for tests under fullstack-test directory
+  # (engine DeltaTree)
+  tiflash0:
+    image: hub.pingcap.net/tiflash/tiflash-ci-base
+    volumes:
+      - ./config/tiflash_dt_lightweight_compression.toml:/config.toml:ro
+      - ./data/tiflash:/tmp/tiflash/data
+      - ./log/tiflash:/tmp/tiflash/log
+      - ..:/tests
+      - ../docker/_env.sh:/tests/_env.sh
+      - ./log/tiflash-cluster-manager:/tmp/tiflash/data/tmp
+      - ./config/proxy.toml:/proxy.toml:ro
+      - ./config/cipher-file-256:/cipher-file-256:ro
+      - ./data/proxy:/data
+      - ./log/proxy:/log
+      - ../.build/tiflash:/tiflash
+    entrypoint:
+      - /tiflash/tiflash
+      - server
+      - --config-file
+      - /config.toml
+    restart: on-failure
+    depends_on:
+      - "pd0"
+      - "tikv0"
+

--- a/tests/tidb-ci/lightweight_compression
+++ b/tests/tidb-ci/lightweight_compression
@@ -1,0 +1,1 @@
+../fullstack-test/mpp/

--- a/tests/tidb-ci/run.sh
+++ b/tests/tidb-ci/run.sh
@@ -62,10 +62,11 @@ docker-compose -f cluster.yaml -f tiflash-dt-force-enable-lm.yaml exec -T tiflas
 docker-compose -f cluster.yaml -f tiflash-dt-force-enable-lm.yaml down
 clean_data_log
 
+# TODO: now set dt_compression_method = "lightweight" by default, so we don't need to run this test.
 # run lighweight compression tests
-docker-compose -f cluster.yaml -f tiflash-dt-lightweight-compression.yaml up -d
-wait_env
-docker-compose -f cluster.yaml -f tiflash-dt-lightweight-compression.yaml exec -T tiflash0 bash -c 'cd /tests ; ./run-test.sh tidb-ci/lightweight_compression'
+# docker-compose -f cluster.yaml -f tiflash-dt-lightweight-compression.yaml up -d
+# wait_env
+# docker-compose -f cluster.yaml -f tiflash-dt-lightweight-compression.yaml exec -T tiflash0 bash -c 'cd /tests ; ./run-test.sh tidb-ci/lightweight_compression'
 
-docker-compose -f cluster.yaml -f tiflash-dt-lightweight-compression.yaml down
-clean_data_log
+# docker-compose -f cluster.yaml -f tiflash-dt-lightweight-compression.yaml down
+# clean_data_log

--- a/tests/tidb-ci/run.sh
+++ b/tests/tidb-ci/run.sh
@@ -61,3 +61,11 @@ docker-compose -f cluster.yaml -f tiflash-dt-force-enable-lm.yaml exec -T tiflas
 
 docker-compose -f cluster.yaml -f tiflash-dt-force-enable-lm.yaml down
 clean_data_log
+
+# run lighweight compression tests
+docker-compose -f cluster.yaml -f tiflash-dt-lightweight-compression.yaml up -d
+wait_env
+docker-compose -f cluster.yaml -f tiflash-dt-lightweight-compression.yaml exec -T tiflash0 bash -c 'cd /tests ; ./run-test.sh tidb-ci/lightweight_compression'
+
+docker-compose -f cluster.yaml -f tiflash-dt-lightweight-compression.yaml down
+clean_data_log

--- a/tests/tidb-ci/tiflash-dt-lightweight-compression.yaml
+++ b/tests/tidb-ci/tiflash-dt-lightweight-compression.yaml
@@ -1,0 +1,1 @@
+../docker/tiflash-dt-lightweight-compression.yaml


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8982, close #9336

Problem Summary:

### What is changed and how it works?

```commit-message
Compression: Support enabling lightweight compression
```

1. fullstack test
2. support use lightweight compression in DMFile
3. metric

<img width="636" alt="image" src="https://github.com/user-attachments/assets/d16558e7-5106-4e53-b102-0074b356f267">

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Add a new option for configuration `profiles.default.dt_compression_method`: lightweight (case insensitive) which can help improve the read performance and data size may be smaller.
```
