### PR TITLE
PageStorage: Fix TiFlash may fail to restart after FAP is enabled

### DIFF
--- a/dbms/src/Storages/Page/V3/PageDirectory.cpp
+++ b/dbms/src/Storages/Page/V3/PageDirectory.cpp
@@ -331,13 +331,22 @@ void VersionedPageEntries<Trait>::createDelete(const PageVersion & ver) NO_THREA
 }
 
 template <typename Trait>
-bool VersionedPageEntries<Trait>::updateLocalCacheForRemotePage(const PageVersion & ver, const PageEntryV3 & entry)
-    NO_THREAD_SAFETY_ANALYSIS
+bool VersionedPageEntries<Trait>::updateLocalCacheForRemotePage(
+    const PageVersion & ver,
+    const PageEntryV3 & entry,
+    bool ignore_delete) NO_THREAD_SAFETY_ANALYSIS
 {
     auto page_lock = acquireLock();
     if (type == EditRecordType::VAR_ENTRY)
     {
         auto last_iter = MapUtils::findMutLess(entries, PageVersion(ver.sequence + 1, 0));
+        if (ignore_delete)
+        {
+            while (last_iter != entries.end() && last_iter != entries.begin() && last_iter->second.isDelete())
+            {
+                --last_iter;
+            }
+        }
         RUNTIME_CHECK_MSG(
             last_iter != entries.end() && last_iter->second.isEntry(),
             "this={}, entries={}, ver={}, entry={}",
@@ -1819,13 +1828,15 @@ typename PageDirectory<Trait>::PageEntries PageDirectory<Trait>::updateLocalCach
                     auto iter = mvcc_table_directory.lower_bound(id_to_resolve);
                     assert(iter != mvcc_table_directory.end());
                     auto & version_list = iter->second;
-                    auto [resolve_state, next_id_to_resolve, next_ver_to_resolve] = version_list->resolveToPageId(
-                        sequence_to_resolve,
-                        /*ignore_delete=*/id_to_resolve != r.page_id,
-                        nullptr);
+                    const bool ignore_delete = id_to_resolve != r.page_id;
+                    auto [resolve_state, next_id_to_resolve, next_ver_to_resolve]
+                        = version_list->resolveToPageId(sequence_to_resolve, ignore_delete, nullptr);
                     if (resolve_state == ResolveResult::TO_NORMAL)
                     {
-                        if (!version_list->updateLocalCacheForRemotePage(PageVersion(sequence_to_resolve, 0), r.entry))
+                        if (!version_list->updateLocalCacheForRemotePage(
+                                PageVersion(sequence_to_resolve, 0),
+                                r.entry,
+                                ignore_delete))
                         {
                             // The entry is not valid for updating the version_list.
                             // Caller should notice these part of "ignored_entries" and release

--- a/dbms/src/Storages/Page/V3/PageDirectory.cpp
+++ b/dbms/src/Storages/Page/V3/PageDirectory.cpp
@@ -342,6 +342,7 @@ bool VersionedPageEntries<Trait>::updateLocalCacheForRemotePage(
         auto last_iter = MapUtils::findMutLess(entries, PageVersion(ver.sequence + 1, 0));
         if (ignore_delete)
         {
+            // find the first non-delete entry until it is the first entry or there is no such entry
             while (last_iter != entries.end() && last_iter != entries.begin() && last_iter->second.isDelete())
             {
                 --last_iter;
@@ -479,8 +480,9 @@ std::shared_ptr<typename VersionedPageEntries<Trait>::PageId> VersionedPageEntri
 }
 
 template <typename Trait>
-std::tuple<ResolveResult, typename VersionedPageEntries<Trait>::PageId, PageVersion> VersionedPageEntries<
-    Trait>::resolveToPageId(UInt64 seq, bool ignore_delete, PageEntryV3 * entry) NO_THREAD_SAFETY_ANALYSIS
+std::tuple<ResolveResult, typename VersionedPageEntries<Trait>::PageId, PageVersion> //
+VersionedPageEntries<Trait>::resolveToPageId(UInt64 seq, bool ignore_delete, PageEntryV3 * entry)
+    NO_THREAD_SAFETY_ANALYSIS
 {
     auto page_lock = acquireLock();
     if (type == EditRecordType::VAR_ENTRY)
@@ -1828,6 +1830,9 @@ typename PageDirectory<Trait>::PageEntries PageDirectory<Trait>::updateLocalCach
                     auto iter = mvcc_table_directory.lower_bound(id_to_resolve);
                     assert(iter != mvcc_table_directory.end());
                     auto & version_list = iter->second;
+                    // We need to ignore the "deletes" both when resolve page id and update local cache.
+                    // Check `PageDirectory::getByIDImpl` or the unit test
+                    // `UniPageStorageRemoteReadTest.WriteReadRefWithRestart` for details.
                     const bool ignore_delete = id_to_resolve != r.page_id;
                     auto [resolve_state, next_id_to_resolve, next_ver_to_resolve]
                         = version_list->resolveToPageId(sequence_to_resolve, ignore_delete, nullptr);

--- a/dbms/src/Storages/Page/V3/PageDirectory.h
+++ b/dbms/src/Storages/Page/V3/PageDirectory.h
@@ -253,7 +253,7 @@ struct EntryOrDelete
             PageStorageMemorySummary::versioned_entry_or_delete_bytes.fetch_sub(sizeof(PageEntryV3));
     }
 
-    static EntryOrDelete newDelete() { return EntryOrDelete(std::nullopt); };
+    static EntryOrDelete newDelete() { return EntryOrDelete(std::nullopt); }
     static EntryOrDelete newNormalEntry(const PageEntryV3 & entry) { return EntryOrDelete(entry); }
     static EntryOrDelete newReplacingEntry(const EntryOrDelete & ori_entry, const PageEntryV3 & entry)
     {
@@ -320,7 +320,7 @@ public:
 
     // Update the local cache info for remote page,
     // Must a hold snap to prevent the page being deleted.
-    bool updateLocalCacheForRemotePage(const PageVersion & ver, const PageEntryV3 & entry);
+    bool updateLocalCacheForRemotePage(const PageVersion & ver, const PageEntryV3 & entry, bool ignore_delete);
 
     std::shared_ptr<PageId> fromRestored(const typename PageEntriesEdit::EditRecord & rec);
 

--- a/dbms/src/Storages/Page/V3/PageDirectoryFactory.cpp
+++ b/dbms/src/Storages/Page/V3/PageDirectoryFactory.cpp
@@ -290,13 +290,15 @@ void PageDirectoryFactory<Trait>::applyRecord(
             while (true)
             {
                 const auto & current_version_list = version_list_iter->second;
-                auto [resolve_state, next_id_to_resolve, next_ver_to_resolve] = current_version_list->resolveToPageId(
-                    sequence_to_resolve,
-                    /*ignore_delete=*/id_to_resolve != r.page_id,
-                    nullptr);
+                const bool ignore_delete = id_to_resolve != r.page_id;
+                auto [resolve_state, next_id_to_resolve, next_ver_to_resolve]
+                    = current_version_list->resolveToPageId(sequence_to_resolve, ignore_delete, nullptr);
                 if (resolve_state == ResolveResult::TO_NORMAL)
                 {
-                    current_version_list->updateLocalCacheForRemotePage(PageVersion(sequence_to_resolve, 0), r.entry);
+                    current_version_list->updateLocalCacheForRemotePage(
+                        PageVersion(sequence_to_resolve, 0),
+                        r.entry,
+                        ignore_delete);
                     break;
                 }
                 else if (resolve_state == ResolveResult::TO_REF)

--- a/dbms/src/Storages/Page/V3/PageDirectoryFactory.cpp
+++ b/dbms/src/Storages/Page/V3/PageDirectoryFactory.cpp
@@ -290,6 +290,9 @@ void PageDirectoryFactory<Trait>::applyRecord(
             while (true)
             {
                 const auto & current_version_list = version_list_iter->second;
+                // We need to ignore the "deletes" both when resolve page id and update local cache.
+                // Check `PageDirectory::getByIDImpl` or the unit test
+                // `UniPageStorageRemoteReadTest.WriteReadRefWithRestart` for details.
                 const bool ignore_delete = id_to_resolve != r.page_id;
                 auto [resolve_state, next_id_to_resolve, next_ver_to_resolve]
                     = current_version_list->resolveToPageId(sequence_to_resolve, ignore_delete, nullptr);

--- a/dbms/src/Storages/Page/V3/WAL/WALReader.cpp
+++ b/dbms/src/Storages/Page/V3/WAL/WALReader.cpp
@@ -173,7 +173,7 @@ LogReaderPtr WALStoreReader::createLogReader(
     const auto fullname = filename.fullname(filename.stage);
     Poco::File f(fullname);
     const auto file_size = f.getSize();
-    LOG_DEBUG(logger, "Open log file for reading, file={} size={}", fullname, file_size);
+    LOG_INFO(logger, "Open log file for reading, file={} size={}", fullname, file_size);
     auto read_buf = ReadBufferFromRandomAccessFileBuilder::buildPtr(
         provider,
         fullname,

--- a/dbms/src/Storages/Page/V3/WALStore.cpp
+++ b/dbms/src/Storages/Page/V3/WALStore.cpp
@@ -33,7 +33,6 @@
 #include <Storages/PathPool.h>
 #include <common/logger_useful.h>
 
-#include <cassert>
 #include <memory>
 #include <mutex>
 
@@ -140,7 +139,7 @@ std::tuple<std::unique_ptr<LogWriter>, LogFilename> WALStore::createLogWriter(
     auto filename = log_filename.filename(log_filename.stage);
     auto fullname = log_filename.fullname(log_filename.stage);
     // TODO check whether the file already existed
-    LOG_INFO(logger, "Creating log file for writing [fullname={}]", fullname);
+    LOG_INFO(logger, "Creating log file for writing, fullname={}", fullname);
     // if it is a temp file, we will manually sync it after writing snapshot
     auto log_writer = std::make_unique<LogWriter>(
         fullname,
@@ -255,21 +254,21 @@ bool WALStore::saveSnapshot(
         normal_fullname,
         EncryptionPath(normal_fullname, ""),
         true);
-    LOG_INFO(logger, "Rename log file to normal done [tempname={}] [fullname={}]", temp_fullname, normal_fullname);
+    LOG_INFO(logger, "Rename log file to normal done, tempname={} fullname={}", temp_fullname, normal_fullname);
 
     // Remove compacted log files.
     removeLogFiles(files_snap.persisted_log_files);
 
     auto get_logging_str = [&]() {
         FmtBuffer fmt_buf;
-        fmt_buf.append("Dumped directory snapshot to log file done. [files_snapshot=");
+        fmt_buf.append("Dumped directory snapshot to log file done. files_snapshot=");
         fmt_buf.joinStr(
             files_snap.persisted_log_files.begin(),
             files_snap.persisted_log_files.end(),
             [](const auto & arg, FmtBuffer & fb) { fb.append(arg.filename(arg.stage)); },
             ", ");
         fmt_buf.fmtAppend(
-            "] [dump_cost={}] [num_records={}] [file={}] [size={}].",
+            " dump_cost={} num_records={} file={} size={}",
             files_snap.dump_elapsed_ms,
             files_snap.num_records,
             normal_fullname,

--- a/dbms/src/Storages/Page/V3/tests/gtest_page_directory.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_page_directory.cpp
@@ -27,6 +27,7 @@
 #include <Storages/Page/V3/PageDirectoryFactory.h>
 #include <Storages/Page/V3/PageEntriesEdit.h>
 #include <Storages/Page/V3/PageEntry.h>
+#include <Storages/Page/V3/PageEntryCheckpointInfo.h>
 #include <Storages/Page/V3/WAL/serialize.h>
 #include <Storages/Page/V3/WALStore.h>
 #include <Storages/Page/V3/tests/entries_helper.h>
@@ -45,8 +46,6 @@
 #include <random>
 #include <unordered_map>
 #include <unordered_set>
-
-#include "Storages/Page/V3/PageEntryCheckpointInfo.h"
 
 namespace DB
 {

--- a/dbms/src/Storages/Page/V3/tests/gtest_page_directory.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_page_directory.cpp
@@ -46,6 +46,8 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include "Storages/Page/V3/PageEntryCheckpointInfo.h"
+
 namespace DB
 {
 namespace PS::V3::tests
@@ -822,6 +824,96 @@ try
 
     auto snap = dir->createSnapshot();
     ASSERT_ENTRY_EQ(entry1, dir, 998, snap);
+}
+CATCH
+
+TEST_F(PageDirectoryTest, NewRefAfterDelThreeHopsRemotePage)
+try
+{
+    // Fix issue: https://github.com/pingcap/tiflash/issues/9307
+    PageEntryV3 entry1{
+        .file_id = 0,
+        .size = 1024,
+        .padded_size = 0,
+        .tag = 0,
+        .offset = 0,
+        .checksum = 0x0,
+        .checkpoint_info = OptionalCheckpointInfo(
+            CheckpointLocation{
+                .data_file_id = std::make_shared<const std::string>("s3://path/to/file"),
+                .offset_in_file = 0xa0,
+                .size_in_file = 1024},
+            true,
+            true),
+    };
+
+    {
+        PageEntriesEdit edit;
+        edit.put(buildV3Id(TEST_NAMESPACE_ID, 951), entry1);
+        dir->apply(std::move(edit));
+    }
+
+    {
+        PageEntriesEdit edit;
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 954), buildV3Id(TEST_NAMESPACE_ID, 951));
+        dir->apply(std::move(edit));
+    }
+
+    {
+        PageEntriesEdit edit;
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 951));
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 951));
+        dir->apply(std::move(edit));
+    }
+
+    {
+        PageEntriesEdit edit;
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 972), buildV3Id(TEST_NAMESPACE_ID, 954));
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 985), buildV3Id(TEST_NAMESPACE_ID, 954));
+        dir->apply(std::move(edit));
+    }
+
+    {
+        PageEntriesEdit edit;
+        edit.del(buildV3Id(TEST_NAMESPACE_ID, 954));
+        dir->apply(std::move(edit));
+    }
+
+    {
+        PageEntriesEdit edit;
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 998), buildV3Id(TEST_NAMESPACE_ID, 985));
+        edit.ref(buildV3Id(TEST_NAMESPACE_ID, 1011), buildV3Id(TEST_NAMESPACE_ID, 985));
+        dir->apply(std::move(edit));
+    }
+
+    auto snap = dir->createSnapshot();
+    ASSERT_ENTRY_EQ(entry1, dir, 998, snap);
+
+    // Assume we download the data into this file offset
+    PageEntryV3 entry2{
+        .file_id = 11,
+        .size = 1024,
+        .padded_size = 0,
+        .tag = 0,
+        .offset = 0xf0,
+        .checksum = 0xabcd,
+        .checkpoint_info = OptionalCheckpointInfo(
+            CheckpointLocation{
+                .data_file_id = std::make_shared<const std::string>("s3://path/to/file"),
+                .offset_in_file = 0xa0,
+                .size_in_file = 1024},
+            true,
+            true),
+    };
+
+    // Mock that "update remote" after download from remote store by "snap"
+    {
+        PageEntriesEdit edit;
+        edit.updateRemote(buildV3Id(TEST_NAMESPACE_ID, 998), entry2);
+        dir->updateLocalCacheForRemotePages(std::move(edit), snap, nullptr);
+    }
+    snap = dir->createSnapshot();
+    ASSERT_ENTRY_EQ(entry2, dir, 998, snap);
 }
 CATCH
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/9307

Problem Summary: 

A RemotePage
1. Ingested into a Segment by FAP
2. The Segment get logical split, two RefPage to the RemotePage is created
3. The Ingested RemotePage is deleted
4. The split left and right segment get logical split again
5. A read to the segment is performed, and the original RemotePage get updated

The sequence that PageStorage see is
```
--- The page_id '0x78000001746C0000000000000060.3359'
---  created @ ver=676072, epoch=0
---  ref by .3439 @ ver=685132
---  ref by .3441 @ ver=685134
---  deleted @ ver=685265
---  ref by .3493 @ ver=693249
---  ref by .3495 @ ver=693251
---  ref by .3497 @ ver=693272
---  ref by .3499 @ ver=693274
--- Then '.3497' get read, UPDATE_DATA_FROM_REMOTE @ ver=729397
```

### What is changed and how it works?

```commit-message
PageStorage: Fix TiFlash may fail to restart after FAP is enabled
```

`PageDirectory::updateLocalCacheForRemotePages` and `PageDirectoryFactory::applyRecord` will call `updateLocalCacheForRemotePage` with ignore_delete=true when trying to update local cache of a RefPage (`id_to_resolve != r.page_id`)

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
