### PR TITLE
build: make `cmake --install` work well

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,10 @@ set(CMAKE_MACOSX_RPATH 1)
 
 option(TIFLASH_ENABLE_LLVM_DEVELOPMENT "enable facilities for development with LLVM" OFF)
 
+if(NOT CMAKE_PREFIX_PATH AND DEFINED ENV{CMAKE_PREFIX_PATH})
+    message(STATUS "Reading CMAKE_PREFIX_PATH from env... $ENV{CMAKE_PREFIX_PATH}")
+    set(CMAKE_PREFIX_PATH "$ENV{CMAKE_PREFIX_PATH}")
+endif()
 if(CMAKE_PREFIX_PATH)
     # append paths for cmake to check libs
     set(ENV{LD_LIBRARY_PATH}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/6233

Problem Summary:
Executing `cmake --install` failed in the new compile env. The error message is as follow
```
> cmake .. -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo
> ninja tiflash
...
> cmake --install . --component=tiflash-release --prefix=artifacts
Install the project...
-- Install configuration: "RELWITHDEBINFO"
-- Up-to-date: /tiflash/build/release/install_tiflash/tiflash/./tiflash
CMake Error at dbms/src/Server/cmake_install.cmake:66 (file):
  file Could not resolve runtime dependencies:
    libc++.so.1
    libc++abi.so.1
Call Stack (most recent call first):
  dbms/src/cmake_install.cmake:107 (include)
  dbms/cmake_install.cmake:47 (include)
  cmake_install.cmake:47 (include)
```

When executing `cmake --install`, cmake will try to find the libraries defined in `TIFLASH_DEPENDENCY_DIRECTORIES` which is derived from `CMAKE_PREFIX_PATH`.
https://github.com/pingcap/tiflash/blob/14ed7c021b23fffda165ad6a23ea4358001bd54e/dbms/src/Server/CMakeLists.txt#L91-L122

tiflash-env scripts will generate a env `CMAKE_PREFIX_PATH`, but cmake does not use the env value by default.
https://github.com/pingcap/tiflash/blob/14ed7c021b23fffda165ad6a23ea4358001bd54e/release-centos7-llvm/env/loader#L52


Release build does not suffer from this because `CMAKE_PREFIX_PATH` is explicitly set.
https://github.com/pingcap/tiflash/blob/14ed7c021b23fffda165ad6a23ea4358001bd54e/release-centos7-llvm/scripts/build-tiflash-release.sh#L70-L71

### What is changed and how it works?

```commit-message
build: make `cmake --install . --component=tiflash-release ` work well
```

* When `CMAKE_PREFIX_PATH` is explicitly set, use that directory. `cmake .. -DCMAKE_PREFIX_PATH=<dir>`
* When `CMAKE_PREFIX_PATH` is not explicitly set, try to read from env `${CMAKE_PREFIX_PATH}`


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```
>  cmake --install . --component=tiflash-release --prefix=artifacts
-- Install configuration: "DEBUG"
-- Installing: /DATA/disk1/jaysonhuang/tiflash/cmake-build-debug/artifacts/./tiflash
-- Set non-toolchain portion of runtime path of "artifacts/./tiflash" to "$ORIGIN/"
CMake Warning at dbms/src/Server/cmake_install.cmake:70 (file):
  Dependency libc++abi.so.1 found in search directory:

    /DATA/disk1/ra_common/tiflash-env-17/sysroot//lib/x86_64-unknown-linux-gnu/

  See file(GET_RUNTIME_DEPENDENCIES) documentation for more information.
Call Stack (most recent call first):
  dbms/src/cmake_install.cmake:107 (include)
  dbms/cmake_install.cmake:47 (include)
  cmake_install.cmake:47 (include)


CMake Warning at dbms/src/Server/cmake_install.cmake:70 (file):
  Dependency libc++.so.1 found in search directory:

    /DATA/disk1/ra_common/tiflash-env-17/sysroot//lib/x86_64-unknown-linux-gnu/

  See file(GET_RUNTIME_DEPENDENCIES) documentation for more information.
Call Stack (most recent call first):
  dbms/src/cmake_install.cmake:107 (include)
  dbms/cmake_install.cmake:47 (include)
  cmake_install.cmake:47 (include)


CMake Warning at dbms/src/Server/cmake_install.cmake:70 (file):
  Dependency libc++abi.so.1 found in search directory:

    /DATA/disk1/ra_common/tiflash-env-17/sysroot//lib/x86_64-unknown-linux-gnu/

  See file(GET_RUNTIME_DEPENDENCIES) documentation for more information.
Call Stack (most recent call first):
  dbms/src/cmake_install.cmake:107 (include)
  dbms/cmake_install.cmake:47 (include)
  cmake_install.cmake:47 (include)


-- Installing: /DATA/disk1/jaysonhuang/tiflash/cmake-build-debug/artifacts/./libc++.so.1
-- Installing: /DATA/disk1/jaysonhuang/tiflash/cmake-build-debug/artifacts/./libc++.so.1.0
-- Installing: /DATA/disk1/jaysonhuang/tiflash/cmake-build-debug/artifacts/./libc++abi.so.1
-- Installing: /DATA/disk1/jaysonhuang/tiflash/cmake-build-debug/artifacts/./libc++abi.so.1.0
-- Installing: /DATA/disk1/jaysonhuang/tiflash/cmake-build-debug/artifacts/./libtiflash_proxy.so
-- Installing: /DATA/disk1/jaysonhuang/tiflash/cmake-build-debug/artifacts/./libgmssld.so.3.0
-- Installing: /DATA/disk1/jaysonhuang/tiflash/cmake-build-debug/artifacts/./libgmssld.so.3
-- Installing: /DATA/disk1/jaysonhuang/tiflash/cmake-build-debug/artifacts/./libgmssld.so
```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
