### PR TITLE
*: Refine include of TiDB.h to speedup re-compiling

### DIFF
--- a/dbms/src/DataStreams/MockExchangeReceiverInputStream.cpp
+++ b/dbms/src/DataStreams/MockExchangeReceiverInputStream.cpp
@@ -14,6 +14,7 @@
 
 #include <DataStreams/MockExchangeReceiverInputStream.h>
 #include <Flash/Coprocessor/ChunkCodec.h>
+#include <TiDB/Decode/TypeMapping.h>
 
 namespace DB
 {

--- a/dbms/src/DataStreams/RuntimeFilter.cpp
+++ b/dbms/src/DataStreams/RuntimeFilter.cpp
@@ -207,7 +207,7 @@ bool RuntimeFilter::updateStatus(RuntimeFilterStatus status_, const std::string 
 }
 
 void RuntimeFilter::setTargetAttr(
-    const DM::ColumnInfos & scan_column_infos,
+    const TiDB::ColumnInfos & scan_column_infos,
     const DM::ColumnDefines & table_column_defines)
 {
     target_attr = DM::FilterParser::createAttr(target_expr, scan_column_infos, table_column_defines);

--- a/dbms/src/DataStreams/RuntimeFilter.h
+++ b/dbms/src/DataStreams/RuntimeFilter.h
@@ -77,7 +77,7 @@ public:
 
     bool await(int64_t ms_remaining);
 
-    void setTargetAttr(const DM::ColumnInfos & scan_column_infos, const DM::ColumnDefines & table_column_defines);
+    void setTargetAttr(const TiDB::ColumnInfos & scan_column_infos, const DM::ColumnDefines & table_column_defines);
     DM::RSOperatorPtr parseToRSOperator();
 
     const int id;

--- a/dbms/src/Debug/MockExecutor/AstToPB.cpp
+++ b/dbms/src/Debug/MockExecutor/AstToPB.cpp
@@ -694,7 +694,7 @@ TiDB::ColumnInfo compileExpr(const DAGSchema & input, ASTPtr ast)
     }
 }
 
-void compileFilter(const DAGSchema & input, ASTPtr ast, std::vector<ASTPtr> & conditions)
+void compileFilter(const DAGSchema & input, ASTPtr ast, ASTs & conditions)
 {
     if (auto * func = typeid_cast<ASTFunction *>(ast.get()))
     {

--- a/dbms/src/Debug/MockExecutor/AstToPB.cpp
+++ b/dbms/src/Debug/MockExecutor/AstToPB.cpp
@@ -34,7 +34,7 @@
 
 namespace DB
 {
-void literalFieldToTiPBExpr(const ColumnInfo & ci, const Field & val_field, tipb::Expr * expr, Int32 collator_id)
+void literalFieldToTiPBExpr(const TiDB::ColumnInfo & ci, const Field & val_field, tipb::Expr * expr, Int32 collator_id)
 {
     *(expr->mutable_field_type()) = columnInfoToFieldType(ci);
     expr->mutable_field_type()->set_collate(collator_id);
@@ -126,7 +126,7 @@ void literalFieldToTiPBExpr(const ColumnInfo & ci, const Field & val_field, tipb
 void literalToPB(tipb::Expr * expr, const Field & value, int32_t collator_id)
 {
     DataTypePtr type = applyVisitor(FieldToDataType(), value);
-    ColumnInfo ci = reverseGetColumnInfo({"", type}, 0, Field(), true);
+    TiDB::ColumnInfo ci = reverseGetColumnInfo({"", type}, 0, Field(), true);
     literalFieldToTiPBExpr(ci, value, expr, collator_id);
 }
 

--- a/dbms/src/Debug/MockExecutor/AstToPB.h
+++ b/dbms/src/Debug/MockExecutor/AstToPB.h
@@ -86,7 +86,7 @@ struct TaskMeta
 };
 
 using TaskMetas = std::vector<TaskMeta>;
-void literalFieldToTiPBExpr(const ColumnInfo & ci, const Field & field, tipb::Expr * expr, Int32 collator_id);
+void literalFieldToTiPBExpr(const TiDB::ColumnInfo & ci, const Field & field, tipb::Expr * expr, Int32 collator_id);
 void literalToPB(tipb::Expr * expr, const Field & value, int32_t collator_id);
 String getFunctionNameForConstantFolding(tipb::Expr * expr);
 void foldConstant(tipb::Expr * expr, int32_t collator_id, const Context & context);

--- a/dbms/src/Debug/MockExecutor/AstToPB.h
+++ b/dbms/src/Debug/MockExecutor/AstToPB.h
@@ -16,7 +16,7 @@
 
 #include <Flash/Coprocessor/ChunkCodec.h>
 #include <Parsers/IAST_fwd.h>
-#include <TiDB/Schema/TiDB.h>
+#include <TiDB/Schema/TiDB_fwd.h>
 #include <kvproto/mpp.pb.h>
 
 namespace DB

--- a/dbms/src/Debug/MockExecutor/AstToPB.h
+++ b/dbms/src/Debug/MockExecutor/AstToPB.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <Flash/Coprocessor/ChunkCodec.h>
+#include <Parsers/IAST_fwd.h>
 #include <TiDB/Schema/TiDB.h>
 #include <kvproto/mpp.pb.h>
 

--- a/dbms/src/Debug/MockExecutor/AstToPB.h
+++ b/dbms/src/Debug/MockExecutor/AstToPB.h
@@ -101,7 +101,7 @@ void identifierToPB(const DAGSchema & input, ASTIdentifier * id, tipb::Expr * ex
 void astToPB(const DAGSchema & input, ASTPtr ast, tipb::Expr * expr, int32_t collator_id, const Context & context);
 void collectUsedColumnsFromExpr(const DAGSchema & input, ASTPtr ast, std::unordered_set<String> & used_columns);
 TiDB::ColumnInfo compileExpr(const DAGSchema & input, ASTPtr ast);
-void compileFilter(const DAGSchema & input, ASTPtr ast, std::vector<ASTPtr> & conditions);
+void compileFilter(const DAGSchema & input, ASTPtr ast, ASTs & conditions);
 void fillTaskMetaWithMPPInfo(mpp::TaskMeta & task_meta, const MPPInfo & mpp_info);
 
 } // namespace DB

--- a/dbms/src/Debug/MockExecutor/ExpandBinder2.cpp
+++ b/dbms/src/Debug/MockExecutor/ExpandBinder2.cpp
@@ -85,7 +85,7 @@ ExecutorBinderPtr compileExpand2(
                     // base col ref (since ast can't derive the expression's field type, use the test injected one)
                     if (ft->second.hasNotNullFlag() && (fts[j].flag() & TiDB::ColumnFlagNotNull) == 0)
                     {
-                        ColumnInfo ci;
+                        TiDB::ColumnInfo ci;
                         ci.flag = ft->second.flag;
                         ci.tp = ft->second.tp;
                         ci.name = ft->second.name;

--- a/dbms/src/Debug/MockExecutor/ExpandBinder2.cpp
+++ b/dbms/src/Debug/MockExecutor/ExpandBinder2.cpp
@@ -57,17 +57,17 @@ bool ExpandBinder2::toTiPBExecutor(
 ExecutorBinderPtr compileExpand2(
     ExecutorBinderPtr input,
     size_t & executor_index,
-    ASTPtrVec level_select_list,
+    ASTs level_select_list,
     std::vector<String> output_names,
     std::vector<tipb::FieldType> fts)
 {
     DAGSchema output_schema;
-    std::vector<std::vector<ASTPtr>> expand_exprs;
+    std::vector<ASTs> expand_exprs;
     auto input_col_size = input->output_schema.size();
     for (size_t i = 0; i < level_select_list.size(); i++)
     {
         auto level_proj = level_select_list[i];
-        std::vector<ASTPtr> level_exprs;
+        ASTs level_exprs;
         for (size_t j = 0; j < level_proj->children.size(); j++)
         {
             auto expr = level_proj->children[j];

--- a/dbms/src/Debug/MockExecutor/ExpandBinder2.cpp
+++ b/dbms/src/Debug/MockExecutor/ExpandBinder2.cpp
@@ -16,6 +16,7 @@
 #include <Debug/MockExecutor/ExecutorBinder.h>
 #include <Debug/MockExecutor/ExpandBinder2.h>
 #include <Parsers/ASTAsterisk.h>
+#include <Parsers/IAST_fwd.h>
 
 
 namespace DB::mock

--- a/dbms/src/Debug/MockExecutor/ExpandBinder2.h
+++ b/dbms/src/Debug/MockExecutor/ExpandBinder2.h
@@ -51,7 +51,7 @@ private:
 ExecutorBinderPtr compileExpand2(
     ExecutorBinderPtr input,
     size_t & executor_index,
-    std::vector<ASTPtr> level_select_list,
+    ASTs level_select_list,
     std::vector<String> output_names,
     std::vector<tipb::FieldType> fts);
 } // namespace DB::mock

--- a/dbms/src/Debug/MockExecutor/TableScanBinder.cpp
+++ b/dbms/src/Debug/MockExecutor/TableScanBinder.cpp
@@ -124,7 +124,7 @@ ExecutorBinderPtr compileTableScan(
     DAGSchema ts_output;
     for (const auto & column_info : table_info.columns)
     {
-        ColumnInfo ci;
+        TiDB::ColumnInfo ci;
         ci.id = column_info.id;
         ci.tp = column_info.tp;
         ci.flag = column_info.flag;
@@ -140,7 +140,7 @@ ExecutorBinderPtr compileTableScan(
     }
     if (append_pk_column)
     {
-        ColumnInfo ci;
+        TiDB::ColumnInfo ci;
         ci.tp = TiDB::TypeLongLong;
         ci.id = TiDBPkColumnID;
         ci.setPriKeyFlag();

--- a/dbms/src/Debug/MockExecutor/TableScanBinder.cpp
+++ b/dbms/src/Debug/MockExecutor/TableScanBinder.cpp
@@ -16,6 +16,7 @@
 #include <Debug/MockExecutor/ExecutorBinder.h>
 #include <Debug/MockExecutor/TableScanBinder.h>
 #include <Storages/MutableSupport.h>
+#include <TiDB/Schema/TiDB.h>
 
 namespace DB::mock
 {
@@ -114,7 +115,7 @@ void TableScanBinder::buildTable(tipb::Executor * tipb_executor)
 
 ExecutorBinderPtr compileTableScan(
     size_t & executor_index,
-    TableInfo & table_info,
+    TiDB::TableInfo & table_info,
     const String & db,
     const String & table_name,
     bool append_pk_column,

--- a/dbms/src/Debug/MockExecutor/TableScanBinder.h
+++ b/dbms/src/Debug/MockExecutor/TableScanBinder.h
@@ -19,11 +19,15 @@
 
 namespace DB::mock
 {
-using TableInfo = TiDB::TableInfo;
+
 class TableScanBinder : public ExecutorBinder
 {
 public:
-    TableScanBinder(size_t & index_, const DAGSchema & output_schema_, const TableInfo & table_info_, bool keep_order_)
+    TableScanBinder(
+        size_t & index_,
+        const DAGSchema & output_schema_,
+        const TiDB::TableInfo & table_info_,
+        bool keep_order_)
         : ExecutorBinder(index_, "table_scan_" + std::to_string(index_), output_schema_)
         , table_info(table_info_)
         , keep_order(keep_order_)
@@ -47,7 +51,7 @@ public:
     TableID getTableId() const;
 
 private:
-    TableInfo table_info; /// used by column pruner
+    TiDB::TableInfo table_info; /// used by column pruner
     bool keep_order;
     std::vector<int> rf_ids;
 
@@ -59,7 +63,7 @@ private:
 
 ExecutorBinderPtr compileTableScan(
     size_t & executor_index,
-    TableInfo & table_info,
+    TiDB::TableInfo & table_info,
     const String & db,
     const String & table_name,
     bool append_pk_column,

--- a/dbms/src/Debug/MockStorage.cpp
+++ b/dbms/src/Debug/MockStorage.cpp
@@ -503,7 +503,9 @@ CutColumnInfo getCutColumnInfo(size_t rows, Int64 partition_id, Int64 partition_
     return {start, cur_rows};
 }
 
-ColumnsWithTypeAndName getUsedColumns(const ColumnInfos & used_columns, const ColumnsWithTypeAndName & all_columns)
+ColumnsWithTypeAndName getUsedColumns(
+    const TiDB::ColumnInfos & used_columns,
+    const ColumnsWithTypeAndName & all_columns)
 {
     if (used_columns.empty())
         /// if used columns is not set, just return all the columns
@@ -585,10 +587,10 @@ DM::ColumnDefines MockStorage::getStoreColumnDefines(Int64 table_id)
     return storage_delta_merge_map[table_id]->getStoreColumnDefines();
 }
 
-ColumnInfos mockColumnInfosToTiDBColumnInfos(const MockColumnInfoVec & mock_column_infos)
+TiDB::ColumnInfos mockColumnInfosToTiDBColumnInfos(const MockColumnInfoVec & mock_column_infos)
 {
     ColumnID col_id = 0;
-    ColumnInfos ret;
+    TiDB::ColumnInfos ret;
     ret.reserve(mock_column_infos.size());
     for (const auto & mock_column_info : mock_column_infos)
     {

--- a/dbms/src/Debug/MockStorage.h
+++ b/dbms/src/Debug/MockStorage.h
@@ -54,8 +54,10 @@ private:
     std::atomic<Int64> current_id = 0;
 };
 
-ColumnInfos mockColumnInfosToTiDBColumnInfos(const MockColumnInfoVec & mock_column_infos);
-ColumnsWithTypeAndName getUsedColumns(const ColumnInfos & used_columns, const ColumnsWithTypeAndName & all_columns);
+TiDB::ColumnInfos mockColumnInfosToTiDBColumnInfos(const MockColumnInfoVec & mock_column_infos);
+ColumnsWithTypeAndName getUsedColumns(
+    const TiDB::ColumnInfos & used_columns,
+    const ColumnsWithTypeAndName & all_columns);
 
 /** Responsible for mock data for executor tests and mpp tests.
   * 1. Use this class to add mock table schema and table column data.

--- a/dbms/src/Debug/MockStorage.h
+++ b/dbms/src/Debug/MockStorage.h
@@ -20,7 +20,7 @@
 #include <Flash/Pipeline/Exec/PipelineExecBuilder.h>
 #include <Operators/Operator.h>
 #include <Storages/DeltaMerge/ColumnDefine_fwd.h>
-#include <TiDB/Schema/TiDB.h>
+#include <TiDB/Schema/TiDB_fwd.h>
 #include <common/types.h>
 
 #include <atomic>

--- a/dbms/src/Debug/dbgFuncCoprocessorUtils.cpp
+++ b/dbms/src/Debug/dbgFuncCoprocessorUtils.cpp
@@ -52,7 +52,7 @@ DAGSchema getSelectSchema(Context & context)
     auto result_field_types = dag_context->result_field_types;
     for (size_t i = 0; i < result_field_types.size(); ++i)
     {
-        ColumnInfo info = TiDB::fieldTypeToColumnInfo(result_field_types[i]);
+        TiDB::ColumnInfo info = TiDB::fieldTypeToColumnInfo(result_field_types[i]);
         String col_name = "col_" + std::to_string(i);
         schema.emplace_back(col_name, info);
     }

--- a/dbms/src/Debug/dbgKVStore/dbgFuncInvestigator.cpp
+++ b/dbms/src/Debug/dbgKVStore/dbgFuncInvestigator.cpp
@@ -143,16 +143,16 @@ void dbgFuncFindKey(Context & context, const ASTs & args, DBGInvoker::Printer ou
                 "start_col, [, start_col2, ..., end_col1, end_col2, ...]",
                 arg_size);
         }
-        size_t handle_column_size = table_info.is_common_handle ? table_info.getPrimaryIndexInfo().idx_cols.size() : 1;
         auto key_size = arg_size / 2;
         std::vector<Field> start_field;
         start_field.reserve(key_size);
         std::vector<Field> end_field;
         end_field.reserve(key_size);
 
-        for (size_t i = 0; i < handle_column_size; i++)
+        const auto & pk_index = table_info.getPrimaryIndexInfo();
+        for (size_t i = 0; i < pk_index.idx_cols.size(); i++)
         {
-            auto & column_info = table_info.columns[table_info.getPrimaryIndexInfo().idx_cols[i].offset];
+            auto & column_info = table_info.columns[pk_index.idx_cols[i].offset];
             auto start_datum = TiDB::DatumBumpy(
                 RegionBench::convertField(column_info, typeid_cast<const ASTLiteral &>(*args[OFFSET + i]).value),
                 column_info.tp);

--- a/dbms/src/Debug/dbgKVStore/dbgFuncMockRaftSnapshot.cpp
+++ b/dbms/src/Debug/dbgKVStore/dbgFuncMockRaftSnapshot.cpp
@@ -132,9 +132,9 @@ RegionPtr GenDbgRegionSnapshotWithData(Context & context, const ASTs & args)
             if (is_common_handle)
             {
                 std::vector<Field> keys; // handle key
-                for (size_t i = 0; i < table_info.getPrimaryIndexInfo().idx_cols.size(); i++)
+                const auto & pk_index = table_info.getPrimaryIndexInfo();
+                for (const auto & idx_col : pk_index.idx_cols)
                 {
-                    auto & idx_col = table_info.getPrimaryIndexInfo().idx_cols[i];
                     auto & column_info = table_info.columns[idx_col.offset];
                     auto start_field = RegionBench::convertField(column_info, fields[idx_col.offset]);
                     TiDB::DatumBumpy start_datum = TiDB::DatumBumpy(start_field, column_info.tp);

--- a/dbms/src/Debug/dbgNaturalDag.h
+++ b/dbms/src/Debug/dbgNaturalDag.h
@@ -21,9 +21,6 @@
 #include <kvproto/coprocessor.pb.h>
 #include <kvproto/mpp.pb.h>
 
-#include <fstream>
-#include <iostream>
-#include <sstream>
 #include <vector>
 
 namespace DB

--- a/dbms/src/Debug/dbgTools.cpp
+++ b/dbms/src/Debug/dbgTools.cpp
@@ -357,10 +357,9 @@ void insert( //
     if (table_info.is_common_handle)
     {
         std::vector<Field> keys;
-
-        for (size_t i = 0; i < table_info.getPrimaryIndexInfo().idx_cols.size(); i++)
+        const auto & pk_index = table_info.getPrimaryIndexInfo();
+        for (const auto & idx_col : pk_index.idx_cols)
         {
-            const auto & idx_col = table_info.getPrimaryIndexInfo().idx_cols[i];
             const auto & column_info = table_info.columns[idx_col.offset];
             auto start_field = RegionBench::convertField(column_info, fields[idx_col.offset]);
             TiDB::DatumBumpy start_datum = TiDB::DatumBumpy(start_field, column_info.tp);

--- a/dbms/src/Debug/dbgTools.h
+++ b/dbms/src/Debug/dbgTools.h
@@ -19,7 +19,7 @@
 #include <Storages/DeltaMerge/DeltaMergeInterfaces.h>
 #include <Storages/KVStore/Decode/DecodedTiKVKeyValue.h>
 #include <Storages/KVStore/FFI/ProxyFFI.h>
-#include <TiDB/Schema/TiDB.h>
+#include <TiDB/Schema/TiDB_fwd.h>
 #include <kvproto/raft_cmdpb.pb.h>
 
 #include <optional>

--- a/dbms/src/Flash/Coprocessor/ArrowChunkCodec.cpp
+++ b/dbms/src/Flash/Coprocessor/ArrowChunkCodec.cpp
@@ -15,6 +15,7 @@
 #include <Flash/Coprocessor/ArrowChunkCodec.h>
 #include <Flash/Coprocessor/ArrowColCodec.h>
 #include <IO/copyData.h>
+#include <TiDB/Decode/TypeMapping.h>
 
 namespace DB
 {

--- a/dbms/src/Flash/Coprocessor/ArrowColCodec.cpp
+++ b/dbms/src/Flash/Coprocessor/ArrowColCodec.cpp
@@ -27,9 +27,12 @@
 #include <Flash/Coprocessor/DAGUtils.h>
 #include <Functions/FunctionHelpers.h>
 #include <IO/copyData.h>
+#include <TiDB/Schema/TiDB.h>
 
 namespace DB
 {
+using TiDB::ColumnInfo;
+
 namespace ErrorCodes
 {
 extern const int LOGICAL_ERROR;

--- a/dbms/src/Flash/Coprocessor/ArrowColCodec.cpp
+++ b/dbms/src/Flash/Coprocessor/ArrowColCodec.cpp
@@ -27,6 +27,7 @@
 #include <Flash/Coprocessor/DAGUtils.h>
 #include <Functions/FunctionHelpers.h>
 #include <IO/copyData.h>
+#include <TiDB/Decode/TypeMapping.h>
 #include <TiDB/Schema/TiDB.h>
 
 namespace DB

--- a/dbms/src/Flash/Coprocessor/ArrowColCodec.h
+++ b/dbms/src/Flash/Coprocessor/ArrowColCodec.h
@@ -32,7 +32,7 @@ const char * arrowColToFlashCol(
     const std::vector<UInt8> & null_bitmap,
     const std::vector<UInt64> & offsets,
     const ColumnWithTypeAndName & flash_col,
-    const ColumnInfo & col_info,
+    const TiDB::ColumnInfo & col_info,
     UInt32 length);
 
 } // namespace DB

--- a/dbms/src/Flash/Coprocessor/CHBlockChunkCodec.cpp
+++ b/dbms/src/Flash/Coprocessor/CHBlockChunkCodec.cpp
@@ -20,6 +20,7 @@
 #include <Flash/Coprocessor/CHBlockChunkCodec.h>
 #include <Flash/Coprocessor/DAGUtils.h>
 #include <IO/Buffer/ReadBufferFromString.h>
+#include <TiDB/Decode/TypeMapping.h>
 
 namespace DB
 {

--- a/dbms/src/Flash/Coprocessor/CHBlockChunkCodecV1.cpp
+++ b/dbms/src/Flash/Coprocessor/CHBlockChunkCodecV1.cpp
@@ -20,6 +20,9 @@
 #include <IO/Buffer/ReadBufferFromString.h>
 #include <IO/Compression/CompressionCodecFactory.h>
 #include <IO/Compression/CompressionInfo.h>
+#include <IO/ReadHelpers.h>
+#include <IO/VarInt.h>
+#include <IO/WriteHelpers.h>
 
 namespace DB
 {

--- a/dbms/src/Flash/Coprocessor/ChunkCodec.h
+++ b/dbms/src/Flash/Coprocessor/ChunkCodec.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <Core/Block.h>
+#include <TiDB/Schema/TiDB.h>
 #include <tipb/select.pb.h>
 
 namespace DB

--- a/dbms/src/Flash/Coprocessor/ChunkCodec.h
+++ b/dbms/src/Flash/Coprocessor/ChunkCodec.h
@@ -15,7 +15,6 @@
 #pragma once
 
 #include <Core/Block.h>
-#include <TiDB/Decode/TypeMapping.h>
 #include <tipb/select.pb.h>
 
 namespace DB

--- a/dbms/src/Flash/Coprocessor/ChunkCodec.h
+++ b/dbms/src/Flash/Coprocessor/ChunkCodec.h
@@ -20,7 +20,7 @@
 
 namespace DB
 {
-using DAGColumnInfo = std::pair<String, ColumnInfo>;
+using DAGColumnInfo = std::pair<String, TiDB::ColumnInfo>;
 using DAGSchema = std::vector<DAGColumnInfo>;
 
 class ChunkCodecStream

--- a/dbms/src/Flash/Coprocessor/CoprocessorReader.h
+++ b/dbms/src/Flash/Coprocessor/CoprocessorReader.h
@@ -23,10 +23,6 @@
 #include <Flash/Coprocessor/DefaultChunkCodec.h>
 #include <common/logger_useful.h>
 
-#include <chrono>
-#include <mutex>
-#include <thread>
-
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"

--- a/dbms/src/Flash/Coprocessor/DAGContext.h
+++ b/dbms/src/Flash/Coprocessor/DAGContext.h
@@ -40,7 +40,7 @@
 #include <Parsers/makeDummyQuery.h>
 #include <Storages/DeltaMerge/Remote/DisaggTaskId.h>
 #include <Storages/DeltaMerge/ScanContext_fwd.h>
-#include <TiDB/Schema/TiDB.h>
+
 namespace DB
 {
 class Context;

--- a/dbms/src/Flash/Coprocessor/DAGExpressionAnalyzer.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGExpressionAnalyzer.cpp
@@ -1145,7 +1145,7 @@ String DAGExpressionAnalyzer::appendTimeZoneCast(
 std::pair<bool, std::vector<String>> DAGExpressionAnalyzer::buildExtraCastsAfterTS(
     const ExpressionActionsPtr & actions,
     const std::vector<UInt8> & may_need_add_cast_column,
-    const ColumnInfos & table_scan_columns)
+    const TiDB::ColumnInfos & table_scan_columns)
 {
     bool has_cast = false;
     std::vector<String> casted_columns;

--- a/dbms/src/Flash/Coprocessor/DAGExpressionAnalyzer.h
+++ b/dbms/src/Flash/Coprocessor/DAGExpressionAnalyzer.h
@@ -188,7 +188,7 @@ public:
     std::pair<bool, std::vector<String>> buildExtraCastsAfterTS(
         const ExpressionActionsPtr & actions,
         const std::vector<UInt8> & may_need_add_cast_column,
-        const ColumnInfos & table_scan_columns);
+        const TiDB::ColumnInfos & table_scan_columns);
 
 #ifndef DBMS_PUBLIC_GTEST
 private:

--- a/dbms/src/Flash/Coprocessor/DAGQueryInfo.h
+++ b/dbms/src/Flash/Coprocessor/DAGQueryInfo.h
@@ -29,7 +29,7 @@ struct DAGQueryInfo
     DAGQueryInfo(
         const google::protobuf::RepeatedPtrField<tipb::Expr> & filters_,
         const google::protobuf::RepeatedPtrField<tipb::Expr> & pushed_down_filters_,
-        const ColumnInfos & source_columns_,
+        const TiDB::ColumnInfos & source_columns_,
         const std::vector<int> & runtime_filter_ids_,
         const int rf_max_wait_time_ms_,
         const TimezoneInfo & timezone_info_)
@@ -41,7 +41,7 @@ struct DAGQueryInfo
         , timezone_info(timezone_info_){};
 
     // A light copy of tipb::TableScan::columns from TiDB, some attributes are empty, like name.
-    const ColumnInfos & source_columns;
+    const TiDB::ColumnInfos & source_columns;
     // filters in dag request
     const google::protobuf::RepeatedPtrField<tipb::Expr> & filters;
     // filters have been push down to storage engine in dag request

--- a/dbms/src/Flash/Coprocessor/DAGUtils.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGUtils.cpp
@@ -1162,7 +1162,7 @@ String getColumnNameForColumnExpr(const tipb::Expr & expr, const std::vector<Nam
     return input_col[column_index].name;
 }
 
-ColumnID getColumnIDForColumnExpr(const tipb::Expr & expr, const std::vector<ColumnInfo> & input_col)
+ColumnID getColumnIDForColumnExpr(const tipb::Expr & expr, const std::vector<TiDB::ColumnInfo> & input_col)
 {
     auto column_index = decodeDAGInt64(expr.val());
     if (column_index < 0 || column_index >= static_cast<Int64>(input_col.size()))
@@ -1178,7 +1178,7 @@ ColumnID getColumnIDForColumnExpr(const tipb::Expr & expr, const std::vector<Col
 
 void getColumnIDsFromExpr(
     const tipb::Expr & expr,
-    const std::vector<ColumnInfo> & input_col,
+    const std::vector<TiDB::ColumnInfo> & input_col,
     std::unordered_set<ColumnID> & col_id_set)
 {
     if (expr.children_size() == 0)

--- a/dbms/src/Flash/Coprocessor/DAGUtils.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGUtils.cpp
@@ -23,6 +23,7 @@
 #include <Functions/FunctionHelpers.h>
 #include <Interpreters/Context.h>
 #include <TiDB/Decode/Datum.h>
+#include <TiDB/Decode/TypeMapping.h>
 
 #include <unordered_map>
 

--- a/dbms/src/Flash/Coprocessor/DAGUtils.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGUtils.cpp
@@ -24,6 +24,8 @@
 #include <Interpreters/Context.h>
 #include <TiDB/Decode/Datum.h>
 #include <TiDB/Decode/TypeMapping.h>
+#include <TiDB/Schema/TiDB.h>
+#include <TiDB/Schema/TiDBTypes.h>
 
 #include <unordered_map>
 

--- a/dbms/src/Flash/Coprocessor/DAGUtils.h
+++ b/dbms/src/Flash/Coprocessor/DAGUtils.h
@@ -49,7 +49,7 @@ bool isColumnExpr(const tipb::Expr & expr);
 String getColumnNameForColumnExpr(const tipb::Expr & expr, const std::vector<NameAndTypePair> & input_col);
 void getColumnIDsFromExpr(
     const tipb::Expr & expr,
-    const std::vector<ColumnInfo> & input_col,
+    const std::vector<TiDB::ColumnInfo> & input_col,
     std::unordered_set<ColumnID> & col_id_set);
 NameAndTypePair getColumnNameAndTypeForColumnExpr(
     const tipb::Expr & expr,

--- a/dbms/src/Flash/Coprocessor/DAGUtils.h
+++ b/dbms/src/Flash/Coprocessor/DAGUtils.h
@@ -20,7 +20,6 @@
 #include <Core/SortDescription.h>
 #include <Storages/KVStore/Types.h>
 #include <TiDB/Collation/Collator.h>
-#include <TiDB/Decode/TypeMapping.h>
 #include <TiDB/Schema/TiDB_fwd.h>
 #include <grpcpp/impl/codegen/status_code_enum.h>
 #include <tipb/executor.pb.h>

--- a/dbms/src/Flash/Coprocessor/DAGUtils.h
+++ b/dbms/src/Flash/Coprocessor/DAGUtils.h
@@ -21,7 +21,7 @@
 #include <Storages/KVStore/Types.h>
 #include <TiDB/Collation/Collator.h>
 #include <TiDB/Decode/TypeMapping.h>
-#include <TiDB/Schema/TiDB.h>
+#include <TiDB/Schema/TiDB_fwd.h>
 #include <grpcpp/impl/codegen/status_code_enum.h>
 #include <tipb/executor.pb.h>
 #include <tipb/select.pb.h>

--- a/dbms/src/Flash/Coprocessor/GenSchemaAndColumn.cpp
+++ b/dbms/src/Flash/Coprocessor/GenSchemaAndColumn.cpp
@@ -23,7 +23,7 @@ namespace DB
 {
 namespace
 {
-DataTypePtr getPkType(const ColumnInfo & column_info)
+DataTypePtr getPkType(const TiDB::ColumnInfo & column_info)
 {
     const auto & pk_data_type = getDataTypeByColumnInfoForComputingLayer(column_info);
     /// primary key type must be tidb_pk_column_int_type or tidb_pk_column_string_type.
@@ -61,7 +61,7 @@ String genNameForExchangeReceiver(Int32 col_index)
     return fmt::format("exchange_receiver_{}", col_index);
 }
 
-NamesAndTypes genNamesAndTypes(const ColumnInfos & column_infos, const StringRef & column_prefix)
+NamesAndTypes genNamesAndTypes(const TiDB::ColumnInfos & column_infos, const StringRef & column_prefix)
 {
     NamesAndTypes names_and_types;
     names_and_types.reserve(column_infos.size());

--- a/dbms/src/Flash/Coprocessor/GenSchemaAndColumn.h
+++ b/dbms/src/Flash/Coprocessor/GenSchemaAndColumn.h
@@ -19,6 +19,7 @@
 #include <Flash/Coprocessor/ChunkCodec.h>
 #include <Flash/Coprocessor/TiDBTableScan.h>
 #include <Storages/DeltaMerge/ColumnDefine_fwd.h>
+#include <TiDB/Schema/TiDB_fwd.h>
 #include <common/StringRef.h>
 
 namespace DB
@@ -28,7 +29,7 @@ NamesAndTypes genNamesAndTypesForTableScan(const TiDBTableScan & table_scan);
 String genNameForExchangeReceiver(Int32 col_index);
 
 NamesAndTypes genNamesAndTypes(const TiDBTableScan & table_scan, const StringRef & column_prefix);
-NamesAndTypes genNamesAndTypes(const ColumnInfos & column_infos, const StringRef & column_prefix);
+NamesAndTypes genNamesAndTypes(const TiDB::ColumnInfos & column_infos, const StringRef & column_prefix);
 ColumnsWithTypeAndName getColumnWithTypeAndName(const NamesAndTypes & names_and_types);
 NamesAndTypes toNamesAndTypes(const DAGSchema & dag_schema);
 

--- a/dbms/src/Flash/Coprocessor/GenSchemaAndColumn.h
+++ b/dbms/src/Flash/Coprocessor/GenSchemaAndColumn.h
@@ -19,7 +19,6 @@
 #include <Flash/Coprocessor/ChunkCodec.h>
 #include <Flash/Coprocessor/TiDBTableScan.h>
 #include <Storages/DeltaMerge/ColumnDefine_fwd.h>
-#include <TiDB/Schema/TiDB.h>
 #include <common/StringRef.h>
 
 namespace DB

--- a/dbms/src/Flash/Coprocessor/MockSourceStream.h
+++ b/dbms/src/Flash/Coprocessor/MockSourceStream.h
@@ -86,7 +86,7 @@ std::pair<NamesAndTypes, std::vector<std::shared_ptr<SourceType>>> mockSourceStr
     DB::LoggerPtr log,
     String executor_id,
     Int64 table_id = 0,
-    const ColumnInfos & used_columns = {})
+    const TiDB::ColumnInfos & used_columns = {})
 {
     ColumnsWithTypeAndName columns_with_type_and_name;
     if constexpr (std::is_same_v<SourceType, MockExchangeReceiverInputStream>)

--- a/dbms/src/Flash/Coprocessor/RemoteRequest.cpp
+++ b/dbms/src/Flash/Coprocessor/RemoteRequest.cpp
@@ -55,7 +55,7 @@ RemoteRequest RemoteRequest::build(
 
             if (col_id == DB::TiDBPkColumnID)
             {
-                ColumnInfo ci;
+                TiDB::ColumnInfo ci;
                 ci.tp = TiDB::TypeLongLong;
                 ci.setPriKeyFlag();
                 ci.setNotNullFlag();
@@ -63,7 +63,7 @@ RemoteRequest RemoteRequest::build(
             }
             else if (col_id == ExtraTableIDColumnID)
             {
-                ColumnInfo ci;
+                TiDB::ColumnInfo ci;
                 ci.tp = TiDB::TypeLongLong;
                 schema.emplace_back(std::make_pair(MutableSupport::extra_table_id_column_name, std::move(ci)));
             }

--- a/dbms/src/Flash/Coprocessor/TiDBChunk.h
+++ b/dbms/src/Flash/Coprocessor/TiDBChunk.h
@@ -16,7 +16,6 @@
 
 #include <DataStreams/IBlockInputStream.h>
 #include <Flash/Coprocessor/TiDBColumn.h>
-#include <TiDB/Schema/TiDB.h>
 
 namespace DB
 {
@@ -41,7 +40,7 @@ public:
         size_t start_index,
         size_t end_index);
 
-    TiDBColumn & getColumn(int index) { return columns[index]; };
+    TiDBColumn & getColumn(int index) { return columns[index]; }
     void clear()
     {
         for (auto & c : columns)

--- a/dbms/src/Flash/Coprocessor/TiDBColumn.h
+++ b/dbms/src/Flash/Coprocessor/TiDBColumn.h
@@ -20,13 +20,14 @@
 #include <Flash/Coprocessor/TiDBDecimal.h>
 #include <Flash/Coprocessor/TiDBEnum.h>
 #include <Flash/Coprocessor/TiDBTime.h>
+#include <IO/Buffer/WriteBufferFromString.h>
 
 namespace DB
 {
 class TiDBColumn
 {
 public:
-    TiDBColumn(Int8 element_len);
+    explicit TiDBColumn(Int8 element_len);
 
     void appendNull();
     void append(Int64 value);
@@ -44,7 +45,7 @@ public:
     void clear();
 
 private:
-    bool isFixed() { return fixed_size != VAR_SIZE; }
+    bool isFixed() const { return fixed_size != VAR_SIZE; }
     void finishAppendFixed();
     void finishAppendVar(UInt32 size);
     void appendNullBitMap(bool value);

--- a/dbms/src/Flash/Coprocessor/TiDBColumn.h
+++ b/dbms/src/Flash/Coprocessor/TiDBColumn.h
@@ -20,7 +20,6 @@
 #include <Flash/Coprocessor/TiDBDecimal.h>
 #include <Flash/Coprocessor/TiDBEnum.h>
 #include <Flash/Coprocessor/TiDBTime.h>
-#include <TiDB/Schema/TiDB.h>
 
 namespace DB
 {
@@ -45,7 +44,7 @@ public:
     void clear();
 
 private:
-    bool isFixed() { return fixed_size != VAR_SIZE; };
+    bool isFixed() { return fixed_size != VAR_SIZE; }
     void finishAppendFixed();
     void finishAppendVar(UInt32 size);
     void appendNullBitMap(bool value);

--- a/dbms/src/Flash/Coprocessor/TiDBTableScan.h
+++ b/dbms/src/Flash/Coprocessor/TiDBTableScan.h
@@ -14,7 +14,8 @@
 
 #pragma once
 
-#include <TiDB/Decode/TypeMapping.h>
+#include <Storages/KVStore/Types.h>
+#include <TiDB/Schema/TiDB.h>
 #include <common/types.h>
 #include <tipb/executor.pb.h>
 

--- a/dbms/src/Flash/Coprocessor/TiDBTableScan.h
+++ b/dbms/src/Flash/Coprocessor/TiDBTableScan.h
@@ -21,7 +21,6 @@
 namespace DB
 {
 class DAGContext;
-using ColumnInfos = std::vector<TiDB::ColumnInfo>;
 
 /// TiDBTableScan is a wrap to hide the difference of `TableScan` and `PartitionTableScan`
 class TiDBTableScan
@@ -30,7 +29,7 @@ public:
     TiDBTableScan(const tipb::Executor * table_scan_, const String & executor_id_, const DAGContext & dag_context);
     bool isPartitionTableScan() const { return is_partition_table_scan; }
     Int64 getColumnSize() const { return columns.size(); }
-    const ColumnInfos & getColumns() const { return columns; }
+    const TiDB::ColumnInfos & getColumns() const { return columns; }
     void constructTableScanForRemoteRead(tipb::TableScan * tipb_table_scan, TableID table_id) const;
     Int64 getLogicalTableID() const { return logical_table_id; }
     const std::vector<Int64> & getPhysicalTableIDs() const { return physical_table_ids; }
@@ -49,7 +48,7 @@ private:
     const tipb::Executor * table_scan;
     String executor_id;
     bool is_partition_table_scan;
-    const ColumnInfos columns;
+    const TiDB::ColumnInfos columns;
     /// logical_table_id is the table id for a TiDB' table, while if the
     /// TiDB table is partition, each partition is a physical table, and
     /// the partition's table id is the physical table id.

--- a/dbms/src/Flash/Coprocessor/TiDBTime.h
+++ b/dbms/src/Flash/Coprocessor/TiDBTime.h
@@ -21,7 +21,7 @@
 
 #include <Common/MyTime.h>
 #include <Core/Types.h>
-#include <TiDB/Schema/TiDB.h>
+#include <TiDB/Schema/TiDBTypes.h>
 
 namespace DB
 {
@@ -47,7 +47,7 @@ public:
             return ret;
         }
         if (fsp > 0)
-            ret |= UInt64(fsp) << 1u;
+            ret |= static_cast<UInt64>(fsp) << 1u;
         if (time_type == TiDB::TypeTimestamp)
             ret |= 1u;
         return ret;

--- a/dbms/src/Flash/Coprocessor/collectOutputFieldTypes.cpp
+++ b/dbms/src/Flash/Coprocessor/collectOutputFieldTypes.cpp
@@ -15,6 +15,7 @@
 #include <Flash/Coprocessor/DAGCodec.h>
 #include <Flash/Coprocessor/DAGUtils.h>
 #include <Flash/Coprocessor/collectOutputFieldTypes.h>
+#include <TiDB/Schema/TiDB.h>
 #include <common/types.h>
 
 namespace DB

--- a/dbms/src/Flash/Coprocessor/tests/gtest_chunk_decode_and_squash.cpp
+++ b/dbms/src/Flash/Coprocessor/tests/gtest_chunk_decode_and_squash.cpp
@@ -65,7 +65,7 @@ public:
         DAGSchema schema;
         for (size_t i = 0; i < fields.size(); ++i)
         {
-            ColumnInfo info = TiDB::fieldTypeToColumnInfo(fields[i]);
+            TiDB::ColumnInfo info = TiDB::fieldTypeToColumnInfo(fields[i]);
             schema.emplace_back(String("col") + std::to_string(i), std::move(info));
         }
         return schema;

--- a/dbms/src/Flash/Coprocessor/tests/gtest_streaming_writer.cpp
+++ b/dbms/src/Flash/Coprocessor/tests/gtest_streaming_writer.cpp
@@ -61,7 +61,7 @@ public:
         DAGSchema schema;
         for (size_t i = 0; i < fields.size(); ++i)
         {
-            ColumnInfo info = TiDB::fieldTypeToColumnInfo(fields[i]);
+            TiDB::ColumnInfo info = TiDB::fieldTypeToColumnInfo(fields[i]);
             schema.emplace_back(String("col") + std::to_string(i), std::move(info));
         }
         return schema;

--- a/dbms/src/Flash/Coprocessor/tests/gtest_ti_remote_block_inputstream.cpp
+++ b/dbms/src/Flash/Coprocessor/tests/gtest_ti_remote_block_inputstream.cpp
@@ -224,7 +224,7 @@ struct MockReceiverContext
         for (size_t i = 0; i < field_types.size(); ++i)
         {
             String name = "exchange_receiver_" + std::to_string(i);
-            ColumnInfo info = TiDB::fieldTypeToColumnInfo(field_types[i]);
+            TiDB::ColumnInfo info = TiDB::fieldTypeToColumnInfo(field_types[i]);
             schema.emplace_back(std::move(name), std::move(info));
         }
     }
@@ -306,7 +306,7 @@ public:
         DAGSchema schema;
         for (size_t i = 0; i < fields.size(); ++i)
         {
-            ColumnInfo info = TiDB::fieldTypeToColumnInfo(fields[i]);
+            TiDB::ColumnInfo info = TiDB::fieldTypeToColumnInfo(fields[i]);
             schema.emplace_back(String("col") + std::to_string(i), std::move(info));
         }
         return schema;

--- a/dbms/src/Flash/Mpp/BroadcastOrPassThroughWriter.cpp
+++ b/dbms/src/Flash/Mpp/BroadcastOrPassThroughWriter.cpp
@@ -18,6 +18,7 @@
 #include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Mpp/BroadcastOrPassThroughWriter.h>
 #include <Flash/Mpp/MPPTunnelSetWriter.h>
+#include <TiDB/Decode/TypeMapping.h>
 
 namespace DB
 {

--- a/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.cpp
+++ b/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.cpp
@@ -19,6 +19,7 @@
 #include <Flash/Mpp/FineGrainedShuffleWriter.h>
 #include <Flash/Mpp/HashBaseWriterHelper.h>
 #include <Flash/Mpp/MPPTunnelSetWriter.h>
+#include <TiDB/Decode/TypeMapping.h>
 
 namespace DB
 {

--- a/dbms/src/Flash/Mpp/GRPCReceiverContext.cpp
+++ b/dbms/src/Flash/Mpp/GRPCReceiverContext.cpp
@@ -256,7 +256,7 @@ void GRPCReceiverContext::fillSchema(DAGSchema & schema) const
     for (int i = 0; i < exchange_receiver_meta.field_types_size(); ++i)
     {
         String name = genNameForExchangeReceiver(i);
-        ColumnInfo info = TiDB::fieldTypeToColumnInfo(exchange_receiver_meta.field_types(i));
+        TiDB::ColumnInfo info = TiDB::fieldTypeToColumnInfo(exchange_receiver_meta.field_types(i));
         schema.emplace_back(std::move(name), std::move(info));
     }
 }

--- a/dbms/src/Flash/Mpp/HashPartitionWriter.cpp
+++ b/dbms/src/Flash/Mpp/HashPartitionWriter.cpp
@@ -19,6 +19,7 @@
 #include <Flash/Mpp/HashBaseWriterHelper.h>
 #include <Flash/Mpp/HashPartitionWriter.h>
 #include <Flash/Mpp/MPPTunnelSetWriter.h>
+#include <TiDB/Decode/TypeMapping.h>
 
 namespace DB
 {

--- a/dbms/src/Flash/tests/gtest_aggregation_executor.cpp
+++ b/dbms/src/Flash/tests/gtest_aggregation_executor.cpp
@@ -17,6 +17,7 @@
 #include <TestUtils/ColumnGenerator.h>
 #include <TestUtils/ExecutorTestUtils.h>
 #include <TestUtils/mockExecutor.h>
+#include <TiDB/Decode/TypeMapping.h>
 
 namespace DB
 {

--- a/dbms/src/Flash/tests/gtest_auto_spill_aggregation.cpp
+++ b/dbms/src/Flash/tests/gtest_auto_spill_aggregation.cpp
@@ -17,6 +17,7 @@
 #include <TestUtils/ColumnGenerator.h>
 #include <TestUtils/ExecutorTestUtils.h>
 #include <TestUtils/mockExecutor.h>
+#include <TiDB/Decode/TypeMapping.h>
 
 namespace DB
 {

--- a/dbms/src/Flash/tests/gtest_auto_spill_join.cpp
+++ b/dbms/src/Flash/tests/gtest_auto_spill_join.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <Flash/tests/gtest_join.h>
+#include <TiDB/Decode/TypeMapping.h>
 
 #include <magic_enum.hpp>
 

--- a/dbms/src/Flash/tests/gtest_auto_spill_sort.cpp
+++ b/dbms/src/Flash/tests/gtest_auto_spill_sort.cpp
@@ -17,6 +17,7 @@
 #include <TestUtils/ColumnGenerator.h>
 #include <TestUtils/ExecutorTestUtils.h>
 #include <TestUtils/mockExecutor.h>
+#include <TiDB/Decode/TypeMapping.h>
 
 namespace DB
 {

--- a/dbms/src/Functions/FunctionsJson.h
+++ b/dbms/src/Functions/FunctionsJson.h
@@ -35,7 +35,8 @@
 #include <TiDB/Decode/JsonBinary.h>
 #include <TiDB/Decode/JsonPathExprRef.h>
 #include <TiDB/Decode/JsonScanner.h>
-#include <TiDB/Schema/TiDB.h>
+#include <TiDB/Schema/TiDBTypes.h>
+#include <TiDB/Schema/TiDB_fwd.h>
 #include <common/JSON.h>
 #include <simdjson.h>
 #include <tipb/expression.pb.h>

--- a/dbms/src/Functions/FunctionsTiDBConversion.h
+++ b/dbms/src/Functions/FunctionsTiDBConversion.h
@@ -54,7 +54,7 @@
 #include <Interpreters/Context_fwd.h>
 #include <Interpreters/ExpressionActions.h>
 #include <TiDB/Collation/Collator.h>
-#include <TiDB/Schema/TiDB.h>
+#include <TiDB/Schema/TiDBTypes.h>
 
 #include <ext/collection_cast.h>
 #include <ext/enumerate.h>

--- a/dbms/src/Functions/FunctionsTiDBConversion.h
+++ b/dbms/src/Functions/FunctionsTiDBConversion.h
@@ -54,6 +54,7 @@
 #include <Interpreters/Context_fwd.h>
 #include <Interpreters/ExpressionActions.h>
 #include <TiDB/Collation/Collator.h>
+#include <TiDB/Schema/TiDB.h>
 
 #include <ext/collection_cast.h>
 #include <ext/enumerate.h>

--- a/dbms/src/Functions/tests/gtest_cast_as_json.cpp
+++ b/dbms/src/Functions/tests/gtest_cast_as_json.cpp
@@ -17,11 +17,11 @@
 #include <TestUtils/FunctionTestUtils.h>
 #include <TestUtils/TiFlashTestBasic.h>
 #include <TiDB/Decode/JsonBinary.h>
+#include <TiDB/Schema/TiDB.h>
 #include <gtest/gtest.h>
 
 #include <string>
 #include <type_traits>
-#include <vector>
 
 namespace DB::tests
 {

--- a/dbms/src/Functions/tests/gtest_cast_as_json.cpp
+++ b/dbms/src/Functions/tests/gtest_cast_as_json.cpp
@@ -17,7 +17,7 @@
 #include <TestUtils/FunctionTestUtils.h>
 #include <TestUtils/TiFlashTestBasic.h>
 #include <TiDB/Decode/JsonBinary.h>
-#include <TiDB/Schema/TiDB.h>
+#include <TiDB/Schema/TiDBTypes.h>
 #include <gtest/gtest.h>
 
 #include <string>

--- a/dbms/src/Functions/tests/gtest_cast_json_as_string.cpp
+++ b/dbms/src/Functions/tests/gtest_cast_json_as_string.cpp
@@ -21,9 +21,7 @@
 #include <TestUtils/FunctionTestUtils.h>
 #include <TestUtils/TiFlashTestBasic.h>
 #include <TiDB/Decode/JsonBinary.h>
-
-#include <string>
-#include <vector>
+#include <TiDB/Schema/TiDB.h>
 
 namespace DB::tests
 {

--- a/dbms/src/Functions/tests/gtest_cast_json_as_string.cpp
+++ b/dbms/src/Functions/tests/gtest_cast_json_as_string.cpp
@@ -21,7 +21,7 @@
 #include <TestUtils/FunctionTestUtils.h>
 #include <TestUtils/TiFlashTestBasic.h>
 #include <TiDB/Decode/JsonBinary.h>
-#include <TiDB/Schema/TiDB.h>
+#include <TiDB/Schema/TiDBTypes.h>
 
 namespace DB::tests
 {

--- a/dbms/src/Functions/tests/gtest_json_array.cpp
+++ b/dbms/src/Functions/tests/gtest_json_array.cpp
@@ -16,7 +16,7 @@
 #include <TestUtils/FunctionTestUtils.h>
 #include <TestUtils/TiFlashTestBasic.h>
 #include <TiDB/Decode/JsonBinary.h>
-#include <TiDB/Schema/TiDB.h>
+#include <TiDB/Schema/TiDBTypes.h>
 
 namespace DB::tests
 {

--- a/dbms/src/Functions/tests/gtest_json_array.cpp
+++ b/dbms/src/Functions/tests/gtest_json_array.cpp
@@ -16,9 +16,7 @@
 #include <TestUtils/FunctionTestUtils.h>
 #include <TestUtils/TiFlashTestBasic.h>
 #include <TiDB/Decode/JsonBinary.h>
-
-#include <string>
-#include <vector>
+#include <TiDB/Schema/TiDB.h>
 
 namespace DB::tests
 {

--- a/dbms/src/Parsers/IAST.h
+++ b/dbms/src/Parsers/IAST.h
@@ -16,6 +16,7 @@
 
 #include <Common/Exception.h>
 #include <Core/Types.h>
+#include <Parsers/IAST_fwd.h>
 #include <Parsers/StringRange.h>
 
 #include <memory>
@@ -39,9 +40,6 @@ extern const int LOGICAL_ERROR;
 
 using IdentifierNameSet = std::set<String>;
 
-class IAST;
-using ASTPtr = std::shared_ptr<IAST>;
-using ASTs = std::vector<ASTPtr>;
 
 class WriteBuffer;
 

--- a/dbms/src/Parsers/IAST_fwd.h
+++ b/dbms/src/Parsers/IAST_fwd.h
@@ -1,4 +1,4 @@
-// Copyright 2023 PingCAP, Inc.
+// Copyright 2024 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dbms/src/Parsers/IAST_fwd.h
+++ b/dbms/src/Parsers/IAST_fwd.h
@@ -14,24 +14,16 @@
 
 #pragma once
 
-#include <Flash/Coprocessor/TiDBColumn.h>
+#include <memory>
+#include <vector>
 
 namespace DB
 {
-void flashColToArrowCol(
-    TiDBColumn & dag_column,
-    const ColumnWithTypeAndName & flash_col,
-    const tipb::FieldType & field_type,
-    size_t start_index,
-    size_t end_index);
-const char * arrowColToFlashCol(
-    const char * pos,
-    UInt8 field_length,
-    UInt32 null_count,
-    const std::vector<UInt8> & null_bitmap,
-    const std::vector<UInt64> & offsets,
-    const ColumnWithTypeAndName & flash_col,
-    const TiDB::ColumnInfo & col_info,
-    UInt32 length);
+
+class IAST;
+using ASTPtr = std::shared_ptr<IAST>;
+using ASTs = std::vector<ASTPtr>;
+using ASTPtrVec = std::vector<ASTPtr>;
+
 
 } // namespace DB

--- a/dbms/src/Parsers/IAST_fwd.h
+++ b/dbms/src/Parsers/IAST_fwd.h
@@ -23,7 +23,6 @@ namespace DB
 class IAST;
 using ASTPtr = std::shared_ptr<IAST>;
 using ASTs = std::vector<ASTPtr>;
-using ASTPtrVec = std::vector<ASTPtr>;
 
 
 } // namespace DB

--- a/dbms/src/Storages/DeltaMerge/ColumnDefine_fwd.h
+++ b/dbms/src/Storages/DeltaMerge/ColumnDefine_fwd.h
@@ -15,15 +15,11 @@
 #pragma once
 
 #include <Storages/KVStore/Types.h>
+#include <TiDB/Schema/TiDB_fwd.h>
 
 #include <memory>
 #include <unordered_map>
 #include <vector>
-
-namespace TiDB
-{
-struct ColumnInfo;
-}
 
 namespace DB::DM
 {
@@ -32,5 +28,4 @@ using ColumnDefines = std::vector<ColumnDefine>;
 using ColumnDefinesPtr = std::shared_ptr<ColumnDefines>;
 using ColumnDefineMap = std::unordered_map<DB::ColumnID, ColumnDefine>;
 
-using ColumnInfos = std::vector<TiDB::ColumnInfo>;
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeHelpers.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeHelpers.h
@@ -24,7 +24,6 @@
 #include <Interpreters/sortBlock.h>
 #include <Storages/ColumnsDescription.h>
 #include <Storages/DeltaMerge/DeltaMergeDefines.h>
-#include <TiDB/Schema/TiDB.h>
 
 #include <utility>
 

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -53,6 +53,8 @@
 #include <Storages/Page/PageStorage.h>
 #include <Storages/Page/V2/VersionSet/PageEntriesVersionSetWithDelta.h>
 #include <Storages/PathPool.h>
+#include <TiDB/Decode/TypeMapping.h>
+#include <TiDB/Schema/TiDB.h>
 #include <common/logger_useful.h>
 
 #include <atomic>

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -1873,7 +1873,7 @@ BlockPtr DeltaMergeStore::getHeader() const
     return std::atomic_load<Block>(&original_table_header);
 }
 
-void DeltaMergeStore::applySchemaChanges(TableInfo & table_info)
+void DeltaMergeStore::applySchemaChanges(TiDB::TableInfo & table_info)
 {
     std::unique_lock lock(read_write_mutex);
 

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
@@ -38,6 +38,7 @@
 #include <Storages/KVStore/MultiRaft/Disagg/CheckpointIngestInfo.h>
 #include <Storages/Page/PageStorage_fwd.h>
 #include <Storages/TableNameMeta.h>
+#include <TiDB/Schema/TiDB_fwd.h>
 
 #include <queue>
 
@@ -179,7 +180,7 @@ public:
     friend struct DB::CheckpointIngestInfo;
     struct Settings
     {
-        NotCompress not_compress_columns{};
+        NotCompress not_compress_columns;
     };
     static Settings EMPTY_SETTINGS;
 
@@ -507,7 +508,7 @@ public:
     std::vector<SegmentPtr> getMergeableSegments(const DMContextPtr & context, const SegmentPtr & base_segment);
 
     /// Apply schema change on `table_columns`
-    void applySchemaChanges(TableInfo & table_info);
+    void applySchemaChanges(TiDB::TableInfo & table_info);
 
     ColumnDefinesPtr getStoreColumns() const
     {

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
@@ -38,7 +38,6 @@
 #include <Storages/KVStore/MultiRaft/Disagg/CheckpointIngestInfo.h>
 #include <Storages/Page/PageStorage_fwd.h>
 #include <Storages/TableNameMeta.h>
-#include <TiDB/Schema/TiDB.h>
 
 #include <queue>
 

--- a/dbms/src/Storages/DeltaMerge/Filter/PushDownFilter.cpp
+++ b/dbms/src/Storages/DeltaMerge/Filter/PushDownFilter.cpp
@@ -26,7 +26,7 @@ namespace DB::DM
 {
 PushDownFilterPtr PushDownFilter::build(
     const RSOperatorPtr & rs_operator,
-    const ColumnInfos & table_scan_column_info,
+    const TiDB::ColumnInfos & table_scan_column_info,
     const google::protobuf::RepeatedPtrField<tipb::Expr> & pushed_down_filters,
     const ColumnDefines & columns_to_read,
     const Context & context,

--- a/dbms/src/Storages/DeltaMerge/Filter/PushDownFilter.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/PushDownFilter.h
@@ -57,7 +57,7 @@ public:
     // Use by StorageDisaggregated.
     static PushDownFilterPtr build(
         const DM::RSOperatorPtr & rs_operator,
-        const ColumnInfos & table_scan_column_info,
+        const TiDB::ColumnInfos & table_scan_column_info,
         const google::protobuf::RepeatedPtrField<tipb::Expr> & pushed_down_filters,
         const ColumnDefines & columns_to_read,
         const Context & context,

--- a/dbms/src/Storages/DeltaMerge/Filter/RSOperator.cpp
+++ b/dbms/src/Storages/DeltaMerge/Filter/RSOperator.cpp
@@ -51,7 +51,7 @@ RSOperatorPtr createUnsupported(const String & reason)                          
 
 RSOperatorPtr RSOperator::build(
     const std::unique_ptr<DAGQueryInfo> & dag_query,
-    const ColumnInfos & scan_column_infos,
+    const TiDB::ColumnInfos & scan_column_infos,
     const ColumnDefines & table_column_defines,
     bool enable_rs_filter,
     const LoggerPtr & tracing_logger)

--- a/dbms/src/Storages/DeltaMerge/Filter/RSOperator.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/RSOperator.h
@@ -56,7 +56,7 @@ public:
 
     static RSOperatorPtr build(
         const std::unique_ptr<DAGQueryInfo> & dag_query,
-        const ColumnInfos & scan_column_infos,
+        const TiDB::ColumnInfos & scan_column_infos,
         const ColumnDefines & table_column_defines,
         bool enable_rs_filter,
         const LoggerPtr & tracing_logger);

--- a/dbms/src/Storages/DeltaMerge/FilterParser/FilterParser.cpp
+++ b/dbms/src/Storages/DeltaMerge/FilterParser/FilterParser.cpp
@@ -79,7 +79,7 @@ inline bool isRoughSetFilterSupportType(const Int32 field_type)
     return false;
 }
 
-ColumnID getColumnIDForColumnExpr(const tipb::Expr & expr, const ColumnInfos & scan_column_infos)
+ColumnID getColumnIDForColumnExpr(const tipb::Expr & expr, const TiDB::ColumnInfos & scan_column_infos)
 {
     assert(isColumnExpr(expr));
     auto column_index = decodeDAGInt64(expr.val());
@@ -110,7 +110,7 @@ inline void convertFieldWithTimezone(Field & value, const TimezoneInfo & timezon
 inline RSOperatorPtr parseTiCompareExpr( //
     const tipb::Expr & expr,
     const FilterParser::RSFilterType filter_type,
-    const ColumnInfos & scan_column_infos,
+    const TiDB::ColumnInfos & scan_column_infos,
     const FilterParser::AttrCreatorByColumnID & creator,
     const TimezoneInfo & timezone_info)
 {
@@ -243,7 +243,7 @@ inline RSOperatorPtr parseTiCompareExpr( //
 
 RSOperatorPtr parseTiExpr(
     const tipb::Expr & expr,
-    const ColumnInfos & scan_column_infos,
+    const TiDB::ColumnInfos & scan_column_infos,
     const FilterParser::AttrCreatorByColumnID & creator,
     const TimezoneInfo & timezone_info,
     const LoggerPtr & log)
@@ -358,7 +358,7 @@ RSOperatorPtr parseTiExpr(
 
 RSOperatorPtr FilterParser::parseDAGQuery(
     const DAGQueryInfo & dag_info,
-    const ColumnInfos & scan_column_infos,
+    const TiDB::ColumnInfos & scan_column_infos,
     FilterParser::AttrCreatorByColumnID && creator,
     const LoggerPtr & log)
 {
@@ -422,7 +422,7 @@ RSOperatorPtr FilterParser::parseRFInExpr(
 
 std::optional<Attr> FilterParser::createAttr(
     const tipb::Expr & expr,
-    const ColumnInfos & scan_column_infos,
+    const TiDB::ColumnInfos & scan_column_infos,
     const ColumnDefines & table_column_defines)
 {
     if (!isColumnExpr(expr))

--- a/dbms/src/Storages/DeltaMerge/FilterParser/FilterParser.h
+++ b/dbms/src/Storages/DeltaMerge/FilterParser/FilterParser.h
@@ -41,7 +41,7 @@ public:
     using AttrCreatorByColumnID = std::function<Attr(const DB::ColumnID)>;
     static RSOperatorPtr parseDAGQuery(
         const DAGQueryInfo & dag_info,
-        const ColumnInfos & scan_column_infos,
+        const TiDB::ColumnInfos & scan_column_infos,
         AttrCreatorByColumnID && creator,
         const LoggerPtr & log);
 
@@ -55,7 +55,7 @@ public:
 
     static std::optional<Attr> createAttr(
         const tipb::Expr & expr,
-        const ColumnInfos & scan_column_infos,
+        const TiDB::ColumnInfos & scan_column_infos,
         const ColumnDefines & table_column_defines);
 
     static bool isRSFilterSupportType(Int32 field_type);

--- a/dbms/src/Storages/DeltaMerge/RowKeyRange.h
+++ b/dbms/src/Storages/DeltaMerge/RowKeyRange.h
@@ -25,7 +25,6 @@
 #include <Storages/KVStore/TiKVHelpers/TiKVRecordFormat.h>
 #include <Storages/KVStore/Types.h>
 #include <TiDB/Decode/DatumCodec.h>
-#include <TiDB/Schema/TiDB.h>
 
 namespace DB::DM
 {

--- a/dbms/src/Storages/DeltaMerge/tests/DMTestEnv.h
+++ b/dbms/src/Storages/DeltaMerge/tests/DMTestEnv.h
@@ -231,7 +231,7 @@ public:
         {
             table_info.is_common_handle = true;
             table_info.pk_is_handle = false;
-            ColumnInfo pk_column; // For common handle, there must be a user-given primary key.
+            TiDB::ColumnInfo pk_column; // For common handle, there must be a user-given primary key.
             pk_column.id = PK_ID_PK_IS_HANDLE;
             pk_column.name = PK_NAME_PK_IS_HANDLE;
             pk_column.setPriKeyFlag();
@@ -242,7 +242,7 @@ public:
         {
             table_info.is_common_handle = false;
             table_info.pk_is_handle = true;
-            ColumnInfo pk_column;
+            TiDB::ColumnInfo pk_column;
             pk_column.id = PK_ID_PK_IS_HANDLE;
             pk_column.name = PK_NAME_PK_IS_HANDLE;
             pk_column.setPriKeyFlag();

--- a/dbms/src/Storages/DeltaMerge/tests/DMTestEnv.h
+++ b/dbms/src/Storages/DeltaMerge/tests/DMTestEnv.h
@@ -27,6 +27,7 @@
 #include <Storages/DeltaMerge/RowKeyRange.h>
 #include <TestUtils/FunctionTestUtils.h>
 #include <TestUtils/TiFlashTestBasic.h>
+#include <TiDB/Schema/TiDB.h>
 
 #include <vector>
 

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_convert_column.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_convert_column.cpp
@@ -19,6 +19,7 @@
 #include <Storages/DeltaMerge/SchemaUpdate.h>
 #include <Storages/DeltaMerge/convertColumnTypeHelpers.h>
 #include <Storages/DeltaMerge/tests/DMTestEnv.h>
+#include <TiDB/Decode/TypeMapping.h>
 #include <TiDB/Schema/TiDB.h>
 
 namespace DB::DM::tests

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_minmax_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_minmax_index.cpp
@@ -2219,7 +2219,7 @@ try
     TiDB::ColumnInfo a, b;
     a.id = 1;
     b.id = 2;
-    ColumnInfos column_infos = {a, b};
+    TiDB::ColumnInfos column_infos = {a, b};
     auto dag_query = std::make_unique<DAGQueryInfo>(
         filters,
         pushed_down_filters, // Not care now

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_storage_delta_merge.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_storage_delta_merge.cpp
@@ -128,7 +128,7 @@ try
     // keep a ref on them
     const google::protobuf::RepeatedPtrField<tipb::Expr> filters{};
     const google::protobuf::RepeatedPtrField<tipb::Expr> pushed_down_filters{};
-    ColumnInfos source_columns{};
+    TiDB::ColumnInfos source_columns{};
     const std::vector<int> runtime_filter_ids;
     query_info.dag_query = std::make_unique<DAGQueryInfo>(
         filters,
@@ -683,7 +683,7 @@ try
     // keep a ref on them
     const google::protobuf::RepeatedPtrField<tipb::Expr> filters{};
     const google::protobuf::RepeatedPtrField<tipb::Expr> pushed_down_filters{};
-    ColumnInfos source_columns{};
+    TiDB::ColumnInfos source_columns{};
     const std::vector<int> runtime_filter_ids;
     query_info.dag_query = std::make_unique<DAGQueryInfo>(
         filters,
@@ -801,7 +801,7 @@ try
         // keep a ref on them
         const google::protobuf::RepeatedPtrField<tipb::Expr> filters{};
         const google::protobuf::RepeatedPtrField<tipb::Expr> pushed_down_filters{};
-        ColumnInfos source_columns{};
+        TiDB::ColumnInfos source_columns{};
         const std::vector<int> runtime_filter_ids;
         query_info.dag_query = std::make_unique<DAGQueryInfo>(
             filters,

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_key_range.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_key_range.cpp
@@ -15,6 +15,7 @@
 #include <Storages/DeltaMerge/Range.h>
 #include <Storages/DeltaMerge/RowKeyRange.h>
 #include <TestUtils/TiFlashTestBasic.h>
+#include <TiDB/Schema/TiDB.h>
 
 namespace DB::DM::tests
 {

--- a/dbms/src/Storages/GCManager.cpp
+++ b/dbms/src/Storages/GCManager.cpp
@@ -20,6 +20,7 @@
 #include <Storages/IManageableStorage.h>
 #include <Storages/KVStore/KVStore.h>
 #include <Storages/KVStore/TMTContext.h>
+#include <TiDB/Schema/TiDB.h>
 
 namespace DB
 {

--- a/dbms/src/Storages/KVStore/Decode/DecodingStorageSchemaSnapshot.cpp
+++ b/dbms/src/Storages/KVStore/Decode/DecodingStorageSchemaSnapshot.cpp
@@ -54,7 +54,7 @@ DecodingStorageSchemaSnapshot::DecodingStorageSchemaSnapshot(
         }
         else
         {
-            column_infos.push_back(ColumnInfo());
+            column_infos.push_back(TiDB::ColumnInfo());
         }
     }
 

--- a/dbms/src/Storages/KVStore/Decode/DecodingStorageSchemaSnapshot.cpp
+++ b/dbms/src/Storages/KVStore/Decode/DecodingStorageSchemaSnapshot.cpp
@@ -14,6 +14,7 @@
 
 #include <DataTypes/DataTypeString.h>
 #include <Storages/KVStore/Decode/DecodingStorageSchemaSnapshot.h>
+#include <TiDB/Schema/TiDB.h>
 
 namespace DB
 {

--- a/dbms/src/Storages/KVStore/Decode/DecodingStorageSchemaSnapshot.h
+++ b/dbms/src/Storages/KVStore/Decode/DecodingStorageSchemaSnapshot.h
@@ -40,9 +40,6 @@ TMTPKType getTMTPKType(const IDataType & rhs);
  */
 using SortedColumnIDWithPos = std::map<ColumnID, size_t>;
 using SortedColumnIDWithPosConstIter = SortedColumnIDWithPos::const_iterator;
-using TableInfo = TiDB::TableInfo;
-using ColumnInfo = TiDB::ColumnInfo;
-using ColumnInfos = std::vector<ColumnInfo>;
 struct DecodingStorageSchemaSnapshot
 {
     DecodingStorageSchemaSnapshot(
@@ -63,7 +60,7 @@ struct DecodingStorageSchemaSnapshot
     // Note that some columns(EXTRA_HANDLE_COLUMN, VERSION_COLUMN, TAG_COLUMN) may not be a real column in tidb schema,
     // so their corresponding elements in `column_infos` are just nullptr and won't be used when decoding.
     DM::ColumnDefinesPtr column_defines;
-    ColumnInfos column_infos;
+    TiDB::ColumnInfos column_infos;
 
     // 1. when the table doesn't have a common handle,
     //    1) if `pk_is_handle` is false, `pk_column_ids` is empty

--- a/dbms/src/Storages/KVStore/Decode/DecodingStorageSchemaSnapshot.h
+++ b/dbms/src/Storages/KVStore/Decode/DecodingStorageSchemaSnapshot.h
@@ -16,7 +16,6 @@
 
 #include <Common/nocopyable.h>
 #include <Storages/DeltaMerge/DeltaMergeDefines.h>
-#include <TiDB/Schema/TiDB.h>
 
 
 namespace DB

--- a/dbms/src/Storages/KVStore/Decode/PartitionStreams.h
+++ b/dbms/src/Storages/KVStore/Decode/PartitionStreams.h
@@ -20,7 +20,6 @@
 #include <Storages/KVStore/Decode/DecodingStorageSchemaSnapshot.h>
 #include <Storages/KVStore/Decode/RegionDataRead.h>
 #include <Storages/TableLockHolder.h>
-#include <TiDB/Schema/TiDB.h>
 
 namespace DB
 {

--- a/dbms/src/Storages/KVStore/Decode/RegionTable.h
+++ b/dbms/src/Storages/KVStore/Decode/RegionTable.h
@@ -146,7 +146,7 @@ public:
     using ResolveLocksAndWriteRegionRes = std::variant<LockInfoPtr, RegionException::RegionReadStatus>;
     static ResolveLocksAndWriteRegionRes resolveLocksAndWriteRegion(
         TMTContext & tmt,
-        const TiDB::TableID table_id,
+        const TableID table_id,
         const RegionPtr & region,
         const Timestamp start_ts,
         const std::unordered_set<UInt64> * bypass_lock_ts,

--- a/dbms/src/Storages/KVStore/KVStore.h
+++ b/dbms/src/Storages/KVStore/KVStore.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <Interpreters/Context_fwd.h>
+#include <Parsers/IAST_fwd.h>
 #include <Storages/DeltaMerge/DeltaMergeInterfaces.h>
 #include <Storages/DeltaMerge/RowKeyRange.h>
 #include <Storages/KVStore/Decode/RegionDataRead.h>
@@ -25,7 +26,6 @@
 #include <Storages/KVStore/MultiRaft/RegionRangeKeys.h>
 #include <Storages/KVStore/StorageEngineType.h>
 
-#include <condition_variable>
 #include <magic_enum.hpp>
 
 namespace TiDB
@@ -48,10 +48,6 @@ namespace tests
 {
 class KVStoreTestBase;
 } // namespace tests
-
-class IAST;
-using ASTPtr = std::shared_ptr<IAST>;
-using ASTs = std::vector<ASTPtr>;
 
 class KVStore;
 using KVStorePtr = std::shared_ptr<KVStore>;

--- a/dbms/src/Storages/KVStore/TiKVHelpers/TiKVRecordFormat.cpp
+++ b/dbms/src/Storages/KVStore/TiKVHelpers/TiKVRecordFormat.cpp
@@ -1,0 +1,39 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Storages/KVStore/TiKVHelpers/TiKVRecordFormat.h>
+#include <TiDB/Schema/TiDB.h>
+
+namespace DB::RecordKVFormat
+{
+
+TiKVKey genKey(const TiDB::TableInfo & table_info, std::vector<Field> keys)
+{
+    std::string key(RecordKVFormat::RAW_KEY_NO_HANDLE_SIZE, 0);
+    memcpy(key.data(), &RecordKVFormat::TABLE_PREFIX, 1);
+    auto big_endian_table_id = encodeInt64(table_info.id);
+    memcpy(key.data() + 1, reinterpret_cast<const char *>(&big_endian_table_id), 8);
+    memcpy(key.data() + 1 + 8, RecordKVFormat::RECORD_PREFIX_SEP, 2);
+    WriteBufferFromOwnString ss;
+
+    for (size_t i = 0; i < keys.size(); i++)
+    {
+        DB::EncodeDatum(
+            keys[i],
+            table_info.columns[table_info.getPrimaryIndexInfo().idx_cols[i].offset].getCodecFlag(),
+            ss);
+    }
+    return encodeAsTiKVKey(key + ss.releaseStr());
+}
+} // namespace DB::RecordKVFormat

--- a/dbms/src/Storages/KVStore/TiKVHelpers/TiKVRecordFormat.h
+++ b/dbms/src/Storages/KVStore/TiKVHelpers/TiKVRecordFormat.h
@@ -26,16 +26,12 @@
 #include <TiDB/Decode/DatumCodec.h>
 #include <common/likely.h>
 
-#include <sstream>
-
-namespace DB
-{
-namespace ErrorCodes
+namespace DB::ErrorCodes
 {
 extern const int LOGICAL_ERROR;
 }
 
-namespace RecordKVFormat
+namespace DB::RecordKVFormat
 {
 enum CFModifyFlag : UInt8
 {
@@ -151,24 +147,7 @@ inline TiKVKey genKey(const TableID tableId, const HandleID handleId)
     return encodeAsTiKVKey(genRawKey(tableId, handleId));
 }
 
-inline TiKVKey genKey(const TiDB::TableInfo & table_info, std::vector<Field> keys)
-{
-    std::string key(RecordKVFormat::RAW_KEY_NO_HANDLE_SIZE, 0);
-    memcpy(key.data(), &RecordKVFormat::TABLE_PREFIX, 1);
-    auto big_endian_table_id = encodeInt64(table_info.id);
-    memcpy(key.data() + 1, reinterpret_cast<const char *>(&big_endian_table_id), 8);
-    memcpy(key.data() + 1 + 8, RecordKVFormat::RECORD_PREFIX_SEP, 2);
-    WriteBufferFromOwnString ss;
-
-    for (size_t i = 0; i < keys.size(); i++)
-    {
-        DB::EncodeDatum(
-            keys[i],
-            table_info.columns[table_info.getPrimaryIndexInfo().idx_cols[i].offset].getCodecFlag(),
-            ss);
-    }
-    return encodeAsTiKVKey(key + ss.releaseStr());
-}
+TiKVKey genKey(const TiDB::TableInfo & table_info, std::vector<Field> keys);
 
 inline bool checkKeyPaddingValid(const char * ptr, const UInt8 pad_size)
 {
@@ -185,7 +164,7 @@ inline std::tuple<DecodedTiKVKey, size_t> decodeTiKVKeyFull(const TiKVKey & key)
     {
         if (ptr + chunk_len > key.dataSize() + key.data())
             throw Exception("Unexpected eof", ErrorCodes::LOGICAL_ERROR);
-        auto marker = (UInt8) * (ptr + ENC_GROUP_SIZE);
+        auto marker = static_cast<UInt8>(*(ptr + ENC_GROUP_SIZE));
         UInt8 pad_size = (ENC_MARKER - marker);
         if (pad_size == 0)
         {
@@ -308,7 +287,7 @@ inline R readVarInt(const char *& data, size_t & len)
     static_assert(std::is_same_v<R, UInt64> || std::is_same_v<R, Int64>);
 
     R res = 0;
-    auto cur = data;
+    const auto * cur = data;
     if constexpr (std::is_same_v<R, UInt64>)
     {
         cur = TiKV::readVarUInt(res, data, len);
@@ -328,14 +307,14 @@ inline UInt64 readVarUInt(const char *& data, size_t & len)
 
 inline UInt8 readUInt8(const char *& data, size_t & len)
 {
-    UInt8 res = static_cast<UInt8>(*data);
+    auto res = static_cast<UInt8>(*data);
     data += sizeof(UInt8), len -= sizeof(UInt8);
     return res;
 }
 
 inline UInt64 readUInt64(const char *& data, size_t & len)
 {
-    UInt64 res = readBigEndian<UInt64>(data);
+    auto res = readBigEndian<UInt64>(data);
     data += sizeof(UInt64), len -= sizeof(UInt64);
     return res;
 }
@@ -374,7 +353,7 @@ struct InnerDecodedWriteCFValue
     std::shared_ptr<const TiKVValue> short_value;
 };
 
-typedef std::optional<InnerDecodedWriteCFValue> DecodedWriteCFValue;
+using DecodedWriteCFValue = std::optional<InnerDecodedWriteCFValue>;
 
 inline DecodedWriteCFValue decodeWriteCfValue(const TiKVValue & value)
 {
@@ -494,6 +473,5 @@ inline std::string DecodedTiKVKeyRangeToDebugString(const std::pair<DecodedTiKVK
         + ")";
 }
 
-} // namespace RecordKVFormat
 
-} // namespace DB
+} // namespace DB::RecordKVFormat

--- a/dbms/src/Storages/KVStore/tests/gtest_tikv_keyvalue.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_tikv_keyvalue.cpp
@@ -19,6 +19,7 @@
 #include <Storages/KVStore/TiKVHelpers/TiKVRecordFormat.h>
 #include <Storages/KVStore/tests/region_helper.h>
 #include <TestUtils/TiFlashTestBasic.h>
+#include <TiDB/Schema/TiDB.h>
 
 namespace DB
 {

--- a/dbms/src/Storages/StorageDeltaMerge.cpp
+++ b/dbms/src/Storages/StorageDeltaMerge.cpp
@@ -55,6 +55,7 @@
 #include <Storages/StorageDeltaMergeHelpers.h>
 #include <TiDB/Decode/TypeMapping.h>
 #include <TiDB/Schema/SchemaNameMapper.h>
+#include <TiDB/Schema/TiDB.h>
 #include <common/logger_useful.h>
 
 

--- a/dbms/src/Storages/StorageDeltaMerge.cpp
+++ b/dbms/src/Storages/StorageDeltaMerge.cpp
@@ -177,7 +177,7 @@ void StorageDeltaMerge::updateTableColumnInfo()
             /// If TableInfo from TiDB is not empty, we get column id and default value from TiDB
             auto & columns = tidb_table_info.columns;
             col_def.id = tidb_table_info.getColumnID(col_def.name);
-            auto itr = std::find_if(columns.begin(), columns.end(), [&](const ColumnInfo & v) {
+            auto itr = std::find_if(columns.begin(), columns.end(), [&](const TiDB::ColumnInfo & v) {
                 return v.id == col_def.id;
             });
             if (itr != columns.end())

--- a/dbms/src/Storages/StorageDeltaMerge.h
+++ b/dbms/src/Storages/StorageDeltaMerge.h
@@ -30,7 +30,8 @@
 #include <Storages/IManageableStorage.h>
 #include <Storages/IStorage.h>
 #include <Storages/KVStore/Decode/DecodingStorageSchemaSnapshot.h>
-#include <TiDB/Schema/TiDB.h>
+#include <Storages/KVStore/StorageEngineType.h>
+#include <TiDB/Schema/TiDB_fwd.h>
 
 #include <ext/shared_ptr_helper.h>
 
@@ -172,7 +173,7 @@ public:
 
     void setTableInfo(const TiDB::TableInfo & table_info_) override { tidb_table_info = table_info_; }
 
-    ::TiDB::StorageEngine engineType() const override { return ::TiDB::StorageEngine::DT; }
+    TiDB::StorageEngine engineType() const override { return TiDB::StorageEngine::DT; }
 
     const TiDB::TableInfo & getTableInfo() const override { return tidb_table_info; }
 

--- a/dbms/src/Storages/tests/gtest_filter_parser.cpp
+++ b/dbms/src/Storages/tests/gtest_filter_parser.cpp
@@ -29,10 +29,10 @@
 #include <Storages/DeltaMerge/Index/RSResult.h>
 #include <Storages/KVStore/TMTContext.h>
 #include <TestUtils/TiFlashTestBasic.h>
+#include <TiDB/Decode/TypeMapping.h>
 #include <TiDB/Schema/SchemaNameMapper.h>
 #include <common/logger_useful.h>
 
-#include <optional>
 #include <regex>
 
 namespace DB

--- a/dbms/src/Storages/tests/gtests_parse_push_down_filter.cpp
+++ b/dbms/src/Storages/tests/gtests_parse_push_down_filter.cpp
@@ -25,6 +25,7 @@
 #include <Storages/StorageDeltaMerge.h>
 #include <TestUtils/FunctionTestUtils.h>
 #include <TestUtils/TiFlashTestBasic.h>
+#include <TiDB/Decode/TypeMapping.h>
 #include <common/logger_useful.h>
 
 #include <regex>

--- a/dbms/src/TestUtils/ColumnsToTiPBExpr.cpp
+++ b/dbms/src/TestUtils/ColumnsToTiPBExpr.cpp
@@ -29,7 +29,7 @@ namespace
 {
 void columnToTiPBExpr(tipb::Expr * expr, const ColumnWithTypeAndName column, size_t index)
 {
-    ColumnInfo ci = reverseGetColumnInfo({column.name, column.type}, 0, Field(), true);
+    auto ci = reverseGetColumnInfo({column.name, column.type}, 0, Field(), true);
     bool is_const = false;
     if (column.column != nullptr)
     {
@@ -113,7 +113,7 @@ void columnsToTiPBExprForTiDBCast(
     DataTypePtr target_type = DataTypeFactory::instance().get(type_string);
     auto * argument_expr = expr->add_children();
     columnToTiPBExpr(argument_expr, columns[argument_column_number[0]], 0);
-    ColumnInfo ci = reverseGetColumnInfo({type_string, target_type}, 0, Field(), true);
+    auto ci = reverseGetColumnInfo({type_string, target_type}, 0, Field(), true);
     if (ci.tp == TiDB::TypeString)
     {
         ci.flen = -1;

--- a/dbms/src/TestUtils/ExecutorTestUtils.h
+++ b/dbms/src/TestUtils/ExecutorTestUtils.h
@@ -20,6 +20,7 @@
 #include <TestUtils/ExecutorSerializer.h>
 #include <TestUtils/FunctionTestUtils.h>
 #include <TestUtils/mockExecutor.h>
+#include <TiDB/Decode/TypeMapping.h>
 #include <WindowFunctions/registerWindowFunctions.h>
 
 #include <functional>

--- a/dbms/src/TestUtils/ProjectionTestUtil.cpp
+++ b/dbms/src/TestUtils/ProjectionTestUtil.cpp
@@ -61,7 +61,7 @@ std::pair<ExpressionActionsPtr, std::vector<String>> buildProjection(
     {
         tipb::Expr literal_expr;
         const auto & val_field = val_fields[i];
-        ColumnInfo ci = reverseGetColumnInfo(
+        auto ci = reverseGetColumnInfo(
             {columns[column_literal_numbers[i]].name, columns[column_literal_numbers[i]].type},
             0,
             Field(),
@@ -102,7 +102,7 @@ std::pair<ExpressionActionsPtr, std::vector<String>> buildLiteralProjection(
         const auto & val_field = val_fields[i];
         source_columns.emplace_back(column.name, column.type);
         tipb::Expr literal_expr;
-        ColumnInfo ci = reverseGetColumnInfo({column.name, column.type}, 0, Field(), true);
+        auto ci = reverseGetColumnInfo({column.name, column.type}, 0, Field(), true);
         literalFieldToTiPBExpr(ci, val_field, &literal_expr, 0);
         tipb_exprs.push_back(literal_expr);
     }

--- a/dbms/src/TestUtils/ProjectionTestUtil.cpp
+++ b/dbms/src/TestUtils/ProjectionTestUtil.cpp
@@ -17,6 +17,7 @@
 #include <Interpreters/Context.h>
 #include <TestUtils/ColumnsToTiPBExpr.h>
 #include <TestUtils/ProjectionTestUtil.h>
+#include <TiDB/Decode/TypeMapping.h>
 
 
 namespace DB

--- a/dbms/src/TestUtils/mockExecutor.cpp
+++ b/dbms/src/TestUtils/mockExecutor.cpp
@@ -59,7 +59,7 @@ ASTPtr buildLiteral(const Field & field)
 
 ASTPtr buildOrderByItemVec(MockOrderByItemVec order_by_items)
 {
-    std::vector<ASTPtr> vec(order_by_items.size());
+    MockAstVec vec(order_by_items.size());
     size_t i = 0;
     for (auto item : order_by_items)
     {

--- a/dbms/src/TiDB/Collation/Collator.h
+++ b/dbms/src/TiDB/Collation/Collator.h
@@ -15,15 +15,13 @@
 #pragma once
 
 #include <TiDB/Collation/CollatorCompare.h>
+#include <TiDB/Schema/TiDB_fwd.h>
 #include <common/StringRef.h>
 
 #include <memory>
-#include <unordered_map>
 
 namespace TiDB
 {
-using TiDBCollatorPtr = class ITiDBCollator const *;
-using TiDBCollators = std::vector<TiDBCollatorPtr>;
 
 class ITiDBCollator
 {

--- a/dbms/src/TiDB/Decode/Datum.cpp
+++ b/dbms/src/TiDB/Decode/Datum.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <TiDB/Decode/Datum.h>
+#include <TiDB/Schema/TiDB.h>
 
 #include <ext/bit_cast.h>
 

--- a/dbms/src/TiDB/Decode/Datum.h
+++ b/dbms/src/TiDB/Decode/Datum.h
@@ -15,7 +15,8 @@
 #pragma once
 
 #include <Core/Field.h>
-#include <TiDB/Schema/TiDB.h>
+#include <TiDB/Schema/TiDBTypes.h>
+#include <TiDB/Schema/TiDB_fwd.h>
 
 #include <optional>
 

--- a/dbms/src/TiDB/Decode/DatumCodec.cpp
+++ b/dbms/src/TiDB/Decode/DatumCodec.cpp
@@ -571,7 +571,7 @@ void EncodeDecimalImpl(const T & dec, PrecType prec, ScaleType frac, WriteBuffer
     ss.write(buf.c_str(), buf.size());
 }
 
-void EncodeDecimalForRow(const Field & field, WriteBuffer & ss, const ColumnInfo & column_info)
+void EncodeDecimalForRow(const Field & field, WriteBuffer & ss, const TiDB::ColumnInfo & column_info)
 {
     if (field.getType() == Field::Types::Decimal32)
     {
@@ -627,7 +627,11 @@ void EncodeDecimal(const Field & field, WriteBuffer & ss)
     }
 }
 
-void EncodeDatumForRow(const Field & field, TiDB::CodecFlag flag, WriteBuffer & ss, const ColumnInfo & column_info)
+void EncodeDatumForRow(
+    const Field & field,
+    TiDB::CodecFlag flag,
+    WriteBuffer & ss,
+    const TiDB::ColumnInfo & column_info)
 {
     if (flag == TiDB::CodecFlagDecimal && !field.isNull())
     {

--- a/dbms/src/TiDB/Decode/DatumCodec.h
+++ b/dbms/src/TiDB/Decode/DatumCodec.h
@@ -18,7 +18,6 @@
 #include <Core/Field.h>
 #include <IO/Buffer/WriteBuffer.h>
 #include <IO/Endian.h>
-#include <TiDB/Decode/TypeMapping.h>
 #include <TiDB/Schema/TiDB.h>
 
 /// Functions in this file are used for individual datum codec, i.e. UInt/Int64, Float64, String/Bytes, Decimal, Enum, Set, etc.

--- a/dbms/src/TiDB/Decode/DatumCodec.h
+++ b/dbms/src/TiDB/Decode/DatumCodec.h
@@ -28,11 +28,11 @@
 /// But be noted that each layer could have their own datum codec implementations other than this file for endianness or specific data types - TiDB does so, thus so does TiFlash.
 namespace DB
 {
-static const size_t ENC_GROUP_SIZE = 8;
-static const UInt8 ENC_MARKER = static_cast<UInt8>(0xff);
-static const char ENC_ASC_PADDING[ENC_GROUP_SIZE] = {0};
+static constexpr size_t ENC_GROUP_SIZE = 8;
+static constexpr UInt8 ENC_MARKER = static_cast<UInt8>(0xff);
+static constexpr char ENC_ASC_PADDING[ENC_GROUP_SIZE] = {0};
 
-static const UInt64 SIGN_MASK = UInt64(1) << 63;
+static constexpr UInt64 SIGN_MASK = static_cast<UInt64>(1) << 63;
 
 template <typename T>
 inline std::enable_if_t<std::is_unsigned_v<T>, T> DecodeUInt(size_t & cursor, const String & raw_value)
@@ -95,10 +95,14 @@ void EncodeVarInt(Int64 num, WriteBuffer & ss);
 
 void EncodeDecimal(const Field & field, WriteBuffer & ss);
 
-void EncodeDecimalForRow(const Field & field, WriteBuffer & ss, const ColumnInfo & column_info);
+void EncodeDecimalForRow(const Field & field, WriteBuffer & ss, const TiDB::ColumnInfo & column_info);
 
 void EncodeDatum(const Field & field, TiDB::CodecFlag flag, WriteBuffer & ss);
 
-void EncodeDatumForRow(const Field & field, TiDB::CodecFlag flag, WriteBuffer & ss, const ColumnInfo & column_info);
+void EncodeDatumForRow(
+    const Field & field,
+    TiDB::CodecFlag flag,
+    WriteBuffer & ss,
+    const TiDB::ColumnInfo & column_info);
 
 } // namespace DB

--- a/dbms/src/TiDB/Decode/DatumCodec.h
+++ b/dbms/src/TiDB/Decode/DatumCodec.h
@@ -18,7 +18,8 @@
 #include <Core/Field.h>
 #include <IO/Buffer/WriteBuffer.h>
 #include <IO/Endian.h>
-#include <TiDB/Schema/TiDB.h>
+#include <TiDB/Schema/TiDBTypes.h>
+#include <TiDB/Schema/TiDB_fwd.h>
 
 /// Functions in this file are used for individual datum codec, i.e. UInt/Int64, Float64, String/Bytes, Decimal, Enum, Set, etc.
 /// The internal representation of a datum in TiFlash is Field.

--- a/dbms/src/TiDB/Decode/RowCodec.cpp
+++ b/dbms/src/TiDB/Decode/RowCodec.cpp
@@ -18,10 +18,15 @@
 #include <TiDB/Decode/Datum.h>
 #include <TiDB/Decode/DatumCodec.h>
 #include <TiDB/Decode/RowCodec.h>
+#include <TiDB/Schema/TiDB.h>
 
 
 namespace DB
 {
+using TiDB::ColumnInfo;
+using TiDB::ColumnInfos;
+using TiDB::TableInfo;
+
 template <typename T>
 static T decodeUInt(size_t & cursor, const TiKVValue::Base & raw_value)
 {

--- a/dbms/src/TiDB/Decode/RowCodec.cpp
+++ b/dbms/src/TiDB/Decode/RowCodec.cpp
@@ -184,11 +184,7 @@ struct RowEncoderV2
 
     void encode(WriteBuffer & ss) &&
     {
-        size_t column_in_key = 0;
-        if (table_info.pk_is_handle)
-            column_in_key = 1;
-        else if (table_info.is_common_handle)
-            column_in_key = table_info.getPrimaryIndexInfo().idx_cols.size();
+        size_t column_in_key = table_info.numColumnsInKey();
         if (table_info.columns.size() < fields.size() + column_in_key)
             throw Exception(
                 std::string("Encoding row has ") + std::to_string(table_info.columns.size()) + " columns but "

--- a/dbms/src/TiDB/Decode/TypeMapping.cpp
+++ b/dbms/src/TiDB/Decode/TypeMapping.cpp
@@ -38,6 +38,8 @@
 
 namespace DB
 {
+using TiDB::ColumnInfo;
+
 class TypeMapping : public ext::Singleton<TypeMapping>
 {
 public:

--- a/dbms/src/TiDB/Decode/TypeMapping.h
+++ b/dbms/src/TiDB/Decode/TypeMapping.h
@@ -25,7 +25,6 @@
 
 namespace DB
 {
-using ColumnInfo = TiDB::ColumnInfo;
 class IAST;
 using ASTPtr = std::shared_ptr<IAST>;
 using ASTPtrVec = std::vector<ASTPtr>;
@@ -47,7 +46,7 @@ TiDB::CodecFlag getCodecFlagByFieldType(const tipb::FieldType & field_type);
 // such as mock TiDB table using TiFlash SQL parser, and getting field type for `void` column in DAG.
 // Note that not every TiFlash type has a corresponding TiDB type,
 // caller should make sure the source type is valid, otherwise exception will be thrown.
-ColumnInfo reverseGetColumnInfo(
+TiDB::ColumnInfo reverseGetColumnInfo(
     const NameAndTypePair & column,
     ColumnID id,
     const Field & default_value,

--- a/dbms/src/TiDB/Decode/TypeMapping.h
+++ b/dbms/src/TiDB/Decode/TypeMapping.h
@@ -17,7 +17,10 @@
 #include <Core/NamesAndTypes.h>
 #include <DataTypes/IDataType.h>
 #include <Parsers/IAST_fwd.h>
-#include <TiDB/Schema/TiDB.h>
+#include <Storages/KVStore/Types.h>
+#include <TiDB/Schema/TiDBTypes.h>
+#include <TiDB/Schema/TiDB_fwd.h>
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <tipb/expression.pb.h>

--- a/dbms/src/TiDB/Decode/TypeMapping.h
+++ b/dbms/src/TiDB/Decode/TypeMapping.h
@@ -32,13 +32,13 @@ using ASTPtrVec = std::vector<ASTPtr>;
 
 // Because for compatible issues, we need to deal with the duration type separately for computing layer.
 // TODO: Need a better implement.
-DataTypePtr getDataTypeByColumnInfo(const ColumnInfo & column_info);
-DataTypePtr getDataTypeByColumnInfoForComputingLayer(const ColumnInfo & column_info);
+DataTypePtr getDataTypeByColumnInfo(const TiDB::ColumnInfo & column_info);
+DataTypePtr getDataTypeByColumnInfoForComputingLayer(const TiDB::ColumnInfo & column_info);
 
 DataTypePtr getDataTypeByFieldType(const tipb::FieldType & field_type);
 DataTypePtr getDataTypeByFieldTypeForComputingLayer(const tipb::FieldType & field_type);
 
-DataTypePtr getDataTypeByColumnInfoForDisaggregatedStorageLayer(const ColumnInfo & column_info);
+DataTypePtr getDataTypeByColumnInfoForDisaggregatedStorageLayer(const TiDB::ColumnInfo & column_info);
 
 TiDB::CodecFlag getCodecFlagByFieldType(const tipb::FieldType & field_type);
 

--- a/dbms/src/TiDB/Decode/TypeMapping.h
+++ b/dbms/src/TiDB/Decode/TypeMapping.h
@@ -16,18 +16,15 @@
 
 #include <Core/NamesAndTypes.h>
 #include <DataTypes/IDataType.h>
+#include <Parsers/IAST_fwd.h>
 #include <TiDB/Schema/TiDB.h>
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <tipb/expression.pb.h>
-
 #pragma GCC diagnostic pop
 
 namespace DB
 {
-class IAST;
-using ASTPtr = std::shared_ptr<IAST>;
-using ASTPtrVec = std::vector<ASTPtr>;
 
 // Because for compatible issues, we need to deal with the duration type separately for computing layer.
 // TODO: Need a better implement.

--- a/dbms/src/TiDB/Schema/DatabaseInfoCache.h
+++ b/dbms/src/TiDB/Schema/DatabaseInfoCache.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include <Storages/KVStore/Types.h>
-#include <TiDB/Schema/TiDB.h>
+#include <TiDB/Schema/TiDB_fwd.h>
 
 #include <shared_mutex>
 #include <unordered_map>

--- a/dbms/src/TiDB/Schema/DatabaseInfoCache.h
+++ b/dbms/src/TiDB/Schema/DatabaseInfoCache.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include <Storages/KVStore/Types.h>
-#include <TiDB/Schema/TiDB_fwd.h>
+#include <TiDB/Schema/TiDB.h>
 
 #include <shared_mutex>
 #include <unordered_map>

--- a/dbms/src/TiDB/Schema/SchemaBuilder.h
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.h
@@ -87,7 +87,7 @@ private:
     /// Parameter schema_name should be mapped.
     void applyDropPhysicalTable(const String & db_name, TableID table_id, std::string_view action);
 
-    void applyRecoverTable(DatabaseID database_id, TiDB::TableID table_id);
+    void applyRecoverTable(DatabaseID database_id, TableID table_id);
     void applyRecoverLogicalTable(
         DatabaseID database_id,
         const TiDB::TableInfoPtr & table_info,
@@ -103,7 +103,7 @@ private:
         const TiDB::TableInfoPtr & table_info,
         const ManageableStoragePtr & storage);
 
-    void applyRenameTable(DatabaseID database_id, TiDB::TableID table_id);
+    void applyRenameTable(DatabaseID database_id, TableID table_id);
 
     void applyRenameLogicalTable(
         DatabaseID new_database_id,

--- a/dbms/src/TiDB/Schema/SchemaGetter.cpp
+++ b/dbms/src/TiDB/Schema/SchemaGetter.cpp
@@ -16,6 +16,7 @@
 #include <Storages/KVStore/TiKVHelpers/KeyspaceSnapshot.h>
 #include <TiDB/Decode/DatumCodec.h>
 #include <TiDB/Schema/SchemaGetter.h>
+#include <TiDB/Schema/TiDB.h>
 #include <common/logger_useful.h>
 
 #include <utility>

--- a/dbms/src/TiDB/Schema/SchemaGetter.h
+++ b/dbms/src/TiDB/Schema/SchemaGetter.h
@@ -15,10 +15,15 @@
 #pragma once
 
 #include <Storages/KVStore/TiKVHelpers/KeyspaceSnapshot.h>
-#include <TiDB/Schema/TiDB.h>
+#include <TiDB/Schema/TiDB_fwd.h>
 #include <common/logger_useful.h>
 
 #include <optional>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#include <Poco/JSON/Object.h>
+#pragma GCC diagnostic pop
 
 namespace DB
 {

--- a/dbms/src/TiDB/Schema/SchemaSyncService.h
+++ b/dbms/src/TiDB/Schema/SchemaSyncService.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <Interpreters/Context_fwd.h>
+#include <Parsers/IAST_fwd.h>
 #include <Storages/BackgroundProcessingPool.h>
 #include <Storages/KVStore/Types.h>
 
@@ -33,9 +34,6 @@ class SchemaSyncTest;
 class Logger;
 using LoggerPtr = std::shared_ptr<Logger>;
 
-class IAST;
-using ASTPtr = std::shared_ptr<IAST>;
-using ASTs = std::vector<ASTPtr>;
 using DBGInvokerPrinter = std::function<void(const std::string &)>;
 extern void dbgFuncGcSchemas(Context &, const ASTs &, DBGInvokerPrinter);
 

--- a/dbms/src/TiDB/Schema/TiDB.cpp
+++ b/dbms/src/TiDB/Schema/TiDB.cpp
@@ -1137,6 +1137,14 @@ const IndexInfo & TableInfo::getPrimaryIndexInfo() const
 #endif
     return index_infos[0];
 }
+size_t TableInfo::numColumnsInKey() const
+{
+    if (pk_is_handle)
+        return 1;
+    else if (is_common_handle)
+        return getPrimaryIndexInfo().idx_cols.size();
+    return 0;
+}
 
 String TableInfo::getColumnName(const ColumnID id) const
 {

--- a/dbms/src/TiDB/Schema/TiDB.cpp
+++ b/dbms/src/TiDB/Schema/TiDB.cpp
@@ -1129,6 +1129,15 @@ KeyspaceID TableInfo::getKeyspaceID() const
     return keyspace_id;
 }
 
+const IndexInfo & TableInfo::getPrimaryIndexInfo() const
+{
+    assert(is_common_handle);
+#ifndef NDEBUG
+    RUNTIME_CHECK(index_infos[0].is_primary);
+#endif
+    return index_infos[0];
+}
+
 String TableInfo::getColumnName(const ColumnID id) const
 {
     for (const auto & col : columns)

--- a/dbms/src/TiDB/Schema/TiDB.h
+++ b/dbms/src/TiDB/Schema/TiDB.h
@@ -334,6 +334,7 @@ struct TableInfo
 
     /// should not be called if is_common_handle = false.
     const IndexInfo & getPrimaryIndexInfo() const;
+    size_t numColumnsInKey() const;
 };
 
 

--- a/dbms/src/TiDB/Schema/TiDB.h
+++ b/dbms/src/TiDB/Schema/TiDB.h
@@ -20,6 +20,7 @@
 #include <IO/WriteHelpers.h>
 #include <Storages/KVStore/StorageEngineType.h>
 #include <Storages/KVStore/Types.h>
+#include <TiDB/Schema/TiDBTypes.h>
 #include <TiDB/Schema/TiDB_fwd.h>
 #include <tipb/schema.pb.h>
 
@@ -54,52 +55,6 @@ using DB::String;
 using DB::TableID;
 using DB::Timestamp;
 
-// Column types.
-// In format:
-// TiDB type, int value, codec flag, CH type.
-#ifdef M
-#error "Please undefine macro M first."
-#endif
-#define COLUMN_TYPES(M)                       \
-    M(Decimal, 0, Decimal, Decimal32)         \
-    M(Tiny, 1, VarInt, Int8)                  \
-    M(Short, 2, VarInt, Int16)                \
-    M(Long, 3, VarInt, Int32)                 \
-    M(Float, 4, Float, Float32)               \
-    M(Double, 5, Float, Float64)              \
-    M(Null, 6, Nil, Nothing)                  \
-    M(Timestamp, 7, UInt, MyDateTime)         \
-    M(LongLong, 8, Int, Int64)                \
-    M(Int24, 9, VarInt, Int32)                \
-    M(Date, 10, UInt, MyDate)                 \
-    M(Time, 11, Duration, Int64)              \
-    M(Datetime, 12, UInt, MyDateTime)         \
-    M(Year, 13, Int, Int16)                   \
-    M(NewDate, 14, Int, MyDate)               \
-    M(Varchar, 15, CompactBytes, String)      \
-    M(Bit, 16, VarInt, UInt64)                \
-    M(JSON, 0xf5, Json, String)               \
-    M(NewDecimal, 0xf6, Decimal, Decimal32)   \
-    M(Enum, 0xf7, VarUInt, Enum16)            \
-    M(Set, 0xf8, VarUInt, UInt64)             \
-    M(TinyBlob, 0xf9, CompactBytes, String)   \
-    M(MediumBlob, 0xfa, CompactBytes, String) \
-    M(LongBlob, 0xfb, CompactBytes, String)   \
-    M(Blob, 0xfc, CompactBytes, String)       \
-    M(VarString, 0xfd, CompactBytes, String)  \
-    M(String, 0xfe, CompactBytes, String)     \
-    M(Geometry, 0xff, CompactBytes, String)
-
-enum TP
-{
-#ifdef M
-#error "Please undefine macro M first."
-#endif
-#define M(tt, v, cf, ct) Type##tt = (v),
-    COLUMN_TYPES(M)
-#undef M
-};
-
 // Column flags.
 #ifdef M
 #error "Please undefine macro M first."
@@ -132,35 +87,6 @@ enum ColumnFlag
 #endif
 #define M(cf, v) ColumnFlag##cf = (v),
     COLUMN_FLAGS(M)
-#undef M
-};
-
-// Codec flags.
-// In format: TiDB codec flag, int value.
-#ifdef M
-#error "Please undefine macro M first."
-#endif
-#define CODEC_FLAGS(M) \
-    M(Nil, 0)          \
-    M(Bytes, 1)        \
-    M(CompactBytes, 2) \
-    M(Int, 3)          \
-    M(UInt, 4)         \
-    M(Float, 5)        \
-    M(Decimal, 6)      \
-    M(Duration, 7)     \
-    M(VarInt, 8)       \
-    M(VarUInt, 9)      \
-    M(Json, 10)        \
-    M(Max, 250)
-
-enum CodecFlag
-{
-#ifdef M
-#error "Please undefine macro M first."
-#endif
-#define M(cf, v) CodecFlag##cf = (v),
-    CODEC_FLAGS(M)
 #undef M
 };
 
@@ -388,7 +314,7 @@ struct TableInfo
     // The TiFlash replica info persisted by TiDB
     TiFlashReplicaInfo replica_info;
 
-    ::TiDB::StorageEngine engine_type = ::TiDB::StorageEngine::UNSPECIFIED; // TODO(hyy):seems could be removed
+    TiDB::StorageEngine engine_type = TiDB::StorageEngine::UNSPECIFIED; // TODO(hyy):seems could be removed
 
     ColumnID getColumnID(const String & name) const;
     String getColumnName(ColumnID id) const;
@@ -408,8 +334,6 @@ struct TableInfo
 
     /// should not be called if is_common_handle = false.
     const IndexInfo & getPrimaryIndexInfo() const { return index_infos[0]; }
-
-    IndexInfo & getPrimaryIndexInfo() { return index_infos[0]; }
 };
 
 

--- a/dbms/src/TiDB/Schema/TiDB.h
+++ b/dbms/src/TiDB/Schema/TiDB.h
@@ -333,7 +333,7 @@ struct TableInfo
     }
 
     /// should not be called if is_common_handle = false.
-    const IndexInfo & getPrimaryIndexInfo() const { return index_infos[0]; }
+    const IndexInfo & getPrimaryIndexInfo() const;
 };
 
 

--- a/dbms/src/TiDB/Schema/TiDB.h
+++ b/dbms/src/TiDB/Schema/TiDB.h
@@ -20,6 +20,7 @@
 #include <IO/WriteHelpers.h>
 #include <Storages/KVStore/StorageEngineType.h>
 #include <Storages/KVStore/Types.h>
+#include <TiDB/Schema/TiDB_fwd.h>
 #include <tipb/schema.pb.h>
 
 #include <optional>
@@ -285,8 +286,6 @@ struct DBInfo
     void deserialize(const String & json_str);
 };
 
-struct TableInfo;
-using TableInfoPtr = std::shared_ptr<TableInfo>;
 
 struct TiFlashReplicaInfo
 {
@@ -413,7 +412,6 @@ struct TableInfo
     IndexInfo & getPrimaryIndexInfo() { return index_infos[0]; }
 };
 
-using DBInfoPtr = std::shared_ptr<DBInfo>;
 
 String genJsonNull();
 

--- a/dbms/src/TiDB/Schema/TiDBSchemaSyncer.h
+++ b/dbms/src/TiDB/Schema/TiDBSchemaSyncer.h
@@ -19,7 +19,6 @@
 #include <Debug/MockSchemaNameMapper.h>
 #include <TiDB/Schema/DatabaseInfoCache.h>
 #include <TiDB/Schema/TableIDMap.h>
-#include <TiDB/Schema/TiDB.h>
 #include <pingcap/kv/Cluster.h>
 
 #include <ext/scope_guard.h>

--- a/dbms/src/TiDB/Schema/TiDBTypes.h
+++ b/dbms/src/TiDB/Schema/TiDBTypes.h
@@ -1,0 +1,96 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace TiDB
+{
+
+// Column types.
+// In format:
+// TiDB type, int value, codec flag, CH type.
+#ifdef M
+#error "Please undefine macro M first."
+#endif
+#define COLUMN_TYPES(M)                       \
+    M(Decimal, 0, Decimal, Decimal32)         \
+    M(Tiny, 1, VarInt, Int8)                  \
+    M(Short, 2, VarInt, Int16)                \
+    M(Long, 3, VarInt, Int32)                 \
+    M(Float, 4, Float, Float32)               \
+    M(Double, 5, Float, Float64)              \
+    M(Null, 6, Nil, Nothing)                  \
+    M(Timestamp, 7, UInt, MyDateTime)         \
+    M(LongLong, 8, Int, Int64)                \
+    M(Int24, 9, VarInt, Int32)                \
+    M(Date, 10, UInt, MyDate)                 \
+    M(Time, 11, Duration, Int64)              \
+    M(Datetime, 12, UInt, MyDateTime)         \
+    M(Year, 13, Int, Int16)                   \
+    M(NewDate, 14, Int, MyDate)               \
+    M(Varchar, 15, CompactBytes, String)      \
+    M(Bit, 16, VarInt, UInt64)                \
+    M(JSON, 0xf5, Json, String)               \
+    M(NewDecimal, 0xf6, Decimal, Decimal32)   \
+    M(Enum, 0xf7, VarUInt, Enum16)            \
+    M(Set, 0xf8, VarUInt, UInt64)             \
+    M(TinyBlob, 0xf9, CompactBytes, String)   \
+    M(MediumBlob, 0xfa, CompactBytes, String) \
+    M(LongBlob, 0xfb, CompactBytes, String)   \
+    M(Blob, 0xfc, CompactBytes, String)       \
+    M(VarString, 0xfd, CompactBytes, String)  \
+    M(String, 0xfe, CompactBytes, String)     \
+    M(Geometry, 0xff, CompactBytes, String)
+
+enum TP
+{
+#ifdef M
+#error "Please undefine macro M first."
+#endif
+#define M(tt, v, cf, ct) Type##tt = (v),
+    COLUMN_TYPES(M)
+#undef M
+};
+
+
+// Codec flags.
+// In format: TiDB codec flag, int value.
+#ifdef M
+#error "Please undefine macro M first."
+#endif
+#define CODEC_FLAGS(M) \
+    M(Nil, 0)          \
+    M(Bytes, 1)        \
+    M(CompactBytes, 2) \
+    M(Int, 3)          \
+    M(UInt, 4)         \
+    M(Float, 5)        \
+    M(Decimal, 6)      \
+    M(Duration, 7)     \
+    M(VarInt, 8)       \
+    M(VarUInt, 9)      \
+    M(Json, 10)        \
+    M(Max, 250)
+
+enum CodecFlag
+{
+#ifdef M
+#error "Please undefine macro M first."
+#endif
+#define M(cf, v) CodecFlag##cf = (v),
+    CODEC_FLAGS(M)
+#undef M
+};
+
+} // namespace TiDB

--- a/dbms/src/TiDB/Schema/TiDB_fwd.h
+++ b/dbms/src/TiDB/Schema/TiDB_fwd.h
@@ -20,6 +20,7 @@ namespace TiDB
 {
 
 struct ColumnInfo;
+using ColumnInfos = std::vector<ColumnInfo>;
 
 struct TableInfo;
 using TableInfoPtr = std::shared_ptr<TableInfo>;

--- a/dbms/src/TiDB/Schema/TiDB_fwd.h
+++ b/dbms/src/TiDB/Schema/TiDB_fwd.h
@@ -1,4 +1,4 @@
-// Copyright 2023 PingCAP, Inc.
+// Copyright 2024 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,18 +14,21 @@
 
 #pragma once
 
+#include <memory>
+
 namespace TiDB
 {
 
-// Indicate that use 'TMT' or 'DM' as storage engine in AP. (TMT by default now)
-enum class StorageEngine
-{
-    UNSPECIFIED = 0,
-    TMT,
-    DT,
+struct ColumnInfo;
 
-    // indicate other engine type in ClickHouse
-    UNSUPPORTED_ENGINES = 128,
-};
+struct TableInfo;
+using TableInfoPtr = std::shared_ptr<TableInfo>;
+
+struct DBInfo;
+using DBInfoPtr = std::shared_ptr<DBInfo>;
+
+class ITiDBCollator;
+using TiDBCollatorPtr = ITiDBCollator const *;
+using TiDBCollators = std::vector<TiDBCollatorPtr>;
 
 } // namespace TiDB


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/6233

Problem Summary:

Changing TiDB.h will make about 600 files being re-compile, which cost too much time.

### What is changed and how it works?

```commit-message
*: Refine include of TiDB.h to speedup re-compiling

  * Split `TiDB_fwd.h`, `TiDBTypes.h`
  * Include `TiDB.h`, `TypeMapping.h` in .cpp files instead of .h files as possible to reduce the re-compiling involve files

```

After these changes, the re-compile files down from 600 to 300

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
