### PR TITLE
Set thread name for seg task scheduler

### DIFF
--- a/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.cpp
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.cpp
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#include <Common/setThreadName.h>
 #include <Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.h>
 #include <Storages/DeltaMerge/ReadThread/SegmentReader.h>
 #include <Storages/DeltaMerge/Segment.h>
@@ -236,6 +237,7 @@ bool SegmentReadTaskScheduler::schedule()
 
 void SegmentReadTaskScheduler::schedLoop()
 {
+    setThreadName("segment-sched");
     while (!isStop())
     {
         if (!schedule())


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/8652

Problem Summary:

In https://github.com/pingcap/tiflash/pull/8653 (release-7.1 cherry-pick: https://github.com/pingcap/tiflash/pull/8661) we add CPU panel for segment read task scheduler. But the thread name is not set.
The thread name is originally set in https://github.com/pingcap/tiflash/pull/8557 which refactor the scheduler.

### What is changed and how it works?

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
