### PR TITLE
avoid potential TiFlash crash in `NonJoinedBlockInputStream`

### DIFF
--- a/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.cpp
@@ -314,6 +314,7 @@ void DAGQueryBlockInterpreter::handleJoin(const tipb::Join & join, DAGPipeline &
         for (size_t i = 0; i < not_joined_concurrency; ++i)
         {
             auto non_joined_stream = join_ptr->createStreamWithNonJoinedRows(
+                join_ptr,
                 pipeline.firstStream()->getHeader(),
                 i,
                 not_joined_concurrency,

--- a/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.cpp
@@ -313,7 +313,7 @@ void DAGQueryBlockInterpreter::handleJoin(const tipb::Join & join, DAGPipeline &
         size_t not_joined_concurrency = join_ptr->getNotJoinedStreamConcurrency();
         for (size_t i = 0; i < not_joined_concurrency; ++i)
         {
-            auto non_joined_stream = join_ptr->createStreamWithNonJoinedRows(
+            auto non_joined_stream = createStreamWithNonJoinedRows(
                 join_ptr,
                 pipeline.firstStream()->getHeader(),
                 i,

--- a/dbms/src/Flash/Planner/plans/PhysicalJoin.cpp
+++ b/dbms/src/Flash/Planner/plans/PhysicalJoin.cpp
@@ -187,7 +187,7 @@ void PhysicalJoin::probeSideTransform(DAGPipeline & probe_pipeline, Context & co
         const auto & input_header = probe_pipeline.firstStream()->getHeader();
         for (size_t i = 0; i < not_joined_concurrency; ++i)
         {
-            auto non_joined_stream = join_ptr->createStreamWithNonJoinedRows(join_ptr, input_header, i, not_joined_concurrency, settings.max_block_size);
+            auto non_joined_stream = createStreamWithNonJoinedRows(join_ptr, input_header, i, not_joined_concurrency, settings.max_block_size);
             non_joined_stream->setExtraInfo("add stream with non_joined_data if full_or_right_join");
             probe_pipeline.streams_with_non_joined_data.push_back(non_joined_stream);
             join_execute_info.non_joined_streams.push_back(non_joined_stream);

--- a/dbms/src/Flash/Planner/plans/PhysicalJoin.cpp
+++ b/dbms/src/Flash/Planner/plans/PhysicalJoin.cpp
@@ -187,7 +187,7 @@ void PhysicalJoin::probeSideTransform(DAGPipeline & probe_pipeline, Context & co
         const auto & input_header = probe_pipeline.firstStream()->getHeader();
         for (size_t i = 0; i < not_joined_concurrency; ++i)
         {
-            auto non_joined_stream = join_ptr->createStreamWithNonJoinedRows(input_header, i, not_joined_concurrency, settings.max_block_size);
+            auto non_joined_stream = join_ptr->createStreamWithNonJoinedRows(join_ptr, input_header, i, not_joined_concurrency, settings.max_block_size);
             non_joined_stream->setExtraInfo("add stream with non_joined_data if full_or_right_join");
             probe_pipeline.streams_with_non_joined_data.push_back(non_joined_stream);
             join_execute_info.non_joined_streams.push_back(non_joined_stream);

--- a/dbms/src/Interpreters/ExpressionActions.cpp
+++ b/dbms/src/Interpreters/ExpressionActions.cpp
@@ -743,13 +743,9 @@ std::string ExpressionActions::dumpActions() const
     return ss.str();
 }
 
-BlockInputStreamPtr ExpressionActions::createStreamWithNonJoinedDataIfFullOrRightJoin(const Block & source_header, size_t index, size_t step, size_t max_block_size) const
+BlockInputStreamPtr ExpressionActions::createStreamWithNonJoinedDataIfFullOrRightJoin(const Block & , size_t , size_t , size_t ) const
 {
-    for (const auto & action : actions)
-        if (action.join && (action.join->getKind() == ASTTableJoin::Kind::Full || action.join->getKind() == ASTTableJoin::Kind::Right))
-            return action.join->createStreamWithNonJoinedRows(source_header, index, step, max_block_size);
-
-    return {};
+    throw Exception("Not supported");
 }
 
 void ExpressionActionsChain::addStep()

--- a/dbms/src/Interpreters/ExpressionActions.cpp
+++ b/dbms/src/Interpreters/ExpressionActions.cpp
@@ -745,7 +745,10 @@ std::string ExpressionActions::dumpActions() const
 
 BlockInputStreamPtr ExpressionActions::createStreamWithNonJoinedDataIfFullOrRightJoin(const Block &, size_t, size_t, size_t) const
 {
-    throw Exception("Not supported");
+    for (const auto & action : actions)
+        if (action.join && (action.join->getKind() == ASTTableJoin::Kind::Full || action.join->getKind() == ASTTableJoin::Kind::Right))
+            throw Exception("Not supported");
+    return {};
 }
 
 void ExpressionActionsChain::addStep()

--- a/dbms/src/Interpreters/ExpressionActions.cpp
+++ b/dbms/src/Interpreters/ExpressionActions.cpp
@@ -743,7 +743,7 @@ std::string ExpressionActions::dumpActions() const
     return ss.str();
 }
 
-BlockInputStreamPtr ExpressionActions::createStreamWithNonJoinedDataIfFullOrRightJoin(const Block & , size_t , size_t , size_t ) const
+BlockInputStreamPtr ExpressionActions::createStreamWithNonJoinedDataIfFullOrRightJoin(const Block &, size_t, size_t, size_t) const
 {
     throw Exception("Not supported");
 }

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -2296,7 +2296,7 @@ private:
 };
 
 
-BlockInputStreamPtr Join::createStreamWithNonJoinedRows(const JoinPtr & parent, const Block & left_sample_block, size_t index, size_t step, size_t max_block_size) const
+BlockInputStreamPtr createStreamWithNonJoinedRows(const JoinPtr & parent, const Block & left_sample_block, size_t index, size_t step, size_t max_block_size)
 {
     return std::make_shared<NonJoinedBlockInputStream>(parent, left_sample_block, index, step, max_block_size);
 }

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -2067,14 +2067,14 @@ struct AdderNonJoined<ASTTableJoin::Strictness::All, Mapped>
 class NonJoinedBlockInputStream : public IProfilingBlockInputStream
 {
 public:
-    NonJoinedBlockInputStream(const Join & parent_, const Block & left_sample_block, size_t index_, size_t step_, size_t max_block_size_)
+    NonJoinedBlockInputStream(const JoinPtr & parent_, const Block & left_sample_block, size_t index_, size_t step_, size_t max_block_size_)
         : parent(parent_)
         , index(index_)
         , step(step_)
         , max_block_size(max_block_size_)
         , add_not_mapped_rows(true)
     {
-        size_t build_concurrency = parent.getBuildConcurrency();
+        size_t build_concurrency = parent->getBuildConcurrency();
         if (unlikely(step > build_concurrency || index >= build_concurrency))
             throw Exception("The concurrency of NonJoinedBlockInputStream should not be larger than join build concurrency");
 
@@ -2083,14 +2083,14 @@ public:
           */
 
         size_t num_columns_left = left_sample_block.columns();
-        size_t num_columns_right = parent.sample_block_with_columns_to_add.columns();
+        size_t num_columns_right = parent->sample_block_with_columns_to_add.columns();
 
         result_sample_block = materializeBlock(left_sample_block);
 
         /// Add columns from the right-side table to the block.
         for (size_t i = 0; i < num_columns_right; ++i)
         {
-            const ColumnWithTypeAndName & src_column = parent.sample_block_with_columns_to_add.getByPosition(i);
+            const ColumnWithTypeAndName & src_column = parent->sample_block_with_columns_to_add.getByPosition(i);
             result_sample_block.insert(src_column.cloneEmpty());
         }
 
@@ -2107,7 +2107,7 @@ public:
             column_indices_right.push_back(num_columns_left + i);
 
         /// If use_nulls, convert left columns to Nullable.
-        if (parent.use_nulls)
+        if (parent->use_nulls)
         {
             for (size_t i = 0; i < num_columns_left; ++i)
             {
@@ -2128,7 +2128,7 @@ public:
 protected:
     Block readImpl() override
     {
-        if (parent.blocks.empty())
+        if (parent->blocks.empty())
             return Block();
 
         if (add_not_mapped_rows)
@@ -2137,16 +2137,16 @@ protected:
             add_not_mapped_rows = false;
         }
 
-        if (parent.strictness == ASTTableJoin::Strictness::Any)
-            return createBlock<ASTTableJoin::Strictness::Any>(parent.maps_any_full);
-        else if (parent.strictness == ASTTableJoin::Strictness::All)
-            return createBlock<ASTTableJoin::Strictness::All>(parent.maps_all_full);
+        if (parent->strictness == ASTTableJoin::Strictness::Any)
+            return createBlock<ASTTableJoin::Strictness::Any>(parent->maps_any_full);
+        else if (parent->strictness == ASTTableJoin::Strictness::All)
+            return createBlock<ASTTableJoin::Strictness::All>(parent->maps_all_full);
         else
             throw Exception("Logical error: unknown JOIN strictness (must be ANY or ALL)", ErrorCodes::LOGICAL_ERROR);
     }
 
 private:
-    const Join & parent;
+    const JoinPtr parent;
     size_t index;
     size_t step;
     size_t max_block_size;
@@ -2170,9 +2170,9 @@ private:
 
     void setNextCurrentNotMappedRow()
     {
-        while (current_not_mapped_row == nullptr && next_index < parent.rows_not_inserted_to_map.size())
+        while (current_not_mapped_row == nullptr && next_index < parent->rows_not_inserted_to_map.size())
         {
-            current_not_mapped_row = parent.rows_not_inserted_to_map[next_index]->next;
+            current_not_mapped_row = parent->rows_not_inserted_to_map[next_index]->next;
             next_index += step;
         }
     }
@@ -2197,7 +2197,7 @@ private:
 
         size_t rows_added = 0;
 
-        switch (parent.type)
+        switch (parent->type)
         {
 #define M(TYPE)                                                                                                             \
     case Join::Type::TYPE:                                                                                                  \
@@ -2231,7 +2231,7 @@ private:
                        MutableColumns & mutable_columns_right)
     {
         size_t rows_added = 0;
-        size_t key_num = parent.key_names_right.size();
+        size_t key_num = parent->key_names_right.size();
         while (current_not_mapped_row != nullptr)
         {
             rows_added++;
@@ -2296,9 +2296,9 @@ private:
 };
 
 
-BlockInputStreamPtr Join::createStreamWithNonJoinedRows(const Block & left_sample_block, size_t index, size_t step, size_t max_block_size) const
+BlockInputStreamPtr Join::createStreamWithNonJoinedRows(const JoinPtr & parent, const Block & left_sample_block, size_t index, size_t step, size_t max_block_size) const
 {
-    return std::make_shared<NonJoinedBlockInputStream>(*this, left_sample_block, index, step, max_block_size);
+    return std::make_shared<NonJoinedBlockInputStream>(parent, left_sample_block, index, step, max_block_size);
 }
 
 } // namespace DB

--- a/dbms/src/Interpreters/Join.h
+++ b/dbms/src/Interpreters/Join.h
@@ -32,6 +32,10 @@
 
 namespace DB
 {
+class Join;
+using JoinPtr = std::shared_ptr<Join>;
+using Joins = std::vector<JoinPtr>;
+
 /** Data structure for implementation of JOIN.
   * It is just a hash table: keys -> rows of joined ("right") table.
   * Additionally, CROSS JOIN is supported: instead of hash table, it use just set of blocks without keys.
@@ -134,7 +138,7 @@ public:
       * Use only after all calls to joinBlock was done.
       * left_sample_block is passed without account of 'use_nulls' setting (columns will be converted to Nullable inside).
       */
-    BlockInputStreamPtr createStreamWithNonJoinedRows(const Block & left_sample_block, size_t index, size_t step, size_t max_block_size) const;
+    BlockInputStreamPtr createStreamWithNonJoinedRows(const JoinPtr & parent, const Block & left_sample_block, size_t index, size_t step, size_t max_block_size) const;
 
     /// Number of keys in all built JOIN maps.
     size_t getTotalRowCount() const;
@@ -398,9 +402,6 @@ private:
     template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS, bool has_null_map>
     void joinBlockImplCrossInternal(Block & block, ConstNullMapPtr null_map) const;
 };
-
-using JoinPtr = std::shared_ptr<Join>;
-using Joins = std::vector<JoinPtr>;
 
 
 } // namespace DB

--- a/dbms/src/Interpreters/Join.h
+++ b/dbms/src/Interpreters/Join.h
@@ -35,6 +35,13 @@ namespace DB
 class Join;
 using JoinPtr = std::shared_ptr<Join>;
 using Joins = std::vector<JoinPtr>;
+/** For RIGHT and FULL JOINs.
+* A stream that will contain default values from left table, joined with rows from right table, that was not joined before.
+* Use only after all calls to joinBlock was done.
+* left_sample_block is passed without account of 'use_nulls' setting (columns will be converted to Nullable inside).
+*/
+BlockInputStreamPtr createStreamWithNonJoinedRows(const JoinPtr & parent, const Block & left_sample_block, size_t index, size_t step, size_t max_block_size);
+
 
 /** Data structure for implementation of JOIN.
   * It is just a hash table: keys -> rows of joined ("right") table.
@@ -132,13 +139,6 @@ public:
     bool hasTotals() const { return static_cast<bool>(totals); };
 
     void joinTotals(Block & block) const;
-
-    /** For RIGHT and FULL JOINs.
-      * A stream that will contain default values from left table, joined with rows from right table, that was not joined before.
-      * Use only after all calls to joinBlock was done.
-      * left_sample_block is passed without account of 'use_nulls' setting (columns will be converted to Nullable inside).
-      */
-    BlockInputStreamPtr createStreamWithNonJoinedRows(const JoinPtr & parent, const Block & left_sample_block, size_t index, size_t step, size_t max_block_size) const;
 
     /// Number of keys in all built JOIN maps.
     size_t getTotalRowCount() const;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9190

Problem Summary:
Hold shared pointer of `Join` in `NonJoinedBlockInputStream`
### What is changed and how it works?

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
