### PR TITLE
storage: Fix TiFlash system tables cannot query in Keyspace Mode

### DIFF
--- a/dbms/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterSelectQuery.cpp
@@ -224,13 +224,19 @@ void InterpreterSelectQuery::getAndLockStorageWithSchemaVersion(const String & d
     // always sync schema first and then read table
     const String qualified_name = database_name + "." + table_name;
 
+    bool need_sync_schema = true;
+    if (database_name == "system")
+        need_sync_schema = false;
+    else if (database_name.empty() && context.getCurrentDatabase() == "system")
+        need_sync_schema = false;
 
     {
         auto start_time = Clock::now();
         // Since InterpreterSelectQuery will only be trigger while using ClickHouse client,
         // and we do not support keyspace feature for ClickHouse interface,
         // we could use nullspace id here safely.
-        context.getTMTContext().getSchemaSyncerManager()->syncSchemas(context, NullspaceID);
+        if (need_sync_schema)
+            context.getTMTContext().getSchemaSyncerManager()->syncSchemas(context, NullspaceID);
         auto storage_tmp = context.getTable(database_name, table_name);
         auto managed_storage = std::dynamic_pointer_cast<IManageableStorage>(storage_tmp);
         if (!managed_storage
@@ -243,10 +249,11 @@ void InterpreterSelectQuery::getAndLockStorageWithSchemaVersion(const String & d
             return;
         }
 
-        context.getTMTContext().getSchemaSyncerManager()->syncTableSchema(
-            context,
-            NullspaceID,
-            managed_storage->getTableInfo().id);
+        if (need_sync_schema)
+            context.getTMTContext().getSchemaSyncerManager()->syncTableSchema(
+                context,
+                NullspaceID,
+                managed_storage->getTableInfo().id);
         auto schema_sync_cost
             = std::chrono::duration_cast<std::chrono::milliseconds>(Clock::now() - start_time).count();
         LOG_DEBUG(log, "Table {} schema sync cost {}ms.", qualified_name, schema_sync_cost);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #9032 

Problem Summary:

A.

```
❯ ~/Work/tiflash-cse/cmake-build-Debug/dbms/src/Server/tiflash client --port=9100 --host=127.0.0.1
ClickHouse client version 1.1.54381.
Connecting to 127.0.0.1:9100.
Connected to TiFlash server version 1.1.54381.

TiFlash :) show tables;

SHOW TABLES

Received exception from server (version 1.1.54381):
Code: 49. DB::Exception: Received from 127.0.0.1:9100. DB::Exception: pingcap::Exception code=UnknownError msg=unknown error : abort: "Error(InvalidKeyMode { cmd: get, storage_api_version: V2, key: \"6D536368656D6156FF65FF7273696F6E4BFF6579FF0000000000FF000000F700000000FF0000007300000000FB\" })".

0 rows in set. Elapsed: 0.641 sec.
```

B:

```
mysql> select * from information_schema.tiflash_tables;
ERROR 1105 (HY000): rpc error: code = Internal desc = pingcap::Exception code=UnknownError msg=unknown error : abort: "Error(InvalidKeyMode { cmd: get, storage_api_version: V2, key: \"6D536368656D6156FF65FF7273696F6E4BFF6579FF0000000000FF000000F700000000FF0000007300000000FB\" })"
```

This is because we always try to sync the schema version when querying from CLI client. Under keyspace mode, a KeyspaceID is required for it to work.

### What is changed and how it works?

TiFlash's system tables don't need to sync schemas before querying. It does not belong to any keyspace as well. So we just skip sync schemas for these tables.

After this PR:

```
TiFlash :) show databases;

SHOW DATABASES

┌─name──────┐
│ ks_1_db_1 │
│ ks_1_db_2 │
│ system    │
└───────────┘

3 rows in set. Elapsed: 0.001 sec.

TiFlash :) select * from dt_segments;

SELECT *
FROM dt_segments

┌─database──┬─table─────┬─tidb_database─┬─tidb_table──┬─table_id─┬─is_tombstone─┬─segment_id─┬─range──────────────────────────────────────┬─epoch─┬──rows─┬──────size─┬─delta_rate─┬─delta_memtable_rows─┬─delta_memtable_size─┬─delta_memtable_column_files─┬─delta_memtable_delete_ranges─┬─delta_persisted_page_id─┬─delta_persisted_rows─┬─delta_persisted_size─┬─delta_persisted_column_files─┬─delta_persisted_delete_ranges─┬─delta_cache_size─┬─delta_index_size─┬─stable_page_id─┬─stable_rows─┬─stable_size─┬─stable_dmfiles─┬─stable_dmfiles_id_0─┬─stable_dmfiles_rows─┬─stable_dmfiles_size─┬─stable_dmfiles_size_on_disk─┬─stable_dmfiles_packs─┐
│ ks_1_db_2 │ ks_1_t_96 │ ks_1_test     │ ks_1_sample │       96 │            0 │          1 │ [-9223372036854775808,9223372036854775807) │     5 │ 60000 │ 189900000 │          0 │                   0 │                   0 │                           0 │                            0 │                      42 │                    0 │                    0 │                            0 │                             0 │                0 │             2032 │             43 │       60000 │   189900000 │              1 │                 105 │               60000 │           189900000 │                    53891161 │                    8 │
└───────────┴───────────┴───────────────┴─────────────┴──────────┴──────────────┴────────────┴────────────────────────────────────────────┴───────┴───────┴───────────┴────────────┴─────────────────────┴─────────────────────┴─────────────────────────────┴──────────────────────────────┴─────────────────────────┴──────────────────────┴──────────────────────┴──────────────────────────────┴───────────────────────────────┴──────────────────┴──────────────────┴────────────────┴─────────────┴─────────────┴────────────────┴─────────────────────┴─────────────────────┴─────────────────────┴─────────────────────────────┴──────────────────────┘

1 rows in set. Elapsed: 0.003 sec.
```

```
mysql> select * from information_schema.tiflash_tables;
+-----------+-----------+---------------+-------------+----------+--------------+---------------+------------+------------+---------------------+-----------------+---------------------+-------------------+------------------+------------------+-------------------------+------------------+------------------+------------------+-------------+------------------+------------------+----------------+----------------+-------------------------+--------------+-------------------+-------------------+---------------------------+-----------------+-----------------+---------------------------+-------------------------+-------------------------+------------------------+------------------------+----------------------------+--------------------------+-------------------------+-------------------------+------------------------------+-----------------------------------------+------------------------------------------+-------------------------------------------+-----------------------------+----------------------------------------+-----------------------------------------+------------------------------------------+----------------------------+---------------------------------------+----------------------------------------+-----------------------------------------+-------------------------+------------------+
| DATABASE  | TABLE     | TIDB_DATABASE | TIDB_TABLE  | TABLE_ID | IS_TOMBSTONE | SEGMENT_COUNT | TOTAL_ROWS | TOTAL_SIZE | TOTAL_DELETE_RANGES | DELTA_RATE_ROWS | DELTA_RATE_SEGMENTS | DELTA_PLACED_RATE | DELTA_CACHE_SIZE | DELTA_CACHE_RATE | DELTA_CACHE_WASTED_RATE | DELTA_INDEX_SIZE | AVG_SEGMENT_ROWS | AVG_SEGMENT_SIZE | DELTA_COUNT | TOTAL_DELTA_ROWS | TOTAL_DELTA_SIZE | AVG_DELTA_ROWS | AVG_DELTA_SIZE | AVG_DELTA_DELETE_RANGES | STABLE_COUNT | TOTAL_STABLE_ROWS | TOTAL_STABLE_SIZE | TOTAL_STABLE_SIZE_ON_DISK | AVG_STABLE_ROWS | AVG_STABLE_SIZE | TOTAL_PACK_COUNT_IN_DELTA | MAX_PACK_COUNT_IN_DELTA | AVG_PACK_COUNT_IN_DELTA | AVG_PACK_ROWS_IN_DELTA | AVG_PACK_SIZE_IN_DELTA | TOTAL_PACK_COUNT_IN_STABLE | AVG_PACK_COUNT_IN_STABLE | AVG_PACK_ROWS_IN_STABLE | AVG_PACK_SIZE_IN_STABLE | STORAGE_STABLE_NUM_SNAPSHOTS | STORAGE_STABLE_OLDEST_SNAPSHOT_LIFETIME | STORAGE_STABLE_OLDEST_SNAPSHOT_THREAD_ID | STORAGE_STABLE_OLDEST_SNAPSHOT_TRACING_ID | STORAGE_DELTA_NUM_SNAPSHOTS | STORAGE_DELTA_OLDEST_SNAPSHOT_LIFETIME | STORAGE_DELTA_OLDEST_SNAPSHOT_THREAD_ID | STORAGE_DELTA_OLDEST_SNAPSHOT_TRACING_ID | STORAGE_META_NUM_SNAPSHOTS | STORAGE_META_OLDEST_SNAPSHOT_LIFETIME | STORAGE_META_OLDEST_SNAPSHOT_THREAD_ID | STORAGE_META_OLDEST_SNAPSHOT_TRACING_ID | BACKGROUND_TASKS_LENGTH | TIFLASH_INSTANCE |
+-----------+-----------+---------------+-------------+----------+--------------+---------------+------------+------------+---------------------+-----------------+---------------------+-------------------+------------------+------------------+-------------------------+------------------+------------------+------------------+-------------+------------------+------------------+----------------+----------------+-------------------------+--------------+-------------------+-------------------+---------------------------+-----------------+-----------------+---------------------------+-------------------------+-------------------------+------------------------+------------------------+----------------------------+--------------------------+-------------------------+-------------------------+------------------------------+-----------------------------------------+------------------------------------------+-------------------------------------------+-----------------------------+----------------------------------------+-----------------------------------------+------------------------------------------+----------------------------+---------------------------------------+----------------------------------------+-----------------------------------------+-------------------------+------------------+
| ks_1_db_2 | ks_1_t_96 | ks_1_test     | ks_1_sample |       96 |            0 |             1 |      60000 |  189900000 |                   0 |               0 |                   0 |              NULL |                0 |             NULL |                    NULL |                0 |            60000 |        189900000 |           0 |                0 |                0 |           NULL |           NULL |                    NULL |            1 |             60000 |         189900000 |                  53891161 |           60000 |       189900000 |                         0 |                       0 |                    NULL |                   NULL |                   NULL |                          8 |                        8 |                    7500 |                23737500 |                            0 |                                       0 |                                        0 |                                           |                           0 |                                      0 |                                       0 |                                          |                          0 |                                     0 |                                      0 |                                         |                       0 | 127.0.0.1:3930   |
+-----------+-----------+---------------+-------------+----------+--------------+---------------+------------+------------+---------------------+-----------------+---------------------+-------------------+------------------+------------------+-------------------------+------------------+------------------+------------------+-------------+------------------+------------------+----------------+----------------+-------------------------+--------------+-------------------+-------------------+---------------------------+-----------------+-----------------+---------------------------+-------------------------+-------------------------+------------------------+------------------------+----------------------------+--------------------------+-------------------------+-------------------------+------------------------------+-----------------------------------------+------------------------------------------+-------------------------------------------+-----------------------------+----------------------------------------+-----------------------------------------+------------------------------------------+----------------------------+---------------------------------------+----------------------------------------+-----------------------------------------+-------------------------+------------------+
1 row in set (0.00 sec)
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```