### PR TITLE
storage: Add keyspace_id to DT system tables

### DIFF
--- a/dbms/src/Storages/System/StorageSystemDTSegments.cpp
+++ b/dbms/src/Storages/System/StorageSystemDTSegments.cpp
@@ -14,6 +14,7 @@
 
 #include <Columns/ColumnString.h>
 #include <DataStreams/OneBlockInputStream.h>
+#include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <Databases/DatabaseTiFlash.h>
@@ -37,6 +38,7 @@ StorageSystemDTSegments::StorageSystemDTSegments(const std::string & name_)
 
         {"tidb_database", std::make_shared<DataTypeString>()},
         {"tidb_table", std::make_shared<DataTypeString>()},
+        {"keyspace_id", std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt64>())},
         {"table_id", std::make_shared<DataTypeInt64>()},
         {"is_tombstone", std::make_shared<DataTypeUInt64>()},
 
@@ -115,11 +117,19 @@ BlockInputStreams StorageSystemDTSegments::read(
                 res_columns[j++]->insert(table_name);
 
                 String tidb_db_name;
+                KeyspaceID keyspace_id = NullspaceID;
                 if (db_tiflash)
-                    tidb_db_name = mapper.displayDatabaseName(db_tiflash->getDatabaseInfo());
+                {
+                    tidb_db_name = db_tiflash->getDatabaseInfo().name;
+                    keyspace_id = db_tiflash->getDatabaseInfo().keyspace_id;
+                }
                 res_columns[j++]->insert(tidb_db_name);
-                String tidb_table_name = mapper.displayTableName(table_info);
+                String tidb_table_name = table_info.name;
                 res_columns[j++]->insert(tidb_table_name);
+                if (keyspace_id == NullspaceID)
+                    res_columns[j++]->insert(Field());
+                else
+                    res_columns[j++]->insert(static_cast<UInt64>(keyspace_id));
                 res_columns[j++]->insert(table_id);
                 res_columns[j++]->insert(dm_storage->getTombstone());
 

--- a/dbms/src/Storages/System/StorageSystemDTTables.cpp
+++ b/dbms/src/Storages/System/StorageSystemDTTables.cpp
@@ -14,12 +14,14 @@
 
 #include <Columns/ColumnString.h>
 #include <DataStreams/OneBlockInputStream.h>
+#include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <Databases/DatabaseTiFlash.h>
 #include <Databases/IDatabase.h>
 #include <Interpreters/Context.h>
 #include <Storages/DeltaMerge/DeltaMergeStore.h>
+#include <Storages/KVStore/Types.h>
 #include <Storages/MutableSupport.h>
 #include <Storages/StorageDeltaMerge.h>
 #include <Storages/System/StorageSystemDTTables.h>
@@ -37,6 +39,7 @@ StorageSystemDTTables::StorageSystemDTTables(const std::string & name_)
 
         {"tidb_database", std::make_shared<DataTypeString>()},
         {"tidb_table", std::make_shared<DataTypeString>()},
+        {"keyspace_id", std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt64>())},
         {"table_id", std::make_shared<DataTypeInt64>()},
         {"is_tombstone", std::make_shared<DataTypeUInt64>()},
 
@@ -146,11 +149,19 @@ BlockInputStreams StorageSystemDTTables::read(
             res_columns[j++]->insert(table_name);
 
             String tidb_db_name;
+            KeyspaceID keyspace_id = NullspaceID;
             if (db_tiflash)
-                tidb_db_name = mapper.displayDatabaseName(db_tiflash->getDatabaseInfo());
+            {
+                tidb_db_name = db_tiflash->getDatabaseInfo().name;
+                keyspace_id = db_tiflash->getDatabaseInfo().keyspace_id;
+            }
             res_columns[j++]->insert(tidb_db_name);
-            String tidb_table_name = mapper.displayTableName(table_info);
+            String tidb_table_name = table_info.name;
             res_columns[j++]->insert(tidb_table_name);
+            if (keyspace_id == NullspaceID)
+                res_columns[j++]->insert(Field());
+            else
+                res_columns[j++]->insert(static_cast<UInt64>(keyspace_id));
             res_columns[j++]->insert(table_id);
             res_columns[j++]->insert(dm_storage->getTombstone());
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #9032

Problem Summary:

### What is changed and how it works?

Add a `keyspace_id` field, so that TiDB could query TiFlash system tables over it.

`mapper.displayDatabaseName` is used in some other places so that it is unchanged.

```
TiFlash :) select * from dt_segments where keyspace_id=4

SELECT *
FROM dt_segments
WHERE keyspace_id = 4

Ok.

0 rows in set. Elapsed: 0.107 sec.

TiFlash :) select * from dt_segments where keyspace_id=1

SELECT *
FROM dt_segments
WHERE keyspace_id = 1

┌─database──┬─table─────┬─tidb_database─┬─tidb_table─┬─keyspace_id─┬─table_id─┬─is_tombstone─┬─segment_id─┬─range──────────────────────────────────────┬─epoch─┬──rows─┬──────size─┬─delta_rate─┬─delta_memtable_rows─┬─delta_memtable_size─┬─delta_memtable_column_files─┬─delta_memtable_delete_ranges─┬─delta_persisted_page_id─┬─delta_persisted_rows─┬─delta_persisted_size─┬─delta_persisted_column_files─┬─delta_persisted_delete_ranges─┬─delta_cache_size─┬─delta_index_size─┬─stable_page_id─┬─stable_rows─┬─stable_size─┬─stable_dmfiles─┬─stable_dmfiles_id_0─┬─stable_dmfiles_rows─┬─stable_dmfiles_size─┬─stable_dmfiles_size_on_disk─┬─stable_dmfiles_packs─┐
│ ks_1_db_2 │ ks_1_t_96 │ test          │ sample     │           1 │       96 │            0 │          1 │ [-9223372036854775808,9223372036854775807) │     5 │ 60000 │ 189900000 │          0 │                   0 │                   0 │                           0 │                            0 │                      42 │                    0 │                    0 │                            0 │                             0 │                0 │             2032 │             43 │       60000 │   189900000 │              1 │                 105 │               60000 │           189900000 │                    53891161 │                    8 │
└───────────┴───────────┴───────────────┴────────────┴─────────────┴──────────┴──────────────┴────────────┴────────────────────────────────────────────┴───────┴───────┴───────────┴────────────┴─────────────────────┴─────────────────────┴─────────────────────────────┴──────────────────────────────┴─────────────────────────┴──────────────────────┴──────────────────────┴──────────────────────────────┴───────────────────────────────┴──────────────────┴──────────────────┴────────────────┴─────────────┴─────────────┴────────────────┴─────────────────────┴─────────────────────┴─────────────────────┴─────────────────────────────┴──────────────────────┘

1 rows in set. Elapsed: 0.006 sec.
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```