### PR TITLE
Storages: Fix comparing null in MinMaxIndex

### DIFF
--- a/dbms/src/Storages/DeltaMerge/Index/MinMaxIndex.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/MinMaxIndex.cpp
@@ -258,8 +258,6 @@ RSResults MinMaxIndex::checkNullableIn(
 {
     const auto & column_nullable = static_cast<const ColumnNullable &>(*minmaxes);
     const auto & null_map = column_nullable.getNullMapColumn();
-
-    RSResults results(pack_count, RSResult::SomeNull);
     const auto * raw_type = type.get();
 
 #define DISPATCH(TYPE)                                 \
@@ -284,6 +282,7 @@ RSResults MinMaxIndex::checkNullableIn(
         const auto * string_column = checkAndGetColumn<ColumnString>(column_nullable.getNestedColumnPtr().get());
         const auto & chars = string_column->getChars();
         const auto & offsets = string_column->getOffsets();
+        RSResults results(pack_count, RSResult::SomeNull);
         for (size_t i = start_pack; i < start_pack + pack_count; ++i)
         {
             if (details::minIsNull(null_map, i))
@@ -321,7 +320,7 @@ RSResults MinMaxIndex::checkNullableIn(
             values,
             type);
     }
-    return results;
+    return RSResults(pack_count, RSResult::SomeNull);
 }
 
 template <typename T>
@@ -351,8 +350,6 @@ RSResults MinMaxIndex::checkIn(
     const std::vector<Field> & values,
     const DataTypePtr & type)
 {
-    RSResults results(pack_count, RSResult::None);
-
     const auto * raw_type = type.get();
     if (typeid_cast<const DataTypeNullable *>(raw_type))
     {
@@ -371,6 +368,7 @@ RSResults MinMaxIndex::checkIn(
     }
     if (typeid_cast<const DataTypeString *>(raw_type))
     {
+        RSResults results(pack_count, RSResult::None);
         const auto * string_column = checkAndGetColumn<ColumnString>(minmaxes.get());
         const auto & chars = string_column->getChars();
         const auto & offsets = string_column->getOffsets();
@@ -421,9 +419,8 @@ RSResults MinMaxIndex::checkCmpImpl(size_t start_pack, size_t pack_count, const 
 template <typename Op>
 RSResults MinMaxIndex::checkCmp(size_t start_pack, size_t pack_count, const Field & value, const DataTypePtr & type)
 {
-    RSResults results(pack_count, RSResult::None);
     if (value.isNull())
-        return results;
+        return RSResults(pack_count, RSResult::NoneNull);
 
     const auto * raw_type = type.get();
     if (typeid_cast<const DataTypeNullable *>(raw_type))
@@ -445,6 +442,7 @@ RSResults MinMaxIndex::checkCmp(size_t start_pack, size_t pack_count, const Fiel
         const auto * string_column = checkAndGetColumn<ColumnString>(minmaxes.get());
         const auto & chars = string_column->getChars();
         const auto & offsets = string_column->getOffsets();
+        RSResults results(pack_count, RSResult::None);
         for (size_t i = start_pack; i < start_pack + pack_count; ++i)
         {
             if (!has_value_marks[i])
@@ -520,8 +518,6 @@ RSResults MinMaxIndex::checkNullableCmp(
 {
     const auto & column_nullable = static_cast<const ColumnNullable &>(*minmaxes);
     const auto & null_map = column_nullable.getNullMapColumn();
-
-    RSResults results(pack_count, RSResult::SomeNull);
     const auto * raw_type = type.get();
 
 #define DISPATCH(TYPE)                                 \
@@ -546,6 +542,7 @@ RSResults MinMaxIndex::checkNullableCmp(
         const auto * string_column = checkAndGetColumn<ColumnString>(column_nullable.getNestedColumnPtr().get());
         const auto & chars = string_column->getChars();
         const auto & offsets = string_column->getOffsets();
+        RSResults results(pack_count, RSResult::SomeNull);
         for (size_t i = start_pack; i < start_pack + pack_count; ++i)
         {
             if (details::minIsNull(null_map, i))
@@ -583,7 +580,7 @@ RSResults MinMaxIndex::checkNullableCmp(
             value,
             type);
     }
-    return results;
+    return RSResults(pack_count, RSResult::SomeNull);
 }
 
 // If a pack only contains null marks and delete marks, checkIsNull will return RSResult::All.

--- a/dbms/src/Storages/DeltaMerge/Index/MinMaxIndex.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/MinMaxIndex.cpp
@@ -420,7 +420,7 @@ template <typename Op>
 RSResults MinMaxIndex::checkCmp(size_t start_pack, size_t pack_count, const Field & value, const DataTypePtr & type)
 {
     if (value.isNull())
-        return RSResults(pack_count, RSResult::NoneNull);
+        return RSResults(pack_count, RSResult::NoneNull); // the result of any arithmetic comparison with NULL is also NULL
 
     const auto * raw_type = type.get();
     if (typeid_cast<const DataTypeNullable *>(raw_type))

--- a/dbms/src/Storages/DeltaMerge/Index/MinMaxIndex.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/MinMaxIndex.cpp
@@ -420,7 +420,9 @@ template <typename Op>
 RSResults MinMaxIndex::checkCmp(size_t start_pack, size_t pack_count, const Field & value, const DataTypePtr & type)
 {
     if (value.isNull())
-        return RSResults(pack_count, RSResult::NoneNull); // the result of any arithmetic comparison with NULL is also NULL
+        return RSResults(
+            pack_count,
+            RSResult::NoneNull); // the result of any arithmetic comparison with NULL is also NULL
 
     const auto * raw_type = type.get();
     if (typeid_cast<const DataTypeNullable *>(raw_type))

--- a/dbms/src/Storages/DeltaMerge/Index/RoughCheck.h
+++ b/dbms/src/Storages/DeltaMerge/Index/RoughCheck.h
@@ -75,7 +75,7 @@ struct CheckIn
                 break;
 
             if (v.isNull())
-                result = result || RSResult::NoneNull;
+                result = result || RSResult::NoneNull; // the result of any arithmetic comparison with NULL is also NULL
             else
                 result = result || CheckEqual::check<T>(v, type, min, max);
         }

--- a/dbms/src/Storages/DeltaMerge/Index/RoughCheck.h
+++ b/dbms/src/Storages/DeltaMerge/Index/RoughCheck.h
@@ -73,10 +73,11 @@ struct CheckIn
         {
             if (result == RSResult::All)
                 break;
-            // skip null value
+
             if (v.isNull())
-                continue;
-            result = result || CheckEqual::check<T>(v, type, min, max);
+                result = result || RSResult::NoneNull;
+            else
+                result = result || CheckEqual::check<T>(v, type, min, max);
         }
         return result;
     }

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_minmax_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_minmax_index.cpp
@@ -2662,4 +2662,82 @@ try
     }
 }
 CATCH
+
+TEST_F(MinMaxIndexTest, CheckCmpNullValue)
+try
+{
+    auto col_type = DataTypeFactory::instance().get("Int64");
+    auto minmax_index = createMinMaxIndex(*col_type, min_max_check_test_data);
+    auto rs_index = RSIndex(col_type, minmax_index);
+    RSCheckParam param;
+    param.indexes.emplace(DEFAULT_COL_ID, rs_index);
+
+    Field null_value;
+    ASSERT_TRUE(null_value.isNull());
+
+    auto check = [&](RSOperatorPtr rs, RSResult expected_res) {
+        auto results = rs->roughCheck(0, min_max_check_test_data.size(), param);
+        for (auto actual_res : results)
+            ASSERT_EQ(actual_res, expected_res) << fmt::format("actual: {}, expected: {}", actual_res, expected_res);
+    };
+
+    check(createGreater(attr("Int64"), null_value), RSResult::NoneNull);
+    check(createGreaterEqual(attr("Int64"), null_value), RSResult::NoneNull);
+    check(createLess(attr("Int64"), null_value), RSResult::AllNull);
+    check(createLessEqual(attr("Int64"), null_value), RSResult::AllNull);
+    check(createEqual(attr("Int64"), null_value), RSResult::NoneNull);
+    check(createNotEqual(attr("Int64"), null_value), RSResult::AllNull);
+}
+CATCH
+
+TEST_F(MinMaxIndexTest, CheckInNullValue)
+try
+{
+    auto col_type = DataTypeFactory::instance().get("Nullable(Int64)");
+    auto minmax_index = createMinMaxIndex(*col_type, min_max_check_test_data);
+    auto rs_index = RSIndex(col_type, minmax_index);
+    RSCheckParam param;
+    param.indexes.emplace(DEFAULT_COL_ID, rs_index);
+
+    Field null_value;
+    ASSERT_TRUE(null_value.isNull());
+
+    {
+        auto rs = createIn(attr("Nullable(Int64)"), {null_value});
+        auto results = rs->roughCheck(0, min_max_check_test_data.size(), param);
+        auto excepted_results = {
+            RSResult::NoneNull,
+            RSResult::NoneNull,
+            RSResult::SomeNull, // All the fields are null, the default value is null, meet the compatibility check
+            RSResult::NoneNull,
+            RSResult::NoneNull,
+            RSResult::SomeNull, // All the fields are null, the default value is null, meet the compatibility check
+            RSResult::SomeNull, // All the fields are deleted, the default value is null, meet the compatibility check
+            RSResult::SomeNull, // All the fields are deleted, the default value is null, meet the compatibility check
+            RSResult::NoneNull,
+            RSResult::NoneNull,
+        };
+        ASSERT_TRUE(std::equal(results.cbegin(), results.cend(), excepted_results.begin()));
+    }
+
+    {
+        auto rs = createIn(attr("Nullable(Int64)"), {Field{static_cast<Int64>(1)}, null_value});
+        auto results = rs->roughCheck(0, min_max_check_test_data.size(), param);
+        auto excepted_results = {
+            RSResult::SomeNull,
+            RSResult::NoneNull,
+            RSResult::SomeNull, // All the fields are null, the default value is null, meet the compatibility check
+            RSResult::SomeNull,
+            RSResult::NoneNull,
+            RSResult::SomeNull, // All the fields are null, the default value is null, meet the compatibility check
+            RSResult::SomeNull, // All the fields are deleted, the default value is null, meet the compatibility check
+            RSResult::SomeNull, // All the fields are deleted, the default value is null, meet the compatibility check
+            RSResult::All,
+            RSResult::AllNull,
+        };
+        ASSERT_TRUE(std::equal(results.cbegin(), results.cend(), excepted_results.begin()));
+    }
+}
+CATCH
+
 } // namespace DB::DM::tests

--- a/tests/fullstack-test-dt/expr/compare_null.test
+++ b/tests/fullstack-test-dt/expr/compare_null.test
@@ -1,4 +1,4 @@
-# Copyright 2023 PingCAP, Inc.
+# Copyright 2024 PingCAP, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ mysql> drop table if exists test.t;
 
 mysql> create table test.t (a date);
 
-mysql> insert into test.t values("2024-08-26"),("2024-08-25"),("2024-08-24"),("2024-08-23");
+mysql> insert into test.t values('2024-08-26'),('2024-08-25'),('2024-08-24'),('2024-08-23');
 
 mysql> alter table test.t set tiflash replica 1;
 
@@ -38,24 +38,24 @@ mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t w
 
 mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a not in (NULL);
 
-mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a in (NULL, "2024-08-26");
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a in (NULL, '2024-08-26');
 +------------+
 | a          |
 +------------+
 | 2024-08-26 |
 +------------+
 
-mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a not in (NULL, "2024-08-26");
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a not in (NULL, '2024-08-26');
 
-mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a in (NULL, "2024-09-01");
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a in (NULL, '2024-09-01');
 
-mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a not in (NULL, "2024-09-01");
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a not in (NULL, '2024-09-01');
 
 mysql> drop table if exists test.t;
 
 mysql> create table test.t (a date);
 
-mysql> insert into test.t values("2024-08-26"),("2024-08-26"),("2024-08-26"),("2024-08-26");
+mysql> insert into test.t values('2024-08-26'),('2024-08-26'),('2024-08-26'),('2024-08-26');
 
 mysql> alter table test.t set tiflash replica 1;
 
@@ -63,7 +63,7 @@ func> wait_table test t
 
 mysql> alter table test.t compact tiflash replica;
 
-mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a in (NULL, "2024-08-26");
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a in (NULL, '2024-08-26');
 +------------+
 | a          |
 +------------+
@@ -73,7 +73,7 @@ mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t w
 | 2024-08-26 |
 +------------+
 
-mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a not in (NULL, "2024-08-26");
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a not in (NULL, '2024-08-26');
 
 # not null
 
@@ -81,7 +81,7 @@ mysql> drop table if exists test.t;
 
 mysql> create table test.t (a date not null);
 
-mysql> insert into test.t values("2024-08-26"),("2024-08-25"),("2024-08-24"),("2024-08-23");
+mysql> insert into test.t values('2024-08-26'),('2024-08-25'),('2024-08-24'),('2024-08-23');
 
 mysql> alter table test.t set tiflash replica 1;
 
@@ -102,24 +102,24 @@ mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t w
 
 mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a not in (NULL);
 
-mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a in (NULL, "2024-08-26");
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a in (NULL, '2024-08-26');
 +------------+
 | a          |
 +------------+
 | 2024-08-26 |
 +------------+
 
-mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a not in (NULL, "2024-08-26");
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a not in (NULL, '2024-08-26');
 
-mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a in (NULL, "2024-09-01");
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a in (NULL, '2024-09-01');
 
-mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a not in (NULL, "2024-09-01");
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a not in (NULL, '2024-09-01');
 
 mysql> drop table if exists test.t;
 
 mysql> create table test.t (a date not null);
 
-mysql> insert into test.t values("2024-08-26"),("2024-08-26"),("2024-08-26"),("2024-08-26");
+mysql> insert into test.t values('2024-08-26'),('2024-08-26'),('2024-08-26'),('2024-08-26');
 
 mysql> alter table test.t set tiflash replica 1;
 
@@ -127,7 +127,7 @@ func> wait_table test t
 
 mysql> alter table test.t compact tiflash replica;
 
-mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a in (NULL, "2024-08-26");
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a in (NULL, '2024-08-26');
 +------------+
 | a          |
 +------------+
@@ -137,4 +137,4 @@ mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t w
 | 2024-08-26 |
 +------------+
 
-mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a not in (NULL, "2024-08-26");
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a not in (NULL, '2024-08-26');

--- a/tests/fullstack-test-dt/expr/compare_null.test
+++ b/tests/fullstack-test-dt/expr/compare_null.test
@@ -231,7 +231,7 @@ func> wait_table test t
 
 mysql> alter table test.t compact tiflash replica;
 
-mysql> set session tidb_isolation_read_engines='tiflash'; select sum(b) from test.t group by a order by a desc;
+mysql> set session tidb_isolation_read_engines='tiflash'; select a, sum(b) from test.t group by a order by a desc;
 +------------+--------+
 | a          | sum(b) |
 +------------+--------+
@@ -242,7 +242,7 @@ mysql> set session tidb_isolation_read_engines='tiflash'; select sum(b) from tes
 | NULL       |     15 |
 +------------+--------+
 
-mysql> set session tidb_isolation_read_engines='tiflash'; select sum(b) from test.t group by a order by a desc;
+mysql> set session tidb_isolation_read_engines='tiflash'; select a, sum(b) from test.t group by a order by a desc;
 +------------+--------+
 | a          | sum(b) |
 +------------+--------+

--- a/tests/fullstack-test-dt/expr/compare_null.test
+++ b/tests/fullstack-test-dt/expr/compare_null.test
@@ -138,3 +138,81 @@ mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t w
 +------------+
 
 mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a not in (NULL, '2024-08-26');
+
+
+mysql> drop table if exists test.t;
+
+mysql> create table test.t (a date);
+
+mysql> insert into test.t values('2024-08-21'),('2024-08-22'),('2024-08-23'),('2024-08-24');
+
+mysql> alter table test.t set tiflash replica 1;
+
+func> wait_table test t
+
+mysql> alter table test.t compact tiflash replica;
+
+mysql> set session tidb_isolation_read_engines='tiflash';select * from test.t where a is NULL;
+
+mysql> set session tidb_isolation_read_engines='tiflash';select * from test.t where a is not NULL;
++------------+
+| a          |
++------------+
+| 2024-08-21 |
+| 2024-08-22 |
+| 2024-08-23 |
+| 2024-08-24 |
++------------+
+
+mysql> drop table if exists test.t;
+
+mysql> create table test.t (a date);
+
+mysql> insert into test.t values(NULL),(NULL),(NULL),(NULL);
+
+mysql> alter table test.t set tiflash replica 1;
+
+func> wait_table test t
+
+mysql> alter table test.t compact tiflash replica;
+
+mysql> set session tidb_isolation_read_engines='tiflash';select * from test.t where a is NULL;
++------+
+| a    |
++------+
+| NULL |
+| NULL |
+| NULL |
+| NULL |
++------+
+
+mysql> set session tidb_isolation_read_engines='tiflash';select * from test.t where a is not NULL;
+
+mysql> drop table if exists test.t;
+
+mysql> create table test.t (a date);
+
+mysql> insert into test.t values('2024-08-21'),('2024-08-22'),('2024-08-23'),('2024-08-24'),(NULL);
+
+mysql> alter table test.t set tiflash replica 1;
+
+func> wait_table test t
+
+mysql> alter table test.t compact tiflash replica;
+
+mysql> set session tidb_isolation_read_engines='tiflash';select * from test.t where a is NULL;
++------+
+| a    |
++------+
+| NULL |
++------+
+
+mysql> set session tidb_isolation_read_engines='tiflash';select * from test.t where a is not NULL;
++------------+
+| a          |
++------------+
+| 2024-08-21 |
+| 2024-08-22 |
+| 2024-08-23 |
+| 2024-08-24 |
++------------+

--- a/tests/fullstack-test-dt/expr/compare_null.test
+++ b/tests/fullstack-test-dt/expr/compare_null.test
@@ -1,0 +1,140 @@
+# Copyright 2023 PingCAP, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Must enable DT rough set filter and open debug level log to run this test, otherwise disable this test
+mysql> drop table if exists test.t;
+
+mysql> create table test.t (a datetime);
+
+mysql> insert into test.t values("2024-08-26"),("2024-08-25"),("2024-08-24"),("2024-08-23");
+
+mysql> alter table test.t set tiflash replica 1;
+
+func> wait_table test t
+
+mysql> alter table test.t compact tiflash replica;
+
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a between NULL and '2024-08-25';
+
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where not (a between NULL and '2024-08-25');
++---------------------+
+| a                   |
++---------------------+
+| 2024-08-26 00:00:00 |
++---------------------+
+
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a in (NULL);
+
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a not in (NULL);
+
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a in (NULL, "2024-08-26");
++---------------------+
+| a                   |
++---------------------+
+| 2024-08-26 00:00:00 |
++---------------------+
+
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a not in (NULL, "2024-08-26");
+
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a in (NULL, "2024-09-01");
+
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a not in (NULL, "2024-09-01");
+
+mysql> drop table if exists test.t;
+
+mysql> create table test.t (a datetime);
+
+mysql> insert into test.t values("2024-08-26"),("2024-08-26"),("2024-08-26"),("2024-08-26");
+
+mysql> alter table test.t set tiflash replica 1;
+
+func> wait_table test t
+
+mysql> alter table test.t compact tiflash replica;
+
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a in (NULL, "2024-08-26");
++---------------------+
+| a                   |
++---------------------+
+| 2024-08-26 00:00:00 |
+| 2024-08-26 00:00:00 |
+| 2024-08-26 00:00:00 |
+| 2024-08-26 00:00:00 |
++---------------------+
+
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a not in (NULL, "2024-08-26");
+
+# not null
+
+mysql> drop table if exists test.t;
+
+mysql> create table test.t (a datetime not null);
+
+mysql> insert into test.t values("2024-08-26"),("2024-08-25"),("2024-08-24"),("2024-08-23");
+
+mysql> alter table test.t set tiflash replica 1;
+
+func> wait_table test t
+
+mysql> alter table test.t compact tiflash replica;
+
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a between NULL and '2024-08-25';
+
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where not (a between NULL and '2024-08-25');
++---------------------+
+| a                   |
++---------------------+
+| 2024-08-26 00:00:00 |
++---------------------+
+
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a in (NULL);
+
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a not in (NULL);
+
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a in (NULL, "2024-08-26");
++---------------------+
+| a                   |
++---------------------+
+| 2024-08-26 00:00:00 |
++---------------------+
+
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a not in (NULL, "2024-08-26");
+
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a in (NULL, "2024-09-01");
+
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a not in (NULL, "2024-09-01");
+
+mysql> drop table if exists test.t;
+
+mysql> create table test.t (a datetime not null);
+
+mysql> insert into test.t values("2024-08-26"),("2024-08-26"),("2024-08-26"),("2024-08-26");
+
+mysql> alter table test.t set tiflash replica 1;
+
+func> wait_table test t
+
+mysql> alter table test.t compact tiflash replica;
+
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a in (NULL, "2024-08-26");
++---------------------+
+| a                   |
++---------------------+
+| 2024-08-26 00:00:00 |
+| 2024-08-26 00:00:00 |
+| 2024-08-26 00:00:00 |
+| 2024-08-26 00:00:00 |
++---------------------+
+
+mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a not in (NULL, "2024-08-26");

--- a/tests/fullstack-test-dt/expr/compare_null.test
+++ b/tests/fullstack-test-dt/expr/compare_null.test
@@ -15,7 +15,7 @@
 # Must enable DT rough set filter and open debug level log to run this test, otherwise disable this test
 mysql> drop table if exists test.t;
 
-mysql> create table test.t (a datetime);
+mysql> create table test.t (a date);
 
 mysql> insert into test.t values("2024-08-26"),("2024-08-25"),("2024-08-24"),("2024-08-23");
 
@@ -28,22 +28,22 @@ mysql> alter table test.t compact tiflash replica;
 mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a between NULL and '2024-08-25';
 
 mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where not (a between NULL and '2024-08-25');
-+---------------------+
-| a                   |
-+---------------------+
-| 2024-08-26 00:00:00 |
-+---------------------+
++------------+
+| a          |
++------------+
+| 2024-08-26 |
++------------+
 
 mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a in (NULL);
 
 mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a not in (NULL);
 
 mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a in (NULL, "2024-08-26");
-+---------------------+
-| a                   |
-+---------------------+
-| 2024-08-26 00:00:00 |
-+---------------------+
++------------+
+| a          |
++------------+
+| 2024-08-26 |
++------------+
 
 mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a not in (NULL, "2024-08-26");
 
@@ -53,7 +53,7 @@ mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t w
 
 mysql> drop table if exists test.t;
 
-mysql> create table test.t (a datetime);
+mysql> create table test.t (a date);
 
 mysql> insert into test.t values("2024-08-26"),("2024-08-26"),("2024-08-26"),("2024-08-26");
 
@@ -64,14 +64,14 @@ func> wait_table test t
 mysql> alter table test.t compact tiflash replica;
 
 mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a in (NULL, "2024-08-26");
-+---------------------+
-| a                   |
-+---------------------+
-| 2024-08-26 00:00:00 |
-| 2024-08-26 00:00:00 |
-| 2024-08-26 00:00:00 |
-| 2024-08-26 00:00:00 |
-+---------------------+
++------------+
+| a          |
++------------+
+| 2024-08-26 |
+| 2024-08-26 |
+| 2024-08-26 |
+| 2024-08-26 |
++------------+
 
 mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a not in (NULL, "2024-08-26");
 
@@ -79,7 +79,7 @@ mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t w
 
 mysql> drop table if exists test.t;
 
-mysql> create table test.t (a datetime not null);
+mysql> create table test.t (a date not null);
 
 mysql> insert into test.t values("2024-08-26"),("2024-08-25"),("2024-08-24"),("2024-08-23");
 
@@ -92,22 +92,22 @@ mysql> alter table test.t compact tiflash replica;
 mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a between NULL and '2024-08-25';
 
 mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where not (a between NULL and '2024-08-25');
-+---------------------+
-| a                   |
-+---------------------+
-| 2024-08-26 00:00:00 |
-+---------------------+
++------------+
+| a          |
++------------+
+| 2024-08-26 |
++------------+
 
 mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a in (NULL);
 
 mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a not in (NULL);
 
 mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a in (NULL, "2024-08-26");
-+---------------------+
-| a                   |
-+---------------------+
-| 2024-08-26 00:00:00 |
-+---------------------+
++------------+
+| a          |
++------------+
+| 2024-08-26 |
++------------+
 
 mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a not in (NULL, "2024-08-26");
 
@@ -117,7 +117,7 @@ mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t w
 
 mysql> drop table if exists test.t;
 
-mysql> create table test.t (a datetime not null);
+mysql> create table test.t (a date not null);
 
 mysql> insert into test.t values("2024-08-26"),("2024-08-26"),("2024-08-26"),("2024-08-26");
 
@@ -128,13 +128,13 @@ func> wait_table test t
 mysql> alter table test.t compact tiflash replica;
 
 mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a in (NULL, "2024-08-26");
-+---------------------+
-| a                   |
-+---------------------+
-| 2024-08-26 00:00:00 |
-| 2024-08-26 00:00:00 |
-| 2024-08-26 00:00:00 |
-| 2024-08-26 00:00:00 |
-+---------------------+
++------------+
+| a          |
++------------+
+| 2024-08-26 |
+| 2024-08-26 |
+| 2024-08-26 |
+| 2024-08-26 |
++------------+
 
 mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t where a not in (NULL, "2024-08-26");

--- a/tests/fullstack-test-dt/expr/compare_null.test
+++ b/tests/fullstack-test-dt/expr/compare_null.test
@@ -216,3 +216,39 @@ mysql> set session tidb_isolation_read_engines='tiflash';select * from test.t wh
 | 2024-08-23 |
 | 2024-08-24 |
 +------------+
+
+mysql> drop table if exists test.t;
+
+mysql> create table test.t (a date, b int);
+
+mysql> insert into test.t values('2024-08-21', 1),('2024-08-22', 2),('2024-08-23', 3),('2024-08-24', 4), (NULL, 5);
+
+mysql> insert into test.t values('2024-08-21', 6),('2024-08-22', 7),('2024-08-23', 8),('2024-08-24', 9), (NULL, 10);
+
+mysql> alter table test.t set tiflash replica 1;
+
+func> wait_table test t
+
+mysql> alter table test.t compact tiflash replica;
+
+mysql> set session tidb_isolation_read_engines='tiflash'; select sum(b) from test.t group by a order by a desc;
++------------+--------+
+| a          | sum(b) |
++------------+--------+
+| 2024-08-24 |     13 |
+| 2024-08-23 |     11 |
+| 2024-08-22 |      9 |
+| 2024-08-21 |      7 |
+| NULL       |     15 |
++------------+--------+
+
+mysql> set session tidb_isolation_read_engines='tiflash'; select sum(b) from test.t group by a order by a desc;
++------------+--------+
+| a          | sum(b) |
++------------+--------+
+| NULL       |     15 |
+| 2024-08-21 |      7 |
+| 2024-08-22 |      9 |
+| 2024-08-23 |     11 |
+| 2024-08-24 |     13 |
++------------+--------+


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9374

Problem Summary:

The filter of `select * from test.t where not (a between NULL and '2024-08-25')` will be transformed in TiFlash as `not (a between NULL and '2024-08-25')` => `not (a >= NULL and a <= '2024-08-25')` => `a < NULL or a > '2024-08-25'`.

The problem is how `RSOperator` and `MinMaxIndex` handle `a < NULL`. 

As the code below, `Less` will be transformed into `not GreaterEqual`:
https://github.com/pingcap/tiflash/blob/81cd94782a912d3a61e38b7ebc5c2cfabe5694e9/dbms/src/Storages/DeltaMerge/Filter/Less.h#L32-L37

`MinMaxIndex` execute `GreaterEqual` and the result for comparing with `NULL` is `RSResult::None`.
https://github.com/pingcap/tiflash/blob/81cd94782a912d3a61e38b7ebc5c2cfabe5694e9/dbms/src/Storages/DeltaMerge/Index/MinMaxIndex.cpp#L422-L426

`not RSResult::None` equals to `RSResult::All`. And PR https://github.com/pingcap/tiflash/pull/9361 will skip filter if the filter result of a Block is `RSResult::All`.

**The root cause is that the result of comparing any value with null is null, returning `RSResult::None` is incorrect.**

### What is changed and how it works?

```commit-message
In `MinMaxIndex`, if the input value is null, return `RSResult::NoneNull`.
```

Handling null input value, in `checkCmp`: https://github.com/pingcap/tiflash/blob/81cd94782a912d3a61e38b7ebc5c2cfabe5694e9/dbms/src/Storages/DeltaMerge/Index/MinMaxIndex.cpp#L422-L426

Handling null input value, in `checkIn`: https://github.com/pingcap/tiflash/blob/81cd94782a912d3a61e38b7ebc5c2cfabe5694e9/dbms/src/Storages/DeltaMerge/Index/RoughCheck.h#L76-L78



For some filters like `checkCmp(null)`, the result is `RSResult::NoneNull` and the block can be skipped.
For some filters like `not checkCmp(null)`, the result is `RSResult::AllNull` and the block will be read and filtered.

In fact, the result `checkCmp(null)` and `not checkCmp(null)`  should always be null. Maybe we can extend `RSResult` to support this. However, **comparing(>, <, >=, <=, ==, !=, in) with null is not a normal operation in MySQL. So just let it fallback to `FilterTransforamAction` if neccessary**. 


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
