### PR TITLE
Disagg: Wait tasks in thread pool finished before return

### DIFF
--- a/dbms/src/IO/IOThreadPools.h
+++ b/dbms/src/IO/IOThreadPools.h
@@ -19,9 +19,8 @@
 namespace DB
 {
 
-namespace io_pool_details
+namespace IOPoolHelper
 {
-
 struct S3FileCacheTrait
 {
 };
@@ -47,19 +46,69 @@ struct BuildReadTaskForWNTableTrait
 struct BuildReadTaskTrait
 {
 };
-} // namespace io_pool_details
+
+// FutureContainer will wait for all futures finished automatically.
+class FutureContainer
+{
+public:
+    FutureContainer(const LoggerPtr & log_, size_t reserve_size = 0)
+        : log(log_)
+    {
+        futures.reserve(reserve_size);
+    }
+
+    ~FutureContainer() { waitFinish(); }
+
+    void add(std::future<void> && f) { futures.push_back(std::move(f)); }
+
+    // Get the results of all futures.
+    // If exceptions happened, rethrow the first exception.
+    void getAllResults()
+    {
+        std::exception_ptr first_exception;
+        for (auto & f : futures)
+        {
+            try
+            {
+                f.get();
+            }
+            catch (...)
+            {
+                if (!first_exception)
+                    first_exception = std::current_exception();
+                tryLogCurrentException(log);
+            }
+        }
+
+        if (first_exception)
+            std::rethrow_exception(first_exception);
+    }
+
+private:
+    // Just wait futures finished. Don't care about the results.
+    void waitFinish()
+    {
+        for (auto & f : futures)
+            if (f.valid())
+                f.wait();
+    }
+    std::vector<std::future<void>> futures;
+    LoggerPtr log;
+};
+
+} // namespace IOPoolHelper
 
 // TODO: Move these out.
-using DataStoreS3Pool = IOThreadPool<io_pool_details::DataStoreS3Trait>;
-using S3FileCachePool = IOThreadPool<io_pool_details::S3FileCacheTrait>;
-using RNWritePageCachePool = IOThreadPool<io_pool_details::RNWritePageCacheTrait>;
-using WNEstablishDisaggTaskPool = IOThreadPool<io_pool_details::WNEstablishDisaggTaskTrait>;
+using DataStoreS3Pool = IOThreadPool<IOPoolHelper::DataStoreS3Trait>;
+using S3FileCachePool = IOThreadPool<IOPoolHelper::S3FileCacheTrait>;
+using RNWritePageCachePool = IOThreadPool<IOPoolHelper::RNWritePageCacheTrait>;
+using WNEstablishDisaggTaskPool = IOThreadPool<IOPoolHelper::WNEstablishDisaggTaskTrait>;
 
 // The call chain is `buildReadTaskForWriteNode => buildReadTaskForWriteNodeTable => buildRNReadSegmentTask`.
 // Each of them will use the corresponding thread pool.
 // Cannot share one thread pool. Because in extreme cases, if the previous function exhausts all threads,
 // the subsequent functions will wait for idle threads, causing a deadlock.
-using BuildReadTaskForWNPool = IOThreadPool<io_pool_details::BuildReadTaskForWNTrait>;
-using BuildReadTaskForWNTablePool = IOThreadPool<io_pool_details::BuildReadTaskForWNTableTrait>;
-using BuildReadTaskPool = IOThreadPool<io_pool_details::BuildReadTaskTrait>;
+using BuildReadTaskForWNPool = IOThreadPool<IOPoolHelper::BuildReadTaskForWNTrait>;
+using BuildReadTaskForWNTablePool = IOThreadPool<IOPoolHelper::BuildReadTaskForWNTableTrait>;
+using BuildReadTaskPool = IOThreadPool<IOPoolHelper::BuildReadTaskTrait>;
 } // namespace DB

--- a/dbms/src/IO/tests/gtest_io_thread.cpp
+++ b/dbms/src/IO/tests/gtest_io_thread.cpp
@@ -1,0 +1,149 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#include <IO/IOThreadPools.h>
+#include <gtest/gtest.h>
+
+#include <exception>
+#include <ext/scope_guard.h>
+#include <future>
+#include <random>
+
+namespace DB::tests
+{
+namespace
+{
+using SPtr = std::shared_ptr<std::atomic<int>>;
+using WPtr = std::weak_ptr<std::atomic<int>>;
+
+void buildReadTasks(bool throw_in_build_read_tasks, bool throw_in_build_task, WPtr wp, SPtr invalid_count)
+{
+    auto async_build_read_task = [=]() {
+        return BuildReadTaskPool::get().scheduleWithFuture([=]() {
+            std::random_device rd;
+            std::mt19937 gen(rd());
+            auto sleep_ms = gen() % 100 + 1; // 1~100
+            std::this_thread::sleep_for(std::chrono::milliseconds(sleep_ms));
+
+            if (auto sp = wp.lock(); sp)
+                sp->fetch_add(1);
+            else
+                invalid_count->fetch_add(1);
+
+            if (throw_in_build_task)
+                throw Exception("From build_read_task");
+        });
+    };
+
+    IOPoolHelper::FutureContainer futures(Logger::get("buildReadTasks"));
+    for (int i = 0; i < 10; i++)
+    {
+        futures.add(async_build_read_task());
+        if (i >= 5 && throw_in_build_read_tasks)
+            throw Exception("From buildReadTasks");
+    }
+    futures.getAllResults();
+}
+
+void buildReadTasksForTables(
+    bool throw_in_build_read_tasks_for_tables,
+    bool throw_in_build_read_tasks,
+    bool throw_in_build_task,
+    WPtr wp,
+    SPtr invalid_count)
+{
+    auto async_build_read_tasks_for_table = [=]() {
+        return BuildReadTaskForWNTablePool::get().scheduleWithFuture(
+            [=]() { buildReadTasks(throw_in_build_read_tasks, throw_in_build_task, wp, invalid_count); });
+    };
+
+    IOPoolHelper::FutureContainer futures(Logger::get("buildReadTasksForTables"));
+    for (int i = 0; i < 10; i++)
+    {
+        futures.add(async_build_read_tasks_for_table());
+        if (i >= 5 && throw_in_build_read_tasks_for_tables)
+            throw Exception("From buildReadTasksForTables");
+    }
+    futures.getAllResults();
+}
+
+void buildReadTasksForWNs(
+    bool throw_in_build_read_tasks_for_wns,
+    bool throw_in_build_read_tasks_for_tables,
+    bool throw_in_build_read_tasks,
+    bool throw_in_build_task)
+{
+    auto log = Logger::get("buildReadTasksForWNs");
+    LOG_INFO(
+        log,
+        "throw_in_build_read_tasks_for_wns={}, "
+        "throw_in_build_read_tasks_for_tables={}, throw_in_build_read_tasks={}, throw_in_build_task={}",
+        throw_in_build_read_tasks_for_wns,
+        throw_in_build_read_tasks_for_tables,
+        throw_in_build_read_tasks,
+        throw_in_build_task);
+    auto sp = std::make_shared<std::atomic<int>>(0);
+    auto invalid_count = std::make_shared<std::atomic<int>>(0);
+    // Use weak_ptr to simulate capture by reference.
+    auto async_build_tasks_for_wn = [wp = WPtr{sp},
+                                     invalid_count,
+                                     throw_in_build_read_tasks_for_tables,
+                                     throw_in_build_read_tasks,
+                                     throw_in_build_task]() {
+        return BuildReadTaskForWNPool::get().scheduleWithFuture([=]() {
+            buildReadTasksForTables(
+                throw_in_build_read_tasks_for_tables,
+                throw_in_build_read_tasks,
+                throw_in_build_task,
+                wp,
+                invalid_count);
+        });
+    };
+
+    try
+    {
+        IOPoolHelper::FutureContainer futures(log);
+        SCOPE_EXIT({
+            if (!throw_in_build_read_tasks_for_wns && !throw_in_build_read_tasks_for_tables
+                && !throw_in_build_read_tasks)
+                ASSERT_EQ(*sp, 10 * 10 * 10);
+            ASSERT_EQ(*invalid_count, 0);
+        });
+        for (int i = 0; i < 10; i++)
+        {
+            futures.add(async_build_tasks_for_wn());
+            if (i >= 5 && throw_in_build_read_tasks_for_wns)
+                throw Exception("From buildReadTasksForWNs");
+        }
+        futures.getAllResults();
+    }
+    catch (...)
+    {
+        tryLogCurrentException(log);
+    }
+}
+} // namespace
+
+TEST(IOThreadPool, TaskChain)
+{
+    constexpr std::array<bool, 2> arr{false, true};
+    for (auto a : arr)
+        for (auto b : arr)
+            for (auto c : arr)
+                for (auto d : arr)
+                    buildReadTasksForWNs(a, b, c, d);
+}
+
+} // namespace DB::tests


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #9378

Problem Summary:

If exception thrown in building read tasks, exception will propagate by the future object, and the request will abort immediately. 
https://github.com/pingcap/tiflash/blob/9afd0b2d83b19af8900576b7c9b11dc6555b1af5/dbms/src/Storages/StorageDisaggregatedRemote.cpp#L102-L106


However, there are many tasks running in the thread pool and these task has caught many local variables by reference. If the request aborted before these tasks finished, these reference will be dangling.

### What is changed and how it works?

Wait the tasks in the thread pool finished before return like before https://github.com/pingcap/tiflash/blob/e6fc04addfedf88c77403760e9bea2049648c008/dbms/src/Storages/StorageDisaggregatedRemote.cpp#L223-L225

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
