### PR TITLE
unittest: Fix ASAN reports of SkippableBlockInputStreamTest

### DIFF
--- a/dbms/src/Storages/DeltaMerge/tests/gtest_skippable_block_input_stream.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_skippable_block_input_stream.cpp
@@ -91,6 +91,7 @@ protected:
     static constexpr auto SEG_ID = DELTA_MERGE_FIRST_SEGMENT_ID;
     RowKeyRanges read_ranges;
 
+    String default_filter_column_name;
 
     SkippableBlockInputStreamPtr getInputStream(
         const SegmentPtr & segment,
@@ -247,7 +248,7 @@ protected:
         }
         auto late_materialization_stream = std::make_shared<LateMaterializationBlockInputStream>(
             columns_to_read,
-            "",
+            default_filter_column_name,
             filter_cloumn_stream,
             rest_column_stream,
             bitmap_filter,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6233

Problem Summary:
https://ci.pingcap.net/blue/rest/organizations/jenkins/pipelines/tiflash-sanitizer-daily/runs/2109/nodes/86/log/?start=0

```
[2024-08-28T19:08:47.150Z] ==232506==ERROR: AddressSanitizer: stack-use-after-return on address 0x7f08686ea920 at pc 0x5651201f34d0 bp 0x7ffc3b905590 sp 0x7ffc3b905588
[2024-08-28T19:08:47.150Z] READ of size 1 at 0x7f08686ea920 thread T0
[2024-08-28T19:08:47.150Z]     #0 0x5651201f34cf in std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::__is_long[abi:ue170006]() const /usr/local/bin/../include/c++/v1/string:1734:33
[2024-08-28T19:08:47.150Z]     #1 0x5651201f34cf in std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::size[abi:ue170006]() const /usr/local/bin/../include/c++/v1/string:1168:17
[2024-08-28T19:08:47.150Z]     #2 0x5651201f34cf in bool std::__1::operator==[abi:ue170006]<std::__1::allocator<char>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) /usr/local/bin/../include/c++/v1/string:3898:27
[2024-08-28T19:08:47.150Z]     #3 0x5651201f34cf in DB::DM::LateMaterializationBlockInputStream::read() /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/dbms/src/Storages/DeltaMerge/LateMaterializationBlockInputStream.cpp:133:34
[2024-08-28T19:08:47.150Z]     #4 0x5651109fcfdf in DB::DM::tests::SkippableBlockInputStreamTest::testLateMaterializationCase(std::__1::basic_string_view<char, std::__1::char_traits<char>>) /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/dbms/src/Storages/DeltaMerge/tests/gtest_skippable_block_input_stream.cpp:261:54
[2024-08-28T19:08:47.150Z]     #5 0x5651109e1520 in DB::DM::tests::SkippableBlockInputStreamTest_InMemory1_Test::TestBody() /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/dbms/src/Storages/DeltaMerge/tests/gtest_skippable_block_input_stream.cpp:338:5
[2024-08-28T19:08:47.150Z]     #6 0x565120e139f1 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/contrib/googletest/googletest/src/gtest.cc:2443:10
[2024-08-28T19:08:47.150Z]     #7 0x565120e139f1 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/contrib/googletest/googletest/src/gtest.cc:2479:14
[2024-08-28T19:08:47.150Z]     #8 0x565120db4035 in testing::Test::Run() /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/contrib/googletest/googletest/src/gtest.cc:2517:5
[2024-08-28T19:08:47.150Z]     #9 0x565120db759a in testing::TestInfo::Run() /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/contrib/googletest/googletest/src/gtest.cc:2693:11
[2024-08-28T19:08:47.150Z]     #10 0x565120db8c4f in testing::TestCase::Run() /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/contrib/googletest/googletest/src/gtest.cc:2811:28
[2024-08-28T19:08:47.150Z]     #11 0x565120de414a in testing::internal::UnitTestImpl::RunAllTests() /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/contrib/googletest/googletest/src/gtest.cc:5177:43
[2024-08-28T19:08:47.150Z]     #12 0x565120e16131 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/contrib/googletest/googletest/src/gtest.cc:2443:10
[2024-08-28T19:08:47.150Z]     #13 0x565120e16131 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/contrib/googletest/googletest/src/gtest.cc:2479:14
[2024-08-28T19:08:47.150Z]     #14 0x565120de33e6 in testing::UnitTest::Run() /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/contrib/googletest/googletest/src/gtest.cc:4786:10
[2024-08-28T19:08:47.150Z]     #15 0x565111c87a41 in RUN_ALL_TESTS() /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/contrib/googletest/googletest/include/gtest/gtest.h:2341:46
[2024-08-28T19:08:47.150Z]     #16 0x565111c87a41 in main /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/dbms/src/TestUtils/gtests_dbms_main.cpp:116:16
[2024-08-28T19:08:47.150Z]     #17 0x7f086a61c554 in __libc_start_main (/lib64/libc.so.6+0x22554) (BuildId: 9470e279388f7f9cb2ed3b2872d0c2095b191ff4)
[2024-08-28T19:08:47.150Z]     #18 0x565108e6f528 in _start (/tiflash/gtests_dbms+0x69ef528)
[2024-08-28T19:08:47.150Z] 
[2024-08-28T19:08:47.150Z] Address 0x7f08686ea920 is located in stack of thread T0 at offset 32 in frame
[2024-08-28T19:08:47.150Z]     #0 0x565128872c5f in DB::FieldVisitorDump::operator()(long const&) const /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/dbms/src/Common/FieldVisitors.cpp:63
[2024-08-28T19:08:47.150Z] 
[2024-08-28T19:08:47.150Z]   This frame has 1 object(s):
[2024-08-28T19:08:47.150Z]     [32, 128) 'wb.i' (line 47) <== Memory access at offset 32 is inside this variable
[2024-08-28T19:08:47.150Z] HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
[2024-08-28T19:08:47.150Z]       (longjmp and C++ exceptions *are* supported)
[2024-08-28T19:08:47.150Z] SUMMARY: AddressSanitizer: stack-use-after-return /usr/local/bin/../include/c++/v1/string:1734:33 in std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::__is_long[abi:ue170006]() const
[2024-08-28T19:08:47.150Z] Shadow bytes around the buggy address:
[2024-08-28T19:08:47.150Z]   0x7f08686ea680: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
[2024-08-28T19:08:47.150Z]   0x7f08686ea700: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
[2024-08-28T19:08:47.150Z]   0x7f08686ea780: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
[2024-08-28T19:08:47.150Z]   0x7f08686ea800: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
[2024-08-28T19:08:47.150Z]   0x7f08686ea880: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
[2024-08-28T19:08:47.150Z] =>0x7f08686ea900: f5 f5 f5 f5[f5]f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
[2024-08-28T19:08:47.150Z]   0x7f08686ea980: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
[2024-08-28T19:08:47.150Z]   0x7f08686eaa00: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
[2024-08-28T19:08:47.150Z]   0x7f08686eaa80: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
[2024-08-28T19:08:47.150Z]   0x7f08686eab00: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
[2024-08-28T19:08:47.150Z]   0x7f08686eab80: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
[2024-08-28T19:08:47.150Z] Shadow byte legend (one shadow byte represents 8 application bytes):
[2024-08-28T19:08:47.150Z]   Addressable:           00
[2024-08-28T19:08:47.150Z]   Partially addressable: 01 02 03 04 05 06 07
[2024-08-28T19:08:47.150Z]   Heap left redzone:       fa
[2024-08-28T19:08:47.150Z]   Freed heap region:       fd
[2024-08-28T19:08:47.150Z]   Stack left redzone:      f1
[2024-08-28T19:08:47.150Z]   Stack mid redzone:       f2
[2024-08-28T19:08:47.150Z]   Stack right redzone:     f3
[2024-08-28T19:08:47.150Z]   Stack after return:      f5
[2024-08-28T19:08:47.150Z]   Stack use after scope:   f8
[2024-08-28T19:08:47.150Z]   Global redzone:          f9
[2024-08-28T19:08:47.150Z]   Global init order:       f6
[2024-08-28T19:08:47.150Z]   Poisoned by user:        f7
[2024-08-28T19:08:47.150Z]   Container overflow:      fc
[2024-08-28T19:08:47.150Z]   Array cookie:            ac
[2024-08-28T19:08:47.150Z]   Intra object redzone:    bb
[2024-08-28T19:08:47.150Z]   ASan internal:           fe
[2024-08-28T19:08:47.150Z]   Left alloca redzone:     ca
[2024-08-28T19:08:47.150Z]   Right alloca redzone:    cb
[2024-08-28T19:08:47.150Z] ==232506==ABORTING
```

### What is changed and how it works?

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
