### PR TITLE
Disagg: Set the waiting time for thread pool.

### DIFF
--- a/dbms/src/Common/UniThreadPool.cpp
+++ b/dbms/src/Common/UniThreadPool.cpp
@@ -90,6 +90,13 @@ void ThreadPoolImpl<Thread>::setQueueSize(size_t value)
     jobs.reserve(queue_size);
 }
 
+template <typename Thread>
+size_t ThreadPoolImpl<Thread>::getQueueSize() const
+{
+    std::lock_guard lock(mutex);
+    return queue_size;
+}
+
 
 template <typename Thread>
 template <typename ReturnType>
@@ -202,7 +209,7 @@ template <typename Thread>
 std::future<void> ThreadPoolImpl<Thread>::scheduleWithFuture(Job job, uint64_t wait_timeout_us)
 {
     auto task = std::make_shared<std::packaged_task<void()>>(std::move(job));
-    scheduleOrThrow([task]() { (*task)(); }, 0, wait_timeout_us);
+    scheduleImpl<void>([task]() { (*task)(); }, /*priority*/ 0, wait_timeout_us);
     return task->get_future();
 }
 

--- a/dbms/src/Common/UniThreadPool.h
+++ b/dbms/src/Common/UniThreadPool.h
@@ -74,16 +74,19 @@ public:
     void scheduleOrThrowOnError(Job job, ssize_t priority = 0);
 
     /// Similar to scheduleOrThrowOnError(...). Wait for specified amount of time and schedule a job or return false.
+    /// If wait_microseconds is zero, it means never wait.
     bool trySchedule(Job job, ssize_t priority = 0, uint64_t wait_microseconds = 0) noexcept;
 
     /// Similar to scheduleOrThrowOnError(...). Wait for specified amount of time and schedule a job or throw an exception.
+    /// If wait_microseconds is zero, it means never wait.
     void scheduleOrThrow(
         Job job,
         ssize_t priority = 0,
         uint64_t wait_microseconds = 0,
         bool propagate_opentelemetry_tracing_context = true);
 
-    /// Wrap job with std::packaged_task<void> and returns a std::future<void> object to check result of the job.
+    /// Wrap job with std::packaged_task<void> and returns a std::future<void> object to check if the task has finished or thrown an exception.
+    /// If wait_microseconds is zero, it means never wait.
     std::future<void> scheduleWithFuture(Job job, uint64_t wait_timeout_us = 0);
 
     /// Wait for all currently active jobs to be done.
@@ -107,6 +110,7 @@ public:
     void setMaxFreeThreads(size_t value);
     void setQueueSize(size_t value);
     size_t getMaxThreads() const;
+    size_t getQueueSize() const;
 
     std::unique_ptr<ThreadPoolWaitGroup<Thread>> waitGroup()
     {

--- a/dbms/src/Storages/StorageDisaggregated.h
+++ b/dbms/src/Storages/StorageDisaggregated.h
@@ -143,6 +143,9 @@ private:
         DAGExpressionAnalyzer & analyzer);
     tipb::Executor buildTableScanTiPB();
 
+    size_t getBuildTaskRPCTimeout() const;
+    size_t getBuildTaskIOThreadPoolTimeout() const;
+
 private:
     Context & context;
     const TiDBTableScan & table_scan;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9392 

Problem Summary:

The default `wait_microseconds` is 0, which means never wait.

### What is changed and how it works?

Set `wait_microseconds` to `disagg_build_task_timeout`.

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
