### PR TITLE
Fix TiFlash hang issue after #9072

### DIFF
--- a/dbms/src/Common/GRPCQueue.h
+++ b/dbms/src/Common/GRPCQueue.h
@@ -138,6 +138,7 @@ public:
     }
 
     bool isWritable() const { return send_queue.isWritable(); }
+    void triggerPipelineNotify() { send_queue.triggerPipelineNotify(); }
 
     void registerPipeReadTask(TaskPtr && task) { send_queue.registerPipeReadTask(std::move(task)); }
     void registerPipeWriteTask(TaskPtr && task) { send_queue.registerPipeWriteTask(std::move(task)); }
@@ -299,6 +300,7 @@ public:
     }
 
     bool isWritable() const { return recv_queue.isWritable(); }
+    void triggerPipelineNotify() { return recv_queue.triggerPipelineNotify(); }
 
     void registerPipeReadTask(TaskPtr && task) { recv_queue.registerPipeReadTask(std::move(task)); }
     void registerPipeWriteTask(TaskPtr && task) { recv_queue.registerPipeWriteTask(std::move(task)); }

--- a/dbms/src/Common/GRPCQueue.h
+++ b/dbms/src/Common/GRPCQueue.h
@@ -138,7 +138,7 @@ public:
     }
 
     bool isWritable() const { return send_queue.isWritable(); }
-    void triggerPipelineNotify() { send_queue.triggerPipelineNotify(); }
+    void triggerPipelineWriterNotify() { send_queue.triggerPipelineWriterNotify(); }
 
     void registerPipeReadTask(TaskPtr && task) { send_queue.registerPipeReadTask(std::move(task)); }
     void registerPipeWriteTask(TaskPtr && task) { send_queue.registerPipeWriteTask(std::move(task)); }
@@ -300,7 +300,7 @@ public:
     }
 
     bool isWritable() const { return recv_queue.isWritable(); }
-    void triggerPipelineNotify() { return recv_queue.triggerPipelineNotify(); }
+    void triggerPipelineWriterNotify() { return recv_queue.triggerPipelineWriterNotify(); }
 
     void registerPipeReadTask(TaskPtr && task) { recv_queue.registerPipeReadTask(std::move(task)); }
     void registerPipeWriteTask(TaskPtr && task) { recv_queue.registerPipeWriteTask(std::move(task)); }

--- a/dbms/src/Common/LooseBoundedMPMCQueue.h
+++ b/dbms/src/Common/LooseBoundedMPMCQueue.h
@@ -19,7 +19,6 @@
 
 #include <condition_variable>
 #include <deque>
-#include <mutex>
 
 namespace DB
 {
@@ -221,7 +220,7 @@ public:
         return !isFullWithoutLock();
     }
 
-    void triggerPipelineNotify()
+    void triggerPipelineWriterNotify()
     {
         auto should_notify = false;
         {

--- a/dbms/src/Flash/Coprocessor/DAGResponseWriter.h
+++ b/dbms/src/Flash/Coprocessor/DAGResponseWriter.h
@@ -43,12 +43,12 @@ public:
     void flush() 
     {
         if (!flushImpl()) {
-            triggerPipelineNotify();
+            triggerPipelineWriterNotify();
         }
     }
     // return true if flush is actually flush data
     virtual bool flushImpl() = 0;
-    virtual void triggerPipelineNotify() {}
+    virtual void triggerPipelineWriterNotify() = 0;
     virtual ~DAGResponseWriter() = default;
 
 protected:

--- a/dbms/src/Flash/Coprocessor/DAGResponseWriter.h
+++ b/dbms/src/Flash/Coprocessor/DAGResponseWriter.h
@@ -40,7 +40,15 @@ public:
     virtual WaitResult waitForWritable() const { throw Exception("Unsupport"); }
 
     /// flush cached blocks for batch writer
-    virtual void flush() = 0;
+    void flush() 
+    {
+        if (!flushImpl()) {
+            triggerPipelineNotify();
+        }
+    }
+    // return true if flush is actually flush data
+    virtual bool flushImpl() = 0;
+    virtual void triggerPipelineNotify() const {}
     virtual ~DAGResponseWriter() = default;
 
 protected:

--- a/dbms/src/Flash/Coprocessor/DAGResponseWriter.h
+++ b/dbms/src/Flash/Coprocessor/DAGResponseWriter.h
@@ -48,7 +48,7 @@ public:
     }
     // return true if flush is actually flush data
     virtual bool flushImpl() = 0;
-    virtual void triggerPipelineNotify() const {}
+    virtual void triggerPipelineNotify() {}
     virtual ~DAGResponseWriter() = default;
 
 protected:

--- a/dbms/src/Flash/Coprocessor/StreamWriter.h
+++ b/dbms/src/Flash/Coprocessor/StreamWriter.h
@@ -59,7 +59,7 @@ struct CopStreamWriter
             throw Exception("Failed to write resp");
     }
     static WaitResult waitForWritable() { throw Exception("Unsupport async write"); }
-    static void triggerPipelineNotify() {}
+    static void triggerPipelineWriterNotify() {}
 };
 
 struct BatchCopStreamWriter
@@ -84,7 +84,7 @@ struct BatchCopStreamWriter
             throw Exception("Failed to write resp");
     }
     static WaitResult waitForWritable() { throw Exception("Unsupport async write"); }
-    static void triggerPipelineNotify() {}
+    static void triggerPipelineWriterNotify() {}
 };
 
 using CopStreamWriterPtr = std::shared_ptr<CopStreamWriter>;

--- a/dbms/src/Flash/Coprocessor/StreamWriter.h
+++ b/dbms/src/Flash/Coprocessor/StreamWriter.h
@@ -59,6 +59,7 @@ struct CopStreamWriter
             throw Exception("Failed to write resp");
     }
     static WaitResult waitForWritable() { throw Exception("Unsupport async write"); }
+    static void triggerPipelineNotify() {}
 };
 
 struct BatchCopStreamWriter
@@ -83,6 +84,7 @@ struct BatchCopStreamWriter
             throw Exception("Failed to write resp");
     }
     static WaitResult waitForWritable() { throw Exception("Unsupport async write"); }
+    static void triggerPipelineNotify() {}
 };
 
 using CopStreamWriterPtr = std::shared_ptr<CopStreamWriter>;

--- a/dbms/src/Flash/Coprocessor/StreamingDAGResponseWriter.cpp
+++ b/dbms/src/Flash/Coprocessor/StreamingDAGResponseWriter.cpp
@@ -78,7 +78,7 @@ WaitResult StreamingDAGResponseWriter<StreamWriterPtr>::waitForWritable() const
 }
 
 template <class StreamWriterPtr>
-void StreamingDAGResponseWriter<StreamWriterPtr>::triggerPipelineNotify() const
+void StreamingDAGResponseWriter<StreamWriterPtr>::triggerPipelineNotify()
 {
     return writer->triggerPipelineNotify();
 }

--- a/dbms/src/Flash/Coprocessor/StreamingDAGResponseWriter.cpp
+++ b/dbms/src/Flash/Coprocessor/StreamingDAGResponseWriter.cpp
@@ -78,6 +78,12 @@ WaitResult StreamingDAGResponseWriter<StreamWriterPtr>::waitForWritable() const
 }
 
 template <class StreamWriterPtr>
+void StreamingDAGResponseWriter<StreamWriterPtr>::triggerPipelineNotify() const
+{
+    return writer->triggerPipelineNotify();
+}
+
+template <class StreamWriterPtr>
 void StreamingDAGResponseWriter<StreamWriterPtr>::write(const Block & block)
 {
     RUNTIME_CHECK_MSG(

--- a/dbms/src/Flash/Coprocessor/StreamingDAGResponseWriter.cpp
+++ b/dbms/src/Flash/Coprocessor/StreamingDAGResponseWriter.cpp
@@ -78,9 +78,9 @@ WaitResult StreamingDAGResponseWriter<StreamWriterPtr>::waitForWritable() const
 }
 
 template <class StreamWriterPtr>
-void StreamingDAGResponseWriter<StreamWriterPtr>::triggerPipelineNotify()
+void StreamingDAGResponseWriter<StreamWriterPtr>::triggerPipelineWriterNotify()
 {
-    return writer->triggerPipelineNotify();
+    return writer->triggerPipelineWriterNotify();
 }
 
 template <class StreamWriterPtr>

--- a/dbms/src/Flash/Coprocessor/StreamingDAGResponseWriter.cpp
+++ b/dbms/src/Flash/Coprocessor/StreamingDAGResponseWriter.cpp
@@ -61,10 +61,14 @@ StreamingDAGResponseWriter<StreamWriterPtr>::StreamingDAGResponseWriter(
 }
 
 template <class StreamWriterPtr>
-void StreamingDAGResponseWriter<StreamWriterPtr>::flush()
+bool StreamingDAGResponseWriter<StreamWriterPtr>::flushImpl()
 {
     if (rows_in_blocks > 0)
+    {
         encodeThenWriteBlocks();
+        return true;
+    }
+    return false;
 }
 
 template <class StreamWriterPtr>
@@ -93,8 +97,7 @@ void StreamingDAGResponseWriter<StreamWriterPtr>::write(const Block & block)
 template <class StreamWriterPtr>
 void StreamingDAGResponseWriter<StreamWriterPtr>::encodeThenWriteBlocks()
 {
-    if (unlikely(blocks.empty()))
-        return;
+    assert(!blocks.empty());
 
     TrackedSelectResp response;
     response.setEncodeType(dag_context.encode_type);

--- a/dbms/src/Flash/Coprocessor/StreamingDAGResponseWriter.cpp
+++ b/dbms/src/Flash/Coprocessor/StreamingDAGResponseWriter.cpp
@@ -61,7 +61,7 @@ StreamingDAGResponseWriter<StreamWriterPtr>::StreamingDAGResponseWriter(
 }
 
 template <class StreamWriterPtr>
-bool StreamingDAGResponseWriter<StreamWriterPtr>::flushImpl()
+bool StreamingDAGResponseWriter<StreamWriterPtr>::doFlush()
 {
     if (rows_in_blocks > 0)
     {
@@ -84,7 +84,7 @@ void StreamingDAGResponseWriter<StreamWriterPtr>::triggerPipelineWriterNotify()
 }
 
 template <class StreamWriterPtr>
-void StreamingDAGResponseWriter<StreamWriterPtr>::write(const Block & block)
+bool StreamingDAGResponseWriter<StreamWriterPtr>::doWrite(const Block & block)
 {
     RUNTIME_CHECK_MSG(
         block.columns() == dag_context.result_field_types.size(),
@@ -97,7 +97,11 @@ void StreamingDAGResponseWriter<StreamWriterPtr>::write(const Block & block)
     }
 
     if (static_cast<Int64>(rows_in_blocks) > batch_send_min_limit)
+    {
         encodeThenWriteBlocks();
+        return true;
+    }
+    return false;
 }
 
 template <class StreamWriterPtr>

--- a/dbms/src/Flash/Coprocessor/StreamingDAGResponseWriter.h
+++ b/dbms/src/Flash/Coprocessor/StreamingDAGResponseWriter.h
@@ -39,7 +39,7 @@ public:
     void write(const Block & block) override;
     WaitResult waitForWritable() const override;
     bool flushImpl() override;
-    void triggerPipelineNotify() override;
+    void triggerPipelineWriterNotify() override;
 
 private:
     void encodeThenWriteBlocks();

--- a/dbms/src/Flash/Coprocessor/StreamingDAGResponseWriter.h
+++ b/dbms/src/Flash/Coprocessor/StreamingDAGResponseWriter.h
@@ -39,6 +39,7 @@ public:
     void write(const Block & block) override;
     WaitResult waitForWritable() const override;
     bool flushImpl() override;
+    void triggerPipelineNotify() override;
 
 private:
     void encodeThenWriteBlocks();

--- a/dbms/src/Flash/Coprocessor/StreamingDAGResponseWriter.h
+++ b/dbms/src/Flash/Coprocessor/StreamingDAGResponseWriter.h
@@ -36,9 +36,9 @@ public:
         Int64 records_per_chunk_,
         Int64 batch_send_min_limit_,
         DAGContext & dag_context_);
-    void write(const Block & block) override;
+    bool doWrite(const Block & block) override;
     WaitResult waitForWritable() const override;
-    bool flushImpl() override;
+    bool doFlush() override;
     void triggerPipelineWriterNotify() override;
 
 private:

--- a/dbms/src/Flash/Coprocessor/StreamingDAGResponseWriter.h
+++ b/dbms/src/Flash/Coprocessor/StreamingDAGResponseWriter.h
@@ -38,7 +38,7 @@ public:
         DAGContext & dag_context_);
     void write(const Block & block) override;
     WaitResult waitForWritable() const override;
-    void flush() override;
+    bool flushImpl() override;
 
 private:
     void encodeThenWriteBlocks();

--- a/dbms/src/Flash/Coprocessor/UnaryDAGResponseWriter.cpp
+++ b/dbms/src/Flash/Coprocessor/UnaryDAGResponseWriter.cpp
@@ -71,7 +71,7 @@ void UnaryDAGResponseWriter::appendWarningsToDAGResponse()
     dag_response->set_warning_count(dag_context.getWarningCount());
 }
 
-bool UnaryDAGResponseWriter::flushImpl()
+bool UnaryDAGResponseWriter::doFlush()
 {
     if (current_records_num > 0)
     {
@@ -89,7 +89,7 @@ bool UnaryDAGResponseWriter::flushImpl()
     return true;
 }
 
-void UnaryDAGResponseWriter::write(const Block & block)
+bool UnaryDAGResponseWriter::doWrite(const Block & block)
 {
     if (block.columns() != dag_context.result_field_types.size())
         throw TiFlashException("Output column size mismatch with field type size", Errors::Coprocessor::Internal);
@@ -117,5 +117,6 @@ void UnaryDAGResponseWriter::write(const Block & block)
             row_index = upper;
         }
     }
+    return true;
 }
 } // namespace DB

--- a/dbms/src/Flash/Coprocessor/UnaryDAGResponseWriter.cpp
+++ b/dbms/src/Flash/Coprocessor/UnaryDAGResponseWriter.cpp
@@ -71,7 +71,7 @@ void UnaryDAGResponseWriter::appendWarningsToDAGResponse()
     dag_response->set_warning_count(dag_context.getWarningCount());
 }
 
-void UnaryDAGResponseWriter::flush()
+bool UnaryDAGResponseWriter::flushImpl()
 {
     if (current_records_num > 0)
     {
@@ -86,6 +86,7 @@ void UnaryDAGResponseWriter::flush()
         throw TiFlashException(
             "DAG response is too big, please check config about region size or region merge scheduler",
             Errors::Coprocessor::Internal);
+    return true;
 }
 
 void UnaryDAGResponseWriter::write(const Block & block)

--- a/dbms/src/Flash/Coprocessor/UnaryDAGResponseWriter.h
+++ b/dbms/src/Flash/Coprocessor/UnaryDAGResponseWriter.h
@@ -34,7 +34,7 @@ public:
     UnaryDAGResponseWriter(tipb::SelectResponse * response_, Int64 records_per_chunk_, DAGContext & dag_context_);
 
     void write(const Block & block) override;
-    void flush() override;
+    bool flushImpl() override;
     void encodeChunkToDAGResponse();
     void appendWarningsToDAGResponse();
 

--- a/dbms/src/Flash/Coprocessor/UnaryDAGResponseWriter.h
+++ b/dbms/src/Flash/Coprocessor/UnaryDAGResponseWriter.h
@@ -33,8 +33,8 @@ class UnaryDAGResponseWriter : public DAGResponseWriter
 public:
     UnaryDAGResponseWriter(tipb::SelectResponse * response_, Int64 records_per_chunk_, DAGContext & dag_context_);
 
-    void write(const Block & block) override;
-    bool flushImpl() override;
+    bool doWrite(const Block & block) override;
+    bool doFlush() override;
     void triggerPipelineWriterNotify() override {};
     void encodeChunkToDAGResponse();
     void appendWarningsToDAGResponse();

--- a/dbms/src/Flash/Coprocessor/UnaryDAGResponseWriter.h
+++ b/dbms/src/Flash/Coprocessor/UnaryDAGResponseWriter.h
@@ -35,6 +35,7 @@ public:
 
     void write(const Block & block) override;
     bool flushImpl() override;
+    void triggerPipelineWriterNotify() override {};
     void encodeChunkToDAGResponse();
     void appendWarningsToDAGResponse();
 

--- a/dbms/src/Flash/Coprocessor/tests/gtest_streaming_writer.cpp
+++ b/dbms/src/Flash/Coprocessor/tests/gtest_streaming_writer.cpp
@@ -94,6 +94,7 @@ struct MockStreamWriter
 
     void write(tipb::SelectResponse & response) { checker(response); }
     static WaitResult waitForWritable() { throw Exception("Unsupport async write"); }
+    static void triggerPipelineWriterNotify() {}
 
 private:
     MockStreamWriterChecker checker;
@@ -137,7 +138,7 @@ try
             batch_send_min_limit,
             *dag_context_ptr);
         for (const auto & block : blocks)
-            dag_writer->write(block);
+            dag_writer->doWrite(block);
         dag_writer->flush();
 
         // 4. Start to check write_report.

--- a/dbms/src/Flash/Coprocessor/tests/gtest_ti_remote_block_inputstream.cpp
+++ b/dbms/src/Flash/Coprocessor/tests/gtest_ti_remote_block_inputstream.cpp
@@ -148,6 +148,7 @@ struct MockWriter
     }
     static uint16_t getPartitionNum() { return 1; }
     static WaitResult waitForWritable() { throw Exception("Unsupport async write"); }
+    static void triggerPipelineWriterNotify() {}
 
     std::vector<tipb::FieldType> result_field_types;
 
@@ -352,7 +353,7 @@ public:
 
         // 2. encode all blocks
         for (const auto & block : source_blocks)
-            dag_writer->write(block);
+            dag_writer->doWrite(block);
         dag_writer->flush();
 
         // 3. send execution summary
@@ -378,7 +379,7 @@ public:
 
         // 2. encode all blocks
         for (const auto & block : source_blocks)
-            dag_writer->write(block);
+            dag_writer->doWrite(block);
         dag_writer->flush();
 
         // 3. send execution summary

--- a/dbms/src/Flash/Mpp/BroadcastOrPassThroughWriter.cpp
+++ b/dbms/src/Flash/Mpp/BroadcastOrPassThroughWriter.cpp
@@ -64,7 +64,7 @@ BroadcastOrPassThroughWriter<ExchangeWriterPtr>::BroadcastOrPassThroughWriter(
 }
 
 template <class ExchangeWriterPtr>
-bool BroadcastOrPassThroughWriter<ExchangeWriterPtr>::flushImpl()
+bool BroadcastOrPassThroughWriter<ExchangeWriterPtr>::doFlush()
 {
     if (rows_in_blocks > 0)
     {
@@ -87,7 +87,7 @@ void BroadcastOrPassThroughWriter<ExchangeWriterPtr>::triggerPipelineWriterNotif
 }
 
 template <class ExchangeWriterPtr>
-void BroadcastOrPassThroughWriter<ExchangeWriterPtr>::write(const Block & block)
+bool BroadcastOrPassThroughWriter<ExchangeWriterPtr>::doWrite(const Block & block)
 {
     RUNTIME_CHECK(!block.info.selective);
     RUNTIME_CHECK_MSG(
@@ -101,7 +101,11 @@ void BroadcastOrPassThroughWriter<ExchangeWriterPtr>::write(const Block & block)
     }
 
     if (static_cast<Int64>(rows_in_blocks) > batch_send_min_limit)
+    {
         writeBlocks();
+        return true;
+    }
+    return false;
 }
 
 template <class ExchangeWriterPtr>

--- a/dbms/src/Flash/Mpp/BroadcastOrPassThroughWriter.cpp
+++ b/dbms/src/Flash/Mpp/BroadcastOrPassThroughWriter.cpp
@@ -81,9 +81,9 @@ WaitResult BroadcastOrPassThroughWriter<ExchangeWriterPtr>::waitForWritable() co
 }
 
 template <class ExchangeWriterPtr>
-void BroadcastOrPassThroughWriter<ExchangeWriterPtr>::triggerPipelineNotify()
+void BroadcastOrPassThroughWriter<ExchangeWriterPtr>::triggerPipelineWriterNotify()
 {
-    writer->triggerPipelineNotify();
+    writer->triggerPipelineWriterNotify();
 }
 
 template <class ExchangeWriterPtr>

--- a/dbms/src/Flash/Mpp/BroadcastOrPassThroughWriter.cpp
+++ b/dbms/src/Flash/Mpp/BroadcastOrPassThroughWriter.cpp
@@ -64,10 +64,14 @@ BroadcastOrPassThroughWriter<ExchangeWriterPtr>::BroadcastOrPassThroughWriter(
 }
 
 template <class ExchangeWriterPtr>
-void BroadcastOrPassThroughWriter<ExchangeWriterPtr>::flush()
+bool BroadcastOrPassThroughWriter<ExchangeWriterPtr>::flushImpl()
 {
     if (rows_in_blocks > 0)
+    {
         writeBlocks();
+        return true;
+    }
+    return false;
 }
 
 template <class ExchangeWriterPtr>
@@ -97,8 +101,7 @@ void BroadcastOrPassThroughWriter<ExchangeWriterPtr>::write(const Block & block)
 template <class ExchangeWriterPtr>
 void BroadcastOrPassThroughWriter<ExchangeWriterPtr>::writeBlocks()
 {
-    if unlikely (blocks.empty())
-        return;
+    assert(!blocks.empty());
 
     // check schema
     if (!expected_types.empty())

--- a/dbms/src/Flash/Mpp/BroadcastOrPassThroughWriter.cpp
+++ b/dbms/src/Flash/Mpp/BroadcastOrPassThroughWriter.cpp
@@ -81,6 +81,12 @@ WaitResult BroadcastOrPassThroughWriter<ExchangeWriterPtr>::waitForWritable() co
 }
 
 template <class ExchangeWriterPtr>
+void BroadcastOrPassThroughWriter<ExchangeWriterPtr>::triggerPipelineNotify()
+{
+    writer->triggerPipelineNotify();
+}
+
+template <class ExchangeWriterPtr>
 void BroadcastOrPassThroughWriter<ExchangeWriterPtr>::write(const Block & block)
 {
     RUNTIME_CHECK(!block.info.selective);

--- a/dbms/src/Flash/Mpp/BroadcastOrPassThroughWriter.h
+++ b/dbms/src/Flash/Mpp/BroadcastOrPassThroughWriter.h
@@ -39,7 +39,7 @@ public:
     void write(const Block & block) override;
     WaitResult waitForWritable() const override;
     bool flushImpl() override;
-    void triggerPipelineNotify() override;
+    void triggerPipelineWriterNotify() override;
 
 private:
     void writeBlocks();

--- a/dbms/src/Flash/Mpp/BroadcastOrPassThroughWriter.h
+++ b/dbms/src/Flash/Mpp/BroadcastOrPassThroughWriter.h
@@ -39,6 +39,7 @@ public:
     void write(const Block & block) override;
     WaitResult waitForWritable() const override;
     bool flushImpl() override;
+    void triggerPipelineNotify() override;
 
 private:
     void writeBlocks();

--- a/dbms/src/Flash/Mpp/BroadcastOrPassThroughWriter.h
+++ b/dbms/src/Flash/Mpp/BroadcastOrPassThroughWriter.h
@@ -36,9 +36,9 @@ public:
         MPPDataPacketVersion data_codec_version_,
         tipb::CompressionMode compression_mode_,
         tipb::ExchangeType exchange_type_);
-    void write(const Block & block) override;
+    bool doWrite(const Block & block) override;
     WaitResult waitForWritable() const override;
-    bool flushImpl() override;
+    bool doFlush() override;
     void triggerPipelineWriterNotify() override;
 
 private:

--- a/dbms/src/Flash/Mpp/BroadcastOrPassThroughWriter.h
+++ b/dbms/src/Flash/Mpp/BroadcastOrPassThroughWriter.h
@@ -38,7 +38,7 @@ public:
         tipb::ExchangeType exchange_type_);
     void write(const Block & block) override;
     WaitResult waitForWritable() const override;
-    void flush() override;
+    bool flushImpl() override;
 
 private:
     void writeBlocks();

--- a/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.cpp
+++ b/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.cpp
@@ -101,9 +101,9 @@ bool FineGrainedShuffleWriter<ExchangeWriterPtr>::flushImpl()
 }
 
 template <class ExchangeWriterPtr>
-void FineGrainedShuffleWriter<ExchangeWriterPtr>::triggerPipelineNotify()
+void FineGrainedShuffleWriter<ExchangeWriterPtr>::triggerPipelineWriterNotify()
 {
-    writer->triggerPipelineNotify();
+    writer->triggerPipelineWriterNotify();
 }
 
 template <class ExchangeWriterPtr>

--- a/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.cpp
+++ b/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.cpp
@@ -90,10 +90,14 @@ void FineGrainedShuffleWriter<ExchangeWriterPtr>::prepare(const Block & sample_b
 }
 
 template <class ExchangeWriterPtr>
-void FineGrainedShuffleWriter<ExchangeWriterPtr>::flush()
+bool FineGrainedShuffleWriter<ExchangeWriterPtr>::flushImpl()
 {
     if (rows_in_blocks > 0)
+    {
         batchWriteFineGrainedShuffle();
+        return true;
+    }
+    return false;
 }
 
 template <class ExchangeWriterPtr>
@@ -148,8 +152,7 @@ template <class ExchangeWriterPtr>
 template <MPPDataPacketVersion version>
 void FineGrainedShuffleWriter<ExchangeWriterPtr>::batchWriteFineGrainedShuffleImpl()
 {
-    if (blocks.empty())
-        return;
+    assert(!blocks.empty());
 
     {
         assert(rows_in_blocks > 0);

--- a/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.cpp
+++ b/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.cpp
@@ -101,6 +101,12 @@ bool FineGrainedShuffleWriter<ExchangeWriterPtr>::flushImpl()
 }
 
 template <class ExchangeWriterPtr>
+void FineGrainedShuffleWriter<ExchangeWriterPtr>::triggerPipelineNotify()
+{
+    writer->triggerPipelineNotify();
+}
+
+template <class ExchangeWriterPtr>
 WaitResult FineGrainedShuffleWriter<ExchangeWriterPtr>::waitForWritable() const
 {
     return writer->waitForWritable();

--- a/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.cpp
+++ b/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.cpp
@@ -90,7 +90,7 @@ void FineGrainedShuffleWriter<ExchangeWriterPtr>::prepare(const Block & sample_b
 }
 
 template <class ExchangeWriterPtr>
-bool FineGrainedShuffleWriter<ExchangeWriterPtr>::flushImpl()
+bool FineGrainedShuffleWriter<ExchangeWriterPtr>::doFlush()
 {
     if (rows_in_blocks > 0)
     {
@@ -113,7 +113,7 @@ WaitResult FineGrainedShuffleWriter<ExchangeWriterPtr>::waitForWritable() const
 }
 
 template <class ExchangeWriterPtr>
-void FineGrainedShuffleWriter<ExchangeWriterPtr>::write(const Block & block)
+bool FineGrainedShuffleWriter<ExchangeWriterPtr>::doWrite(const Block & block)
 {
     RUNTIME_CHECK_MSG(prepared, "FineGrainedShuffleWriter should be prepared before writing.");
     RUNTIME_CHECK_MSG(
@@ -134,7 +134,11 @@ void FineGrainedShuffleWriter<ExchangeWriterPtr>::write(const Block & block)
 
     if (blocks.size() == fine_grained_shuffle_stream_count
         || static_cast<UInt64>(rows_in_blocks) >= batch_send_row_limit)
+    {
         batchWriteFineGrainedShuffle();
+        return true;
+    }
+    return false;
 }
 
 template <class ExchangeWriterPtr>

--- a/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.h
+++ b/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.h
@@ -42,7 +42,7 @@ public:
     void write(const Block & block) override;
     WaitResult waitForWritable() const override;
     bool flushImpl() override;
-    void triggerPipelineNotify() override;
+    void triggerPipelineWriterNotify() override;
 
 private:
     void batchWriteFineGrainedShuffle();

--- a/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.h
+++ b/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.h
@@ -41,7 +41,7 @@ public:
     void prepare(const Block & sample_block) override;
     void write(const Block & block) override;
     WaitResult waitForWritable() const override;
-    void flush() override;
+    bool flushImpl() override;
 
 private:
     void batchWriteFineGrainedShuffle();

--- a/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.h
+++ b/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.h
@@ -42,6 +42,7 @@ public:
     void write(const Block & block) override;
     WaitResult waitForWritable() const override;
     bool flushImpl() override;
+    void triggerPipelineNotify() override;
 
 private:
     void batchWriteFineGrainedShuffle();

--- a/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.h
+++ b/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.h
@@ -39,9 +39,9 @@ public:
         MPPDataPacketVersion data_codec_version_,
         tipb::CompressionMode compression_mode_);
     void prepare(const Block & sample_block) override;
-    void write(const Block & block) override;
+    bool doWrite(const Block & block) override;
     WaitResult waitForWritable() const override;
-    bool flushImpl() override;
+    bool doFlush() override;
     void triggerPipelineWriterNotify() override;
 
 private:

--- a/dbms/src/Flash/Mpp/HashPartitionWriter.cpp
+++ b/dbms/src/Flash/Mpp/HashPartitionWriter.cpp
@@ -95,6 +95,12 @@ bool HashPartitionWriter<ExchangeWriterPtr>::flushImpl()
 }
 
 template <class ExchangeWriterPtr>
+void HashPartitionWriter<ExchangeWriterPtr>::triggerPipelineNotify()
+{
+    writer->triggerPipelineNotify();
+}
+
+template <class ExchangeWriterPtr>
 WaitResult HashPartitionWriter<ExchangeWriterPtr>::waitForWritable() const
 {
     return writer->waitForWritable();

--- a/dbms/src/Flash/Mpp/HashPartitionWriter.cpp
+++ b/dbms/src/Flash/Mpp/HashPartitionWriter.cpp
@@ -72,10 +72,10 @@ HashPartitionWriter<ExchangeWriterPtr>::HashPartitionWriter(
 }
 
 template <class ExchangeWriterPtr>
-void HashPartitionWriter<ExchangeWriterPtr>::flush()
+bool HashPartitionWriter<ExchangeWriterPtr>::flushImpl()
 {
     if (0 == rows_in_blocks)
-        return;
+        return false;
 
     switch (data_codec_version)
     {
@@ -91,6 +91,7 @@ void HashPartitionWriter<ExchangeWriterPtr>::flush()
         break;
     }
     }
+    return true;
 }
 
 template <class ExchangeWriterPtr>
@@ -228,8 +229,7 @@ void HashPartitionWriter<ExchangeWriterPtr>::partitionAndWriteBlocksV1()
 template <class ExchangeWriterPtr>
 void HashPartitionWriter<ExchangeWriterPtr>::partitionAndWriteBlocks()
 {
-    if unlikely (blocks.empty())
-        return;
+    assert(!blocks.empty());
 
     std::vector<Blocks> partition_blocks;
     partition_blocks.resize(partition_num);
@@ -282,11 +282,8 @@ void HashPartitionWriter<ExchangeWriterPtr>::writePartitionBlocks(std::vector<Bl
     for (size_t part_id = 0; part_id < partition_num; ++part_id)
     {
         auto & blocks = partition_blocks[part_id];
-        if (likely(!blocks.empty()))
-        {
-            writer->partitionWrite(blocks, part_id);
-            blocks.clear();
-        }
+        writer->partitionWrite(blocks, part_id);
+        blocks.clear();
     }
 }
 

--- a/dbms/src/Flash/Mpp/HashPartitionWriter.cpp
+++ b/dbms/src/Flash/Mpp/HashPartitionWriter.cpp
@@ -95,9 +95,9 @@ bool HashPartitionWriter<ExchangeWriterPtr>::flushImpl()
 }
 
 template <class ExchangeWriterPtr>
-void HashPartitionWriter<ExchangeWriterPtr>::triggerPipelineNotify()
+void HashPartitionWriter<ExchangeWriterPtr>::triggerPipelineWriterNotify()
 {
-    writer->triggerPipelineNotify();
+    writer->triggerPipelineWriterNotify();
 }
 
 template <class ExchangeWriterPtr>

--- a/dbms/src/Flash/Mpp/HashPartitionWriter.h
+++ b/dbms/src/Flash/Mpp/HashPartitionWriter.h
@@ -40,6 +40,7 @@ public:
     void write(const Block & block) override;
     WaitResult waitForWritable() const override;
     bool flushImpl() override;
+    void triggerPipelineNotify() override;
 
 private:
     void writeImpl(const Block & block);

--- a/dbms/src/Flash/Mpp/HashPartitionWriter.h
+++ b/dbms/src/Flash/Mpp/HashPartitionWriter.h
@@ -39,7 +39,7 @@ public:
         tipb::CompressionMode compression_mode_);
     void write(const Block & block) override;
     WaitResult waitForWritable() const override;
-    void flush() override;
+    bool flushImpl() override;
 
 private:
     void writeImpl(const Block & block);

--- a/dbms/src/Flash/Mpp/HashPartitionWriter.h
+++ b/dbms/src/Flash/Mpp/HashPartitionWriter.h
@@ -37,14 +37,14 @@ public:
         DAGContext & dag_context_,
         MPPDataPacketVersion data_codec_version_,
         tipb::CompressionMode compression_mode_);
-    void write(const Block & block) override;
+    bool doWrite(const Block & block) override;
     WaitResult waitForWritable() const override;
-    bool flushImpl() override;
+    bool doFlush() override;
     void triggerPipelineWriterNotify() override;
 
 private:
-    void writeImpl(const Block & block);
-    void writeImplV1(const Block & block);
+    bool writeImpl(const Block & block);
+    bool writeImplV1(const Block & block);
     void partitionAndWriteBlocks();
     void partitionAndWriteBlocksV1();
 

--- a/dbms/src/Flash/Mpp/HashPartitionWriter.h
+++ b/dbms/src/Flash/Mpp/HashPartitionWriter.h
@@ -40,7 +40,7 @@ public:
     void write(const Block & block) override;
     WaitResult waitForWritable() const override;
     bool flushImpl() override;
-    void triggerPipelineNotify() override;
+    void triggerPipelineWriterNotify() override;
 
 private:
     void writeImpl(const Block & block);

--- a/dbms/src/Flash/Mpp/LocalRequestHandler.h
+++ b/dbms/src/Flash/Mpp/LocalRequestHandler.h
@@ -41,6 +41,7 @@ struct LocalRequestHandler
     }
 
     bool isWritable() const { return msg_queue->isWritable(); }
+    void triggerPipelineNotify() const { return msg_queue->triggerPipelineNotify(); }
 
     void registerPipeReadTask(TaskPtr && task) const { msg_queue->registerPipeReadTask(std::move(task)); }
     void registerPipeWriteTask(TaskPtr && task) const { msg_queue->registerPipeWriteTask(std::move(task)); }

--- a/dbms/src/Flash/Mpp/LocalRequestHandler.h
+++ b/dbms/src/Flash/Mpp/LocalRequestHandler.h
@@ -41,7 +41,7 @@ struct LocalRequestHandler
     }
 
     bool isWritable() const { return msg_queue->isWritable(); }
-    void triggerPipelineNotify() const { return msg_queue->triggerPipelineNotify(); }
+    void triggerPipelineWriterNotify() const { return msg_queue->triggerPipelineWriterNotify(); }
 
     void registerPipeReadTask(TaskPtr && task) const { msg_queue->registerPipeReadTask(std::move(task)); }
     void registerPipeWriteTask(TaskPtr && task) const { msg_queue->registerPipeWriteTask(std::move(task)); }

--- a/dbms/src/Flash/Mpp/MPPTunnel.h
+++ b/dbms/src/Flash/Mpp/MPPTunnel.h
@@ -119,7 +119,7 @@ public:
     virtual bool finish() = 0;
 
     virtual bool isWritable() const = 0;
-    virtual void triggerPipelineNotify() = 0;
+    virtual void triggerPipelineWriterNotify() = 0;
 
     void consumerFinish(const String & err_msg);
     String getConsumerFinishMsg() { return consumer_state.getMsg(); }
@@ -198,7 +198,7 @@ public:
 
     bool isWritable() const override { return send_queue.isWritable(); }
 
-    void triggerPipelineNotify() override { send_queue.triggerPipelineNotify(); }
+    void triggerPipelineWriterNotify() override { send_queue.triggerPipelineWriterNotify(); }
 
     void registerTask(TaskPtr && task) override { send_queue.registerPipeWriteTask(std::move(task)); }
 
@@ -252,7 +252,7 @@ public:
 
     bool isWritable() const override { return queue.isWritable(); }
 
-    void triggerPipelineNotify() override { queue.triggerPipelineNotify(); }
+    void triggerPipelineWriterNotify() override { queue.triggerPipelineWriterNotify(); }
 
     void cancelWith(const String & reason) override { queue.cancelWith(reason); }
 
@@ -324,14 +324,14 @@ public:
         }
     }
 
-    void triggerPipelineNotify() override 
+    void triggerPipelineWriterNotify() override 
     {
         if constexpr (local_only)
-            local_request_handler.triggerPipelineNotify();
+            local_request_handler.triggerPipelineWriterNotify();
         else 
         {
             std::lock_guard lock(mu);
-            local_request_handler.triggerPipelineNotify();
+            local_request_handler.triggerPipelineWriterNotify();
         }
     }
 
@@ -439,7 +439,7 @@ public:
     bool finish() override { return send_queue.finish(); }
 
     bool isWritable() const override { return send_queue.isWritable(); }
-    void triggerPipelineNotify() override { send_queue.triggerPipelineNotify(); }
+    void triggerPipelineWriterNotify() override { send_queue.triggerPipelineWriterNotify(); }
 
     void registerTask(TaskPtr && task) override { send_queue.registerPipeWriteTask(std::move(task)); }
 
@@ -519,9 +519,9 @@ public:
     WaitResult waitForWritable() const;
     void forceWrite(TrackedMppDataPacketPtr && data);
 
-    void triggerPipelineNotify() {
+    void triggerPipelineWriterNotify() {
         assert(tunnel_sender != nullptr);
-        tunnel_sender->triggerPipelineNotify();
+        tunnel_sender->triggerPipelineWriterNotify();
     };
 
     // finish the writing, and wait until the sender finishes.

--- a/dbms/src/Flash/Mpp/MPPTunnelSet.cpp
+++ b/dbms/src/Flash/Mpp/MPPTunnelSet.cpp
@@ -79,11 +79,11 @@ WaitResult MPPTunnelSetBase<Tunnel>::waitForWritable() const
 }
 
 template <typename Tunnel>
-void MPPTunnelSetBase<Tunnel>::triggerPipelineNotify() const
+void MPPTunnelSetBase<Tunnel>::triggerPipelineWriterNotify() const
 {
     for (const auto & tunnel : tunnels)
     {
-        tunnel->triggerPipelineNotify();
+        tunnel->triggerPipelineWriterNotify();
     }
 }
 

--- a/dbms/src/Flash/Mpp/MPPTunnelSet.cpp
+++ b/dbms/src/Flash/Mpp/MPPTunnelSet.cpp
@@ -79,6 +79,15 @@ WaitResult MPPTunnelSetBase<Tunnel>::waitForWritable() const
 }
 
 template <typename Tunnel>
+void MPPTunnelSetBase<Tunnel>::triggerPipelineNotify() const
+{
+    for (const auto & tunnel : tunnels)
+    {
+        tunnel->triggerPipelineNotify();
+    }
+}
+
+template <typename Tunnel>
 void MPPTunnelSetBase<Tunnel>::registerTunnel(const MPPTaskId & receiver_task_id, const TunnelPtr & tunnel)
 {
     RUNTIME_CHECK_MSG(

--- a/dbms/src/Flash/Mpp/MPPTunnelSet.h
+++ b/dbms/src/Flash/Mpp/MPPTunnelSet.h
@@ -61,6 +61,7 @@ public:
     const std::vector<TunnelPtr> & getTunnels() const { return tunnels; }
 
     WaitResult waitForWritable() const;
+    void triggerPipelineNotify() const;
 
     bool isLocal(size_t index) const;
 

--- a/dbms/src/Flash/Mpp/MPPTunnelSet.h
+++ b/dbms/src/Flash/Mpp/MPPTunnelSet.h
@@ -61,7 +61,7 @@ public:
     const std::vector<TunnelPtr> & getTunnels() const { return tunnels; }
 
     WaitResult waitForWritable() const;
-    void triggerPipelineNotify() const;
+    void triggerPipelineWriterNotify() const;
 
     bool isLocal(size_t index) const;
 

--- a/dbms/src/Flash/Mpp/MPPTunnelSetHelper.cpp
+++ b/dbms/src/Flash/Mpp/MPPTunnelSetHelper.cpp
@@ -67,9 +67,6 @@ TrackedMppDataPacketPtr ToPacket(
 
 TrackedMppDataPacketPtr ToPacketV0(Blocks & blocks, const std::vector<tipb::FieldType> & field_types)
 {
-    if (blocks.empty())
-        return nullptr;
-
     CHBlockChunkCodec codec;
     auto codec_stream = codec.newCodecStream(field_types);
     auto tracked_packet = std::make_shared<TrackedMppDataPacket>(MPPDataPacketV0);

--- a/dbms/src/Flash/Mpp/MPPTunnelSetWriter.cpp
+++ b/dbms/src/Flash/Mpp/MPPTunnelSetWriter.cpp
@@ -365,8 +365,7 @@ void MPPTunnelSetWriterBase::passThroughWrite(
 void MPPTunnelSetWriterBase::partitionWrite(Blocks & blocks, int16_t partition_id)
 {
     auto && tracked_packet = MPPTunnelSetHelper::ToPacketV0(blocks, result_field_types);
-    if (!tracked_packet)
-        return;
+    assert(!tracked_packet);
     auto packet_bytes = tracked_packet->getPacket().ByteSizeLong();
     checkPacketSize(packet_bytes);
     writeToTunnel(std::move(tracked_packet), partition_id);

--- a/dbms/src/Flash/Mpp/MPPTunnelSetWriter.h
+++ b/dbms/src/Flash/Mpp/MPPTunnelSetWriter.h
@@ -70,7 +70,7 @@ public:
     uint16_t getPartitionNum() const { return mpp_tunnel_set->getPartitionNum(); }
 
     virtual WaitResult waitForWritable() const = 0;
-    virtual void triggerPipelineNotify() const = 0;
+    virtual void triggerPipelineWriterNotify() const = 0;
 
 protected:
     virtual void writeToTunnel(TrackedMppDataPacketPtr && data, size_t index) = 0;
@@ -94,7 +94,7 @@ public:
 
     // For sync writer, `waitForWritable` will not be called, so an exception is thrown here.
     WaitResult waitForWritable() const override { throw Exception("Unsupport sync writer"); }
-    void triggerPipelineNotify() const override {}
+    void triggerPipelineWriterNotify() const override {}
 
 protected:
     void writeToTunnel(TrackedMppDataPacketPtr && data, size_t index) override;
@@ -113,7 +113,7 @@ public:
     {}
 
     WaitResult waitForWritable() const override { return mpp_tunnel_set->waitForWritable(); }
-    void triggerPipelineNotify() const override { mpp_tunnel_set->triggerPipelineNotify(); }
+    void triggerPipelineWriterNotify() const override { mpp_tunnel_set->triggerPipelineWriterNotify(); }
 
 protected:
     void writeToTunnel(TrackedMppDataPacketPtr && data, size_t index) override;

--- a/dbms/src/Flash/Mpp/MPPTunnelSetWriter.h
+++ b/dbms/src/Flash/Mpp/MPPTunnelSetWriter.h
@@ -70,6 +70,7 @@ public:
     uint16_t getPartitionNum() const { return mpp_tunnel_set->getPartitionNum(); }
 
     virtual WaitResult waitForWritable() const = 0;
+    virtual void triggerPipelineNotify() const = 0;
 
 protected:
     virtual void writeToTunnel(TrackedMppDataPacketPtr && data, size_t index) = 0;
@@ -93,6 +94,7 @@ public:
 
     // For sync writer, `waitForWritable` will not be called, so an exception is thrown here.
     WaitResult waitForWritable() const override { throw Exception("Unsupport sync writer"); }
+    void triggerPipelineNotify() const override {}
 
 protected:
     void writeToTunnel(TrackedMppDataPacketPtr && data, size_t index) override;
@@ -111,6 +113,7 @@ public:
     {}
 
     WaitResult waitForWritable() const override { return mpp_tunnel_set->waitForWritable(); }
+    void triggerPipelineNotify() const override { mpp_tunnel_set->triggerPipelineNotify(); }
 
 protected:
     void writeToTunnel(TrackedMppDataPacketPtr && data, size_t index) override;

--- a/dbms/src/Flash/Mpp/ReceivedMessageQueue.h
+++ b/dbms/src/Flash/Mpp/ReceivedMessageQueue.h
@@ -98,6 +98,7 @@ public:
     }
 
     bool isWritable() const { return grpc_recv_queue.isWritable(); }
+    void triggerPipelineNotify() { grpc_recv_queue.triggerPipelineNotify(); }
 
     void registerPipeReadTask(TaskPtr && task) { grpc_recv_queue.registerPipeReadTask(std::move(task)); }
     void registerPipeWriteTask(TaskPtr && task) { grpc_recv_queue.registerPipeWriteTask(std::move(task)); }

--- a/dbms/src/Flash/Mpp/ReceivedMessageQueue.h
+++ b/dbms/src/Flash/Mpp/ReceivedMessageQueue.h
@@ -98,7 +98,7 @@ public:
     }
 
     bool isWritable() const { return grpc_recv_queue.isWritable(); }
-    void triggerPipelineNotify() { grpc_recv_queue.triggerPipelineNotify(); }
+    void triggerPipelineWriterNotify() { grpc_recv_queue.triggerPipelineWriterNotify(); }
 
     void registerPipeReadTask(TaskPtr && task) { grpc_recv_queue.registerPipeReadTask(std::move(task)); }
     void registerPipeWriteTask(TaskPtr && task) { grpc_recv_queue.registerPipeWriteTask(std::move(task)); }

--- a/dbms/src/Flash/Mpp/tests/gtest_mpp_exchange_writer.cpp
+++ b/dbms/src/Flash/Mpp/tests/gtest_mpp_exchange_writer.cpp
@@ -169,6 +169,7 @@ struct MockExchangeWriter
         return index == 0;
     }
     static WaitResult waitForWritable() { throw Exception("Unsupport async write"); }
+    static void triggerPipelineWriterNotify() {}
 
 private:
     MockExchangeWriterChecker checker;

--- a/dbms/src/Flash/Mpp/tests/gtest_trigger_pipeline_writer.cpp
+++ b/dbms/src/Flash/Mpp/tests/gtest_trigger_pipeline_writer.cpp
@@ -1,0 +1,176 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Flash/Coprocessor/DAGContext.h>
+#include <Flash/Coprocessor/DAGResponseWriter.h>
+#include <Flash/Coprocessor/WaitResult.h>
+#include <TestUtils/ColumnGenerator.h>
+#include <TestUtils/TiFlashTestBasic.h>
+#include <TiDB/Schema/TiDB.h>
+#include <gtest/gtest.h>
+
+#include <random>
+
+namespace DB
+{
+namespace tests
+{
+class MockPipelineTriggerWriter : public DAGResponseWriter
+{
+public:
+    MockPipelineTriggerWriter(Int64 records_per_chunk, DAGContext & dag_context)
+        : DAGResponseWriter(records_per_chunk, dag_context)
+        , rng(dev())
+    {}
+    bool doWrite(const Block &) override
+    {
+        std::uniform_int_distribution<Int32> dist;
+        auto next = dist(rng);
+        return next % 3 == 1;
+    }
+    bool doFlush() override
+    {
+        std::uniform_int_distribution<Int32> dist;
+        auto next = dist(rng);
+        return next % 3 == 0;
+    }
+    void triggerPipelineWriterNotify() override { writer_notify_count--; }
+    WaitResult waitForWritable() const override
+    {
+        std::uniform_int_distribution<Int32> dist;
+        auto next = dist(rng);
+        if (next % 3 == 1 && need_notify_pipeline_writer)
+        {
+            writer_notify_count++;
+            return WaitResult::WaitForNotify;
+        }
+        return WaitResult::Ready;
+    }
+    bool needNotifyPipelineWriter() const { return need_notify_pipeline_writer; }
+
+    Int64 getPipelineNotifyCount() const { return writer_notify_count; }
+
+private:
+    mutable Int64 writer_notify_count = 0;
+    std::random_device dev;
+    mutable std::mt19937 rng;
+};
+
+class TestTriggerPipelineWriter : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        dag_context_ptr = std::make_unique<DAGContext>(1024);
+        dag_context_ptr->encode_type = tipb::EncodeType::TypeCHBlock;
+        dag_context_ptr->kind = DAGRequestKind::MPP;
+        dag_context_ptr->is_root_mpp_task = false;
+        dag_context_ptr->result_field_types = makeFields();
+    }
+
+public:
+    TestTriggerPipelineWriter() = default;
+
+    // Return 10 Int64 column.
+    static std::vector<tipb::FieldType> makeFields()
+    {
+        std::vector<tipb::FieldType> fields(10);
+        for (int i = 0; i < 10; ++i)
+        {
+            fields[i].set_tp(TiDB::TypeLongLong);
+            fields[i].set_flag(TiDB::ColumnFlagNotNull);
+        }
+        return fields;
+    }
+
+    // Return a block with **rows** and 10 Int64 column.
+    static Block prepareRandomBlock(size_t rows)
+    {
+        Block block;
+        for (size_t i = 0; i < 10; ++i)
+        {
+            DataTypePtr int64_data_type = std::make_shared<DataTypeInt64>();
+            auto int64_column = ColumnGenerator::instance().generate({rows, "Int64", RANDOM}).column;
+            block.insert(
+                ColumnWithTypeAndName{std::move(int64_column), int64_data_type, String("col") + std::to_string(i)});
+        }
+        return block;
+    }
+
+    std::unique_ptr<DAGContext> dag_context_ptr;
+};
+
+TEST_F(TestTriggerPipelineWriter, testPipelineWriterOff)
+try
+{
+    const size_t block_rows = 1024;
+    // 1. Build Block.
+    auto block = prepareRandomBlock(block_rows);
+
+    // 2. Build MockWriter.
+    auto mock_writer = std::make_shared<MockPipelineTriggerWriter>(-1, *dag_context_ptr);
+
+    // 3. disable pipeline writer trigger
+    ASSERT_EQ(false, mock_writer->needNotifyPipelineWriter());
+
+    // 4. write something
+    for (int i = 0; i < 100; i++)
+    {
+        mock_writer->waitForWritable();
+        mock_writer->write(block);
+    }
+
+    // 5. flush
+    mock_writer->waitForWritable();
+    mock_writer->flush();
+
+    // 6. check results
+    ASSERT_EQ(0, mock_writer->getPipelineNotifyCount());
+}
+CATCH
+
+TEST_F(TestTriggerPipelineWriter, testPipelineWriterOn)
+try
+{
+    const size_t block_rows = 1024;
+    // 1. Build Block.
+    auto block = prepareRandomBlock(block_rows);
+
+    for (int test_index = 0; test_index < 100; test_index++)
+    {
+        // 2. Build MockWriter.
+        auto mock_writer = std::make_shared<MockPipelineTriggerWriter>(-1, *dag_context_ptr);
+
+        // 3. enable pipeline writer trigger
+        mock_writer->setNeedNotifyPipelineWriter(true);
+
+        // 4. write something
+        for (int i = 0; i < 100; i++)
+        {
+            mock_writer->waitForWritable();
+            mock_writer->write(block);
+        }
+
+        // 5. flush
+        mock_writer->waitForWritable();
+        mock_writer->flush();
+
+        // 6. check results, note redudent notify is allowed
+        ASSERT_EQ(true, mock_writer->getPipelineNotifyCount() <= 0);
+    }
+}
+CATCH
+
+} // namespace tests
+} // namespace DB

--- a/dbms/src/Operators/ExchangeSenderSinkOp.h
+++ b/dbms/src/Operators/ExchangeSenderSinkOp.h
@@ -29,7 +29,9 @@ public:
         std::unique_ptr<DAGResponseWriter> && writer)
         : SinkOp(exec_context_, req_id)
         , writer(std::move(writer))
-    {}
+    {
+        writer->setNeedNotifyPipelineWriter(true);
+    }
 
     String getName() const override { return "ExchangeSenderSinkOp"; }
 

--- a/dbms/src/Operators/ExchangeSenderSinkOp.h
+++ b/dbms/src/Operators/ExchangeSenderSinkOp.h
@@ -26,9 +26,9 @@ public:
     ExchangeSenderSinkOp(
         PipelineExecutorContext & exec_context_,
         const String & req_id,
-        std::unique_ptr<DAGResponseWriter> && writer)
+        std::unique_ptr<DAGResponseWriter> && writer_)
         : SinkOp(exec_context_, req_id)
-        , writer(std::move(writer))
+        , writer(std::move(writer_))
     {
         writer->setNeedNotifyPipelineWriter(true);
     }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9413

Problem Summary:

### What is changed and how it works?
The root casue of the hang issue introduced by #9072 is
1. `ExchangeSenderSinkOp` eventually write data to `LooseBoundedMPMCQueue`, although `LooseBoundedMPMCQueue` is named with `LooseBounded`, it actually has a upper bound
2. For the same `MPPTunnel`(which holds a `LooseBoundedMPMCQueue`), all the `ExchangeSenderSinkOp` will try to write data the the same `LooseBoundedMPMCQueue` concurrently
3. If current MPPTunnel is not writable(its `LooseBoundedMPMCQueue` is full), `ExchangeSenderSinkOp` will register itself to the pipeline notify furture(the `tunnelSender`)
4. pipeline notify future notify one task at a time when the consumer of `LooseBoundedMPMCQueue` read a message from `LooseBoundedMPMCQueue`
5. In current implementation, when an `ExchangeSenderSinkOp` is notified in stage 4, it is not 100% sure that the `ExchangeSenderSinkOp` will write data to `LooseBoundedMPMCQueue` because
    * `ExchangeSenderSinkOp` only calls `writer->write(block);` to write the data, and inside `writer->write(block)` the data can be cached in `writer` instead of writting to `LooseBoundedMPMCQueue`
    * If current `block` is empty, it will call `writer->flush()` to flush the cached data, and if there is no cached data, it will not write to `LooseBoundedMPMCQueue`
6. Consider a case that there is `M` `ExchangeSenderSinkOp`, and the `LooseBoundedMPMCQueue` has a limited size of `N`, where `M > N`, and all the `M` `ExchangeSenderSinkOp` tries to write to a full `LooseBoundedMPMCQueue` at the same time. Then all the `M` `ExchangeSenderSinkOp` are registered to the pipeline notify future. As described in stage 4, the pipeline notify future only notify one task at a time when the consumer of `LooseBoundedMPMCQueue` read a message from `LooseBoundedMPMCQueue`, then at most `N` `ExchangeSenderSinkOp` will be notified. If all the notified `N` `ExchangeSenderSinkOp` do not write data to `LooseBoundedMPMCQueue`, then the `LooseBoundedMPMCQueue` become empty queue, and there is still `M - N` `ExchangeSenderSinkOp` waiting on the pipeline notify future. Since `LooseBoundedMPMCQueue` is empty, all the `M - N` `ExchangeSenderSinkOp` have on chance to be notified. Then the whole query hangs.

There is 2 possible fix
* For each read from `LooseBoundedMPMCQueue`, triger a notification if current queue is empty
* Make sure that each time an `ExchangeSenderSinkOp` is notified, the `ExchangeSenderSinkOp` should either write data to `LooseBoundedMPMCQueue`, or try to notify another `ExchangeSenderSinkOp`

The first fix should be earier, but consider that `ExchangeReceiver` will also using the notify way after #9073, the first fix may not work in the furture, so this pr use the second fix. 

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
