### PR TITLE
Add info log when pipeline even is scheduled

### DIFF
--- a/dbms/src/Flash/Pipeline/Schedule/Events/Event.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/Events/Event.cpp
@@ -79,7 +79,10 @@ void Event::onInputFinish()
     auto cur_value = unfinished_inputs.fetch_sub(1) - 1;
     RUNTIME_ASSERT(cur_value >= 0, log, "unfinished_inputs cannot < 0, but actual value is {}", cur_value);
     if (0 == cur_value)
+    {
         schedule();
+        LOG_INFO(log, "Event is scheduled");
+    }
 }
 
 bool Event::prepare()


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6233

Problem Summary:

Add info level log when pipeline event is scheduled, this will be usefull for troubleshooting.

The log looks like this
```
[2024/09/11 14:45:35.865 +08:00] [INFO] [Event.cpp:84] ["Event is scheduled"] [source="MPP<gather_id:1, query_ts:1726037135481137861, local_query_id:5, server_id:2011, start_ts:452470278835142658,task_id:1> 0"] [thread_id=57]
```

### What is changed and how it works?

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
