### PR TITLE
Add metrics about the last time a region is sent a snapshot

### DIFF
--- a/dbms/src/Common/TiFlashMetrics.h
+++ b/dbms/src/Common/TiFlashMetrics.h
@@ -477,6 +477,10 @@ static_assert(RAFT_REGION_BIG_WRITE_THRES * 4 < RAFT_REGION_BIG_WRITE_MAX, "Inva
       F(type_admin_commit_merge, {{"type", "admin_commit_merge"}}, ExpBuckets{0.0005, 2, 20}),                                      \
       F(type_admin_change_peer, {{"type", "admin_change_peer"}}, ExpBuckets{0.0005, 2, 20}),                                        \
       F(type_flush_region, {{"type", "flush_region"}}, ExpBuckets{0.0005, 2, 20}))                                                  \
+    M(tiflash_raft_long_term_event_duration_seconds,                                                                                \
+      "Bucketed histogram of applying write command Raft logs",                                                                     \
+      Histogram,                                                                                                                    \
+      F(type_apply_snapshot_gap, {{"type", "apply_snapshot_gap"}}, ExpBucketsWithRange{1, 8, 60 * 60 * 24}))                        \
     M(tiflash_raft_upstream_latency,                                                                                                \
       "The latency that tikv sends raft log to tiflash.",                                                                           \
       Histogram,                                                                                                                    \

--- a/dbms/src/Storages/KVStore/MultiRaft/ApplySnapshot.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/ApplySnapshot.cpp
@@ -75,7 +75,7 @@ void KVStore::checkAndApplyPreHandledSnapshot(const RegionPtrWrap & new_region, 
         }
 
         {
-            LOG_INFO(log, "{} set state to `Applying`", old_region->toString());
+            LOG_INFO(log, "{} set state to `Applying`, lastAppliedTime={}", old_region->toString(), old_region->lastSnapshotAppliedTime());
             // Set original region state to `Applying` and any read request toward this region should be rejected because
             // engine may delete data unsafely.
             auto region_lock = region_manager.genRegionTaskLock(old_region->id());
@@ -351,7 +351,7 @@ void KVStore::onSnapshot(
 
         tmt.getRegionTable().shrinkRegionRange(*new_region);
     }
-
+    new_region->updateSnapshotAppliedTime();
     prehandling_trace.deregisterTask(new_region->id());
 }
 

--- a/dbms/src/Storages/KVStore/Region.cpp
+++ b/dbms/src/Storages/KVStore/Region.cpp
@@ -233,6 +233,23 @@ UInt64 Region::lastCompactLogApplied() const
     return last_compact_log_applied;
 }
 
+UInt64 Region::lastSnapshotAppliedTime() const
+{
+    return last_snapshot_applied_time.load();
+}
+
+void Region::updateSnapshotAppliedTime() const
+{
+    auto secs = std::chrono::duration_cast<std::chrono::seconds>(
+                   std::chrono::system_clock::now().time_since_epoch())
+            .count();
+    auto old = last_snapshot_applied_time.exchange(secs);
+    if (old != 0) {
+        GET_METRIC(tiflash_raft_long_term_event_duration_seconds, type_apply_snapshot_gap).Observe(secs - old);
+    }
+    return;
+}
+
 void Region::setLastCompactLogApplied(UInt64 new_value) const
 {
     last_compact_log_applied = new_value;

--- a/dbms/src/Storages/KVStore/Region.h
+++ b/dbms/src/Storages/KVStore/Region.h
@@ -164,8 +164,10 @@ public: // Stats
 
     UInt64 lastRestartLogApplied() const;
     UInt64 lastCompactLogApplied() const;
+    UInt64 lastSnapshotAppliedTime() const;
     void setLastCompactLogApplied(UInt64 new_value) const;
     void updateLastCompactLogApplied(const RegionTaskLock &) const;
+    void updateSnapshotAppliedTime() const;
 
     // Return <last_eager_truncated_index, applied_index> of this Region
     std::pair<UInt64, UInt64> getRaftLogEagerGCRange() const;
@@ -311,6 +313,8 @@ private:
     mutable std::atomic<UInt64> last_compact_log_applied{0};
     // Applied index since last restart. Should only be set after restart.
     UInt64 last_restart_log_applied{0};
+    // Time since last restart.
+    mutable std::atomic<uint64_t> last_snapshot_applied_time{0};
     mutable std::atomic<size_t> approx_mem_cache_rows{0};
     mutable std::atomic<size_t> approx_mem_cache_bytes{0};
     mutable std::atomic<Timestamp> last_observed_read_tso{0};

--- a/metrics/grafana/tiflash_summary.json
+++ b/metrics/grafana/tiflash_summary.json
@@ -52,7 +52,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1718272201438,
+  "iteration": 1726237973256,
   "links": [],
   "panels": [
     {
@@ -8413,7 +8413,10 @@
               "id": "filterFieldsByName",
               "options": {
                 "include": {
-                  "names": ["Time", "mark cache effectiveness"]
+                  "names": [
+                    "Time",
+                    "mark cache effectiveness"
+                  ]
                 }
               }
             }
@@ -8595,7 +8598,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.5.17",
+          "pluginVersion": "7.5.11",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -8661,7 +8664,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:222",
               "format": "µs",
               "label": null,
               "logBase": 1,
@@ -8670,7 +8672,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:223",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -9374,7 +9375,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.5.17",
+          "pluginVersion": "7.5.11",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -9413,7 +9414,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:304",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -9422,7 +9422,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:305",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -9475,7 +9474,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.5.17",
+          "pluginVersion": "7.5.11",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -12350,6 +12349,113 @@
           }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "grid": {},
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 44
+          },
+          "hiddenSeries": false,
+          "id": 295,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.11",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "histogram_quantile(0.1, sum(rate(tiflash_raft_long_term_event_duration_seconds{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", type=~\"apply_snapshot_gap\"}[1m])) by (le, type))",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "10%-{{type}}",
+              "refId": "D",
+              "step": 4
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Long-term Raft Events Duration",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 2,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
           "cards": {
             "cardPadding": null,
             "cardRound": null
@@ -12373,7 +12479,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 44
+            "y": 51
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -12443,7 +12549,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 44
+            "y": 51
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -12513,7 +12619,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 51
+            "y": 58
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -12585,7 +12691,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 51
+            "y": 58
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -12647,7 +12753,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 58
+            "y": 65
           },
           "hiddenSeries": false,
           "id": 235,
@@ -12747,7 +12853,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 58
+            "y": 65
           },
           "hiddenSeries": false,
           "id": 241,
@@ -12855,7 +12961,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 65
+            "y": 72
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -12936,7 +13042,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 65
+            "y": 72
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -13009,7 +13115,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 72
+            "y": 79
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -13085,7 +13191,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 72
+            "y": 79
           },
           "hiddenSeries": false,
           "id": 249,
@@ -13191,7 +13297,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 79
+            "y": 86
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -13264,7 +13370,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 79
+            "y": 86
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -13337,7 +13443,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 86
+            "y": 93
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -13410,7 +13516,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 86
+            "y": 93
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -13475,7 +13581,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 93
+            "y": 100
           },
           "hiddenSeries": false,
           "id": 240,
@@ -13579,7 +13685,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 93
+            "y": 100
           },
           "hiddenSeries": false,
           "id": 239,
@@ -13716,7 +13822,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 100
+            "y": 107
           },
           "hiddenSeries": false,
           "id": 75,
@@ -13840,7 +13946,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 107
+            "y": 114
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -13910,7 +14016,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 107
+            "y": 114
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -13973,7 +14079,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 114
+            "y": 121
           },
           "hiddenSeries": false,
           "id": 263,
@@ -14071,7 +14177,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 114
+            "y": 121
           },
           "hiddenSeries": false,
           "id": 272,
@@ -14186,7 +14292,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 121
+            "y": 128
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -14258,7 +14364,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 121
+            "y": 128
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -14324,7 +14430,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 128
+            "y": 135
           },
           "height": "",
           "hiddenSeries": false,
@@ -14434,7 +14540,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 135
+            "y": 142
           },
           "height": "",
           "hiddenSeries": false,
@@ -14550,7 +14656,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 142
+            "y": 149
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -14619,7 +14725,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 142
+            "y": 149
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -14689,7 +14795,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 149
+            "y": 156
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -14755,7 +14861,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 149
+            "y": 156
           },
           "hiddenSeries": false,
           "id": 91,
@@ -19779,7 +19885,7 @@
       "type": "row"
     }
   ],
-  "refresh": "30s",
+  "refresh": "5s",
   "schemaVersion": 27,
   "style": "dark",
   "tags": [],
@@ -19885,7 +19991,17 @@
       "2h",
       "1d"
     ],
-    "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
   },
   "timezone": "",
   "title": "Test-Cluster-TiFlash-Summary",


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #9241

Problem Summary:

The idea is when a region got stuck, TiKV leader could send it a snapshot. We will record how many time has passed since the last snapshot. If the time is short, then the region may have some problems here.

### What is changed and how it works?

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
