### PR TITLE
Compat serverless FAP features including shard_ver, txn ref and enc key

### DIFF
--- a/dbms/src/Storages/KVStore/MultiRaft/Disagg/FastAddPeer.h
+++ b/dbms/src/Storages/KVStore/MultiRaft/Disagg/FastAddPeer.h
@@ -25,7 +25,15 @@ class Region;
 using RegionPtr = std::shared_ptr<Region>;
 using CheckpointRegionInfoAndData
     = std::tuple<CheckpointInfoPtr, RegionPtr, raft_serverpb::RaftApplyState, raft_serverpb::RegionLocalState>;
-FastAddPeerRes genFastAddPeerRes(FastAddPeerStatus status, std::string && apply_str, std::string && region_str);
+FastAddPeerRes genFastAddPeerRes(
+    FastAddPeerStatus status,
+    std::string && apply_str,
+    std::string && region_str,
+    uint64_t shard_ver,
+    std::string && inner_key_str,
+    std::string && enc_key_str,
+    std::string && txn_file_ref_str);
+FastAddPeerRes genFastAddPeerResFail(FastAddPeerStatus status);
 std::variant<CheckpointRegionInfoAndData, FastAddPeerRes> FastAddPeerImplSelect(
     TMTContext & tmt,
     const TiFlashRaftProxyHelper * proxy_helper,

--- a/dbms/src/Storages/KVStore/MultiRaft/Disagg/ServerlessUtils.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/Disagg/ServerlessUtils.cpp
@@ -48,47 +48,47 @@ String makeRegionPrefix(uint64_t region_id, uint8_t suffix)
 
 #if SERVERLESS_PROXY == 0
 // pub const KEYSPACE_INNER_KEY_OFF_SUFFIX: u8 = 0x01;
-String getKeyspaceInnerKey(UniversalPageStoragePtr uni_ps, uint32_t keyspace_id)
+String getKeyspaceInnerKey(UniversalPageStoragePtr, uint32_t keyspace_id)
 {
     return "";
 }
 
 // pub const REGION_INNER_KEY_OFF_SUFFIX: u8 = 0x06;
-String getRegionInnerKey(UniversalPageStoragePtr uni_ps, uint64_t region_id)
+String getRegionInnerKey(UniversalPageStoragePtr, uint64_t region_id)
 {
     return "";
 }
 
-String getCompactibleInnerKey(UniversalPageStoragePtr uni_ps, uint32_t keyspace_id, uint64_t region_id)
+String getCompactibleInnerKey(UniversalPageStoragePtr, uint32_t keyspace_id, uint64_t region_id)
 {
     return "";
 }
 
 // pub const REGION_ENCRYPTION_KEY_SUFFIX: u8 = 0x07;
-String getRegionEncKey(UniversalPageStoragePtr uni_ps, uint64_t region_id)
+String getRegionEncKey(UniversalPageStoragePtr, uint64_t region_id)
 {
     return "";
 }
 
 // pub const KEYSPACE_ENCRYPTION_KEY_SUFFIX: u8 = 0x02;
-String getKeyspaceEncKey(UniversalPageStoragePtr uni_ps, uint32_t keyspace_id)
+String getKeyspaceEncKey(UniversalPageStoragePtr, uint32_t keyspace_id)
 {
     return "";
 }
 
-String getCompactibleEncKey(UniversalPageStoragePtr uni_ps, uint32_t keyspace_id, uint64_t region_id)
+String getCompactibleEncKey(UniversalPageStoragePtr, uint32_t keyspace_id, uint64_t region_id)
 {
     return "";
 }
 
 // pub const REGION_META_VERSION_SUFFIX: u8 = 0x09;
-UInt64 getShardVer(UniversalPageStoragePtr uni_ps, uint64_t region_id)
+UInt64 getShardVer(UniversalPageStoragePtr, uint64_t region_id)
 {
     return 0;
 }
 
 // pub const REGION_TXN_FILE_LOCKS_SUFFIX: u8 = 0x08;
-String getTxnFileRef(UniversalPageStoragePtr uni_ps, uint64_t region_id)
+String getTxnFileRef(UniversalPageStoragePtr, uint64_t region_id)
 {
     return "";
 }

--- a/dbms/src/Storages/KVStore/MultiRaft/Disagg/ServerlessUtils.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/Disagg/ServerlessUtils.cpp
@@ -48,47 +48,47 @@ String makeRegionPrefix(uint64_t region_id, uint8_t suffix)
 
 #if SERVERLESS_PROXY == 0
 // pub const KEYSPACE_INNER_KEY_OFF_SUFFIX: u8 = 0x01;
-String getKeyspaceInnerKey(UniversalPageStoragePtr, uint32_t keyspace_id)
+String getKeyspaceInnerKey(UniversalPageStoragePtr, uint32_t)
 {
     return "";
 }
 
 // pub const REGION_INNER_KEY_OFF_SUFFIX: u8 = 0x06;
-String getRegionInnerKey(UniversalPageStoragePtr, uint64_t region_id)
+String getRegionInnerKey(UniversalPageStoragePtr, uint64_t)
 {
     return "";
 }
 
-String getCompactibleInnerKey(UniversalPageStoragePtr, uint32_t keyspace_id, uint64_t region_id)
+String getCompactibleInnerKey(UniversalPageStoragePtr, uint32_t, uint64_t)
 {
     return "";
 }
 
 // pub const REGION_ENCRYPTION_KEY_SUFFIX: u8 = 0x07;
-String getRegionEncKey(UniversalPageStoragePtr, uint64_t region_id)
+String getRegionEncKey(UniversalPageStoragePtr, uint64_t)
 {
     return "";
 }
 
 // pub const KEYSPACE_ENCRYPTION_KEY_SUFFIX: u8 = 0x02;
-String getKeyspaceEncKey(UniversalPageStoragePtr, uint32_t keyspace_id)
+String getKeyspaceEncKey(UniversalPageStoragePtr, uint32_t)
 {
     return "";
 }
 
-String getCompactibleEncKey(UniversalPageStoragePtr, uint32_t keyspace_id, uint64_t region_id)
+String getCompactibleEncKey(UniversalPageStoragePtr, uint32_t, uint64_t)
 {
     return "";
 }
 
 // pub const REGION_META_VERSION_SUFFIX: u8 = 0x09;
-UInt64 getShardVer(UniversalPageStoragePtr, uint64_t region_id)
+UInt64 getShardVer(UniversalPageStoragePtr, uint64_t)
 {
     return 0;
 }
 
 // pub const REGION_TXN_FILE_LOCKS_SUFFIX: u8 = 0x08;
-String getTxnFileRef(UniversalPageStoragePtr, uint64_t region_id)
+String getTxnFileRef(UniversalPageStoragePtr, uint64_t)
 {
     return "";
 }

--- a/dbms/src/Storages/KVStore/MultiRaft/Disagg/ServerlessUtils.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/Disagg/ServerlessUtils.cpp
@@ -1,0 +1,285 @@
+// Copyright 2024 PingCAP, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Storages/KVStore/MultiRaft/Disagg/ServerlessUtils.h>
+#include <Storages/Page/V3/Universal/UniversalPageIdFormatImpl.h>
+#include <Storages/Page/V3/Universal/UniversalPageStorage.h>
+
+namespace DB
+{
+// make_keyspace_prefix
+String makeKeyspacePrefix(uint32_t keyspace_id, uint8_t suffix)
+{
+    WriteBufferFromOwnString buff;
+    writeChar(UniversalPageIdFormat::KV_PREFIX, buff);
+    // pub const KEYSPACE_META_PREFIX_KEY: &[u8] = &[LOCAL_PREFIX, KEYSPACE_META_PREFIX];
+    // pub const KEYSPACE_META_PREFIX: u8 = 0x04;
+    writeChar(0x01, buff);
+    writeChar(0x04, buff);
+    UniversalPageIdFormat::encodeUInt32(keyspace_id, buff);
+    writeChar(suffix, buff);
+    return buff.releaseStr();
+}
+
+// make_region_prefix
+String makeRegionPrefix(uint64_t region_id, uint8_t suffix)
+{
+    WriteBufferFromOwnString buff;
+    writeChar(UniversalPageIdFormat::KV_PREFIX, buff);
+    // pub const REGION_RAFT_PREFIX: u8 = 0x02;
+    // pub const REGION_RAFT_PREFIX_KEY: &[u8] = &[LOCAL_PREFIX, REGION_RAFT_PREFIX];
+    writeChar(0x01, buff);
+    writeChar(0x02, buff);
+    UniversalPageIdFormat::encodeUInt64(region_id, buff);
+    writeChar(suffix, buff);
+    return buff.releaseStr();
+}
+
+#if SERVERLESS_PROXY == 0
+// pub const KEYSPACE_INNER_KEY_OFF_SUFFIX: u8 = 0x01;
+String getKeyspaceInnerKey(UniversalPageStoragePtr uni_ps, uint32_t keyspace_id)
+{
+    return "";
+}
+
+// pub const REGION_INNER_KEY_OFF_SUFFIX: u8 = 0x06;
+String getRegionInnerKey(UniversalPageStoragePtr uni_ps, uint64_t region_id)
+{
+    return "";
+}
+
+String getCompactibleInnerKey(UniversalPageStoragePtr uni_ps, uint32_t keyspace_id, uint64_t region_id)
+{
+    return "";
+}
+
+// pub const REGION_ENCRYPTION_KEY_SUFFIX: u8 = 0x07;
+String getRegionEncKey(UniversalPageStoragePtr uni_ps, uint64_t region_id)
+{
+    return "";
+}
+
+// pub const KEYSPACE_ENCRYPTION_KEY_SUFFIX: u8 = 0x02;
+String getKeyspaceEncKey(UniversalPageStoragePtr uni_ps, uint32_t keyspace_id)
+{
+    return "";
+}
+
+String getCompactibleEncKey(UniversalPageStoragePtr uni_ps, uint32_t keyspace_id, uint64_t region_id)
+{
+    return "";
+}
+
+// pub const REGION_META_VERSION_SUFFIX: u8 = 0x09;
+UInt64 getShardVer(UniversalPageStoragePtr uni_ps, uint64_t region_id)
+{
+    return 0;
+}
+
+// pub const REGION_TXN_FILE_LOCKS_SUFFIX: u8 = 0x08;
+String getTxnFileRef(UniversalPageStoragePtr uni_ps, uint64_t region_id)
+{
+    return "";
+}
+#else
+// pub const KEYSPACE_INNER_KEY_OFF_SUFFIX: u8 = 0x01;
+String getKeyspaceInnerKey(UniversalPageStoragePtr uni_ps, uint32_t keyspace_id)
+{
+    auto key = makeKeyspacePrefix(keyspace_id, 0x01);
+    try
+    {
+        auto page = uni_ps->read(key, /*read_limiter*/ nullptr, {}, /*throw_on_not_exist*/ false);
+        if (page.isValid())
+        {
+            return String(page.data.begin(), page.data.size());
+        }
+        else
+        {
+            return "";
+        }
+    }
+    catch (...)
+    {
+        return "";
+    }
+}
+
+// pub const REGION_INNER_KEY_OFF_SUFFIX: u8 = 0x06;
+String getRegionInnerKey(UniversalPageStoragePtr uni_ps, uint64_t region_id)
+{
+    auto key = makeRegionPrefix(region_id, 0x06);
+    try
+    {
+        auto page = uni_ps->read(key, /*read_limiter*/ nullptr, {}, /*throw_on_not_exist*/ false);
+        if (page.isValid())
+        {
+            return String(page.data.begin(), page.data.size());
+        }
+        else
+        {
+            return "";
+        }
+    }
+    catch (...)
+    {
+        return "";
+    }
+}
+
+String getCompactibleInnerKey(UniversalPageStoragePtr uni_ps, uint32_t keyspace_id, uint64_t region_id)
+{
+    auto keyspace = getKeyspaceInnerKey(uni_ps, keyspace_id);
+    if unlikely (keyspace.empty())
+    {
+        auto region = getRegionInnerKey(uni_ps, region_id);
+        if unlikely (region.empty())
+        {
+            LOG_INFO(
+                DB::Logger::get(),
+                "Failed to find compactible inner key, region_id={}, keyspace_id={}",
+                region_id,
+                keyspace_id);
+        }
+        return region;
+    }
+    else
+    {
+        return keyspace;
+    }
+}
+
+// pub const REGION_ENCRYPTION_KEY_SUFFIX: u8 = 0x07;
+String getRegionEncKey(UniversalPageStoragePtr uni_ps, uint64_t region_id)
+{
+    auto key = makeRegionPrefix(region_id, 0x07);
+    try
+    {
+        auto page = uni_ps->read(key, /*read_limiter*/ nullptr, {}, /*throw_on_not_exist*/ false);
+        if (page.isValid())
+        {
+            return String(page.data.begin(), page.data.size());
+        }
+        else
+        {
+            return "";
+        }
+    }
+    catch (...)
+    {
+        return "";
+    }
+}
+
+// pub const KEYSPACE_ENCRYPTION_KEY_SUFFIX: u8 = 0x02;
+String getKeyspaceEncKey(UniversalPageStoragePtr uni_ps, uint32_t keyspace_id)
+{
+    auto key = makeKeyspacePrefix(keyspace_id, 0x02);
+    try
+    {
+        auto page = uni_ps->read(key, /*read_limiter*/ nullptr, {}, /*throw_on_not_exist*/ false);
+        if (page.isValid())
+        {
+            return String(page.data.begin(), page.data.size());
+        }
+        else
+        {
+            return "";
+        }
+    }
+    catch (...)
+    {
+        return "";
+    }
+}
+
+String getCompactibleEncKey(UniversalPageStoragePtr uni_ps, uint32_t keyspace_id, uint64_t region_id)
+{
+    auto keyspace = getKeyspaceEncKey(uni_ps, keyspace_id);
+    if unlikely (keyspace.empty())
+    {
+        auto region = getRegionEncKey(uni_ps, region_id);
+        if unlikely (region.empty())
+        {
+            LOG_INFO(
+                DB::Logger::get(),
+                "Failed to find compactible enc key, region_id={}, keyspace_id={}",
+                region_id,
+                keyspace_id);
+        }
+        return region;
+    }
+    else
+    {
+        return keyspace;
+    }
+}
+
+// pub const REGION_META_VERSION_SUFFIX: u8 = 0x09;
+UInt64 getShardVer(UniversalPageStoragePtr uni_ps, uint64_t region_id)
+{
+    auto key = makeRegionPrefix(region_id, 0x09);
+    try
+    {
+        auto page = uni_ps->read(key, /*read_limiter*/ nullptr, {}, /*throw_on_not_exist*/ false);
+        if (page.isValid())
+        {
+            return UniversalPageIdFormat::decodeUInt64(page.data.data());
+        }
+        else
+        {
+            LOG_INFO(DB::Logger::get(), "Failed to find shard_ver, region_id={}, key={}", region_id, key);
+            return 0;
+        }
+    }
+    catch (...)
+    {
+        LOG_INFO(
+            DB::Logger::get(),
+            "Failed to find shard_ver, region_id={}, key={}",
+            region_id,
+            Redact::keyToHexString(key.data(), key.size()));
+        return 0;
+    }
+}
+
+// pub const REGION_TXN_FILE_LOCKS_SUFFIX: u8 = 0x08;
+String getTxnFileRef(UniversalPageStoragePtr uni_ps, uint64_t region_id)
+{
+    auto key = makeRegionPrefix(region_id, 0x08);
+    try
+    {
+        auto page = uni_ps->read(key, /*read_limiter*/ nullptr, {}, /*throw_on_not_exist*/ false);
+        if (page.isValid())
+        {
+            return String(page.data.begin(), page.data.size());
+        }
+        else
+        {
+            LOG_INFO(DB::Logger::get(), "Failed to find txn ref, region_id={}, key={}", region_id, key);
+            return "";
+        }
+    }
+    catch (...)
+    {
+        LOG_INFO(
+            DB::Logger::get(),
+            "Failed to find txn ref, region_id={}, key={}",
+            region_id,
+            Redact::keyToHexString(key.data(), key.size()));
+        return "";
+    }
+}
+#endif
+
+} // namespace DB

--- a/dbms/src/Storages/KVStore/MultiRaft/Disagg/ServerlessUtils.h
+++ b/dbms/src/Storages/KVStore/MultiRaft/Disagg/ServerlessUtils.h
@@ -1,0 +1,31 @@
+// Copyright 2024 PingCAP, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <Storages/Page/PageStorage_fwd.h>
+
+namespace DB
+{
+String makeKeyspacePrefix(uint32_t keyspace_id, uint8_t suffix);
+String makeRegionPrefix(uint64_t region_id, uint8_t suffix);
+String getKeyspaceInnerKey(UniversalPageStoragePtr uni_ps, uint32_t keyspace_id);
+String getRegionInnerKey(UniversalPageStoragePtr uni_ps, uint64_t region_id);
+String getCompactibleInnerKey(UniversalPageStoragePtr uni_ps, uint32_t keyspace_id, uint64_t region_id);
+String getRegionEncKey(UniversalPageStoragePtr uni_ps, uint64_t region_id);
+String getKeyspaceEncKey(UniversalPageStoragePtr uni_ps, uint32_t keyspace_id);
+String getCompactibleEncKey(UniversalPageStoragePtr uni_ps, uint32_t keyspace_id, uint64_t region_id);
+UInt64 getShardVer(UniversalPageStoragePtr uni_ps, uint64_t region_id);
+String getTxnFileRef(UniversalPageStoragePtr uni_ps, uint64_t region_id);
+} // namespace DB

--- a/dbms/src/Storages/KVStore/TiKVHelpers/TiKVRecordFormat.h
+++ b/dbms/src/Storages/KVStore/TiKVHelpers/TiKVRecordFormat.h
@@ -87,6 +87,11 @@ inline UInt64 encodeUInt64(const UInt64 x)
     return toBigEndian(x);
 }
 
+inline UInt32 encodeUInt32(const UInt32 x)
+{
+    return toBigEndian(x);
+}
+
 inline UInt64 encodeInt64(const Int64 x)
 {
     return encodeUInt64(static_cast<UInt64>(x) ^ SIGN_MASK);

--- a/dbms/src/Storages/KVStore/tests/gtest_kvstore_fast_add_peer.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_kvstore_fast_add_peer.cpp
@@ -974,7 +974,7 @@ try
     fap_context->tasks_trace->addTask(region_id, [&]() {
         // Keep the task in `tasks_trace` to prevent from canceling.
         std::scoped_lock wait_exe_lock(exe_mut);
-        return genFastAddPeerRes(FastAddPeerStatus::NoSuitable, "", "");
+        return genFastAddPeerResFail(FastAddPeerStatus::NoSuitable);
     });
 
     // Mock that the storage instance have been dropped

--- a/dbms/src/Storages/KVStore/tests/gtest_kvstore_fast_add_peer.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_kvstore_fast_add_peer.cpp
@@ -449,7 +449,7 @@ try
     fap_context->tasks_trace->addTask(region_id, [&]() {
         // Keep the task in `tasks_trace` to prevent from canceling.
         std::scoped_lock wait_exe_lock(exe_mut);
-        return genFastAddPeerRes(FastAddPeerStatus::NoSuitable, "", "");
+        return genFastAddPeerResFail(FastAddPeerStatus::NoSuitable);
     });
     FastAddPeerImplWrite(global_context.getTMTContext(), proxy_helper.get(), region_id, 2333, std::move(mock_data), 0);
     exe_lock.unlock();
@@ -517,7 +517,7 @@ try
     fap_context->tasks_trace->addTask(region_id, [&]() {
         // Keep the task in `tasks_trace` to prevent from canceling.
         std::scoped_lock wait_exe_lock(exe_mut);
-        return genFastAddPeerRes(FastAddPeerStatus::NoSuitable, "", "");
+        return genFastAddPeerResFail(FastAddPeerStatus::NoSuitable);
     });
     FastAddPeerImplWrite(global_context.getTMTContext(), proxy_helper.get(), region_id, 2333, std::move(mock_data), 0);
     exe_lock.unlock();
@@ -550,7 +550,7 @@ try
     fap_context->tasks_trace->addTask(region_id, [&]() {
         // Keep the task in `tasks_trace` to prevent from canceling.
         std::scoped_lock wait_exe_lock(exe_mut);
-        return genFastAddPeerRes(FastAddPeerStatus::NoSuitable, "", "");
+        return genFastAddPeerResFail(FastAddPeerStatus::NoSuitable);
     });
     // Will generate and persist some information in local ps, which will not be uploaded.
     FastAddPeerImplWrite(global_context.getTMTContext(), proxy_helper.get(), region_id, 2333, std::move(mock_data), 0);
@@ -822,7 +822,7 @@ try
     auto fap_context = global_context.getSharedContextDisagg()->fap_context;
     uint64_t region_id = 1;
     fap_context->tasks_trace->addTask(region_id, []() {
-        return genFastAddPeerRes(FastAddPeerStatus::NoSuitable, "", "");
+        return genFastAddPeerResFail(FastAddPeerStatus::NoSuitable);
     });
     EXPECT_THROW(
         FastAddPeerImplWrite(
@@ -869,7 +869,7 @@ try
     fap_context->tasks_trace->addTask(region_id, [&]() {
         // Keep the task in `tasks_trace` to prevent from canceling.
         std::scoped_lock wait_exe_lock(exe_mut);
-        return genFastAddPeerRes(FastAddPeerStatus::NoSuitable, "", "");
+        return genFastAddPeerResFail(FastAddPeerStatus::NoSuitable);
     });
     FastAddPeerImplWrite(global_context.getTMTContext(), proxy_helper.get(), region_id, 2333, std::move(mock_data), 0);
     exe_lock.unlock();

--- a/dbms/src/Storages/KVStore/tests/gtest_kvstore_fast_add_peer.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_kvstore_fast_add_peer.cpp
@@ -821,9 +821,7 @@ try
     auto & global_context = TiFlashTestEnv::getGlobalContext();
     auto fap_context = global_context.getSharedContextDisagg()->fap_context;
     uint64_t region_id = 1;
-    fap_context->tasks_trace->addTask(region_id, []() {
-        return genFastAddPeerResFail(FastAddPeerStatus::NoSuitable);
-    });
+    fap_context->tasks_trace->addTask(region_id, []() { return genFastAddPeerResFail(FastAddPeerStatus::NoSuitable); });
     EXPECT_THROW(
         FastAddPeerImplWrite(
             global_context.getTMTContext(),

--- a/dbms/src/Storages/Page/V3/CheckpointFile/CPFilesWriter.cpp
+++ b/dbms/src/Storages/Page/V3/CheckpointFile/CPFilesWriter.cpp
@@ -97,6 +97,12 @@ CPDataDumpStats CPFilesWriter::writeEditsAndApplyCheckpointInfo(
     //    and collect the lock files from applied entries.
     auto & records = edits.getMutRecords();
     write_down_stats.num_records = records.size();
+    LOG_DEBUG(
+        log,
+        "Prepare to dump {} records, sequence={}, manifest_file_id={}",
+        write_down_stats.num_records,
+        sequence,
+        manifest_file_id);
     for (auto & rec_edit : records)
     {
         StorageType id_storage_type = StorageType::Unknown;

--- a/dbms/src/Storages/Page/V3/Universal/UniversalPageIdFormatImpl.h
+++ b/dbms/src/Storages/Page/V3/Universal/UniversalPageIdFormatImpl.h
@@ -291,7 +291,13 @@ public:
         return StorageType::Unknown;
     }
 
-private:
+public:
+    static inline void encodeUInt32(const UInt32 x, WriteBuffer & ss)
+    {
+        auto u = toBigEndian(x);
+        ss.write(reinterpret_cast<const char *>(&u), sizeof(u));
+    }
+
     static inline void encodeUInt64(const UInt64 x, WriteBuffer & ss)
     {
         auto u = toBigEndian(x);
@@ -304,6 +310,7 @@ private:
         return toBigEndian(v);
     }
 
+private:
     static String getSubPrefix(StorageType type)
     {
         switch (type)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #8673

Problem Summary:

Ref https://github.com/tidbcloud/tiflash-cse/pull/287.

We have to add some dummy implementations in TiFlash master, to reduce the divergence between serverless interfaces and codes.

The PR includes:
1. In Proxy, we update ProxyFFI.h for some changes. We also introduce a serverless_extra.rs file that does nothing as a stub file.
2. In TiFlash, we add and change some functions in FastAddPeer.cpp to support newly added interfaces. The newly add functions will always return empty(string or int). So there is little side effect.

### What is changed and how it works?

```commit-message
Compatibility for serverless FAP features including shard_ver, txn ref and enc key
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
