### PR TITLE
storage: create minmax for Enum type

### DIFF
--- a/dbms/src/Storages/DeltaMerge/File/DMFileWriter.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileWriter.cpp
@@ -59,10 +59,10 @@ DMFileWriter::DMFileWriter(
 
     for (auto & cd : write_columns)
     {
-        // TODO: currently we only generate index for Integers, Date, DateTime types, and this should be configurable by user.
+        // TODO: currently we only generate index for Integers, Date, DateTime and Enum types, and this should be configurable by user.
         /// for handle column always generate index
         auto type = removeNullable(cd.type);
-        bool do_index = cd.id == EXTRA_HANDLE_COLUMN_ID || type->isInteger() || type->isDateOrDateTime();
+        bool do_index = cd.id == EXTRA_HANDLE_COLUMN_ID || type->isValueRepresentedByInteger();
         addStreams(cd.id, cd.type, do_index);
         dmfile->meta->getColumnStats().emplace(cd.id, ColumnStat{cd.id, cd.type, /*avg_size=*/0});
     }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #9172

Problem Summary:

### What is changed and how it works?

```commit-message
storage: create minmax for Enum type
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
