### PR TITLE
ddl: Do not physical drop table after tiflash replica is set to 0

### DIFF
--- a/dbms/src/TiDB/Schema/SchemaBuilder.cpp
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.cpp
@@ -391,7 +391,6 @@ void SchemaBuilder<Getter, NameMapper>::applySetTiFlashReplica(DatabaseID databa
     auto & tmt_context = context.getTMTContext();
     if (table_info->replica_info.count == 0)
     {
-        // Replicat number is to 0, mark the table as tombstone in TiFlash
         auto storage = tmt_context.getStorages().get(keyspace_id, table_info->id);
         if (unlikely(storage == nullptr))
         {
@@ -407,8 +406,8 @@ void SchemaBuilder<Getter, NameMapper>::applySetTiFlashReplica(DatabaseID databa
         // There could be a concurrent issue that cause data loss. Check the following link for details:
         // https://github.com/pingcap/tiflash/issues/9438#issuecomment-2360370761
         // applyDropTable(database_id, table_id, "SetTiFlashReplica-0");
-        // Now only update the replica number to be 0
-        auto action = fmt::format("SetTiFlashReplica-{}", table_info->replica_info.count);
+
+        // Now only update the replica number to be 0 instead
         updateTiFlashReplicaNumOnStorage(database_id, table_id, storage, table_info);
         return;
     }

--- a/dbms/src/TiDB/Schema/SchemaBuilder.cpp
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.cpp
@@ -402,7 +402,11 @@ void SchemaBuilder<Getter, NameMapper>::applySetTiFlashReplica(DatabaseID databa
             return;
         }
 
-        applyDropTable(database_id, table_id, "SetTiFlashReplica-0");
+        // We can not mark the table is safe to be physically drop from the tiflash instances when
+        // the number of tiflash replica is set to be 0.
+        // There could be a concurrent issue that cause data loss. Check the following link for details:
+        // https://github.com/pingcap/tiflash/issues/9438#issuecomment-2360370761
+        // applyDropTable(database_id, table_id, "SetTiFlashReplica-0");
         return;
     }
 

--- a/dbms/src/TiDB/Schema/SchemaBuilder.cpp
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.cpp
@@ -407,6 +407,9 @@ void SchemaBuilder<Getter, NameMapper>::applySetTiFlashReplica(DatabaseID databa
         // There could be a concurrent issue that cause data loss. Check the following link for details:
         // https://github.com/pingcap/tiflash/issues/9438#issuecomment-2360370761
         // applyDropTable(database_id, table_id, "SetTiFlashReplica-0");
+        // Now only update the replica number to be 0
+        auto action = fmt::format("SetTiFlashReplica-{}", table_info->replica_info.count);
+        updateTiFlashReplicaNumOnStorage(database_id, table_id, storage, table_info);
         return;
     }
 

--- a/tests/fullstack-test2/ddl/alter_table_tiflash_replica.test
+++ b/tests/fullstack-test2/ddl/alter_table_tiflash_replica.test
@@ -82,9 +82,7 @@ mysql> set session tidb_isolation_read_engines='tiflash';select * from test.t;
 | x  |
 +----+
 |  1 |
-+----+
 |  8 |
-+----+
 | 50 |
 +----+
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/9438

Problem Summary:

In v8.1.0 and v8.1.1, if the tiflash replica num is set to 0, `applyDropTable(database_id, table_id, "SetTiFlashReplica-0")` will be executed and add a `tombstone_ts` to the IStorage instance.
https://github.com/pingcap/tiflash/blob/v8.1.1/dbms/src/TiDB/Schema/SchemaBuilder.cpp#L392-L407

If all the regions are removed from the tiflash instance, and the `tombstone_ts` exceeds the gc_safepoint, then we will generate a `InterpreterDropQuery` to physically drop the IStorage instance.
https://github.com/pingcap/tiflash/blob/v8.1.1/dbms/src/TiDB/Schema/SchemaSyncService.cpp#L304-L354

However, there could be a chance that data loss due to a concurrent issue:
1. In `SchemaSyncService::gcImpl`, a table is judge as both "tombstone_ts exceed the gc_safepoint" and "no region peer exists". So `InterpreterDropQuery` is generated
2. User set tiflash replica to be K where K > 0, and new region snapshot is applied to tiflash before `InterpreterDropQuery` get executed.
3. `InterpreterDropQuery` get executed, and all the data in the `StorageDeltaMerge` get physically removed. But the region is still exist in the raft-layer. And the query result after that will meet data loss.

* * *
> Note: The mechanism of "if the tiflash replica num is set to 0, `applyDropTable(database_id, table_id, "SetTiFlashReplica-0")` will be executed" is trying to remove the empty segment and .sql schema file from tiflash instance after the tiflash replica num is set to 0. But seems there is no easy way to fix such a concurrent issue.

### What is changed and how it works?

```commit-message
ddl: Do not physical drop table after tiflash replica is set to 0
To avoid a potential data loss issue when altering tiflash replica
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
