### PR TITLE
ddl: Fix the physically drop storage instance may block removing regions

### DIFF
--- a/dbms/src/Common/FailPoint.cpp
+++ b/dbms/src/Common/FailPoint.cpp
@@ -77,6 +77,7 @@ namespace DB
     M(skip_check_segment_update)                             \
     M(force_set_page_file_write_errno)                       \
     M(force_split_io_size_4k)                                \
+    M(force_set_num_regions_for_table)                       \
     M(minimum_block_size_for_cross_join)                     \
     M(random_exception_after_dt_write_done)                  \
     M(random_slow_page_storage_write)                        \

--- a/dbms/src/Debug/MockTiDB.h
+++ b/dbms/src/Debug/MockTiDB.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <Storages/ColumnsDescription.h>
+#include <Storages/IStorage.h>
 #include <Storages/Transaction/TiDB.h>
 #include <Storages/Transaction/Types.h>
 #include <TiDB/Schema/SchemaGetter.h>
@@ -82,7 +83,7 @@ public:
         const String & handle_pk_name,
         const String & engine_type);
 
-    int newTables(
+    std::vector<TableID> newTables(
         const String & database_name,
         const std::vector<std::tuple<String, ColumnsDescription, String>> & tables,
         Timestamp tso,
@@ -104,6 +105,7 @@ public:
     void dropPartition(const String & database_name, const String & table_name, TableID partition_id);
 
     void dropTable(Context & context, const String & database_name, const String & table_name, bool drop_regions);
+    void dropTableById(Context & context, const TableID & table_id, bool drop_regions);
 
     void dropDB(Context & context, const String & database_name, bool drop_regions);
 
@@ -151,7 +153,9 @@ public:
 
 private:
     TableID newPartitionImpl(const TablePtr & logical_table, TableID partition_id, const String & partition_name, Timestamp tso, bool is_add_part);
-    TablePtr dropTableInternal(Context & context, const String & database_name, const String & table_name, bool drop_regions);
+    TablePtr dropTableByNameImpl(Context & context, const String & database_name, const String & table_name, bool drop_regions);
+    TablePtr dropTableByIdImpl(Context & context, TableID table_id, bool drop_regions);
+    TablePtr dropTableInternal(Context & context, const TablePtr & table, bool drop_regions);
     TablePtr getTableByNameInternal(const String & database_name, const String & table_name);
     TablePtr getTableByID(TableID table_id);
 

--- a/dbms/src/Debug/dbgFuncSchema.cpp
+++ b/dbms/src/Debug/dbgFuncSchema.cpp
@@ -86,16 +86,20 @@ void dbgFuncRefreshSchemas(Context & context, const ASTs &, DBGInvoker::Printer 
 
 // Trigger gc on all databases / tables.
 // Usage:
-//   ./storage-client.sh "DBGInvoke gc_schemas([gc_safe_point])"
+//   ./storage-client.sh "DBGInvoke gc_schemas([gc_safe_point, ignore_remain_regions])"
 void dbgFuncGcSchemas(Context & context, const ASTs & args, DBGInvoker::Printer output)
 {
     auto & service = context.getSchemaSyncService();
     Timestamp gc_safe_point = 0;
+    bool ignore_remain_regions = false;
     if (args.empty())
         gc_safe_point = PDClientHelper::getGCSafePointWithRetry(context.getTMTContext().getPDClient());
-    else
+    if (!args.empty())
         gc_safe_point = safeGet<Timestamp>(typeid_cast<const ASTLiteral &>(*args[0]).value);
-    service->gc(gc_safe_point, NullspaceID);
+    if (args.size() >= 2)
+        ignore_remain_regions = safeGet<String>(typeid_cast<const ASTLiteral &>(*args[1]).value) == "true";
+    // Note that only call it in tests, we need to ignore remain regions
+    service->gcImpl(gc_safe_point, NullspaceID, ignore_remain_regions);
 
     output("schemas gc done");
 }

--- a/dbms/src/Debug/dbgFuncSchema.h
+++ b/dbms/src/Debug/dbgFuncSchema.h
@@ -34,7 +34,7 @@ void dbgFuncRefreshSchemas(Context & context, const ASTs & args, DBGInvoker::Pri
 
 // Trigger gc on all databases / tables.
 // Usage:
-//   ./storage-client.sh "DBGInvoke gc_schemas([gc_safe_point])"
+//   ./storage-client.sh "DBGInvoke gc_schemas([gc_safe_point, ignore_remain_regions])"
 void dbgFuncGcSchemas(Context & context, const ASTs & args, DBGInvoker::Printer output);
 
 // Reset schemas.

--- a/dbms/src/Storages/Transaction/RegionTable.cpp
+++ b/dbms/src/Storages/Transaction/RegionTable.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <Common/Exception.h>
+#include <Common/FailPoint.h>
 #include <Common/setThreadName.h>
 #include <Interpreters/Context.h>
 #include <Storages/DeltaMerge/ExternalDTFileInfo.h>
@@ -26,7 +27,11 @@
 #include <Storages/Transaction/RegionTable.h>
 #include <Storages/Transaction/TMTContext.h>
 #include <Storages/Transaction/TiKVRange.h>
+#include <Storages/Transaction/Types.h>
 #include <TiDB/Schema/SchemaSyncer.h>
+#include <fiu.h>
+
+#include <any>
 
 namespace DB
 {
@@ -37,6 +42,10 @@ extern const int UNKNOWN_TABLE;
 extern const int ILLFORMAT_RAFT_ROW;
 extern const int TABLE_IS_DROPPED;
 } // namespace ErrorCodes
+namespace FailPoints
+{
+extern const char force_set_num_regions_for_table[];
+} // namespace FailPoints
 
 RegionTable::Table & RegionTable::getOrCreateTable(const KeyspaceID keyspace_id, const TableID table_id)
 {
@@ -285,8 +294,8 @@ void RegionTable::removeRegion(const RegionID region_id, bool remove_data, const
         {
             tables.erase(ks_tb_id);
         }
-        LOG_INFO(log, "remove [region {}] in RegionTable done", region_id);
     }
+    LOG_INFO(log, "remove [region {}] in RegionTable done", region_id);
 
     // Sometime we don't need to remove data. e.g. remove region after region merge.
     if (remove_data)
@@ -429,6 +438,31 @@ void RegionTable::handleInternalRegionsByTable(const KeyspaceID keyspace_id, con
     {
         callback(it->second.regions);
     }
+}
+
+std::vector<RegionID> RegionTable::getRegionIdsByTable(KeyspaceID keyspace_id, TableID table_id) const
+{
+    fiu_do_on(FailPoints::force_set_num_regions_for_table, {
+        if (auto v = FailPointHelper::getFailPointVal(FailPoints::force_set_num_regions_for_table); v)
+        {
+            auto num_regions = std::any_cast<std::vector<RegionID>>(v.value());
+            return num_regions;
+        }
+    });
+
+    std::lock_guard lock(mutex);
+    if (auto iter = tables.find(KeyspaceTableID{keyspace_id, table_id}); //
+        unlikely(iter != tables.end()))
+    {
+        std::vector<RegionID> ret_regions;
+        ret_regions.reserve(iter->second.regions.size());
+        for (const auto & r : iter->second.regions)
+        {
+            ret_regions.emplace_back(r.first);
+        }
+        return ret_regions;
+    }
+    return {};
 }
 
 std::vector<std::pair<RegionID, RegionPtr>> RegionTable::getRegionsByTable(const KeyspaceID keyspace_id, const TableID table_id) const

--- a/dbms/src/Storages/Transaction/RegionTable.h
+++ b/dbms/src/Storages/Transaction/RegionTable.h
@@ -170,6 +170,8 @@ public:
     RegionDataReadInfoList tryWriteBlockByRegionAndFlush(const RegionPtrWithBlock & region, bool try_persist);
 
     void handleInternalRegionsByTable(KeyspaceID keyspace_id, TableID table_id, std::function<void(const InternalRegions &)> && callback) const;
+
+    std::vector<RegionID> getRegionIdsByTable(KeyspaceID keyspace_id, TableID table_id) const;
     std::vector<std::pair<RegionID, RegionPtr>> getRegionsByTable(KeyspaceID keyspace_id, TableID table_id) const;
 
     /// Write the data of the given region into the table with the given table ID, fill the data list for outer to remove.

--- a/dbms/src/TiDB/Schema/SchemaSyncService.cpp
+++ b/dbms/src/TiDB/Schema/SchemaSyncService.cpp
@@ -41,15 +41,26 @@ SchemaSyncService::SchemaSyncService(DB::Context & context_)
     , log(Logger::get())
 {
     // Add task for adding and removing keyspace sync schema tasks.
-    handle = background_pool.addTask(
-        [&, this] {
-            addKeyspaceGCTasks();
-            removeKeyspaceGCTasks();
+    auto interval_ms = interval_seconds * 1000;
+    if (interval_ms == 0)
+    {
+        LOG_WARNING(
+            log,
+            "The background task of SchemaSyncService is disabled, please check the ddl_sync_interval_seconds "
+            "settings");
+    }
+    else
+    {
+        handle = background_pool.addTask(
+            [&, this] {
+                addKeyspaceGCTasks();
+                removeKeyspaceGCTasks();
 
-            return false;
-        },
-        false,
-        interval_seconds * 1000);
+                return false;
+            },
+            false,
+            interval_ms);
+    }
 }
 
 void SchemaSyncService::addKeyspaceGCTasks()

--- a/dbms/src/TiDB/Schema/SchemaSyncService.cpp
+++ b/dbms/src/TiDB/Schema/SchemaSyncService.cpp
@@ -293,6 +293,7 @@ bool SchemaSyncService::gcImpl(Timestamp gc_safepoint, KeyspaceID keyspace_id, b
                     storage->getTombstone(),
                     gc_safepoint,
                     canonical_name);
+                succeeded = false; // dropping this table is skipped, do not succee the `last_gc_safepoint`
                 continue;
             }
             else
@@ -330,7 +331,7 @@ bool SchemaSyncService::gcImpl(Timestamp gc_safepoint, KeyspaceID keyspace_id, b
         }
         catch (DB::Exception & e)
         {
-            succeeded = false;
+            succeeded = false; // dropping this table is skipped, do not succee the `last_gc_safepoint`
             String err_msg;
             // Maybe a read lock of a table is held for a long time, just ignore it this round.
             if (e.code() == ErrorCodes::DEADLOCK_AVOIDED)
@@ -380,7 +381,7 @@ bool SchemaSyncService::gcImpl(Timestamp gc_safepoint, KeyspaceID keyspace_id, b
         }
         catch (DB::Exception & e)
         {
-            succeeded = false;
+            succeeded = false; // dropping this database is skipped, do not succee the `last_gc_safepoint`
             String err_msg;
             if (e.code() == ErrorCodes::DEADLOCK_AVOIDED)
                 err_msg = "locking attempt has timed out!"; // ignore verbose stack for this error

--- a/dbms/src/TiDB/Schema/SchemaSyncService.h
+++ b/dbms/src/TiDB/Schema/SchemaSyncService.h
@@ -35,6 +35,11 @@ using ASTs = std::vector<ASTPtr>;
 using DBGInvokerPrinter = std::function<void(const std::string &)>;
 extern void dbgFuncGcSchemas(Context &, const ASTs &, DBGInvokerPrinter);
 
+namespace tests
+{
+class SchemaSyncTest;
+}
+
 class SchemaSyncService
     : public std::enable_shared_from_this<SchemaSyncService>
     , private boost::noncopyable
@@ -43,17 +48,22 @@ public:
     explicit SchemaSyncService(Context & context_);
     ~SchemaSyncService();
 
+    friend class tests::SchemaSyncTest;
+    bool gc(Timestamp gc_safepoint, KeyspaceID keyspace_id);
+
+    void shutdown();
+
 private:
     bool syncSchemas(KeyspaceID keyspace_id);
     void removeCurrentVersion(KeyspaceID keyspace_id);
 
-    bool gc(Timestamp gc_safepoint, KeyspaceID keyspace_id);
 
     void addKeyspaceGCTasks();
     void removeKeyspaceGCTasks();
 
     std::optional<Timestamp> lastGcSafePoint(KeyspaceID keyspace_id) const;
     void updateLastGcSafepoint(KeyspaceID keyspace_id, Timestamp gc_safepoint);
+    bool gcImpl(Timestamp gc_safepoint, KeyspaceID keyspace_id, bool ignore_remain_regions);
 
 private:
     Context & context;

--- a/dbms/src/TiDB/Schema/tests/gtest_schema_sync.cpp
+++ b/dbms/src/TiDB/Schema/tests/gtest_schema_sync.cpp
@@ -236,6 +236,52 @@ try
 }
 CATCH
 
+TEST_F(SchemaSyncTest, PhysicalDropTable)
+try
+{
+    auto pd_client = global_ctx.getTMTContext().getPDClient();
+
+    const String db_name = "mock_db";
+    MockTiDB::instance().newDataBase(db_name);
+
+    auto cols = ColumnsDescription({
+        {"col1", typeFromString("String")},
+        {"col2", typeFromString("Int64")},
+    });
+    // table_name, cols, pk_name
+    std::vector<std::tuple<String, ColumnsDescription, String>> tables{
+        {"t1", cols, ""},
+        {"t2", cols, ""},
+    };
+    auto table_ids = MockTiDB::instance().newTables(db_name, tables, pd_client->getTS(), "dt");
+
+    refreshSchema();
+
+    mustGetSyncedTableByName(db_name, "t1");
+    mustGetSyncedTableByName(db_name, "t2");
+
+    MockTiDB::instance().dropTable(global_ctx, db_name, "t1", true);
+
+    refreshSchema();
+
+    // Create a temporary context with ddl sync task disabled
+    auto sync_service = std::make_shared<SchemaSyncService>(global_ctx);
+    sync_service->shutdown(); // shutdown the background tasks
+
+    // run gc with safepoint == 0, will be skip
+    ASSERT_FALSE(sync_service->gc(0, NullspaceID));
+    ASSERT_TRUE(sync_service->gc(10000000, NullspaceID));
+    // run gc with the same safepoint, will be skip
+    ASSERT_FALSE(sync_service->gc(10000000, NullspaceID));
+    // run gc for another keyspace with same safepoint, will be executed
+    ASSERT_TRUE(sync_service->gc(10000000, 1024));
+    // run gc with changed safepoint
+    ASSERT_TRUE(sync_service->gc(20000000, 1024));
+    // run gc with the same safepoint
+    ASSERT_FALSE(sync_service->gc(20000000, 1024));
+}
+CATCH
+
 TEST_F(SchemaSyncTest, PhysicalDropTableMeetsUnRemovedRegions)
 try
 {
@@ -269,6 +315,8 @@ try
     SCOPE_EXIT({ FailPointHelper::disableFailPoint(FailPoints::force_set_num_regions_for_table); });
 
     auto sync_service = std::make_shared<SchemaSyncService>(global_ctx);
+    sync_service->shutdown(); // shutdown the background tasks
+
     {
         // ensure gc_safe_point cache is empty
         auto last_gc_safe_point = lastGcSafePoint(sync_service, NullspaceID);
@@ -292,8 +340,6 @@ try
         ++num_remain_tables;
     }
     ASSERT_EQ(num_remain_tables, 1);
-
-    sync_service->shutdown();
 }
 CATCH
 

--- a/tests/fullstack-test2/ddl/alter_exchange_partition.test
+++ b/tests/fullstack-test2/ddl/alter_exchange_partition.test
@@ -303,7 +303,7 @@ mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.e2 
 
 # ensure the swap out table is not mark as tombstone
 >> DBGInvoke __enable_schema_sync_service('true')
->> DBGInvoke __gc_schemas(18446744073709551615)
+>> DBGInvoke __gc_schemas(18446744073709551615, 'true')
 >> DBGInvoke __enable_schema_sync_service('false')
 mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.e order by id;
 +-----+-------+-------+
@@ -348,7 +348,7 @@ mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.e2 
 +-----+-------+-------+
 # ensure the swap out table is not mark as tombstone
 >> DBGInvoke __enable_schema_sync_service('true')
->> DBGInvoke __gc_schemas(18446744073709551615)
+>> DBGInvoke __gc_schemas(18446744073709551615, 'true')
 >> DBGInvoke __enable_schema_sync_service('false')
 mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.e order by id;
 +-----+-------+-------+

--- a/tests/fullstack-test2/ddl/flashback_database.test
+++ b/tests/fullstack-test2/ddl/flashback_database.test
@@ -55,7 +55,7 @@ mysql> set session tidb_isolation_read_engines='tiflash'; select * from d1_new.t
 
 # ensure the flashbacked table and database is not mark as tombstone
 >> DBGInvoke __enable_schema_sync_service('true')
->> DBGInvoke __gc_schemas(18446744073709551615)
+>> DBGInvoke __gc_schemas(18446744073709551615, 'true')
 
 mysql> set session tidb_isolation_read_engines='tiflash'; select * from d1_new.t3 order by a;
 +------+------+


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/9437

Problem Summary:

When a table is dropped in tidb, and exceeds the gc_safepoint, tiflash will generate an `InterpreterDropQuery` to physically remove the data from the tiflash instance. The "DropQuery" will call `DeltaMergeStore::dropAllSegments` to remove the Segment at DeltaTree storage one by one. Because there are many segments for the table, running `DeltaMergeStore::dropAllSegments` is slow.
https://github.com/pingcap/tiflash/blob/v7.1.3/dbms/src/TiDB/Schema/SchemaSyncService.cpp#L216-L227
https://github.com/pingcap/tiflash/blob/v7.1.3/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp#L342-L349


```
[2024/09/16 21:29:29.604 +00:00] [INFO] [SchemaSyncService.cpp:170] ["Performing GC using safe point 452597098965106688"] [source="keyspace=4294967295"] [thread_id=4314]
[2024/09/16 21:29:29.610 +00:00] [INFO] [SchemaSyncService.cpp:216] ["Physically dropping table test_db(694).test_tbl(563080)"] [source="keyspace=4294967295"] [thread_id=4314]
[2024/09/16 21:29:30.446 +00:00] [INFO] [DeltaMergeStore.cpp:413] ["Clear DeltaMerge segments data"] [source="keyspace_id=4294967295 table_id=563080"] [thread_id=4314]
[2024/09/16 21:29:30.465 +00:00] [INFO] [Segment.cpp:2004] ["Finish segment drop its next segment, segment=<segment_id=292469 epoch=2 range=[?,?) next_segment_id=292472 delta_rows=0 delta_bytes=0 delta_deletes=0 stable_file=dmf_1174749 stable_rows=98304 stable_bytes=576748236 dmf_rows=98304 dmf_bytes=576748236 dmf_packs=12>"] [source="keyspace_id=4294967295 table_id=563080 segment_id=292469 epoch=2"] [thread_id=4314]
[2024/09/16 21:29:30.553 +00:00] [INFO] [Segment.cpp:2004] ["Finish segment drop its next segment, segment=<segment_id=292223 epoch=3 range=[?,?) next_segment_id=292469 delta_rows=0 delta_bytes=0 delta_deletes=0 stable_file=dmf_1205953 stable_rows=86440 stable_bytes=507435226 dmf_rows=86440 dmf_bytes=507435226 dmf_packs=11>"] [source="keyspace_id=4294967295 table_id=563080 segment_id=292223 epoch=3"] [thread_id=4314]
...
```

However, `DeltaMergeStore::dropAllSegments` does not check that all Regions have been removed from TiFlash before the physical drop action is performed. So at the same time, there are some Region removed actions are performed.
All the raftstore threads that try to remove Region will run into `removeObsoleteDataInStorage`, calling `DeltaMergeStore::flushCache` and try to acquire a read latch on table_id=563080. At last, all the raftsotre threads are blocked by the thread that executing `DeltaMergeStore::dropAllSegments`.

![image](https://github.com/user-attachments/assets/2b369d31-8bca-45bd-839d-12562fb1d045)

But more raft-message comes into the tiflash instance, the memory usage grows and cause OOM kills. After restarts, the tiflash instance runs into the same blocking again. And at last, all the segments (around 30,000 in total) are removed from tiflash. And tiflash begins to catch-up the raft message.

```
[2024/09/16 23:25:37.681 +00:00] [INFO] [DeltaMergeStore.cpp:413] ["Clear DeltaMerge segments data"] [source="keyspace_id=4294967295 table_id=563080"] [thread_id=4143]
...
[2024/09/16 23:46:11.570 +00:00] [INFO] [Segment.cpp:2004] ["Finish segment drop its next segment, segment=<segment_id=281216 epoch=2 range=[?,?) next_segment_id=281738 delta_rows=0 delta_bytes=0 delta_deletes=1 stable_file=dmf_1205957 stable_rows=59514 stable_bytes=348855913 dmf_rows=59514 dmf_bytes=348855913 dmf_packs=8>"] [source="keyspace_id=4294967295 table_id=563080 segment_id=281216 epoch=2"] [thread_id=4143]
[2024/09/16 23:46:11.714 +00:00] [INFO] [DeltaMergeStore.cpp:419] ["Clear DeltaMerge segments data done"] [source="keyspace_id=4294967295 table_id=563080"] [thread_id=4143]
```

![image](https://github.com/user-attachments/assets/f1800745-5e46-498e-bf1b-2f90bb8177e4)


### What is changed and how it works?

```commit-message
ddl: Fix the physical drop storage instance may block removing regions
Make sure physical drop storage instance only happen after all related regions are removed
```

Pick PRs:
* https://github.com/pingcap/tiflash/pull/8721
* https://github.com/pingcap/tiflash/pull/8955
* https://github.com/pingcap/tiflash/pull/8910
* https://github.com/pingcap/tiflash/pull/8972

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
