### PR TITLE
disable some json functions pushdown

### DIFF
--- a/dbms/src/Flash/Coprocessor/DAGUtils.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGUtils.cpp
@@ -151,7 +151,7 @@ const std::unordered_map<tipb::ScalarFuncSig, String> scalar_func_map({
     {tipb::ScalarFuncSig::LTDecimal, "less"},
     {tipb::ScalarFuncSig::LTTime, "less"},
     {tipb::ScalarFuncSig::LTDuration, "less"},
-    {tipb::ScalarFuncSig::LTJson, "less"},
+    //{tipb::ScalarFuncSig::LTJson, "less"},
     {tipb::ScalarFuncSig::LTVectorFloat32, "less"},
 
     {tipb::ScalarFuncSig::LEInt, "lessOrEquals"},
@@ -160,7 +160,7 @@ const std::unordered_map<tipb::ScalarFuncSig, String> scalar_func_map({
     {tipb::ScalarFuncSig::LEDecimal, "lessOrEquals"},
     {tipb::ScalarFuncSig::LETime, "lessOrEquals"},
     {tipb::ScalarFuncSig::LEDuration, "lessOrEquals"},
-    {tipb::ScalarFuncSig::LEJson, "lessOrEquals"},
+    //{tipb::ScalarFuncSig::LEJson, "lessOrEquals"},
     {tipb::ScalarFuncSig::LEVectorFloat32, "lessOrEquals"},
 
     {tipb::ScalarFuncSig::GTInt, "greater"},
@@ -169,7 +169,7 @@ const std::unordered_map<tipb::ScalarFuncSig, String> scalar_func_map({
     {tipb::ScalarFuncSig::GTDecimal, "greater"},
     {tipb::ScalarFuncSig::GTTime, "greater"},
     {tipb::ScalarFuncSig::GTDuration, "greater"},
-    {tipb::ScalarFuncSig::GTJson, "greater"},
+    //{tipb::ScalarFuncSig::GTJson, "greater"},
     {tipb::ScalarFuncSig::GTVectorFloat32, "greater"},
 
     {tipb::ScalarFuncSig::GreatestInt, "tidbGreatest"},
@@ -193,7 +193,7 @@ const std::unordered_map<tipb::ScalarFuncSig, String> scalar_func_map({
     {tipb::ScalarFuncSig::GEDecimal, "greaterOrEquals"},
     {tipb::ScalarFuncSig::GETime, "greaterOrEquals"},
     {tipb::ScalarFuncSig::GEDuration, "greaterOrEquals"},
-    {tipb::ScalarFuncSig::GEJson, "greaterOrEquals"},
+    //{tipb::ScalarFuncSig::GEJson, "greaterOrEquals"},
     {tipb::ScalarFuncSig::GEVectorFloat32, "greaterOrEquals"},
 
     {tipb::ScalarFuncSig::EQInt, "equals"},
@@ -202,7 +202,7 @@ const std::unordered_map<tipb::ScalarFuncSig, String> scalar_func_map({
     {tipb::ScalarFuncSig::EQDecimal, "equals"},
     {tipb::ScalarFuncSig::EQTime, "equals"},
     {tipb::ScalarFuncSig::EQDuration, "equals"},
-    {tipb::ScalarFuncSig::EQJson, "equals"},
+    //{tipb::ScalarFuncSig::EQJson, "equals"},
     {tipb::ScalarFuncSig::EQVectorFloat32, "equals"},
 
     {tipb::ScalarFuncSig::NEInt, "notEquals"},
@@ -211,7 +211,7 @@ const std::unordered_map<tipb::ScalarFuncSig, String> scalar_func_map({
     {tipb::ScalarFuncSig::NEDecimal, "notEquals"},
     {tipb::ScalarFuncSig::NETime, "notEquals"},
     {tipb::ScalarFuncSig::NEDuration, "notEquals"},
-    {tipb::ScalarFuncSig::NEJson, "notEquals"},
+    //{tipb::ScalarFuncSig::NEJson, "notEquals"},
     {tipb::ScalarFuncSig::NEVectorFloat32, "notEquals"},
 
     //{tipb::ScalarFuncSig::NullEQInt, "cast"},
@@ -329,7 +329,7 @@ const std::unordered_map<tipb::ScalarFuncSig, String> scalar_func_map({
     {tipb::ScalarFuncSig::StringIsNull, "isNull"},
     {tipb::ScalarFuncSig::TimeIsNull, "isNull"},
     {tipb::ScalarFuncSig::IntIsNull, "isNull"},
-    {tipb::ScalarFuncSig::JsonIsNull, "isNull"},
+    //{tipb::ScalarFuncSig::JsonIsNull, "isNull"},
     {tipb::ScalarFuncSig::VectorFloat32IsNull, "isNull"},
 
     {tipb::ScalarFuncSig::BitAndSig, "bitAnd"},
@@ -371,7 +371,7 @@ const std::unordered_map<tipb::ScalarFuncSig, String> scalar_func_map({
     {tipb::ScalarFuncSig::InDecimal, "tidbIn"},
     {tipb::ScalarFuncSig::InTime, "tidbIn"},
     {tipb::ScalarFuncSig::InDuration, "tidbIn"},
-    {tipb::ScalarFuncSig::InJson, "tidbIn"},
+    //{tipb::ScalarFuncSig::InJson, "tidbIn"},
 
     {tipb::ScalarFuncSig::IfNullInt, "ifNull"},
     {tipb::ScalarFuncSig::IfNullReal, "ifNull"},


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9444

Problem Summary:

Json comparision is not supported in TiFlash, this pr disable them.
### What is changed and how it works?

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
