### PR TITLE
ddl: Support parsing VectorIndex defined in IndexInfo

### DIFF
--- a/dbms/src/TiDB/Schema/TiDB.h
+++ b/dbms/src/TiDB/Schema/TiDB.h
@@ -261,6 +261,8 @@ struct IndexInfo
     bool is_primary = false;
     bool is_invisible = false;
     bool is_global = false;
+
+    VectorIndexDefinitionPtr vector_index = nullptr;
 };
 
 struct TableInfo
@@ -331,6 +333,7 @@ struct TableInfo
 
     /// should not be called if is_common_handle = false.
     const IndexInfo & getPrimaryIndexInfo() const;
+
     size_t numColumnsInKey() const;
 };
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9032 

Problem Summary:

### What is changed and how it works?

* Support parsing VectorIndex defined in IndexInfo
* Use constant `TiDB::MAX_VECTOR_DIMENSION` to replace magic number in codes
* Fix a fake lock safe func `FileCache::fgDownload`

```commit-message
ddl: Support parsing VectorIndex defined in IndexInfo
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
