### PR TITLE
storage: support the HTTP API of sync table schema

### DIFF
--- a/dbms/src/Common/FailPoint.cpp
+++ b/dbms/src/Common/FailPoint.cpp
@@ -70,7 +70,8 @@ namespace DB
     M(force_fail_to_create_etcd_session)                          \
     M(force_remote_read_for_batch_cop_once)                       \
     M(exception_new_dynamic_thread)                               \
-    M(force_wait_index_timeout)
+    M(force_wait_index_timeout)                                   \
+    M(sync_schema_request_failure)
 
 #define APPLY_FOR_FAILPOINTS(M)                              \
     M(skip_check_segment_update)                             \

--- a/dbms/src/Storages/KVStore/tests/gtest_sync_schema.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_sync_schema.cpp
@@ -13,9 +13,7 @@
 // limitations under the License.
 
 #include <Common/FailPoint.h>
-#include <Common/StringUtils/StringRefUtils.h>
 #include <Databases/DatabaseTiFlash.h>
-#include <Encryption/ReadBufferFromFileProvider.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/InterpreterCreateQuery.h>
 #include <Interpreters/InterpreterDropQuery.h>
@@ -23,7 +21,6 @@
 #include <Parsers/ASTDropQuery.h>
 #include <Parsers/ParserCreateQuery.h>
 #include <Parsers/parseQuery.h>
-#include <Poco/File.h>
 #include <Storages/IManageableStorage.h>
 #include <Storages/KVStore/FFI/ProxyFFI.h>
 #include <Storages/KVStore/FFI/ProxyFFICommon.h>
@@ -32,7 +29,6 @@
 #include <Storages/KVStore/Types.h>
 #include <Storages/KVStore/tests/region_helper.h>
 #include <Storages/KVStore/tests/region_kvstore_test.h>
-#include <Storages/MutableSupport.h>
 #include <Storages/StorageDeltaMerge.h>
 #include <Storages/registerStorages.h>
 #include <TestUtils/TiFlashTestBasic.h>

--- a/dbms/src/Storages/KVStore/tests/gtest_sync_schema.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_sync_schema.cpp
@@ -1,0 +1,181 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Common/FailPoint.h>
+#include <Common/StringUtils/StringRefUtils.h>
+#include <Databases/DatabaseTiFlash.h>
+#include <Encryption/ReadBufferFromFileProvider.h>
+#include <Interpreters/Context.h>
+#include <Interpreters/InterpreterCreateQuery.h>
+#include <Interpreters/InterpreterDropQuery.h>
+#include <Parsers/ASTCreateQuery.h>
+#include <Parsers/ASTDropQuery.h>
+#include <Parsers/ParserCreateQuery.h>
+#include <Parsers/parseQuery.h>
+#include <Poco/File.h>
+#include <Storages/IManageableStorage.h>
+#include <Storages/KVStore/FFI/ProxyFFI.h>
+#include <Storages/KVStore/FFI/ProxyFFICommon.h>
+#include <Storages/KVStore/TMTContext.h>
+#include <Storages/KVStore/TMTStorages.h>
+#include <Storages/KVStore/Types.h>
+#include <Storages/KVStore/tests/region_helper.h>
+#include <Storages/KVStore/tests/region_kvstore_test.h>
+#include <Storages/MutableSupport.h>
+#include <Storages/StorageDeltaMerge.h>
+#include <Storages/registerStorages.h>
+#include <TestUtils/TiFlashTestBasic.h>
+#include <TiDB/Schema/SchemaNameMapper.h>
+#include <TiDB/Schema/TiDBSchemaManager.h>
+
+namespace DB
+{
+namespace ErrorCodes
+{
+extern const int SYNTAX_ERROR;
+} // namespace ErrorCodes
+
+namespace FailPoints
+{
+extern const char sync_schema_request_failure[];
+} // namespace FailPoints
+
+namespace tests
+{
+class SyncSchemaTest : public ::testing::Test
+{
+public:
+    SyncSchemaTest() = default;
+    static void SetUpTestCase()
+    {
+        try
+        {
+            registerStorages();
+        }
+        catch (DB::Exception &)
+        {
+            // Maybe another test has already registed, ignore exception here.
+        }
+    }
+    void SetUp() override { recreateMetadataPath(); }
+
+    void TearDown() override
+    {
+        // Clean all database from context.
+        auto ctx = TiFlashTestEnv::getContext();
+        for (const auto & [name, db] : ctx->getDatabases())
+        {
+            ctx->detachDatabase(name);
+            db->shutdown();
+        }
+    }
+    static void recreateMetadataPath()
+    {
+        String path = TiFlashTestEnv::getContext()->getPath();
+        auto p = path + "/metadata/";
+        TiFlashTestEnv::tryRemovePath(p, /*recreate=*/true);
+        p = path + "/data/";
+        TiFlashTestEnv::tryRemovePath(p, /*recreate=*/true);
+    }
+};
+
+TEST_F(SyncSchemaTest, TestNormal)
+try
+{
+    auto ctx = TiFlashTestEnv::getContext();
+    auto pd_client = ctx->getGlobalContext().getTMTContext().getPDClient();
+
+    MockTiDB::instance().newDataBase("db_1");
+    auto cols = ColumnsDescription({
+        {"col1", typeFromString("Int64")},
+    });
+    auto table_id = MockTiDB::instance().newTable("db_1", "t_1", cols, pd_client->getTS(), "");
+    auto schema_syncer = ctx->getTMTContext().getSchemaSyncerManager();
+    KeyspaceID keyspace_id = NullspaceID;
+    schema_syncer->syncSchemas(ctx->getGlobalContext(), keyspace_id);
+
+    EngineStoreServerWrap store_server_wrap{};
+    store_server_wrap.tmt = &ctx->getTMTContext();
+    auto helper = GetEngineStoreServerHelper(&store_server_wrap);
+    String path = fmt::format("/tiflash/sync-schema/keyspace/{}/table/{}", keyspace_id, table_id);
+    auto res = helper.fn_handle_http_request(
+        &store_server_wrap,
+        BaseBuffView{path.data(), path.length()},
+        BaseBuffView{path.data(), path.length()},
+        BaseBuffView{"", 0});
+    EXPECT_EQ(res.status, HttpRequestStatus::Ok);
+    {
+        // normal errmsg is nil.
+        EXPECT_EQ(res.res.view.len, 0);
+    }
+    delete (static_cast<RawCppString *>(res.res.inner.ptr));
+
+    // do sync table schema twice
+    {
+        path = fmt::format("/tiflash/sync-schema/keyspace/{}/table/{}", keyspace_id, table_id);
+        auto res = helper.fn_handle_http_request(
+            &store_server_wrap,
+            BaseBuffView{path.data(), path.length()},
+            BaseBuffView{path.data(), path.length()},
+            BaseBuffView{"", 0});
+        EXPECT_EQ(res.status, HttpRequestStatus::Ok);
+        {
+            // normal errmsg is nil.
+            EXPECT_EQ(res.res.view.len, 0);
+        }
+        delete (static_cast<RawCppString *>(res.res.inner.ptr));
+    }
+
+    // test wrong table ID
+    {
+        TableID wrong_table_id = table_id + 1;
+        path = fmt::format("/tiflash/sync-schema/keyspace/{}/table/{}", keyspace_id, wrong_table_id);
+        auto res_err = helper.fn_handle_http_request(
+            &store_server_wrap,
+            BaseBuffView{path.data(), path.length()},
+            BaseBuffView{path.data(), path.length()},
+            BaseBuffView{"", 0});
+        EXPECT_EQ(res_err.status, HttpRequestStatus::ErrorParam);
+        StringRef sr(res_err.res.view.data, res_err.res.view.len);
+        {
+            EXPECT_EQ(sr.toString(), "{\"errMsg\":\"sync schema failed\"}");
+        }
+        delete (static_cast<RawCppString *>(res_err.res.inner.ptr));
+    }
+
+    // test sync schema failed
+    {
+        path = fmt::format("/tiflash/sync-schema/keyspace/{}/table/{}", keyspace_id, table_id);
+        FailPointHelper::enableFailPoint(FailPoints::sync_schema_request_failure);
+        auto res_err1 = helper.fn_handle_http_request(
+            &store_server_wrap,
+            BaseBuffView{path.data(), path.length()},
+            BaseBuffView{path.data(), path.length()},
+            BaseBuffView{"", 0});
+        EXPECT_EQ(res_err1.status, HttpRequestStatus::ErrorParam);
+        StringRef sr(res_err1.res.view.data, res_err1.res.view.len);
+        {
+            EXPECT_EQ(
+                sr.toString(),
+                "{\"errMsg\":\"Fail point FailPoints::sync_schema_request_failure is triggered.\"}");
+        }
+        delete (static_cast<RawCppString *>(res_err1.res.inner.ptr));
+    }
+
+    dropDataBase("db_1");
+}
+CATCH
+
+} // namespace tests
+} // namespace DB

--- a/dbms/src/Storages/KVStore/tests/region_kvstore_test.h
+++ b/dbms/src/Storages/KVStore/tests/region_kvstore_test.h
@@ -88,4 +88,8 @@ inline void validateSSTGeneration(
     ASSERT_EQ(counter, key_count);
 }
 
+ASTPtr parseCreateStatement(const String & statement);
+TableID createDBAndTable(String db_name, String table_name);
+void dropDataBase(String db_name);
+
 } // namespace DB::tests


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #9032

Problem Summary:

### What is changed and how it works?

Pick https://github.com/tidbcloud/tiflash-cse/pull/281

```commit-message
storage: support the HTTP API of sync table schema
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
