### PR TITLE
join be aware of cancel signal

### DIFF
--- a/dbms/src/DataStreams/AggregatingBlockInputStream.cpp
+++ b/dbms/src/DataStreams/AggregatingBlockInputStream.cpp
@@ -32,7 +32,7 @@ Block AggregatingBlockInputStream::readImpl()
         executed = true;
         AggregatedDataVariantsPtr data_variants = std::make_shared<AggregatedDataVariants>();
 
-        Aggregator::CancellationHook hook = [&]() {
+        CancellationHook hook = [&]() {
             return this->isCancelled();
         };
         aggregator.setCancellationHook(hook);

--- a/dbms/src/DataStreams/HashJoinProbeBlockInputStream.cpp
+++ b/dbms/src/DataStreams/HashJoinProbeBlockInputStream.cpp
@@ -36,10 +36,6 @@ HashJoinProbeBlockInputStream::HashJoinProbeBlockInputStream(
 
     probe_exec.set(HashJoinProbeExec::build(req_id, original_join, stream_index, input, max_block_size_));
     probe_exec->setCancellationHook([&]() { return isCancelledOrThrowIfKilled(); });
-    if (stream_index == 0)
-    {
-        original_join->setCancellationHook([&]() { return isCancelledOrThrowIfKilled(); });
-    }
 
     ProbeProcessInfo header_probe_process_info(0, 0);
     header_probe_process_info.resetBlock(input->getHeader());

--- a/dbms/src/DataStreams/HashJoinProbeBlockInputStream.cpp
+++ b/dbms/src/DataStreams/HashJoinProbeBlockInputStream.cpp
@@ -36,6 +36,10 @@ HashJoinProbeBlockInputStream::HashJoinProbeBlockInputStream(
 
     probe_exec.set(HashJoinProbeExec::build(req_id, original_join, stream_index, input, max_block_size_));
     probe_exec->setCancellationHook([&]() { return isCancelledOrThrowIfKilled(); });
+    if (stream_index == 0)
+    {
+        original_join->setCancellationHook([&]() { return isCancelledOrThrowIfKilled(); });
+    }
 
     ProbeProcessInfo header_probe_process_info(0, 0);
     header_probe_process_info.resetBlock(input->getHeader());

--- a/dbms/src/DataStreams/HashJoinProbeExec.h
+++ b/dbms/src/DataStreams/HashJoinProbeExec.h
@@ -36,8 +36,6 @@ public:
         const BlockInputStreamPtr & probe_stream,
         size_t max_block_size);
 
-    using CancellationHook = std::function<bool()>;
-
     HashJoinProbeExec(
         const String & req_id,
         const JoinPtr & join_,

--- a/dbms/src/DataStreams/ParallelAggregatingBlockInputStream.cpp
+++ b/dbms/src/DataStreams/ParallelAggregatingBlockInputStream.cpp
@@ -70,7 +70,7 @@ Block ParallelAggregatingBlockInputStream::readImpl()
 {
     if (!executed)
     {
-        Aggregator::CancellationHook hook = [&]() {
+        CancellationHook hook = [&]() {
             return this->isCancelled();
         };
         aggregator.setCancellationHook(hook);

--- a/dbms/src/Flash/Mpp/MPPTask.cpp
+++ b/dbms/src/Flash/Mpp/MPPTask.cpp
@@ -776,6 +776,8 @@ void MPPTask::abort(const String & message, AbortType abort_type)
             return;
         }
     }
+    if (context != nullptr)
+        context->cancelContext();
 }
 
 bool MPPTask::switchStatus(TaskStatus from, TaskStatus to)

--- a/dbms/src/Flash/Mpp/MPPTask.h
+++ b/dbms/src/Flash/Mpp/MPPTask.h
@@ -177,6 +177,7 @@ private:
 
     MPPTaskManager * manager;
     std::atomic<bool> is_registered{false};
+    std::atomic<bool> is_cancelled{false};
 
     MPPTaskScheduleEntry schedule_entry;
 

--- a/dbms/src/Flash/Planner/Plans/PhysicalJoin.cpp
+++ b/dbms/src/Flash/Planner/Plans/PhysicalJoin.cpp
@@ -221,6 +221,7 @@ void PhysicalJoin::probeSideTransform(DAGPipeline & probe_pipeline, Context & co
         execId(),
         needScanHashMapAfterProbe(join_ptr->getKind()));
     join_ptr->initProbe(probe_pipeline.firstStream()->getHeader(), probe_pipeline.streams.size());
+    join_ptr->setCancellationHook([&] { return context.isCancelled(); });
     size_t probe_index = 0;
     for (auto & stream : probe_pipeline.streams)
     {

--- a/dbms/src/Flash/Planner/Plans/PhysicalJoinBuild.cpp
+++ b/dbms/src/Flash/Planner/Plans/PhysicalJoinBuild.cpp
@@ -14,6 +14,7 @@
 
 #include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/InterpreterUtils.h>
+#include <Flash/Executor/PipelineExecutorContext.h>
 #include <Flash/Pipeline/Exec/PipelineExecBuilder.h>
 #include <Flash/Planner/Plans/PhysicalJoinBuild.h>
 #include <Interpreters/Context.h>
@@ -39,6 +40,7 @@ void PhysicalJoinBuild::buildPipelineExecGroupImpl(
     join_execute_info.join_build_profile_infos = group_builder.getCurProfileInfos();
     join_ptr->initBuild(group_builder.getCurrentHeader(), group_builder.concurrency());
     join_ptr->setInitActiveBuildThreads();
+    join_ptr->setCancellationHook([&]() { return exec_context.isCancelled(); });
     join_ptr.reset();
 }
 } // namespace DB

--- a/dbms/src/Interpreters/Aggregator.h
+++ b/dbms/src/Interpreters/Aggregator.h
@@ -32,6 +32,7 @@
 #include <Interpreters/AggSpillContext.h>
 #include <Interpreters/AggregateDescription.h>
 #include <Interpreters/AggregationCommon.h>
+#include <Interpreters/CancellationHook.h>
 #include <TiDB/Collation/Collator.h>
 #include <common/StringRef.h>
 #include <common/logger_useful.h>
@@ -1369,8 +1370,6 @@ public:
       * This is needed to simplify merging of that data with other results, that are already two-level.
       */
     Blocks convertBlockToTwoLevel(const Block & block);
-
-    using CancellationHook = std::function<bool()>;
 
     /** Set a function that checks whether the current task can be aborted.
       */

--- a/dbms/src/Interpreters/CancellationHook.h
+++ b/dbms/src/Interpreters/CancellationHook.h
@@ -1,0 +1,22 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <functional>
+
+namespace DB
+{
+using CancellationHook = std::function<bool()>;
+} // namespace DB

--- a/dbms/src/Interpreters/Context.h
+++ b/dbms/src/Interpreters/Context.h
@@ -27,6 +27,7 @@
 #include <Server/ServerInfo.h>
 #include <common/MultiVersion.h>
 
+#include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <functional>
@@ -180,6 +181,7 @@ private:
     TimezoneInfo timezone_info;
 
     DAGContext * dag_context = nullptr;
+    std::atomic_bool is_cancelled{false};
     using DatabasePtr = std::shared_ptr<IDatabase>;
     using Databases = std::map<String, std::shared_ptr<IDatabase>>;
     /// Use copy constructor or createGlobal() instead
@@ -237,8 +239,8 @@ public:
     /// Compute and set actual user settings, client_info.current_user should be set
     void calculateUserSettings();
 
-    ClientInfo & getClientInfo() { return client_info; };
-    const ClientInfo & getClientInfo() const { return client_info; };
+    ClientInfo & getClientInfo() { return client_info; }
+    const ClientInfo & getClientInfo() const { return client_info; }
 
     void setQuota(
         const String & name,
@@ -375,6 +377,9 @@ public:
     void setDAGContext(DAGContext * dag_context);
     DAGContext * getDAGContext() const;
 
+    bool isCancelled() const { return is_cancelled; }
+    void cancelContext() { is_cancelled.store(true); }
+
     /// List all queries.
     ProcessList & getProcessList();
     const ProcessList & getProcessList() const;
@@ -505,8 +510,8 @@ public:
 
     SharedQueriesPtr getSharedQueries();
 
-    const TimezoneInfo & getTimezoneInfo() const { return timezone_info; };
-    TimezoneInfo & getTimezoneInfo() { return timezone_info; };
+    const TimezoneInfo & getTimezoneInfo() const { return timezone_info; }
+    TimezoneInfo & getTimezoneInfo() { return timezone_info; }
 
     /// User name and session identifier. Named sessions are local to users.
     using SessionKey = std::pair<String, String>;

--- a/dbms/src/Interpreters/Context.h
+++ b/dbms/src/Interpreters/Context.h
@@ -28,7 +28,6 @@
 #include <Server/ServerInfo.h>
 #include <common/MultiVersion.h>
 
-#include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <functional>

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -1382,6 +1382,8 @@ Block Join::joinBlockHash(ProbeProcessInfo & probe_process_info) const
         restore_config.restore_round);
     while (true)
     {
+        if (is_cancelled())
+            return {};
         auto block = doJoinBlockHash(probe_process_info, join_build_info);
         assert(block);
         block = removeUselessColumn(block);
@@ -1486,6 +1488,10 @@ Block Join::joinBlockCross(ProbeProcessInfo & probe_process_info) const
 
     while (true)
     {
+        if (is_cancelled())
+        {
+            return {};
+        }
         Block block = doJoinBlockCross(probe_process_info);
         assert(block);
         block = removeUselessColumn(block);
@@ -1567,6 +1573,9 @@ Block Join::joinBlockNullAwareSemiImpl(const ProbeProcessInfo & probe_process_in
 
     RUNTIME_ASSERT(res.size() == rows, "SemiJoinResult size {} must be equal to block size {}", res.size(), rows);
 
+    if (is_cancelled())
+        return {};
+
     Block block{};
     for (size_t i = 0; i < probe_process_info.block.columns(); ++i)
     {
@@ -1603,12 +1612,16 @@ Block Join::joinBlockNullAwareSemiImpl(const ProbeProcessInfo & probe_process_in
             blocks,
             null_rows,
             max_block_size,
-            non_equal_conditions);
+            non_equal_conditions,
+            is_cancelled);
 
         helper.joinResult(res_list);
 
         RUNTIME_CHECK_MSG(res_list.empty(), "NASemiJoinResult list must be empty after calculating join result");
     }
+
+    if (is_cancelled())
+        return {};
 
     /// Now all results are known.
 
@@ -1754,6 +1767,8 @@ Block Join::joinBlockSemiImpl(const JoinBuildInfo & join_build_info, const Probe
         probe_process_info);
 
     RUNTIME_ASSERT(res.size() == rows, "SemiJoinResult size {} must be equal to block size {}", res.size(), rows);
+    if (is_cancelled())
+        return {};
 
     const NameSet & probe_output_name_set = has_other_condition
         ? output_columns_names_set_for_other_condition_after_finalize
@@ -1788,14 +1803,22 @@ Block Join::joinBlockSemiImpl(const JoinBuildInfo & join_build_info, const Probe
     {
         if (!res_list.empty())
         {
-            SemiJoinHelper<KIND, typename Maps::MappedType>
-                helper(block, left_columns, right_column_indices_to_add, max_block_size, non_equal_conditions);
+            SemiJoinHelper<KIND, typename Maps::MappedType> helper(
+                block,
+                left_columns,
+                right_column_indices_to_add,
+                max_block_size,
+                non_equal_conditions,
+                is_cancelled);
 
             helper.joinResult(res_list);
 
             RUNTIME_CHECK_MSG(res_list.empty(), "SemiJoinResult list must be empty after calculating join result");
         }
     }
+
+    if (is_cancelled())
+        return {};
 
     /// Now all results are known.
 
@@ -2469,6 +2492,7 @@ std::optional<RestoreInfo> Join::getOneRestoreStream(size_t max_block_size_)
             restore_join->initBuild(build_sample_block, restore_join_build_concurrency);
             restore_join->setInitActiveBuildThreads();
             restore_join->initProbe(probe_sample_block, restore_join_build_concurrency);
+            restore_join->setCancellationHook(is_cancelled);
             BlockInputStreams restore_scan_hash_map_streams;
             restore_scan_hash_map_streams.resize(restore_join_build_concurrency, nullptr);
             if (needScanHashMapAfterProbe(kind))

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -1489,9 +1489,7 @@ Block Join::joinBlockCross(ProbeProcessInfo & probe_process_info) const
     while (true)
     {
         if (is_cancelled())
-        {
             return {};
-        }
         Block block = doJoinBlockCross(probe_process_info);
         assert(block);
         block = removeUselessColumn(block);

--- a/dbms/src/Interpreters/Join.h
+++ b/dbms/src/Interpreters/Join.h
@@ -25,6 +25,7 @@
 #include <Flash/Coprocessor/JoinInterpreterHelper.h>
 #include <Flash/Coprocessor/RuntimeFilterMgr.h>
 #include <Interpreters/AggregationCommon.h>
+#include <Interpreters/CancellationHook.h>
 #include <Interpreters/ExpressionActions.h>
 #include <Interpreters/HashJoinSpillContext.h>
 #include <Interpreters/JoinHashMap.h>
@@ -314,6 +315,8 @@ public:
     void flushProbeSideMarkedSpillData(size_t stream_index);
     size_t getProbeCacheColumnThreshold() const { return probe_cache_column_threshold; }
 
+    void setCancellationHook(CancellationHook cancellation_hook) { is_cancelled = cancellation_hook; }
+
     static const String match_helper_prefix;
     static const DataTypePtr match_helper_type;
     static const String flag_mapped_entry_helper_prefix;
@@ -452,6 +455,9 @@ private:
     // the index of vector is the stream_index.
     std::vector<MarkedSpillData> build_side_marked_spilled_data;
     std::vector<MarkedSpillData> probe_side_marked_spilled_data;
+    CancellationHook is_cancelled{[]() {
+        return false;
+    }};
 
 private:
     /** Set information about structure of right hand of JOIN (joined data).

--- a/dbms/src/Interpreters/NullAwareSemiJoinHelper.cpp
+++ b/dbms/src/Interpreters/NullAwareSemiJoinHelper.cpp
@@ -244,13 +244,15 @@ NASemiJoinHelper<KIND, STRICTNESS, Mapped>::NASemiJoinHelper(
     const BlocksList & right_blocks_,
     const std::vector<RowsNotInsertToMap *> & null_rows_,
     size_t max_block_size_,
-    const JoinNonEqualConditions & non_equal_conditions_)
+    const JoinNonEqualConditions & non_equal_conditions_,
+    CancellationHook is_cancelled_)
     : block(block_)
     , left_columns(left_columns_)
     , right_column_indices_to_add(right_column_indices_to_add_)
     , right_blocks(right_blocks_)
     , null_rows(null_rows_)
     , max_block_size(max_block_size_)
+    , is_cancelled(is_cancelled_)
     , non_equal_conditions(non_equal_conditions_)
 {
     static_assert(KIND == NullAware_Anti || KIND == NullAware_LeftOuterAnti || KIND == NullAware_LeftOuterSemi);
@@ -280,17 +282,17 @@ void NASemiJoinHelper<KIND, STRICTNESS, Mapped>::joinResult(std::list<NASemiJoin
         res_list.swap(next_step_res_list);
     }
 
-    if (res_list.empty())
+    if (is_cancelled() || res_list.empty())
         return;
 
     runStep<NASemiJoinStep::NOT_NULL_KEY_CHECK_NULL_ROWS>(res_list, next_step_res_list);
     res_list.swap(next_step_res_list);
-    if (res_list.empty())
+    if (is_cancelled() || res_list.empty())
         return;
 
     runStep<NASemiJoinStep::NULL_KEY_CHECK_NULL_ROWS>(res_list, next_step_res_list);
     res_list.swap(next_step_res_list);
-    if (res_list.empty())
+    if (is_cancelled() || res_list.empty())
         return;
 
     runStepAllBlocks(res_list);
@@ -324,6 +326,8 @@ void NASemiJoinHelper<KIND, STRICTNESS, Mapped>::runStep(
 
     while (!res_list.empty())
     {
+        if (is_cancelled())
+            return;
         MutableColumns columns(block_columns);
         for (size_t i = 0; i < block_columns; ++i)
         {
@@ -384,6 +388,8 @@ void NASemiJoinHelper<KIND, STRICTNESS, Mapped>::runStepAllBlocks(std::list<NASe
         NASemiJoinHelper::Result * res = *res_list.begin();
         for (const auto & right_block : right_blocks)
         {
+            if (is_cancelled())
+                return;
             if (res->getStep() == NASemiJoinStep::DONE)
                 break;
 

--- a/dbms/src/Interpreters/NullAwareSemiJoinHelper.h
+++ b/dbms/src/Interpreters/NullAwareSemiJoinHelper.h
@@ -17,6 +17,7 @@
 #include <Common/Logger.h>
 #include <Core/Block.h>
 #include <Flash/Coprocessor/JoinInterpreterHelper.h>
+#include <Interpreters/CancellationHook.h>
 #include <Interpreters/SemiJoinHelper.h>
 #include <Parsers/ASTTablesInSelectQuery.h>
 
@@ -167,7 +168,8 @@ public:
         const BlocksList & right_blocks,
         const std::vector<RowsNotInsertToMap *> & null_rows,
         size_t max_block_size,
-        const JoinNonEqualConditions & non_equal_conditions);
+        const JoinNonEqualConditions & non_equal_conditions,
+        CancellationHook is_cancelled_);
 
     void joinResult(std::list<Result *> & res_list);
 
@@ -192,6 +194,7 @@ private:
     const BlocksList & right_blocks;
     const std::vector<RowsNotInsertToMap *> & null_rows;
     size_t max_block_size;
+    CancellationHook is_cancelled;
 
     const JoinNonEqualConditions & non_equal_conditions;
 };

--- a/dbms/src/Interpreters/SemiJoinHelper.cpp
+++ b/dbms/src/Interpreters/SemiJoinHelper.cpp
@@ -147,11 +147,13 @@ SemiJoinHelper<KIND, Mapped>::SemiJoinHelper(
     size_t left_columns_,
     const std::vector<size_t> & right_column_indices_to_added_,
     size_t max_block_size_,
-    const JoinNonEqualConditions & non_equal_conditions_)
+    const JoinNonEqualConditions & non_equal_conditions_,
+    CancellationHook is_cancelled_)
     : block(block_)
     , left_columns(left_columns_)
     , right_column_indices_to_add(right_column_indices_to_added_)
     , max_block_size(max_block_size_)
+    , is_cancelled(is_cancelled_)
     , non_equal_conditions(non_equal_conditions_)
 {
     static_assert(KIND == Semi || KIND == Anti || KIND == LeftOuterAnti || KIND == LeftOuterSemi);
@@ -178,6 +180,8 @@ void SemiJoinHelper<KIND, Mapped>::joinResult(std::list<Result *> & res_list)
 
     while (!res_list.empty())
     {
+        if (is_cancelled())
+            return;
         MutableColumns columns(block_columns);
         for (size_t i = 0; i < block_columns; ++i)
         {

--- a/dbms/src/Interpreters/SemiJoinHelper.h
+++ b/dbms/src/Interpreters/SemiJoinHelper.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <Flash/Coprocessor/JoinInterpreterHelper.h>
+#include <Interpreters/CancellationHook.h>
 #include <Parsers/ASTTablesInSelectQuery.h>
 
 namespace DB
@@ -137,7 +138,8 @@ public:
         size_t left_columns,
         const std::vector<size_t> & right_column_indices_to_add,
         size_t max_block_size,
-        const JoinNonEqualConditions & non_equal_conditions);
+        const JoinNonEqualConditions & non_equal_conditions,
+        CancellationHook is_cancelled_);
 
     void joinResult(std::list<Result *> & res_list);
 
@@ -156,6 +158,7 @@ private:
     size_t right_columns;
     std::vector<size_t> right_column_indices_to_add;
     size_t max_block_size;
+    CancellationHook is_cancelled;
 
     const JoinNonEqualConditions & non_equal_conditions;
 };

--- a/dbms/src/Operators/AggregateContext.cpp
+++ b/dbms/src/Operators/AggregateContext.cpp
@@ -19,7 +19,7 @@ namespace DB
 void AggregateContext::initBuild(
     const Aggregator::Params & params,
     size_t max_threads_,
-    Aggregator::CancellationHook && hook,
+    CancellationHook && hook,
     const RegisterOperatorSpillContext & register_operator_spill_context)
 {
     assert(status.load() == AggStatus::init);

--- a/dbms/src/Operators/AggregateContext.h
+++ b/dbms/src/Operators/AggregateContext.h
@@ -44,7 +44,7 @@ public:
     void initBuild(
         const Aggregator::Params & params,
         size_t max_threads_,
-        Aggregator::CancellationHook && hook,
+        CancellationHook && hook,
         const RegisterOperatorSpillContext & register_operator_spill_context);
 
     size_t getBuildConcurrency() const { return max_threads; }
@@ -112,7 +112,7 @@ private:
     };
     std::atomic<AggStatus> status{AggStatus::init};
 
-    Aggregator::CancellationHook is_cancelled{[]() {
+    CancellationHook is_cancelled{[]() {
         return false;
     }};
 

--- a/dbms/src/Operators/AutoPassThroughHashAggContext.h
+++ b/dbms/src/Operators/AutoPassThroughHashAggContext.h
@@ -53,7 +53,7 @@ public:
     AutoPassThroughHashAggContext(
         const Block & child_header_,
         const Aggregator::Params & params_,
-        Aggregator::CancellationHook && hook,
+        CancellationHook && hook,
         const String & req_id_,
         UInt64 row_limit_unit_,
         UInt64 normal_unit_num_ = DEF_NORMAL_UNIT_NUM,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9430

Problem Summary:

### What is changed and how it works?
Check cancel signal inside join
```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Cancel a query with a cross join
```
mysql> select count(*) from t1;
+----------+
| count(*) |
+----------+
|  8000392 |
+----------+
mysql> explain select count(*) from t1 where id not in (select id from t1);
+------------------------------------------+------------+--------------+---------------+-----------------------------------------------------------------+
| id                                       | estRows    | task         | access object | operator info                                                   |
+------------------------------------------+------------+--------------+---------------+-----------------------------------------------------------------+
| HashAgg_35                               | 1.00       | root         |               | funcs:count(Column#8)->Column#7                                 |
| └─TableReader_37                         | 1.00       | root         |               | MppVersion: 2, data:ExchangeSender_36                           |
|   └─ExchangeSender_36                    | 1.00       | mpp[tiflash] |               | ExchangeType: PassThrough                                       |
|     └─HashAgg_13                         | 1.00       | mpp[tiflash] |               | funcs:count(1)->Column#8                                        |
|       └─HashJoin_34                      | 6400313.60 | mpp[tiflash] |               | CARTESIAN anti semi join, other cond:eq(test.t1.id, test.t1.id) |
|         ├─ExchangeReceiver_21(Build)     | 8000392.00 | mpp[tiflash] |               |                                                                 |
|         │ └─ExchangeSender_20            | 8000392.00 | mpp[tiflash] |               | ExchangeType: Broadcast, Compression: FAST                      |
|         │   └─TableFullScan_19           | 8000392.00 | mpp[tiflash] | table:t1      | keep order:false                                                |
|         └─TableFullScan_18(Probe)        | 8000392.00 | mpp[tiflash] | table:t1      | keep order:false                                                |
+------------------------------------------+------------+--------------+---------------+-----------------------------------------------------------------+
```

Before this pr
![屏幕截图 2024-09-20 165644](https://github.com/user-attachments/assets/b018fda1-051f-4493-9269-83c75944fd49)


After this pr
![屏幕截图 2024-09-20 170114](https://github.com/user-attachments/assets/3eb96a6c-d832-4185-8d3f-79455887ea93)

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
fix bug that join can not be cancelled timely.
```
