### PR TITLE
*: support vector index and adding/dropping vector index when doing syncTableSchema

### DIFF
--- a/dbms/src/Debug/MockTiDB.cpp
+++ b/dbms/src/Debug/MockTiDB.cpp
@@ -30,6 +30,7 @@
 #include <Poco/StringTokenizer.h>
 #include <Storages/KVStore/KVStore.h>
 #include <Storages/KVStore/TMTContext.h>
+#include <Storages/KVStore/Types.h>
 #include <TiDB/Decode/TypeMapping.h>
 #include <TiDB/Schema/TiDB.h>
 
@@ -46,6 +47,7 @@ extern const int UNKNOWN_TABLE;
 } // namespace ErrorCodes
 
 using ColumnInfo = TiDB::ColumnInfo;
+using IndexInfo = TiDB::IndexInfo;
 using TableInfo = TiDB::TableInfo;
 using PartitionInfo = TiDB::PartitionInfo;
 using PartitionDefinition = TiDB::PartitionDefinition;
@@ -540,6 +542,87 @@ void MockTiDB::dropPartition(const String & database_name, const String & table_
 
     SchemaDiff diff;
     diff.type = SchemaActionType::DropTablePartition;
+    diff.schema_id = table->database_id;
+    diff.table_id = table->id();
+    diff.version = version;
+    version_diff[version] = diff;
+}
+
+IndexInfo reverseGetIndexInfo(
+    IndexID id,
+    const NameAndTypePair & column,
+    Int32 offset,
+    TiDB::VectorIndexDefinitionPtr vector_index)
+{
+    IndexInfo index_info;
+    index_info.id = id;
+    index_info.state = TiDB::StatePublic;
+
+    std::vector<TiDB::IndexColumnInfo> idx_cols;
+    Poco::JSON::Object::Ptr idx_col_json = new Poco::JSON::Object();
+    Poco::JSON::Object::Ptr name_json = new Poco::JSON::Object();
+    name_json->set("O", column.name);
+    name_json->set("L", column.name);
+    idx_col_json->set("name", name_json);
+    idx_col_json->set("length", -1);
+    idx_col_json->set("offset", offset);
+    TiDB::IndexColumnInfo idx_col(idx_col_json);
+    index_info.idx_cols.push_back(idx_col);
+    index_info.vector_index = vector_index;
+
+    return index_info;
+}
+
+void MockTiDB::addVectorIndexToTable(
+    const String & database_name,
+    const String & table_name,
+    const IndexID index_id,
+    const NameAndTypePair & column_name,
+    Int32 offset,
+    TiDB::VectorIndexDefinitionPtr vector_index)
+{
+    std::lock_guard lock(tables_mutex);
+
+    TablePtr table = getTableByNameInternal(database_name, table_name);
+    String qualified_name = database_name + "." + table_name;
+    auto & indexes = table->table_info.index_infos;
+    if (std::find_if(indexes.begin(), indexes.end(), [&](const IndexInfo & index_) { return index_.id == index_id; })
+        != indexes.end())
+        throw Exception(
+            ErrorCodes::LOGICAL_ERROR,
+            "Index {} already exists in TiDB table {}",
+            index_id,
+            qualified_name);
+    IndexInfo index_info = reverseGetIndexInfo(index_id, column_name, offset, vector_index);
+    indexes.push_back(index_info);
+
+    version++;
+
+    SchemaDiff diff;
+    diff.type = SchemaActionType::ActionAddVectorIndex;
+    diff.schema_id = table->database_id;
+    diff.table_id = table->id();
+    diff.version = version;
+    version_diff[version] = diff;
+}
+
+void MockTiDB::dropVectorIndexFromTable(const String & database_name, const String & table_name, IndexID index_id)
+{
+    std::lock_guard lock(tables_mutex);
+
+    TablePtr table = getTableByNameInternal(database_name, table_name);
+    String qualified_name = database_name + "." + table_name;
+
+    auto & indexes = table->table_info.index_infos;
+    auto it
+        = std::find_if(indexes.begin(), indexes.end(), [&](const IndexInfo & index_) { return index_.id == index_id; });
+    RUNTIME_CHECK_MSG(it != indexes.end(), "Index {} does not exist in TiDB table {}", index_id, qualified_name);
+    indexes.erase(it);
+
+    version++;
+
+    SchemaDiff diff;
+    diff.type = SchemaActionType::DropIndex;
     diff.schema_id = table->database_id;
     diff.table_id = table->id();
     diff.version = version;

--- a/dbms/src/Debug/MockTiDB.h
+++ b/dbms/src/Debug/MockTiDB.h
@@ -125,6 +125,16 @@ public:
 
     void dropDB(Context & context, const String & database_name, bool drop_regions);
 
+    void addVectorIndexToTable(
+        const String & database_name,
+        const String & table_name,
+        IndexID index_id,
+        const NameAndTypePair & column_name,
+        Int32 offset,
+        TiDB::VectorIndexDefinitionPtr vector_index);
+
+    void dropVectorIndexFromTable(const String & database_name, const String & table_name, IndexID index_id);
+
     void addColumnToTable(
         const String & database_name,
         const String & table_name,

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -2029,7 +2029,7 @@ void DeltaMergeStore::applySchemaChanges(TiDB::TableInfo & table_info)
 
     std::atomic_store(&original_table_header, std::make_shared<Block>(toEmptyBlock(original_table_columns)));
 
-    // release the lock because `applyLocalIndexChange` will try to acquire the lock
+    // release the lock because `checkAllSegmentsLocalIndex` will try to acquire the lock
     // and generate tasks on segments
     lock.unlock();
 

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -39,6 +39,7 @@
 #include <Storages/DeltaMerge/File/DMFile.h>
 #include <Storages/DeltaMerge/Filter/PushDownFilter.h>
 #include <Storages/DeltaMerge/Filter/RSOperator.h>
+#include <Storages/DeltaMerge/Index/IndexInfo.h>
 #include <Storages/DeltaMerge/LocalIndexerScheduler.h>
 #include <Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.h>
 #include <Storages/DeltaMerge/ReadThread/UnorderedInputStream.h>
@@ -62,6 +63,8 @@
 #include <ext/scope_guard.h>
 #include <magic_enum.hpp>
 #include <memory>
+#include <mutex>
+#include <shared_mutex>
 
 
 namespace ProfileEvents
@@ -219,7 +222,7 @@ DeltaMergeStore::DeltaMergeStore(
     const ColumnDefine & handle,
     bool is_common_handle_,
     size_t rowkey_column_size_,
-    IndexInfosPtr local_index_infos_,
+    LocalIndexInfosPtr local_index_infos_,
     const Settings & settings_,
     ThreadPool * thread_pool)
     : global_context(db_context.getGlobalContext())
@@ -339,7 +342,7 @@ DeltaMergeStorePtr DeltaMergeStore::create(
     const ColumnDefine & handle,
     bool is_common_handle_,
     size_t rowkey_column_size_,
-    IndexInfosPtr local_index_infos_,
+    LocalIndexInfosPtr local_index_infos_,
     const Settings & settings_,
     ThreadPool * thread_pool)
 {
@@ -2017,8 +2020,29 @@ void DeltaMergeStore::applySchemaChanges(TiDB::TableInfo & table_info)
     original_table_columns.swap(new_original_table_columns);
     store_columns.swap(new_store_columns);
 
-    // TODO(local index): There could be some local indexes added/dropped after DDL
+    // copy the local_index_infos to check whether any new index is created
+    LocalIndexInfosPtr local_index_infos_copy = nullptr;
+    {
+        std::shared_lock index_read_lock(mtx_local_index_infos);
+        local_index_infos_copy = std::shared_ptr<LocalIndexInfos>(local_index_infos);
+    }
+
     std::atomic_store(&original_table_header, std::make_shared<Block>(toEmptyBlock(original_table_columns)));
+
+    // release the lock because `applyLocalIndexChange` will try to acquire the lock
+    // and generate tasks on segments
+    lock.unlock();
+
+    auto new_local_index_infos = generateLocalIndexInfos(local_index_infos_copy, table_info, log);
+    if (new_local_index_infos)
+    {
+        {
+            // new index created, update the info in-memory
+            std::unique_lock index_write_lock(mtx_local_index_infos);
+            local_index_infos.swap(new_local_index_infos);
+        }
+        checkAllSegmentsLocalIndex();
+    } // else no new index is created
 }
 
 SortDescription DeltaMergeStore::getPrimarySortDescription() const

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalSegment.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalSegment.cpp
@@ -452,7 +452,7 @@ SegmentPtr DeltaMergeStore::segmentMerge(
 
 void DeltaMergeStore::checkAllSegmentsLocalIndex()
 {
-    if (!local_index_infos || local_index_infos->empty())
+    if (!getLocalIndexInfosSnapshot())
         return;
 
     LOG_INFO(log, "CheckAllSegmentsLocalIndex - Begin");
@@ -529,12 +529,13 @@ bool DeltaMergeStore::segmentEnsureStableIndexAsync(const SegmentPtr & segment)
     RUNTIME_CHECK(segment != nullptr);
 
     // TODO(local index): There could be some indexes are built while some indexes is not yet built after DDL
-    if (!local_index_infos || local_index_infos->empty())
+    auto local_index_infos_snap = getLocalIndexInfosSnapshot();
+    if (!local_index_infos_snap)
         return false;
 
     // No lock is needed, stable meta is immutable.
     auto dm_files = segment->getStable()->getDMFiles();
-    auto build_info = DMFileIndexWriter::getLocalIndexBuildInfo(local_index_infos, dm_files);
+    auto build_info = DMFileIndexWriter::getLocalIndexBuildInfo(local_index_infos_snap, dm_files);
     if (!build_info.indexes_to_build || build_info.indexes_to_build->empty())
         return false;
 
@@ -569,13 +570,14 @@ bool DeltaMergeStore::segmentWaitStableIndexReady(const SegmentPtr & segment) co
     RUNTIME_CHECK(segment != nullptr);
 
     // TODO(local index): There could be some indexes are built while some indexes is not yet built after DDL
-    if (!local_index_infos || local_index_infos->empty())
+    auto local_index_infos_snap = getLocalIndexInfosSnapshot();
+    if (!local_index_infos_snap)
         return true;
 
     // No lock is needed, stable meta is immutable.
     auto segment_id = segment->segmentId();
     auto dm_files = segment->getStable()->getDMFiles();
-    auto build_info = DMFileIndexWriter::getLocalIndexBuildInfo(local_index_infos, dm_files);
+    auto build_info = DMFileIndexWriter::getLocalIndexBuildInfo(local_index_infos_snap, dm_files);
     if (!build_info.indexes_to_build || build_info.indexes_to_build->empty())
         return true;
 
@@ -653,7 +655,7 @@ SegmentPtr DeltaMergeStore::segmentUpdateMeta(
 
 void DeltaMergeStore::segmentEnsureStableIndex(
     DMContext & dm_context,
-    const IndexInfosPtr & index_info,
+    const LocalIndexInfosPtr & index_info,
     const DMFiles & dm_files,
     const String & source_segment_info)
 {

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_Statistics.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore_Statistics.cpp
@@ -194,16 +194,18 @@ SegmentsStats DeltaMergeStore::getSegmentsStats()
 
 LocalIndexesStats DeltaMergeStore::getLocalIndexStats()
 {
-    std::shared_lock lock(read_write_mutex);
-
-    if (!local_index_infos || local_index_infos->empty())
+    auto local_index_infos_snap = getLocalIndexInfosSnapshot();
+    if (!local_index_infos_snap)
         return {};
 
+    std::shared_lock lock(read_write_mutex);
+
     LocalIndexesStats stats;
-    for (const auto & index_info : *local_index_infos)
+    for (const auto & index_info : *local_index_infos_snap)
     {
         LocalIndexStats index_stats;
         index_stats.column_id = index_info.column_id;
+        index_stats.index_id = index_info.index_id;
         index_stats.column_name = index_info.column_name;
         index_stats.index_kind = "HNSW"; // TODO: Support more.
 

--- a/dbms/src/Storages/DeltaMerge/File/DMFileIndexWriter.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileIndexWriter.cpp
@@ -19,6 +19,7 @@
 #include <Storages/DeltaMerge/File/DMFileBlockInputStream.h>
 #include <Storages/DeltaMerge/File/DMFileIndexWriter.h>
 #include <Storages/DeltaMerge/File/DMFileV3IncrementWriter.h>
+#include <Storages/DeltaMerge/Index/IndexInfo.h>
 #include <Storages/DeltaMerge/Index/VectorIndex.h>
 #include <Storages/DeltaMerge/ScanContext.h>
 #include <Storages/PathPool.h>
@@ -32,14 +33,14 @@ namespace DB::DM
 {
 
 DMFileIndexWriter::LocalIndexBuildInfo DMFileIndexWriter::getLocalIndexBuildInfo(
-    const IndexInfosPtr & index_infos,
+    const LocalIndexInfosPtr & index_infos,
     const DMFiles & dm_files)
 {
     assert(index_infos != nullptr);
     static constexpr double VECTOR_INDEX_SIZE_FACTOR = 1.2;
 
     LocalIndexBuildInfo build;
-    build.indexes_to_build = std::make_shared<IndexInfos>();
+    build.indexes_to_build = std::make_shared<LocalIndexInfos>();
     build.file_ids.reserve(dm_files.size());
     for (const auto & dmfile : dm_files)
     {

--- a/dbms/src/Storages/DeltaMerge/File/DMFileIndexWriter.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileIndexWriter.h
@@ -44,15 +44,15 @@ public:
     {
         std::vector<LocalIndexerScheduler::FileID> file_ids;
         size_t estimated_memory_bytes = 0;
-        IndexInfosPtr indexes_to_build;
+        LocalIndexInfosPtr indexes_to_build;
     };
 
-    static LocalIndexBuildInfo getLocalIndexBuildInfo(const IndexInfosPtr & index_infos, const DMFiles & dm_files);
+    static LocalIndexBuildInfo getLocalIndexBuildInfo(const LocalIndexInfosPtr & index_infos, const DMFiles & dm_files);
 
     struct Options
     {
         const StoragePathPoolPtr path_pool;
-        const IndexInfosPtr index_infos;
+        const LocalIndexInfosPtr index_infos;
         const DMFiles dm_files;
         const DMContext & dm_context;
     };

--- a/dbms/src/Storages/DeltaMerge/Index/IndexInfo.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/IndexInfo.cpp
@@ -140,7 +140,7 @@ LocalIndexInfosPtr generateLocalIndexInfos(
     if (!existing_indexes)
     {
         auto index_infos = initLocalIndexInfos(new_table_info, logger);
-        if (index_infos && index_infos->empty())
+        if (!index_infos || index_infos->empty())
             return nullptr;
         new_index_infos = std::move(index_infos);
         return new_index_infos;

--- a/dbms/src/Storages/DeltaMerge/Index/IndexInfo.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/IndexInfo.cpp
@@ -1,0 +1,208 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Storages/DeltaMerge/Index/IndexInfo.h>
+#include <Storages/FormatVersion.h>
+#include <Storages/KVStore/Types.h>
+#include <TiDB/Schema/TiDB.h>
+
+#include <cstddef>
+
+namespace DB::DM
+{
+
+bool isVectorIndexSupported(const LoggerPtr & logger)
+{
+    // Vector Index requires a specific storage format to work.
+    if ((STORAGE_FORMAT_CURRENT.identifier > 0 && STORAGE_FORMAT_CURRENT.identifier < 6)
+        || STORAGE_FORMAT_CURRENT.identifier == 100)
+    {
+        LOG_ERROR(
+            logger,
+            "The current storage format is {}, which does not support building vector index. TiFlash will "
+            "write data without vector index.",
+            STORAGE_FORMAT_CURRENT.identifier);
+        return false;
+    }
+
+    return true;
+}
+
+TiDB::ColumnInfo getVectorIndxColumnInfo(
+    const TiDB::TableInfo & table_info,
+    const TiDB::IndexInfo & idx_info,
+    const LoggerPtr & logger)
+{
+    if (!idx_info.vector_index
+        || (idx_info.state != TiDB::StatePublic && idx_info.state != TiDB::StateWriteReorganization))
+    {
+        return {};
+    }
+
+    // Vector Index requires a specific storage format to work.
+    if (!isVectorIndexSupported(logger))
+    {
+        return {};
+    }
+
+    if (idx_info.idx_cols.size() != 1)
+    {
+        LOG_ERROR(
+            logger,
+            "The index columns length is {}, which does not support building vector index, index_id={}, table_id={}.",
+            idx_info.idx_cols.size(),
+            idx_info.id,
+            table_info.id);
+        return {};
+    }
+
+    for (const auto & col : table_info.columns)
+    {
+        if (col.name == idx_info.idx_cols[0].name)
+        {
+            return col;
+        }
+    }
+
+    LOG_ERROR(
+        logger,
+        "The index column does not exist, table_id={} index_id={} idx_col_name={}.",
+        table_info.id,
+        idx_info.id,
+        idx_info.idx_cols[0].name);
+    return {};
+}
+
+LocalIndexInfosPtr initLocalIndexInfos(const TiDB::TableInfo & table_info, const LoggerPtr & logger)
+{
+    LocalIndexInfosPtr index_infos = std::make_shared<LocalIndexInfos>();
+    index_infos->reserve(table_info.columns.size() + table_info.index_infos.size());
+    for (const auto & col : table_info.columns)
+    {
+        if (col.vector_index && isVectorIndexSupported(logger))
+        {
+            index_infos->emplace_back(LocalIndexInfo{
+                .type = IndexType::Vector,
+                .column_id = col.id,
+                .column_name = col.name,
+                .index_definition = col.vector_index,
+            });
+            LOG_INFO(logger, "Add a new index by column comments, column_id={}, table_id={}.", col.id, table_info.id);
+        }
+    }
+
+    for (const auto & idx : table_info.index_infos)
+    {
+        auto column = getVectorIndxColumnInfo(table_info, idx, logger);
+        // column.id <= 0 means we don't get the valid column ID.
+        if (column.id <= DB::EmptyColumnID)
+        {
+            LOG_ERROR(
+                Logger::get(),
+                "The current storage format is {}, which does not support building vector index. TiFlash will "
+                "write data without vector index.",
+                STORAGE_FORMAT_CURRENT.identifier);
+            return {};
+        }
+
+        LOG_INFO(logger, "Add a new index, index_id={}, table_id={}.", idx.id, table_info.id);
+        index_infos->emplace_back(LocalIndexInfo{
+            .type = IndexType::Vector,
+            .index_id = idx.id,
+            .column_id = column.id,
+            .column_name = column.name,
+            .index_definition = idx.vector_index,
+        });
+    }
+
+    index_infos->shrink_to_fit();
+    return index_infos;
+}
+
+LocalIndexInfosPtr generateLocalIndexInfos(
+    const LocalIndexInfosPtr & existing_indexes,
+    const TiDB::TableInfo & new_table_info,
+    const LoggerPtr & logger)
+{
+    LocalIndexInfosPtr new_index_infos = std::make_shared<std::vector<LocalIndexInfo>>();
+    // The first time generate index infos.
+    if (!existing_indexes)
+    {
+        auto index_infos = initLocalIndexInfos(new_table_info, logger);
+        if (index_infos && index_infos->empty())
+            return nullptr;
+        new_index_infos = std::move(index_infos);
+        return new_index_infos;
+    }
+
+    new_index_infos->insert(new_index_infos->cend(), existing_indexes->begin(), existing_indexes->end());
+
+    std::unordered_map<IndexID, int> original_local_index_id_map;
+    for (size_t index = 0; index < new_index_infos->size(); ++index)
+    {
+        original_local_index_id_map[new_index_infos->at(index).index_id] = index;
+    }
+
+    bool any_new_index_created = false;
+    bool any_index_removed = false;
+    for (const auto & idx : new_table_info.index_infos)
+    {
+        if (!idx.vector_index)
+            continue;
+
+        auto iter = original_local_index_id_map.find(idx.id);
+        if (iter == original_local_index_id_map.end())
+        {
+            if (idx.state == TiDB::StatePublic || idx.state == TiDB::StateWriteReorganization)
+            {
+                // create a new index
+                auto column = getVectorIndxColumnInfo(new_table_info, idx, logger);
+                LocalIndexInfo index_info{
+                    .type = IndexType::Vector,
+                    .index_id = idx.id,
+                    .column_id = column.id,
+                    .column_name = column.name,
+                    .index_definition = idx.vector_index,
+                };
+                new_index_infos->emplace_back(std::move(index_info));
+                any_new_index_created = true;
+                LOG_INFO(logger, "Add a new index, index_id={}, table_id={}.", idx.id, new_table_info.id);
+            }
+        }
+        else
+        {
+            if (idx.state == TiDB::StateDeleteReorganization)
+                continue;
+            // remove the existing index
+            original_local_index_id_map.erase(iter);
+        }
+    }
+
+    // drop nonexistent indices
+    for (auto & iter : original_local_index_id_map)
+    {
+        // It means this index is create by column comments which we don't support drop index.
+        if (iter.first == DB::EmptyIndexID)
+            continue;
+        new_index_infos->erase(new_index_infos->begin() + iter.second);
+        any_index_removed = true;
+        LOG_INFO(logger, "Drop a index, index_id={}, table_id={}.", iter.first, new_table_info.id);
+    }
+
+    if (!any_new_index_created && !any_index_removed)
+        return nullptr;
+    return new_index_infos;
+}
+
+} // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/Index/IndexInfo.h
+++ b/dbms/src/Storages/DeltaMerge/Index/IndexInfo.h
@@ -17,25 +17,48 @@
 #include <Storages/KVStore/Types.h>
 #include <TiDB/Schema/VectorIndex.h>
 
+namespace TiDB
+{
+struct TableInfo;
+struct ColumnInfo;
+struct IndexInfo;
+} // namespace TiDB
+
+namespace DB
+{
+class Logger;
+using LoggerPtr = std::shared_ptr<Logger>;
+} // namespace DB
 namespace DB::DM
 {
-
 enum class IndexType
 {
     Vector = 1,
 };
 
-struct IndexInfo
+struct LocalIndexInfo
 {
     IndexType type;
-    ColumnID column_id;
+    IndexID index_id = DB::EmptyIndexID;
+    ColumnID column_id = DB::EmptyColumnID;
     String column_name;
     // Now we only support vector index.
     // In the future, we may support more types of indexes, using std::variant.
     TiDB::VectorIndexDefinitionPtr index_definition;
 };
 
-using IndexInfos = std::vector<IndexInfo>;
-using IndexInfosPtr = std::shared_ptr<IndexInfos>;
+using LocalIndexInfos = std::vector<LocalIndexInfo>;
+using LocalIndexInfosPtr = std::shared_ptr<LocalIndexInfos>;
+
+bool isVectorIndexSupported(const LoggerPtr & logger);
+LocalIndexInfosPtr initLocalIndexInfos(const TiDB::TableInfo & table_info, const LoggerPtr & logger);
+TiDB::ColumnInfo getVectorIndxColumnInfo(
+    const TiDB::TableInfo & table_info,
+    const TiDB::IndexInfo & idx_info,
+    const LoggerPtr & logger);
+LocalIndexInfosPtr generateLocalIndexInfos(
+    const LocalIndexInfosPtr & existing_indexes,
+    const TiDB::TableInfo & new_table_info,
+    const LoggerPtr & logger);
 
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_test_basic.h
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_test_basic.h
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#pragma once
 
 #include <Common/Exception.h>
 #include <Common/FailPoint.h>

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_vector_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_vector_index.cpp
@@ -79,7 +79,7 @@ public:
             {cdVec()},
             {range},
             /* num_streams= */ 1,
-            /* max_version= */ std::numeric_limits<UInt64>::max(),
+            /* start_ts= */ std::numeric_limits<UInt64>::max(),
             filter,
             std::vector<RuntimeFilterPtr>{},
             0,

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_vector_index_utils.h
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_vector_index_utils.h
@@ -65,7 +65,7 @@ public:
         return wb.str();
     }
 
-    ColumnDefine cdVec()
+    ColumnDefine cdVec() const
     {
         // When used in read, no need to assign vector_index.
         return ColumnDefine(vec_column_id, vec_column_name, ::DB::tests::typeFromString("Array(Float32)"));
@@ -157,7 +157,7 @@ public:
             {cdVec()},
             {range},
             /* num_streams= */ 1,
-            /* max_version= */ std::numeric_limits<UInt64>::max(),
+            /* start_ts= */ std::numeric_limits<UInt64>::max(),
             filter,
             std::vector<RuntimeFilterPtr>{},
             0,

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_local_index_info.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_local_index_info.cpp
@@ -1,0 +1,290 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Storages/DeltaMerge/Index/IndexInfo.h>
+#include <Storages/KVStore/Types.h>
+#include <TestUtils/TiFlashTestBasic.h>
+#include <TiDB/Schema/TiDB.h>
+#include <gtest/gtest.h>
+#include <tipb/executor.pb.h>
+
+namespace DB::tests
+{
+
+TEST(LocalIndexInfo, CheckIndexChanged)
+try
+{
+    TiDB::TableInfo table_info;
+    {
+        TiDB::ColumnInfo column_info;
+        column_info.name = "vec";
+        column_info.id = 100;
+        table_info.columns.emplace_back(column_info);
+    }
+
+    auto logger = Logger::get();
+    DM::LocalIndexInfosPtr index_info = nullptr;
+    // check the same
+    {
+        auto new_index_info = generateLocalIndexInfos(index_info, table_info, logger);
+        ASSERT_EQ(new_index_info, nullptr);
+        // check again, nothing changed, return nullptr
+        ASSERT_EQ(nullptr, generateLocalIndexInfos(new_index_info, table_info, logger));
+
+        // update
+        index_info = new_index_info;
+    }
+
+    // Add a vector index to the TableInfo.
+    TiDB::IndexColumnInfo default_index_col_info;
+    default_index_col_info.name = "vec";
+    default_index_col_info.length = -1;
+    default_index_col_info.offset = 0;
+    TiDB::IndexInfo expect_idx;
+    {
+        expect_idx.id = 1;
+        expect_idx.idx_cols.emplace_back(default_index_col_info);
+        expect_idx.vector_index = TiDB::VectorIndexDefinitionPtr(new TiDB::VectorIndexDefinition{
+            .kind = tipb::VectorIndexKind::HNSW,
+            .dimension = 1,
+            .distance_metric = tipb::VectorDistanceMetric::L2,
+        });
+        table_info.index_infos.emplace_back(expect_idx);
+    }
+
+    // check the different
+    {
+        auto new_index_info = generateLocalIndexInfos(index_info, table_info, logger);
+        ASSERT_NE(new_index_info, nullptr);
+        ASSERT_EQ(new_index_info->size(), 1);
+        const auto & idx = (*new_index_info)[0];
+        ASSERT_EQ(DM::IndexType::Vector, idx.type);
+        ASSERT_EQ(expect_idx.id, idx.index_id);
+        ASSERT_EQ(100, idx.column_id);
+        ASSERT_NE(nullptr, idx.index_definition);
+        ASSERT_EQ(expect_idx.vector_index->kind, idx.index_definition->kind);
+        ASSERT_EQ(expect_idx.vector_index->dimension, idx.index_definition->dimension);
+        ASSERT_EQ(expect_idx.vector_index->distance_metric, idx.index_definition->distance_metric);
+
+        // check again, nothing changed, return nullptr
+        ASSERT_EQ(nullptr, generateLocalIndexInfos(new_index_info, table_info, logger));
+
+        // update
+        index_info = new_index_info;
+    }
+
+    // Add another vector index to the TableInfo.
+    TiDB::IndexInfo expect_idx2;
+    {
+        expect_idx2.id = 2; // another index_id
+        expect_idx2.idx_cols.emplace_back(default_index_col_info);
+        expect_idx2.vector_index = TiDB::VectorIndexDefinitionPtr(new TiDB::VectorIndexDefinition{
+            .kind = tipb::VectorIndexKind::HNSW,
+            .dimension = 2,
+            .distance_metric = tipb::VectorDistanceMetric::COSINE, // another distance
+        });
+        table_info.index_infos.emplace_back(expect_idx2);
+    }
+    // check the different
+    {
+        auto new_index_info = generateLocalIndexInfos(index_info, table_info, logger);
+        ASSERT_NE(new_index_info, nullptr);
+        ASSERT_EQ(new_index_info->size(), 2);
+        const auto & idx0 = (*new_index_info)[0];
+        ASSERT_EQ(DM::IndexType::Vector, idx0.type);
+        ASSERT_EQ(expect_idx.id, idx0.index_id);
+        ASSERT_EQ(100, idx0.column_id);
+        ASSERT_NE(nullptr, idx0.index_definition);
+        ASSERT_EQ(expect_idx.vector_index->kind, idx0.index_definition->kind);
+        ASSERT_EQ(expect_idx.vector_index->dimension, idx0.index_definition->dimension);
+        ASSERT_EQ(expect_idx.vector_index->distance_metric, idx0.index_definition->distance_metric);
+        const auto & idx1 = (*new_index_info)[1];
+        ASSERT_EQ(DM::IndexType::Vector, idx1.type);
+        ASSERT_EQ(expect_idx2.id, idx1.index_id);
+        ASSERT_EQ(100, idx1.column_id);
+        ASSERT_NE(nullptr, idx1.index_definition);
+        ASSERT_EQ(expect_idx2.vector_index->kind, idx1.index_definition->kind);
+        ASSERT_EQ(expect_idx2.vector_index->dimension, idx1.index_definition->dimension);
+        ASSERT_EQ(expect_idx2.vector_index->distance_metric, idx1.index_definition->distance_metric);
+
+        // check again, nothing changed, return nullptr
+        ASSERT_EQ(nullptr, generateLocalIndexInfos(new_index_info, table_info, logger));
+
+        // update
+        index_info = new_index_info;
+    }
+
+    // Remove the second vecotr index and add a new vector index to the TableInfo.
+    TiDB::IndexInfo expect_idx3;
+    {
+        // drop the second index
+        table_info.index_infos.pop_back();
+        // add a new index
+        expect_idx3.id = 3; // another index_id
+        expect_idx3.idx_cols.emplace_back(default_index_col_info);
+        expect_idx3.vector_index = TiDB::VectorIndexDefinitionPtr(new TiDB::VectorIndexDefinition{
+            .kind = tipb::VectorIndexKind::HNSW,
+            .dimension = 3,
+            .distance_metric = tipb::VectorDistanceMetric::COSINE, // another distance
+        });
+        table_info.index_infos.emplace_back(expect_idx3);
+    }
+    // check the different
+    {
+        auto new_index_info = generateLocalIndexInfos(index_info, table_info, logger);
+        ASSERT_NE(new_index_info, nullptr);
+        ASSERT_EQ(new_index_info->size(), 2);
+        const auto & idx0 = (*new_index_info)[0];
+        ASSERT_EQ(DM::IndexType::Vector, idx0.type);
+        ASSERT_EQ(expect_idx.id, idx0.index_id);
+        ASSERT_EQ(100, idx0.column_id);
+        ASSERT_NE(nullptr, idx0.index_definition);
+        ASSERT_EQ(expect_idx.vector_index->kind, idx0.index_definition->kind);
+        ASSERT_EQ(expect_idx.vector_index->dimension, idx0.index_definition->dimension);
+        ASSERT_EQ(expect_idx.vector_index->distance_metric, idx0.index_definition->distance_metric);
+        const auto & idx1 = (*new_index_info)[1];
+        ASSERT_EQ(DM::IndexType::Vector, idx1.type);
+        ASSERT_EQ(expect_idx3.id, idx1.index_id);
+        ASSERT_EQ(100, idx1.column_id);
+        ASSERT_NE(nullptr, idx1.index_definition);
+        ASSERT_EQ(expect_idx3.vector_index->kind, idx1.index_definition->kind);
+        ASSERT_EQ(expect_idx3.vector_index->dimension, idx1.index_definition->dimension);
+        ASSERT_EQ(expect_idx3.vector_index->distance_metric, idx1.index_definition->distance_metric);
+
+        // check again, nothing changed, return nullptr
+        ASSERT_EQ(nullptr, generateLocalIndexInfos(new_index_info, table_info, logger));
+    }
+}
+CATCH
+
+TEST(LocalIndexInfo, CheckIndexAddWithVecIndexOnColumnInfo)
+try
+{
+    // The serverless branch, vector index may directly defined on the ColumnInfo.
+    // Create table info with a vector index by column comments.
+    auto col_vector_index = TiDB::VectorIndexDefinitionPtr(new TiDB::VectorIndexDefinition{
+        .kind = tipb::VectorIndexKind::HNSW,
+        .dimension = 3,
+        .distance_metric = tipb::VectorDistanceMetric::INNER_PRODUCT,
+    });
+    TiDB::TableInfo table_info;
+    {
+        TiDB::ColumnInfo column_info;
+        column_info.name = "vec";
+        column_info.id = 98;
+        table_info.columns.emplace_back(column_info);
+
+        TiDB::ColumnInfo column_info_v1;
+        column_info_v1.name = "vec1";
+        column_info_v1.id = 99;
+        column_info_v1.vector_index = col_vector_index;
+        table_info.columns.emplace_back(column_info_v1);
+    }
+
+    // Add a vector index by add vector index dirctly.
+    TiDB::IndexColumnInfo default_index_col_info;
+    default_index_col_info.name = "vec";
+    default_index_col_info.length = -1;
+    default_index_col_info.offset = 0;
+    TiDB::IndexInfo expect_idx;
+    {
+        expect_idx.id = 1;
+        expect_idx.idx_cols.emplace_back(default_index_col_info);
+        expect_idx.vector_index = TiDB::VectorIndexDefinitionPtr(new TiDB::VectorIndexDefinition{
+            .kind = tipb::VectorIndexKind::HNSW,
+            .dimension = 1,
+            .distance_metric = tipb::VectorDistanceMetric::L2,
+        });
+        table_info.index_infos.emplace_back(expect_idx);
+    }
+
+    // check the different
+    auto logger = Logger::get();
+    DM::LocalIndexInfosPtr index_info = nullptr;
+    {
+        auto new_index_info = generateLocalIndexInfos(index_info, table_info, logger);
+        ASSERT_NE(new_index_info, nullptr);
+        ASSERT_EQ(new_index_info->size(), 2);
+
+        const auto & idx0 = (*new_index_info)[0];
+        ASSERT_EQ(DM::IndexType::Vector, idx0.type);
+        ASSERT_EQ(EmptyIndexID, idx0.index_id);
+        ASSERT_EQ(99, idx0.column_id);
+        ASSERT_NE(nullptr, idx0.index_definition);
+        ASSERT_EQ(col_vector_index->kind, idx0.index_definition->kind);
+        ASSERT_EQ(col_vector_index->dimension, idx0.index_definition->dimension);
+        ASSERT_EQ(col_vector_index->distance_metric, idx0.index_definition->distance_metric);
+
+        const auto & idx1 = (*new_index_info)[1];
+        ASSERT_EQ(DM::IndexType::Vector, idx1.type);
+        ASSERT_EQ(expect_idx.id, idx1.index_id);
+        ASSERT_EQ(98, idx1.column_id);
+        ASSERT_NE(nullptr, idx1.index_definition);
+        ASSERT_EQ(expect_idx.vector_index->kind, idx1.index_definition->kind);
+        ASSERT_EQ(expect_idx.vector_index->dimension, idx1.index_definition->dimension);
+        ASSERT_EQ(expect_idx.vector_index->distance_metric, idx1.index_definition->distance_metric);
+        // check again, table_info.index_infos doesn't change and return them
+        DM::LocalIndexInfosPtr empty_index_info = nullptr;
+        ASSERT_EQ(2, generateLocalIndexInfos(empty_index_info, table_info, logger)->size());
+
+        // update
+        index_info = new_index_info;
+    }
+
+    // Drop the first vector index on column vec1.
+    table_info.index_infos.erase(table_info.index_infos.begin());
+
+    // Add another vector index to the TableInfo
+    TiDB::IndexInfo expect_idx2;
+    {
+        expect_idx2.id = 2; // another index_id
+        expect_idx2.idx_cols.emplace_back(default_index_col_info);
+        expect_idx2.vector_index = TiDB::VectorIndexDefinitionPtr(new TiDB::VectorIndexDefinition{
+            .kind = tipb::VectorIndexKind::HNSW,
+            .dimension = 2,
+            .distance_metric = tipb::VectorDistanceMetric::COSINE, // another distance
+        });
+        table_info.index_infos.emplace_back(expect_idx2);
+    }
+    // check the different
+    {
+        auto new_index_info = generateLocalIndexInfos(index_info, table_info, logger);
+        ASSERT_NE(new_index_info, nullptr);
+        ASSERT_EQ(new_index_info->size(), 2);
+
+        const auto & idx0 = (*new_index_info)[0];
+        ASSERT_EQ(DM::IndexType::Vector, idx0.type);
+        ASSERT_EQ(EmptyIndexID, idx0.index_id);
+        ASSERT_EQ(99, idx0.column_id);
+        ASSERT_NE(nullptr, idx0.index_definition);
+        ASSERT_EQ(col_vector_index->kind, idx0.index_definition->kind);
+        ASSERT_EQ(col_vector_index->dimension, idx0.index_definition->dimension);
+        ASSERT_EQ(col_vector_index->distance_metric, idx0.index_definition->distance_metric);
+
+        const auto & idx1 = (*new_index_info)[1];
+        ASSERT_EQ(DM::IndexType::Vector, idx1.type);
+        ASSERT_EQ(expect_idx2.id, idx1.index_id);
+        ASSERT_EQ(98, idx1.column_id);
+        ASSERT_NE(nullptr, idx1.index_definition);
+        ASSERT_EQ(expect_idx2.vector_index->kind, idx1.index_definition->kind);
+        ASSERT_EQ(expect_idx2.vector_index->dimension, idx1.index_definition->dimension);
+        ASSERT_EQ(expect_idx2.vector_index->distance_metric, idx1.index_definition->distance_metric);
+
+        // check again, nothing changed, return nullptr
+        ASSERT_EQ(nullptr, generateLocalIndexInfos(new_index_info, table_info, logger));
+    }
+}
+CATCH
+
+} // namespace DB::tests

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_test_basic.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_test_basic.cpp
@@ -736,7 +736,7 @@ bool SegmentTestBasic::replaceSegmentStableData(PageIdU64 segment_id, const DMFi
     return success;
 }
 
-bool SegmentTestBasic::ensureSegmentStableIndex(PageIdU64 segment_id, IndexInfosPtr local_index_infos)
+bool SegmentTestBasic::ensureSegmentStableIndex(PageIdU64 segment_id, LocalIndexInfosPtr local_index_infos)
 {
     LOG_INFO(logger_op, "EnsureSegmentStableIndex, segment_id={}", segment_id);
 

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_test_basic.h
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_test_basic.h
@@ -104,7 +104,7 @@ public:
     /**
      * Returns whether segment stable index is created.
      */
-    bool ensureSegmentStableIndex(PageIdU64 segment_id, IndexInfosPtr local_index_infos);
+    bool ensureSegmentStableIndex(PageIdU64 segment_id, LocalIndexInfosPtr local_index_infos);
 
     Block prepareWriteBlock(Int64 start_key, Int64 end_key, bool is_deleted = false);
     Block prepareWriteBlockInSegmentRange(

--- a/dbms/src/Storages/KVStore/Types.h
+++ b/dbms/src/Storages/KVStore/Types.h
@@ -45,6 +45,18 @@ using KeyspaceDatabaseID = std::pair<KeyspaceID, DatabaseID>;
 
 using ColumnID = Int64;
 
+enum : ColumnID
+{
+    EmptyColumnID = 0,
+};
+
+using IndexID = Int64;
+
+enum : IndexID
+{
+    EmptyIndexID = 0,
+};
+
 // Constants for column id, prevent conflict with TiDB.
 static constexpr ColumnID TiDBPkColumnID = -1;
 static constexpr ColumnID ExtraTableIDColumnID = -3;

--- a/dbms/src/Storages/StorageDeltaMerge.h
+++ b/dbms/src/Storages/StorageDeltaMerge.h
@@ -24,6 +24,7 @@
 #include <Storages/DeltaMerge/DeltaMergeInterfaces.h>
 #include <Storages/DeltaMerge/DeltaMergeStore.h>
 #include <Storages/DeltaMerge/Filter/PushDownFilter.h>
+#include <Storages/DeltaMerge/Index/IndexInfo.h>
 #include <Storages/DeltaMerge/Remote/DisaggSnapshot_fwd.h>
 #include <Storages/DeltaMerge/ScanContext_fwd.h>
 #include <Storages/DeltaMerge/Segment_fwd.h>
@@ -308,6 +309,4 @@ private:
 
     friend class MockStorage;
 };
-
-
 } // namespace DB

--- a/dbms/src/Storages/System/StorageSystemDTLocalIndexes.cpp
+++ b/dbms/src/Storages/System/StorageSystemDTLocalIndexes.cpp
@@ -45,6 +45,7 @@ StorageSystemDTLocalIndexes::StorageSystemDTLocalIndexes(const std::string & nam
 
         {"column_name", std::make_shared<DataTypeString>()},
         {"column_id", std::make_shared<DataTypeUInt64>()},
+        {"index_id", std::make_shared<DataTypeInt64>()},
         {"index_kind", std::make_shared<DataTypeString>()},
 
         {"rows_stable_indexed", std::make_shared<DataTypeUInt64>()}, // Total rows
@@ -120,6 +121,7 @@ BlockInputStreams StorageSystemDTLocalIndexes::read(
 
                 res_columns[j++]->insert(stat.column_name);
                 res_columns[j++]->insert(stat.column_id);
+                res_columns[j++]->insert(stat.index_id);
                 res_columns[j++]->insert(stat.index_kind);
 
                 res_columns[j++]->insert(stat.rows_stable_indexed);

--- a/dbms/src/TiDB/Schema/SchemaGetter.h
+++ b/dbms/src/TiDB/Schema/SchemaGetter.h
@@ -103,12 +103,13 @@ enum class SchemaActionType : Int8
     ActionDropResourceGroup = 70,
     ActionAlterTablePartitioning = 71,
     ActionRemovePartitioning = 72,
+    ActionAddVectorIndex = 73,
 
 
     // If we support new type from TiDB.
     // MaxRecognizedType also needs to be changed.
     // It should always be equal to the maximum supported type + 1
-    MaxRecognizedType = 73,
+    MaxRecognizedType = 74,
 };
 
 struct AffectedOption


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #9032

Problem Summary:

### What is changed and how it works?

- Support the vector index from tableInfo.IndexInfo.
- Support adding/dropping vector index when doing syncTableSchema.

```commit-message
*: support vector index and adding/dropping vector index when doing syncTableSchema
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
