### PR TITLE
Compression: still using LZ4 by default

### DIFF
--- a/dbms/src/Interpreters/Settings.h
+++ b/dbms/src/Interpreters/Settings.h
@@ -214,8 +214,8 @@ struct Settings
     /* Checksum and compressions */ \
     M(SettingUInt64, dt_checksum_frame_size, DBMS_DEFAULT_BUFFER_SIZE, "Frame size for delta tree stable storage")                                                                                                                      \
     M(SettingChecksumAlgorithm, dt_checksum_algorithm, ChecksumAlgo::XXH3, "Checksum algorithm for delta tree stable storage")                                                                                                          \
-    M(SettingCompressionMethod, dt_compression_method, CompressionMethod::Lightweight, "The method of data compression when writing.")                                                                                                  \
-    M(SettingInt64, dt_compression_level, 3, "The compression level.")                                                                                                                                                                  \
+    M(SettingCompressionMethod, dt_compression_method, CompressionMethod::LZ4, "The method of data compression when writing.")                                                                                                          \
+    M(SettingInt64, dt_compression_level, 1, "The compression level.")                                                                                                                                                                  \
     M(SettingUInt64, min_compress_block_size, DEFAULT_MIN_COMPRESS_BLOCK_SIZE, "The actual size of the block to compress, if the uncompressed data less than max_compress_block_size is no less than this value "                       \
                                                                                "and no less than the volume of data for one mark.")                                                                                                     \
     M(SettingUInt64, max_compress_block_size, DEFAULT_MAX_COMPRESS_BLOCK_SIZE, "The maximum size of blocks of uncompressed data before compressing for writing to a table.")                                                            \

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFilePersisted.cpp
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFilePersisted.cpp
@@ -101,10 +101,15 @@ void serializeColumn(
     CompressionMethod compression_method,
     Int64 compression_level)
 {
+#ifdef NDEBUG
     // Do not use lightweight compression in ColumnFile whose write performance is the bottleneck.
     auto settings = compression_method == CompressionMethod::Lightweight
         ? CompressionSettings(CompressionMethod::LZ4)
         : CompressionSettings(compression_method, compression_level);
+#else
+    // In debug mode, still support lightweight compression for testing.
+    auto settings = CompressionSettings(compression_method, compression_level);
+#endif
     CompressedWriteBuffer compressed(buf, settings);
     type->serializeBinaryBulkWithMultipleStreams(
         column,

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_file.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_file.cpp
@@ -413,8 +413,9 @@ try
                 files.insert(itr.name());
             }
         }
-        ASSERT_EQ(files.size(), 2); // col data and merged file
+        ASSERT_EQ(files.size(), 3); // handle, col data and merged file
         ASSERT(files.find("0.merged") != files.end());
+        ASSERT(files.find("%2D1.dat") != files.end());
         ASSERT(files.find("1.dat") != files.end());
     }
 

--- a/tests/tidb-ci/run.sh
+++ b/tests/tidb-ci/run.sh
@@ -62,11 +62,10 @@ docker-compose -f cluster.yaml -f tiflash-dt-force-enable-lm.yaml exec -T tiflas
 docker-compose -f cluster.yaml -f tiflash-dt-force-enable-lm.yaml down
 clean_data_log
 
-# TODO: now set dt_compression_method = "lightweight" by default, so we don't need to run this test.
 # run lighweight compression tests
-# docker-compose -f cluster.yaml -f tiflash-dt-lightweight-compression.yaml up -d
-# wait_env
-# docker-compose -f cluster.yaml -f tiflash-dt-lightweight-compression.yaml exec -T tiflash0 bash -c 'cd /tests ; ./run-test.sh tidb-ci/lightweight_compression'
+docker-compose -f cluster.yaml -f tiflash-dt-lightweight-compression.yaml up -d
+wait_env
+docker-compose -f cluster.yaml -f tiflash-dt-lightweight-compression.yaml exec -T tiflash0 bash -c 'cd /tests ; ./run-test.sh tidb-ci/lightweight_compression'
 
-# docker-compose -f cluster.yaml -f tiflash-dt-lightweight-compression.yaml down
-# clean_data_log
+docker-compose -f cluster.yaml -f tiflash-dt-lightweight-compression.yaml down
+clean_data_log


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8982

Problem Summary:

### What is changed and how it works?

```commit-message
Compression: still using LZ4 by default
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
