### PR TITLE
Storage: Support multiple vec indexes on the same column

### DIFF
--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
@@ -176,7 +176,6 @@ struct StoreStats
 
 struct LocalIndexStats
 {
-    String column_name{};
     UInt64 column_id{};
     UInt64 index_id{};
     String index_kind{};
@@ -864,13 +863,16 @@ private:
         const SegmentPtr & segment,
         const DMFiles & new_dm_files);
 
-    // Get a snap of local_index_infos to check whether any new index is created.
-    LocalIndexInfosPtr getLocalIndexInfosSnapshot() const
+    // Get a snap of local_index_infos for checking.
+    // Note that this is just a shallow copy of `local_index_infos`, do not
+    // modify the local indexes inside the snapshot.
+    LocalIndexInfosSnapshot getLocalIndexInfosSnapshot() const
     {
         std::shared_lock index_read_lock(mtx_local_index_infos);
         if (!local_index_infos || local_index_infos->empty())
             return nullptr;
-        return std::make_shared<LocalIndexInfos>(*local_index_infos);
+        // only make a shallow copy on the shared_ptr is OK
+        return local_index_infos;
     }
 
     /**

--- a/dbms/src/Storages/DeltaMerge/File/DMFileIndexWriter.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileIndexWriter.cpp
@@ -213,7 +213,7 @@ size_t DMFileIndexWriter::buildIndexForFile(const DMFilePtr & dm_file_mutable, P
                 pb_idx.set_dimensions(index_builder->definition->dimension);
                 pb_idx.set_index_id(index_id);
                 pb_idx.set_index_bytes(Poco::File(index_path).getSize());
-                new_indexes.emplace_back(std::move(pb_idx));
+                new_indexes.emplace_back(pb_idx);
 
                 total_built_index_bytes += pb_idx.index_bytes();
                 iw->include(index_file_name);

--- a/dbms/src/Storages/DeltaMerge/File/DMFileIndexWriter.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileIndexWriter.cpp
@@ -212,10 +212,11 @@ size_t DMFileIndexWriter::buildIndexForFile(const DMFilePtr & dm_file_mutable, P
                 pb_idx.set_distance_metric(tipb::VectorDistanceMetric_Name(index_builder->definition->distance_metric));
                 pb_idx.set_dimensions(index_builder->definition->dimension);
                 pb_idx.set_index_id(index_id);
-                pb_idx.set_index_bytes(Poco::File(index_path).getSize());
-                new_indexes.emplace_back(pb_idx);
+                auto index_bytes = Poco::File(index_path).getSize();
+                pb_idx.set_index_bytes(index_bytes);
+                new_indexes.emplace_back(std::move(pb_idx));
 
-                total_built_index_bytes += pb_idx.index_bytes();
+                total_built_index_bytes += index_bytes;
                 iw->include(index_file_name);
             }
             // Inorder to avoid concurrency reading on ColumnStat, the new added indexes

--- a/dbms/src/Storages/DeltaMerge/File/DMFileIndexWriter.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileIndexWriter.cpp
@@ -22,7 +22,11 @@
 #include <Storages/DeltaMerge/Index/IndexInfo.h>
 #include <Storages/DeltaMerge/Index/VectorIndex.h>
 #include <Storages/DeltaMerge/ScanContext.h>
+#include <Storages/DeltaMerge/dtpb/dmfile.pb.h>
 #include <Storages/PathPool.h>
+#include <tipb/executor.pb.h>
+
+#include <unordered_map>
 
 namespace DB::ErrorCodes
 {
@@ -33,7 +37,7 @@ namespace DB::DM
 {
 
 DMFileIndexWriter::LocalIndexBuildInfo DMFileIndexWriter::getLocalIndexBuildInfo(
-    const LocalIndexInfosPtr & index_infos,
+    const LocalIndexInfosSnapshot & index_infos,
     const DMFiles & dm_files)
 {
     assert(index_infos != nullptr);
@@ -48,18 +52,22 @@ DMFileIndexWriter::LocalIndexBuildInfo DMFileIndexWriter::getLocalIndexBuildInfo
         for (const auto & index : *index_infos)
         {
             auto col_id = index.column_id;
-            // The dmfile may be built before col_id is added. Skip build indexes for it
-            if (!dmfile->isColumnExist(col_id))
-                continue;
+            const auto [state, data_bytes] = dmfile->getLocalIndexState(col_id, index.index_id);
+            switch (state)
+            {
+            case DMFileMeta::LocalIndexState::NoNeed:
+            case DMFileMeta::LocalIndexState::IndexBuilt:
+                // The dmfile may be built before col_id is added, or has been built. Skip build indexes for it
+                break;
+            case DMFileMeta::LocalIndexState::IndexPending:
+            {
+                any_new_index_build = true;
 
-            if (dmfile->getColumnStat(col_id).index_bytes > 0)
-                continue;
-
-            any_new_index_build = true;
-
-            auto col_stat = dmfile->getColumnStat(col_id);
-            build.indexes_to_build->emplace_back(index);
-            build.estimated_memory_bytes += col_stat.serialized_bytes * VECTOR_INDEX_SIZE_FACTOR;
+                build.indexes_to_build->emplace_back(index);
+                build.estimated_memory_bytes += data_bytes * VECTOR_INDEX_SIZE_FACTOR;
+                break;
+            }
+            }
         }
 
         if (any_new_index_build)
@@ -82,36 +90,50 @@ size_t DMFileIndexWriter::buildIndexForFile(const DMFilePtr & dm_file_mutable, P
         dm_file_mutable->path());
 
     // read_columns are: DEL_MARK, COL_A, COL_B, ...
-    // index_builders are: COL_A, COL_B, ...
+    // index_builders are: COL_A -> {idx_M, idx_N}, COL_B -> {idx_O}, ...
 
     ColumnDefines read_columns{*del_cd_iter};
     read_columns.reserve(options.index_infos->size() + 1);
 
-    std::vector<VectorIndexBuilderPtr> index_builders;
-    index_builders.reserve(options.index_infos->size());
+    std::unordered_map<ColId, std::vector<VectorIndexBuilderPtr>> index_builders;
 
-    // The caller should avoid building index for the same column multiple times.
+    std::unordered_map<ColId, std::vector<LocalIndexInfo>> col_indexes;
     for (const auto & index_info : *options.index_infos)
     {
+        if (index_info.type != IndexType::Vector)
+            continue;
+        col_indexes[index_info.column_id].emplace_back(index_info);
+    }
+
+    for (const auto & [col_id, index_infos] : col_indexes)
+    {
         const auto cd_iter = std::find_if(column_defines.cbegin(), column_defines.cend(), [&](const auto & cd) {
-            return cd.id == index_info.column_id;
+            return cd.id == col_id;
         });
         RUNTIME_CHECK_MSG(
             cd_iter != column_defines.cend(),
             "Cannot find column_id={} in file={}",
-            index_info.column_id,
+            col_id,
             dm_file_mutable->path());
 
-        // Index already built. We don't allow. The caller should filter away.
-        RUNTIME_CHECK(dm_file_mutable->getColumnStat(index_info.column_id).index_bytes == 0, index_info.column_id);
-
+        for (const auto & idx_info : index_infos)
+        {
+            // Index already built. We don't allow. The caller should filter away,
+            RUNTIME_CHECK(
+                !dm_file_mutable->isLocalIndexExist(idx_info.column_id, idx_info.index_id),
+                idx_info.column_id,
+                idx_info.index_id);
+            index_builders[col_id].emplace_back(
+                VectorIndexBuilder::create(idx_info.index_id, idx_info.index_definition));
+        }
         read_columns.push_back(*cd_iter);
-        index_builders.push_back(VectorIndexBuilder::create(index_info.index_definition));
     }
 
-    // If no index to build.
-    if (index_builders.empty())
+    if (read_columns.size() == 1 || index_builders.empty())
+    {
+        // No index to build.
         return 0;
+    }
 
     DMFileV3IncrementWriter::Options iw_options{
         .dm_file = dm_file_mutable,
@@ -133,6 +155,7 @@ size_t DMFileIndexWriter::buildIndexForFile(const DMFilePtr & dm_file_mutable, P
         scan_context);
 
     // Read all blocks and build index
+    const size_t num_cols = read_columns.size();
     while (true)
     {
         if (!should_proceed())
@@ -142,7 +165,7 @@ size_t DMFileIndexWriter::buildIndexForFile(const DMFilePtr & dm_file_mutable, P
         if (!block)
             break;
 
-        RUNTIME_CHECK(block.columns() == read_columns.size());
+        RUNTIME_CHECK(block.columns() == num_cols);
         RUNTIME_CHECK(block.getByPosition(0).column_id == TAG_COLUMN_ID);
 
         auto del_mark_col = block.safeGetByPosition(0).column;
@@ -150,49 +173,60 @@ size_t DMFileIndexWriter::buildIndexForFile(const DMFilePtr & dm_file_mutable, P
         const auto * del_mark = static_cast<const ColumnVector<UInt8> *>(del_mark_col.get());
         RUNTIME_CHECK(del_mark != nullptr);
 
-        for (size_t col_idx = 0, col_idx_max = index_builders.size(); col_idx < col_idx_max; ++col_idx)
+        for (size_t col_idx = 1; col_idx < num_cols; ++col_idx)
         {
-            const auto & index_builder = index_builders[col_idx];
-            const auto & col_with_type_and_name = block.safeGetByPosition(col_idx + 1);
-            RUNTIME_CHECK(col_with_type_and_name.column_id == read_columns[col_idx + 1].id);
+            const auto & col_with_type_and_name = block.safeGetByPosition(col_idx);
+            RUNTIME_CHECK(col_with_type_and_name.column_id == read_columns[col_idx].id);
             const auto & col = col_with_type_and_name.column;
-            index_builder->addBlock(*col, del_mark, should_proceed);
+            for (const auto & index_builder : index_builders[read_columns[col_idx].id])
+            {
+                index_builder->addBlock(*col, del_mark, should_proceed);
+            }
         }
     }
 
     // Write down the index
     size_t total_built_index_bytes = 0;
-    for (size_t col_idx = 0, col_idx_max = index_builders.size(); col_idx < col_idx_max; col_idx++)
+    std::unordered_map<ColId, std::vector<dtpb::VectorIndexFileProps>> new_indexes_on_cols;
+    for (size_t col_idx = 1; col_idx < num_cols; ++col_idx)
     {
-        const auto & index_builder = index_builders[col_idx];
-        const auto & cd = read_columns[col_idx + 1];
-
+        const auto & cd = read_columns[col_idx];
         // Save index and update column stats
         auto callback = [&](const IDataType::SubstreamPath & substream_path) -> void {
             if (IDataType::isNullMap(substream_path) || IDataType::isArraySizes(substream_path))
                 return;
 
-            const auto stream_name = DMFile::getFileNameBase(cd.id, substream_path);
-            const auto index_file_name = colIndexFileName(stream_name);
-            const auto index_path = iw->localPath() + "/" + index_file_name;
-            index_builder->save(index_path);
+            std::vector<dtpb::VectorIndexFileProps> new_indexes;
+            for (const auto & index_builder : index_builders[cd.id])
+            {
+                const IndexID index_id = index_builder->index_id;
+                const auto index_file_name = index_id > 0
+                    ? dm_file_mutable->vectorIndexFileName(index_id)
+                    : colIndexFileName(DMFile::getFileNameBase(cd.id, substream_path));
+                const auto index_path = iw->localPath() + "/" + index_file_name;
+                index_builder->save(index_path);
 
-            auto & col_stat = dm_file_mutable->meta->getColumnStats().at(cd.id);
-            col_stat.index_bytes = Poco::File(index_path).getSize();
-            total_built_index_bytes += col_stat.index_bytes;
-            // Memorize what kind of vector index it is, so that we can correctly restore it when reading.
-            col_stat.vector_index.emplace();
-            col_stat.vector_index->set_index_kind(tipb::VectorIndexKind_Name(index_builder->definition->kind));
-            col_stat.vector_index->set_distance_metric(
-                tipb::VectorDistanceMetric_Name(index_builder->definition->distance_metric));
-            col_stat.vector_index->set_dimensions(index_builder->definition->dimension);
+                // Memorize what kind of vector index it is, so that we can correctly restore it when reading.
+                dtpb::VectorIndexFileProps pb_idx;
+                pb_idx.set_index_kind(tipb::VectorIndexKind_Name(index_builder->definition->kind));
+                pb_idx.set_distance_metric(tipb::VectorDistanceMetric_Name(index_builder->definition->distance_metric));
+                pb_idx.set_dimensions(index_builder->definition->dimension);
+                pb_idx.set_index_id(index_id);
+                pb_idx.set_index_bytes(Poco::File(index_path).getSize());
+                new_indexes.emplace_back(std::move(pb_idx));
 
-            iw->include(index_file_name);
+                total_built_index_bytes += pb_idx.index_bytes();
+                iw->include(index_file_name);
+            }
+            // Inorder to avoid concurrency reading on ColumnStat, the new added indexes
+            // will be insert into DMFile instance in `bumpMetaVersion`.
+            new_indexes_on_cols.emplace(cd.id, std::move(new_indexes));
         };
+
         cd.type->enumerateStreams(callback);
     }
 
-    dm_file_mutable->meta->bumpMetaVersion();
+    dm_file_mutable->meta->bumpMetaVersion(DMFileMetaChangeset{new_indexes_on_cols});
     iw->finalize(); // Note: There may be S3 uploads here.
     return total_built_index_bytes;
 }

--- a/dbms/src/Storages/DeltaMerge/File/DMFileIndexWriter.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileIndexWriter.h
@@ -47,7 +47,9 @@ public:
         LocalIndexInfosPtr indexes_to_build;
     };
 
-    static LocalIndexBuildInfo getLocalIndexBuildInfo(const LocalIndexInfosPtr & index_infos, const DMFiles & dm_files);
+    static LocalIndexBuildInfo getLocalIndexBuildInfo(
+        const LocalIndexInfosSnapshot & index_infos,
+        const DMFiles & dm_files);
 
     struct Options
     {

--- a/dbms/src/Storages/DeltaMerge/File/DMFileMetaV2.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileMetaV2.h
@@ -102,16 +102,20 @@ public:
     EncryptionPath encryptionMergedPath(UInt32 number) const;
     static String mergedFilename(UInt32 number) { return fmt::format("{}.merged", number); }
 
+public:
+    std::tuple<LocalIndexState, size_t> getLocalIndexState(ColId col_id, IndexID index_id) const override;
+
+    std::optional<dtpb::VectorIndexFileProps> getLocalIndex(ColId col_id, IndexID index_id) const override;
+
+public:
     UInt32 metaVersion() const override { return meta_version; }
-    UInt32 bumpMetaVersion() override
-    {
-        ++meta_version;
-        return meta_version;
-    }
+    UInt32 bumpMetaVersion(DMFileMetaChangeset && changeset) override;
 
     UInt64 small_file_size_threshold;
     UInt64 merged_file_max_size;
     UInt64 meta_version = 0; // Note: meta_version affects the output file name.
+
+    mutable std::mutex mtx_bump;
 
 private:
     UInt64 getMergedFileSizeOfColumn(const MergedSubFileInfo & file_info) const;

--- a/dbms/src/Storages/DeltaMerge/File/DMFileWriter.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileWriter.cpp
@@ -65,7 +65,16 @@ DMFileWriter::DMFileWriter(
         bool do_index = cd.id == EXTRA_HANDLE_COLUMN_ID || type->isInteger() || type->isDateOrDateTime();
 
         addStreams(cd.id, cd.type, do_index);
-        dmfile->meta->getColumnStats().emplace(cd.id, ColumnStat{cd.id, cd.type, /*avg_size=*/0});
+        dmfile->meta->getColumnStats().emplace(
+            cd.id,
+            ColumnStat{
+                .col_id = cd.id,
+                .type = cd.type,
+                .avg_size = 0,
+                // ... here ignore some fields with default initializers
+                .vector_index = {},
+                .additional_data_for_test = {},
+            });
     }
 }
 

--- a/dbms/src/Storages/DeltaMerge/Index/IndexInfo.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/IndexInfo.cpp
@@ -95,7 +95,6 @@ LocalIndexInfosPtr initLocalIndexInfos(const TiDB::TableInfo & table_info, const
             index_infos->emplace_back(LocalIndexInfo{
                 .type = IndexType::Vector,
                 .column_id = col.id,
-                .column_name = col.name,
                 .index_definition = col.vector_index,
             });
             LOG_INFO(logger, "Add a new index by column comments, column_id={}, table_id={}.", col.id, table_info.id);
@@ -121,7 +120,6 @@ LocalIndexInfosPtr initLocalIndexInfos(const TiDB::TableInfo & table_info, const
             .type = IndexType::Vector,
             .index_id = idx.id,
             .column_id = column.id,
-            .column_name = column.name,
             .index_definition = idx.vector_index,
         });
     }
@@ -131,7 +129,7 @@ LocalIndexInfosPtr initLocalIndexInfos(const TiDB::TableInfo & table_info, const
 }
 
 LocalIndexInfosPtr generateLocalIndexInfos(
-    const LocalIndexInfosPtr & existing_indexes,
+    const LocalIndexInfosSnapshot & existing_indexes,
     const TiDB::TableInfo & new_table_info,
     const LoggerPtr & logger)
 {
@@ -172,7 +170,6 @@ LocalIndexInfosPtr generateLocalIndexInfos(
                     .type = IndexType::Vector,
                     .index_id = idx.id,
                     .column_id = column.id,
-                    .column_name = column.name,
                     .index_definition = idx.vector_index,
                 };
                 new_index_infos->emplace_back(std::move(index_info));
@@ -189,7 +186,7 @@ LocalIndexInfosPtr generateLocalIndexInfos(
         }
     }
 
-    // drop nonexistent indices
+    // drop nonexistent indexes
     for (auto & iter : original_local_index_id_map)
     {
         // It means this index is create by column comments which we don't support drop index.

--- a/dbms/src/Storages/DeltaMerge/Index/IndexInfo.h
+++ b/dbms/src/Storages/DeltaMerge/Index/IndexInfo.h
@@ -39,9 +39,10 @@ enum class IndexType
 struct LocalIndexInfo
 {
     IndexType type;
+    // If the index is defined on TiDB::ColumnInfo, use EmptyIndexID as index_id
     IndexID index_id = DB::EmptyIndexID;
+    // Which column_id the index is built on
     ColumnID column_id = DB::EmptyColumnID;
-    String column_name;
     // Now we only support vector index.
     // In the future, we may support more types of indexes, using std::variant.
     TiDB::VectorIndexDefinitionPtr index_definition;
@@ -49,15 +50,11 @@ struct LocalIndexInfo
 
 using LocalIndexInfos = std::vector<LocalIndexInfo>;
 using LocalIndexInfosPtr = std::shared_ptr<LocalIndexInfos>;
+using LocalIndexInfosSnapshot = std::shared_ptr<const LocalIndexInfos>;
 
-bool isVectorIndexSupported(const LoggerPtr & logger);
 LocalIndexInfosPtr initLocalIndexInfos(const TiDB::TableInfo & table_info, const LoggerPtr & logger);
-TiDB::ColumnInfo getVectorIndxColumnInfo(
-    const TiDB::TableInfo & table_info,
-    const TiDB::IndexInfo & idx_info,
-    const LoggerPtr & logger);
 LocalIndexInfosPtr generateLocalIndexInfos(
-    const LocalIndexInfosPtr & existing_indexes,
+    const LocalIndexInfosSnapshot & existing_indexes,
     const TiDB::TableInfo & new_table_info,
     const LoggerPtr & logger);
 

--- a/dbms/src/Storages/DeltaMerge/Index/VectorIndex.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/VectorIndex.cpp
@@ -24,6 +24,7 @@
 namespace DB::ErrorCodes
 {
 extern const int BAD_ARGUMENTS;
+extern const int INCORRECT_QUERY;
 } // namespace DB::ErrorCodes
 
 namespace DB::DM
@@ -38,7 +39,7 @@ bool VectorIndexBuilder::isSupportedType(const IDataType & type)
     return checkDataTypeArray<DataTypeFloat32>(&type);
 }
 
-VectorIndexBuilderPtr VectorIndexBuilder::create(const TiDB::VectorIndexDefinitionPtr & definition)
+VectorIndexBuilderPtr VectorIndexBuilder::create(IndexID index_id, const TiDB::VectorIndexDefinitionPtr & definition)
 {
     RUNTIME_CHECK(definition->dimension > 0);
     RUNTIME_CHECK(definition->dimension <= TiDB::MAX_VECTOR_DIMENSION);
@@ -46,11 +47,12 @@ VectorIndexBuilderPtr VectorIndexBuilder::create(const TiDB::VectorIndexDefiniti
     switch (definition->kind)
     {
     case tipb::VectorIndexKind::HNSW:
-        return std::make_shared<VectorIndexHNSWBuilder>(definition);
+        return std::make_shared<VectorIndexHNSWBuilder>(index_id, definition);
     default:
-        throw Exception(
-            ErrorCodes::BAD_ARGUMENTS,
-            "Unsupported vector index {}",
+        throw Exception( //
+            ErrorCodes::INCORRECT_QUERY,
+            "Unsupported vector index, index_id={} def={}",
+            index_id,
             tipb::VectorIndexKind_Name(definition->kind));
     }
 }

--- a/dbms/src/Storages/DeltaMerge/Index/VectorIndex.h
+++ b/dbms/src/Storages/DeltaMerge/Index/VectorIndex.h
@@ -22,6 +22,7 @@
 #include <Storages/DeltaMerge/BitmapFilter/BitmapFilterView.h>
 #include <Storages/DeltaMerge/Index/VectorIndex_fwd.h>
 #include <Storages/DeltaMerge/dtpb/dmfile.pb.h>
+#include <Storages/KVStore/Types.h>
 #include <TiDB/Schema/VectorIndex.h>
 
 
@@ -38,13 +39,14 @@ public:
     using ProceedCheckFn = std::function<bool()>;
 
 public:
-    static VectorIndexBuilderPtr create(const TiDB::VectorIndexDefinitionPtr & definition);
+    static VectorIndexBuilderPtr create(IndexID index_id, const TiDB::VectorIndexDefinitionPtr & definition);
 
     static bool isSupportedType(const IDataType & type);
 
 public:
-    explicit VectorIndexBuilder(const TiDB::VectorIndexDefinitionPtr & definition_)
-        : definition(definition_)
+    explicit VectorIndexBuilder(IndexID index_id_, const TiDB::VectorIndexDefinitionPtr & definition_)
+        : index_id(index_id_)
+        , definition(definition_)
     {}
 
     virtual ~VectorIndexBuilder() = default;
@@ -58,6 +60,7 @@ public:
     virtual void save(std::string_view path) const = 0;
 
 public:
+    const IndexID index_id;
     const TiDB::VectorIndexDefinitionPtr definition;
 };
 

--- a/dbms/src/Storages/DeltaMerge/Index/VectorIndexHNSW/Index.h
+++ b/dbms/src/Storages/DeltaMerge/Index/VectorIndexHNSW/Index.h
@@ -29,7 +29,7 @@ class VectorIndexHNSWBuilder : public VectorIndexBuilder
 public:
     static tipb::VectorIndexKind kind();
 
-    explicit VectorIndexHNSWBuilder(const TiDB::VectorIndexDefinitionPtr & definition_);
+    explicit VectorIndexHNSWBuilder(IndexID index_id_, const TiDB::VectorIndexDefinitionPtr & definition_);
 
     ~VectorIndexHNSWBuilder() override;
 

--- a/dbms/src/Storages/DeltaMerge/LocalIndexerScheduler.h
+++ b/dbms/src/Storages/DeltaMerge/LocalIndexerScheduler.h
@@ -180,7 +180,7 @@ private:
 
     const LoggerPtr logger;
 
-    /// The thread pool for creating indices in the background.
+    /// The thread pool for creating indexes in the background.
     std::unique_ptr<ThreadPool> pool;
     /// The current memory usage of the pool. It is not accurate and the memory
     /// is determined when task is adding to the pool.

--- a/dbms/src/Storages/DeltaMerge/dtpb/dmfile.proto
+++ b/dbms/src/Storages/DeltaMerge/dtpb/dmfile.proto
@@ -64,8 +64,8 @@ message ColumnStat {
 
     // Only used in tests. Modifying other fields of ColumnStat is hard.
     optional string additional_data_for_test = 101;
-    // TODO(vector-index) Support multiple vector index on the same column
     optional VectorIndexFileProps vector_index = 102;
+    repeated VectorIndexFileProps vector_indexes = 103;
 }
 
 message ColumnStats {
@@ -93,4 +93,6 @@ message VectorIndexFileProps {
     optional string index_kind = 1;       // The value is tipb.VectorIndexKind
     optional string distance_metric = 2;  // The value is tipb.VectorDistanceMetric
     optional uint64 dimensions = 3;
+    optional int64 index_id = 4;
+    optional uint64 index_bytes = 5;
 }

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_meta_version.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_meta_version.cpp
@@ -159,7 +159,7 @@ try
         .disagg_ctx = db_context->getSharedContextDisagg(),
     });
     dm_file->meta->getColumnStats()[::DB::TiDBPkColumnID].additional_data_for_test = "test";
-    ASSERT_EQ(1, dm_file->meta->bumpMetaVersion());
+    ASSERT_EQ(1, dm_file->meta->bumpMetaVersion({}));
     iw->finalize();
 
     // Read out meta version = 0
@@ -203,7 +203,7 @@ try
         .disagg_ctx = db_context->getSharedContextDisagg(),
     });
     dm_file_for_write->meta->getColumnStats()[::DB::TiDBPkColumnID].additional_data_for_test = "test";
-    ASSERT_EQ(1, dm_file_for_write->meta->bumpMetaVersion());
+    ASSERT_EQ(1, dm_file_for_write->meta->bumpMetaVersion({}));
     iw->finalize();
 
     auto dm_file_for_read_v1 = DMFile::restore(
@@ -226,7 +226,7 @@ try
         .disagg_ctx = db_context->getSharedContextDisagg(),
     });
     dm_file_for_write->meta->getColumnStats()[::DB::TiDBPkColumnID].additional_data_for_test = "test2";
-    ASSERT_EQ(2, dm_file_for_write->meta->bumpMetaVersion());
+    ASSERT_EQ(2, dm_file_for_write->meta->bumpMetaVersion({}));
     iw->finalize();
 
     // Current DMFile instance does not affect
@@ -262,7 +262,7 @@ try
         .disagg_ctx = db_context->getSharedContextDisagg(),
     });
     dm_file->meta->getColumnStats()[::DB::TiDBPkColumnID].additional_data_for_test = "test";
-    ASSERT_EQ(1, dm_file->meta->bumpMetaVersion());
+    ASSERT_EQ(1, dm_file->meta->bumpMetaVersion({}));
     iw->finalize();
 
     // Overwrite meta v1.
@@ -282,7 +282,7 @@ try
         .disagg_ctx = db_context->getSharedContextDisagg(),
     });
     dm_file_2->meta->getColumnStats()[::DB::TiDBPkColumnID].additional_data_for_test = "test_overwrite";
-    ASSERT_EQ(1, dm_file_2->meta->bumpMetaVersion());
+    ASSERT_EQ(1, dm_file_2->meta->bumpMetaVersion({}));
     ASSERT_NO_THROW({
         iw->finalize();
     }); // No exception should be thrown because it may be a file left by previous writes but segment failed to update meta version.
@@ -318,12 +318,12 @@ try
         .disagg_ctx = db_context->getSharedContextDisagg(),
     });
     dm_file->meta->getColumnStats()[::DB::TiDBPkColumnID].additional_data_for_test = "test";
-    dm_file->meta->bumpMetaVersion();
+    dm_file->meta->bumpMetaVersion({});
     iw->finalize();
 
     ASSERT_THROW({ iw->finalize(); }, DB::Exception);
 
-    dm_file->meta->bumpMetaVersion();
+    dm_file->meta->bumpMetaVersion({});
     ASSERT_THROW({ iw->finalize(); }, DB::Exception);
 }
 CATCH
@@ -443,7 +443,7 @@ try
         .disagg_ctx = db_context->getSharedContextDisagg(),
     });
     dm_file->meta->getColumnStats()[::DB::TiDBPkColumnID].additional_data_for_test = "test";
-    ASSERT_EQ(1, dm_file->meta->bumpMetaVersion());
+    ASSERT_EQ(1, dm_file->meta->bumpMetaVersion({}));
     iw->finalize();
 
     // Read out meta version = 0
@@ -491,7 +491,7 @@ try
         .disagg_ctx = db_context->getSharedContextDisagg(),
     });
     dm_file->meta->getColumnStats()[::DB::TiDBPkColumnID].additional_data_for_test = "test";
-    ASSERT_EQ(1, dm_file->meta->bumpMetaVersion());
+    ASSERT_EQ(1, dm_file->meta->bumpMetaVersion({}));
     iw->finalize();
 
     {

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_vector_index_utils.h
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_vector_index_utils.h
@@ -86,8 +86,8 @@ public:
         const LocalIndexInfos index_infos = LocalIndexInfos{
             LocalIndexInfo{
                 .type = IndexType::Vector,
+                .index_id = EmptyIndexID,
                 .column_id = vec_column_id,
-                .column_name = "",
                 .index_definition = std::make_shared<TiDB::VectorIndexDefinition>(definition),
             },
         };

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_local_index_info.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_local_index_info.cpp
@@ -19,10 +19,10 @@
 #include <gtest/gtest.h>
 #include <tipb/executor.pb.h>
 
-namespace DB::tests
+namespace DB::DM::tests
 {
 
-TEST(LocalIndexInfo, CheckIndexChanged)
+TEST(LocalIndexInfoTest, CheckIndexChanged)
 try
 {
     TiDB::TableInfo table_info;
@@ -34,7 +34,7 @@ try
     }
 
     auto logger = Logger::get();
-    DM::LocalIndexInfosPtr index_info = nullptr;
+    LocalIndexInfosPtr index_info = nullptr;
     // check the same
     {
         auto new_index_info = generateLocalIndexInfos(index_info, table_info, logger);
@@ -69,7 +69,7 @@ try
         ASSERT_NE(new_index_info, nullptr);
         ASSERT_EQ(new_index_info->size(), 1);
         const auto & idx = (*new_index_info)[0];
-        ASSERT_EQ(DM::IndexType::Vector, idx.type);
+        ASSERT_EQ(IndexType::Vector, idx.type);
         ASSERT_EQ(expect_idx.id, idx.index_id);
         ASSERT_EQ(100, idx.column_id);
         ASSERT_NE(nullptr, idx.index_definition);
@@ -102,7 +102,7 @@ try
         ASSERT_NE(new_index_info, nullptr);
         ASSERT_EQ(new_index_info->size(), 2);
         const auto & idx0 = (*new_index_info)[0];
-        ASSERT_EQ(DM::IndexType::Vector, idx0.type);
+        ASSERT_EQ(IndexType::Vector, idx0.type);
         ASSERT_EQ(expect_idx.id, idx0.index_id);
         ASSERT_EQ(100, idx0.column_id);
         ASSERT_NE(nullptr, idx0.index_definition);
@@ -110,7 +110,7 @@ try
         ASSERT_EQ(expect_idx.vector_index->dimension, idx0.index_definition->dimension);
         ASSERT_EQ(expect_idx.vector_index->distance_metric, idx0.index_definition->distance_metric);
         const auto & idx1 = (*new_index_info)[1];
-        ASSERT_EQ(DM::IndexType::Vector, idx1.type);
+        ASSERT_EQ(IndexType::Vector, idx1.type);
         ASSERT_EQ(expect_idx2.id, idx1.index_id);
         ASSERT_EQ(100, idx1.column_id);
         ASSERT_NE(nullptr, idx1.index_definition);
@@ -146,7 +146,7 @@ try
         ASSERT_NE(new_index_info, nullptr);
         ASSERT_EQ(new_index_info->size(), 2);
         const auto & idx0 = (*new_index_info)[0];
-        ASSERT_EQ(DM::IndexType::Vector, idx0.type);
+        ASSERT_EQ(IndexType::Vector, idx0.type);
         ASSERT_EQ(expect_idx.id, idx0.index_id);
         ASSERT_EQ(100, idx0.column_id);
         ASSERT_NE(nullptr, idx0.index_definition);
@@ -154,7 +154,7 @@ try
         ASSERT_EQ(expect_idx.vector_index->dimension, idx0.index_definition->dimension);
         ASSERT_EQ(expect_idx.vector_index->distance_metric, idx0.index_definition->distance_metric);
         const auto & idx1 = (*new_index_info)[1];
-        ASSERT_EQ(DM::IndexType::Vector, idx1.type);
+        ASSERT_EQ(IndexType::Vector, idx1.type);
         ASSERT_EQ(expect_idx3.id, idx1.index_id);
         ASSERT_EQ(100, idx1.column_id);
         ASSERT_NE(nullptr, idx1.index_definition);
@@ -168,7 +168,7 @@ try
 }
 CATCH
 
-TEST(LocalIndexInfo, CheckIndexAddWithVecIndexOnColumnInfo)
+TEST(LocalIndexInfoTest, CheckIndexAddWithVecIndexOnColumnInfo)
 try
 {
     // The serverless branch, vector index may directly defined on the ColumnInfo.
@@ -211,15 +211,15 @@ try
 
     // check the different
     auto logger = Logger::get();
-    DM::LocalIndexInfosPtr index_info = nullptr;
+    LocalIndexInfosPtr index_info = nullptr;
     {
         auto new_index_info = generateLocalIndexInfos(index_info, table_info, logger);
         ASSERT_NE(new_index_info, nullptr);
         ASSERT_EQ(new_index_info->size(), 2);
 
         const auto & idx0 = (*new_index_info)[0];
-        ASSERT_EQ(DM::IndexType::Vector, idx0.type);
-        ASSERT_EQ(EmptyIndexID, idx0.index_id);
+        ASSERT_EQ(IndexType::Vector, idx0.type);
+        ASSERT_EQ(EmptyIndexID, idx0.index_id); // defined on TiDB::ColumnInfo
         ASSERT_EQ(99, idx0.column_id);
         ASSERT_NE(nullptr, idx0.index_definition);
         ASSERT_EQ(col_vector_index->kind, idx0.index_definition->kind);
@@ -227,7 +227,7 @@ try
         ASSERT_EQ(col_vector_index->distance_metric, idx0.index_definition->distance_metric);
 
         const auto & idx1 = (*new_index_info)[1];
-        ASSERT_EQ(DM::IndexType::Vector, idx1.type);
+        ASSERT_EQ(IndexType::Vector, idx1.type);
         ASSERT_EQ(expect_idx.id, idx1.index_id);
         ASSERT_EQ(98, idx1.column_id);
         ASSERT_NE(nullptr, idx1.index_definition);
@@ -235,8 +235,10 @@ try
         ASSERT_EQ(expect_idx.vector_index->dimension, idx1.index_definition->dimension);
         ASSERT_EQ(expect_idx.vector_index->distance_metric, idx1.index_definition->distance_metric);
         // check again, table_info.index_infos doesn't change and return them
-        DM::LocalIndexInfosPtr empty_index_info = nullptr;
+        LocalIndexInfosPtr empty_index_info = nullptr;
         ASSERT_EQ(2, generateLocalIndexInfos(empty_index_info, table_info, logger)->size());
+        // check again with the same table_info, nothing changed, return nullptr
+        ASSERT_EQ(nullptr, generateLocalIndexInfos(new_index_info, table_info, logger));
 
         // update
         index_info = new_index_info;
@@ -264,8 +266,8 @@ try
         ASSERT_EQ(new_index_info->size(), 2);
 
         const auto & idx0 = (*new_index_info)[0];
-        ASSERT_EQ(DM::IndexType::Vector, idx0.type);
-        ASSERT_EQ(EmptyIndexID, idx0.index_id);
+        ASSERT_EQ(IndexType::Vector, idx0.type);
+        ASSERT_EQ(EmptyIndexID, idx0.index_id); // defined on TiDB::ColumnInfo
         ASSERT_EQ(99, idx0.column_id);
         ASSERT_NE(nullptr, idx0.index_definition);
         ASSERT_EQ(col_vector_index->kind, idx0.index_definition->kind);
@@ -273,7 +275,7 @@ try
         ASSERT_EQ(col_vector_index->distance_metric, idx0.index_definition->distance_metric);
 
         const auto & idx1 = (*new_index_info)[1];
-        ASSERT_EQ(DM::IndexType::Vector, idx1.type);
+        ASSERT_EQ(IndexType::Vector, idx1.type);
         ASSERT_EQ(expect_idx2.id, idx1.index_id);
         ASSERT_EQ(98, idx1.column_id);
         ASSERT_NE(nullptr, idx1.index_definition);
@@ -287,4 +289,4 @@ try
 }
 CATCH
 
-} // namespace DB::tests
+} // namespace DB::DM::tests

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_replace_stable_data.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_replace_stable_data.cpp
@@ -103,7 +103,7 @@ protected:
             RUNTIME_CHECK(column_stats.find(::DB::TiDBPkColumnID) != column_stats.end());
             column_stats[::DB::TiDBPkColumnID].additional_data_for_test = pk_additiona_data;
 
-            new_dm_file->meta->bumpMetaVersion();
+            new_dm_file->meta->bumpMetaVersion({});
             iw->finalize();
 
             new_dm_files.emplace_back(new_dm_file);
@@ -572,7 +572,7 @@ try
         RUNTIME_CHECK(column_stats.find(::DB::TiDBPkColumnID) != column_stats.end());
         column_stats[::DB::TiDBPkColumnID].additional_data_for_test = "tiflash_foo";
 
-        new_dm_file->meta->bumpMetaVersion();
+        new_dm_file->meta->bumpMetaVersion({});
         iw->finalize();
 
         auto lock = wn_segment->mustGetUpdateLock();

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_test_basic.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_test_basic.cpp
@@ -736,7 +736,7 @@ bool SegmentTestBasic::replaceSegmentStableData(PageIdU64 segment_id, const DMFi
     return success;
 }
 
-bool SegmentTestBasic::ensureSegmentStableIndex(PageIdU64 segment_id, LocalIndexInfosPtr local_index_infos)
+bool SegmentTestBasic::ensureSegmentStableIndex(PageIdU64 segment_id, const LocalIndexInfosPtr & local_index_infos)
 {
     LOG_INFO(logger_op, "EnsureSegmentStableIndex, segment_id={}", segment_id);
 

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_test_basic.h
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_test_basic.h
@@ -104,7 +104,7 @@ public:
     /**
      * Returns whether segment stable index is created.
      */
-    bool ensureSegmentStableIndex(PageIdU64 segment_id, LocalIndexInfosPtr local_index_infos);
+    bool ensureSegmentStableIndex(PageIdU64 segment_id, const LocalIndexInfosPtr & local_index_infos);
 
     Block prepareWriteBlock(Int64 start_key, Int64 end_key, bool is_deleted = false);
     Block prepareWriteBlockInSegmentRange(

--- a/dbms/src/Storages/S3/FileCache.cpp
+++ b/dbms/src/Storages/S3/FileCache.cpp
@@ -638,6 +638,10 @@ FileType FileCache::getFileType(const String & fname)
     {
         return getFileTypeOfColData(p.stem());
     }
+    else if (ext == ".vector")
+    {
+        return FileType::VectorIndex;
+    }
     else if (ext == ".meta")
     {
         // Example: v1.meta

--- a/dbms/src/Storages/S3/FileCache.h
+++ b/dbms/src/Storages/S3/FileCache.h
@@ -44,10 +44,15 @@ public:
         Failed,
     };
 
+    // The smaller the enum value, the higher the cache priority.
     enum class FileType : UInt64
     {
         Unknow = 0,
         Meta,
+        // Vector index is always stored as a separate file and requires to be read through `mmap`
+        // which must be downloaded to the local disk.
+        // So the priority of caching is relatively high
+        VectorIndex,
         Merged,
         Index,
         Mark, // .mkr, .null.mrk
@@ -293,6 +298,7 @@ public:
     static constexpr UInt64 estimated_size_of_file_type[] = {
         0, // Unknow type, currently never cache it.
         8 * 1024, // Estimated size of meta.
+        12 * 1024 * 1024, // Estimated size of vector index
         1 * 1024 * 1024, // Estimated size of merged.
         8 * 1024, // Estimated size of index.
         8 * 1024, // Estimated size of mark.

--- a/dbms/src/Storages/S3/tests/gtest_filecache.cpp
+++ b/dbms/src/Storages/S3/tests/gtest_filecache.cpp
@@ -432,6 +432,8 @@ try
         s3_fname,
         IDataType::getFileNameForStream(std::to_string(EXTRA_HANDLE_COLUMN_ID), {}));
     ASSERT_EQ(FileCache::getFileType(handle_fname), FileType::HandleColData);
+    auto vec_index_fname = fmt::format("{}/idx_{}.vector", s3_fname, /*index_id*/ 50); // DMFile::vectorIndexFileName
+    ASSERT_EQ(FileCache::getFileType(vec_index_fname), FileType::VectorIndex);
     auto version_fname
         = fmt::format("{}/{}.dat", s3_fname, IDataType::getFileNameForStream(std::to_string(VERSION_COLUMN_ID), {}));
     ASSERT_EQ(FileCache::getFileType(version_fname), FileType::VersionColData);
@@ -444,12 +446,9 @@ try
     ASSERT_EQ(FileCache::getFileType(unknow_fname1), FileType::Unknow);
 
     {
-        const UInt64 cache_level = 0;
-        auto cache_dir = fmt::format("{}/filetype{}", tmp_dir, cache_level);
-        StorageRemoteCacheConfig cache_config{
-            .dir = cache_dir,
-            .capacity = cache_capacity,
-            .dtfile_level = cache_level};
+        UInt64 level = 0;
+        auto cache_dir = fmt::format("{}/filetype{}", tmp_dir, level);
+        StorageRemoteCacheConfig cache_config{.dir = cache_dir, .capacity = cache_capacity, .dtfile_level = level};
         FileCache file_cache(capacity_metrics, cache_config);
         ASSERT_FALSE(file_cache.canCache(FileType::Unknow));
         ASSERT_FALSE(file_cache.canCache(FileType::Meta));
@@ -463,15 +462,13 @@ try
         ASSERT_FALSE(file_cache.canCache(FileType::ColData));
     }
     {
-        const UInt64 cache_level = 1;
-        auto cache_dir = fmt::format("{}/filetype{}", tmp_dir, cache_level);
-        StorageRemoteCacheConfig cache_config{
-            .dir = cache_dir,
-            .capacity = cache_capacity,
-            .dtfile_level = cache_level};
+        UInt64 level = 1;
+        auto cache_dir = fmt::format("{}/filetype{}", tmp_dir, level);
+        StorageRemoteCacheConfig cache_config{.dir = cache_dir, .capacity = cache_capacity, .dtfile_level = level};
         FileCache file_cache(capacity_metrics, cache_config);
         ASSERT_FALSE(file_cache.canCache(FileType::Unknow));
         ASSERT_TRUE(file_cache.canCache(FileType::Meta));
+        ASSERT_FALSE(file_cache.canCache(FileType::VectorIndex));
         ASSERT_FALSE(file_cache.canCache(FileType::Merged));
         ASSERT_FALSE(file_cache.canCache(FileType::Index));
         ASSERT_FALSE(file_cache.canCache(FileType::Mark));
@@ -482,15 +479,30 @@ try
         ASSERT_FALSE(file_cache.canCache(FileType::ColData));
     }
     {
-        const UInt64 cache_level = 2;
-        auto cache_dir = fmt::format("{}/filetype{}", tmp_dir, cache_level);
-        StorageRemoteCacheConfig cache_config{
-            .dir = cache_dir,
-            .capacity = cache_capacity,
-            .dtfile_level = cache_level};
+        UInt64 level = 2;
+        auto cache_dir = fmt::format("{}/filetype{}", tmp_dir, level);
+        StorageRemoteCacheConfig cache_config{.dir = cache_dir, .capacity = cache_capacity, .dtfile_level = level};
         FileCache file_cache(capacity_metrics, cache_config);
         ASSERT_FALSE(file_cache.canCache(FileType::Unknow));
         ASSERT_TRUE(file_cache.canCache(FileType::Meta));
+        ASSERT_TRUE(file_cache.canCache(FileType::VectorIndex));
+        ASSERT_FALSE(file_cache.canCache(FileType::Merged));
+        ASSERT_FALSE(file_cache.canCache(FileType::Index));
+        ASSERT_FALSE(file_cache.canCache(FileType::Mark));
+        ASSERT_FALSE(file_cache.canCache(FileType::NullMap));
+        ASSERT_FALSE(file_cache.canCache(FileType::DeleteMarkColData));
+        ASSERT_FALSE(file_cache.canCache(FileType::VersionColData));
+        ASSERT_FALSE(file_cache.canCache(FileType::HandleColData));
+        ASSERT_FALSE(file_cache.canCache(FileType::ColData));
+    }
+    {
+        UInt64 level = 3;
+        auto cache_dir = fmt::format("{}/filetype{}", tmp_dir, level);
+        StorageRemoteCacheConfig cache_config{.dir = cache_dir, .capacity = cache_capacity, .dtfile_level = level};
+        FileCache file_cache(capacity_metrics, cache_config);
+        ASSERT_FALSE(file_cache.canCache(FileType::Unknow));
+        ASSERT_TRUE(file_cache.canCache(FileType::Meta));
+        ASSERT_TRUE(file_cache.canCache(FileType::VectorIndex));
         ASSERT_TRUE(file_cache.canCache(FileType::Merged));
         ASSERT_FALSE(file_cache.canCache(FileType::Index));
         ASSERT_FALSE(file_cache.canCache(FileType::Mark));
@@ -501,15 +513,13 @@ try
         ASSERT_FALSE(file_cache.canCache(FileType::ColData));
     }
     {
-        const UInt64 cache_level = 3;
-        auto cache_dir = fmt::format("{}/filetype{}", tmp_dir, cache_level);
-        StorageRemoteCacheConfig cache_config{
-            .dir = cache_dir,
-            .capacity = cache_capacity,
-            .dtfile_level = cache_level};
+        UInt64 level = 4;
+        auto cache_dir = fmt::format("{}/filetype{}", tmp_dir, level);
+        StorageRemoteCacheConfig cache_config{.dir = cache_dir, .capacity = cache_capacity, .dtfile_level = level};
         FileCache file_cache(capacity_metrics, cache_config);
         ASSERT_FALSE(file_cache.canCache(FileType::Unknow));
         ASSERT_TRUE(file_cache.canCache(FileType::Meta));
+        ASSERT_TRUE(file_cache.canCache(FileType::VectorIndex));
         ASSERT_TRUE(file_cache.canCache(FileType::Merged));
         ASSERT_TRUE(file_cache.canCache(FileType::Index));
         ASSERT_FALSE(file_cache.canCache(FileType::Mark));
@@ -520,15 +530,13 @@ try
         ASSERT_FALSE(file_cache.canCache(FileType::ColData));
     }
     {
-        const UInt64 cache_level = 4;
-        auto cache_dir = fmt::format("{}/filetype{}", tmp_dir, cache_level);
-        StorageRemoteCacheConfig cache_config{
-            .dir = cache_dir,
-            .capacity = cache_capacity,
-            .dtfile_level = cache_level};
+        UInt64 level = 5;
+        auto cache_dir = fmt::format("{}/filetype{}", tmp_dir, level);
+        StorageRemoteCacheConfig cache_config{.dir = cache_dir, .capacity = cache_capacity, .dtfile_level = level};
         FileCache file_cache(capacity_metrics, cache_config);
         ASSERT_FALSE(file_cache.canCache(FileType::Unknow));
         ASSERT_TRUE(file_cache.canCache(FileType::Meta));
+        ASSERT_TRUE(file_cache.canCache(FileType::VectorIndex));
         ASSERT_TRUE(file_cache.canCache(FileType::Merged));
         ASSERT_TRUE(file_cache.canCache(FileType::Index));
         ASSERT_TRUE(file_cache.canCache(FileType::Mark));
@@ -539,15 +547,13 @@ try
         ASSERT_FALSE(file_cache.canCache(FileType::ColData));
     }
     {
-        const UInt64 cache_level = 5;
-        auto cache_dir = fmt::format("{}/filetype{}", tmp_dir, cache_level);
-        StorageRemoteCacheConfig cache_config{
-            .dir = cache_dir,
-            .capacity = cache_capacity,
-            .dtfile_level = cache_level};
+        UInt64 level = 6;
+        auto cache_dir = fmt::format("{}/filetype{}", tmp_dir, level);
+        StorageRemoteCacheConfig cache_config{.dir = cache_dir, .capacity = cache_capacity, .dtfile_level = level};
         FileCache file_cache(capacity_metrics, cache_config);
         ASSERT_FALSE(file_cache.canCache(FileType::Unknow));
         ASSERT_TRUE(file_cache.canCache(FileType::Meta));
+        ASSERT_TRUE(file_cache.canCache(FileType::VectorIndex));
         ASSERT_TRUE(file_cache.canCache(FileType::Merged));
         ASSERT_TRUE(file_cache.canCache(FileType::Index));
         ASSERT_TRUE(file_cache.canCache(FileType::Mark));
@@ -558,15 +564,13 @@ try
         ASSERT_FALSE(file_cache.canCache(FileType::ColData));
     }
     {
-        const UInt64 cache_level = 6;
-        auto cache_dir = fmt::format("{}/filetype{}", tmp_dir, cache_level);
-        StorageRemoteCacheConfig cache_config{
-            .dir = cache_dir,
-            .capacity = cache_capacity,
-            .dtfile_level = cache_level};
+        UInt64 level = 7;
+        auto cache_dir = fmt::format("{}/filetype{}", tmp_dir, level);
+        StorageRemoteCacheConfig cache_config{.dir = cache_dir, .capacity = cache_capacity, .dtfile_level = level};
         FileCache file_cache(capacity_metrics, cache_config);
         ASSERT_FALSE(file_cache.canCache(FileType::Unknow));
         ASSERT_TRUE(file_cache.canCache(FileType::Meta));
+        ASSERT_TRUE(file_cache.canCache(FileType::VectorIndex));
         ASSERT_TRUE(file_cache.canCache(FileType::Merged));
         ASSERT_TRUE(file_cache.canCache(FileType::Index));
         ASSERT_TRUE(file_cache.canCache(FileType::Mark));
@@ -577,15 +581,13 @@ try
         ASSERT_FALSE(file_cache.canCache(FileType::ColData));
     }
     {
-        const UInt64 cache_level = 7;
-        auto cache_dir = fmt::format("{}/filetype{}", tmp_dir, cache_level);
-        StorageRemoteCacheConfig cache_config{
-            .dir = cache_dir,
-            .capacity = cache_capacity,
-            .dtfile_level = cache_level};
+        UInt64 level = 8;
+        auto cache_dir = fmt::format("{}/filetype{}", tmp_dir, level);
+        StorageRemoteCacheConfig cache_config{.dir = cache_dir, .capacity = cache_capacity, .dtfile_level = level};
         FileCache file_cache(capacity_metrics, cache_config);
         ASSERT_FALSE(file_cache.canCache(FileType::Unknow));
         ASSERT_TRUE(file_cache.canCache(FileType::Meta));
+        ASSERT_TRUE(file_cache.canCache(FileType::VectorIndex));
         ASSERT_TRUE(file_cache.canCache(FileType::Merged));
         ASSERT_TRUE(file_cache.canCache(FileType::Index));
         ASSERT_TRUE(file_cache.canCache(FileType::Mark));
@@ -596,15 +598,13 @@ try
         ASSERT_FALSE(file_cache.canCache(FileType::ColData));
     }
     {
-        const UInt64 cache_level = 8;
-        auto cache_dir = fmt::format("{}/filetype{}", tmp_dir, cache_level);
-        StorageRemoteCacheConfig cache_config{
-            .dir = cache_dir,
-            .capacity = cache_capacity,
-            .dtfile_level = cache_level};
+        UInt64 level = 9;
+        auto cache_dir = fmt::format("{}/filetype{}", tmp_dir, level);
+        StorageRemoteCacheConfig cache_config{.dir = cache_dir, .capacity = cache_capacity, .dtfile_level = level};
         FileCache file_cache(capacity_metrics, cache_config);
         ASSERT_FALSE(file_cache.canCache(FileType::Unknow));
         ASSERT_TRUE(file_cache.canCache(FileType::Meta));
+        ASSERT_TRUE(file_cache.canCache(FileType::VectorIndex));
         ASSERT_TRUE(file_cache.canCache(FileType::Merged));
         ASSERT_TRUE(file_cache.canCache(FileType::Index));
         ASSERT_TRUE(file_cache.canCache(FileType::Mark));
@@ -615,15 +615,13 @@ try
         ASSERT_FALSE(file_cache.canCache(FileType::ColData));
     }
     {
-        const UInt64 cache_level = 9;
-        auto cache_dir = fmt::format("{}/filetype{}", tmp_dir, cache_level);
-        StorageRemoteCacheConfig cache_config{
-            .dir = cache_dir,
-            .capacity = cache_capacity,
-            .dtfile_level = cache_level};
+        UInt64 level = 10;
+        auto cache_dir = fmt::format("{}/filetype{}", tmp_dir, level);
+        StorageRemoteCacheConfig cache_config{.dir = cache_dir, .capacity = cache_capacity, .dtfile_level = level};
         FileCache file_cache(capacity_metrics, cache_config);
         ASSERT_FALSE(file_cache.canCache(FileType::Unknow));
         ASSERT_TRUE(file_cache.canCache(FileType::Meta));
+        ASSERT_TRUE(file_cache.canCache(FileType::VectorIndex));
         ASSERT_TRUE(file_cache.canCache(FileType::Merged));
         ASSERT_TRUE(file_cache.canCache(FileType::Index));
         ASSERT_TRUE(file_cache.canCache(FileType::Mark));

--- a/dbms/src/Storages/System/StorageSystemDTLocalIndexes.cpp
+++ b/dbms/src/Storages/System/StorageSystemDTLocalIndexes.cpp
@@ -119,7 +119,7 @@ BlockInputStreams StorageSystemDTLocalIndexes::read(
                 res_columns[j++]->insert(table_id);
                 res_columns[j++]->insert(table_info.belonging_table_id);
 
-                res_columns[j++]->insert(stat.column_name);
+                res_columns[j++]->insert(String("")); // TODO: let tidb set the column_name and index_name by itself
                 res_columns[j++]->insert(stat.column_id);
                 res_columns[j++]->insert(stat.index_id);
                 res_columns[j++]->insert(stat.index_kind);

--- a/dbms/src/TiDB/Schema/tests/gtest_schema_sync.cpp
+++ b/dbms/src/TiDB/Schema/tests/gtest_schema_sync.cpp
@@ -37,6 +37,7 @@
 #include <TiDB/Schema/TiDBSchemaManager.h>
 #include <common/defines.h>
 #include <common/logger_useful.h>
+#include <gtest/gtest.h>
 
 #include <ext/scope_guard.h>
 #include <limits>
@@ -833,6 +834,7 @@ try
     {
         // check stable index has built for all segments
         dmsv.waitStableIndexReady();
+        LOG_INFO(Logger::get(), "waitStableIndexReady done");
         const auto range = DM::RowKeyRange::newAll(dmsv.store->is_common_handle, dmsv.store->rowkey_column_size);
 
         // read from store
@@ -847,11 +849,13 @@ try
         }
 
         auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
+        ann_query_info->set_index_id(idx_id);
         ann_query_info->set_column_id(dmsv.vec_column_id);
         ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::L2);
 
         // read with ANN query
         {
+            SCOPED_TRACE(fmt::format("after add vector index, read with ANN query 1"));
             ann_query_info->set_top_k(1);
             ann_query_info->set_ref_vec_f32(dmsv.encodeVectorFloat32({1.0, 2.0, 3.5}));
 
@@ -862,6 +866,7 @@ try
 
         // read with ANN query
         {
+            SCOPED_TRACE(fmt::format("after add vector index, read with ANN query 2"));
             ann_query_info->set_top_k(1);
             ann_query_info->set_ref_vec_f32(dmsv.encodeVectorFloat32({1.0, 2.0, 3.8}));
 

--- a/tests/fullstack-test2/vector/distance.test
+++ b/tests/fullstack-test2/vector/distance.test
@@ -1,0 +1,61 @@
+# Copyright 2024 PingCAP, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Preparation.
+mysql> drop table if exists test.t;
+
+mysql> CREATE TABLE test.t (`v` vector(5) DEFAULT NULL);
+mysql> INSERT INTO test.t VALUES ('[8.7, 5.7, 7.7, 9.8, 1.5]'),('[3.6, 9.7, 2.4, 6.6, 4.9]'),('[4.7, 4.9, 2.6, 5.2, 7.4]'),('[7.7, 6.7, 8.3, 7.8, 5.7]'),('[1.4, 4.5, 8.5, 7.7, 6.2]');
+mysql> alter table test.t set tiflash replica 1;
+func> wait_table test t
+
+mysql> set tidb_isolation_read_engines='tiflash';SELECT * FROM test.t ORDER BY VEC_L2_DISTANCE(v, '[1.0,4.0,8.0,7.0,6.0]') LIMIT 3;
++-----------------------+
+| v                     |
++-----------------------+
+| [1.4,4.5,8.5,7.7,6.2] |
+| [4.7,4.9,2.6,5.2,7.4] |
+| [7.7,6.7,8.3,7.8,5.7] |
++-----------------------+
+
+mysql> set tidb_isolation_read_engines='tiflash';SELECT * FROM test.t ORDER BY VEC_COSINE_DISTANCE(v, '[1.0,4.0,8.0,7.0,6.0]') LIMIT 3;
++-----------------------+
+| v                     |
++-----------------------+
+| [1.4,4.5,8.5,7.7,6.2] |
+| [7.7,6.7,8.3,7.8,5.7] |
+| [4.7,4.9,2.6,5.2,7.4] |
++-----------------------+
+
+mysql> set tidb_isolation_read_engines='tiflash';SELECT * FROM test.t ORDER BY VEC_NEGATIVE_INNER_PRODUCT(v, '[1.0,4.0,8.0,7.0,6.0]') LIMIT 3;
++-----------------------+
+| v                     |
++-----------------------+
+| [7.7,6.7,8.3,7.8,5.7] |
+| [1.4,4.5,8.5,7.7,6.2] |
+| [8.7,5.7,7.7,9.8,1.5] |
++-----------------------+
+
+mysql> set tidb_isolation_read_engines='tiflash';SELECT * FROM test.t ORDER BY VEC_L1_DISTANCE(v, '[1.0,4.0,8.0,7.0,6.0]') LIMIT 3;
++-----------------------+
+| v                     |
++-----------------------+
+| [1.4,4.5,8.5,7.7,6.2] |
+| [7.7,6.7,8.3,7.8,5.7] |
+| [4.7,4.9,2.6,5.2,7.4] |
++-----------------------+
+
+
+# Cleanup
+mysql> drop table if exists test.t

--- a/tests/fullstack-test2/vector/distance.test
+++ b/tests/fullstack-test2/vector/distance.test
@@ -11,7 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+#TODO: enable vector-index fullstack test
+#RETURN
 # Preparation.
 mysql> drop table if exists test.t;
 

--- a/tests/fullstack-test2/vector/vector-index.test
+++ b/tests/fullstack-test2/vector/vector-index.test
@@ -11,7 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+#TODO: enable vector-index fullstack test
+#RETURN
 # Preparation.
 mysql> drop table if exists test.t;
 

--- a/tests/fullstack-test2/vector/vector-index.test
+++ b/tests/fullstack-test2/vector/vector-index.test
@@ -1,0 +1,105 @@
+# Copyright 2024 PingCAP, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Preparation.
+mysql> drop table if exists test.t;
+
+mysql> CREATE TABLE test.t (`v` vector(5) DEFAULT NULL);
+mysql> INSERT INTO test.t VALUES ('[8.7, 5.7, 7.7, 9.8, 1.5]'),('[3.6, 9.7, 2.4, 6.6, 4.9]'),('[4.7, 4.9, 2.6, 5.2, 7.4]'),('[7.7, 6.7, 8.3, 7.8, 5.7]'),('[1.4, 4.5, 8.5, 7.7, 6.2]');
+mysql> alter table test.t set tiflash replica 1;
+func> wait_table test t
+
+# build vector index with "L2"
+mysql> set tidb_isolation_read_engines='tiflash';SELECT * FROM test.t ORDER BY VEC_L2_DISTANCE(v, '[1.0,4.0,8.0,7.0,6.0]') LIMIT 3;
++-----------------------+
+| v                     |
++-----------------------+
+| [1.4,4.5,8.5,7.7,6.2] |
+| [4.7,4.9,2.6,5.2,7.4] |
+| [7.7,6.7,8.3,7.8,5.7] |
++-----------------------+
+mysql> ALTER TABLE test.t ADD VECTOR INDEX idx_v_l2 ((VEC_L2_DISTANCE(v))) USING HNSW;
+mysql> set tidb_isolation_read_engines='tiflash';SELECT * FROM test.t ORDER BY VEC_L2_DISTANCE(v, '[1.0,4.0,8.0,7.0,6.0]') LIMIT 3;
++-----------------------+
+| v                     |
++-----------------------+
+| [1.4,4.5,8.5,7.7,6.2] |
+| [4.7,4.9,2.6,5.2,7.4] |
+| [7.7,6.7,8.3,7.8,5.7] |
++-----------------------+
+
+# build vector index with "cosine"
+mysql> set tidb_isolation_read_engines='tiflash';SELECT * FROM test.t ORDER BY VEC_COSINE_DISTANCE(v, '[1.0,4.0,8.0,7.0,6.0]') LIMIT 3;
++-----------------------+
+| v                     |
++-----------------------+
+| [1.4,4.5,8.5,7.7,6.2] |
+| [7.7,6.7,8.3,7.8,5.7] |
+| [4.7,4.9,2.6,5.2,7.4] |
++-----------------------+
+mysql> ALTER TABLE test.t ADD VECTOR INDEX idx_v_cos ((VEC_COSINE_DISTANCE(v))) USING HNSW;
+mysql> set tidb_isolation_read_engines='tiflash';SELECT * FROM test.t ORDER BY VEC_COSINE_DISTANCE(v, '[1.0,4.0,8.0,7.0,6.0]') LIMIT 3;
++-----------------------+
+| v                     |
++-----------------------+
+| [1.4,4.5,8.5,7.7,6.2] |
+| [7.7,6.7,8.3,7.8,5.7] |
+| [4.7,4.9,2.6,5.2,7.4] |
++-----------------------+
+
+#TODO: support "negative inner product" and "L1"
+#RETURN
+
+# build vector index with "negative inner product"
+mysql> set tidb_isolation_read_engines='tiflash';SELECT * FROM test.t ORDER BY VEC_NEGATIVE_INNER_PRODUCT(v, '[1.0,4.0,8.0,7.0,6.0]') LIMIT 3;
++-----------------------+
+| v                     |
++-----------------------+
+| [7.7,6.7,8.3,7.8,5.7] |
+| [1.4,4.5,8.5,7.7,6.2] |
+| [8.7,5.7,7.7,9.8,1.5] |
++-----------------------+
+## FIXME: not yet support
+mysql> ALTER TABLE test.t ADD VECTOR INDEX idx_v_cos ((VEC_NEGATIVE_INNER_PRODUCT(v))) USING HNSW;
+mysql> set tidb_isolation_read_engines='tiflash';SELECT * FROM test.t ORDER BY VEC_NEGATIVE_INNER_PRODUCT(v, '[1.0,4.0,8.0,7.0,6.0]') LIMIT 3;
++-----------------------+
+| v                     |
++-----------------------+
+| [7.7,6.7,8.3,7.8,5.7] |
+| [1.4,4.5,8.5,7.7,6.2] |
+| [8.7,5.7,7.7,9.8,1.5] |
++-----------------------+
+
+# build vector index with "L1"
+mysql> set tidb_isolation_read_engines='tiflash';SELECT * FROM test.t ORDER BY VEC_L1_DISTANCE(v, '[1.0,4.0,8.0,7.0,6.0]') LIMIT 3;
++-----------------------+
+| v                     |
++-----------------------+
+| [1.4,4.5,8.5,7.7,6.2] |
+| [7.7,6.7,8.3,7.8,5.7] |
+| [4.7,4.9,2.6,5.2,7.4] |
++-----------------------+
+## FIXME: not yet support
+mysql> ALTER TABLE test.t ADD VECTOR INDEX idx_v_cos ((VEC_L1_DISTANCE(v))) USING HNSW;
+mysql> set tidb_isolation_read_engines='tiflash';SELECT * FROM test.t ORDER BY VEC_L1_DISTANCE(v, '[1.0,4.0,8.0,7.0,6.0]') LIMIT 3;
++-----------------------+
+| v                     |
++-----------------------+
+| [1.4,4.5,8.5,7.7,6.2] |
+| [7.7,6.7,8.3,7.8,5.7] |
+| [4.7,4.9,2.6,5.2,7.4] |
++-----------------------+
+
+# Cleanup
+mysql> drop table if exists test.t

--- a/tests/run-gtest.sh
+++ b/tests/run-gtest.sh
@@ -56,8 +56,8 @@ function run_test_parallel() {
 		args="--gtest_break_on_failure --gtest_catch_exceptions=0"
 	fi
 
-	# run with 45 min timeout
-	python ${SRC_TESTS_PATH}/gtest_parallel.py ${test_bins} --workers=${NPROC} ${args} --print_test_times --timeout=2700
+	# run with 60 min timeout
+	python ${SRC_TESTS_PATH}/gtest_parallel.py ${test_bins} --workers=${NPROC} ${args} --print_test_times --timeout=3600
 }
 
 set -e


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #9032 

Problem Summary:

### What is changed and how it works?

* For query, add index_id in ANNQueryInfo (DMFileWithVectorIndexBlockInputStream.cpp)
  * If the index_id > 0, then try to query with the vector index defined by index_id
  * If the index_id <= 0, then try to query with the vector index defined in column
* For write, turn `ColumnStat.vector_index` from `std::optional<dtpb::VectorIndexFileProps> vector_index` to `std::vector<dtpb::VectorIndexFileProps>`
  * `DMFileIndexWriter.cpp` supports saving multiple vector index with different index_id
  * Save the size of index into each `dtpb::VectorIndexFileProps` instead of `ColumnStat.index_bytes`
  * The vector index filename is defined as "idx_${index_id}.vector"
* Ensure the atomic between reading vector index from DMFile and bumping meta version of DMFile

```commit-message
Storage: Support multiple vec indexes on the same column
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
