### PR TITLE
Storage: Support drop vector index defined on ColumnInfo when column is dropped

### DIFF
--- a/dbms/src/Common/FailPoint.cpp
+++ b/dbms/src/Common/FailPoint.cpp
@@ -71,6 +71,7 @@ namespace DB
     M(force_remote_read_for_batch_cop_once)                       \
     M(exception_new_dynamic_thread)                               \
     M(force_wait_index_timeout)                                   \
+    M(force_not_support_vector_index)                             \
     M(sync_schema_request_failure)
 
 #define APPLY_FOR_FAILPOINTS(M)                              \

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -2022,7 +2022,7 @@ void DeltaMergeStore::applySchemaChanges(TiDB::TableInfo & table_info)
 
     std::atomic_store(&original_table_header, std::make_shared<Block>(toEmptyBlock(original_table_columns)));
 
-    // release the lock because `checkAllSegmentsLocalIndex` will try to acquire the lock
+    // release the lock because `applyLocalIndexChange ` will try to acquire the lock
     // and generate tasks on segments
     lock.unlock();
 

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -2020,25 +2020,32 @@ void DeltaMergeStore::applySchemaChanges(TiDB::TableInfo & table_info)
     original_table_columns.swap(new_original_table_columns);
     store_columns.swap(new_store_columns);
 
-    // Get a snapshot on the local_index_infos to check whether any new index is created
-    LocalIndexInfosSnapshot local_index_infos_snap = getLocalIndexInfosSnapshot();
-
     std::atomic_store(&original_table_header, std::make_shared<Block>(toEmptyBlock(original_table_columns)));
 
     // release the lock because `checkAllSegmentsLocalIndex` will try to acquire the lock
     // and generate tasks on segments
     lock.unlock();
 
-    auto new_local_index_infos = generateLocalIndexInfos(local_index_infos_snap, table_info, log);
-    if (new_local_index_infos)
+    applyLocalIndexChange(table_info);
+}
+
+void DeltaMergeStore::applyLocalIndexChange(const TiDB::TableInfo & new_table_info)
+{
+    // Get a snapshot on the local_index_infos to check whether any new index is created
+    auto new_local_index_infos = generateLocalIndexInfos(getLocalIndexInfosSnapshot(), new_table_info, log);
+
+    // no index is created or dropped
+    if (!new_local_index_infos)
+        return;
+
     {
-        {
-            // new index created, update the info in-memory thread safety between `getLocalIndexInfosSnapshot`
-            std::unique_lock index_write_lock(mtx_local_index_infos);
-            local_index_infos.swap(new_local_index_infos);
-        }
-        checkAllSegmentsLocalIndex();
-    } // else no new index is created
+        // new index created, update the info in-memory thread safety between `getLocalIndexInfosSnapshot`
+        std::unique_lock index_write_lock(mtx_local_index_infos);
+        local_index_infos.swap(new_local_index_infos);
+    }
+
+    // generate async tasks for building local index for all segments
+    checkAllSegmentsLocalIndex();
 }
 
 SortDescription DeltaMergeStore::getPrimarySortDescription() const

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
@@ -582,6 +582,18 @@ public:
         bool keep_order,
         const PushDownFilterPtr & filter);
 
+    // Get a snap of local_index_infos for checking.
+    // Note that this is just a shallow copy of `local_index_infos`, do not
+    // modify the local indexes inside the snapshot.
+    LocalIndexInfosSnapshot getLocalIndexInfosSnapshot() const
+    {
+        std::shared_lock index_read_lock(mtx_local_index_infos);
+        if (!local_index_infos || local_index_infos->empty())
+            return nullptr;
+        // only make a shallow copy on the shared_ptr is OK
+        return local_index_infos;
+    }
+
 public:
     /// Methods mainly used by region split.
 
@@ -863,18 +875,6 @@ private:
         const SegmentPtr & segment,
         const DMFiles & new_dm_files);
 
-    // Get a snap of local_index_infos for checking.
-    // Note that this is just a shallow copy of `local_index_infos`, do not
-    // modify the local indexes inside the snapshot.
-    LocalIndexInfosSnapshot getLocalIndexInfosSnapshot() const
-    {
-        std::shared_lock index_read_lock(mtx_local_index_infos);
-        if (!local_index_infos || local_index_infos->empty())
-            return nullptr;
-        // only make a shallow copy on the shared_ptr is OK
-        return local_index_infos;
-    }
-
     /**
      * Check whether there are new local indexes should be built for all segments.
      */
@@ -894,6 +894,9 @@ private:
 #else
 public:
 #endif
+
+    void applyLocalIndexChange(const TiDB::TableInfo & new_table_info);
+
     /**
      * Wait until the segment has stable index.
      * If the index is ready or no need to build, it will return immediately.

--- a/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.cpp
@@ -152,7 +152,7 @@ SkippableBlockInputStreamPtr DMFileBlockInputStreamBuilder::tryBuildWithVectorIn
         return fallback();
 
     auto ann_query_info = filter_with_ann->ann_query_info;
-    if (!ann_query_info)
+    if (!ann_query_info || ann_query_info->top_k() == std::numeric_limits<UInt32>::max())
         return fallback();
 
     if (!bitmap_filter.has_value())

--- a/dbms/src/Storages/DeltaMerge/File/DMFileIndexWriter.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileIndexWriter.cpp
@@ -43,6 +43,9 @@ DMFileIndexWriter::LocalIndexBuildInfo DMFileIndexWriter::getLocalIndexBuildInfo
     assert(index_infos != nullptr);
     static constexpr double VECTOR_INDEX_SIZE_FACTOR = 1.2;
 
+    // TODO(vector-index): Now we only generate the build info when new index is added.
+    //    The built indexes will be dropped (lazily) after the segment instance is updated.
+    //    We can support dropping the vector index more quickly later.
     LocalIndexBuildInfo build;
     build.indexes_to_build = std::make_shared<LocalIndexInfos>();
     build.file_ids.reserve(dm_files.size());

--- a/dbms/src/Storages/DeltaMerge/Index/IndexInfo.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/IndexInfo.cpp
@@ -34,9 +34,7 @@ struct ComplexIndexID
 
 bool operator==(const ComplexIndexID & lhs, const ComplexIndexID & rhs)
 {
-    if (lhs.index_id != rhs.index_id)
-        return false;
-    return lhs.column_id == rhs.column_id;
+    return lhs.index_id == rhs.index_id && lhs.column_id == rhs.column_id;
 }
 
 struct ComplexIndexIDHasher

--- a/dbms/src/Storages/DeltaMerge/Index/IndexInfo.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/IndexInfo.cpp
@@ -12,15 +12,55 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Common/FmtUtils.h>
 #include <Storages/DeltaMerge/Index/IndexInfo.h>
 #include <Storages/FormatVersion.h>
 #include <Storages/KVStore/Types.h>
 #include <TiDB/Schema/TiDB.h>
+#include <fiu.h>
 
-#include <cstddef>
-
+namespace DB::FailPoints
+{
+extern const char force_not_support_vector_index[];
+} // namespace DB::FailPoints
 namespace DB::DM
 {
+
+struct ComplexIndexID
+{
+    IndexID index_id;
+    ColumnID column_id;
+};
+
+bool operator==(const ComplexIndexID & lhs, const ComplexIndexID & rhs)
+{
+    if (lhs.index_id != rhs.index_id)
+        return false;
+    return lhs.column_id == rhs.column_id;
+}
+
+struct ComplexIndexIDHasher
+{
+    std::size_t operator()(const ComplexIndexID & id) const
+    {
+        using boost::hash_combine;
+        using boost::hash_value;
+
+        std::size_t seed = 0;
+        if (id.index_id > EmptyIndexID)
+        {
+            hash_combine(seed, hash_value(0x01));
+            hash_combine(seed, hash_value(id.index_id));
+        }
+        else
+        {
+            hash_combine(seed, hash_value(0x02));
+            hash_combine(seed, hash_value(id.column_id));
+        }
+        return seed;
+    }
+};
+
 
 bool isVectorIndexSupported(const LoggerPtr & logger)
 {
@@ -39,22 +79,17 @@ bool isVectorIndexSupported(const LoggerPtr & logger)
     return true;
 }
 
-TiDB::ColumnInfo getVectorIndxColumnInfo(
+ColumnID getVectorIndxColumnID(
     const TiDB::TableInfo & table_info,
     const TiDB::IndexInfo & idx_info,
     const LoggerPtr & logger)
 {
-    if (!idx_info.vector_index
-        || (idx_info.state != TiDB::StatePublic && idx_info.state != TiDB::StateWriteReorganization))
-    {
-        return {};
-    }
+    if (!idx_info.vector_index)
+        return EmptyColumnID;
 
     // Vector Index requires a specific storage format to work.
-    if (!isVectorIndexSupported(logger))
-    {
-        return {};
-    }
+    if (unlikely(!isVectorIndexSupported(logger)))
+        return EmptyColumnID;
 
     if (idx_info.idx_cols.size() != 1)
     {
@@ -64,14 +99,14 @@ TiDB::ColumnInfo getVectorIndxColumnInfo(
             idx_info.idx_cols.size(),
             idx_info.id,
             table_info.id);
-        return {};
+        return EmptyColumnID;
     }
 
     for (const auto & col : table_info.columns)
     {
         if (col.name == idx_info.idx_cols[0].name)
         {
-            return col;
+            return col.id;
         }
     }
 
@@ -81,51 +116,13 @@ TiDB::ColumnInfo getVectorIndxColumnInfo(
         table_info.id,
         idx_info.id,
         idx_info.idx_cols[0].name);
-    return {};
+    return EmptyColumnID;
 }
 
 LocalIndexInfosPtr initLocalIndexInfos(const TiDB::TableInfo & table_info, const LoggerPtr & logger)
 {
-    LocalIndexInfosPtr index_infos = std::make_shared<LocalIndexInfos>();
-    index_infos->reserve(table_info.columns.size() + table_info.index_infos.size());
-    for (const auto & col : table_info.columns)
-    {
-        if (col.vector_index && isVectorIndexSupported(logger))
-        {
-            index_infos->emplace_back(LocalIndexInfo{
-                .type = IndexType::Vector,
-                .column_id = col.id,
-                .index_definition = col.vector_index,
-            });
-            LOG_INFO(logger, "Add a new index by column comments, column_id={}, table_id={}.", col.id, table_info.id);
-        }
-    }
-
-    for (const auto & idx : table_info.index_infos)
-    {
-        auto column = getVectorIndxColumnInfo(table_info, idx, logger);
-        // column.id <= 0 means we don't get the valid column ID.
-        if (column.id <= DB::EmptyColumnID)
-        {
-            LOG_ERROR(
-                Logger::get(),
-                "The current storage format is {}, which does not support building vector index. TiFlash will "
-                "write data without vector index.",
-                STORAGE_FORMAT_CURRENT.identifier);
-            return {};
-        }
-
-        LOG_INFO(logger, "Add a new index, index_id={}, table_id={}.", idx.id, table_info.id);
-        index_infos->emplace_back(LocalIndexInfo{
-            .type = IndexType::Vector,
-            .index_id = idx.id,
-            .column_id = column.id,
-            .index_definition = idx.vector_index,
-        });
-    }
-
-    index_infos->shrink_to_fit();
-    return index_infos;
+    // The same as generate local index infos with no existing_indexes
+    return generateLocalIndexInfos(nullptr, table_info, logger);
 }
 
 LocalIndexInfosPtr generateLocalIndexInfos(
@@ -133,72 +130,173 @@ LocalIndexInfosPtr generateLocalIndexInfos(
     const TiDB::TableInfo & new_table_info,
     const LoggerPtr & logger)
 {
-    LocalIndexInfosPtr new_index_infos = std::make_shared<std::vector<LocalIndexInfo>>();
-    // The first time generate index infos.
-    if (!existing_indexes)
+    LocalIndexInfosPtr new_index_infos = std::make_shared<LocalIndexInfos>();
     {
-        auto index_infos = initLocalIndexInfos(new_table_info, logger);
-        if (!index_infos || index_infos->empty())
-            return nullptr;
-        new_index_infos = std::move(index_infos);
-        return new_index_infos;
+        // If the storage format does not support vector index, always return an empty
+        // index_info. Meaning we should drop all indexes
+        bool is_storage_format_support = isVectorIndexSupported(logger);
+        fiu_do_on(FailPoints::force_not_support_vector_index, { is_storage_format_support = false; });
+        if (!is_storage_format_support)
+            return new_index_infos;
     }
 
-    new_index_infos->insert(new_index_infos->cend(), existing_indexes->begin(), existing_indexes->end());
-
-    std::unordered_map<IndexID, int> original_local_index_id_map;
-    for (size_t index = 0; index < new_index_infos->size(); ++index)
+    // Keep a map of "indexes in existing_indexes" -> "offset in new_index_infos"
+    std::unordered_map<ComplexIndexID, size_t, ComplexIndexIDHasher> original_local_index_id_map;
+    if (existing_indexes)
     {
-        original_local_index_id_map[new_index_infos->at(index).index_id] = index;
+        // Create a copy of existing indexes
+        for (size_t offset = 0; offset < existing_indexes->size(); ++offset)
+        {
+            const auto & index = (*existing_indexes)[offset];
+            original_local_index_id_map.emplace(
+                ComplexIndexID{.index_id = index.index_id, .column_id = index.column_id},
+                offset);
+            new_index_infos->emplace_back(index);
+        }
     }
 
-    bool any_new_index_created = false;
-    bool any_index_removed = false;
+    std::unordered_set<ComplexIndexID, ComplexIndexIDHasher> index_ids_in_new_table;
+    std::vector<ComplexIndexID> newly_added;
+    std::vector<ComplexIndexID> newly_dropped;
+
+    // In the serverless branch, previously we define vector index on TiDB::ColumnInfo
+    for (const auto & col : new_table_info.columns)
+    {
+        if (!col.vector_index)
+            continue;
+
+        // We do the check at the beginning, only assert check under debug mode
+        // is enough
+        assert(isVectorIndexSupported(logger));
+
+        const ComplexIndexID cindex_id{.index_id = EmptyIndexID, .column_id = col.id};
+        index_ids_in_new_table.emplace(cindex_id);
+        // already exist in `existing_indexes`
+        if (original_local_index_id_map.contains(cindex_id))
+            continue;
+        // newly added
+        new_index_infos->emplace_back(LocalIndexInfo{
+            .type = IndexType::Vector,
+            .index_id = EmptyIndexID, // the vector index created on ColumnInfo, use EmptyIndexID as the index_id
+            .column_id = col.id,
+            .index_definition = col.vector_index,
+        });
+        newly_added.emplace_back(cindex_id);
+    }
+
     for (const auto & idx : new_table_info.index_infos)
     {
         if (!idx.vector_index)
             continue;
 
-        auto iter = original_local_index_id_map.find(idx.id);
+        const auto column_id = getVectorIndxColumnID(new_table_info, idx, logger);
+        if (column_id <= EmptyColumnID)
+            continue;
+
+        const ComplexIndexID cindex_id{.index_id = idx.id, .column_id = column_id};
+        auto iter = original_local_index_id_map.find(cindex_id);
         if (iter == original_local_index_id_map.end())
         {
             if (idx.state == TiDB::StatePublic || idx.state == TiDB::StateWriteReorganization)
             {
                 // create a new index
-                auto column = getVectorIndxColumnInfo(new_table_info, idx, logger);
-                LocalIndexInfo index_info{
+                new_index_infos->emplace_back(LocalIndexInfo{
                     .type = IndexType::Vector,
                     .index_id = idx.id,
-                    .column_id = column.id,
+                    .column_id = column_id,
                     .index_definition = idx.vector_index,
-                };
-                new_index_infos->emplace_back(std::move(index_info));
-                any_new_index_created = true;
-                LOG_INFO(logger, "Add a new index, index_id={}, table_id={}.", idx.id, new_table_info.id);
+                });
+                newly_added.emplace_back(cindex_id);
+                index_ids_in_new_table.emplace(cindex_id);
             }
+            // else the index is not public or write reorg, consider this index as not exist
         }
         else
         {
-            if (idx.state == TiDB::StateDeleteReorganization)
-                continue;
-            // remove the existing index
-            original_local_index_id_map.erase(iter);
+            if (idx.state != TiDB::StateDeleteReorganization)
+                index_ids_in_new_table.emplace(cindex_id);
+            // else exist in both `existing_indexes` and `new_table_info`, but enter "delete reorg". We consider this
+            // index as not exist in the `new_table_info` and drop it later
         }
     }
 
     // drop nonexistent indexes
-    for (auto & iter : original_local_index_id_map)
+    for (auto iter = original_local_index_id_map.begin(); iter != original_local_index_id_map.end(); /* empty */)
     {
-        // It means this index is create by column comments which we don't support drop index.
-        if (iter.first == DB::EmptyIndexID)
+        // the index_id exists in both `existing_indexes` and `new_table_info`
+        if (index_ids_in_new_table.contains(iter->first))
+        {
+            ++iter;
             continue;
-        new_index_infos->erase(new_index_infos->begin() + iter.second);
-        any_index_removed = true;
-        LOG_INFO(logger, "Drop a index, index_id={}, table_id={}.", iter.first, new_table_info.id);
+        }
+
+        // not exists in `new_table_info`, drop it
+        newly_dropped.emplace_back(iter->first);
+        new_index_infos->erase(new_index_infos->begin() + iter->second);
+        iter = original_local_index_id_map.erase(iter);
     }
 
-    if (!any_new_index_created && !any_index_removed)
+    if (newly_added.empty() && newly_dropped.empty())
+    {
+        auto get_logging = [&]() -> String {
+            FmtBuffer buf;
+            buf.append("keep=[");
+            buf.joinStr(
+                original_local_index_id_map.begin(),
+                original_local_index_id_map.end(),
+                [](const auto & id, FmtBuffer & fb) {
+                    if (id.first.index_id != EmptyIndexID)
+                        fb.fmtAppend("index_id={}", id.first.index_id);
+                    else
+                        fb.fmtAppend("index_on_column_id={}", id.first.column_id);
+                },
+                ",");
+            buf.append("]");
+            return buf.toString();
+        };
+        LOG_DEBUG(logger, "Local index info does not changed, {}", get_logging());
         return nullptr;
+    }
+
+    auto get_changed_logging = [&]() -> String {
+        FmtBuffer buf;
+        buf.append("keep=[");
+        buf.joinStr(
+            original_local_index_id_map.begin(),
+            original_local_index_id_map.end(),
+            [](const auto & id, FmtBuffer & fb) {
+                if (id.first.index_id != EmptyIndexID)
+                    fb.fmtAppend("index_id={}", id.first.index_id);
+                else
+                    fb.fmtAppend("index_on_column_id={}", id.first.column_id);
+            },
+            ",");
+        buf.append("] added=[");
+        buf.joinStr(
+            newly_added.begin(),
+            newly_added.end(),
+            [](const ComplexIndexID & id, FmtBuffer & fb) {
+                if (id.index_id != EmptyIndexID)
+                    fb.fmtAppend("index_id={}", id.index_id);
+                else
+                    fb.fmtAppend("index_on_column_id={}", id.column_id);
+            },
+            ",");
+        buf.append("] dropped=[");
+        buf.joinStr(
+            newly_dropped.begin(),
+            newly_dropped.end(),
+            [](const ComplexIndexID & id, FmtBuffer & fb) {
+                if (id.index_id != EmptyIndexID)
+                    fb.fmtAppend("index_id={}", id.index_id);
+                else
+                    fb.fmtAppend("index_on_column_id={}", id.column_id);
+            },
+            ",");
+        buf.append("]");
+        return buf.toString();
+    };
+    LOG_INFO(logger, "Local index info generated, {}", get_changed_logging());
     return new_index_infos;
 }
 

--- a/dbms/src/TiDB/Schema/TiDB.cpp
+++ b/dbms/src/TiDB/Schema/TiDB.cpp
@@ -1064,7 +1064,7 @@ try
         {
             auto index_info_json = index_arr->getObject(i);
             IndexInfo index_info(index_info_json);
-            // We only keep the "primary index" in tiflash now
+            // We only keep the "primary index" or "vector index" in tiflash now
             if (index_info.is_primary)
             {
                 has_primary_index = true;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #9032

Problem Summary:

### What is changed and how it works?

Pick https://github.com/tidbcloud/tiflash-cse/pull/283 and https://github.com/tidbcloud/tiflash-cse/pull/300

* Unify the logic of `generateLocalIndexInfos` and `initLocalIndexInfos`
  * Print 1 logging for the vector index added/dropped/existing in one table instead. This can avoid the flood of logging when tiflash restart with lots of table with vector index defined
  * Support drop the vector index defined on ColumnInfo after the Column has been dropped in TiDB
* Add more ut in the DeltaMergeStore read level
* vector search fallback when top_k = max uint32

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
