### PR TITLE
Storage: Add error message when fail to build local index

### DIFF
--- a/dbms/src/Common/FailPoint.cpp
+++ b/dbms/src/Common/FailPoint.cpp
@@ -71,6 +71,8 @@ namespace DB
     M(force_remote_read_for_batch_cop_once)                       \
     M(exception_new_dynamic_thread)                               \
     M(force_wait_index_timeout)                                   \
+    M(force_local_index_task_memory_limit_exceeded)               \
+    M(exception_build_local_index_for_file)                       \
     M(force_not_support_vector_index)                             \
     M(sync_schema_request_failure)
 

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_Statistics.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore_Statistics.cpp
@@ -16,6 +16,7 @@
 #include <Storages/DeltaMerge/Segment.h>
 #include <Storages/DeltaMerge/StoragePool/StoragePool.h>
 #include <Storages/Page/PageStorage.h>
+#include <tipb/executor.pb.h>
 
 namespace DB
 {
@@ -206,7 +207,7 @@ LocalIndexesStats DeltaMergeStore::getLocalIndexStats()
         LocalIndexStats index_stats;
         index_stats.column_id = index_info.column_id;
         index_stats.index_id = index_info.index_id;
-        index_stats.index_kind = "HNSW"; // TODO: Support more.
+        index_stats.index_kind = tipb::VectorIndexKind_Name(index_info.index_definition->kind);
 
         for (const auto & [handle, segment] : segments)
         {
@@ -240,6 +241,14 @@ LocalIndexesStats DeltaMergeStore::getLocalIndexStats()
             else
             {
                 index_stats.rows_stable_not_indexed += stable->getRows();
+            }
+
+            const auto index_build_error = segment->getIndexBuildError();
+            // Set error_message to the first error_message we meet among all segments
+            if (auto err_iter = index_build_error.find(index_info.index_id);
+                err_iter != index_build_error.end() && index_stats.error_message.empty())
+            {
+                index_stats.error_message = err_iter->second;
             }
         }
 

--- a/dbms/src/Storages/DeltaMerge/File/DMFileIndexWriter.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileIndexWriter.cpp
@@ -19,7 +19,7 @@
 #include <Storages/DeltaMerge/File/DMFileBlockInputStream.h>
 #include <Storages/DeltaMerge/File/DMFileIndexWriter.h>
 #include <Storages/DeltaMerge/File/DMFileV3IncrementWriter.h>
-#include <Storages/DeltaMerge/Index/IndexInfo.h>
+#include <Storages/DeltaMerge/Index/LocalIndexInfo.h>
 #include <Storages/DeltaMerge/Index/VectorIndex.h>
 #include <Storages/DeltaMerge/ScanContext.h>
 #include <Storages/DeltaMerge/dtpb/dmfile.pb.h>
@@ -32,11 +32,15 @@ namespace DB::ErrorCodes
 {
 extern const int ABORTED;
 }
+namespace DB::FailPoints
+{
+extern const char exception_build_local_index_for_file[];
+} // namespace DB::FailPoints
 
 namespace DB::DM
 {
 
-DMFileIndexWriter::LocalIndexBuildInfo DMFileIndexWriter::getLocalIndexBuildInfo(
+LocalIndexBuildInfo DMFileIndexWriter::getLocalIndexBuildInfo(
     const LocalIndexInfosSnapshot & index_infos,
     const DMFiles & dm_files)
 {
@@ -48,7 +52,7 @@ DMFileIndexWriter::LocalIndexBuildInfo DMFileIndexWriter::getLocalIndexBuildInfo
     //    We can support dropping the vector index more quickly later.
     LocalIndexBuildInfo build;
     build.indexes_to_build = std::make_shared<LocalIndexInfos>();
-    build.file_ids.reserve(dm_files.size());
+    build.dm_files.reserve(dm_files.size());
     for (const auto & dmfile : dm_files)
     {
         bool any_new_index_build = false;
@@ -74,10 +78,10 @@ DMFileIndexWriter::LocalIndexBuildInfo DMFileIndexWriter::getLocalIndexBuildInfo
         }
 
         if (any_new_index_build)
-            build.file_ids.emplace_back(LocalIndexerScheduler::DMFileID(dmfile->fileId()));
+            build.dm_files.emplace_back(dmfile);
     }
 
-    build.file_ids.shrink_to_fit();
+    build.dm_files.shrink_to_fit();
     return build;
 }
 
@@ -187,6 +191,8 @@ size_t DMFileIndexWriter::buildIndexForFile(const DMFilePtr & dm_file_mutable, P
             }
         }
     }
+
+    FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::exception_build_local_index_for_file);
 
     // Write down the index
     size_t total_built_index_bytes = 0;

--- a/dbms/src/Storages/DeltaMerge/File/DMFileIndexWriter.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileIndexWriter.h
@@ -39,13 +39,13 @@ struct LocalIndexBuildInfo
     LocalIndexInfosPtr indexes_to_build;
 
 public:
-    std::vector<PageIdU64> filesIDs() const
+    std::vector<LocalIndexerScheduler::FileID> filesIDs() const
     {
-        std::vector<PageIdU64> ids;
+        std::vector<LocalIndexerScheduler::FileID> ids;
         ids.reserve(dm_files.size());
         for (const auto & dmf : dm_files)
         {
-            ids.emplace_back(dmf->fileId());
+            ids.emplace_back(LocalIndexerScheduler::DMFileID(dmf->fileId()));
         }
         return ids;
     }

--- a/dbms/src/Storages/DeltaMerge/File/DMFileIndexWriter.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileIndexWriter.h
@@ -17,7 +17,8 @@
 #include <Common/Logger.h>
 #include <Interpreters/Context.h>
 #include <Storages/DeltaMerge/DMContext.h>
-#include <Storages/DeltaMerge/Index/IndexInfo.h>
+#include <Storages/DeltaMerge/File/DMFile.h>
+#include <Storages/DeltaMerge/Index/LocalIndexInfo.h>
 #include <Storages/DeltaMerge/LocalIndexerScheduler.h>
 #include <Storages/Page/PageDefinesBase.h>
 
@@ -27,26 +28,45 @@ class StoragePathPool;
 using StoragePathPoolPtr = std::shared_ptr<StoragePathPool>;
 } // namespace DB
 
-namespace DB::DM
-{
-class DMFile;
-using DMFilePtr = std::shared_ptr<DMFile>;
-using DMFiles = std::vector<DMFilePtr>;
-} // namespace DB::DM
 
 namespace DB::DM
 {
+
+struct LocalIndexBuildInfo
+{
+    DMFiles dm_files;
+    size_t estimated_memory_bytes = 0;
+    LocalIndexInfosPtr indexes_to_build;
+
+public:
+    std::vector<PageIdU64> filesIDs() const
+    {
+        std::vector<PageIdU64> ids;
+        ids.reserve(dm_files.size());
+        for (const auto & dmf : dm_files)
+        {
+            ids.emplace_back(dmf->fileId());
+        }
+        return ids;
+    }
+    std::vector<IndexID> indexesIDs() const
+    {
+        std::vector<IndexID> ids;
+        if (indexes_to_build)
+        {
+            ids.reserve(indexes_to_build->size());
+            for (const auto & index : *indexes_to_build)
+            {
+                ids.emplace_back(index.index_id);
+            }
+        }
+        return ids;
+    }
+};
 
 class DMFileIndexWriter
 {
 public:
-    struct LocalIndexBuildInfo
-    {
-        std::vector<LocalIndexerScheduler::FileID> file_ids;
-        size_t estimated_memory_bytes = 0;
-        LocalIndexInfosPtr indexes_to_build;
-    };
-
     static LocalIndexBuildInfo getLocalIndexBuildInfo(
         const LocalIndexInfosSnapshot & index_infos,
         const DMFiles & dm_files);

--- a/dbms/src/Storages/DeltaMerge/Index/LocalIndexInfo.h
+++ b/dbms/src/Storages/DeltaMerge/Index/LocalIndexInfo.h
@@ -53,7 +53,17 @@ using LocalIndexInfosPtr = std::shared_ptr<LocalIndexInfos>;
 using LocalIndexInfosSnapshot = std::shared_ptr<const LocalIndexInfos>;
 
 LocalIndexInfosPtr initLocalIndexInfos(const TiDB::TableInfo & table_info, const LoggerPtr & logger);
-LocalIndexInfosPtr generateLocalIndexInfos(
+
+struct LocalIndexInfosChangeset
+{
+    LocalIndexInfosPtr new_local_index_infos;
+    std::vector<IndexID> dropped_indexes;
+};
+
+// Generate a changeset according to `existing_indexes` and `new_table_info`
+// If there are newly added or dropped indexes according to `new_table_info`,
+// return a changeset with changeset.new_local_index_infos != nullptr
+LocalIndexInfosChangeset generateLocalIndexInfos(
     const LocalIndexInfosSnapshot & existing_indexes,
     const TiDB::TableInfo & new_table_info,
     const LoggerPtr & logger);

--- a/dbms/src/Storages/DeltaMerge/LocalIndexerScheduler.h
+++ b/dbms/src/Storages/DeltaMerge/LocalIndexerScheduler.h
@@ -107,10 +107,10 @@ public:
 
     /**
      * @brief Push a task to the pool. The task may not be scheduled immediately.
-     * Support adding the same task multiple times, but they are not allowed to execute at the same time.
-     * If the request_memory of task is larger than the memory_limit, will throw an exception.
+     * Return <true, ""> if pushing the task is done.
+     * Return <false, reason> if the task is not valid.
      */
-    void pushTask(const Task & task);
+    std::tuple<bool, String> pushTask(const Task & task);
 
     /**
     * @brief Drop all tasks matching specified keyspace id and table id.

--- a/dbms/src/Storages/DeltaMerge/Segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/Segment.cpp
@@ -37,7 +37,7 @@
 #include <Storages/DeltaMerge/File/DMFileBlockInputStream.h>
 #include <Storages/DeltaMerge/File/DMFileBlockOutputStream.h>
 #include <Storages/DeltaMerge/Filter/FilterHelper.h>
-#include <Storages/DeltaMerge/Index/IndexInfo.h>
+#include <Storages/DeltaMerge/Index/LocalIndexInfo.h>
 #include <Storages/DeltaMerge/LateMaterializationBlockInputStream.h>
 #include <Storages/DeltaMerge/PKSquashingBlockInputStream.h>
 #include <Storages/DeltaMerge/Range.h>

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_vector_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_vector_index.cpp
@@ -21,7 +21,7 @@
 #include <Storages/DeltaMerge/File/DMFileBlockOutputStream.h>
 #include <Storages/DeltaMerge/File/DMFileIndexWriter.h>
 #include <Storages/DeltaMerge/Filter/RSOperator.h>
-#include <Storages/DeltaMerge/Index/IndexInfo.h>
+#include <Storages/DeltaMerge/Index/LocalIndexInfo.h>
 #include <Storages/DeltaMerge/Index/VectorIndexCache.h>
 #include <Storages/DeltaMerge/Remote/Serializer.h>
 #include <Storages/DeltaMerge/ScanContext.h>

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_vector_index_utils.h
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_vector_index_utils.h
@@ -16,7 +16,7 @@
 
 #include <Core/ColumnWithTypeAndName.h>
 #include <Storages/DeltaMerge/Filter/RSOperator.h>
-#include <Storages/DeltaMerge/Index/IndexInfo.h>
+#include <Storages/DeltaMerge/Index/LocalIndexInfo.h>
 #include <Storages/DeltaMerge/Index/VectorIndexCache.h>
 #include <Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_test_basic.h>
 #include <Storages/DeltaMerge/tests/gtest_segment_util.h>

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_local_index_info.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_local_index_info.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include <Common/FailPoint.h>
-#include <Storages/DeltaMerge/Index/IndexInfo.h>
+#include <Storages/DeltaMerge/Index/LocalIndexInfo.h>
 #include <Storages/KVStore/Types.h>
 #include <TestUtils/TiFlashTestBasic.h>
 #include <TiDB/Schema/TiDB.h>
@@ -42,10 +42,10 @@ try
     LocalIndexInfosPtr index_info = nullptr;
     // check the same
     {
-        auto new_index_info = generateLocalIndexInfos(index_info, table_info, logger);
+        auto new_index_info = generateLocalIndexInfos(index_info, table_info, logger).new_local_index_infos;
         ASSERT_EQ(new_index_info, nullptr);
         // check again, nothing changed, return nullptr
-        ASSERT_EQ(nullptr, generateLocalIndexInfos(new_index_info, table_info, logger));
+        ASSERT_EQ(nullptr, generateLocalIndexInfos(new_index_info, table_info, logger).new_local_index_infos);
 
         // update
         index_info = new_index_info;
@@ -71,7 +71,7 @@ try
     FailPointHelper::enableFailPoint(FailPoints::force_not_support_vector_index);
 
     // check the result when storage format not support
-    auto new_index_info = generateLocalIndexInfos(index_info, table_info, logger);
+    auto new_index_info = generateLocalIndexInfos(index_info, table_info, logger).new_local_index_infos;
     ASSERT_NE(new_index_info, nullptr);
     // always return empty index_info, we need to drop all existing indexes
     ASSERT_TRUE(new_index_info->empty());
@@ -93,10 +93,10 @@ try
     LocalIndexInfosPtr index_info = nullptr;
     // check the same
     {
-        auto new_index_info = generateLocalIndexInfos(index_info, table_info, logger);
+        auto new_index_info = generateLocalIndexInfos(index_info, table_info, logger).new_local_index_infos;
         ASSERT_EQ(new_index_info, nullptr);
         // check again, nothing changed, return nullptr
-        ASSERT_EQ(nullptr, generateLocalIndexInfos(new_index_info, table_info, logger));
+        ASSERT_EQ(nullptr, generateLocalIndexInfos(new_index_info, table_info, logger).new_local_index_infos);
 
         // update
         index_info = new_index_info;
@@ -121,7 +121,7 @@ try
 
     // check the different
     {
-        auto new_index_info = generateLocalIndexInfos(index_info, table_info, logger);
+        auto new_index_info = generateLocalIndexInfos(index_info, table_info, logger).new_local_index_infos;
         ASSERT_NE(new_index_info, nullptr);
         ASSERT_EQ(new_index_info->size(), 1);
         const auto & idx = (*new_index_info)[0];
@@ -134,7 +134,7 @@ try
         ASSERT_EQ(expect_idx.vector_index->distance_metric, idx.index_definition->distance_metric);
 
         // check again, nothing changed, return nullptr
-        ASSERT_EQ(nullptr, generateLocalIndexInfos(new_index_info, table_info, logger));
+        ASSERT_EQ(nullptr, generateLocalIndexInfos(new_index_info, table_info, logger).new_local_index_infos);
 
         // update
         index_info = new_index_info;
@@ -154,7 +154,7 @@ try
     }
     // check the different
     {
-        auto new_index_info = generateLocalIndexInfos(index_info, table_info, logger);
+        auto new_index_info = generateLocalIndexInfos(index_info, table_info, logger).new_local_index_infos;
         ASSERT_NE(new_index_info, nullptr);
         ASSERT_EQ(new_index_info->size(), 2);
         const auto & idx0 = (*new_index_info)[0];
@@ -175,7 +175,7 @@ try
         ASSERT_EQ(expect_idx2.vector_index->distance_metric, idx1.index_definition->distance_metric);
 
         // check again, nothing changed, return nullptr
-        ASSERT_EQ(nullptr, generateLocalIndexInfos(new_index_info, table_info, logger));
+        ASSERT_EQ(nullptr, generateLocalIndexInfos(new_index_info, table_info, logger).new_local_index_infos);
 
         // update
         index_info = new_index_info;
@@ -198,7 +198,7 @@ try
     }
     // check the different
     {
-        auto new_index_info = generateLocalIndexInfos(index_info, table_info, logger);
+        auto new_index_info = generateLocalIndexInfos(index_info, table_info, logger).new_local_index_infos;
         ASSERT_NE(new_index_info, nullptr);
         ASSERT_EQ(new_index_info->size(), 2);
         const auto & idx0 = (*new_index_info)[0];
@@ -219,7 +219,7 @@ try
         ASSERT_EQ(expect_idx3.vector_index->distance_metric, idx1.index_definition->distance_metric);
 
         // check again, nothing changed, return nullptr
-        ASSERT_EQ(nullptr, generateLocalIndexInfos(new_index_info, table_info, logger));
+        ASSERT_EQ(nullptr, generateLocalIndexInfos(new_index_info, table_info, logger).new_local_index_infos);
     }
 }
 CATCH
@@ -269,7 +269,7 @@ try
     auto logger = Logger::get();
     LocalIndexInfosPtr index_info = nullptr;
     {
-        auto new_index_info = generateLocalIndexInfos(index_info, table_info, logger);
+        auto new_index_info = generateLocalIndexInfos(index_info, table_info, logger).new_local_index_infos;
         ASSERT_NE(new_index_info, nullptr);
         ASSERT_EQ(new_index_info->size(), 2);
 
@@ -292,9 +292,9 @@ try
         ASSERT_EQ(expect_idx.vector_index->distance_metric, idx1.index_definition->distance_metric);
         // check again, table_info.index_infos doesn't change and return them
         LocalIndexInfosPtr empty_index_info = nullptr;
-        ASSERT_EQ(2, generateLocalIndexInfos(empty_index_info, table_info, logger)->size());
+        ASSERT_EQ(2, generateLocalIndexInfos(empty_index_info, table_info, logger).new_local_index_infos->size());
         // check again with the same table_info, nothing changed, return nullptr
-        ASSERT_EQ(nullptr, generateLocalIndexInfos(new_index_info, table_info, logger));
+        ASSERT_EQ(nullptr, generateLocalIndexInfos(new_index_info, table_info, logger).new_local_index_infos);
 
         // update
         index_info = new_index_info;
@@ -317,7 +317,7 @@ try
     }
     // check the different
     {
-        auto new_index_info = generateLocalIndexInfos(index_info, table_info, logger);
+        auto new_index_info = generateLocalIndexInfos(index_info, table_info, logger).new_local_index_infos;
         ASSERT_NE(new_index_info, nullptr);
         ASSERT_EQ(new_index_info->size(), 2);
 
@@ -340,7 +340,7 @@ try
         ASSERT_EQ(expect_idx2.vector_index->distance_metric, idx1.index_definition->distance_metric);
 
         // check again, nothing changed, return nullptr
-        ASSERT_EQ(nullptr, generateLocalIndexInfos(new_index_info, table_info, logger));
+        ASSERT_EQ(nullptr, generateLocalIndexInfos(new_index_info, table_info, logger).new_local_index_infos);
     }
 }
 CATCH
@@ -373,7 +373,7 @@ TEST(LocalIndexInfoTest, CheckIndexDropDefinedInColumnInfo)
     LocalIndexInfosPtr index_info = nullptr;
     {
         // check the different with nullptr
-        auto new_index_info = generateLocalIndexInfos(index_info, table_info, logger);
+        auto new_index_info = generateLocalIndexInfos(index_info, table_info, logger).new_local_index_infos;
         ASSERT_NE(nullptr, new_index_info);
         ASSERT_EQ(new_index_info->size(), 1);
         const auto & idx0 = (*new_index_info)[0];
@@ -386,7 +386,7 @@ TEST(LocalIndexInfoTest, CheckIndexDropDefinedInColumnInfo)
         ASSERT_EQ(tipb::VectorDistanceMetric::INNER_PRODUCT, idx0.index_definition->distance_metric);
 
         // check again, nothing changed, return nullptr
-        ASSERT_EQ(nullptr, generateLocalIndexInfos(new_index_info, table_info, logger));
+        ASSERT_EQ(nullptr, generateLocalIndexInfos(new_index_info, table_info, logger).new_local_index_infos);
 
         // update
         index_info = new_index_info;
@@ -396,7 +396,7 @@ TEST(LocalIndexInfoTest, CheckIndexDropDefinedInColumnInfo)
     table_info.columns.erase(table_info.columns.begin());
     {
         // check the different with existing index_info
-        auto new_index_info = generateLocalIndexInfos(index_info, table_info, logger);
+        auto new_index_info = generateLocalIndexInfos(index_info, table_info, logger).new_local_index_infos;
         ASSERT_NE(nullptr, new_index_info);
         // not null
         ASSERT_NE(new_index_info, nullptr);
@@ -404,7 +404,7 @@ TEST(LocalIndexInfoTest, CheckIndexDropDefinedInColumnInfo)
         ASSERT_EQ(new_index_info->size(), 0);
 
         // check again, nothing changed, return nullptr
-        ASSERT_EQ(nullptr, generateLocalIndexInfos(new_index_info, table_info, logger));
+        ASSERT_EQ(nullptr, generateLocalIndexInfos(new_index_info, table_info, logger).new_local_index_infos);
 
         // update
         index_info = new_index_info;

--- a/dbms/src/Storages/StorageDeltaMerge.cpp
+++ b/dbms/src/Storages/StorageDeltaMerge.cpp
@@ -44,7 +44,7 @@
 #include <Storages/DeltaMerge/Filter/PushDownFilter.h>
 #include <Storages/DeltaMerge/Filter/RSOperator.h>
 #include <Storages/DeltaMerge/FilterParser/FilterParser.h>
-#include <Storages/DeltaMerge/Index/IndexInfo.h>
+#include <Storages/DeltaMerge/Index/LocalIndexInfo.h>
 #include <Storages/DeltaMerge/Index/VectorIndex.h>
 #include <Storages/DeltaMerge/Remote/DisaggSnapshot.h>
 #include <Storages/KVStore/Region.h>

--- a/dbms/src/Storages/StorageDeltaMerge.h
+++ b/dbms/src/Storages/StorageDeltaMerge.h
@@ -24,7 +24,7 @@
 #include <Storages/DeltaMerge/DeltaMergeInterfaces.h>
 #include <Storages/DeltaMerge/DeltaMergeStore.h>
 #include <Storages/DeltaMerge/Filter/PushDownFilter.h>
-#include <Storages/DeltaMerge/Index/IndexInfo.h>
+#include <Storages/DeltaMerge/Index/LocalIndexInfo.h>
 #include <Storages/DeltaMerge/Remote/DisaggSnapshot_fwd.h>
 #include <Storages/DeltaMerge/ScanContext_fwd.h>
 #include <Storages/DeltaMerge/Segment_fwd.h>

--- a/dbms/src/Storages/System/StorageSystemDTLocalIndexes.cpp
+++ b/dbms/src/Storages/System/StorageSystemDTLocalIndexes.cpp
@@ -43,7 +43,6 @@ StorageSystemDTLocalIndexes::StorageSystemDTLocalIndexes(const std::string & nam
         {"table_id", std::make_shared<DataTypeInt64>()},
         {"belonging_table_id", std::make_shared<DataTypeInt64>()},
 
-        {"column_name", std::make_shared<DataTypeString>()},
         {"column_id", std::make_shared<DataTypeUInt64>()},
         {"index_id", std::make_shared<DataTypeInt64>()},
         {"index_kind", std::make_shared<DataTypeString>()},
@@ -52,6 +51,10 @@ StorageSystemDTLocalIndexes::StorageSystemDTLocalIndexes(const std::string & nam
         {"rows_stable_not_indexed", std::make_shared<DataTypeUInt64>()}, // Total rows
         {"rows_delta_indexed", std::make_shared<DataTypeUInt64>()}, // Total rows
         {"rows_delta_not_indexed", std::make_shared<DataTypeUInt64>()}, // Total rows
+
+        // Fatal message when building local index
+        // when this is not an empty string, it means the build job of this local is aborted
+        {"error_message", std::make_shared<DataTypeString>()},
     }));
 }
 
@@ -119,7 +122,6 @@ BlockInputStreams StorageSystemDTLocalIndexes::read(
                 res_columns[j++]->insert(table_id);
                 res_columns[j++]->insert(table_info.belonging_table_id);
 
-                res_columns[j++]->insert(String("")); // TODO: let tidb set the column_name and index_name by itself
                 res_columns[j++]->insert(stat.column_id);
                 res_columns[j++]->insert(stat.index_id);
                 res_columns[j++]->insert(stat.index_kind);
@@ -128,6 +130,8 @@ BlockInputStreams StorageSystemDTLocalIndexes::read(
                 res_columns[j++]->insert(stat.rows_stable_not_indexed);
                 res_columns[j++]->insert(stat.rows_delta_indexed);
                 res_columns[j++]->insert(stat.rows_delta_not_indexed);
+
+                res_columns[j++]->insert(stat.error_message);
             }
         }
     }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #9032

Problem Summary:

### What is changed and how it works?

* Add 2 columns to `system.dt_local_indexes`
  * `column_name` is removed from the `system.dt_local_indexes`, let the tidb fill the index_name
  * `error_message` when it contains non-empty string, it means the index can not be built on tiflash
* An std::unordered_map<IndexID, String> fatal_error_when_building_local_index is added to each Segment:
  * The error message will be set when:
    * When the task can not be pushed to the LocalIndexScheduler, for example, need to large memory to be built
    * When the task throws any exception in `DeltaMergeStore::segmentEnsureStableIndex`
  * The error message will be clear when:
    * New local tasks is pushed to the LocalIndexScheduler with the same index_id
    * The index is dropped from tidb
  * `generateLocalIndexInfos` now will also return the index_ids that is dropped, so that we can cleanup the error message of the dropped indexes

```commit-message
Storage: Add error message when fail to build local index
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

```
create table x(e vector(3) not null);
set sql_mode='';
alter table x set tiflash replica 1;
insert into x values(); -- now this will insert a vector with dimension=0

# create vector index on tidb, fail to build index
ALTER TABLE x ADD VECTOR INDEX idx_e_l2 ((VEC_L2_DISTANCE(e))) USING HNSW;

# check the error message is returned to `information_schema.tiflash_indexes`
select * from information_schema.tiflash_indexes where tidb_table = 'x';
```
or:
```
# starts a tifalsh server with tcp_port enabled
> /path/to/tiflash server --config-file=... --tcp_port=9099

# connect to tidb and create the table and vector index
CREATE TABLE `t` (  `v` vector(5) DEFAULT NULL,  `v2` vector(3) DEFAULT NULL);
INSERT INTO t VALUES ('[8.7, 5.7, 7.7, 9.8, 1.5]','[1, 2, 3]')
alter table t set tiflash replica 1;

# starts a tiflash client to enable the failpoint of building local index
>  /path/to/tiflash client --host=127.0.0.1 --port=9099
TiFlash :) DBGInvoke enable_fail_point(exception_build_local_index_for_file)

# create vector index on tidb
ALTER TABLE t ADD VECTOR INDEX idx_v2_l2 ((VEC_L2_DISTANCE(v2))) USING HNSW;
# check the error message is returned to `information_schema.tiflash_indexes`
select * from information_schema.tiflash_indexes where tidb_table = 't';
```

![image](https://github.com/user-attachments/assets/81ad5e31-9f9d-4cd1-9fda-1b1904f67625)


Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
