### PR TITLE
storage: fix block rows not match when filter column is the first non-empty column in the block

### DIFF
--- a/dbms/src/Core/Block.cpp
+++ b/dbms/src/Core/Block.cpp
@@ -531,7 +531,7 @@ static ReturnType checkBlockStructure(const Block & lhs, const Block & rhs, cons
         }
     }
 
-    return ReturnType(true);
+    return static_cast<ReturnType>(true);
 }
 
 /// join blocks by columns
@@ -541,10 +541,8 @@ Block hstackBlocks(Blocks && blocks, const Block & header)
         return {};
 
     Block res = header.cloneEmpty();
-    size_t num_rows = blocks.front().rows();
     for (const auto & block : blocks)
     {
-        RUNTIME_CHECK_MSG(block.rows() == num_rows, "Cannot hstack blocks with different number of rows");
         for (const auto & elem : block)
         {
             if (likely(res.has(elem.name)))

--- a/dbms/src/Core/Block.h
+++ b/dbms/src/Core/Block.h
@@ -175,11 +175,14 @@ using BucketBlocksListMap = std::map<Int32, BlocksList>;
 /// Join blocks by columns
 /// The schema of the output block is the same as the header block.
 /// The columns not in the header block will be ignored.
-/// For example:
-/// header: (a UInt32, b UInt32, c UInt32, d UInt32)
-/// block1: (a UInt32, b UInt32, c UInt32, e UInt32), rows: 3
-/// block2: (d UInt32), rows: 3
-/// result: (a UInt32, b UInt32, c UInt32, d UInt32), rows: 3
+/// NOTE: The input blocks can have columns with different sizes,
+///       but the columns in the header block must have the same size,
+///       Otherwise, the returned block will contain columns with the different size.
+/// Example:
+///       header: (a UInt32, b UInt32, c UInt32, d UInt32)
+///       block1: (a UInt32, b UInt32, c UInt32, e UInt32), rows: 3
+///       block2: (d UInt32), rows: 3
+///       result: (a UInt32, b UInt32, c UInt32, d UInt32), rows: 3
 Block hstackBlocks(Blocks && blocks, const Block & header);
 
 /// Join blocks by rows

--- a/dbms/src/Storages/DeltaMerge/LateMaterializationBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/LateMaterializationBlockInputStream.cpp
@@ -110,12 +110,18 @@ Block LateMaterializationBlockInputStream::readImpl()
                 // so only if the number of rows left after filtering out is large enough,
                 // we can skip some packs of the next block, call readWithFilter to get the next block.
                 rest_column_block = rest_column_stream->readWithFilter(*filter);
+                ColumnPtr filter_column;
                 for (auto & col : filter_column_block)
                 {
                     if (col.name == filter_column_name)
+                    {
+                        filter_column = col.column;
                         continue;
+                    }
                     col.column = col.column->filter(*filter, passed_count);
                 }
+                if (header.has(filter_column_name))
+                    filter_column = filter_column->filter(*filter, passed_count);
             }
             else if (filter_out_count > 0)
             {
@@ -126,12 +132,19 @@ Block LateMaterializationBlockInputStream::readImpl()
                 {
                     col.column = col.column->filter(*filter, passed_count);
                 }
+                ColumnPtr filter_column;
+
                 for (auto & col : filter_column_block)
                 {
                     if (col.name == filter_column_name)
+                    {
+                        filter_column = col.column;
                         continue;
+                    }
                     col.column = col.column->filter(*filter, passed_count);
                 }
+                if (header.has(filter_column_name))
+                    filter_column = filter_column->filter(*filter, passed_count);
             }
             else
             {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #9472

Problem Summary:

### What is changed and how it works?

Try to fix #9472, failed to reproduce the issue. But when the filter column is the first non-empty column in the block, block.rows() = filter_column->size(), but filter_column is not filtered, so the rows may not match.

**But filter_column is usually added to the back of the block, so it is kind of weird.**

```commit-message
storage: fix block rows not match when filter column is the first non-empty column in the block
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
