### PR TITLE
vector: Fix join by array meet error "no supertype for types Array(Float32), Nullable(Array(Float32))"

### DIFF
--- a/dbms/src/DataTypes/getMostSubtype.cpp
+++ b/dbms/src/DataTypes/getMostSubtype.cpp
@@ -105,34 +105,6 @@ DataTypePtr getMostSubtype(const DataTypes & types, bool throw_if_result_is_noth
                 return get_nothing_or_throw(" because some of them are Nothing");
     }
 
-    /// For Arrays
-    {
-        bool have_array = false;
-        bool all_arrays = true;
-
-        DataTypes nested_types;
-        nested_types.reserve(types.size());
-
-        for (const auto & type : types)
-        {
-            if (const auto * const type_array = typeid_cast<const DataTypeArray *>(type.get()))
-            {
-                have_array = true;
-                nested_types.emplace_back(type_array->getNestedType());
-            }
-            else
-                all_arrays = false;
-        }
-
-        if (have_array)
-        {
-            if (!all_arrays)
-                return get_nothing_or_throw(" because some of them are Array and some of them are not");
-
-            return std::make_shared<DataTypeArray>(getMostSubtype(nested_types, false, force_support_conversion));
-        }
-    }
-
     /// For tuples
     {
         bool have_tuple = false;
@@ -207,6 +179,34 @@ DataTypePtr getMostSubtype(const DataTypes & types, bool throw_if_result_is_noth
                     getMostSubtype(nested_types, false, force_support_conversion));
 
             return getMostSubtype(nested_types, throw_if_result_is_nothing, force_support_conversion);
+        }
+    }
+
+    /// For Arrays, canBeInsideNullable = true, should check it after handling Nullable
+    {
+        bool have_array = false;
+        bool all_arrays = true;
+
+        DataTypes nested_types;
+        nested_types.reserve(types.size());
+
+        for (const auto & type : types)
+        {
+            if (const auto * const type_array = typeid_cast<const DataTypeArray *>(type.get()))
+            {
+                have_array = true;
+                nested_types.emplace_back(type_array->getNestedType());
+            }
+            else
+                all_arrays = false;
+        }
+
+        if (have_array)
+        {
+            if (!all_arrays)
+                return get_nothing_or_throw(" because some of them are Array and some of them are not");
+
+            return std::make_shared<DataTypeArray>(getMostSubtype(nested_types, false, force_support_conversion));
         }
     }
 

--- a/dbms/src/DataTypes/tests/gtest_data_type_get_common_type.cpp
+++ b/dbms/src/DataTypes/tests/gtest_data_type_get_common_type.cpp
@@ -150,10 +150,14 @@ try
                     ->equals(*typeFromString("Array(Array(UInt8))")));
     ASSERT_TRUE(getLeastSupertype(typesFromString("Array(Array(UInt8)) Array(Array(Int8))"))
                     ->equals(*typeFromString("Array(Array(Int16))")));
-    ASSERT_TRUE(
-        getLeastSupertype(typesFromString("Array(Date) Array(DateTime)"))->equals(*typeFromString("Array(DateTime)")));
+    ASSERT_TRUE(getLeastSupertype(typesFromString("Array(Date) Array(DateTime)")) //
+                    ->equals(*typeFromString("Array(DateTime)")));
     ASSERT_TRUE(getLeastSupertype(typesFromString("Array(String) Array(FixedString(32))"))
                     ->equals(*typeFromString("Array(String)")));
+    ASSERT_TRUE(getLeastSupertype(typesFromString("Array(Float32) Array(Float32)")) //
+                    ->equals(*typeFromString("Array(Float32)")));
+    ASSERT_TRUE(getLeastSupertype(typesFromString("Array(Float32) Nullable(Array(Float32))")) //
+                    ->equals(*typeFromString("Nullable(Array(Float32))")));
 
     ASSERT_TRUE(
         getLeastSupertype(typesFromString("Nullable(Nothing) Nothing"))->equals(*typeFromString("Nullable(Nothing)")));
@@ -214,11 +218,16 @@ try
                     ->equals(*typeFromString("Array(Array(UInt8))")));
     ASSERT_TRUE(getMostSubtype(typesFromString("Array(Array(UInt8)) Array(Array(Int8))"))
                     ->equals(*typeFromString("Array(Array(UInt8))")));
-    ASSERT_TRUE(getMostSubtype(typesFromString("Array(Date) Array(DateTime)"))->equals(*typeFromString("Array(Date)")));
+    ASSERT_TRUE(getMostSubtype(typesFromString("Array(Date) Array(DateTime)")) //
+                    ->equals(*typeFromString("Array(Date)")));
     ASSERT_TRUE(getMostSubtype(typesFromString("Array(String) Array(FixedString(32))"))
                     ->equals(*typeFromString("Array(FixedString(32))")));
     ASSERT_TRUE(getMostSubtype(typesFromString("Array(String) Array(FixedString(32))"))
                     ->equals(*typeFromString("Array(FixedString(32))")));
+    ASSERT_TRUE(getMostSubtype(typesFromString("Array(Float32) Array(Float32)")) //
+                    ->equals(*typeFromString("Array(Float32)")));
+    ASSERT_TRUE(getMostSubtype(typesFromString("Array(Float32) Nullable(Array(Float32))")) //
+                    ->equals(*typeFromString("Array(Float32)")));
 
     ASSERT_TRUE(getMostSubtype(typesFromString("Nullable(Nothing) Nothing"))->equals(*typeFromString("Nothing")));
     ASSERT_TRUE(getMostSubtype(typesFromString("Nullable(UInt8) Int8"))->equals(*typeFromString("UInt8")));

--- a/dbms/src/Flash/Mpp/MPPTaskScheduleEntry.cpp
+++ b/dbms/src/Flash/Mpp/MPPTaskScheduleEntry.cpp
@@ -46,7 +46,7 @@ bool MPPTaskScheduleEntry::schedule(ScheduleState state)
             log,
             log_level,
             "task is {}.",
-            state == ScheduleState::SCHEDULED ? "scheduled" : " failed to schedule");
+            state == ScheduleState::SCHEDULED ? "scheduled" : "failed to schedule");
         schedule_state = state;
         schedule_cv.notify_one();
         return true;

--- a/dbms/src/Flash/Mpp/MPPTaskScheduleEntry.cpp
+++ b/dbms/src/Flash/Mpp/MPPTaskScheduleEntry.cpp
@@ -42,11 +42,7 @@ bool MPPTaskScheduleEntry::schedule(ScheduleState state)
     if (schedule_state == ScheduleState::WAITING)
     {
         auto log_level = state == ScheduleState::SCHEDULED ? Poco::Message::PRIO_DEBUG : Poco::Message::PRIO_WARNING;
-        LOG_IMPL(
-            log,
-            log_level,
-            "task is {}.",
-            state == ScheduleState::SCHEDULED ? "scheduled" : "failed to schedule");
+        LOG_IMPL(log, log_level, "task is {}.", state == ScheduleState::SCHEDULED ? "scheduled" : "failed to schedule");
         schedule_state = state;
         schedule_cv.notify_one();
         return true;

--- a/dbms/src/Storages/DeltaMerge/File/ColumnStat.h
+++ b/dbms/src/Storages/DeltaMerge/File/ColumnStat.h
@@ -185,7 +185,9 @@ readText(ColumnStats & column_sats, DMFileFormat::Version ver, ReadBuffer & buf)
                 .serialized_bytes = serialized_bytes,
                 // ... here ignore some fields with default initializers
                 .vector_index = {},
+#ifndef NDEBUG
                 .additional_data_for_test = {},
+#endif
             });
     }
 }

--- a/dbms/src/Storages/DeltaMerge/File/DMFileIndexWriter.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileIndexWriter.cpp
@@ -110,9 +110,10 @@ size_t DMFileIndexWriter::buildIndexForFile(const DMFilePtr & dm_file_mutable, P
 
     for (const auto & [col_id, index_infos] : col_indexes)
     {
-        const auto cd_iter = std::find_if(column_defines.cbegin(), column_defines.cend(), [&](const auto & cd) {
-            return cd.id == col_id;
-        });
+        const auto cd_iter
+            = std::find_if(column_defines.cbegin(), column_defines.cend(), [col_id = col_id](const auto & cd) {
+                  return cd.id == col_id;
+              });
         RUNTIME_CHECK_MSG(
             cd_iter != column_defines.cend(),
             "Cannot find column_id={} in file={}",


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/9032

Problem Summary:

```
 CREATE TABLE `t413684e6` (
  `col_1` time DEFAULT NULL,
  `col_2` vector(2) NOT NULL DEFAULT '[0.476802, 0.584379]',
  `col_3` timestamp NOT NULL
) ENGINE=InnoDB DEFAULT CHARSET=gbk COLLATE=gbk_chinese_ci;

CREATE TABLE `t5bd2e4da` (
  `col_46` datetime NOT NULL DEFAULT '1982-12-17 00:00:00',
  `col_47` mediumint(8) unsigned DEFAULT '114607',
  `col_48` timestamp DEFAULT '1982-08-02 00:00:00',
  `col_49` json NOT NULL,
  `col_50` json NOT NULL,
  `col_51` time NOT NULL,
  `col_52` json NOT NULL,
  `col_53` vector(3) NOT NULL DEFAULT '[0.825384, 0.251245, 0.464911]',
  `col_54` vector NOT NULL DEFAULT '[0.424734, 0.467973, 0.326344, 0.107600, 0.398175]',
  `col_55` vector DEFAULT NULL
) ENGINE=InnoDB DEFAULT CHARSET=gbk COLLATE=gbk_chinese_ci
PARTITION BY HASH (`col_47`) PARTITIONS 2;

select /*+ read_from_storage(tiflash[ t413684e6,t5bd2e4da ]) */ t413684e6.col_3 as r0 from t413684e6 join t5bd2e4da on t413684e6.col_2 = t5bd2e4da.col_55


[2024/09/29 13:40:41.263 +08:00] [ERROR] [MPPTask.cpp:644] ["task running meets error: Code: 386, e.displayText() = DB::Exception: There is no supertype for types Array(Float32), Nullable(Array(Float32)) because some of them are Array and some of them are not, e.what() = DB::Exception, Stack trace:
  0x561bd56688ae    StackTrace::StackTrace() [tiflash+74066094]
                    dbms/src/Common/StackTrace.cpp:23
  0x561bd5658152    DB::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, int) [tiflash+73998674]
                    dbms/src/Common/Exception.h:46
  0x561bddad5b3f    DB::getLeastSupertype(std::__1::vector<std::__1::shared_ptr<DB::IDataType const>, std::__1::allocator<std::__1::shared_ptr<DB::IDataType const>>> const&) [tiflash+212925247]
                    dbms/src/DataTypes/getLeastSupertype.cpp:125
  0x561bdff7faa1    DB::JoinInterpreterHelper::(anonymous namespace)::geCommonTypeForJoinOn(std::__1::shared_ptr<DB::IDataType const> const&, std::__1::shared_ptr<DB::IDataType const> const&) [tiflash+251370145]
                    dbms/src/Flash/Coprocessor/JoinInterpreterHelper.cpp:142
  0x561bdff7cc1e    DB::JoinInterpreterHelper::(anonymous namespace)::getJoinKeyTypes(tipb::Join const&) [tiflash+251358238]
                    dbms/src/Flash/Coprocessor/JoinInterpreterHelper.cpp:181
  0x561bdff7c7ef    DB::JoinInterpreterHelper::TiFlashJoin::TiFlashJoin(tipb::Join const&, bool) [tiflash+251357167]
                    dbms/src/Flash/Coprocessor/JoinInterpreterHelper.cpp:213
  0x561bdff6f250    DB::PhysicalJoin::build(DB::Context const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<DB::Logger> const&, tipb::Join const&, DB::FineGrainedShuffle const&, std::__1::shared_ptr<DB::PhysicalPlanNode> const&, std::__1::shared_ptr<DB::PhysicalPlanNode> const&) [tiflash+251302480]
                    dbms/src/Flash/Planner/Plans/PhysicalJoin.cpp:74
  0x561bdfce4f36    DB::PhysicalPlan::build(tipb::Executor const*) [tiflash+248639286]
                    dbms/src/Flash/Planner/PhysicalPlan.cpp:212
  0x561bdfce7710    DB::PhysicalPlan::build(tipb::DAGRequest const*)::$_0::operator()(tipb::Executor const&) const [tiflash+248649488]
                    dbms/src/Flash/Planner/PhysicalPlan.cpp:71
  0x561bdfce77f3    void DB::traverseExecutorTreePostOrder<DB::PhysicalPlan::build(tipb::DAGRequest const*)::$_0&>(tipb::Executor const&, DB::PhysicalPlan::build(tipb::DAGRequest const*)::$_0&) [tiflash+248649715]
                    dbms/src/Flash/Statistics/traverseExecutors.h:114
  0x561bdfce7880    void DB::traverseExecutorTreePostOrder<DB::PhysicalPlan::build(tipb::DAGRequest const*)::$_0&>(tipb::Executor const&, DB::PhysicalPlan::build(tipb::DAGRequest const*)::$_0&)::'lambda'(tipb::Executor const&)::operator()(tipb::Executor const&) const [tiflash+248649856]
                    dbms/src/Flash/Statistics/traverseExecutors.h:113
  0x561bdfce7832    void DB::Children::forEach<void DB::traverseExecutorTreePostOrder<DB::PhysicalPlan::build(tipb::DAGRequest const*)::$_0&>(tipb::Executor const&, DB::PhysicalPlan::build(tipb::DAGRequest const*)::$_0&)::'lambda'(tipb::Executor const&)>(DB::PhysicalPlan::build(tipb::DAGRequest const*)::$_0&) [tiflash+248649778]
                    dbms/src/Flash/Statistics/traverseExecutors.h:47
  0x561bdfce77e6    void DB::traverseExecutorTreePostOrder<DB::PhysicalPlan::build(tipb::DAGRequest const*)::$_0&>(tipb::Executor const&, DB::PhysicalPlan::build(tipb::DAGRequest const*)::$_0&) [tiflash+248649702]
                    dbms/src/Flash/Statistics/traverseExecutors.h:113
  0x561bdfce77a0    void DB::traverseExecutorTreePostOrder<DB::PhysicalPlan::build(tipb::DAGRequest const*)::$_0>(tipb::Executor const&, DB::PhysicalPlan::build(tipb::DAGRequest const*)::$_0&&)::'lambda'(tipb::Executor const&)::operator()(tipb::Executor const&) const [tiflash+248649632]
                    dbms/src/Flash/Statistics/traverseExecutors.h:113
  0x561bdfce7752    void DB::Children::forEach<void DB::traverseExecutorTreePostOrder<DB::PhysicalPlan::build(tipb::DAGRequest const*)::$_0>(tipb::Executor const&, DB::PhysicalPlan::build(tipb::DAGRequest const*)::$_0&&)::'lambda'(tipb::Executor const&)>(DB::PhysicalPlan::build(tipb::DAGRequest const*)::$_0&&) [tiflash+248649554]
                    dbms/src/Flash/Statistics/traverseExecutors.h:47
  0x561bdfce76d6    void DB::traverseExecutorTreePostOrder<DB::PhysicalPlan::build(tipb::DAGRequest const*)::$_0>(tipb::Executor const&, DB::PhysicalPlan::build(tipb::DAGRequest const*)::$_0&&) [tiflash+248649430]
                    dbms/src/Flash/Statistics/traverseExecutors.h:113
  0x561bdfce2e58    void DB::traverseExecutorsReverse<DB::PhysicalPlan::build(tipb::DAGRequest const*)::$_0>(tipb::DAGRequest const*, DB::PhysicalPlan::build(tipb::DAGRequest const*)::$_0&&) [tiflash+248630872]
                    dbms/src/Flash/Statistics/traverseExecutors.h:129
  0x561bdfce2d8e    DB::PhysicalPlan::build(tipb::DAGRequest const*) [tiflash+248630670]
                    dbms/src/Flash/Planner/PhysicalPlan.cpp:70
  0x561bdfc44baf    DB::PipelineExecutor::PipelineExecutor(std::__1::shared_ptr<MemoryTracker> const&, DB::AutoSpillTrigger*, std::__1::function<void (std::__1::shared_ptr<DB::OperatorSpillContext> const&)> const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) [tiflash+247983023]
                    dbms/src/Flash/Executor/PipelineExecutor.cpp:43
  0x561bdfa9b6f3    std::__1::__unique_if<DB::PipelineExecutor>::__unique_single std::__1::make_unique[abi:ue170006]<DB::PipelineExecutor, std::__1::shared_ptr<MemoryTracker>&, std::nullptr_t, std::nullptr_t, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&>(std::__1::shared_ptr<MemoryTracker>&, std::nullptr_t&&, std::nullptr_t&&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) [tiflash+246241011]
                    /DATA/disk1/ra_common/tiflash-env-17/sysroot/bin/../include/c++/v1/__memory/unique_ptr.h:689
  0x561bdfa96d16    DB::(anonymous namespace)::executeAsPipeline(DB::Context&, bool) [tiflash+246222102]
                    dbms/src/Flash/executeQuery.cpp:171
  0x561bdfa9681f    DB::queryExecute(DB::Context&, bool) [tiflash+246220831]
                    dbms/src/Flash/executeQuery.cpp:191
  0x561bdfb80588    DB::MPPTask::preprocess() [tiflash+247178632]
                    dbms/src/Flash/Mpp/MPPTask.cpp:482
  0x561bdfb80ea9    DB::MPPTask::runImpl() [tiflash+247180969]
                    dbms/src/Flash/Mpp/MPPTask.cpp:524
  0x561bdfb86a3d    DB::MPPTask::run()::$_0::operator()() const [tiflash+247204413]
                    dbms/src/Flash/Mpp/MPPTask.cpp:203
  0x561bdfb86a15    decltype(std::declval<DB::MPPTask::run()::$_0&>()()) std::__1::__invoke[abi:ue170006]<DB::MPPTask::run()::$_0&>(DB::MPPTask::run()::$_0&) [tiflash+247204373]
                    /DATA/disk1/ra_common/tiflash-env-17/sysroot/bin/../include/c++/v1/__type_traits/invoke.h:340
  0x561bdfb869d5    void std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:ue170006]<DB::MPPTask::run()::$_0&>(DB::MPPTask::run()::$_0&) [tiflash+247204309]
                    /DATA/disk1/ra_common/tiflash-env-17/sysroot/bin/../include/c++/v1/__type_traits/invoke.h:415
  0x561bdfb869ad    std::__1::__function::__alloc_func<DB::MPPTask::run()::$_0, std::__1::allocator<DB::MPPTask::run()::$_0>, void ()>::operator()[abi:ue170006]() [tiflash+247204269]
                    /DATA/disk1/ra_common/tiflash-env-17/sysroot/bin/../include/c++/v1/__functional/function.h:192
  0x561bdfb85ca9    std::__1::__function::__func<DB::MPPTask::run()::$_0, std::__1::allocator<DB::MPPTask::run()::$_0>, void ()>::operator()() [tiflash+247200937]
                    /DATA/disk1/ra_common/tiflash-env-17/sysroot/bin/../include/c++/v1/__functional/function.h:363
  0x561bd5792882    std::__1::__function::__value_func<void ()>::operator()[abi:ue170006]() const [tiflash+75286658]
                    /DATA/disk1/ra_common/tiflash-env-17/sysroot/bin/../include/c++/v1/__functional/function.h:517
  0x561bd5785a05    std::__1::function<void ()>::operator()() const [tiflash+75233797]
                    /DATA/disk1/ra_common/tiflash-env-17/sysroot/bin/../include/c++/v1/__functional/function.h:1168
  0x561bddddbd95    decltype(std::declval<std::__1::function<void ()>>()()) std::__1::__invoke[abi:ue170006]<std::__1::function<void ()>>(std::__1::function<void ()>&&) [tiflash+216096149]
                    /DATA/disk1/ra_common/tiflash-env-17/sysroot/bin/../include/c++/v1/__type_traits/invoke.h:340"] [source="MPP<gather_id:1, query_ts:1727588441255458338, local_query_id:67414, server_id:167, start_ts:452876944336486401,task_id:2>"] [thread_id=1379]
```

### What is changed and how it works?

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
