### PR TITLE
tests: fix build on m1 macbook && re-enable clang-tidy checks

### DIFF
--- a/dbms/CMakeLists.txt
+++ b/dbms/CMakeLists.txt
@@ -215,7 +215,7 @@ target_link_libraries(tiflash_vector_search
     tiflash_contrib::usearch
     tiflash_contrib::simsimd
 
-    fmt 
+    fmt
 )
 
 target_link_libraries (dbms

--- a/dbms/src/VectorSearch/SimSIMD.h
+++ b/dbms/src/VectorSearch/SimSIMD.h
@@ -25,8 +25,13 @@
 #define SIMSIMD_DYNAMIC_DISPATCH 0
 
 // Force enable all target features. We will do our own dynamic dispatch.
+#if defined (__APPLE__)
+#define SIMSIMD_TARGET_NEON 0
+#define SIMSIMD_TARGET_SVE 0
+#else
 #define SIMSIMD_TARGET_NEON 1
 #define SIMSIMD_TARGET_SVE 1
+#endif
 #define SIMSIMD_TARGET_HASWELL 1
 #define SIMSIMD_TARGET_SKYLAKE 1
 #define SIMSIMD_TARGET_ICE 1

--- a/dbms/src/VectorSearch/SimSIMD.h
+++ b/dbms/src/VectorSearch/SimSIMD.h
@@ -25,7 +25,7 @@
 #define SIMSIMD_DYNAMIC_DISPATCH 0
 
 // Force enable all target features. We will do our own dynamic dispatch.
-#if defined (__APPLE__)
+#if defined(__APPLE__)
 #define SIMSIMD_TARGET_NEON 0
 #define SIMSIMD_TARGET_SVE 0
 #else

--- a/dbms/src/VectorSearch/USearch.h
+++ b/dbms/src/VectorSearch/USearch.h
@@ -39,6 +39,9 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpass-failed"
 
+#if !defined(__APPLE__)
+#include <type_traits>
+#endif
 #include <usearch/index.hpp>
 #include <usearch/index_dense.hpp>
 #include <usearch/index_plugins.hpp>

--- a/dbms/src/VectorSearch/USearch.h
+++ b/dbms/src/VectorSearch/USearch.h
@@ -22,8 +22,13 @@
 #define SIMSIMD_NATIVE_BF16 0
 
 // Force enable all target features.
+#if defined (__APPLE__)
+#define SIMSIMD_TARGET_NEON 0
+#define SIMSIMD_TARGET_SVE 0
+#else
 #define SIMSIMD_TARGET_NEON 1
 #define SIMSIMD_TARGET_SVE 1
+#endif
 #define SIMSIMD_TARGET_HASWELL 1
 #define SIMSIMD_TARGET_SKYLAKE 1
 #define SIMSIMD_TARGET_ICE 1
@@ -34,7 +39,7 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpass-failed"
 
-#include <type_traits>
+// #include <type_traits>
 #include <usearch/index.hpp>
 #include <usearch/index_dense.hpp>
 #include <usearch/index_plugins.hpp>

--- a/dbms/src/VectorSearch/USearch.h
+++ b/dbms/src/VectorSearch/USearch.h
@@ -39,7 +39,6 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpass-failed"
 
-// #include <type_traits>
 #include <usearch/index.hpp>
 #include <usearch/index_dense.hpp>
 #include <usearch/index_plugins.hpp>

--- a/dbms/src/VectorSearch/USearch.h
+++ b/dbms/src/VectorSearch/USearch.h
@@ -22,7 +22,7 @@
 #define SIMSIMD_NATIVE_BF16 0
 
 // Force enable all target features.
-#if defined (__APPLE__)
+#if defined(__APPLE__)
 #define SIMSIMD_TARGET_NEON 0
 #define SIMSIMD_TARGET_SVE 0
 #else

--- a/release-centos7-llvm/scripts/run-clang-tidy.py
+++ b/release-centos7-llvm/scripts/run-clang-tidy.py
@@ -360,5 +360,4 @@ def main():
 
 
 if __name__ == '__main__':
-    sys.exit(0)# temporary skip clang-tidy
     main()


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/9032

Problem Summary:
clang-tidy is temporary disable to merge the feature branch
https://github.com/pingcap/tiflash/pull/9486#discussion_r1780614126

### What is changed and how it works?

```commit-message

```

re-enable the clang-tidy checks

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
