### PR TITLE
Storage: Abort adding vector index if encryption enabled

### DIFF
--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalSegment.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalSegment.cpp
@@ -543,6 +543,14 @@ bool DeltaMergeStore::segmentEnsureStableIndexAsync(const SegmentPtr & segment)
     if (!build_info.indexes_to_build || build_info.indexes_to_build->empty() || build_info.dm_files.empty())
         return false;
 
+    if (auto encryption_enabled = global_context.getFileProvider()->isEncryptionEnabled(); encryption_enabled)
+    {
+        segment->setIndexBuildError(
+            build_info.indexesIDs(),
+            "Encryption-at-rest on TiFlash is enabled, which does not support building vector index");
+        return false;
+    }
+
     auto store_weak_ptr = weak_from_this();
     auto tracing_id
         = fmt::format("segmentEnsureStableIndex<{}> source_segment={}", log->identifier(), segment->simpleInfo());

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalSegment.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalSegment.cpp
@@ -15,6 +15,7 @@
 #include <Common/Exception.h>
 #include <Common/SyncPoint/SyncPoint.h>
 #include <Common/TiFlashMetrics.h>
+#include <IO/FileProvider/FileProvider.h>
 #include <Interpreters/Context.h>
 #include <Storages/DeltaMerge/DMContext.h>
 #include <Storages/DeltaMerge/DeltaMergeStore.h>

--- a/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter.cpp
@@ -197,8 +197,9 @@ void DMFilePackFilter::loadIndex(
             if (info == dmfile_meta->merged_sub_file_infos.end())
             {
                 throw Exception(
-                    fmt::format("Unknown index file {}", dmfile->colIndexPath(file_name_base)),
-                    ErrorCodes::LOGICAL_ERROR);
+                    ErrorCodes::LOGICAL_ERROR,
+                    "Unknown index file {}",
+                    dmfile->colIndexPath(file_name_base));
             }
 
             auto file_path = dmfile->meta->mergedPath(info->second.number);
@@ -221,7 +222,7 @@ void DMFilePackFilter::loadIndex(
 
             auto buf = ChecksumReadBufferBuilder::build(
                 std::move(raw_data),
-                dmfile->colDataPath(file_name_base),
+                dmfile->colIndexPath(file_name_base), // just for debug
                 dmfile->getConfiguration()->getChecksumFrameLength(),
                 dmfile->getConfiguration()->getChecksumAlgorithm(),
                 dmfile->getConfiguration()->getChecksumFrameLength());

--- a/dbms/src/Storages/DeltaMerge/File/DMFileV3IncrementWriter.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileV3IncrementWriter.cpp
@@ -150,7 +150,7 @@ void DMFileV3IncrementWriter::writeAndIncludeMetaFile()
         options.file_provider,
         meta_file_path_for_write, // Must not use meta->metaPath(), because DMFile may be a S3 DMFile
         EncryptionPath(local_path, meta_file_name),
-        /*create_new_encryption_info*/ true,
+        /*create_new_encryption_info*/ false, // must be false to reuse the encryption_info of exisiting dmfile
         options.write_limiter,
         DMFileMetaV2::meta_buffer_size);
 

--- a/dbms/src/Storages/DeltaMerge/ScanContext.cpp
+++ b/dbms/src/Storages/DeltaMerge/ScanContext.cpp
@@ -119,8 +119,11 @@ String ScanContext::toJson() const
 
     json->set("read_bytes", user_read_bytes.load());
 
-    json->set("disagg_cache_hit_size", disagg_read_cache_hit_size.load());
-    json->set("disagg_cache_miss_size", disagg_read_cache_miss_size.load());
+    if (disagg_read_cache_hit_size.load() > 0 && disagg_read_cache_miss_size.load() > 0)
+    {
+        json->set("disagg_cache_hit_size", disagg_read_cache_hit_size.load());
+        json->set("disagg_cache_miss_size", disagg_read_cache_miss_size.load());
+    }
 
     json->set("num_segments", num_segments.load());
     json->set("num_read_tasks", num_read_tasks.load());
@@ -163,6 +166,22 @@ String ScanContext::toJson() const
         return arr;
     };
     json->set("region_num_of_instance", to_json_array(region_num_of_instance));
+
+    if (total_vector_idx_load_from_cache.load() //
+            + total_vector_idx_load_from_disk.load() //
+            + total_vector_idx_load_from_s3.load()
+        > 0)
+    {
+        Poco::JSON::Object::Ptr vec_idx = new Poco::JSON::Object();
+        vec_idx->set("tot_load", total_vector_idx_load_time_ms.load());
+        vec_idx->set("load_s3", total_vector_idx_load_from_s3.load());
+        vec_idx->set("load_disk", total_vector_idx_load_from_disk.load());
+        vec_idx->set("load_cache", total_vector_idx_load_from_cache.load());
+        vec_idx->set("tot_search", total_vector_idx_search_time_ms.load());
+        vec_idx->set("read_vec", total_vector_idx_read_vec_time_ms.load());
+        vec_idx->set("read_others", total_vector_idx_read_others_time_ms.load());
+        json->set("vector_idx", vec_idx);
+    }
 
     std::stringstream buf;
     json->stringify(buf);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/9505, ref https://github.com/pingcap/tiflash/issues/9032

Problem Summary:

Encryption-at-rest is not compatible with building vector-index. We need more tests.

### What is changed and how it works?

```commit-message
Storage: Abort adding vector index if encryption enabled
```

Encryption-at-rest is not compatible with building vector-index. We need more tests. Abort adding vector-index when encryption-at-rest is enabled in tiflash for now.

One of the reason is `DMFileV3IncrementWriter::writeAndIncludeMetaFile` call `WriteBufferFromWritableFileBuilder::buildPtr(..., /* create_new_encryption_info */ true, ...)` and it renew the encryption_info of the DMFile. It causes the encryption_info mismatch after generating the new DMFile meta v1.

There is still something wrong after fixing it. Still under investigation.

Other:
Add info level logging message when vector search is performed in tiflash.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
