### PR TITLE
tests: Fix asan check failures

### DIFF
--- a/dbms/src/Debug/MockStorage.cpp
+++ b/dbms/src/Debug/MockStorage.cpp
@@ -194,6 +194,7 @@ BlockInputStreamPtr MockStorage::getStreamFromDeltaMerge(
     int rf_max_wait_time_ms)
 {
     static const google::protobuf::RepeatedPtrField<tipb::Expr> empty_pushed_down_filters{};
+    static const auto empty_ann_query_info = tipb::ANNQueryInfo{};
 
     QueryProcessingStage::Enum stage;
     auto [storage, column_names, query_info] = prepareForRead(context, table_id, keep_order);
@@ -203,7 +204,7 @@ BlockInputStreamPtr MockStorage::getStreamFromDeltaMerge(
         auto scan_column_infos = mockColumnInfosToTiDBColumnInfos(table_schema_for_delta_merge[table_id]);
         query_info.dag_query = std::make_unique<DAGQueryInfo>(
             filter_conditions->conditions,
-            tipb::ANNQueryInfo(),
+            empty_ann_query_info,
             empty_pushed_down_filters, // Not care now
             scan_column_infos,
             runtime_filter_ids,
@@ -232,7 +233,7 @@ BlockInputStreamPtr MockStorage::getStreamFromDeltaMerge(
         auto scan_column_infos = mockColumnInfosToTiDBColumnInfos(table_schema_for_delta_merge[table_id]);
         query_info.dag_query = std::make_unique<DAGQueryInfo>(
             empty_filters,
-            tipb::ANNQueryInfo(),
+            empty_ann_query_info,
             empty_pushed_down_filters, // Not care now
             scan_column_infos,
             runtime_filter_ids,
@@ -256,6 +257,7 @@ void MockStorage::buildExecFromDeltaMerge(
     int rf_max_wait_time_ms)
 {
     static const google::protobuf::RepeatedPtrField<tipb::Expr> empty_pushed_down_filters{};
+    static const auto empty_ann_query_info = tipb::ANNQueryInfo{};
 
     auto [storage, column_names, query_info] = prepareForRead(context, table_id, keep_order);
     if (filter_conditions && filter_conditions->hasValue())
@@ -264,7 +266,7 @@ void MockStorage::buildExecFromDeltaMerge(
         auto scan_column_infos = mockColumnInfosToTiDBColumnInfos(table_schema_for_delta_merge[table_id]);
         query_info.dag_query = std::make_unique<DAGQueryInfo>(
             filter_conditions->conditions,
-            tipb::ANNQueryInfo(),
+            empty_ann_query_info,
             empty_pushed_down_filters, // Not care now
             scan_column_infos,
             runtime_filter_ids,
@@ -298,7 +300,7 @@ void MockStorage::buildExecFromDeltaMerge(
         auto scan_column_infos = mockColumnInfosToTiDBColumnInfos(table_schema_for_delta_merge[table_id]);
         query_info.dag_query = std::make_unique<DAGQueryInfo>(
             empty_filters,
-            tipb::ANNQueryInfo(),
+            empty_ann_query_info,
             empty_pushed_down_filters, // Not care now
             scan_column_infos,
             runtime_filter_ids,

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_minmax_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_minmax_index.cpp
@@ -2214,17 +2214,19 @@ try
         filters.Add()->CopyFrom(expr);
     }
 
-    const ColumnDefines columns_to_read
-        = {ColumnDefine{1, "a", std::make_shared<DataTypeInt64>()},
-           ColumnDefine{2, "b", std::make_shared<DataTypeInt64>()}};
+    const ColumnDefines columns_to_read = {
+        ColumnDefine{1, "a", std::make_shared<DataTypeInt64>()},
+        ColumnDefine{2, "b", std::make_shared<DataTypeInt64>()},
+    };
     // Only need id of ColumnInfo
     TiDB::ColumnInfo a, b;
     a.id = 1;
     b.id = 2;
     TiDB::ColumnInfos column_infos = {a, b};
+    const auto ann_query_info = tipb::ANNQueryInfo{};
     auto dag_query = std::make_unique<DAGQueryInfo>(
         filters,
-        tipb::ANNQueryInfo{},
+        ann_query_info,
         pushed_down_filters, // Not care now
         column_infos,
         std::vector<int>{},

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_storage_delta_merge.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_storage_delta_merge.cpp
@@ -44,6 +44,7 @@
 #include <TestUtils/FunctionTestUtils.h>
 #include <TestUtils/InputStreamTestUtils.h>
 #include <TiDB/Schema/TiDB.h>
+#include <tipb/executor.pb.h>
 
 #include <ext/scope_guard.h>
 #include <limits>
@@ -128,11 +129,12 @@ try
     // keep a ref on them
     const google::protobuf::RepeatedPtrField<tipb::Expr> filters{};
     const google::protobuf::RepeatedPtrField<tipb::Expr> pushed_down_filters{};
+    const auto ann_query_info = tipb::ANNQueryInfo{};
     TiDB::ColumnInfos source_columns{};
     const std::vector<int> runtime_filter_ids;
     query_info.dag_query = std::make_unique<DAGQueryInfo>(
         filters,
-        tipb::ANNQueryInfo{},
+        ann_query_info,
         pushed_down_filters, // Not care now
         source_columns, // Not care now
         runtime_filter_ids,
@@ -684,11 +686,12 @@ try
     // keep a ref on them
     const google::protobuf::RepeatedPtrField<tipb::Expr> filters{};
     const google::protobuf::RepeatedPtrField<tipb::Expr> pushed_down_filters{};
+    const auto ann_query_info = tipb::ANNQueryInfo{};
     TiDB::ColumnInfos source_columns{};
     const std::vector<int> runtime_filter_ids;
     query_info.dag_query = std::make_unique<DAGQueryInfo>(
         filters,
-        tipb::ANNQueryInfo{},
+        ann_query_info,
         pushed_down_filters, // Not care now
         source_columns, // Not care now
         runtime_filter_ids,
@@ -805,9 +808,10 @@ try
         const google::protobuf::RepeatedPtrField<tipb::Expr> pushed_down_filters{};
         TiDB::ColumnInfos source_columns{};
         const std::vector<int> runtime_filter_ids;
+        const auto ann_query_info = tipb::ANNQueryInfo{};
         query_info.dag_query = std::make_unique<DAGQueryInfo>(
             filters,
-            tipb::ANNQueryInfo{},
+            ann_query_info,
             pushed_down_filters, // Not care now
             source_columns, // Not care now
             runtime_filter_ids,

--- a/dbms/src/Storages/tests/gtest_filter_parser.cpp
+++ b/dbms/src/Storages/tests/gtest_filter_parser.cpp
@@ -103,13 +103,16 @@ DM::RSOperatorPtr FilterParserTest::generateRsOperator(
     {
         columns_to_read.push_back(DM::ColumnDefine(column.id, column.name, getDataTypeByColumnInfo(column)));
     }
+    // these variables need to live long enough as it is kept as reference in `dag_query`
+    const auto ann_query_info = tipb::ANNQueryInfo{};
+    const auto runtime_filter_ids = std::vector<int>();
     const google::protobuf::RepeatedPtrField<tipb::Expr> pushed_down_filters{}; // don't care pushed down filters
     std::unique_ptr<DAGQueryInfo> dag_query = std::make_unique<DAGQueryInfo>(
         conditions,
-        tipb::ANNQueryInfo{},
+        ann_query_info,
         pushed_down_filters,
         table_info.columns,
-        std::vector<int>(), // don't care runtime filter
+        runtime_filter_ids, // don't care runtime filter
         0,
         timezone_info);
     auto create_attr_by_column_id = [&columns_to_read](ColumnID column_id) -> DM::Attr {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/9032

Problem Summary:

https://ci.pingcap.net/blue/rest/organizations/jenkins/pipelines/tiflash-sanitizer-daily/runs/2195/nodes/86/log/?start=0

The class `DAGQueryInfo` only keep reference to the query. So when writing unit test case, it is easy for us to pass a temporary variable and construct a `DAGQueryInfo` on the temporary variables. That cause stack-use-after-scope error.

https://github.com/pingcap/tiflash/blob/2f584c0949cd1a08811920cfa810390b694290ea/dbms/src/Flash/Coprocessor/DAGQueryInfo.h#L28-L58

```
[2024-10-10T19:09:42.918Z] ==53983==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7f98b52a4c88 at pc 0x559a56ea95db bp 0x7fff3e8cca50 sp 0x7fff3e8cca48
[2024-10-10T19:09:42.918Z] READ of size 4 at 0x7f98b52a4c88 thread T0
[2024-10-10T19:09:42.918Z]     #0 0x559a56ea95da in tipb::ANNQueryInfo::_internal_query_type() const /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/build-ASan/contrib/tipb/cpp/tipb/executor.pb.h:10480:46
[2024-10-10T19:09:42.918Z]     #1 0x559a56ea95da in tipb::ANNQueryInfo::query_type() const /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/build-ASan/contrib/tipb/cpp/tipb/executor.pb.h:10484:10
[2024-10-10T19:09:42.918Z]     #2 0x559a56ea95da in DB::DM::RSOperator::build(std::__1::unique_ptr<DB::DAGQueryInfo, std::__1::default_delete<DB::DAGQueryInfo>> const&, std::__1::vector<TiDB::ColumnInfo, std::__1::allocator<TiDB::ColumnInfo>> const&, std::__1::vector<DB::DM::ColumnDefine, std::__1::allocator<DB::DM::ColumnDefine>> const&, bool, std::__1::shared_ptr<DB::Logger> const&) /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/dbms/src/Storages/DeltaMerge/Filter/RSOperator.cpp:88:35
[2024-10-10T19:09:42.918Z]     #3 0x559a56e9832a in DB::DM::PushDownFilter::build(DB::SelectQueryInfo const&, std::__1::vector<DB::DM::ColumnDefine, std::__1::allocator<DB::DM::ColumnDefine>> const&, std::__1::vector<DB::DM::ColumnDefine, std::__1::allocator<DB::DM::ColumnDefine>> const&, DB::Context const&, std::__1::shared_ptr<DB::Logger> const&) /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/dbms/src/Storages/DeltaMerge/Filter/PushDownFilter.cpp:171:30
[2024-10-10T19:09:42.918Z]     #4 0x559a5be8a451 in DB::StorageDeltaMerge::read(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&, DB::SelectQueryInfo const&, DB::Context const&, DB::QueryProcessingStage::Enum&, unsigned long, unsigned int) /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/dbms/src/Storages/StorageDeltaMerge.cpp:837:19
[2024-10-10T19:09:42.918Z]     #5 0x559a59b8733f in DB::MockStorage::getStreamFromDeltaMerge(DB::Context&, long, DB::FilterConditions const*, bool, std::__1::vector<int, std::__1::allocator<int>>, int) /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/dbms/src/Debug/MockStorage.cpp:241:42
[2024-10-10T19:09:42.918Z]     #6 0x559a402f4a09 in DB::tests::MockStorageTestRunner_DeltaMergeStorageBasic_Test::TestBody() /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/dbms/src/Flash/tests/gtest_mock_storage.cpp:44:28
[2024-10-10T19:09:42.918Z]     #7 0x559a578e7771 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/contrib/googletest/googletest/src/gtest.cc:2443:10
...
```

### What is changed and how it works?

```commit-message

```

Use local variable instead of temporary variable to eliminate the "stack-use-after-scope" warning

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
