### PR TITLE
metrics: Add Thread CPU panel for building vector index

### DIFF
--- a/dbms/src/DataStreams/AsynchronousBlockInputStream.h
+++ b/dbms/src/DataStreams/AsynchronousBlockInputStream.h
@@ -16,7 +16,6 @@
 
 #include <Common/CurrentMetrics.h>
 #include <Common/MemoryTracker.h>
-#include <Common/setThreadName.h>
 #include <Common/wrapInvocable.h>
 #include <DataStreams/IProfilingBlockInputStream.h>
 #include <Poco/Event.h>

--- a/dbms/src/DataStreams/ParallelInputsProcessor.h
+++ b/dbms/src/DataStreams/ParallelInputsProcessor.h
@@ -20,7 +20,6 @@
 #include <Common/MemoryTracker.h>
 #include <Common/ThreadFactory.h>
 #include <Common/ThreadManager.h>
-#include <Common/setThreadName.h>
 #include <DataStreams/IProfilingBlockInputStream.h>
 #include <common/logger_useful.h>
 

--- a/dbms/src/Flash/FlashService.cpp
+++ b/dbms/src/Flash/FlashService.cpp
@@ -19,7 +19,6 @@
 #include <Common/TiFlashMetrics.h>
 #include <Common/VariantOp.h>
 #include <Common/getNumberOfCPUCores.h>
-#include <Common/setThreadName.h>
 #include <Debug/MockStorage.h>
 #include <Flash/BatchCoprocessorHandler.h>
 #include <Flash/Coprocessor/DAGContext.h>

--- a/dbms/src/Server/MetricsPrometheus.cpp
+++ b/dbms/src/Server/MetricsPrometheus.cpp
@@ -19,7 +19,6 @@
 #include <Common/StringUtils/StringUtils.h>
 #include <Common/TiFlashMetrics.h>
 #include <Common/TiFlashSecurity.h>
-#include <Common/setThreadName.h>
 #include <Interpreters/AsynchronousMetrics.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/SharedContexts/Disagg.h>

--- a/dbms/src/Storages/DeltaMerge/LocalIndexerScheduler.cpp
+++ b/dbms/src/Storages/DeltaMerge/LocalIndexerScheduler.cpp
@@ -261,6 +261,9 @@ bool LocalIndexerScheduler::tryAddTaskToPool(std::unique_lock<std::mutex> & lock
     }
 
     auto real_job = [task, this]() {
+        const auto old_thread_name = getThreadName();
+        setThreadName("LocalIndexPool");
+
         SCOPE_EXIT({
             std::unique_lock lock(mutex);
             pool_current_memory -= task->user_task.request_memory;
@@ -270,6 +273,7 @@ bool LocalIndexerScheduler::tryAddTaskToPool(std::unique_lock<std::mutex> & lock
 
             scheduler_need_wakeup = true;
             scheduler_notifier.notify_all();
+            setThreadName(old_thread_name.c_str());
         });
 
         task->scheduled_at.start();

--- a/dbms/src/Storages/DeltaMerge/LocalIndexerScheduler.cpp
+++ b/dbms/src/Storages/DeltaMerge/LocalIndexerScheduler.cpp
@@ -261,6 +261,8 @@ bool LocalIndexerScheduler::tryAddTaskToPool(std::unique_lock<std::mutex> & lock
     }
 
     auto real_job = [task, this]() {
+        // The task is executed by a thread that is created by UniThreadPool. We need to set the thread name
+        // before executing and reset it after the task is done.
         const auto old_thread_name = getThreadName();
         setThreadName("LocalIndexPool");
 

--- a/dbms/src/Storages/KVStore/Decode/PartitionStreams.cpp
+++ b/dbms/src/Storages/KVStore/Decode/PartitionStreams.cpp
@@ -19,7 +19,6 @@
 #include <Common/setThreadName.h>
 #include <Core/Block.h>
 #include <Interpreters/Context.h>
-#include <Parsers/ASTInsertQuery.h>
 #include <Storages/DeltaMerge/DeltaMergeStore.h>
 #include <Storages/KVStore/Decode/PartitionStreams.h>
 #include <Storages/KVStore/Decode/RegionBlockReader.h>

--- a/dbms/src/Storages/KVStore/MultiRaft/RaftCommandsKVS.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/RaftCommandsKVS.cpp
@@ -15,7 +15,6 @@
 #include <Common/FmtUtils.h>
 #include <Common/Stopwatch.h>
 #include <Common/TiFlashMetrics.h>
-#include <Common/setThreadName.h>
 #include <Interpreters/Context.h>
 #include <RaftStoreProxyFFI/ProxyFFI.h>
 #include <Storages/KVStore/Decode/RegionTable.h>

--- a/dbms/src/Storages/KVStore/Read/ReadIndexWorkerImpl.h
+++ b/dbms/src/Storages/KVStore/Read/ReadIndexWorkerImpl.h
@@ -17,7 +17,6 @@
 #include <Common/MemoryAllocTrace.h>
 #include <Common/Stopwatch.h>
 #include <Common/TiFlashMetrics.h>
-#include <Common/setThreadName.h>
 #include <Storages/KVStore/FFI/ProxyFFI.h>
 #include <Storages/KVStore/KVStore.h>
 #include <Storages/KVStore/Read/ReadIndexWorker.h>

--- a/dbms/src/Storages/KVStore/Read/ReadIndexWorkerManager.cpp
+++ b/dbms/src/Storages/KVStore/Read/ReadIndexWorkerManager.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Common/setThreadName.h>
 #include <Storages/KVStore/Read/ReadIndexWorkerImpl.h>
 
 namespace DB

--- a/metrics/grafana/tiflash_summary.json
+++ b/metrics/grafana/tiflash_summary.json
@@ -52,7 +52,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1718272201438,
+  "iteration": 1728897014230,
   "links": [],
   "panels": [
     {
@@ -2831,6 +2831,147 @@
           "timeRegions": [],
           "timeShift": null,
           "title": "Segment Scheduler",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": 1,
+              "format": "percentunit",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "decimals": null,
+          "description": "",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "grid": {},
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 51
+          },
+          "hiddenSeries": false,
+          "id": 295,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": 250,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "Limit",
+              "color": "#F2495C",
+              "hideTooltip": true,
+              "legend": false,
+              "linewidth": 2,
+              "nullPointMode": "connected"
+            }
+          ],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum by (instance) (rate(tiflash_proxy_thread_cpu_seconds_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", name=~\"LocalIndexPool*\"}[1m]))",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "pool-{{instance}}",
+              "refId": "A",
+              "step": 40
+            },
+            {
+              "exemplar": true,
+              "expr": "count by (instance) (tiflash_proxy_thread_cpu_seconds_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", name=~\"LocalIndexPool*\"})",
+              "hide": true,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "Limit",
+              "refId": "B"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum by (instance) (rate(tiflash_proxy_thread_cpu_seconds_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", name=~\"LocalIndexSched*\"}[1m]))",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "sched-{{instance}}",
+              "refId": "C",
+              "step": 40
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Local Index Pool",
           "tooltip": {
             "msResolution": false,
             "shared": true,
@@ -8661,7 +8802,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:222",
               "format": "µs",
               "label": null,
               "logBase": 1,
@@ -8670,7 +8810,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:223",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -9413,7 +9552,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:304",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -9422,7 +9560,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:305",
               "format": "short",
               "label": null,
               "logBase": 1,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/9032

Problem Summary:

### What is changed and how it works?

```commit-message

```

* Set the thread name when the thread is executing task of building vector index
* Add thread CPU panel in the TiFlash-Summary Grafana

![image](https://github.com/user-attachments/assets/abd92e84-7b75-4a29-9a20-f4fca188a8f8)


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Add Grafana panel about CPU usage on building vector index
```
