### PR TITLE
Storages: fix outdated unit tests

### DIFF
--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store.cpp
@@ -77,24 +77,7 @@ namespace DB::DM::tests
 
 String testModeToString(const ::testing::TestParamInfo<TestMode> & info)
 {
-    const auto mode = info.param;
-    switch (mode)
-    {
-    case TestMode::PageStorageV2_MemoryOnly:
-        return "PageStorageV2_MemoryOnly";
-    case TestMode::PageStorageV2_DiskOnly:
-        return "PageStorageV2_DiskOnly";
-    case TestMode::PageStorageV2_MemoryAndDisk:
-        return "PageStorageV2_MemoryAndDisk";
-    case TestMode::Current_MemoryOnly:
-        return "Current_MemoryOnly";
-    case TestMode::Current_DiskOnly:
-        return "Current_DiskOnly";
-    case TestMode::Current_MemoryAndDisk:
-        return "Current_MemoryAndDisk";
-    default:
-        return "Unknown";
-    }
+    return String{magic_enum::enum_name(info.param)};
 }
 
 

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_test_basic.h
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_test_basic.h
@@ -31,9 +31,7 @@
 #include <TestUtils/TiFlashStorageTestBasic.h>
 #include <TestUtils/TiFlashTestBasic.h>
 
-namespace DB
-{
-namespace DM
+namespace DB::DM
 {
 extern DMFilePtr writeIntoNewDMFile(
     DMContext & dm_context,
@@ -41,8 +39,11 @@ extern DMFilePtr writeIntoNewDMFile(
     const BlockInputStreamPtr & input_stream,
     UInt64 file_id,
     const String & parent_path);
-namespace tests
+}
+
+namespace DB::DM::tests
 {
+
 // Simple test suit for DeltaMergeStore.
 class DeltaMergeStoreTest : public DB::base::TiFlashStorageTestBasic
 {
@@ -120,15 +121,14 @@ protected:
     DeltaMergeStorePtr store;
 };
 
-enum TestMode
+enum class TestMode
 {
-    V1_BlockOnly,
-    V2_BlockOnly,
-    V2_FileOnly,
-    V2_Mix,
-    V3_BlockOnly,
-    V3_FileOnly,
-    V3_Mix
+    PageStorageV2_MemoryOnly,
+    PageStorageV2_DiskOnly,
+    PageStorageV2_MemoryAndDisk,
+    Current_MemoryOnly,
+    Current_DiskOnly,
+    Current_MemoryAndDisk
 };
 
 // Read write test suit for DeltaMergeStore.
@@ -146,18 +146,15 @@ public:
 
         switch (mode)
         {
-        case TestMode::V1_BlockOnly:
-            setStorageFormat(1);
-            break;
-        case TestMode::V2_BlockOnly:
-        case TestMode::V2_FileOnly:
-        case TestMode::V2_Mix:
-            setStorageFormat(2);
-            break;
-        case TestMode::V3_BlockOnly:
-        case TestMode::V3_FileOnly:
-        case TestMode::V3_Mix:
+        case TestMode::PageStorageV2_MemoryOnly:
+        case TestMode::PageStorageV2_DiskOnly:
+        case TestMode::PageStorageV2_MemoryAndDisk:
             setStorageFormat(3);
+            break;
+        case TestMode::Current_MemoryOnly:
+        case TestMode::Current_DiskOnly:
+        case TestMode::Current_MemoryAndDisk:
+            setStorageFormat(STORAGE_FORMAT_CURRENT);
             break;
         }
     }
@@ -239,6 +236,5 @@ protected:
 
     void dupHandleVersionAndDeltaIndexAdvancedThanSnapshot();
 };
-} // namespace tests
-} // namespace DM
-} // namespace DB
+
+} // namespace DB::DM::tests

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment.cpp
@@ -1274,11 +1274,10 @@ CATCH
 
 enum SegmentTestMode
 {
-    V1_BlockOnly,
-    V2_BlockOnly,
-    V2_FileOnly,
-    V3_BlockOnly,
-    V3_FileOnly,
+    PageStorageV2_MemoryOnly,
+    PageStorageV2_DiskOnly,
+    Current_MemoryOnly,
+    Current_DiskOnly,
 };
 
 String testModeToString(const ::testing::TestParamInfo<SegmentTestMode> & info)
@@ -1286,16 +1285,14 @@ String testModeToString(const ::testing::TestParamInfo<SegmentTestMode> & info)
     const auto mode = info.param;
     switch (mode)
     {
-    case SegmentTestMode::V1_BlockOnly:
-        return "V1_BlockOnly";
-    case SegmentTestMode::V2_BlockOnly:
-        return "V2_BlockOnly";
-    case SegmentTestMode::V2_FileOnly:
-        return "V2_FileOnly";
-    case SegmentTestMode::V3_BlockOnly:
-        return "V3_BlockOnly";
-    case SegmentTestMode::V3_FileOnly:
-        return "V3_FileOnly";
+    case SegmentTestMode::PageStorageV2_MemoryOnly:
+        return "PageStorageV2_MemoryOnly";
+    case SegmentTestMode::PageStorageV2_DiskOnly:
+        return "PageStorageV2_DiskOnly";
+    case SegmentTestMode::Current_MemoryOnly:
+        return "Current_MemoryOnly";
+    case SegmentTestMode::Current_DiskOnly:
+        return "Current_DiskOnly";
     default:
         return "Unknown";
     }
@@ -1317,16 +1314,13 @@ public:
         mode = GetParam();
         switch (mode)
         {
-        case SegmentTestMode::V1_BlockOnly:
-            setStorageFormat(1);
-            break;
-        case SegmentTestMode::V2_BlockOnly:
-        case SegmentTestMode::V2_FileOnly:
-            setStorageFormat(2);
-            break;
-        case SegmentTestMode::V3_BlockOnly:
-        case SegmentTestMode::V3_FileOnly:
+        case SegmentTestMode::PageStorageV2_MemoryOnly:
+        case SegmentTestMode::PageStorageV2_DiskOnly:
             setStorageFormat(3);
+            break;
+        case SegmentTestMode::Current_MemoryOnly:
+        case SegmentTestMode::Current_DiskOnly:
+            setStorageFormat(STORAGE_FORMAT_CURRENT);
             break;
         }
 
@@ -1373,13 +1367,12 @@ try
             row_offset += 100;
             switch (mode)
             {
-            case SegmentTestMode::V1_BlockOnly:
-            case SegmentTestMode::V2_BlockOnly:
-            case SegmentTestMode::V3_BlockOnly:
+            case SegmentTestMode::PageStorageV2_MemoryOnly:
+            case SegmentTestMode::Current_MemoryOnly:
                 segment->write(dmContext(), std::move(block));
                 break;
-            case SegmentTestMode::V2_FileOnly:
-            case SegmentTestMode::V3_FileOnly:
+            case SegmentTestMode::PageStorageV2_DiskOnly:
+            case SegmentTestMode::Current_DiskOnly:
             {
                 auto delegate = dmContext().path_pool->getStableDiskDelegator();
                 auto file_provider = dmContext().global_context.getFileProvider();
@@ -1487,11 +1480,10 @@ INSTANTIATE_TEST_CASE_P(
     SegmentTestMode, //
     SegmentTest2,
     testing::Values(
-        SegmentTestMode::V1_BlockOnly,
-        SegmentTestMode::V2_BlockOnly,
-        SegmentTestMode::V2_FileOnly,
-        SegmentTestMode::V3_BlockOnly,
-        SegmentTestMode::V3_FileOnly),
+        SegmentTestMode::PageStorageV2_MemoryOnly,
+        SegmentTestMode::PageStorageV2_DiskOnly,
+        SegmentTestMode::Current_MemoryOnly,
+        SegmentTestMode::Current_DiskOnly),
     testModeToString);
 
 enum class SegmentWriteType

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment.cpp
@@ -1282,20 +1282,7 @@ enum SegmentTestMode
 
 String testModeToString(const ::testing::TestParamInfo<SegmentTestMode> & info)
 {
-    const auto mode = info.param;
-    switch (mode)
-    {
-    case SegmentTestMode::PageStorageV2_MemoryOnly:
-        return "PageStorageV2_MemoryOnly";
-    case SegmentTestMode::PageStorageV2_DiskOnly:
-        return "PageStorageV2_DiskOnly";
-    case SegmentTestMode::Current_MemoryOnly:
-        return "Current_MemoryOnly";
-    case SegmentTestMode::Current_DiskOnly:
-        return "Current_DiskOnly";
-    default:
-        return "Unknown";
-    }
+    return String{magic_enum::enum_name(info.param)};
 }
 
 class SegmentTest2

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment.cpp
@@ -1272,7 +1272,7 @@ try
 }
 CATCH
 
-enum SegmentTestMode
+enum class SegmentTestMode
 {
     PageStorageV2_MemoryOnly,
     PageStorageV2_DiskOnly,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6233

Problem Summary:

`STORAGE_FORMAT_CURRENT = STORAGE_FORMAT_V7` but many unit tests are still testing V1/V2/V3.

### What is changed and how it works?

Test V3 which uses PageStorage V2 and the latest format version.

```commit-message
Storages: fix outdated unit tests
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
