### PR TITLE
build: Fix cmake preset command

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -145,7 +145,7 @@
       "name": "unit-tests-all",
       "displayName": "Build all unit tests",
       "configurePreset": "dev",
-      "targets": ["gtests_dbms, gtests_libdaemon, gtests_libcommon"]
+      "targets": ["gtests_dbms", "gtests_libdaemon", "gtests_libcommon"]
     },
     {
       "name": "dev-coverage",
@@ -157,7 +157,7 @@
       "name": "dev-coverage-all",
       "displayName": "Build all unit tests with code coverage",
       "configurePreset": "dev-coverage",
-      "targets": ["gtests_dbms, gtests_libdaemon, gtests_libcommon"]
+      "targets": ["gtests_dbms", "gtests_libdaemon", "gtests_libcommon"]
     },
     {
       "name": "release",
@@ -175,7 +175,7 @@
       "name": "asan-all",
       "displayName": "Build all Address Sanitizer tests",
       "configurePreset": "asan",
-      "targets": ["gtests_dbms, gtests_libdaemon, gtests_libcommon"]
+      "targets": ["gtests_dbms", "gtests_libdaemon", "gtests_libcommon"]
     },
     {
       "name": "tsan",
@@ -187,7 +187,7 @@
       "name": "tsan-all",
       "displayName": "Build all Thread Sanitizer tests",
       "configurePreset": "tsan",
-      "targets": ["gtests_dbms, gtests_libdaemon, gtests_libcommon"]
+      "targets": ["gtests_dbms", "gtests_libdaemon", "gtests_libcommon"]
     },
     {
       "name": "benchmarks",


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/6233

Problem Summary:

The command added in https://github.com/pingcap/tiflash/pull/9304 is broken

```
> cmake --workflow --preset unit-tests-all
...
Executing workflow step 2 of 2: build preset "unit-tests-all"

[0/2] Re-checking globbed directories...
ninja: error: unknown target 'gtests_dbms, gtests_libdaemon, gtests_libcommon'
```

### What is changed and how it works?

```commit-message
build: Fix cmake preset command
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
