### PR TITLE
tests: fix unstable unittests

### DIFF
--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_test_basic.h
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_test_basic.h
@@ -79,7 +79,7 @@ public:
         std::optional<Int64> start_at = std::nullopt,
         bool clear = false,
         std::optional<size_t> pack_size = std::nullopt,
-        bool check_range = false);
+        bool check_range = true);
     void ingestDTFileByReplace(
         PageIdU64 segment_id,
         UInt64 write_rows = 100,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9537

Problem Summary:

If `check_range` of `SegmentTestBasic::ingestDTFileIntoDelta` is false, it may generate data out of the range of segment.

In https://github.com/pingcap/tiflash/pull/9531, we want to generate data out of the segment range, but in most other test cases, it doesn't.


### What is changed and how it works?
Change the default of `check_range` to false. 

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
