### PR TITLE
Fix potential hang issues when fine grained shuffle is enabled

### DIFF
--- a/dbms/src/Flash/Mpp/MPPTunnelSetWriter.cpp
+++ b/dbms/src/Flash/Mpp/MPPTunnelSetWriter.cpp
@@ -432,9 +432,6 @@ void MPPTunnelSetWriterBase::fineGrainedShuffleWrite(
         compression_method,
         original_size);
 
-    if unlikely (tracked_packet->getPacket().chunks_size() <= 0)
-        return;
-
     auto packet_bytes = tracked_packet->getPacket().ByteSizeLong();
     checkPacketSize(packet_bytes);
     writeToTunnel(std::move(tracked_packet), partition_id);
@@ -456,9 +453,6 @@ void MPPTunnelSetWriterBase::fineGrainedShuffleWrite(
         fine_grained_shuffle_stream_count,
         num_columns,
         result_field_types);
-
-    if unlikely (tracked_packet->getPacket().chunks_size() <= 0)
-        return;
 
     auto packet_bytes = tracked_packet->getPacket().ByteSizeLong();
     checkPacketSize(packet_bytes);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #9413

Problem Summary:
#9424 fix #9413 by "Make sure that each time an ExchangeSenderSinkOp is notified, the ExchangeSenderSinkOp should either write data to LooseBoundedMPMCQueue, or try to notify another ExchangeSenderSinkOp", and actually requires that when `ExchangeSenderSinkOp` write data to `MPPTunnelSetWriter`, it will write data to all tunnels in `MPPTunnelSetWriter`. But for fine grained write, current code may skip the write if some tunnel does not have data to write, this is unexpected, and may make query hang in some extrame cases.

### What is changed and how it works?

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
