### PR TITLE
overwrite `addBatchSinglePlace` and `addBatchSinglePlaceNotNull` in `AggregateFunctionCountNotNullUnary`

### DIFF
--- a/dbms/src/AggregateFunctions/AggregateFunctionCount.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionCount.h
@@ -131,6 +131,47 @@ public:
                 ErrorCodes::LOGICAL_ERROR);
     }
 
+    void addBatchSinglePlace(
+        size_t start_offset,
+        size_t batch_size,
+        AggregateDataPtr place,
+        const IColumn ** columns,
+        Arena *,
+        ssize_t if_argument_pos) const override
+    {
+        const auto & nc = assert_cast<const ColumnNullable &>(*columns[0]);
+        if (if_argument_pos >= 0)
+        {
+            const auto & flags = assert_cast<const ColumnUInt8 &>(*columns[if_argument_pos]).getData();
+            data(place).count
+                += countBytesInFilterWithNull(flags, nc.getNullMapData().data(), start_offset, batch_size);
+        }
+        else
+        {
+            data(place).count += batch_size - countBytesInFilter(nc.getNullMapData().data(), start_offset, batch_size);
+        }
+    }
+
+    void addBatchSinglePlaceNotNull(
+        size_t start_offset,
+        size_t batch_size,
+        AggregateDataPtr place,
+        const IColumn ** columns,
+        const UInt8 * null_map,
+        Arena *,
+        ssize_t if_argument_pos) const override
+    {
+        if (if_argument_pos >= 0)
+        {
+            const auto & flags = assert_cast<const ColumnUInt8 &>(*columns[if_argument_pos]).getData();
+            data(place).count += countBytesInFilterWithNull(flags, null_map, start_offset, batch_size);
+        }
+        else
+        {
+            data(place).count += batch_size - countBytesInFilter(null_map, start_offset, batch_size);
+        }
+    }
+
     String getName() const override { return "count"; }
 
     DataTypePtr getReturnType() const override { return std::make_shared<DataTypeUInt64>(); }

--- a/dbms/src/AggregateFunctions/AggregateFunctionCount.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionCount.h
@@ -136,20 +136,12 @@ public:
         size_t batch_size,
         AggregateDataPtr place,
         const IColumn ** columns,
-        Arena *,
+        Arena * arena,
         ssize_t if_argument_pos) const override
     {
         const auto & nc = assert_cast<const ColumnNullable &>(*columns[0]);
-        if (if_argument_pos >= 0)
-        {
-            const auto & flags = assert_cast<const ColumnUInt8 &>(*columns[if_argument_pos]).getData();
-            data(place).count
-                += countBytesInFilterWithNull(flags, nc.getNullMapData().data(), start_offset, batch_size);
-        }
-        else
-        {
-            data(place).count += batch_size - countBytesInFilter(nc.getNullMapData().data(), start_offset, batch_size);
-        }
+        const UInt8 * null_map = nc.getNullMapData().data();
+        addBatchSinglePlaceNotNull(start_offset, batch_size, place, columns, null_map, arena, if_argument_pos);
     }
 
     void addBatchSinglePlaceNotNull(


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #9146

Problem Summary:

### What is changed and how it works?
`AggregateFunctionCountNotNullUnary` does not overwrite `addBatchSinglePlace` and `addBatchSinglePlaceNotNull`, so the code path will be 
https://github.com/pingcap/tiflash/blob/08535236b8f3d6d41656f22ebb8c2334f3081d86/dbms/src/AggregateFunctions/IAggregateFunction.h#L267-L289

In fact, `AggregateFunctionCountNotNullUnary` can be optimized by count the element number in batch like `AggregateFunctionCount` by overwrite `addBatchSinglePlace` and `addBatchSinglePlaceNotNull` 
```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
