### PR TITLE
Minor refine `Join`

### DIFF
--- a/dbms/src/DataStreams/HashJoinProbeBlockInputStream.cpp
+++ b/dbms/src/DataStreams/HashJoinProbeBlockInputStream.cpp
@@ -33,13 +33,12 @@ HashJoinProbeBlockInputStream::HashJoinProbeBlockInputStream(
 
     RUNTIME_CHECK_MSG(original_join != nullptr, "join ptr should not be null.");
     RUNTIME_CHECK_MSG(original_join->getProbeConcurrency() > 0, "Join probe concurrency must be greater than 0");
+    RUNTIME_CHECK_MSG(original_join->isFinalize(), "join should be finalized first.");
 
     probe_exec.set(HashJoinProbeExec::build(req_id, original_join, stream_index, input, max_block_size_));
     probe_exec->setCancellationHook([&]() { return isCancelledOrThrowIfKilled(); });
 
-    ProbeProcessInfo header_probe_process_info(0, 0);
-    header_probe_process_info.resetBlock(input->getHeader());
-    header = original_join->joinBlock(header_probe_process_info, true);
+    header = original_join->getOutputBlock();
 }
 
 void HashJoinProbeBlockInputStream::readSuffixImpl()

--- a/dbms/src/DataStreams/ScanHashMapAfterProbeBlockInputStream.cpp
+++ b/dbms/src/DataStreams/ScanHashMapAfterProbeBlockInputStream.cpp
@@ -206,9 +206,6 @@ ScanHashMapAfterProbeBlockInputStream::ScanHashMapAfterProbeBlockInputStream(
     columns_left.resize(column_indices_left.size());
     columns_right.resize(column_indices_right.size());
     current_partition_index = index;
-    projected_sample_block = result_sample_block;
-
-    projected_sample_block = parent.removeUselessColumn(projected_sample_block);
 }
 
 Block ScanHashMapAfterProbeBlockInputStream::readImpl()

--- a/dbms/src/DataStreams/ScanHashMapAfterProbeBlockInputStream.h
+++ b/dbms/src/DataStreams/ScanHashMapAfterProbeBlockInputStream.h
@@ -33,7 +33,7 @@ public:
 
     String getName() const override { return "ScanHashMapAfterProbe"; }
 
-    Block getHeader() const override { return projected_sample_block; };
+    Block getHeader() const override { return parent.getOutputBlock(); }
 
     size_t getIndex() const { return index; }
 
@@ -59,7 +59,6 @@ private:
 
 
     Block result_sample_block;
-    Block projected_sample_block; /// same schema with join's final schema
     /// Indices of columns in left sample block
     ColumnNumbers column_indices_left;
     /// Indices of columns in right sample block

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -2597,7 +2597,7 @@ void Join::finalize(const Names & parent_require)
     }
     RUNTIME_CHECK_MSG(
         output_column_names_set_after_finalize.size() == output_columns_after_finalize.size(),
-        "Logical error, the output of join containning duplicated column");
+        "Logical error, the output of join contains duplicated columns");
 
     output_block_after_finalize = Block(output_columns_after_finalize);
     Names updated_require;

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -1356,6 +1356,7 @@ Block Join::removeUselessColumn(Block & block) const
     if (!block)
         return block;
 
+    // remove useless columns and adjust the order of columns
     Block projected_block;
     for (const auto & name_and_type : output_columns_after_finalize)
     {

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -2191,22 +2191,15 @@ void Join::finishOneNonJoin(size_t partition_index)
     }
 }
 
-Block Join::joinBlock(ProbeProcessInfo & probe_process_info, bool dry_run) const
+Block Join::joinBlock(ProbeProcessInfo & probe_process_info) const
 {
     assert(!probe_process_info.all_rows_joined_finish);
     assert(finalized);
-    if unlikely (dry_run)
+    if unlikely (!build_finished)
     {
-        assert(probe_process_info.block.rows() == 0);
-    }
-    else
-    {
-        if unlikely (!build_finished)
-        {
-            /// build is not finished yet, the query must be cancelled, so just return {}
-            LOG_WARNING(log, "JoinBlock without non zero active_build_threads, return empty block");
-            return {};
-        }
+        /// build is not finished yet, the query must be cancelled, so just return {}
+        LOG_WARNING(log, "JoinBlock without non zero active_build_threads, return empty block");
+        return {};
     }
     std::shared_lock lock(rwlock);
 
@@ -2602,6 +2595,10 @@ void Join::finalize(const Names & parent_require)
             output_column_names_set_after_finalize.insert(name_and_type.name);
         }
     }
+    RUNTIME_CHECK_MSG(
+        output_column_names_set_after_finalize.size() == output_columns_after_finalize.size(),
+        "Logical error, the output of join containning duplicated column");
+
     output_block_after_finalize = Block(output_columns_after_finalize);
     Names updated_require;
     if (match_helper_name.empty())

--- a/dbms/src/Interpreters/Join.h
+++ b/dbms/src/Interpreters/Join.h
@@ -202,7 +202,7 @@ public:
     /** Join data from the map (that was previously built by calls to insertFromBlock) to the block with data from "left" table.
       * Could be called from different threads in parallel.
       */
-    Block joinBlock(ProbeProcessInfo & probe_process_info, bool dry_run = false) const;
+    Block joinBlock(ProbeProcessInfo & probe_process_info) const;
 
     void checkTypes(const Block & block) const;
 
@@ -333,6 +333,7 @@ public:
     const Block & getOutputBlock() const { return finalized ? output_block_after_finalize : output_block; }
     const Names & getRequiredColumns() const { return required_columns; }
     void finalize(const Names & parent_require);
+    bool isFinalize() const { return finalized; }
 
     OneTimeNotifyFuturePtr wait_build_finished_future;
     OneTimeNotifyFuturePtr wait_probe_finished_future;

--- a/dbms/src/Operators/HashJoinProbeTransformOp.cpp
+++ b/dbms/src/Operators/HashJoinProbeTransformOp.cpp
@@ -39,6 +39,7 @@ HashJoinProbeTransformOp::HashJoinProbeTransformOp(
 {
     RUNTIME_CHECK_MSG(origin_join != nullptr, "join ptr should not be null.");
     RUNTIME_CHECK_MSG(origin_join->getProbeConcurrency() > 0, "Join probe concurrency must be greater than 0");
+    RUNTIME_CHECK_MSG(origin_join->isFinalize(), "join should be finalized first.");
 
     BlockInputStreamPtr scan_hash_map_after_probe_stream;
     if (needScanHashMapAfterProbe(origin_join->getKind()))
@@ -58,9 +59,7 @@ HashJoinProbeTransformOp::HashJoinProbeTransformOp(
 
 void HashJoinProbeTransformOp::transformHeaderImpl(Block & header_)
 {
-    ProbeProcessInfo header_probe_process_info(0, 0);
-    header_probe_process_info.resetBlock(std::move(header_));
-    header_ = origin_join->joinBlock(header_probe_process_info, true);
+    header_ = origin_join->getOutputBlock();
 }
 
 void HashJoinProbeTransformOp::operateSuffixImpl()


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6233

Problem Summary:

### What is changed and how it works?
Currently there is two way to get the output schema of `Join`
- use `Join::joinBlock` with `dry_run = true`
- use `Join::getOutputBlock`

This pr remove `dry_run` argument from `Join::joinBlock`. So the only way to get the output schema of `Join` is to use `Join::getOutputBlock`


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
