### PR TITLE
Storages: Optimize vector search in scenarios with updates

### DIFF
--- a/dbms/src/DataStreams/PushingToViewsBlockOutputStream.cpp
+++ b/dbms/src/DataStreams/PushingToViewsBlockOutputStream.cpp
@@ -14,7 +14,6 @@
 
 #include <Common/Exception.h>
 #include <DataStreams/PushingToViewsBlockOutputStream.h>
-#include <DataStreams/SquashingBlockInputStream.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/InterpreterSelectQuery.h>
 #include <Storages/IStorage.h>

--- a/dbms/src/DataStreams/SquashingBlockInputStream.cpp
+++ b/dbms/src/DataStreams/SquashingBlockInputStream.cpp
@@ -16,6 +16,7 @@
 
 namespace DB
 {
+
 SquashingBlockInputStream::SquashingBlockInputStream(
     const BlockInputStreamPtr & src,
     size_t min_block_size_rows,
@@ -28,7 +29,7 @@ SquashingBlockInputStream::SquashingBlockInputStream(
 }
 
 
-Block SquashingBlockInputStream::readImpl()
+Block SquashingBlockInputStream::read()
 {
     if (all_read)
         return {};

--- a/dbms/src/DataStreams/SquashingBlockInputStream.h
+++ b/dbms/src/DataStreams/SquashingBlockInputStream.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include <DataStreams/IProfilingBlockInputStream.h>
+#include <DataStreams/IBlockInputStream.h>
 #include <DataStreams/SquashingTransform.h>
 
 
@@ -22,7 +22,7 @@ namespace DB
 {
 /** Merging consecutive blocks of stream to specified minimum size.
   */
-class SquashingBlockInputStream : public IProfilingBlockInputStream
+class SquashingBlockInputStream : public IBlockInputStream
 {
     static constexpr auto NAME = "Squashing";
 
@@ -37,8 +37,7 @@ public:
 
     Block getHeader() const override { return children.at(0)->getHeader(); }
 
-protected:
-    Block readImpl() override;
+    Block read() override;
 
 private:
     const LoggerPtr log;

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSetWithVectorIndexInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSetWithVectorIndexInputStream.cpp
@@ -39,19 +39,6 @@ SkippableBlockInputStreamPtr ColumnFileSetWithVectorIndexInputStream::tryBuild(
     if (!bitmap_filter || !ann_query_info)
         return fallback();
 
-    // Fast check: ANNQueryInfo is available in the whole read path. However we may not reading vector column now.
-    bool is_matching_ann_query = false;
-    for (const auto & cd : *col_defs)
-    {
-        if (cd.id == ann_query_info->column_id())
-        {
-            is_matching_ann_query = true;
-            break;
-        }
-    }
-    if (!is_matching_ann_query)
-        return fallback();
-
     std::optional<ColumnDefine> vec_cd;
     auto rest_columns = std::make_shared<ColumnDefines>();
     rest_columns->reserve(col_defs->size() - 1);

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSetWithVectorIndexInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSetWithVectorIndexInputStream.cpp
@@ -21,13 +21,13 @@
 namespace DB::DM
 {
 
-ColumnFileSetInputStreamPtr ColumnFileSetWithVectorIndexInputStream::tryBuild(
+SkippableBlockInputStreamPtr ColumnFileSetWithVectorIndexInputStream::tryBuild(
     const DMContext & context,
     const ColumnFileSetSnapshotPtr & delta_snap,
     const ColumnDefinesPtr & col_defs,
     const RowKeyRange & segment_range_,
     const IColumnFileDataProviderPtr & data_provider,
-    const RSOperatorPtr & rs_operator,
+    const ANNQueryInfoPtr & ann_query_info,
     const BitmapFilterPtr & bitmap_filter,
     size_t offset,
     ReadTag read_tag_)
@@ -36,15 +36,7 @@ ColumnFileSetInputStreamPtr ColumnFileSetWithVectorIndexInputStream::tryBuild(
         return std::make_shared<ColumnFileSetInputStream>(context, delta_snap, col_defs, segment_range_, read_tag_);
     };
 
-    if (rs_operator == nullptr || bitmap_filter == nullptr)
-        return fallback();
-
-    auto filter_with_ann = std::dynamic_pointer_cast<WithANNQueryInfo>(rs_operator);
-    if (filter_with_ann == nullptr)
-        return fallback();
-
-    auto ann_query_info = filter_with_ann->ann_query_info;
-    if (!ann_query_info)
+    if (!bitmap_filter || !ann_query_info)
         return fallback();
 
     // Fast check: ANNQueryInfo is available in the whole read path. However we may not reading vector column now.
@@ -140,16 +132,8 @@ Block ColumnFileSetWithVectorIndexInputStream::readImpl(FilterPtr & res_filter)
         if (tiny_readers[current_file_index] != nullptr)
         {
             const auto file_rows = column_files[current_file_index]->getRows();
-            auto selected_row_begin = std::lower_bound(
-                selected_rows.cbegin(),
-                selected_rows.cend(),
-                read_rows,
-                [](const auto & row, UInt32 offset) { return row.key < offset; });
-            auto selected_row_end = std::lower_bound(
-                selected_row_begin,
-                selected_rows.cend(),
-                read_rows + file_rows,
-                [](const auto & row, UInt32 offset) { return row.key < offset; });
+            auto selected_row_begin = std::lower_bound(sorted_results.cbegin(), sorted_results.cend(), read_rows);
+            auto selected_row_end = std::lower_bound(selected_row_begin, sorted_results.cend(), read_rows + file_rows);
             size_t selected_rows = std::distance(selected_row_begin, selected_row_end);
             // If all rows are filtered out, skip this file.
             if (selected_rows == 0)
@@ -184,7 +168,7 @@ Block ColumnFileSetWithVectorIndexInputStream::readImpl(FilterPtr & res_filter)
             {
                 filter.clear();
                 filter.resize_fill(file_rows, 0);
-                for (const auto & [rowid, _] : file_selected_rows)
+                for (const auto rowid : file_selected_rows)
                     filter[rowid - read_rows] = 1;
                 res_filter = &filter;
             }
@@ -211,13 +195,14 @@ Block ColumnFileSetWithVectorIndexInputStream::readImpl(FilterPtr & res_filter)
     return {};
 }
 
-void ColumnFileSetWithVectorIndexInputStream::load()
+std::vector<VectorIndexViewer::SearchResult> ColumnFileSetWithVectorIndexInputStream::load()
 {
     if (loaded)
-        return;
+        return {};
 
     tiny_readers.reserve(column_files.size());
     UInt32 precedes_rows = 0;
+    std::vector<VectorIndexViewer::SearchResult> search_results;
     for (const auto & column_file : column_files)
     {
         if (auto * tiny_file = column_file->tryToTinyFile();
@@ -233,7 +218,7 @@ void ColumnFileSetWithVectorIndexInputStream::load()
             auto sr = tiny_reader->load();
             for (auto & row : sr)
                 row.key += precedes_rows;
-            selected_rows.insert(selected_rows.end(), sr.begin(), sr.end());
+            search_results.insert(search_results.end(), sr.begin(), sr.end());
             tiny_readers.push_back(tiny_reader);
             // avoid virutal function call
             precedes_rows += tiny_file->getRows();
@@ -245,18 +230,26 @@ void ColumnFileSetWithVectorIndexInputStream::load()
         }
     }
     // Keep the top k minimum distances rows.
-    auto select_size = selected_rows.size() > ann_query_info->top_k() ? ann_query_info->top_k() : selected_rows.size();
-    auto top_k_end = selected_rows.begin() + select_size;
-    std::nth_element(selected_rows.begin(), top_k_end, selected_rows.end(), [](const auto & lhs, const auto & rhs) {
+    auto select_size
+        = search_results.size() > ann_query_info->top_k() ? ann_query_info->top_k() : search_results.size();
+    auto top_k_end = search_results.begin() + select_size;
+    std::nth_element(search_results.begin(), top_k_end, search_results.end(), [](const auto & lhs, const auto & rhs) {
         return lhs.distance < rhs.distance;
     });
-    selected_rows.resize(select_size);
+    search_results.resize(select_size);
     // Sort by key again.
-    std::sort(selected_rows.begin(), selected_rows.end(), [](const auto & lhs, const auto & rhs) {
+    std::sort(search_results.begin(), search_results.end(), [](const auto & lhs, const auto & rhs) {
         return lhs.key < rhs.key;
     });
 
     loaded = true;
+    return search_results;
+}
+
+void ColumnFileSetWithVectorIndexInputStream::setSelectedRows(const std::span<const UInt32> & selected_rows)
+{
+    sorted_results.reserve(selected_rows.size());
+    std::copy(selected_rows.begin(), selected_rows.end(), std::back_inserter(sorted_results));
 }
 
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSetWithVectorIndexInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSetWithVectorIndexInputStream.h
@@ -20,14 +20,20 @@
 #include <Storages/DeltaMerge/ColumnFile/ColumnFileTinyVectorIndexReader.h>
 #include <Storages/DeltaMerge/DMContext.h>
 #include <Storages/DeltaMerge/Filter/RSOperator.h>
+#include <Storages/DeltaMerge/VectorIndexBlockInputStream.h>
 
 
 namespace DB::DM
 {
 
-class ColumnFileSetWithVectorIndexInputStream : public ColumnFileSetInputStream
+class ColumnFileSetWithVectorIndexInputStream : public VectorIndexBlockInputStream
 {
 private:
+    ColumnFileSetReader reader;
+
+    std::vector<ColumnFileReaderPtr>::iterator cur_column_file_reader;
+    size_t read_rows = 0;
+
     const IColumnFileDataProviderPtr data_provider;
     const ANNQueryInfoPtr ann_query_info;
     const BitmapFilterView valid_rows;
@@ -37,7 +43,7 @@ private:
     const ColumnDefinesPtr rest_col_defs;
 
     // Set after load(). Top K search results in files with vector index.
-    std::vector<VectorIndexViewer::SearchResult> selected_rows;
+    std::vector<VectorIndexViewer::Key> sorted_results;
     std::vector<ColumnFileTinyVectorIndexReaderPtr> tiny_readers;
 
     ColumnFiles & column_files;
@@ -59,7 +65,7 @@ public:
         ColumnDefine && vec_cd_,
         const ColumnDefinesPtr & rest_col_defs_,
         ReadTag read_tag_)
-        : ColumnFileSetInputStream(context_, delta_snap_, col_defs_, segment_range_, read_tag_)
+        : reader(context_, delta_snap_, col_defs_, segment_range_, read_tag_)
         , data_provider(data_provider_)
         , ann_query_info(ann_query_info_)
         , valid_rows(std::move(valid_rows_))
@@ -67,26 +73,39 @@ public:
         , vec_cd(std::move(vec_cd_))
         , rest_col_defs(rest_col_defs_)
         , column_files(reader.snapshot->getColumnFiles())
-        , header(getHeader())
-    {}
+        , header(toEmptyBlock(*(reader.col_defs)))
+    {
+        cur_column_file_reader = reader.column_file_readers.begin();
+    }
 
-    static ColumnFileSetInputStreamPtr tryBuild(
+    static SkippableBlockInputStreamPtr tryBuild(
         const DMContext & context,
         const ColumnFileSetSnapshotPtr & delta_snap,
         const ColumnDefinesPtr & col_defs,
         const RowKeyRange & segment_range_,
         const IColumnFileDataProviderPtr & data_provider,
-        const RSOperatorPtr & rs_operator,
+        const ANNQueryInfoPtr & ann_query_info,
         const BitmapFilterPtr & bitmap_filter,
         size_t offset,
         ReadTag read_tag_);
 
     String getName() const override { return "ColumnFileSetWithVectorIndex"; }
+    Block getHeader() const override { return header; }
+
+    Block read() override
+    {
+        FilterPtr filter = nullptr;
+        return read(filter, false);
+    }
 
     // When all rows in block are not filtered out,
     // `res_filter` will be set to null.
     // The caller needs to do handle this situation.
     Block read(FilterPtr & res_filter, bool return_filter) override;
+
+    std::vector<VectorIndexViewer::SearchResult> load() override;
+
+    void setSelectedRows(const std::span<const UInt32> & selected_rows) override;
 
 private:
     Block readImpl(FilterPtr & res_filter);
@@ -94,8 +113,6 @@ private:
     Block readOtherColumns();
 
     void toNextFile(size_t current_file_index, size_t current_file_rows);
-
-    void load();
 };
 
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileTinyVectorIndexReader.h
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileTinyVectorIndexReader.h
@@ -80,7 +80,7 @@ public:
     // others will be filled with default values.
     void read(
         MutableColumnPtr & vec_column,
-        const std::span<const VectorIndexViewer::SearchResult> & read_rowids,
+        const std::span<const VectorIndexViewer::Key> & read_rowids,
         size_t rowid_start_offset,
         size_t read_rows);
 

--- a/dbms/src/Storages/DeltaMerge/ConcatSkippableBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/ConcatSkippableBlockInputStream.cpp
@@ -200,7 +200,7 @@ void ConcatVectorIndexBlockInputStream::load()
     std::vector<VectorIndexViewer::SearchResult> search_results;
     for (size_t i = 0; i < stream->children.size(); ++i)
     {
-        if (auto * index_stream = dynamic_cast<VectorIndexBlockInputStream *>(children[i].get()); index_stream)
+        if (auto * index_stream = dynamic_cast<VectorIndexBlockInputStream *>(stream->children[i].get()); index_stream)
         {
             auto sr = index_stream->load();
             for (auto & row : sr)
@@ -233,7 +233,7 @@ void ConcatVectorIndexBlockInputStream::load()
         // Convert to local offset.
         for (auto it = begin; it != end; ++it)
             *it -= precedes_rows;
-        if (auto * index_stream = dynamic_cast<VectorIndexBlockInputStream *>(children[i].get()); index_stream)
+        if (auto * index_stream = dynamic_cast<VectorIndexBlockInputStream *>(stream->children[i].get()); index_stream)
             index_stream->setSelectedRows({begin, end});
         else
             RUNTIME_CHECK(begin == end);

--- a/dbms/src/Storages/DeltaMerge/ConcatSkippableBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/ConcatSkippableBlockInputStream.h
@@ -1,0 +1,73 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <Flash/ResourceControl/LocalAdmissionController.h>
+#include <Storages/DeltaMerge/ScanContext_fwd.h>
+#include <Storages/DeltaMerge/SkippableBlockInputStream.h>
+
+namespace DB::DM
+{
+
+template <bool need_row_id = false>
+class ConcatSkippableBlockInputStream : public SkippableBlockInputStream
+{
+public:
+    ConcatSkippableBlockInputStream(SkippableBlockInputStreams inputs_, const ScanContextPtr & scan_context_);
+
+    ConcatSkippableBlockInputStream(
+        SkippableBlockInputStreams inputs_,
+        std::vector<size_t> && rows_,
+        const ScanContextPtr & scan_context_);
+
+    void appendChild(SkippableBlockInputStreamPtr child, size_t rows_);
+
+    String getName() const override { return "ConcatSkippable"; }
+
+    Block getHeader() const override { return children.at(0)->getHeader(); }
+
+    bool getSkippedRows(size_t & skip_rows) override;
+
+    size_t skipNextBlock() override;
+
+    Block readWithFilter(const IColumn::Filter & filter) override;
+
+    Block read() override
+    {
+        FilterPtr filter = nullptr;
+        return read(filter, false);
+    }
+
+    Block read(FilterPtr & res_filter, bool return_filter) override;
+
+    void setTopK(UInt32 topk_) { topk = topk_; }
+
+private:
+    void load();
+
+    ColumnPtr createSegmentRowIdCol(UInt64 start, UInt64 limit);
+
+    void addReadBytes(UInt64 bytes);
+
+    BlockInputStreams::iterator current_stream;
+    std::vector<size_t> rows;
+    size_t precede_stream_rows;
+    const ScanContextPtr scan_context;
+    LACBytesCollector lac_bytes_collector;
+    UInt32 topk = 0;
+    bool loaded = false;
+};
+
+} // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/ConcatSkippableBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/ConcatSkippableBlockInputStream.h
@@ -113,6 +113,7 @@ private:
     void load();
 
     std::shared_ptr<ConcatSkippableBlockInputStream<false>> stream;
+    // Pointers to stream's children, nullptr if the child is not a VectorIndexBlockInputStream.
     std::vector<VectorIndexBlockInputStream *> index_streams;
     UInt32 topk = 0;
     bool loaded = false;

--- a/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.cpp
@@ -140,7 +140,7 @@ SkippableBlockInputStreamPtr DMFileBlockInputStreamBuilder::tryBuildWithVectorIn
         return build(dmfile, read_columns, rowkey_ranges, scan_context);
     };
 
-    if (rs_filter == nullptr)
+    if (!rs_filter)
         return fallback();
 
     // Fast Scan and Clean Read does not affect our behavior. (TODO(vector-index): Confirm?)
@@ -148,11 +148,11 @@ SkippableBlockInputStreamPtr DMFileBlockInputStreamBuilder::tryBuildWithVectorIn
     //    return fallback();
 
     auto filter_with_ann = std::dynamic_pointer_cast<WithANNQueryInfo>(rs_filter);
-    if (filter_with_ann == nullptr)
+    if (!filter_with_ann)
         return fallback();
 
     auto ann_query_info = filter_with_ann->ann_query_info;
-    if (!ann_query_info || ann_query_info->top_k() == std::numeric_limits<UInt32>::max())
+    if (!ann_query_info)
         return fallback();
 
     if (!bitmap_filter.has_value())

--- a/dbms/src/Storages/DeltaMerge/File/DMFileVectorIndexReader.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileVectorIndexReader.h
@@ -83,13 +83,13 @@ public:
 
     // Load vector index and search results.
     // Return the rowids of the selected rows.
-    std::vector<VectorIndexViewer::Key> load();
+    std::vector<VectorIndexViewer::SearchResult> load();
 
     String perfStat() const;
 
 private:
     void loadVectorIndex();
-    std::vector<VectorIndexViewer::Key> loadVectorSearchResult();
+    std::vector<VectorIndexViewer::SearchResult> loadVectorSearchResult();
 };
 
 using DMFileVectorIndexReaderPtr = std::shared_ptr<DMFileVectorIndexReader>;

--- a/dbms/src/Storages/DeltaMerge/File/DMFileWithVectorIndexBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileWithVectorIndexBlockInputStream.cpp
@@ -86,7 +86,7 @@ Block DMFileWithVectorIndexBlockInputStream::read(FilterPtr & res_filter, bool r
 
 Block DMFileWithVectorIndexBlockInputStream::readImpl(FilterPtr & res_filter)
 {
-    load();
+    internalLoad();
 
     auto [res, real_rows] = reader.read_columns.empty() ? readByIndexReader() : readByFollowingOtherColumns();
 
@@ -208,12 +208,30 @@ std::tuple<Block, size_t> DMFileWithVectorIndexBlockInputStream::readByFollowing
     return {block_others, block_selected_rows.size()};
 }
 
-void DMFileWithVectorIndexBlockInputStream::load()
+std::vector<VectorIndexViewer::SearchResult> DMFileWithVectorIndexBlockInputStream::load()
+{
+    if (loaded)
+        return {};
+
+    auto search_results = vec_index_reader->load();
+    return search_results;
+}
+
+void DMFileWithVectorIndexBlockInputStream::internalLoad()
 {
     if (loaded)
         return;
 
-    sorted_results = vec_index_reader->load();
+    auto search_results = vec_index_reader->load();
+    sorted_results.reserve(search_results.size());
+    for (const auto & row : search_results)
+        sorted_results.push_back(row.key);
+
+    updateRSResult();
+}
+
+void DMFileWithVectorIndexBlockInputStream::updateRSResult()
+{
     // Vector index is very likely to filter out some packs. For example,
     // if we query for Top 1, then only 1 pack will be remained. So we
     // update the pack filter used by the DMFileReader to avoid reading
@@ -250,6 +268,15 @@ void DMFileWithVectorIndexBlockInputStream::load()
         "All packs has been visited but not all results are consumed");
 
     loaded = true;
+}
+
+void DMFileWithVectorIndexBlockInputStream::setSelectedRows(const std::span<const UInt32> & selected_rows)
+{
+    sorted_results.clear();
+    sorted_results.reserve(selected_rows.size());
+    std::copy(selected_rows.begin(), selected_rows.end(), std::back_inserter(sorted_results));
+
+    updateRSResult();
 }
 
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/Filter/RSOperator.cpp
+++ b/dbms/src/Storages/DeltaMerge/Filter/RSOperator.cpp
@@ -99,4 +99,14 @@ RSOperatorPtr wrapWithANNQueryInfo(const RSOperatorPtr & op, const ANNQueryInfoP
     return std::make_shared<WithANNQueryInfo>(op, ann_query_info);
 }
 
+ANNQueryInfoPtr getANNQueryInfo(const RSOperatorPtr & op)
+{
+    if (op == nullptr)
+        return nullptr;
+    auto with_ann = std::dynamic_pointer_cast<WithANNQueryInfo>(op);
+    if (with_ann == nullptr)
+        return nullptr;
+    return with_ann->ann_query_info;
+}
+
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/Filter/RSOperator.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/RSOperator.h
@@ -166,7 +166,10 @@ RSOperatorPtr createIsNull(const Attr & attr);
 //
 RSOperatorPtr createUnsupported(const String & reason);
 
-/// Wrap with a ANNQueryInfo
+// Wrap with a ANNQueryInfo
 RSOperatorPtr wrapWithANNQueryInfo(const RSOperatorPtr & op, const ANNQueryInfoPtr & ann_query_info);
+
+// Get ANNQueryInfo from RSOperator
+ANNQueryInfoPtr getANNQueryInfo(const RSOperatorPtr & op);
 
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/Filter/WithANNQueryInfo.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/WithANNQueryInfo.h
@@ -31,7 +31,9 @@ public:
     explicit WithANNQueryInfo(const RSOperatorPtr & child_, const ANNQueryInfoPtr & ann_query_info_)
         : child(child_)
         , ann_query_info(ann_query_info_)
-    {}
+    {
+        RUNTIME_CHECK(ann_query_info != nullptr);
+    }
 
     String name() override { return "ann"; }
 

--- a/dbms/src/Storages/DeltaMerge/Index/VectorIndex.h
+++ b/dbms/src/Storages/DeltaMerge/Index/VectorIndex.h
@@ -96,11 +96,7 @@ public:
     virtual ~VectorIndexViewer() = default;
 
     // Invalid rows in `valid_rows` will be discared when applying the search
-    virtual std::vector<Key> search(const ANNQueryInfoPtr & queryInfo, const RowFilter & valid_rows) const = 0;
-    virtual std::vector<SearchResult> searchWithDistance(
-        const ANNQueryInfoPtr & query_info,
-        const RowFilter & valid_rows) const
-        = 0;
+    virtual std::vector<SearchResult> search(const ANNQueryInfoPtr & queryInfo, const RowFilter & valid_rows) const = 0;
 
     virtual size_t size() const = 0;
 

--- a/dbms/src/Storages/DeltaMerge/Index/VectorIndexHNSW/Index.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/VectorIndexHNSW/Index.cpp
@@ -308,27 +308,7 @@ auto VectorIndexHNSWViewer::searchImpl(const ANNQueryInfoPtr & query_info, const
     return result;
 }
 
-std::vector<VectorIndexViewer::Key> VectorIndexHNSWViewer::search(
-    const ANNQueryInfoPtr & query_info,
-    const RowFilter & valid_rows) const
-{
-    auto result = searchImpl(query_info, valid_rows);
-
-    // For some reason usearch does not always do the predicate for all search results.
-    // So we need to filter again.
-    const size_t result_size = result.size();
-    std::vector<Key> keys;
-    keys.reserve(result_size);
-    for (size_t i = 0; i < result_size; ++i)
-    {
-        const auto rowid = result[i].member.key;
-        if (valid_rows[rowid])
-            keys.push_back(rowid);
-    }
-    return keys;
-}
-
-std::vector<VectorIndexViewer::SearchResult> VectorIndexHNSWViewer::searchWithDistance(
+std::vector<VectorIndexViewer::SearchResult> VectorIndexHNSWViewer::search(
     const ANNQueryInfoPtr & query_info,
     const RowFilter & valid_rows) const
 {

--- a/dbms/src/Storages/DeltaMerge/Index/VectorIndexHNSW/Index.h
+++ b/dbms/src/Storages/DeltaMerge/Index/VectorIndexHNSW/Index.h
@@ -58,10 +58,7 @@ public:
 
     ~VectorIndexHNSWViewer() override;
 
-    std::vector<Key> search(const ANNQueryInfoPtr & query_info, const RowFilter & valid_rows) const override;
-
-    std::vector<SearchResult> searchWithDistance(const ANNQueryInfoPtr & query_info, const RowFilter & valid_rows)
-        const override;
+    std::vector<SearchResult> search(const ANNQueryInfoPtr & query_info, const RowFilter & valid_rows) const override;
 
     size_t size() const override;
 

--- a/dbms/src/Storages/DeltaMerge/Segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/Segment.cpp
@@ -3347,8 +3347,9 @@ SkippableBlockInputStreamPtr Segment::getConcatSkippableBlockInputStream(
     assert(stream != nullptr);
     stream->appendChild(persisted_files_stream, persisted_files->getRows());
     stream->appendChild(mem_table_stream, memtable->getRows());
+
     if (ann_query_info)
-        stream->setTopK(ann_query_info->top_k());
+        return std::make_shared<ConcatVectorIndexBlockInputStream>(stream, ann_query_info->top_k());
     return stream;
 }
 

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTask.cpp
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTask.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <Common/CurrentMetrics.h>
+#include <Common/TiFlashMetrics.h>
 #include <IO/IOThreadPools.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/SharedContexts/Disagg.h>

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTask.h
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTask.h
@@ -21,6 +21,7 @@
 #include <Storages/DeltaMerge/RowKeyRange.h>
 #include <Storages/DeltaMerge/Segment.h>
 #include <Storages/KVStore/Types.h>
+#include <grpcpp/support/sync_stream.h>
 
 namespace DB::DM
 {

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.h
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.h
@@ -15,11 +15,13 @@
 #pragma once
 #include <Common/MemoryTrackerSetter.h>
 #include <Flash/Pipeline/Schedule/Tasks/NotifyFuture.h>
+#include <Flash/ResourceControl/LocalAdmissionController.h>
 #include <Storages/DeltaMerge/DMContext_fwd.h>
 #include <Storages/DeltaMerge/Filter/PushDownFilter.h>
 #include <Storages/DeltaMerge/ReadMode.h>
 #include <Storages/DeltaMerge/ReadThread/WorkQueue.h>
 #include <Storages/DeltaMerge/SegmentReadTask.h>
+
 
 namespace DB::DM
 {

--- a/dbms/src/Storages/DeltaMerge/SkippableBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/SkippableBlockInputStream.h
@@ -14,18 +14,15 @@
 
 #pragma once
 
-#include <Columns/ColumnsNumber.h>
 #include <Core/Block.h>
 #include <DataStreams/IBlockInputStream.h>
-#include <Flash/ResourceControl/LocalAdmissionController.h>
 #include <Storages/DeltaMerge/DeltaMergeDefines.h>
 #include <Storages/DeltaMerge/DeltaMergeHelpers.h>
-#include <Storages/DeltaMerge/ScanContext_fwd.h>
 
-namespace DB
+
+namespace DB::DM
 {
-namespace DM
-{
+
 class SkippableBlockInputStream : public IBlockInputStream
 {
 public:
@@ -72,50 +69,4 @@ private:
     ColumnDefines read_columns;
 };
 
-template <bool need_row_id = false>
-class ConcatSkippableBlockInputStream : public SkippableBlockInputStream
-{
-public:
-    ConcatSkippableBlockInputStream(SkippableBlockInputStreams inputs_, const ScanContextPtr & scan_context_);
-
-    ConcatSkippableBlockInputStream(
-        SkippableBlockInputStreams inputs_,
-        std::vector<size_t> && rows_,
-        const ScanContextPtr & scan_context_);
-
-    void appendChild(SkippableBlockInputStreamPtr child, size_t rows_);
-
-    String getName() const override { return "ConcatSkippable"; }
-
-    Block getHeader() const override { return children.at(0)->getHeader(); }
-
-    bool getSkippedRows(size_t & skip_rows) override;
-
-    size_t skipNextBlock() override;
-
-    Block readWithFilter(const IColumn::Filter & filter) override;
-
-    Block read() override
-    {
-        FilterPtr filter = nullptr;
-        return read(filter, false);
-    }
-
-    Block read(FilterPtr & res_filter, bool return_filter) override;
-
-private:
-    ColumnPtr createSegmentRowIdCol(UInt64 start, UInt64 limit);
-
-    void addReadBytes(UInt64 bytes);
-
-    BlockInputStreams::iterator current_stream;
-    std::vector<size_t> rows;
-    size_t precede_stream_rows;
-    const ScanContextPtr scan_context;
-    LACBytesCollector lac_bytes_collector;
-};
-
-using ConcatSkippableBlockInputStreamPtr = std::shared_ptr<ConcatSkippableBlockInputStream</*need_row_id*/ false>>;
-
-} // namespace DM
-} // namespace DB
+} // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/StableValueSpace.cpp
+++ b/dbms/src/Storages/DeltaMerge/StableValueSpace.cpp
@@ -14,6 +14,7 @@
 
 #include <Interpreters/Context.h>
 #include <Interpreters/SharedContexts/Disagg.h>
+#include <Storages/DeltaMerge/ConcatSkippableBlockInputStream.h>
 #include <Storages/DeltaMerge/DMVersionFilterBlockInputStream.h>
 #include <Storages/DeltaMerge/File/DMFile.h>
 #include <Storages/DeltaMerge/File/DMFileBlockInputStream.h>

--- a/dbms/src/Storages/DeltaMerge/VectorIndexBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/VectorIndexBlockInputStream.h
@@ -1,0 +1,55 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <Storages/DeltaMerge/Index/VectorIndex.h>
+#include <Storages/DeltaMerge/SkippableBlockInputStream.h>
+
+
+namespace DB::DM
+{
+
+class VectorIndexBlockInputStream : public SkippableBlockInputStream
+{
+public:
+    bool getSkippedRows(size_t &) override
+    {
+        RUNTIME_CHECK_MSG(false, "DMFileWithVectorIndexBlockInputStream does not support getSkippedRows");
+    }
+
+    size_t skipNextBlock() override
+    {
+        RUNTIME_CHECK_MSG(false, "DMFileWithVectorIndexBlockInputStream does not support skipNextBlock");
+    }
+
+    Block readWithFilter(const IColumn::Filter &) override
+    {
+        // We don't support the normal late materialization, because
+        // we are already doing it.
+        RUNTIME_CHECK_MSG(false, "DMFileWithVectorIndexBlockInputStream does not support late materialization");
+    }
+
+    // Load vector index and search results.
+    // Return the rowids of the selected rows.
+    virtual std::vector<VectorIndexViewer::SearchResult> load() = 0;
+
+    // Set the real selected rows offset (local offset). This is used to update Packs/ColumnFiles to read.
+    // For example, DMFile should update DMFilePackFilter, only packs with selected rows will be read.
+    virtual void setSelectedRows(const std::span<const UInt32> & selected_rows) = 0;
+};
+
+using VectorIndexBlockInputStreamPtr = std::shared_ptr<VectorIndexBlockInputStream>;
+
+} // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_vector_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_vector_index.cpp
@@ -247,22 +247,20 @@ try
 
     // read with ANN query
     {
-        ann_query_info->set_top_k(1);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({72.0}));
+        ann_query_info->set_top_k(2);
+        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({127.5}));
 
         auto filter = std::make_shared<PushDownFilter>(wrapWithANNQueryInfo(nullptr, ann_query_info));
-        // stable 72.0, delta 128.0
-        read(range, filter, createVecFloat32Column<Array>({{72.0}, {128.0}}));
+        read(range, filter, createVecFloat32Column<Array>({{127.0}, {128.0}}));
     }
 
     // read with ANN query
     {
-        ann_query_info->set_top_k(1);
+        ann_query_info->set_top_k(2);
         ann_query_info->set_ref_vec_f32(encodeVectorFloat32({72.1}));
 
         auto filter = std::make_shared<PushDownFilter>(wrapWithANNQueryInfo(nullptr, ann_query_info));
-        // stable 72.0, delta 128.0
-        read(range, filter, createVecFloat32Column<Array>({{72.0}, {128.0}}));
+        read(range, filter, createVecFloat32Column<Array>({{72.0}, {73.0}}));
     }
 }
 CATCH
@@ -309,10 +307,10 @@ try
     // read with ANN query
     {
         ann_query_info->set_top_k(2);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({172.1}));
+        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({127.5}));
 
         auto filter = std::make_shared<PushDownFilter>(wrapWithANNQueryInfo(nullptr, ann_query_info));
-        read(range, filter, createVecFloat32Column<Array>({{172.0}, {173.0}}));
+        read(range, filter, createVecFloat32Column<Array>({{127.0}, {128.0}}));
     }
 }
 CATCH
@@ -842,7 +840,7 @@ try
 
         auto filter = std::make_shared<PushDownFilter>(wrapWithANNQueryInfo(nullptr, ann_query_info));
 
-        read(range, filter, createVecFloat32Column<Array>({{2.0}, {128.0}}));
+        read(range, filter, createVecFloat32Column<Array>({{2.0}}));
     }
 
     // read with ANN query
@@ -852,7 +850,7 @@ try
 
         auto filter = std::make_shared<PushDownFilter>(wrapWithANNQueryInfo(nullptr, ann_query_info));
 
-        read(range, filter, createVecFloat32Column<Array>({{127.0}, {222.0}}));
+        read(range, filter, createVecFloat32Column<Array>({{222.0}}));
     }
 }
 CATCH
@@ -929,7 +927,7 @@ try
 
         auto filter = std::make_shared<PushDownFilter>(wrapWithANNQueryInfo(nullptr, ann_query_info));
 
-        read(range, filter, createVecFloat32Column<Array>({{2.0}, {128.0}}));
+        read(range, filter, createVecFloat32Column<Array>({{2.0}}));
     }
 
     // read with ANN query
@@ -939,7 +937,7 @@ try
 
         auto filter = std::make_shared<PushDownFilter>(wrapWithANNQueryInfo(nullptr, ann_query_info));
 
-        read(range, filter, createVecFloat32Column<Array>({{127.0}, {222.0}}));
+        read(range, filter, createVecFloat32Column<Array>({{222.0}}));
     }
 
     {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #9600 , close #9599

Problem Summary:

### What is changed and how it works?

Before, the read path of vector search is:

1. load stable vector index.
2. read all packs that contain TopK results.
3. load all ColumnFileTiny vector index.
4. read all ColumnFileTiny that contain TopK results.
5. read Memtable.

A simple example:

We have cf_0 (indexed, offset: 100-110), cf_1 (indexed, offset: 110-120), cf_3 (indexed, offset: 120-130), cf_4 (memtable, offset: 130-140), dmfile_0 (indexed, offset: 0-100, each 10 rows as a pack), to find top5:

1.  load stable vector index: top5 is [0, 10, 13, 25, 99]
2. read all packs that contain TopK results: read pack_0, pack_1, pack_2, pack_9
3. load all ColumnFileTiny vector index: top5 is [100, 101, 115, 116, 119]
4. read all ColumnFileTiny that contain TopK results: read cf_0, cf_1
5. read Memtable: read cf_4.

So, in this example, we need to read 3 packs and 3 ColumnFileTinys.

This PR changes the read path to: 

1. load stable vector index and all ColumnFileTiny vector index.
2. read all packs that contain TopK results.
3. read all ColumnFileTiny that contain TopK results.
4. read Memtable.

Still using the above example, now to find top5:

1. load stable vector index and all ColumnFileTiny vector index: top5 is [0, 10, 13, 100, 101]
2. read all packs that contain TopK results: read pack_0, pack_1
3. read all ColumnFileTiny that contain TopK results: read cf_0
4. read Memtable: read cf_4

Now, we only need to read 2 packs and 2 ColumnFileTinys.


#### Benchmark

Run [VectorDBBench](https://github.com/wd0517/VectorDBBench), about 750k stable, 250k delta with vector index, 4k delta without vector index.

Note: should disable compact tiflash replica

```diff
diff --git a/vectordb_bench/backend/clients/tidb_serverless/tidb.py b/vectordb_bench/backend/clients/tidb_serverless/tidb.py
index b927568..fe9d5e3 100644
--- a/vectordb_bench/backend/clients/tidb_serverless/tidb.py
+++ b/vectordb_bench/backend/clients/tidb_serverless/tidb.py
@@ -104,9 +104,9 @@ class TiDBServeless(VectorDB):
             else:
                 break
 
-        log.info("Begin compact tiflash replica")
-        self._compact_tiflash()
-        log.info("Successful compacted tiflash replica")
+        # log.info("Begin compact tiflash replica")
+        # self._compact_tiflash()
+        # log.info("Successful compacted tiflash replica")
 
         log_reduce_seq = 0
         while True:
```

**Without this PR (after fix #9599)**

```json
"metrics": {
    "max_load_count": 0,
    "load_duration": 747.9345,
    "qps": 71.4146,
    "serial_latency_p99": 0.1081,
    "recall": 0.9327
}
```

**With this PR**

```json
"metrics": {
    "max_load_count": 0,
    "load_duration": 778.9001,
    "qps": 125.046,
    "serial_latency_p99": 0.0851,
    "recall": 0.931
}
```

**All data are in stable**

```json
"metrics": {
    "max_load_count": 0,
    "load_duration": 0.0,
    "qps": 205.3793,
    "serial_latency_p99": 0.0282,
    "recall": 0.9016
}
```

```commit-message
Improve 75% the performance of vector search in scenarios with updates.
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
