### PR TITLE
Fix the fail start of tiflash because of the zero division when getting cpu number

### DIFF
--- a/dbms/src/Common/getNumberOfCPUCores.cpp
+++ b/dbms/src/Common/getNumberOfCPUCores.cpp
@@ -46,6 +46,8 @@ void computeAndSetNumberOfPhysicalCPUCores(
     UInt16 number_of_logical_cpu_cores_,
     UInt16 number_of_hardware_physical_cores)
 {
+    number_of_hardware_physical_cores = std::max<UInt16>(1, number_of_hardware_physical_cores);
+
     // First of all, we need to take consideration of two situation:
     //   1. tiflash on physical machine.
     //      In old codes, tiflash needs to set max_threads which is equal to
@@ -62,8 +64,11 @@ void computeAndSetNumberOfPhysicalCPUCores(
     // - `(hardware_logical_cpu_cores / number_of_hardware_physical_cores)` means how many logical cpu core a physical cpu core has.
     // - `number_of_logical_cpu_cores_ / (hardware_logical_cpu_cores / number_of_hardware_physical_cores)` means how many physical cpu cores the tiflash process could use. (Actually, it's needless to get physical cpu cores in virtual environment, but we must ensure the behavior `1` is not broken)
     auto hardware_logical_cpu_cores = std::thread::hardware_concurrency();
-    UInt16 physical_cpu_cores
-        = number_of_logical_cpu_cores_ / (hardware_logical_cpu_cores / number_of_hardware_physical_cores);
+
+    UInt16 cpu_num_per_physical_core = hardware_logical_cpu_cores / number_of_hardware_physical_cores;
+    cpu_num_per_physical_core = std::max<UInt16>(1, cpu_num_per_physical_core);
+
+    UInt16 physical_cpu_cores = number_of_logical_cpu_cores_ / cpu_num_per_physical_core;
     CPUCores::number_of_physical_cpu_cores = physical_cpu_cores > 0 ? physical_cpu_cores : 1;
     LOG_INFO(
         DB::Logger::get(),

--- a/dbms/src/Common/getNumberOfCPUCores.cpp
+++ b/dbms/src/Common/getNumberOfCPUCores.cpp
@@ -65,10 +65,10 @@ void computeAndSetNumberOfPhysicalCPUCores(
     // - `number_of_logical_cpu_cores_ / (hardware_logical_cpu_cores / number_of_hardware_physical_cores)` means how many physical cpu cores the tiflash process could use. (Actually, it's needless to get physical cpu cores in virtual environment, but we must ensure the behavior `1` is not broken)
     auto hardware_logical_cpu_cores = std::thread::hardware_concurrency();
 
-    UInt16 cpu_num_per_physical_core = hardware_logical_cpu_cores / number_of_hardware_physical_cores;
-    cpu_num_per_physical_core = std::max<UInt16>(1, cpu_num_per_physical_core);
+    UInt16 thread_num_per_physical_core = hardware_logical_cpu_cores / number_of_hardware_physical_cores;
+    thread_num_per_physical_core = std::max<UInt16>(1, thread_num_per_physical_core);
 
-    UInt16 physical_cpu_cores = number_of_logical_cpu_cores_ / cpu_num_per_physical_core;
+    UInt16 physical_cpu_cores = number_of_logical_cpu_cores_ / thread_num_per_physical_core;
     CPUCores::number_of_physical_cpu_cores = physical_cpu_cores > 0 ? physical_cpu_cores : 1;
     LOG_INFO(
         DB::Logger::get(),

--- a/dbms/src/Common/tests/gtest_miscellaneous.cpp
+++ b/dbms/src/Common/tests/gtest_miscellaneous.cpp
@@ -1,0 +1,46 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <TestUtils/TiFlashTestBasic.h>
+#include <Common/getNumberOfCPUCores.h>
+
+namespace DB
+{
+namespace tests
+{
+
+TEST(CommonMiscellaneousTest, cpuRelated)
+{
+    auto hardware_logical_cpu_cores = std::thread::hardware_concurrency();
+    UInt16 number_of_logical_cpu_cores = std::thread::hardware_concurrency();
+
+    computeAndSetNumberOfPhysicalCPUCores(number_of_logical_cpu_cores, hardware_logical_cpu_cores);
+    ASSERT_EQ(getNumberOfPhysicalCPUCores(), hardware_logical_cpu_cores);
+    
+    computeAndSetNumberOfPhysicalCPUCores(number_of_logical_cpu_cores, 0);
+    ASSERT_EQ(1, getNumberOfPhysicalCPUCores());
+
+    UInt16 test_num = 123;
+    computeAndSetNumberOfPhysicalCPUCores(test_num, hardware_logical_cpu_cores * 2);
+    ASSERT_EQ(test_num, getNumberOfPhysicalCPUCores());
+
+    computeAndSetNumberOfPhysicalCPUCores(1, hardware_logical_cpu_cores * 2);
+    ASSERT_EQ(1, getNumberOfPhysicalCPUCores());
+
+    computeAndSetNumberOfPhysicalCPUCores(0, hardware_logical_cpu_cores);
+    ASSERT_EQ(1, getNumberOfPhysicalCPUCores());
+}
+
+} // namespace tests
+} // namespace DB

--- a/dbms/src/Common/tests/gtest_miscellaneous.cpp
+++ b/dbms/src/Common/tests/gtest_miscellaneous.cpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <TestUtils/TiFlashTestBasic.h>
 #include <Common/getNumberOfCPUCores.h>
+#include <TestUtils/TiFlashTestBasic.h>
 
 namespace DB
 {
@@ -27,7 +27,7 @@ TEST(CommonMiscellaneousTest, cpuRelated)
 
     computeAndSetNumberOfPhysicalCPUCores(number_of_logical_cpu_cores, hardware_logical_cpu_cores);
     ASSERT_EQ(getNumberOfPhysicalCPUCores(), hardware_logical_cpu_cores);
-    
+
     computeAndSetNumberOfPhysicalCPUCores(number_of_logical_cpu_cores, 0);
     ASSERT_EQ(1, getNumberOfPhysicalCPUCores());
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9212

Problem Summary:

### What is changed and how it works?

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix the that fail to start tiflash because of the zero division when getting cpu number
```
