### PR TITLE
Storage: Refine the snapshot creation on DeltaValueSpace

### DIFF
--- a/dbms/src/DataStreams/RuntimeFilter.h
+++ b/dbms/src/DataStreams/RuntimeFilter.h
@@ -17,7 +17,7 @@
 #include <Columns/IColumn.h>
 #include <Interpreters/Set.h>
 #include <Storages/DeltaMerge/DeltaMergeDefines.h>
-#include <Storages/DeltaMerge/Filter/RSOperator.h>
+#include <Storages/DeltaMerge/Filter/RSOperator_fwd.h>
 #include <tipb/executor.pb.h>
 
 namespace DB

--- a/dbms/src/Flash/Mpp/tests/gtest_mpp_exchange_writer.cpp
+++ b/dbms/src/Flash/Mpp/tests/gtest_mpp_exchange_writer.cpp
@@ -25,6 +25,7 @@
 #include <DataTypes/DataTypeFixedString.h>
 #include <DataTypes/DataTypeNothing.h>
 #include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypeTuple.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <Flash/Coprocessor/CHBlockChunkCodec.h>

--- a/dbms/src/Operators/DMSegmentThreadSourceOp.h
+++ b/dbms/src/Operators/DMSegmentThreadSourceOp.h
@@ -21,8 +21,6 @@
 
 namespace DB
 {
-class RSOperator;
-using RSOperatorPtr = std::shared_ptr<RSOperator>;
 
 class DMSegmentThreadSourceOp : public SourceOp
 {

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSetSnapshot.h
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSetSnapshot.h
@@ -59,10 +59,10 @@ class ColumnFileSetSnapshot
     friend struct Remote::Serializer;
 
 private:
-    ColumnFiles column_files;
-    size_t rows{0};
-    size_t bytes{0};
-    size_t deletes{0};
+    const ColumnFiles column_files;
+    const size_t rows{0};
+    const size_t bytes{0};
+    const size_t deletes{0};
 
 public:
     /// This field is public writeable intentionally. It allows us to build a snapshot first,
@@ -72,23 +72,40 @@ public:
     /// Why we don't know the data provider at that time? Because when we have remote proto, data is not yet received.
     IColumnFileDataProviderPtr data_provider = nullptr;
 
-    explicit ColumnFileSetSnapshot(const IColumnFileDataProviderPtr & data_provider_)
-        : data_provider{data_provider_}
+    ColumnFileSetSnapshot(
+        const IColumnFileDataProviderPtr & data_provider_,
+        ColumnFiles && column_files_,
+        size_t rows_,
+        size_t bytes_,
+        size_t deletes_)
+        : column_files(std::move(column_files_))
+        , rows(rows_)
+        , bytes(bytes_)
+        , deletes(deletes_)
+        , data_provider{data_provider_}
     {}
+
+    static ColumnFileSetSnapshotPtr buildFromColumnFiles(
+        const IColumnFileDataProviderPtr & data_provider_,
+        ColumnFiles && column_files_)
+    {
+        size_t rows = 0, bytes = 0, deletes = 0;
+        for (const auto & column_file : column_files_)
+        {
+            rows += column_file->getRows();
+            bytes += column_file->getBytes();
+            deletes += column_file->getDeletes();
+        }
+        return std::make_shared<ColumnFileSetSnapshot>(data_provider_, std::move(column_files_), rows, bytes, deletes);
+    }
 
     ColumnFileSetSnapshotPtr clone()
     {
-        auto c = std::make_shared<ColumnFileSetSnapshot>(data_provider);
-        c->data_provider = data_provider;
-        c->column_files = column_files;
-        c->rows = rows;
-        c->bytes = bytes;
-        c->deletes = deletes;
-
-        return c;
+        ColumnFiles cf_copy = column_files;
+        return std::make_shared<ColumnFileSetSnapshot>(data_provider, std::move(cf_copy), rows, bytes, deletes);
     }
 
-    ColumnFiles & getColumnFiles() { return column_files; }
+    const ColumnFiles & getColumnFiles() const { return column_files; }
 
     size_t getColumnFileCount() const { return column_files.size(); }
     size_t getRows() const { return rows; }

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSetWithVectorIndexInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSetWithVectorIndexInputStream.h
@@ -46,7 +46,7 @@ private:
     std::vector<VectorIndexViewer::Key> sorted_results;
     std::vector<ColumnFileTinyVectorIndexReaderPtr> tiny_readers;
 
-    ColumnFiles & column_files;
+    const ColumnFiles & column_files;
 
     const Block header;
     IColumn::Filter filter;

--- a/dbms/src/Storages/DeltaMerge/DMSegmentThreadInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/DMSegmentThreadInputStream.h
@@ -30,8 +30,6 @@ extern const char pause_when_reading_from_dt_stream[];
 
 namespace DM
 {
-class RSOperator;
-using RSOperatorPtr = std::shared_ptr<RSOperator>;
 
 class DMSegmentThreadInputStream : public IProfilingBlockInputStream
 {

--- a/dbms/src/Storages/DeltaMerge/Delta/ColumnFilePersistedSet.cpp
+++ b/dbms/src/Storages/DeltaMerge/Delta/ColumnFilePersistedSet.cpp
@@ -25,10 +25,9 @@
 
 #include <ext/scope_guard.h>
 
-namespace DB
+namespace DB::DM
 {
-namespace DM
-{
+
 inline UInt64 serializeColumnFilePersisteds(WriteBuffer & buf, const ColumnFilePersisteds & persisted_files)
 {
     serializeSavedColumnFiles(buf, persisted_files);
@@ -403,24 +402,21 @@ bool ColumnFilePersistedSet::installCompactionResults(const MinorCompactionPtr &
 
 ColumnFileSetSnapshotPtr ColumnFilePersistedSet::createSnapshot(const IColumnFileDataProviderPtr & data_provider)
 {
-    auto snap = std::make_shared<ColumnFileSetSnapshot>(data_provider);
-    snap->rows = rows;
-    snap->bytes = bytes;
-    snap->deletes = deletes;
-
     size_t total_rows = 0;
     size_t total_deletes = 0;
+    ColumnFiles column_files;
+    column_files.reserve(persisted_files.size());
     for (const auto & file : persisted_files)
     {
         if (auto * t = file->tryToTinyFile(); (t && t->getCache()))
         {
             // Compact threads could update the value of ColumnTinyFile::cache,
             // and since ColumnFile is not multi-threads safe, we should create a new column file object.
-            snap->column_files.push_back(std::make_shared<ColumnFileTiny>(*t));
+            column_files.push_back(std::make_shared<ColumnFileTiny>(*t));
         }
         else
         {
-            snap->column_files.push_back(file);
+            column_files.push_back(file);
         }
         total_rows += file->getRows();
         total_deletes += file->getDeletes();
@@ -438,7 +434,7 @@ ColumnFileSetSnapshotPtr ColumnFilePersistedSet::createSnapshot(const IColumnFil
         throw Exception("Rows and deletes check failed.", ErrorCodes::LOGICAL_ERROR);
     }
 
-    return snap;
+    return std::make_shared<ColumnFileSetSnapshot>(data_provider, std::move(column_files), rows, bytes, deletes);
 }
-} // namespace DM
-} // namespace DB
+
+} // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/Delta/Snapshot.cpp
+++ b/dbms/src/Storages/DeltaMerge/Delta/Snapshot.cpp
@@ -38,19 +38,23 @@ DeltaSnapshotPtr DeltaValueSpace::createSnapshot(
     if (abandoned.load(std::memory_order_relaxed))
         return {};
 
-    auto snap = std::make_shared<DeltaValueSnapshot>(type, for_update);
-    snap->delta = this->shared_from_this();
-
     auto storage_snap = std::make_shared<StorageSnapshot>(
         *context.storage_pool,
         context.getReadLimiter(),
         context.tracing_id,
         /*snapshot_read*/ true);
     auto data_from_storage_snap = ColumnFileDataProviderLocalStoragePool::create(storage_snap);
-    snap->persisted_files_snap = persisted_file_set->createSnapshot(data_from_storage_snap);
-    snap->mem_table_snap = mem_table_set->createSnapshot(data_from_storage_snap, for_update);
-    snap->shared_delta_index = delta_index;
-    snap->delta_index_epoch = delta_index_epoch;
+    auto persisted_snap = persisted_file_set->createSnapshot(data_from_storage_snap);
+    auto mem_snap = mem_table_set->createSnapshot(data_from_storage_snap, for_update);
+
+    auto snap = std::make_shared<DeltaValueSnapshot>(
+        type,
+        for_update,
+        std::move(mem_snap),
+        std::move(persisted_snap),
+        delta_index,
+        delta_index_epoch);
+    snap->delta = this->shared_from_this();
 
     return snap;
 }

--- a/dbms/src/Storages/DeltaMerge/Delta/Snapshot.cpp
+++ b/dbms/src/Storages/DeltaMerge/Delta/Snapshot.cpp
@@ -52,9 +52,9 @@ DeltaSnapshotPtr DeltaValueSpace::createSnapshot(
         for_update,
         std::move(mem_snap),
         std::move(persisted_snap),
+        /*delta_vs=*/this->shared_from_this(),
         delta_index,
         delta_index_epoch);
-    snap->delta = this->shared_from_this();
 
     return snap;
 }

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
@@ -29,6 +29,7 @@
 #include <Storages/DeltaMerge/DeltaMergeInterfaces.h>
 #include <Storages/DeltaMerge/File/DMFile_fwd.h>
 #include <Storages/DeltaMerge/Filter/PushDownFilter.h>
+#include <Storages/DeltaMerge/Filter/RSOperator_fwd.h>
 #include <Storages/DeltaMerge/Index/LocalIndexInfo.h>
 #include <Storages/DeltaMerge/Remote/DisaggSnapshot_fwd.h>
 #include <Storages/DeltaMerge/RowKeyRange.h>
@@ -64,8 +65,6 @@ namespace DM
 {
 class StoragePool;
 using StoragePoolPtr = std::shared_ptr<StoragePool>;
-class RSOperator;
-using RSOperatorPtr = std::shared_ptr<RSOperator>;
 using NotCompress = std::unordered_set<ColId>;
 using SegmentIdSet = std::unordered_set<UInt64>;
 struct ExternalDTFileInfo;

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalBg.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalBg.cpp
@@ -527,7 +527,7 @@ bool shouldCompactDeltaWithStable(
     double invalid_data_ratio_threshold,
     const LoggerPtr & log)
 {
-    auto actual_delete_range
+    const auto actual_delete_range
         = snap->delta->getSquashDeleteRange(segment_range.is_common_handle, segment_range.rowkey_column_size)
               .shrink(segment_range);
     if (actual_delete_range.none())

--- a/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter.h
@@ -21,7 +21,7 @@
 #include <Storages/DeltaMerge/File/DMFile.h>
 #include <Storages/DeltaMerge/File/DMFilePackFilter_fwd.h>
 #include <Storages/DeltaMerge/Filter/FilterHelper.h>
-#include <Storages/DeltaMerge/Filter/RSOperator.h>
+#include <Storages/DeltaMerge/Filter/RSOperator_fwd.h>
 #include <Storages/DeltaMerge/ReadMode.h>
 #include <Storages/DeltaMerge/RowKeyRange.h>
 #include <Storages/DeltaMerge/ScanContext_fwd.h>

--- a/dbms/src/Storages/DeltaMerge/File/DMFileReader.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileReader.h
@@ -21,6 +21,7 @@
 #include <Storages/DeltaMerge/File/ColumnStream.h>
 #include <Storages/DeltaMerge/File/DMFile.h>
 #include <Storages/DeltaMerge/File/DMFilePackFilter.h>
+#include <Storages/DeltaMerge/Filter/RSOperator_fwd.h>
 #include <Storages/DeltaMerge/ReadMode.h>
 #include <Storages/DeltaMerge/ReadThread/ColumnSharingCache.h>
 #include <Storages/DeltaMerge/RowKeyRange.h>
@@ -31,9 +32,6 @@ namespace DB::DM
 {
 
 class DMFileWithVectorIndexBlockInputStream;
-
-class RSOperator;
-using RSOperatorPtr = std::shared_ptr<RSOperator>;
 
 
 class DMFileReader

--- a/dbms/src/Storages/DeltaMerge/Filter/RSOperator.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/RSOperator.h
@@ -16,6 +16,7 @@
 
 #include <Common/FieldVisitors.h>
 #include <Storages/DeltaMerge/DeltaMergeDefines.h>
+#include <Storages/DeltaMerge/Filter/RSOperator_fwd.h>
 #include <Storages/DeltaMerge/Index/RSIndex.h>
 #include <Storages/DeltaMerge/Index/RSResult.h>
 #include <Storages/DeltaMerge/Index/VectorIndex_fwd.h>
@@ -28,9 +29,6 @@ struct DAGQueryInfo;
 namespace DB::DM
 {
 
-class RSOperator;
-using RSOperatorPtr = std::shared_ptr<RSOperator>;
-using RSOperators = std::vector<RSOperatorPtr>;
 using Fields = std::vector<Field>;
 
 inline static const RSOperatorPtr EMPTY_RS_OPERATOR{};

--- a/dbms/src/Storages/DeltaMerge/Filter/RSOperator_fwd.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/RSOperator_fwd.h
@@ -1,4 +1,4 @@
-// Copyright 2023 PingCAP, Inc.
+// Copyright 2024 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dbms/src/Storages/DeltaMerge/Filter/RSOperator_fwd.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/RSOperator_fwd.h
@@ -1,0 +1,27 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+namespace DB::DM
+{
+
+class RSOperator;
+using RSOperatorPtr = std::shared_ptr<RSOperator>;
+using RSOperators = std::vector<RSOperatorPtr>;
+
+} // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/FilterParser/FilterParser.h
+++ b/dbms/src/Storages/DeltaMerge/FilterParser/FilterParser.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <Storages/DeltaMerge/DeltaMergeDefines.h>
+#include <Storages/DeltaMerge/Filter/RSOperator_fwd.h>
 #include <Storages/DeltaMerge/Index/RSResult.h>
 #include <Storages/KVStore/Types.h>
 #include <tipb/executor.pb.h>
@@ -30,9 +31,6 @@ struct DAGQueryInfo;
 
 namespace DM
 {
-
-class RSOperator;
-using RSOperatorPtr = std::shared_ptr<RSOperator>;
 
 class FilterParser
 {

--- a/dbms/src/Storages/DeltaMerge/Remote/Serializer.cpp
+++ b/dbms/src/Storages/DeltaMerge/Remote/Serializer.cpp
@@ -162,10 +162,11 @@ SegmentSnapshotPtr Serializer::deserializeSegment(
         false,
         std::move(mem_snap),
         std::move(persisted_snap),
+        // There is no DeltaValueSpace in the disagg arch read node
+        /*delta_vs*/ nullptr,
         std::move(delta_index),
         // Actually we will not access delta_snap->delta_index_epoch in read node. Just for completeness.
         proto.delta_index_epoch());
-    // delta_snap->delta is nullptr because there is no DeltaValueSpace in the disagg arch read node
 
     auto new_stable = std::make_shared<StableValueSpace>(/* id */ 0);
     DMFiles dmfiles;

--- a/dbms/src/Storages/DeltaMerge/Segment.h
+++ b/dbms/src/Storages/DeltaMerge/Segment.h
@@ -21,6 +21,7 @@
 #include <Storages/DeltaMerge/DeltaIndex.h>
 #include <Storages/DeltaMerge/DeltaMergeDefines.h>
 #include <Storages/DeltaMerge/DeltaTree.h>
+#include <Storages/DeltaMerge/Filter/RSOperator_fwd.h>
 #include <Storages/DeltaMerge/Range.h>
 #include <Storages/DeltaMerge/RowKeyRange.h>
 #include <Storages/DeltaMerge/Segment_fwd.h>
@@ -40,8 +41,6 @@ class StableValueSpace;
 using StableValueSpacePtr = std::shared_ptr<StableValueSpace>;
 class DeltaValueSpace;
 using DeltaValueSpacePtr = std::shared_ptr<DeltaValueSpace>;
-class RSOperator;
-using RSOperatorPtr = std::shared_ptr<RSOperator>;
 class PushDownFilter;
 using PushDownFilterPtr = std::shared_ptr<PushDownFilter>;
 

--- a/dbms/src/Storages/DeltaMerge/StableValueSpace.h
+++ b/dbms/src/Storages/DeltaMerge/StableValueSpace.h
@@ -18,6 +18,7 @@
 #include <Storages/DeltaMerge/File/ColumnCache.h>
 #include <Storages/DeltaMerge/File/DMFilePackFilter_fwd.h>
 #include <Storages/DeltaMerge/File/DMFile_fwd.h>
+#include <Storages/DeltaMerge/Filter/RSOperator_fwd.h>
 #include <Storages/DeltaMerge/Index/RSResult.h>
 #include <Storages/DeltaMerge/RowKeyRange.h>
 #include <Storages/DeltaMerge/SkippableBlockInputStream.h>
@@ -29,9 +30,6 @@ namespace DM
 {
 
 struct WriteBatches;
-
-class RSOperator;
-using RSOperatorPtr = std::shared_ptr<RSOperator>;
 
 class StableValueSpace;
 using StableValueSpacePtr = std::shared_ptr<StableValueSpace>;

--- a/dbms/src/Storages/DeltaMerge/tests/DMTestEnv.h
+++ b/dbms/src/Storages/DeltaMerge/tests/DMTestEnv.h
@@ -63,7 +63,7 @@ inline ::testing::AssertionResult RowKeyRangeCompare(
     const RowKeyRange & lhs,
     const RowKeyRange & rhs)
 {
-    if (lhs == rhs)
+    if (lhs.is_common_handle == rhs.is_common_handle && lhs == rhs)
         return ::testing::AssertionSuccess();
     return ::testing::internal::EqFailure(lhs_expr, rhs_expr, lhs.toDebugString(), rhs.toDebugString(), false);
 }

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment_common_handle.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment_common_handle.cpp
@@ -38,6 +38,7 @@ extern const Metric DT_SnapshotOfSegmentMerge;
 extern const Metric DT_SnapshotOfDeltaMerge;
 extern const Metric DT_SnapshotOfPlaceIndex;
 } // namespace CurrentMetrics
+
 namespace DB::DM::tests
 {
 
@@ -679,10 +680,8 @@ try
         auto del_row_range = DMTestEnv::getRowKeyRangeForClusteredIndex(1, 32, rowkey_column_size);
         SCOPED_TRACE("check after range: " + del_row_range.toDebugString()); // Add trace msg when ASSERT failed
         segment->write(dmContext(), {del_row_range});
-        auto merged_del_range = DMTestEnv::getRowKeyRangeForClusteredIndex(
-            1,
-            100,
-            rowkey_column_size); // suqash_delete_range will consider [1, 100) maybe deleted
+        // suqash_delete_range will consider [1, 100) maybe deleted
+        auto merged_del_range = DMTestEnv::getRowKeyRangeForClusteredIndex(1, 100, rowkey_column_size);
         check_segment_squash_delete_range(segment, merged_del_range);
     }
 

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_read_task.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_read_task.cpp
@@ -87,7 +87,7 @@ protected:
             placed_deletes,
             first_snap->delta->getSharedDeltaIndex()->getRNCacheKey());
 
-        // hack to change to delta-index for testing
+        // hack to change the "immutable" delta-index on delta-snapshot for testing
         (*const_cast<DeltaIndexPtr *>(&first_snap->delta->shared_delta_index)) = broken_delta_index;
 
         auto task = std::make_shared<DM::SegmentReadTask>(

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_read_task.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_read_task.cpp
@@ -88,7 +88,7 @@ protected:
             first_snap->delta->getSharedDeltaIndex()->getRNCacheKey());
 
         // hack to change the "immutable" delta-index on delta-snapshot for testing
-        (*const_cast<DeltaIndexPtr *>(&first_snap->delta->shared_delta_index)) = broken_delta_index;
+        (*const_cast<DeltaIndexPtr *>(&first_snap->delta->getSharedDeltaIndex())) = broken_delta_index;
 
         auto task = std::make_shared<DM::SegmentReadTask>(
             first,

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_read_task.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_read_task.cpp
@@ -86,7 +86,9 @@ protected:
             placed_rows,
             placed_deletes,
             first_snap->delta->getSharedDeltaIndex()->getRNCacheKey());
-        first_snap->delta->shared_delta_index = broken_delta_index;
+
+        // hack to change to delta-index for testing
+        (*const_cast<DeltaIndexPtr *>(&first_snap->delta->shared_delta_index)) = broken_delta_index;
 
         auto task = std::make_shared<DM::SegmentReadTask>(
             first,

--- a/dbms/src/Storages/StorageDisaggregated.h
+++ b/dbms/src/Storages/StorageDisaggregated.h
@@ -21,6 +21,7 @@
 #include <Flash/Mpp/MPPTaskId.h>
 #include <Interpreters/Context_fwd.h>
 #include <Storages/DeltaMerge/ColumnDefine_fwd.h>
+#include <Storages/DeltaMerge/Filter/RSOperator_fwd.h>
 #include <Storages/DeltaMerge/Remote/DisaggTaskId.h>
 #include <Storages/DeltaMerge/Remote/RNWorkers_fwd.h>
 #include <Storages/DeltaMerge/SegmentReadTask.h>
@@ -36,12 +37,6 @@
 namespace DB
 {
 class DAGContext;
-
-namespace DM
-{
-class RSOperator;
-using RSOperatorPtr = std::shared_ptr<RSOperator>;
-} // namespace DM
 
 class StorageDisaggregated : public IStorage
 {

--- a/dbms/src/TestUtils/ColumnGenerator.h
+++ b/dbms/src/TestUtils/ColumnGenerator.h
@@ -38,7 +38,7 @@ struct ColumnGeneratorOpts
     size_t string_max_size = 128;
     // - `array_elems_distribution == RANDOM` generate array with random num of elems
     //    the range for num of elems is [0, array_elems_max_size)
-    // - `array_elems_distribution == RANDOM` generate array with fixed num of elems
+    // - `array_elems_distribution == FIXED` generate array with fixed num of elems
     //    the num of elems == array_elems_max_size
     DataDistribution array_elems_distribution = DataDistribution::RANDOM;
     size_t array_elems_max_size = 10;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6233

Problem Summary:

In the previous code, `DeltaValueSnapshot` and `ColumnFileSetSnapshot` instances will be created then set belonging members. This is not a good code practice may lead to some fields missing to be assign when implementing "clone" and "deserialize". It led to unexpected bug likes https://github.com/pingcap/tiflash/pull/9530

### What is changed and how it works?

```commit-message

```

* Make the members of `DeltaValueSnapshot` and `ColumnFileSetSnapshot` "const" as possible
* Refine the include header of `RSOperator`


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
