### PR TITLE
ddl: Fix unstable test "fullstack-test/mpp/rollup_tpcds.test"

### DIFF
--- a/dbms/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterCreateQuery.cpp
@@ -531,6 +531,7 @@ std::unique_ptr<DDLGuard> tryGetDDLGuard(
                     "Table " + database_name + "." + table_name + " already exists.",
                     ErrorCodes::TABLE_ALREADY_EXISTS);
         }
+        return guard;
     }
     catch (Exception & e)
     {

--- a/dbms/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterCreateQuery.cpp
@@ -41,9 +41,11 @@
 #include <Poco/FileStream.h>
 #include <Storages/StorageFactory.h>
 #include <Storages/StorageLog.h>
+#include <common/logger_useful.h>
 
 #include <boost/range/join.hpp>
 #include <memory>
+#include <string_view>
 
 
 namespace DB
@@ -67,9 +69,13 @@ extern const char exception_between_create_database_meta_and_directory[];
 }
 
 
-InterpreterCreateQuery::InterpreterCreateQuery(const ASTPtr & query_ptr_, Context & context_)
+InterpreterCreateQuery::InterpreterCreateQuery(
+    const ASTPtr & query_ptr_,
+    Context & context_,
+    std::string_view log_suffix_)
     : query_ptr(query_ptr_)
     , context(context_)
+    , log_suffix(log_suffix_)
 {}
 
 
@@ -447,7 +453,6 @@ ColumnsDescription InterpreterCreateQuery::setColumns(
     return res;
 }
 
-
 void InterpreterCreateQuery::setEngine(ASTCreateQuery & create) const
 {
     if (create.storage)
@@ -487,6 +492,77 @@ void InterpreterCreateQuery::setEngine(ASTCreateQuery & create) const
     }
 }
 
+
+/** If the table already exists, and the request specifies IF NOT EXISTS,
+ *  then we allow concurrent CREATE queries (which do nothing).
+ * Otherwise, concurrent queries for creating a table, if the table does not exist,
+ *  can throw an exception, even if IF NOT EXISTS is specified.
+ */
+std::unique_ptr<DDLGuard> tryGetDDLGuard(
+    Context & context,
+    const String & database_name,
+    const String & table_name,
+    bool create_if_not_exists,
+    size_t timeout_seconds,
+    std::string_view log_suffix)
+{
+    constexpr int wait_useconds = 50'000;
+    const size_t max_retries = timeout_seconds * 1'000'000 / wait_useconds;
+    try
+    {
+        auto guard = context.getDDLGuardIfTableDoesntExist(
+            database_name,
+            table_name,
+            "Table " + database_name + "." + table_name + " is creating or attaching right now");
+
+        if (!guard)
+        {
+            if (create_if_not_exists)
+                return {};
+            else
+                throw Exception(
+                    "Table " + database_name + "." + table_name + " already exists.",
+                    ErrorCodes::TABLE_ALREADY_EXISTS);
+        }
+    }
+    catch (Exception & e)
+    {
+        // Concurrent queries for creating the same table may run into this branch.
+        // We have to wait for the table created completely, then return to use the table.
+        // Thus, we choose to do a retry here to wait the table created completed.
+        if (e.code() == ErrorCodes::TABLE_ALREADY_EXISTS || e.code() == ErrorCodes::DDL_GUARD_IS_ACTIVE)
+        {
+            auto log = Logger::get(log_suffix);
+            LOG_WARNING(log, "createTable failed, error_code={} error_msg={}", e.code(), e.message());
+            for (size_t i = 0; i < max_retries; i++)
+            {
+                // Once we can get the table from `context`, consider the table create has been "completed"
+                // and return a null guard
+                if (context.isTableExist(database_name, table_name))
+                    return {};
+
+                // sleep a while and retry
+                LOG_ERROR(
+                    log,
+                    "createTable failed but table not exist now, we will sleep for {} ms and try again",
+                    wait_useconds / 1000);
+                usleep(wait_useconds);
+            }
+            LOG_ERROR(
+                log,
+                "still failed to createTable in InterpreterCreateQuery for retry {} times, stack_info={}",
+                max_retries,
+                e.getStackTrace().toString());
+            e.rethrow();
+        }
+        else
+        {
+            e.addMessage(std::string(log_suffix));
+            e.rethrow();
+        }
+    }
+    return {}; // not reachable
+}
 
 BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
 {
@@ -534,8 +610,6 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
     /// Set the table engine if it was not specified explicitly.
     setEngine(create);
 
-    StoragePtr res;
-
     {
         std::unique_ptr<DDLGuard> guard;
 
@@ -552,67 +626,19 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
               * Otherwise, concurrent queries for creating a table, if the table does not exist,
               *  can throw an exception, even if IF NOT EXISTS is specified.
               */
-            try
-            {
-                guard = context.getDDLGuardIfTableDoesntExist(
-                    database_name,
-                    table_name,
-                    "Table " + database_name + "." + table_name + " is creating or attaching right now");
-
-                if (!guard)
-                {
-                    if (create.if_not_exists)
-                        return {};
-                    else
-                        throw Exception(
-                            "Table " + database_name + "." + table_name + " already exists.",
-                            ErrorCodes::TABLE_ALREADY_EXISTS);
-                }
-            }
-            catch (Exception & e)
-            {
-                // Due to even if it throws this two error code, it can't ensure the table is completely created
-                // So we have to wait for the table created completely, then return to use the table.
-                // Thus, we choose to do a retry here to wait the table created completed.
-                if (e.code() == ErrorCodes::TABLE_ALREADY_EXISTS || e.code() == ErrorCodes::DDL_GUARD_IS_ACTIVE)
-                {
-                    auto log = Logger::get(fmt::format("InterpreterCreateQuery {} {}", database_name, table_name));
-                    LOG_WARNING(
-                        log,
-                        "createTable failed with error code is {}, error info is {}, stack_info is {}",
-                        e.code(),
-                        e.displayText(),
-                        e.getStackTrace().toString());
-                    const size_t max_retry = 50;
-                    const int wait_useconds = 20000;
-                    for (size_t i = 0; i < max_retry; i++) // retry
-                    {
-                        if (context.isTableExist(database_name, table_name))
-                            return {};
-
-                        // sleep a while and retry
-                        LOG_ERROR(
-                            log,
-                            "createTable failed but table not exist now, \nWe will sleep for {} ms and try again.",
-                            wait_useconds / 1000);
-                        usleep(wait_useconds); // sleep 20ms
-                    }
-                    LOG_ERROR(
-                        log,
-                        "still failed to createTable in InterpreterCreateQuery for retry {} times",
-                        max_retry);
-                    e.rethrow();
-                }
-                else
-                {
-                    e.rethrow();
-                }
-            }
+            guard = tryGetDDLGuard(
+                context,
+                database_name,
+                table_name,
+                create.if_not_exists,
+                /*timeout_seconds=*/5,
+                log_suffix);
         }
         else if (context.tryGetExternalTable(table_name) && create.if_not_exists)
             return {};
 
-        res = StorageFactory::instance().get(
+        // Guard is acquired, let's create the IStorage instance
+        StoragePtr res = StorageFactory::instance().get(
             create,
             data_path,
             table_name,

--- a/dbms/src/Interpreters/InterpreterCreateQuery.h
+++ b/dbms/src/Interpreters/InterpreterCreateQuery.h
@@ -34,7 +34,7 @@ using StoragePtr = std::shared_ptr<IStorage>;
 class InterpreterCreateQuery : public IInterpreter
 {
 public:
-    InterpreterCreateQuery(const ASTPtr & query_ptr_, Context & context_, std::string_view log_suffix_="");
+    InterpreterCreateQuery(const ASTPtr & query_ptr_, Context & context_, std::string_view log_suffix_ = "");
 
     BlockIO execute() override;
 

--- a/dbms/src/Interpreters/InterpreterCreateQuery.h
+++ b/dbms/src/Interpreters/InterpreterCreateQuery.h
@@ -34,7 +34,7 @@ using StoragePtr = std::shared_ptr<IStorage>;
 class InterpreterCreateQuery : public IInterpreter
 {
 public:
-    InterpreterCreateQuery(const ASTPtr & query_ptr_, Context & context_);
+    InterpreterCreateQuery(const ASTPtr & query_ptr_, Context & context_, std::string_view log_suffix_="");
 
     BlockIO execute() override;
 
@@ -68,6 +68,7 @@ private:
 
     ASTPtr query_ptr;
     Context & context;
+    std::string_view log_suffix;
 
     /// Using while loading database.
     ThreadPool * thread_pool = nullptr;

--- a/dbms/src/TiDB/Schema/SchemaBuilder.cpp
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.cpp
@@ -939,7 +939,10 @@ void SchemaBuilder<Getter, NameMapper>::applyCreateDatabaseByInfo(const TiDB::DB
 
     ASTPtr ast = parseCreateStatement(statement);
 
-    InterpreterCreateQuery interpreter(ast, context);
+    InterpreterCreateQuery interpreter(
+        ast,
+        context,
+        fmt::format("keyspace={} database_id={}", keyspace_id, db_info->id));
     interpreter.setInternal(true);
     interpreter.setForceRestoreData(false);
     interpreter.execute();
@@ -1169,7 +1172,15 @@ void SchemaBuilder<Getter, NameMapper>::applyCreateStorageInstance(
     ast_create_query->if_not_exists = true;
     ast_create_query->database = database_mapped_name;
 
-    InterpreterCreateQuery interpreter(ast, context);
+    InterpreterCreateQuery interpreter(
+        ast,
+        context,
+        fmt::format(
+            "keyspace={} database_id={} table_id={} action={}",
+            keyspace_id,
+            database_id,
+            table_info->id,
+            action));
     interpreter.setInternal(true);
     interpreter.setForceRestoreData(false);
     interpreter.execute();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9613

Problem Summary:
Checkout the details logging in https://github.com/pingcap/tiflash/issues/9613#issuecomment-2478382674 
According to the log, it took about 4 seconds to create an empty table when the CI environment is busy.
 
### What is changed and how it works?

```commit-message

```

* Increate the max wait time for concurrent create table to 5 seconds.
* Refine the logging when concurrent create table happen

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
