### PR TITLE
Abort uploading checkpoint if s3 lock client is not initialized

### DIFF
--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_vector_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_vector_index.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <Common/Exception.h>
+#include <Storages/KVStore/TMTContext.h>
 #include <Common/FailPoint.h>
 #include <Common/SyncPoint/Ctl.h>
 #include <Storages/DeltaMerge/Filter/RSOperator.h>
@@ -40,6 +41,8 @@ public:
     void SetUp() override
     {
         TiFlashStorageTestBasic::SetUp();
+        auto & global_context = TiFlashTestEnv::getGlobalContext();
+        global_context.getTMTContext().initS3GCManager(nullptr);
         store = reload();
     }
 

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_vector_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_vector_index.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <Common/Exception.h>
-#include <Storages/KVStore/TMTContext.h>
 #include <Common/FailPoint.h>
 #include <Common/SyncPoint/Ctl.h>
 #include <Storages/DeltaMerge/Filter/RSOperator.h>
@@ -21,6 +20,7 @@
 #include <Storages/DeltaMerge/LocalIndexerScheduler.h>
 #include <Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_test_basic.h>
 #include <Storages/DeltaMerge/tests/gtest_dm_vector_index_utils.h>
+#include <Storages/KVStore/TMTContext.h>
 #include <Storages/KVStore/Types.h>
 #include <TestUtils/InputStreamTestUtils.h>
 

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment_s3.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment_s3.cpp
@@ -65,6 +65,7 @@ public:
         ASSERT_TRUE(::DB::tests::TiFlashTestEnv::createBucketIfNotExist(*s3_client));
         TiFlashStorageTestBasic::SetUp();
         auto & global_context = TiFlashTestEnv::getGlobalContext();
+        global_context.getTMTContext().initS3GCManager(nullptr);
         if (global_context.getSharedContextDisagg()->remote_data_store == nullptr)
         {
             already_initialize_data_store = false;

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_vector_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_vector_index.cpp
@@ -1708,6 +1708,7 @@ public:
         TiFlashStorageTestBasic::SetUp();
 
         auto & global_context = TiFlashTestEnv::getGlobalContext();
+        global_context.getTMTContext().initS3GCManager(nullptr);
 
         global_context.getSharedContextDisagg()->initRemoteDataStore(
             global_context.getFileProvider(),

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_replace_stable_data.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_replace_stable_data.cpp
@@ -388,6 +388,7 @@ public:
         TiFlashStorageTestBasic::SetUp();
 
         auto & global_context = TiFlashTestEnv::getGlobalContext();
+        global_context.getTMTContext().initS3GCManager(nullptr);
 
         ASSERT_TRUE(global_context.getSharedContextDisagg()->remote_data_store == nullptr);
         global_context.getSharedContextDisagg()->initRemoteDataStore(

--- a/dbms/src/Storages/KVStore/TMTContext.cpp
+++ b/dbms/src/Storages/KVStore/TMTContext.cpp
@@ -205,6 +205,7 @@ void TMTContext::initS3GCManager(const TiFlashRaftProxyHelper * proxy_helper)
         s3gc_owner->campaignOwner(); // start campaign
         s3lock_client = std::make_shared<S3::S3LockClient>(cluster.get(), s3gc_owner);
 
+        LOG_INFO(Logger::get(), "Build s3lock client success");
         S3::S3GCConfig remote_gc_config;
         {
             Int64 gc_method_int = context.getSettingsRef().remote_gc_method;

--- a/dbms/src/Storages/KVStore/TMTContext.cpp
+++ b/dbms/src/Storages/KVStore/TMTContext.cpp
@@ -170,8 +170,7 @@ TMTContext::TMTContext(
 
 void TMTContext::initS3GCManager(const TiFlashRaftProxyHelper * proxy_helper)
 {
-    if (!raftproxy_config.pd_addrs.empty() && S3::ClientFactory::instance().isEnabled()
-        && !context.getSharedContextDisagg()->isDisaggregatedComputeMode())
+    if (S3::ClientFactory::instance().isEnabled() && !context.getSharedContextDisagg()->isDisaggregatedComputeMode())
     {
         kvstore->fetchProxyConfig(proxy_helper);
         if (kvstore->getProxyConfigSummay().valid)
@@ -185,7 +184,7 @@ void TMTContext::initS3GCManager(const TiFlashRaftProxyHelper * proxy_helper)
                 /*id*/ kvstore->getProxyConfigSummay().engine_addr,
                 etcd_client);
         }
-        else
+        else if (!raftproxy_config.pd_addrs.empty())
         {
             LOG_INFO(
                 Logger::get(),
@@ -193,6 +192,15 @@ void TMTContext::initS3GCManager(const TiFlashRaftProxyHelper * proxy_helper)
                 raftproxy_config.advertise_engine_addr);
             s3gc_owner
                 = OwnerManager::createS3GCOwner(context, /*id*/ raftproxy_config.advertise_engine_addr, etcd_client);
+        }
+        else
+        {
+#ifdef DBMS_PUBLIC_GTEST
+            s3gc_owner = OwnerManager::createMockOwner("mocked");
+#else
+            LOG_INFO(Logger::get(), "quit init s3 gc manager, no effective pd addr");
+            return;
+#endif
         }
         s3gc_owner->campaignOwner(); // start campaign
         s3lock_client = std::make_shared<S3::S3LockClient>(cluster.get(), s3gc_owner);

--- a/dbms/src/Storages/KVStore/tests/gtest_kvstore_fast_add_peer.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_kvstore_fast_add_peer.cpp
@@ -63,8 +63,11 @@ class RegionKVStoreTestFAP : public KVStoreTestBase
 public:
     void SetUp() override
     {
+        // Need S3 for S3 lock client, otherwise UniversalPageStorage::write would block waiting.
+        DB::tests::TiFlashTestEnv::enableS3Config();
         test_path = TiFlashTestEnv::getTemporaryPath("/region_kvs_fap_test");
         auto & global_context = TiFlashTestEnv::getGlobalContext();
+        global_context.getTMTContext().initS3GCManager(nullptr);
         // clean data and create path pool instance
         path_pool = TiFlashTestEnv::createCleanPathPool(test_path);
 

--- a/dbms/src/Storages/Page/V3/Universal/UniversalPageStorageService.cpp
+++ b/dbms/src/Storages/Page/V3/Universal/UniversalPageStorageService.cpp
@@ -155,6 +155,12 @@ bool UniversalPageStorageService::uploadCheckpoint()
         return false;
     }
     auto s3lock_client = tmt.getS3LockClient();
+    if (s3lock_client == nullptr)
+    {
+        LOG_INFO(log, "Skip checkpoint because s3lock_client is not initialized");
+        return false;
+    }
+
     const bool force_upload = upload_all_at_next_upload.load();
     bool upload_done = uploadCheckpointImpl(store_info, s3lock_client, remote_store, force_upload);
     if (force_upload && upload_done)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9394

Problem Summary:

there is a time gap after TMTContext is created but before `TMTContext::initS3GCManager` finished


### What is changed and how it works?

Do not init S3LocalLockManager, if the client is not set.

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
