### PR TITLE
`WindowTransformAction::tryCalculate()` calculate at most 1 block result at a time

### DIFF
--- a/dbms/src/DataStreams/WindowBlockInputStream.cpp
+++ b/dbms/src/DataStreams/WindowBlockInputStream.cpp
@@ -1325,6 +1325,7 @@ void WindowTransformAction::appendBlock(Block & current_block)
 
 void WindowTransformAction::tryCalculate()
 {
+    auto start_block_index = current_row.block;
     // Start the calculations. First, advance the partition end.
     for (;;)
     {
@@ -1396,6 +1397,11 @@ void WindowTransformAction::tryCalculate()
             first_not_ready_row = current_row;
             frame_ended = false;
             frame_started = false;
+            // each `tryCalculate()` will calculate at most 1 block's data
+            // this is to make sure that in pipeline mode, the execution time
+            // of each iterator won't be too long
+            if (current_row.block != start_block_index)
+                return;
         }
 
         if (input_is_finished)

--- a/dbms/src/DataStreams/WindowBlockInputStream.cpp
+++ b/dbms/src/DataStreams/WindowBlockInputStream.cpp
@@ -1242,7 +1242,7 @@ void WindowTransformAction::writeOutCurrentRow()
 
 Block WindowTransformAction::tryGetOutputBlock()
 {
-    // first try calculate the window function if there is input data
+    // first try calculate the result based on current data
     tryCalculate();
     // then return block if it is ready
     assert(first_not_ready_row.block >= first_block_number);

--- a/dbms/src/DataStreams/WindowBlockInputStream.cpp
+++ b/dbms/src/DataStreams/WindowBlockInputStream.cpp
@@ -318,7 +318,7 @@ Block WindowBlockInputStream::readImpl()
 {
     // first try to get result without reading from children
     auto block = action.tryGetOutputBlock();
-    if (block || action.input_is_finished)
+    if (block)
         return block;
 
     // then if input is not finished, keep reading input until one result block is generated

--- a/dbms/src/DataStreams/WindowBlockInputStream.cpp
+++ b/dbms/src/DataStreams/WindowBlockInputStream.cpp
@@ -1492,7 +1492,7 @@ void WindowTransformAction::advanceRowNumber(RowNumber & row_num) const
 RowNumber WindowTransformAction::getPreviousRowNumber(const RowNumber & row_num) const
 {
     assert(row_num.block >= first_block_number);
-    assert(!(row_num.block == 0 && row_num.row == 0));
+    assert(row_num.block != 0 || row_num.row != 0);
 
     RowNumber prev_row_num = row_num;
     if (row_num.row > 0)

--- a/dbms/src/DataStreams/WindowBlockInputStream.h
+++ b/dbms/src/DataStreams/WindowBlockInputStream.h
@@ -101,8 +101,6 @@ public:
 
     void appendBlock(Block & current_block);
 
-    void tryCalculate();
-
     bool onlyHaveRowNumber();
 
     Int64 getPartitionEndRow(size_t block_rows);
@@ -149,6 +147,8 @@ private:
 
     template <typename AuxColType, typename OrderByColType, bool is_begin, bool is_desc>
     RowNumber moveCursorAndFindRangeFrame(RowNumber cursor, AuxColType current_row_aux_value);
+
+    void tryCalculate();
 
     template <
         typename AuxColType,

--- a/dbms/src/DataStreams/WindowBlockInputStream.h
+++ b/dbms/src/DataStreams/WindowBlockInputStream.h
@@ -258,7 +258,7 @@ public:
         const WindowDescription & window_description_,
         const String & req_id);
 
-    Block getHeader() const override { return action.output_header; };
+    Block getHeader() const override { return action.output_header; }
 
     String getName() const override { return NAME; }
 

--- a/dbms/src/Operators/WindowTransformOp.cpp
+++ b/dbms/src/Operators/WindowTransformOp.cpp
@@ -44,14 +44,12 @@ OperatorStatus WindowTransformOp::transformImpl(Block & block)
     if unlikely (!block)
     {
         action->input_is_finished = true;
-        action->tryCalculate();
         block = action->tryGetOutputBlock();
         return OperatorStatus::HAS_OUTPUT;
     }
     else
     {
         action->appendBlock(block);
-        action->tryCalculate();
         block = action->tryGetOutputBlock();
         return block ? OperatorStatus::HAS_OUTPUT : OperatorStatus::NEED_INPUT;
     }

--- a/dbms/src/TestUtils/WindowTestUtils.h
+++ b/dbms/src/TestUtils/WindowTestUtils.h
@@ -102,15 +102,20 @@ protected:
         bool is_restrict = true)
     {
         std::vector<size_t> block_sizes{1, 2, 3, 4, DEFAULT_BLOCK_SIZE};
-        for (auto block_size : block_sizes)
+        std::vector<bool> enable_pipeline{false, true};
+        for (auto use_pipeline : enable_pipeline)
         {
-            context.context->setSetting("max_block_size", Field(static_cast<UInt64>(block_size)));
-            if (is_restrict)
-                ASSERT_COLUMNS_EQ_R(expect_columns, executeStreams(request));
-            else
-                ASSERT_COLUMNS_EQ_UR(expect_columns, executeStreams(request));
-            ASSERT_COLUMNS_EQ_UR(expect_columns, executeStreams(request, 2));
-            ASSERT_COLUMNS_EQ_UR(expect_columns, executeStreams(request, MAX_CONCURRENCY_LEVEL));
+            context.context->setSetting("enable_resource_control", use_pipeline ? "true" : "false");
+            for (auto block_size : block_sizes)
+            {
+                context.context->setSetting("max_block_size", Field(static_cast<UInt64>(block_size)));
+                if (is_restrict)
+                    ASSERT_COLUMNS_EQ_R(expect_columns, executeStreams(request));
+                else
+                    ASSERT_COLUMNS_EQ_UR(expect_columns, executeStreams(request));
+                ASSERT_COLUMNS_EQ_UR(expect_columns, executeStreams(request, 2));
+                ASSERT_COLUMNS_EQ_UR(expect_columns, executeStreams(request, MAX_CONCURRENCY_LEVEL));
+            }
         }
     }
 

--- a/dbms/src/WindowFunctions/tests/gtest_lead_lag.cpp
+++ b/dbms/src/WindowFunctions/tests/gtest_lead_lag.cpp
@@ -386,13 +386,36 @@ TEST_F(LeadLag, crossBlock)
     executeFunctionAndAssert(
         toNullableVec<Int64>({{}, {}, {}, {}, {}, {}, {}, {}}),
         Lead2(value_col, lit(Field(static_cast<UInt64>(10)))),
-        // all input is 1 partition
+        {toNullableVec<Int64>(/*partition*/ {1, 1, 1, 1, 1, 1, 1, 1}),
+         toNullableVec<Int64>(/*order*/ {1, 2, 3, 4, 5, 6, 7, 8}),
+         toNullableVec<Int64>(/*value*/ {1, Limits<Int64>::max(), Limits<Int64>::min(), 4, 5, 6, 0, 8})});
+    executeFunctionAndAssert(
+        toNullableVec<Int64>({6, 0, 8, {}, {}, {}, {}, {}}),
+        Lead2(value_col, lit(Field(static_cast<UInt64>(5)))),
+        {toNullableVec<Int64>(/*partition*/ {1, 1, 1, 1, 1, 1, 1, 1}),
+         toNullableVec<Int64>(/*order*/ {1, 2, 3, 4, 5, 6, 7, 8}),
+         toNullableVec<Int64>(/*value*/ {1, Limits<Int64>::max(), Limits<Int64>::min(), 4, 5, 6, 0, 8})});
+    executeFunctionAndAssert(
+        toNullableVec<Int64>({Limits<Int64>::min(), 4, 5, 6, 0, 8, {}, {}}),
+        Lead2(value_col, lit(Field(static_cast<UInt64>(2)))),
         {toNullableVec<Int64>(/*partition*/ {1, 1, 1, 1, 1, 1, 1, 1}),
          toNullableVec<Int64>(/*order*/ {1, 2, 3, 4, 5, 6, 7, 8}),
          toNullableVec<Int64>(/*value*/ {1, Limits<Int64>::max(), Limits<Int64>::min(), 4, 5, 6, 0, 8})});
     executeFunctionAndAssert(
         toNullableVec<Int64>({{}, {}, {}, {}, {}, {}, {}, {}}),
         Lag2(value_col, lit(Field(static_cast<UInt64>(10)))),
+        {toNullableVec<Int64>(/*partition*/ {1, 1, 1, 1, 2, 2, 2, 2}),
+         toNullableVec<Int64>(/*order*/ {1, 2, 3, 4, 5, 6, 7, 8}),
+         toNullableVec<Int64>(/*value*/ {1, Limits<Int64>::max(), Limits<Int64>::min(), 4, 5, 6, 0, 8})});
+    executeFunctionAndAssert(
+        toNullableVec<Int64>({{}, {}, {}, {}, {}, {}, {}, {}}),
+        Lag2(value_col, lit(Field(static_cast<UInt64>(5)))),
+        {toNullableVec<Int64>(/*partition*/ {1, 1, 1, 1, 2, 2, 2, 2}),
+         toNullableVec<Int64>(/*order*/ {1, 2, 3, 4, 5, 6, 7, 8}),
+         toNullableVec<Int64>(/*value*/ {1, Limits<Int64>::max(), Limits<Int64>::min(), 4, 5, 6, 0, 8})});
+    executeFunctionAndAssert(
+        toNullableVec<Int64>({{}, {}, 1,Limits<Int64>::max(), {}, {}, 5, 6}),
+        Lag2(value_col, lit(Field(static_cast<UInt64>(2)))),
         {toNullableVec<Int64>(/*partition*/ {1, 1, 1, 1, 2, 2, 2, 2}),
          toNullableVec<Int64>(/*order*/ {1, 2, 3, 4, 5, 6, 7, 8}),
          toNullableVec<Int64>(/*value*/ {1, Limits<Int64>::max(), Limits<Int64>::min(), 4, 5, 6, 0, 8})});

--- a/dbms/src/WindowFunctions/tests/gtest_lead_lag.cpp
+++ b/dbms/src/WindowFunctions/tests/gtest_lead_lag.cpp
@@ -414,7 +414,7 @@ TEST_F(LeadLag, crossBlock)
          toNullableVec<Int64>(/*order*/ {1, 2, 3, 4, 5, 6, 7, 8}),
          toNullableVec<Int64>(/*value*/ {1, Limits<Int64>::max(), Limits<Int64>::min(), 4, 5, 6, 0, 8})});
     executeFunctionAndAssert(
-        toNullableVec<Int64>({{}, {}, 1,Limits<Int64>::max(), {}, {}, 5, 6}),
+        toNullableVec<Int64>({{}, {}, 1, Limits<Int64>::max(), {}, {}, 5, 6}),
         Lag2(value_col, lit(Field(static_cast<UInt64>(2)))),
         {toNullableVec<Int64>(/*partition*/ {1, 1, 1, 1, 2, 2, 2, 2}),
          toNullableVec<Int64>(/*order*/ {1, 2, 3, 4, 5, 6, 7, 8}),

--- a/dbms/src/WindowFunctions/tests/gtest_lead_lag.cpp
+++ b/dbms/src/WindowFunctions/tests/gtest_lead_lag.cpp
@@ -381,6 +381,23 @@ try
 }
 CATCH
 
+TEST_F(LeadLag, crossBlock)
+{
+    executeFunctionAndAssert(
+        toNullableVec<Int64>({{}, {}, {}, {}, {}, {}, {}, {}}),
+        Lead2(value_col, lit(Field(static_cast<UInt64>(10)))),
+        // all input is 1 partition
+        {toNullableVec<Int64>(/*partition*/ {1, 1, 1, 1, 1, 1, 1, 1}),
+         toNullableVec<Int64>(/*order*/ {1, 2, 3, 4, 5, 6, 7, 8}),
+         toNullableVec<Int64>(/*value*/ {1, Limits<Int64>::max(), Limits<Int64>::min(), 4, 5, 6, 0, 8})});
+    executeFunctionAndAssert(
+        toNullableVec<Int64>({{}, {}, {}, {}, {}, {}, {}, {}}),
+        Lag2(value_col, lit(Field(static_cast<UInt64>(10)))),
+        {toNullableVec<Int64>(/*partition*/ {1, 1, 1, 1, 2, 2, 2, 2}),
+         toNullableVec<Int64>(/*order*/ {1, 2, 3, 4, 5, 6, 7, 8}),
+         toNullableVec<Int64>(/*value*/ {1, Limits<Int64>::max(), Limits<Int64>::min(), 4, 5, 6, 0, 8})});
+}
+
 // TODO support decimal
 
 } // namespace DB::tests


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #9433

Problem Summary:
Before this pr, `WindowTransformAction::tryCalculate()` will try to calculate as many as possible results at a time. This makes the calling time of `WindowTransformAction::tryCalculate()` unpredictable.
This pr let `WindowTransformAction::tryCalculate()` to calculate at most 1 block result at a time, so the calling time of `WindowTransformAction::tryCalculate()` won't be too long, and be more friendly for pipeline model.

### What is changed and how it works?

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
