### PR TITLE
Storages: remove ColumnFileTiny cache

### DIFF
--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileInMemory.cpp
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileInMemory.cpp
@@ -18,10 +18,9 @@
 #include <Storages/DeltaMerge/convertColumnTypeHelpers.h>
 
 
-namespace DB
+namespace DB::DM
 {
-namespace DM
-{
+
 void ColumnFileInMemory::fillColumns(const ColumnDefines & col_defs, size_t col_count, Columns & result) const
 {
     if (result.size() >= col_count)
@@ -108,17 +107,10 @@ Block ColumnFileInMemory::readDataForFlush() const
     return cache_block.cloneWithColumns(std::move(columns));
 }
 
-
-ColumnPtr ColumnFileInMemoryReader::getPKColumn()
-{
-    memory_file.fillColumns(*col_defs, 1, cols_data_cache);
-    return cols_data_cache[0];
-}
-
-ColumnPtr ColumnFileInMemoryReader::getVersionColumn()
+std::pair<ColumnPtr, ColumnPtr> ColumnFileInMemoryReader::getPKAndVersionColumns()
 {
     memory_file.fillColumns(*col_defs, 2, cols_data_cache);
-    return cols_data_cache[1];
+    return {cols_data_cache[0], cols_data_cache[1]};
 }
 
 std::pair<size_t, size_t> ColumnFileInMemoryReader::readRows(
@@ -162,5 +154,4 @@ ColumnFileReaderPtr ColumnFileInMemoryReader::createNewReader(const ColumnDefine
     return std::make_shared<ColumnFileInMemoryReader>(memory_file, new_col_defs, cols_data_cache);
 }
 
-} // namespace DM
-} // namespace DB
+} // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileInMemory.cpp
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileInMemory.cpp
@@ -109,6 +109,7 @@ Block ColumnFileInMemory::readDataForFlush() const
 
 std::pair<ColumnPtr, ColumnPtr> ColumnFileInMemoryReader::getPKAndVersionColumns()
 {
+    // fill the first 2 columns into `cols_data_cache`
     memory_file.fillColumns(*col_defs, 2, cols_data_cache);
     return {cols_data_cache[0], cols_data_cache[1]};
 }

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileInMemory.h
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileInMemory.h
@@ -18,10 +18,9 @@
 #include <Storages/DeltaMerge/ColumnFile/ColumnFileSchema.h>
 #include <Storages/DeltaMerge/Remote/Serializer_fwd.h>
 
-namespace DB
+namespace DB::DM
 {
-namespace DM
-{
+
 class ColumnFileInMemory;
 using ColumnFileInMemoryPtr = std::shared_ptr<ColumnFileInMemory>;
 
@@ -126,8 +125,7 @@ public:
     {}
 
     /// This is a ugly hack to fast return PK & Version column.
-    ColumnPtr getPKColumn();
-    ColumnPtr getVersionColumn();
+    std::pair<ColumnPtr, ColumnPtr> getPKAndVersionColumns();
 
     std::pair<size_t, size_t> readRows(
         MutableColumns & output_cols,
@@ -142,5 +140,4 @@ public:
     ColumnFileReaderPtr createNewReader(const ColumnDefinesPtr & new_col_defs, ReadTag) override;
 };
 
-} // namespace DM
-} // namespace DB
+} // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileInMemory.h
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileInMemory.h
@@ -98,7 +98,7 @@ public:
             bytes,
             disable_append,
             (schema ? schema->toString() : "none"),
-            (cache ? cache->block.dumpStructure() : "none"));
+            (cache ? cache->block.dumpJsonStructure() : "none"));
     }
 };
 

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileInMemory.h
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileInMemory.h
@@ -43,6 +43,8 @@ private:
     CachePtr cache;
 
 private:
+    // Ensure the columns[0~`col_count`] in the `result` are filled with the data of this
+    // ColumnFileInMemory. The column id and data type in `result` is defined by `col_defs`.
     void fillColumns(const ColumnDefines & col_defs, size_t col_count, Columns & result) const;
 
     const DataTypePtr & getDataType(ColId column_id) const { return schema->getDataType(column_id); }
@@ -90,12 +92,13 @@ public:
 
     String toString() const override
     {
-        String s = "{in_memory_file,rows:" + DB::toString(rows) //
-            + ",bytes:" + DB::toString(bytes) //
-            + ",disable_append:" + DB::toString(disable_append) //
-            + ",schema:" + (schema ? schema->toString() : "none") //
-            + ",cache_block:" + (cache ? cache->block.dumpStructure() : "none") + "}";
-        return s;
+        return fmt::format(
+            "{{in_memory_file,rows:{},bytes:{},disable_append:{},schema:{},cache_block:{}}}",
+            rows,
+            bytes,
+            disable_append,
+            (schema ? schema->toString() : "none"),
+            (cache ? cache->block.dumpStructure() : "none"));
     }
 };
 

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSetReader.cpp
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSetReader.cpp
@@ -290,8 +290,7 @@ bool ColumnFileSetReader::shouldPlace(
         if (column_file->isInMemoryFile())
         {
             auto & dpb_reader = typeid_cast<ColumnFileInMemoryReader &>(*column_file_reader);
-            auto pk_column = dpb_reader.getPKColumn();
-            auto version_column = dpb_reader.getVersionColumn();
+            auto [pk_column, version_column] = dpb_reader.getPKAndVersionColumns();
 
             auto rkcc = RowKeyColumnContainer(pk_column, context.is_common_handle);
             const auto & version_col_data = toColumnVectorData<UInt64>(version_column);
@@ -305,8 +304,7 @@ bool ColumnFileSetReader::shouldPlace(
         else if (column_file->isTinyFile())
         {
             auto & dpb_reader = typeid_cast<ColumnFileTinyReader &>(*column_file_reader);
-            auto pk_column = dpb_reader.getPKColumn();
-            auto version_column = dpb_reader.getVersionColumn();
+            auto [pk_column, version_column] = dpb_reader.getPKAndVersionColumns();
 
             auto rkcc = RowKeyColumnContainer(pk_column, context.is_common_handle);
             const auto & version_col_data = toColumnVectorData<UInt64>(version_column);

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileTinyReader.cpp
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileTinyReader.cpp
@@ -94,7 +94,7 @@ Columns ColumnFileTinyReader::readFromDisk(
 
     for (size_t index = 0; index < num_columns_read; ++index)
     {
-        // the column is fill with default values.
+        // the column is filled with default values.
         if (columns[index] != nullptr)
             continue;
 

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileTinyReader.cpp
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileTinyReader.cpp
@@ -12,23 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Storages/DeltaMerge/ColumnFile/ColumnFileDataProvider.h>
 #include <Storages/DeltaMerge/ColumnFile/ColumnFileTiny.h>
 #include <Storages/DeltaMerge/ColumnFile/ColumnFileTinyReader.h>
+#include <Storages/DeltaMerge/convertColumnTypeHelpers.h>
+#include <Storages/Page/V3/Universal/UniversalPageStorage.h>
 
 
 namespace DB::DM
 {
 
-ColumnPtr ColumnFileTinyReader::getPKColumn()
+std::pair<ColumnPtr, ColumnPtr> ColumnFileTinyReader::getPKAndVersionColumns()
 {
-    tiny_file.fillColumns(data_provider, *col_defs, 1, cols_data_cache);
-    return cols_data_cache[0];
-}
+    if (const size_t cached_columns = cols_data_cache.size(); cached_columns < 2)
+    {
+        auto columns = readFromDisk(data_provider, {(*col_defs).begin() + cached_columns, (*col_defs).begin() + 2});
+        cols_data_cache.insert(cols_data_cache.end(), columns.begin(), columns.end());
+    }
 
-ColumnPtr ColumnFileTinyReader::getVersionColumn()
-{
-    tiny_file.fillColumns(data_provider, *col_defs, 2, cols_data_cache);
-    return cols_data_cache[1];
+    return {cols_data_cache[0], cols_data_cache[1]};
 }
 
 std::pair<size_t, size_t> ColumnFileTinyReader::readRows(
@@ -37,10 +39,78 @@ std::pair<size_t, size_t> ColumnFileTinyReader::readRows(
     size_t rows_limit,
     const RowKeyRange * range)
 {
-    tiny_file.fillColumns(data_provider, *col_defs, output_cols.size(), cols_data_cache);
+    const size_t cached_columns = cols_data_cache.size();
+    const size_t read_columns = output_cols.size();
+    if (cached_columns < read_columns)
+    {
+        auto columns
+            = readFromDisk(data_provider, {(*col_defs).begin() + cached_columns, (*col_defs).begin() + read_columns});
+        cols_data_cache.insert(cols_data_cache.end(), columns.begin(), columns.end());
+    }
 
     auto & pk_col = cols_data_cache[0];
     return copyColumnsData(cols_data_cache, pk_col, output_cols, rows_offset, rows_limit, range);
+}
+
+Columns ColumnFileTinyReader::readFromDisk(
+    const IColumnFileDataProviderPtr & data_provider,
+    const std::span<const ColumnDefine> & column_defines) const
+{
+    const size_t num_columns_read = column_defines.size();
+    Columns columns(num_columns_read); // allocate empty columns
+
+    std::vector<size_t> fields;
+    const auto & colid_to_offset = tiny_file.schema->getColIdToOffset();
+    for (size_t index = 0; index < num_columns_read; ++index)
+    {
+        const auto & cd = column_defines[index];
+        if (auto it = colid_to_offset.find(cd.id); it != colid_to_offset.end())
+        {
+            auto col_index = it->second;
+            fields.emplace_back(col_index);
+        }
+        else
+        {
+            // New column after ddl is not exist in this CFTiny, fill with default value
+            columns[index] = createColumnWithDefaultValue(cd, tiny_file.rows);
+        }
+    }
+
+    // All columns to be read are not exist in this CFTiny and filled with default value,
+    // we can skip reading from disk
+    if (fields.empty())
+        return columns;
+
+    // Read the columns from disk and apply DDL cast if need
+    Page page = data_provider->readTinyData(tiny_file.data_page_id, fields);
+    // use `unlikely` to reduce performance impact on keyspaces without enable encryption
+    if (unlikely(tiny_file.file_provider->isEncryptionEnabled(tiny_file.keyspace_id)))
+    {
+        // decrypt the page data in place
+        size_t data_size = page.data.size();
+        char * data = page.mem_holder.get();
+        tiny_file.file_provider->decryptPage(tiny_file.keyspace_id, data, data_size, tiny_file.data_page_id);
+    }
+
+    for (size_t index = 0; index < num_columns_read; ++index)
+    {
+        // the column is fill with default values.
+        if (columns[index] != nullptr)
+            continue;
+
+        const auto & cd = column_defines[index];
+        auto col_index = colid_to_offset.at(cd.id);
+        auto data_buf = page.getFieldData(col_index);
+
+        // Deserialize column by pack's schema
+        const auto & type = tiny_file.getDataType(cd.id);
+        auto col_data = type->createColumn();
+        deserializeColumn(*col_data, type, data_buf, tiny_file.rows);
+
+        columns[index] = convertColumnByColumnDefineIfNeed(type, std::move(col_data), cd);
+    }
+
+    return columns;
 }
 
 Block ColumnFileTinyReader::readNextBlock()
@@ -48,11 +118,9 @@ Block ColumnFileTinyReader::readNextBlock()
     if (read_done)
         return {};
 
-    Columns columns;
-    tiny_file.fillColumns(data_provider, *col_defs, col_defs->size(), columns);
+    auto columns = readFromDisk(data_provider, *col_defs);
 
     read_done = true;
-
     return genBlock(*col_defs, columns);
 }
 

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileTinyReader.h
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileTinyReader.h
@@ -14,7 +14,10 @@
 
 #pragma once
 
+#include <IO/FileProvider/FileProvider_fwd.h>
 #include <Storages/DeltaMerge/ColumnFile/ColumnFile.h>
+
+#include <span>
 
 namespace DB::DM
 {
@@ -26,6 +29,7 @@ private:
     const IColumnFileDataProviderPtr data_provider;
     const ColumnDefinesPtr col_defs;
 
+    // PK & Version column cache.
     Columns cols_data_cache;
     bool read_done = false;
 
@@ -51,14 +55,17 @@ public:
     {}
 
     /// This is a ugly hack to fast return PK & Version column.
-    ColumnPtr getPKColumn();
-    ColumnPtr getVersionColumn();
+    std::pair<ColumnPtr, ColumnPtr> getPKAndVersionColumns();
 
     std::pair<size_t, size_t> readRows(
         MutableColumns & output_cols,
         size_t rows_offset,
         size_t rows_limit,
         const RowKeyRange * range) override;
+
+    Columns readFromDisk(
+        const IColumnFileDataProviderPtr & data_provider,
+        const std::span<const ColumnDefine> & column_defines) const;
 
     Block readNextBlock() override;
 

--- a/dbms/src/Storages/DeltaMerge/Delta/ColumnFilePersistedSet.h
+++ b/dbms/src/Storages/DeltaMerge/Delta/ColumnFilePersistedSet.h
@@ -144,10 +144,6 @@ public:
     size_t getDeletes() const { return deletes.load(); }
     /// Thread safe part end
 
-    size_t getTotalCacheRows() const;
-    size_t getTotalCacheBytes() const;
-    size_t getValidCacheRows() const;
-
     size_t getCurrentFlushVersion() const { return flush_version; }
 
     /// Check whether the task_flush_version is valid,

--- a/dbms/src/Storages/DeltaMerge/Delta/DeltaValueSpace.cpp
+++ b/dbms/src/Storages/DeltaMerge/Delta/DeltaValueSpace.cpp
@@ -266,19 +266,19 @@ std::pair<ColumnFiles, ColumnFilePersisteds> DeltaValueSpace::cloneAllColumnFile
 size_t DeltaValueSpace::getTotalCacheRows() const
 {
     std::scoped_lock lock(mutex);
-    return mem_table_set->getRows() + persisted_file_set->getTotalCacheRows();
+    return mem_table_set->getRows();
 }
 
 size_t DeltaValueSpace::getTotalCacheBytes() const
 {
     std::scoped_lock lock(mutex);
-    return mem_table_set->getBytes() + persisted_file_set->getTotalCacheBytes();
+    return mem_table_set->getBytes();
 }
 
 size_t DeltaValueSpace::getValidCacheRows() const
 {
     std::scoped_lock lock(mutex);
-    return mem_table_set->getRows() + persisted_file_set->getValidCacheRows();
+    return mem_table_set->getRows();
 }
 
 void DeltaValueSpace::recordRemoveColumnFilesPages(WriteBatches & wbs) const

--- a/dbms/src/Storages/DeltaMerge/Delta/MinorCompaction.h
+++ b/dbms/src/Storages/DeltaMerge/Delta/MinorCompaction.h
@@ -78,14 +78,6 @@ public:
         bool is_trivial_move = false;
         if (task.to_compact.size() == 1)
         {
-            // Maybe this column file is small, but it cannot be merged with other column files, so also remove it's cache if possible.
-            for (auto & f : task.to_compact)
-            {
-                if (auto * t_file = f->tryToTinyFile(); t_file)
-                {
-                    t_file->clearCache();
-                }
-            }
             is_trivial_move = true;
         }
 

--- a/dbms/src/Storages/DeltaMerge/PKSquashingBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/PKSquashingBlockInputStream.h
@@ -88,9 +88,9 @@ public:
             {
                 throw Exception(
                     ErrorCodes::LOGICAL_ERROR,
-                    "schema not match! [cur_block={}] [next_block={}]",
-                    cur_block.dumpStructure(),
-                    next_block.dumpStructure());
+                    "schema not match! cur_block={} next_block={}",
+                    cur_block.dumpJsonStructure(),
+                    next_block.dumpJsonStructure());
             }
 #endif
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6233

Problem Summary:

### What is changed and how it works?

```commit-message
remove the code of ColumnFileTiny cache which is useless.
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
