### PR TITLE
limit the max exec time for nasemi/semi join probe

### DIFF
--- a/dbms/src/Common/FailPoint.cpp
+++ b/dbms/src/Common/FailPoint.cpp
@@ -121,7 +121,8 @@ namespace DB
     M(disable_flush_cache)                                   \
     M(force_agg_two_level_hash_table_before_merge)           \
     M(force_thread_0_no_agg_spill)                           \
-    M(force_checkpoint_dump_throw_datafile)
+    M(force_checkpoint_dump_throw_datafile)                  \
+    M(force_semi_join_time_exceed)
 
 #define APPLY_FOR_PAUSEABLE_FAILPOINTS_ONCE(M)    \
     M(pause_with_alter_locks_acquired)            \

--- a/dbms/src/Flash/Pipeline/Schedule/Tasks/Task.h
+++ b/dbms/src/Flash/Pipeline/Schedule/Tasks/Task.h
@@ -18,6 +18,7 @@
 #include <Common/MemoryTracker.h>
 #include <Flash/Executor/PipelineExecutorContext.h>
 #include <Flash/Pipeline/Schedule/Tasks/TaskProfileInfo.h>
+#include <Flash/Pipeline/Schedule/Tasks/TaskTimer.h>
 #include <memory.h>
 
 namespace DB
@@ -74,6 +75,18 @@ public:
     // `TaskHelper::FINALIZE_TASK` can help this.
     void finalize();
 
+    ALWAYS_INLINE void beforeExec(TaskTimer * timer)
+    {
+        assert(nullptr == current_task_timer);
+        current_task_timer = timer;
+        startTraceMemory();
+    }
+    ALWAYS_INLINE static void afterExec()
+    {
+        current_task_timer = nullptr;
+        CurrentMemoryTracker::submitLocalDeltaMemory();
+        current_memory_tracker = nullptr;
+    }
     ALWAYS_INLINE void startTraceMemory()
     {
         assert(nullptr == current_memory_tracker);

--- a/dbms/src/Flash/Pipeline/Schedule/Tasks/Task.h
+++ b/dbms/src/Flash/Pipeline/Schedule/Tasks/Task.h
@@ -84,8 +84,7 @@ public:
     ALWAYS_INLINE static void afterExec()
     {
         current_task_timer = nullptr;
-        CurrentMemoryTracker::submitLocalDeltaMemory();
-        current_memory_tracker = nullptr;
+        endTraceMemory();
     }
     ALWAYS_INLINE void startTraceMemory()
     {

--- a/dbms/src/Flash/Pipeline/Schedule/Tasks/TaskHelper.h
+++ b/dbms/src/Flash/Pipeline/Schedule/Tasks/TaskHelper.h
@@ -23,7 +23,9 @@
 
 namespace DB
 {
-#define FINISH_STATUS ExecTaskStatus::FINISHED : case ExecTaskStatus::ERROR : case ExecTaskStatus::CANCELLED
+#define FINISH_STATUS                                      \
+    ExecTaskStatus::FINISHED : case ExecTaskStatus::ERROR: \
+    case ExecTaskStatus::CANCELLED
 
 #define UNEXPECTED_STATUS(logger, status) \
     RUNTIME_ASSERT(false, (logger), "Unexpected task status {}", magic_enum::enum_name(status));
@@ -48,7 +50,5 @@ namespace DB
             "Unexpected error reported, detail:\n{}", \
             getCurrentExceptionMessage(true, true));  \
     }
-
-static constexpr int64_t YIELD_MAX_TIME_SPENT_NS = 100'000'000L;
 
 } // namespace DB

--- a/dbms/src/Flash/Pipeline/Schedule/Tasks/TaskTimer.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/Tasks/TaskTimer.cpp
@@ -1,0 +1,20 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Flash/Pipeline/Schedule/Tasks/TaskTimer.h>
+
+namespace DB
+{
+thread_local TaskTimer * current_task_timer = nullptr;
+} // namespace DB

--- a/dbms/src/Flash/Pipeline/Schedule/Tasks/TaskTimer.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/Tasks/TaskTimer.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 PingCAP, Inc.
+// Copyright 2024 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dbms/src/Flash/Pipeline/Schedule/Tasks/TaskTimer.h
+++ b/dbms/src/Flash/Pipeline/Schedule/Tasks/TaskTimer.h
@@ -1,4 +1,4 @@
-// Copyright 2023 PingCAP, Inc.
+// Copyright 2024 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,11 +24,11 @@ static constexpr int64_t YIELD_MAX_TIME_SPENT_NS = 100'000'000L;
 struct TaskTimer
 {
     TaskProfileInfo & profile_info;
-    UInt64 current_exec_time = 0;
-    UInt64 updateCurrentExecTime()
+    UInt64 executing_time = 0;
+    UInt64 updateExecutingTime()
     {
-        current_exec_time += profile_info.elapsedFromPrev();
-        return current_exec_time;
+        executing_time += profile_info.elapsedFromPrev();
+        return executing_time;
     }
 };
 

--- a/dbms/src/Flash/Pipeline/Schedule/Tasks/TaskTimer.h
+++ b/dbms/src/Flash/Pipeline/Schedule/Tasks/TaskTimer.h
@@ -1,0 +1,36 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <Flash/Pipeline/Schedule/Tasks/TaskProfileInfo.h>
+#include <common/types.h>
+
+namespace DB
+{
+static constexpr int64_t YIELD_MAX_TIME_SPENT_NS = 100'000'000L;
+
+struct TaskTimer
+{
+    TaskProfileInfo & profile_info;
+    UInt64 current_exec_time = 0;
+    UInt64 updateCurrentExecTime()
+    {
+        current_exec_time += profile_info.elapsedFromPrev();
+        return current_exec_time;
+    }
+};
+
+extern thread_local TaskTimer * current_task_timer;
+} // namespace DB

--- a/dbms/src/Flash/Pipeline/Schedule/ThreadPool/TaskThreadPool.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/ThreadPool/TaskThreadPool.cpp
@@ -103,13 +103,13 @@ void TaskThreadPool<Impl>::handleTask(TaskPtr & task)
     while (true)
     {
         status_after_exec = Impl::exec(task);
-        auto total_time_spent = timer.updateCurrentExecTime();
+        auto total_time_spent = timer.updateExecutingTime();
         // The executing task should yield if it takes more than `YIELD_MAX_TIME_SPENT_NS`.
         if (!Impl::isTargetStatus(status_after_exec) || total_time_spent >= YIELD_MAX_TIME_SPENT_NS)
             break;
     }
-    task_queue->updateStatistics(task, status_before_exec, timer.current_exec_time);
-    metrics.addExecuteTime(task, timer.current_exec_time);
+    task_queue->updateStatistics(task, status_before_exec, timer.executing_time);
+    metrics.addExecuteTime(task, timer.executing_time);
     metrics.decExecutingTask();
     switch (status_after_exec)
     {

--- a/dbms/src/Flash/tests/gtest_join_executor.cpp
+++ b/dbms/src/Flash/tests/gtest_join_executor.cpp
@@ -18,6 +18,10 @@
 
 namespace DB
 {
+namespace FailPoints
+{
+extern const char force_semi_join_time_exceed[];
+} // namespace FailPoints
 namespace tests
 {
 class JoinExecutorTestRunner : public DB::tests::JoinTestRunner
@@ -2864,6 +2868,7 @@ try
 {
     using tipb::JoinType;
     std::vector<UInt64> cross_join_shallow_copy_thresholds{1, DEFAULT_BLOCK_SIZE * 100};
+    std::vector<bool> semi_join_time_exceed = {true, false};
     /// One join key(t.a = s.a) + no other condition.
     /// left table(t) + right table(s) + result column.
     const std::vector<std::tuple<ColumnsWithTypeAndName, ColumnsWithTypeAndName, ColumnWithTypeAndName>> t1
@@ -2915,7 +2920,18 @@ try
                 = context.scan("null_aware_semi", "t")
                       .join(context.scan("null_aware_semi", "s"), type, {col("a")}, {}, {}, {}, {}, 0, is_null_aware)
                       .build(context);
-            executeAndAssertColumnsEqual(request, reference);
+            for (auto need_force_semi_join_time_exceed : semi_join_time_exceed)
+            {
+                if (need_force_semi_join_time_exceed)
+                {
+                    FailPointHelper::enableFailPoint(FailPoints::force_semi_join_time_exceed);
+                }
+                else
+                {
+                    FailPointHelper::disableFailPoint(FailPoints::force_semi_join_time_exceed);
+                }
+                executeAndAssertColumnsEqual(request, reference);
+            }
             auto request_column_prune
                 = context.scan("null_aware_semi", "t")
                       .join(context.scan("null_aware_semi", "s"), type, {col("a")}, {}, {}, {}, {}, 0, is_null_aware)
@@ -3018,7 +3034,18 @@ try
                                    0,
                                    is_null_aware)
                                .build(context);
-            executeAndAssertColumnsEqual(request, reference);
+            for (auto need_force_semi_join_time_exceed : semi_join_time_exceed)
+            {
+                if (need_force_semi_join_time_exceed)
+                {
+                    FailPointHelper::enableFailPoint(FailPoints::force_semi_join_time_exceed);
+                }
+                else
+                {
+                    FailPointHelper::disableFailPoint(FailPoints::force_semi_join_time_exceed);
+                }
+                executeAndAssertColumnsEqual(request, reference);
+            }
             auto request_column_prune = context.scan("null_aware_semi", "t")
                                             .join(
                                                 context.scan("null_aware_semi", "s"),
@@ -3130,7 +3157,18 @@ try
                                    0,
                                    is_null_aware)
                                .build(context);
-            executeAndAssertColumnsEqual(request, reference);
+            for (auto need_force_semi_join_time_exceed : semi_join_time_exceed)
+            {
+                if (need_force_semi_join_time_exceed)
+                {
+                    FailPointHelper::enableFailPoint(FailPoints::force_semi_join_time_exceed);
+                }
+                else
+                {
+                    FailPointHelper::disableFailPoint(FailPoints::force_semi_join_time_exceed);
+                }
+                executeAndAssertColumnsEqual(request, reference);
+            }
             auto request_column_prune = context.scan("null_aware_semi", "t")
                                             .join(
                                                 context.scan("null_aware_semi", "s"),
@@ -3298,7 +3336,18 @@ try
                                    0,
                                    is_null_aware)
                                .build(context);
-            executeAndAssertColumnsEqual(request, reference);
+            for (auto need_force_semi_join_time_exceed : semi_join_time_exceed)
+            {
+                if (need_force_semi_join_time_exceed)
+                {
+                    FailPointHelper::enableFailPoint(FailPoints::force_semi_join_time_exceed);
+                }
+                else
+                {
+                    FailPointHelper::disableFailPoint(FailPoints::force_semi_join_time_exceed);
+                }
+                executeAndAssertColumnsEqual(request, reference);
+            }
             auto request_column_prune = context.scan("null_aware_semi", "t")
                                             .join(
                                                 context.scan("null_aware_semi", "s"),
@@ -3408,7 +3457,18 @@ try
                                    0,
                                    is_null_aware)
                                .build(context);
-            executeAndAssertColumnsEqual(request, reference);
+            for (auto need_force_semi_join_time_exceed : semi_join_time_exceed)
+            {
+                if (need_force_semi_join_time_exceed)
+                {
+                    FailPointHelper::enableFailPoint(FailPoints::force_semi_join_time_exceed);
+                }
+                else
+                {
+                    FailPointHelper::disableFailPoint(FailPoints::force_semi_join_time_exceed);
+                }
+                executeAndAssertColumnsEqual(request, reference);
+            }
             auto request_column_prune = context.scan("null_aware_semi", "t")
                                             .join(
                                                 context.scan("null_aware_semi", "s"),
@@ -3509,7 +3569,18 @@ try
                                    0,
                                    is_null_aware)
                                .build(context);
-            executeAndAssertColumnsEqual(request, reference);
+            for (auto need_force_semi_join_time_exceed : semi_join_time_exceed)
+            {
+                if (need_force_semi_join_time_exceed)
+                {
+                    FailPointHelper::enableFailPoint(FailPoints::force_semi_join_time_exceed);
+                }
+                else
+                {
+                    FailPointHelper::disableFailPoint(FailPoints::force_semi_join_time_exceed);
+                }
+                executeAndAssertColumnsEqual(request, reference);
+            }
             auto request_column_prune = context.scan("null_aware_semi", "t")
                                             .join(
                                                 context.scan("null_aware_semi", "s"),
@@ -3565,6 +3636,7 @@ CATCH
 TEST_F(JoinExecutorTestRunner, SemiJoin)
 try
 {
+    std::vector<bool> semi_join_time_exceed = {true, false};
     using tipb::JoinType;
     /// One join key(t.a = s.a) + no other condition.
     /// left table(t) + right table(s) + result column.
@@ -3608,7 +3680,18 @@ try
         {
             auto reference = genSemiJoinResult(type, left, res);
             auto request = context.scan("semi", "t").join(context.scan("semi", "s"), type, {col("a")}).build(context);
-            executeAndAssertColumnsEqual(request, reference);
+            for (auto need_force_semi_join_time_exceed : semi_join_time_exceed)
+            {
+                if (need_force_semi_join_time_exceed)
+                {
+                    FailPointHelper::enableFailPoint(FailPoints::force_semi_join_time_exceed);
+                }
+                else
+                {
+                    FailPointHelper::disableFailPoint(FailPoints::force_semi_join_time_exceed);
+                }
+                executeAndAssertColumnsEqual(request, reference);
+            }
         }
     }
 
@@ -3652,7 +3735,18 @@ try
                 = context.scan("semi", "t")
                       .join(context.scan("semi", "s"), type, {col("a")}, {}, {}, {lt(col("t.c"), col("s.c"))}, {})
                       .build(context);
-            executeAndAssertColumnsEqual(request, reference);
+            for (auto need_force_semi_join_time_exceed : semi_join_time_exceed)
+            {
+                if (need_force_semi_join_time_exceed)
+                {
+                    FailPointHelper::enableFailPoint(FailPoints::force_semi_join_time_exceed);
+                }
+                else
+                {
+                    FailPointHelper::disableFailPoint(FailPoints::force_semi_join_time_exceed);
+                }
+                executeAndAssertColumnsEqual(request, reference);
+            }
         }
     }
 
@@ -3696,7 +3790,18 @@ try
             auto request = context.scan("semi", "t")
                                .join(context.scan("semi", "s"), type, {col("a"), col("b")}, {})
                                .build(context);
-            executeAndAssertColumnsEqual(request, reference);
+            for (auto need_force_semi_join_time_exceed : semi_join_time_exceed)
+            {
+                if (need_force_semi_join_time_exceed)
+                {
+                    FailPointHelper::enableFailPoint(FailPoints::force_semi_join_time_exceed);
+                }
+                else
+                {
+                    FailPointHelper::disableFailPoint(FailPoints::force_semi_join_time_exceed);
+                }
+                executeAndAssertColumnsEqual(request, reference);
+            }
         }
     }
 
@@ -3778,7 +3883,18 @@ try
                                    {lt(col("t.c"), col("s.c"))},
                                    {})
                                .build(context);
-            executeAndAssertColumnsEqual(request, reference);
+            for (auto need_force_semi_join_time_exceed : semi_join_time_exceed)
+            {
+                if (need_force_semi_join_time_exceed)
+                {
+                    FailPointHelper::enableFailPoint(FailPoints::force_semi_join_time_exceed);
+                }
+                else
+                {
+                    FailPointHelper::disableFailPoint(FailPoints::force_semi_join_time_exceed);
+                }
+                executeAndAssertColumnsEqual(request, reference);
+            }
         }
     }
 
@@ -3810,7 +3926,18 @@ try
             auto request = context.scan("semi", "t")
                                .join(context.scan("semi", "s"), type, {col("a"), col("b")}, {})
                                .build(context);
-            executeAndAssertColumnsEqual(request, reference);
+            for (auto need_force_semi_join_time_exceed : semi_join_time_exceed)
+            {
+                if (need_force_semi_join_time_exceed)
+                {
+                    FailPointHelper::enableFailPoint(FailPoints::force_semi_join_time_exceed);
+                }
+                else
+                {
+                    FailPointHelper::disableFailPoint(FailPoints::force_semi_join_time_exceed);
+                }
+                executeAndAssertColumnsEqual(request, reference);
+            }
         }
     }
 }

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -32,7 +32,6 @@
 #include <Interpreters/NullableUtils.h>
 #include <common/logger_useful.h>
 
-#include <ctime>
 #include <exception>
 #include <magic_enum.hpp>
 
@@ -1536,12 +1535,12 @@ Block doNASemiJoinOrSemiJoin(
         // because pipeline model is enabled by default, current_task_timer should be not null in most senarios
         if likely (current_task_timer != nullptr)
         {
-            auto elapsed = current_task_timer->updateCurrentExecTime();
+            auto elapsed = current_task_timer->updateExecutingTime();
             auto time_exceed = elapsed >= 6 * YIELD_MAX_TIME_SPENT_NS;
             fiu_do_on(FailPoints::force_semi_join_time_exceed, { time_exceed = true; });
             if unlikely (time_exceed)
             {
-                // task execution time exceeds 10 times of the maximum time spent, yield the thread by returning an empty result block
+                // task execution time exceeds the maximum time, yield the thread by returning an empty result block
                 return empty_result_block;
             }
         }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9433

Problem Summary:

### What is changed and how it works?
Limit the max execution time for nasemi/semi join probe.

Testing result:
Testing data set
```
mysql> desc t1;
+-------+------+------+------+---------+-------+
| Field | Type | Null | Key  | Default | Extra |
+-------+------+------+------+---------+-------+
| id    | int  | NO   |      | NULL    |       |
| value | int  | YES  |      | NULL    |       |
+-------+------+------+------+---------+-------+
2 rows in set (0.00 sec)

mysql> desc t2;
+-------+------+------+------+---------+-------+
| Field | Type | Null | Key  | Default | Extra |
+-------+------+------+------+---------+-------+
| id    | int  | NO   |      | NULL    |       |
| value | int  | YES  |      | NULL    |       |
+-------+------+------+------+---------+-------+
2 rows in set (0.00 sec)

mysql> select id, value, count(*) from t1 group by id, value;
+----+-------+----------+
| id | value | count(*) |
+----+-------+----------+
|  1 |     2 |   524288 |
+----+-------+----------+
1 row in set (0.05 sec)

mysql> select id, value, count(*) from t2 group by id, value;
+----+-------+----------+
| id | value | count(*) |
+----+-------+----------+
|  1 |     3 |    16384 |
+----+-------+----------+
1 row in set (0.04 sec)
mysql> desc t1_null;
+-------+------+------+------+---------+-------+
| Field | Type | Null | Key  | Default | Extra |
+-------+------+------+------+---------+-------+
| id    | int  | YES  |      | NULL    |       |
| value | int  | YES  |      | NULL    |       |
+-------+------+------+------+---------+-------+
2 rows in set (0.00 sec)

mysql> desc t2_null;
+-------+------+------+------+---------+-------+
| Field | Type | Null | Key  | Default | Extra |
+-------+------+------+------+---------+-------+
| id    | int  | YES  |      | NULL    |       |
| value | int  | YES  |      | NULL    |       |
+-------+------+------+------+---------+-------+
2 rows in set (0.00 sec)

mysql> select id, value, count(*) from t1_null group by id, value;
+------+-------+----------+
| id   | value | count(*) |
+------+-------+----------+
|    1 |     2 |   524288 |
+------+-------+----------+
1 row in set (0.04 sec)

mysql> select id, value, count(*) from t2_null group by id, value;
+------+-------+----------+
| id   | value | count(*) |
+------+-------+----------+
|    1 |     3 |    16384 |
+------+-------+----------+
1 row in set (0.04 sec)
```
Testing sql
semi join:
```
mysql> explain select count(*) from t1 t1 where id not in (select id from t2 t2 where t1.value > t2.value);
+--------------------------------------------+-----------+--------------+---------------+-------------------------------------------------------------------------------------------------+
| id                                         | estRows   | task         | access object | operator info                                                                                   |
+--------------------------------------------+-----------+--------------+---------------+-------------------------------------------------------------------------------------------------+
| HashAgg_38                                 | 1.00      | root         |               | funcs:count(Column#8)->Column#7                                                                 |
| └─TableReader_40                           | 1.00      | root         |               | MppVersion: 2, data:ExchangeSender_39                                                           |
|   └─ExchangeSender_39                      | 1.00      | mpp[tiflash] |               | ExchangeType: PassThrough                                                                       |
|     └─HashAgg_14                           | 1.00      | mpp[tiflash] |               | funcs:count(1)->Column#8                                                                        |
|       └─Projection_37                      | 419430.40 | mpp[tiflash] |               | test.t1.id                                                                                      |
|         └─HashJoin_36                      | 419430.40 | mpp[tiflash] |               | anti semi join, equal:[eq(test.t1.id, test.t2.id)], other cond:gt(test.t1.value, test.t2.value) |
|           ├─ExchangeReceiver_22(Build)     | 16384.00  | mpp[tiflash] |               |                                                                                                 |
|           │ └─ExchangeSender_21            | 16384.00  | mpp[tiflash] |               | ExchangeType: Broadcast, Compression: FAST                                                      |
|           │   └─TableFullScan_20           | 16384.00  | mpp[tiflash] | table:t2      | keep order:false, stats:pseudo                                                                  |
|           └─TableFullScan_19(Probe)        | 524288.00 | mpp[tiflash] | table:t1      | keep order:false, stats:pseudo                                                                  |
+--------------------------------------------+-----------+--------------+---------------+-------------------------------------------------------------------------------------------------+
```
na-semi join:
```
mysql> explain select count(*) from t1_null t1 where id not in (select id from t2_null t2 where t1.value > t2.value);
+--------------------------------------------+-----------+--------------+---------------+--------------------------------------------------------------------------------------------------------------------------------+
| id                                         | estRows   | task         | access object | operator info                                                                                                                  |
+--------------------------------------------+-----------+--------------+---------------+--------------------------------------------------------------------------------------------------------------------------------+
| HashAgg_38                                 | 1.00      | root         |               | funcs:count(Column#8)->Column#7                                                                                                |
| └─TableReader_40                           | 1.00      | root         |               | MppVersion: 2, data:ExchangeSender_39                                                                                          |
|   └─ExchangeSender_39                      | 1.00      | mpp[tiflash] |               | ExchangeType: PassThrough                                                                                                      |
|     └─HashAgg_14                           | 1.00      | mpp[tiflash] |               | funcs:count(1)->Column#8                                                                                                       |
|       └─Projection_37                      | 419430.40 | mpp[tiflash] |               | test.t1_null.id                                                                                                                |
|         └─HashJoin_36                      | 419430.40 | mpp[tiflash] |               | Null-aware anti semi join, equal:[eq(test.t1_null.id, test.t2_null.id)], other cond:gt(test.t1_null.value, test.t2_null.value) |
|           ├─ExchangeReceiver_22(Build)     | 16384.00  | mpp[tiflash] |               |                                                                                                                                |
|           │ └─ExchangeSender_21            | 16384.00  | mpp[tiflash] |               | ExchangeType: Broadcast, Compression: FAST                                                                                     |
|           │   └─TableFullScan_20           | 16384.00  | mpp[tiflash] | table:t2      | keep order:false, stats:pseudo                                                                                                 |
|           └─TableFullScan_19(Probe)        | 524288.00 | mpp[tiflash] | table:t1      | keep order:false, stats:pseudo                                                                                                 |
+--------------------------------------------+-----------+--------------+---------------+--------------------------------------------------------------------------------------------------------------------------------+
```
The overall sql performance: almost the same
| | semi join | na semi join |
|---|-------|---------------|
| before this pr | ~ 12.8s      | ~ 23.2s      |
|after this pr | ~12.8s       | ~23.2s         |

Max task execution time per round:
<img width="981" alt="Screenshot 2024-12-03 at 10 30 42" src="https://github.com/user-attachments/assets/a7d8ead4-12e2-4cde-9cfc-d0ed9d1bf20b">

As you can see the p999 cpu execution time per round is reduced greatly from 40s(na semi join)/20s(semi join) to 620ms for both na semi jon and semi join

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
