### PR TITLE
Storages: refactor DMFileReader

### DIFF
--- a/dbms/src/Storages/DeltaMerge/File/DMFileReader.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileReader.cpp
@@ -128,8 +128,8 @@ bool DMFileReader::getSkippedRows(size_t & skip_rows)
     skip_rows = 0;
     const auto & pack_stats = dmfile->getPackStats();
     const auto end_pack_id = read_block_infos.empty() ? pack_stats.size() : std::get<0>(read_block_infos.front());
-    for (size_t i = next_pack_id; i < end_pack_id; ++i)
-        skip_rows += pack_stats[i].rows;
+    for (; next_pack_id < end_pack_id; ++next_pack_id)
+        skip_rows += pack_stats[next_pack_id].rows;
     addSkippedRows(skip_rows);
 
     return !read_block_infos.empty();

--- a/dbms/src/Storages/DeltaMerge/ScanContext.cpp
+++ b/dbms/src/Storages/DeltaMerge/ScanContext.cpp
@@ -139,7 +139,6 @@ String ScanContext::toJson() const
     json->set("mvcc_input_rows", mvcc_input_rows.load());
     json->set("mvcc_input_bytes", mvcc_input_bytes.load());
     json->set("mvcc_skip_rows", mvcc_input_rows.load() - mvcc_output_rows.load());
-    json->set("late_materialization_skip_rows", late_materialization_skip_rows.load());
 
     json->set("learner_read_time", fmt::format("{:.3f}ms", learner_read_ns.load() / NS_TO_MS_SCALE));
     json->set("create_snapshot_time", fmt::format("{:.3f}ms", create_snapshot_time_ns.load() / NS_TO_MS_SCALE));

--- a/dbms/src/Storages/DeltaMerge/ScanContext.h
+++ b/dbms/src/Storages/DeltaMerge/ScanContext.h
@@ -78,7 +78,6 @@ public:
     std::atomic<uint64_t> mvcc_input_rows{0};
     std::atomic<uint64_t> mvcc_input_bytes{0};
     std::atomic<uint64_t> mvcc_output_rows{0};
-    std::atomic<uint64_t> late_materialization_skip_rows{0};
 
     // Learner read
     std::atomic<uint64_t> learner_read_ns{0};
@@ -133,7 +132,6 @@ public:
         mvcc_input_rows = tiflash_scan_context_pb.mvcc_input_rows();
         mvcc_input_bytes = tiflash_scan_context_pb.mvcc_input_bytes();
         mvcc_output_rows = tiflash_scan_context_pb.mvcc_output_rows();
-        late_materialization_skip_rows = tiflash_scan_context_pb.lm_skip_rows();
         build_bitmap_time_ns = tiflash_scan_context_pb.total_build_bitmap_ms() * 1000000;
         num_stale_read = tiflash_scan_context_pb.stale_read_regions();
         build_inputstream_time_ns = tiflash_scan_context_pb.total_build_inputstream_ms() * 1000000;
@@ -186,7 +184,6 @@ public:
         tiflash_scan_context_pb.set_mvcc_input_rows(mvcc_input_rows);
         tiflash_scan_context_pb.set_mvcc_input_bytes(mvcc_input_bytes);
         tiflash_scan_context_pb.set_mvcc_output_rows(mvcc_output_rows);
-        tiflash_scan_context_pb.set_lm_skip_rows(late_materialization_skip_rows);
         tiflash_scan_context_pb.set_total_build_bitmap_ms(build_bitmap_time_ns / 1000000);
         tiflash_scan_context_pb.set_stale_read_regions(num_stale_read);
         tiflash_scan_context_pb.set_total_build_inputstream_ms(build_inputstream_time_ns / 1000000);
@@ -243,7 +240,6 @@ public:
         mvcc_input_rows += other.mvcc_input_rows;
         mvcc_input_bytes += other.mvcc_input_bytes;
         mvcc_output_rows += other.mvcc_output_rows;
-        late_materialization_skip_rows += other.late_materialization_skip_rows;
 
         learner_read_ns += other.learner_read_ns;
         create_snapshot_time_ns += other.create_snapshot_time_ns;
@@ -300,7 +296,6 @@ public:
         mvcc_input_rows += other.mvcc_input_rows();
         mvcc_input_bytes += other.mvcc_input_bytes();
         mvcc_output_rows += other.mvcc_output_rows();
-        late_materialization_skip_rows += other.lm_skip_rows();
         build_bitmap_time_ns += other.total_build_bitmap_ms() * 1000000;
         num_stale_read += other.stale_read_regions();
         build_inputstream_time_ns += other.total_build_inputstream_ms() * 1000000;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6233

Problem Summary:

### What is changed and how it works?

Pre-compute each read block information to simplify DMFileReader, and we can use the read_block_infos to simplify vector search read path.

https://github.com/pingcap/tidb/pull/58076

```commit-message
Pre-compute each read block information to simplify DMFileReader.
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
