### PR TITLE
Storages: Shutdown the LocalIndexScheduler before shutting down PageStorage/DeltaMergeStore

### DIFF
--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -271,6 +271,13 @@ struct ContextShared
             return;
         shutdown_called = true;
 
+        // The local index scheduler must be shutdown to stop all
+        // running tasks before shutting down `global_storage_pool`.
+        if (global_local_indexer_scheduler)
+        {
+            global_local_indexer_scheduler->shutdown();
+        }
+
         if (global_storage_pool)
         {
             // shutdown the gc task of global storage pool before

--- a/dbms/src/Interpreters/executeQuery.cpp
+++ b/dbms/src/Interpreters/executeQuery.cpp
@@ -311,7 +311,7 @@ std::tuple<ASTPtr, BlockIO> executeQueryImpl(
 
                 if (elem.read_rows != 0)
                 {
-                    LOG_INFO(
+                    LOG_DEBUG(
                         execute_query_logger,
                         "Read {} rows, {} in {:.3f} sec., {} rows/sec., {}/sec.",
                         elem.read_rows,
@@ -421,7 +421,7 @@ void logQueryPipeline(const LoggerPtr & logger, const BlockInputStreamPtr & in)
         in->dumpTree(log_buffer);
         return log_buffer.toString();
     };
-    LOG_INFO(logger, pipeline_log_str());
+    LOG_DEBUG(logger, pipeline_log_str());
 }
 
 BlockIO executeQuery(const String & query, Context & context, bool internal, QueryProcessingStage::Enum stage)

--- a/dbms/src/Storages/DeltaMerge/LocalIndexerScheduler.cpp
+++ b/dbms/src/Storages/DeltaMerge/LocalIndexerScheduler.cpp
@@ -303,7 +303,10 @@ bool LocalIndexerScheduler::tryAddTaskToPool(std::unique_lock<std::mutex> & lock
         }
     };
 
-    RUNTIME_CHECK(pool);
+    if (is_shutting_down || !pool)
+        // shutting down, retry again
+        return false;
+
     if (!pool->trySchedule(real_job))
         // Concurrent task limit reached
         return false;

--- a/dbms/src/Storages/DeltaMerge/LocalIndexerScheduler.cpp
+++ b/dbms/src/Storages/DeltaMerge/LocalIndexerScheduler.cpp
@@ -64,9 +64,9 @@ LocalIndexerScheduler::LocalIndexerScheduler(const Options & options)
         start();
 }
 
-LocalIndexerScheduler::~LocalIndexerScheduler()
+void LocalIndexerScheduler::shutdown()
 {
-    LOG_INFO(logger, "LocalIndexerScheduler is destroying. Waiting scheduler and tasks to finish...");
+    LOG_INFO(logger, "LocalIndexerScheduler is shutting down. Waiting scheduler and tasks to finish...");
 
     // First quit the scheduler. Don't schedule more tasks.
     is_shutting_down = true;
@@ -81,7 +81,15 @@ LocalIndexerScheduler::~LocalIndexerScheduler()
 
     // Then wait all running tasks to finish.
     pool.reset();
+    LOG_INFO(logger, "LocalIndexerScheduler is shutdown.");
+}
 
+LocalIndexerScheduler::~LocalIndexerScheduler()
+{
+    if (!is_shutting_down)
+    {
+        shutdown();
+    }
     LOG_INFO(logger, "LocalIndexerScheduler is destroyed");
 }
 

--- a/dbms/src/Storages/DeltaMerge/LocalIndexerScheduler.h
+++ b/dbms/src/Storages/DeltaMerge/LocalIndexerScheduler.h
@@ -73,6 +73,16 @@ public:
         bool auto_start = true;
     };
 
+private:
+    struct InternalTask
+    {
+        const Task user_task;
+        Stopwatch created_at{};
+        Stopwatch scheduled_at{};
+    };
+
+    using InternalTaskPtr = std::shared_ptr<InternalTask>;
+
 public:
     static LocalIndexerSchedulerPtr create(const Options & options)
     {
@@ -96,6 +106,12 @@ public:
     void start();
 
     /**
+     * @brief Blocks until there is no tasks remaining in the queue and there is no running tasks.
+     * **Should be only used in tests**.
+     */
+    void waitForFinish();
+
+    /**
      * @brief Push a task to the pool. The task may not be scheduled immediately.
      * Return <true, ""> if pushing the task is done.
      * Return <false, reason> if the task is not valid.
@@ -108,21 +124,7 @@ public:
     */
     size_t dropTasks(KeyspaceID keyspace_id, TableID table_id);
 
-    /**
-     * @brief Blocks until there is no tasks remaining in the queue and there is no running tasks.
-     * **Should be only used in tests**.
-     */
-    void waitForFinish();
-
 private:
-    struct InternalTask
-    {
-        const Task user_task;
-        Stopwatch created_at{};
-        Stopwatch scheduled_at{};
-    };
-    using InternalTaskPtr = std::shared_ptr<InternalTask>;
-
     struct FileIDHasher
     {
         std::size_t operator()(const FileID & id) const

--- a/dbms/src/Storages/DeltaMerge/Segment.h
+++ b/dbms/src/Storages/DeltaMerge/Segment.h
@@ -170,6 +170,19 @@ public:
         PageIdU64 next_segment_id{};
         PageIdU64 delta_id{};
         PageIdU64 stable_id{};
+
+        String toString() const
+        {
+            return fmt::format(
+                "{{version={} epoch={} range={} segment_id={} next_segment_id={} delta_id={} stable_id={}}}",
+                version,
+                epoch,
+                range.toString(),
+                segment_id,
+                next_segment_id,
+                delta_id,
+                stable_id);
+        }
     };
 
     using SegmentMetaInfos = std::vector<SegmentMetaInfo>;

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment.cpp
@@ -32,9 +32,6 @@
 
 #include <future>
 
-#include "IO/Buffer/ReadBufferFromString.h"
-#include "Storages/DeltaMerge/Segment.h"
-
 namespace ProfileEvents
 {
 extern const Event DMSegmentIsEmptyFastPath;
@@ -51,11 +48,7 @@ namespace DB::ErrorCodes
 extern const int DT_DELTA_INDEX_ERROR;
 }
 
-namespace DB
-{
-namespace DM
-{
-namespace GC
+namespace DB::DM::GC
 {
 bool shouldCompactStableWithTooMuchDataOutOfSegmentRange(
     const DMContext & context, //
@@ -66,7 +59,7 @@ bool shouldCompactStableWithTooMuchDataOutOfSegmentRange(
     double invalid_data_ratio_threshold,
     const LoggerPtr & log);
 }
-namespace tests
+namespace DB::DM::tests
 {
 
 class SegmentOperationTest : public SegmentTestBasic
@@ -1369,58 +1362,4 @@ try
 }
 CATCH
 
-dtpb::StableLayerMeta derializeMetaV2FromBuf(ReadBuffer & buf)
-{
-    dtpb::StableLayerMeta meta;
-    String data;
-    readStringBinary(data, buf);
-    RUNTIME_CHECK_MSG(
-        meta.ParseFromString(data),
-        "Failed to parse StableLayerMeta from string: {}",
-        Redact::keyToHexString(data.data(), data.size()));
-    return meta;
-}
-
-dtpb::StableLayerMeta derializeMetaFromBuf(ReadBuffer & buf)
-{
-    UInt64 version;
-    readIntBinary(version, buf);
-    if (version == StableFormat::V2)
-        return derializeMetaV2FromBuf(buf);
-    else
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected version: {}", version);
-}
-TEST(SSS, sss)
-{
-    // page_id:451.8822
-    std::string_view hex_datas[] = {
-        // version:250723.0
-        "030000000300000000000000230A18080010011A08800000000003D05C2208800000000007A11510F04418F74420F544",
-        // version:251826.0
-        "030000000400000000000000230A18080010011A08800000000003D05C2208800000000007A11510F04418F74420F544",
-        // version:251829.0
-        // "02000000000000001108B9A10F1092C9A9F2021A0508F4661001",
-        // version:251830.0
-        "030000000500000000000000220A18080010011A08800000000003D05C2208800000000007A11510F04418F744201A",
-    };
-    for (const auto & hex_data : hex_datas)
-    {
-        auto data = Redact::hexStringToKey(hex_data.data(), hex_data.size());
-        ReadBufferFromString buf(data);
-        Segment::SegmentMetaInfo info;
-        readSegmentMetaInfo(buf, info);
-        LOG_INFO(Logger::get(), "hex:{} segment_info:{}", hex_data, info.toString());
-    }
-
-    {
-        std::string_view hex_data = "02000000000000001108B9A10F1092C9A9F2021A0508F4661001";
-        auto data = Redact::hexStringToKey(hex_data.data(), hex_data.size());
-        ReadBufferFromString buf(data);
-        auto stable_meta = derializeMetaFromBuf(buf);
-        LOG_INFO(Logger::get(), "hex:{} stable_meta:{}", hex_data, stable_meta.DebugString());
-    }
-}
-
-} // namespace tests
-} // namespace DM
-} // namespace DB
+} // namespace DB::DM::tests

--- a/dbms/src/Storages/Page/tools/PageCtl/PageStorageCtlV3.cpp
+++ b/dbms/src/Storages/Page/tools/PageCtl/PageStorageCtlV3.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Common/Checksum.h>
 #include <IO/Encryption/MockKeyManager.h>
 #include <IO/FileProvider/FileProvider.h>
 #include <Interpreters/Context.h>
@@ -871,7 +872,7 @@ private:
         ChecksumClass digest;
         digest.update(buffer, size);
         auto checksum = digest.checksum();
-        fmt::print("checksum: 0x{:X}\n", checksum);
+        fmt::println("checksum: 0x{:X}", checksum);
 
         auto hex_str = Redact::keyToHexString(buffer, size);
         delete[] buffer;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/9714

Problem Summary:

Checkout the logging in issue.

From "Invalid page id, entry not exist [page_id=451.26] [resolve_id=451.26]" and the StackTrace     `DB::DM::Segment::restoreSegment(std::__1::shared_ptr<DB::Logger> const&, DB::DM::DMContext&, unsigned long)  dbms/src/Storages/DeltaMerge/Segment.cpp:427` we can know that something is wrong when restoring the StableValueSpace of Segment. After adding some debugging message, we know that the error comes from restoring table_id=451, segment_id=8822.

Then dump the BlobData from PageStorage "meta". We found that the last two records persisted on disk is invalid as a SegmentMetaInfo.

Before the error happen, we saw that the table_id=451, segment_id=8822 had applied a `SegmentUpdateMeta` task after `DeltaMergeStore::shutdown`. `Segment::replaceStableMetaVersion` will access to a already shutdown PageStorage. Causing the WriteBatch wrote broken data.

```
[2024/12/10 00:04:03.027 +08:00] [INFO] [Server.cpp:1589] ["Shutting down storages."] [thread_id=1]
...
-- called by `DeltaMergeStore::shutdown` on table_id=451
[2024/12/10 00:04:03.050 +08:00] [INFO] [LocalIndexerScheduler.cpp:170] ["Removed 0 tasks, keyspace_id=4294967295 table_id=451"] [thread_id=1]
[2024/12/10 00:04:03.050 +08:00] [INFO] [RegionTable.cpp:152] ["remove table from RegionTable success, keyspace=4294967295 table_id=451"] [thread_id=1]
...
[2024/12/10 00:04:03.065 +08:00] [INFO] [LocalIndexerScheduler.cpp:69] ["LocalIndexerScheduler is destroying. Waiting scheduler and tasks to finish..."] [thread_id=1]
-- the running task on table_id=451, segment_id=8822, file_id=13172 is not removed. And 
[2024/12/10 00:05:28.470 +08:00] [INFO] [DMFileV3IncrementWriter.cpp:104] ["Write incremental update for DMFile, local_path=/data1/gengliqi/tidb/data/tiflash-9000/data/t_451/stable/dmf_13172 dmfile_path=/data1/gengliqi/tidb/data/tiflash-9000/data/t_451/stable/dmf_13172 old_meta_version=0 new_meta_version=1"] [thread_id=403]
[2024/12/10 00:05:28.474 +08:00] [INFO] [DeltaMergeStore_InternalSegment.cpp:772] ["EnsureStableLocalIndex - Finish building index, dm_files=[dmf_13172(v=0)]"] [source="keyspace=4294967295 table_id=451 segmentEnsureStableLocalIndex source_segment=<segment_id=8822 epoch=4 range=[249948,499989)>"] [thread_id=403]
-- `Segment::replaceStableMetaVersion` will access to a already shutdown PageStorage. Causing the WriteBatch wrote broken data.
[2024/12/10 00:05:28.479 +08:00] [INFO] [DeltaMergeStore_InternalSegment.cpp:690] ["SegmentUpdateMeta - Finish, old_segment=<segment_id=8822 epoch=4 range=[249948,499989)> new_segment=<segment_id=8822 epoch=5 range=[249948,499989)>"] [source="keyspace=4294967295 table_id=451"] [thread_id=403]
-- `DeltaMergeStore::~DeltaMergeStore` is called
[2024/12/10 00:05:28.479 +08:00] [INFO] [DeltaMergeStore.cpp:372] ["Release DeltaMerge Store start"] [source="keyspace=4294967295 table_id=451"] [thread_id=403]
[2024/12/10 00:05:28.479 +08:00] [INFO] [DeltaMergeStore.cpp:376] ["Release DeltaMerge Store end"] [source="keyspace=4294967295 table_id=451"] [thread_id=403]
[2024/12/10 00:05:28.479 +08:00] [INFO] [LocalIndexerScheduler.cpp:85] ["LocalIndexerScheduler is destroyed"] [thread_id=1]
```

### What is changed and how it works?

```commit-message
Storages: Shutdown the LocalIndexScheduler before shutting down PageStorage/DeltaMergeStore
* Add a method `LocalIndexerScheduler::shutdown()` and ensure the running task are all finished before shutting down the GlobalPageStorage in `ContextShared::shutdown()`.
```

* Add a method `LocalIndexerScheduler::shutdown()` and ensure the running task are all finished before shutting down the GlobalPageStorage in `ContextShared::shutdown()`.
* Add error message about the segment_id when `restoreSegment` failed
* Add debugging tool command for reading the BlobData from PageStorage instance

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```
1. Deploy a cluster with vector data
2. Create a script to run add/drop vector index repeatly 
`alter table vector_bench_test drop index idx_emb_l2;`
`alter table vector_bench_test add vector index idx_emb_l2 ((VEC_L2_DISTANCE(embedding)));`
3. Create a script to restart tiflash repeatly
4. Check whether tiflash restart successfully
5. TiFlash restart successfully after running those 2 scripts for 7 hours
```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix an issue that TiFlash may fail to restart after applying vector index build jobs
```
