### PR TITLE
Storages: Shutdown the LocalIndexScheduler before shutting down PageStorage/DeltaMergeStore (release-8.5)

### DIFF
--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -271,6 +271,13 @@ struct ContextShared
             return;
         shutdown_called = true;
 
+        // The local index scheduler must be shutdown to stop all
+        // running tasks before shutting down `global_storage_pool`.
+        if (global_local_indexer_scheduler)
+        {
+            global_local_indexer_scheduler->shutdown();
+        }
+
         if (global_storage_pool)
         {
             // shutdown the gc task of global storage pool before

--- a/dbms/src/Interpreters/executeQuery.cpp
+++ b/dbms/src/Interpreters/executeQuery.cpp
@@ -311,7 +311,7 @@ std::tuple<ASTPtr, BlockIO> executeQueryImpl(
 
                 if (elem.read_rows != 0)
                 {
-                    LOG_INFO(
+                    LOG_DEBUG(
                         execute_query_logger,
                         "Read {} rows, {} in {:.3f} sec., {} rows/sec., {}/sec.",
                         elem.read_rows,
@@ -421,7 +421,7 @@ void logQueryPipeline(const LoggerPtr & logger, const BlockInputStreamPtr & in)
         in->dumpTree(log_buffer);
         return log_buffer.toString();
     };
-    LOG_INFO(logger, pipeline_log_str());
+    LOG_DEBUG(logger, pipeline_log_str());
 }
 
 BlockIO executeQuery(const String & query, Context & context, bool internal, QueryProcessingStage::Enum stage)

--- a/dbms/src/Storages/DeltaMerge/LocalIndexerScheduler.cpp
+++ b/dbms/src/Storages/DeltaMerge/LocalIndexerScheduler.cpp
@@ -303,7 +303,10 @@ bool LocalIndexerScheduler::tryAddTaskToPool(std::unique_lock<std::mutex> & lock
         }
     };
 
-    RUNTIME_CHECK(pool);
+    if (is_shutting_down || !pool)
+        // shutting down, retry again
+        return false;
+
     if (!pool->trySchedule(real_job))
         // Concurrent task limit reached
         return false;

--- a/dbms/src/Storages/DeltaMerge/LocalIndexerScheduler.cpp
+++ b/dbms/src/Storages/DeltaMerge/LocalIndexerScheduler.cpp
@@ -64,9 +64,9 @@ LocalIndexerScheduler::LocalIndexerScheduler(const Options & options)
         start();
 }
 
-LocalIndexerScheduler::~LocalIndexerScheduler()
+void LocalIndexerScheduler::shutdown()
 {
-    LOG_INFO(logger, "LocalIndexerScheduler is destroying. Waiting scheduler and tasks to finish...");
+    LOG_INFO(logger, "LocalIndexerScheduler is shutting down. Waiting scheduler and tasks to finish...");
 
     // First quit the scheduler. Don't schedule more tasks.
     is_shutting_down = true;
@@ -81,7 +81,15 @@ LocalIndexerScheduler::~LocalIndexerScheduler()
 
     // Then wait all running tasks to finish.
     pool.reset();
+    LOG_INFO(logger, "LocalIndexerScheduler is shutdown.");
+}
 
+LocalIndexerScheduler::~LocalIndexerScheduler()
+{
+    if (!is_shutting_down)
+    {
+        shutdown();
+    }
     LOG_INFO(logger, "LocalIndexerScheduler is destroyed");
 }
 

--- a/dbms/src/Storages/DeltaMerge/LocalIndexerScheduler.h
+++ b/dbms/src/Storages/DeltaMerge/LocalIndexerScheduler.h
@@ -73,6 +73,16 @@ public:
         bool auto_start = true;
     };
 
+private:
+    struct InternalTask
+    {
+        const Task user_task;
+        Stopwatch created_at{};
+        Stopwatch scheduled_at{};
+    };
+
+    using InternalTaskPtr = std::shared_ptr<InternalTask>;
+
 public:
     static LocalIndexerSchedulerPtr create(const Options & options)
     {
@@ -96,6 +106,12 @@ public:
     void start();
 
     /**
+     * @brief Blocks until there is no tasks remaining in the queue and there is no running tasks.
+     * **Should be only used in tests**.
+     */
+    void waitForFinish();
+
+    /**
      * @brief Push a task to the pool. The task may not be scheduled immediately.
      * Return <true, ""> if pushing the task is done.
      * Return <false, reason> if the task is not valid.
@@ -108,21 +124,7 @@ public:
     */
     size_t dropTasks(KeyspaceID keyspace_id, TableID table_id);
 
-    /**
-     * @brief Blocks until there is no tasks remaining in the queue and there is no running tasks.
-     * **Should be only used in tests**.
-     */
-    void waitForFinish();
-
 private:
-    struct InternalTask
-    {
-        const Task user_task;
-        Stopwatch created_at{};
-        Stopwatch scheduled_at{};
-    };
-    using InternalTaskPtr = std::shared_ptr<InternalTask>;
-
     struct FileIDHasher
     {
         std::size_t operator()(const FileID & id) const

--- a/dbms/src/Storages/Page/tools/PageCtl/PageStorageCtlV3.cpp
+++ b/dbms/src/Storages/Page/tools/PageCtl/PageStorageCtlV3.cpp
@@ -12,15 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Common/Checksum.h>
 #include <IO/Encryption/MockKeyManager.h>
 #include <Interpreters/Context.h>
 #include <Poco/ConsoleChannel.h>
 #include <Poco/PatternFormatter.h>
 #include <Server/CLIService.h>
+#include <Storages/Page/PageDefinesBase.h>
+#include <Storages/Page/V3/PageDefines.h>
 #include <Storages/Page/V3/PageDirectory.h>
 #include <Storages/Page/V3/PageDirectoryFactory.h>
 #include <Storages/Page/V3/PageStorageImpl.h>
 #include <Storages/Page/V3/Universal/RaftDataReader.h>
+#include <Storages/Page/V3/Universal/UniversalPageId.h>
 #include <Storages/Page/V3/Universal/UniversalPageIdFormatImpl.h>
 #include <Storages/Page/V3/Universal/UniversalPageStorage.h>
 #include <Storages/PathPool.h>
@@ -29,6 +33,7 @@
 #include <common/types.h>
 
 #include <boost/program_options.hpp>
+#include <cstdint>
 #include <magic_enum.hpp>
 #include <unordered_set>
 
@@ -47,12 +52,15 @@ struct ControlOptions
         CHECK_ALL_DATA_CRC = 4,
         DISPLAY_WAL_ENTRIES = 5,
         DISPLAY_REGION_INFO = 6,
+        DISPLAY_BLOB_DATA = 7,
     };
 
     std::vector<std::string> paths;
     DisplayType mode = DisplayType::DISPLAY_SUMMARY_INFO;
     UInt64 page_id = UINT64_MAX;
     UInt32 blob_id = UINT32_MAX;
+    BlobFileOffset blob_offset = INVALID_BLOBFILE_OFFSET;
+    size_t blob_size = UINT64_MAX;
     UInt64 namespace_id = DB::TEST_NAMESPACE_ID;
     StorageType storage_type = StorageType::Unknown; // only useful for universal page storage
     UInt32 keyspace_id = NullspaceID; // only useful for universal page storage
@@ -85,6 +93,7 @@ ControlOptions ControlOptions::parse(int argc, char ** argv)
  4 is check every data is valid
  5 is dump entries in WAL log files
  6 is display all region info
+ 7 is display blob data (in hex)
 )") //
         ("show_entries",
          value<bool>()->default_value(true),
@@ -106,8 +115,14 @@ ControlOptions ControlOptions::parse(int argc, char ** argv)
          value<UInt64>()->default_value(UINT64_MAX),
          "Query a single Page id, and print its version chain.") //
         ("blob_id,B",
-         value<UInt32>()->default_value(UINT32_MAX),
-         "Query a single Blob id, and print its data distribution.") //
+         value<BlobFileId>()->default_value(INVALID_BLOBFILE_ID),
+         "Specify the blob_id") //
+        ("blob_offset",
+         value<BlobFileOffset>()->default_value(INVALID_BLOBFILE_OFFSET),
+         "Specify the offset.") //
+        ("blob_size",
+         value<size_t>()->default_value(0),
+         "Specify the size.") //
         //
         ("imitative,I",
          value<bool>()->default_value(true),
@@ -140,7 +155,9 @@ ControlOptions ControlOptions::parse(int argc, char ** argv)
     opt.paths = options["paths"].as<std::vector<std::string>>();
     auto mode_int = options["mode"].as<int>();
     opt.page_id = options["page_id"].as<UInt64>();
-    opt.blob_id = options["blob_id"].as<UInt32>();
+    opt.blob_id = options["blob_id"].as<BlobFileId>();
+    opt.blob_offset = options["blob_offset"].as<BlobFileOffset>();
+    opt.blob_size = options["blob_size"].as<size_t>();
     opt.show_entries = options["show_entries"].as<bool>();
     opt.check_fields = options["check_fields"].as<bool>();
     auto storage_type_int = options["storage_type"].as<int>();
@@ -344,6 +361,12 @@ private:
                 {
                     std::cout << "Only UniversalPageStorage support this mode." << std::endl;
                 }
+                break;
+            }
+            case ControlOptions::DisplayType::DISPLAY_BLOB_DATA:
+            {
+                String hex_data = getBlobData(blob_store, opts.blob_id, opts.blob_offset, opts.blob_size);
+                fmt::println("hex:{}", hex_data);
                 break;
             }
             default:
@@ -819,6 +842,32 @@ private:
         error_msg.append("Please use `--query_table_id` + `--page_id` to get the more error info.");
 
         return error_msg.toString();
+    }
+
+    static String getBlobData(
+        typename Trait::BlobStore & blob_store,
+        BlobFileId blob_id,
+        BlobFileOffset offset,
+        size_t size)
+    {
+        auto page_id = []() {
+            if constexpr (std::is_same_v<Trait, u128::PageStorageControlV3Trait>)
+                return PageIdV3Internal(0, 0);
+            else
+                return UniversalPageId("");
+        }();
+        char * buffer = new char[size];
+        blob_store.read(page_id, blob_id, offset, buffer, size, nullptr, false);
+
+        using ChecksumClass = Digest::CRC64;
+        ChecksumClass digest;
+        digest.update(buffer, size);
+        auto checksum = digest.checksum();
+        fmt::println("checksum: 0x{:X}", checksum);
+
+        auto hex_str = Redact::keyToHexString(buffer, size);
+        delete[] buffer;
+        return hex_str;
     }
 
 private:


### PR DESCRIPTION
pre-cherry-pick of https://github.com/pingcap/tiflash/pull/9712 on release-8.5 to fix the issue

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/9714

Problem Summary:

Checkout the logging in issue.

From "Invalid page id, entry not exist [page_id=451.26] [resolve_id=451.26]" and the StackTrace     `DB::DM::Segment::restoreSegment(std::__1::shared_ptr<DB::Logger> const&, DB::DM::DMContext&, unsigned long)  dbms/src/Storages/DeltaMerge/Segment.cpp:427` we can know that something is wrong when restoring the StableValueSpace of Segment. After adding some debugging message, we know that the error comes from restoring table_id=451, segment_id=8822.

Then dump the BlobData from PageStorage "meta". We found that the last two records persisted on disk is invalid as a SegmentMetaInfo.

Before the error happen, we saw that the table_id=451, segment_id=8822 had applied a `SegmentUpdateMeta` task after `DeltaMergeStore::shutdown`. `Segment::replaceStableMetaVersion` will access to a already shutdown PageStorage. Causing the WriteBatch wrote broken data.

```
[2024/12/10 00:04:03.027 +08:00] [INFO] [Server.cpp:1589] ["Shutting down storages."] [thread_id=1]
...
-- called by `DeltaMergeStore::shutdown` on table_id=451
[2024/12/10 00:04:03.050 +08:00] [INFO] [LocalIndexerScheduler.cpp:170] ["Removed 0 tasks, keyspace_id=4294967295 table_id=451"] [thread_id=1]
[2024/12/10 00:04:03.050 +08:00] [INFO] [RegionTable.cpp:152] ["remove table from RegionTable success, keyspace=4294967295 table_id=451"] [thread_id=1]
...
[2024/12/10 00:04:03.065 +08:00] [INFO] [LocalIndexerScheduler.cpp:69] ["LocalIndexerScheduler is destroying. Waiting scheduler and tasks to finish..."] [thread_id=1]
-- the running task on table_id=451, segment_id=8822, file_id=13172 is not removed. And 
[2024/12/10 00:05:28.470 +08:00] [INFO] [DMFileV3IncrementWriter.cpp:104] ["Write incremental update for DMFile, local_path=/data1/gengliqi/tidb/data/tiflash-9000/data/t_451/stable/dmf_13172 dmfile_path=/data1/gengliqi/tidb/data/tiflash-9000/data/t_451/stable/dmf_13172 old_meta_version=0 new_meta_version=1"] [thread_id=403]
[2024/12/10 00:05:28.474 +08:00] [INFO] [DeltaMergeStore_InternalSegment.cpp:772] ["EnsureStableLocalIndex - Finish building index, dm_files=[dmf_13172(v=0)]"] [source="keyspace=4294967295 table_id=451 segmentEnsureStableLocalIndex source_segment=<segment_id=8822 epoch=4 range=[249948,499989)>"] [thread_id=403]
-- `Segment::replaceStableMetaVersion` will access to a already shutdown PageStorage. Causing the WriteBatch wrote broken data.
[2024/12/10 00:05:28.479 +08:00] [INFO] [DeltaMergeStore_InternalSegment.cpp:690] ["SegmentUpdateMeta - Finish, old_segment=<segment_id=8822 epoch=4 range=[249948,499989)> new_segment=<segment_id=8822 epoch=5 range=[249948,499989)>"] [source="keyspace=4294967295 table_id=451"] [thread_id=403]
-- `DeltaMergeStore::~DeltaMergeStore` is called
[2024/12/10 00:05:28.479 +08:00] [INFO] [DeltaMergeStore.cpp:372] ["Release DeltaMerge Store start"] [source="keyspace=4294967295 table_id=451"] [thread_id=403]
[2024/12/10 00:05:28.479 +08:00] [INFO] [DeltaMergeStore.cpp:376] ["Release DeltaMerge Store end"] [source="keyspace=4294967295 table_id=451"] [thread_id=403]
[2024/12/10 00:05:28.479 +08:00] [INFO] [LocalIndexerScheduler.cpp:85] ["LocalIndexerScheduler is destroyed"] [thread_id=1]
```

### What is changed and how it works?

```commit-message
Storages: Shutdown the LocalIndexScheduler before shutting down PageStorage/DeltaMergeStore
* Add a method `LocalIndexerScheduler::shutdown()` and ensure the running task are all finished before shutting down the GlobalPageStorage in `ContextShared::shutdown()`.
```

* Add a method `LocalIndexerScheduler::shutdown()` and ensure the running task are all finished before shutting down the GlobalPageStorage in `ContextShared::shutdown()`.
* Add error message about the segment_id when `restoreSegment` failed
* Add debugging tool command for reading the BlobData from PageStorage instance

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```
1. Deploy a cluster with vector data
2. Create a script to run add/drop vector index repeatly 
`alter table vector_bench_test drop index idx_emb_l2;`
`alter table vector_bench_test add vector index idx_emb_l2 ((VEC_L2_DISTANCE(embedding)));`
3. Create a script to restart tiflash repeatly
4. Check whether tiflash restart successfully
5. TiFlash restart successfully after running those 2 scripts for 7 hours
```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix an issue that TiFlash may fail to restart after applying vector index build jobs
```
