### PR TITLE
Storages: load RSResult only once

### DIFF
--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileBig.cpp
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileBig.cpp
@@ -37,14 +37,11 @@ ColumnFileBig::ColumnFileBig(const DMContext & dm_context, const DMFilePtr & fil
 
 void ColumnFileBig::calculateStat(const DMContext & dm_context)
 {
-    auto pack_filter = DMFilePackFilter::loadFrom(
+    std::tie(valid_rows, valid_bytes) = DMFilePackFilter::loadValidRowsAndBytes(
         dm_context,
         file,
         /*set_cache_if_miss*/ false,
-        {segment_range},
-        EMPTY_RS_OPERATOR,
-        {});
-    std::tie(valid_rows, valid_bytes) = pack_filter->validRowsAndBytes();
+        {segment_range});
 }
 
 void ColumnFileBig::removeData(WriteBatches & wbs) const

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileBig.cpp
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileBig.cpp
@@ -37,11 +37,13 @@ ColumnFileBig::ColumnFileBig(const DMContext & dm_context, const DMFilePtr & fil
 
 void ColumnFileBig::calculateStat(const DMContext & dm_context)
 {
-    std::tie(valid_rows, valid_bytes) = DMFilePackFilter::loadValidRowsAndBytes(
+    auto m = DMFilePackFilter::loadValidRowsAndBytes(
         dm_context,
         file,
         /*set_cache_if_miss*/ false,
         {segment_range});
+    valid_rows = m.match_rows;
+    valid_bytes = m.match_bytes;
 }
 
 void ColumnFileBig::removeData(WriteBatches & wbs) const

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileBig.cpp
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileBig.cpp
@@ -38,21 +38,13 @@ ColumnFileBig::ColumnFileBig(const DMContext & dm_context, const DMFilePtr & fil
 
 void ColumnFileBig::calculateStat(const DMContext & dm_context)
 {
-    auto index_cache = dm_context.global_context.getMinMaxIndexCache();
-
     auto pack_filter = DMFilePackFilter::loadFrom(
+        dm_context,
         file,
-        index_cache,
         /*set_cache_if_miss*/ false,
         {segment_range},
         EMPTY_RS_OPERATOR,
-        {},
-        dm_context.global_context.getFileProvider(),
-        dm_context.getReadLimiter(),
-        dm_context.scan_context,
-        /*tracing_id*/ dm_context.tracing_id,
-        ReadTag::Internal);
-
+        {});
     std::tie(valid_rows, valid_bytes) = pack_filter.validRowsAndBytes();
 }
 

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileBig.cpp
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileBig.cpp
@@ -45,7 +45,7 @@ void ColumnFileBig::calculateStat(const DMContext & dm_context)
         {segment_range},
         EMPTY_RS_OPERATOR,
         {});
-    std::tie(valid_rows, valid_bytes) = pack_filter.validRowsAndBytes();
+    std::tie(valid_rows, valid_bytes) = pack_filter->validRowsAndBytes();
 }
 
 void ColumnFileBig::removeData(WriteBatches & wbs) const

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileBig.cpp
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileBig.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <Interpreters/Context.h>
 #include <Interpreters/SharedContexts/Disagg.h>
 #include <Storages/DeltaMerge/ColumnFile/ColumnFileBig.h>
 #include <Storages/DeltaMerge/DMContext.h>

--- a/dbms/src/Storages/DeltaMerge/File/ColumnStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/ColumnStream.cpp
@@ -157,7 +157,7 @@ std::unique_ptr<CompressedSeekableReaderBuffer> ColumnReadStream::buildColDataRe
 
     // Try to get the largest buffer size of reading continuous packs
     size_t buffer_size = 0;
-    const auto & pack_res = reader.pack_filter->getPackResConst();
+    const auto & pack_res = reader.pack_filter->getPackRes();
     for (size_t i = 0; i < n_packs; /*empty*/)
     {
         if (!pack_res[i].isUse())

--- a/dbms/src/Storages/DeltaMerge/File/ColumnStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/ColumnStream.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <IO/FileProvider/ChecksumReadBufferBuilder.h>
 #include <Storages/DeltaMerge/File/ColumnStream.h>
 #include <Storages/DeltaMerge/File/DMFileReader.h>
 #include <Storages/Page/PageUtil.h>

--- a/dbms/src/Storages/DeltaMerge/File/ColumnStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/ColumnStream.cpp
@@ -157,7 +157,7 @@ std::unique_ptr<CompressedSeekableReaderBuffer> ColumnReadStream::buildColDataRe
 
     // Try to get the largest buffer size of reading continuous packs
     size_t buffer_size = 0;
-    const auto & pack_res = reader.pack_filter.getPackResConst();
+    const auto & pack_res = reader.pack_filter->getPackResConst();
     for (size_t i = 0; i < n_packs; /*empty*/)
     {
         if (!pack_res[i].isUse())

--- a/dbms/src/Storages/DeltaMerge/File/DMFile.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFile.cpp
@@ -219,7 +219,7 @@ size_t DMFile::colIndexSize(ColId id) const
         }
         else
         {
-            throw Exception(ErrorCodes::FILE_DOESNT_EXIST, "Index of {} not exist", id);
+            throw Exception(ErrorCodes::FILE_DOESNT_EXIST, "Index is not exist, col_id={}", id);
         }
     }
     else

--- a/dbms/src/Storages/DeltaMerge/File/DMFile.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFile.h
@@ -210,6 +210,8 @@ public:
 
     UInt32 metaVersion() const { return meta->metaVersion(); }
 
+    bool isColIndexExist(const ColId & col_id) const;
+
 private:
     DMFile(
         UInt64 file_id_,
@@ -292,8 +294,6 @@ private:
 
     String colIndexCacheKey(const FileNameBase & file_name_base) const;
     String colMarkCacheKey(const FileNameBase & file_name_base) const;
-
-    bool isColIndexExist(const ColId & col_id) const;
 
     String encryptionBasePath() const;
     EncryptionPath encryptionDataPath(const FileNameBase & file_name_base) const;

--- a/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.cpp
@@ -68,8 +68,17 @@ DMFileBlockInputStreamPtr DMFileBlockInputStreamBuilder::build(
     // If pack_filter is not set, we will create a default one.
     if (!pack_filter)
     {
-        pack_filter
-            = std::make_shared<DMFilePackFilterResult>(index_cache, file_provider, read_limiter, scan_context, dmfile);
+        pack_filter = DMFilePackFilter::loadFrom(
+            index_cache,
+            file_provider,
+            read_limiter,
+            scan_context,
+            dmfile,
+            true,
+            rowkey_ranges,
+            EMPTY_RS_OPERATOR,
+            read_packs,
+            tracing_id);
     }
 
     DMFileReader reader(
@@ -175,8 +184,17 @@ SkippableBlockInputStreamPtr DMFileBlockInputStreamBuilder::tryBuildWithVectorIn
     // If pack_filter is not set, we will create a default one.
     if (!pack_filter)
     {
-        pack_filter
-            = std::make_shared<DMFilePackFilterResult>(index_cache, file_provider, read_limiter, scan_context, dmfile);
+        pack_filter = DMFilePackFilter::loadFrom(
+            index_cache,
+            file_provider,
+            read_limiter,
+            scan_context,
+            dmfile,
+            true,
+            rowkey_ranges,
+            EMPTY_RS_OPERATOR,
+            read_packs,
+            tracing_id);
     }
 
     DMFileReader rest_columns_reader(

--- a/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.cpp
@@ -15,7 +15,6 @@
 #include <Interpreters/Context.h>
 #include <Storages/DeltaMerge/File/DMFileBlockInputStream.h>
 #include <Storages/DeltaMerge/File/DMFileWithVectorIndexBlockInputStream.h>
-#include <Storages/DeltaMerge/Filter/WithANNQueryInfo.h>
 #include <Storages/DeltaMerge/Index/VectorIndex.h>
 #include <Storages/DeltaMerge/ScanContext.h>
 
@@ -65,7 +64,7 @@ DMFileBlockInputStreamPtr DMFileBlockInputStreamBuilder::build(
         max_sharing_column_bytes_for_all = 0;
     }
 
-    // If pack_filter is not set, we will create a default one.
+    // If pack_filter is not set, load from EMPTY_RS_OPERATOR.
     if (!pack_filter)
     {
         pack_filter = DMFilePackFilter::loadFrom(
@@ -181,7 +180,7 @@ SkippableBlockInputStreamPtr DMFileBlockInputStreamBuilder::tryBuildWithVectorIn
     bool enable_read_thread = SegmentReaderPoolManager::instance().isSegmentReader();
     bool is_common_handle = !rowkey_ranges.empty() && rowkey_ranges[0].is_common_handle;
 
-    // If pack_filter is not set, we will create a default one.
+    // If pack_filter is not set, load from EMPTY_RS_OPERATOR.
     if (!pack_filter)
     {
         pack_filter = DMFilePackFilter::loadFrom(

--- a/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.cpp
@@ -65,6 +65,13 @@ DMFileBlockInputStreamPtr DMFileBlockInputStreamBuilder::build(
         max_sharing_column_bytes_for_all = 0;
     }
 
+    // If pack_filter is not set, we will create a default one.
+    if (!pack_filter)
+    {
+        pack_filter
+            = std::make_shared<DMFilePackFilterResult>(index_cache, file_provider, read_limiter, scan_context, dmfile);
+    }
+
     DMFileReader reader(
         dmfile,
         read_columns,
@@ -73,7 +80,7 @@ DMFileBlockInputStreamPtr DMFileBlockInputStreamBuilder::build(
         enable_del_clean_read,
         is_fast_scan,
         max_data_version,
-        *pack_filter,
+        pack_filter,
         mark_cache,
         enable_column_cache,
         column_cache,
@@ -165,6 +172,13 @@ SkippableBlockInputStreamPtr DMFileBlockInputStreamBuilder::tryBuildWithVectorIn
     bool enable_read_thread = SegmentReaderPoolManager::instance().isSegmentReader();
     bool is_common_handle = !rowkey_ranges.empty() && rowkey_ranges[0].is_common_handle;
 
+    // If pack_filter is not set, we will create a default one.
+    if (!pack_filter)
+    {
+        pack_filter
+            = std::make_shared<DMFilePackFilterResult>(index_cache, file_provider, read_limiter, scan_context, dmfile);
+    }
+
     DMFileReader rest_columns_reader(
         dmfile,
         rest_columns,
@@ -173,7 +187,7 @@ SkippableBlockInputStreamPtr DMFileBlockInputStreamBuilder::tryBuildWithVectorIn
         enable_del_clean_read,
         is_fast_scan,
         max_data_version,
-        *pack_filter,
+        pack_filter,
         mark_cache,
         enable_column_cache,
         column_cache,
@@ -185,7 +199,7 @@ SkippableBlockInputStreamPtr DMFileBlockInputStreamBuilder::tryBuildWithVectorIn
         tracing_id,
         enable_read_thread,
         scan_context,
-        ReadTag::Query);
+        read_tag);
 
     if (column_cache_long_term && pk_col_id)
         // ColumnCacheLongTerm is only filled in Vector Search.

--- a/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.h
@@ -138,9 +138,9 @@ public:
         return *this;
     }
 
-    DMFileBlockInputStreamBuilder & setRSOperator(const RSOperatorPtr & filter_)
+    DMFileBlockInputStreamBuilder setAnnQureyInfo(const ANNQueryInfoPtr & ann_query_info_)
     {
-        rs_filter = filter_;
+        ann_query_info = ann_query_info_;
         return *this;
     }
 
@@ -177,6 +177,12 @@ public:
     DMFileBlockInputStreamBuilder & setReadTag(ReadTag read_tag_)
     {
         read_tag = read_tag_;
+        return *this;
+    }
+
+    DMFileBlockInputStreamBuilder & setDMFilePackFilterResult(const DMFilePackFilterResultPtr & pack_filter_)
+    {
+        pack_filter = pack_filter_;
         return *this;
     }
 
@@ -217,8 +223,6 @@ private:
     bool is_fast_scan = false;
     bool enable_del_clean_read = false;
     UInt64 max_data_version = std::numeric_limits<UInt64>::max();
-    // Rough set filter
-    RSOperatorPtr rs_filter;
     // packs filter (filter by pack index)
     IdSetPtr read_packs;
     MarkCachePtr mark_cache;
@@ -233,6 +237,10 @@ private:
     size_t max_sharing_column_bytes_for_all = 0;
     String tracing_id;
     ReadTag read_tag = ReadTag::Internal;
+
+    DMFilePackFilterResultPtr pack_filter;
+
+    ANNQueryInfoPtr ann_query_info = nullptr;
 
     VectorIndexCachePtr vector_index_cache;
     // Note: Currently thie field is assigned only for Stable streams, not available for ColumnFileBig

--- a/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.h
@@ -138,7 +138,7 @@ public:
         return *this;
     }
 
-    DMFileBlockInputStreamBuilder setAnnQureyInfo(const ANNQueryInfoPtr & ann_query_info_)
+    DMFileBlockInputStreamBuilder & setAnnQureyInfo(const ANNQueryInfoPtr & ann_query_info_)
     {
         ann_query_info = ann_query_info_;
         return *this;
@@ -162,6 +162,7 @@ public:
         read_one_pack_every_time = true;
         return *this;
     }
+
     DMFileBlockInputStreamBuilder & setRowsThreshold(size_t rows_threshold_per_read_)
     {
         rows_threshold_per_read = rows_threshold_per_read_;

--- a/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter.cpp
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 #include <Common/Exception.h>
+#include <Common/TiFlashMetrics.h>
+#include <IO/FileProvider/ChecksumReadBufferBuilder.h>
 #include <Storages/DeltaMerge/File/DMFilePackFilter.h>
+#include <Storages/DeltaMerge/Filter/FilterHelper.h>
 #include <Storages/DeltaMerge/RowKeyRange.h>
 #include <Storages/DeltaMerge/ScanContext.h>
 

--- a/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter.cpp
@@ -21,12 +21,12 @@
 namespace DB::DM
 {
 
-DMFilePackFilterResultPtr DMFilePackFilter::load(const DMContext & dm_context)
+DMFilePackFilterResultPtr DMFilePackFilter::load()
 {
     Stopwatch watch;
     SCOPE_EXIT({ scan_context->total_rs_pack_filter_check_time_ns += watch.elapsed(); });
     size_t pack_count = dmfile->getPacks();
-    DMFilePackFilterResult result(dm_context, dmfile);
+    DMFilePackFilterResult result(index_cache, file_provider, read_limiter, scan_context, dmfile);
     auto read_all_packs = (rowkey_ranges.size() == 1 && rowkey_ranges[0].all()) || rowkey_ranges.empty();
     if (!read_all_packs)
     {

--- a/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter.cpp
@@ -21,12 +21,12 @@
 namespace DB::DM
 {
 
-DMFilePackFilterResult DMFilePackFilter::load(const DMContext & dm_context)
+DMFilePackFilterResultPtr DMFilePackFilter::load(const DMContext & dm_context)
 {
     Stopwatch watch;
     SCOPE_EXIT({ scan_context->total_rs_pack_filter_check_time_ns += watch.elapsed(); });
     size_t pack_count = dmfile->getPacks();
-    DMFilePackFilterResult result(dm_context, dmfile, pack_count);
+    DMFilePackFilterResult result(dm_context, dmfile);
     auto read_all_packs = (rowkey_ranges.size() == 1 && rowkey_ranges[0].all()) || rowkey_ranges.empty();
     if (!read_all_packs)
     {
@@ -153,7 +153,7 @@ DMFilePackFilterResult DMFilePackFilter::load(const DMContext & dm_context)
         some_count,
         all_count,
         all_null_count);
-    return result;
+    return std::make_shared<DMFilePackFilterResult>(std::move(result));
 }
 
 void DMFilePackFilter::loadIndex(

--- a/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter.cpp
@@ -1,5 +1,4 @@
-
-// Copyright 2023 PingCAP, Inc.
+// Copyright 2024 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,20 +17,20 @@
 #include <Storages/DeltaMerge/RowKeyRange.h>
 #include <Storages/DeltaMerge/ScanContext.h>
 
-#include <magic_enum.hpp>
 
 namespace DB::DM
 {
 
-void DMFilePackFilter::init(ReadTag read_tag)
+DMFilePackFilterResult DMFilePackFilter::load(const DMContext & dm_context)
 {
     Stopwatch watch;
     SCOPE_EXIT({ scan_context->total_rs_pack_filter_check_time_ns += watch.elapsed(); });
     size_t pack_count = dmfile->getPacks();
+    DMFilePackFilterResult result(dm_context, dmfile, pack_count);
     auto read_all_packs = (rowkey_ranges.size() == 1 && rowkey_ranges[0].all()) || rowkey_ranges.empty();
     if (!read_all_packs)
     {
-        tryLoadIndex(EXTRA_HANDLE_COLUMN_ID);
+        tryLoadIndex(result.param, EXTRA_HANDLE_COLUMN_ID);
         std::vector<RSOperatorPtr> handle_filters;
         for (auto & rowkey_range : rowkey_ranges)
             handle_filters.emplace_back(toFilter(rowkey_range));
@@ -64,16 +63,16 @@ void DMFilePackFilter::init(ReadTag read_tag)
 #endif
         for (size_t i = 0; i < pack_count; ++i)
         {
-            handle_res[i] = RSResult::None;
+            result.handle_res[i] = RSResult::None;
         }
         for (auto & handle_filter : handle_filters)
         {
-            auto res = handle_filter->roughCheck(0, pack_count, param);
+            auto res = handle_filter->roughCheck(0, pack_count, result.param);
             std::transform(
-                handle_res.begin(),
-                handle_res.end(),
+                result.handle_res.begin(),
+                result.handle_res.end(),
                 res.begin(),
-                handle_res.begin(),
+                result.handle_res.begin(),
                 [](RSResult a, RSResult b) { return a || b; });
         }
     }
@@ -81,18 +80,18 @@ void DMFilePackFilter::init(ReadTag read_tag)
     ProfileEvents::increment(ProfileEvents::DMFileFilterNoFilter, pack_count);
 
     /// Check packs by handle_res
-    pack_res = handle_res;
-    auto after_pk = countUsePack();
+    result.pack_res = result.handle_res;
+    auto after_pk = result.countUsePack();
 
     /// Check packs by read_packs
     if (read_packs)
     {
         for (size_t i = 0; i < pack_count; ++i)
         {
-            pack_res[i] = read_packs->contains(i) ? pack_res[i] : RSResult::None;
+            result.pack_res[i] = read_packs->contains(i) ? result.pack_res[i] : RSResult::None;
         }
     }
-    auto after_read_packs = countUsePack();
+    auto after_read_packs = result.countUsePack();
     ProfileEvents::increment(ProfileEvents::DMFileFilterAftPKAndPackSet, after_read_packs);
 
     /// Check packs by filter in where clause
@@ -102,36 +101,30 @@ void DMFilePackFilter::init(ReadTag read_tag)
         ColIds ids = filter->getColumnIDs();
         for (const auto & id : ids)
         {
-            tryLoadIndex(id);
+            tryLoadIndex(result.param, id);
         }
 
-        const auto check_results = filter->roughCheck(0, pack_count, param);
+        const auto check_results = filter->roughCheck(0, pack_count, result.param);
         std::transform(
-            pack_res.cbegin(),
-            pack_res.cend(),
+            result.pack_res.cbegin(),
+            result.pack_res.cend(),
             check_results.cbegin(),
-            pack_res.begin(),
+            result.pack_res.begin(),
             [](RSResult a, RSResult b) { return a && b; });
     }
     else
     {
         // ColumnFileBig in DeltaValueSpace never pass a filter to DMFilePackFilter.
         // Assume its filter always return Some.
-        std::transform(pack_res.cbegin(), pack_res.cend(), pack_res.begin(), [](RSResult a) {
+        std::transform(result.pack_res.cbegin(), result.pack_res.cend(), result.pack_res.begin(), [](RSResult a) {
             return a && RSResult::Some;
         });
     }
 
-    auto [none_count, some_count, all_count, all_null_count] = countPackRes();
+    auto [none_count, some_count, all_count, all_null_count] = result.countPackRes();
     auto after_filter = some_count + all_count + all_null_count;
     ProfileEvents::increment(ProfileEvents::DMFileFilterAftRoughSet, after_filter);
-    // In table scanning, DMFilePackFilter of a DMFile may be created several times:
-    // 1. When building MVCC bitmap (ReadTag::MVCC).
-    // 2. When building LM filter stream (ReadTag::LM).
-    // 3. When building stream of other columns (ReadTag::Query).
-    // Only need to count the filter result once.
-    // TODO: We can create DMFilePackFilter at the beginning and pass it to the stages described above.
-    if (read_tag == ReadTag::Query)
+    if (scan_context)
     {
         scan_context->rs_pack_filter_none += none_count;
         scan_context->rs_pack_filter_some += some_count;
@@ -148,8 +141,7 @@ void DMFilePackFilter::init(ReadTag read_tag)
     LOG_DEBUG(
         log,
         "RSFilter exclude rate: {:.2f}, after_pk: {}, after_read_packs: {}, after_filter: {}, handle_ranges: {}"
-        ", read_packs: {}, pack_count: {}, none_count: {}, some_count: {}, all_count: {}, all_null_count: {}, "
-        "read_tag: {}",
+        ", read_packs: {}, pack_count: {}, none_count: {}, some_count: {}, all_count: {}, all_null_count: {}",
         ((after_read_packs == 0) ? std::numeric_limits<double>::quiet_NaN() : filter_rate),
         after_pk,
         after_read_packs,
@@ -160,33 +152,8 @@ void DMFilePackFilter::init(ReadTag read_tag)
         none_count,
         some_count,
         all_count,
-        all_null_count,
-        magic_enum::enum_name(read_tag));
-}
-
-std::tuple<UInt64, UInt64, UInt64, UInt64> DMFilePackFilter::countPackRes() const
-{
-    UInt64 none_count = 0;
-    UInt64 some_count = 0;
-    UInt64 all_count = 0;
-    UInt64 all_null_count = 0;
-    for (auto res : pack_res)
-    {
-        if (res == RSResult::None || res == RSResult::NoneNull)
-            ++none_count;
-        else if (res == RSResult::Some || res == RSResult::SomeNull)
-            ++some_count;
-        else if (res == RSResult::All)
-            ++all_count;
-        else if (res == RSResult::AllNull)
-            ++all_null_count;
-    }
-    return {none_count, some_count, all_count, all_null_count};
-}
-
-UInt64 DMFilePackFilter::countUsePack() const
-{
-    return std::count_if(pack_res.cbegin(), pack_res.cend(), [](RSResult res) { return res.isUse(); });
+        all_null_count);
+    return result;
 }
 
 void DMFilePackFilter::loadIndex(
@@ -296,7 +263,7 @@ void DMFilePackFilter::loadIndex(
     indexes.emplace(col_id, RSIndex(type, minmax_index));
 }
 
-void DMFilePackFilter::tryLoadIndex(ColId col_id)
+void DMFilePackFilter::tryLoadIndex(RSCheckParam & param, ColId col_id)
 {
     if (param.indexes.count(col_id))
         return;

--- a/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter.cpp
@@ -25,7 +25,7 @@
 namespace DB::DM
 {
 
-std::pair<size_t, size_t> DMFilePackFilter::loadValidRowsAndBytes(
+DMFilePackFilter::MatchDetails DMFilePackFilter::loadValidRowsAndBytes(
     const DMContext & dm_context,
     const DMFilePtr & dmfile,
     bool set_cache_if_miss,
@@ -33,18 +33,18 @@ std::pair<size_t, size_t> DMFilePackFilter::loadValidRowsAndBytes(
 {
     auto pack_filter = loadFrom(dm_context, dmfile, set_cache_if_miss, rowkey_ranges, EMPTY_RS_OPERATOR, {});
 
-    size_t rows = 0;
-    size_t bytes = 0;
+    MatchDetails res;
     const auto & pack_stats = dmfile->getPackStats();
     for (size_t i = 0; i < pack_stats.size(); ++i)
     {
         if (pack_filter->pack_res[i].isUse())
         {
-            rows += pack_stats[i].rows;
-            bytes += pack_stats[i].bytes;
+            res.match_packs += 1;
+            res.match_rows += pack_stats[i].rows;
+            res.match_bytes += pack_stats[i].bytes;
         }
     }
-    return {rows, bytes};
+    return res;
 }
 
 DMFilePackFilterResultPtr DMFilePackFilter::load()

--- a/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter.h
@@ -45,7 +45,7 @@ class DMFilePackFilter
 
 public:
     // Empty `rowkey_ranges` means do not filter by rowkey_ranges
-    static DMFilePackFilterResult loadFrom(
+    static DMFilePackFilterResultPtr loadFrom(
         const DMContext & dm_context,
         const DMFilePtr & dmfile,
         bool set_cache_if_miss,
@@ -91,7 +91,7 @@ private:
         , read_limiter(read_limiter_)
     {}
 
-    DMFilePackFilterResult load(const DMContext & dm_context);
+    DMFilePackFilterResultPtr load(const DMContext & dm_context);
 
     static void loadIndex(
         ColumnIndexes & indexes,

--- a/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter.h
@@ -14,21 +14,15 @@
 
 #pragma once
 
-#include <Common/Exception.h>
-#include <Common/Logger.h>
-#include <Common/TiFlashMetrics.h>
-#include <IO/FileProvider/ChecksumReadBufferBuilder.h>
 #include <Interpreters/Context.h>
 #include <Storages/DeltaMerge/DMContext.h>
 #include <Storages/DeltaMerge/File/DMFile.h>
 #include <Storages/DeltaMerge/File/DMFilePackFilterResult.h>
 #include <Storages/DeltaMerge/File/DMFilePackFilter_fwd.h>
-#include <Storages/DeltaMerge/Filter/FilterHelper.h>
 #include <Storages/DeltaMerge/Filter/RSOperator_fwd.h>
-#include <Storages/DeltaMerge/ReadMode.h>
 #include <Storages/DeltaMerge/RowKeyRange.h>
 #include <Storages/DeltaMerge/ScanContext_fwd.h>
-#include <Storages/S3/S3Common.h>
+
 
 namespace ProfileEvents
 {

--- a/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter.h
@@ -39,8 +39,14 @@ class DMFilePackFilter
     friend class DMFilePackFilterResult;
 
 public:
-    // Get valid rows and bytes after filter invalid packs by rowkey_ranges
-    static std::pair<size_t, size_t> loadValidRowsAndBytes(
+    struct MatchDetails
+    {
+        size_t match_packs = 0;
+        size_t match_rows = 0;
+        size_t match_bytes = 0;
+    };
+    // Get approximate valid rows and bytes after filter invalid packs by rowkey_ranges
+    static MatchDetails loadValidRowsAndBytes(
         const DMContext & dm_context,
         const DMFilePtr & dmfile,
         bool set_cache_if_miss,

--- a/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter.h
@@ -39,6 +39,13 @@ class DMFilePackFilter
     friend class DMFilePackFilterResult;
 
 public:
+    // Get valid rows and bytes after filter invalid packs by rowkey_ranges
+    static std::pair<size_t, size_t> loadValidRowsAndBytes(
+        const DMContext & dm_context,
+        const DMFilePtr & dmfile,
+        bool set_cache_if_miss,
+        const RowKeyRanges & rowkey_ranges);
+
     // Empty `rowkey_ranges` means do not filter by rowkey_ranges
     static DMFilePackFilterResultPtr loadFrom(
         const DMContext & dm_context,

--- a/dbms/src/Storages/DeltaMerge/File/DMFilePackFilterResult.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFilePackFilterResult.cpp
@@ -73,7 +73,7 @@ void DMFilePackFilterResult::tryLoadIndex(ColId col_id) const
         dmfile,
         file_provider,
         index_cache,
-        true,
+        /*set_cache_if_miss=*/true,
         col_id,
         read_limiter,
         scan_context);

--- a/dbms/src/Storages/DeltaMerge/File/DMFilePackFilterResult.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFilePackFilterResult.cpp
@@ -23,22 +23,6 @@ UInt64 DMFilePackFilterResult::countUsePack() const
     return std::count_if(pack_res.begin(), pack_res.end(), [](RSResult res) { return res.isUse(); });
 }
 
-std::pair<size_t, size_t> DMFilePackFilterResult::validRowsAndBytes()
-{
-    size_t rows = 0;
-    size_t bytes = 0;
-    const auto & pack_stats = dmfile->getPackStats();
-    for (size_t i = 0; i < pack_stats.size(); ++i)
-    {
-        if (pack_res[i].isUse())
-        {
-            rows += pack_stats[i].rows;
-            bytes += pack_stats[i].bytes;
-        }
-    }
-    return {rows, bytes};
-}
-
 std::tuple<UInt64, UInt64, UInt64, UInt64> DMFilePackFilterResult::countPackRes() const
 {
     UInt64 none_count = 0;
@@ -59,7 +43,11 @@ std::tuple<UInt64, UInt64, UInt64, UInt64> DMFilePackFilterResult::countPackRes(
     return {none_count, some_count, all_count, all_null_count};
 }
 
-void DMFilePackFilterResult::tryLoadIndex(ColId col_id) const
+void DMFilePackFilterResult::tryLoadIndex(
+    const DMFilePtr & dmfile,
+    ColId col_id,
+    const FileProviderPtr & file_provider,
+    const ScanContextPtr & scan_context) const
 {
     if (param.indexes.count(col_id))
         return;

--- a/dbms/src/Storages/DeltaMerge/File/DMFilePackFilterResult.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFilePackFilterResult.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <Interpreters/Context.h>
 #include <Storages/DeltaMerge/File/DMFilePackFilter.h>
 #include <Storages/DeltaMerge/File/DMFilePackFilterResult.h>
 
@@ -72,12 +71,12 @@ void DMFilePackFilterResult::tryLoadIndex(ColId col_id) const
     DMFilePackFilter::loadIndex(
         param.indexes,
         dmfile,
-        dm_context.global_context.getFileProvider(),
-        dm_context.global_context.getMinMaxIndexCache(),
+        file_provider,
+        index_cache,
         true,
         col_id,
-        dm_context.global_context.getReadLimiter(),
-        dm_context.scan_context);
+        read_limiter,
+        scan_context);
 }
 
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/File/DMFilePackFilterResult.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFilePackFilterResult.cpp
@@ -1,0 +1,83 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Interpreters/Context.h>
+#include <Storages/DeltaMerge/File/DMFilePackFilter.h>
+#include <Storages/DeltaMerge/File/DMFilePackFilterResult.h>
+
+namespace DB::DM
+{
+
+UInt64 DMFilePackFilterResult::countUsePack() const
+{
+    return std::count_if(pack_res.begin(), pack_res.end(), [](RSResult res) { return res.isUse(); });
+}
+
+std::pair<size_t, size_t> DMFilePackFilterResult::validRowsAndBytes()
+{
+    size_t rows = 0;
+    size_t bytes = 0;
+    const auto & pack_stats = dmfile->getPackStats();
+    for (size_t i = 0; i < pack_stats.size(); ++i)
+    {
+        if (pack_res[i].isUse())
+        {
+            rows += pack_stats[i].rows;
+            bytes += pack_stats[i].bytes;
+        }
+    }
+    return {rows, bytes};
+}
+
+std::tuple<UInt64, UInt64, UInt64, UInt64> DMFilePackFilterResult::countPackRes() const
+{
+    UInt64 none_count = 0;
+    UInt64 some_count = 0;
+    UInt64 all_count = 0;
+    UInt64 all_null_count = 0;
+    for (auto res : pack_res)
+    {
+        if (res == RSResult::None || res == RSResult::NoneNull)
+            ++none_count;
+        else if (res == RSResult::Some || res == RSResult::SomeNull)
+            ++some_count;
+        else if (res == RSResult::All)
+            ++all_count;
+        else if (res == RSResult::AllNull)
+            ++all_null_count;
+    }
+    return {none_count, some_count, all_count, all_null_count};
+}
+
+void DMFilePackFilterResult::tryLoadIndex(ColId col_id) const
+{
+    if (param.indexes.count(col_id))
+        return;
+
+    if (!dmfile->isColIndexExist(col_id))
+        return;
+
+    Stopwatch watch;
+    DMFilePackFilter::loadIndex(
+        param.indexes,
+        dmfile,
+        dm_context.global_context.getFileProvider(),
+        dm_context.global_context.getMinMaxIndexCache(),
+        true,
+        col_id,
+        dm_context.global_context.getReadLimiter(),
+        dm_context.scan_context);
+}
+
+} // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/File/DMFilePackFilterResult.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFilePackFilterResult.h
@@ -14,9 +14,8 @@
 
 #pragma once
 
-#include <Interpreters/Context.h>
-#include <Storages/DeltaMerge/DMContext.h>
 #include <Storages/DeltaMerge/File/DMFile.h>
+#include <Storages/DeltaMerge/File/DMFilePackFilter_fwd.h>
 #include <Storages/DeltaMerge/Filter/RSOperator.h>
 #include <Storages/DeltaMerge/Index/RSResult.h>
 
@@ -32,16 +31,6 @@ class DMFilePackFilterResult
     friend class DMFilePackFilter;
 
 public:
-    DMFilePackFilterResult(const DMContext & dm_context_, const DMFilePtr & dmfile_)
-        : index_cache(dm_context_.global_context.getMinMaxIndexCache())
-        , file_provider(dm_context_.global_context.getFileProvider())
-        , read_limiter(dm_context_.global_context.getReadLimiter())
-        , scan_context(dm_context_.scan_context)
-        , dmfile(dmfile_)
-        , handle_res(dmfile->getPacks(), RSResult::All)
-        , pack_res(dmfile->getPacks(), RSResult::Some)
-    {}
-
     DMFilePackFilterResult(
         const MinMaxIndexCachePtr & index_cache_,
         const FileProviderPtr & file_provider_,
@@ -83,16 +72,6 @@ public:
             tryLoadIndex(VERSION_COLUMN_ID);
         auto & minmax_index = param.indexes.find(VERSION_COLUMN_ID)->second.minmax;
         return minmax_index->getUInt64MinMax(pack_id).second;
-    }
-
-    // Only for test
-    static DMFilePackFilterResults defaultResults(const DMContext & dm_context, const DMFiles & files)
-    {
-        DMFilePackFilterResults results;
-        results.reserve(files.size());
-        for (const auto & file : files)
-            results.push_back(std::make_shared<DMFilePackFilterResult>(dm_context, file));
-        return results;
     }
 
     // Get valid rows and bytes after filter invalid packs by handle_range and filter

--- a/dbms/src/Storages/DeltaMerge/File/DMFilePackFilterResult.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFilePackFilterResult.h
@@ -58,7 +58,7 @@ public:
     {}
 
     const RSResults & getHandleRes() const { return handle_res; }
-    const RSResults & getPackResConst() const { return pack_res; }
+    const RSResults & getPackRes() const { return pack_res; }
     UInt64 countUsePack() const;
 
     Handle getMinHandle(size_t pack_id) const

--- a/dbms/src/Storages/DeltaMerge/File/DMFilePackFilterResult.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFilePackFilterResult.h
@@ -21,10 +21,6 @@
 namespace DB::DM
 {
 
-class DMFilePackFilterResult;
-using DMFilePackFilterResultPtr = std::shared_ptr<DMFilePackFilterResult>;
-using DMFilePackFilterResults = std::vector<DMFilePackFilterResultPtr>;
-
 class DMFilePackFilterResult
 {
     friend class DMFilePackFilter;

--- a/dbms/src/Storages/DeltaMerge/File/DMFilePackFilterResult.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFilePackFilterResult.h
@@ -1,0 +1,106 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <Storages/DeltaMerge/DMContext.h>
+#include <Storages/DeltaMerge/File/DMFile.h>
+#include <Storages/DeltaMerge/Filter/RSOperator.h>
+#include <Storages/DeltaMerge/Index/RSResult.h>
+
+namespace DB::DM
+{
+
+class DMFilePackFilterResult;
+using DMFilePackFilterResultPtr = std::shared_ptr<DMFilePackFilterResult>;
+using DMFilePackFilterResults = std::vector<DMFilePackFilterResultPtr>;
+
+class DMFilePackFilterResult
+{
+    friend class DMFilePackFilter;
+
+public:
+    DMFilePackFilterResult(const DMContext & dm_context_, const DMFilePtr & dmfile_, size_t pack_count_)
+        : dm_context(dm_context_)
+        , dmfile(dmfile_)
+        , handle_res(pack_count_, RSResult::All)
+    {}
+
+    const RSResults & getHandleRes() const { return handle_res; }
+    const RSResults & getPackResConst() const { return pack_res; }
+    RSResults & getPackRes() { return pack_res; }
+    UInt64 countUsePack() const;
+
+    Handle getMinHandle(size_t pack_id) const
+    {
+        if (!param.indexes.count(EXTRA_HANDLE_COLUMN_ID))
+            tryLoadIndex(EXTRA_HANDLE_COLUMN_ID);
+        auto & minmax_index = param.indexes.find(EXTRA_HANDLE_COLUMN_ID)->second.minmax;
+        return minmax_index->getIntMinMax(pack_id).first;
+    }
+
+    StringRef getMinStringHandle(size_t pack_id) const
+    {
+        if (!param.indexes.count(EXTRA_HANDLE_COLUMN_ID))
+            tryLoadIndex(EXTRA_HANDLE_COLUMN_ID);
+        auto & minmax_index = param.indexes.find(EXTRA_HANDLE_COLUMN_ID)->second.minmax;
+        return minmax_index->getStringMinMax(pack_id).first;
+    }
+
+    UInt64 getMaxVersion(size_t pack_id) const
+    {
+        if (!param.indexes.count(VERSION_COLUMN_ID))
+            tryLoadIndex(VERSION_COLUMN_ID);
+        auto & minmax_index = param.indexes.find(VERSION_COLUMN_ID)->second.minmax;
+        return minmax_index->getUInt64MinMax(pack_id).second;
+    }
+
+    static DMFilePackFilterResultPtr emptyResult(const DMContext & dm_context, const DMFilePtr & dmfile)
+    {
+        return std::make_shared<DMFilePackFilterResult>(dm_context, dmfile, 0);
+    }
+
+    static DMFilePackFilterResults emptyResults(const DMContext & dm_context, const DMFiles & files)
+    {
+        DMFilePackFilterResults results;
+        results.reserve(files.size());
+        for (const auto & file : files)
+        {
+            results.push_back(emptyResult(dm_context, file));
+        }
+        return results;
+    }
+
+    // Get valid rows and bytes after filter invalid packs by handle_range and filter
+    std::pair<size_t, size_t> validRowsAndBytes();
+
+    // None+NoneNull, Some+SomeNull, All, AllNull
+    std::tuple<UInt64, UInt64, UInt64, UInt64> countPackRes() const;
+
+private:
+    void tryLoadIndex(ColId col_id) const;
+
+private:
+    const DMContext & dm_context;
+
+    DMFilePtr dmfile;
+    mutable RSCheckParam param;
+
+    // `handle_res` is the filter results of `rowkey_ranges`.
+    std::vector<RSResult> handle_res;
+    // `pack_res` is the filter results of `rowkey_ranges && filter && read_packs`.
+    std::vector<RSResult> pack_res;
+};
+
+} // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/File/DMFilePackFilterResult.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFilePackFilterResult.h
@@ -15,7 +15,6 @@
 #pragma once
 
 #include <Storages/DeltaMerge/File/DMFile.h>
-#include <Storages/DeltaMerge/File/DMFilePackFilter_fwd.h>
 #include <Storages/DeltaMerge/Filter/RSOperator.h>
 #include <Storages/DeltaMerge/Index/RSResult.h>
 
@@ -30,7 +29,6 @@ class DMFilePackFilterResult
 {
     friend class DMFilePackFilter;
 
-public:
     DMFilePackFilterResult(
         const MinMaxIndexCachePtr & index_cache_,
         const FileProviderPtr & file_provider_,
@@ -46,6 +44,7 @@ public:
         , pack_res(dmfile->getPacks(), RSResult::Some)
     {}
 
+public:
     const RSResults & getHandleRes() const { return handle_res; }
     const RSResults & getPackRes() const { return pack_res; }
     UInt64 countUsePack() const;

--- a/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter_fwd.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter_fwd.h
@@ -24,4 +24,8 @@ using IdSetPtr = std::shared_ptr<IdSet>;
 
 class DMFilePackFilter;
 
+class DMFilePackFilterResult;
+using DMFilePackFilterResultPtr = std::shared_ptr<DMFilePackFilterResult>;
+using DMFilePackFilterResults = std::vector<DMFilePackFilterResultPtr>;
+
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/File/DMFileReader.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileReader.cpp
@@ -706,7 +706,7 @@ void DMFileReader::addSkippedRows(UInt64 rows)
 
 void DMFileReader::initReadBlockInfos()
 {
-    const auto & pack_res = pack_filter->getPackResConst();
+    const auto & pack_res = pack_filter->getPackRes();
     const auto & pack_stats = dmfile->getPackStats();
 
     const size_t read_pack_limit = read_one_pack_every_time ? 1 : std::numeric_limits<size_t>::max();
@@ -756,7 +756,7 @@ std::vector<DMFileReader::ReadBlockInfo> DMFileReader::splitReadBlockInfos(
 {
     const auto pack_end = read_info.start_pack_id + read_info.pack_count;
     const size_t start_row_offset = pack_offset[read_info.start_pack_id];
-    const auto & pack_res = pack_filter->getPackResConst();
+    const auto & pack_res = pack_filter->getPackRes();
     const auto & pack_stats = dmfile->getPackStats();
     std::vector<ReadBlockInfo> new_read_block_infos;
     new_read_block_infos.reserve(pack_end - read_info.start_pack_id);

--- a/dbms/src/Storages/DeltaMerge/File/DMFileReader.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileReader.cpp
@@ -312,7 +312,7 @@ Block DMFileReader::readImpl(const ReadBlockInfo & read_info)
             // If all handle in a pack are in the given range, no not_clean rows, and max version <= max_read_version,
             // we do not need to read handle column.
             if (handle_res[i] == RSResult::All && pack_stats[i].not_clean == 0
-                && pack_filter->getMaxVersion(i) <= max_read_version)
+                && pack_filter->getMaxVersion(dmfile, i, file_provider, scan_context) <= max_read_version)
             {
                 handle_column_clean_read_packs.push_back(i);
                 version_column_clean_read_packs.push_back(i);
@@ -375,12 +375,12 @@ ColumnPtr DMFileReader::cleanRead(
     {
         if (is_common_handle)
         {
-            StringRef min_handle = pack_filter->getMinStringHandle(range.first);
+            StringRef min_handle = pack_filter->getMinStringHandle(dmfile, range.first, file_provider, scan_context);
             return cd.type->createColumnConst(rows_count, Field(min_handle.data, min_handle.size));
         }
         else
         {
-            Handle min_handle = pack_filter->getMinHandle(range.first);
+            Handle min_handle = pack_filter->getMinHandle(dmfile, range.first, file_provider, scan_context);
             return cd.type->createColumnConst(rows_count, Field(min_handle));
         }
     }

--- a/dbms/src/Storages/DeltaMerge/File/DMFileReader.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileReader.cpp
@@ -46,7 +46,7 @@ DMFileReader::DMFileReader(
     bool is_fast_scan_,
     UInt64 max_read_version_,
     // filters
-    DMFilePackFilter && pack_filter_,
+    const DMFilePackFilterResult & pack_filter_,
     // caches
     const MarkCachePtr & mark_cache_,
     bool enable_column_cache_,
@@ -69,7 +69,7 @@ DMFileReader::DMFileReader(
     , is_fast_scan(is_fast_scan_)
     , enable_column_cache(enable_column_cache_ && column_cache_)
     , max_read_version(max_read_version_)
-    , pack_filter(std::move(pack_filter_))
+    , pack_filter(pack_filter_)
     , mark_cache(mark_cache_)
     , column_cache(column_cache_)
     , scan_context(scan_context_)

--- a/dbms/src/Storages/DeltaMerge/File/DMFileReader.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileReader.cpp
@@ -16,6 +16,7 @@
 #include <Common/Exception.h>
 #include <Common/MemoryTracker.h>
 #include <Common/Stopwatch.h>
+#include <Common/TiFlashMetrics.h>
 #include <Common/escapeForFileName.h>
 #include <DataTypes/IDataType.h>
 #include <Storages/DeltaMerge/DeltaMergeDefines.h>

--- a/dbms/src/Storages/DeltaMerge/File/DMFileReader.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileReader.h
@@ -56,7 +56,7 @@ public:
         // The the MVCC filter version. Used by clean read check.
         UInt64 max_read_version_,
         // filters
-        const DMFilePackFilterResult & pack_filter_,
+        const DMFilePackFilterResultPtr & pack_filter_,
         // caches
         const MarkCachePtr & mark_cache_,
         bool enable_column_cache_,
@@ -184,7 +184,7 @@ private:
     const UInt64 max_read_version;
 
     /// Filters
-    const DMFilePackFilterResult & pack_filter;
+    const DMFilePackFilterResultPtr pack_filter;
 
     /// Caches
     MarkCachePtr mark_cache;

--- a/dbms/src/Storages/DeltaMerge/File/DMFileReader.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileReader.h
@@ -56,7 +56,7 @@ public:
         // The the MVCC filter version. Used by clean read check.
         UInt64 max_read_version_,
         // filters
-        DMFilePackFilter && pack_filter_,
+        const DMFilePackFilterResult & pack_filter_,
         // caches
         const MarkCachePtr & mark_cache_,
         bool enable_column_cache_,
@@ -184,7 +184,7 @@ private:
     const UInt64 max_read_version;
 
     /// Filters
-    DMFilePackFilter pack_filter;
+    const DMFilePackFilterResult & pack_filter;
 
     /// Caches
     MarkCachePtr mark_cache;

--- a/dbms/src/Storages/DeltaMerge/File/DMFileWithVectorIndexBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileWithVectorIndexBlockInputStream.cpp
@@ -151,7 +151,7 @@ void DMFileWithVectorIndexBlockInputStream::updateReadBlockInfos()
 
     read_block_infos.clear();
     const auto & pack_stats = dmfile->getPackStats();
-    const auto & pack_res = reader.pack_filter->getPackResConst();
+    const auto & pack_res = reader.pack_filter->getPackRes();
 
     // Update valid_packs_before_search
     for (const auto res : pack_res)

--- a/dbms/src/Storages/DeltaMerge/File/DMFileWithVectorIndexBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileWithVectorIndexBlockInputStream.cpp
@@ -151,7 +151,7 @@ void DMFileWithVectorIndexBlockInputStream::updateReadBlockInfos()
 
     read_block_infos.clear();
     const auto & pack_stats = dmfile->getPackStats();
-    const auto & pack_res = reader.pack_filter.getPackResConst();
+    const auto & pack_res = reader.pack_filter->getPackResConst();
 
     // Update valid_packs_before_search
     for (const auto res : pack_res)

--- a/dbms/src/Storages/DeltaMerge/Index/RSResult.h
+++ b/dbms/src/Storages/DeltaMerge/Index/RSResult.h
@@ -46,9 +46,6 @@ private:
     static ValueResult logicalAnd(ValueResult v0, ValueResult v1) noexcept;
     static ValueResult logicalOr(ValueResult v0, ValueResult v1) noexcept;
 
-    // Deleting or privating constructors, so that cannot create invalid objects.
-    // Use the static member variables below.
-    RSResult() = delete;
     RSResult(ValueResult v_, bool has_null_)
         : v(v_)
         , has_null(has_null_)
@@ -60,6 +57,10 @@ private:
     bool has_null;
 
 public:
+    // Deleting constructors, so that cannot create invalid objects.
+    // Use the static member variables below.
+    RSResult() = delete;
+
     bool isUse() const noexcept { return v != ValueResult::None; }
 
     bool allMatch() const noexcept { return *this == RSResult::All; }

--- a/dbms/src/Storages/DeltaMerge/Segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/Segment.cpp
@@ -3526,7 +3526,6 @@ BlockInputStreamPtr Segment::getBitmapFilterInputStream(
             read_data_block_rows);
     }
 
-    std::cout << "getBitmapFilterInputStream" << std::endl;
     auto stream = getConcatSkippableBlockInputStream(
         bitmap_filter,
         segment_snap,

--- a/dbms/src/Storages/DeltaMerge/Segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/Segment.cpp
@@ -950,16 +950,17 @@ BlockInputStreamPtr Segment::getInputStream(
 
     // load DMilePackFilterResult for each DMFile
     DMFilePackFilterResults pack_filter_results;
+    pack_filter_results.reserve(segment_snap->stable->getDMFiles().size());
     for (const auto & dmfile : segment_snap->stable->getDMFiles())
     {
-        auto result = std::make_shared<DMFilePackFilterResult>(DMFilePackFilter::loadFrom(
+        auto result = DMFilePackFilter::loadFrom(
             dm_context,
             dmfile,
             /*set_cache_if_miss*/ true,
             read_ranges,
             filter ? filter->rs_operator : EMPTY_RS_OPERATOR,
-            /*read_pack*/ {}));
-        pack_filter_results.emplace_back(std::move(result));
+            /*read_pack*/ {});
+        pack_filter_results.push_back(result);
     }
 
     switch (read_mode)
@@ -3525,6 +3526,7 @@ BlockInputStreamPtr Segment::getBitmapFilterInputStream(
             read_data_block_rows);
     }
 
+    std::cout << "getBitmapFilterInputStream" << std::endl;
     auto stream = getConcatSkippableBlockInputStream(
         bitmap_filter,
         segment_snap,

--- a/dbms/src/Storages/DeltaMerge/Segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/Segment.cpp
@@ -3151,7 +3151,7 @@ std::pair<std::vector<Range>, std::vector<IdSetPtr>> parseDMFilePackInfo(
     {
         const auto & dmfile = dmfiles[i];
         const auto & pack_filter = pack_filter_result[i];
-        const auto & pack_res = pack_filter->getPackResConst();
+        const auto & pack_res = pack_filter->getPackRes();
         const auto & handle_res = pack_filter->getHandleRes();
         const auto & pack_stats = dmfile->getPackStats();
 

--- a/dbms/src/Storages/DeltaMerge/Segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/Segment.cpp
@@ -947,6 +947,21 @@ BlockInputStreamPtr Segment::getInputStream(
         expected_block_size,
         columns_to_read,
         segment_snap->stable->stable);
+
+    // load DMilePackFilterResult for each DMFile
+    DMFilePackFilterResults pack_filter_results;
+    for (const auto & dmfile : segment_snap->stable->getDMFiles())
+    {
+        auto result = std::make_shared<DMFilePackFilterResult>(DMFilePackFilter::loadFrom(
+            dm_context,
+            dmfile,
+            /*set_cache_if_miss*/ true,
+            read_ranges,
+            filter ? filter->rs_operator : EMPTY_RS_OPERATOR,
+            /*read_pack*/ {}));
+        pack_filter_results.emplace_back(std::move(result));
+    }
+
     switch (read_mode)
     {
     case ReadMode::Normal:
@@ -955,7 +970,7 @@ BlockInputStreamPtr Segment::getInputStream(
             columns_to_read,
             segment_snap,
             read_ranges,
-            filter ? filter->rs_operator : EMPTY_RS_OPERATOR,
+            pack_filter_results,
             start_ts,
             clipped_block_rows);
     case ReadMode::Fast:
@@ -964,7 +979,7 @@ BlockInputStreamPtr Segment::getInputStream(
             columns_to_read,
             segment_snap,
             read_ranges,
-            filter ? filter->rs_operator : EMPTY_RS_OPERATOR,
+            pack_filter_results,
             clipped_block_rows);
     case ReadMode::Raw:
         return getInputStreamModeRaw( //
@@ -980,6 +995,7 @@ BlockInputStreamPtr Segment::getInputStream(
             segment_snap,
             read_ranges,
             filter,
+            pack_filter_results,
             start_ts,
             expected_block_size,
             clipped_block_rows);
@@ -1002,7 +1018,7 @@ BlockInputStreamPtr Segment::getInputStreamModeNormal(
     const ColumnDefines & columns_to_read,
     const SegmentSnapshotPtr & segment_snap,
     const RowKeyRanges & read_ranges,
-    const RSOperatorPtr & filter,
+    const DMFilePackFilterResults & pack_filter_results,
     UInt64 start_ts,
     size_t expected_block_size,
     bool need_row_id)
@@ -1027,11 +1043,11 @@ BlockInputStreamPtr Segment::getInputStreamModeNormal(
             dm_context,
             *read_info.read_columns,
             real_ranges,
-            filter,
             start_ts,
             expected_block_size,
             false,
-            read_tag);
+            read_tag,
+            pack_filter_results);
     }
     else if (useCleanRead(segment_snap, columns_to_read))
     {
@@ -1041,11 +1057,11 @@ BlockInputStreamPtr Segment::getInputStreamModeNormal(
             dm_context,
             *read_info.read_columns,
             real_ranges,
-            filter,
             start_ts,
             expected_block_size,
             true,
-            read_tag);
+            read_tag,
+            pack_filter_results);
     }
     else
     {
@@ -1053,13 +1069,13 @@ BlockInputStreamPtr Segment::getInputStreamModeNormal(
             dm_context,
             *read_info.read_columns,
             real_ranges,
-            filter,
             segment_snap->stable,
             read_info.getDeltaReader(need_row_id ? ReadTag::MVCC : ReadTag::Query),
             read_info.index_begin,
             read_info.index_end,
             expected_block_size,
             read_tag,
+            pack_filter_results,
             start_ts,
             need_row_id);
     }
@@ -1086,7 +1102,7 @@ BlockInputStreamPtr Segment::getInputStreamModeNormal(
     const DMContext & dm_context,
     const ColumnDefines & columns_to_read,
     const RowKeyRanges & read_ranges,
-    const RSOperatorPtr & filter,
+    const DMFilePackFilterResults & pack_filter_results,
     UInt64 start_ts,
     size_t expected_block_size)
 {
@@ -1098,7 +1114,7 @@ BlockInputStreamPtr Segment::getInputStreamModeNormal(
         columns_to_read,
         segment_snap,
         read_ranges,
-        filter,
+        pack_filter_results,
         start_ts,
         expected_block_size);
 }
@@ -1118,7 +1134,6 @@ BlockInputStreamPtr Segment::getInputStreamForDataExport(
         dm_context,
         *read_info.read_columns,
         data_ranges,
-        EMPTY_RS_OPERATOR,
         segment_snap->stable,
         read_info.getDeltaReader(ReadTag::Internal),
         read_info.index_begin,
@@ -1153,7 +1168,7 @@ BlockInputStreamPtr Segment::getInputStreamModeFast(
     const ColumnDefines & columns_to_read,
     const SegmentSnapshotPtr & segment_snap,
     const RowKeyRanges & read_ranges,
-    const RSOperatorPtr & filter,
+    const DMFilePackFilterResults & pack_filter_results,
     size_t expected_block_size)
 {
     auto real_ranges = shrinkRowKeyRanges(read_ranges);
@@ -1206,11 +1221,11 @@ BlockInputStreamPtr Segment::getInputStreamModeFast(
         dm_context,
         *new_columns_to_read,
         real_ranges,
-        filter,
         std::numeric_limits<UInt64>::max(),
         expected_block_size,
         enable_handle_clean_read,
         ReadTag::Query,
+        pack_filter_results,
         /* is_fast_scan */ true,
         enable_del_clean_read);
 
@@ -1272,7 +1287,6 @@ BlockInputStreamPtr Segment::getInputStreamModeRaw(
         dm_context,
         *new_columns_to_read,
         data_ranges,
-        EMPTY_RS_OPERATOR,
         std::numeric_limits<UInt64>::max(),
         expected_block_size,
         /* enable_handle_clean_read */ false,
@@ -1790,7 +1804,6 @@ std::optional<RowKeyValue> Segment::getSplitPointSlow(
             dm_context,
             *pk_col_defs,
             rowkey_ranges,
-            EMPTY_RS_OPERATOR,
             segment_snap->stable,
             delta_reader,
             read_info.index_begin,
@@ -1817,7 +1830,6 @@ std::optional<RowKeyValue> Segment::getSplitPointSlow(
         dm_context,
         *pk_col_defs,
         rowkey_ranges,
-        EMPTY_RS_OPERATOR,
         segment_snap->stable,
         delta_reader,
         read_info.index_begin,
@@ -2107,7 +2119,6 @@ std::optional<Segment::SplitInfo> Segment::prepareSplitPhysical( //
             dm_context,
             *read_info.read_columns,
             my_ranges,
-            EMPTY_RS_OPERATOR,
             segment_snap->stable,
             my_delta_reader,
             read_info.index_begin,
@@ -2139,14 +2150,12 @@ std::optional<Segment::SplitInfo> Segment::prepareSplitPhysical( //
             dm_context,
             *read_info.read_columns,
             other_ranges,
-            EMPTY_RS_OPERATOR,
             segment_snap->stable,
             other_delta_reader,
             read_info.index_begin,
             read_info.index_end,
             dm_context.stable_pack_rows,
             ReadTag::Internal);
-
 
         other_data = std::make_shared<DMRowKeyFilterBlockInputStream<true>>(other_data, other_ranges, 0);
         other_data = std::make_shared<PKSquashingBlockInputStream<false>>(
@@ -2342,7 +2351,6 @@ StableValueSpacePtr Segment::prepareMerge(
             dm_context,
             *read_info.read_columns,
             rowkey_ranges,
-            EMPTY_RS_OPERATOR,
             segment_snap->stable,
             read_info.getDeltaReader(ReadTag::Internal),
             read_info.index_begin,
@@ -2706,13 +2714,13 @@ SkippableBlockInputStreamPtr Segment::getPlacedStream(
     const DMContext & dm_context,
     const ColumnDefines & read_columns,
     const RowKeyRanges & rowkey_ranges,
-    const RSOperatorPtr & filter,
     const StableSnapshotPtr & stable_snap,
     const DeltaValueReaderPtr & delta_reader,
     const DeltaIndexIterator & delta_index_begin,
     const DeltaIndexIterator & delta_index_end,
     size_t expected_block_size,
     ReadTag read_tag,
+    const DMFilePackFilterResults & pack_filter_results,
     UInt64 start_ts,
     bool need_row_id)
 {
@@ -2723,11 +2731,11 @@ SkippableBlockInputStreamPtr Segment::getPlacedStream(
         dm_context,
         read_columns,
         rowkey_ranges,
-        filter,
         start_ts,
         expected_block_size,
         /* enable_handle_clean_read */ false,
         read_tag,
+        pack_filter_results,
         /* is_fast_scan */ false,
         /* enable_del_clean_read */ false);
     RowKeyRange rowkey_range = rowkey_ranges.size() == 1
@@ -2928,7 +2936,6 @@ bool Segment::placeUpsert(
         dm_context,
         {handle, getVersionColumnDefine()},
         {place_handle_range},
-        EMPTY_RS_OPERATOR,
         stable_snap,
         delta_reader,
         compacted_index->begin(),
@@ -2981,7 +2988,6 @@ bool Segment::placeDelete(
             dm_context,
             {handle, getVersionColumnDefine()},
             delete_ranges,
-            EMPTY_RS_OPERATOR,
             stable_snap,
             delta_reader,
             compacted_index->begin(),
@@ -3019,7 +3025,6 @@ bool Segment::placeDelete(
             dm_context,
             {handle, getVersionColumnDefine()},
             {place_handle_range},
-            EMPTY_RS_OPERATOR,
             stable_snap,
             delta_reader,
             compacted_index->begin(),
@@ -3041,7 +3046,7 @@ BitmapFilterPtr Segment::buildBitmapFilter(
     const DMContext & dm_context,
     const SegmentSnapshotPtr & segment_snap,
     const RowKeyRanges & read_ranges,
-    const RSOperatorPtr & filter,
+    const DMFilePackFilterResults & pack_filter_results,
     UInt64 start_ts,
     size_t expected_block_size)
 {
@@ -3052,13 +3057,19 @@ BitmapFilterPtr Segment::buildBitmapFilter(
             dm_context,
             segment_snap,
             read_ranges,
-            filter,
+            pack_filter_results,
             start_ts,
             expected_block_size);
     }
     else
     {
-        return buildBitmapFilterNormal(dm_context, segment_snap, read_ranges, filter, start_ts, expected_block_size);
+        return buildBitmapFilterNormal(
+            dm_context,
+            segment_snap,
+            read_ranges,
+            pack_filter_results,
+            start_ts,
+            expected_block_size);
     }
 }
 
@@ -3066,7 +3077,7 @@ BitmapFilterPtr Segment::buildBitmapFilterNormal(
     const DMContext & dm_context,
     const SegmentSnapshotPtr & segment_snap,
     const RowKeyRanges & read_ranges,
-    const RSOperatorPtr & filter,
+    const DMFilePackFilterResults & pack_filter_results,
     UInt64 start_ts,
     size_t expected_block_size)
 {
@@ -3080,7 +3091,7 @@ BitmapFilterPtr Segment::buildBitmapFilterNormal(
         columns_to_read,
         segment_snap,
         read_ranges,
-        filter,
+        pack_filter_results,
         start_ts,
         expected_block_size,
         /*need_row_id*/ true);
@@ -3116,9 +3127,7 @@ struct Range
 
 std::pair<std::vector<Range>, std::vector<IdSetPtr>> parseDMFilePackInfo(
     const DMFiles & dmfiles,
-    const DMContext & dm_context,
-    const RowKeyRanges & read_ranges,
-    const RSOperatorPtr & filter,
+    const DMFilePackFilterResults & pack_filter_result,
     UInt64 start_ts)
 {
     // Packs that all rows compliant with MVCC filter and RowKey filter requirements.
@@ -3137,22 +3146,12 @@ std::pair<std::vector<Range>, std::vector<IdSetPtr>> parseDMFilePackInfo(
     size_t rows = 0;
     UInt32 preceded_rows = 0;
 
-    for (const auto & dmfile : dmfiles)
+    for (size_t i = 0; i < dmfiles.size(); ++i)
     {
-        DMFilePackFilter pack_filter = DMFilePackFilter::loadFrom(
-            dmfile,
-            dm_context.global_context.getMinMaxIndexCache(),
-            /*set_cache_if_miss*/ true,
-            read_ranges,
-            filter,
-            /*read_pack*/ {},
-            dm_context.global_context.getFileProvider(),
-            dm_context.global_context.getReadLimiter(),
-            dm_context.scan_context,
-            dm_context.tracing_id,
-            ReadTag::MVCC);
-        const auto & pack_res = pack_filter.getPackResConst();
-        const auto & handle_res = pack_filter.getHandleRes();
+        const auto & dmfile = dmfiles[i];
+        const auto & pack_filter = pack_filter_result[i];
+        const auto & pack_res = pack_filter->getPackResConst();
+        const auto & handle_res = pack_filter->getHandleRes();
         const auto & pack_stats = dmfile->getPackStats();
 
         auto some_packs_set = std::make_shared<IdSet>();
@@ -3167,7 +3166,7 @@ std::pair<std::vector<Range>, std::vector<IdSetPtr>> parseDMFilePackInfo(
             }
 
             if (handle_res[pack_id] == RSResult::Some || pack_stat.not_clean > 0
-                || pack_filter.getMaxVersion(pack_id) > start_ts)
+                || pack_filter->getMaxVersion(pack_id) > start_ts)
             {
                 // We need to read this pack to do RowKey or MVCC filter.
                 some_packs_set->insert(pack_id);
@@ -3202,7 +3201,7 @@ BitmapFilterPtr Segment::buildBitmapFilterStableOnly(
     const DMContext & dm_context,
     const SegmentSnapshotPtr & segment_snap,
     const RowKeyRanges & read_ranges,
-    const RSOperatorPtr & filter,
+    const DMFilePackFilterResults & pack_filter_results,
     UInt64 start_ts,
     size_t expected_block_size)
 {
@@ -3216,7 +3215,7 @@ BitmapFilterPtr Segment::buildBitmapFilterStableOnly(
         return elapse_ns / 1'000'000.0;
     };
 
-    auto [skipped_ranges, some_packs_sets] = parseDMFilePackInfo(dmfiles, dm_context, read_ranges, filter, start_ts);
+    auto [skipped_ranges, some_packs_sets] = parseDMFilePackInfo(dmfiles, pack_filter_results, start_ts);
 
     if (skipped_ranges.size() == 1 && skipped_ranges[0].offset == 0
         && skipped_ranges[0].rows == segment_snap->stable->getDMFilesRows())
@@ -3266,11 +3265,11 @@ BitmapFilterPtr Segment::buildBitmapFilterStableOnly(
         dm_context,
         columns_to_read,
         read_ranges,
-        filter,
         start_ts,
         expected_block_size,
         /*enable_handle_clean_read*/ false,
         ReadTag::MVCC,
+        pack_filter_results,
         /*is_fast_scan*/ false,
         /*enable_del_clean_read*/ false,
         /*read_packs*/ some_packs_sets,
@@ -3304,6 +3303,7 @@ SkippableBlockInputStreamPtr Segment::getConcatSkippableBlockInputStream(
     const ColumnDefines & columns_to_read,
     const RowKeyRanges & read_ranges,
     const RSOperatorPtr & filter,
+    const DMFilePackFilterResults & pack_filter_results,
     UInt64 start_ts,
     size_t expected_block_size,
     ReadTag read_tag)
@@ -3314,15 +3314,17 @@ SkippableBlockInputStreamPtr Segment::getConcatSkippableBlockInputStream(
     constexpr auto is_fast_scan = true;
     auto enable_del_clean_read = !hasColumn(columns_to_read, TAG_COLUMN_ID);
 
-    SkippableBlockInputStreamPtr stable_stream = segment_snap->stable->getInputStream(
+    auto ann_query_info = getANNQueryInfo(filter);
+    SkippableBlockInputStreamPtr stable_stream = segment_snap->stable->tryGetInputStreamWithVectorIndex(
         dm_context,
         columns_to_read,
         read_ranges,
-        filter,
+        ann_query_info,
         start_ts,
         expected_block_size,
         enable_handle_clean_read,
         read_tag,
+        pack_filter_results,
         is_fast_scan,
         enable_del_clean_read,
         /* read_packs */ {},
@@ -3339,7 +3341,6 @@ SkippableBlockInputStreamPtr Segment::getConcatSkippableBlockInputStream(
         columns_to_read_ptr,
         this->rowkey_range,
         read_tag);
-    auto ann_query_info = getANNQueryInfo(filter);
     SkippableBlockInputStreamPtr persisted_files_stream = ColumnFileSetWithVectorIndexInputStream::tryBuild(
         dm_context,
         persisted_files,
@@ -3365,6 +3366,7 @@ BlockInputStreamPtr Segment::getLateMaterializationStream(
     const SegmentSnapshotPtr & segment_snap,
     const RowKeyRanges & data_ranges,
     const PushDownFilterPtr & filter,
+    const DMFilePackFilterResults & pack_filter_results,
     UInt64 start_ts,
     size_t expected_block_size)
 {
@@ -3376,6 +3378,7 @@ BlockInputStreamPtr Segment::getLateMaterializationStream(
         *filter_columns,
         data_ranges,
         filter->rs_operator,
+        pack_filter_results,
         start_ts,
         expected_block_size,
         ReadTag::LMFilter);
@@ -3444,6 +3447,7 @@ BlockInputStreamPtr Segment::getLateMaterializationStream(
         *rest_columns_to_read,
         data_ranges,
         filter->rs_operator,
+        pack_filter_results,
         start_ts,
         expected_block_size,
         ReadTag::Query);
@@ -3481,6 +3485,7 @@ BlockInputStreamPtr Segment::getBitmapFilterInputStream(
     const SegmentSnapshotPtr & segment_snap,
     const RowKeyRanges & read_ranges,
     const PushDownFilterPtr & filter,
+    const DMFilePackFilterResults & pack_filter_results,
     UInt64 start_ts,
     size_t build_bitmap_filter_block_rows,
     size_t read_data_block_rows)
@@ -3495,7 +3500,7 @@ BlockInputStreamPtr Segment::getBitmapFilterInputStream(
         dm_context,
         segment_snap,
         real_ranges,
-        filter ? filter->rs_operator : EMPTY_RS_OPERATOR,
+        pack_filter_results,
         start_ts,
         build_bitmap_filter_block_rows);
 
@@ -3515,6 +3520,7 @@ BlockInputStreamPtr Segment::getBitmapFilterInputStream(
             segment_snap,
             real_ranges,
             filter,
+            pack_filter_results,
             start_ts,
             read_data_block_rows);
     }
@@ -3526,6 +3532,7 @@ BlockInputStreamPtr Segment::getBitmapFilterInputStream(
         columns_to_read,
         real_ranges,
         filter ? filter->rs_operator : EMPTY_RS_OPERATOR,
+        pack_filter_results,
         start_ts,
         read_data_block_rows,
         ReadTag::Query);

--- a/dbms/src/Storages/DeltaMerge/Segment.h
+++ b/dbms/src/Storages/DeltaMerge/Segment.h
@@ -239,7 +239,7 @@ public:
         const ColumnDefines & columns_to_read,
         const SegmentSnapshotPtr & segment_snap,
         const RowKeyRanges & read_ranges,
-        const RSOperatorPtr & filter,
+        const DMFilePackFilterResults & pack_filter_results,
         UInt64 start_ts,
         size_t expected_block_size,
         bool need_row_id = false);
@@ -248,7 +248,7 @@ public:
         const DMContext & dm_context,
         const ColumnDefines & columns_to_read,
         const RowKeyRanges & read_ranges,
-        const RSOperatorPtr & filter = {},
+        const DMFilePackFilterResults & pack_filter_results = {},
         UInt64 start_ts = std::numeric_limits<UInt64>::max(),
         size_t expected_block_size = DEFAULT_BLOCK_SIZE);
 
@@ -270,7 +270,7 @@ public:
         const ColumnDefines & columns_to_read,
         const SegmentSnapshotPtr & segment_snap,
         const RowKeyRanges & read_ranges,
-        const RSOperatorPtr & filter,
+        const DMFilePackFilterResults & pack_filter_results,
         size_t expected_block_size = DEFAULT_BLOCK_SIZE);
 
     BlockInputStreamPtr getInputStreamModeRaw(
@@ -684,13 +684,13 @@ public:
         const DMContext & dm_context,
         const ColumnDefines & read_columns,
         const RowKeyRanges & rowkey_ranges,
-        const RSOperatorPtr & filter,
         const StableSnapshotPtr & stable_snap,
         const DeltaValueReaderPtr & delta_reader,
         const DeltaIndexIterator & delta_index_begin,
         const DeltaIndexIterator & delta_index_end,
         size_t expected_block_size,
         ReadTag read_tag,
+        const DMFilePackFilterResults & pack_filter_results = {},
         UInt64 start_ts = std::numeric_limits<UInt64>::max(),
         bool need_row_id = false);
 
@@ -734,21 +734,21 @@ public:
         const DMContext & dm_context,
         const SegmentSnapshotPtr & segment_snap,
         const RowKeyRanges & read_ranges,
-        const RSOperatorPtr & filter,
+        const DMFilePackFilterResults & pack_filter_results,
         UInt64 start_ts,
         size_t expected_block_size);
     BitmapFilterPtr buildBitmapFilterNormal(
         const DMContext & dm_context,
         const SegmentSnapshotPtr & segment_snap,
         const RowKeyRanges & read_ranges,
-        const RSOperatorPtr & filter,
+        const DMFilePackFilterResults & pack_filter_results,
         UInt64 start_ts,
         size_t expected_block_size);
     BitmapFilterPtr buildBitmapFilterStableOnly(
         const DMContext & dm_context,
         const SegmentSnapshotPtr & segment_snap,
         const RowKeyRanges & read_ranges,
-        const RSOperatorPtr & filter,
+        const DMFilePackFilterResults & pack_filter_results,
         UInt64 start_ts,
         size_t expected_block_size);
     SkippableBlockInputStreamPtr getConcatSkippableBlockInputStream(
@@ -758,6 +758,7 @@ public:
         const ColumnDefines & columns_to_read,
         const RowKeyRanges & read_ranges,
         const RSOperatorPtr & filter,
+        const DMFilePackFilterResults & pack_filter_results,
         UInt64 start_ts,
         size_t expected_block_size,
         ReadTag read_tag);
@@ -767,6 +768,7 @@ public:
         const SegmentSnapshotPtr & segment_snap,
         const RowKeyRanges & read_ranges,
         const PushDownFilterPtr & filter,
+        const DMFilePackFilterResults & pack_filter_results,
         UInt64 start_ts,
         size_t build_bitmap_filter_block_rows,
         size_t read_data_block_rows);
@@ -778,6 +780,7 @@ public:
         const SegmentSnapshotPtr & segment_snap,
         const RowKeyRanges & data_ranges,
         const PushDownFilterPtr & filter,
+        const DMFilePackFilterResults & pack_filter_results,
         UInt64 start_ts,
         size_t expected_block_size);
 

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTask.cpp
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTask.cpp
@@ -521,7 +521,7 @@ void SegmentReadTask::checkMemTableSet(const ColumnFileSetSnapshotPtr & mem_tabl
 void SegmentReadTask::checkMemTableSetReady() const
 {
     const auto & mem_table_snap = read_snapshot->delta->getMemTableSetSnapshot();
-    for (auto & cf : mem_table_snap->getColumnFiles())
+    for (const auto & cf : mem_table_snap->getColumnFiles())
     {
         if (auto * in_mem_cf = cf->tryToInMemoryFile(); in_mem_cf)
         {

--- a/dbms/src/Storages/DeltaMerge/StableValueSpace.cpp
+++ b/dbms/src/Storages/DeltaMerge/StableValueSpace.cpp
@@ -49,14 +49,11 @@ void StableValueSpace::setFiles(const DMFiles & files_, const RowKeyRange & rang
     {
         for (const auto & file : files_)
         {
-            auto pack_filter = DMFilePackFilter::loadFrom(
+            auto [file_valid_rows, file_valid_bytes] = DMFilePackFilter::loadValidRowsAndBytes(
                 *dm_context,
                 file,
                 /*set_cache_if_miss*/ true,
-                {range},
-                EMPTY_RS_OPERATOR,
-                {});
-            auto [file_valid_rows, file_valid_bytes] = pack_filter->validRowsAndBytes();
+                {range});
             rows += file_valid_rows;
             bytes += file_valid_bytes;
         }

--- a/dbms/src/Storages/DeltaMerge/StableValueSpace.cpp
+++ b/dbms/src/Storages/DeltaMerge/StableValueSpace.cpp
@@ -377,7 +377,7 @@ void StableValueSpace::calculateStableProperty(
             {rowkey_range},
             EMPTY_RS_OPERATOR,
             {});
-        const auto & pack_res = pack_filter->getPackResConst();
+        const auto & pack_res = pack_filter->getPackRes();
         size_t new_pack_properties_index = 0;
         const bool use_new_pack_properties = pack_properties.property_size() == 0;
         if (use_new_pack_properties)
@@ -598,7 +598,7 @@ RowsAndBytes StableValueSpace::Snapshot::getApproxRowsAndBytes(const DMContext &
             RSOperatorPtr{},
             IdSetPtr{});
         const auto & pack_stats = f->getPackStats();
-        const auto & pack_res = filter->getPackResConst();
+        const auto & pack_res = filter->getPackRes();
         for (size_t i = 0; i < pack_stats.size(); ++i)
         {
             if (pack_res[i].isUse())

--- a/dbms/src/Storages/DeltaMerge/StableValueSpace.cpp
+++ b/dbms/src/Storages/DeltaMerge/StableValueSpace.cpp
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <Interpreters/Context.h>
 #include <Interpreters/SharedContexts/Disagg.h>
 #include <Storages/DeltaMerge/ConcatSkippableBlockInputStream.h>
 #include <Storages/DeltaMerge/DMVersionFilterBlockInputStream.h>
 #include <Storages/DeltaMerge/File/DMFile.h>
 #include <Storages/DeltaMerge/File/DMFileBlockInputStream.h>
-#include <Storages/DeltaMerge/Filter/FilterHelper.h>
 #include <Storages/DeltaMerge/Remote/DataStore/DataStore.h>
 #include <Storages/DeltaMerge/RestoreDMFile.h>
 #include <Storages/DeltaMerge/RowKeyFilter.h>

--- a/dbms/src/Storages/DeltaMerge/StableValueSpace.h
+++ b/dbms/src/Storages/DeltaMerge/StableValueSpace.h
@@ -46,8 +46,8 @@ public:
         , log(Logger::get())
     {}
 
-    static StableValueSpacePtr restore(DMContext & context, PageIdU64 id);
-    static StableValueSpacePtr restore(DMContext & context, ReadBuffer & buf, PageIdU64 id);
+    static StableValueSpacePtr restore(DMContext & dm_context, PageIdU64 id);
+    static StableValueSpacePtr restore(DMContext & dm_context, ReadBuffer & buf, PageIdU64 id);
 
     static StableValueSpacePtr createFromCheckpoint( //
         const LoggerPtr & parent_log,
@@ -112,7 +112,7 @@ public:
      */
     size_t getDMFilesBytes() const;
 
-    void enableDMFilesGC(DMContext & context);
+    void enableDMFilesGC(DMContext & dm_context);
 
     void recordRemovePacksPages(WriteBatches & wbs) const;
 
@@ -139,7 +139,7 @@ public:
 
     const StableProperty & getStableProperty() const { return property; }
 
-    void calculateStableProperty(const DMContext & context, const RowKeyRange & rowkey_range, bool is_common_handle);
+    void calculateStableProperty(const DMContext & dm_context, const RowKeyRange & rowkey_range, bool is_common_handle);
 
     struct Snapshot;
     using SnapshotPtr = std::shared_ptr<Snapshot>;
@@ -225,7 +225,7 @@ public:
         }
 
         SkippableBlockInputStreamPtr getInputStream(
-            const DMContext & context, //
+            const DMContext & dm_context, //
             const ColumnDefines & read_columns,
             const RowKeyRanges & rowkey_ranges,
             UInt64 max_data_version,
@@ -239,7 +239,7 @@ public:
             bool need_row_id = false);
 
         SkippableBlockInputStreamPtr tryGetInputStreamWithVectorIndex(
-            const DMContext & context,
+            const DMContext & dm_context,
             const ColumnDefines & read_columns,
             const RowKeyRanges & rowkey_ranges,
             const ANNQueryInfoPtr & ann_query_info,
@@ -254,7 +254,7 @@ public:
             bool need_row_id = false,
             BitmapFilterPtr bitmap_filter = nullptr);
 
-        RowsAndBytes getApproxRowsAndBytes(const DMContext & context, const RowKeyRange & range) const;
+        RowsAndBytes getApproxRowsAndBytes(const DMContext & dm_context, const RowKeyRange & range) const;
 
         struct AtLeastRowsAndBytesResult
         {
@@ -268,7 +268,7 @@ public:
          * Get the rows and bytes calculated from packs that is **fully contained** by the given range.
          * If the pack is partially intersected, then it is not counted.
          */
-        AtLeastRowsAndBytesResult getAtLeastRowsAndBytes(const DMContext & context, const RowKeyRange & range) const;
+        AtLeastRowsAndBytesResult getAtLeastRowsAndBytes(const DMContext & dm_context, const RowKeyRange & range) const;
 
     private:
         LoggerPtr log;

--- a/dbms/src/Storages/DeltaMerge/StableValueSpace.h
+++ b/dbms/src/Storages/DeltaMerge/StableValueSpace.h
@@ -14,12 +14,16 @@
 
 #pragma once
 
+#include <IO/FileProvider/FileProvider_fwd.h>
+#include <Storages/DeltaMerge/BitmapFilter/BitmapFilter.h>
 #include <Storages/DeltaMerge/DMContext_fwd.h>
 #include <Storages/DeltaMerge/File/ColumnCache.h>
 #include <Storages/DeltaMerge/File/DMFilePackFilter_fwd.h>
 #include <Storages/DeltaMerge/File/DMFile_fwd.h>
 #include <Storages/DeltaMerge/Filter/RSOperator_fwd.h>
 #include <Storages/DeltaMerge/Index/RSResult.h>
+#include <Storages/DeltaMerge/Index/VectorIndex_fwd.h>
+#include <Storages/DeltaMerge/ReadMode.h>
 #include <Storages/DeltaMerge/RowKeyRange.h>
 #include <Storages/DeltaMerge/SkippableBlockInputStream.h>
 #include <Storages/Page/PageStorage_fwd.h>
@@ -224,11 +228,26 @@ public:
             const DMContext & context, //
             const ColumnDefines & read_columns,
             const RowKeyRanges & rowkey_ranges,
-            const RSOperatorPtr & filter,
             UInt64 max_data_version,
             size_t expected_block_size,
             bool enable_handle_clean_read,
             ReadTag read_tag,
+            const DMFilePackFilterResults & pack_filter_results = {},
+            bool is_fast_scan = false,
+            bool enable_del_clean_read = false,
+            const std::vector<IdSetPtr> & read_packs = {},
+            bool need_row_id = false);
+
+        SkippableBlockInputStreamPtr tryGetInputStreamWithVectorIndex(
+            const DMContext & context,
+            const ColumnDefines & read_columns,
+            const RowKeyRanges & rowkey_ranges,
+            const ANNQueryInfoPtr & ann_query_info,
+            UInt64 max_data_version,
+            size_t expected_block_size,
+            bool enable_handle_clean_read,
+            ReadTag read_tag,
+            const DMFilePackFilterResults & pack_filter_results,
             bool is_fast_scan = false,
             bool enable_del_clean_read = false,
             const std::vector<IdSetPtr> & read_packs = {},

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store.cpp
@@ -4172,7 +4172,14 @@ try
         return filter;
     };
 
-    DB::registerFunctions();
+    try
+    {
+        DB::registerFunctions();
+    }
+    catch (DB::Exception &)
+    {
+        // Maybe another test has already registered, ignore exception here.
+    }
 
     constexpr Int64 num_rows = 128;
     auto filter_all = create_filter(0);
@@ -4295,7 +4302,14 @@ try
         return filter;
     };
 
-    DB::registerFunctions();
+    try
+    {
+        DB::registerFunctions();
+    }
+    catch (DB::Exception &)
+    {
+        // Maybe another test has already registered, ignore exception here.
+    }
 
     constexpr Int64 num_rows = 128;
     auto filter_all = create_filter(0);

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store.cpp
@@ -2778,7 +2778,7 @@ Block createBlock(const ColumnDefine & cd, size_t begin, size_t end)
 
 } // namespace
 
-TEST_F(DeltaMergeStoreTest, ReadLegacyStringData_CFTiny)
+TEST_F(DeltaMergeStoreTest, ReadLegacyStringDataCFTiny)
 try
 {
     // Write legacy string data to CFTiny.
@@ -2843,7 +2843,7 @@ try
 }
 CATCH
 
-TEST_F(DeltaMergeStoreTest, ReadLegacyStringData_DMFile)
+TEST_F(DeltaMergeStoreTest, ReadLegacyStringDataDMFile)
 try
 {
     // Write legacy string data to DMFile.

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_file.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_file.cpp
@@ -1575,12 +1575,14 @@ try
     auto test_read_filter = [&](const HandleRange & range) {
         // Filtered by rough set filter
         auto filter = toRSFilter(i64_cd, range);
+        const auto read_ranges = RowKeyRanges{RowKeyRange::newAll(false, 1)};
+        auto pack_result = std::make_shared<DMFilePackFilterResult>(
+            DMFilePackFilter::loadFrom(dmContext(), dm_file, false, read_ranges, filter, {}));
         // Test read
         DMFileBlockInputStreamBuilder builder(dbContext());
-        auto stream
-            = builder.setColumnCache(column_cache)
-                  .setRSOperator(filter) // Filtered by rough set filter
-                  .build(dm_file, *cols, RowKeyRanges{RowKeyRange::newAll(false, 1)}, std::make_shared<ScanContext>());
+        auto stream = builder.setColumnCache(column_cache)
+                          .setDMFilePackFilterResult(pack_result)
+                          .build(dm_file, *cols, read_ranges, std::make_shared<ScanContext>());
 
         Int64 expect_first_pk = static_cast<int>(std::floor(std::max(0, range.start) / span_per_part)) * span_per_part;
         Int64 expect_last_pk = std::min(
@@ -1656,12 +1658,14 @@ try
     // (first range) Or (Unsupported) -> should NOT filter any chunk
     filters.emplace_back(createOr({one_part_filter, createUnsupported("test")}), num_rows_write);
     auto test_read_filter = [&](const DM::RSOperatorPtr & filter, const size_t num_rows_should_read) {
+        const auto read_ranges = RowKeyRanges{RowKeyRange::newAll(false, 1)};
+        auto pack_result = std::make_shared<DMFilePackFilterResult>(
+            DMFilePackFilter::loadFrom(dmContext(), dm_file, false, read_ranges, filter, {}));
         // Test read
         DMFileBlockInputStreamBuilder builder(dbContext());
-        auto stream
-            = builder.setColumnCache(column_cache)
-                  .setRSOperator(filter) // Filtered by rough set filter
-                  .build(dm_file, *cols, RowKeyRanges{RowKeyRange::newAll(false, 1)}, std::make_shared<ScanContext>());
+        auto stream = builder.setColumnCache(column_cache)
+                          .setDMFilePackFilterResult(pack_result)
+                          .build(dm_file, *cols, read_ranges, std::make_shared<ScanContext>());
 
         Int64 expect_first_pk = 0;
         Int64 expect_last_pk = num_rows_should_read;

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_file.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_file.cpp
@@ -1576,8 +1576,7 @@ try
         // Filtered by rough set filter
         auto filter = toRSFilter(i64_cd, range);
         const auto read_ranges = RowKeyRanges{RowKeyRange::newAll(false, 1)};
-        auto pack_result = std::make_shared<DMFilePackFilterResult>(
-            DMFilePackFilter::loadFrom(dmContext(), dm_file, false, read_ranges, filter, {}));
+        auto pack_result = DMFilePackFilter::loadFrom(dmContext(), dm_file, false, read_ranges, filter, {});
         // Test read
         DMFileBlockInputStreamBuilder builder(dbContext());
         auto stream = builder.setColumnCache(column_cache)
@@ -1659,8 +1658,7 @@ try
     filters.emplace_back(createOr({one_part_filter, createUnsupported("test")}), num_rows_write);
     auto test_read_filter = [&](const DM::RSOperatorPtr & filter, const size_t num_rows_should_read) {
         const auto read_ranges = RowKeyRanges{RowKeyRange::newAll(false, 1)};
-        auto pack_result = std::make_shared<DMFilePackFilterResult>(
-            DMFilePackFilter::loadFrom(dmContext(), dm_file, false, read_ranges, filter, {}));
+        auto pack_result = DMFilePackFilter::loadFrom(dmContext(), dm_file, false, read_ranges, filter, {});
         // Test read
         DMFileBlockInputStreamBuilder builder(dbContext());
         auto stream = builder.setColumnCache(column_cache)

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment.cpp
@@ -21,6 +21,7 @@
 #include <Storages/DeltaMerge/DMContext.h>
 #include <Storages/DeltaMerge/DeltaMergeStore.h>
 #include <Storages/DeltaMerge/File/DMFileBlockOutputStream.h>
+#include <Storages/DeltaMerge/File/DMFilePackFilterResult.h>
 #include <Storages/DeltaMerge/Range.h>
 #include <Storages/DeltaMerge/RowKeyRange.h>
 #include <Storages/DeltaMerge/Segment.h>
@@ -1087,7 +1088,7 @@ try
             dmContext(),
             segment_snap,
             real_ranges,
-            EMPTY_RS_OPERATOR,
+            DMFilePackFilterResult::emptyResults(dmContext(), segment_snap->stable->getDMFiles()),
             std::numeric_limits<UInt64>::max(),
             DEFAULT_BLOCK_SIZE);
         // the bitmap only contains the overlapped packs of ColumnFileBig. So only 60 here.
@@ -1107,6 +1108,7 @@ try
             segment_snap,
             {RowKeyRange::newAll(false, 1)},
             EMPTY_FILTER,
+            DMFilePackFilterResult::emptyResults(dmContext(), segment_snap->stable->getDMFiles()),
             std::numeric_limits<UInt64>::max(),
             DEFAULT_BLOCK_SIZE,
             DEFAULT_BLOCK_SIZE);
@@ -1148,17 +1150,14 @@ try
             segment_snap,
             {RowKeyRange::newAll(false, 1)},
             EMPTY_FILTER,
+            DMFilePackFilterResult::emptyResults(dmContext(), segment_snap->stable->getDMFiles()),
             std::numeric_limits<UInt64>::max(),
             DEFAULT_BLOCK_SIZE,
             DEFAULT_BLOCK_SIZE);
         // Only the rows in [30, 50) and [80, 90) valid
         auto vec = createNumbers<Int64>(30, 50);
         vec.append_range(createNumbers<Int64>(80, 90));
-        ASSERT_INPUTSTREAM_BLOCK_UR(
-            in,
-            Block({
-                createColumn<Int64>(vec),
-            }));
+        ASSERT_INPUTSTREAM_BLOCK_UR(in, Block({createColumn<Int64>(vec)}));
     }
 }
 CATCH

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment.cpp
@@ -1088,7 +1088,7 @@ try
             dmContext(),
             segment_snap,
             real_ranges,
-            DMFilePackFilterResult::emptyResults(dmContext(), segment_snap->stable->getDMFiles()),
+            DMFilePackFilterResult::defaultResults(dmContext(), segment_snap->stable->getDMFiles()),
             std::numeric_limits<UInt64>::max(),
             DEFAULT_BLOCK_SIZE);
         // the bitmap only contains the overlapped packs of ColumnFileBig. So only 60 here.
@@ -1108,7 +1108,7 @@ try
             segment_snap,
             {RowKeyRange::newAll(false, 1)},
             EMPTY_FILTER,
-            DMFilePackFilterResult::emptyResults(dmContext(), segment_snap->stable->getDMFiles()),
+            DMFilePackFilterResult::defaultResults(dmContext(), segment_snap->stable->getDMFiles()),
             std::numeric_limits<UInt64>::max(),
             DEFAULT_BLOCK_SIZE,
             DEFAULT_BLOCK_SIZE);
@@ -1150,7 +1150,7 @@ try
             segment_snap,
             {RowKeyRange::newAll(false, 1)},
             EMPTY_FILTER,
-            DMFilePackFilterResult::emptyResults(dmContext(), segment_snap->stable->getDMFiles()),
+            DMFilePackFilterResult::defaultResults(dmContext(), segment_snap->stable->getDMFiles()),
             std::numeric_limits<UInt64>::max(),
             DEFAULT_BLOCK_SIZE,
             DEFAULT_BLOCK_SIZE);

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment.cpp
@@ -1088,7 +1088,7 @@ try
             dmContext(),
             segment_snap,
             real_ranges,
-            DMFilePackFilterResult::defaultResults(dmContext(), segment_snap->stable->getDMFiles()),
+            {},
             std::numeric_limits<UInt64>::max(),
             DEFAULT_BLOCK_SIZE);
         // the bitmap only contains the overlapped packs of ColumnFileBig. So only 60 here.
@@ -1108,7 +1108,7 @@ try
             segment_snap,
             {RowKeyRange::newAll(false, 1)},
             EMPTY_FILTER,
-            DMFilePackFilterResult::defaultResults(dmContext(), segment_snap->stable->getDMFiles()),
+            {},
             std::numeric_limits<UInt64>::max(),
             DEFAULT_BLOCK_SIZE,
             DEFAULT_BLOCK_SIZE);
@@ -1150,7 +1150,7 @@ try
             segment_snap,
             {RowKeyRange::newAll(false, 1)},
             EMPTY_FILTER,
-            DMFilePackFilterResult::defaultResults(dmContext(), segment_snap->stable->getDMFiles()),
+            {},
             std::numeric_limits<UInt64>::max(),
             DEFAULT_BLOCK_SIZE,
             DEFAULT_BLOCK_SIZE);

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment.cpp
@@ -21,7 +21,6 @@
 #include <Storages/DeltaMerge/DMContext.h>
 #include <Storages/DeltaMerge/DeltaMergeStore.h>
 #include <Storages/DeltaMerge/File/DMFileBlockOutputStream.h>
-#include <Storages/DeltaMerge/File/DMFilePackFilterResult.h>
 #include <Storages/DeltaMerge/Range.h>
 #include <Storages/DeltaMerge/RowKeyRange.h>
 #include <Storages/DeltaMerge/Segment.h>

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_vector_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_vector_index.cpp
@@ -240,7 +240,7 @@ try
         ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0, 2.0, 3.5}));
 
         DMFileBlockInputStreamBuilder builder(dbContext());
-        auto stream = builder.setRSOperator(wrapWithANNQueryInfo(nullptr, ann_query_info))
+        auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView::createWithFilter(3, true))
                           .tryBuildWithVectorIndex(
                               dm_file,
@@ -265,7 +265,7 @@ try
         ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0, 2.0, 3.8}));
 
         DMFileBlockInputStreamBuilder builder(dbContext());
-        auto stream = builder.setRSOperator(wrapWithANNQueryInfo(nullptr, ann_query_info))
+        auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView::createWithFilter(3, true))
                           .tryBuildWithVectorIndex(
                               dm_file,
@@ -290,7 +290,7 @@ try
         ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0, 2.0, 3.8}));
 
         DMFileBlockInputStreamBuilder builder(dbContext());
-        auto stream = builder.setRSOperator(wrapWithANNQueryInfo(nullptr, ann_query_info))
+        auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView::createWithFilter(3, true))
                           .tryBuildWithVectorIndex(
                               dm_file,
@@ -318,7 +318,7 @@ try
         bitmap_filter->set(/* start */ 2, /* limit */ 1, false);
 
         DMFileBlockInputStreamBuilder builder(dbContext());
-        auto stream = builder.setRSOperator(wrapWithANNQueryInfo(nullptr, ann_query_info))
+        auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView(bitmap_filter, 0, 3))
                           .tryBuildWithVectorIndex(
                               dm_file,
@@ -343,7 +343,7 @@ try
         ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0, 2.0, 3.8}));
 
         DMFileBlockInputStreamBuilder builder(dbContext());
-        auto stream = builder.setRSOperator(wrapWithANNQueryInfo(nullptr, ann_query_info))
+        auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView::createWithFilter(3, true))
                           .tryBuildWithVectorIndex(
                               dm_file,
@@ -368,7 +368,7 @@ try
         ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0, 2.0, 3.8}));
 
         DMFileBlockInputStreamBuilder builder(dbContext());
-        auto stream = builder.setRSOperator(wrapWithANNQueryInfo(nullptr, ann_query_info))
+        auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView::createWithFilter(3, true))
                           .tryBuildWithVectorIndex(
                               dm_file,
@@ -393,7 +393,7 @@ try
         ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0}));
 
         DMFileBlockInputStreamBuilder builder(dbContext());
-        auto stream = builder.setRSOperator(wrapWithANNQueryInfo(nullptr, ann_query_info))
+        auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView::createWithFilter(3, true))
                           .tryBuildWithVectorIndex(
                               dm_file,
@@ -428,7 +428,7 @@ try
         ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0, 2.0, 3.8}));
 
         DMFileBlockInputStreamBuilder builder(dbContext());
-        auto stream = builder.setRSOperator(wrapWithANNQueryInfo(nullptr, ann_query_info))
+        auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView::createWithFilter(3, true))
                           .tryBuildWithVectorIndex(
                               dm_file,
@@ -453,7 +453,7 @@ try
         ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0, 2.0, 3.8}));
 
         DMFileBlockInputStreamBuilder builder(dbContext());
-        auto stream = builder.setRSOperator(wrapWithANNQueryInfo(nullptr, ann_query_info))
+        auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView::createWithFilter(3, true))
                           .tryBuildWithVectorIndex(
                               dm_file,
@@ -491,7 +491,7 @@ try
         ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0, 2.0, 3.8}));
 
         DMFileBlockInputStreamBuilder builder(dbContext());
-        auto stream = builder.setRSOperator(wrapWithANNQueryInfo(nullptr, ann_query_info))
+        auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView::createWithFilter(3, true))
                           .tryBuildWithVectorIndex(
                               dm_file,
@@ -589,7 +589,7 @@ try
             ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0, 2.0, 3.8}));
 
             DMFileBlockInputStreamBuilder builder(dbContext());
-            auto stream = builder.setRSOperator(wrapWithANNQueryInfo(nullptr, ann_query_info))
+            auto stream = builder.setAnnQureyInfo(ann_query_info)
                               .setBitmapFilter(BitmapFilterView::createWithFilter(3, true))
                               .tryBuildWithVectorIndex(
                                   dm_file,
@@ -615,7 +615,7 @@ try
             ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0, 2.0, 3.8}));
 
             DMFileBlockInputStreamBuilder builder(dbContext());
-            auto stream = builder.setRSOperator(wrapWithANNQueryInfo(nullptr, ann_query_info))
+            auto stream = builder.setAnnQureyInfo(ann_query_info)
                               .setBitmapFilter(BitmapFilterView::createWithFilter(3, true))
                               .tryBuildWithVectorIndex(
                                   dm_file,
@@ -644,7 +644,7 @@ try
             bitmap_filter->set(/* start */ 2, /* limit */ 1, false);
 
             DMFileBlockInputStreamBuilder builder(dbContext());
-            auto stream = builder.setRSOperator(wrapWithANNQueryInfo(nullptr, ann_query_info))
+            auto stream = builder.setAnnQureyInfo(ann_query_info)
                               .setBitmapFilter(BitmapFilterView(bitmap_filter, 0, 3))
                               .tryBuildWithVectorIndex(
                                   dm_file,
@@ -674,7 +674,7 @@ try
             ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0, 2.0, 3.8}));
 
             DMFileBlockInputStreamBuilder builder(dbContext());
-            auto stream = builder.setRSOperator(wrapWithANNQueryInfo(nullptr, ann_query_info))
+            auto stream = builder.setAnnQureyInfo(ann_query_info)
                               .setBitmapFilter(BitmapFilterView::createWithFilter(3, true))
                               .tryBuildWithVectorIndex(
                                   dm_file,
@@ -700,7 +700,7 @@ try
             ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0, 2.0, 3.8}));
 
             DMFileBlockInputStreamBuilder builder(dbContext());
-            auto stream = builder.setRSOperator(wrapWithANNQueryInfo(nullptr, ann_query_info))
+            auto stream = builder.setAnnQureyInfo(ann_query_info)
                               .setBitmapFilter(BitmapFilterView::createWithFilter(3, true))
                               .tryBuildWithVectorIndex(
                                   dm_file,
@@ -729,7 +729,7 @@ try
             bitmap_filter->set(/* start */ 2, /* limit */ 1, false);
 
             DMFileBlockInputStreamBuilder builder(dbContext());
-            auto stream = builder.setRSOperator(wrapWithANNQueryInfo(nullptr, ann_query_info))
+            auto stream = builder.setAnnQureyInfo(ann_query_info)
                               .setBitmapFilter(BitmapFilterView(bitmap_filter, 0, 3))
                               .tryBuildWithVectorIndex(
                                   dm_file,
@@ -759,7 +759,7 @@ try
             ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0, 2.0, 3.8}));
 
             DMFileBlockInputStreamBuilder builder(dbContext());
-            auto stream = builder.setRSOperator(wrapWithANNQueryInfo(nullptr, ann_query_info))
+            auto stream = builder.setAnnQureyInfo(ann_query_info)
                               .setBitmapFilter(BitmapFilterView::createWithFilter(3, true))
                               .tryBuildWithVectorIndex(
                                   dm_file,
@@ -784,7 +784,7 @@ try
             ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0, 2.0, 3.8}));
 
             DMFileBlockInputStreamBuilder builder(dbContext());
-            auto stream = builder.setRSOperator(wrapWithANNQueryInfo(nullptr, ann_query_info))
+            auto stream = builder.setAnnQureyInfo(ann_query_info)
                               .setBitmapFilter(BitmapFilterView::createWithFilter(3, true))
                               .tryBuildWithVectorIndex(
                                   dm_file,
@@ -812,7 +812,7 @@ try
             bitmap_filter->set(/* start */ 2, /* limit */ 1, false);
 
             DMFileBlockInputStreamBuilder builder(dbContext());
-            auto stream = builder.setRSOperator(wrapWithANNQueryInfo(nullptr, ann_query_info))
+            auto stream = builder.setAnnQureyInfo(ann_query_info)
                               .setBitmapFilter(BitmapFilterView(bitmap_filter, 0, 3))
                               .tryBuildWithVectorIndex(
                                   dm_file,
@@ -876,7 +876,7 @@ try
         ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0, 2.0, 3.5}));
 
         DMFileBlockInputStreamBuilder builder(dbContext());
-        auto stream = builder.setRSOperator(wrapWithANNQueryInfo(nullptr, ann_query_info))
+        auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView::createWithFilter(5, true))
                           .tryBuildWithVectorIndex(
                               dm_file,
@@ -944,7 +944,7 @@ try
         ann_query_info->set_ref_vec_f32(encodeVectorFloat32({5.0, 5.0, 5.5}));
 
         DMFileBlockInputStreamBuilder builder(dbContext());
-        auto stream = builder.setRSOperator(wrapWithANNQueryInfo(nullptr, ann_query_info))
+        auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView::createWithFilter(6, true))
                           .tryBuildWithVectorIndex(
                               dm_file,
@@ -969,7 +969,7 @@ try
         ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0, 2.0, 3.0}));
 
         DMFileBlockInputStreamBuilder builder(dbContext());
-        auto stream = builder.setRSOperator(wrapWithANNQueryInfo(nullptr, ann_query_info))
+        auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView::createWithFilter(6, true))
                           .tryBuildWithVectorIndex(
                               dm_file,
@@ -994,7 +994,7 @@ try
         ann_query_info->set_ref_vec_f32(encodeVectorFloat32({0.0, 0.0, 0.0}));
 
         DMFileBlockInputStreamBuilder builder(dbContext());
-        auto stream = builder.setRSOperator(wrapWithANNQueryInfo(nullptr, ann_query_info))
+        auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView::createWithFilter(6, true))
                           .tryBuildWithVectorIndex(
                               dm_file,
@@ -1022,7 +1022,7 @@ try
         bitmap_filter->set(/* start */ 5, /* limit */ 1, false);
 
         DMFileBlockInputStreamBuilder builder(dbContext());
-        auto stream = builder.setRSOperator(wrapWithANNQueryInfo(nullptr, ann_query_info))
+        auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView(bitmap_filter, 0, 6))
                           .tryBuildWithVectorIndex(
                               dm_file,
@@ -1093,7 +1093,7 @@ try
         bitmap_filter->set(0, 6); // 0~6 rows are valid, 6~9 rows are invalid due to pack filter.
 
         DMFileBlockInputStreamBuilder builder(dbContext());
-        auto stream = builder.setRSOperator(wrapWithANNQueryInfo(nullptr, ann_query_info))
+        auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView(bitmap_filter, 0, 9))
                           .tryBuildWithVectorIndex(dm_file, read_cols, row_key_ranges, std::make_shared<ScanContext>());
         ASSERT_INPUTSTREAM_COLS_UR(
@@ -1107,7 +1107,7 @@ try
         // TopK=4
         ann_query_info->set_top_k(4);
         builder = DMFileBlockInputStreamBuilder(dbContext());
-        stream = builder.setRSOperator(wrapWithANNQueryInfo(nullptr, ann_query_info))
+        stream = builder.setAnnQureyInfo(ann_query_info)
                      .setBitmapFilter(BitmapFilterView(bitmap_filter, 0, 9))
                      .tryBuildWithVectorIndex(dm_file, read_cols, row_key_ranges, std::make_shared<ScanContext>());
         ASSERT_INPUTSTREAM_COLS_UR(
@@ -1136,7 +1136,7 @@ try
         bitmap_filter->set(3, 2);
 
         DMFileBlockInputStreamBuilder builder(dbContext());
-        auto stream = builder.setRSOperator(wrapWithANNQueryInfo(nullptr, ann_query_info))
+        auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView(bitmap_filter, 0, 9))
                           .tryBuildWithVectorIndex(dm_file, read_cols, row_key_ranges, std::make_shared<ScanContext>());
         ASSERT_INPUTSTREAM_COLS_UR(
@@ -1204,6 +1204,7 @@ public:
             snapshot,
             {range},
             std::make_shared<PushDownFilter>(wrapWithANNQueryInfo({}, ann_query)),
+            {},
             std::numeric_limits<UInt64>::max(),
             DEFAULT_BLOCK_SIZE,
             DEFAULT_BLOCK_SIZE);

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_bitmap.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_bitmap.cpp
@@ -16,11 +16,14 @@
 #include <DataStreams/OneBlockInputStream.h>
 #include <Interpreters/Context.h>
 #include <Storages/DeltaMerge/DeltaMergeStore.h>
+#include <Storages/DeltaMerge/File/DMFilePackFilterResult.h>
 #include <Storages/DeltaMerge/tests/gtest_segment_test_basic.h>
 #include <Storages/DeltaMerge/tests/gtest_segment_util.h>
 #include <TestUtils/FunctionTestUtils.h>
 #include <TestUtils/TiFlashTestBasic.h>
 #include <common/defines.h>
+
+
 using namespace std::chrono_literals;
 using namespace DB::tests;
 
@@ -371,7 +374,7 @@ TEST_F(SegmentBitmapFilterTest, CleanStable)
         *dm_context,
         snap,
         {seg->getRowKeyRange()},
-        EMPTY_RS_OPERATOR,
+        DMFilePackFilterResult::emptyResults(*dm_context, snap->stable->getDMFiles()),
         std::numeric_limits<UInt64>::max(),
         DEFAULT_BLOCK_SIZE);
     ASSERT_NE(bitmap_filter, nullptr);
@@ -393,7 +396,7 @@ TEST_F(SegmentBitmapFilterTest, NotCleanStable)
             *dm_context,
             snap,
             {seg->getRowKeyRange()},
-            EMPTY_RS_OPERATOR,
+            DMFilePackFilterResult::emptyResults(*dm_context, snap->stable->getDMFiles()),
             std::numeric_limits<UInt64>::max(),
             DEFAULT_BLOCK_SIZE);
         ASSERT_NE(bitmap_filter, nullptr);
@@ -413,7 +416,7 @@ TEST_F(SegmentBitmapFilterTest, NotCleanStable)
             *dm_context,
             snap,
             {seg->getRowKeyRange()},
-            EMPTY_RS_OPERATOR,
+            DMFilePackFilterResult::emptyResults(*dm_context, snap->stable->getDMFiles()),
             1,
             DEFAULT_BLOCK_SIZE);
         ASSERT_NE(bitmap_filter, nullptr);
@@ -441,7 +444,7 @@ TEST_F(SegmentBitmapFilterTest, StableRange)
         *dm_context,
         snap,
         {buildRowKeyRange(10000, 50000)}, // [10000, 50000)
-        EMPTY_RS_OPERATOR,
+        DMFilePackFilterResult::emptyResults(*dm_context, snap->stable->getDMFiles()),
         std::numeric_limits<UInt64>::max(),
         DEFAULT_BLOCK_SIZE);
     ASSERT_NE(bitmap_filter, nullptr);
@@ -510,7 +513,7 @@ try
         *dm_context,
         snap,
         {seg->getRowKeyRange()},
-        nullptr,
+        DMFilePackFilterResult::emptyResults(*dm_context, snap->stable->getDMFiles()),
         std::numeric_limits<UInt64>::max(),
         DEFAULT_BLOCK_SIZE);
     ASSERT_EQ(bitmap_filter->size(), 30);
@@ -540,7 +543,7 @@ try
         *dm_context,
         snap,
         {seg->getRowKeyRange()},
-        nullptr,
+        DMFilePackFilterResult::emptyResults(*dm_context, snap->stable->getDMFiles()),
         std::numeric_limits<UInt64>::max(),
         DEFAULT_BLOCK_SIZE);
     ASSERT_EQ(bitmap_filter->size(), 750);

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_bitmap.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_bitmap.cpp
@@ -374,7 +374,7 @@ TEST_F(SegmentBitmapFilterTest, CleanStable)
         *dm_context,
         snap,
         {seg->getRowKeyRange()},
-        DMFilePackFilterResult::emptyResults(*dm_context, snap->stable->getDMFiles()),
+        DMFilePackFilterResult::defaultResults(*dm_context, snap->stable->getDMFiles()),
         std::numeric_limits<UInt64>::max(),
         DEFAULT_BLOCK_SIZE);
     ASSERT_NE(bitmap_filter, nullptr);
@@ -396,7 +396,7 @@ TEST_F(SegmentBitmapFilterTest, NotCleanStable)
             *dm_context,
             snap,
             {seg->getRowKeyRange()},
-            DMFilePackFilterResult::emptyResults(*dm_context, snap->stable->getDMFiles()),
+            DMFilePackFilterResult::defaultResults(*dm_context, snap->stable->getDMFiles()),
             std::numeric_limits<UInt64>::max(),
             DEFAULT_BLOCK_SIZE);
         ASSERT_NE(bitmap_filter, nullptr);
@@ -416,7 +416,7 @@ TEST_F(SegmentBitmapFilterTest, NotCleanStable)
             *dm_context,
             snap,
             {seg->getRowKeyRange()},
-            DMFilePackFilterResult::emptyResults(*dm_context, snap->stable->getDMFiles()),
+            DMFilePackFilterResult::defaultResults(*dm_context, snap->stable->getDMFiles()),
             1,
             DEFAULT_BLOCK_SIZE);
         ASSERT_NE(bitmap_filter, nullptr);
@@ -444,7 +444,7 @@ TEST_F(SegmentBitmapFilterTest, StableRange)
         *dm_context,
         snap,
         {buildRowKeyRange(10000, 50000)}, // [10000, 50000)
-        DMFilePackFilterResult::emptyResults(*dm_context, snap->stable->getDMFiles()),
+        DMFilePackFilterResult::defaultResults(*dm_context, snap->stable->getDMFiles()),
         std::numeric_limits<UInt64>::max(),
         DEFAULT_BLOCK_SIZE);
     ASSERT_NE(bitmap_filter, nullptr);
@@ -513,7 +513,7 @@ try
         *dm_context,
         snap,
         {seg->getRowKeyRange()},
-        DMFilePackFilterResult::emptyResults(*dm_context, snap->stable->getDMFiles()),
+        DMFilePackFilterResult::defaultResults(*dm_context, snap->stable->getDMFiles()),
         std::numeric_limits<UInt64>::max(),
         DEFAULT_BLOCK_SIZE);
     ASSERT_EQ(bitmap_filter->size(), 30);
@@ -543,7 +543,7 @@ try
         *dm_context,
         snap,
         {seg->getRowKeyRange()},
-        DMFilePackFilterResult::emptyResults(*dm_context, snap->stable->getDMFiles()),
+        DMFilePackFilterResult::defaultResults(*dm_context, snap->stable->getDMFiles()),
         std::numeric_limits<UInt64>::max(),
         DEFAULT_BLOCK_SIZE);
     ASSERT_EQ(bitmap_filter->size(), 750);

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_test_basic.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_test_basic.cpp
@@ -1025,7 +1025,7 @@ std::vector<Block> SegmentTestBasic::readSegment(PageIdU64 segment_id, bool need
         columns_to_read,
         snapshot,
         ranges.empty() ? RowKeyRanges{segment->getRowKeyRange()} : ranges,
-        nullptr,
+        {},
         std::numeric_limits<UInt64>::max(),
         DEFAULT_BLOCK_SIZE,
         need_row_id);

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_skippable_block_input_stream.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_skippable_block_input_stream.cpp
@@ -105,6 +105,7 @@ protected:
             columns_to_read,
             read_ranges,
             EMPTY_RS_OPERATOR,
+            {},
             std::numeric_limits<UInt64>::max(),
             DEFAULT_BLOCK_SIZE,
             ReadTag::Internal);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6233

Problem Summary:

### What is changed and how it workss

```commit-message
Before, TiFlash will load the `RSResult` three times for one query (MVCC/Build Bitmap/Query).

This PR introduces `DMFilePackFilterResult` which load `RSResult` only once, and only passes the `RSResult` to `DMFileReader`.
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
