### PR TITLE
*: Refine the error message when schema mismatch in ExchangeReceiver

### DIFF
--- a/dbms/src/Flash/Coprocessor/CodecUtils.cpp
+++ b/dbms/src/Flash/Coprocessor/CodecUtils.cpp
@@ -12,39 +12,39 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Common/Exception.h>
 #include <Common/TiFlashException.h>
 #include <Flash/Coprocessor/CodecUtils.h>
 #include <Flash/Coprocessor/DAGUtils.h>
 
-namespace DB
-{
-namespace ErrorCodes
+namespace DB::ErrorCodes
 {
 extern const int LOGICAL_ERROR;
-} // namespace ErrorCodes
+} // namespace DB::ErrorCodes
 
-namespace CodecUtils
+namespace DB::CodecUtils
 {
 void checkColumnSize(const String & identifier, size_t expected, size_t actual)
 {
-    if unlikely (expected != actual)
+    if (unlikely(expected != actual))
         throw Exception(
-            fmt::format("{} schema size mismatch, expected {}, actual {}.", identifier, expected, actual),
-            ErrorCodes::LOGICAL_ERROR);
+            ErrorCodes::LOGICAL_ERROR,
+            "{} schema size mismatch, expected {}, actual {}.",
+            identifier,
+            expected,
+            actual);
 }
 
 void checkDataTypeName(const String & identifier, size_t column_index, const String & expected, const String & actual)
 {
-    if unlikely (expected != actual)
+    if (unlikely(expected != actual))
         throw Exception(
-            fmt::format(
-                "{} schema mismatch at column {}, expected {}, actual {}",
-                identifier,
-                column_index,
-                expected,
-                actual),
-            ErrorCodes::LOGICAL_ERROR);
+            ErrorCodes::LOGICAL_ERROR,
+            "{} schema mismatch at column {}, expected {}, actual {}",
+            identifier,
+            column_index,
+            expected,
+            actual);
 }
 
-} // namespace CodecUtils
-} // namespace DB
+} // namespace DB::CodecUtils

--- a/dbms/src/Flash/Mpp/ExchangeReceiver.h
+++ b/dbms/src/Flash/Mpp/ExchangeReceiver.h
@@ -20,10 +20,8 @@
 #include <Flash/Mpp/AsyncRequestHandler.h>
 #include <Flash/Mpp/GRPCReceiverContext.h>
 
-#include <future>
 #include <memory>
 #include <mutex>
-#include <thread>
 
 namespace DB
 {
@@ -36,8 +34,8 @@ struct ExchangeReceiverResult
     size_t call_index;
     String req_info;
     bool meet_error;
-    String error_msg;
     bool eof;
+    String error_msg;
     DecodeDetail decode_detail;
 
     ExchangeReceiverResult()
@@ -74,8 +72,8 @@ private:
         , call_index(call_index_)
         , req_info(req_info_)
         , meet_error(meet_error_)
-        , error_msg(error_msg_)
         , eof(eof_)
+        , error_msg(error_msg_)
     {}
 };
 

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -1021,8 +1021,6 @@ int Server::main(const std::vector<std::string> & /*args*/)
         }
     }
 
-    LOG_INFO(log, "Using api_version={}", storage_config.api_version);
-
     // Set whether to use safe point v2.
     PDClientHelper::enable_safepoint_v2 = config().getBool("enable_safe_point_v2", false);
 

--- a/dbms/src/Server/StorageConfigParser.cpp
+++ b/dbms/src/Server/StorageConfigParser.cpp
@@ -258,7 +258,12 @@ void TiFlashStorageConfig::parseMisc(const String & storage_section, const Logge
 
     lazily_init_store = get_bool_config_or_default("lazily_init_store", lazily_init_store);
 
-    LOG_INFO(log, "format_version={} lazily_init_store={} api_version={}", format_version, lazily_init_store, api_version);
+    LOG_INFO(
+        log,
+        "format_version={} lazily_init_store={} api_version={}",
+        format_version,
+        lazily_init_store,
+        api_version);
 }
 
 Strings TiFlashStorageConfig::getAllNormalPaths() const

--- a/dbms/src/Server/StorageConfigParser.cpp
+++ b/dbms/src/Server/StorageConfigParser.cpp
@@ -258,7 +258,7 @@ void TiFlashStorageConfig::parseMisc(const String & storage_section, const Logge
 
     lazily_init_store = get_bool_config_or_default("lazily_init_store", lazily_init_store);
 
-    LOG_INFO(log, "format_version {} lazily_init_store {}", format_version, lazily_init_store);
+    LOG_INFO(log, "format_version={} lazily_init_store={} api_version={}", format_version, lazily_init_store, api_version);
 }
 
 Strings TiFlashStorageConfig::getAllNormalPaths() const

--- a/dbms/src/Storages/DeltaMerge/Segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/Segment.cpp
@@ -440,7 +440,7 @@ SegmentPtr Segment::restoreSegment( //
     }
     catch (DB::Exception & e)
     {
-        e.addMessage(fmt::format("while restoreSegment, segment_id={}", segment_id));
+        e.addMessage(fmt::format("while restoreSegment, segment_id={} ident={}", segment_id, parent_log->identifier()));
         e.rethrow();
     }
     RUNTIME_CHECK_MSG(false, "unreachable");

--- a/dbms/src/Storages/FormatVersion.cpp
+++ b/dbms/src/Storages/FormatVersion.cpp
@@ -49,7 +49,7 @@ const StorageFormatVersion & toStorageFormat(UInt64 setting)
     case 103:
         return STORAGE_FORMAT_V103;
     default:
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Illegal setting value: {}", setting);
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Illegal format_version value: {}", setting);
     }
 }
 } // namespace


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/9673

Problem Summary:

### What is changed and how it works?

```commit-message

```

Changes:
* Refine the error message when storage.format_version is invalid
* Refine the error message with keyspace_id, table_id, page_id, meta_version when restoring segment from disk
* Refine the error message with exectuor name when exchange receiver meet unexpected data type

After this PR:

If we set a illegal storage.format_version
```
[2024/12/26 18:35:35.117 +08:00] [ERROR] [<unknown>] ["DB::Exception: Illegal format_version value: 9"] [source=Application] [thread_id=1]
```

If we meet unexpected data type when restarting tiflash
```
[2024/12/26 23:27:43.778 +08:00] [ERROR] [Exception.cpp:91] ["Storage inited fail, keyspace=4294967295 table_id=127: Code: 50, e.displayText() = DB::Exception: Unknown data type family: StringV2: file_page_id=14494 meta_version=0: while restoreSegment, segment_id=7997 ident=keyspace=4294967295 table_id=127: ...
```

If some tiflash is upgrade to use the new string serde format, while some tiflash is not
```
tidb> select
->     l_returnflag,
->     l_linestatus,
->     sum(l_quantity) as sum_qty,
->     sum(l_extendedprice) as sum_base_price,
->     sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,
->     sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge,
->     avg(l_quantity) as avg_qty,
->     avg(l_extendedprice) as avg_price,
->     avg(l_discount) as avg_disc,
->     count(*) as count_order
-> from
->     lineitem
-> where
->     l_shipdate <= '1992-1-31'
-> group by
->     l_returnflag,
->     l_linestatus
-> order by
->     l_returnflag,
->     l_linestatus;
(1105, 'other error for mpp stream: Code: 49, e.displayText() = DB::Exception: CHBlockChunkCodecV1 schema mismatch at column 11, expected String, actual StringV2: MPP<gather_id:1, query_ts:1735122411743666484, local_query_id:2, server_id:1851, start_ts:454851929482461196,task_id:4> ExchangeReceiver_52, e.what() = DB::Exception,')

-- the plan
+--------------------------------------+-----------+--------------+----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| id                                   | estRows   | task         | access object  | operator info                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+--------------------------------------+-----------+--------------+----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Sort_6                               | 1.00      | root         |                | test.lineitem.l_returnflag, test.lineitem.l_linestatus                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
| └─TableReader_54                     | 1.00      | root         |                | MppVersion: 2, data:ExchangeSender_53                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
|   └─ExchangeSender_53                | 1.00      | mpp[tiflash] |                | ExchangeType: PassThrough                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
|     └─Projection_9                   | 1.00      | mpp[tiflash] |                | test.lineitem.l_returnflag, test.lineitem.l_linestatus, Column#18, Column#19, Column#20, Column#21, Column#22, Column#23, Column#24, Column#25                                                                                                                                                                                                                                                                                                                                                                       |
|       └─Projection_49                | 1.00      | mpp[tiflash] |                | Column#18, Column#19, Column#20, Column#21, div(Column#22, cast(case(eq(Column#74, 0), 1, Column#74), decimal(20,0) BINARY))->Column#22, div(Column#23, cast(case(eq(Column#75, 0), 1, Column#75), decimal(20,0) BINARY))->Column#23, div(Column#24, cast(case(eq(Column#76, 0), 1, Column#76), decimal(20,0) BINARY))->Column#24, Column#25, test.lineitem.l_returnflag, test.lineitem.l_linestatus                                                                                                                 |
|         └─HashAgg_50                 | 1.00      | mpp[tiflash] |                | group by:test.lineitem.l_linestatus, test.lineitem.l_returnflag, funcs:sum(Column#77)->Column#18, funcs:sum(Column#78)->Column#19, funcs:sum(Column#79)->Column#20, funcs:sum(Column#80)->Column#21, funcs:sum(Column#81)->Column#74, funcs:sum(Column#82)->Column#22, funcs:sum(Column#83)->Column#75, funcs:sum(Column#84)->Column#23, funcs:sum(Column#85)->Column#76, funcs:sum(Column#86)->Column#24, funcs:sum(Column#87)->Column#25, funcs:firstrow(test.lineitem.l_returnflag)->test.lineitem.l_returnfla... |
|           └─ExchangeReceiver_52      | 1.00      | mpp[tiflash] |                |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
|             └─ExchangeSender_51      | 1.00      | mpp[tiflash] |                | ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.lineitem.l_returnflag, collate: utf8mb4_bin], [name: test.lineitem.l_linestatus, collate: utf8mb4_bin]                                                                                                                                                                                                                                                                                                                                        |
|               └─HashAgg_47           | 1.00      | mpp[tiflash] |                | group by:Column#100, Column#101, funcs:sum(Column#90)->Column#77, funcs:sum(Column#91)->Column#78, funcs:sum(Column#92)->Column#79, funcs:sum(Column#93)->Column#80, funcs:count(Column#94)->Column#81, funcs:sum(Column#95)->Column#82, funcs:count(Column#96)->Column#83, funcs:sum(Column#97)->Column#84, funcs:count(Column#98)->Column#85, funcs:sum(Column#99)->Column#86, funcs:count(1)->Column#87                                                                                                           |
|                 └─Projection_57      | 763070.18 | mpp[tiflash] |                | test.lineitem.l_quantity->Column#90, test.lineitem.l_extendedprice->Column#91, mul(test.lineitem.l_extendedprice, minus(1, test.lineitem.l_discount))->Column#92, mul(mul(test.lineitem.l_extendedprice, minus(1, test.lineitem.l_discount)), plus(1, test.lineitem.l_tax))->Column#93, test.lineitem.l_quantity->Column#94, test.lineitem.l_quantity->Column#95, test.lineitem.l_extendedprice->Column#96, test.lineitem.l_extendedprice->Column#97, test.lineitem.l_discount->Column#98, test.lineitem.l_discou... |
|                   └─TableFullScan_35 | 763070.18 | mpp[tiflash] | table:lineitem | pushed down filter:le(test.lineitem.l_shipdate, 1992-01-31 00:00:00.000000), keep order:false                                                                                                                                                                                                                                                                                                                                                                                                                        |
+--------------------------------------+-----------+--------------+----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
