### PR TITLE
Stats inner/inter zone network traffic for mpp tasks

### DIFF
--- a/dbms/src/Flash/Coprocessor/CoprocessorReader.h
+++ b/dbms/src/Flash/Coprocessor/CoprocessorReader.h
@@ -165,6 +165,8 @@ public:
     static const inline ConnectionProfileInfo::ConnTypeVec conn_type_vec{
         ConnectionProfileInfo::InnerZoneRemote,
         ConnectionProfileInfo::InterZoneRemote};
+    static const Int32 inner_zone_index = 0;
+    static const Int32 inter_zone_index = 1;
 
 private:
     const DAGSchema schema;

--- a/dbms/src/Flash/Coprocessor/CoprocessorReader.h
+++ b/dbms/src/Flash/Coprocessor/CoprocessorReader.h
@@ -21,9 +21,8 @@
 #include <Flash/Coprocessor/ChunkDecodeAndSquash.h>
 #include <Flash/Coprocessor/DecodeDetail.h>
 #include <Flash/Coprocessor/DefaultChunkCodec.h>
+#include <Flash/Statistics/ConnectionProfileInfo.h>
 #include <common/logger_useful.h>
-
-#include "Flash/Statistics/ConnectionProfileInfo.h"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"

--- a/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
@@ -748,6 +748,7 @@ CoprocessorReaderPtr DAGStorageInterpreter::buildCoprocessorReader(const std::ve
             if (kv_store->getStoreMeta().labels().at(i).key() == "zone")
             {
                 store_zone_label = kv_store->getStoreMeta().labels().at(i).value();
+                break;
             }
         }
     }

--- a/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
@@ -739,7 +739,18 @@ CoprocessorReaderPtr DAGStorageInterpreter::buildCoprocessorReader(const std::ve
         : concurrent_num * 4;
     bool enable_cop_stream = context.getSettingsRef().enable_cop_stream_for_remote_read;
     UInt64 cop_timeout = context.getSettingsRef().cop_timeout_for_remote_read;
-
+    String store_zone_label;
+    auto kv_store = tmt.getKVStore();
+    if likely (kv_store)
+    {
+        for (int i = 0; i < kv_store->getStoreMeta().labels_size(); ++i)
+        {
+            if (kv_store->getStoreMeta().labels().at(i).key() == "zone")
+            {
+                store_zone_label = kv_store->getStoreMeta().labels().at(i).value();
+            }
+        }
+    }
     auto coprocessor_reader = std::make_shared<CoprocessorReader>(
         schema,
         cluster,
@@ -750,7 +761,8 @@ CoprocessorReaderPtr DAGStorageInterpreter::buildCoprocessorReader(const std::ve
         queue_size,
         cop_timeout,
         tiflash_label_filter,
-        log->identifier());
+        log->identifier(),
+        store_zone_label);
     context.getDAGContext()->addCoprocessorReader(coprocessor_reader);
 
     return coprocessor_reader;

--- a/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
@@ -751,6 +751,7 @@ CoprocessorReaderPtr DAGStorageInterpreter::buildCoprocessorReader(const std::ve
             }
         }
     }
+    LOG_DEBUG(log, "KVStore Zone Label {}", store_zone_label);
     auto coprocessor_reader = std::make_shared<CoprocessorReader>(
         schema,
         cluster,

--- a/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
@@ -751,7 +751,6 @@ CoprocessorReaderPtr DAGStorageInterpreter::buildCoprocessorReader(const std::ve
             }
         }
     }
-    LOG_DEBUG(log, "KVStore Zone Label {}", store_zone_label);
     auto coprocessor_reader = std::make_shared<CoprocessorReader>(
         schema,
         cluster,

--- a/dbms/src/Flash/Coprocessor/ExecutionSummary.cpp
+++ b/dbms/src/Flash/Coprocessor/ExecutionSummary.cpp
@@ -37,6 +37,10 @@ void ExecutionSummary::merge(const ExecutionSummary & other)
     num_produced_rows += other.num_produced_rows;
     num_iterations += other.num_iterations;
     concurrency += other.concurrency;
+    inner_zone_send_bytes += other.inner_zone_send_bytes;
+    inner_zone_receive_bytes += other.inner_zone_receive_bytes;
+    inter_zone_send_bytes += other.inter_zone_send_bytes;
+    inter_zone_receive_bytes += other.inter_zone_receive_bytes;
     ru_consumption = mergeRUConsumption(ru_consumption, other.ru_consumption);
     scan_context->merge(*other.scan_context);
 }
@@ -53,6 +57,10 @@ void ExecutionSummary::merge(const tipb::ExecutorExecutionSummary & other)
     num_produced_rows += other.num_produced_rows();
     num_iterations += other.num_iterations();
     concurrency += other.concurrency();
+    inner_zone_send_bytes += other.tiflash_network_summary().inner_zone_send_bytes();
+    inner_zone_receive_bytes += other.tiflash_network_summary().inner_zone_receive_bytes();
+    inter_zone_send_bytes += other.tiflash_network_summary().inter_zone_send_bytes();
+    inter_zone_receive_bytes += other.tiflash_network_summary().inter_zone_send_bytes();
     ru_consumption = mergeRUConsumption(ru_consumption, parseRUConsumption(other));
     scan_context->merge(other.tiflash_scan_context());
 }
@@ -66,6 +74,10 @@ void ExecutionSummary::fill(const BaseRuntimeStatistics & other)
     num_produced_rows = other.rows;
     num_iterations = other.blocks;
     concurrency = other.concurrency;
+    inner_zone_send_bytes = other.inner_zone_send_bytes;
+    inner_zone_receive_bytes = other.inner_zone_receive_bytes;
+    inter_zone_send_bytes = other.inter_zone_send_bytes;
+    inter_zone_receive_bytes = other.inter_zone_receive_bytes;
 }
 
 void ExecutionSummary::init(const tipb::ExecutorExecutionSummary & other)
@@ -77,6 +89,10 @@ void ExecutionSummary::init(const tipb::ExecutorExecutionSummary & other)
     num_produced_rows = other.num_produced_rows();
     num_iterations = other.num_iterations();
     concurrency = other.concurrency();
+    inner_zone_send_bytes = other.tiflash_network_summary().inner_zone_send_bytes();
+    inner_zone_receive_bytes = other.tiflash_network_summary().inner_zone_receive_bytes();
+    inter_zone_send_bytes = other.tiflash_network_summary().inter_zone_send_bytes();
+    inter_zone_receive_bytes = other.tiflash_network_summary().inter_zone_send_bytes();
     ru_consumption = parseRUConsumption(other);
     scan_context->deserialize(other.tiflash_scan_context());
 }

--- a/dbms/src/Flash/Coprocessor/ExecutionSummary.h
+++ b/dbms/src/Flash/Coprocessor/ExecutionSummary.h
@@ -35,6 +35,10 @@ struct ExecutionSummary
     UInt64 num_produced_rows = 0;
     UInt64 num_iterations = 0;
     UInt64 concurrency = 0;
+    UInt64 inner_zone_send_bytes = 0;
+    UInt64 inner_zone_receive_bytes = 0;
+    UInt64 inter_zone_send_bytes = 0;
+    UInt64 inter_zone_receive_bytes = 0;
     resource_manager::Consumption ru_consumption{};
 
     DM::ScanContextPtr scan_context;

--- a/dbms/src/Flash/Mpp/ExchangeReceiver.cpp
+++ b/dbms/src/Flash/Mpp/ExchangeReceiver.cpp
@@ -383,7 +383,7 @@ ExchangeReceiverBase<RPCContext>::~ExchangeReceiverBase()
 }
 
 template <typename RPCContext>
-const ConnTypeVec & ExchangeReceiverBase<RPCContext>::getConnTypeVec() const
+const ConnectionProfileInfo::ConnTypeVec & ExchangeReceiverBase<RPCContext>::getConnTypeVec() const
 {
     return rpc_context->getConnTypeVec();
 }

--- a/dbms/src/Flash/Mpp/ExchangeReceiver.cpp
+++ b/dbms/src/Flash/Mpp/ExchangeReceiver.cpp
@@ -383,6 +383,12 @@ ExchangeReceiverBase<RPCContext>::~ExchangeReceiverBase()
 }
 
 template <typename RPCContext>
+const ConnTypeVec & ExchangeReceiverBase<RPCContext>::getConnTypeVec() const
+{
+    return rpc_context->getConnTypeVec();
+}
+
+template <typename RPCContext>
 void ExchangeReceiverBase<RPCContext>::handleConnectionAfterException()
 {
     std::lock_guard lock(mu);

--- a/dbms/src/Flash/Mpp/ExchangeReceiver.h
+++ b/dbms/src/Flash/Mpp/ExchangeReceiver.h
@@ -25,7 +25,6 @@
 #include <mutex>
 
 
-
 namespace DB
 {
 constexpr Int32 batch_packet_count_v1 = 16;
@@ -145,7 +144,7 @@ public:
     std::atomic<Int64> * getDataSizeInQueue() { return &data_size_in_queue; }
 
     void verifyStreamId(size_t stream_id) const;
-    const ConnTypeVec & getConnTypeVec() const;
+    const ConnectionProfileInfo::ConnTypeVec & getConnTypeVec() const;
 
 private:
     std::shared_ptr<MemoryTracker> mem_tracker;

--- a/dbms/src/Flash/Mpp/ExchangeReceiver.h
+++ b/dbms/src/Flash/Mpp/ExchangeReceiver.h
@@ -19,9 +19,12 @@
 #include <Flash/Coprocessor/DAGUtils.h>
 #include <Flash/Mpp/AsyncRequestHandler.h>
 #include <Flash/Mpp/GRPCReceiverContext.h>
+#include <Flash/Statistics/ConnectionProfileInfo.h>
 
 #include <memory>
 #include <mutex>
+
+
 
 namespace DB
 {
@@ -142,6 +145,7 @@ public:
     std::atomic<Int64> * getDataSizeInQueue() { return &data_size_in_queue; }
 
     void verifyStreamId(size_t stream_id) const;
+    const ConnTypeVec & getConnTypeVec() const;
 
 private:
     std::shared_ptr<MemoryTracker> mem_tracker;

--- a/dbms/src/Flash/Mpp/ExchangeReceiver.h
+++ b/dbms/src/Flash/Mpp/ExchangeReceiver.h
@@ -202,9 +202,7 @@ private:
 
     std::shared_ptr<RPCContext> rpc_context;
 
-    const tipb::ExchangeReceiver pb_exchange_receiver;
     const size_t source_num;
-    const ::mpp::TaskMeta task_meta;
     const bool enable_fine_grained_shuffle_flag;
     const size_t output_stream_count;
     const size_t max_buffer_size;

--- a/dbms/src/Flash/Mpp/ExchangeReceiver.h
+++ b/dbms/src/Flash/Mpp/ExchangeReceiver.h
@@ -24,7 +24,6 @@
 #include <memory>
 #include <mutex>
 
-
 namespace DB
 {
 constexpr Int32 batch_packet_count_v1 = 16;

--- a/dbms/src/Flash/Mpp/GRPCReceiverContext.cpp
+++ b/dbms/src/Flash/Mpp/GRPCReceiverContext.cpp
@@ -17,12 +17,12 @@
 #include <Flash/Coprocessor/GenSchemaAndColumn.h>
 #include <Flash/Mpp/GRPCCompletionQueuePool.h>
 #include <Flash/Mpp/GRPCReceiverContext.h>
+#include <Flash/Statistics/ConnectionProfileInfo.h>
 #include <fmt/core.h>
 #include <grpcpp/completion_queue.h>
 
 #include <cassert>
 #include <tuple>
-#include "Flash/Statistics/ConnectionProfileInfo.h"
 
 namespace DB
 {
@@ -124,10 +124,16 @@ ExchangeRecvRequest GRPCReceiverContext::makeRequest(int index) const
     req.req.set_allocated_receiver_meta(new mpp::TaskMeta(task_meta)); // NOLINT
     req.req.set_allocated_sender_meta(sender_task.release()); // NOLINT
 
-    bool valid_zone_flag = exchange_receiver_meta.same_zone_flag_size() == exchange_receiver_meta.encoded_task_meta_size();
-    if likely (valid_zone_flag) {
-        conn_type_vec[index] = ConnectionProfileInfo::inferConnectionType(req.is_local, exchange_receiver_meta.same_zone_flag().Get(index));
-    } else {
+    bool valid_zone_flag
+        = exchange_receiver_meta.same_zone_flag_size() == exchange_receiver_meta.encoded_task_meta_size();
+    if likely (valid_zone_flag)
+    {
+        conn_type_vec[index] = ConnectionProfileInfo::inferConnectionType(
+            req.is_local,
+            exchange_receiver_meta.same_zone_flag().Get(index));
+    }
+    else
+    {
         conn_type_vec[index] = ConnectionProfileInfo::inferConnectionType(req.is_local, true);
     }
     return req;

--- a/dbms/src/Flash/Mpp/GRPCReceiverContext.cpp
+++ b/dbms/src/Flash/Mpp/GRPCReceiverContext.cpp
@@ -22,6 +22,7 @@
 
 #include <cassert>
 #include <tuple>
+#include "Flash/Statistics/ConnectionProfileInfo.h"
 
 namespace DB
 {
@@ -104,7 +105,9 @@ GRPCReceiverContext::GRPCReceiverContext(
     , task_manager(std::move(task_manager_))
     , enable_local_tunnel(enable_local_tunnel_)
     , enable_async_grpc(enable_async_grpc_)
-{}
+{
+    conn_type_vec.resize(exchange_receiver_meta.encoded_task_meta_size(), ConnectionProfileInfo::Local);
+}
 
 ExchangeRecvRequest GRPCReceiverContext::makeRequest(int index) const
 {
@@ -120,6 +123,13 @@ ExchangeRecvRequest GRPCReceiverContext::makeRequest(int index) const
     req.recv_task_id = task_meta.task_id();
     req.req.set_allocated_receiver_meta(new mpp::TaskMeta(task_meta)); // NOLINT
     req.req.set_allocated_sender_meta(sender_task.release()); // NOLINT
+
+    bool valid_zone_flag = exchange_receiver_meta.same_zone_flag_size() == exchange_receiver_meta.encoded_task_meta_size();
+    if likely (valid_zone_flag) {
+        conn_type_vec[index] = ConnectionProfileInfo::inferConnectionType(req.is_local, exchange_receiver_meta.same_zone_flag().Get(index));
+    } else {
+        conn_type_vec[index] = ConnectionProfileInfo::inferConnectionType(req.is_local, true);
+    }
     return req;
 }
 

--- a/dbms/src/Flash/Mpp/GRPCReceiverContext.h
+++ b/dbms/src/Flash/Mpp/GRPCReceiverContext.h
@@ -18,6 +18,7 @@
 #include <Flash/Coprocessor/ChunkCodec.h>
 #include <Flash/Mpp/LocalRequestHandler.h>
 #include <Flash/Mpp/MPPTaskManager.h>
+#include <Flash/Statistics/ConnectionProfileInfo.h>
 #include <common/types.h>
 #include <grpcpp/completion_queue.h>
 #include <kvproto/mpp.pb.h>
@@ -104,12 +105,15 @@ public:
         LocalRequestHandler & local_request_handler,
         bool has_remote_conn);
 
+    const ConnTypeVec & getConnTypeVec() const { return conn_type_vec; }
+
     static std::tuple<MPPTunnelPtr, grpc::Status> establishMPPConnectionLocalV1(
         const ::mpp::EstablishMPPConnectionRequest * request,
         const std::shared_ptr<MPPTaskManager> & task_manager);
 
 private:
     tipb::ExchangeReceiver exchange_receiver_meta;
+    mutable ConnTypeVec conn_type_vec;
     mpp::TaskMeta task_meta;
     pingcap::kv::Cluster * cluster;
     std::shared_ptr<MPPTaskManager> task_manager;

--- a/dbms/src/Flash/Mpp/GRPCReceiverContext.h
+++ b/dbms/src/Flash/Mpp/GRPCReceiverContext.h
@@ -105,7 +105,7 @@ public:
         LocalRequestHandler & local_request_handler,
         bool has_remote_conn);
 
-    const ConnTypeVec & getConnTypeVec() const { return conn_type_vec; }
+    const ConnectionProfileInfo::ConnTypeVec & getConnTypeVec() const { return conn_type_vec; }
 
     static std::tuple<MPPTunnelPtr, grpc::Status> establishMPPConnectionLocalV1(
         const ::mpp::EstablishMPPConnectionRequest * request,
@@ -113,7 +113,7 @@ public:
 
 private:
     tipb::ExchangeReceiver exchange_receiver_meta;
-    mutable ConnTypeVec conn_type_vec;
+    mutable ConnectionProfileInfo::ConnTypeVec conn_type_vec;
     mpp::TaskMeta task_meta;
     pingcap::kv::Cluster * cluster;
     std::shared_ptr<MPPTaskManager> task_manager;

--- a/dbms/src/Flash/Mpp/MPPTask.cpp
+++ b/dbms/src/Flash/Mpp/MPPTask.cpp
@@ -215,6 +215,7 @@ void MPPTask::registerTunnels(const mpp::DispatchTaskRequest & task_request)
         std::max(5, context->getSettingsRef().max_threads * 5),
         tunnel_queue_memory_bound); // MPMCQueue can benefit from a slightly larger queue size
 
+    bool safe_zone_flag_fields = exchange_sender.same_zone_flag_size() == exchange_sender.encoded_task_meta_size();
     for (int i = 0; i < exchange_sender.encoded_task_meta_size(); ++i)
     {
         // exchange sender will register the tunnels and wait receiver to found a connection.
@@ -235,6 +236,7 @@ void MPPTask::registerTunnels(const mpp::DispatchTaskRequest & task_request)
             queue_limit,
             is_local,
             is_async,
+            safe_zone_flag_fields ? exchange_sender.same_zone_flag().Get(i) : true,
             log->identifier());
 
         LOG_DEBUG(log, "begin to register the tunnel {}, is_local: {}, is_async: {}", tunnel->id(), is_local, is_async);

--- a/dbms/src/Flash/Mpp/MPPTask.cpp
+++ b/dbms/src/Flash/Mpp/MPPTask.cpp
@@ -215,7 +215,7 @@ void MPPTask::registerTunnels(const mpp::DispatchTaskRequest & task_request)
         std::max(5, context->getSettingsRef().max_threads * 5),
         tunnel_queue_memory_bound); // MPMCQueue can benefit from a slightly larger queue size
 
-    bool safe_zone_flag_fields = exchange_sender.same_zone_flag_size() == exchange_sender.encoded_task_meta_size();
+    bool valid_zone_flag_fields = exchange_sender.same_zone_flag_size() == exchange_sender.encoded_task_meta_size();
     for (int i = 0; i < exchange_sender.encoded_task_meta_size(); ++i)
     {
         // exchange sender will register the tunnels and wait receiver to found a connection.
@@ -236,7 +236,7 @@ void MPPTask::registerTunnels(const mpp::DispatchTaskRequest & task_request)
             queue_limit,
             is_local,
             is_async,
-            safe_zone_flag_fields ? exchange_sender.same_zone_flag().Get(i) : true,
+            valid_zone_flag_fields ? exchange_sender.same_zone_flag().Get(i) : true,
             log->identifier());
 
         LOG_DEBUG(log, "begin to register the tunnel {}, is_local: {}, is_async: {}", tunnel->id(), is_local, is_async);

--- a/dbms/src/Flash/Mpp/MPPTunnel.cpp
+++ b/dbms/src/Flash/Mpp/MPPTunnel.cpp
@@ -23,6 +23,8 @@
 
 #include <magic_enum.hpp>
 
+#include "Flash/Statistics/ConnectionProfileInfo.h"
+
 namespace DB
 {
 namespace FailPoints
@@ -74,6 +76,7 @@ MPPTunnel::MPPTunnel(
     const CapacityLimits & queue_limits_,
     bool is_local_,
     bool is_async_,
+    bool same_zone,
     const String & req_id)
     : MPPTunnel(
         fmt::format("tunnel{}+{}", sender_meta_.task_id(), receiver_meta_.task_id()),
@@ -81,6 +84,7 @@ MPPTunnel::MPPTunnel(
         queue_limits_,
         is_local_,
         is_async_,
+        same_zone,
         req_id)
 {}
 
@@ -90,6 +94,7 @@ MPPTunnel::MPPTunnel(
     const CapacityLimits & queue_limits_,
     bool is_local_,
     bool is_async_,
+    bool same_zone,
     const String & req_id)
     : status(TunnelStatus::Unconnected)
     , timeout(timeout_)
@@ -107,6 +112,7 @@ MPPTunnel::MPPTunnel(
         mode = TunnelSenderMode::ASYNC_GRPC;
     else
         mode = TunnelSenderMode::SYNC_GRPC;
+    connection_profile_info.type = ConnectionProfileInfo::inferConnectionType(is_local_, same_zone);
     GET_METRIC(tiflash_object_count, type_count_of_mpptunnel).Increment();
 }
 

--- a/dbms/src/Flash/Mpp/MPPTunnel.cpp
+++ b/dbms/src/Flash/Mpp/MPPTunnel.cpp
@@ -102,6 +102,7 @@ MPPTunnel::MPPTunnel(
     , tunnel_id(tunnel_id_)
     , mem_tracker(current_memory_tracker ? current_memory_tracker->shared_from_this() : nullptr)
     , queue_limit(queue_limits_)
+    , connection_profile_info(is_local_, same_zone)
     , log(Logger::get(req_id, tunnel_id))
     , data_size_in_queue(0)
 {
@@ -112,7 +113,6 @@ MPPTunnel::MPPTunnel(
         mode = TunnelSenderMode::ASYNC_GRPC;
     else
         mode = TunnelSenderMode::SYNC_GRPC;
-    connection_profile_info.type = ConnectionProfileInfo::inferConnectionType(is_local_, same_zone);
     GET_METRIC(tiflash_object_count, type_count_of_mpptunnel).Increment();
 }
 

--- a/dbms/src/Flash/Mpp/MPPTunnel.cpp
+++ b/dbms/src/Flash/Mpp/MPPTunnel.cpp
@@ -19,11 +19,10 @@
 #include <Flash/Mpp/MPPTunnel.h>
 #include <Flash/Mpp/PacketWriter.h>
 #include <Flash/Mpp/Utils.h>
+#include <Flash/Statistics/ConnectionProfileInfo.h>
 #include <fmt/core.h>
 
 #include <magic_enum.hpp>
-
-#include "Flash/Statistics/ConnectionProfileInfo.h"
 
 namespace DB
 {

--- a/dbms/src/Flash/Mpp/MPPTunnel.h
+++ b/dbms/src/Flash/Mpp/MPPTunnel.h
@@ -474,6 +474,7 @@ public:
         const CapacityLimits & queue_limits,
         bool is_local_,
         bool is_async_,
+        bool same_zone,
         const String & req_id);
 
     // For gtest usage
@@ -483,6 +484,7 @@ public:
         const CapacityLimits & queue_limits,
         bool is_local_,
         bool is_async_,
+        bool same_zone,
         const String & req_id);
 
     ~MPPTunnel();

--- a/dbms/src/Flash/Mpp/tests/gtest_mpptunnel.cpp
+++ b/dbms/src/Flash/Mpp/tests/gtest_mpptunnel.cpp
@@ -255,19 +255,19 @@ protected:
 public:
     MPPTunnelPtr constructRemoteSyncTunnel()
     {
-        auto tunnel = std::make_shared<MPPTunnel>(String("0000_0001"), timeout, 2, false, false, String("0"));
+        auto tunnel = std::make_shared<MPPTunnel>(String("0000_0001"), timeout, 2, false, false, true, String("0"));
         return tunnel;
     }
 
     MPPTunnelPtr constructRemoteAsyncTunnel()
     {
-        auto tunnel = std::make_shared<MPPTunnel>(String("0000_0001"), timeout, 2, false, true, String("0"));
+        auto tunnel = std::make_shared<MPPTunnel>(String("0000_0001"), timeout, 2, false, true, true, String("0"));
         return tunnel;
     }
 
     MPPTunnelPtr constructLocalTunnel()
     {
-        auto tunnel = std::make_shared<MPPTunnel>(String("0000_0001"), timeout, 2, true, false, String("0"));
+        auto tunnel = std::make_shared<MPPTunnel>(String("0000_0001"), timeout, 2, true, false, true, String("0"));
         return tunnel;
     }
 

--- a/dbms/src/Flash/Statistics/BaseRuntimeStatistics.cpp
+++ b/dbms/src/Flash/Statistics/BaseRuntimeStatistics.cpp
@@ -43,7 +43,7 @@ void BaseRuntimeStatistics::append(const OperatorProfileInfo & profile_info)
     ++concurrency;
 }
 
-void BaseRuntimeStatistics::updateConnectionInfo(const ConnectionProfileInfo & conn_profile_info)
+void BaseRuntimeStatistics::updateReceiveConnectionInfo(const ConnectionProfileInfo & conn_profile_info)
 {
     switch (conn_profile_info.type)
     {
@@ -52,6 +52,21 @@ void BaseRuntimeStatistics::updateConnectionInfo(const ConnectionProfileInfo & c
         break;
     case DB::ConnectionProfileInfo::InterZoneRemote:
         inter_zone_receive_bytes += bytes;
+        break;
+    default:
+        break;
+    }
+}
+
+void BaseRuntimeStatistics::updateSendConnectionInfo(const ConnectionProfileInfo & conn_profile_info)
+{
+    switch (conn_profile_info.type)
+    {
+    case ConnectionProfileInfo::InnerZoneRemote:
+        inner_zone_send_bytes += bytes;
+        break;
+    case DB::ConnectionProfileInfo::InterZoneRemote:
+        inter_zone_send_bytes += bytes;
         break;
     default:
         break;

--- a/dbms/src/Flash/Statistics/BaseRuntimeStatistics.cpp
+++ b/dbms/src/Flash/Statistics/BaseRuntimeStatistics.cpp
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Common/TiFlashException.h>
 #include <DataStreams/BlockStreamProfileInfo.h>
 #include <Flash/Statistics/BaseRuntimeStatistics.h>
+#include <Flash/Statistics/ConnectionProfileInfo.h>
 #include <Operators/OperatorProfileInfo.h>
-#include "Common/TiFlashException.h"
-#include "Flash/Statistics/ConnectionProfileInfo.h"
 
 namespace DB
 {

--- a/dbms/src/Flash/Statistics/BaseRuntimeStatistics.cpp
+++ b/dbms/src/Flash/Statistics/BaseRuntimeStatistics.cpp
@@ -15,6 +15,8 @@
 #include <DataStreams/BlockStreamProfileInfo.h>
 #include <Flash/Statistics/BaseRuntimeStatistics.h>
 #include <Operators/OperatorProfileInfo.h>
+#include "Common/TiFlashException.h"
+#include "Flash/Statistics/ConnectionProfileInfo.h"
 
 namespace DB
 {
@@ -47,6 +49,8 @@ void BaseRuntimeStatistics::updateReceiveConnectionInfo(const ConnectionProfileI
 {
     switch (conn_profile_info.type)
     {
+    case DB::ConnectionProfileInfo::Local:
+        break;
     case ConnectionProfileInfo::InnerZoneRemote:
         inner_zone_receive_bytes += bytes;
         break;
@@ -54,7 +58,9 @@ void BaseRuntimeStatistics::updateReceiveConnectionInfo(const ConnectionProfileI
         inter_zone_receive_bytes += bytes;
         break;
     default:
-        break;
+        throw TiFlashException(
+            fmt::format("{} connection profile type is unexpected", fmt::underlying(conn_profile_info.type)),
+            Errors::Planner::Internal);
     }
 }
 
@@ -62,6 +68,8 @@ void BaseRuntimeStatistics::updateSendConnectionInfo(const ConnectionProfileInfo
 {
     switch (conn_profile_info.type)
     {
+    case DB::ConnectionProfileInfo::Local:
+        break;
     case ConnectionProfileInfo::InnerZoneRemote:
         inner_zone_send_bytes += bytes;
         break;
@@ -69,7 +77,9 @@ void BaseRuntimeStatistics::updateSendConnectionInfo(const ConnectionProfileInfo
         inter_zone_send_bytes += bytes;
         break;
     default:
-        break;
+        throw TiFlashException(
+            fmt::format("{} connection profile type is unexpected", fmt::underlying(conn_profile_info.type)),
+            Errors::Planner::Internal);
     }
 }
 } // namespace DB

--- a/dbms/src/Flash/Statistics/BaseRuntimeStatistics.cpp
+++ b/dbms/src/Flash/Statistics/BaseRuntimeStatistics.cpp
@@ -42,4 +42,19 @@ void BaseRuntimeStatistics::append(const OperatorProfileInfo & profile_info)
     }
     ++concurrency;
 }
+
+void BaseRuntimeStatistics::updateConnectionInfo(const ConnectionProfileInfo & conn_profile_info)
+{
+    switch (conn_profile_info.type)
+    {
+    case ConnectionProfileInfo::InnerZoneRemote:
+        inner_zone_receive_bytes += bytes;
+        break;
+    case DB::ConnectionProfileInfo::InterZoneRemote:
+        inter_zone_receive_bytes += bytes;
+        break;
+    default:
+        break;
+    }
+}
 } // namespace DB

--- a/dbms/src/Flash/Statistics/BaseRuntimeStatistics.h
+++ b/dbms/src/Flash/Statistics/BaseRuntimeStatistics.h
@@ -15,9 +15,8 @@
 #pragma once
 
 #include <Common/FmtUtils.h>
+#include <Flash/Statistics/ConnectionProfileInfo.h>
 #include <common/types.h>
-
-#include "Flash/Statistics/ConnectionProfileInfo.h"
 
 namespace DB
 {

--- a/dbms/src/Flash/Statistics/BaseRuntimeStatistics.h
+++ b/dbms/src/Flash/Statistics/BaseRuntimeStatistics.h
@@ -17,6 +17,8 @@
 #include <Common/FmtUtils.h>
 #include <common/types.h>
 
+#include "Flash/Statistics/ConnectionProfileInfo.h"
+
 namespace DB
 {
 struct BlockStreamProfileInfo;
@@ -39,5 +41,6 @@ struct BaseRuntimeStatistics
 
     void append(const BlockStreamProfileInfo &);
     void append(const OperatorProfileInfo &);
+    void updateConnectionInfo(const ConnectionProfileInfo & conn_profile_info);
 };
 } // namespace DB

--- a/dbms/src/Flash/Statistics/BaseRuntimeStatistics.h
+++ b/dbms/src/Flash/Statistics/BaseRuntimeStatistics.h
@@ -32,6 +32,10 @@ struct BaseRuntimeStatistics
     UInt64 minTSO_wait_time_ns = 0;
     UInt64 queue_wait_time_ns = 0;
     UInt64 pipeline_breaker_wait_time_ns = 0;
+    UInt64 inner_zone_send_bytes = 0;
+    UInt64 inner_zone_receive_bytes = 0;
+    UInt64 inter_zone_send_bytes = 0;
+    UInt64 inter_zone_receive_bytes = 0;
 
     void append(const BlockStreamProfileInfo &);
     void append(const OperatorProfileInfo &);

--- a/dbms/src/Flash/Statistics/BaseRuntimeStatistics.h
+++ b/dbms/src/Flash/Statistics/BaseRuntimeStatistics.h
@@ -40,6 +40,7 @@ struct BaseRuntimeStatistics
 
     void append(const BlockStreamProfileInfo &);
     void append(const OperatorProfileInfo &);
-    void updateConnectionInfo(const ConnectionProfileInfo & conn_profile_info);
+    void updateSendConnectionInfo(const ConnectionProfileInfo & conn_profile_info);
+    void updateReceiveConnectionInfo(const ConnectionProfileInfo & conn_profile_info);
 };
 } // namespace DB

--- a/dbms/src/Flash/Statistics/ConnectionProfileInfo.h
+++ b/dbms/src/Flash/Statistics/ConnectionProfileInfo.h
@@ -14,9 +14,10 @@
 
 #pragma once
 
+#include <common/defines.h>
 #include <common/types.h>
 
-#include "common/defines.h"
+#include <magic_enum.hpp>
 
 namespace DB
 {
@@ -44,6 +45,15 @@ struct ConnectionProfileInfo
             return InterZoneRemote;
         }
     }
+    ConnectionProfileInfo() = default;
+    explicit ConnectionProfileInfo(ConnectionType type_)
+        : type(type_)
+    {}
+    ConnectionProfileInfo(bool is_local, bool same_zone)
+        : ConnectionProfileInfo(inferConnectionType(is_local, same_zone))
+    {}
+
+    String getTypeString() const { return String(magic_enum::enum_name(type)); }
 
     Int64 packets = 0;
     Int64 bytes = 0;

--- a/dbms/src/Flash/Statistics/ConnectionProfileInfo.h
+++ b/dbms/src/Flash/Statistics/ConnectionProfileInfo.h
@@ -16,11 +16,37 @@
 
 #include <common/types.h>
 
+#include "common/defines.h"
+
 namespace DB
 {
+
 struct ConnectionProfileInfo
 {
+    enum ConnectionType
+    {
+        Local = 0,
+        InnerZoneRemote = 1,
+        InterZoneRemote = 2,
+    };
+    static ALWAYS_INLINE ConnectionType inferConnectionType(bool is_local, bool same_zone)
+    {
+        if (is_local)
+        {
+            return Local;
+        }
+        else if (same_zone)
+        {
+            return InnerZoneRemote;
+        }
+        else
+        {
+            return InterZoneRemote;
+        }
+    }
+
     Int64 packets = 0;
     Int64 bytes = 0;
+    ConnectionType type = Local;
 };
 } // namespace DB

--- a/dbms/src/Flash/Statistics/ConnectionProfileInfo.h
+++ b/dbms/src/Flash/Statistics/ConnectionProfileInfo.h
@@ -30,6 +30,7 @@ struct ConnectionProfileInfo
         InnerZoneRemote = 1,
         InterZoneRemote = 2,
     };
+    using ConnTypeVec = std::vector<ConnectionProfileInfo::ConnectionType>;
     static ALWAYS_INLINE ConnectionType inferConnectionType(bool is_local, bool same_zone)
     {
         if (is_local)

--- a/dbms/src/Flash/Statistics/ExchangeReceiverImpl.cpp
+++ b/dbms/src/Flash/Statistics/ExchangeReceiverImpl.cpp
@@ -49,19 +49,8 @@ void ExchangeReceiverStatistics::updateExchangeReceiveDetail(
     {
         exchange_receive_details[i].conn_profile_info.type = connection_profile_infos[i].type;
         exchange_receive_details[i].conn_profile_info.packets += connection_profile_infos[i].packets;
-        auto bytes = connection_profile_infos[i].bytes;
-        exchange_receive_details[i].conn_profile_info.bytes += bytes;
-        switch (exchange_receive_details[i].conn_profile_info.type)
-        {
-        case ConnectionProfileInfo::InnerZoneRemote:
-            base.inner_zone_receive_bytes += bytes;
-            break;
-        case DB::ConnectionProfileInfo::InterZoneRemote:
-            base.inter_zone_receive_bytes += bytes;
-            break;
-        default:
-            break;
-        }
+        exchange_receive_details[i].conn_profile_info.bytes += connection_profile_infos[i].bytes;
+        base.updateConnectionInfo(connection_profile_infos[i]);
     }
 }
 

--- a/dbms/src/Flash/Statistics/ExchangeReceiverImpl.cpp
+++ b/dbms/src/Flash/Statistics/ExchangeReceiverImpl.cpp
@@ -50,7 +50,7 @@ void ExchangeReceiverStatistics::updateExchangeReceiveDetail(
         exchange_receive_details[i].conn_profile_info.type = connection_profile_infos[i].type;
         exchange_receive_details[i].conn_profile_info.packets += connection_profile_infos[i].packets;
         exchange_receive_details[i].conn_profile_info.bytes += connection_profile_infos[i].bytes;
-        base.updateConnectionInfo(connection_profile_infos[i]);
+        base.updateReceiveConnectionInfo(connection_profile_infos[i]);
     }
 }
 

--- a/dbms/src/Flash/Statistics/ExchangeReceiverImpl.h
+++ b/dbms/src/Flash/Statistics/ExchangeReceiverImpl.h
@@ -20,9 +20,10 @@
 
 namespace DB
 {
-struct ExchangeReceiveDetail : public ConnectionProfileInfo
+struct ExchangeReceiveDetail
 {
     Int64 receiver_source_task_id;
+    ConnectionProfileInfo conn_profile_info;
 
     explicit ExchangeReceiveDetail(Int64 receiver_source_task_id_)
         : receiver_source_task_id(receiver_source_task_id_)

--- a/dbms/src/Flash/Statistics/ExchangeSenderImpl.cpp
+++ b/dbms/src/Flash/Statistics/ExchangeSenderImpl.cpp
@@ -18,18 +18,21 @@
 #include <Flash/Mpp/MPPTunnelSet.h>
 #include <Flash/Statistics/ExchangeSenderImpl.h>
 
+#include "Flash/Statistics/ConnectionProfileInfo.h"
+
 namespace DB
 {
 String MPPTunnelDetail::toJson() const
 {
     return fmt::format(
-        R"({{"tunnel_id":"{}","sender_target_task_id":{},"sender_target_host":"{}","is_local":{},"packets":{},"bytes":{}}})",
+        R"({{"tunnel_id":"{}","sender_target_task_id":{},"sender_target_host":"{}","is_local":{},"conn_type":{},"packets":{},"bytes":{}}})",
         tunnel_id,
         sender_target_task_id,
         sender_target_host,
         is_local,
-        packets,
-        bytes);
+        static_cast<Int32>(conn_profile_info.type),
+        conn_profile_info.packets,
+        conn_profile_info.bytes);
 }
 
 void ExchangeSenderStatistics::appendExtraJson(FmtBuffer & fmt_buffer) const
@@ -53,8 +56,19 @@ void ExchangeSenderStatistics::collectExtraRuntimeDetail()
     for (UInt16 i = 0; i < partition_num; ++i)
     {
         const auto & connection_profile_info = mpp_tunnels[i]->getConnectionProfileInfo();
-        mpp_tunnel_details[i].packets = connection_profile_info.packets;
-        mpp_tunnel_details[i].bytes = connection_profile_info.bytes;
+        mpp_tunnel_details[i].conn_profile_info.packets = connection_profile_info.packets;
+        mpp_tunnel_details[i].conn_profile_info.bytes = connection_profile_info.bytes;
+        switch (mpp_tunnel_details[i].conn_profile_info.type)
+        {
+        case ConnectionProfileInfo::InnerZoneRemote:
+            base.inner_zone_send_bytes += connection_profile_info.bytes;
+            break;
+        case DB::ConnectionProfileInfo::InterZoneRemote:
+            base.inter_zone_send_bytes += connection_profile_info.bytes;
+            break;
+        default:
+            break;
+        }
     }
 }
 
@@ -83,8 +97,12 @@ ExchangeSenderStatistics::ExchangeSenderStatistics(const tipb::Executor * execut
         sender_target_task_ids.push_back(task_meta.task_id());
 
         const auto & mpp_tunnel = mpp_tunnels[i];
-        mpp_tunnel_details
-            .emplace_back(mpp_tunnel->id(), task_meta.task_id(), task_meta.address(), mpp_tunnel->isLocal());
+        mpp_tunnel_details.emplace_back(
+            mpp_tunnel->getConnectionProfileInfo(),
+            mpp_tunnel->id(),
+            task_meta.task_id(),
+            task_meta.address(),
+            mpp_tunnel->isLocal());
     }
 
     // for root task, exchange_sender_executor.task_meta[0].address is blank or not tidb host

--- a/dbms/src/Flash/Statistics/ExchangeSenderImpl.cpp
+++ b/dbms/src/Flash/Statistics/ExchangeSenderImpl.cpp
@@ -57,19 +57,8 @@ void ExchangeSenderStatistics::collectExtraRuntimeDetail()
     {
         const auto & connection_profile_info = mpp_tunnels[i]->getConnectionProfileInfo();
         mpp_tunnel_details[i].conn_profile_info.packets = connection_profile_info.packets;
-        auto bytes = connection_profile_info.bytes;
-        mpp_tunnel_details[i].conn_profile_info.bytes += bytes;
-        switch (mpp_tunnel_details[i].conn_profile_info.type)
-        {
-        case ConnectionProfileInfo::InnerZoneRemote:
-            base.inner_zone_send_bytes += bytes;
-            break;
-        case DB::ConnectionProfileInfo::InterZoneRemote:
-            base.inter_zone_send_bytes += bytes;
-            break;
-        default:
-            break;
-        }
+        mpp_tunnel_details[i].conn_profile_info.bytes += connection_profile_info.bytes;
+        base.updateConnectionInfo(connection_profile_info);
     }
 }
 

--- a/dbms/src/Flash/Statistics/ExchangeSenderImpl.cpp
+++ b/dbms/src/Flash/Statistics/ExchangeSenderImpl.cpp
@@ -57,7 +57,7 @@ void ExchangeSenderStatistics::collectExtraRuntimeDetail()
         const auto & connection_profile_info = mpp_tunnels[i]->getConnectionProfileInfo();
         mpp_tunnel_details[i].conn_profile_info.packets = connection_profile_info.packets;
         mpp_tunnel_details[i].conn_profile_info.bytes += connection_profile_info.bytes;
-        base.updateConnectionInfo(connection_profile_info);
+        base.updateSendConnectionInfo(connection_profile_info);
     }
 }
 

--- a/dbms/src/Flash/Statistics/ExchangeSenderImpl.cpp
+++ b/dbms/src/Flash/Statistics/ExchangeSenderImpl.cpp
@@ -55,7 +55,7 @@ void ExchangeSenderStatistics::collectExtraRuntimeDetail()
     for (UInt16 i = 0; i < partition_num; ++i)
     {
         const auto & connection_profile_info = mpp_tunnels[i]->getConnectionProfileInfo();
-        mpp_tunnel_details[i].conn_profile_info.packets = connection_profile_info.packets;
+        mpp_tunnel_details[i].conn_profile_info.packets += connection_profile_info.packets;
         mpp_tunnel_details[i].conn_profile_info.bytes += connection_profile_info.bytes;
         base.updateSendConnectionInfo(connection_profile_info);
     }

--- a/dbms/src/Flash/Statistics/ExchangeSenderImpl.cpp
+++ b/dbms/src/Flash/Statistics/ExchangeSenderImpl.cpp
@@ -16,9 +16,8 @@
 #include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/DAGUtils.h>
 #include <Flash/Mpp/MPPTunnelSet.h>
+#include <Flash/Statistics/ConnectionProfileInfo.h>
 #include <Flash/Statistics/ExchangeSenderImpl.h>
-
-#include "Flash/Statistics/ConnectionProfileInfo.h"
 
 namespace DB
 {

--- a/dbms/src/Flash/Statistics/ExchangeSenderImpl.cpp
+++ b/dbms/src/Flash/Statistics/ExchangeSenderImpl.cpp
@@ -30,7 +30,7 @@ String MPPTunnelDetail::toJson() const
         sender_target_task_id,
         sender_target_host,
         is_local,
-        static_cast<Int32>(conn_profile_info.type),
+        conn_profile_info.getTypeString(),
         conn_profile_info.packets,
         conn_profile_info.bytes);
 }
@@ -57,14 +57,15 @@ void ExchangeSenderStatistics::collectExtraRuntimeDetail()
     {
         const auto & connection_profile_info = mpp_tunnels[i]->getConnectionProfileInfo();
         mpp_tunnel_details[i].conn_profile_info.packets = connection_profile_info.packets;
-        mpp_tunnel_details[i].conn_profile_info.bytes = connection_profile_info.bytes;
+        auto bytes = connection_profile_info.bytes;
+        mpp_tunnel_details[i].conn_profile_info.bytes += bytes;
         switch (mpp_tunnel_details[i].conn_profile_info.type)
         {
         case ConnectionProfileInfo::InnerZoneRemote:
-            base.inner_zone_send_bytes += connection_profile_info.bytes;
+            base.inner_zone_send_bytes += bytes;
             break;
         case DB::ConnectionProfileInfo::InterZoneRemote:
-            base.inter_zone_send_bytes += connection_profile_info.bytes;
+            base.inter_zone_send_bytes += bytes;
             break;
         default:
             break;

--- a/dbms/src/Flash/Statistics/ExchangeSenderImpl.h
+++ b/dbms/src/Flash/Statistics/ExchangeSenderImpl.h
@@ -20,18 +20,25 @@
 
 namespace DB
 {
-struct MPPTunnelDetail : public ConnectionProfileInfo
+struct MPPTunnelDetail
 {
     String tunnel_id;
     Int64 sender_target_task_id;
     String sender_target_host;
     bool is_local;
+    ConnectionProfileInfo conn_profile_info;
 
-    MPPTunnelDetail(String tunnel_id_, Int64 sender_target_task_id_, String sender_target_host_, bool is_local_)
+    MPPTunnelDetail(
+        const ConnectionProfileInfo & conn_profile_info_,
+        String tunnel_id_,
+        Int64 sender_target_task_id_,
+        String sender_target_host_,
+        bool is_local_)
         : tunnel_id(std::move(tunnel_id_))
         , sender_target_task_id(sender_target_task_id_)
         , sender_target_host(std::move(sender_target_host_))
         , is_local(is_local_)
+        , conn_profile_info(conn_profile_info_)
     {}
 
     String toJson() const;

--- a/dbms/src/Flash/Statistics/ExecutionSummaryHelper.cpp
+++ b/dbms/src/Flash/Statistics/ExecutionSummaryHelper.cpp
@@ -34,6 +34,12 @@ void fillTiExecutionSummary(
     execution_summary->mutable_tiflash_wait_summary()->set_pipeline_breaker_wait_ns(
         current.time_pipeline_breaker_wait_ns);
     execution_summary->mutable_tiflash_wait_summary()->set_pipeline_queue_wait_ns(current.time_pipeline_queue_ns);
+    execution_summary->mutable_tiflash_network_summary()->set_inner_zone_send_bytes(current.inner_zone_send_bytes);
+    execution_summary->mutable_tiflash_network_summary()->set_inner_zone_receive_bytes(
+        current.inner_zone_receive_bytes);
+    execution_summary->mutable_tiflash_network_summary()->set_inter_zone_send_bytes(current.inter_zone_send_bytes);
+    execution_summary->mutable_tiflash_network_summary()->set_inter_zone_receive_bytes(
+        current.inter_zone_receive_bytes);
     RUNTIME_CHECK(current.ru_consumption.SerializeToString(execution_summary->mutable_ru_consumption()));
 
     // tree-based executors will have executor_id.

--- a/dbms/src/Flash/Statistics/TableScanImpl.cpp
+++ b/dbms/src/Flash/Statistics/TableScanImpl.cpp
@@ -13,11 +13,10 @@
 // limitations under the License.
 
 #include <DataStreams/TiRemoteBlockInputStream.h>
+#include <Flash/Statistics/ConnectionProfileInfo.h>
 #include <Flash/Statistics/TableScanImpl.h>
 #include <Interpreters/Join.h>
 #include <Storages/DeltaMerge/ScanContext.h>
-
-#include "Flash/Statistics/ConnectionProfileInfo.h"
 
 namespace DB
 {

--- a/dbms/src/Flash/Statistics/TableScanImpl.cpp
+++ b/dbms/src/Flash/Statistics/TableScanImpl.cpp
@@ -28,7 +28,7 @@ String TableScanTimeDetail::toJson() const
 }
 String LocalTableScanDetail::toJson() const
 {
-    return fmt::format(R"({{"is_local":false,"bytes":{},{}}})", bytes, time_detail.toJson());
+    return fmt::format(R"({{"is_local":true,"bytes":{},{}}})", bytes, time_detail.toJson());
 }
 String RemoteTableScanDetail::toJson() const
 {

--- a/dbms/src/Flash/Statistics/TableScanImpl.cpp
+++ b/dbms/src/Flash/Statistics/TableScanImpl.cpp
@@ -68,7 +68,9 @@ void TableScanStatistics::updateTableScanDetail(const std::vector<ConnectionProf
             remote_table_scan_detail.inter_zone_conn_profile_info.packets += connection_profile_info.packets;
             remote_table_scan_detail.inter_zone_conn_profile_info.bytes += connection_profile_info.bytes;
         }
-        base.updateConnectionInfo(connection_profile_info);
+        // Stats both send and receive bytes here, because remote execution summaries are not used now
+        base.updateSendConnectionInfo(connection_profile_info);
+        base.updateReceiveConnectionInfo(connection_profile_info);
     }
 }
 

--- a/dbms/src/Flash/Statistics/TableScanImpl.h
+++ b/dbms/src/Flash/Statistics/TableScanImpl.h
@@ -20,9 +20,10 @@
 
 namespace DB
 {
-struct TableScanDetail : public ConnectionProfileInfo
+struct TableScanDetail
 {
     const bool is_local;
+    ConnectionProfileInfo conn_profile_info;
     double min_stream_cost_ns = -1.0;
     double max_stream_cost_ns = -1.0;
 

--- a/dbms/src/Flash/Statistics/TableScanImpl.h
+++ b/dbms/src/Flash/Statistics/TableScanImpl.h
@@ -18,19 +18,27 @@
 #include <Flash/Statistics/ExecutorStatistics.h>
 #include <tipb/executor.pb.h>
 
+#include "common/types.h"
+
 namespace DB
 {
-struct TableScanDetail
+struct TableScanTimeDetail
 {
-    const bool is_local;
-    ConnectionProfileInfo conn_profile_info;
     double min_stream_cost_ns = -1.0;
     double max_stream_cost_ns = -1.0;
-
-    explicit TableScanDetail(bool is_local_)
-        : is_local(is_local_)
-    {}
-
+    String toJson() const;
+};
+struct LocalTableScanDetail
+{
+    Int64 bytes = 0;
+    TableScanTimeDetail time_detail;
+    String toJson() const;
+};
+struct RemoteTableScanDetail
+{
+    ConnectionProfileInfo inner_zone_conn_profile_info{ConnectionProfileInfo::InnerZoneRemote};
+    ConnectionProfileInfo inter_zone_conn_profile_info{ConnectionProfileInfo::InterZoneRemote};
+    TableScanTimeDetail time_detail;
     String toJson() const;
 };
 
@@ -55,8 +63,8 @@ public:
     TableScanStatistics(const tipb::Executor * executor, DAGContext & dag_context_);
 
 private:
-    TableScanDetail local_table_scan_detail{true};
-    TableScanDetail remote_table_scan_detail{false};
+    LocalTableScanDetail local_table_scan_detail;
+    RemoteTableScanDetail remote_table_scan_detail;
 
 protected:
     void appendExtraJson(FmtBuffer &) const override;

--- a/dbms/src/Flash/Statistics/TableScanImpl.h
+++ b/dbms/src/Flash/Statistics/TableScanImpl.h
@@ -18,8 +18,6 @@
 #include <Flash/Statistics/ExecutorStatistics.h>
 #include <tipb/executor.pb.h>
 
-#include "common/types.h"
-
 namespace DB
 {
 struct TableScanTimeDetail

--- a/dbms/src/Operators/CoprocessorReaderSourceOp.cpp
+++ b/dbms/src/Operators/CoprocessorReaderSourceOp.cpp
@@ -13,10 +13,9 @@
 // limitations under the License.
 
 #include <DataStreams/IBlockInputStream.h>
+#include <Flash/Coprocessor/CoprocessorReader.h>
 #include <Flash/Coprocessor/GenSchemaAndColumn.h>
 #include <Operators/CoprocessorReaderSourceOp.h>
-
-#include "Flash/Coprocessor/CoprocessorReader.h"
 
 namespace DB
 {

--- a/dbms/src/Operators/CoprocessorReaderSourceOp.cpp
+++ b/dbms/src/Operators/CoprocessorReaderSourceOp.cpp
@@ -94,16 +94,13 @@ OperatorStatus CoprocessorReaderSourceOp::readImpl(Block & block)
             }
 
             const auto & decode_detail = result.decode_detail;
-            if (result.same_zone_flag)
+            auto conn_profile_info_index = CoprocessorReader::inner_zone_index;
+            if (!result.same_zone_flag)
             {
-                io_profile_info->connection_profile_infos[0].packets += decode_detail.packets;
-                io_profile_info->connection_profile_infos[0].bytes += decode_detail.packet_bytes;
+                conn_profile_info_index = CoprocessorReader::inter_zone_index;
             }
-            else
-            {
-                io_profile_info->connection_profile_infos[1].packets += decode_detail.packets;
-                io_profile_info->connection_profile_infos[1].bytes += decode_detail.packet_bytes;
-            }
+            io_profile_info->connection_profile_infos[conn_profile_info_index].packets += decode_detail.packets;
+            io_profile_info->connection_profile_infos[conn_profile_info_index].bytes += decode_detail.packet_bytes;
 
             total_rows += decode_detail.rows;
             LOG_TRACE(

--- a/dbms/src/Operators/ExchangeReceiverSourceOp.h
+++ b/dbms/src/Operators/ExchangeReceiverSourceOp.h
@@ -32,7 +32,10 @@ public:
         : SourceOp(exec_context_, req_id)
         , exchange_receiver(exchange_receiver_)
         , stream_id(stream_id_)
-        , io_profile_info(IOProfileInfo::createForRemote(profile_info_ptr, exchange_receiver->getSourceNum()))
+        , io_profile_info(IOProfileInfo::createForRemote(
+              profile_info_ptr,
+              exchange_receiver->getSourceNum(),
+              exchange_receiver->getConnTypeVec()))
     {
         exchange_receiver->verifyStreamId(stream_id);
         setHeader(Block(getColumnWithTypeAndName(toNamesAndTypes(exchange_receiver->getOutputSchema()))));

--- a/dbms/src/Operators/IOProfileInfo.h
+++ b/dbms/src/Operators/IOProfileInfo.h
@@ -14,11 +14,10 @@
 
 #pragma once
 
+#include <Common/Exception.h>
 #include <Flash/Coprocessor/RemoteExecutionSummary.h>
 #include <Flash/Statistics/ConnectionProfileInfo.h>
 #include <Operators/OperatorProfileInfo.h>
-
-#include "Common/Exception.h"
 
 namespace DB
 {

--- a/dbms/src/Operators/IOProfileInfo.h
+++ b/dbms/src/Operators/IOProfileInfo.h
@@ -18,6 +18,8 @@
 #include <Flash/Statistics/ConnectionProfileInfo.h>
 #include <Operators/OperatorProfileInfo.h>
 
+#include "Common/Exception.h"
+
 namespace DB
 {
 struct IOProfileInfo;
@@ -49,6 +51,7 @@ struct IOProfileInfo
         size_t connections,
         const ConnectionProfileInfo::ConnTypeVec & conn_type_vec)
     {
+        RUNTIME_CHECK(connections == conn_type_vec.size());
         auto info = std::make_shared<IOProfileInfo>(profile_info, false);
         info->connection_profile_infos.resize(connections);
         for (size_t i = 0; i < connections; ++i)

--- a/dbms/src/Operators/IOProfileInfo.h
+++ b/dbms/src/Operators/IOProfileInfo.h
@@ -44,6 +44,20 @@ struct IOProfileInfo
         return info;
     }
 
+    static IOProfileInfoPtr createForRemote(
+        const OperatorProfileInfoPtr & profile_info,
+        size_t connections,
+        const ConnTypeVec & conn_type_vec)
+    {
+        auto info = std::make_shared<IOProfileInfo>(profile_info, false);
+        info->connection_profile_infos.resize(connections);
+        for (size_t i = 0; i < connections; ++i)
+        {
+            info->connection_profile_infos[i].type = conn_type_vec[i];
+        }
+        return info;
+    }
+
     OperatorProfileInfoPtr operator_info;
 
     const bool is_local;

--- a/dbms/src/Operators/IOProfileInfo.h
+++ b/dbms/src/Operators/IOProfileInfo.h
@@ -47,7 +47,7 @@ struct IOProfileInfo
     static IOProfileInfoPtr createForRemote(
         const OperatorProfileInfoPtr & profile_info,
         size_t connections,
-        const ConnTypeVec & conn_type_vec)
+        const ConnectionProfileInfo::ConnTypeVec & conn_type_vec)
     {
         auto info = std::make_shared<IOProfileInfo>(profile_info, false);
         info->connection_profile_infos.resize(connections);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9748

Problem Summary:

### What is changed and how it works?
Inner/inter zone network traffic is priced differently in cloud, thus trace each mpp query's such info will help users to locate the most network-expensive query. 
This PR stats thress kinds of network traffic:
1. Exchange sender
2. Exchange receiver
3. Remote table reader using coprocessor request
```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
Currently, set same and different zone labels for tiflash proxy config, and hack DAGStorageInterpreter to always use remote coprocessor read. Then check the MPPTaskStatistics.cpp output to see if local/inner/inter zone label is set correctly.
When tidb side change is merged, will check slow log and statements summary.
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
