### PR TITLE
*: Make tiflash compatible with the cse branch

### DIFF
--- a/dbms/src/Flash/BatchCoprocessorHandler.cpp
+++ b/dbms/src/Flash/BatchCoprocessorHandler.cpp
@@ -82,7 +82,7 @@ grpc::Status BatchCoprocessorHandler::execute()
             {
                 LOG_DEBUG(
                     log,
-                    "cop request disabled for keyspace or regions in keyspace {}",
+                    "cop request disabled for keyspace or regions, keyspace={}",
                     cop_request->context().keyspace_id());
                 return recordError(grpc::StatusCode::INTERNAL, "cop request disabled");
             }

--- a/dbms/src/Flash/Coprocessor/TablesRegionsInfo.cpp
+++ b/dbms/src/Flash/Coprocessor/TablesRegionsInfo.cpp
@@ -141,4 +141,22 @@ TablesRegionsInfo TablesRegionsInfo::create(
     return tables_regions_info;
 }
 
+std::vector<RegionID> TablesRegionsInfo::getAllRegionID() const
+{
+    std::vector<RegionID> all_regions;
+    for (const auto & ele : table_regions_info_map)
+    {
+        const auto & single_table_region = ele.second;
+        for (const auto & region : single_table_region.local_regions)
+        {
+            all_regions.push_back(region.first);
+        }
+        for (const auto & region : single_table_region.remote_regions)
+        {
+            all_regions.push_back(region.region_id);
+        }
+    }
+    return all_regions;
+}
+
 } // namespace DB

--- a/dbms/src/Flash/Coprocessor/TablesRegionsInfo.h
+++ b/dbms/src/Flash/Coprocessor/TablesRegionsInfo.h
@@ -80,6 +80,8 @@ public:
     }
     UInt64 tableCount() const { return table_regions_info_map.size(); }
 
+    std::vector<RegionID> getAllRegionID() const;
+
 private:
     bool is_single_table;
     std::unordered_map<TableID, SingleTableRegions> table_regions_info_map;

--- a/dbms/src/Flash/CoprocessorHandler.cpp
+++ b/dbms/src/Flash/CoprocessorHandler.cpp
@@ -130,6 +130,18 @@ grpc::Status CoprocessorHandler<is_stream>::execute()
             TablesRegionsInfo tables_regions_info(true);
             auto & table_regions_info = tables_regions_info.getSingleTableRegions();
 
+#if SERVERLESS_PROXY != 0
+            if (cop_context.db_context.isKeyspaceInBlocklist(cop_request->context().keyspace_id())
+                || cop_context.db_context.isRegionInBlocklist(cop_context.kv_context.region_id()))
+            {
+                LOG_DEBUG(
+                    log,
+                    "cop request disabled for keyspace or regions in keyspace {}",
+                    cop_request->context().keyspace_id());
+                return recordError(grpc::StatusCode::INTERNAL, "cop request disabled");
+            }
+#endif
+
             const std::unordered_set<UInt64> bypass_lock_ts(
                 cop_context.kv_context.resolved_locks().begin(),
                 cop_context.kv_context.resolved_locks().end());

--- a/dbms/src/Flash/CoprocessorHandler.cpp
+++ b/dbms/src/Flash/CoprocessorHandler.cpp
@@ -212,7 +212,12 @@ grpc::Status CoprocessorHandler<is_stream>::execute()
     }
     catch (LockException & e)
     {
-        LOG_WARNING(log, "LockException: region_id={}, message: {}", cop_request->context().region_id(), e.message());
+        LOG_WARNING(
+            log,
+            "LockException: region_id={}, message: {}, is_txn_file={}",
+            cop_request->context().region_id(),
+            e.message(),
+            e.locks[0].second->is_txn_file());
         GET_METRIC(tiflash_coprocessor_request_error, reason_meet_lock).Increment();
         if constexpr (is_stream)
         {

--- a/dbms/src/Flash/CoprocessorHandler.cpp
+++ b/dbms/src/Flash/CoprocessorHandler.cpp
@@ -136,7 +136,7 @@ grpc::Status CoprocessorHandler<is_stream>::execute()
             {
                 LOG_DEBUG(
                     log,
-                    "cop request disabled for keyspace or regions in keyspace {}",
+                    "cop request disabled for keyspace or regions, keyspace={}",
                     cop_request->context().keyspace_id());
                 return recordError(grpc::StatusCode::INTERNAL, "cop request disabled");
             }

--- a/dbms/src/Flash/Disaggregated/WNEstablishDisaggTaskHandler.cpp
+++ b/dbms/src/Flash/Disaggregated/WNEstablishDisaggTaskHandler.cpp
@@ -54,6 +54,17 @@ void WNEstablishDisaggTaskHandler::prepare(const disaggregated::EstablishDisaggT
         tables_regions_info.regionCount(),
         tables_regions_info.tableCount());
 
+#if SERVERLESS_PROXY != 0
+    if (context->isKeyspaceInBlocklist(meta.keyspace_id())
+        || context->isRegionsContainsInBlocklist(tables_regions_info.getAllRegionID()))
+    {
+        throw TiFlashException(
+            Errors::Coprocessor::BadRequest,
+            "disaggregated request disabled for keyspace or regions in keyspace",
+            meta.keyspace_id());
+    }
+#endif
+
     // set schema ver and start ts
     auto schema_ver = request->schema_ver();
     context->setSetting("schema_version", schema_ver);

--- a/dbms/src/Flash/Disaggregated/WNEstablishDisaggTaskHandler.cpp
+++ b/dbms/src/Flash/Disaggregated/WNEstablishDisaggTaskHandler.cpp
@@ -60,7 +60,7 @@ void WNEstablishDisaggTaskHandler::prepare(const disaggregated::EstablishDisaggT
     {
         throw TiFlashException(
             Errors::Coprocessor::BadRequest,
-            "disaggregated request disabled for keyspace or regions in keyspace",
+            "disaggregated request disabled for keyspace or regions, keyspace={}",
             meta.keyspace_id());
     }
 #endif

--- a/dbms/src/Flash/Mpp/MPPHandler.cpp
+++ b/dbms/src/Flash/Mpp/MPPHandler.cpp
@@ -86,7 +86,7 @@ grpc::Status MPPHandler::execute(const ContextPtr & context, mpp::DispatchTaskRe
         {
             LOG_DEBUG(
                 log,
-                "mpp request disabled for keyspace or regions in keyspace {}",
+                "mpp request disabled for keyspace or regions, keyspace={}",
                 task_request.meta().keyspace_id());
             auto * err = response->mutable_error();
             err->set_msg("mpp request disabled");

--- a/dbms/src/Flash/Mpp/MPPHandler.cpp
+++ b/dbms/src/Flash/Mpp/MPPHandler.cpp
@@ -80,6 +80,21 @@ grpc::Status MPPHandler::execute(const ContextPtr & context, mpp::DispatchTaskRe
         task = MPPTask::newTask(task_request.meta(), context);
         task->prepare(task_request);
 
+#if SERVERLESS_PROXY != 0
+        if (context->isKeyspaceInBlocklist(task_request.meta().keyspace_id())
+            || context->isRegionsContainsInBlocklist(context->getDAGContext()->tables_regions_info.getAllRegionID()))
+        {
+            LOG_DEBUG(
+                log,
+                "mpp request disabled for keyspace or regions in keyspace {}",
+                task_request.meta().keyspace_id());
+            auto * err = response->mutable_error();
+            err->set_msg("mpp request disabled");
+            handleError(task, "mpp request disabled");
+            return grpc::Status::OK;
+        }
+#endif
+
         addRetryRegion(context, response);
 
 #ifndef NDEBUG

--- a/dbms/src/Functions/FunctionsVector.h
+++ b/dbms/src/Functions/FunctionsVector.h
@@ -25,7 +25,6 @@
 #include <DataTypes/DataTypesNumber.h>
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionHelpers.h>
-#include <Functions/FunctionsVector.h>
 #include <Functions/IFunction.h>
 #include <TiDB/Decode/Vector.h>
 

--- a/dbms/src/Interpreters/Context.h
+++ b/dbms/src/Interpreters/Context.h
@@ -27,6 +27,7 @@
 #include <Interpreters/TimezoneInfo.h>
 #include <Server/ServerInfo.h>
 #include <Storages/DeltaMerge/LocalIndexerScheduler_fwd.h>
+#include <Storages/KVStore/Types.h>
 #include <common/MultiVersion.h>
 
 #include <chrono>
@@ -550,6 +551,12 @@ public:
     void initializeSharedBlockSchemas(size_t shared_block_schemas_size);
 
     void mockConfigLoaded() { is_config_loaded = true; }
+
+    void initKeyspaceBlocklist(const std::unordered_set<KeyspaceID> & keyspace_ids);
+    bool isKeyspaceInBlocklist(KeyspaceID keyspace_id);
+    void initRegionBlocklist(const std::unordered_set<RegionID> & region_ids);
+    bool isRegionInBlocklist(RegionID region_id);
+    bool isRegionsContainsInBlocklist(const std::vector<RegionID> & regions);
 
     bool initializeStoreIdBlockList(const String &);
     const std::unordered_set<uint64_t> * getStoreIdBlockList() const;

--- a/dbms/src/Interpreters/Settings.h
+++ b/dbms/src/Interpreters/Settings.h
@@ -252,7 +252,6 @@ struct Settings
     M(SettingUInt64, disagg_build_task_timeout, DEFAULT_DISAGG_TASK_BUILD_TIMEOUT_SEC, "disagg task establish timeout, unit is second.")                                                                                                \
     M(SettingUInt64, disagg_task_snapshot_timeout, DEFAULT_DISAGG_TASK_TIMEOUT_SEC, "disagg task snapshot max endurable time, unit is second.")                                                                                         \
     M(SettingUInt64, disagg_fetch_pages_timeout, DEFAULT_DISAGG_FETCH_PAGES_TIMEOUT_SEC, "fetch disagg pages timeout for one segment, unit is second.")                                                                                 \
-    M(SettingString, disagg_blocklist_wn_store_id, "", "comma seperated unsigned integers representing `store_id`s of stores that are blacklisted.")                                                                                    \
     /* Disagg arch FastAddPeer settings */ \
     M(SettingInt64, fap_wait_checkpoint_timeout_seconds, 80, "The max time wait for a usable checkpoint for FAP")                                                                                                                       \
     M(SettingUInt64, fap_task_timeout_seconds, 120, "The max time FAP can take before fallback")                                                                                                                                        \

--- a/dbms/src/Interpreters/Settings.h
+++ b/dbms/src/Interpreters/Settings.h
@@ -252,6 +252,7 @@ struct Settings
     M(SettingUInt64, disagg_build_task_timeout, DEFAULT_DISAGG_TASK_BUILD_TIMEOUT_SEC, "disagg task establish timeout, unit is second.")                                                                                                \
     M(SettingUInt64, disagg_task_snapshot_timeout, DEFAULT_DISAGG_TASK_TIMEOUT_SEC, "disagg task snapshot max endurable time, unit is second.")                                                                                         \
     M(SettingUInt64, disagg_fetch_pages_timeout, DEFAULT_DISAGG_FETCH_PAGES_TIMEOUT_SEC, "fetch disagg pages timeout for one segment, unit is second.")                                                                                 \
+    M(SettingString, disagg_blocklist_wn_store_id, "", "comma seperated unsigned integers representing `store_id`s of stores that are blacklisted.")                                                                                    \
     /* Disagg arch FastAddPeer settings */ \
     M(SettingInt64, fap_wait_checkpoint_timeout_seconds, 80, "The max time wait for a usable checkpoint for FAP")                                                                                                                       \
     M(SettingUInt64, fap_task_timeout_seconds, 120, "The max time FAP can take before fallback")                                                                                                                                        \

--- a/dbms/src/Interpreters/loadMetadata.cpp
+++ b/dbms/src/Interpreters/loadMetadata.cpp
@@ -121,6 +121,16 @@ void loadMetadata(Context & context)
         if (db_name == SYSTEM_DATABASE)
             continue;
 
+#if SERVERLESS_PROXY == 1
+        // Ignore database owned by keyspace in blacklist
+        auto keyspace_id = SchemaNameMapper::getMappedNameKeyspaceID(db_name);
+        if (context.isKeyspaceInBlocklist(keyspace_id))
+        {
+            LOG_WARNING(log, "database {} ignored because keyspace in blacklist, keyspace={}", db_name, keyspace_id);
+            continue;
+        }
+#endif
+
         databases.emplace(db_name, path + file);
     }
 

--- a/dbms/src/Interpreters/loadMetadata.cpp
+++ b/dbms/src/Interpreters/loadMetadata.cpp
@@ -122,11 +122,11 @@ void loadMetadata(Context & context)
             continue;
 
 #if SERVERLESS_PROXY == 1
-        // Ignore database owned by keyspace in blacklist
+        // Ignore database owned by keyspace in blocklist
         auto keyspace_id = SchemaNameMapper::getMappedNameKeyspaceID(db_name);
         if (context.isKeyspaceInBlocklist(keyspace_id))
         {
-            LOG_WARNING(log, "database {} ignored because keyspace in blacklist, keyspace={}", db_name, keyspace_id);
+            LOG_WARNING(log, "database {} ignored because keyspace in blocklist, keyspace={}", db_name, keyspace_id);
             continue;
         }
 #endif

--- a/dbms/src/Server/MetricsPrometheus.cpp
+++ b/dbms/src/Server/MetricsPrometheus.cpp
@@ -164,7 +164,13 @@ std::shared_ptr<Poco::Net::HTTPServer> getHTTPServer(
         key_path,
         cert_path,
         ca_path,
-        Poco::Net::Context::VerificationMode::VERIFY_STRICT);
+#if SERVERLESS_PROXY == 0
+        Poco::Net::Context::VerificationMode::VERIFY_STRICT
+#else
+        // mtls: metrics server allows anonymous pullers @iosmanthus
+        Poco::Net::Context::VerificationMode::VERIFY_RELAXED
+#endif
+    );
 
     auto check_common_name = [&](const Poco::Crypto::X509Certificate & cert) {
         return global_context.getSecurityConfig()->checkCommonName(cert);

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -247,7 +247,7 @@ struct TiFlashProxyConfig
                 args_map["engine-role-label"] = DISAGGREGATED_MODE_WRITE_ENGINE_ROLE;
 #if SERVERLESS_PROXY == 1
             if (config.has("blacklist_file"))
-                args_map["blacklist_file"] = config.getString("blacklist_file");
+                args_map["blacklist-ile"] = config.getString("blacklist_file");
 #endif
 
             for (auto && [k, v] : args_map)

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -570,14 +570,12 @@ void loadBlockList(
     Context & global_context,
     [[maybe_unused]] const LoggerPtr & log)
 {
-#if SERVERLESS_PROXY == 1
-    global_context.initializeStoreIdBlockList(global_context.getSettingsRef().disagg_blocklist_wn_store_id);
-#else
+#if SERVERLESS_PROXY != 1
     // We do not support blocking store by id in OP mode currently.
     global_context.initializeStoreIdBlockList("");
-#endif
+#else
+    global_context.initializeStoreIdBlockList(global_context.getSettingsRef().disagg_blocklist_wn_store_id);
 
-#if SERVERLESS_PROXY == 1
     /// Load keyspace blacklist json file
     LOG_INFO(log, "Loading blacklist file.");
     auto blacklist_file_path = config.getString("blacklist_file", "");

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -245,6 +245,10 @@ struct TiFlashProxyConfig
             // For tiflash write node, it should report a extra label with "key" == "engine-role-label"
             if (disaggregated_mode == DisaggregatedMode::Storage)
                 args_map["engine-role-label"] = DISAGGREGATED_MODE_WRITE_ENGINE_ROLE;
+#if SERVERLESS_PROXY == 1
+            if (config.has("blacklist_file"))
+                args_map["blacklist_file"] = config.getString("blacklist_file");
+#endif
 
             for (auto && [k, v] : args_map)
                 val_map.emplace("--" + k, std::move(v));
@@ -559,6 +563,76 @@ void syncSchemaWithTiDB(
 
     // init schema sync service with tidb
     global_context->initializeSchemaSyncService();
+}
+
+void loadBlockList(
+    [[maybe_unused]] const Poco::Util::LayeredConfiguration & config,
+    Context & global_context,
+    [[maybe_unused]] const LoggerPtr & log)
+{
+#if SERVERLESS_PROXY == 1
+    global_context.initializeStoreIdBlockList(global_context.getSettingsRef().disagg_blocklist_wn_store_id);
+#else
+    // We do not support blocking store by id in OP mode currently.
+    global_context.initializeStoreIdBlockList("");
+#endif
+
+#if SERVERLESS_PROXY == 1
+    /// Load keyspace blacklist json file
+    LOG_INFO(log, "Loading blacklist file.");
+    auto blacklist_file_path = config.getString("blacklist_file", "");
+    if (blacklist_file_path.length() == 0)
+    {
+        LOG_INFO(log, "blacklist file not enabled, ignore it.");
+    }
+    else
+    {
+        auto blacklist_file = Poco::File(blacklist_file_path);
+        if (blacklist_file.exists() && blacklist_file.isFile() && blacklist_file.canRead())
+        {
+            // Read the json file
+            std::ifstream ifs(blacklist_file_path);
+            std::string json_content((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+            Poco::JSON::Parser parser;
+            Poco::Dynamic::Var json_var = parser.parse(json_content);
+            const auto & json_obj = json_var.extract<Poco::JSON::Object::Ptr>();
+
+            // load keyspace list
+            auto keyspace_arr = json_obj->getArray("keyspace_ids");
+            if (!keyspace_arr.isNull())
+            {
+                std::unordered_set<KeyspaceID> keyspace_blocklist;
+                for (size_t i = 0; i < keyspace_arr->size(); i++)
+                {
+                    keyspace_blocklist.emplace(keyspace_arr->getElement<KeyspaceID>(i));
+                }
+                global_context.initKeyspaceBlocklist(keyspace_blocklist);
+            }
+
+            // load region list
+            auto region_arr = json_obj->getArray("region_ids");
+            if (!region_arr.isNull())
+            {
+                std::unordered_set<RegionID> region_blocklist;
+                for (size_t i = 0; i < region_arr->size(); i++)
+                {
+                    region_blocklist.emplace(region_arr->getElement<RegionID>(i));
+                }
+                global_context.initRegionBlocklist(region_blocklist);
+            }
+
+            LOG_INFO(
+                log,
+                "Load blacklist file done, total {} keyspaces and {} regions in blacklist.",
+                keyspace_arr.isNull() ? 0 : keyspace_arr->size(),
+                region_arr.isNull() ? 0 : region_arr->size());
+        }
+        else
+        {
+            LOG_INFO(log, "blacklist file not exists or non-readble, ignore it.");
+        }
+    }
+#endif
 }
 
 int Server::main(const std::vector<std::string> & /*args*/)
@@ -1116,8 +1190,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
         global_context->setDeltaIndexManager(n);
     }
 
-    // We do not support blocking store by id in OP mode currently.
-    global_context->initializeStoreIdBlockList("");
+    loadBlockList(config(), *global_context, log);
 
     LOG_INFO(log, "Loading metadata.");
     loadMetadataSystem(*global_context); // Load "system" database. Its engine keeps as Ordinary.

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -581,7 +581,7 @@ void loadBlockList(
     auto blacklist_file_path = config.getString("blacklist_file", "");
     if (blacklist_file_path.length() == 0)
     {
-        LOG_INFO(log, "blacklist file not enabled, ignore it.");
+        LOG_INFO(log, "blocklist file not enabled, ignore it.");
     }
     else
     {
@@ -621,13 +621,13 @@ void loadBlockList(
 
             LOG_INFO(
                 log,
-                "Load blacklist file done, total {} keyspaces and {} regions in blacklist.",
+                "Load blocklist file done, total {} keyspaces and {} regions in blacklist.",
                 keyspace_arr.isNull() ? 0 : keyspace_arr->size(),
                 region_arr.isNull() ? 0 : region_arr->size());
         }
         else
         {
-            LOG_INFO(log, "blacklist file not exists or non-readble, ignore it.");
+            LOG_INFO(log, "blocklist file not exists or non-readble, ignore it.");
         }
     }
 #endif

--- a/dbms/src/Storages/KVStore/Decode/RegionTable.cpp
+++ b/dbms/src/Storages/KVStore/Decode/RegionTable.cpp
@@ -59,6 +59,7 @@ RegionTable::Table & RegionTable::getOrCreateTable(const KeyspaceID keyspace_id,
     {
         // Load persisted info.
         it = tables.emplace(ks_table_id, table_id).first;
+        addTableToIndex(keyspace_id, table_id);
         LOG_INFO(log, "get new table, keyspace={} table_id={}", keyspace_id, table_id);
     }
     return it->second;
@@ -153,6 +154,7 @@ void RegionTable::removeTable(KeyspaceID keyspace_id, TableID table_id)
 
     // Remove from table map.
     tables.erase(it);
+    removeTableFromIndex(keyspace_id, table_id);
 
     LOG_INFO(log, "remove table from RegionTable success, keyspace={} table_id={}", keyspace_id, table_id);
 }
@@ -336,6 +338,22 @@ void RegionTable::handleInternalRegionsByTable(
     }
 }
 
+void RegionTable::handleInternalRegionsByKeyspace(
+    KeyspaceID keyspace_id,
+    std::function<void(const TableID table_id, const InternalRegions &)> && callback) const
+{
+    std::lock_guard lock(mutex);
+    auto table_set = keyspace_index.find(keyspace_id);
+    if (table_set != keyspace_index.end())
+    {
+        for (auto table_id : table_set->second)
+        {
+            if (auto it = tables.find(KeyspaceTableID{keyspace_id, table_id}); it != tables.end())
+                callback(table_id, it->second.regions);
+        }
+    }
+}
+
 std::vector<RegionID> RegionTable::getRegionIdsByTable(KeyspaceID keyspace_id, TableID table_id) const
 {
     fiu_do_on(FailPoints::force_set_num_regions_for_table, {
@@ -435,6 +453,29 @@ void RegionTable::extendRegionRange(const RegionID region_id, const RegionRangeK
         auto & table = getOrCreateTable(keyspace_id, table_id);
         insertRegion(table, region_range_keys, region_id);
         LOG_INFO(log, "insert internal region, keyspace={} table_id={} region_id={}", keyspace_id, table_id, region_id);
+    }
+}
+
+void RegionTable::addTableToIndex(KeyspaceID keyspace_id, TableID table_id)
+{
+    auto it = keyspace_index.find(keyspace_id);
+    if (it == keyspace_index.end())
+    {
+        keyspace_index.emplace(keyspace_id, std::unordered_set<TableID>{table_id});
+    }
+    else
+    {
+        it->second.insert(table_id);
+    }
+}
+void RegionTable::removeTableFromIndex(KeyspaceID keyspace_id, TableID table_id)
+{
+    auto it = keyspace_index.find(keyspace_id);
+    if (it != keyspace_index.end())
+    {
+        it->second.erase(table_id);
+        if (it->second.empty())
+            keyspace_index.erase(it);
     }
 }
 

--- a/dbms/src/Storages/KVStore/Decode/RegionTable.h
+++ b/dbms/src/Storages/KVStore/Decode/RegionTable.h
@@ -121,6 +121,9 @@ public:
         KeyspaceID keyspace_id,
         TableID table_id,
         std::function<void(const InternalRegions &)> && callback) const;
+    void handleInternalRegionsByKeyspace(
+        KeyspaceID keyspace_id,
+        std::function<void(const TableID table_id, const InternalRegions &)> && callback) const;
 
     std::vector<RegionID> getRegionIdsByTable(KeyspaceID keyspace_id, TableID table_id) const;
     std::vector<std::pair<RegionID, RegionPtr>> getRegionsByTable(KeyspaceID keyspace_id, TableID table_id) const;
@@ -185,6 +188,8 @@ private:
     InternalRegion & insertRegion(Table & table, const RegionRangeKeys & region_range_keys, RegionID region_id);
     InternalRegion & insertRegion(Table & table, const Region & region);
     InternalRegion & doGetInternalRegion(KeyspaceTableID ks_table_id, RegionID region_id);
+    void addTableToIndex(KeyspaceID keyspace_id, TableID table_id);
+    void removeTableFromIndex(KeyspaceID keyspace_id, TableID table_id);
 
 private:
     using TableMap = std::unordered_map<KeyspaceTableID, Table, boost::hash<KeyspaceTableID>>;
@@ -192,6 +197,10 @@ private:
 
     using RegionInfoMap = std::unordered_map<RegionID, KeyspaceTableID>;
     RegionInfoMap regions;
+
+    using KeyspaceIndex = std::unordered_map<KeyspaceID, std::unordered_set<TableID>, boost::hash<KeyspaceID>>;
+    KeyspaceIndex keyspace_index;
+
     SafeTsMap safe_ts_map;
 
     Context * const context;

--- a/dbms/src/Storages/KVStore/FFI/ProxyFFI.cpp
+++ b/dbms/src/Storages/KVStore/FFI/ProxyFFI.cpp
@@ -305,13 +305,14 @@ CppStrWithView HandleReadPage(const EngineStoreServerWrap * server, BaseBuffView
     {
         auto uni_ps = server->tmt->getContext().getWriteNodePageStorage();
         RaftDataReader reader(*uni_ps);
-        auto * page = new Page(reader.read(UniversalPageId(page_id.data, page_id.len)));
-        if (page->isValid())
+        auto p = reader.read(UniversalPageId(page_id.data, page_id.len));
+        if (p.isValid())
         {
             LOG_TRACE(
                 &Poco::Logger::get("ProxyFFI"),
                 "FFI read page {} success",
                 UniversalPageId(page_id.data, page_id.len));
+            auto * page = new Page(std::move(p));
             return CppStrWithView{
                 .inner = GenRawCppPtr(page, RawCppPtrTypeImpl::UniversalPage),
                 .view = BaseBuffView{page->data.begin(), page->data.size()},

--- a/dbms/src/Storages/KVStore/FFI/ProxyFFI.cpp
+++ b/dbms/src/Storages/KVStore/FFI/ProxyFFI.cpp
@@ -1009,11 +1009,7 @@ BaseBuffView GetLockByKey(const EngineStoreServerWrap * server, uint64_t region_
         if (!value)
         {
             // key not exist
-            LOG_WARNING(
-                Logger::get(),
-                "Failed to get lock by key {}, region_id={}",
-                tikv_key.toDebugString(),
-                region_id);
+            LOG_DEBUG(Logger::get(), "Failed to get lock by key {}, region_id={}", tikv_key.toDebugString(), region_id);
             return BaseBuffView{};
         }
 

--- a/dbms/src/Storages/KVStore/FFI/ProxyFFIStatusService.cpp
+++ b/dbms/src/Storages/KVStore/FFI/ProxyFFIStatusService.cpp
@@ -105,7 +105,6 @@ HttpRequestRes HandleHttpRequestSyncStatus(
     const size_t max_print_region = 30;
     static const std::chrono::minutes PRINT_LOG_INTERVAL = std::chrono::minutes{5};
     static Timepoint last_print_log_time = Clock::now();
-    // TODO(iosmanthus): TiDB should support tiflash replica.
     RegionTable & region_table = tmt.getRegionTable();
     // Note that the IStorage instance could be not exist if there is only empty region for the table in this TiFlash instance.
     region_table.handleInternalRegionsByTable(keyspace_id, table_id, [&](const RegionTable::InternalRegions & regions) {
@@ -287,6 +286,70 @@ HttpRequestRes HandleHttpRequestRemoteGC(
     };
 }
 
+// Acquiring the all the region ids created in this TiFlash node with given keyspace id.
+HttpRequestRes HandleHttpRequestSyncRegion(
+    EngineStoreServerWrap * server,
+    std::string_view path,
+    const std::string & api_name,
+    std::string_view,
+    std::string_view)
+{
+    HttpRequestStatus status = HttpRequestStatus::Ok;
+    pingcap::pd::KeyspaceID keyspace_id = NullspaceID;
+    {
+        auto log = Logger::get("HandleHttpRequestSyncRegion");
+        LOG_TRACE(log, "handling sync region request, path: {}, api_name: {}", path, api_name);
+        // schema: /keyspace/{keyspace_id}
+        auto query = path.substr(api_name.size());
+        std::vector<std::string> query_parts;
+        boost::split(query_parts, query, boost::is_any_of("/"));
+        if (query_parts.size() != 2 || query_parts[0] != "keyspace")
+        {
+            LOG_ERROR(log, "invalid SyncRegion request: {}", query);
+            status = HttpRequestStatus::ErrorParam;
+            return HttpRequestRes{
+                .status = status,
+                .res = CppStrWithView{.inner = GenRawCppPtr(), .view = BaseBuffView{nullptr, 0}}};
+        }
+        try
+        {
+            keyspace_id = std::stoll(query_parts[1]);
+        }
+        catch (...)
+        {
+            status = HttpRequestStatus::ErrorParam;
+        }
+        if (status != HttpRequestStatus::Ok)
+            return HttpRequestRes{
+                .status = status,
+                .res = CppStrWithView{.inner = GenRawCppPtr(), .view = BaseBuffView{nullptr, 0}}};
+    }
+    auto & tmt = *server->tmt;
+    std::stringstream ss;
+    Poco::JSON::Object::Ptr json = new Poco::JSON::Object();
+    Poco::JSON::Array::Ptr list = new Poco::JSON::Array();
+    RegionTable & region_table = tmt.getRegionTable();
+    region_table.handleInternalRegionsByKeyspace(
+        keyspace_id,
+        [&](const TableID table_id, const RegionTable::InternalRegions & regions) {
+            if (!tmt.getStorages().get(keyspace_id, table_id))
+                return;
+            for (const auto & region : regions)
+            {
+                list->add(region.first);
+            }
+        });
+    json->set("count", list->size());
+    json->set("regions", list);
+    json->stringify(ss);
+    auto * s = RawCppString::New(ss.str());
+    return HttpRequestRes{
+        .status = status,
+        .res = CppStrWithView{
+            .inner = GenRawCppPtr(s, RawCppPtrTypeImpl::String),
+            .view = BaseBuffView{s->data(), s->size()}}};
+}
+
 // Acquiring load schema to sync schema from TiKV in this TiFlash node with given keyspace id.
 HttpRequestRes HandleHttpRequestSyncSchema(
     EngineStoreServerWrap * server,
@@ -391,6 +454,7 @@ using HANDLE_HTTP_URI_METHOD = HttpRequestRes (*)(
 
 static const std::map<std::string, HANDLE_HTTP_URI_METHOD> AVAILABLE_HTTP_URI = {
     {"/tiflash/sync-status/", HandleHttpRequestSyncStatus},
+    {"/tiflash/sync-region/", HandleHttpRequestSyncRegion},
     {"/tiflash/sync-schema/", HandleHttpRequestSyncSchema},
     {"/tiflash/store-status", HandleHttpRequestStoreStatus},
     {"/tiflash/remote/owner/info", HandleHttpRequestRemoteOwnerInfo},

--- a/dbms/src/Storages/KVStore/FFI/ProxyFFIStatusService.cpp
+++ b/dbms/src/Storages/KVStore/FFI/ProxyFFIStatusService.cpp
@@ -322,8 +322,10 @@ HttpRequestRes HandleHttpRequestSyncRegion(
         if (status != HttpRequestStatus::Ok)
             return HttpRequestRes{
                 .status = status,
-                .res = CppStrWithView{.inner = GenRawCppPtr(), .view = BaseBuffView{nullptr, 0}}};
+                .res = CppStrWithView{.inner = GenRawCppPtr(), .view = BaseBuffView{nullptr, 0}},
+            };
     }
+
     auto & tmt = *server->tmt;
     std::stringstream ss;
     Poco::JSON::Object::Ptr json = new Poco::JSON::Object();
@@ -347,7 +349,9 @@ HttpRequestRes HandleHttpRequestSyncRegion(
         .status = status,
         .res = CppStrWithView{
             .inner = GenRawCppPtr(s, RawCppPtrTypeImpl::String),
-            .view = BaseBuffView{s->data(), s->size()}}};
+            .view = BaseBuffView{s->data(), s->size()},
+        },
+    };
 }
 
 // Acquiring load schema to sync schema from TiKV in this TiFlash node with given keyspace id.

--- a/dbms/src/Storages/KVStore/FFI/SSTReader.h
+++ b/dbms/src/Storages/KVStore/FFI/SSTReader.h
@@ -73,8 +73,8 @@ private:
 };
 
 /// MultiSSTReader helps when there are multiple sst files in a column family.
-/// It is derived from virtual class SSTReader, so it can be holded in a SSTReaderPtr.
-/// It also maintains instance of `R` which is normaly SSTReader(and MockSSTReader in tests),
+/// It is derived from virtual class SSTReader, so it can be held in a SSTReaderPtr.
+/// It also maintains instance of `R` which is normally SSTReader(and MockSSTReader in tests),
 /// to read a single sst file.
 /// An `Initer` function is need to create a instance of `R` from a instance of `E`,
 /// which is usually path of the SST file.
@@ -156,6 +156,7 @@ public:
         {
             // We don't drop if mono is the last instance for safety,
             // and it will be dropped as MultiSSTReader is dropped.
+#if SERVERLESS_PROXY != 1
             LOG_INFO(
                 log,
                 "Open sst file {}, range={} sst_idx={} sst_tot={}",
@@ -163,6 +164,14 @@ public:
                 range->toDebugString(),
                 sst_idx,
                 args.size());
+#else
+            LOG_INFO(
+                log,
+                "Open sst file, range={} sst_idx={} sst_tot={}",
+                range->toDebugString(),
+                sst_idx,
+                args.size());
+#endif
             mono = initer(proxy_helper, args[sst_idx], range, log);
         }
     }
@@ -183,12 +192,16 @@ public:
         , range(range_)
     {
         assert(args.size() > 0);
+#if SERVERLESS_PROXY != 1
         LOG_INFO(
             log,
             "Open sst file first {}, range={} sst_tot={}",
             buffToStrView(args[sst_idx].path),
             range->toDebugString(),
             args.size());
+#else
+        LOG_INFO(log, "Open sst file first, range={} sst_tot={}", range->toDebugString(), args.size());
+#endif
         mono = initer(proxy_helper, args[sst_idx], range, log);
     }
 

--- a/dbms/src/Storages/KVStore/KVStore.h
+++ b/dbms/src/Storages/KVStore/KVStore.h
@@ -230,6 +230,7 @@ public: // Raft Snapshot
     size_t getOngoingPrehandleSubtaskCount() const;
     EngineStoreApplyRes handleIngestSST(UInt64 region_id, SSTViewVec, UInt64 index, UInt64 term, TMTContext & tmt);
     size_t getMaxParallelPrehandleSize() const;
+    size_t getMaxPrehandleSubtaskSize() const;
 
 public: // Raft Read
     void addReadIndexEvent(Int64 f) { read_index_event_flag += f; }

--- a/dbms/src/Storages/KVStore/MultiRaft/PrehandleSnapshot.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/PrehandleSnapshot.cpp
@@ -314,7 +314,13 @@ size_t KVStore::getMaxParallelPrehandleSize() const
         auto cpu_num = std::thread::hardware_concurrency();
         total_concurrency = static_cast<size_t>(std::clamp(cpu_num * 0.7, 2.0, 16.0));
     }
+#if SERVERLESS_PROXY == 0
     return total_concurrency;
+#else
+    // In serverless mode, IO takes more part in decoding stage, so we can increase parallel limit.
+    // In real test, the prehandling speed decreases if we use higher concurrency.
+    return std::min(4, total_concurrency);
+#endif
 }
 
 // If size is 0, do not parallel prehandle for this snapshot, which is regular.

--- a/dbms/src/Storages/KVStore/MultiRaft/PrehandleSnapshot.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/PrehandleSnapshot.cpp
@@ -309,7 +309,7 @@ size_t KVStore::getMaxParallelPrehandleSize() const
     auto max_subtask_size = getMaxPrehandleSubtaskSize();
     // In serverless mode, IO takes more part in decoding stage, so we can increase parallel limit.
     // In real test, the prehandling speed decreases if we use higher concurrency.
-    return std::min(4, total_concurrency);
+    return std::min(4, max_subtask_size);
 #endif
 }
 

--- a/dbms/src/Storages/KVStore/MultiRaft/RegionData.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/RegionData.cpp
@@ -236,8 +236,9 @@ std::shared_ptr<const TiKVValue> RegionData::getLockByKey(const TiKVKey & key) c
         return tikv_val;
     }
 
-    // It is safe to ignore the missing lock key after restart, print a warning log and return nullptr
-    LOG_WARNING(
+    // It is safe to ignore the missing lock key after restart, print a debug log and return nullptr.
+    // In txn file prewrite, proxy will try to get the lock to check the txn existence, the logs may be massive.
+    LOG_DEBUG(
         Logger::get(),
         "Failed to get lock by key in region data, key={} map_size={} count={}",
         key.toDebugString(),

--- a/dbms/src/Storages/KVStore/MultiRaft/RegionPersister.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/RegionPersister.cpp
@@ -403,7 +403,7 @@ RegionMap RegionPersister::restore(
         {
             LOG_WARNING(
                 log,
-                "Region skip restore because keyspace in blacklist, region_id={} keyspace={}",
+                "Region skip restore because keyspace in blocklist, region_id={} keyspace={}",
                 region->id(),
                 region->getKeyspaceID());
             return;

--- a/dbms/src/Storages/KVStore/MultiRaft/RegionPersister.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/RegionPersister.cpp
@@ -398,6 +398,22 @@ RegionMap RegionPersister::restore(
             "region_id and page_id not match! region_id={} page_id={}",
             region->id(),
             page.page_id);
+#if SERVERLESS_PROXY == 1
+        if (global_context.isKeyspaceInBlocklist(region->getKeyspaceID()))
+        {
+            LOG_WARNING(
+                log,
+                "Region skip restore because keyspace in blacklist, region_id={} keyspace={}",
+                region->id(),
+                region->getKeyspaceID());
+            return;
+        }
+        if (global_context.isRegionInBlocklist(region->id()))
+        {
+            LOG_WARNING(log, "Region skip restore because region_id in blacklist, region_id={}", region->id());
+            return;
+        }
+#endif
 
         regions.emplace(page.page_id, region);
     };

--- a/dbms/src/Storages/KVStore/TiKVHelpers/DecodedLockCFValue.cpp
+++ b/dbms/src/Storages/KVStore/TiKVHelpers/DecodedLockCFValue.cpp
@@ -62,7 +62,11 @@ namespace RecordKVFormat
             {
             case SHORT_VALUE_PREFIX:
             {
+#if SERVERLESS_PROXY != 0
+                size_t str_len = readVarUInt(data, len);
+#else
                 size_t str_len = readUInt8(data, len);
+#endif
                 if (len < str_len)
                     throw Exception("content len shorter than short value len", ErrorCodes::LOGICAL_ERROR);
                 // no need short value

--- a/dbms/src/Storages/KVStore/TiKVHelpers/TiKVRecordFormat.cpp
+++ b/dbms/src/Storages/KVStore/TiKVHelpers/TiKVRecordFormat.cpp
@@ -36,4 +36,130 @@ TiKVKey genKey(const TiDB::TableInfo & table_info, std::vector<Field> keys)
     }
     return encodeAsTiKVKey(key + ss.releaseStr());
 }
+
+TiKVValue encodeLockCfValue(
+    UInt8 lock_type,
+    const String & primary,
+    Timestamp ts,
+    UInt64 ttl,
+    const String * short_value,
+    Timestamp min_commit_ts)
+{
+    WriteBufferFromOwnString res;
+    res.write(lock_type);
+    TiKV::writeVarInt(static_cast<Int64>(primary.size()), res);
+    res.write(primary.data(), primary.size());
+    TiKV::writeVarUInt(ts, res);
+    TiKV::writeVarUInt(ttl, res);
+    if (short_value)
+    {
+#if SERVERLESS_PROXY != 0
+        TiKV::writeVarUInt(short_value->size(), res);
+#else
+        res.write(SHORT_VALUE_PREFIX);
+#endif
+        res.write(static_cast<char>(short_value->size()));
+        res.write(short_value->data(), short_value->size());
+    }
+    if (min_commit_ts)
+    {
+        res.write(MIN_COMMIT_TS_PREFIX);
+        encodeUInt64(min_commit_ts, res);
+    }
+    return TiKVValue(res.releaseStr());
+}
+
+DecodedWriteCFValue decodeWriteCfValue(const TiKVValue & value)
+{
+    const char * data = value.data();
+    size_t len = value.dataSize();
+
+    auto write_type = RecordKVFormat::readUInt8(data, len); //write type
+
+    bool can_ignore = write_type != CFModifyFlag::DelFlag && write_type != CFModifyFlag::PutFlag;
+    if (can_ignore)
+        return std::nullopt;
+
+    Timestamp prewrite_ts = RecordKVFormat::readVarUInt(data, len); // ts
+
+    std::string_view short_value;
+    while (len)
+    {
+        auto flag = RecordKVFormat::readUInt8(data, len);
+        switch (flag)
+        {
+        case RecordKVFormat::SHORT_VALUE_PREFIX:
+        {
+#if SERVERLESS_PROXY != 0
+            size_t slen = RecordKVFormat::readVarUInt(data, len);
+#else
+            size_t slen = RecordKVFormat::readUInt8(data, len);
+#endif
+            if (slen > len)
+                throw Exception("content len not equal to short value len", ErrorCodes::LOGICAL_ERROR);
+            short_value = RecordKVFormat::readRawString<std::string_view>(data, len, slen);
+            break;
+        }
+        case RecordKVFormat::FLAG_OVERLAPPED_ROLLBACK:
+            // ignore
+            break;
+        case RecordKVFormat::GC_FENCE_PREFIX:
+            /**
+                 * according to https://github.com/tikv/tikv/pull/9207, when meet `GC fence` flag, it is definitely a
+                 * rewriting record and there must be a complete row written to tikv, just ignore it in tiflash.
+                 */
+            return std::nullopt;
+        case RecordKVFormat::LAST_CHANGE_PREFIX:
+        {
+            // Used to accelerate TiKV MVCC scan, useless for TiFlash.
+            UInt64 last_change_ts = readUInt64(data, len);
+            UInt64 versions_to_last_change = readVarUInt(data, len);
+            UNUSED(last_change_ts);
+            UNUSED(versions_to_last_change);
+            break;
+        }
+        case RecordKVFormat::TXN_SOURCE_PREFIX_FOR_WRITE:
+        {
+            // Used for CDC, useless for TiFlash.
+            UInt64 txn_source_prefic = readVarUInt(data, len);
+            UNUSED(txn_source_prefic);
+            break;
+        }
+        default:
+            throw Exception("invalid flag " + std::to_string(flag) + " in write cf", ErrorCodes::LOGICAL_ERROR);
+        }
+    }
+
+    return InnerDecodedWriteCFValue{
+        write_type,
+        prewrite_ts,
+        short_value.empty() ? nullptr : std::make_shared<const TiKVValue>(short_value.data(), short_value.length()),
+    };
+}
+
+TiKVValue encodeWriteCfValue(UInt8 write_type, Timestamp ts, std::string_view short_value, bool gc_fence)
+{
+    WriteBufferFromOwnString res;
+    res.write(write_type);
+    TiKV::writeVarUInt(ts, res);
+    if (!short_value.empty())
+    {
+        res.write(SHORT_VALUE_PREFIX);
+#if SERVERLESS_PROXY != 0
+        TiKV::writeVarUInt(short_value.size(), res);
+#else
+        res.write(static_cast<char>(short_value.size()));
+#endif
+        res.write(short_value.data(), short_value.size());
+    }
+    // just for test
+    res.write(FLAG_OVERLAPPED_ROLLBACK);
+    if (gc_fence)
+    {
+        res.write(GC_FENCE_PREFIX);
+        encodeUInt64(8888, res);
+    }
+    return TiKVValue(res.releaseStr());
+}
+
 } // namespace DB::RecordKVFormat

--- a/dbms/src/Storages/KVStore/TiKVHelpers/TiKVRecordFormat.h
+++ b/dbms/src/Storages/KVStore/TiKVHelpers/TiKVRecordFormat.h
@@ -342,11 +342,7 @@ using DecodedWriteCFValue = std::optional<InnerDecodedWriteCFValue>;
 
 DecodedWriteCFValue decodeWriteCfValue(const TiKVValue & value);
 
-TiKVValue encodeWriteCfValue(
-    UInt8 write_type,
-    Timestamp ts,
-    std::string_view short_value = {},
-    bool gc_fence = false);
+TiKVValue encodeWriteCfValue(UInt8 write_type, Timestamp ts, std::string_view short_value = {}, bool gc_fence = false);
 
 template <bool start>
 inline std::string DecodedTiKVKeyToDebugString(const DecodedTiKVKey & decoded_key)

--- a/dbms/src/Storages/KVStore/tests/gtest_new_kvstore.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_new_kvstore.cpp
@@ -1294,7 +1294,11 @@ CATCH
 TEST(ProxyMode, Normal)
 try
 {
+#if SERVERLESS_PROXY == 0
     ASSERT_EQ(SERVERLESS_PROXY, 0);
+#else
+    ASSERT_EQ(SERVERLESS_PROXY, 1);
+#endif
 }
 CATCH
 

--- a/dbms/src/Storages/KVStore/tests/gtest_tikv_keyvalue.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_tikv_keyvalue.cpp
@@ -17,9 +17,11 @@
 #include <Storages/KVStore/Decode/TiKVRange.h>
 #include <Storages/KVStore/Region.h>
 #include <Storages/KVStore/TiKVHelpers/TiKVRecordFormat.h>
+#include <Storages/KVStore/Types.h>
 #include <Storages/KVStore/tests/region_helper.h>
 #include <TestUtils/TiFlashTestBasic.h>
 #include <TiDB/Schema/TiDB.h>
+#include <gtest/gtest.h>
 
 using namespace DB;
 
@@ -29,7 +31,9 @@ inline bool checkTableInvolveRange(const TableID table_id, const RangeRef & rang
 {
     const TiKVKey start_key = RecordKVFormat::genKey(table_id, std::numeric_limits<HandleID>::min());
     const TiKVKey end_key = RecordKVFormat::genKey(table_id, std::numeric_limits<HandleID>::max());
-    return !(end_key < range.first || (!range.second.empty() && start_key >= range.second));
+    // clang-format off
+    return !(end_key < range.first|| (!range.second.empty() && start_key >= range.second)); // NOLINT(readability-simplify-boolean-expr)
+    // clang-format on
 }
 
 inline TiKVKey genIndex(const TableID tableId, const Int64 id)
@@ -42,6 +46,42 @@ inline TiKVKey genIndex(const TableID tableId, const Int64 id)
     auto big_endian_handle_id = RecordKVFormat::encodeInt64(id);
     memcpy(key.data() + 1 + 8 + 2, reinterpret_cast<const char *>(&big_endian_handle_id), 8);
     return RecordKVFormat::encodeAsTiKVKey(key);
+}
+
+TEST(TiKVKeyValueTest, KeyFormat)
+{
+    Timestamp prewrite_ts = 5;
+    {
+        std::string short_value(128, 'F');
+        auto v = RecordKVFormat::encodeWriteCfValue(
+            RecordKVFormat::CFModifyFlag::PutFlag,
+            prewrite_ts,
+            short_value,
+            false);
+        auto decoded = RecordKVFormat::decodeWriteCfValue(v);
+        ASSERT_TRUE(decoded.has_value());
+        ASSERT_EQ(decoded->write_type, RecordKVFormat::CFModifyFlag::PutFlag);
+        ASSERT_EQ(decoded->prewrite_ts, prewrite_ts);
+        ASSERT_NE(decoded->short_value, nullptr);
+        ASSERT_EQ(*decoded->short_value, short_value);
+    }
+#if SERVERLESS_PROXY != 0
+    {
+        // For serverless branch, the short_value length use varUInt
+        std::string short_value(1025, 'F');
+        auto v = RecordKVFormat::encodeWriteCfValue(
+            RecordKVFormat::CFModifyFlag::PutFlag,
+            prewrite_ts,
+            short_value,
+            false);
+        auto decoded = RecordKVFormat::decodeWriteCfValue(v);
+        ASSERT_TRUE(decoded.has_value());
+        ASSERT_EQ(decoded->write_type, RecordKVFormat::CFModifyFlag::PutFlag);
+        ASSERT_EQ(decoded->prewrite_ts, prewrite_ts);
+        ASSERT_NE(decoded->short_value, nullptr);
+        ASSERT_EQ(*decoded->short_value, short_value);
+    }
+#endif
 }
 
 TEST(TiKVKeyValueTest, PortedTests)

--- a/dbms/src/Storages/KVStore/tests/gtest_tikv_keyvalue.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_tikv_keyvalue.cpp
@@ -21,7 +21,6 @@
 #include <Storages/KVStore/tests/region_helper.h>
 #include <TestUtils/TiFlashTestBasic.h>
 #include <TiDB/Schema/TiDB.h>
-#include <gtest/gtest.h>
 
 using namespace DB;
 

--- a/dbms/src/Storages/Page/Page.h
+++ b/dbms/src/Storages/Page/Page.h
@@ -47,7 +47,7 @@ struct FieldOffsetInsidePage
     bool operator<(const FieldOffsetInsidePage & rhs) const { return index < rhs.index; }
 };
 
-struct Page
+class Page
 {
 public:
     static Page invalidPage()
@@ -69,7 +69,7 @@ public:
     std::set<FieldOffsetInsidePage> field_offsets;
 
 private:
-    bool is_valid;
+    bool is_valid = false;
 
 public:
     inline bool isValid() const { return is_valid; }

--- a/dbms/src/TiDB/Schema/TiDBSchemaSyncer.cpp
+++ b/dbms/src/TiDB/Schema/TiDBSchemaSyncer.cpp
@@ -84,10 +84,17 @@ bool TiDBSchemaSyncer<mock_getter, mock_mapper>::syncSchemasByGetter(Context & c
     }
     else
     {
+#if SERVERLESS_PROXY == 0
         if (version <= cur_version)
         {
             return false;
         }
+#else
+        if (version == cur_version)
+        {
+            return false;
+        }
+#endif
 
         LOG_INFO(
             log,
@@ -100,6 +107,19 @@ bool TiDBSchemaSyncer<mock_getter, mock_mapper>::syncSchemasByGetter(Context & c
             // first load all db and tables
             cur_version = syncAllSchemas(context, getter, version);
         }
+#if SERVERLESS_PROXY == 1
+        // if the `version` is less than `cur_version`, it means that the schema version in TiKV has been rolled back by restore.
+        // We should sync the schema again.
+        else if (version < cur_version)
+        {
+            LOG_INFO(
+                log,
+                "The latest schema version is less than current version, sync all schema, version={} cur_version={}",
+                version,
+                cur_version);
+            cur_version = syncAllSchemas(context, getter, version);
+        }
+#endif
         else
         {
             // After the feature concurrent DDL, TiDB does `update schema version` before `set schema diff`, and they are done in separate transactions.

--- a/format-diff.py
+++ b/format-diff.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Copyright 2023 PingCAP, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/9767

Problem Summary:

### What is changed and how it works?

```commit-message

```

The following adoption of cse only enable when `SERVERLESS_PROXY = 1` is defined

* Length of short value in lock CF encode as `varInt` instead of `u8`
* Blocklist feature
  * keyspace blocklist
  * region_id blocklist
  * store_id blocklist under disagg arch
* mtls
* A HTTP API for `Acquiring the all the region ids created in this TiFlash node with given keyspace id`
* File-base large txn
* Special threshold on parallel prehandle

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
