### PR TITLE
storage: Remove tryBuildWithVectorIndex

### DIFF
--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileBig.h
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileBig.h
@@ -18,6 +18,7 @@
 #include <Storages/DeltaMerge/ColumnFile/ColumnFilePersisted.h>
 #include <Storages/DeltaMerge/File/DMFile.h>
 #include <Storages/DeltaMerge/Remote/Serializer_fwd.h>
+#include <Storages/DeltaMerge/SkippableBlockInputStream.h>
 
 namespace DB::DM
 {
@@ -132,7 +133,7 @@ private:
 
     bool pk_ver_only;
 
-    DMFileBlockInputStreamPtr file_stream;
+    SkippableBlockInputStreamPtr file_stream;
 
     // The data members for reading only pk and version columns.
     // we cache them to minimize the cost.

--- a/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.cpp
@@ -36,7 +36,7 @@ DMFileBlockInputStreamBuilder::DMFileBlockInputStreamBuilder(const Context & con
     setFromSettings(context.getSettingsRef());
 }
 
-DMFileBlockInputStreamPtr DMFileBlockInputStreamBuilder::build(
+DMFileBlockInputStreamPtr DMFileBlockInputStreamBuilder::buildNoLocalIndex(
     const DMFilePtr & dmfile,
     const ColumnDefines & read_columns,
     const RowKeyRanges & rowkey_ranges,
@@ -105,7 +105,7 @@ DMFileBlockInputStreamPtr DMFileBlockInputStreamBuilder::build(
     return std::make_shared<DMFileBlockInputStream>(std::move(reader), max_sharing_column_bytes_for_all > 0);
 }
 
-DMFileBlockInputStreamPtr createSimpleBlockInputStream(
+SkippableBlockInputStreamPtr createSimpleBlockInputStream(
     const DB::Context & context,
     const DMFilePtr & file,
     ColumnDefines cols)
@@ -131,14 +131,14 @@ DMFileBlockInputStreamBuilder & DMFileBlockInputStreamBuilder::setFromSettings(c
     return *this;
 }
 
-SkippableBlockInputStreamPtr DMFileBlockInputStreamBuilder::tryBuildWithVectorIndex(
+SkippableBlockInputStreamPtr DMFileBlockInputStreamBuilder::build(
     const DMFilePtr & dmfile,
     const ColumnDefines & read_columns,
     const RowKeyRanges & rowkey_ranges,
     const ScanContextPtr & scan_context)
 {
     auto fallback = [&]() {
-        return build(dmfile, read_columns, rowkey_ranges, scan_context);
+        return buildNoLocalIndex(dmfile, read_columns, rowkey_ranges, scan_context);
     };
 
     if (!ann_query_info)

--- a/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.h
@@ -85,24 +85,9 @@ public:
     // - current file provider from this context
     explicit DMFileBlockInputStreamBuilder(const Context & context);
 
-    // Build the final stream ptr.
+    // Build the final stream ptr. LocalIndex will take effect.
     // Empty `rowkey_ranges` means not filter by rowkey
-    // Should not use the builder again after `build` is called.
-    DMFileBlockInputStreamPtr build(
-        const DMFilePtr & dmfile,
-        const ColumnDefines & read_columns,
-        const RowKeyRanges & rowkey_ranges,
-        const ScanContextPtr & scan_context);
-
-    // Build the final stream ptr. The return value could be DMFileBlockInputStreamPtr or DMFileWithVectorIndexBlockInputStream.
-    // Empty `rowkey_ranges` means not filter by rowkey
-    // Should not use the builder again after `build` is called.
-    // In the following conditions DMFileWithVectorIndexBlockInputStream will be returned:
-    // 1. BitmapFilter is provided
-    // 2. ANNQueryInfo is available in the RSFilter
-    // 3. The vector column mentioned by ANNQueryInfo is in the read_columns
-    // 4. The vector column mentioned by ANNQueryInfo exists vector index file
-    SkippableBlockInputStreamPtr tryBuildWithVectorIndex(
+    SkippableBlockInputStreamPtr build(
         const DMFilePtr & dmfile,
         const ColumnDefines & read_columns,
         const RowKeyRanges & rowkey_ranges,
@@ -198,6 +183,14 @@ public:
     }
 
 private:
+    DMFileBlockInputStreamPtr buildNoLocalIndex(
+        const DMFilePtr & dmfile,
+        const ColumnDefines & read_columns,
+        const RowKeyRanges & rowkey_ranges,
+        const ScanContextPtr & scan_context);
+
+
+private:
     // These methods are called by the ctor
 
     DMFileBlockInputStreamBuilder & setFromSettings(const Settings & settings);
@@ -260,7 +253,7 @@ private:
  * @param cols The columns to read. Empty means read all columns.
  * @return A shared pointer of an input stream
  */
-DMFileBlockInputStreamPtr createSimpleBlockInputStream(
+SkippableBlockInputStreamPtr createSimpleBlockInputStream(
     const DB::Context & context,
     const DMFilePtr & file,
     ColumnDefines cols = {});

--- a/dbms/src/Storages/DeltaMerge/StableValueSpace.cpp
+++ b/dbms/src/Storages/DeltaMerge/StableValueSpace.cpp
@@ -549,7 +549,7 @@ SkippableBlockInputStreamPtr StableValueSpace::Snapshot::tryGetInputStreamWithVe
             last_rows += stable->files[i]->getRows();
         }
 
-        streams.push_back(builder.tryBuildWithVectorIndex( //
+        streams.push_back(builder.build( //
             stable->files[i],
             read_columns,
             rowkey_ranges,

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_file.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_file.cpp
@@ -170,8 +170,9 @@ public:
         ASSERT_EQ(n, s.size());
     }
 
-    static void skipFirstPack(DMFileBlockInputStreamPtr & stream)
+    static void skipFirstPack(SkippableBlockInputStreamPtr & stream_)
     {
+        const auto stream = std::dynamic_pointer_cast<DMFileBlockInputStream>(stream_);
         const auto & pack_stats = stream->reader.dmfile->getPackStats();
         auto [pack_id, pack_count, res, rows] = stream->reader.read_block_infos.front();
         stream->reader.read_block_infos.pop_front();

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_vector_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_vector_index.cpp
@@ -242,7 +242,7 @@ try
         DMFileBlockInputStreamBuilder builder(dbContext());
         auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView::createWithFilter(3, true))
-                          .tryBuildWithVectorIndex(
+                          .build(
                               dm_file,
                               read_cols,
                               RowKeyRanges{RowKeyRange::newAll(false, 1)},
@@ -267,7 +267,7 @@ try
         DMFileBlockInputStreamBuilder builder(dbContext());
         auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView::createWithFilter(3, true))
-                          .tryBuildWithVectorIndex(
+                          .build(
                               dm_file,
                               read_cols,
                               RowKeyRanges{RowKeyRange::newAll(false, 1)},
@@ -292,7 +292,7 @@ try
         DMFileBlockInputStreamBuilder builder(dbContext());
         auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView::createWithFilter(3, true))
-                          .tryBuildWithVectorIndex(
+                          .build(
                               dm_file,
                               read_cols,
                               RowKeyRanges{RowKeyRange::newAll(false, 1)},
@@ -320,7 +320,7 @@ try
         DMFileBlockInputStreamBuilder builder(dbContext());
         auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView(bitmap_filter, 0, 3))
-                          .tryBuildWithVectorIndex(
+                          .build(
                               dm_file,
                               read_cols,
                               RowKeyRanges{RowKeyRange::newAll(false, 1)},
@@ -345,7 +345,7 @@ try
         DMFileBlockInputStreamBuilder builder(dbContext());
         auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView::createWithFilter(3, true))
-                          .tryBuildWithVectorIndex(
+                          .build(
                               dm_file,
                               read_cols,
                               RowKeyRanges{RowKeyRange::newAll(false, 1)},
@@ -370,7 +370,7 @@ try
         DMFileBlockInputStreamBuilder builder(dbContext());
         auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView::createWithFilter(3, true))
-                          .tryBuildWithVectorIndex(
+                          .build(
                               dm_file,
                               read_cols,
                               RowKeyRanges{RowKeyRange::newAll(false, 1)},
@@ -395,7 +395,7 @@ try
         DMFileBlockInputStreamBuilder builder(dbContext());
         auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView::createWithFilter(3, true))
-                          .tryBuildWithVectorIndex(
+                          .build(
                               dm_file,
                               read_cols,
                               RowKeyRanges{RowKeyRange::newAll(false, 1)},
@@ -430,7 +430,7 @@ try
         DMFileBlockInputStreamBuilder builder(dbContext());
         auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView::createWithFilter(3, true))
-                          .tryBuildWithVectorIndex(
+                          .build(
                               dm_file,
                               read_cols,
                               RowKeyRanges{RowKeyRange::newAll(false, 1)},
@@ -455,7 +455,7 @@ try
         DMFileBlockInputStreamBuilder builder(dbContext());
         auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView::createWithFilter(3, true))
-                          .tryBuildWithVectorIndex(
+                          .build(
                               dm_file,
                               read_cols,
                               RowKeyRanges{RowKeyRange::newAll(false, 1)},
@@ -493,7 +493,7 @@ try
         DMFileBlockInputStreamBuilder builder(dbContext());
         auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView::createWithFilter(3, true))
-                          .tryBuildWithVectorIndex(
+                          .build(
                               dm_file,
                               read_cols,
                               RowKeyRanges{RowKeyRange::newAll(false, 1)},
@@ -591,7 +591,7 @@ try
             DMFileBlockInputStreamBuilder builder(dbContext());
             auto stream = builder.setAnnQureyInfo(ann_query_info)
                               .setBitmapFilter(BitmapFilterView::createWithFilter(3, true))
-                              .tryBuildWithVectorIndex(
+                              .build(
                                   dm_file,
                                   read_cols,
                                   RowKeyRanges{RowKeyRange::newAll(false, 1)},
@@ -617,7 +617,7 @@ try
             DMFileBlockInputStreamBuilder builder(dbContext());
             auto stream = builder.setAnnQureyInfo(ann_query_info)
                               .setBitmapFilter(BitmapFilterView::createWithFilter(3, true))
-                              .tryBuildWithVectorIndex(
+                              .build(
                                   dm_file,
                                   read_cols,
                                   RowKeyRanges{RowKeyRange::newAll(false, 1)},
@@ -646,7 +646,7 @@ try
             DMFileBlockInputStreamBuilder builder(dbContext());
             auto stream = builder.setAnnQureyInfo(ann_query_info)
                               .setBitmapFilter(BitmapFilterView(bitmap_filter, 0, 3))
-                              .tryBuildWithVectorIndex(
+                              .build(
                                   dm_file,
                                   read_cols,
                                   RowKeyRanges{RowKeyRange::newAll(false, 1)},
@@ -676,7 +676,7 @@ try
             DMFileBlockInputStreamBuilder builder(dbContext());
             auto stream = builder.setAnnQureyInfo(ann_query_info)
                               .setBitmapFilter(BitmapFilterView::createWithFilter(3, true))
-                              .tryBuildWithVectorIndex(
+                              .build(
                                   dm_file,
                                   read_cols,
                                   RowKeyRanges{RowKeyRange::newAll(false, 1)},
@@ -702,7 +702,7 @@ try
             DMFileBlockInputStreamBuilder builder(dbContext());
             auto stream = builder.setAnnQureyInfo(ann_query_info)
                               .setBitmapFilter(BitmapFilterView::createWithFilter(3, true))
-                              .tryBuildWithVectorIndex(
+                              .build(
                                   dm_file,
                                   read_cols,
                                   RowKeyRanges{RowKeyRange::newAll(false, 1)},
@@ -731,7 +731,7 @@ try
             DMFileBlockInputStreamBuilder builder(dbContext());
             auto stream = builder.setAnnQureyInfo(ann_query_info)
                               .setBitmapFilter(BitmapFilterView(bitmap_filter, 0, 3))
-                              .tryBuildWithVectorIndex(
+                              .build(
                                   dm_file,
                                   read_cols,
                                   RowKeyRanges{RowKeyRange::newAll(false, 1)},
@@ -761,7 +761,7 @@ try
             DMFileBlockInputStreamBuilder builder(dbContext());
             auto stream = builder.setAnnQureyInfo(ann_query_info)
                               .setBitmapFilter(BitmapFilterView::createWithFilter(3, true))
-                              .tryBuildWithVectorIndex(
+                              .build(
                                   dm_file,
                                   read_cols,
                                   RowKeyRanges{RowKeyRange::newAll(false, 1)},
@@ -786,7 +786,7 @@ try
             DMFileBlockInputStreamBuilder builder(dbContext());
             auto stream = builder.setAnnQureyInfo(ann_query_info)
                               .setBitmapFilter(BitmapFilterView::createWithFilter(3, true))
-                              .tryBuildWithVectorIndex(
+                              .build(
                                   dm_file,
                                   read_cols,
                                   RowKeyRanges{RowKeyRange::newAll(false, 1)},
@@ -814,7 +814,7 @@ try
             DMFileBlockInputStreamBuilder builder(dbContext());
             auto stream = builder.setAnnQureyInfo(ann_query_info)
                               .setBitmapFilter(BitmapFilterView(bitmap_filter, 0, 3))
-                              .tryBuildWithVectorIndex(
+                              .build(
                                   dm_file,
                                   read_cols,
                                   RowKeyRanges{RowKeyRange::newAll(false, 1)},
@@ -878,7 +878,7 @@ try
         DMFileBlockInputStreamBuilder builder(dbContext());
         auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView::createWithFilter(5, true))
-                          .tryBuildWithVectorIndex(
+                          .build(
                               dm_file,
                               read_cols,
                               RowKeyRanges{RowKeyRange::newAll(false, 1)},
@@ -946,7 +946,7 @@ try
         DMFileBlockInputStreamBuilder builder(dbContext());
         auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView::createWithFilter(6, true))
-                          .tryBuildWithVectorIndex(
+                          .build(
                               dm_file,
                               read_cols,
                               RowKeyRanges{RowKeyRange::newAll(false, 1)},
@@ -971,7 +971,7 @@ try
         DMFileBlockInputStreamBuilder builder(dbContext());
         auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView::createWithFilter(6, true))
-                          .tryBuildWithVectorIndex(
+                          .build(
                               dm_file,
                               read_cols,
                               RowKeyRanges{RowKeyRange::newAll(false, 1)},
@@ -996,7 +996,7 @@ try
         DMFileBlockInputStreamBuilder builder(dbContext());
         auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView::createWithFilter(6, true))
-                          .tryBuildWithVectorIndex(
+                          .build(
                               dm_file,
                               read_cols,
                               RowKeyRanges{RowKeyRange::newAll(false, 1)},
@@ -1024,7 +1024,7 @@ try
         DMFileBlockInputStreamBuilder builder(dbContext());
         auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView(bitmap_filter, 0, 6))
-                          .tryBuildWithVectorIndex(
+                          .build(
                               dm_file,
                               read_cols,
                               RowKeyRanges{RowKeyRange::newAll(false, 1)},
@@ -1095,7 +1095,7 @@ try
         DMFileBlockInputStreamBuilder builder(dbContext());
         auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView(bitmap_filter, 0, 9))
-                          .tryBuildWithVectorIndex(dm_file, read_cols, row_key_ranges, std::make_shared<ScanContext>());
+                          .build(dm_file, read_cols, row_key_ranges, std::make_shared<ScanContext>());
         ASSERT_INPUTSTREAM_COLS_UR(
             stream,
             createColumnNames(),
@@ -1109,7 +1109,7 @@ try
         builder = DMFileBlockInputStreamBuilder(dbContext());
         stream = builder.setAnnQureyInfo(ann_query_info)
                      .setBitmapFilter(BitmapFilterView(bitmap_filter, 0, 9))
-                     .tryBuildWithVectorIndex(dm_file, read_cols, row_key_ranges, std::make_shared<ScanContext>());
+                     .build(dm_file, read_cols, row_key_ranges, std::make_shared<ScanContext>());
         ASSERT_INPUTSTREAM_COLS_UR(
             stream,
             createColumnNames(),
@@ -1138,7 +1138,7 @@ try
         DMFileBlockInputStreamBuilder builder(dbContext());
         auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView(bitmap_filter, 0, 9))
-                          .tryBuildWithVectorIndex(dm_file, read_cols, row_key_ranges, std::make_shared<ScanContext>());
+                          .build(dm_file, read_cols, row_key_ranges, std::make_shared<ScanContext>());
         ASSERT_INPUTSTREAM_COLS_UR(
             stream,
             createColumnNames(),


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/6233

Problem Summary:

### What is changed and how it works?


Make changes for DMFileBlockInputStreamBuilder:

- public build → private buildNoLocalIndex
- public tryBuildWithLocalIndex → public build

Local index aware is by default now, so that we don't need to care about "local index" or not.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
