### PR TITLE
Fix several network stats issues

### DIFF
--- a/dbms/src/Flash/Coprocessor/DecodeDetail.h
+++ b/dbms/src/Flash/Coprocessor/DecodeDetail.h
@@ -29,7 +29,7 @@ struct DecodeDetail
     // This will be the row number of all blocks of the original packet if it's not fine grained shuffle.
     Int64 rows = 0;
 
-    // Total byte size of the origin packet, even for fine grained shuffle.
+    // Total byte size of the origin packet. When fine grained shuffle is enabled, only records once.
     Int64 packet_bytes = 0;
 };
 } // namespace DB

--- a/dbms/src/Flash/Coprocessor/ExecutionSummary.cpp
+++ b/dbms/src/Flash/Coprocessor/ExecutionSummary.cpp
@@ -60,7 +60,7 @@ void ExecutionSummary::merge(const tipb::ExecutorExecutionSummary & other)
     inner_zone_send_bytes += other.tiflash_network_summary().inner_zone_send_bytes();
     inner_zone_receive_bytes += other.tiflash_network_summary().inner_zone_receive_bytes();
     inter_zone_send_bytes += other.tiflash_network_summary().inter_zone_send_bytes();
-    inter_zone_receive_bytes += other.tiflash_network_summary().inter_zone_send_bytes();
+    inter_zone_receive_bytes += other.tiflash_network_summary().inter_zone_receive_bytes();
     ru_consumption = mergeRUConsumption(ru_consumption, parseRUConsumption(other));
     scan_context->merge(other.tiflash_scan_context());
 }
@@ -92,7 +92,7 @@ void ExecutionSummary::init(const tipb::ExecutorExecutionSummary & other)
     inner_zone_send_bytes = other.tiflash_network_summary().inner_zone_send_bytes();
     inner_zone_receive_bytes = other.tiflash_network_summary().inner_zone_receive_bytes();
     inter_zone_send_bytes = other.tiflash_network_summary().inter_zone_send_bytes();
-    inter_zone_receive_bytes = other.tiflash_network_summary().inter_zone_send_bytes();
+    inter_zone_receive_bytes = other.tiflash_network_summary().inter_zone_receive_bytes();
     ru_consumption = parseRUConsumption(other);
     scan_context->deserialize(other.tiflash_scan_context());
 }

--- a/dbms/src/Flash/Mpp/ExchangeReceiver.cpp
+++ b/dbms/src/Flash/Mpp/ExchangeReceiver.cpp
@@ -733,8 +733,11 @@ DecodeDetail ExchangeReceiverBase<RPCContext>::decodeChunks(
         return detail;
     const auto & packet = recv_msg->getPacket();
 
-    // Record total packet size even if fine grained shuffle is enabled.
-    detail.packet_bytes = packet.ByteSizeLong();
+    // Record total packet size when fine grained shuffle is disabled or only records in the first stream.
+    if (getFineGrainedShuffleStreamCount() == 0 || stream_id == 0)
+    {
+        detail.packet_bytes = packet.ByteSizeLong();
+    }
 
     switch (auto version = packet.version(); version)
     {

--- a/dbms/src/Flash/Mpp/MPPTunnel.h
+++ b/dbms/src/Flash/Mpp/MPPTunnel.h
@@ -564,7 +564,7 @@ private:
     {
         std::lock_guard lock(mu);
         // TODO(hyb): Figure out which type of packets are equal or smaller than 2 bytes
-        // Currently doesn't record these packets, because in receiver side, it seems unnoticable, 
+        // Currently doesn't record these packets, because in receiver side, it seems unnoticable,
         // so to ensure the total_recorded_send_bytes == total_recorded_received_bytes, just ignore these packets now.
         if likely (pushed_data_size > 2)
         {

--- a/dbms/src/Flash/Mpp/MPPTunnel.h
+++ b/dbms/src/Flash/Mpp/MPPTunnel.h
@@ -563,8 +563,14 @@ private:
     void updateConnProfileInfo(size_t pushed_data_size)
     {
         std::lock_guard lock(mu);
-        connection_profile_info.bytes += pushed_data_size;
-        connection_profile_info.packets += 1;
+        // TODO(hyb): Figure out which type of packets are equal or smaller than 2 bytes
+        // Currently doesn't record these packets, because in receiver side, it seems unnoticable, 
+        // so to ensure the total_recorded_send_bytes == total_recorded_received_bytes, just ignore these packets now.
+        if likely (pushed_data_size > 2)
+        {
+            connection_profile_info.bytes += pushed_data_size;
+            connection_profile_info.packets += 1;
+        }
     }
 
 private:

--- a/dbms/src/Flash/Mpp/ReceivedMessage.h
+++ b/dbms/src/Flash/Mpp/ReceivedMessage.h
@@ -18,6 +18,7 @@
 #include <Common/LooseBoundedMPMCQueue.h>
 #include <Flash/Mpp/TrackedMppDataPacket.h>
 
+#include <atomic>
 #include <memory>
 
 namespace DB
@@ -35,6 +36,7 @@ class ReceivedMessage
     std::vector<std::vector<const String *>> fine_grained_chunks;
     std::atomic<size_t> remaining_consumers;
     size_t fine_grained_consumer_size;
+    std::atomic<bool> packet_size_recorded{false}; // used to flag if fined grained shuffle packet size is recorded
 
 public:
     // Constructor that move chunks.
@@ -54,6 +56,7 @@ public:
     std::atomic<size_t> & getRemainingConsumers() { return remaining_consumers; }
     const std::vector<const String *> & getChunks(size_t stream_id) const;
     const mpp::MPPDataPacket & getPacket() const { return packet->packet; }
+    std::atomic<bool> & getPacketSizeRecorded() { return packet_size_recorded; }
     bool containUsefulMessage() const;
 };
 } // namespace DB

--- a/dbms/src/Flash/Statistics/BaseRuntimeStatistics.cpp
+++ b/dbms/src/Flash/Statistics/BaseRuntimeStatistics.cpp
@@ -52,10 +52,10 @@ void BaseRuntimeStatistics::updateReceiveConnectionInfo(const ConnectionProfileI
     case DB::ConnectionProfileInfo::Local:
         break;
     case ConnectionProfileInfo::InnerZoneRemote:
-        inner_zone_receive_bytes += bytes;
+        inner_zone_receive_bytes += conn_profile_info.bytes;
         break;
     case DB::ConnectionProfileInfo::InterZoneRemote:
-        inter_zone_receive_bytes += bytes;
+        inter_zone_receive_bytes += conn_profile_info.bytes;
         break;
     default:
         throw TiFlashException(
@@ -71,10 +71,10 @@ void BaseRuntimeStatistics::updateSendConnectionInfo(const ConnectionProfileInfo
     case DB::ConnectionProfileInfo::Local:
         break;
     case ConnectionProfileInfo::InnerZoneRemote:
-        inner_zone_send_bytes += bytes;
+        inner_zone_send_bytes += conn_profile_info.bytes;
         break;
     case DB::ConnectionProfileInfo::InterZoneRemote:
-        inter_zone_send_bytes += bytes;
+        inter_zone_send_bytes += conn_profile_info.bytes;
         break;
     default:
         throw TiFlashException(


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #9748 

Problem Summary:

### What is changed and how it works?
Fix several issues for network traffic stats:
1. Two typo-like issues for mixing variable names. Previously, no tidb side changes, so only checks the remote coprocessor read code path manually, This time tests with tidb side changes, found these issues. RT.
2. Currently, in exchange sender side, we stats very small packets which don't look like data packets, with size <= 2 bytes; while in receiver side, these packets are not found. Maybe they include eof or other kinds of packets. Since they are so small that we can just ignore them now.
3. For fine grained shuffle exchange receiver, the network traffic is counted duplicatedly. 

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
Manually test with https://github.com/pingcap/tidb/pull/58683, check execution summary values.
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
