### PR TITLE
Fix compilation errors with unused variables

### DIFF
--- a/dbms/src/AggregateFunctions/AggregateFunctionNull.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionNull.h
@@ -513,7 +513,7 @@ inline size_t enlargePrefixSize(size_t prefix_size) noexcept
     static_assert((sizeof(prefix_size_look_up_table) / sizeof(UInt64)) == 7);
 
     // align_size is equal to prefix_size at the beginning
-    auto align_size = prefix_size;
+    [[maybe_unused]] const auto align_size = prefix_size;
 
     if (prefix_size < 8)
         prefix_size = prefix_size_look_up_table[prefix_size - 1];


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9794

Problem Summary:

`align_size` is unused in release mode.

### What is changed and how it works?

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
