### PR TITLE
Re-enable jemalloc's background thread by default

### DIFF
--- a/dbms/src/Server/Setup.cpp
+++ b/dbms/src/Server/Setup.cpp
@@ -112,7 +112,7 @@ void setupAllocator([[maybe_unused]] const LoggerPtr & log)
 
     LOG_INFO(log, "Got jemalloc config: opt.background_thread {}, opt.max_background_threads {}", old_b, old_max_thd);
 
-    bool not_config_bg = !malloc_conf || strstr(malloc_conf, "background_thread") == NULL;
+    bool not_config_bg = !malloc_conf || strstr(malloc_conf, "background_thread") == nullptr;
     if (not_config_bg && !old_b)
     {
         // If the user doesn't explicitly set the background_thread opt, and it is actually false, then set it to true.

--- a/dbms/src/Server/Setup.cpp
+++ b/dbms/src/Server/Setup.cpp
@@ -112,8 +112,10 @@ void setupAllocator([[maybe_unused]] const LoggerPtr & log)
 
     LOG_INFO(log, "Got jemalloc config: opt.background_thread {}, opt.max_background_threads {}", old_b, old_max_thd);
 
-    if (!malloc_conf && !old_b)
+    bool not_config_bg = !malloc_conf || strstr(malloc_conf, "background_thread") == NULL;
+    if (not_config_bg && !old_b)
     {
+        // If the user doesn't explicitly set the background_thread opt, and it is actually false, then set it to true.
         LOG_INFO(log, "Try to use background_thread of jemalloc to handle purging asynchronously");
 
         RUN_FAIL_RETURN(je_mallctl("max_background_threads", nullptr, nullptr, (void *)&new_max_thd, sz_st));


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9812 ref #9722 

Problem Summary:

See issue 9812

### What is changed and how it works?

```commit-message
Re-enable jemalloc's background thread by default
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix an issue that the memory may stay in high level after large amount of data ingested
```
