### PR TITLE
fix false assert in tiflash debug binary after enable new string serde

### DIFF
--- a/dbms/src/Flash/Mpp/HashPartitionWriter.cpp
+++ b/dbms/src/Flash/Mpp/HashPartitionWriter.cpp
@@ -127,14 +127,14 @@ WriteResult HashPartitionWriter<ExchangeWriterPtr>::write(const Block & block)
     if (rows > 0)
     {
         rows_in_blocks += rows;
-        if (data_codec_version == MPPDataPacketV1)
+        if (data_codec_version >= MPPDataPacketV1)
             mem_size_in_blocks += block.bytes();
         blocks.push_back(block);
     }
 
     auto row_count_exceed = static_cast<Int64>(rows_in_blocks) >= batch_send_min_limit;
     auto row_bytes_exceed
-        = data_codec_version == MPPDataPacketV1 && mem_size_in_blocks >= MAX_BATCH_SEND_MIN_LIMIT_MEM_SIZE;
+        = data_codec_version >= MPPDataPacketV1 && mem_size_in_blocks >= MAX_BATCH_SEND_MIN_LIMIT_MEM_SIZE;
 
     if (row_count_exceed || row_bytes_exceed)
         return flush();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9824

Problem Summary:

### What is changed and how it works?
The root cause is in HashPartitionWriter, it need update `mem_size_in_blocks` if using `partitionAndWriteBlocksV1`, and if data_codec_version is MPPDataPacketV2, it use `partitionAndWriteBlocksV1` but not update `mem_size_in_blocks`  

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
