### PR TITLE
Storages: refine VectorIndexCache to LocalIndexCache

### DIFF
--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -53,8 +53,8 @@
 #include <Storages/DeltaMerge/ColumnFile/ColumnFileSchema.h>
 #include <Storages/DeltaMerge/DeltaIndexManager.h>
 #include <Storages/DeltaMerge/File/ColumnCacheLongTerm.h>
+#include <Storages/DeltaMerge/Index/LocalIndexCache.h>
 #include <Storages/DeltaMerge/Index/MinMaxIndex.h>
-#include <Storages/DeltaMerge/Index/VectorIndexCache.h>
 #include <Storages/DeltaMerge/LocalIndexerScheduler.h>
 #include <Storages/DeltaMerge/StoragePool/GlobalPageIdAllocator.h>
 #include <Storages/DeltaMerge/StoragePool/GlobalStoragePool.h>
@@ -148,7 +148,7 @@ struct ContextShared
     mutable DBGInvoker dbg_invoker; /// Execute inner functions, debug only.
     mutable MarkCachePtr mark_cache; /// Cache of marks in compressed files.
     mutable DM::MinMaxIndexCachePtr minmax_index_cache; /// Cache of minmax index in compressed files.
-    mutable DM::VectorIndexCachePtr vector_index_cache;
+    mutable DM::LocalIndexCachePtr local_index_cache;
     mutable DM::ColumnCacheLongTermPtr column_cache_long_term;
     mutable DM::DeltaIndexManagerPtr delta_index_manager; /// Manage the Delta Indies of Segments.
     ProcessList process_list; /// Executing queries at the moment.
@@ -1370,26 +1370,26 @@ void Context::dropMinMaxIndexCache() const
         shared->minmax_index_cache->reset();
 }
 
-void Context::setVectorIndexCache(size_t cache_entities)
+void Context::setLocalIndexCache(size_t cache_entities)
 {
     auto lock = getLock();
 
-    RUNTIME_CHECK(!shared->vector_index_cache);
+    RUNTIME_CHECK(!shared->local_index_cache);
 
-    shared->vector_index_cache = std::make_shared<DM::VectorIndexCache>(cache_entities);
+    shared->local_index_cache = std::make_shared<DM::LocalIndexCache>(cache_entities);
 }
 
-DM::VectorIndexCachePtr Context::getVectorIndexCache() const
+DM::LocalIndexCachePtr Context::getLocalIndexCache() const
 {
     auto lock = getLock();
-    return shared->vector_index_cache;
+    return shared->local_index_cache;
 }
 
-void Context::dropVectorIndexCache() const
+void Context::dropLocalIndexCache() const
 {
     auto lock = getLock();
-    if (shared->vector_index_cache)
-        shared->vector_index_cache.reset();
+    if (shared->local_index_cache)
+        shared->local_index_cache.reset();
 }
 
 void Context::setColumnCacheLongTerm(size_t cache_size_in_bytes)

--- a/dbms/src/Interpreters/Context.h
+++ b/dbms/src/Interpreters/Context.h
@@ -109,7 +109,7 @@ enum class PageStorageRunMode : UInt8;
 namespace DM
 {
 class MinMaxIndexCache;
-class VectorIndexCache;
+class LocalIndexCache;
 class ColumnCacheLongTerm;
 class DeltaIndexManager;
 class GlobalStoragePool;
@@ -399,9 +399,9 @@ public:
     std::shared_ptr<DM::MinMaxIndexCache> getMinMaxIndexCache() const;
     void dropMinMaxIndexCache() const;
 
-    void setVectorIndexCache(size_t cache_entities);
-    std::shared_ptr<DM::VectorIndexCache> getVectorIndexCache() const;
-    void dropVectorIndexCache() const;
+    void setLocalIndexCache(size_t cache_entities);
+    std::shared_ptr<DM::LocalIndexCache> getLocalIndexCache() const;
+    void dropLocalIndexCache() const;
 
     void setColumnCacheLongTerm(size_t cache_size_in_bytes);
     std::shared_ptr<DM::ColumnCacheLongTerm> getColumnCacheLongTerm() const;

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -1083,7 +1083,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
     /// The vector index cache by number instead of bytes. Because it use `mmap` and let the operator system decide the memory usage.
     size_t vec_index_cache_entities = config().getUInt64("vec_index_cache_entities", 1000);
     if (vec_index_cache_entities)
-        global_context->setVectorIndexCache(vec_index_cache_entities);
+        global_context->setLocalIndexCache(vec_index_cache_entities);
 
     size_t column_cache_long_term_size
         = config().getUInt64("column_cache_long_term_size", 512 * 1024 * 1024 /* 512MB */);

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSetWithVectorIndexInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSetWithVectorIndexInputStream.h
@@ -38,7 +38,7 @@ private:
     const ANNQueryInfoPtr ann_query_info;
     const BitmapFilterView valid_rows;
     // Global vector index cache
-    const VectorIndexCachePtr vec_index_cache;
+    const LocalIndexCachePtr vec_index_cache;
     const ColumnDefine vec_cd;
     const ColumnDefinesPtr rest_col_defs;
 
@@ -69,7 +69,7 @@ public:
         , data_provider(data_provider_)
         , ann_query_info(ann_query_info_)
         , valid_rows(std::move(valid_rows_))
-        , vec_index_cache(context_.global_context.getVectorIndexCache())
+        , vec_index_cache(context_.global_context.getLocalIndexCache())
         , vec_cd(std::move(vec_cd_))
         , rest_col_defs(rest_col_defs_)
         , column_files(reader.snapshot->getColumnFiles())

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileTinyVectorIndexReader.h
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileTinyVectorIndexReader.h
@@ -16,8 +16,8 @@
 
 #include <Storages/DeltaMerge/BitmapFilter/BitmapFilterView.h>
 #include <Storages/DeltaMerge/ColumnFile/ColumnFile.h>
+#include <Storages/DeltaMerge/Index/LocalIndex_fwd.h>
 #include <Storages/DeltaMerge/Index/VectorIndex.h>
-#include <Storages/DeltaMerge/Index/VectorIndexCache_fwd.h>
 
 
 namespace DB::DM
@@ -35,8 +35,8 @@ private:
     const BitmapFilterView valid_rows;
     // Note: ColumnDefine comes from read path does not have vector_index fields.
     const ColumnDefine vec_cd;
-    // Global vector index cache
-    const VectorIndexCachePtr vec_index_cache;
+    // Global local index cache
+    const LocalIndexCachePtr local_index_cache;
     LoggerPtr log;
 
     // Performance statistics
@@ -62,13 +62,13 @@ public:
         const ANNQueryInfoPtr & ann_query_info_,
         const BitmapFilterView && valid_rows_,
         const ColumnDefine & vec_cd_,
-        const VectorIndexCachePtr & vec_index_cache_)
+        const LocalIndexCachePtr & local_index_cache_)
         : tiny_file(tiny_file_)
         , data_provider(data_provider_)
         , ann_query_info(ann_query_info_)
         , valid_rows(std::move(valid_rows_))
         , vec_cd(vec_cd_)
-        , vec_index_cache(vec_index_cache_)
+        , local_index_cache(local_index_cache_)
         , log(Logger::get())
     {}
 

--- a/dbms/src/Storages/DeltaMerge/ConcatSkippableBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/ConcatSkippableBlockInputStream.h
@@ -15,7 +15,6 @@
 #pragma once
 
 #include <Flash/ResourceControl/LocalAdmissionController.h>
-#include <Storages/DeltaMerge/Index/VectorIndex_fwd.h>
 #include <Storages/DeltaMerge/ScanContext_fwd.h>
 #include <Storages/DeltaMerge/SkippableBlockInputStream.h>
 #include <Storages/DeltaMerge/VectorIndexBlockInputStream.h>

--- a/dbms/src/Storages/DeltaMerge/File/DMFile.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFile.h
@@ -191,7 +191,7 @@ public:
      */
     ColumnDefines getColumnDefines(bool sort_by_id = true) const
     {
-        ColumnDefines results{};
+        ColumnDefines results;
         results.reserve(this->meta->column_stats.size());
         for (const auto & cs : this->meta->column_stats)
         {

--- a/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.cpp
@@ -30,7 +30,7 @@ DMFileBlockInputStreamBuilder::DMFileBlockInputStreamBuilder(const Context & con
     setCaches(
         global_context.getMarkCache(),
         global_context.getMinMaxIndexCache(),
-        global_context.getVectorIndexCache(),
+        global_context.getLocalIndexCache(),
         global_context.getColumnCacheLongTerm());
     // init from settings
     setFromSettings(context.getSettingsRef());
@@ -229,7 +229,7 @@ SkippableBlockInputStreamPtr DMFileBlockInputStreamBuilder::build(
         std::move(rest_columns_reader),
         std::move(vec_column.value()),
         scan_context,
-        vector_index_cache,
+        local_index_cache,
         bitmap_filter.value(),
         tracing_id);
 

--- a/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.h
@@ -23,7 +23,6 @@
 #include <Storages/DeltaMerge/File/ColumnCacheLongTerm_fwd.h>
 #include <Storages/DeltaMerge/File/DMFileReader.h>
 #include <Storages/DeltaMerge/File/DMFileWithVectorIndexBlockInputStream_fwd.h>
-#include <Storages/DeltaMerge/Index/VectorIndexCache_fwd.h>
 #include <Storages/DeltaMerge/ReadThread/SegmentReader.h>
 #include <Storages/DeltaMerge/RowKeyRange.h>
 #include <Storages/DeltaMerge/ScanContext_fwd.h>
@@ -205,12 +204,12 @@ private:
     DMFileBlockInputStreamBuilder & setCaches(
         const MarkCachePtr & mark_cache_,
         const MinMaxIndexCachePtr & index_cache_,
-        const VectorIndexCachePtr & vector_index_cache_,
+        const LocalIndexCachePtr & local_index_cache_,
         const ColumnCacheLongTermPtr & column_cache_long_term_)
     {
         mark_cache = mark_cache_;
         index_cache = index_cache_;
-        vector_index_cache = vector_index_cache_;
+        local_index_cache = local_index_cache_;
         column_cache_long_term = column_cache_long_term_;
         return *this;
     }
@@ -243,7 +242,7 @@ private:
 
     ANNQueryInfoPtr ann_query_info = nullptr;
 
-    VectorIndexCachePtr vector_index_cache;
+    LocalIndexCachePtr local_index_cache;
     // Note: Currently thie field is assigned only for Stable streams, not available for ColumnFileBig
     std::optional<BitmapFilterView> bitmap_filter;
 

--- a/dbms/src/Storages/DeltaMerge/File/DMFileVectorIndexReader.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileVectorIndexReader.h
@@ -16,6 +16,7 @@
 
 #include <Storages/DeltaMerge/DeltaMergeDefines.h>
 #include <Storages/DeltaMerge/File/DMFile_fwd.h>
+#include <Storages/DeltaMerge/Index/LocalIndex_fwd.h>
 #include <Storages/DeltaMerge/Index/VectorIndex.h>
 #include <Storages/DeltaMerge/Index/VectorIndexCache_fwd.h>
 #include <Storages/DeltaMerge/ScanContext_fwd.h>
@@ -30,8 +31,8 @@ private:
     const ANNQueryInfoPtr & ann_query_info;
     const BitmapFilterView valid_rows;
     const ScanContextPtr & scan_context;
-    // Global vector index cache
-    const VectorIndexCachePtr vec_index_cache;
+    // Global local index cache
+    const LocalIndexCachePtr local_index_cache;
 
     // Performance statistics
     struct PerfStat
@@ -60,12 +61,12 @@ public:
         const DMFilePtr & dmfile_,
         const BitmapFilterView & valid_rows_,
         const ScanContextPtr & scan_context_,
-        const VectorIndexCachePtr & vec_index_cache_)
+        const LocalIndexCachePtr & local_index_cache_)
         : dmfile(dmfile_)
         , ann_query_info(ann_query_info_)
         , valid_rows(valid_rows_)
         , scan_context(scan_context_)
-        , vec_index_cache(vec_index_cache_)
+        , local_index_cache(local_index_cache_)
         , perf_stat()
     {}
 

--- a/dbms/src/Storages/DeltaMerge/File/DMFileWithVectorIndexBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileWithVectorIndexBlockInputStream.cpp
@@ -26,7 +26,7 @@ DMFileWithVectorIndexBlockInputStream::DMFileWithVectorIndexBlockInputStream(
     DMFileReader && reader_,
     ColumnDefine && vec_cd_,
     const ScanContextPtr & scan_context_,
-    const VectorIndexCachePtr & vec_index_cache_,
+    const LocalIndexCachePtr & local_index_cache_,
     const BitmapFilterView & valid_rows_,
     const String & tracing_id)
     : log(Logger::get(tracing_id))
@@ -41,7 +41,7 @@ DMFileWithVectorIndexBlockInputStream::DMFileWithVectorIndexBlockInputStream(
           dmfile,
           valid_rows_,
           scan_context,
-          vec_index_cache_))
+          local_index_cache_))
 {}
 
 DMFileWithVectorIndexBlockInputStream::~DMFileWithVectorIndexBlockInputStream()

--- a/dbms/src/Storages/DeltaMerge/File/DMFileWithVectorIndexBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileWithVectorIndexBlockInputStream.h
@@ -19,7 +19,7 @@
 #include <Storages/DeltaMerge/File/DMFileReader.h>
 #include <Storages/DeltaMerge/File/DMFileVectorIndexReader.h>
 #include <Storages/DeltaMerge/File/DMFileWithVectorIndexBlockInputStream_fwd.h>
-#include <Storages/DeltaMerge/Index/VectorIndex_fwd.h>
+#include <Storages/DeltaMerge/Index/LocalIndex_fwd.h>
 #include <Storages/DeltaMerge/VectorIndexBlockInputStream.h>
 
 
@@ -60,7 +60,7 @@ public:
         DMFileReader && reader,
         ColumnDefine && vec_cd,
         const ScanContextPtr & scan_context,
-        const VectorIndexCachePtr & vec_index_cache,
+        const LocalIndexCachePtr & local_index_cache,
         const BitmapFilterView & valid_rows,
         const String & tracing_id)
     {
@@ -71,7 +71,7 @@ public:
             std::move(reader),
             std::move(vec_cd),
             scan_context,
-            vec_index_cache,
+            local_index_cache,
             valid_rows,
             tracing_id);
     }
@@ -83,7 +83,7 @@ public:
         DMFileReader && reader_,
         ColumnDefine && vec_cd_,
         const ScanContextPtr & scan_context_,
-        const VectorIndexCachePtr & vec_index_cache_,
+        const LocalIndexCachePtr & local_index_cache_,
         const BitmapFilterView & valid_rows_,
         const String & tracing_id);
 

--- a/dbms/src/Storages/DeltaMerge/Filter/RSOperator.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/RSOperator.h
@@ -17,9 +17,9 @@
 #include <Common/FieldVisitors.h>
 #include <Storages/DeltaMerge/DeltaMergeDefines.h>
 #include <Storages/DeltaMerge/Filter/RSOperator_fwd.h>
+#include <Storages/DeltaMerge/Index/LocalIndex_fwd.h>
 #include <Storages/DeltaMerge/Index/RSIndex.h>
 #include <Storages/DeltaMerge/Index/RSResult.h>
-#include <Storages/DeltaMerge/Index/VectorIndex_fwd.h>
 
 namespace DB
 {

--- a/dbms/src/Storages/DeltaMerge/Index/LocalIndexCache.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/LocalIndexCache.cpp
@@ -13,14 +13,14 @@
 // limitations under the License.
 
 #include <Poco/File.h>
-#include <Storages/DeltaMerge/Index/VectorIndexCache.h>
+#include <Storages/DeltaMerge/Index/LocalIndexCache.h>
 
 #include <mutex>
 
 namespace DB::DM
 {
 
-size_t VectorIndexCache::cleanOutdatedCacheEntries()
+size_t LocalIndexCache::cleanOutdatedCacheEntries()
 {
     size_t cleaned = 0;
 
@@ -60,7 +60,7 @@ size_t VectorIndexCache::cleanOutdatedCacheEntries()
     return cleaned;
 }
 
-void VectorIndexCache::cleanOutdatedLoop()
+void LocalIndexCache::cleanOutdatedLoop()
 {
     while (true)
     {
@@ -83,14 +83,14 @@ void VectorIndexCache::cleanOutdatedLoop()
     }
 }
 
-VectorIndexCache::VectorIndexCache(size_t max_entities)
+LocalIndexCache::LocalIndexCache(size_t max_entities)
     : cache(max_entities)
     , log(Logger::get())
 {
     cleaner_thread = std::thread([this] { cleanOutdatedLoop(); });
 }
 
-VectorIndexCache::~VectorIndexCache()
+LocalIndexCache::~LocalIndexCache()
 {
     is_shutting_down = true;
     shutdown_cv.notify_all();

--- a/dbms/src/Storages/DeltaMerge/Index/LocalIndexCache.h
+++ b/dbms/src/Storages/DeltaMerge/Index/LocalIndexCache.h
@@ -63,7 +63,7 @@ private:
     std::thread cleaner_thread;
 
 public:
-    static constexpr const char * COLUMNFILETINY_INDEX_NAME_PREFIX = "vec_index_page_";
+    static constexpr const char * COLUMNFILETINY_INDEX_NAME_PREFIX = "local_index_page_";
     explicit LocalIndexCache(size_t max_entities);
 
     ~LocalIndexCache();

--- a/dbms/src/Storages/DeltaMerge/Index/LocalIndexCache.h
+++ b/dbms/src/Storages/DeltaMerge/Index/LocalIndexCache.h
@@ -15,8 +15,8 @@
 #pragma once
 
 #include <Common/LRUCache.h>
-#include <Storages/DeltaMerge/Index/VectorIndexCache_fwd.h>
-#include <Storages/DeltaMerge/Index/VectorIndex_fwd.h>
+#include <Storages/DeltaMerge/Index/LocalIndexViewer.h>
+#include <Storages/DeltaMerge/Index/LocalIndex_fwd.h>
 #include <common/types.h>
 
 #include <condition_variable>
@@ -33,10 +33,10 @@ class VectorIndexTestUtils;
 namespace DB::DM
 {
 
-class VectorIndexCache
+class LocalIndexCache
 {
 private:
-    using Cache = LRUCache<String, VectorIndexViewer>;
+    using Cache = LRUCache<String, LocalIndexViewer>;
 
     Cache cache;
     LoggerPtr log;
@@ -64,9 +64,9 @@ private:
 
 public:
     static constexpr const char * COLUMNFILETINY_INDEX_NAME_PREFIX = "vec_index_page_";
-    explicit VectorIndexCache(size_t max_entities);
+    explicit LocalIndexCache(size_t max_entities);
 
-    ~VectorIndexCache();
+    ~LocalIndexCache();
 
     template <typename LoadFunc>
     Cache::MappedPtr getOrSet(const Cache::Key & file_path, LoadFunc && load)

--- a/dbms/src/Storages/DeltaMerge/Index/LocalIndexViewer.h
+++ b/dbms/src/Storages/DeltaMerge/Index/LocalIndexViewer.h
@@ -14,17 +14,16 @@
 
 #pragma once
 
-#include <tipb/executor.pb.h>
-
 namespace DB::DM
 {
 
-using ANNQueryInfoPtr = std::shared_ptr<tipb::ANNQueryInfo>;
+/// Viewer for local index. 
+class LocalIndexViewer
+{
+public:
+    explicit LocalIndexViewer() = default;
 
-class VectorIndexBuilder;
-using VectorIndexBuilderPtr = std::shared_ptr<VectorIndexBuilder>;
-
-class VectorIndexViewer;
-using VectorIndexViewerPtr = std::shared_ptr<VectorIndexViewer>;
+    virtual ~LocalIndexViewer() = default;
+};
 
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/Index/LocalIndex_fwd.h
+++ b/dbms/src/Storages/DeltaMerge/Index/LocalIndex_fwd.h
@@ -1,4 +1,4 @@
-// Copyright 2023 PingCAP, Inc.
+// Copyright 2024 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,16 +14,28 @@
 
 #pragma once
 
-#include <Storages/KVStore/Types.h>
-#include <TiDB/Schema/TiDB_fwd.h>
+#include <tipb/executor.pb.h>
 
 #include <memory>
-#include <vector>
 
 namespace DB::DM
 {
-struct ColumnDefine;
-using ColumnDefines = std::vector<ColumnDefine>;
-using ColumnDefinesPtr = std::shared_ptr<ColumnDefines>;
+
+class LocalIndexViewer;
+using LocalIndexViewerPtr = std::shared_ptr<LocalIndexViewer>;
+
+class LocalIndexBuilder;
+using LocalIndexBuilderPtr = std::shared_ptr<LocalIndexBuilder>;
+
+class LocalIndexCache;
+using LocalIndexCachePtr = std::shared_ptr<LocalIndexCache>;
+
+using ANNQueryInfoPtr = std::shared_ptr<tipb::ANNQueryInfo>;
+
+class VectorIndexBuilder;
+using VectorIndexBuilderPtr = std::shared_ptr<VectorIndexBuilder>;
+
+class VectorIndexViewer;
+using VectorIndexViewerPtr = std::shared_ptr<VectorIndexViewer>;
 
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/Index/VectorIndex.h
+++ b/dbms/src/Storages/DeltaMerge/Index/VectorIndex.h
@@ -20,7 +20,8 @@
 #include <IO/Buffer/ReadBuffer.h>
 #include <IO/Buffer/WriteBuffer.h>
 #include <Storages/DeltaMerge/BitmapFilter/BitmapFilterView.h>
-#include <Storages/DeltaMerge/Index/VectorIndex_fwd.h>
+#include <Storages/DeltaMerge/Index/LocalIndexViewer.h>
+#include <Storages/DeltaMerge/Index/LocalIndex_fwd.h>
 #include <Storages/DeltaMerge/dtpb/dmfile.pb.h>
 #include <Storages/KVStore/Types.h>
 #include <TiDB/Schema/VectorIndex.h>
@@ -65,7 +66,7 @@ public:
 
 /// Views a VectorIndex file.
 /// It may nor may not read the whole content of the file into memory.
-class VectorIndexViewer
+class VectorIndexViewer : public LocalIndexViewer
 {
 public:
     /// The key is the row's offset in the DMFile.
@@ -91,7 +92,7 @@ public:
         : file_props(file_props_)
     {}
 
-    virtual ~VectorIndexViewer() = default;
+    ~VectorIndexViewer() override = default;
 
     // Invalid rows in `valid_rows` will be discared when applying the search
     virtual std::vector<SearchResult> search(const ANNQueryInfoPtr & queryInfo, const RowFilter & valid_rows) const = 0;

--- a/dbms/src/Storages/DeltaMerge/StableValueSpace.h
+++ b/dbms/src/Storages/DeltaMerge/StableValueSpace.h
@@ -21,8 +21,8 @@
 #include <Storages/DeltaMerge/File/DMFilePackFilter_fwd.h>
 #include <Storages/DeltaMerge/File/DMFile_fwd.h>
 #include <Storages/DeltaMerge/Filter/RSOperator_fwd.h>
+#include <Storages/DeltaMerge/Index/LocalIndex_fwd.h>
 #include <Storages/DeltaMerge/Index/RSResult.h>
-#include <Storages/DeltaMerge/Index/VectorIndex_fwd.h>
 #include <Storages/DeltaMerge/ReadMode.h>
 #include <Storages/DeltaMerge/RowKeyRange.h>
 #include <Storages/DeltaMerge/SkippableBlockInputStream.h>

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_vector_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_vector_index.cpp
@@ -21,8 +21,8 @@
 #include <Storages/DeltaMerge/File/DMFileBlockOutputStream.h>
 #include <Storages/DeltaMerge/File/DMFileLocalIndexWriter.h>
 #include <Storages/DeltaMerge/Filter/RSOperator.h>
+#include <Storages/DeltaMerge/Index/LocalIndexCache.h>
 #include <Storages/DeltaMerge/Index/LocalIndexInfo.h>
-#include <Storages/DeltaMerge/Index/VectorIndexCache.h>
 #include <Storages/DeltaMerge/Remote/Serializer.h>
 #include <Storages/DeltaMerge/ScanContext.h>
 #include <Storages/DeltaMerge/StoragePool/GlobalPageIdAllocator.h>
@@ -1735,7 +1735,7 @@ public:
         global_context.tryReleaseWriteNodePageStorageForTest();
         global_context.initializeWriteNodePageStorageIfNeed(global_context.getPathPool());
 
-        global_context.setVectorIndexCache(1000);
+        global_context.setLocalIndexCache(1000);
 
         auto kvstore = db_context->getTMTContext().getKVStore();
         {
@@ -1784,7 +1784,7 @@ public:
         FileCache::shutdown();
 
         auto & global_context = TiFlashTestEnv::getGlobalContext();
-        global_context.dropVectorIndexCache();
+        global_context.dropLocalIndexCache();
         global_context.getSharedContextDisagg()->remote_data_store = nullptr;
         global_context.setPageStorageRunMode(orig_mode);
 
@@ -2308,9 +2308,9 @@ try
     }
     {
         // We should be able to clear something from the vector index cache.
-        auto vec_cache = TiFlashTestEnv::getGlobalContext().getVectorIndexCache();
-        ASSERT_NE(vec_cache, nullptr);
-        ASSERT_EQ(1, cleanVectorCacheEntries(vec_cache));
+        auto local_index_cache = TiFlashTestEnv::getGlobalContext().getLocalIndexCache();
+        ASSERT_NE(local_index_cache, nullptr);
+        ASSERT_EQ(1, cleanLocalIndexCacheEntries(local_index_cache));
     }
     {
         // When cache is evicted (and memory cache is dropped), the query should be fine.
@@ -2448,9 +2448,9 @@ try
     }
     {
         // We should be able to clear something from the vector index cache.
-        auto vec_cache = TiFlashTestEnv::getGlobalContext().getVectorIndexCache();
-        ASSERT_NE(vec_cache, nullptr);
-        ASSERT_EQ(1, cleanVectorCacheEntries(vec_cache));
+        auto local_index_cache = TiFlashTestEnv::getGlobalContext().getLocalIndexCache();
+        ASSERT_NE(local_index_cache, nullptr);
+        ASSERT_EQ(1, cleanLocalIndexCacheEntries(local_index_cache));
     }
     {
         // Query should be fine.

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_vector_index_utils.h
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_vector_index_utils.h
@@ -16,8 +16,8 @@
 
 #include <Core/ColumnWithTypeAndName.h>
 #include <Storages/DeltaMerge/Filter/RSOperator.h>
+#include <Storages/DeltaMerge/Index/LocalIndexCache.h>
 #include <Storages/DeltaMerge/Index/LocalIndexInfo.h>
-#include <Storages/DeltaMerge/Index/VectorIndexCache.h>
 #include <Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_test_basic.h>
 #include <Storages/DeltaMerge/tests/gtest_segment_util.h>
 #include <TestUtils/FunctionTestUtils.h>
@@ -72,7 +72,7 @@ public:
         return ColumnDefine(vec_column_id, vec_column_name, ::DB::tests::typeFromString("Array(Float32)"));
     }
 
-    static size_t cleanVectorCacheEntries(const std::shared_ptr<VectorIndexCache> & cache)
+    static size_t cleanLocalIndexCacheEntries(const std::shared_ptr<LocalIndexCache> & cache)
     {
         return cache->cleanOutdatedCacheEntries();
     }

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_replace_stable_data.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_replace_stable_data.cpp
@@ -451,7 +451,7 @@ public:
         }
 
         auto & global_context = TiFlashTestEnv::getGlobalContext();
-        // global_context.dropVectorIndexCache();
+        // global_context.dropLocalIndexCache();
         global_context.getSharedContextDisagg()->remote_data_store = nullptr;
         global_context.setPageStorageRunMode(orig_mode);
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #9032

Problem Summary:

### What is changed and how it works?

```commit-message
In order to accept more index kinds like FullTextIndex, this PR refine VectorIndexCache to LocalIndexCache.
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
