### PR TITLE
vector: fix ANN query info not wrapped in disaggregated mode

### DIFF
--- a/dbms/src/Storages/StorageDisaggregatedRemote.cpp
+++ b/dbms/src/Storages/StorageDisaggregatedRemote.cpp
@@ -483,16 +483,7 @@ DM::RSOperatorPtr StorageDisaggregated::buildRSOperator(
     const Context & db_context,
     const DM::ColumnDefinesPtr & columns_to_read)
 {
-    if (!filter_conditions.hasValue())
-        return DM::EMPTY_RS_OPERATOR;
-
     const bool enable_rs_filter = db_context.getSettingsRef().dt_enable_rough_set_filter;
-    if (!enable_rs_filter)
-    {
-        LOG_DEBUG(log, "Rough set filter is disabled.");
-        return DM::EMPTY_RS_OPERATOR;
-    }
-
     auto dag_query = std::make_unique<DAGQueryInfo>(
         filter_conditions.conditions,
         table_scan.getANNQueryInfo(),


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9847

Problem Summary:

### What is changed and how it works?

We will wrap ANN query info in `DM::RSOperator::build()`, but `filter_conditions.hasValue() = false` makes early return.

Introduce by https://github.com/pingcap/tiflash/pull/9547, fixed by https://github.com/pingcap/tiflash/pull/9741 in master branch.

```commit-message
vector: fix ANN query info not wrapped
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix a bug that vector index is not used when executing vector search queries under disaggregated compute and storage arch
```
