### PR TITLE
vector: Reduce logging under debug level

### DIFF
--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -2047,7 +2047,7 @@ void DeltaMergeStore::applyLocalIndexChange(const TiDB::TableInfo & new_table_in
     // no index is created or dropped
     if (!changeset.new_local_index_infos)
     {
-        LOG_DEBUG(log, "Local index info does not changed, {}", changeset.toDebugString(/*simple*/ false));
+        LOG_DEBUG(log, "Local index info does not changed, {}", changeset.toDebugString());
         return;
     }
 
@@ -2057,10 +2057,10 @@ void DeltaMergeStore::applyLocalIndexChange(const TiDB::TableInfo & new_table_in
         local_index_infos.swap(changeset.new_local_index_infos);
     }
 
-    LOG_INFO(log, "Local index info generated, {}", changeset.toDebugString(/*simple*/ true));
+    LOG_INFO(log, "Local index info generated, {}", changeset.toDebugString());
 
     // generate async tasks for building local index for all segments
-    checkAllSegmentsLocalIndex(std::move(changeset.dropped_indexes));
+    checkAllSegmentsLocalIndex(changeset.copyDroppedIndexes());
 }
 
 SortDescription DeltaMergeStore::getPrimarySortDescription() const

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -2047,7 +2047,7 @@ void DeltaMergeStore::applyLocalIndexChange(const TiDB::TableInfo & new_table_in
     // no index is created or dropped
     if (!changeset.new_local_index_infos)
     {
-        LOG_DEBUG(log, "Local index info does not changed, {}", changeset.toDebugString());
+        LOG_DEBUG(log, "Local index info does not changed, {}", changeset.toString());
         return;
     }
 
@@ -2057,7 +2057,7 @@ void DeltaMergeStore::applyLocalIndexChange(const TiDB::TableInfo & new_table_in
         local_index_infos.swap(changeset.new_local_index_infos);
     }
 
-    LOG_INFO(log, "Local index info generated, {}", changeset.toDebugString());
+    LOG_INFO(log, "Local index info generated, {}", changeset.toString());
 
     // generate async tasks for building local index for all segments
     checkAllSegmentsLocalIndex(changeset.copyDroppedIndexes());

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -2046,13 +2046,18 @@ void DeltaMergeStore::applyLocalIndexChange(const TiDB::TableInfo & new_table_in
 
     // no index is created or dropped
     if (!changeset.new_local_index_infos)
+    {
+        LOG_DEBUG(log, "Local index info does not changed, {}", changeset.toDebugString(/*simple*/ false));
         return;
+    }
 
     {
         // new index created, update the info in-memory thread safety between `getLocalIndexInfosSnapshot`
         std::unique_lock index_write_lock(mtx_local_index_infos);
         local_index_infos.swap(changeset.new_local_index_infos);
     }
+
+    LOG_INFO(log, "Local index info generated, {}", changeset.toDebugString(/*simple*/ true));
 
     // generate async tasks for building local index for all segments
     checkAllSegmentsLocalIndex(std::move(changeset.dropped_indexes));

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
@@ -30,7 +30,7 @@
 #include <Storages/DeltaMerge/File/DMFile_fwd.h>
 #include <Storages/DeltaMerge/Filter/PushDownExecutor.h>
 #include <Storages/DeltaMerge/Filter/RSOperator_fwd.h>
-#include <Storages/DeltaMerge/Index/LocalIndexInfo.h>
+#include <Storages/DeltaMerge/Index/LocalIndexInfo_fwd.h>
 #include <Storages/DeltaMerge/Remote/DisaggSnapshot_fwd.h>
 #include <Storages/DeltaMerge/RowKeyRange.h>
 #include <Storages/DeltaMerge/ScanContext_fwd.h>

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalSegment.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalSegment.cpp
@@ -517,7 +517,7 @@ void DeltaMergeStore::checkAllSegmentsLocalIndex(std::vector<IndexID> && dropped
         for (const auto & [end, segment] : segments)
         {
             UNUSED(end);
-            // cleanup the index error messaage for dropped indexes
+            // cleanup the index error message for dropped indexes
             segment->clearIndexBuildError(dropped_indexes);
 
             if (segmentEnsureStableLocalIndexAsync(segment))

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_Statistics.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore_Statistics.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <Storages/DeltaMerge/DeltaMergeStore.h>
+#include <Storages/DeltaMerge/Index/LocalIndexInfo.h>
 #include <Storages/DeltaMerge/Segment.h>
 #include <Storages/DeltaMerge/StoragePool/StoragePool.h>
 #include <Storages/Page/PageStorage.h>

--- a/dbms/src/Storages/DeltaMerge/Index/LocalIndexInfo.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/LocalIndexInfo.cpp
@@ -225,7 +225,7 @@ LocalIndexInfosChangeset generateLocalIndexInfos(
     return getChangeset(std::move(new_index_infos), original_local_index_id_map, newly_added, newly_dropped);
 }
 
-String LocalIndexInfosChangeset::toDebugString() const
+String LocalIndexInfosChangeset::toString() const
 {
     FmtBuffer buf;
     buf.append("keep=[");

--- a/dbms/src/Storages/DeltaMerge/Index/LocalIndexInfo.h
+++ b/dbms/src/Storages/DeltaMerge/Index/LocalIndexInfo.h
@@ -61,7 +61,11 @@ LocalIndexInfosPtr initLocalIndexInfos(const TiDB::TableInfo & table_info, const
 struct LocalIndexInfosChangeset
 {
     LocalIndexInfosPtr new_local_index_infos;
+    std::vector<IndexID> keep_indexes;
+    std::vector<IndexID> added_indexes;
     std::vector<IndexID> dropped_indexes;
+
+    String toDebugString(bool simple) const;
 };
 
 // Generate a changeset according to `existing_indexes` and `new_table_info`

--- a/dbms/src/Storages/DeltaMerge/Index/LocalIndexInfo.h
+++ b/dbms/src/Storages/DeltaMerge/Index/LocalIndexInfo.h
@@ -97,7 +97,7 @@ public:
         return r;
     }
 
-    String toDebugString() const;
+    String toString() const;
 };
 
 // Generate a changeset according to `existing_indexes` and `new_table_info`

--- a/dbms/src/Storages/DeltaMerge/Index/LocalIndexInfo.h
+++ b/dbms/src/Storages/DeltaMerge/Index/LocalIndexInfo.h
@@ -66,7 +66,7 @@ public:
     LocalIndexInfosPtr new_local_index_infos;
     // This vector store all the keep/added/dropped index IDs.
     // The keep indexes: [0, added_indexes_offset)
-    // The added indexes: [added_indexes_offset, added_indexes_offset + dropped_indexes_offset)
+    // The added indexes: [added_indexes_offset, dropped_indexes_offset)
     // The dropped indexes: [dropped_index_offset, end-of-the-vector)
     const std::vector<IndexID> all_indexes;
     const size_t added_indexes_offset;
@@ -75,17 +75,19 @@ public:
 public:
     std::span<const IndexID> keepIndexes() const
     {
+        assert(added_indexes_offset <= all_indexes.size());
         return std::span(all_indexes.begin(), all_indexes.begin() + added_indexes_offset);
     }
     std::span<const IndexID> addedIndexes() const
     {
-        return std::span(
-            all_indexes.begin() + added_indexes_offset,
-            all_indexes.begin() + added_indexes_offset + dropped_indexes_offset);
+        assert(added_indexes_offset <= dropped_indexes_offset && added_indexes_offset <= all_indexes.size());
+        assert(dropped_indexes_offset <= all_indexes.size());
+        return std::span(all_indexes.begin() + added_indexes_offset, all_indexes.begin() + dropped_indexes_offset);
     }
     std::span<const IndexID> droppedIndexes() const
     {
-        return std::span(all_indexes.begin() + added_indexes_offset + dropped_indexes_offset, all_indexes.end());
+        assert(dropped_indexes_offset <= all_indexes.size());
+        return std::span(all_indexes.begin() + dropped_indexes_offset, all_indexes.end());
     }
     std::vector<IndexID> copyDroppedIndexes() const
     {

--- a/dbms/src/Storages/DeltaMerge/Index/LocalIndexInfo_fwd.h
+++ b/dbms/src/Storages/DeltaMerge/Index/LocalIndexInfo_fwd.h
@@ -25,6 +25,6 @@ using LocalIndexInfos = std::vector<LocalIndexInfo>;
 using LocalIndexInfosPtr = std::shared_ptr<LocalIndexInfos>;
 using LocalIndexInfosSnapshot = std::shared_ptr<const LocalIndexInfos>;
 
-struct LocalIndexInfosChangeset;
+class LocalIndexInfosChangeset;
 
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_local_index_info.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_local_index_info.cpp
@@ -42,8 +42,10 @@ try
     LocalIndexInfosPtr index_info = nullptr;
     // check the same
     {
-        auto new_index_info = generateLocalIndexInfos(index_info, table_info, logger).new_local_index_infos;
+        auto changeset = generateLocalIndexInfos(index_info, table_info, logger);
+        auto new_index_info = changeset.new_local_index_infos;
         ASSERT_EQ(new_index_info, nullptr);
+        LOG_INFO(logger, changeset.toString());
         // check again, nothing changed, return nullptr
         ASSERT_EQ(nullptr, generateLocalIndexInfos(new_index_info, table_info, logger).new_local_index_infos);
 
@@ -121,7 +123,8 @@ try
 
     // check the different
     {
-        auto new_index_info = generateLocalIndexInfos(index_info, table_info, logger).new_local_index_infos;
+        auto changeset = generateLocalIndexInfos(index_info, table_info, logger);
+        auto new_index_info = changeset.new_local_index_infos;
         ASSERT_NE(new_index_info, nullptr);
         ASSERT_EQ(new_index_info->size(), 1);
         const auto & idx = (*new_index_info)[0];
@@ -132,6 +135,11 @@ try
         ASSERT_EQ(expect_idx.vector_index->kind, idx.def_vector_index->kind);
         ASSERT_EQ(expect_idx.vector_index->dimension, idx.def_vector_index->dimension);
         ASSERT_EQ(expect_idx.vector_index->distance_metric, idx.def_vector_index->distance_metric);
+
+        ASSERT_EQ(0, changeset.keepIndexes().size());
+        ASSERT_EQ(1, changeset.addedIndexes().size());
+        ASSERT_EQ(0, changeset.droppedIndexes().size());
+        LOG_INFO(logger, changeset.toString());
 
         // check again, nothing changed, return nullptr
         ASSERT_EQ(nullptr, generateLocalIndexInfos(new_index_info, table_info, logger).new_local_index_infos);
@@ -154,7 +162,8 @@ try
     }
     // check the different
     {
-        auto new_index_info = generateLocalIndexInfos(index_info, table_info, logger).new_local_index_infos;
+        auto changeset = generateLocalIndexInfos(index_info, table_info, logger);
+        auto new_index_info = changeset.new_local_index_infos;
         ASSERT_NE(new_index_info, nullptr);
         ASSERT_EQ(new_index_info->size(), 2);
         const auto & idx0 = (*new_index_info)[0];
@@ -174,6 +183,11 @@ try
         ASSERT_EQ(expect_idx2.vector_index->dimension, idx1.def_vector_index->dimension);
         ASSERT_EQ(expect_idx2.vector_index->distance_metric, idx1.def_vector_index->distance_metric);
 
+        ASSERT_EQ(1, changeset.keepIndexes().size());
+        ASSERT_EQ(1, changeset.addedIndexes().size());
+        ASSERT_EQ(0, changeset.droppedIndexes().size());
+        LOG_INFO(logger, changeset.toString());
+
         // check again, nothing changed, return nullptr
         ASSERT_EQ(nullptr, generateLocalIndexInfos(new_index_info, table_info, logger).new_local_index_infos);
 
@@ -181,7 +195,7 @@ try
         index_info = new_index_info;
     }
 
-    // Remove the second vecotr index and add a new vector index to the TableInfo.
+    // Remove the second vector index and add a new vector index to the TableInfo.
     TiDB::IndexInfo expect_idx3;
     {
         // drop the second index
@@ -198,7 +212,8 @@ try
     }
     // check the different
     {
-        auto new_index_info = generateLocalIndexInfos(index_info, table_info, logger).new_local_index_infos;
+        auto changeset = generateLocalIndexInfos(index_info, table_info, logger);
+        auto new_index_info = changeset.new_local_index_infos;
         ASSERT_NE(new_index_info, nullptr);
         ASSERT_EQ(new_index_info->size(), 2);
         const auto & idx0 = (*new_index_info)[0];
@@ -217,6 +232,11 @@ try
         ASSERT_EQ(expect_idx3.vector_index->kind, idx1.def_vector_index->kind);
         ASSERT_EQ(expect_idx3.vector_index->dimension, idx1.def_vector_index->dimension);
         ASSERT_EQ(expect_idx3.vector_index->distance_metric, idx1.def_vector_index->distance_metric);
+
+        ASSERT_EQ(1, changeset.keepIndexes().size());
+        ASSERT_EQ(1, changeset.addedIndexes().size());
+        ASSERT_EQ(1, changeset.droppedIndexes().size());
+        LOG_INFO(logger, changeset.toString());
 
         // check again, nothing changed, return nullptr
         ASSERT_EQ(nullptr, generateLocalIndexInfos(new_index_info, table_info, logger).new_local_index_infos);

--- a/dbms/src/Storages/KVStore/FFI/ProxyFFIStatusService.cpp
+++ b/dbms/src/Storages/KVStore/FFI/ProxyFFIStatusService.cpp
@@ -390,7 +390,8 @@ HttpRequestRes HandleHttpRequestSyncSchema(
             status = HttpRequestStatus::ErrorParam;
             return HttpRequestRes{
                 .status = HttpRequestStatus::ErrorParam,
-                .res = CppStrWithView{.inner = GenRawCppPtr(), .view = BaseBuffView{nullptr, 0}}};
+                .res = CppStrWithView{.inner = GenRawCppPtr(), .view = BaseBuffView{nullptr, 0}},
+            };
         }
 
         try
@@ -406,7 +407,9 @@ HttpRequestRes HandleHttpRequestSyncSchema(
         if (status != HttpRequestStatus::Ok)
             return HttpRequestRes{
                 .status = status,
-                .res = CppStrWithView{.inner = GenRawCppPtr(), .view = BaseBuffView{nullptr, 0}}};
+                .res = CppStrWithView{.inner = GenRawCppPtr(), .view = BaseBuffView{nullptr, 0},
+                },
+            };
     }
 
     std::string err_msg;
@@ -441,12 +444,15 @@ HttpRequestRes HandleHttpRequestSyncSchema(
             .status = HttpRequestStatus::ErrorParam,
             .res = CppStrWithView{
                 .inner = GenRawCppPtr(s, RawCppPtrTypeImpl::String),
-                .view = BaseBuffView{s->data(), s->size()}}};
+                .view = BaseBuffView{s->data(), s->size()},
+            },
+        };
     }
 
     return HttpRequestRes{
         .status = status,
-        .res = CppStrWithView{.inner = GenRawCppPtr(), .view = BaseBuffView{nullptr, 0}}};
+        .res = CppStrWithView{.inner = GenRawCppPtr(), .view = BaseBuffView{nullptr, 0}},
+    };
 }
 
 using HANDLE_HTTP_URI_METHOD = HttpRequestRes (*)(

--- a/dbms/src/Storages/StorageDeltaMerge.h
+++ b/dbms/src/Storages/StorageDeltaMerge.h
@@ -24,7 +24,7 @@
 #include <Storages/DeltaMerge/DeltaMergeInterfaces.h>
 #include <Storages/DeltaMerge/DeltaMergeStore.h>
 #include <Storages/DeltaMerge/Filter/PushDownExecutor.h>
-#include <Storages/DeltaMerge/Index/LocalIndexInfo.h>
+#include <Storages/DeltaMerge/Index/LocalIndexInfo_fwd.h>
 #include <Storages/DeltaMerge/Remote/DisaggSnapshot_fwd.h>
 #include <Storages/DeltaMerge/ScanContext_fwd.h>
 #include <Storages/DeltaMerge/Segment_fwd.h>

--- a/dbms/src/Storages/System/StorageSystemDTLocalIndexes.cpp
+++ b/dbms/src/Storages/System/StorageSystemDTLocalIndexes.cpp
@@ -67,11 +67,11 @@ std::optional<DM::LocalIndexesStats> getLocalIndexesStatsFromStorage(const Stora
         return std::nullopt;
 
     const auto & table_info = dm_storage->getTableInfo();
-    auto store = dm_storage->getStoreIfInited();
-    if (!store)
-        return DM::DeltaMergeStore::genLocalIndexStatsByTableInfo(table_info);
+    if (auto store = dm_storage->getStoreIfInited(); store)
+        return store->getLocalIndexStats();
 
-    return store->getLocalIndexStats();
+    // Check whether there exist any local index without initiating the store
+    return DM::DeltaMergeStore::genLocalIndexStatsByTableInfo(table_info);
 }
 
 BlockInputStreams StorageSystemDTLocalIndexes::read(


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/9854

Problem Summary:

When we try to add a vector index on a relative large table, there are much useless logging under debug level

* After DDL owner try to add a vector index, the tidb ddl owner will get the add index progress by fetching `system.dt_local_indexes` from all tiflash instances
* `StorageSystemDTLocalIndexes::read` call `getLocalIndexesStatsFromStorage`. For non-inited `DeltaMergeStore`, the function calls `genLocalIndexStatsByTableInfo` -> `initLocalIndexInfos` -> `generateLocalIndexInfos` and generate useless logging like `"Local index info does not changed, ..."` for each `StorageDeltaMerge`. This will cause much debug logging when there are lots of tables in the cluster

### What is changed and how it works?

```commit-message
* Move the logging from `generateLocalIndexInfos` to `DeltaMergeStore::applyLocalIndexChange`. Reduce logging that is not cause by DDL changed
* Return the keep/added/dropped index ids in `LocalIndexInfosChangeset` and generate the changeset logging string by `LocalIndexInfosChangeset::toString`
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```
Deploy a cluster with tiflash and enable debug level logging
Load a dataset with 1m vector data
Add vector index and wait
```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
