### PR TITLE
remove OVERFLOW_AS_WARNING flag

### DIFF
--- a/dbms/src/Debug/dbgQueryCompiler.h
+++ b/dbms/src/Debug/dbgQueryCompiler.h
@@ -95,8 +95,7 @@ struct QueryFragment
         tipb::DAGRequest & dag_request = *dag_request_ptr;
         dag_request.set_time_zone_name(properties.tz_name);
         dag_request.set_time_zone_offset(properties.tz_offset);
-        dag_request.set_flags(
-            dag_request.flags() | (1u << 1u /* TRUNCATE_AS_WARNING */) | (1u << 6u /* OVERFLOW_AS_WARNING */));
+        dag_request.set_flags(dag_request.flags() | (1u << 1u /* TRUNCATE_AS_WARNING */));
         if (is_top_fragment)
         {
             if (properties.encode_type == "chunk")

--- a/dbms/src/Flash/Coprocessor/DAGContext.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGContext.cpp
@@ -358,22 +358,24 @@ std::unordered_map<String, BlockInputStreams> & DAGContext::getInBoundIOInputStr
     return inbound_io_input_streams_map;
 }
 
-void DAGContext::handleTruncateError(const String & msg)
+void DAGContext::handleTruncateErrorInternal(const String & msg)
 {
     if (!(flags & TiDBSQLFlags::IGNORE_TRUNCATE || flags & TiDBSQLFlags::TRUNCATE_AS_WARNING))
     {
-        throw TiFlashException("Truncate error " + msg, Errors::Types::Truncated);
+        throw TiFlashException(msg, Errors::Types::Truncated);
     }
     appendWarning(msg);
 }
 
-void DAGContext::handleOverflowError(const String & msg, const TiFlashError & error)
+void DAGContext::handleTruncateError(const String & msg)
 {
-    if (!(flags & TiDBSQLFlags::OVERFLOW_AS_WARNING))
-    {
-        throw TiFlashException("Overflow error: " + msg, error);
-    }
-    appendWarning("Overflow error: " + msg);
+    handleTruncateErrorInternal("Truncate error " + msg);
+}
+
+void DAGContext::handleOverflowError(const String & msg)
+{
+    // TiDB removed OverflowAsWarning flag in tidb/pull/49122.
+    handleTruncateErrorInternal("Overflow error " + msg);
 }
 
 void DAGContext::handleDivisionByZero()

--- a/dbms/src/Flash/Coprocessor/DAGContext.h
+++ b/dbms/src/Flash/Coprocessor/DAGContext.h
@@ -89,7 +89,8 @@ constexpr UInt64 PAD_CHAR_TO_FULL_LENGTH = 1u << 2u;
 constexpr UInt64 IN_INSERT_STMT = 1u << 3u;
 constexpr UInt64 IN_UPDATE_OR_DELETE_STMT = 1u << 4u;
 constexpr UInt64 IN_SELECT_STMT = 1u << 5u;
-constexpr UInt64 OVERFLOW_AS_WARNING = 1u << 6u;
+// TiDB removed OverflowAsWarning flag in tidb/pull/49122.
+// constexpr UInt64 OVERFLOW_AS_WARNING = 1u << 6u;
 constexpr UInt64 IGNORE_ZERO_IN_DATE = 1u << 7u;
 constexpr UInt64 DIVIDED_BY_ZERO_AS_WARNING = 1u << 8u;
 constexpr UInt64 IN_LOAD_DATA_STMT = 1u << 10u;
@@ -210,7 +211,7 @@ public:
         bool is_append = false);
 
     void handleTruncateError(const String & msg);
-    void handleOverflowError(const String & msg, const TiFlashError & error);
+    void handleOverflowError(const String & msg);
     void handleDivisionByZero();
     void handleInvalidTime(const String & msg, const TiFlashError & error);
     void appendWarning(const String & msg, int32_t code = 0);
@@ -408,6 +409,7 @@ private:
     void initExecutorIdToJoinIdMap();
     void initOutputInfo();
     tipb::EncodeType analyzeDAGEncodeType() const;
+    void handleTruncateErrorInternal(const String & msg);
 
 private:
     std::shared_ptr<ProcessListEntry> process_list_entry;

--- a/dbms/src/Flash/Coprocessor/tests/gtest_dag_context.cpp
+++ b/dbms/src/Flash/Coprocessor/tests/gtest_dag_context.cpp
@@ -34,7 +34,7 @@ TEST(DAGContextTest, FlagsTest)
     ASSERT_EQ(context.getFlags(), f1);
 
     context.delFlag(TiDBSQLFlags::TRUNCATE_AS_WARNING);
-    ASSERT_EQ(context.getFlags(), f);
+    ASSERT_EQ(context.getFlags(), TiDBSQLFlags::IN_LOAD_DATA_STMT);
 }
 
 } // namespace tests

--- a/dbms/src/Flash/Coprocessor/tests/gtest_dag_context.cpp
+++ b/dbms/src/Flash/Coprocessor/tests/gtest_dag_context.cpp
@@ -29,11 +29,11 @@ TEST(DAGContextTest, FlagsTest)
     context.setFlags(f);
     ASSERT_EQ(context.getFlags(), f);
 
-    UInt64 f1 = f | TiDBSQLFlags::OVERFLOW_AS_WARNING;
-    context.addFlag(TiDBSQLFlags::OVERFLOW_AS_WARNING);
+    UInt64 f1 = f | TiDBSQLFlags::TRUNCATE_AS_WARNING;
+    context.addFlag(TiDBSQLFlags::TRUNCATE_AS_WARNING);
     ASSERT_EQ(context.getFlags(), f1);
 
-    context.delFlag(TiDBSQLFlags::OVERFLOW_AS_WARNING);
+    context.delFlag(TiDBSQLFlags::TRUNCATE_AS_WARNING);
     ASSERT_EQ(context.getFlags(), f);
 }
 

--- a/dbms/src/Functions/FunctionsTiDBConversion.h
+++ b/dbms/src/Functions/FunctionsTiDBConversion.h
@@ -1197,8 +1197,7 @@ struct TiDBConvertToDecimal
                     v *= 10;
                     if (v > max_value)
                     {
-                        context.getDAGContext()->handleOverflowError(
-                            "cast string as decimal");
+                        context.getDAGContext()->handleOverflowError("cast string as decimal");
                         return static_cast<UType>(is_negative ? -max_value : max_value);
                     }
                     current_scale++;

--- a/dbms/src/Functions/FunctionsTiDBConversion.h
+++ b/dbms/src/Functions/FunctionsTiDBConversion.h
@@ -295,7 +295,7 @@ struct TiDBConvertToInteger
         T rounded_value = std::round(value);
         if (rounded_value < 0)
         {
-            context.getDAGContext()->handleOverflowError("Cast real as integer", Errors::Types::Truncated);
+            context.getDAGContext()->handleOverflowError("Cast real as integer");
             if (context.getDAGContext()->shouldClipToZero())
                 return static_cast<ToFieldType>(0);
             return static_cast<ToFieldType>(rounded_value);
@@ -303,12 +303,12 @@ struct TiDBConvertToInteger
         auto field_max = static_cast<T>(std::numeric_limits<ToFieldType>::max());
         if (rounded_value > field_max)
         {
-            context.getDAGContext()->handleOverflowError("Cast real as integer", Errors::Types::Truncated);
+            context.getDAGContext()->handleOverflowError("Cast real as integer");
             return std::numeric_limits<ToFieldType>::max();
         }
         else if (rounded_value == field_max)
         {
-            context.getDAGContext()->handleOverflowError("cast real as int", Errors::Types::Truncated);
+            context.getDAGContext()->handleOverflowError("cast real as int");
             return std::numeric_limits<ToFieldType>::max();
         }
         else
@@ -323,12 +323,12 @@ struct TiDBConvertToInteger
         auto field_max = static_cast<T>(std::numeric_limits<ToFieldType>::max());
         if (rounded_value < field_min)
         {
-            context.getDAGContext()->handleOverflowError("cast real as int", Errors::Types::Truncated);
+            context.getDAGContext()->handleOverflowError("cast real as int");
             return std::numeric_limits<ToFieldType>::min();
         }
         if (rounded_value >= field_max)
         {
-            context.getDAGContext()->handleOverflowError("cast real as int", Errors::Types::Truncated);
+            context.getDAGContext()->handleOverflowError("cast real as int");
             return std::numeric_limits<ToFieldType>::max();
         }
         return static_cast<ToFieldType>(rounded_value);
@@ -340,7 +340,7 @@ struct TiDBConvertToInteger
         auto v = value.getValue().value;
         if (v < 0)
         {
-            context.getDAGContext()->handleOverflowError("cast decimal as int", Errors::Types::Truncated);
+            context.getDAGContext()->handleOverflowError("cast decimal as int");
             return static_cast<ToFieldType>(0);
         }
         ScaleType scale = value.getScale();
@@ -352,7 +352,7 @@ struct TiDBConvertToInteger
         Int128 max_value = std::numeric_limits<ToFieldType>::max();
         if (v > max_value)
         {
-            context.getDAGContext()->handleOverflowError("cast decimal as int", Errors::Types::Truncated);
+            context.getDAGContext()->handleOverflowError("cast decimal as int");
             return max_value;
         }
         return static_cast<ToFieldType>(v);
@@ -369,7 +369,7 @@ struct TiDBConvertToInteger
         }
         if (v > std::numeric_limits<ToFieldType>::max() || v < std::numeric_limits<ToFieldType>::min())
         {
-            context.getDAGContext()->handleOverflowError("cast decimal as int", Errors::Types::Truncated);
+            context.getDAGContext()->handleOverflowError("cast decimal as int");
             if (v > 0)
                 return std::numeric_limits<ToFieldType>::max();
             return std::numeric_limits<ToFieldType>::min();
@@ -476,7 +476,7 @@ struct TiDBConvertToInteger
         {
             auto [value, err] = toUInt<T>(int_string);
             if (err == OVERFLOW_ERR)
-                context.getDAGContext()->handleOverflowError("cast str as int", Errors::Types::Truncated);
+                context.getDAGContext()->handleOverflowError("cast str as int");
             return static_cast<T>(value);
         }
         else
@@ -484,7 +484,7 @@ struct TiDBConvertToInteger
             /// TODO: append warning CastAsSignedOverflow if try to cast negative value to unsigned
             auto [value, err] = toInt<T>(int_string);
             if (err == OVERFLOW_ERR)
-                context.getDAGContext()->handleOverflowError("cast str as int", Errors::Types::Truncated);
+                context.getDAGContext()->handleOverflowError("cast str as int");
             return static_cast<T>(value);
         }
     }
@@ -632,12 +632,12 @@ struct TiDBConvertToFloat
             value = std::round(value) / shift;
             if (value > max_f)
             {
-                context.getDAGContext()->handleOverflowError("cast as real", Errors::Types::Truncated);
+                context.getDAGContext()->handleOverflowError("cast as real");
                 value = max_f;
             }
             if (value < -max_f)
             {
-                context.getDAGContext()->handleOverflowError("cast as real", Errors::Types::Truncated);
+                context.getDAGContext()->handleOverflowError("cast as real");
                 value = -max_f;
             }
         }
@@ -645,7 +645,7 @@ struct TiDBConvertToFloat
         {
             if (value < 0)
             {
-                context.getDAGContext()->handleOverflowError("cast as real", Errors::Types::Truncated);
+                context.getDAGContext()->handleOverflowError("cast as real");
                 value = 0;
             }
         }
@@ -743,12 +743,12 @@ struct TiDBConvertToFloat
         Float64 f = strtod(float_string.data, nullptr);
         if (f == std::numeric_limits<Float64>::infinity())
         {
-            context.getDAGContext()->handleOverflowError("Truncated incorrect DOUBLE value", Errors::Types::Truncated);
+            context.getDAGContext()->handleOverflowError("Truncated incorrect DOUBLE value");
             return std::numeric_limits<Float64>::max();
         }
         if (f == -std::numeric_limits<double>::infinity())
         {
-            context.getDAGContext()->handleOverflowError("Truncated incorrect DOUBLE value", Errors::Types::Truncated);
+            context.getDAGContext()->handleOverflowError("Truncated incorrect DOUBLE value");
             return -std::numeric_limits<Float64>::max();
         }
         return produceTargetFloat64(f, need_truncate, shift, max_f, context);
@@ -981,7 +981,7 @@ struct TiDBConvertToDecimal
         auto max_value = DecimalMaxValue::get(prec);
         if (value > static_cast<Float64>(max_value))
         {
-            context.getDAGContext()->handleOverflowError("cast real to decimal", Errors::Types::Truncated);
+            context.getDAGContext()->handleOverflowError("cast real to decimal");
             if (!neg)
                 return static_cast<UType>(max_value);
             else
@@ -1116,7 +1116,7 @@ struct TiDBConvertToDecimal
             if (err == OVERFLOW_ERR || frac_offset_by_exponent > std::numeric_limits<Int32>::max() / 2
                 || frac_offset_by_exponent < std::numeric_limits<Int32>::min() / 2)
             {
-                context.getDAGContext()->handleOverflowError("cast string as decimal", Errors::Types::Truncated);
+                context.getDAGContext()->handleOverflowError("cast string as decimal");
                 if (decimal_parts.exp_part.data[0] == '-')
                     return static_cast<UType>(0);
                 else
@@ -1146,7 +1146,7 @@ struct TiDBConvertToDecimal
             v = v * 10 + decimal_parts.int_part.data[pos] - '0';
             if (v > max_value)
             {
-                context.getDAGContext()->handleOverflowError("cast string as decimal", Errors::Types::Truncated);
+                context.getDAGContext()->handleOverflowError("cast string as decimal");
                 return static_cast<UType>(is_negative ? -max_value : max_value);
             }
             current_scale++;
@@ -1178,7 +1178,7 @@ struct TiDBConvertToDecimal
                 v = v * 10 + decimal_parts.frac_part.data[pos] - '0';
                 if (v > max_value)
                 {
-                    context.getDAGContext()->handleOverflowError("cast string as decimal", Errors::Types::Truncated);
+                    context.getDAGContext()->handleOverflowError("cast string as decimal");
                     return static_cast<UType>(is_negative ? -max_value : max_value);
                 }
                 current_scale++;
@@ -1198,8 +1198,7 @@ struct TiDBConvertToDecimal
                     if (v > max_value)
                     {
                         context.getDAGContext()->handleOverflowError(
-                            "cast string as decimal",
-                            Errors::Types::Truncated);
+                            "cast string as decimal");
                         return static_cast<UType>(is_negative ? -max_value : max_value);
                     }
                     current_scale++;
@@ -1209,7 +1208,7 @@ struct TiDBConvertToDecimal
 
         if (v > max_value)
         {
-            context.getDAGContext()->handleOverflowError("cast string as decimal", Errors::Types::Truncated);
+            context.getDAGContext()->handleOverflowError("cast string as decimal");
             return static_cast<UType>(is_negative ? -max_value : max_value);
         }
         return static_cast<UType>(is_negative ? -v : v);
@@ -1361,7 +1360,7 @@ struct TiDBConvertToDecimal
         {
             if (to_value > max_value || to_value < -max_value)
             {
-                context.getDAGContext()->handleOverflowError(msg, Errors::Types::Truncated);
+                context.getDAGContext()->handleOverflowError(msg);
                 if (to_value > 0)
                     return static_cast<ReturnType>(max_value);
                 else

--- a/dbms/src/Functions/tests/bench_function_cast.cpp
+++ b/dbms/src/Functions/tests/bench_function_cast.cpp
@@ -364,7 +364,6 @@ public:
         auto context = DB::tests::TiFlashTestEnv::getContext();        \
         auto dag_context_ptr = std::make_unique<DAGContext>(1024);     \
         UInt64 ori_flags = dag_context_ptr->getFlags();                \
-        dag_context_ptr->addFlag(TiDBSQLFlags::OVERFLOW_AS_WARNING);   \
         dag_context_ptr->addFlag(TiDBSQLFlags::TRUNCATE_AS_WARNING);   \
         dag_context_ptr->clearWarnings();                              \
         context->setDAGContext(dag_context_ptr.get());                 \

--- a/dbms/src/Functions/tests/gtest_tidb_conversion.cpp
+++ b/dbms/src/Functions/tests/gtest_tidb_conversion.cpp
@@ -1004,7 +1004,7 @@ try
 
     auto & dag_context = getDAGContext();
     UInt64 ori_flags = dag_context.getFlags();
-    dag_context.addFlag(TiDBSQLFlags::OVERFLOW_AS_WARNING);
+    dag_context.addFlag(TiDBSQLFlags::TRUNCATE_AS_WARNING);
     dag_context.clearWarnings();
 
     ASSERT_COLUMN_EQ(
@@ -2258,7 +2258,7 @@ try
     // from_prec(3) + to_scale(7) > Int32::real_prec(10) - 1, so CastInternalType should be **Int64**.
     auto & dag_context = getDAGContext();
     UInt64 ori_flags = dag_context.getFlags();
-    dag_context.addFlag(TiDBSQLFlags::OVERFLOW_AS_WARNING);
+    dag_context.addFlag(TiDBSQLFlags::TRUNCATE_AS_WARNING);
     dag_context.clearWarnings();
     ASSERT_COLUMN_EQ(
         createColumn<Nullable<Decimal32>>(

--- a/dbms/src/TestUtils/mockExecutor.cpp
+++ b/dbms/src/TestUtils/mockExecutor.cpp
@@ -88,8 +88,7 @@ void DAGRequestBuilder::initDAGRequest(tipb::DAGRequest & dag_request)
 {
     dag_request.set_time_zone_name(properties.tz_name);
     dag_request.set_time_zone_offset(properties.tz_offset);
-    dag_request.set_flags(
-        dag_request.flags() | (1u << 1u /* TRUNCATE_AS_WARNING */) | (1u << 6u /* OVERFLOW_AS_WARNING */));
+    dag_request.set_flags(dag_request.flags() | (1u << 1u /* TRUNCATE_AS_WARNING */));
 
     if (properties.encode_type == "chunk")
         dag_request.set_encode_type(tipb::EncodeType::TypeChunk);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9752

Problem Summary: check description in issue. tidb removed `OverflowAsWarning` flag, because its semantics is same with `TruncateAsWarning`

### What is changed and how it works?

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
