### PR TITLE
KVStore: Move the configs of Raft Read to KVStoreConfig

### DIFF
--- a/dbms/src/Storages/KVStore/KVStore.cpp
+++ b/dbms/src/Storages/KVStore/KVStore.cpp
@@ -36,7 +36,6 @@
 
 #include <mutex>
 #include <tuple>
-#include <variant>
 
 namespace DB
 {
@@ -58,10 +57,6 @@ KVStore::KVStore(Context & context)
         context.getSharedContextDisagg()->isDisaggregatedComputeMode() ? nullptr
                                                                        : std::make_unique<RegionPersister>(context))
     , log(Logger::get())
-    , region_compact_log_min_rows(40 * 1024)
-    , region_compact_log_min_bytes(32 * 1024 * 1024)
-    , region_compact_log_gap(200)
-    , region_eager_gc_log_gap(512)
     // Eager RaftLog GC is only enabled under UniPS
     , eager_raft_log_gc_enabled(context.getPageStorageRunMode() == PageStorageRunMode::UNI_PS)
 {
@@ -314,7 +309,7 @@ bool KVStore::tryRegisterEagerRaftLogGCTask(const RegionPtr & region, RegionTask
 {
     if (!eager_raft_log_gc_enabled)
         return false;
-    const UInt64 threshold = region_eager_gc_log_gap.load();
+    const UInt64 threshold = config.regionEagerGCLogGap();
     if (threshold == 0) // disabled
         return false;
 
@@ -370,22 +365,6 @@ void KVStore::handleDestroy(UInt64 region_id, TMTContext & tmt, const KVStoreTas
         tmt.getRegionTable(),
         task_lock,
         region_manager.genRegionTaskLock(region_id));
-}
-
-void KVStore::setRegionCompactLogConfig(UInt64 rows, UInt64 bytes, UInt64 gap, UInt64 eager_gc_gap)
-{
-    region_compact_log_min_rows = rows;
-    region_compact_log_min_bytes = bytes;
-    region_compact_log_gap = gap;
-    region_eager_gc_log_gap = eager_gc_gap;
-
-    LOG_INFO(
-        log,
-        "Region compact log thresholds, rows={} bytes={} gap={} eager_gc_gap={}",
-        rows,
-        bytes,
-        gap,
-        eager_gc_gap);
 }
 
 void KVStore::setStore(metapb::Store store_)

--- a/dbms/src/Storages/KVStore/KVStore.h
+++ b/dbms/src/Storages/KVStore/KVStore.h
@@ -20,6 +20,7 @@
 #include <Storages/DeltaMerge/RowKeyRange.h>
 #include <Storages/KVStore/Decode/RegionDataRead.h>
 #include <Storages/KVStore/FFI/JointThreadAllocInfo.h>
+#include <Storages/KVStore/KVStoreConfig.h>
 #include <Storages/KVStore/MultiRaft/Disagg/RaftLogManager.h>
 #include <Storages/KVStore/MultiRaft/PreHandlingTrace.h>
 #include <Storages/KVStore/MultiRaft/RegionManager.h>
@@ -181,6 +182,14 @@ public: // Raft Read and Write
         TMTContext & tmt,
         DM::WriteResult & write_result);
 
+public: // Configs
+    void reloadConfig(const Poco::Util::AbstractConfiguration & config_file) { config.reloadConfig(config_file, log); }
+    const KVStoreConfig & getConfigRef() const { return config; }
+    UInt64 getRaftLogEagerGCRows() const { return config.regionEagerGCLogGap(); }
+
+    // debug only
+    KVStoreConfig & debugGetConfigMut() { return config; }
+
 public: // Flush
     static bool tryFlushRegionCacheInStorage(
         TMTContext & tmt,
@@ -197,8 +206,6 @@ public: // Flush
         UInt64 term,
         uint64_t truncated_index,
         uint64_t truncated_term);
-    void setRegionCompactLogConfig(UInt64 rows, UInt64 bytes, UInt64 gap, UInt64 eager_gc_gap);
-    UInt64 getRaftLogEagerGCRows() const { return region_eager_gc_log_gap.load(); }
     // TODO(proactive flush)
     // void proactiveFlushCacheAndRegion(TMTContext & tmt, const DM::RowKeyRange & rowkey_range, KeyspaceID keyspace_id, TableID table_id, bool is_background);
     void notifyCompactLog(
@@ -347,7 +354,7 @@ private:
         UInt64 index,
         UInt64 term,
         UInt64 truncated_index,
-        UInt64 truncated_term);
+        UInt64 truncated_term) const;
 
     bool forceFlushRegionDataImpl(
         Region & curr_region,
@@ -382,15 +389,7 @@ private:
 
     LoggerPtr log;
 
-    std::atomic<UInt64> region_compact_log_min_rows;
-    std::atomic<UInt64> region_compact_log_min_bytes;
-    std::atomic<UInt64> region_compact_log_gap;
-    // `region_eager_gc_log_gap` is checked after each write command applied,
-    // It should be large enough to avoid unnecessary flushes and also not
-    // too large to control the memory when there are down peers.
-    // The 99% of passive flush is 512, so we use it as default value.
-    // 0 means eager gc is disabled.
-    std::atomic<UInt64> region_eager_gc_log_gap;
+    KVStoreConfig config;
 
     mutable std::mutex bg_gc_region_data_mutex;
     std::list<RegionDataReadInfoList> bg_gc_region_data;
@@ -430,7 +429,7 @@ class KVStoreTaskLock : private boost::noncopyable
     std::lock_guard<std::mutex> lock;
 };
 
-void WaitCheckRegionReady(const TMTContext &, KVStore & kvstore, const std::atomic_size_t & terminate_signals_counter);
+void WaitCheckRegionReady(KVStore & kvstore, const std::atomic_size_t & terminate_signals_counter);
 void WaitCheckRegionReadyImpl(
     KVStore & kvstore,
     const std::atomic_size_t &,

--- a/dbms/src/Storages/KVStore/KVStoreConfig.cpp
+++ b/dbms/src/Storages/KVStore/KVStoreConfig.cpp
@@ -1,0 +1,101 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Common/Logger.h>
+#include <Poco/Util/AbstractConfiguration.h>
+#include <Storages/KVStore/KVStoreConfig.h>
+#include <common/logger_useful.h>
+
+namespace DB
+{
+// default config about compact-log: rows 40k, bytes 32MB, gap 200
+const UInt64 DEFAULT_COMPACT_LOG_ROWS = 40 * 1024;
+const UInt64 DEFAULT_COMPACT_LOG_BYTES = 32 * 1024 * 1024;
+const UInt64 DEFAULT_COMPACT_LOG_GAP = 200;
+const UInt64 DEFAULT_EAGER_GC_LOG_GAP = 512;
+
+// default batch-read-index timeout is 10_000ms.
+const uint64_t DEFAULT_BATCH_READ_INDEX_TIMEOUT_MS = 10 * 1000;
+// default wait-index timeout is 5 * 60_000ms.
+const uint64_t DEFAULT_WAIT_INDEX_TIMEOUT_MS = 5 * 60 * 1000;
+
+const int64_t DEFAULT_WAIT_REGION_READY_TIMEOUT_SEC = 20 * 60;
+
+const int64_t DEFAULT_READ_INDEX_WORKER_TICK_MS = 10;
+
+KVStoreConfig::KVStoreConfig()
+    : region_compact_log_min_rows(DEFAULT_COMPACT_LOG_ROWS)
+    , region_compact_log_min_bytes(DEFAULT_COMPACT_LOG_BYTES)
+    , region_compact_log_gap(DEFAULT_COMPACT_LOG_GAP)
+    , region_eager_gc_log_gap(DEFAULT_EAGER_GC_LOG_GAP)
+    , batch_read_index_timeout_ms(DEFAULT_BATCH_READ_INDEX_TIMEOUT_MS)
+    , wait_index_timeout_ms(DEFAULT_WAIT_INDEX_TIMEOUT_MS)
+    , read_index_worker_tick_ms(DEFAULT_READ_INDEX_WORKER_TICK_MS)
+    , wait_region_ready_tick(0)
+    , wait_region_ready_timeout_sec(DEFAULT_WAIT_REGION_READY_TIMEOUT_SEC)
+{}
+
+void KVStoreConfig::reloadConfig(const Poco::Util::AbstractConfiguration & config, const LoggerPtr & log)
+{
+    // static constexpr const char * COMPACT_LOG_MIN_PERIOD = "flash.compact_log_min_period"; // deprecated
+    static constexpr const char * COMPACT_LOG_MIN_ROWS = "flash.compact_log_min_rows";
+    static constexpr const char * COMPACT_LOG_MIN_BYTES = "flash.compact_log_min_bytes";
+    static constexpr const char * COMPACT_LOG_MIN_GAP = "flash.compact_log_min_gap";
+    static constexpr const char * EAGER_GC_LOG_GAP = "flash.eager_gc_log_gap";
+
+    static constexpr const char * BATCH_READ_INDEX_TIMEOUT_MS = "flash.batch_read_index_timeout_ms";
+    static constexpr const char * WAIT_INDEX_TIMEOUT_MS = "flash.wait_index_timeout_ms";
+    static constexpr const char * WAIT_REGION_READY_TICK = "flash.wait_region_ready_tick";
+    static constexpr const char * WAIT_REGION_READY_TIMEOUT_SEC = "flash.wait_region_ready_timeout_sec";
+    static constexpr const char * READ_INDEX_WORKER_TICK_MS = "flash.read_index_worker_tick_ms";
+
+    {
+        region_compact_log_min_rows = std::max(config.getUInt64(COMPACT_LOG_MIN_ROWS, DEFAULT_COMPACT_LOG_ROWS), 1);
+        region_compact_log_min_bytes = std::max(config.getUInt64(COMPACT_LOG_MIN_BYTES, DEFAULT_COMPACT_LOG_BYTES), 1);
+        region_compact_log_gap = std::max(config.getUInt64(COMPACT_LOG_MIN_GAP, DEFAULT_COMPACT_LOG_GAP), 1);
+        region_eager_gc_log_gap = config.getUInt64(EAGER_GC_LOG_GAP, DEFAULT_EAGER_GC_LOG_GAP);
+
+        LOG_INFO(
+            log,
+            "Region compact log thresholds, rows={} bytes={} gap={} eager_gc_gap={}",
+            region_compact_log_min_rows,
+            region_compact_log_min_bytes,
+            region_compact_log_gap,
+            region_eager_gc_log_gap);
+    }
+    {
+        batch_read_index_timeout_ms
+            = config.getUInt64(BATCH_READ_INDEX_TIMEOUT_MS, DEFAULT_BATCH_READ_INDEX_TIMEOUT_MS);
+        wait_index_timeout_ms = config.getUInt64(WAIT_INDEX_TIMEOUT_MS, DEFAULT_WAIT_INDEX_TIMEOUT_MS);
+        read_index_worker_tick_ms = config.getUInt64(READ_INDEX_WORKER_TICK_MS, DEFAULT_READ_INDEX_WORKER_TICK_MS);
+
+        wait_region_ready_tick = config.getUInt64(WAIT_REGION_READY_TICK, 0);
+        wait_region_ready_timeout_sec = ({
+            int64_t t = config.getInt64(WAIT_REGION_READY_TIMEOUT_SEC, /*20min*/ DEFAULT_WAIT_REGION_READY_TIMEOUT_SEC);
+            t = t >= 0 ? t : std::numeric_limits<int64_t>::max(); // set -1 to wait infinitely
+            t;
+        });
+
+        LOG_INFO(
+            log,
+            "read-index timeout: {}ms; wait-index timeout: {}ms; wait-region-ready timeout: {}s; "
+            "read-index-worker-tick: {}ms",
+            batchReadIndexTimeout(),
+            waitIndexTimeout(),
+            waitRegionReadyTimeout(),
+            readIndexWorkerTick());
+    }
+}
+
+} // namespace DB

--- a/dbms/src/Storages/KVStore/KVStoreConfig.h
+++ b/dbms/src/Storages/KVStore/KVStoreConfig.h
@@ -1,0 +1,79 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <Common/Logger_fwd.h>
+#include <common/types.h>
+
+namespace Poco::Util
+{
+class AbstractConfiguration;
+} // namespace Poco::Util
+
+namespace DB
+{
+struct KVStoreConfig
+{
+    KVStoreConfig();
+
+    void reloadConfig(const Poco::Util::AbstractConfiguration & config, const LoggerPtr & log);
+
+    void debugSetCompactLogConfig(UInt64 rows, UInt64 bytes, UInt64 gap, UInt64 eager_gc_gap)
+    {
+        region_compact_log_min_rows = rows;
+        region_compact_log_min_bytes = bytes;
+        region_compact_log_gap = gap;
+        region_eager_gc_log_gap = eager_gc_gap;
+    }
+
+public: // Flush
+    UInt64 regionComactLogMinRows() const { return region_compact_log_min_rows.load(std::memory_order_relaxed); }
+    UInt64 regionComactLogMinBytes() const { return region_compact_log_min_bytes.load(std::memory_order_relaxed); }
+    UInt64 regionComactLogGap() const { return region_compact_log_gap.load(std::memory_order_relaxed); }
+    UInt64 regionEagerGCLogGap() const { return region_eager_gc_log_gap.load(std::memory_order_relaxed); }
+
+public: // Raft Read
+    UInt64 batchReadIndexTimeout() const { return batch_read_index_timeout_ms.load(std::memory_order_relaxed); }
+    // timeout for wait index (ms). "0" means wait infinitely
+    UInt64 waitIndexTimeout() const { return wait_index_timeout_ms.load(std::memory_order_relaxed); }
+    void debugSetWaitIndexTimeout(UInt64 timeout)
+    {
+        return wait_index_timeout_ms.store(timeout, std::memory_order_relaxed);
+    }
+    UInt64 readIndexWorkerTick() const { return read_index_worker_tick_ms.load(std::memory_order_relaxed); }
+
+    Int64 waitRegionReadyTick() const { return wait_region_ready_tick.load(std::memory_order_relaxed); }
+    Int64 waitRegionReadyTimeout() const { return wait_region_ready_timeout_sec.load(std::memory_order_relaxed); }
+
+private:
+    std::atomic<UInt64> region_compact_log_min_rows;
+    std::atomic<UInt64> region_compact_log_min_bytes;
+    std::atomic<UInt64> region_compact_log_gap;
+    // `region_eager_gc_log_gap` is checked after each write command applied,
+    // It should be large enough to avoid unnecessary flushes and also not
+    // too large to control the memory when there are down peers.
+    // The 99% of passive flush is 512, so we use it as default value.
+    // 0 means eager gc is disabled.
+    std::atomic<UInt64> region_eager_gc_log_gap;
+
+    std::atomic<UInt64> batch_read_index_timeout_ms;
+    std::atomic<UInt64> wait_index_timeout_ms;
+    std::atomic<UInt64> read_index_worker_tick_ms;
+
+    std::atomic<UInt64> wait_region_ready_tick;
+    std::atomic<Int64> wait_region_ready_timeout_sec;
+};
+
+} // namespace DB

--- a/dbms/src/Storages/KVStore/ProxyStateMachine.h
+++ b/dbms/src/Storages/KVStore/ProxyStateMachine.h
@@ -347,14 +347,12 @@ struct ProxyStateMachine
         if (proxy_conf.getReadIndexRunnerCount() > 0)
         {
             auto & kvstore_ptr = tmt_context.getKVStore();
+            auto worker_tick = kvstore_ptr->getConfigRef().readIndexWorkerTick();
             kvstore_ptr->initReadIndexWorkers(
-                [&]() {
-                    // get from tmt context
-                    return std::chrono::milliseconds(tmt_context.readIndexWorkerTick());
-                },
+                [worker_tick]() { return std::chrono::milliseconds(worker_tick); },
                 /*running thread count*/ proxy_conf.getReadIndexRunnerCount());
             tmt_context.getKVStore()->asyncRunReadIndexWorkers();
-            WaitCheckRegionReady(tmt_context, *kvstore_ptr, terminate_signals_counter);
+            WaitCheckRegionReady(*kvstore_ptr, terminate_signals_counter);
         }
     }
 

--- a/dbms/src/Storages/KVStore/Read/LearnerRead.cpp
+++ b/dbms/src/Storages/KVStore/Read/LearnerRead.cpp
@@ -52,12 +52,13 @@ LearnerReadSnapshot doLearnerRead(
     const bool is_wn_disagg_read = context.getDAGContext() ? context.getDAGContext()->is_disaggregated_task : false;
 
     auto & tmt = context.getTMTContext();
+    const auto & config = tmt.getKVStore()->getConfigRef();
     LearnerReadWorker worker(mvcc_query_info, tmt, for_batch_cop, is_wn_disagg_read, log);
     LearnerReadSnapshot regions_snapshot = worker.buildRegionsSnapshot();
     const auto & [start_time, end_time] = worker.waitUntilDataAvailable( //
         regions_snapshot,
-        tmt.batchReadIndexTimeout(),
-        tmt.waitIndexTimeout());
+        config.batchReadIndexTimeout(),
+        config.waitIndexTimeout());
 
     if (auto * dag_context = context.getDAGContext())
     {

--- a/dbms/src/Storages/KVStore/Read/ReadIndex.cpp
+++ b/dbms/src/Storages/KVStore/Read/ReadIndex.cpp
@@ -307,18 +307,16 @@ void WaitCheckRegionReadyImpl(
         total_regions_cnt);
 }
 
-void WaitCheckRegionReady(
-    const TMTContext & tmt,
-    KVStore & kvstore,
-    const std::atomic_size_t & terminate_signals_counter)
+void WaitCheckRegionReady(KVStore & kvstore, const std::atomic_size_t & terminate_signals_counter)
 {
+    const auto & config = kvstore.getConfigRef();
     // wait interval to check region ready, not recommended to modify only if for testing
-    auto wait_region_ready_timeout_sec = static_cast<double>(tmt.waitRegionReadyTimeout());
-    const auto wait_region_ready_tick = tmt.waitRegionReadyTick();
+    auto wait_region_ready_timeout_sec = static_cast<double>(config.waitRegionReadyTimeout());
+    const auto wait_region_ready_tick = config.waitRegionReadyTick();
     // default tick in TiKV is about 2s (without hibernate-region)
     const double min_wait_tick_time = 0 == wait_region_ready_tick ? 2.5 : static_cast<double>(wait_region_ready_tick);
     const double max_wait_tick_time = 0 == wait_region_ready_tick ? 20.0 : wait_region_ready_timeout_sec;
-    auto read_index_timeout = tmt.batchReadIndexTimeout();
+    auto read_index_timeout = config.batchReadIndexTimeout();
 
     return WaitCheckRegionReadyImpl(
         kvstore,

--- a/dbms/src/Storages/KVStore/TMTContext.cpp
+++ b/dbms/src/Storages/KVStore/TMTContext.cpp
@@ -39,14 +39,6 @@
 
 namespace DB
 {
-// default batch-read-index timeout is 10_000ms.
-const uint64_t DEFAULT_BATCH_READ_INDEX_TIMEOUT_MS = 10 * 1000;
-// default wait-index timeout is 5 * 60_000ms.
-const uint64_t DEFAULT_WAIT_INDEX_TIMEOUT_MS = 5 * 60 * 1000;
-
-const int64_t DEFAULT_WAIT_REGION_READY_TIMEOUT_SEC = 20 * 60;
-
-const int64_t DEFAULT_READ_INDEX_WORKER_TICK_MS = 10;
 
 namespace
 {
@@ -158,11 +150,6 @@ TMTContext::TMTContext(
           context.getSettingsRef().task_scheduler_thread_soft_limit,
           context.getSettingsRef().task_scheduler_thread_hard_limit,
           context.getSettingsRef().task_scheduler_active_set_soft_limit)))
-    , batch_read_index_timeout_ms(DEFAULT_BATCH_READ_INDEX_TIMEOUT_MS)
-    , wait_index_timeout_ms(DEFAULT_WAIT_INDEX_TIMEOUT_MS)
-    , read_index_worker_tick_ms(DEFAULT_READ_INDEX_WORKER_TICK_MS)
-    , wait_region_ready_tick(0)
-    , wait_region_ready_timeout_sec(DEFAULT_WAIT_REGION_READY_TIMEOUT_SEC)
     , raftproxy_config(raft_config)
 {
     startMonitorMPPTaskThread(mpp_task_manager);
@@ -415,45 +402,7 @@ void TMTContext::reloadConfig(const Poco::Util::AbstractConfiguration & config)
         && context.getSharedContextDisagg()->use_autoscaler)
         return;
 
-    // static constexpr const char * COMPACT_LOG_MIN_PERIOD = "flash.compact_log_min_period"; // disabled
-    static constexpr const char * COMPACT_LOG_MIN_ROWS = "flash.compact_log_min_rows";
-    static constexpr const char * COMPACT_LOG_MIN_BYTES = "flash.compact_log_min_bytes";
-    static constexpr const char * COMPACT_LOG_MIN_GAP = "flash.compact_log_min_gap";
-    static constexpr const char * EAGER_GC_LOG_GAP = "flash.eager_gc_log_gap";
-    static constexpr const char * BATCH_READ_INDEX_TIMEOUT_MS = "flash.batch_read_index_timeout_ms";
-    static constexpr const char * WAIT_INDEX_TIMEOUT_MS = "flash.wait_index_timeout_ms";
-    static constexpr const char * WAIT_REGION_READY_TICK = "flash.wait_region_ready_tick";
-    static constexpr const char * WAIT_REGION_READY_TIMEOUT_SEC = "flash.wait_region_ready_timeout_sec";
-    static constexpr const char * READ_INDEX_WORKER_TICK_MS = "flash.read_index_worker_tick_ms";
-
-    // default config about compact-log: period 120s, rows 40k, bytes 32MB.
-    getKVStore()->setRegionCompactLogConfig(
-        std::max(config.getUInt64(COMPACT_LOG_MIN_ROWS, 40 * 1024), 1),
-        std::max(config.getUInt64(COMPACT_LOG_MIN_BYTES, 32 * 1024 * 1024), 1),
-        std::max(config.getUInt64(COMPACT_LOG_MIN_GAP, 200), 1),
-        config.getUInt64(EAGER_GC_LOG_GAP, 512));
-    {
-        batch_read_index_timeout_ms
-            = config.getUInt64(BATCH_READ_INDEX_TIMEOUT_MS, DEFAULT_BATCH_READ_INDEX_TIMEOUT_MS);
-        wait_index_timeout_ms = config.getUInt64(WAIT_INDEX_TIMEOUT_MS, DEFAULT_WAIT_INDEX_TIMEOUT_MS);
-        wait_region_ready_tick = config.getUInt64(WAIT_REGION_READY_TICK, 0);
-        wait_region_ready_timeout_sec = ({
-            int64_t t = config.getInt64(WAIT_REGION_READY_TIMEOUT_SEC, /*20min*/ DEFAULT_WAIT_REGION_READY_TIMEOUT_SEC);
-            t = t >= 0 ? t : std::numeric_limits<int64_t>::max(); // set -1 to wait infinitely
-            t;
-        });
-        read_index_worker_tick_ms = config.getUInt64(READ_INDEX_WORKER_TICK_MS, DEFAULT_READ_INDEX_WORKER_TICK_MS);
-    }
-    {
-        LOG_INFO(
-            Logger::get(),
-            "read-index timeout: {}ms; wait-index timeout: {}ms; wait-region-ready timeout: {}s; "
-            "read-index-worker-tick: {}ms",
-            batchReadIndexTimeout(),
-            waitIndexTimeout(),
-            waitRegionReadyTimeout(),
-            readIndexWorkerTick());
-    }
+    getKVStore()->reloadConfig(config);
 }
 
 bool TMTContext::checkShuttingDown(std::memory_order memory_order) const
@@ -479,31 +428,6 @@ void TMTContext::setStatusStopping()
 void TMTContext::setStatusTerminated()
 {
     store_status = StoreStatus::Terminated;
-}
-
-UInt64 TMTContext::batchReadIndexTimeout() const
-{
-    return batch_read_index_timeout_ms.load(std::memory_order_relaxed);
-}
-UInt64 TMTContext::waitIndexTimeout() const
-{
-    return wait_index_timeout_ms.load(std::memory_order_relaxed);
-}
-void TMTContext::debugSetWaitIndexTimeout(UInt64 timeout)
-{
-    return wait_index_timeout_ms.store(timeout, std::memory_order_relaxed);
-}
-Int64 TMTContext::waitRegionReadyTick() const
-{
-    return wait_region_ready_tick.load(std::memory_order_relaxed);
-}
-Int64 TMTContext::waitRegionReadyTimeout() const
-{
-    return wait_region_ready_timeout_sec.load(std::memory_order_relaxed);
-}
-uint64_t TMTContext::readIndexWorkerTick() const
-{
-    return read_index_worker_tick_ms.load(std::memory_order_relaxed);
 }
 
 void TMTContext::debugSetKVStore(const KVStorePtr & new_kvstore)

--- a/dbms/src/Storages/KVStore/TMTContext.h
+++ b/dbms/src/Storages/KVStore/TMTContext.h
@@ -137,15 +137,6 @@ public:
     bool checkTerminated(std::memory_order = std::memory_order_seq_cst) const;
     bool checkRunning(std::memory_order = std::memory_order_seq_cst) const;
 
-    UInt64 batchReadIndexTimeout() const;
-    // timeout for wait index (ms). "0" means wait infinitely
-    UInt64 waitIndexTimeout() const;
-    void debugSetWaitIndexTimeout(UInt64 timeout);
-    uint64_t readIndexWorkerTick() const;
-
-    Int64 waitRegionReadyTick() const;
-    Int64 waitRegionReadyTimeout() const;
-
     Etcd::ClientPtr getEtcdClient() const { return etcd_client; }
     void initS3GCManager(const TiFlashRaftProxyHelper * proxy_helper);
 
@@ -171,13 +162,6 @@ private:
     const std::unordered_set<std::string> ignore_databases;
     std::shared_ptr<TiDBSchemaSyncerManager> schema_sync_manager;
     MPPTaskManagerPtr mpp_task_manager;
-
-    std::atomic_uint64_t batch_read_index_timeout_ms;
-    std::atomic_uint64_t wait_index_timeout_ms;
-    std::atomic_uint64_t read_index_worker_tick_ms;
-
-    std::atomic_uint64_t wait_region_ready_tick;
-    std::atomic_int64_t wait_region_ready_timeout_sec;
 
     TiFlashRaftConfig raftproxy_config;
 };

--- a/dbms/src/Storages/KVStore/tests/gtest_kvstore.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_kvstore.cpp
@@ -50,7 +50,7 @@ try
     {
         // test CompactLog
         auto region = kvs.getRegion(1);
-        kvs.setRegionCompactLogConfig(1000, 1000, 0, 512);
+        kvs.debugGetConfigMut().debugSetCompactLogConfig(1000, 1000, 0, 512);
 
         raft_cmdpb::AdminRequest request;
         request.mutable_compact_log();

--- a/dbms/src/Storages/KVStore/tests/gtest_kvstore_fast_add_peer.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_kvstore_fast_add_peer.cpp
@@ -283,7 +283,7 @@ try
     // Write some data, and persist meta.
     auto [index, term]
         = proxy_instance->normalWrite(region_id, {34}, {"v2"}, {WriteCmdType::Put}, {ColumnFamilyType::Default});
-    kvs.setRegionCompactLogConfig(0, 0, 0, 0);
+    kvs.debugGetConfigMut().debugSetCompactLogConfig(0, 0, 0, 0);
     persistAfterWrite(global_context, kvs, proxy_instance, page_storage, region_id, index);
 
     auto s3_client = S3::ClientFactory::instance().sharedTiFlashClient();
@@ -406,7 +406,7 @@ std::vector<CheckpointRegionInfoAndData> RegionKVStoreTestFAP::prepareForRestart
                 {WriteCmdType::Put, WriteCmdType::Put},
                 {ColumnFamilyType::Default, ColumnFamilyType::Write});
         }
-        kvs.setRegionCompactLogConfig(0, 0, 0, 0);
+        kvs.debugGetConfigMut().debugSetCompactLogConfig(0, 0, 0, 0);
         if (opt.mock_add_new_peer)
         {
             *kvs.getRegion(id)->mutMeta().debugMutRegionState().getMutRegion().add_peers() = createPeer(peer_id, true);
@@ -647,7 +647,7 @@ try
     // Write some data, and persist meta.
     auto [index, term]
         = proxy_instance->normalWrite(region_id, {34}, {"v2"}, {WriteCmdType::Put}, {ColumnFamilyType::Default});
-    kvs.setRegionCompactLogConfig(0, 0, 0, 0);
+    kvs.debugGetConfigMut().debugSetCompactLogConfig(0, 0, 0, 0);
     persistAfterWrite(global_context, kvs, proxy_instance, page_storage, region_id, index);
 
     auto s3_client = S3::ClientFactory::instance().sharedTiFlashClient();

--- a/dbms/src/Storages/KVStore/tests/gtest_new_kvstore.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_new_kvstore.cpp
@@ -428,7 +428,7 @@ try
             auto [indexc, termc]
                 = proxy_instance->adminCommand(region_id, std::move(req), std::move(res), std::nullopt);
             // Reject compact log.
-            kvs.setRegionCompactLogConfig(10000000, 10000000, 10000000, 0);
+            kvs.debugGetConfigMut().debugSetCompactLogConfig(10000000, 10000000, 10000000, 0);
             proxy_instance->doApply(kvs, ctx.getTMTContext(), cond, region_id, indexc);
             ASSERT_EQ(kvr1->lastCompactLogApplied(), 5);
         }
@@ -663,7 +663,7 @@ try
             EngineStoreApplyRes::None);
 
         {
-            kvs.setRegionCompactLogConfig(0, 0, 0, 0);
+            kvs.debugGetConfigMut().debugSetCompactLogConfig(0, 0, 0, 0);
             request.set_cmd_type(::raft_cmdpb::AdminCmdType::CompactLog);
             ASSERT_EQ(
                 kvs.handleAdminRaftCmd(std::move(request), std::move(response2), region_id, 26, 6, ctx.getTMTContext()),
@@ -895,7 +895,7 @@ try
     ctx.getTMTContext().debugSetKVStore(kvstore);
     initStorages();
 
-    ctx.getTMTContext().debugSetWaitIndexTimeout(1);
+    kvs.debugGetConfigMut().debugSetWaitIndexTimeout(1);
 
     startReadIndexUtils(ctx);
     SCOPE_EXIT({ stopReadIndexUtils(); });

--- a/dbms/src/Storages/KVStore/tests/gtest_proactive_flush.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_proactive_flush.cpp
@@ -46,7 +46,7 @@ try
             ASSERT_EQ(r1->getPersistedAppliedIndex(), applied_index + 1);
             ASSERT_EQ(kvr1->appliedIndex(), applied_index + 1);
 
-            kvs.setRegionCompactLogConfig(0, 0, 0, 0);
+            kvs.debugGetConfigMut().debugSetCompactLogConfig(0, 0, 0, 0);
             auto && [request, response] = MockRaftStoreProxy::composeCompactLog(r1, index);
             auto && [index2, term2] = proxy_instance->adminCommand(region_id, std::move(request), std::move(response));
             // In tryFlushRegionData we will call handleWriteRaftCmd, which will already cause an advance.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6233 

Problem Summary:

### What is changed and how it works?

```commit-message
KVStore: Move the configs of Raft Read and Region Flush to KVStoreConfig
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
