### PR TITLE
tests: refine some test utils

### DIFF
--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_bitmap.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_bitmap.cpp
@@ -173,11 +173,11 @@ protected:
         {
             ASSERT_EQ(test_case.expected_size, row_id->size());
             auto expected_row_id = genSequence<UInt32>(test_case.expected_row_id);
-            ASSERT_TRUE(sequenceEqual(expected_row_id.data(), row_id->data(), test_case.expected_size));
+            ASSERT_TRUE(sequenceEqual(expected_row_id, *row_id));
 
             ASSERT_EQ(test_case.expected_size, handle->size());
             auto expected_handle = genSequence<Int64>(test_case.expected_handle);
-            ASSERT_TRUE(sequenceEqual(expected_handle.data(), handle->data(), test_case.expected_size));
+            ASSERT_TRUE(sequenceEqual(expected_handle, *handle));
         }
     }
 
@@ -349,28 +349,24 @@ try
     ASSERT_TRUE(areSegmentsSharingStable({SEG_ID, *new_seg_id}));
 
     auto left_handle = getSegmentHandle(SEG_ID, {});
-    const auto * left_h = toColumnVectorDataPtr<Int64>(left_handle);
+    const auto & left_h = toColumnVectorData<Int64>(left_handle);
     auto expected_left_handle = genSequence<Int64>("[0, 128)|[200, 255)|[256, 305)|[310, 512)");
-    ASSERT_EQ(expected_left_handle.size(), left_h->size());
-    ASSERT_TRUE(sequenceEqual(expected_left_handle.data(), left_h->data(), left_h->size()));
+    ASSERT_TRUE(sequenceEqual(expected_left_handle, left_h));
 
     auto left_row_id = getSegmentRowId(SEG_ID, {});
-    const auto * left_r = toColumnVectorDataPtr<UInt32>(left_row_id);
+    const auto & left_r = toColumnVectorData<UInt32>(left_row_id);
     auto expected_left_row_id = genSequence<UInt32>("[0, 128)|[1034, 1089)|[256, 298)|[1089, 1096)|[310, 512)");
-    ASSERT_EQ(expected_left_row_id.size(), left_r->size());
-    ASSERT_TRUE(sequenceEqual(expected_left_row_id.data(), left_r->data(), left_r->size()));
+    ASSERT_TRUE(sequenceEqual(expected_left_row_id, left_r));
 
     auto right_handle = getSegmentHandle(*new_seg_id, {});
-    const auto * right_h = toColumnVectorDataPtr<Int64>(right_handle);
+    const auto & right_h = toColumnVectorData<Int64>(right_handle);
     auto expected_right_handle = genSequence<Int64>("[512, 1024)");
-    ASSERT_EQ(expected_right_handle.size(), right_h->size());
-    ASSERT_TRUE(sequenceEqual(expected_right_handle.data(), right_h->data(), right_h->size()));
+    ASSERT_TRUE(sequenceEqual(expected_right_handle, right_h));
 
     auto right_row_id = getSegmentRowId(*new_seg_id, {});
-    const auto * right_r = toColumnVectorDataPtr<UInt32>(right_row_id);
+    const auto & right_r = toColumnVectorData<UInt32>(right_row_id);
     auto expected_right_row_id = genSequence<UInt32>("[512, 1024)");
-    ASSERT_EQ(expected_right_row_id.size(), right_r->size());
-    ASSERT_TRUE(sequenceEqual(expected_right_row_id.data(), right_r->data(), right_r->size()));
+    ASSERT_TRUE(sequenceEqual(expected_right_row_id, right_r));
 }
 CATCH
 
@@ -484,28 +480,24 @@ try
     ASSERT_TRUE(areSegmentsSharingStable({SEG_ID, *new_seg_id}));
 
     auto left_handle = getSegmentHandle(SEG_ID, {});
-    const auto * left_h = toColumnVectorDataPtr<Int64>(left_handle);
+    const auto & left_h = toColumnVectorData<Int64>(left_handle);
     auto expected_left_handle = genSequence<Int64>("[0, 25000)");
-    ASSERT_EQ(expected_left_handle.size(), left_h->size());
-    ASSERT_TRUE(sequenceEqual(expected_left_handle.data(), left_h->data(), left_h->size()));
+    ASSERT_TRUE(sequenceEqual(expected_left_handle, left_h));
 
     auto left_row_id = getSegmentRowId(SEG_ID, {});
-    const auto * left_r = toColumnVectorDataPtr<UInt32>(left_row_id);
+    const auto & left_r = toColumnVectorData<UInt32>(left_row_id);
     auto expected_left_row_id = genSequence<UInt32>("[0, 25000)");
-    ASSERT_EQ(expected_left_row_id.size(), left_r->size());
-    ASSERT_TRUE(sequenceEqual(expected_left_row_id.data(), left_r->data(), left_r->size()));
+    ASSERT_TRUE(sequenceEqual(expected_left_row_id, left_r));
 
     auto right_handle = getSegmentHandle(*new_seg_id, {});
-    const auto * right_h = toColumnVectorDataPtr<Int64>(right_handle);
+    const auto & right_h = toColumnVectorData<Int64>(right_handle);
     auto expected_right_handle = genSequence<Int64>("[25000, 50000)");
-    ASSERT_EQ(expected_right_handle.size(), right_h->size());
-    ASSERT_TRUE(sequenceEqual(expected_right_handle.data(), right_h->data(), right_h->size()));
+    ASSERT_TRUE(sequenceEqual(expected_right_handle, right_h));
 
     auto right_row_id = getSegmentRowId(*new_seg_id, {});
-    const auto * right_r = toColumnVectorDataPtr<UInt32>(right_row_id);
+    const auto & right_r = toColumnVectorData<UInt32>(right_row_id);
     auto expected_right_row_id = genSequence<UInt32>("[25000, 50000)");
-    ASSERT_EQ(expected_right_row_id.size(), right_r->size());
-    ASSERT_TRUE(sequenceEqual(expected_right_row_id.data(), right_r->data(), right_r->size()));
+    ASSERT_TRUE(sequenceEqual(expected_right_row_id, right_r));
 }
 CATCH
 

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_replace_stable_data.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_replace_stable_data.cpp
@@ -189,10 +189,9 @@ protected:
     inline void assertPK(PageIdU64 segment_id, std::string_view expected_sequence)
     {
         auto left_handle = getSegmentHandle(segment_id, {});
-        const auto * left_r = toColumnVectorDataPtr<Int64>(left_handle);
+        const auto & left_r = toColumnVectorData<Int64>(left_handle);
         auto expected_left_handle = genSequence<Int64>(expected_sequence);
-        ASSERT_EQ(expected_left_handle.size(), left_r->size());
-        ASSERT_TRUE(sequenceEqual(expected_left_handle.data(), left_r->data(), left_r->size()));
+        ASSERT_TRUE(sequenceEqual(expected_left_handle, left_r));
     }
 
 private:

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_util.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_util.cpp
@@ -19,6 +19,8 @@
 namespace DB::DM::tests
 {
 
+namespace
+{
 // "[a, b)" => std::pair{a, b}
 template <typename T>
 std::pair<T, T> parseRange(String & str_range)
@@ -98,21 +100,6 @@ void check(const std::vector<SegDataUnit> & seg_data_units)
     RUNTIME_CHECK(mem_units == expected_mem_units, expected_mem_units, mem_units);
 }
 
-std::vector<SegDataUnit> parseSegData(std::string_view seg_data)
-{
-    std::vector<String> str_seg_data_units;
-    boost::split(str_seg_data_units, seg_data, boost::is_any_of("|"));
-    RUNTIME_CHECK(!str_seg_data_units.empty(), seg_data);
-    std::vector<SegDataUnit> seg_data_units;
-    seg_data_units.reserve(str_seg_data_units.size());
-    for (auto & s : str_seg_data_units)
-    {
-        seg_data_units.emplace_back(parseSegDataUnit(s));
-    }
-    check(seg_data_units);
-    return seg_data_units;
-}
-
 template <typename T>
 std::vector<T> genSequence(T begin, T end)
 {
@@ -133,6 +120,22 @@ std::vector<T> genSequence(const std::vector<std::pair<T, T>> & ranges)
     }
     return res;
 }
+} // namespace
+
+std::vector<SegDataUnit> parseSegData(std::string_view seg_data)
+{
+    std::vector<String> str_seg_data_units;
+    boost::split(str_seg_data_units, seg_data, boost::is_any_of("|"));
+    RUNTIME_CHECK(!str_seg_data_units.empty(), seg_data);
+    std::vector<SegDataUnit> seg_data_units;
+    seg_data_units.reserve(str_seg_data_units.size());
+    for (auto & s : str_seg_data_units)
+    {
+        seg_data_units.emplace_back(parseSegDataUnit(s));
+    }
+    check(seg_data_units);
+    return seg_data_units;
+}
 
 template <typename T>
 std::vector<T> genSequence(std::string_view str_ranges)
@@ -141,28 +144,6 @@ std::vector<T> genSequence(std::string_view str_ranges)
     return genSequence(vector_ranges);
 }
 
-template <typename E, typename A>
-::testing::AssertionResult sequenceEqual(const E * expected, const A * actual, size_t size)
-{
-    for (size_t i = 0; i < size; i++)
-    {
-        if (expected[i] != actual[i])
-        {
-            return ::testing::AssertionFailure() << fmt::format(
-                       "Value at index {} mismatch: expected {} vs actual {}. expected => {} actual => {}",
-                       i,
-                       expected[i],
-                       actual[i],
-                       std::vector<E>(expected, expected + size),
-                       std::vector<A>(actual, actual + size));
-        }
-    }
-    return ::testing::AssertionSuccess();
-}
-
 template std::vector<Int64> genSequence(std::string_view str_ranges);
 template std::vector<UInt32> genSequence(std::string_view str_ranges);
-template ::testing::AssertionResult sequenceEqual(const UInt32 * expected, const UInt32 * actual, size_t size);
-template ::testing::AssertionResult sequenceEqual(const Int64 * expected, const Int64 * actual, size_t size);
-
 } // namespace DB::DM::tests

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_util.h
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_util.h
@@ -18,18 +18,8 @@
 #include <common/types.h>
 #include <gtest/gtest.h>
 
-
 namespace DB::DM::tests
 {
-
-// "[a, b)" => std::pair{a, b}
-template <typename T>
-std::pair<T, T> parseRange(String & str_range);
-
-// "[a, b)|[c, d)" => [std::pair{a, b}, std::pair{c, d}]
-template <typename T>
-std::vector<std::pair<T, T>> parseRanges(std::string_view str_ranges);
-
 struct SegDataUnit
 {
     String type;
@@ -37,23 +27,33 @@ struct SegDataUnit
     std::optional<size_t> pack_size; // For DMFile
 };
 
-// "type:[a, b)" => SegDataUnit
-SegDataUnit parseSegDataUnit(String & s);
-
-void check(const std::vector<SegDataUnit> & seg_data_units);
-
 std::vector<SegDataUnit> parseSegData(std::string_view seg_data);
-
-template <typename T>
-std::vector<T> genSequence(T begin, T end);
-
-template <typename T>
-std::vector<T> genSequence(const std::vector<std::pair<T, T>> & ranges);
 
 template <typename T>
 std::vector<T> genSequence(std::string_view str_ranges);
 
 template <typename E, typename A>
-::testing::AssertionResult sequenceEqual(const E * expected, const A * actual, size_t size);
+::testing::AssertionResult sequenceEqual(const E & expected, const A & actual)
+{
+    if (expected.size() != actual.size())
+    {
+        return ::testing::AssertionFailure()
+            << fmt::format("Size mismatch: expected {} vs actual {}.", expected.size(), actual.size());
+    }
+    for (size_t i = 0; i < expected.size(); i++)
+    {
+        if (expected[i] != actual[i])
+        {
+            return ::testing::AssertionFailure() << fmt::format(
+                       "Value at index {} mismatch: expected {} vs actual {}. expected => {} actual => {}",
+                       i,
+                       expected[i],
+                       actual[i],
+                       expected,
+                       actual);
+        }
+    }
+    return ::testing::AssertionSuccess();
+}
 
 } // namespace DB::DM::tests


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #9866

Problem Summary:

This PR mainly refine `sequenceEqual` to accept two vector-like sequence, instead of two pointer.

### What is changed and how it works?

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
