### PR TITLE
*: Set ApplicationType and disagg param when GlobalContext created

### DIFF
--- a/dbms/src/Core/TiFlashDisaggregatedMode.cpp
+++ b/dbms/src/Core/TiFlashDisaggregatedMode.cpp
@@ -18,9 +18,11 @@
 
 namespace DB
 {
-DisaggregatedMode getDisaggregatedMode(const Poco::Util::LayeredConfiguration & config)
+DisaggOptions DisaggOptions::parseFromConfig(const Poco::Util::LayeredConfiguration & config)
 {
     static const std::string config_key = "flash.disaggregated_mode";
+    static const std::string autoscaler_config_key = "flash.use_autoscaler";
+
     DisaggregatedMode mode = DisaggregatedMode::None;
     if (config.has(config_key))
     {
@@ -41,16 +43,13 @@ DisaggregatedMode getDisaggregatedMode(const Poco::Util::LayeredConfiguration & 
             mode = DisaggregatedMode::Storage;
         }
     }
-    return mode;
-}
 
-bool useAutoScaler(const Poco::Util::LayeredConfiguration & config)
-{
-    static const std::string autoscaler_config_key = "flash.use_autoscaler";
+
     bool use_autoscaler = false;
     if (config.has(autoscaler_config_key))
         use_autoscaler = config.getBool(autoscaler_config_key);
-    return use_autoscaler;
+
+    return DisaggOptions{mode, use_autoscaler};
 }
 
 std::string getProxyLabelByDisaggregatedMode(DisaggregatedMode mode)

--- a/dbms/src/Core/TiFlashDisaggregatedMode.h
+++ b/dbms/src/Core/TiFlashDisaggregatedMode.h
@@ -37,7 +37,13 @@ enum class DisaggregatedMode
     Storage,
 };
 
-DisaggregatedMode getDisaggregatedMode(const Poco::Util::LayeredConfiguration & config);
-bool useAutoScaler(const Poco::Util::LayeredConfiguration & config);
+struct DisaggOptions
+{
+    DisaggregatedMode mode = DisaggregatedMode::None;
+    bool use_autoscaler = false;
+
+    static DisaggOptions parseFromConfig(const Poco::Util::LayeredConfiguration & config);
+};
+
 std::string getProxyLabelByDisaggregatedMode(DisaggregatedMode mode);
 } // namespace DB

--- a/dbms/src/DataTypes/DataTypeAggregateFunction.cpp
+++ b/dbms/src/DataTypes/DataTypeAggregateFunction.cpp
@@ -341,7 +341,7 @@ static DataTypePtr create(const ASTPtr & arguments)
         throw Exception("Logical error: empty name of aggregate function passed", ErrorCodes::LOGICAL_ERROR);
 
     /// This is for test usage only
-    auto context_ptr = Context::createGlobal();
+    auto context_ptr = Context::createGlobal(Context::ApplicationType::LOCAL);
     function = AggregateFunctionFactory::instance().get(*context_ptr, function_name, argument_types, params_row);
     return std::make_shared<DataTypeAggregateFunction>(function, argument_types, params_row);
 }

--- a/dbms/src/Flash/Mpp/tests/gtest_mpp_task_manager.cpp
+++ b/dbms/src/Flash/Mpp/tests/gtest_mpp_task_manager.cpp
@@ -31,8 +31,7 @@ class TestMPPTaskManager : public testing::Test
 public:
     TestMPPTaskManager()
     {
-        global_context = Context::createGlobal();
-        global_context->mockConfigLoaded();
+        global_context = Context::createGlobal(Context::ApplicationType::LOCAL);
         TiFlashRaftConfig raft_config;
         global_context->createTMTContext(raft_config, pingcap::ClusterConfig());
     }

--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -347,7 +347,7 @@ std::unique_ptr<Context> Context::createGlobal(
     res->shared->ctx_disagg = SharedContextDisagg::create(*res);
     if (disagg_opt)
     {
-        res->shared->ctx_disagg->disaggregated_mode = disagg_opt->disagg_mode;
+        res->shared->ctx_disagg->disaggregated_mode = disagg_opt->mode;
         res->shared->ctx_disagg->use_autoscaler = disagg_opt->use_autoscaler;
     }
     res->quota = std::make_shared<QuotaForIntervals>();

--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -337,21 +337,29 @@ Context::Context() = default;
 
 std::unique_ptr<Context> Context::createGlobal(
     std::shared_ptr<IRuntimeComponentsFactory> runtime_components_factory,
-    ApplicationType app_type)
+    ApplicationType app_type,
+    const std::optional<DisaggOptions> & disagg_opt)
 {
     std::unique_ptr<Context> res(new Context());
     res->setGlobalContext(*res);
     res->runtime_components_factory = runtime_components_factory;
     res->shared = std::make_shared<ContextShared>(runtime_components_factory, app_type);
     res->shared->ctx_disagg = SharedContextDisagg::create(*res);
+    if (disagg_opt)
+    {
+        res->shared->ctx_disagg->disaggregated_mode = disagg_opt->disagg_mode;
+        res->shared->ctx_disagg->use_autoscaler = disagg_opt->use_autoscaler;
+    }
     res->quota = std::make_shared<QuotaForIntervals>();
     res->timezone_info.init();
     return res;
 }
 
-std::unique_ptr<Context> Context::createGlobal(ApplicationType app_type)
+std::unique_ptr<Context> Context::createGlobal(
+    ApplicationType app_type,
+    const std::optional<DisaggOptions> & disagg_opt)
 {
-    return createGlobal(std::make_unique<RuntimeComponentsFactory>(), app_type);
+    return createGlobal(std::make_unique<RuntimeComponentsFactory>(), app_type, disagg_opt);
 }
 
 Context::~Context()

--- a/dbms/src/Interpreters/Context.h
+++ b/dbms/src/Interpreters/Context.h
@@ -195,9 +195,18 @@ private:
     Context();
 
 public:
+    enum class ApplicationType
+    {
+        SERVER, /// The program is run as clickhouse-server daemon (default behavior)
+        CLIENT, /// clickhouse-client
+        LOCAL /// clickhouse-local
+    };
+
     /// Create initial Context with ContextShared and etc.
-    static std::unique_ptr<Context> createGlobal(std::shared_ptr<IRuntimeComponentsFactory> runtime_components_factory);
-    static std::unique_ptr<Context> createGlobal();
+    static std::unique_ptr<Context> createGlobal(
+        std::shared_ptr<IRuntimeComponentsFactory> runtime_components_factory,
+        ApplicationType app_type);
+    static std::unique_ptr<Context> createGlobal(ApplicationType app_type);
 
     ~Context();
 
@@ -501,16 +510,6 @@ public:
 
     void shutdown();
 
-    enum class ApplicationType
-    {
-        SERVER, /// The program is run as clickhouse-server daemon (default behavior)
-        CLIENT, /// clickhouse-client
-        LOCAL /// clickhouse-local
-    };
-
-    ApplicationType getApplicationType() const;
-    void setApplicationType(ApplicationType type);
-
     /// Sets default_profile, must be called once during the initialization
     void setDefaultProfiles();
 
@@ -549,8 +548,6 @@ public:
 
     const std::shared_ptr<DB::DM::SharedBlockSchemas> & getSharedBlockSchemas() const;
     void initializeSharedBlockSchemas(size_t shared_block_schemas_size);
-
-    void mockConfigLoaded() { is_config_loaded = true; }
 
     void initKeyspaceBlocklist(const std::unordered_set<KeyspaceID> & keyspace_ids);
     bool isKeyspaceInBlocklist(KeyspaceID keyspace_id);

--- a/dbms/src/Interpreters/Context.h
+++ b/dbms/src/Interpreters/Context.h
@@ -167,6 +167,7 @@ private:
 
     UInt64 session_close_cycle = 0;
     bool session_is_used = false;
+    bool is_config_loaded = false; /// Is configuration loaded from toml file.
 
     enum TestMode
     {
@@ -582,8 +583,6 @@ private:
     void scheduleCloseSession(const SessionKey & key, std::chrono::steady_clock::duration timeout);
 
     void checkIsConfigLoaded() const;
-
-    bool is_config_loaded = false; /// Is configuration loaded from toml file.
 };
 
 

--- a/dbms/src/Interpreters/Context.h
+++ b/dbms/src/Interpreters/Context.h
@@ -202,11 +202,20 @@ public:
         LOCAL /// clickhouse-local
     };
 
+    struct DisaggOptions
+    {
+        DisaggregatedMode disagg_mode = DisaggregatedMode::None;
+        bool use_autoscaler = false;
+    };
+
     /// Create initial Context with ContextShared and etc.
     static std::unique_ptr<Context> createGlobal(
         std::shared_ptr<IRuntimeComponentsFactory> runtime_components_factory,
-        ApplicationType app_type);
-    static std::unique_ptr<Context> createGlobal(ApplicationType app_type);
+        ApplicationType app_type,
+        const std::optional<DisaggOptions> & disagg_opt);
+    static std::unique_ptr<Context> createGlobal(
+        ApplicationType app_type,
+        const std::optional<DisaggOptions> & disagg_opt = std::nullopt);
 
     ~Context();
 

--- a/dbms/src/Interpreters/Context.h
+++ b/dbms/src/Interpreters/Context.h
@@ -203,12 +203,6 @@ public:
         LOCAL /// clickhouse-local
     };
 
-    struct DisaggOptions
-    {
-        DisaggregatedMode disagg_mode = DisaggregatedMode::None;
-        bool use_autoscaler = false;
-    };
-
     /// Create initial Context with ContextShared and etc.
     static std::unique_ptr<Context> createGlobal(
         std::shared_ptr<IRuntimeComponentsFactory> runtime_components_factory,

--- a/dbms/src/Server/CLIService.h
+++ b/dbms/src/Server/CLIService.h
@@ -218,9 +218,7 @@ int CLIService<Func, Args>::main(const std::vector<std::string> &)
         proxy_runner.join();
     });
 
-    global_context = Context::createGlobal();
-    global_context->setApplicationType(Context::ApplicationType::SERVER);
-    global_context->mockConfigLoaded();
+    global_context = Context::createGlobal(Context::ApplicationType::LOCAL);
 
     /// Init File Provider
     if (proxy_conf.is_proxy_runnable)

--- a/dbms/src/Server/Client.cpp
+++ b/dbms/src/Server/Client.cpp
@@ -133,7 +133,7 @@ private:
 
     bool has_vertical_output_suffix = false; /// Is \G present at the end of the query string?
 
-    std::unique_ptr<Context> context = Context::createGlobal();
+    std::unique_ptr<Context> context = Context::createGlobal(Context::ApplicationType::CLIENT);
 
     /// Buffer that reads from stdin in batch mode.
     ReadBufferFromFileDescriptor std_in{STDIN_FILENO};
@@ -241,8 +241,6 @@ private:
             auto loaded_config = config_processor.loadConfig();
             config().add(loaded_config.configuration);
         }
-
-        context->setApplicationType(Context::ApplicationType::CLIENT);
 
         /// settings and limits could be specified in config file, but passed settings has higher priority
 #define EXTRACT_SETTING(TYPE, NAME, DEFAULT, DESCRIPTION)               \

--- a/dbms/src/Server/DTTool/DTTool.h
+++ b/dbms/src/Server/DTTool/DTTool.h
@@ -89,8 +89,7 @@ class ImitativeEnv
     DB::ContextPtr createImitativeContext(const std::string & workdir, bool encryption = false)
     {
         // set itself as global context
-        global_context = DB::Context::createGlobal();
-        global_context->setApplicationType(DB::Context::ApplicationType::LOCAL);
+        global_context = DB::Context::createGlobal(DB::Context::ApplicationType::LOCAL);
 
         global_context->initializeTiFlashMetrics();
         KeyManagerPtr key_manager = std::make_shared<MockKeyManager>(encryption);

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -481,12 +481,11 @@ int Server::main(const std::vector<std::string> & /*args*/)
     registerTableFunctions();
     registerStorages();
 
-    const auto disaggregated_mode = getDisaggregatedMode(config());
-    const auto use_autoscaler = useAutoScaler(config());
+    const auto disagg_opt = DisaggOptions::parseFromConfig(config());
 
     // Later we may create thread pool from GlobalThreadPool
     // init it before other components
-    initThreadPool(disaggregated_mode);
+    initThreadPool(disagg_opt.mode);
 
     TiFlashErrorRegistry::instance(); // This invocation is for initializing
 
@@ -503,7 +502,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
     {
         storage_config.s3_config.enable(/*check_requirements*/ true, log);
     }
-    else if (disaggregated_mode == DisaggregatedMode::Compute && use_autoscaler)
+    else if (disagg_opt.mode == DisaggregatedMode::Compute && disagg_opt.use_autoscaler)
     {
         // compute node with auto scaler, the requirements will be initted later.
         storage_config.s3_config.enable(/*check_requirements*/ false, log);
@@ -541,7 +540,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
     // sanitize check for disagg mode
     if (storage_config.s3_config.isS3Enabled())
     {
-        if (disaggregated_mode == DisaggregatedMode::None)
+        if (disagg_opt.mode == DisaggregatedMode::None)
         {
             const String message = "'flash.disaggregated_mode' must be set when S3 is enabled!";
             LOG_ERROR(log, message);
@@ -555,9 +554,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
     /** Context contains all that query execution is dependent:
       *  settings, available functions, data types, aggregate functions, databases...
       */
-    global_context = Context::createGlobal(
-        Context::ApplicationType::SERVER,
-        Context::DisaggOptions{disaggregated_mode, use_autoscaler});
+    global_context = Context::createGlobal(Context::ApplicationType::SERVER, disagg_opt);
 
     /// Initialize users config reloader.
     auto users_config_reloader = UserConfig::parseSettings(config(), config_path, global_context, log);
@@ -575,8 +572,8 @@ int Server::main(const std::vector<std::string> & /*args*/)
     // Init Proxy's config
     TiFlashProxyConfig proxy_conf( //
         config(),
-        disaggregated_mode,
-        use_autoscaler,
+        disagg_opt.mode,
+        disagg_opt.use_autoscaler,
         STORAGE_FORMAT_CURRENT,
         settings,
         log);
@@ -639,7 +636,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
         log,
         "disaggregated_mode={} use_autoscaler={} enable_s3={}",
         magic_enum::enum_name(global_context->getSharedContextDisagg()->disaggregated_mode),
-        use_autoscaler,
+        disagg_opt.use_autoscaler,
         storage_config.s3_config.isS3Enabled());
 
     if (storage_config.s3_config.isS3Enabled())
@@ -801,7 +798,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
     std::optional<raft_serverpb::StoreIdent> store_ident;
     // Only when this node is disagg compute node and autoscaler is enabled, we don't need the WriteNodePageStorage instance
     // Disagg compute node without autoscaler still need this instance for proxy's data
-    if (!(is_disagg_compute_mode && use_autoscaler))
+    if (!(is_disagg_compute_mode && disagg_opt.use_autoscaler))
     {
         global_context->initializeWriteNodePageStorageIfNeed(global_context->getPathPool());
         if (auto wn_ps = global_context->tryGetWriteNodePageStorage(); wn_ps != nullptr)
@@ -1210,7 +1207,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
             // And we want to make sure LAC is cleanedup.
             // The effects are there will be no resource control during [lac.safeStop(), FlashGrpcServer destruct done],
             // but it's basically ok, that duration is small(normally 100-200ms).
-            if (is_disagg_compute_mode && use_autoscaler && LocalAdmissionController::global_instance)
+            if (is_disagg_compute_mode && disagg_opt.use_autoscaler && LocalAdmissionController::global_instance)
                 LocalAdmissionController::global_instance->safeStop();
         });
 

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -555,7 +555,10 @@ int Server::main(const std::vector<std::string> & /*args*/)
     /** Context contains all that query execution is dependent:
       *  settings, available functions, data types, aggregate functions, databases...
       */
-    global_context = Context::createGlobal(Context::ApplicationType::SERVER);
+    global_context = Context::createGlobal(
+        Context::ApplicationType::SERVER,
+        Context::DisaggOptions{disaggregated_mode, use_autoscaler});
+
     /// Initialize users config reloader.
     auto users_config_reloader = UserConfig::parseSettings(config(), config_path, global_context, log);
 
@@ -590,9 +593,6 @@ int Server::main(const std::vector<std::string> & /*args*/)
     grpc_log = Logger::get("grpc");
     gpr_set_log_verbosity(GPR_LOG_SEVERITY_DEBUG);
     gpr_set_log_function(&printGRPCLog);
-
-    global_context->getSharedContextDisagg()->disaggregated_mode = disaggregated_mode;
-    global_context->getSharedContextDisagg()->use_autoscaler = use_autoscaler;
 
     // Must init this before KVStore.
     global_context->initializeJointThreadInfoJeallocMap();

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -555,7 +555,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
     /** Context contains all that query execution is dependent:
       *  settings, available functions, data types, aggregate functions, databases...
       */
-    global_context = Context::createGlobal();
+    global_context = Context::createGlobal(Context::ApplicationType::SERVER);
     /// Initialize users config reloader.
     auto users_config_reloader = UserConfig::parseSettings(config(), config_path, global_context, log);
 
@@ -591,7 +591,6 @@ int Server::main(const std::vector<std::string> & /*args*/)
     gpr_set_log_verbosity(GPR_LOG_SEVERITY_DEBUG);
     gpr_set_log_function(&printGRPCLog);
 
-    global_context->setApplicationType(Context::ApplicationType::SERVER);
     global_context->getSharedContextDisagg()->disaggregated_mode = disaggregated_mode;
     global_context->getSharedContextDisagg()->use_autoscaler = use_autoscaler;
 

--- a/dbms/src/Storages/Page/tools/PageCtl/PageStorageCtlV3.cpp
+++ b/dbms/src/Storages/Page/tools/PageCtl/PageStorageCtlV3.cpp
@@ -255,7 +255,7 @@ public:
         {
             if (options.is_imitative)
             {
-                auto context = Context::createGlobal();
+                auto context = Context::createGlobal(Context::ApplicationType::LOCAL);
                 getPageStorageV3Info(*context, options);
             }
             else

--- a/dbms/src/TestUtils/TiFlashTestEnv.cpp
+++ b/dbms/src/TestUtils/TiFlashTestEnv.cpp
@@ -109,9 +109,8 @@ void TiFlashTestEnv::addGlobalContext(
     uint64_t bg_thread_count)
 {
     // set itself as global context
-    auto global_context = std::shared_ptr<Context>(DB::Context::createGlobal());
+    auto global_context = std::shared_ptr<Context>(DB::Context::createGlobal(DB::Context::ApplicationType::LOCAL));
     global_contexts.push_back(global_context);
-    global_context->setApplicationType(DB::Context::ApplicationType::LOCAL);
     global_context->setTemporaryPath(getTemporaryPath());
 
     global_context->initializeTiFlashMetrics();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/9857

Problem Summary: After https://github.com/pingcap/tiflash/pull/9753, the code that set "application_type" and "disagg" params is far away from `Context::createGlobal()`. This could lead to unexpected behavior in later code changes.

`Context::checkIsConfigLoaded` rely on `context->application_type` being set correctly

### What is changed and how it works?

The application type should be set when GlobalContext created. 

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
