### PR TITLE
disagg: Adapt with the GetLifecycleConfig response on AWS S3

### DIFF
--- a/dbms/src/Common/FailPoint.cpp
+++ b/dbms/src/Common/FailPoint.cpp
@@ -74,7 +74,8 @@ namespace DB
     M(force_local_index_task_memory_limit_exceeded)               \
     M(exception_build_local_index_for_file)                       \
     M(force_not_support_local_index)                              \
-    M(sync_schema_request_failure)
+    M(sync_schema_request_failure)                                \
+    M(force_set_lifecycle_resp)
 
 #define APPLY_FOR_FAILPOINTS(M)                              \
     M(skip_check_segment_update)                             \

--- a/dbms/src/Server/StorageConfigParser.h
+++ b/dbms/src/Server/StorageConfigParser.h
@@ -43,6 +43,7 @@ struct StorageS3Config
     String bucket;
     String access_key_id;
     String secret_access_key;
+    String session_token;
     UInt64 max_connections = 4096;
     UInt64 connection_timeout_ms = 1000;
     UInt64 request_timeout_ms = 30000;

--- a/dbms/src/Storages/S3/S3Common.cpp
+++ b/dbms/src/Storages/S3/S3Common.cpp
@@ -461,9 +461,9 @@ bool updateRegionByEndpoint(Aws::Client::ClientConfiguration & cfg, const Logger
 
 std::unique_ptr<Aws::S3::S3Client> ClientFactory::create(const StorageS3Config & config_, const LoggerPtr & log)
 {
-    LOG_INFO(log, "Create ClientConfiguration start");
+    LOG_DEBUG(log, "Create ClientConfiguration start");
     Aws::Client::ClientConfiguration cfg(/*profileName*/ "", /*shouldDisableIMDS*/ true);
-    LOG_INFO(log, "Create ClientConfiguration end");
+    LOG_DEBUG(log, "Create ClientConfiguration end");
     cfg.maxConnections = config_.max_connections;
     cfg.requestTimeoutMs = config_.request_timeout_ms;
     cfg.connectTimeoutMs = config_.connection_timeout_ms;
@@ -485,7 +485,7 @@ std::unique_ptr<Aws::S3::S3Client> ClientFactory::create(const StorageS3Config &
             cfg,
             Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never,
             /*userVirtualAddressing*/ use_virtual_addressing);
-        LOG_DEBUG(log, "Create S3Client end");
+        LOG_INFO(log, "Create S3Client end");
         return cli;
     }
     else
@@ -502,7 +502,7 @@ std::unique_ptr<Aws::S3::S3Client> ClientFactory::create(const StorageS3Config &
             cfg,
             Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never,
             /*useVirtualAddressing*/ use_virtual_addressing);
-        LOG_DEBUG(log, "Create S3Client with given credentials end");
+        LOG_INFO(log, "Create S3Client with given credentials end");
         return cli;
     }
 }

--- a/dbms/src/Storages/S3/S3Common.h
+++ b/dbms/src/Storages/S3/S3Common.h
@@ -63,7 +63,7 @@ class TiFlashS3Client : public Aws::S3::S3Client
 {
 public:
     // Usually one tiflash instance only need access one bucket.
-    // Store the bucket name to simpilfy some param passing.
+    // Store the bucket name to simplify some param passing.
 
     TiFlashS3Client(const String & bucket_name_, const String & root_);
 

--- a/dbms/src/TestUtils/gtests_dbms_main.cpp
+++ b/dbms/src/TestUtils/gtests_dbms_main.cpp
@@ -90,6 +90,7 @@ int main(int argc, char ** argv)
     const auto s3_poco_client = Poco::Environment::get("S3_POCO_CLIENT", "true");
     const auto access_key_id = Poco::Environment::get("AWS_ACCESS_KEY_ID", "");
     const auto secret_access_key = Poco::Environment::get("AWS_SECRET_ACCESS_KEY", "");
+    const auto session_token = Poco::Environment::get("AWS_SESSION_TOKEN", "");
     const auto mock_s3 = Poco::Environment::get("MOCK_S3", "true"); // In unit-tests, use MockS3Client by default.
     auto s3config = DB::StorageS3Config{
         .verbose = s3_verbose == "true",
@@ -98,6 +99,7 @@ int main(int argc, char ** argv)
         .bucket = s3_bucket,
         .access_key_id = access_key_id,
         .secret_access_key = secret_access_key,
+        .session_token = session_token,
         .root = s3_root,
     };
     Poco::Environment::set("AWS_EC2_METADATA_DISABLED", "true"); // disable to speedup testing


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/9889

Problem Summary:

We encounter some error logging as follow after the lifecycle is correctly added.

```
[2025/02/18 15:47:25.784 +00:00] [WARN] [S3Common.cpp:847] ["Create lifecycle rule with tag filter \"tiflash_deleted=true\" failed, please check the bucket lifecycle configuration or create the lifecycle rule manually, bucket=tiflash  s3error=UNKNOWN s3exception_name=InvalidArgument s3msg=Unable to parse ExceptionName: InvalidArgument Message: Rule ID must be unique. Found same ID for more than one rule request_id=WH14MR0TVK0DTGN5"] [source="bucket=tiflash root=tiflash_dev/"] [thread_id=371]
[2025/02/18 15:47:25.784 +00:00] [WARN] [S3Common.cpp:145] ["tag=AWSErrorMarshaller message=Encountered Unknown AWSError 'InvalidArgument': Rule ID must be unique. Found same ID for more than one rule"] [source=AWSClient] [thread_id=371]
[2025/02/18 15:47:25.729 +00:00] [INFO] [S3Common.cpp:816] ["The lifecycle rule with filter \"tiflash_deleted=true\" has not been added, n_rules=1"] [source="bucket=tiflash root=tiflash_dev/"] [thread_id=371]
```

### What is changed and how it works?

```commit-message
* Adapt the logic of checking rule existence with the rule filter response on latest AWS S3
* Accept `AWS_SESSION_TOKEN` to run unit-test with temporary ak, sk, session_token
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
