### PR TITLE
disagg: Add exclusive label for tiflash compute node (release-7.5)

### DIFF
--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -325,8 +325,34 @@ struct TiFlashProxyConfig
             else
                 args_map["advertise-engine-addr"] = args_map["engine-addr"];
             args_map["engine-label"] = getProxyLabelByDisaggregatedMode(disaggregated_mode);
+#if SERVERLESS_PROXY == 0
+            String extra_label;
+            if (disaggregated_mode == DisaggregatedMode::Storage)
+            {
+                // For tiflash write node, it should report a extra label with "key" == "engine-role-label"
+                // to distinguish with the node under non-disagg mode
+                extra_label = fmt::format("engine_role={}", DISAGGREGATED_MODE_WRITE_ENGINE_ROLE);
+            }
+            else if (disaggregated_mode == DisaggregatedMode::Compute)
+            {
+                // For compute node, explicitly add a label with `exclusive=no-data` to avoid Region
+                // being placed to the compute node.
+                // Related logic in pd-server:
+                // https://github.com/tikv/pd/blob/v8.5.0/pkg/schedule/placement/label_constraint.go#L69-L95
+                extra_label = "exclusive=no-data";
+            }
+            if (args_map.contains("labels"))
+                extra_label = fmt::format("{},{}", args_map["labels"], extra_label);
+            // For non-disagg mode, no extra labels is required
+            if (!extra_label.empty())
+            {
+                args_map["labels"] = extra_label;
+            }
+#else
+            // Serverless proxy has not adapted with these changes yet.
             if (disaggregated_mode != DisaggregatedMode::Compute && has_s3_config)
                 args_map["engine-role-label"] = DISAGGREGATED_MODE_WRITE_ENGINE_ROLE;
+#endif
 
             for (auto && [k, v] : args_map)
                 val_map.emplace("--" + k, std::move(v));

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -290,7 +290,10 @@ struct TiFlashProxyConfig
     // Return true if proxy need to be started, and `val_map` will be filled with the
     // proxy start params.
     // Return false if proxy is not need.
-    bool tryParseFromConfig(const Poco::Util::LayeredConfiguration & config, bool has_s3_config, const LoggerPtr & log)
+    bool tryParseFromConfig(
+        const Poco::Util::LayeredConfiguration & config,
+        [[maybe_unused]] bool has_s3_config,
+        const LoggerPtr & log)
     {
         // tiflash_compute doesn't need proxy.
         auto disaggregated_mode = getDisaggregatedMode(config);


### PR DESCRIPTION
cherry-pick of https://github.com/pingcap/tiflash/pull/9849

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/9750

Problem Summary:

When creating a placement policy through tidb, tidb will create a placement-rule with `"engine" notIn "tiflash"` https://github.com/pingcap/tidb/pull/22065
However, under tiflash disaggregated compute and storage arch, the compute node will register store with label `{"engine": "tiflash_compute"}`.

The logic in PD of choosing store for rule: [pkg/schedule/placement/label_constraint.go @ pd](https://github.com/tikv/pd/blob/7d33065019f78d9150a8c89ddb4593f81e6ff9b3/pkg/schedule/placement/label_constraint.go#L81-L95)

1. If the store's label.key is equal to "engine" (or "exclusive," or starts with '$'), and the rule's constraint does not contain a rule with the same label.key, then do not schedule the peer to this store.
2. Otherwise, further check if the rule's constraint matches the store's label. If it matches, schedule the peer to this store.

So the PD would pick tiflash compute node as target store to place the Region peer.


### What is changed and how it works?

```commit-message
Add a label with {"exclusive": "no-data"}, so that PD won't select TiFlash compute node stores for placing Region
```

We avoid Region data being placed to TiFlash compute node in 2 ways:
* After https://github.com/pingcap/tidb/issues/58633, tidb will NOT set the placement rule with "engine" notIn "tiflash" explicitly.
* This PR in TiFlash compute node, it will add a label with {"exclusive": "no-data"}, so that PD won't select this store for placing Region
  * Remove `--engine-role-label` from proxy args, use `--labels` instead
  * Proxy args `--labels` won't overwrite the `server.labels` in tiflash_tikv.toml, instead, proxy append the extra labels to `server.labels`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix a bug that after executing `ALTER TABLE ... PLACEMENT POLICY ...` Region peers may be unexpectedly added to the TiFlash Compute Node in the disaggregated storage and compute architecture
```
