### PR TITLE
*: Add stacktrace logging when exceptions are thrown in `Server::main`

### DIFF
--- a/dbms/src/AggregateFunctions/ReservoirSampler.h
+++ b/dbms/src/AggregateFunctions/ReservoirSampler.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <Common/Exception.h>
 #include <Common/NaNUtils.h>
 #include <Common/PODArray.h>
 #include <IO/Buffer/ReadBuffer.h>
@@ -139,7 +140,7 @@ public:
     void merge(const ReservoirSampler<T, OnEmpty> & b)
     {
         if (sample_count != b.sample_count)
-            throw Poco::Exception("Cannot merge ReservoirSampler's with different sample_count");
+            throw DB::Exception("Cannot merge ReservoirSampler's with different sample_count");
         sorted = false;
 
         if (b.total_values <= sample_count)
@@ -250,7 +251,7 @@ private:
     ResultType onEmpty() const
     {
         if (OnEmpty == ReservoirSamplerOnEmpty::THROW)
-            throw Poco::Exception("Quantile of empty ReservoirSampler");
+            throw DB::Exception("Quantile of empty ReservoirSampler");
         else
             return NanLikeValueConstructor<ResultType, std::is_floating_point_v<ResultType>>::getValue();
     }

--- a/dbms/src/AggregateFunctions/ReservoirSamplerDeterministic.h
+++ b/dbms/src/AggregateFunctions/ReservoirSamplerDeterministic.h
@@ -132,7 +132,7 @@ public:
     void merge(const ReservoirSamplerDeterministic & b)
     {
         if (sample_count != b.sample_count)
-            throw Poco::Exception("Cannot merge ReservoirSamplerDeterministic's with different sample_count");
+            throw DB::Exception("Cannot merge ReservoirSamplerDeterministic's with different sample_count");
         sorted = false;
 
         if (b.skip_degree > skip_degree)
@@ -232,7 +232,7 @@ private:
     ResultType onEmpty() const
     {
         if (OnEmpty == ReservoirSamplerDeterministicOnEmpty::THROW)
-            throw Poco::Exception("Quantile of empty ReservoirSamplerDeterministic");
+            throw DB::Exception("Quantile of empty ReservoirSamplerDeterministic");
         else
             return NanLikeValueConstructor<ResultType, std::is_floating_point_v<ResultType>>::getValue();
     }

--- a/dbms/src/AggregateFunctions/UniquesHashSet.h
+++ b/dbms/src/AggregateFunctions/UniquesHashSet.h
@@ -378,7 +378,7 @@ public:
     void write(DB::WriteBuffer & wb) const
     {
         if (m_size > UNIQUES_HASH_MAX_SIZE)
-            throw Poco::Exception("Cannot write UniquesHashSet: too large size_degree.");
+            throw DB::Exception("Cannot write UniquesHashSet: too large size_degree.");
 
         DB::writeIntBinary(skip_degree, wb);
         DB::writeVarUInt(m_size, wb);
@@ -402,7 +402,7 @@ public:
         DB::readVarUInt(m_size, rb);
 
         if (m_size > UNIQUES_HASH_MAX_SIZE)
-            throw Poco::Exception("Cannot read UniquesHashSet: too large size_degree.");
+            throw DB::Exception("Cannot read UniquesHashSet: too large size_degree.");
 
         free();
 
@@ -438,7 +438,7 @@ public:
         DB::readVarUInt(rhs_size, rb);
 
         if (rhs_size > UNIQUES_HASH_MAX_SIZE)
-            throw Poco::Exception("Cannot read UniquesHashSet: too large size_degree.");
+            throw DB::Exception("Cannot read UniquesHashSet: too large size_degree.");
 
         if ((1ULL << size_degree) < rhs_size)
         {
@@ -463,7 +463,7 @@ public:
         DB::readVarUInt(size, rb);
 
         if (size > UNIQUES_HASH_MAX_SIZE)
-            throw Poco::Exception("Cannot read UniquesHashSet: too large size_degree.");
+            throw DB::Exception("Cannot read UniquesHashSet: too large size_degree.");
 
         rb.ignore(sizeof(HashValue_t) * size);
     }
@@ -471,7 +471,7 @@ public:
     void writeText(DB::WriteBuffer & wb) const
     {
         if (m_size > UNIQUES_HASH_MAX_SIZE)
-            throw Poco::Exception("Cannot write UniquesHashSet: too large size_degree.");
+            throw DB::Exception("Cannot write UniquesHashSet: too large size_degree.");
 
         DB::writeIntText(skip_degree, wb);
         wb.write(",", 1);
@@ -499,7 +499,7 @@ public:
         DB::readIntText(m_size, rb);
 
         if (m_size > UNIQUES_HASH_MAX_SIZE)
-            throw Poco::Exception("Cannot read UniquesHashSet: too large size_degree.");
+            throw DB::Exception("Cannot read UniquesHashSet: too large size_degree.");
 
         free();
 

--- a/dbms/src/Common/CombinedCardinalityEstimator.h
+++ b/dbms/src/Common/CombinedCardinalityEstimator.h
@@ -123,7 +123,7 @@ public:
         else if (container_type == details::ContainerType::LARGE)
             return getContainer<Large>().size();
         else
-            throw Poco::Exception("Internal error", ErrorCodes::LOGICAL_ERROR);
+            throw DB::Exception("Internal error", ErrorCodes::LOGICAL_ERROR);
     }
 
     void merge(const Self & rhs)
@@ -233,7 +233,7 @@ private:
     void toMedium()
     {
         if (getContainerType() != details::ContainerType::SMALL)
-            throw Poco::Exception("Internal error", ErrorCodes::LOGICAL_ERROR);
+            throw DB::Exception("Internal error", ErrorCodes::LOGICAL_ERROR);
 
         CurrentMemoryTracker::alloc(sizeof(Medium));
         auto tmp_medium = std::make_unique<Medium>();
@@ -250,7 +250,7 @@ private:
         auto container_type = getContainerType();
 
         if ((container_type != details::ContainerType::SMALL) && (container_type != details::ContainerType::MEDIUM))
-            throw Poco::Exception("Internal error", ErrorCodes::LOGICAL_ERROR);
+            throw DB::Exception("Internal error", ErrorCodes::LOGICAL_ERROR);
 
         CurrentMemoryTracker::alloc(sizeof(Large));
         auto tmp_large = std::make_unique<Large>();

--- a/dbms/src/Common/CounterInFile.h
+++ b/dbms/src/Common/CounterInFile.h
@@ -63,7 +63,7 @@ public:
         bool file_doesnt_exists = !Poco::File(path).exists();
         if (file_doesnt_exists && !create_if_need)
         {
-            throw Poco::Exception(
+            throw DB::Exception(
                 "File " + path
                 + " does not exist. "
                   "You must create it manulally with appropriate value or 0 for first start.");

--- a/dbms/src/Common/HyperLogLogCounter.h
+++ b/dbms/src/Common/HyperLogLogCounter.h
@@ -463,7 +463,7 @@ private:
             return fixed_estimate;
         }
         else
-            throw Poco::Exception("Internal error", DB::ErrorCodes::LOGICAL_ERROR);
+            throw DB::Exception("Internal error", DB::ErrorCodes::LOGICAL_ERROR);
     }
 
     inline double applyCorrection(double raw_estimate) const

--- a/dbms/src/Common/OptimizedRegularExpression.inl.h
+++ b/dbms/src/Common/OptimizedRegularExpression.inl.h
@@ -298,7 +298,7 @@ OptimizedRegularExpressionImpl<thread_safe>::OptimizedRegularExpressionImpl(cons
 
     /// Just four following options are supported
     if (options & (~(RE_CASELESS | RE_NO_CAPTURE | RE_DOT_NL | RE_NO_OPTIMIZE)))
-        throw Poco::Exception("OptimizedRegularExpression: Unsupported option.");
+        throw DB::Exception("OptimizedRegularExpression: Unsupported option.");
 
     is_case_insensitive = options & RE_CASELESS;
     bool is_dot_nl = options & RE_DOT_NL;
@@ -319,7 +319,7 @@ OptimizedRegularExpressionImpl<thread_safe>::OptimizedRegularExpressionImpl(cons
 
         re2 = std::make_unique<RegexType>(regexp_, reg_options);
         if (!re2->ok())
-            throw Poco::Exception(
+            throw DB::Exception(
                 fmt::format("OptimizedRegularExpression: cannot compile re2: {}, error: {}", regexp_, re2->error()));
 
         capture_num = re2->NumberOfCapturingGroups();
@@ -815,7 +815,7 @@ Instructions OptimizedRegularExpressionImpl<thread_safe>::getInstructions(const 
 
     for (const auto & instr : instructions)
         if (instr.substitution_num > static_cast<Int32>(capture_num))
-            throw Poco::Exception(
+            throw DB::Exception(
                 fmt::format(
                     "Id {} in replacement string is an invalid substitution, regexp has only {} capturing groups",
                     instr.substitution_num,

--- a/dbms/src/Databases/DatabaseTiFlash.cpp
+++ b/dbms/src/Databases/DatabaseTiFlash.cpp
@@ -112,7 +112,7 @@ String DatabaseTiFlash::getDataPath() const
 }
 
 
-static constexpr size_t PRINT_MESSAGE_EACH_N_TABLES = 256;
+static constexpr size_t PRINT_MESSAGE_EACH_N_TABLES = 512;
 static constexpr size_t PRINT_MESSAGE_EACH_N_SECONDS = 5;
 static constexpr size_t TABLES_PARALLEL_LOAD_BUNCH_SIZE = 100;
 
@@ -145,7 +145,12 @@ void DatabaseTiFlash::loadTables(Context & context, ThreadPool * thread_pool, bo
             if ((++tables_processed) % PRINT_MESSAGE_EACH_N_TABLES == 0
                 || watch.compareAndRestart(PRINT_MESSAGE_EACH_N_SECONDS))
             {
-                LOG_INFO(log, "{:.2f}%", tables_processed * 100.0 / total_tables);
+                LOG_INFO(
+                    log,
+                    "processed={} total={} pct={:.2f}%",
+                    tables_processed.load(),
+                    total_tables,
+                    tables_processed * 100.0 / total_tables);
                 watch.restart();
             }
 

--- a/dbms/src/IO/ReadHelpers.h
+++ b/dbms/src/IO/ReadHelpers.h
@@ -130,7 +130,11 @@ inline void readStringBinary(std::string & s, ReadBuffer & buf, size_t MAX_STRIN
     readVarUInt(size, buf);
 
     if (size > MAX_STRING_SIZE)
-        throw Poco::Exception("Too large string size.");
+        throw DB::Exception(
+            ErrorCodes::LOGICAL_ERROR,
+            "Too large string size, size={} max_size={}",
+            size,
+            MAX_STRING_SIZE);
 
     s.resize(size);
     buf.readStrict(&s[0], size);
@@ -161,7 +165,11 @@ void readVectorBinary(std::vector<T> & v, ReadBuffer & buf, size_t MAX_VECTOR_SI
     readVarUInt(size, buf);
 
     if (size > MAX_VECTOR_SIZE)
-        throw Poco::Exception("Too large vector size.");
+        throw DB::Exception(
+            ErrorCodes::LOGICAL_ERROR,
+            "Too large vector size, size={}, max_size={}",
+            size,
+            MAX_VECTOR_SIZE);
 
     v.resize(size);
     for (size_t i = 0; i < size; ++i)
@@ -972,7 +980,11 @@ void readBinary(std::vector<T> & x, ReadBuffer & buf)
     readVarUInt(size, buf);
 
     if (size > DEFAULT_MAX_STRING_SIZE)
-        throw Poco::Exception("Too large vector size.");
+        throw DB::Exception(
+            ErrorCodes::LOGICAL_ERROR,
+            "Too large vector size, size={} max_size={}",
+            size,
+            DEFAULT_MAX_STRING_SIZE);
 
     x.resize(size);
     for (size_t i = 0; i < size; ++i)

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -475,6 +475,7 @@ void loadBlockList(
 }
 
 int Server::main(const std::vector<std::string> & /*args*/)
+try
 {
     setThreadName("TiFlashMain");
 
@@ -1250,6 +1251,15 @@ int Server::main(const std::vector<std::string> & /*args*/)
     }
 
     return Application::EXIT_OK;
+}
+catch (...)
+{
+    // The default exception handler of Poco::Util::Application will catch the
+    // `DB::Exception` as `Poco::Exception` and do not print the stacktrace.
+    // So we catch all exceptions here and print the stacktrace.
+    tryLogCurrentException("Server::main");
+    auto code = getCurrentExceptionCode();
+    return code > 0 ? code : 1;
 }
 } // namespace DB
 

--- a/dbms/src/Server/Setup.cpp
+++ b/dbms/src/Server/Setup.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Common/Exception.h>
 #include <Common/Logger.h>
 #include <Server/Setup.h>
 #include <common/config_common.h> // Included for `USE_JEMALLOC`/`USE_MIMALLOC`
@@ -202,7 +203,7 @@ void setOpenFileLimit(UInt64 new_limit, const LoggerPtr & log)
 
     rlimit rlim{};
     if (getrlimit(RLIMIT_NOFILE, &rlim))
-        throw Poco::Exception("Cannot getrlimit");
+        throw DB::Exception("Cannot getrlimit");
 
     if (rlim.rlim_cur == rlim.rlim_max)
     {

--- a/dbms/src/Storages/DeltaMerge/StoragePool/StoragePool.cpp
+++ b/dbms/src/Storages/DeltaMerge/StoragePool/StoragePool.cpp
@@ -394,7 +394,7 @@ void StoragePool::forceTransformMetaV2toV3()
         nullptr);
 
     Pages pages_transform = {};
-    auto meta_transform_acceptor = [&](const DB::Page & page) {
+    auto meta_transform_acceptor = [&](const DB::Page & page, size_t) {
         pages_transform.emplace_back(page);
     };
 

--- a/dbms/src/Storages/KVStore/KVStore.cpp
+++ b/dbms/src/Storages/KVStore/KVStore.cpp
@@ -81,8 +81,6 @@ void KVStore::restore(PathPool & path_pool, const TiFlashRaftProxyHelper * proxy
     this->proxy_helper = proxy_helper;
     manage_lock.regions = region_persister->restore(path_pool, proxy_helper);
 
-    LOG_INFO(log, "Restored {} regions", manage_lock.regions.size());
-
     // init range index
     for (const auto & [id, region] : manage_lock.regions)
     {
@@ -92,19 +90,18 @@ void KVStore::restore(PathPool & path_pool, const TiFlashRaftProxyHelper * proxy
 
     {
         const size_t batch = 512;
-        std::vector<std::stringstream> msgs;
+        std::vector<FmtBuffer> msgs;
         msgs.resize(batch);
 
         // init range index
         for (const auto & [id, region] : manage_lock.regions)
         {
-            msgs[id % batch] << region->getDebugString() << ";";
+            msgs[id % batch].fmtAppend("{};", region->getDebugString());
         }
 
         for (const auto & msg : msgs)
         {
-            auto str = msg.str();
-            if (!str.empty())
+            if (auto str = msg.toString(); !str.empty())
                 LOG_INFO(log, "{}", str);
         }
     }

--- a/dbms/src/Storages/KVStore/KVStore.cpp
+++ b/dbms/src/Storages/KVStore/KVStore.cpp
@@ -93,7 +93,6 @@ void KVStore::restore(PathPool & path_pool, const TiFlashRaftProxyHelper * proxy
         std::vector<FmtBuffer> msgs;
         msgs.resize(batch);
 
-        // init range index
         for (const auto & [id, region] : manage_lock.regions)
         {
             msgs[id % batch].fmtAppend("{};", region->getDebugString());

--- a/dbms/src/Storages/KVStore/MultiRaft/RegionSerde.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/RegionSerde.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Common/Exception.h>
 #include <Common/FailPoint.h>
 #include <Storages/KVStore/Region.h>
 #include <Storages/KVStore/Utils/SerializationHelper.h>

--- a/dbms/src/Storages/KVStore/Utils/SerializationHelper.h
+++ b/dbms/src/Storages/KVStore/Utils/SerializationHelper.h
@@ -67,7 +67,11 @@ inline std::string readBinary2<std::string>(ReadBuffer & buf)
     readIntBinary(size, buf);
 
     if (size > DEFAULT_MAX_STRING_SIZE)
-        throw Exception("Too large string size.", ErrorCodes::LOGICAL_ERROR);
+        throw Exception(
+            ErrorCodes::LOGICAL_ERROR,
+            "Too large string size, size={} max_size={}",
+            size,
+            DEFAULT_MAX_STRING_SIZE);
     std::string s;
     s.resize(size);
     buf.readStrict(&s[0], size);

--- a/dbms/src/Storages/Page/Page.h
+++ b/dbms/src/Storages/Page/Page.h
@@ -113,7 +113,8 @@ using Pages = std::vector<Page>;
 using PageMapU64 = std::map<PageIdU64, Page>;
 
 // Callback for traversing all pages
-using TraversePageCallback = std::function<void(const DB::Page & page)>;
+// the callback will accept page along with the number of total pages in the storage
+using TraversePageCallback = std::function<void(const DB::Page & page, size_t total_pages)>;
 
 // Indicate the page size && offset in PageFile.
 struct PageEntry

--- a/dbms/src/Storages/Page/Page.h
+++ b/dbms/src/Storages/Page/Page.h
@@ -112,6 +112,9 @@ public:
 using Pages = std::vector<Page>;
 using PageMapU64 = std::map<PageIdU64, Page>;
 
+// Callback for traversing all pages
+using TraversePageCallback = std::function<void(const DB::Page & page)>;
+
 // Indicate the page size && offset in PageFile.
 struct PageEntry
 {

--- a/dbms/src/Storages/Page/PageStorage.cpp
+++ b/dbms/src/Storages/Page/PageStorage.cpp
@@ -80,8 +80,7 @@ public:
 
     virtual FileUsageStatistics getFileUsageStatistics() const = 0;
 
-    virtual void traverse(const TraversePageCallback & acceptor, bool only_v2, bool only_v3)
-        const = 0;
+    virtual void traverse(const TraversePageCallback & acceptor, bool only_v2, bool only_v3) const = 0;
 };
 
 
@@ -441,10 +440,11 @@ public:
     {
         auto snapshot = storage->getSnapshot(fmt::format("scan_{}", prefix));
         const auto page_ids = storage->page_directory->getAllPageIdsWithPrefix(prefix, snapshot);
+        const auto num_pages = page_ids.size();
         for (const auto & page_id : page_ids)
         {
             const auto page_id_and_entry = storage->page_directory->getByID(page_id, snapshot);
-            acceptor(storage->blob_store->read(page_id_and_entry));
+            acceptor(storage->blob_store->read(page_id_and_entry), num_pages);
         }
     }
 
@@ -831,7 +831,7 @@ void PageWriter::reloadSettings(const PageStorageConfig & new_config) const
             fmt::format("Unknown PageStorageRunMode {}", static_cast<UInt8>(run_mode)),
             ErrorCodes::LOGICAL_ERROR);
     }
-};
+}
 
 bool PageWriter::gc(bool not_skip, const WriteLimiterPtr & write_limiter, const ReadLimiterPtr & read_limiter) const
 {

--- a/dbms/src/Storages/Page/PageStorage.cpp
+++ b/dbms/src/Storages/Page/PageStorage.cpp
@@ -80,7 +80,7 @@ public:
 
     virtual FileUsageStatistics getFileUsageStatistics() const = 0;
 
-    virtual void traverse(const std::function<void(const DB::Page & page)> & acceptor, bool only_v2, bool only_v3)
+    virtual void traverse(const TraversePageCallback & acceptor, bool only_v2, bool only_v3)
         const = 0;
 };
 
@@ -135,8 +135,7 @@ public:
     // Get some statistics of all living snapshots and the oldest living snapshot.
     SnapshotsStatistics getSnapshotsStat() const override { return storage->getSnapshotsStat(); }
 
-    void traverse(const std::function<void(const DB::Page & page)> & acceptor, bool /*only_v2*/, bool /*only_v3*/)
-        const override
+    void traverse(const TraversePageCallback & acceptor, bool /*only_v2*/, bool /*only_v3*/) const override
     {
         storage->traverse(acceptor, nullptr);
     }
@@ -308,8 +307,7 @@ public:
 
     FileUsageStatistics getFileUsageStatistics() const override { return storage_v3->getFileUsageStatistics(); }
 
-    void traverse(const std::function<void(const DB::Page & page)> & acceptor, bool only_v2, bool only_v3)
-        const override
+    void traverse(const TraversePageCallback & acceptor, bool only_v2, bool only_v3) const override
     {
         // Used by RegionPersister::restore
         // Must traverse storage_v3 before storage_v2
@@ -439,8 +437,7 @@ public:
     // Get some statistics of all living snapshots and the oldest living snapshot.
     SnapshotsStatistics getSnapshotsStat() const override { return storage->getSnapshotsStat(); }
 
-    void traverse(const std::function<void(const DB::Page & page)> & acceptor, bool /*only_v2*/, bool /*only_v3*/)
-        const override
+    void traverse(const TraversePageCallback & acceptor, bool /*only_v2*/, bool /*only_v3*/) const override
     {
         auto snapshot = storage->getSnapshot(fmt::format("scan_{}", prefix));
         const auto page_ids = storage->page_directory->getAllPageIdsWithPrefix(prefix, snapshot);
@@ -588,7 +585,7 @@ FileUsageStatistics PageReader::getFileUsageStatistics() const
     return impl->getFileUsageStatistics();
 }
 
-void PageReader::traverse(const std::function<void(const DB::Page & page)> & acceptor, bool only_v2, bool only_v3) const
+void PageReader::traverse(const TraversePageCallback & acceptor, bool only_v2, bool only_v3) const
 {
     impl->traverse(acceptor, only_v2, only_v3);
 }

--- a/dbms/src/Storages/Page/PageStorage.h
+++ b/dbms/src/Storages/Page/PageStorage.h
@@ -30,15 +30,9 @@
 #include <common/logger_useful.h>
 #include <fmt/format.h>
 
-#include <condition_variable>
 #include <functional>
 #include <memory>
-#include <optional>
-#include <queue>
 #include <set>
-#include <shared_mutex>
-#include <type_traits>
-#include <unordered_map>
 
 
 namespace DB
@@ -187,10 +181,7 @@ public:
         return readImpl(ns_id, page_field, read_limiter, snapshot, throw_on_not_exist);
     }
 
-    void traverse(const std::function<void(const DB::Page & page)> & acceptor, SnapshotPtr snapshot = {})
-    {
-        traverseImpl(acceptor, snapshot);
-    }
+    void traverse(const TraversePageCallback & acceptor, SnapshotPtr snapshot = {}) { traverseImpl(acceptor, snapshot); }
 
     PageIdU64 getNormalPageId(
         NamespaceID ns_id,
@@ -256,7 +247,7 @@ protected:
         bool throw_on_not_exist)
         = 0;
 
-    virtual void traverseImpl(const std::function<void(const DB::Page & page)> & acceptor, SnapshotPtr snapshot) = 0;
+    virtual void traverseImpl(const TraversePageCallback & acceptor, SnapshotPtr snapshot) = 0;
 
     virtual PageIdU64 getNormalPageIdImpl(
         NamespaceID ns_id,
@@ -325,7 +316,7 @@ public:
     FileUsageStatistics getFileUsageStatistics() const;
 
     void traverse(
-        const std::function<void(const DB::Page & page)> & acceptor,
+        const TraversePageCallback & acceptor,
         bool only_v2 = false,
         bool only_v3 = false) const;
 

--- a/dbms/src/Storages/Page/PageStorage.h
+++ b/dbms/src/Storages/Page/PageStorage.h
@@ -181,7 +181,10 @@ public:
         return readImpl(ns_id, page_field, read_limiter, snapshot, throw_on_not_exist);
     }
 
-    void traverse(const TraversePageCallback & acceptor, SnapshotPtr snapshot = {}) { traverseImpl(acceptor, snapshot); }
+    void traverse(const TraversePageCallback & acceptor, SnapshotPtr snapshot = {})
+    {
+        traverseImpl(acceptor, snapshot);
+    }
 
     PageIdU64 getNormalPageId(
         NamespaceID ns_id,
@@ -315,10 +318,7 @@ public:
 
     FileUsageStatistics getFileUsageStatistics() const;
 
-    void traverse(
-        const TraversePageCallback & acceptor,
-        bool only_v2 = false,
-        bool only_v3 = false) const;
+    void traverse(const TraversePageCallback & acceptor, bool only_v2 = false, bool only_v3 = false) const;
 
 private:
     std::unique_ptr<PageReaderImpl> impl;

--- a/dbms/src/Storages/Page/V2/PageStorage.cpp
+++ b/dbms/src/Storages/Page/V2/PageStorage.cpp
@@ -853,7 +853,7 @@ Page PageStorage::readImpl(
     return file_reader->read(field_info, read_limiter);
 }
 
-void PageStorage::traverseImpl(const std::function<void(const DB::Page & page)> & acceptor, SnapshotPtr snapshot)
+void PageStorage::traverseImpl(const TraversePageCallback & acceptor, SnapshotPtr snapshot)
 {
     if (!snapshot)
     {

--- a/dbms/src/Storages/Page/V2/PageStorage.cpp
+++ b/dbms/src/Storages/Page/V2/PageStorage.cpp
@@ -861,6 +861,7 @@ void PageStorage::traverseImpl(const TraversePageCallback & acceptor, SnapshotPt
     }
 
     std::map<PageFileIdAndLevel, PageIds> file_and_pages;
+    size_t num_pages = 0;
     {
         auto * concrete_snapshot = toConcreteSnapshot(snapshot);
         auto valid_pages_ids = concrete_snapshot->version()->validPageIds();
@@ -873,6 +874,7 @@ void PageStorage::traverseImpl(const TraversePageCallback & acceptor, SnapshotPt
                     ErrorCodes::LOGICAL_ERROR);
             file_and_pages[page_entry->fileIdLevel()].emplace_back(page_id);
         }
+        num_pages += valid_pages_ids.size();
     }
 
     for (const auto & p : file_and_pages)
@@ -881,7 +883,7 @@ void PageStorage::traverseImpl(const TraversePageCallback & acceptor, SnapshotPt
         auto pages = readImpl(MAX_NAMESPACE_ID, p.second, nullptr, snapshot, true);
         for (const auto & id_page : pages)
         {
-            acceptor(id_page.second);
+            acceptor(id_page.second, num_pages);
         }
     }
 }

--- a/dbms/src/Storages/Page/V2/PageStorage.h
+++ b/dbms/src/Storages/Page/V2/PageStorage.h
@@ -150,7 +150,7 @@ public:
         SnapshotPtr snapshot,
         bool throw_on_not_exist) override;
 
-    void traverseImpl(const std::function<void(const DB::Page & page)> & acceptor, SnapshotPtr snapshot) override;
+    void traverseImpl(const TraversePageCallback & acceptor, SnapshotPtr snapshot) override;
 
     bool gcImpl(bool not_skip, const WriteLimiterPtr & write_limiter, const ReadLimiterPtr & read_limiter) override;
 
@@ -236,7 +236,7 @@ public:
     PageMap read(const PageIds & page_ids) { return readImpl(TEST_NAMESPACE_ID, page_ids, nullptr, nullptr, true); }
     PageMap read(const PageIds & page_ids, const ReadLimiterPtr & read_limiter, SnapshotPtr snapshot) { return readImpl(TEST_NAMESPACE_ID, page_ids, read_limiter, snapshot, true); };
     PageMap read(const std::vector<PageReadFields> & page_fields) { return readImpl(TEST_NAMESPACE_ID, page_fields, nullptr, nullptr, true); }
-    void traverse(const std::function<void(const DB::Page & page)> & acceptor) { return traverseImpl(acceptor, nullptr); }
+    void traverse(const TraversePageCallback & acceptor) { return traverseImpl(acceptor, nullptr); }
     bool gc() { return gcImpl(false, nullptr, nullptr); }
     // clang-format on
 #endif

--- a/dbms/src/Storages/Page/V2/tests/gtest_page_storage.cpp
+++ b/dbms/src/Storages/Page/V2/tests/gtest_page_storage.cpp
@@ -832,7 +832,7 @@ try
 
     {
         size_t num_pages = 0;
-        storage->traverse([&num_pages](const DB::Page &) { num_pages += 1; });
+        storage->traverse([&num_pages](const DB::Page &, size_t) { num_pages += 1; });
         ASSERT_EQ(num_pages, 0);
     }
 
@@ -862,7 +862,7 @@ try
 
     {
         size_t num_pages = 0;
-        storage->traverse([&num_pages](const Page &) { num_pages += 1; });
+        storage->traverse([&num_pages](const Page &, size_t) { num_pages += 1; });
         ASSERT_EQ(num_pages, 1);
 
         auto page1 = storage->read(1);
@@ -917,7 +917,7 @@ try
 
     {
         size_t num_pages = 0;
-        storage->traverse([&num_pages](const Page &) { num_pages += 1; });
+        storage->traverse([&num_pages](const Page &, size_t) { num_pages += 1; });
         ASSERT_EQ(num_pages, 0);
     }
 
@@ -947,7 +947,7 @@ try
 
     {
         size_t num_pages = 0;
-        storage->traverse([&num_pages](const Page &) { num_pages += 1; });
+        storage->traverse([&num_pages](const Page &, size_t) { num_pages += 1; });
         ASSERT_EQ(num_pages, 1);
 
         auto page1 = storage->read(1);

--- a/dbms/src/Storages/Page/V3/PageStorageImpl.cpp
+++ b/dbms/src/Storages/Page/V3/PageStorageImpl.cpp
@@ -283,7 +283,7 @@ Page PageStorageImpl::readImpl(
     throw Exception("Not support read single filed on V3", ErrorCodes::NOT_IMPLEMENTED);
 }
 
-void PageStorageImpl::traverseImpl(const std::function<void(const DB::Page & page)> & acceptor, SnapshotPtr snapshot)
+void PageStorageImpl::traverseImpl(const TraversePageCallback & acceptor, SnapshotPtr snapshot)
 {
     if (!snapshot)
     {

--- a/dbms/src/Storages/Page/V3/PageStorageImpl.cpp
+++ b/dbms/src/Storages/Page/V3/PageStorageImpl.cpp
@@ -292,10 +292,11 @@ void PageStorageImpl::traverseImpl(const TraversePageCallback & acceptor, Snapsh
 
     // TODO: This could hold the read lock of `page_directory` for a long time
     const auto & page_ids = page_directory->getAllPageIds();
+    size_t total_pages = page_ids.size();
     for (const auto & valid_page : page_ids)
     {
         const auto & page_id_and_entry = page_directory->getByID(valid_page, snapshot);
-        acceptor(blob_store.read(page_id_and_entry));
+        acceptor(blob_store.read(page_id_and_entry), total_pages);
     }
 }
 

--- a/dbms/src/Storages/Page/V3/PageStorageImpl.h
+++ b/dbms/src/Storages/Page/V3/PageStorageImpl.h
@@ -96,7 +96,7 @@ public:
         SnapshotPtr snapshot,
         bool throw_on_not_exist) override;
 
-    void traverseImpl(const std::function<void(const DB::Page & page)> & acceptor, SnapshotPtr snapshot) override;
+    void traverseImpl(const TraversePageCallback & acceptor, SnapshotPtr snapshot) override;
 
     bool gcImpl(bool not_skip, const WriteLimiterPtr & write_limiter, const ReadLimiterPtr & read_limiter) override;
 

--- a/dbms/src/Storages/Page/V3/tests/gtest_page_storage.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_page_storage.cpp
@@ -791,7 +791,7 @@ try
 
     {
         size_t num_pages = 0;
-        page_storage->traverse([&num_pages](const DB::Page &) { num_pages += 1; });
+        page_storage->traverse([&num_pages](const DB::Page &, size_t) { num_pages += 1; });
         ASSERT_EQ(num_pages, 0);
     }
 
@@ -821,7 +821,7 @@ try
 
     {
         size_t num_pages = 0;
-        page_storage->traverse([&num_pages](const Page &) { num_pages += 1; });
+        page_storage->traverse([&num_pages](const Page &, size_t) { num_pages += 1; });
         ASSERT_EQ(num_pages, 1);
 
         auto page1 = page_storage->read(1);
@@ -877,7 +877,7 @@ try
 
     {
         size_t num_pages = 0;
-        page_storage->traverse([&num_pages](const Page &) { num_pages += 1; });
+        page_storage->traverse([&num_pages](const Page &, size_t) { num_pages += 1; });
         ASSERT_EQ(num_pages, 0);
     }
 
@@ -907,7 +907,7 @@ try
 
     {
         size_t num_pages = 0;
-        page_storage->traverse([&num_pages](const Page &) { num_pages += 1; });
+        page_storage->traverse([&num_pages](const Page &, size_t) { num_pages += 1; });
         ASSERT_EQ(num_pages, 1);
 
         auto page1 = page_storage->read(1);

--- a/dbms/src/Storages/Page/workload/PSWorkload.cpp
+++ b/dbms/src/Storages/Page/workload/PSWorkload.cpp
@@ -174,7 +174,7 @@ void StressWorkload::initPageStorage(DB::PageStorageConfig & config, String path
 
     {
         size_t num_of_pages = 0;
-        ps->traverse([&num_of_pages](const DB::Page & page) {
+        ps->traverse([&num_of_pages](const DB::Page & page, size_t) {
             (void)page;
             num_of_pages++;
         });

--- a/libs/libcommon/include/common/ErrorHandlers.h
+++ b/libs/libcommon/include/common/ErrorHandlers.h
@@ -26,9 +26,9 @@
 class KillingErrorHandler : public Poco::ErrorHandler
 {
 public:
-    void exception(const Poco::Exception &) { std::terminate(); }
-    void exception(const std::exception &) { std::terminate(); }
-    void exception() { std::terminate(); }
+    void exception(const Poco::Exception &) override { std::terminate(); }
+    void exception(const std::exception &) override { std::terminate(); }
+    void exception() override { std::terminate(); }
 };
 
 
@@ -37,9 +37,9 @@ public:
 class ServerErrorHandler : public Poco::ErrorHandler
 {
 public:
-    void exception(const Poco::Exception &) { logException(); }
-    void exception(const std::exception &) { logException(); }
-    void exception() { logException(); }
+    void exception(const Poco::Exception &) override { logException(); }
+    void exception(const std::exception &) override { logException(); }
+    void exception() override { logException(); }
 
 private:
     Poco::Logger * log = &Poco::Logger::get("ServerErrorHandler");


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/9902

Problem Summary:
Under some cases, we meet exception with no stacktrace
```
[2025/01/17 18:11:13.564 +08:00] [ERROR] [<unknown>] ["DB::Exception: Too large string size."] [source=Application] [thread_id=1]
```
### What is changed and how it works?

```commit-message
* Add progress logging in `RegionPersister::restore` so that we can get more info how many region is restoring
* Add stacktrace logging when exceptions are thrown in `Server::main`
* Use DB::Exception instead of Poco::Exception to get more stacktrace info
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
Mock the `KVStore::restore` throw an exception in `Server::main`, and the logging can print the stacktrace info
```
[2025/02/24 13:01:46.197 +08:00] [INFO] [DeltaMergeStore.cpp:375] ["Release DeltaMerge Store start"] [source="keyspace=4294967295 table_id=100079"] [thread_id=1]
[2025/02/24 13:01:46.197 +08:00] [INFO] [DeltaMergeStore.cpp:379] ["Release DeltaMerge Store end"] [source="keyspace=4294967295 table_id=100079"] [thread_id=1]
[2025/02/24 13:01:46.212 +08:00] [INFO] [ProxyStateMachine.h:423] ["Unlink tiflash_instance_wrap.tmt"] [thread_id=1]
[2025/02/24 13:01:46.212 +08:00] [INFO] [LocalIndexerScheduler.cpp:94] ["LocalIndexerScheduler is destroyed"] [thread_id=1]
[2025/02/24 13:01:51.065 +08:00] [INFO] [KVStore.cpp:420] ["Destroy KVStore"] [thread_id=1]
[2025/02/24 13:01:51.065 +08:00] [INFO] [ReadIndex.cpp:388] ["KVStore shutdown, deleting read index worker"] [thread_id=1]
[2025/02/24 13:01:51.065 +08:00] [INFO] [KVStore.cpp:422] ["Destroy KVStore Finished"] [thread_id=1]
[2025/02/24 13:01:51.386 +08:00] [INFO] [JointThreadAllocInfo.cpp:194] ["Stop collecting thread alloc metrics"] [thread_id=1]
[2025/02/24 13:01:51.387 +08:00] [INFO] [Server.cpp:724] ["Destroyed global context."] [thread_id=1]
[2025/02/24 13:01:51.387 +08:00] [INFO] [ProxyStateMachine.h:436] ["Let tiflash proxy shutdown"] [thread_id=1]
[2025/02/24 13:01:51.387 +08:00] [INFO] [ProxyStateMachine.h:439] ["Wait for tiflash proxy thread to join"] [thread_id=1]
[2025/02/24 13:01:51.470 +08:00] [INFO] [ProxyStateMachine.h:441] ["tiflash proxy thread is joined"] [thread_id=1]
[2025/02/24 13:01:53.192 +08:00] [ERROR] [Exception.cpp:96] ["Code: 0, e.displayText() = DB::Exception: mock exception: restoring region_id=1890, e.what() = DB::Exception, Stack trace:\n\n\n  0x555559f0650e\tStackTrace::StackTrace() [tiflash+77276430]\n                \tdbms/src/Common/StackTrace.cpp:23\n  0x555559ef5db2\tDB::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, int) [tiflash+77209010]\n                \tdbms/src/Common/Exception.h:46\n  0x55556547e15a\tDB::Region::deserialize(DB::ReadBuffer&, DB::TiFlashRaftProxyHelper const*) [tiflash+267559258]\n                \tdbms/src/Storages/KVStore/MultiRaft/RegionSerde.cpp:97\n  0x555565472cc8\tDB::RegionPersister::restore(DB::PathPool&, DB::TiFlashRaftProxyHelper const*, DB::PageStorageConfig)::$_3::operator()(DB::Page const&, unsigned long) const [tiflash+267513032]\n                \tdbms/src/Storages/KVStore/MultiRaft/RegionPersister.cpp:414\n  0x555565472578\tdecltype(std::declval<DB::RegionPersister::restore(DB::PathPool&, DB::TiFlashRaftProxyHelper const*, DB::PageStorageConfig)::$_3&>()(std::declval<DB::Page const&>(), std::declval<unsigned long>())) std::__1::__invoke[abi:ue170006]<DB::RegionPersister::restore(DB::PathPool&, DB::TiFlashRaftProxyHelper const*, DB::PageStorageConfig)::$_3&, DB::Page const&, unsigned long>(DB::RegionPersister::restore(DB::PathPool&, DB::TiFlashRaftProxyHelper const*, DB::PageStorageConfig)::$_3&, DB::Page const&, unsigned long&&) [tiflash+267511160]\n                \t/DATA/disk1/ra_common/tiflash-env-17/sysroot/bin/../include/c++/v1/__type_traits/invoke.h:340\n  0x555565472525\tvoid std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:ue170006]<DB::RegionPersister::restore(DB::PathPool&, DB::TiFlashRaftProxyHelper const*, DB::PageStorageConfig)::$_3&, DB::Page const&, unsigned long>(DB::RegionPersister::restore(DB::PathPool&, DB::TiFlashRaftProxyHelper const*, DB::PageStorageConfig)::$_3&, DB::Page const&, unsigned long&&) [tiflash+267511077]\n                \t/DATA/disk1/ra_common/tiflash-env-17/sysroot/bin/../include/c++/v1/__type_traits/invoke.h:415\n  0x5555654724ed\tstd::__1::__function::__alloc_func<DB::RegionPersister::restore(DB::PathPool&, DB::TiFlashRaftProxyHelper const*, DB::PageStorageConfig)::$_3, std::__1::allocator<DB::RegionPersister::restore(DB::PathPool&, DB::TiFlashRaftProxyHelper const*, DB::PageStorageConfig)::$_3>, void (DB::Page const&, unsigned long)>::operator()[abi:ue170006](DB::Page const&, unsigned long&&) [tiflash+267511021]\n                \t/DATA/disk1/ra_common/tiflash-env-17/sysroot/bin/../include/c++/v1/__functional/function.h:192\n  0x555565471a39\tstd::__1::__function::__func<DB::RegionPersister::restore(DB::PathPool&, DB::TiFlashRaftProxyHelper const*, DB::PageStorageConfig)::$_3, std::__1::allocator<DB::RegionPersister::restore(DB::PathPool&, DB::TiFlashRaftProxyHelper const*, DB::PageStorageConfig)::$_3>, void (DB::Page const&, unsigned long)>::operator()(DB::Page const&, unsigned long&&) [tiflash+267508281]\n                \t/DATA/disk1/ra_common/tiflash-env-17/sysroot/bin/../include/c++/v1/__functional/function.h:363\n  0x555564760562\tstd::__1::__function::__value_func<void (DB::Page const&, unsigned long)>::operator()[abi:ue170006](DB::Page const&, unsigned long&&) const [tiflash+253805922]\n                \t/DATA/disk1/ra_common/tiflash-env-17/sysroot/bin/../include/c++/v1/__functional/function.h:517\n  0x555564760285\tstd::__1::function<void (DB::Page const&, unsigned long)>::operator()(DB::Page const&, unsigned long) const [tiflash+253805189]\n                \t/DATA/disk1/ra_common/tiflash-env-17/sysroot/bin/../include/c++/v1/__functional/function.h:1168\n  0x5555648cf0e6\tDB::PS::V3::PageStorageImpl::traverseImpl(std::__1::function<void (DB::Page const&, unsigned long)> const&, std::__1::shared_ptr<DB::PageStorageSnapshot>) [tiflash+255308006]\n                \tdbms/src/Storages/Page/V3/PageStorageImpl.cpp:299\n  0x55555a2d0054\tDB::PageStorage::traverse(std::__1::function<void (DB::Page const&, unsigned long)> const&, std::__1::shared_ptr<DB::PageStorageSnapshot>) [tiflash+81248340]\n                \tdbms/src/Storages/Page/PageStorage.h:186\n  0x55556475953a\tDB::PageReaderImplNormal::traverse(std::__1::function<void (DB::Page const&, unsigned long)> const&, bool, bool) const [tiflash+253777210]\n                \tdbms/src/Storages/Page/PageStorage.cpp:139\n  0x555564753817\tDB::PageReader::traverse(std::__1::function<void (DB::Page const&, unsigned long)> const&, bool, bool) const [tiflash+253753367]\n                \tdbms/src/Storages/Page/PageStorage.cpp:590\n  0x55556546e104\tDB::RegionPersister::restore(DB::PathPool&, DB::TiFlashRaftProxyHelper const*, DB::PageStorageConfig) [tiflash+267493636]\n                \tdbms/src/Storages/KVStore/MultiRaft/RegionPersister.cpp:445\n  0x555565303694\tDB::KVStore::restore(DB::PathPool&, DB::TiFlashRaftProxyHelper const*) [tiflash+266008212]\n                \tdbms/src/Storages/KVStore/KVStore.cpp:82\n  0x55556531de4d\tDB::TMTContext::restore(DB::PathPool&, DB::TiFlashRaftProxyHelper const*) [tiflash+266116685]\n                \tdbms/src/Storages/KVStore/TMTContext.cpp:258\n  0x555559fda534\tDB::ProxyStateMachine::restoreKVStore(DB::TMTContext&, DB::PathPool&) const [tiflash+78144820]\n                \tdbms/src/Storages/KVStore/ProxyStateMachine.h:315\n  0x555559fcd871\tDB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&) [tiflash+78092401]\n                \tdbms/src/Server/Server.cpp:1056\n  0x5555664c7145\tPoco::Util::Application::run() [tiflash+284635461]\n                \tcontrib/poco/Util/src/Application.cpp:335\n  0x5555664e5385\tPoco::Util::ServerApplication::run() [tiflash+284758917]\n                \tcontrib/poco/Util/src/ServerApplication.cpp:94\n  0x555559fc3bb7\tDB::Server::run() [tiflash+78052279]\n                \tdbms/src/Server/Server.cpp:176\n  0x5555664e5560\tPoco::Util::ServerApplication::run(int, char**) [tiflash+284759392]\n                \tcontrib/poco/Util/src/ServerApplication.cpp:618\n  0x555559fd0188\tmainEntryClickHouseServer(int, char**) [tiflash+78102920]\n                \tdbms/src/Server/Server.cpp:1268\n  0x555559e81761\tmain [tiflash+76732257]\n                \tdbms/src/Server/main.cpp:172\n  0x7fffe878e590\t__libc_start_call_main [libc.so.6+169360]\n  0x7fffe878e640\t__libc_start_main_alias_1 [libc.so.6+169536]\n  0x555559e81125\t_start [tiflash+76730661]"] [source=Server::main] [thread_id=1]
[2025/02/24 13:01:53.192 +08:00] [INFO] [<unknown>] ["shutting down"] [source=Application] [thread_id=1]
```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
