### PR TITLE
Storage: Fix init_thread_count_scale == 0, tiflash can not start normally

### DIFF
--- a/dbms/src/Interpreters/loadMetadata.cpp
+++ b/dbms/src/Interpreters/loadMetadata.cpp
@@ -187,30 +187,50 @@ void loadMetadata(Context & context)
             force_restore_data);
     };
 
-    size_t default_num_threads
-        = std::max(4UL, std::thread::hardware_concurrency()) * context.getSettingsRef().init_thread_count_scale;
-    auto load_database_thread_num = std::min(default_num_threads, databases.size());
-
-    auto load_databases_thread_pool
-        = ThreadPool(load_database_thread_num, load_database_thread_num / 2, load_database_thread_num * 2);
-    auto load_databases_wait_group = load_databases_thread_pool.waitGroup();
-
-    auto load_tables_thread_pool = ThreadPool(default_num_threads, default_num_threads / 2, default_num_threads * 2);
-
-    for (const auto & database : databases)
+    if (context.getSettingsRef().init_thread_count_scale > 0)
     {
-        const auto & db_name = database.first;
-        const auto & meta_file = database.second;
+        size_t default_num_threads = std::max(4UL, std::thread::hardware_concurrency()) //
+            * context.getSettingsRef().init_thread_count_scale;
+        auto load_database_thread_num = std::min(default_num_threads, databases.size());
+        LOG_INFO(log, "Loading metadata with thread pool, thread_count={}", load_database_thread_num);
 
-        auto task
-            = [&load_database, &context, &db_name, &meta_file, has_force_restore_data_flag, &load_tables_thread_pool] {
-                  load_database(context, db_name, meta_file, &load_tables_thread_pool, has_force_restore_data_flag);
-              };
+        auto load_databases_thread_pool
+            = ThreadPool(load_database_thread_num, load_database_thread_num / 2, load_database_thread_num * 2);
+        auto load_databases_wait_group = load_databases_thread_pool.waitGroup();
 
-        load_databases_wait_group->schedule(task);
+        auto load_tables_thread_pool
+            = ThreadPool(default_num_threads, default_num_threads / 2, default_num_threads * 2);
+
+        for (const auto & database : databases)
+        {
+            const auto & db_name = database.first;
+            const auto & meta_file = database.second;
+
+            auto task = [&load_database,
+                         &context,
+                         &db_name,
+                         &meta_file,
+                         has_force_restore_data_flag,
+                         &load_tables_thread_pool] {
+                load_database(context, db_name, meta_file, &load_tables_thread_pool, has_force_restore_data_flag);
+            };
+
+            load_databases_wait_group->schedule(task);
+        }
+
+        load_databases_wait_group->wait();
     }
-
-    load_databases_wait_group->wait();
+    else
+    {
+        // init_thread_count_scale == 0, run in serial order
+        LOG_INFO(log, "Loading metadata without thread pool");
+        for (const auto & database : databases)
+        {
+            const auto & db_name = database.first;
+            const auto & meta_file = database.second;
+            load_database(context, db_name, meta_file, nullptr, has_force_restore_data_flag);
+        }
+    }
 
     if (has_force_restore_data_flag)
         force_restore_data_flag_file.remove();

--- a/dbms/src/Server/BgStorageInit.cpp
+++ b/dbms/src/Server/BgStorageInit.cpp
@@ -18,6 +18,7 @@
 #include <Server/BgStorageInit.h>
 #include <Storages/IManageableStorage.h>
 #include <Storages/KVStore/TMTContext.h>
+#include <Storages/KVStore/Types.h>
 #include <common/logger_useful.h>
 
 #include <thread>
@@ -37,56 +38,92 @@ void BgStorageInitHolder::waitUntilFinish()
     // or has been detach
 }
 
-void doInitStores(Context & global_context, const LoggerPtr & log)
+struct FuncInitStore
 {
-    const auto storages = global_context.getTMTContext().getStorages().getAllStorage();
+    const KeyspaceTableID ks_table_id;
+    ManageableStoragePtr storage;
 
-    std::atomic<int> init_cnt = 0;
-    std::atomic<int> err_cnt = 0;
+    std::atomic<Int64> & init_cnt;
+    std::atomic<Int64> & err_cnt;
+    const size_t total_count;
+    ThreadPool * restore_segments_thread_pool;
+    const LoggerPtr & log;
 
-    auto init_stores_function = [&](const auto & ks_table_id, auto & storage, auto * restore_segments_thread_pool) {
-        // This will skip the init of storages that do not contain any data. TiFlash now sync the schema and
-        // create all tables regardless the table have define TiFlash replica or not, so there may be lots
-        // of empty tables in TiFlash.
-        // Note that we still need to init stores that contains data (defined by the stable dir of this storage
-        // is exist), or the data used size reported to PD is not correct.
-        const auto & [ks_id, table_id] = ks_table_id;
+    void operator()()
+    {
         try
         {
-            init_cnt += storage->initStoreIfDataDirExist(restore_segments_thread_pool) ? 1 : 0;
-            LOG_INFO(log, "Storage inited done, keyspace={} table_id={}", ks_id, table_id);
+            bool init_done = storage->initStoreIfDataDirExist(nullptr);
+            init_cnt += static_cast<Int64>(init_done);
+            LOG_INFO(
+                log,
+                "Storage inited done, keyspace={} table_id={} n_init={} n_err={} n_total={} datatype_fullname_count={}",
+                ks_table_id.first,
+                ks_table_id.second,
+                init_cnt.load(),
+                err_cnt.load(),
+                total_count,
+                DataTypeFactory::instance().getFullNameCacheSize());
         }
         catch (...)
         {
             err_cnt++;
-            tryLogCurrentException(log, fmt::format("Storage inited fail, keyspace={} table_id={}", ks_id, table_id));
+            tryLogCurrentException(
+                log,
+                fmt::format(
+                    "Storage inited fail, keyspace={} table_id={} n_init={} n_err={} n_total={}",
+                    ks_table_id.first,
+                    ks_table_id.second,
+                    init_cnt.load(),
+                    err_cnt.load(),
+                    total_count));
         }
-    };
-
-    size_t num_threads
-        = std::max(4UL, std::thread::hardware_concurrency()) * global_context.getSettingsRef().init_thread_count_scale;
-    auto init_storages_thread_pool = ThreadPool(num_threads, num_threads / 2, num_threads * 2);
-    auto init_storages_wait_group = init_storages_thread_pool.waitGroup();
-
-    auto restore_segments_thread_pool = ThreadPool(num_threads, num_threads / 2, num_threads * 2);
-
-    for (const auto & iter : storages)
-    {
-        const auto & ks_table_id = iter.first;
-        const auto & storage = iter.second;
-        auto task = [&init_stores_function, &ks_table_id, &storage, &restore_segments_thread_pool] {
-            init_stores_function(ks_table_id, storage, &restore_segments_thread_pool);
-        };
-
-        init_storages_wait_group->schedule(task);
     }
+};
 
-    init_storages_wait_group->wait();
+void doInitStores(Context & global_context, const LoggerPtr & log)
+{
+    const auto storages = global_context.getTMTContext().getStorages().getAllStorage();
+
+    const size_t total_count = storages.size();
+
+    std::atomic<Int64> init_cnt = 0;
+    std::atomic<Int64> err_cnt = 0;
+
+    if (global_context.getSettingsRef().init_thread_count_scale > 0)
+    {
+        size_t num_threads = std::max(4UL, std::thread::hardware_concurrency()) //
+            * global_context.getSettingsRef().init_thread_count_scale;
+        LOG_INFO(log, "Init stores with thread pool, thread_count={}", num_threads);
+        auto init_storages_thread_pool = ThreadPool(num_threads, num_threads / 2, num_threads * 2);
+        auto init_storages_wait_group = init_storages_thread_pool.waitGroup();
+
+        auto restore_segments_thread_pool = ThreadPool(num_threads, num_threads / 2, num_threads * 2);
+
+        for (const auto & [ks_tbl_id, storage] : storages)
+        {
+            auto task
+                = FuncInitStore{ks_tbl_id, storage, init_cnt, err_cnt, total_count, &restore_segments_thread_pool, log};
+
+            init_storages_wait_group->schedule(task);
+        }
+
+        init_storages_wait_group->wait();
+    }
+    else
+    {
+        LOG_INFO(log, "Init stores without thread pool");
+        for (const auto & [ks_tbl_id, storage] : storages)
+        {
+            // run in serial order
+            FuncInitStore{ks_tbl_id, storage, init_cnt, err_cnt, total_count, nullptr, log}();
+        }
+    }
 
     LOG_INFO(
         log,
-        "Storage inited finish. [total_count={}] [init_count={}] [error_count={}] [datatype_fullname_count={}]",
-        storages.size(),
+        "Storage inited finish. total_count={} init_count={} error_count={} datatype_fullname_count={}",
+        total_count,
         init_cnt,
         err_cnt,
         DataTypeFactory::instance().getFullNameCacheSize());
@@ -111,15 +148,17 @@ void BgStorageInitHolder::start(
         doInitStores(global_context, log);
     }
 
-    LOG_INFO(log, "Lazily init store.");
+    LOG_INFO(log, "Lazily init store");
     // apply the inited in another thread to shorten the start time of TiFlash
     if (is_s3_enabled)
     {
+        // If s3 enabled, we need to call `waitUntilFinish` before accepting read request later
         init_thread = std::make_unique<std::thread>([&global_context, &log] { doInitStores(global_context, log); });
         need_join = true;
     }
     else
     {
+        // Otherwise, just detach the thread
         init_thread = std::make_unique<std::thread>([&global_context, &log] { doInitStores(global_context, log); });
         init_thread->detach();
         need_join = false;

--- a/dbms/src/Server/BgStorageInit.cpp
+++ b/dbms/src/Server/BgStorageInit.cpp
@@ -64,6 +64,11 @@ struct FuncInitStore
 
         try
         {
+            // This will skip the init of storages that do not contain any data. TiFlash now sync the schema and
+            // create all tables regardless the table have define TiFlash replica or not, so there may be lots
+            // of empty tables in TiFlash.
+            // Note that we still need to init stores that contains data (defined by the stable dir of this storage
+            // is exist), or the data used size reported to PD is not correct.
             bool init_done = storage->initStoreIfDataDirExist(nullptr);
             init_cnt += static_cast<Int64>(init_done);
             LOG_INFO(

--- a/dbms/src/Server/BgStorageInit.cpp
+++ b/dbms/src/Server/BgStorageInit.cpp
@@ -43,6 +43,7 @@ struct FuncInitStore
     const KeyspaceTableID ks_table_id;
     ManageableStoragePtr storage;
 
+    const std::atomic_size_t & terminated;
     std::atomic<Int64> & init_cnt;
     std::atomic<Int64> & err_cnt;
     const size_t total_count;
@@ -51,6 +52,16 @@ struct FuncInitStore
 
     void operator()()
     {
+        if (terminated.load() != 0)
+        {
+            LOG_INFO(
+                log,
+                "cancel init storage, shutting down, keyspace={} table_id={}",
+                ks_table_id.first,
+                ks_table_id.second);
+            return;
+        }
+
         try
         {
             bool init_done = storage->initStoreIfDataDirExist(nullptr);
@@ -81,7 +92,7 @@ struct FuncInitStore
     }
 };
 
-void doInitStores(Context & global_context, const LoggerPtr & log)
+void doInitStores(Context & global_context, const std::atomic_size_t & terminated, const LoggerPtr & log)
 {
     const auto storages = global_context.getTMTContext().getStorages().getAllStorage();
 
@@ -102,8 +113,15 @@ void doInitStores(Context & global_context, const LoggerPtr & log)
 
         for (const auto & [ks_tbl_id, storage] : storages)
         {
-            auto task
-                = FuncInitStore{ks_tbl_id, storage, init_cnt, err_cnt, total_count, &restore_segments_thread_pool, log};
+            auto task = FuncInitStore{
+                ks_tbl_id,
+                storage,
+                terminated,
+                init_cnt,
+                err_cnt,
+                total_count,
+                &restore_segments_thread_pool,
+                log};
 
             init_storages_wait_group->schedule(task);
         }
@@ -115,22 +133,29 @@ void doInitStores(Context & global_context, const LoggerPtr & log)
         LOG_INFO(log, "Init stores without thread pool");
         for (const auto & [ks_tbl_id, storage] : storages)
         {
-            // run in serial order
-            FuncInitStore{ks_tbl_id, storage, init_cnt, err_cnt, total_count, nullptr, log}();
+            // execute serially
+            if (terminated.load() != 0)
+            {
+                LOG_INFO(log, "cancel init storage, shutting down");
+                break;
+            }
+            FuncInitStore{ks_tbl_id, storage, terminated, init_cnt, err_cnt, total_count, nullptr, log}();
         }
     }
 
     LOG_INFO(
         log,
-        "Storage inited finish. total_count={} init_count={} error_count={} datatype_fullname_count={}",
+        "Storage inited finish. total_count={} init_count={} error_count={} terminated={} datatype_fullname_count={}",
         total_count,
         init_cnt,
         err_cnt,
+        terminated.load(),
         DataTypeFactory::instance().getFullNameCacheSize());
 }
 
 void BgStorageInitHolder::start(
     Context & global_context,
+    const std::atomic_size_t & terminated,
     const LoggerPtr & log,
     bool lazily_init_store,
     bool is_s3_enabled)
@@ -145,7 +170,7 @@ void BgStorageInitHolder::start(
     {
         LOG_INFO(log, "Not lazily init store.");
         need_join = false;
-        doInitStores(global_context, log);
+        doInitStores(global_context, terminated, log);
     }
 
     LOG_INFO(log, "Lazily init store");
@@ -153,13 +178,15 @@ void BgStorageInitHolder::start(
     if (is_s3_enabled)
     {
         // If s3 enabled, we need to call `waitUntilFinish` before accepting read request later
-        init_thread = std::make_unique<std::thread>([&global_context, &log] { doInitStores(global_context, log); });
+        init_thread = std::make_unique<std::thread>(
+            [&global_context, &terminated, &log] { doInitStores(global_context, terminated, log); });
         need_join = true;
     }
     else
     {
         // Otherwise, just detach the thread
-        init_thread = std::make_unique<std::thread>([&global_context, &log] { doInitStores(global_context, log); });
+        init_thread = std::make_unique<std::thread>(
+            [&global_context, &terminated, &log] { doInitStores(global_context, terminated, log); });
         init_thread->detach();
         need_join = false;
     }

--- a/dbms/src/Server/BgStorageInit.h
+++ b/dbms/src/Server/BgStorageInit.h
@@ -18,7 +18,7 @@
 #include <Common/nocopyable.h>
 #include <Interpreters/Context_fwd.h>
 
-#include <memory>
+#include <thread>
 
 namespace DB
 {
@@ -27,7 +27,12 @@ struct BgStorageInitHolder
     bool need_join = false;
     std::unique_ptr<std::thread> init_thread;
 
-    void start(Context & global_context, const LoggerPtr & log, bool lazily_init_store, bool is_s3_enabled);
+    void start(
+        Context & global_context,
+        const std::atomic_size_t & terminated,
+        const LoggerPtr & log,
+        bool lazily_init_store,
+        bool is_s3_enabled);
 
     // wait until finish if need
     void waitUntilFinish();

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -349,6 +349,7 @@ void adjustThreadPoolSize(const Settings & settings, size_t logical_cores)
 void syncSchemaWithTiDB(
     const TiFlashStorageConfig & storage_config,
     BgStorageInitHolder & bg_init_stores,
+    const std::atomic_size_t & terminate_signals_counter,
     const std::unique_ptr<Context> & global_context,
     const LoggerPtr & log)
 {
@@ -382,8 +383,12 @@ void syncSchemaWithTiDB(
     // Init the DeltaMergeStore instances if data exist.
     // Make the disk usage correct and prepare for serving
     // queries.
-    bg_init_stores
-        .start(*global_context, log, storage_config.lazily_init_store, storage_config.s3_config.isS3Enabled());
+    bg_init_stores.start(
+        *global_context,
+        terminate_signals_counter,
+        log,
+        storage_config.lazily_init_store,
+        storage_config.s3_config.isS3Enabled());
 
     // init schema sync service with tidb
     global_context->initializeSchemaSyncService();
@@ -1007,7 +1012,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
             // do not depend on `store_id`. Start sync schema before serving any requests.
             // For the node has not been bootstrapped, this stage will be postpone.
             // FIXME: (bootstrap) we should bootstrap the tiflash node more early!
-            syncSchemaWithTiDB(storage_config, bg_init_stores, global_context, log);
+            syncSchemaWithTiDB(storage_config, bg_init_stores, terminate_signals_counter, global_context, log);
         }
     }
     // set default database for ch-client
@@ -1136,7 +1141,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
                     // Not disagg node done it before
                     // For the disagg node has not been bootstrap, begin the very first schema sync with TiDB.
                     // FIXME: (bootstrap) we should bootstrap the tiflash node more early!
-                    syncSchemaWithTiDB(storage_config, bg_init_stores, global_context, log);
+                    syncSchemaWithTiDB(storage_config, bg_init_stores, terminate_signals_counter, global_context, log);
                     bg_init_stores.waitUntilFinish();
                 }
                 proxy_machine.waitProxyServiceReady(tmt_context, terminate_signals_counter);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/9906

Problem Summary:


If `profiles.default.init_thread_count_scale` to 0, tiflash stuck at loading metadata because we try to add task into a thread pool with num_thread == 0.

### What is changed and how it works?

```commit-message
* If `profiles.default.init_thread_count_scale == 0`, run `loadMetadata` and `BgStorageInit` in serial order.
* Respect `terminate_signals_counter` in `BGStorageInit`
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
deploy a cluster and add this config line to tiflash by tiup edit-config
```
    profiles.default.init_thread_count_scale: 0
```
```
[2025/02/24 16:14:18.240 +08:00] [INFO] [BgStorageInit.cpp:181] ["Lazily init store"] [thread_id=1]
[2025/02/24 16:14:18.361 +08:00] [INFO] [BgStorageInit.cpp:138] ["Init stores without thread pool"] [thread_id=77]
[2025/02/24 16:17:35.796 +08:00] [INFO] [BgStorageInit.cpp:158] ["Storage inited finish. total_count=60258 init_count=57697 error_count=0 terminated=0 datatype_fullname_count=24"] [thread_id=77]
```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
