### PR TITLE
FFI: Fix NPE when GetLockByKey is called when region is not exist

### DIFF
--- a/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
@@ -268,9 +268,9 @@ void injectFailPointForLocalRead([[maybe_unused]] const SelectQueryInfo & query_
 String genErrMsgForLocalRead(const KeyspaceID keyspace_id, const TableID & table_id, const TableID & logical_table_id)
 {
     return table_id == logical_table_id
-        ? fmt::format("(while creating read sources from storage, keyspace_id={} table_id={})", keyspace_id, table_id)
+        ? fmt::format("(while creating read sources from storage, keyspace={} table_id={})", keyspace_id, table_id)
         : fmt::format(
-            "(while creating read sources from storage, keyspace_id={} table_id={} logical_table_id={})",
+            "(while creating read sources from storage, keyspace={} table_id={} logical_table_id={})",
             keyspace_id,
             table_id,
             logical_table_id);

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_Ingest.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore_Ingest.cpp
@@ -1226,7 +1226,7 @@ UInt64 DeltaMergeStore::ingestSegmentsFromCheckpointInfo(
 
     auto restored_segments = checkpoint_info->getRestoredSegments();
     auto updated_segments = ingestSegmentsUsingSplit(dm_context, range, restored_segments);
-    auto estimated_bytes = 0;
+    size_t estimated_bytes = 0;
 
     for (const auto & segment : restored_segments)
     {

--- a/dbms/src/Storages/DeltaMerge/LocalIndexerScheduler.cpp
+++ b/dbms/src/Storages/DeltaMerge/LocalIndexerScheduler.cpp
@@ -176,7 +176,7 @@ size_t LocalIndexerScheduler::dropTasks(KeyspaceID keyspace_id, TableID table_id
         }
     }
 
-    LOG_INFO(logger, "Removed {} tasks, keyspace_id={} table_id={}", dropped_tasks, keyspace_id, table_id);
+    LOG_INFO(logger, "Removed {} tasks, keyspace={} table_id={}", dropped_tasks, keyspace_id, table_id);
 
     return dropped_tasks;
 }
@@ -206,7 +206,7 @@ void LocalIndexerScheduler::taskOnSchedule(std::unique_lock<std::mutex> &, const
 
     LOG_DEBUG( //
         logger,
-        "Start LocalIndex task, keyspace_id={} table_id={} file_ids={} "
+        "Start LocalIndex task, keyspace={} table_id={} file_ids={} "
         "memory_[this/total/limit]_mb={:.1f}/{:.1f}/{:.1f} all_tasks={}",
         task->user_task.keyspace_id,
         task->user_task.table_id,
@@ -235,7 +235,7 @@ void LocalIndexerScheduler::taskOnFinish(std::unique_lock<std::mutex> & lock, co
 
     LOG_DEBUG( //
         logger,
-        "Finish LocalIndex task, keyspace_id={} table_id={} file_ids={} "
+        "Finish LocalIndex task, keyspace={} table_id={} file_ids={} "
         "memory_[this/total/limit]_mb={:.1f}/{:.1f}/{:.1f} "
         "[schedule/task]_cost_sec={:.1f}/{:.1f}",
         task->user_task.keyspace_id,
@@ -302,7 +302,7 @@ bool LocalIndexerScheduler::tryAddTaskToPool(std::unique_lock<std::mutex> & lock
             tryLogCurrentException(
                 logger,
                 fmt::format(
-                    "LocalIndexScheduler meet exception when running task: keyspace_id={} table_id={}",
+                    "LocalIndexScheduler meet exception when running task: keyspace={} table_id={}",
                     task->user_task.keyspace_id,
                     task->user_task.table_id));
         }
@@ -375,7 +375,7 @@ LocalIndexerScheduler::ScheduleResult LocalIndexerScheduler::scheduleNextTask(st
         LOG_DEBUG(
             logger,
             "LocalIndex task is not ready, will try again later when it is ready. "
-            "keyspace_id={} table_id={} file_ids={}",
+            "keyspace={} table_id={} file_ids={}",
             task->user_task.keyspace_id,
             task->user_task.table_id,
             task->user_task.file_ids);

--- a/dbms/src/Storages/DeltaMerge/StoragePool/StoragePool.cpp
+++ b/dbms/src/Storages/DeltaMerge/StoragePool/StoragePool.cpp
@@ -710,7 +710,7 @@ PageStorageRunMode StoragePool::restore()
     const auto [max_log_page_id, max_data_page_id, max_meta_page_id] = global_id_allocator->getCurrentIds();
     LOG_INFO(
         logger,
-        "Finished StoragePool restore. run_mode={} keyspace_id={} table_id={}"
+        "Finished StoragePool restore. run_mode={} keyspace={} table_id={}"
         " max_log_page_id={} max_data_page_id={} max_meta_page_id={}",
         magic_enum::enum_name(run_mode),
         keyspace_id,

--- a/dbms/src/Storages/KVStore/FFI/ProxyFFI.h
+++ b/dbms/src/Storages/KVStore/FFI/ProxyFFI.h
@@ -175,7 +175,7 @@ RawCppPtr PreHandleSnapshot(
 void ApplyPreHandledSnapshot(EngineStoreServerWrap * server, void * res, RawCppPtrType type);
 void AbortPreHandledSnapshot(EngineStoreServerWrap * server, uint64_t region_id, uint64_t peer_id);
 void ReleasePreHandledSnapshot(EngineStoreServerWrap * server, void * res, RawCppPtrType type);
-BaseBuffView GetLockByKey(const EngineStoreServerWrap * server, uint64_t region_id, BaseBuffView key);
+CppStrWithView GetLockByKey(const EngineStoreServerWrap * server, uint64_t region_id, BaseBuffView key);
 HttpRequestRes HandleHttpRequest(EngineStoreServerWrap *, BaseBuffView path, BaseBuffView query, BaseBuffView body);
 uint8_t CheckHttpUriAvailable(BaseBuffView);
 void GcRawCppPtr(void * ptr, RawCppPtrType type);

--- a/dbms/src/Storages/KVStore/FFI/ProxyFFICommon.h
+++ b/dbms/src/Storages/KVStore/FFI/ProxyFFICommon.h
@@ -16,7 +16,7 @@
 
 #include <Common/nocopyable.h>
 
-#include <cstring>
+#include <string>
 
 namespace DB
 {
@@ -25,16 +25,16 @@ struct RawCppString : std::string
     using Base = std::string;
     using Base::Base;
     RawCppString() = delete;
-    RawCppString(Base && src)
+    RawCppString(Base && src) // NOLINT(google-explicit-constructor)
         : Base(std::move(src))
     {}
-    RawCppString(const Base & src)
+    RawCppString(const Base & src) // NOLINT(google-explicit-constructor)
         : Base(src)
     {}
     DISALLOW_COPY(RawCppString);
 
     template <class... Args>
-    static RawCppString * New(Args &&... _args)
+    static RawCppString * New(Args &&... _args) // NOLINT(readability-identifier-naming)
     {
         return new RawCppString{std::forward<Args>(_args)...};
     }

--- a/dbms/src/Storages/KVStore/KVStore.h
+++ b/dbms/src/Storages/KVStore/KVStore.h
@@ -154,7 +154,6 @@ public:
 public: // Region Management
     void restore(PathPool & path_pool, const TiFlashRaftProxyHelper *);
     void gcPersistedRegion(Seconds gc_persist_period = Seconds(60 * 5));
-    RegionPtr getRegion(RegionID region_id) const;
     RegionMap getRegionsByRangeOverlap(const RegionRange & range) const;
     void traverseRegions(std::function<void(RegionID, const RegionPtr &)> && callback) const;
     RegionPtr genRegionPtr(
@@ -167,7 +166,10 @@ public: // Region Management
     void setKVStoreMemoryLimit(size_t s) { maximum_kvstore_memory = s; }
     size_t getKVStoreMemoryLimit() const { return maximum_kvstore_memory; }
 
-    std::shared_ptr<const TiKVValue> getLockByKey(RegionID region_id, const TiKVKey & tikv_key) const;
+    // `genRegionTaskLock` make public for `GetLockByKey`.
+    // TODO: find a better way to wrap the function?
+    RegionTaskLock genRegionTaskLock(UInt64 region_id) const;
+    RegionPtr getRegion(RegionID region_id) const;
 
 public: // Raft Read and Write
     EngineStoreApplyRes handleAdminRaftCmd(
@@ -338,7 +340,6 @@ private:
     RegionManager::RegionReadLock genRegionMgrReadLock() const;
     RegionManager::RegionWriteLock genRegionMgrWriteLock(const KVStoreTaskLock &);
     void handleDestroy(UInt64 region_id, TMTContext & tmt, const KVStoreTaskLock &);
-    RegionTaskLock genRegionTaskLock(UInt64 region_id) const;
 
     //  ---- Region Write ----  //
 

--- a/dbms/src/Storages/KVStore/KVStore.h
+++ b/dbms/src/Storages/KVStore/KVStore.h
@@ -167,6 +167,8 @@ public: // Region Management
     void setKVStoreMemoryLimit(size_t s) { maximum_kvstore_memory = s; }
     size_t getKVStoreMemoryLimit() const { return maximum_kvstore_memory; }
 
+    std::shared_ptr<const TiKVValue> getLockByKey(RegionID region_id, const TiKVKey & tikv_key) const;
+
 public: // Raft Read and Write
     EngineStoreApplyRes handleAdminRaftCmd(
         raft_cmdpb::AdminRequest && request,

--- a/dbms/src/Storages/KVStore/MultiRaft/ApplySnapshot.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/ApplySnapshot.cpp
@@ -339,7 +339,7 @@ void KVStore::applyPreHandledSnapshot(const RegionPtrWrap & new_region, TMTConte
     {
         LOG_INFO(
             log,
-            "Begin apply snapshot, new_region={} keyspace_id={} table_id={}",
+            "Begin apply snapshot, new_region={} keyspace={} table_id={}",
             new_region->toString(true),
             keyspace_id,
             table_id);
@@ -357,7 +357,7 @@ void KVStore::applyPreHandledSnapshot(const RegionPtrWrap & new_region, TMTConte
         // `new_region` may change in the previous function, just log the region_id down
         LOG_INFO(
             log,
-            "Finish apply snapshot, cost={:.3f}s region_id={} keyspace_id={} table_id={}",
+            "Finish apply snapshot, cost={:.3f}s region_id={} keyspace={} table_id={}",
             watch.elapsedSeconds(),
             new_region->id(),
             keyspace_id,
@@ -366,7 +366,7 @@ void KVStore::applyPreHandledSnapshot(const RegionPtrWrap & new_region, TMTConte
     catch (Exception & e)
     {
         e.addMessage(fmt::format(
-            "(while applyPreHandledSnapshot region_id={} keyspace_id={} table_id={})",
+            "(while applyPreHandledSnapshot region_id={} keyspace={} table_id={})",
             new_region->id(),
             keyspace_id,
             table_id));

--- a/dbms/src/Storages/KVStore/MultiRaft/Disagg/ServerlessUtils.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/Disagg/ServerlessUtils.cpp
@@ -147,7 +147,7 @@ String getCompactibleInnerKey(UniversalPageStoragePtr uni_ps, uint32_t keyspace_
         {
             LOG_INFO(
                 DB::Logger::get(),
-                "Failed to find compactible inner key, region_id={}, keyspace_id={}",
+                "Failed to find compactible inner key, region_id={}, keyspace={}",
                 region_id,
                 keyspace_id);
         }
@@ -213,7 +213,7 @@ String getCompactibleEncKey(UniversalPageStoragePtr uni_ps, uint32_t keyspace_id
         {
             LOG_INFO(
                 DB::Logger::get(),
-                "Failed to find compactible enc key, region_id={}, keyspace_id={}",
+                "Failed to find compactible enc key, region_id={}, keyspace={}",
                 region_id,
                 keyspace_id);
         }

--- a/dbms/src/Storages/KVStore/tests/gtest_kvstore.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_kvstore.cpp
@@ -1299,7 +1299,7 @@ try
                 e.message(),
                 fmt::format(
                     "try to apply with older index, region_id={} applied_index={} new_index={}: (while "
-                    "applyPreHandledSnapshot region_id={} keyspace_id=4294967295 table_id={})",
+                    "applyPreHandledSnapshot region_id={} keyspace=4294967295 table_id={})",
                     region_id,
                     8,
                     6,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/9915

Problem Summary:
There could be a chance that GetLockByKey is called when region is not exist
And returning `BaseBuffView` to rust is not memory safe

### What is changed and how it works?


Pending on https://github.com/pingcap/tidb-engine-ext/pull/426

```commit-message
FFI: Fix NPE when GetLockByKey is called when region is not exist
FFI: Use CppStrWithView as the return type of fn_get_lock_by_key
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
