### PR TITLE
fix virtual column not found when remote read happens

### DIFF
--- a/dbms/src/Common/FailPoint.cpp
+++ b/dbms/src/Common/FailPoint.cpp
@@ -92,6 +92,7 @@ namespace DB
     M(force_set_page_data_compact_batch)                     \
     M(force_set_dtfile_exist_when_acquire_id)                \
     M(force_no_local_region_for_mpp_task)                    \
+    M(force_random_remote_read_for_partition_table)          \
     M(force_remote_read_for_batch_cop)                       \
     M(force_pd_grpc_error)                                   \
     M(force_context_path)                                    \

--- a/dbms/src/Common/FailPoint.cpp
+++ b/dbms/src/Common/FailPoint.cpp
@@ -92,7 +92,7 @@ namespace DB
     M(force_set_page_data_compact_batch)                     \
     M(force_set_dtfile_exist_when_acquire_id)                \
     M(force_no_local_region_for_mpp_task)                    \
-    M(force_random_remote_read_for_partition_table)          \
+    M(force_random_remote_read)                              \
     M(force_remote_read_for_batch_cop)                       \
     M(force_pd_grpc_error)                                   \
     M(force_context_path)                                    \

--- a/dbms/src/Flash/Coprocessor/RemoteRequest.cpp
+++ b/dbms/src/Flash/Coprocessor/RemoteRequest.cpp
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 #include <Common/FmtUtils.h>
+#include <DataStreams/GeneratedColumnPlaceholderBlockInputStream.h>
 #include <Flash/Coprocessor/ChunkCodec.h>
 #include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/RemoteRequest.h>
 #include <Storages/MutableSupport.h>
 #include <common/logger_useful.h>
-#include <DataStreams/GeneratedColumnPlaceholderBlockInputStream.h>
 
 namespace DB
 {

--- a/dbms/src/Flash/Coprocessor/RemoteRequest.cpp
+++ b/dbms/src/Flash/Coprocessor/RemoteRequest.cpp
@@ -18,6 +18,7 @@
 #include <Flash/Coprocessor/RemoteRequest.h>
 #include <Storages/MutableSupport.h>
 #include <common/logger_useful.h>
+#include <DataStreams/GeneratedColumnPlaceholderBlockInputStream.h>
 
 namespace DB
 {
@@ -53,7 +54,12 @@ RemoteRequest RemoteRequest::build(
             const auto & col = table_scan.getColumns()[i];
             auto col_id = col.id;
 
-            if (col_id == MutSup::extra_handle_id)
+            if (col.hasGeneratedColumnFlag())
+            {
+                const auto & col_name = GeneratedColumnPlaceholderBlockInputStream::getColumnName(i);
+                schema.emplace_back(std::make_pair(col_name, std::move(col)));
+            }
+            else if (col_id == MutSup::extra_handle_id)
             {
                 TiDB::ColumnInfo ci;
                 ci.tp = TiDB::TypeLongLong;

--- a/dbms/src/Flash/Coprocessor/TablesRegionsInfo.cpp
+++ b/dbms/src/Flash/Coprocessor/TablesRegionsInfo.cpp
@@ -74,11 +74,9 @@ static void insertRegionInfoToTablesRegionInfo(
     const TMTContext & tmt_context)
 {
     auto & table_region_info = tables_region_infos.getOrCreateTableRegionInfoByTableID(table_id);
-#ifndef NDEBUG
-    size_t i = 0;
-#endif
-    for (const auto & r : regions)
+    for (int i = 0; i < regions.size(); ++i) // NOLINT
     {
+        const auto & r = regions[i];
         RegionInfo region_info(
             r.region_id(),
             r.region_epoch().version(),
@@ -102,18 +100,15 @@ static void insertRegionInfoToTablesRegionInfo(
         /// 4. The remote read will fetch the newest region info via key ranges. So it is possible to find the region
         ///    is served by the same node (but still read from remote).
         bool duplicated_region = local_region_id_set.contains(region_info.region_id);
+        bool is_remote = duplicated_region || needRemoteRead(region_info, tmt_context);
 #ifndef NDEBUG
         fiu_do_on(FailPoints::force_random_remote_read, {
             if ((i % 2) != 0)
-            {
-                table_region_info.remote_regions.push_back(region_info);
-                continue;
-            }
+                is_remote = true;
         });
-        ++i;
 #endif
 
-        if (duplicated_region || needRemoteRead(region_info, tmt_context))
+        if (is_remote)
             table_region_info.remote_regions.push_back(region_info);
         else
         {

--- a/dbms/src/Flash/Coprocessor/TablesRegionsInfo.cpp
+++ b/dbms/src/Flash/Coprocessor/TablesRegionsInfo.cpp
@@ -25,7 +25,7 @@ namespace DB
 namespace FailPoints
 {
 extern const char force_no_local_region_for_mpp_task[];
-extern const char force_random_remote_read_for_partition_table[];
+extern const char force_random_remote_read[];
 } // namespace FailPoints
 
 SingleTableRegions & TablesRegionsInfo::getOrCreateTableRegionInfoByTableID(Int64 table_id)
@@ -103,7 +103,7 @@ static void insertRegionInfoToTablesRegionInfo(
         ///    is served by the same node (but still read from remote).
         bool duplicated_region = local_region_id_set.contains(region_info.region_id);
 #ifndef NDEBUG
-        fiu_do_on(FailPoints::force_random_remote_read_for_partition_table, {
+        fiu_do_on(FailPoints::force_random_remote_read, {
             if ((i % 2) != 0)
             {
                 table_region_info.remote_regions.push_back(region_info);

--- a/tests/fullstack-test/mpp/remote_read_virtual_column.test
+++ b/tests/fullstack-test/mpp/remote_read_virtual_column.test
@@ -26,7 +26,7 @@ mysql> split table test.test_vir by (100), (500), (1000);
 TOTAL_SPLIT_REGION	SCATTER_FINISH_RATIO
 3	1
 
-=> DBGInvoke __enable_fail_point(force_random_remote_read_for_partition_table)
+=> DBGInvoke __enable_fail_point(force_random_remote_read)
 mysql> set @@tidb_isolation_read_engines='tiflash'; set @@tidb_enforce_mpp=1; select * from test.test_vir order by 1, 2, 3 limit 5;
 id	str	str_vir
 1	ABC	abc
@@ -34,7 +34,7 @@ id	str	str_vir
 2
 2	Def	def
 3
-=> DBGInvoke __disable_fail_point(force_random_remote_read_for_partition_table)
+=> DBGInvoke __disable_fail_point(force_random_remote_read)
 
 # Clean up.
 mysql> drop table if exists test.test_vir

--- a/tests/fullstack-test/mpp/remote_read_virtual_column.test
+++ b/tests/fullstack-test/mpp/remote_read_virtual_column.test
@@ -1,0 +1,35 @@
+# Copyright 2025 PingCAP, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Preparation.
+=> DBGInvoke __init_fail_point()
+
+mysql> drop table if exists test.test_vir;
+mysql> create table test.test_vir (id int not null, str varchar(100), str_vir varchar(100) as (lower(str))) partition by hash(id) partitions 3;
+mysql> insert into test.test_vir (id, str) values(1, 'ABC'), (2, 'Def'), (3, 'xXXX');
+mysql> alter table test.test_vir set tiflash replica 1;
+
+func> wait_table test test_vir
+
+=> DBGInvoke __enable_fail_point(force_random_remote_read_for_partition_table)
+mysql> set @@tidb_isolation_read_engines='tiflash'; set @@tidb_enforce_mpp=1; select * from test.test_vir order by id;
+id	str	str_vir
+1	ABC	abc
+2	Def	def
+3	xXXX	xxxx
+=> DBGInvoke __disable_fail_point(force_random_remote_read_for_partition_table)
+
+# Clean up.
+mysql> drop table if exists test.test_vir
+

--- a/tests/fullstack-test/mpp/remote_read_virtual_column.test
+++ b/tests/fullstack-test/mpp/remote_read_virtual_column.test
@@ -16,18 +16,24 @@
 => DBGInvoke __init_fail_point()
 
 mysql> drop table if exists test.test_vir;
-mysql> create table test.test_vir (id int not null, str varchar(100), str_vir varchar(100) as (lower(str))) partition by hash(id) partitions 3;
+mysql> create table test.test_vir (id int not null, str varchar(100), str_vir varchar(100) as (lower(str)) VIRTUAL);
 mysql> insert into test.test_vir (id, str) values(1, 'ABC'), (2, 'Def'), (3, 'xXXX');
 mysql> alter table test.test_vir set tiflash replica 1;
+mysql> set @@cte_max_recursion_depth = 10000000; insert into test.test_vir (id, str) with recursive cte1 as (select 1 c1, 'a' c2 union select c1+1 c1, substr(concat(c2, 'B'), 10) c2 from cte1 limit 10000) select * from cte1;
 
 func> wait_table test test_vir
+mysql> split table test.test_vir by (100), (500), (1000);
+TOTAL_SPLIT_REGION	SCATTER_FINISH_RATIO
+3	1
 
 => DBGInvoke __enable_fail_point(force_random_remote_read_for_partition_table)
-mysql> set @@tidb_isolation_read_engines='tiflash'; set @@tidb_enforce_mpp=1; select * from test.test_vir order by id;
+mysql> set @@tidb_isolation_read_engines='tiflash'; set @@tidb_enforce_mpp=1; select * from test.test_vir order by 1, 2, 3 limit 5;
 id	str	str_vir
 1	ABC	abc
+1	a	a
+2
 2	Def	def
-3	xXXX	xxxx
+3
 => DBGInvoke __disable_fail_point(force_random_remote_read_for_partition_table)
 
 # Clean up.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9561

Problem Summary:
```
select col, gen_col from t;
```
gen_col is a virtual generated column. The current approach is that TiFlash generates an empty column and places it in the block. Then, it passes the block to TiDB, allowing TiDB to calculate and populate the column.

I’ve named this column generated_xxx.

The information about this column is marked in tipb_table_scan.columns with a flag. When TiFlash sees this flag, it automatically adds a generated_xxx column.

However, this situation has an issue when a remote read occurs: the block returned from the remote read, when parsed, assigns names to each column based on RemoteRequest.schema. For example, if TiFlash-1 receives a block from TiFlash-2, it will parse it as <col, gen_col>.

But TiFlash-1, in the table scan's projection, expects the block to be <col, generated_xxx>. So, when projecting the block from the remote read, an error occurs because it cannot find the generated_xxx column.

### What is changed and how it works?
make the column name of local read and remote read be same

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
fix virtual column not found when remote read happens
```
