### PR TITLE
Storages: split LocalIndexCache

### DIFF
--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -148,8 +148,10 @@ struct ContextShared
     mutable DBGInvoker dbg_invoker; /// Execute inner functions, debug only.
     mutable MarkCachePtr mark_cache; /// Cache of marks in compressed files.
     mutable DM::MinMaxIndexCachePtr minmax_index_cache; /// Cache of minmax index in compressed files.
-    mutable DM::LocalIndexCachePtr light_local_index_cache; // Cache of local index reader which memory usage is small < 1MB.
-    mutable DM::LocalIndexCachePtr heavy_local_index_cache; // Cache of local index reader which memory usage is large > 1MB.
+    mutable DM::LocalIndexCachePtr
+        light_local_index_cache; // Cache of local index reader which memory usage is small < 1MB.
+    mutable DM::LocalIndexCachePtr
+        heavy_local_index_cache; // Cache of local index reader which memory usage is large > 1MB.
     mutable DM::ColumnCacheLongTermPtr column_cache_long_term;
     mutable DM::DeltaIndexManagerPtr delta_index_manager; /// Manage the Delta Indies of Segments.
     ProcessList process_list; /// Executing queries at the moment.

--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -148,7 +148,8 @@ struct ContextShared
     mutable DBGInvoker dbg_invoker; /// Execute inner functions, debug only.
     mutable MarkCachePtr mark_cache; /// Cache of marks in compressed files.
     mutable DM::MinMaxIndexCachePtr minmax_index_cache; /// Cache of minmax index in compressed files.
-    mutable DM::LocalIndexCachePtr local_index_cache;
+    mutable DM::LocalIndexCachePtr light_local_index_cache; // Cache of local index reader which memory usage is small < 1MB.
+    mutable DM::LocalIndexCachePtr heavy_local_index_cache; // Cache of local index reader which memory usage is large > 1MB.
     mutable DM::ColumnCacheLongTermPtr column_cache_long_term;
     mutable DM::DeltaIndexManagerPtr delta_index_manager; /// Manage the Delta Indies of Segments.
     ProcessList process_list; /// Executing queries at the moment.
@@ -1385,26 +1386,35 @@ void Context::dropMinMaxIndexCache() const
         shared->minmax_index_cache->reset();
 }
 
-void Context::setLocalIndexCache(size_t cache_entities)
+void Context::setLocalIndexCache(size_t light_local_index_cache, size_t heavy_cache_entities)
 {
     auto lock = getLock();
 
-    RUNTIME_CHECK(!shared->local_index_cache);
-
-    shared->local_index_cache = std::make_shared<DM::LocalIndexCache>(cache_entities);
+    RUNTIME_CHECK(!shared->light_local_index_cache);
+    shared->light_local_index_cache = std::make_shared<DM::LocalIndexCache>(light_local_index_cache);
+    RUNTIME_CHECK(!shared->heavy_local_index_cache);
+    shared->heavy_local_index_cache = std::make_shared<DM::LocalIndexCache>(heavy_cache_entities);
 }
 
-DM::LocalIndexCachePtr Context::getLocalIndexCache() const
+DM::LocalIndexCachePtr Context::getLightLocalIndexCache() const
 {
     auto lock = getLock();
-    return shared->local_index_cache;
+    return shared->light_local_index_cache;
+}
+
+DM::LocalIndexCachePtr Context::getHeavyLocalIndexCache() const
+{
+    auto lock = getLock();
+    return shared->heavy_local_index_cache;
 }
 
 void Context::dropLocalIndexCache() const
 {
     auto lock = getLock();
-    if (shared->local_index_cache)
-        shared->local_index_cache.reset();
+    if (shared->light_local_index_cache)
+        shared->light_local_index_cache.reset();
+    if (shared->heavy_local_index_cache)
+        shared->heavy_local_index_cache.reset();
 }
 
 void Context::setColumnCacheLongTerm(size_t cache_size_in_bytes)

--- a/dbms/src/Interpreters/Context.h
+++ b/dbms/src/Interpreters/Context.h
@@ -413,8 +413,9 @@ public:
     std::shared_ptr<DM::MinMaxIndexCache> getMinMaxIndexCache() const;
     void dropMinMaxIndexCache() const;
 
-    void setLocalIndexCache(size_t cache_entities);
-    std::shared_ptr<DM::LocalIndexCache> getLocalIndexCache() const;
+    void setLocalIndexCache(size_t light_local_index_cache, size_t heavy_cache_entities);
+    std::shared_ptr<DM::LocalIndexCache> getLightLocalIndexCache() const;
+    std::shared_ptr<DM::LocalIndexCache> getHeavyLocalIndexCache() const;
     void dropLocalIndexCache() const;
 
     void setColumnCacheLongTerm(size_t cache_size_in_bytes);

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -928,9 +928,10 @@ try
         global_context->setMinMaxIndexCache(minmax_index_cache_size);
 
     /// The vector index cache by number instead of bytes. Because it use `mmap` and let the operator system decide the memory usage.
-    size_t vec_index_cache_entities = config().getUInt64("vec_index_cache_entities", 1000);
-    if (vec_index_cache_entities)
-        global_context->setLocalIndexCache(vec_index_cache_entities);
+    size_t light_local_index_cache_entities = config().getUInt64("light_local_index_cache_entities", 10000);
+    size_t heavy_local_index_cache_entities = config().getUInt64("heavy_local_index_cache_entities", 500);
+    if (light_local_index_cache_entities && heavy_local_index_cache_entities)
+        global_context->setLocalIndexCache(light_local_index_cache_entities, heavy_local_index_cache_entities);
 
     size_t column_cache_long_term_size
         = config().getUInt64("column_cache_long_term_size", 512 * 1024 * 1024 /* 512MB */);

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSetWithVectorIndexInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSetWithVectorIndexInputStream.h
@@ -69,7 +69,7 @@ public:
         , data_provider(data_provider_)
         , ann_query_info(ann_query_info_)
         , valid_rows(std::move(valid_rows_))
-        , vec_index_cache(context_.global_context.getLightLocalIndexCache())
+        , vec_index_cache(context_.global_context.getHeavyLocalIndexCache())
         , vec_cd(std::move(vec_cd_))
         , rest_col_defs(rest_col_defs_)
         , column_files(reader.snapshot->getColumnFiles())

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSetWithVectorIndexInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSetWithVectorIndexInputStream.h
@@ -69,7 +69,7 @@ public:
         , data_provider(data_provider_)
         , ann_query_info(ann_query_info_)
         , valid_rows(std::move(valid_rows_))
-        , vec_index_cache(context_.global_context.getLocalIndexCache())
+        , vec_index_cache(context_.global_context.getLightLocalIndexCache())
         , vec_cd(std::move(vec_cd_))
         , rest_col_defs(rest_col_defs_)
         , column_files(reader.snapshot->getColumnFiles())

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSetWithVectorIndexInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileSetWithVectorIndexInputStream.h
@@ -69,6 +69,7 @@ public:
         , data_provider(data_provider_)
         , ann_query_info(ann_query_info_)
         , valid_rows(std::move(valid_rows_))
+        // ColumnFile vector index stores all data in memory, can not be evicted by system.
         , vec_index_cache(context_.global_context.getHeavyLocalIndexCache())
         , vec_cd(std::move(vec_cd_))
         , rest_col_defs(rest_col_defs_)

--- a/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.cpp
@@ -30,7 +30,7 @@ DMFileBlockInputStreamBuilder::DMFileBlockInputStreamBuilder(const Context & con
     setCaches(
         global_context.getMarkCache(),
         global_context.getMinMaxIndexCache(),
-        global_context.getHeavyLocalIndexCache(),
+        global_context.getLightLocalIndexCache(),
         global_context.getColumnCacheLongTerm());
     // init from settings
     setFromSettings(context.getSettingsRef());

--- a/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.cpp
@@ -30,6 +30,7 @@ DMFileBlockInputStreamBuilder::DMFileBlockInputStreamBuilder(const Context & con
     setCaches(
         global_context.getMarkCache(),
         global_context.getMinMaxIndexCache(),
+        // DMFile vector index uses mmap to read data, does not directly occupy memory.
         global_context.getLightLocalIndexCache(),
         global_context.getColumnCacheLongTerm());
     // init from settings

--- a/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileBlockInputStream.cpp
@@ -30,7 +30,7 @@ DMFileBlockInputStreamBuilder::DMFileBlockInputStreamBuilder(const Context & con
     setCaches(
         global_context.getMarkCache(),
         global_context.getMinMaxIndexCache(),
-        global_context.getLocalIndexCache(),
+        global_context.getHeavyLocalIndexCache(),
         global_context.getColumnCacheLongTerm());
     // init from settings
     setFromSettings(context.getSettingsRef());

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_vector_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_vector_index.cpp
@@ -1735,7 +1735,7 @@ public:
         global_context.tryReleaseWriteNodePageStorageForTest();
         global_context.initializeWriteNodePageStorageIfNeed(global_context.getPathPool());
 
-        global_context.setLocalIndexCache(1000);
+        global_context.setLocalIndexCache(10000, 1000);
 
         auto kvstore = db_context->getTMTContext().getKVStore();
         {
@@ -2308,7 +2308,7 @@ try
     }
     {
         // We should be able to clear something from the vector index cache.
-        auto local_index_cache = TiFlashTestEnv::getGlobalContext().getLocalIndexCache();
+        auto local_index_cache = TiFlashTestEnv::getGlobalContext().getHeavyLocalIndexCache();
         ASSERT_NE(local_index_cache, nullptr);
         ASSERT_EQ(1, cleanLocalIndexCacheEntries(local_index_cache));
     }
@@ -2448,7 +2448,7 @@ try
     }
     {
         // We should be able to clear something from the vector index cache.
-        auto local_index_cache = TiFlashTestEnv::getGlobalContext().getLocalIndexCache();
+        auto local_index_cache = TiFlashTestEnv::getGlobalContext().getHeavyLocalIndexCache();
         ASSERT_NE(local_index_cache, nullptr);
         ASSERT_EQ(1, cleanLocalIndexCacheEntries(local_index_cache));
     }

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_vector_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_vector_index.cpp
@@ -2308,7 +2308,7 @@ try
     }
     {
         // We should be able to clear something from the vector index cache.
-        auto local_index_cache = TiFlashTestEnv::getGlobalContext().getHeavyLocalIndexCache();
+        auto local_index_cache = TiFlashTestEnv::getGlobalContext().getLightLocalIndexCache();
         ASSERT_NE(local_index_cache, nullptr);
         ASSERT_EQ(1, cleanLocalIndexCacheEntries(local_index_cache));
     }
@@ -2448,7 +2448,7 @@ try
     }
     {
         // We should be able to clear something from the vector index cache.
-        auto local_index_cache = TiFlashTestEnv::getGlobalContext().getHeavyLocalIndexCache();
+        auto local_index_cache = TiFlashTestEnv::getGlobalContext().getLightLocalIndexCache();
         ASSERT_NE(local_index_cache, nullptr);
         ASSERT_EQ(1, cleanLocalIndexCacheEntries(local_index_cache));
     }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #9032

Problem Summary:

### What is changed and how it works?

```commit-message
Split local index cache into light/heavy, which distinct by memory usage. It aims to improve cache hit ratio when the table is quite large.
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
