### PR TITLE
build: Fix ENV setting in tiflash-llvm-base image

### DIFF
--- a/release-linux-llvm/Makefile
+++ b/release-linux-llvm/Makefile
@@ -14,10 +14,11 @@
 
 DOCKER ?= docker
 SUFFIX ?= ""
+ARCH = $(shell uname -m)
 
 # Base docker files with prerequisites build tools
 image_tiflash_llvm_base:
-	$(DOCKER) build dockerfiles -f dockerfiles/Dockerfile-tiflash-llvm-base -t hub.pingcap.net/tiflash/tiflash-llvm-base:rocky8$(SUFFIX)
+	$(DOCKER) build dockerfiles -f dockerfiles/Dockerfile-tiflash-llvm-base --build-arg arch="$(ARCH)" -t hub.pingcap.net/tiflash/tiflash-llvm-base:rocky8$(SUFFIX)
 
 # Build tiflash binaries under directory "tiflash"
 build_tiflash_release:

--- a/release-linux-llvm/dockerfiles/Dockerfile-tiflash-llvm-base
+++ b/release-linux-llvm/dockerfiles/Dockerfile-tiflash-llvm-base
@@ -16,14 +16,15 @@
 
 FROM quay.io/rockylinux/rockylinux:8.10.20240528-ubi
 
+ARG arch
 COPY misc /misc
 
 RUN sh /misc/bake_llvm_base.sh
 
 ENV PATH="/opt/cmake/bin:/usr/local/bin/:${PATH}:/usr/local/go/bin:/root/.cargo/bin" \
-    LIBRARY_PATH="/usr/local/lib/$(uname -m)-unknown-linux-gnu/:${LIBRARY_PATH}" \
-    LD_LIBRARY_PATH="/usr/local/lib/$(uname -m)-unknown-linux-gnu/:${LD_LIBRARY_PATH}" \
-    CPLUS_INCLUDE_PATH="/usr/local/include/$(uname -m)-unknown-linux-gnu/c++/v1/:${CPLUS_INCLUDE_PATH}" \
+    LIBRARY_PATH="/usr/local/lib/${arch}-unknown-linux-gnu/:${LIBRARY_PATH}" \
+    LD_LIBRARY_PATH="/usr/local/lib/${arch}-unknown-linux-gnu/:${LD_LIBRARY_PATH}" \
+    CPLUS_INCLUDE_PATH="/usr/local/include/${arch}-unknown-linux-gnu/c++/v1/:${CPLUS_INCLUDE_PATH}" \
     OPENSSL_ROOT_DIR="/usr/local/opt/openssl" \
     CC=clang \
     CXX=clang++ \


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/pull/9587

Problem Summary:
The env in built image of tiflash-llvm-base is not correct

```
> SUFFIX=-llvm-17.0.6 make image_tiflash_llvm_base
> SUFFIX=-llvm-17.0.6
>  docker run -it --rm -v /DATA/disk1/jaysonhuang/tiflash/:/build/tics hub.pingcap.net/tiflash/tiflash-llvm-base:rocky8${SUFFIX} /bin/bash
[root@cdf467e9694f root]# 
[root@cdf467e9694f root]# echo $LIBRARY_PATH 
/usr/local/lib/$(uname -m)-unknown-linux-gnu/:
[root@cdf467e9694f root]# echo $LD_LIBRARY_PATH 
/usr/local/lib/$(uname -m)-unknown-linux-gnu/:
[root@cdf467e9694f root]# echo $CPLUS_INCLUDE_PATH 
/usr/local/include/$(uname -m)-unknown-linux-gnu/c++/v1/:
```

### What is changed and how it works?

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```
> SUFFIX=-llvm-17.0.6
>  docker run -it --rm -v /DATA/disk1/jaysonhuang/tiflash/:/build/tics hub.pingcap.net/tiflash/tiflash-llvm-base:rocky8${SUFFIX} /bin/bash
[root@dd5838604dba root]# echo $LIBRARY_PATH 
/usr/local/lib/x86_64-unknown-linux-gnu/:
[root@dd5838604dba root]# echo $LD_LIBRARY_PATH 
/usr/local/lib/x86_64-unknown-linux-gnu/:
[root@dd5838604dba root]# echo $CPLUS_INCLUDE_PATH 
/usr/local/include/x86_64-unknown-linux-gnu/c++/v1/:
```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
