### PR TITLE
vector: Fix the bug that the local index in CFTiny is not removed during MinorCompaction

### DIFF
--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileDeleteRange.h
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileDeleteRange.h
@@ -73,6 +73,10 @@ public:
             return false;
     }
 
+    // ColumnFileDeleteRange does not store itself into PageStorage.
+    // So there is no need to do anything
+    void removeData(WriteBatches &) const override {}
+
     String toString() const override { return "{delete_range:" + delete_range.toString() + "}"; }
 };
 

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFilePersisted.h
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFilePersisted.h
@@ -36,7 +36,7 @@ class ColumnFilePersisted : public ColumnFile
 public:
     /// Put the data's page id into the corresponding WriteBatch.
     /// The actual remove will be done later.
-    virtual void removeData(WriteBatches &) const {};
+    virtual void removeData(WriteBatches &) const = 0;
 
     virtual void serializeMetadata(WriteBuffer & buf, bool save_schema) const = 0;
 

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileTiny.cpp
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileTiny.cpp
@@ -110,12 +110,12 @@ void ColumnFileTiny::serializeMetadata(dtpb::ColumnFilePersisted * cf_pb, bool s
 }
 
 ColumnFilePersistedPtr ColumnFileTiny::deserializeMetadata(
-    const DMContext & context,
+    const DMContext & dm_context,
     ReadBuffer & buf,
     ColumnFileSchemaPtr & last_schema)
 {
     auto schema_block = deserializeSchema(buf);
-    auto schema = getSchema(context, schema_block, last_schema);
+    auto schema = getSchema(dm_context, schema_block, last_schema);
 
     PageIdU64 data_page_id;
     size_t rows, bytes;
@@ -124,11 +124,11 @@ ColumnFilePersistedPtr ColumnFileTiny::deserializeMetadata(
     readIntBinary(rows, buf);
     readIntBinary(bytes, buf);
 
-    return std::make_shared<ColumnFileTiny>(schema, rows, bytes, data_page_id, context);
+    return std::make_shared<ColumnFileTiny>(schema, rows, bytes, data_page_id, dm_context);
 }
 
 std::shared_ptr<ColumnFileSchema> ColumnFileTiny::getSchema(
-    const DMContext & context,
+    const DMContext & dm_context,
     BlockPtr schema_block,
     ColumnFileSchemaPtr & last_schema)
 {
@@ -138,7 +138,7 @@ std::shared_ptr<ColumnFileSchema> ColumnFileTiny::getSchema(
         schema = last_schema;
     else
     {
-        schema = getSharedBlockSchemas(context)->getOrCreate(*schema_block);
+        schema = getSharedBlockSchemas(dm_context)->getOrCreate(*schema_block);
         last_schema = schema;
     }
 
@@ -148,12 +148,12 @@ std::shared_ptr<ColumnFileSchema> ColumnFileTiny::getSchema(
 }
 
 ColumnFilePersistedPtr ColumnFileTiny::deserializeMetadata(
-    const DMContext & context,
+    const DMContext & dm_context,
     const dtpb::ColumnFileTiny & cf_pb,
     ColumnFileSchemaPtr & last_schema)
 {
     auto schema_block = deserializeSchema(cf_pb.columns());
-    auto schema = getSchema(context, schema_block, last_schema);
+    auto schema = getSchema(dm_context, schema_block, last_schema);
 
     PageIdU64 data_page_id = cf_pb.id();
     size_t rows = cf_pb.rows();
@@ -174,12 +174,12 @@ ColumnFilePersistedPtr ColumnFileTiny::deserializeMetadata(
         index_infos->emplace_back(index_pb);
     }
 
-    return std::make_shared<ColumnFileTiny>(schema, rows, bytes, data_page_id, context, index_infos);
+    return std::make_shared<ColumnFileTiny>(schema, rows, bytes, data_page_id, dm_context, index_infos);
 }
 
 ColumnFilePersistedPtr ColumnFileTiny::restoreFromCheckpoint(
     const LoggerPtr & parent_log,
-    const DMContext & context,
+    const DMContext & dm_context,
     UniversalPageStoragePtr temp_ps,
     WriteBatches & wbs,
     BlockPtr schema,
@@ -189,10 +189,10 @@ ColumnFilePersistedPtr ColumnFileTiny::restoreFromCheckpoint(
     IndexInfosPtr index_infos)
 {
     auto put_remote_page = [&](PageIdU64 page_id) {
-        auto new_cf_id = context.storage_pool->newLogPageId();
+        auto new_cf_id = dm_context.storage_pool->newLogPageId();
         /// Generate a new RemotePage with an entry with data location on S3
         auto remote_page_id = UniversalPageIdFormat::toFullPageId(
-            UniversalPageIdFormat::toFullPrefix(context.keyspace_id, StorageType::Log, context.physical_table_id),
+            UniversalPageIdFormat::toFullPrefix(dm_context.keyspace_id, StorageType::Log, dm_context.physical_table_id),
             page_id);
         // The `data_file_id` in temp_ps is lock key, we need convert it to data key before write to local ps
         auto remote_data_location = temp_ps->getCheckpointLocation(remote_page_id);
@@ -221,7 +221,7 @@ ColumnFilePersistedPtr ColumnFileTiny::restoreFromCheckpoint(
     auto new_cf_id = put_remote_page(data_page_id);
     auto column_file_schema = std::make_shared<ColumnFileSchema>(*schema);
     if (!index_infos)
-        return std::make_shared<ColumnFileTiny>(column_file_schema, rows, bytes, new_cf_id, context);
+        return std::make_shared<ColumnFileTiny>(column_file_schema, rows, bytes, new_cf_id, dm_context);
 
     // Write index data page to local ps
     auto new_index_infos = std::make_shared<IndexInfos>();
@@ -233,12 +233,12 @@ ColumnFilePersistedPtr ColumnFileTiny::restoreFromCheckpoint(
         new_index_info.set_index_page_id(new_index_page_id);
         new_index_infos->emplace_back(std::move(new_index_info));
     }
-    return std::make_shared<ColumnFileTiny>(column_file_schema, rows, bytes, new_cf_id, context, new_index_infos);
+    return std::make_shared<ColumnFileTiny>(column_file_schema, rows, bytes, new_cf_id, dm_context, new_index_infos);
 }
 
 std::tuple<ColumnFilePersistedPtr, BlockPtr> ColumnFileTiny::createFromCheckpoint(
     const LoggerPtr & parent_log,
-    const DMContext & context,
+    const DMContext & dm_context,
     ReadBuffer & buf,
     UniversalPageStoragePtr temp_ps,
     const BlockPtr & last_schema,
@@ -257,14 +257,14 @@ std::tuple<ColumnFilePersistedPtr, BlockPtr> ColumnFileTiny::createFromCheckpoin
     readIntBinary(bytes, buf);
 
     return {
-        restoreFromCheckpoint(parent_log, context, temp_ps, wbs, schema, data_page_id, rows, bytes, nullptr),
+        restoreFromCheckpoint(parent_log, dm_context, temp_ps, wbs, schema, data_page_id, rows, bytes, nullptr),
         schema,
     };
 }
 
 std::tuple<ColumnFilePersistedPtr, BlockPtr> ColumnFileTiny::createFromCheckpoint(
     const LoggerPtr & parent_log,
-    const DMContext & context,
+    const DMContext & dm_context,
     const dtpb::ColumnFileTiny & cf_pb,
     UniversalPageStoragePtr temp_ps,
     const BlockPtr & last_schema,
@@ -294,7 +294,7 @@ std::tuple<ColumnFilePersistedPtr, BlockPtr> ColumnFileTiny::createFromCheckpoin
     }
 
     return {
-        restoreFromCheckpoint(parent_log, context, temp_ps, wbs, schema, data_page_id, rows, bytes, index_infos),
+        restoreFromCheckpoint(parent_log, dm_context, temp_ps, wbs, schema, data_page_id, rows, bytes, index_infos),
         schema,
     };
 }
@@ -320,18 +320,18 @@ Block ColumnFileTiny::readBlockForMinorCompaction(const PageReader & page_reader
 }
 
 ColumnFileTinyPtr ColumnFileTiny::writeColumnFile(
-    const DMContext & context,
+    const DMContext & dm_context,
     const Block & block,
     size_t offset,
     size_t limit,
     WriteBatches & wbs)
 {
-    auto page_id = writeColumnFileData(context, block, offset, limit, wbs);
+    auto page_id = writeColumnFileData(dm_context, block, offset, limit, wbs);
 
-    auto schema = getSharedBlockSchemas(context)->getOrCreate(block);
+    auto schema = getSharedBlockSchemas(dm_context)->getOrCreate(block);
 
     auto bytes = block.bytes(offset, limit);
-    return std::make_shared<ColumnFileTiny>(schema, limit, bytes, page_id, context);
+    return std::make_shared<ColumnFileTiny>(schema, limit, bytes, page_id, dm_context);
 }
 
 PageIdU64 ColumnFileTiny::writeColumnFileData(

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileTiny.h
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileTiny.h
@@ -61,7 +61,7 @@ private:
     IndexInfosPtr index_infos;
 
     /// The id of the keyspace which this ColumnFileTiny belongs to.
-    KeyspaceID keyspace_id;
+    const KeyspaceID keyspace_id;
     /// The global file_provider
     const FileProviderPtr file_provider;
 
@@ -130,37 +130,37 @@ public:
     Block readBlockForMinorCompaction(const PageReader & page_reader) const;
 
     static std::shared_ptr<ColumnFileSchema> getSchema(
-        const DMContext & context,
+        const DMContext & dm_context,
         BlockPtr schema_block,
         ColumnFileSchemaPtr & last_schema);
 
     static ColumnFileTinyPtr writeColumnFile(
-        const DMContext & context,
+        const DMContext & dm_context,
         const Block & block,
         size_t offset,
         size_t limit,
         WriteBatches & wbs);
 
     static PageIdU64 writeColumnFileData(
-        const DMContext & context,
+        const DMContext & dm_context,
         const Block & block,
         size_t offset,
         size_t limit,
         WriteBatches & wbs);
 
     static ColumnFilePersistedPtr deserializeMetadata(
-        const DMContext & context,
+        const DMContext & dm_context,
         ReadBuffer & buf,
         ColumnFileSchemaPtr & last_schema);
 
     static ColumnFilePersistedPtr deserializeMetadata(
-        const DMContext & context,
+        const DMContext & dm_context,
         const dtpb::ColumnFileTiny & cf_pb,
         ColumnFileSchemaPtr & last_schema);
 
     static ColumnFilePersistedPtr restoreFromCheckpoint(
         const LoggerPtr & parent_log,
-        const DMContext & context,
+        const DMContext & dm_context,
         UniversalPageStoragePtr temp_ps,
         WriteBatches & wbs,
         BlockPtr schema,
@@ -170,14 +170,14 @@ public:
         IndexInfosPtr index_infos);
     static std::tuple<ColumnFilePersistedPtr, BlockPtr> createFromCheckpoint(
         const LoggerPtr & parent_log,
-        const DMContext & context,
+        const DMContext & dm_context,
         ReadBuffer & buf,
         UniversalPageStoragePtr temp_ps,
         const BlockPtr & last_schema,
         WriteBatches & wbs);
     static std::tuple<ColumnFilePersistedPtr, BlockPtr> createFromCheckpoint(
         const LoggerPtr & parent_log,
-        const DMContext & context,
+        const DMContext & dm_context,
         const dtpb::ColumnFileTiny & cf_pb,
         UniversalPageStoragePtr temp_ps,
         const BlockPtr & last_schema,

--- a/dbms/src/Storages/DeltaMerge/Delta/ColumnFilePersistedSet.cpp
+++ b/dbms/src/Storages/DeltaMerge/Delta/ColumnFilePersistedSet.cpp
@@ -260,50 +260,50 @@ MinorCompactionPtr ColumnFilePersistedSet::pickUpMinorCompaction(size_t delta_sm
     // For ColumnFileTiny, we will try to combine small `ColumnFileTiny`s to a bigger one.
     // For ColumnFileDeleteRange and ColumnFileBig, we keep them intact.
     // And only if there exists some small `ColumnFileTiny`s which can be combined, we will actually do the compaction.
-    if (persisted_files.empty())
-        return nullptr;
-
-    auto compaction = std::make_shared<MinorCompaction>(minor_compaction_version);
-    bool is_all_trivial_move = true;
-    MinorCompaction::Task cur_task;
-    auto pack_up_cur_task = [&]() {
-        bool is_trivial_move = compaction->packUpTask(std::move(cur_task));
-        is_all_trivial_move = is_all_trivial_move && is_trivial_move;
-        cur_task = {};
-    };
-    size_t index = 0;
-    for (auto & file : persisted_files)
+    if (!persisted_files.empty())
     {
-        if (auto * t_file = file->tryToTinyFile(); t_file)
+        auto compaction = std::make_shared<MinorCompaction>(minor_compaction_version);
+        bool is_all_trivial_move = true;
+        MinorCompaction::Task cur_task;
+        auto pack_up_cur_task = [&]() {
+            bool is_trivial_move = compaction->packUpTask(std::move(cur_task));
+            is_all_trivial_move = is_all_trivial_move && is_trivial_move;
+            cur_task = {};
+        };
+        size_t index = 0;
+        for (auto & file : persisted_files)
         {
-            bool cur_task_full = cur_task.total_rows >= delta_small_column_file_rows;
-            bool small_column_file = t_file->getRows() < delta_small_column_file_rows;
-            bool schema_ok = cur_task.to_compact.empty();
-
-            if (!schema_ok)
+            if (auto * t_file = file->tryToTinyFile(); t_file)
             {
-                if (auto * last_t_file = cur_task.to_compact.back()->tryToTinyFile(); last_t_file)
-                    schema_ok = t_file->getSchema() == last_t_file->getSchema();
+                bool cur_task_full = cur_task.total_rows >= delta_small_column_file_rows;
+                bool small_column_file = t_file->getRows() < delta_small_column_file_rows;
+                bool schema_ok = cur_task.to_compact.empty();
+
+                if (!schema_ok)
+                {
+                    if (auto * last_t_file = cur_task.to_compact.back()->tryToTinyFile(); last_t_file)
+                        schema_ok = t_file->getSchema() == last_t_file->getSchema();
+                }
+
+                if (cur_task_full || !small_column_file || !schema_ok)
+                    pack_up_cur_task();
+
+                cur_task.addColumnFile(file, index);
+            }
+            else
+            {
+                pack_up_cur_task();
+                cur_task.addColumnFile(file, index);
             }
 
-            if (cur_task_full || !small_column_file || !schema_ok)
-                pack_up_cur_task();
-
-            cur_task.addColumnFile(file, index);
+            ++index;
         }
-        else
-        {
-            pack_up_cur_task();
-            cur_task.addColumnFile(file, index);
-        }
+        pack_up_cur_task();
 
-        ++index;
+        if (!is_all_trivial_move)
+            return compaction;
     }
-    pack_up_cur_task();
-
-    if (is_all_trivial_move)
-        return nullptr;
-    return compaction;
+    return nullptr;
 }
 
 bool ColumnFilePersistedSet::installCompactionResults(const MinorCompactionPtr & compaction, WriteBatches & wbs)

--- a/dbms/src/Storages/DeltaMerge/Delta/ColumnFilePersistedSet.h
+++ b/dbms/src/Storages/DeltaMerge/Delta/ColumnFilePersistedSet.h
@@ -157,7 +157,9 @@ public:
         WriteBatches & wbs);
 
     /// Choose all small column files that can be compacted to larger column files
-    MinorCompactionPtr pickUpMinorCompaction(DMContext & context);
+    // Try to compact the CFTiny with rows less than `small_column_file_rows` into larger
+    // CFTiny
+    MinorCompactionPtr pickUpMinorCompaction(size_t delta_small_column_file_rows);
 
     /// Update the metadata to commit the compaction results
     bool installCompactionResults(const MinorCompactionPtr & compaction, WriteBatches & wbs);

--- a/dbms/src/Storages/DeltaMerge/Delta/DeltaValueSpace.cpp
+++ b/dbms/src/Storages/DeltaMerge/Delta/DeltaValueSpace.cpp
@@ -457,7 +457,7 @@ bool DeltaValueSpace::compact(DMContext & context)
             LOG_DEBUG(log, "Compact stop because abandoned, delta={}", simpleInfo());
             return false;
         }
-        compaction_task = persisted_file_set->pickUpMinorCompaction(context);
+        compaction_task = persisted_file_set->pickUpMinorCompaction(context.delta_small_column_file_rows);
         if (!compaction_task)
         {
             LOG_DEBUG(log, "Compact cancel because nothing to compact, delta={}", simpleInfo());

--- a/dbms/src/Storages/DeltaMerge/Delta/MinorCompaction.cpp
+++ b/dbms/src/Storages/DeltaMerge/Delta/MinorCompaction.cpp
@@ -52,7 +52,6 @@ void MinorCompaction::prepare(DMContext & context, WriteBatches & wbs, const Pag
             }
 
             t_file->removeData(wbs); // record the ColumnFile (and its indexes) should be removed
-            // wbs.removed_log.delPage(t_file->getDataPageId());
         }
         Block compact_block = schema.cloneWithColumns(std::move(compact_columns));
         auto compact_rows = compact_block.rows();

--- a/dbms/src/Storages/DeltaMerge/Delta/MinorCompaction.cpp
+++ b/dbms/src/Storages/DeltaMerge/Delta/MinorCompaction.cpp
@@ -51,7 +51,8 @@ void MinorCompaction::prepare(DMContext & context, WriteBatches & wbs, const Pag
                 compact_columns[i]->insertRangeFrom(*block.getByPosition(i).column, 0, block_rows);
             }
 
-            wbs.removed_log.delPage(t_file->getDataPageId());
+            t_file->removeData(wbs); // record the ColumnFile (and its indexes) should be removed
+            // wbs.removed_log.delPage(t_file->getDataPageId());
         }
         Block compact_block = schema.cloneWithColumns(std::move(compact_columns));
         auto compact_rows = compact_block.rows();

--- a/dbms/src/Storages/DeltaMerge/Delta/tests/gtest_dm_delta_value_space.cpp
+++ b/dbms/src/Storages/DeltaMerge/Delta/tests/gtest_dm_delta_value_space.cpp
@@ -149,6 +149,8 @@ protected:
     {
         Block block = DMTestEnv::prepareSimpleWriteBlock(rows_start, rows_start + rows_num, false, /*tso*/ 2);
         auto tiny_file = ColumnFileTiny::writeColumnFile(context, block, 0, block.rows(), wbs);
+        // Just pretend we have those local index pages. It is OK because we don't read
+        // with the page_id of local index during following tests
         tiny_file = tiny_file->cloneWith(tiny_file->getDataPageId(), genIndexInfos(idx_page_ids));
         wbs.writeLogAndData();
         delta->appendColumnFile(context, tiny_file);

--- a/dbms/src/Storages/DeltaMerge/Index/VectorIndex/Writer.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/VectorIndex/Writer.cpp
@@ -92,7 +92,7 @@ void VectorIndexWriterInternal::addBlock(
             continue;
 
         // Expect all data to have matching dimensions.
-        RUNTIME_CHECK(col_array->sizeAt(i) == definition->dimension);
+        RUNTIME_CHECK(col_array->sizeAt(i) == definition->dimension, col_array->sizeAt(i), definition->dimension);
 
         auto data = col_array->getDataAt(i);
         RUNTIME_CHECK(data.size == definition->dimension * sizeof(Float32));

--- a/dbms/src/Storages/DeltaMerge/tests/CMakeLists.txt
+++ b/dbms/src/Storages/DeltaMerge/tests/CMakeLists.txt
@@ -60,8 +60,5 @@ target_link_libraries(dm_test_minmax_index dbms gtest_main tiflash_functions)
 add_executable(dm_test_delta_index_manager EXCLUDE_FROM_ALL gtest_dm_delta_index_manager.cpp)
 target_link_libraries(dm_test_delta_index_manager dbms gtest_main tiflash_functions)
 
-add_executable(dm_test_delta_value_space EXCLUDE_FROM_ALL gtest_dm_delta_value_space.cpp)
-target_link_libraries(dm_test_delta_value_space dbms gtest_main tiflash_functions)
-
 add_executable(dm_test_column_file EXCLUDE_FROM_ALL gtest_dm_column_file.cpp)
 target_link_libraries(dm_test_column_file dbms gtest_main tiflash_functions)

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_vector_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_vector_index.cpp
@@ -319,61 +319,6 @@ try
 }
 CATCH
 
-TEST_F(DeltaMergeStoreVectorTest, TestMultipleColumnFileTinyMinorCompaction)
-try
-{
-    store = reload();
-
-    const size_t num_rows_write = 128;
-
-    // write [0, 128) to store
-    write(0, num_rows_write);
-    // trigger FlushCache for all segments
-    triggerFlushCacheAndEnsureDeltaLocalIndex();
-
-    // write [128, 256) to store
-    write(num_rows_write, num_rows_write * 2);
-    // trigger FlushCache for all segments
-    triggerFlushCacheAndEnsureDeltaLocalIndex();
-
-    // check delta index has built for all segments
-    LOG_INFO(Logger::get(), "wait delta index ready");
-    waitDeltaIndexReady();
-    LOG_INFO(Logger::get(), "wait delta index ready done");
-    triggerCompactDelta();
-    LOG_INFO(Logger::get(), "compact delta done");
-
-    const auto range = RowKeyRange::newAll(store->is_common_handle, store->rowkey_column_size);
-
-    // read from store
-    {
-        read(range, EMPTY_FILTER, colVecFloat32("[0, 256)", vec_column_name, vec_column_id));
-    }
-
-    auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
-    ann_query_info->set_column_id(vec_column_id);
-    ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::L2);
-
-    // read with ANN query
-    {
-        ann_query_info->set_top_k(2);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({72.1}));
-
-        auto filter = std::make_shared<PushDownExecutor>(ann_query_info);
-        read(range, filter, createVecFloat32Column<Array>({{72.0}, {73.0}}));
-    }
-
-    // read with ANN query
-    {
-        ann_query_info->set_top_k(2);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({127.5}));
-
-        auto filter = std::make_shared<PushDownExecutor>(ann_query_info);
-        read(range, filter, createVecFloat32Column<Array>({{127.0}, {128.0}}));
-    }
-}
-CATCH
-
 TEST_F(DeltaMergeStoreVectorTest, TestFlushCache)
 try
 {

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_vector_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_vector_index.cpp
@@ -1386,6 +1386,28 @@ try
 }
 CATCH
 
+TEST_P(VectorIndexSegmentTest1, DataInCFTinyWithLocalIndex)
+try
+{
+    writeSegment(DELTA_MERGE_FIRST_SEGMENT_ID, 5, /* at */ 0);
+    flushSegmentCache(DELTA_MERGE_FIRST_SEGMENT_ID);
+    ensureSegmentDeltaLocalIndex(DELTA_MERGE_FIRST_SEGMENT_ID, indexInfo());
+
+    // the query result should be filtered by local index on DeltaVS
+    auto stream = annQuery(DELTA_MERGE_FIRST_SEGMENT_ID, createQueryColumns(), 1, {100.0});
+    assertStreamOut(stream, "[4, 5)");
+
+    stream = annQuery(DELTA_MERGE_FIRST_SEGMENT_ID, createQueryColumns(), 3, {100.0});
+    assertStreamOut(stream, "[2, 5)");
+
+    stream = annQuery(DELTA_MERGE_FIRST_SEGMENT_ID, createQueryColumns(), 1, {1.1});
+    assertStreamOut(stream, "[1, 2)");
+
+    stream = annQuery(DELTA_MERGE_FIRST_SEGMENT_ID, createQueryColumns(), 2, {1.1});
+    assertStreamOut(stream, "[1, 3)");
+}
+CATCH
+
 TEST_P(VectorIndexSegmentTest2, DataInStable)
 try
 {

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_test_basic.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_test_basic.cpp
@@ -17,19 +17,25 @@
 #include <DataStreams/ConcatBlockInputStream.h>
 #include <DataStreams/OneBlockInputStream.h>
 #include <Interpreters/Context.h>
+#include <Storages/DeltaMerge/ColumnFile/ColumnFileDataProvider.h>
+#include <Storages/DeltaMerge/ColumnFile/ColumnFileTinyLocalIndexWriter.h>
 #include <Storages/DeltaMerge/DMContext.h>
 #include <Storages/DeltaMerge/DeltaMergeStore.h>
 #include <Storages/DeltaMerge/File/DMFileBlockOutputStream.h>
 #include <Storages/DeltaMerge/File/DMFileLocalIndexWriter.h>
+#include <Storages/DeltaMerge/Index/LocalIndexInfo_fwd.h>
 #include <Storages/DeltaMerge/Segment.h>
+#include <Storages/DeltaMerge/Segment_fwd.h>
 #include <Storages/DeltaMerge/StoragePool/StoragePool.h>
 #include <Storages/DeltaMerge/WriteBatchesImpl.h>
 #include <Storages/DeltaMerge/tests/DMTestEnv.h>
 #include <Storages/DeltaMerge/tests/gtest_segment_test_basic.h>
 #include <Storages/KVStore/TMTContext.h>
+#include <Storages/Page/PageDefinesBase.h>
 #include <TestUtils/InputStreamTestUtils.h>
 #include <TestUtils/TiFlashStorageTestBasic.h>
 #include <TestUtils/TiFlashTestBasic.h>
+#include <TiDB/Schema/TiDB.h>
 
 #include <magic_enum.hpp>
 
@@ -811,6 +817,45 @@ bool SegmentTestBasic::ensureSegmentStableLocalIndex(PageIdU64 segment_id, const
 
     operation_statistics["ensureStableLocalIndex"]++;
     return success;
+}
+
+bool SegmentTestBasic::ensureSegmentDeltaLocalIndex(PageIdU64 segment_id, const LocalIndexInfosPtr & local_index_infos)
+{
+    LOG_INFO(logger_op, "EnsureSegmentDeltaLocalIndex, segment_id={}", segment_id);
+
+    RUNTIME_CHECK(segments.find(segment_id) != segments.end());
+    auto segment = segments[segment_id];
+    auto delta = segment->delta;
+    if (auto lock = delta->getLock(); !lock)
+    {
+        return false;
+    }
+    auto storage_snap = std::make_shared<StorageSnapshot>(*storage_pool, nullptr, "", true);
+    auto data_from_storage_snap = ColumnFileDataProviderLocalStoragePool::create(storage_snap);
+    auto persisted_files_snap = delta->getPersistedFileSet()->createSnapshot(data_from_storage_snap);
+    WriteBatches wbs(*storage_pool, nullptr);
+    // Build index
+    ColumnFileTinyLocalIndexWriter iw(ColumnFileTinyLocalIndexWriter::Options{
+        .storage_pool = storage_pool,
+        .write_limiter = nullptr,
+        .files = persisted_files_snap->getColumnFiles(),
+        .data_provider = persisted_files_snap->getDataProvider(),
+        .index_infos = local_index_infos,
+        .wbs = wbs,
+    });
+    auto new_tiny_files = iw.build([] { return true; });
+
+    ColumnFilePersisteds new_persisted_files;
+    for (const auto & f : new_tiny_files)
+    {
+        new_persisted_files.push_back(f);
+    }
+    delta->getPersistedFileSet()->updatePersistedColumnFilesAfterAddingIndex(new_persisted_files, wbs);
+
+    operation_statistics["ensureDeltaLocalIndex"]++;
+    LOG_INFO(logger_op, "EnsureSegmentDeltaLocalIndex, build index done, segment_id={}", segment_id);
+
+    return true;
 }
 
 bool SegmentTestBasic::areSegmentsSharingStable(const std::vector<PageIdU64> & segments_id) const

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_test_basic.h
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_test_basic.h
@@ -104,9 +104,14 @@ public:
     bool replaceSegmentStableData(PageIdU64 segment_id, const DMFilePtr & file);
 
     /**
-     * Returns whether segment stable index is created.
+     * Returns whether segment local index on StableVS is created.
      */
     bool ensureSegmentStableLocalIndex(PageIdU64 segment_id, const LocalIndexInfosPtr & local_index_infos);
+
+    /**
+     * Returns whether segment local index on DeltaVS is created.
+     */
+    bool ensureSegmentDeltaLocalIndex(PageIdU64 segment_id, const LocalIndexInfosPtr & local_index_infos);
 
     Block prepareWriteBlock(Int64 start_key, Int64 end_key, bool is_deleted = false);
     Block prepareWriteBlockInSegmentRange(


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/9946

Problem Summary:

Some pages for local index in the ColumnFileTiny is not removed when doing MinorCompaction

https://github.com/pingcap/tiflash/blob/6fec03d61355a52ae623f0770de0b66f2feefc46/dbms/src/Storages/DeltaMerge/Delta/MinorCompaction.cpp#L53-L54

In `MinorCompaction::prepare` we use `wbs.removed_log.delPage(t_file->getDataPageId());` to remove the ColumnFileTiny. But this will not remove the related LocalIndex page_id with the ColumnFileTiny. We must use `t_file->removeData(wbs);` to remove the ColumnFileTiny along with its LocalIndex page_ids.

BTW, `SegmentSplit`, `SegmentMerge` and `SegmentDeltaMerge` (MajorCompaction) calls `DeltaValueSpace::recordRemoveColumnFilesPages` and can correctly remove the LocalIndex page_ids.

### What is changed and how it works?

```commit-message
vector: Fix the bug that the local index in CFTiny is not removed during MinorCompaction
Add test cases about the removing page_id when doing MinorCompaction
Add test cases about querying the ColumnFileTiny in DeltaVS with VectorIndex could filter the return rows
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix the bug that some data may not be able to be removed after user inserted rows into a table with vector index
```
