### PR TITLE
disagg: Suppress enum overflow warning on S3 SDK

### DIFF
--- a/contrib/aws-cmake/0003-Suppress-enum-overflow.patch
+++ b/contrib/aws-cmake/0003-Suppress-enum-overflow.patch
@@ -1,0 +1,25 @@
+From ab4511229c3cf5c0bd666f4e1c61e16c2fff1bed Mon Sep 17 00:00:00 2001
+From: JaySon-Huang <tshent@qq.com>
+Date: Mon, 3 Mar 2025 14:49:51 +0800
+Subject: [PATCH] Suppress enum overflow
+
+Signed-off-by: JaySon-Huang <tshent@qq.com>
+---
+ .../source/utils/EnumParseOverflowContainer.cpp                 | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/aws-cpp-sdk-core/source/utils/EnumParseOverflowContainer.cpp b/src/aws-cpp-sdk-core/source/utils/EnumParseOverflowContainer.cpp
+index eaeba1d9105..4eb02c05d25 100644
+--- a/src/aws-cpp-sdk-core/source/utils/EnumParseOverflowContainer.cpp
++++ b/src/aws-cpp-sdk-core/source/utils/EnumParseOverflowContainer.cpp
+@@ -28,6 +28,6 @@ const Aws::String& EnumParseOverflowContainer::RetrieveOverflow(int hashCode) co
+ void EnumParseOverflowContainer::StoreOverflow(int hashCode, const Aws::String& value)
+ {
+     WriterLockGuard guard(m_overflowLock);
+-    AWS_LOGSTREAM_WARN(LOG_TAG, "Encountered enum member " << value << " which is not modeled in your clients. You should update your clients when you get a chance.");
++    AWS_LOGSTREAM_DEBUG(LOG_TAG, "Encountered enum member " << value << " which is not modeled in your clients. You should update your clients when you get a chance.");
+     m_overflowMap[hashCode] = value;
+ }
+-- 
+2.43.5
+

--- a/contrib/aws-cmake/CMakeLists.txt
+++ b/contrib/aws-cmake/CMakeLists.txt
@@ -122,6 +122,19 @@ if (HAVE_APPLY_PATCH EQUAL 1)
   else ()
     message(STATUS "aws patch done")
   endif ()
+
+  set (AWS_PATCH_FILE "${TiFlash_SOURCE_DIR}/contrib/aws-cmake/0003-Suppress-enum-overflow.patch")
+  # apply the patch
+  execute_process(
+    COMMAND git apply -v "${AWS_PATCH_FILE}"
+    WORKING_DIRECTORY "${AWS_SDK_CORE_DIR}"
+    COMMAND_ECHO STDOUT
+    RESULT_VARIABLE PATCH_SUCC)
+  if (NOT PATCH_SUCC EQUAL 0)
+    message(FATAL_ERROR "Can not apply aws patch ${AWS_PATCH_FILE}")
+  else ()
+    message(STATUS "aws patch done")
+  endif ()
 elseif (HAVE_APPLY_PATCH EQUAL 0)
   message(STATUS "aws patch have been applied: ${HAVE_APPLY_PATCH}")
 else ()


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/9955

Problem Summary:

### What is changed and how it works?

Apply a patch to suppress enum overflow warning on S3 SDK. And we may upgrade the S3 SDK in later PRs

```commit-message
disagg: Suppress enum overflow warning on S3 SDK
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Suppress a logging that report unknown enum from S3
```
