### PR TITLE
Storages: fix a series of data race issues

### DIFF
--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileTiny.cpp
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileTiny.cpp
@@ -415,4 +415,21 @@ ColumnFileTiny::ColumnFileTiny(
     , file_provider(dm_context.global_context.getFileProvider())
 {}
 
+ColumnFileTiny::ColumnFileTiny(
+    const ColumnFileSchemaPtr & schema_,
+    UInt64 rows_,
+    UInt64 bytes_,
+    PageIdU64 data_page_id_,
+    KeyspaceID keyspace_id_,
+    const FileProviderPtr & file_provider_,
+    const IndexInfosPtr & index_infos_)
+    : schema(schema_)
+    , rows(rows_)
+    , bytes(bytes_)
+    , data_page_id(data_page_id_)
+    , index_infos(index_infos_)
+    , keyspace_id(keyspace_id_)
+    , file_provider(file_provider_)
+{}
+
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileTiny.h
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileTiny.h
@@ -41,7 +41,7 @@ public:
     friend struct Remote::Serializer;
 
     using IndexInfos = std::vector<dtpb::ColumnFileIndexInfo>;
-    using IndexInfosPtr = std::shared_ptr<IndexInfos>;
+    using IndexInfosPtr = std::shared_ptr<const IndexInfos>;
 
 private:
     ColumnFileSchemaPtr schema;
@@ -50,7 +50,7 @@ private:
     UInt64 bytes = 0;
 
     /// The id of data page which stores the data of this pack.
-    PageIdU64 data_page_id;
+    const PageIdU64 data_page_id;
 
     /// HACK: Currently this field is only available when ColumnFileTiny is restored from remote proto.
     /// It is not available when ColumnFileTiny is constructed or restored locally.
@@ -58,7 +58,7 @@ private:
     UInt64 data_page_size = 0;
 
     /// The index information of this file.
-    IndexInfosPtr index_infos;
+    const IndexInfosPtr index_infos;
 
     /// The id of the keyspace which this ColumnFileTiny belongs to.
     const KeyspaceID keyspace_id;
@@ -76,6 +76,15 @@ public:
         PageIdU64 data_page_id_,
         const DMContext & dm_context,
         const IndexInfosPtr & index_infos_ = nullptr);
+
+    ColumnFileTiny(
+        const ColumnFileSchemaPtr & schema_,
+        UInt64 rows_,
+        UInt64 bytes_,
+        PageIdU64 data_page_id_,
+        KeyspaceID keyspace_id_,
+        const FileProviderPtr & file_provider_,
+        const IndexInfosPtr & index_infos_);
 
     Type getType() const override { return Type::TINY_FILE; }
 
@@ -96,17 +105,26 @@ public:
 
     ColumnFileTinyPtr cloneWith(PageIdU64 new_data_page_id)
     {
-        auto new_tiny_file = std::make_shared<ColumnFileTiny>(*this);
-        new_tiny_file->data_page_id = new_data_page_id;
-        return new_tiny_file;
+        return std::make_shared<ColumnFileTiny>(
+            schema,
+            rows,
+            bytes,
+            new_data_page_id,
+            keyspace_id,
+            file_provider,
+            index_infos);
     }
 
-    ColumnFileTinyPtr cloneWith(PageIdU64 new_data_page_id, const IndexInfosPtr & index_infos_) const
+    ColumnFileTinyPtr cloneWith(PageIdU64 new_data_page_id, const IndexInfosPtr & new_index_infos) const
     {
-        auto new_tiny_file = std::make_shared<ColumnFileTiny>(*this);
-        new_tiny_file->data_page_id = new_data_page_id;
-        new_tiny_file->index_infos = index_infos_;
-        return new_tiny_file;
+        return std::make_shared<ColumnFileTiny>(
+            schema,
+            rows,
+            bytes,
+            new_data_page_id,
+            keyspace_id,
+            file_provider,
+            new_index_infos);
     }
 
     ColumnFileReaderPtr getReader(

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalSegment.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalSegment.cpp
@@ -520,9 +520,9 @@ void DeltaMergeStore::checkAllSegmentsLocalIndex(std::vector<IndexID> && dropped
             // cleanup the index error message for dropped indexes
             segment->clearIndexBuildError(dropped_indexes);
 
-            bool missing_indexes = segmentEnsureStableLocalIndexAsync(segment);
-            missing_indexes = segmentEnsureDeltaLocalIndexAsync(segment) || missing_indexes;
-            segments_missing_indexes += missing_indexes;
+            bool stable_missing_indexes = segmentEnsureStableLocalIndexAsync(segment);
+            bool delta_missing_indexes = segmentEnsureDeltaLocalIndexAsync(segment);
+            segments_missing_indexes += (stable_missing_indexes || delta_missing_indexes);
         }
     }
 

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_vector_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_vector_index.cpp
@@ -939,7 +939,7 @@ try
             });
             new_table_info_with_vector_index.index_infos.emplace_back(index);
         }
-        // apply local index change, shuold
+        // apply local index change, should
         // - create the local index
         // - generate the background tasks for building index on stable and delta
         store->applyLocalIndexChange(new_table_info_with_vector_index);

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_vector_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_vector_index.cpp
@@ -154,6 +154,22 @@ public:
         return new_dmfiles[0];
     }
 
+    static ANNQueryInfoPtr createANNQueryInfo(
+        ColumnID column_id,
+        tipb::VectorDistanceMetric metric,
+        UInt32 topk,
+        const std::vector<float> & ref_vec,
+        IndexID index_id = EmptyIndexID)
+    {
+        auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
+        ann_query_info->set_column_id(column_id);
+        ann_query_info->set_distance_metric(metric);
+        ann_query_info->set_top_k(topk);
+        ann_query_info->set_ref_vec_f32(encodeVectorFloat32(ref_vec));
+        ann_query_info->set_index_id(index_id);
+        return ann_query_info;
+    }
+
     Context & dbContext() { return *db_context; }
 
 protected:
@@ -233,12 +249,7 @@ try
 
     // Read with exact match
     {
-        auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
-        ann_query_info->set_column_id(vec_cd.id);
-        ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::L2);
-        ann_query_info->set_top_k(1);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0, 2.0, 3.5}));
-
+        const auto ann_query_info = createANNQueryInfo(vec_cd.id, tipb::VectorDistanceMetric::L2, 1, {1.0, 2.0, 3.5});
         DMFileBlockInputStreamBuilder builder(dbContext());
         auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView::createWithFilter(3, true))
@@ -258,11 +269,7 @@ try
 
     // Read with approximate match
     {
-        auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
-        ann_query_info->set_column_id(vec_cd.id);
-        ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::L2);
-        ann_query_info->set_top_k(1);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0, 2.0, 3.8}));
+        const auto ann_query_info = createANNQueryInfo(vec_cd.id, tipb::VectorDistanceMetric::L2, 1, {1.0, 2.0, 3.8});
 
         DMFileBlockInputStreamBuilder builder(dbContext());
         auto stream = builder.setAnnQureyInfo(ann_query_info)
@@ -283,11 +290,7 @@ try
 
     // Read multiple rows
     {
-        auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
-        ann_query_info->set_column_id(vec_cd.id);
-        ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::L2);
-        ann_query_info->set_top_k(2);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0, 2.0, 3.8}));
+        const auto ann_query_info = createANNQueryInfo(vec_cd.id, tipb::VectorDistanceMetric::L2, 2, {1.0, 2.0, 3.8});
 
         DMFileBlockInputStreamBuilder builder(dbContext());
         auto stream = builder.setAnnQureyInfo(ann_query_info)
@@ -308,11 +311,7 @@ try
 
     // Read with MVCC filter
     {
-        auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
-        ann_query_info->set_column_id(vec_cd.id);
-        ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::L2);
-        ann_query_info->set_top_k(1);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0, 2.0, 3.8}));
+        const auto ann_query_info = createANNQueryInfo(vec_cd.id, tipb::VectorDistanceMetric::L2, 1, {1.0, 2.0, 3.8});
 
         auto bitmap_filter = std::make_shared<BitmapFilter>(3, true);
         bitmap_filter->set(/* start */ 2, /* limit */ 1, false);
@@ -336,11 +335,7 @@ try
 
     // Query Top K = 0: the pack should be filtered out
     {
-        auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
-        ann_query_info->set_column_id(vec_cd.id);
-        ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::L2);
-        ann_query_info->set_top_k(0);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0, 2.0, 3.8}));
+        const auto ann_query_info = createANNQueryInfo(vec_cd.id, tipb::VectorDistanceMetric::L2, 0, {1.0, 2.0, 3.8});
 
         DMFileBlockInputStreamBuilder builder(dbContext());
         auto stream = builder.setAnnQureyInfo(ann_query_info)
@@ -361,11 +356,7 @@ try
 
     // Query Top K > rows
     {
-        auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
-        ann_query_info->set_column_id(vec_cd.id);
-        ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::L2);
-        ann_query_info->set_top_k(10);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0, 2.0, 3.8}));
+        const auto ann_query_info = createANNQueryInfo(vec_cd.id, tipb::VectorDistanceMetric::L2, 10, {1.0, 2.0, 3.8});
 
         DMFileBlockInputStreamBuilder builder(dbContext());
         auto stream = builder.setAnnQureyInfo(ann_query_info)
@@ -386,12 +377,7 @@ try
 
     // Illegal ANNQueryInfo: Ref Vector'dimension is different
     {
-        auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
-        ann_query_info->set_column_id(vec_cd.id);
-        ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::L2);
-        ann_query_info->set_top_k(10);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0}));
-
+        const auto ann_query_info = createANNQueryInfo(vec_cd.id, tipb::VectorDistanceMetric::L2, 10, {1.0});
         DMFileBlockInputStreamBuilder builder(dbContext());
         auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView::createWithFilter(3, true))
@@ -421,12 +407,7 @@ try
     // Illegal ANNQueryInfo: Referencing a non-existed column. This simply cause vector index not used.
     // The query will not fail, because ANNQueryInfo is passed globally in the whole read path.
     {
-        auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
-        ann_query_info->set_column_id(5);
-        ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::L2);
-        ann_query_info->set_top_k(1);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0, 2.0, 3.8}));
-
+        const auto ann_query_info = createANNQueryInfo(5, tipb::VectorDistanceMetric::L2, 1, {1.0, 2.0, 3.8});
         DMFileBlockInputStreamBuilder builder(dbContext());
         auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView::createWithFilter(3, true))
@@ -446,12 +427,8 @@ try
 
     // Illegal ANNQueryInfo: Different distance metric.
     {
-        auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
-        ann_query_info->set_column_id(vec_cd.id);
-        ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::COSINE);
-        ann_query_info->set_top_k(1);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0, 2.0, 3.8}));
-
+        const auto ann_query_info
+            = createANNQueryInfo(vec_cd.id, tipb::VectorDistanceMetric::COSINE, 1, {1.0, 2.0, 3.8});
         DMFileBlockInputStreamBuilder builder(dbContext());
         auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView::createWithFilter(3, true))
@@ -484,12 +461,7 @@ try
     // Currently the query is fine and ANNQueryInfo is discarded, because we discovered that this column
     // does not have index at all.
     {
-        auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
-        ann_query_info->set_column_id(MutSup::extra_handle_id);
-        ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::L2);
-        ann_query_info->set_top_k(1);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0, 2.0, 3.8}));
-
+        const auto ann_query_info = createANNQueryInfo(5, tipb::VectorDistanceMetric::L2, 1, {1.0, 2.0, 3.8});
         DMFileBlockInputStreamBuilder builder(dbContext());
         auto stream = builder.setAnnQureyInfo(ann_query_info)
                           .setBitmapFilter(BitmapFilterView::createWithFilter(3, true))
@@ -581,12 +553,8 @@ try
 
         // Read with approximate match
         {
-            auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
-            ann_query_info->set_column_id(vec_cd.id);
-            ann_query_info->set_index_id(3);
-            ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::L2);
-            ann_query_info->set_top_k(1);
-            ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0, 2.0, 3.8}));
+            const auto ann_query_info
+                = createANNQueryInfo(vec_cd.id, tipb::VectorDistanceMetric::L2, 1, {1.0, 2.0, 3.8}, 3);
 
             DMFileBlockInputStreamBuilder builder(dbContext());
             auto stream = builder.setAnnQureyInfo(ann_query_info)
@@ -607,12 +575,8 @@ try
 
         // Read multiple rows
         {
-            auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
-            ann_query_info->set_column_id(vec_cd.id);
-            ann_query_info->set_index_id(3);
-            ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::L2);
-            ann_query_info->set_top_k(2);
-            ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0, 2.0, 3.8}));
+            const auto ann_query_info
+                = createANNQueryInfo(vec_cd.id, tipb::VectorDistanceMetric::L2, 2, {1.0, 2.0, 3.8}, 3);
 
             DMFileBlockInputStreamBuilder builder(dbContext());
             auto stream = builder.setAnnQureyInfo(ann_query_info)
@@ -633,12 +597,8 @@ try
 
         // Read with MVCC filter
         {
-            auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
-            ann_query_info->set_column_id(vec_cd.id);
-            ann_query_info->set_index_id(3);
-            ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::L2);
-            ann_query_info->set_top_k(1);
-            ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0, 2.0, 3.8}));
+            const auto ann_query_info
+                = createANNQueryInfo(vec_cd.id, tipb::VectorDistanceMetric::L2, 1, {1.0, 2.0, 3.8}, 3);
 
             auto bitmap_filter = std::make_shared<BitmapFilter>(3, true);
             bitmap_filter->set(/* start */ 2, /* limit */ 1, false);
@@ -666,12 +626,8 @@ try
 
         // Read with approximate match
         {
-            auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
-            ann_query_info->set_column_id(vec_cd.id);
-            ann_query_info->set_index_id(4);
-            ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::COSINE);
-            ann_query_info->set_top_k(1);
-            ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0, 2.0, 3.8}));
+            const auto ann_query_info
+                = createANNQueryInfo(vec_cd.id, tipb::VectorDistanceMetric::COSINE, 1, {1.0, 2.0, 3.8}, 4);
 
             DMFileBlockInputStreamBuilder builder(dbContext());
             auto stream = builder.setAnnQureyInfo(ann_query_info)
@@ -692,12 +648,8 @@ try
 
         // Read multiple rows
         {
-            auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
-            ann_query_info->set_column_id(vec_cd.id);
-            ann_query_info->set_index_id(4);
-            ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::COSINE);
-            ann_query_info->set_top_k(2);
-            ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0, 2.0, 3.8}));
+            const auto ann_query_info
+                = createANNQueryInfo(vec_cd.id, tipb::VectorDistanceMetric::COSINE, 2, {1.0, 2.0, 3.8}, 4);
 
             DMFileBlockInputStreamBuilder builder(dbContext());
             auto stream = builder.setAnnQureyInfo(ann_query_info)
@@ -718,12 +670,8 @@ try
 
         // Read with MVCC filter
         {
-            auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
-            ann_query_info->set_column_id(vec_cd.id);
-            ann_query_info->set_index_id(4);
-            ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::COSINE);
-            ann_query_info->set_top_k(1);
-            ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0, 2.0, 3.8}));
+            const auto ann_query_info
+                = createANNQueryInfo(vec_cd.id, tipb::VectorDistanceMetric::COSINE, 1, {1.0, 2.0, 3.8}, 4);
 
             auto bitmap_filter = std::make_shared<BitmapFilter>(3, true);
             bitmap_filter->set(/* start */ 2, /* limit */ 1, false);
@@ -752,11 +700,8 @@ try
 
         // Read with approximate match
         {
-            auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
-            ann_query_info->set_column_id(vec_cd.id);
-            ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::L2);
-            ann_query_info->set_top_k(1);
-            ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0, 2.0, 3.8}));
+            const auto ann_query_info
+                = createANNQueryInfo(vec_cd.id, tipb::VectorDistanceMetric::L2, 1, {1.0, 2.0, 3.8});
 
             DMFileBlockInputStreamBuilder builder(dbContext());
             auto stream = builder.setAnnQureyInfo(ann_query_info)
@@ -777,11 +722,8 @@ try
 
         // Read multiple rows
         {
-            auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
-            ann_query_info->set_column_id(vec_cd.id);
-            ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::L2);
-            ann_query_info->set_top_k(2);
-            ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0, 2.0, 3.8}));
+            const auto ann_query_info
+                = createANNQueryInfo(vec_cd.id, tipb::VectorDistanceMetric::L2, 2, {1.0, 2.0, 3.8});
 
             DMFileBlockInputStreamBuilder builder(dbContext());
             auto stream = builder.setAnnQureyInfo(ann_query_info)
@@ -802,11 +744,8 @@ try
 
         // Read with MVCC filter
         {
-            auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
-            ann_query_info->set_column_id(vec_cd.id);
-            ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::L2);
-            ann_query_info->set_top_k(1);
-            ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0, 2.0, 3.8}));
+            const auto ann_query_info
+                = createANNQueryInfo(vec_cd.id, tipb::VectorDistanceMetric::L2, 1, {1.0, 2.0, 3.8});
 
             auto bitmap_filter = std::make_shared<BitmapFilter>(3, true);
             bitmap_filter->set(/* start */ 2, /* limit */ 1, false);
@@ -869,11 +808,7 @@ try
     dm_file = buildIndex(*vector_index);
 
     {
-        auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
-        ann_query_info->set_column_id(vec_cd.id);
-        ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::L2);
-        ann_query_info->set_top_k(4);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0, 2.0, 3.5}));
+        const auto ann_query_info = createANNQueryInfo(vec_cd.id, tipb::VectorDistanceMetric::L2, 4, {1.0, 2.0, 3.5});
 
         DMFileBlockInputStreamBuilder builder(dbContext());
         auto stream = builder.setAnnQureyInfo(ann_query_info)
@@ -937,11 +872,7 @@ try
 
     // Pack #0 is filtered out according to VecIndex
     {
-        auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
-        ann_query_info->set_column_id(vec_cd.id);
-        ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::L2);
-        ann_query_info->set_top_k(1);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({5.0, 5.0, 5.5}));
+        const auto ann_query_info = createANNQueryInfo(vec_cd.id, tipb::VectorDistanceMetric::L2, 1, {5.0, 5.0, 5.5});
 
         DMFileBlockInputStreamBuilder builder(dbContext());
         auto stream = builder.setAnnQureyInfo(ann_query_info)
@@ -962,11 +893,7 @@ try
 
     // Pack #1 is filtered out according to VecIndex
     {
-        auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
-        ann_query_info->set_column_id(vec_cd.id);
-        ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::L2);
-        ann_query_info->set_top_k(1);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0, 2.0, 3.0}));
+        const auto ann_query_info = createANNQueryInfo(vec_cd.id, tipb::VectorDistanceMetric::L2, 1, {1.0, 2.0, 3.0});
 
         DMFileBlockInputStreamBuilder builder(dbContext());
         auto stream = builder.setAnnQureyInfo(ann_query_info)
@@ -987,11 +914,7 @@ try
 
     // Both packs are reserved
     {
-        auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
-        ann_query_info->set_column_id(vec_cd.id);
-        ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::L2);
-        ann_query_info->set_top_k(2);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({0.0, 0.0, 0.0}));
+        const auto ann_query_info = createANNQueryInfo(vec_cd.id, tipb::VectorDistanceMetric::L2, 2, {0.0, 0.0, 0.0});
 
         DMFileBlockInputStreamBuilder builder(dbContext());
         auto stream = builder.setAnnQureyInfo(ann_query_info)
@@ -1012,11 +935,7 @@ try
 
     // Pack Filter + MVCC (the matching row #5 is marked as filtered out by MVCC)
     {
-        auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
-        ann_query_info->set_column_id(vec_cd.id);
-        ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::L2);
-        ann_query_info->set_top_k(2);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({0.0, 0.0, 0.0}));
+        const auto ann_query_info = createANNQueryInfo(vec_cd.id, tipb::VectorDistanceMetric::L2, 2, {0.0, 0.0, 0.0});
 
         auto bitmap_filter = std::make_shared<BitmapFilter>(6, true);
         bitmap_filter->set(/* start */ 5, /* limit */ 1, false);
@@ -1080,11 +999,7 @@ try
 
     // Pack Filter using RowKeyRange
     {
-        auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
-        ann_query_info->set_column_id(vec_cd.id);
-        ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::L2);
-        ann_query_info->set_top_k(1);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({8.0}));
+        const auto ann_query_info = createANNQueryInfo(vec_cd.id, tipb::VectorDistanceMetric::L2, 1, {8.0});
 
         // This row key range will cause pack#0 and pack#1 reserved, and pack#2 filtered out.
         auto row_key_ranges = RowKeyRanges{RowKeyRange::fromHandleRange(HandleRange(0, 5))};
@@ -1105,9 +1020,9 @@ try
             }));
 
         // TopK=4
-        ann_query_info->set_top_k(4);
+        const auto ann_query_info2 = createANNQueryInfo(vec_cd.id, tipb::VectorDistanceMetric::L2, 4, {8.0});
         builder = DMFileBlockInputStreamBuilder(dbContext());
-        stream = builder.setAnnQureyInfo(ann_query_info)
+        stream = builder.setAnnQureyInfo(ann_query_info2)
                      .setBitmapFilter(BitmapFilterView(bitmap_filter, 0, 9))
                      .build(dm_file, read_cols, row_key_ranges, std::make_shared<ScanContext>());
         ASSERT_INPUTSTREAM_COLS_UR(
@@ -1121,11 +1036,7 @@ try
 
     // Pack Filter + Bitmap Filter
     {
-        auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
-        ann_query_info->set_column_id(vec_cd.id);
-        ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::L2);
-        ann_query_info->set_top_k(3);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({8.0}));
+        const auto ann_query_info = createANNQueryInfo(vec_cd.id, tipb::VectorDistanceMetric::L2, 3, {8.0});
 
         // This row key range will cause pack#0 and pack#1 reserved, and pack#2 filtered out.
         auto row_key_ranges = RowKeyRanges{RowKeyRange::fromHandleRange(HandleRange(0, 5))};

--- a/dbms/src/Storages/S3/FileCache.h
+++ b/dbms/src/Storages/S3/FileCache.h
@@ -17,6 +17,7 @@
 #include <Common/Logger.h>
 #include <Common/nocopyable.h>
 #include <IO/BaseFile/fwd.h>
+#include <IO/IOThreadPools.h>
 #include <Interpreters/Settings_fwd.h>
 #include <Poco/Util/AbstractConfiguration.h>
 #include <Server/StorageConfigParser.h>
@@ -228,7 +229,11 @@ public:
                                                                              : nullptr;
     }
 
-    static void shutdown() { global_file_cache_instance = nullptr; }
+    static void shutdown()
+    {
+        S3FileCachePool::shutdown();
+        global_file_cache_instance = nullptr;
+    }
 
     FileCache(PathCapacityMetricsPtr capacity_metrics_, const StorageRemoteCacheConfig & config_);
 

--- a/dbms/src/Storages/S3/FileCache.h
+++ b/dbms/src/Storages/S3/FileCache.h
@@ -231,6 +231,7 @@ public:
 
     static void shutdown()
     {
+        // wait for all tasks done
         S3FileCachePool::shutdown();
         global_file_cache_instance = nullptr;
     }

--- a/tests/sanitize/tsan.suppression
+++ b/tests/sanitize/tsan.suppression
@@ -8,3 +8,8 @@ race:dbms/src/DataStreams/BlockStreamProfileInfo.h
 race:StackTrace::toString
 race:DB::SyncPointCtl::sync
 race:XXH3_hashLong_64b_withSeed_selection
+race:re2::RE2::NumberOfCapturingGroups
+# PathPool is used in lot of places, but TiFlashStorageTestBasic::reload will try to write it.
+# Since we will never call Context::setPathPool after TiFlash is initialized, it is safe to suppress.
+race:TiFlashStorageTestBasic::reload
+race:*::~shared_ptr


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9961

Problem Summary:

### What is changed and how it works?

```commit-message
1. We should not reuse anything which is not thread-safe between different queries, so do not reuse `ann_query_info` in unit tests.
2. Fix `FileCache::bgDownload` may still be running after `FileCache::shutdown`.
3. Suppress false positive alarm in `~shared_ptr`  and `re2::RE2::NumberOfCapturingGroups`.
4. Suppress alarm in `TiFlashStorageTestBasic::reload` which is only used in unit tests.
5. Fix data race between `DeltaMergeStore::segmentWaitDeltaLocalIndexReady` and `ColumnFilePersistedSet::updatePersistedColumnFilesAfterAddingIndex`
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
Run the unit test cases with TSAN built binary
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix a data race issue by waiting for all background task done when shutting down under disagg arch
```
