### PR TITLE
Storages: fix adding delta vector index does not work with existing indexes 

### DIFF
--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileTinyLocalIndexWriter.cpp
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileTinyLocalIndexWriter.cpp
@@ -229,8 +229,8 @@ ColumnFileTinyPtr ColumnFileTinyLocalIndexWriter::buildIndexForFile(
         }
     }
 
-    if (file->index_infos)
-        file->index_infos->insert(file->index_infos->end(), index_infos->begin(), index_infos->end());
+    if (const auto & file_index_info = file->getIndexInfos(); file_index_info)
+        index_infos->insert(index_infos->end(), file_index_info->begin(), file_index_info->end());
 
     options.wbs.writeLogAndData();
     // Note: The id of the file cannot be changed, otherwise minor compaction will fail.

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileTinyVectorIndexReader.cpp
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileTinyVectorIndexReader.cpp
@@ -64,7 +64,7 @@ std::vector<VectorIndexReader::SearchResult> ColumnFileTinyVectorIndexReader::lo
 
 void ColumnFileTinyVectorIndexReader::loadVectorIndex()
 {
-    const auto & index_infos = tiny_file.index_infos;
+    const auto & index_infos = tiny_file.getIndexInfos();
     if (!index_infos || index_infos->empty())
         return;
     auto index_id = ann_query_info->index_id();

--- a/dbms/src/Storages/DeltaMerge/Delta/ColumnFilePersistedSet.h
+++ b/dbms/src/Storages/DeltaMerge/Delta/ColumnFilePersistedSet.h
@@ -49,7 +49,7 @@ class ColumnFilePersistedSet
     , private boost::noncopyable
 {
 private:
-    PageIdU64 metadata_id;
+    const PageIdU64 metadata_id;
     ColumnFilePersisteds persisted_files;
     // TODO: check the proper memory_order when use this atomic variable
     std::atomic<size_t> persisted_files_count = 0;

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalSegment.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalSegment.cpp
@@ -506,12 +506,12 @@ void DeltaMergeStore::checkAllSegmentsLocalIndex(std::vector<IndexID> && dropped
 
     size_t segments_missing_indexes = 0;
 
-    // 2. Trigger EnsureStableLocalIndex for all segments.
+    // 2. Trigger EnsureStableLocalIndex & EnsureDeltaLocalIndex for all segments.
     // There could be new segments between 1 and 2, which is fine. New segments
-    // will invoke EnsureStableLocalIndex at creation time.
+    // will invoke EnsureStableLocalIndex & EnsureDeltaLocalIndex at creation time.
     {
         // There must be a lock, because segments[] may be mutated.
-        // And one lock for all is fine, because segmentEnsureStableLocalIndexAsync is non-blocking, it
+        // And one lock for all is fine, because segmentEnsureStableLocalIndexAsync & segmentEnsureDeltaLocalIndexAsync is non-blocking, it
         // simply put tasks in the background.
         std::shared_lock lock(read_write_mutex);
         for (const auto & [end, segment] : segments)
@@ -520,8 +520,9 @@ void DeltaMergeStore::checkAllSegmentsLocalIndex(std::vector<IndexID> && dropped
             // cleanup the index error message for dropped indexes
             segment->clearIndexBuildError(dropped_indexes);
 
-            if (segmentEnsureStableLocalIndexAsync(segment))
-                ++segments_missing_indexes;
+            bool missing_indexes = segmentEnsureStableLocalIndexAsync(segment);
+            missing_indexes = segmentEnsureDeltaLocalIndexAsync(segment) || missing_indexes;
+            segments_missing_indexes += missing_indexes;
         }
     }
 
@@ -573,11 +574,13 @@ bool DeltaMergeStore::segmentEnsureStableLocalIndexAsync(const SegmentPtr & segm
     {
         // new task of these index are generated, clear existing error_message in segment
         segment->clearIndexBuildError(build_info.indexesIDs());
-
+        auto file_ids = build_info.filesIDs();
+        if (file_ids.empty())
+            return true;
         auto [ok, reason] = indexer_scheduler->pushTask(LocalIndexerScheduler::Task{
             .keyspace_id = keyspace_id,
             .table_id = physical_table_id,
-            .file_ids = build_info.filesIDs(),
+            .file_ids = file_ids,
             .request_memory = build_info.estimated_memory_bytes,
             .workload = workload,
         });
@@ -961,15 +964,23 @@ bool DeltaMergeStore::segmentWaitDeltaLocalIndexReady(const SegmentPtr & segment
         if (!column_file_persisted_set)
             return false; // ColumnFilePersistedSet is not exist, return false
         bool all_indexes_built = true;
-        for (const auto & index : *build_info.indexes_to_build)
+        auto delta_ptr = delta_weak_ptr.lock();
+        if (auto lock = delta_ptr ? delta_ptr->getLock() : std::nullopt; lock)
         {
-            for (const auto & column_file : column_file_persisted_set->getFiles())
+            const auto & column_files = column_file_persisted_set->getFiles();
+            for (const auto & index : *build_info.indexes_to_build)
             {
-                auto * tiny_file = column_file->tryToTinyFile();
-                if (!tiny_file)
-                    continue;
-                all_indexes_built = all_indexes_built && (tiny_file->hasIndex(index.index_id));
+                for (const auto & column_file : column_files)
+                {
+                    if (auto * tiny_file = column_file->tryToTinyFile(); tiny_file)
+                        all_indexes_built = all_indexes_built && (tiny_file->hasIndex(index.index_id));
+                }
             }
+        }
+        else
+        {
+            // Delta has been abandoned, return false
+            return false;
         }
         if (all_indexes_built)
             return true;

--- a/dbms/src/Storages/DeltaMerge/File/DMFileLocalIndexWriter.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileLocalIndexWriter.h
@@ -45,6 +45,8 @@ public:
         ids.reserve(dm_files.size());
         for (const auto & dmf : dm_files)
         {
+            if (unlikely(dmf->getRows() == 0))
+                continue;
             ids.emplace_back(LocalIndexerScheduler::DMFileID(dmf->fileId()));
         }
         return ids;

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_vector_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store_vector_index.cpp
@@ -151,6 +151,21 @@ public:
         }
     }
 
+    void triggerFlushCache() const
+    {
+        std::vector<SegmentPtr> all_segments;
+        {
+            std::shared_lock lock(store->read_write_mutex);
+            for (const auto & [_, segment] : store->id_to_segment)
+                all_segments.push_back(segment);
+        }
+        auto dm_context = store->newDMContext(*db_context, db_context->getSettingsRef());
+        for (const auto & segment : all_segments)
+        {
+            ASSERT_TRUE(segment->flushCache(*dm_context));
+        }
+    }
+
     void triggerCompactDelta() const
     {
         std::vector<SegmentPtr> all_segments;
@@ -207,6 +222,22 @@ public:
         ASSERT_TRUE(new_segment != nullptr);
     }
 
+    static ANNQueryInfoPtr createANNQueryInfo(
+        ColumnID column_id,
+        tipb::VectorDistanceMetric metric,
+        UInt32 topk,
+        const std::vector<float> & ref_vec,
+        IndexID index_id = EmptyIndexID)
+    {
+        auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
+        ann_query_info->set_column_id(column_id);
+        ann_query_info->set_distance_metric(metric);
+        ann_query_info->set_top_k(topk);
+        ann_query_info->set_ref_vec_f32(encodeVectorFloat32(ref_vec));
+        ann_query_info->set_index_id(index_id);
+        return ann_query_info;
+    }
+
 protected:
     DeltaMergeStorePtr store;
 
@@ -245,24 +276,16 @@ try
         read(range, EMPTY_FILTER, colVecFloat32("[64, 256)", vec_column_name, vec_column_id));
     }
 
-    auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
-    ann_query_info->set_column_id(vec_column_id);
-    ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::L2);
-
     // read with ANN query
     {
-        ann_query_info->set_top_k(2);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({127.5}));
-
+        const auto ann_query_info = createANNQueryInfo(vec_column_id, tipb::VectorDistanceMetric::L2, 2, {127.5});
         auto filter = std::make_shared<PushDownExecutor>(ann_query_info);
         read(range, filter, createVecFloat32Column<Array>({{127.0}, {128.0}}));
     }
 
     // read with ANN query
     {
-        ann_query_info->set_top_k(2);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({72.1}));
-
+        const auto ann_query_info = createANNQueryInfo(vec_column_id, tipb::VectorDistanceMetric::L2, 2, {72.1});
         auto filter = std::make_shared<PushDownExecutor>(ann_query_info);
         read(range, filter, createVecFloat32Column<Array>({{72.0}, {73.0}}));
     }
@@ -295,24 +318,16 @@ try
         read(range, EMPTY_FILTER, colVecFloat32("[0, 256)", vec_column_name, vec_column_id));
     }
 
-    auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
-    ann_query_info->set_column_id(vec_column_id);
-    ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::L2);
-
     // read with ANN query
     {
-        ann_query_info->set_top_k(2);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({72.1}));
-
+        const auto ann_query_info = createANNQueryInfo(vec_column_id, tipb::VectorDistanceMetric::L2, 2, {72.1});
         auto filter = std::make_shared<PushDownExecutor>(ann_query_info);
         read(range, filter, createVecFloat32Column<Array>({{72.0}, {73.0}}));
     }
 
     // read with ANN query
     {
-        ann_query_info->set_top_k(2);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({127.5}));
-
+        const auto ann_query_info = createANNQueryInfo(vec_column_id, tipb::VectorDistanceMetric::L2, 2, {127.5});
         auto filter = std::make_shared<PushDownExecutor>(ann_query_info);
         read(range, filter, createVecFloat32Column<Array>({{127.0}, {128.0}}));
     }
@@ -352,15 +367,9 @@ try
         read(range, EMPTY_FILTER, colVecFloat32("[0, 130)", vec_column_name, vec_column_id));
     }
 
-    auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
-    ann_query_info->set_column_id(vec_column_id);
-    ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::L2);
-
     // read with ANN query
     {
-        ann_query_info->set_top_k(1);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({72.0}));
-
+        const auto ann_query_info = createANNQueryInfo(vec_column_id, tipb::VectorDistanceMetric::L2, 1, {72.0});
         auto filter = std::make_shared<PushDownExecutor>(ann_query_info);
         // [0, 128) with vector index return 72.0, [128, 130) without vector index return all.
         read(range, filter, createVecFloat32Column<Array>({{72.0}, {128.0}, {129.0}}));
@@ -368,9 +377,7 @@ try
 
     // read with ANN query
     {
-        ann_query_info->set_top_k(1);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({72.1}));
-
+        const auto ann_query_info = createANNQueryInfo(vec_column_id, tipb::VectorDistanceMetric::L2, 1, {72.1});
         auto filter = std::make_shared<PushDownExecutor>(ann_query_info);
         // [0, 128) with vector index return 72.0, [128, 130) without vector index return all.
         read(range, filter, createVecFloat32Column<Array>({{72.0}, {128.0}, {129.0}}));
@@ -411,15 +418,9 @@ try
         read(range, EMPTY_FILTER, colVecFloat32("[0, 4)", vec_column_name, vec_column_id));
     }
 
-    auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
-    ann_query_info->set_column_id(vec_column_id);
-    ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::L2);
-
     // read with ANN query
     {
-        ann_query_info->set_top_k(1);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.0}));
-
+        const auto ann_query_info = createANNQueryInfo(vec_column_id, tipb::VectorDistanceMetric::L2, 1, {1.0});
         auto filter = std::make_shared<PushDownExecutor>(ann_query_info);
         // [0, 4) without vector index return all.
         read(range, filter, createVecFloat32Column<Array>({{0.0}, {1.0}, {2.0}, {3.0}}));
@@ -427,9 +428,7 @@ try
 
     // read with ANN query
     {
-        ann_query_info->set_top_k(1);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({1.1}));
-
+        const auto ann_query_info = createANNQueryInfo(vec_column_id, tipb::VectorDistanceMetric::L2, 1, {1.1});
         auto filter = std::make_shared<PushDownExecutor>(ann_query_info);
         // [0, 4) without vector index return all.
         read(range, filter, createVecFloat32Column<Array>({{0.0}, {1.0}, {2.0}, {3.0}}));
@@ -494,27 +493,17 @@ try
             colVecFloat32(fmt::format("[0, {})", num_rows_write), vec_column_name, vec_column_id));
     }
 
-    auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
-    ann_query_info->set_column_id(vec_column_id);
-    ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::L2);
-
     // read with ANN query
     {
-        ann_query_info->set_top_k(1);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({2.0}));
-
+        const auto ann_query_info = createANNQueryInfo(vec_column_id, tipb::VectorDistanceMetric::L2, 1, {2.0});
         auto filter = std::make_shared<PushDownExecutor>(ann_query_info);
-
         read(left_segment_range, filter, createVecFloat32Column<Array>({{2.0}}));
     }
 
     // read with ANN query
     {
-        ann_query_info->set_top_k(1);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({222.1}));
-
+        const auto ann_query_info = createANNQueryInfo(vec_column_id, tipb::VectorDistanceMetric::L2, 1, {222.1});
         auto filter = std::make_shared<PushDownExecutor>(ann_query_info);
-
         read(left_segment_range, filter, createVecFloat32Column<Array>({{127.0}}));
     }
 
@@ -533,21 +522,15 @@ try
 
     // read with ANN query
     {
-        ann_query_info->set_top_k(1);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({2.0}));
-
+        const auto ann_query_info = createANNQueryInfo(vec_column_id, tipb::VectorDistanceMetric::L2, 1, {2.0});
         auto filter = std::make_shared<PushDownExecutor>(ann_query_info);
-
         read(range, filter, createVecFloat32Column<Array>({{2.0}}));
     }
 
     // read with ANN query
     {
-        ann_query_info->set_top_k(1);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({122.1}));
-
+        const auto ann_query_info = createANNQueryInfo(vec_column_id, tipb::VectorDistanceMetric::L2, 1, {122.1});
         auto filter = std::make_shared<PushDownExecutor>(ann_query_info);
-
         read(range, filter, createVecFloat32Column<Array>({{122.0}}));
     }
 }
@@ -622,27 +605,17 @@ try
             colVecFloat32(fmt::format("[0, {})", num_rows_write), vec_column_name, vec_column_id));
     }
 
-    auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
-    ann_query_info->set_column_id(vec_column_id);
-    ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::L2);
-
     // read with ANN query
     {
-        ann_query_info->set_top_k(1);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({2.0}));
-
+        const auto ann_query_info = createANNQueryInfo(vec_column_id, tipb::VectorDistanceMetric::L2, 1, {2.0});
         auto filter = std::make_shared<PushDownExecutor>(ann_query_info);
-
         read(left_segment_range, filter, createVecFloat32Column<Array>({{2.0}}));
     }
 
     // read with ANN query
     {
-        ann_query_info->set_top_k(1);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({222.1}));
-
+        const auto ann_query_info = createANNQueryInfo(vec_column_id, tipb::VectorDistanceMetric::L2, 1, {222.1});
         auto filter = std::make_shared<PushDownExecutor>(ann_query_info);
-
         read(left_segment_range, filter, createVecFloat32Column<Array>({{127.0}}));
     }
 
@@ -661,21 +634,15 @@ try
 
     // read with ANN query
     {
-        ann_query_info->set_top_k(1);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({2.0}));
-
+        const auto ann_query_info = createANNQueryInfo(vec_column_id, tipb::VectorDistanceMetric::L2, 1, {2.0});
         auto filter = std::make_shared<PushDownExecutor>(ann_query_info);
-
         read(range, filter, createVecFloat32Column<Array>({{2.0}}));
     }
 
     // read with ANN query
     {
-        ann_query_info->set_top_k(1);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({122.1}));
-
+        const auto ann_query_info = createANNQueryInfo(vec_column_id, tipb::VectorDistanceMetric::L2, 1, {122.1});
         auto filter = std::make_shared<PushDownExecutor>(ann_query_info);
-
         read(range, filter, createVecFloat32Column<Array>({{122.0}}));
     }
 }
@@ -745,27 +712,17 @@ try
         read(range, EMPTY_FILTER, colVecFloat32("[0, 128)", vec_column_name, vec_column_id));
     }
 
-    auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
-    ann_query_info->set_column_id(vec_column_id);
-    ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::L2);
-
     // read with ANN query
     {
-        ann_query_info->set_top_k(1);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({2.0}));
-
+        const auto ann_query_info = createANNQueryInfo(vec_column_id, tipb::VectorDistanceMetric::L2, 1, {2.0});
         auto filter = std::make_shared<PushDownExecutor>(ann_query_info);
-
         read(range, filter, createVecFloat32Column<Array>({{2.0}}));
     }
 
     // read with ANN query
     {
-        ann_query_info->set_top_k(1);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({2.1}));
-
+        const auto ann_query_info = createANNQueryInfo(vec_column_id, tipb::VectorDistanceMetric::L2, 1, {2.1});
         auto filter = std::make_shared<PushDownExecutor>(ann_query_info);
-
         read(range, filter, createVecFloat32Column<Array>({{2.0}}));
     }
 }
@@ -833,27 +790,17 @@ try
         read(range, EMPTY_FILTER, colVecFloat32("[0, 256)", vec_column_name, vec_column_id));
     }
 
-    auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
-    ann_query_info->set_column_id(vec_column_id);
-    ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::L2);
-
     // read with ANN query
     {
-        ann_query_info->set_top_k(1);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({2.0}));
-
+        const auto ann_query_info = createANNQueryInfo(vec_column_id, tipb::VectorDistanceMetric::L2, 1, {2.0});
         auto filter = std::make_shared<PushDownExecutor>(ann_query_info);
-
         read(range, filter, createVecFloat32Column<Array>({{2.0}}));
     }
 
     // read with ANN query
     {
-        ann_query_info->set_top_k(1);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({222.1}));
-
+        const auto ann_query_info = createANNQueryInfo(vec_column_id, tipb::VectorDistanceMetric::L2, 1, {222.1});
         auto filter = std::make_shared<PushDownExecutor>(ann_query_info);
-
         read(range, filter, createVecFloat32Column<Array>({{222.0}}));
     }
 }
@@ -877,6 +824,9 @@ try
 
     // write [128, 256) to store
     write(num_rows_write, num_rows_write * 2);
+
+    // trigger FlushCache for all segments
+    triggerFlushCache();
 
     {
         // Add vecotr index
@@ -904,9 +854,6 @@ try
         ASSERT_EQ(store->local_index_infos->size(), 1);
     }
 
-    // trigger FlushCache for all segments
-    triggerFlushCacheAndEnsureDeltaLocalIndex();
-
     // check delta index has built for all segments
     waitDeltaIndexReady();
     // check stable index has built for all segments
@@ -919,16 +866,9 @@ try
         read(range, EMPTY_FILTER, colVecFloat32("[0, 256)", vec_column_name, vec_column_id));
     }
 
-    auto ann_query_info = std::make_shared<tipb::ANNQueryInfo>();
-    ann_query_info->set_index_id(2);
-    ann_query_info->set_column_id(vec_column_id);
-    ann_query_info->set_distance_metric(tipb::VectorDistanceMetric::L2);
-
     // read with ANN query
     {
-        ann_query_info->set_top_k(1);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({2.0}));
-
+        const auto ann_query_info = createANNQueryInfo(vec_column_id, tipb::VectorDistanceMetric::L2, 1, {2.0}, 2);
         auto filter = std::make_shared<PushDownExecutor>(ann_query_info);
 
         read(range, filter, createVecFloat32Column<Array>({{2.0}}));
@@ -936,13 +876,116 @@ try
 
     // read with ANN query
     {
-        ann_query_info->set_top_k(1);
-        ann_query_info->set_ref_vec_f32(encodeVectorFloat32({222.1}));
-
+        const auto ann_query_info = createANNQueryInfo(vec_column_id, tipb::VectorDistanceMetric::L2, 1, {222.1}, 2);
         auto filter = std::make_shared<PushDownExecutor>(ann_query_info);
 
         read(range, filter, createVecFloat32Column<Array>({{222.0}}));
     }
+
+    {
+        // vector index is dropped
+        TiDB::TableInfo new_table_info_with_vector_index;
+        TiDB::ColumnInfo column_info;
+        column_info.name = VectorIndexTestUtils::vec_column_name;
+        column_info.id = VectorIndexTestUtils::vec_column_id;
+        new_table_info_with_vector_index.columns.emplace_back(column_info);
+        // apply local index change, shuold drop the local index
+        store->applyLocalIndexChange(new_table_info_with_vector_index);
+        ASSERT_EQ(store->local_index_infos->size(), 0);
+    }
+}
+CATCH
+
+TEST_F(DeltaMergeStoreVectorTest, DDLAddMultipleVectorIndex)
+try
+{
+    {
+        auto indexes = std::make_shared<LocalIndexInfos>();
+        store = reload(indexes);
+        ASSERT_EQ(store->getLocalIndexInfosSnapshot(), nullptr);
+    }
+
+    const size_t num_rows_write = 128;
+
+    // write [0, 128) to store
+    write(0, num_rows_write);
+    // trigger mergeDelta for all segments
+    triggerMergeDelta();
+
+    // write [128, 256) to store
+    write(num_rows_write, num_rows_write * 2);
+
+    // trigger FlushCache for all segments
+    triggerFlushCache();
+
+    auto add_vector_index = [&](std::vector<IndexID> index_id, std::vector<tipb::VectorDistanceMetric> metrics) {
+        TiDB::TableInfo new_table_info_with_vector_index;
+        TiDB::ColumnInfo column_info;
+        column_info.name = VectorIndexTestUtils::vec_column_name;
+        column_info.id = VectorIndexTestUtils::vec_column_id;
+        new_table_info_with_vector_index.columns.emplace_back(column_info);
+        TiDB::IndexColumnInfo index_col_info;
+        index_col_info.name = VectorIndexTestUtils::vec_column_name;
+        index_col_info.offset = 0;
+        for (size_t i = 0; i < index_id.size(); ++i)
+        {
+            TiDB::IndexInfo index;
+            index.id = index_id[i];
+            index.idx_cols.push_back(index_col_info);
+            index.vector_index = TiDB::VectorIndexDefinitionPtr(new TiDB::VectorIndexDefinition{
+                .kind = tipb::VectorIndexKind::HNSW,
+                .dimension = 1,
+                .distance_metric = metrics[i],
+            });
+            new_table_info_with_vector_index.index_infos.emplace_back(index);
+        }
+        // apply local index change, shuold
+        // - create the local index
+        // - generate the background tasks for building index on stable and delta
+        store->applyLocalIndexChange(new_table_info_with_vector_index);
+        ASSERT_EQ(store->local_index_infos->size(), index_id.size());
+
+        // check delta index has built for all segments
+        waitDeltaIndexReady();
+        // check stable index has built for all segments
+        waitStableLocalIndexReady();
+    };
+
+    const auto range = RowKeyRange::newAll(store->is_common_handle, store->rowkey_column_size);
+    auto query = [&](IndexID index_id,
+                     tipb::VectorDistanceMetric metric,
+                     const InferredDataVector<Array> & result_1,
+                     const InferredDataVector<Array> & result_2) {
+        // read from store
+        {
+            read(range, EMPTY_FILTER, colVecFloat32("[0, 256)", vec_column_name, vec_column_id));
+        }
+
+        // read with ANN query
+        {
+            const auto ann_query_info = createANNQueryInfo(vec_column_id, metric, 1, {2.0}, index_id);
+            auto filter = std::make_shared<PushDownExecutor>(ann_query_info);
+
+            read(range, filter, createVecFloat32Column<Array>(result_1));
+        }
+
+        // read with ANN query
+        {
+            const auto ann_query_info = createANNQueryInfo(vec_column_id, metric, 1, {222.1}, index_id);
+            auto filter = std::make_shared<PushDownExecutor>(ann_query_info);
+
+            read(range, filter, createVecFloat32Column<Array>(result_2));
+        }
+    };
+
+    // Add COSINE vector index
+    add_vector_index({1}, {tipb::VectorDistanceMetric::COSINE});
+    query(1, tipb::VectorDistanceMetric::COSINE, {{129.0}}, {{129.0}});
+
+    // Add L2 vector index
+    add_vector_index({1, 2}, {tipb::VectorDistanceMetric::COSINE, tipb::VectorDistanceMetric::L2});
+    query(1, tipb::VectorDistanceMetric::COSINE, {{129.0}}, {{129.0}});
+    query(2, tipb::VectorDistanceMetric::L2, {{2.0}}, {{222.0}});
 
     {
         // vector index is dropped


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9971, close #9972

Problem Summary:

### What is changed and how it works?

```commit-message
1. Fix the existing index infoes in ColumnFileTiny are missed after add new indexes.
2. Do not add task into `LocalIndexerScheduler` if the DMFile is empty.
3. Fix delta data do not build the new added local indexes.
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
