### PR TITLE
Storages: use default string type in DeltaMergeStore

### DIFF
--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -2324,6 +2324,9 @@ void DeltaMergeStore::createFirstSegment(DM::DMContext & dm_context)
 
 void DeltaMergeStore::updateColumnDefines(ColumnDefines && tmp_columns)
 {
+    // Tables created before the new string serialization format takes effect will
+    // not be automatically converted to the new type during restoration.
+    // Here, we force it to algin with default string type.
     convertStringTypeToDefault(tmp_columns);
     original_table_columns = std::move(tmp_columns);
     store_columns = generateStoreColumns(original_table_columns, is_common_handle);

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -209,16 +209,12 @@ ColumnDefinesPtr generateStoreColumns(const ColumnDefines & table_columns, bool 
 
 void convertStringTypeToDefault(DataTypePtr & type)
 {
-    static const auto default_string_type = DataTypeFactory::instance().getOrSet(DataTypeString::getDefaultName());
-    static const auto default_nullable_string_type
-        = DataTypeFactory::instance().getOrSet(DataTypeString::getNullableDefaultName());
-
     if (removeNullable(type)->getTypeId() != TypeIndex::String)
         return;
     if (type->isNullable())
-        type = default_nullable_string_type;
+        type = DataTypeFactory::instance().getOrSet(DataTypeString::getNullableDefaultName());
     else
-        type = default_string_type;
+        type = DataTypeFactory::instance().getOrSet(DataTypeString::getDefaultName());
 }
 
 void convertStringTypeToDefault(ColumnDefines & cds)

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.cpp
@@ -206,6 +206,26 @@ ColumnDefinesPtr generateStoreColumns(const ColumnDefines & table_columns, bool 
     }
     return columns;
 }
+
+void convertStringTypeToDefault(DataTypePtr & type)
+{
+    static const auto default_string_type = DataTypeFactory::instance().getOrSet(DataTypeString::getDefaultName());
+    static const auto default_nullable_string_type
+        = DataTypeFactory::instance().getOrSet(DataTypeString::getNullableDefaultName());
+
+    if (removeNullable(type)->getTypeId() != TypeIndex::String)
+        return;
+    if (type->isNullable())
+        type = default_nullable_string_type;
+    else
+        type = default_string_type;
+}
+
+void convertStringTypeToDefault(ColumnDefines & cds)
+{
+    for (auto & col : cds)
+        convertStringTypeToDefault(col.type);
+}
 } // namespace
 
 DeltaMergeStore::Settings DeltaMergeStore::EMPTY_SETTINGS
@@ -262,18 +282,17 @@ DeltaMergeStore::DeltaMergeStore(
     // Should be done before any background task setup.
     restoreStableFiles();
 
-    original_table_columns.emplace_back(original_table_handle_define);
-    original_table_columns.emplace_back(getVersionColumnDefine());
-    original_table_columns.emplace_back(getTagColumnDefine());
+    ColumnDefines tmp_table_columns;
+    tmp_table_columns.emplace_back(original_table_handle_define);
+    tmp_table_columns.emplace_back(getVersionColumnDefine());
+    tmp_table_columns.emplace_back(getTagColumnDefine());
     for (const auto & col : columns)
     {
         if (col.id != original_table_handle_define.id && col.id != MutSup::version_col_id
             && col.id != MutSup::delmark_col_id)
-            original_table_columns.emplace_back(col);
+            tmp_table_columns.emplace_back(col);
     }
-
-    original_table_header = std::make_shared<Block>(toEmptyBlock(original_table_columns));
-    store_columns = generateStoreColumns(original_table_columns, is_common_handle);
+    updateColumnDefines(std::move(tmp_table_columns));
 
     auto dm_context = newDMContext(db_context, db_context.getSettingsRef());
     PageStorageRunMode page_storage_run_mode;
@@ -2025,12 +2044,7 @@ void DeltaMergeStore::applySchemaChanges(TiDB::TableInfo & table_info)
         replica_exist.store(false);
     }
 
-    auto new_store_columns = generateStoreColumns(new_original_table_columns, is_common_handle);
-
-    original_table_columns.swap(new_original_table_columns);
-    store_columns.swap(new_store_columns);
-
-    std::atomic_store(&original_table_header, std::make_shared<Block>(toEmptyBlock(original_table_columns)));
+    updateColumnDefines(std::move(new_original_table_columns));
 
     // release the lock because `applyLocalIndexChange` will try to acquire the lock
     // and generate tasks on segments
@@ -2308,5 +2322,12 @@ void DeltaMergeStore::createFirstSegment(DM::DMContext & dm_context)
     addSegment(lock, first_segment);
 }
 
+void DeltaMergeStore::updateColumnDefines(ColumnDefines && tmp_columns)
+{
+    convertStringTypeToDefault(tmp_columns);
+    original_table_columns = std::move(tmp_columns);
+    store_columns = generateStoreColumns(original_table_columns, is_common_handle);
+    std::atomic_store(&original_table_header, std::make_shared<Block>(toEmptyBlock(original_table_columns)));
+}
 } // namespace DM
 } // namespace DB

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
@@ -949,6 +949,8 @@ public:
         bool throw_if_notfound);
     void createFirstSegment(DM::DMContext & dm_context);
 
+    void updateColumnDefines(ColumnDefines && tmp_columns);
+
     Context & global_context;
     std::shared_ptr<StoragePathPool> path_pool;
     Settings settings;

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store.cpp
@@ -2969,11 +2969,26 @@ try
         // Mock that after restart, the data type has been changed to new serialize. But still can read old
         // serialized format data.
         auto table_column_defines = DMTestEnv::getDefaultColumns();
-        table_column_defines->emplace_back(str_cd);
+        table_column_defines->emplace_back(legacy_str_cd);
         store = reload(table_column_defines);
+
+        // Verify that the string column with old data type name will be automatically
+        // converted into new serialized format.
+        bool legacy_str_is_converted = false;
+        auto store_cds = *store->getStoreColumns();
+        for (const auto & cd : store_cds)
+        {
+            if (cd.id == legacy_str_cd.id)
+            {
+                ASSERT_EQ(cd.type->getName(), str_cd.type->getName());
+                legacy_str_is_converted = true;
+            }
+        }
+        ASSERT_TRUE(legacy_str_is_converted);
     }
 
     {
+        // Still can read old serialized format data
         auto in = store->read(
             *db_context,
             db_context->getSettingsRef(),

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store.cpp
@@ -2943,7 +2943,12 @@ try
         auto table_column_defines = DMTestEnv::getDefaultColumns();
         table_column_defines->emplace_back(legacy_str_cd);
         dropDataOnDisk(getTemporaryPath());
+
+        auto tmp = STORAGE_FORMAT_CURRENT;
+        setStorageFormat(7); // set to legacy format temporary.
         store = reload(table_column_defines);
+        setStorageFormat(tmp.identifier); // Reset to current format.
+
         auto block = createBlock(legacy_str_cd, 0, 128);
         store->write(*db_context, db_context->getSettingsRef(), block);
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9983

### What is changed and how it works?

```commit-message
- Converting string type to default parameter in DeltaMergeStore
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  - Compacting tiflash replica make string data from `String` to `StringV2`. 

![image](https://github.com/user-attachments/assets/adcb37db-0e1f-48ca-a5aa-c5a229ac6268)

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix a bug that the string serialize method of existing data does not follow `storage.format_version` after upgraded
```
