### PR TITLE
disagg: Fix build under ASAN; Check each aws patch separately

### DIFF
--- a/contrib/aws-cmake/CMakeLists.txt
+++ b/contrib/aws-cmake/CMakeLists.txt
@@ -92,14 +92,14 @@ file(GLOB AWS_SDK_CORE_SRC
     "${AWS_SDK_CORE_DIR}/source/utils/xml/*.cpp"
 )
 
+## Notice: update the patch using `git format-patch` if you upgrade aws!!!
+set (AWS_PATCH_FILE "${TiFlash_SOURCE_DIR}/contrib/aws-cmake/0001-More-reliable-way-to-check-if-there-is-anything-in-r.patch")
 execute_process(
   COMMAND grep "GetResponseBody().peek()" "${AWS_SDK_CORE_DIR}/source/client/AWSXmlClient.cpp"
   RESULT_VARIABLE HAVE_APPLY_PATCH)
 # grep - Normally, the exit status is 0 if selected lines are found and 1 otherwise. But the exit status is 2 if an error occurred.
 if (HAVE_APPLY_PATCH EQUAL 1)
-  message(STATUS "aws patch not apply: ${HAVE_APPLY_PATCH}, patching...")
-  ## update the patch using `git format-patch` if you upgrade aws
-  set (AWS_PATCH_FILE "${TiFlash_SOURCE_DIR}/contrib/aws-cmake/0001-More-reliable-way-to-check-if-there-is-anything-in-r.patch")
+  message(STATUS "aws patch ${AWS_PATCH_FILE} not apply: ${HAVE_APPLY_PATCH}, patching...")
   # apply the patch
   execute_process(
     COMMAND git apply -v "${AWS_PATCH_FILE}"
@@ -108,35 +108,57 @@ if (HAVE_APPLY_PATCH EQUAL 1)
     RESULT_VARIABLE PATCH_SUCC)
   if (NOT PATCH_SUCC EQUAL 0)
     message(FATAL_ERROR "Can not apply aws patch ${AWS_PATCH_FILE}")
-  endif ()
-
-  set (AWS_PATCH_FILE "${TiFlash_SOURCE_DIR}/contrib/aws-cmake/0002-Reduce-verbose-error-logging-and-404-for-HEAD-reques.patch")
-  # apply the patch
-  execute_process(
-    COMMAND git apply -v "${AWS_PATCH_FILE}"
-    WORKING_DIRECTORY "${AWS_SDK_DIR}"
-    COMMAND_ECHO STDOUT
-    RESULT_VARIABLE PATCH_SUCC)
-  if (NOT PATCH_SUCC EQUAL 0)
-    message(FATAL_ERROR "Can not apply aws patch ${AWS_PATCH_FILE}")
-  else ()
-    message(STATUS "aws patch done")
-  endif ()
-
-  set (AWS_PATCH_FILE "${TiFlash_SOURCE_DIR}/contrib/aws-cmake/0003-Suppress-enum-overflow.patch")
-  # apply the patch
-  execute_process(
-    COMMAND git apply -v "${AWS_PATCH_FILE}"
-    WORKING_DIRECTORY "${AWS_SDK_CORE_DIR}"
-    COMMAND_ECHO STDOUT
-    RESULT_VARIABLE PATCH_SUCC)
-  if (NOT PATCH_SUCC EQUAL 0)
-    message(FATAL_ERROR "Can not apply aws patch ${AWS_PATCH_FILE}")
-  else ()
-    message(STATUS "aws patch done")
   endif ()
 elseif (HAVE_APPLY_PATCH EQUAL 0)
-  message(STATUS "aws patch have been applied: ${HAVE_APPLY_PATCH}")
+  message(STATUS "aws patch have been applied, patch=${HAVE_APPLY_PATCH}")
+else ()
+  message(FATAL_ERROR "Can not check the aws patch status")
+endif ()
+
+set (AWS_PATCH_FILE "${TiFlash_SOURCE_DIR}/contrib/aws-cmake/0002-Reduce-verbose-error-logging-and-404-for-HEAD-reques.patch")
+execute_process(
+  COMMAND grep "// ignore error logging for HEAD request with 404 response code" "${AWS_SDK_CORE_DIR}/source/client/AWSXmlClient.cpp"
+  RESULT_VARIABLE HAVE_APPLY_PATCH)
+# grep - Normally, the exit status is 0 if selected lines are found and 1 otherwise. But the exit status is 2 if an error occurred.
+if (HAVE_APPLY_PATCH EQUAL 1)
+  message(STATUS "aws patch ${AWS_PATCH_FILE} not apply: ${HAVE_APPLY_PATCH}, patching...")
+  # apply the patch
+  execute_process(
+    COMMAND git apply -v "${AWS_PATCH_FILE}"
+    WORKING_DIRECTORY "${AWS_SDK_DIR}"
+    COMMAND_ECHO STDOUT
+    RESULT_VARIABLE PATCH_SUCC)
+  if (NOT PATCH_SUCC EQUAL 0)
+    message(FATAL_ERROR "Can not apply aws patch ${AWS_PATCH_FILE}")
+  else ()
+    message(STATUS "aws patch done, patch=${AWS_PATCH_FILE}")
+  endif ()
+elseif (HAVE_APPLY_PATCH EQUAL 0)
+  message(STATUS "aws patch have been applied, patch=${HAVE_APPLY_PATCH}")
+else ()
+  message(FATAL_ERROR "Can not check the aws patch status")
+endif ()
+
+set (AWS_PATCH_FILE "${TiFlash_SOURCE_DIR}/contrib/aws-cmake/0003-Suppress-enum-overflow.patch")
+execute_process(
+  COMMAND grep "AWS_LOGSTREAM_DEBUG.*You should update your clients when you get a chance" "${AWS_SDK_CORE_DIR}/source/utils/EnumParseOverflowContainer.cpp"
+  RESULT_VARIABLE HAVE_APPLY_PATCH)
+# grep - Normally, the exit status is 0 if selected lines are found and 1 otherwise. But the exit status is 2 if an error occurred.
+if (HAVE_APPLY_PATCH EQUAL 1)
+  message(STATUS "aws patch ${AWS_PATCH_FILE} not apply: ${HAVE_APPLY_PATCH}, patching...")
+  # apply the patch
+  execute_process(
+    COMMAND git apply -v "${AWS_PATCH_FILE}"
+    WORKING_DIRECTORY "${AWS_SDK_DIR}"
+    COMMAND_ECHO STDOUT
+    RESULT_VARIABLE PATCH_SUCC)
+  if (NOT PATCH_SUCC EQUAL 0)
+    message(FATAL_ERROR "Can not apply aws patch ${AWS_PATCH_FILE}")
+  else ()
+    message(STATUS "aws patch done, patch=${AWS_PATCH_FILE}")
+  endif ()
+elseif (HAVE_APPLY_PATCH EQUAL 0)
+  message(STATUS "aws patch have been applied, patch=${HAVE_APPLY_PATCH}")
 else ()
   message(FATAL_ERROR "Can not check the aws patch status")
 endif ()


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/9955

Problem Summary:

Ref https://github.com/pingcap/tiflash/pull/9957

```
cmake /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DENABLE_TESTS=ON -DCMAKE_BUILD_TYPE=ASan -DUSE_CCACHE=ON -DRUN_HAVE_STD_REGEX=0 -DCMAKE_PREFIX_PATH=/usr/local -DUSE_GM_SSL=0 -GNinja
...
[2025-03-09T18:47:24.402Z] -- aws patch not apply: 1, patching...
[2025-03-09T18:47:24.402Z] 'git' 'apply' '-v' '/home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/contrib/aws-cmake/0001-More-reliable-way-to-check-if-there-is-anything-in-r.patch'
[2025-03-09T18:47:24.402Z] Checking patch src/aws-cpp-sdk-core/source/client/AWSJsonClient.cpp...
[2025-03-09T18:47:24.402Z] Checking patch src/aws-cpp-sdk-core/source/client/AWSXmlClient.cpp...
[2025-03-09T18:47:24.402Z] Checking patch src/aws-cpp-sdk-core/source/internal/AWSHttpResourceClient.cpp...
[2025-03-09T18:47:24.402Z] Applied patch src/aws-cpp-sdk-core/source/client/AWSJsonClient.cpp cleanly.
[2025-03-09T18:47:24.402Z] Applied patch src/aws-cpp-sdk-core/source/client/AWSXmlClient.cpp cleanly.
[2025-03-09T18:47:24.402Z] Applied patch src/aws-cpp-sdk-core/source/internal/AWSHttpResourceClient.cpp cleanly.
[2025-03-09T18:47:24.402Z] 'git' 'apply' '-v' '/home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/contrib/aws-cmake/0002-Reduce-verbose-error-logging-and-404-for-HEAD-reques.patch'
[2025-03-09T18:47:24.402Z] Checking patch src/aws-cpp-sdk-core/source/client/AWSClient.cpp...
[2025-03-09T18:47:24.402Z] Checking patch src/aws-cpp-sdk-core/source/client/AWSXmlClient.cpp...
[2025-03-09T18:47:24.402Z] Applied patch src/aws-cpp-sdk-core/source/client/AWSClient.cpp cleanly.
[2025-03-09T18:47:24.402Z] Applied patch src/aws-cpp-sdk-core/source/client/AWSXmlClient.cpp cleanly.
[2025-03-09T18:47:24.402Z] -- aws patch done
[2025-03-09T18:47:24.402Z] 'git' 'apply' '-v' '/home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/contrib/aws-cmake/0003-Suppress-enum-overflow.patch'
[2025-03-09T18:47:24.402Z] Checking patch src/aws-cpp-sdk-core/source/utils/EnumParseOverflowContainer.cpp...
[2025-03-09T18:47:24.402Z] error: src/aws-cpp-sdk-core/source/utils/EnumParseOverflowContainer.cpp: No such file or directory
[2025-03-09T18:47:24.402Z] CMake Error at contrib/aws-cmake/CMakeLists.txt:134 (message):
[2025-03-09T18:47:24.402Z]   Can not apply aws patch
[2025-03-09T18:47:24.403Z]   /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash/contrib/aws-cmake/0003-Suppress-enum-overflow.patch
[2025-03-09T18:47:24.403Z] 
[2025-03-09T18:47:24.403Z] 
[2025-03-09T18:47:24.403Z] -- Configuring incomplete, errors occurred!
```

### What is changed and how it works?

```commit-message
disagg: Fix build under ASAN; Check each aws patch separately
* Use "${AWS_SDK_DIR}" as working directory
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
