### PR TITLE
Storages: support build inverted index query info from RSOperator

### DIFF
--- a/dbms/src/Storages/DeltaMerge/BitmapFilter/BitmapFilter.cpp
+++ b/dbms/src/Storages/DeltaMerge/BitmapFilter/BitmapFilter.cpp
@@ -97,6 +97,35 @@ void BitmapFilter::rangeAnd(IColumn::Filter & f, UInt32 start, UInt32 limit) con
     }
 }
 
+void BitmapFilter::merge(const BitmapFilter & other)
+{
+    RUNTIME_CHECK(filter.size() == other.filter.size());
+    if (all_match)
+    {
+        return;
+    }
+    for (UInt32 i = 0; i < filter.size(); i++)
+    {
+        filter[i] = filter[i] || other.filter[i];
+    }
+}
+
+void BitmapFilter::intersect(const BitmapFilter & other)
+{
+    RUNTIME_CHECK(filter.size() == other.filter.size());
+    if (all_match)
+    {
+        std::copy(other.filter.cbegin(), other.filter.cend(), filter.begin());
+        all_match = other.all_match;
+        return;
+    }
+    for (UInt32 i = 0; i < filter.size(); i++)
+    {
+        filter[i] = filter[i] && other.filter[i];
+    }
+    all_match = all_match && other.all_match;
+}
+
 void BitmapFilter::runOptimize()
 {
     all_match = std::find(filter.begin(), filter.end(), static_cast<UInt8>(false)) == filter.end();

--- a/dbms/src/Storages/DeltaMerge/BitmapFilter/BitmapFilter.cpp
+++ b/dbms/src/Storages/DeltaMerge/BitmapFilter/BitmapFilter.cpp
@@ -104,6 +104,12 @@ void BitmapFilter::logicalOr(const BitmapFilter & other)
     {
         return;
     }
+    if (other.all_match)
+    {
+        filter.assign(filter.size(), true);
+        all_match = true;
+        return;
+    }
     for (UInt32 i = 0; i < filter.size(); i++)
     {
         filter[i] = filter[i] || other.filter[i];

--- a/dbms/src/Storages/DeltaMerge/BitmapFilter/BitmapFilter.cpp
+++ b/dbms/src/Storages/DeltaMerge/BitmapFilter/BitmapFilter.cpp
@@ -106,7 +106,7 @@ void BitmapFilter::logicalOr(const BitmapFilter & other)
     }
     if (other.all_match)
     {
-        filter.assign(filter.size(), true);
+        filter.assign(filter.size(), static_cast<UInt8>(true));
         all_match = true;
         return;
     }

--- a/dbms/src/Storages/DeltaMerge/BitmapFilter/BitmapFilter.cpp
+++ b/dbms/src/Storages/DeltaMerge/BitmapFilter/BitmapFilter.cpp
@@ -97,7 +97,7 @@ void BitmapFilter::rangeAnd(IColumn::Filter & f, UInt32 start, UInt32 limit) con
     }
 }
 
-void BitmapFilter::merge(const BitmapFilter & other)
+void BitmapFilter::logicalOr(const BitmapFilter & other)
 {
     RUNTIME_CHECK(filter.size() == other.filter.size());
     if (all_match)
@@ -108,9 +108,10 @@ void BitmapFilter::merge(const BitmapFilter & other)
     {
         filter[i] = filter[i] || other.filter[i];
     }
+    all_match = all_match || other.all_match;
 }
 
-void BitmapFilter::intersect(const BitmapFilter & other)
+void BitmapFilter::logicalAnd(const BitmapFilter & other)
 {
     RUNTIME_CHECK(filter.size() == other.filter.size());
     if (all_match)

--- a/dbms/src/Storages/DeltaMerge/BitmapFilter/BitmapFilter.cpp
+++ b/dbms/src/Storages/DeltaMerge/BitmapFilter/BitmapFilter.cpp
@@ -120,6 +120,8 @@ void BitmapFilter::logicalOr(const BitmapFilter & other)
 void BitmapFilter::logicalAnd(const BitmapFilter & other)
 {
     RUNTIME_CHECK(filter.size() == other.filter.size());
+    if (other.all_match)
+        return;
     if (all_match)
     {
         std::copy(other.filter.cbegin(), other.filter.cend(), filter.begin());

--- a/dbms/src/Storages/DeltaMerge/BitmapFilter/BitmapFilter.h
+++ b/dbms/src/Storages/DeltaMerge/BitmapFilter/BitmapFilter.h
@@ -41,9 +41,9 @@ public:
     void rangeAnd(IColumn::Filter & f, UInt32 start, UInt32 limit) const;
 
     // f = f | other
-    void merge(const BitmapFilter & other);
+    void logicalOr(const BitmapFilter & other);
     // f = f & other
-    void intersect(const BitmapFilter & other);
+    void logicalAnd(const BitmapFilter & other);
 
     void runOptimize();
 

--- a/dbms/src/Storages/DeltaMerge/BitmapFilter/BitmapFilter.h
+++ b/dbms/src/Storages/DeltaMerge/BitmapFilter/BitmapFilter.h
@@ -40,6 +40,11 @@ public:
     // filter[start, satrt+limit) & f -> f
     void rangeAnd(IColumn::Filter & f, UInt32 start, UInt32 limit) const;
 
+    // f = f | other
+    void merge(const BitmapFilter & other);
+    // f = f & other
+    void intersect(const BitmapFilter & other);
+
     void runOptimize();
 
     String toDebugString() const;

--- a/dbms/src/Storages/DeltaMerge/BitmapFilter/BitmapFilter.h
+++ b/dbms/src/Storages/DeltaMerge/BitmapFilter/BitmapFilter.h
@@ -30,14 +30,14 @@ public:
     // Read blocks from `stream` and set the rows_id to be true according to the
     // `segmentRowIdCol` in the block read from `stream`.
     void set(BlockInputStreamPtr & stream);
-    // f[start, satrt+limit) = value
+    // f[start, start+limit) = value
     void set(UInt32 start, UInt32 limit, bool value = true);
     void set(std::span<const UInt32> row_ids, const FilterPtr & f);
     // If return true, all data is match and do not fill the filter.
     bool get(IColumn::Filter & f, UInt32 start, UInt32 limit) const;
     // Caller should ensure n in [0, size).
     inline bool get(UInt32 n) const { return filter[n]; }
-    // filter[start, satrt+limit) & f -> f
+    // filter[start, start+limit) & f -> f
     void rangeAnd(IColumn::Filter & f, UInt32 start, UInt32 limit) const;
 
     // f = f | other

--- a/dbms/src/Storages/DeltaMerge/Filter/And.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/And.h
@@ -43,6 +43,15 @@ public:
         }
         return res;
     }
+
+    ColumnRangePtr buildSets(const LocalIndexInfosSnapshot & index_info) override
+    {
+        ColumnRanges children_sets;
+        children_sets.reserve(children.size());
+        for (const auto & child : children)
+            children_sets.push_back(child->buildSets(index_info));
+        return AndColumnRange::create(children_sets);
+    }
 };
 
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/Filter/ColumnRange.cpp
+++ b/dbms/src/Storages/DeltaMerge/Filter/ColumnRange.cpp
@@ -1,0 +1,176 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Storages/DeltaMerge/Filter/ColumnRange.h>
+
+namespace DB::DM
+{
+
+const ColumnRangePtr UnsupportedColumnRange::Instance = std::make_shared<UnsupportedColumnRange>();
+
+ColumnRangePtr AndColumnRange::invert() const
+{
+    ColumnRanges inverted_children;
+    inverted_children.reserve(children.size());
+    for (const auto & child : children)
+        inverted_children.push_back(child->invert());
+    return OrColumnRange::create(inverted_children);
+}
+
+ColumnRangePtr AndColumnRange::tryOptimize()
+{
+    // Flatten nested AndColumnRange
+    ColumnRanges new_children;
+    for (auto & child : children)
+    {
+        if (auto * and_child = dynamic_cast<AndColumnRange *>(child.get()); and_child)
+            new_children.insert(new_children.end(), and_child->children.begin(), and_child->children.end());
+        else
+            new_children.push_back(child);
+    }
+    children.swap(new_children);
+    new_children.clear();
+
+    // Merge single sets on the same index by intersecting their integer sets
+    // Remove UnsupportedColumnRange
+    std::unordered_map<IndexID, std::pair<ColumnID, IntegerSetPtr>> merged_sets;
+    for (auto & child : children)
+    {
+        if (auto single_child = std::dynamic_pointer_cast<SingleColumnRange>(child); single_child)
+        {
+            if (auto it = merged_sets.find(single_child->index_id); it != merged_sets.end())
+                it->second = {single_child->column_id, it->second.second->intersectWith(single_child->set)};
+            else
+                merged_sets[single_child->index_id] = {single_child->column_id, single_child->set};
+        }
+        else if (child->type == ColumnRangeType::Unsupported)
+        {
+            // Skip
+        }
+        else
+        {
+            // Non-single sets are kept as is
+            new_children.push_back(child);
+        }
+    }
+
+    // Replace children with merged single sets
+    children.clear();
+    for (const auto & [index_id, value] : merged_sets)
+    {
+        children.push_back(SingleColumnRange::create(value.first, index_id, value.second));
+    }
+    children.insert(children.end(), new_children.begin(), new_children.end());
+
+    // If there is only one child, return that child
+    if (children.empty())
+        return UnsupportedColumnRange::Instance;
+    if (children.size() == 1)
+        return children.front();
+    return this->shared_from_this();
+}
+
+BitmapFilterPtr AndColumnRange::check(
+    std::function<BitmapFilterPtr(const ColumnRangePtr &, size_t size)> search,
+    size_t size)
+{
+    BitmapFilterPtr result = nullptr;
+    for (const auto & child : children)
+    {
+        auto child_result = child->check(search, size);
+        if (!result || !child_result)
+            result = child_result;
+        else
+            result->intersect(*child_result);
+    }
+    return result;
+}
+
+ColumnRangePtr OrColumnRange::invert() const
+{
+    ColumnRanges inverted_children;
+    inverted_children.reserve(children.size());
+    for (const auto & child : children)
+        inverted_children.push_back(child->invert());
+    return AndColumnRange::create(inverted_children);
+}
+
+ColumnRangePtr OrColumnRange::tryOptimize()
+{
+    // Flatten nested OrColumnRange
+    ColumnRanges new_children;
+    for (auto & child : children)
+    {
+        if (auto * or_child = dynamic_cast<OrColumnRange *>(child.get()); or_child)
+            new_children.insert(new_children.end(), or_child->children.begin(), or_child->children.end());
+        else
+            new_children.push_back(child);
+    }
+    children.swap(new_children);
+    new_children.clear();
+
+    // Merge single sets on the same index by unioning their integer sets
+    // Return UnsupportedColumnRange if there is any
+    std::unordered_map<IndexID, std::pair<ColumnID, IntegerSetPtr>> merged_sets;
+    for (auto & child : children)
+    {
+        if (auto single_child = std::dynamic_pointer_cast<SingleColumnRange>(child); single_child)
+        {
+            if (auto it = merged_sets.find(single_child->index_id); it != merged_sets.end())
+                it->second = {single_child->column_id, it->second.second->unionWith(single_child->set)};
+            else
+                merged_sets[single_child->index_id] = {single_child->column_id, single_child->set};
+        }
+        else if (child->type == ColumnRangeType::Unsupported)
+        {
+            return UnsupportedColumnRange::Instance;
+        }
+        else
+        {
+            // Non-single sets are kept as is
+            new_children.push_back(child);
+        }
+    }
+
+    // Replace children with merged single sets
+    children.clear();
+    for (const auto & [index_id, value] : merged_sets)
+    {
+        children.push_back(SingleColumnRange::create(value.first, index_id, value.second));
+    }
+    children.insert(children.end(), new_children.begin(), new_children.end());
+
+    // If there is only one child, return that child
+    if (children.size() == 1)
+        return children.front();
+    return this->shared_from_this();
+}
+
+BitmapFilterPtr OrColumnRange::check(
+    std::function<BitmapFilterPtr(const ColumnRangePtr &, size_t size)> search,
+    size_t size)
+{
+    BitmapFilterPtr result = nullptr;
+    for (const auto & child : children)
+    {
+        auto child_result = child->check(search, size);
+        if (!result || !child_result)
+            result = child_result;
+        else
+            result->merge(*child_result);
+    }
+    return result;
+}
+
+} // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/Filter/ColumnRange.cpp
+++ b/dbms/src/Storages/DeltaMerge/Filter/ColumnRange.cpp
@@ -92,7 +92,7 @@ BitmapFilterPtr AndColumnRange::check(
         if (!result || !child_result)
             result = child_result;
         else
-            result->intersect(*child_result);
+            result->logicalAnd(*child_result);
     }
     return result;
 }
@@ -168,7 +168,7 @@ BitmapFilterPtr OrColumnRange::check(
         if (!result || !child_result)
             result = child_result;
         else
-            result->merge(*child_result);
+            result->logicalOr(*child_result);
     }
     return result;
 }

--- a/dbms/src/Storages/DeltaMerge/Filter/ColumnRange.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/ColumnRange.h
@@ -1,0 +1,193 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <Storages/DeltaMerge/Filter/IntegerSet.h>
+#include <Storages/KVStore/Types.h>
+
+#include <magic_enum.hpp>
+
+namespace DB::DM
+{
+
+using IndexID = DB::IndexID;
+using ColumnID = DB::ColumnID;
+
+class ColumnRange;
+using ColumnRangePtr = std::shared_ptr<ColumnRange>;
+using ColumnRanges = std::vector<ColumnRangePtr>;
+
+class SingleColumnRange;
+using SingleColumnRangePtr = std::shared_ptr<SingleColumnRange>;
+
+enum class ColumnRangeType
+{
+    Unsupported,
+    Single,
+    And,
+    Or,
+};
+
+// ColumnRange represents the range of values for columns.
+class ColumnRange : public std::enable_shared_from_this<ColumnRange>
+{
+public:
+    explicit ColumnRange(ColumnRangeType type_)
+        : type(type_)
+    {}
+
+    virtual ~ColumnRange() = default;
+
+    virtual ColumnRangePtr invert() const = 0;
+
+    virtual String toDebugString() = 0;
+
+    virtual BitmapFilterPtr check(std::function<BitmapFilterPtr(const ColumnRangePtr &, size_t)> search, size_t size)
+        = 0;
+
+public:
+    ColumnRangeType type = ColumnRangeType::Unsupported;
+};
+
+class UnsupportedColumnRange : public ColumnRange
+{
+public:
+    explicit UnsupportedColumnRange()
+        : ColumnRange(ColumnRangeType::Unsupported)
+    {}
+
+    static const ColumnRangePtr Instance;
+
+    static ColumnRangePtr create() { return Instance; }
+
+    ColumnRangePtr invert() const override { return Instance; }
+
+    String toDebugString() override { return String(magic_enum::enum_name(type)); }
+
+    BitmapFilterPtr check(std::function<BitmapFilterPtr(const ColumnRangePtr &, size_t size)>, size_t size) override
+    {
+        return std::make_shared<BitmapFilter>(size, true);
+    }
+};
+
+class SingleColumnRange : public ColumnRange
+{
+public:
+    explicit SingleColumnRange(ColumnID column_id_, IndexID index_id_, const IntegerSetPtr & set_)
+        : ColumnRange(ColumnRangeType::Single)
+        , column_id(column_id_)
+        , index_id(index_id_)
+        , set(set_)
+    {}
+
+    static ColumnRangePtr create(ColumnID col_id, IndexID index_id, const IntegerSetPtr & set)
+    {
+        return std::make_shared<SingleColumnRange>(col_id, index_id, set);
+    }
+
+    ColumnRangePtr invert() const override
+    {
+        return std::make_shared<SingleColumnRange>(column_id, index_id, set->invert());
+    }
+
+    String toDebugString() override { return fmt::format("{}: {}", column_id, set->toDebugString()); }
+
+    BitmapFilterPtr check(std::function<BitmapFilterPtr(const ColumnRangePtr &, size_t size)> search, size_t size)
+        override
+    {
+        return search(shared_from_this(), size);
+    }
+
+public:
+    ColumnID column_id;
+    IndexID index_id;
+    IntegerSetPtr set;
+};
+
+class LogicalOpColumnRange : public ColumnRange
+{
+protected:
+    explicit LogicalOpColumnRange(ColumnRangeType type, const ColumnRanges & children_)
+        : ColumnRange(type)
+        , children(children_)
+    {}
+
+public:
+    virtual ColumnRangePtr tryOptimize() = 0;
+
+    String toDebugString() override
+    {
+        FmtBuffer buf;
+        buf.fmtAppend("{}[", magic_enum::enum_name(type));
+        buf.joinStr(
+            children.cbegin(),
+            children.cend(),
+            [](const auto & child, FmtBuffer & fb) { fb.append(child->toDebugString()); },
+            ", ");
+        buf.append("]");
+        return buf.toString();
+    }
+
+protected:
+    ColumnRanges children;
+};
+
+class AndColumnRange : public LogicalOpColumnRange
+{
+public:
+    explicit AndColumnRange(const ColumnRanges & children_)
+        : LogicalOpColumnRange(ColumnRangeType::And, children_)
+    {}
+
+    ~AndColumnRange() override = default;
+
+    static ColumnRangePtr create(const ColumnRanges & children)
+    {
+        auto set = std::make_shared<AndColumnRange>(children);
+        return set->tryOptimize();
+    }
+
+    ColumnRangePtr invert() const override;
+
+    ColumnRangePtr tryOptimize() override;
+
+    BitmapFilterPtr check(std::function<BitmapFilterPtr(const ColumnRangePtr &, size_t size)> search, size_t size)
+        override;
+};
+
+class OrColumnRange : public LogicalOpColumnRange
+{
+public:
+    explicit OrColumnRange(const ColumnRanges & children_)
+        : LogicalOpColumnRange(ColumnRangeType::Or, children_)
+    {}
+
+    ~OrColumnRange() override = default;
+
+    static ColumnRangePtr create(const ColumnRanges & children)
+    {
+        auto set = std::make_shared<OrColumnRange>(children);
+        return set->tryOptimize();
+    }
+
+    ColumnRangePtr invert() const override;
+
+    ColumnRangePtr tryOptimize() override;
+
+    BitmapFilterPtr check(std::function<BitmapFilterPtr(const ColumnRangePtr &, size_t size)> search, size_t size)
+        override;
+};
+
+} // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/Filter/Equal.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/Equal.h
@@ -33,6 +33,19 @@ public:
     {
         return minMaxCheckCmp<RoughCheck::CheckEqual>(start_pack, pack_count, param, attr, value);
     }
+
+    ColumnRangePtr buildSets(const LocalIndexInfosSnapshot & index_info) override
+    {
+        if (auto set = IntegerSet::createValueSet(attr.type->getTypeId(), {value}); set)
+        {
+            auto iter = std::find_if(index_info->begin(), index_info->end(), [&](const auto & info) {
+                return info.column_id == attr.col_id && info.kind == TiDB::ColumnarIndexKind::Inverted;
+            });
+            if (iter != index_info->end())
+                return SingleColumnRange::create(iter->column_id, iter->index_id, set);
+        }
+        return UnsupportedColumnRange::create();
+    }
 };
 
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/Filter/Greater.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/Greater.h
@@ -33,6 +33,19 @@ public:
     {
         return minMaxCheckCmp<RoughCheck::CheckGreater>(start_pack, pack_count, param, attr, value);
     }
+
+    ColumnRangePtr buildSets(const LocalIndexInfosSnapshot & index_info) override
+    {
+        if (auto set = IntegerSet::createGreaterRangeSet(attr.type->getTypeId(), value, /*not_included=*/true); set)
+        {
+            auto iter = std::find_if(index_info->begin(), index_info->end(), [&](const auto & info) {
+                return info.column_id == attr.col_id && info.kind == TiDB::ColumnarIndexKind::Inverted;
+            });
+            if (iter != index_info->end())
+                return SingleColumnRange::create(iter->column_id, iter->index_id, set);
+        }
+        return UnsupportedColumnRange::create();
+    }
 };
 
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/Filter/GreaterEqual.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/GreaterEqual.h
@@ -33,6 +33,19 @@ public:
     {
         return minMaxCheckCmp<RoughCheck::CheckGreaterEqual>(start_pack, pack_count, param, attr, value);
     }
+
+    ColumnRangePtr buildSets(const LocalIndexInfosSnapshot & index_info) override
+    {
+        if (auto set = IntegerSet::createGreaterRangeSet(attr.type->getTypeId(), value, /*not_included=*/false); set)
+        {
+            auto iter = std::find_if(index_info->begin(), index_info->end(), [&](const auto & info) {
+                return info.column_id == attr.col_id && info.kind == TiDB::ColumnarIndexKind::Inverted;
+            });
+            if (iter != index_info->end())
+                return SingleColumnRange::create(iter->column_id, iter->index_id, set);
+        }
+        return UnsupportedColumnRange::create();
+    }
 };
 
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/Filter/In.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/In.h
@@ -47,7 +47,7 @@ public:
             ",");
         buf.append("]}");
         return buf.toString();
-    };
+    }
 
     RSResults roughCheck(size_t start_pack, size_t pack_count, const RSCheckParam & param) override
     {
@@ -58,6 +58,19 @@ public:
         auto rs_index = getRSIndex(param, attr);
         return rs_index ? rs_index->minmax->checkIn(start_pack, pack_count, values, rs_index->type)
                         : RSResults(pack_count, RSResult::Some);
+    }
+
+    ColumnRangePtr buildSets(const LocalIndexInfosSnapshot & index_info) override
+    {
+        if (auto set = IntegerSet::createValueSet(attr.type->getTypeId(), values); set)
+        {
+            auto iter = std::find_if(index_info->begin(), index_info->end(), [&](const auto & info) {
+                return info.column_id == attr.col_id && info.kind == TiDB::ColumnarIndexKind::Inverted;
+            });
+            if (iter != index_info->end())
+                return SingleColumnRange::create(iter->column_id, iter->index_id, set);
+        }
+        return UnsupportedColumnRange::create();
     }
 };
 

--- a/dbms/src/Storages/DeltaMerge/Filter/IntegerSet.cpp
+++ b/dbms/src/Storages/DeltaMerge/Filter/IntegerSet.cpp
@@ -65,38 +65,48 @@ IntegerSetPtr IntegerSet::createValueSet(TypeIndex type_index, const Fields & va
 
 IntegerSetPtr IntegerSet::createLessRangeSet(TypeIndex type_index, const Field & max, bool not_included)
 {
+    auto func = []<typename T>(const Field & max, bool not_included) -> IntegerSetPtr {
+        auto max_value = max.get<T>();
+        if (max_value == std::numeric_limits<T>::min() && not_included)
+            return EmptySet::instance();
+        else if (max_value == std::numeric_limits<T>::min() && !not_included)
+            return std::make_shared<ValueSet<T>>(std::set<T>{std::numeric_limits<T>::min()});
+        else
+            return std::make_shared<RangeSet<T>>(std::numeric_limits<T>::min(), max_value - not_included);
+    };
+
     switch (type_index)
     {
     case TypeIndex::UInt8:
-        return std::make_shared<RangeSet<UInt8>>(0, max.get<UInt8>() - not_included);
+        return func.template operator()<UInt8>(max, not_included);
     case TypeIndex::UInt16:
-        return std::make_shared<RangeSet<UInt16>>(0, max.get<UInt16>() - not_included);
+        return func.template operator()<UInt16>(max, not_included);
     case TypeIndex::UInt32:
-        return std::make_shared<RangeSet<UInt32>>(0, max.get<UInt32>() - not_included);
+        return func.template operator()<UInt32>(max, not_included);
     case TypeIndex::UInt64:
-        return std::make_shared<RangeSet<UInt64>>(0, max.get<UInt64>() - not_included);
+        return func.template operator()<UInt64>(max, not_included);
     case TypeIndex::Int8:
-        return std::make_shared<RangeSet<Int8>>(std::numeric_limits<Int8>::min(), max.get<Int8>() - not_included);
+        return func.template operator()<Int8>(max, not_included);
     case TypeIndex::Int16:
-        return std::make_shared<RangeSet<Int16>>(std::numeric_limits<Int16>::min(), max.get<Int16>() - not_included);
+        return func.template operator()<Int16>(max, not_included);
     case TypeIndex::Int32:
-        return std::make_shared<RangeSet<Int32>>(std::numeric_limits<Int32>::min(), max.get<Int32>() - not_included);
+        return func.template operator()<Int32>(max, not_included);
     case TypeIndex::Int64:
-        return std::make_shared<RangeSet<Int64>>(std::numeric_limits<Int64>::min(), max.get<Int64>() - not_included);
+        return func.template operator()<Int64>(max, not_included);
     case TypeIndex::Date:
-        return std::make_shared<RangeSet<UInt16>>(0, max.get<UInt16>() - not_included);
+        return func.template operator()<UInt16>(max, not_included);
     case TypeIndex::DateTime:
-        return std::make_shared<RangeSet<UInt32>>(0, max.get<UInt32>() - not_included);
+        return func.template operator()<UInt32>(max, not_included);
     case TypeIndex::Enum8:
-        return std::make_shared<RangeSet<Int8>>(std::numeric_limits<Int8>::min(), max.get<Int8>() - not_included);
+        return func.template operator()<Int8>(max, not_included);
     case TypeIndex::Enum16:
-        return std::make_shared<RangeSet<Int16>>(std::numeric_limits<Int16>::min(), max.get<Int16>() - not_included);
+        return func.template operator()<Int16>(max, not_included);
     case TypeIndex::MyDate:
     case TypeIndex::MyDateTime:
     case TypeIndex::MyTimeStamp:
-        return std::make_shared<RangeSet<UInt64>>(0, max.get<UInt64>() - not_included);
+        return func.template operator()<UInt64>(max, not_included);
     case TypeIndex::MyTime:
-        return std::make_shared<RangeSet<Int64>>(std::numeric_limits<Int64>::min(), max.get<Int64>() - not_included);
+        return func.template operator()<Int64>(max, not_included);
     default:
         return nullptr;
     }
@@ -104,38 +114,48 @@ IntegerSetPtr IntegerSet::createLessRangeSet(TypeIndex type_index, const Field &
 
 IntegerSetPtr IntegerSet::createGreaterRangeSet(TypeIndex type_index, const Field & min, bool not_included)
 {
+    auto func = []<typename T>(const Field & min, bool not_included) -> IntegerSetPtr {
+        auto min_value = min.get<T>();
+        if (min_value == std::numeric_limits<T>::max() && not_included)
+            return EmptySet::instance();
+        else if (min_value == std::numeric_limits<T>::max() && !not_included)
+            return std::make_shared<ValueSet<T>>(std::set<T>{std::numeric_limits<T>::max()});
+        else
+            return std::make_shared<RangeSet<T>>(min_value + not_included, std::numeric_limits<T>::max());
+    };
+
     switch (type_index)
     {
     case TypeIndex::UInt8:
-        return std::make_shared<RangeSet<UInt8>>(min.get<UInt8>() + not_included, std::numeric_limits<UInt8>::max());
+        return func.template operator()<UInt8>(min, not_included);
     case TypeIndex::UInt16:
-        return std::make_shared<RangeSet<UInt16>>(min.get<UInt16>() + not_included, std::numeric_limits<UInt16>::max());
+        return func.template operator()<UInt16>(min, not_included);
     case TypeIndex::UInt32:
-        return std::make_shared<RangeSet<UInt32>>(min.get<UInt32>() + not_included, std::numeric_limits<UInt32>::max());
+        return func.template operator()<UInt32>(min, not_included);
     case TypeIndex::UInt64:
-        return std::make_shared<RangeSet<UInt64>>(min.get<UInt64>() + not_included, std::numeric_limits<UInt64>::max());
+        return func.template operator()<UInt64>(min, not_included);
     case TypeIndex::Int8:
-        return std::make_shared<RangeSet<Int8>>(min.get<Int8>() + not_included, std::numeric_limits<Int8>::max());
+        return func.template operator()<Int8>(min, not_included);
     case TypeIndex::Int16:
-        return std::make_shared<RangeSet<Int16>>(min.get<Int16>() + not_included, std::numeric_limits<Int16>::max());
+        return func.template operator()<Int16>(min, not_included);
     case TypeIndex::Int32:
-        return std::make_shared<RangeSet<Int32>>(min.get<Int32>() + not_included, std::numeric_limits<Int32>::max());
+        return func.template operator()<Int32>(min, not_included);
     case TypeIndex::Int64:
-        return std::make_shared<RangeSet<Int64>>(min.get<Int64>() + not_included, std::numeric_limits<Int64>::max());
+        return func.template operator()<Int64>(min, not_included);
     case TypeIndex::Date:
-        return std::make_shared<RangeSet<UInt16>>(min.get<UInt16>() + not_included, std::numeric_limits<UInt16>::max());
+        return func.template operator()<UInt16>(min, not_included);
     case TypeIndex::DateTime:
-        return std::make_shared<RangeSet<UInt32>>(min.get<UInt32>() + not_included, std::numeric_limits<UInt32>::max());
+        return func.template operator()<UInt32>(min, not_included);
     case TypeIndex::Enum8:
-        return std::make_shared<RangeSet<Int8>>(min.get<Int8>() + not_included, std::numeric_limits<Int8>::max());
+        return func.template operator()<Int8>(min, not_included);
     case TypeIndex::Enum16:
-        return std::make_shared<RangeSet<Int16>>(min.get<Int16>() + not_included, std::numeric_limits<Int16>::max());
+        return func.template operator()<Int16>(min, not_included);
     case TypeIndex::MyDate:
     case TypeIndex::MyDateTime:
     case TypeIndex::MyTimeStamp:
-        return std::make_shared<RangeSet<UInt64>>(min.get<UInt64>() + not_included, std::numeric_limits<UInt64>::max());
+        return func.template operator()<UInt64>(min, not_included);
     case TypeIndex::MyTime:
-        return std::make_shared<RangeSet<Int64>>(min.get<Int64>() + not_included, std::numeric_limits<Int64>::max());
+        return func.template operator()<Int64>(min, not_included);
     default:
         return nullptr;
     }
@@ -426,10 +446,13 @@ IntegerSetPtr RangeSet<T>::unionWithRangeSet(const IntegerSetPtr & lhs, const In
     auto left = std::dynamic_pointer_cast<RangeSet<T>>(lhs);
     auto right = std::dynamic_pointer_cast<RangeSet<T>>(rhs);
 
-    T start = std::min(left->start, right->start);
+    if (left->start > right->start)
+        std::swap(left, right);
+
+    T start = left->start;
     T end = std::max(left->end, right->end);
 
-    if (left->end > right->start && right->end > left->start)
+    if (left->end >= right->start)
         return start == std::numeric_limits<T>::min() && end == std::numeric_limits<T>::max()
             ? AllSet::instance()
             : std::make_shared<RangeSet<T>>(start, end);

--- a/dbms/src/Storages/DeltaMerge/Filter/IntegerSet.cpp
+++ b/dbms/src/Storages/DeltaMerge/Filter/IntegerSet.cpp
@@ -574,7 +574,7 @@ BitmapFilterPtr CompositeSet<T>::search(InvertedIndexReaderPtr inverted_index, s
         case SetType::Range:
         case SetType::Composite:
             auto sub_filter = set->search(inverted_index, size);
-            filter->merge(*sub_filter);
+            filter->logicalOr(*sub_filter);
             break;
         }
     }

--- a/dbms/src/Storages/DeltaMerge/Filter/IntegerSet.cpp
+++ b/dbms/src/Storages/DeltaMerge/Filter/IntegerSet.cpp
@@ -1,0 +1,609 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Common/Exception.h>
+#include <Storages/DeltaMerge/Filter/IntegerSet.h>
+#include <Storages/DeltaMerge/Index/InvertedIndex/Reader.h>
+
+#include <algorithm>
+#include <limits>
+#include <vector>
+
+
+namespace DB::DM
+{
+
+IntegerSetPtr IntegerSet::createValueSet(TypeIndex type_index, const Fields & values)
+{
+    switch (type_index)
+    {
+    case TypeIndex::UInt8:
+        return std::make_shared<ValueSet<UInt8>>(values);
+    case TypeIndex::UInt16:
+        return std::make_shared<ValueSet<UInt16>>(values);
+    case TypeIndex::UInt32:
+        return std::make_shared<ValueSet<UInt32>>(values);
+    case TypeIndex::UInt64:
+        return std::make_shared<ValueSet<UInt64>>(values);
+    case TypeIndex::Int8:
+        return std::make_shared<ValueSet<Int8>>(values);
+    case TypeIndex::Int16:
+        return std::make_shared<ValueSet<Int16>>(values);
+    case TypeIndex::Int32:
+        return std::make_shared<ValueSet<Int32>>(values);
+    case TypeIndex::Int64:
+        return std::make_shared<ValueSet<Int64>>(values);
+    case TypeIndex::Date:
+        return std::make_shared<ValueSet<UInt16>>(values);
+    case TypeIndex::DateTime:
+        return std::make_shared<ValueSet<UInt32>>(values);
+    case TypeIndex::Enum8:
+        return std::make_shared<ValueSet<Int8>>(values);
+    case TypeIndex::Enum16:
+        return std::make_shared<ValueSet<Int16>>(values);
+    case TypeIndex::MyDate:
+    case TypeIndex::MyDateTime:
+    case TypeIndex::MyTimeStamp:
+        return std::make_shared<ValueSet<UInt64>>(values);
+    case TypeIndex::MyTime:
+        return std::make_shared<ValueSet<Int64>>(values);
+    default:
+        return nullptr;
+    }
+}
+
+IntegerSetPtr IntegerSet::createLessRangeSet(TypeIndex type_index, Field max, bool not_included)
+{
+    switch (type_index)
+    {
+    case TypeIndex::UInt8:
+        return std::make_shared<RangeSet<UInt8>>(0, max.get<UInt8>() - not_included);
+    case TypeIndex::UInt16:
+        return std::make_shared<RangeSet<UInt16>>(0, max.get<UInt16>() - not_included);
+    case TypeIndex::UInt32:
+        return std::make_shared<RangeSet<UInt32>>(0, max.get<UInt32>() - not_included);
+    case TypeIndex::UInt64:
+        return std::make_shared<RangeSet<UInt64>>(0, max.get<UInt64>() - not_included);
+    case TypeIndex::Int8:
+        return std::make_shared<RangeSet<Int8>>(std::numeric_limits<Int8>::min(), max.get<Int8>() - not_included);
+    case TypeIndex::Int16:
+        return std::make_shared<RangeSet<Int16>>(std::numeric_limits<Int16>::min(), max.get<Int16>() - not_included);
+    case TypeIndex::Int32:
+        return std::make_shared<RangeSet<Int32>>(std::numeric_limits<Int32>::min(), max.get<Int32>() - not_included);
+    case TypeIndex::Int64:
+        return std::make_shared<RangeSet<Int64>>(std::numeric_limits<Int64>::min(), max.get<Int64>() - not_included);
+    case TypeIndex::Date:
+        return std::make_shared<RangeSet<UInt16>>(0, max.get<UInt16>() - not_included);
+    case TypeIndex::DateTime:
+        return std::make_shared<RangeSet<UInt32>>(0, max.get<UInt32>() - not_included);
+    case TypeIndex::Enum8:
+        return std::make_shared<RangeSet<Int8>>(std::numeric_limits<Int8>::min(), max.get<Int8>() - not_included);
+    case TypeIndex::Enum16:
+        return std::make_shared<RangeSet<Int16>>(std::numeric_limits<Int16>::min(), max.get<Int16>() - not_included);
+    case TypeIndex::MyDate:
+    case TypeIndex::MyDateTime:
+    case TypeIndex::MyTimeStamp:
+        return std::make_shared<RangeSet<UInt64>>(0, max.get<UInt64>() - not_included);
+    case TypeIndex::MyTime:
+        return std::make_shared<RangeSet<Int64>>(std::numeric_limits<Int64>::min(), max.get<Int64>() - not_included);
+    default:
+        return nullptr;
+    }
+}
+
+IntegerSetPtr IntegerSet::createGreaterRangeSet(TypeIndex type_index, Field min, bool not_included)
+{
+    switch (type_index)
+    {
+    case TypeIndex::UInt8:
+        return std::make_shared<RangeSet<UInt8>>(min.get<UInt8>() + not_included, std::numeric_limits<UInt8>::max());
+    case TypeIndex::UInt16:
+        return std::make_shared<RangeSet<UInt16>>(min.get<UInt16>() + not_included, std::numeric_limits<UInt16>::max());
+    case TypeIndex::UInt32:
+        return std::make_shared<RangeSet<UInt32>>(min.get<UInt32>() + not_included, std::numeric_limits<UInt32>::max());
+    case TypeIndex::UInt64:
+        return std::make_shared<RangeSet<UInt64>>(min.get<UInt64>() + not_included, std::numeric_limits<UInt64>::max());
+    case TypeIndex::Int8:
+        return std::make_shared<RangeSet<Int8>>(min.get<Int8>() + not_included, std::numeric_limits<Int8>::max());
+    case TypeIndex::Int16:
+        return std::make_shared<RangeSet<Int16>>(min.get<Int16>() + not_included, std::numeric_limits<Int16>::max());
+    case TypeIndex::Int32:
+        return std::make_shared<RangeSet<Int32>>(min.get<Int32>() + not_included, std::numeric_limits<Int32>::max());
+    case TypeIndex::Int64:
+        return std::make_shared<RangeSet<Int64>>(min.get<Int64>() + not_included, std::numeric_limits<Int64>::max());
+    case TypeIndex::Date:
+        return std::make_shared<RangeSet<UInt16>>(min.get<UInt16>() + not_included, std::numeric_limits<UInt16>::max());
+    case TypeIndex::DateTime:
+        return std::make_shared<RangeSet<UInt32>>(min.get<UInt32>() + not_included, std::numeric_limits<UInt32>::max());
+    case TypeIndex::Enum8:
+        return std::make_shared<RangeSet<Int8>>(min.get<Int8>() + not_included, std::numeric_limits<Int8>::max());
+    case TypeIndex::Enum16:
+        return std::make_shared<RangeSet<Int16>>(min.get<Int16>() + not_included, std::numeric_limits<Int16>::max());
+    case TypeIndex::MyDate:
+    case TypeIndex::MyDateTime:
+    case TypeIndex::MyTimeStamp:
+        return std::make_shared<RangeSet<UInt64>>(min.get<UInt64>() + not_included, std::numeric_limits<UInt64>::max());
+    case TypeIndex::MyTime:
+        return std::make_shared<RangeSet<Int64>>(min.get<Int64>() + not_included, std::numeric_limits<Int64>::max());
+    default:
+        return nullptr;
+    }
+}
+
+IntegerSetPtr EmptySet::invert() const
+{
+    return AllSet::instance();
+}
+
+template <typename T>
+IntegerSetPtr ValueSet<T>::intersectWith(const IntegerSetPtr & other)
+{
+    auto type = other->getType();
+    switch (type)
+    {
+    case SetType::Value:
+        return ValueSet<T>::intersectWithValueSet(this->shared_from_this(), other);
+    case SetType::Range:
+        return ValueSet<T>::intersectWithRangeSet(other, this->shared_from_this());
+    case SetType::Composite:
+        return ValueSet<T>::intersectWithCompositeSet(other, this->shared_from_this());
+    case SetType::All:
+    case SetType::Empty:
+        return other->intersectWith(this->shared_from_this());
+    }
+}
+
+template <typename T>
+IntegerSetPtr ValueSet<T>::intersectWithValueSet(const IntegerSetPtr & lhs, const IntegerSetPtr & rhs)
+{
+    RUNTIME_CHECK(lhs->getType() == SetType::Value);
+    RUNTIME_CHECK(rhs->getType() == SetType::Value);
+
+    auto left = std::dynamic_pointer_cast<ValueSet<T>>(lhs);
+    auto right = std::dynamic_pointer_cast<ValueSet<T>>(rhs);
+
+    ValueSet<T> result;
+    std::set_intersection(
+        left->values.begin(),
+        left->values.end(),
+        right->values.begin(),
+        right->values.end(),
+        std::inserter(result.values, result.values.begin()));
+
+    return result.values.empty() ? EmptySet::instance() : std::make_shared<ValueSet<T>>(result);
+}
+
+template <typename T>
+IntegerSetPtr ValueSet<T>::intersectWithRangeSet(const IntegerSetPtr & range_set, const IntegerSetPtr & value_set)
+{
+    RUNTIME_CHECK(range_set->getType() == SetType::Range);
+    RUNTIME_CHECK(value_set->getType() == SetType::Value);
+
+    auto range = std::dynamic_pointer_cast<RangeSet<T>>(range_set);
+    auto value = std::dynamic_pointer_cast<ValueSet<T>>(value_set);
+
+    ValueSet<T> result;
+    for (const auto v : value->values)
+    {
+        if (range->start <= v && v <= range->end)
+            result.values.insert(v);
+    }
+
+    return result.values.empty() ? EmptySet::instance() : std::make_shared<ValueSet<T>>(result);
+}
+
+template <typename T>
+IntegerSetPtr ValueSet<T>::intersectWithCompositeSet(
+    const IntegerSetPtr & composite_set,
+    const IntegerSetPtr & value_set)
+{
+    RUNTIME_CHECK(composite_set->getType() == SetType::Composite);
+    RUNTIME_CHECK(value_set->getType() == SetType::Value);
+
+    auto composite = std::dynamic_pointer_cast<CompositeSet<T>>(composite_set);
+    auto value = std::dynamic_pointer_cast<ValueSet<T>>(value_set);
+
+    CompositeSet<T> result;
+    for (const auto & set : composite->sets)
+    {
+        if (auto new_set = set->intersectWith(value); new_set)
+            result.sets.push_back(new_set);
+    }
+
+    if (result.sets.empty())
+        return EmptySet::instance();
+    if (result.sets.size() == 1)
+        return result.sets.front();
+
+    // Combine all sets
+    ValueSet<T> combined;
+    for (const auto & set : result.sets)
+    {
+        RUNTIME_CHECK(set->getType() == SetType::Value);
+
+        auto value_set = std::dynamic_pointer_cast<ValueSet<T>>(set);
+        combined.values.insert(value_set->values.begin(), value_set->values.end());
+    }
+    return std::make_shared<ValueSet<T>>(combined);
+}
+
+template <typename T>
+IntegerSetPtr ValueSet<T>::unionWith(const IntegerSetPtr & other)
+{
+    auto type = other->getType();
+    switch (type)
+    {
+    case SetType::Value:
+        return ValueSet<T>::unionWithValueSet(this->shared_from_this(), other);
+    case SetType::Range:
+        return ValueSet<T>::unionWithRangeSet(other, this->shared_from_this());
+    case SetType::Composite:
+        return ValueSet<T>::unionWithCompositeSet(other, this->shared_from_this());
+    case SetType::All:
+    case SetType::Empty:
+        return other->unionWith(this->shared_from_this());
+    }
+}
+
+template <typename T>
+IntegerSetPtr ValueSet<T>::unionWithValueSet(const IntegerSetPtr & lhs, const IntegerSetPtr & rhs)
+{
+    RUNTIME_CHECK(lhs->getType() == SetType::Value);
+    RUNTIME_CHECK(rhs->getType() == SetType::Value);
+
+    auto left = std::dynamic_pointer_cast<ValueSet<T>>(lhs);
+    auto right = std::dynamic_pointer_cast<ValueSet<T>>(rhs);
+
+    ValueSet<T> result;
+    std::set_union(
+        left->values.begin(),
+        left->values.end(),
+        right->values.begin(),
+        right->values.end(),
+        std::inserter(result.values, result.values.begin()));
+
+    return std::make_shared<ValueSet<T>>(result);
+}
+
+template <typename T>
+IntegerSetPtr ValueSet<T>::unionWithRangeSet(const IntegerSetPtr & range_set, const IntegerSetPtr & value_set)
+{
+    RUNTIME_CHECK(range_set->getType() == SetType::Range);
+    RUNTIME_CHECK(value_set->getType() == SetType::Value);
+
+    auto range = std::dynamic_pointer_cast<RangeSet<T>>(range_set);
+    auto value = std::dynamic_pointer_cast<ValueSet<T>>(value_set);
+
+    ValueSet<T> exclude_value;
+    for (const auto v : value->values)
+    {
+        if (range->start > v || v > range->end)
+            exclude_value.values.insert(v);
+    }
+
+    return exclude_value.values.empty()
+        ? range_set
+        : std::make_shared<CompositeSet<T>>(
+            std::vector<IntegerSetPtr>{std::make_shared<ValueSet<T>>(exclude_value), range_set});
+}
+
+template <typename T>
+IntegerSetPtr ValueSet<T>::unionWithCompositeSet(const IntegerSetPtr & composite_set, const IntegerSetPtr & value_set)
+{
+    RUNTIME_CHECK(composite_set->getType() == SetType::Composite);
+    RUNTIME_CHECK(value_set->getType() == SetType::Value);
+
+    auto composite = std::dynamic_pointer_cast<CompositeSet<T>>(composite_set);
+    auto value = std::dynamic_pointer_cast<ValueSet<T>>(value_set);
+
+    CompositeSet<T> result;
+    for (const auto & set : composite->sets)
+    {
+        auto new_set = set->unionWith(value);
+        if (new_set && new_set->getType() == SetType::All)
+            return AllSet::instance();
+        else if (new_set)
+            result.sets.push_back(new_set);
+    }
+
+    return std::make_shared<CompositeSet<T>>(result);
+}
+
+template <typename T>
+IntegerSetPtr ValueSet<T>::invert() const
+{
+    std::vector<IntegerSetPtr> sets;
+    T min = std::numeric_limits<T>::min();
+    for (const auto & value : values)
+    {
+        if (value > min)
+            sets.push_back(std::make_shared<RangeSet<T>>(min, value - 1));
+        min = value + 1;
+    }
+    if (min <= std::numeric_limits<T>::max())
+        sets.push_back(std::make_shared<RangeSet<T>>(min, std::numeric_limits<T>::max()));
+    return std::make_shared<CompositeSet<T>>(sets);
+}
+
+template <typename T>
+BitmapFilterPtr ValueSet<T>::search(InvertedIndexReaderPtr inverted_index, size_t size)
+{
+    auto filter = std::make_shared<BitmapFilter>(size, false);
+    for (const auto & value : values)
+        inverted_index->search(filter, value);
+    return filter;
+}
+
+template <typename T>
+IntegerSetPtr RangeSet<T>::intersectWith(const IntegerSetPtr & other)
+{
+    auto type = other->getType();
+    switch (type)
+    {
+    case SetType::Value:
+        return ValueSet<T>::intersectWithRangeSet(other, this->shared_from_this());
+    case SetType::Range:
+        return RangeSet<T>::intersectWithRangeSet(this->shared_from_this(), other);
+    case SetType::Composite:
+        return RangeSet<T>::intersectWithCompositeSet(other, this->shared_from_this());
+    case SetType::All:
+    case SetType::Empty:
+        return other->intersectWith(this->shared_from_this());
+    }
+}
+
+template <typename T>
+IntegerSetPtr RangeSet<T>::intersectWithRangeSet(const IntegerSetPtr & lhs, const IntegerSetPtr & rhs)
+{
+    RUNTIME_CHECK(lhs->getType() == SetType::Range);
+    RUNTIME_CHECK(rhs->getType() == SetType::Range);
+
+    auto left = std::dynamic_pointer_cast<RangeSet<T>>(lhs);
+    auto right = std::dynamic_pointer_cast<RangeSet<T>>(rhs);
+
+    T start = std::max(left->start, right->start);
+    T end = std::min(left->end, right->end);
+
+    return start > end ? EmptySet::instance() : std::make_shared<RangeSet<T>>(start, end);
+}
+
+template <typename T>
+IntegerSetPtr RangeSet<T>::intersectWithCompositeSet(
+    const IntegerSetPtr & composite_set,
+    const IntegerSetPtr & range_set)
+{
+    RUNTIME_CHECK(composite_set->getType() == SetType::Composite);
+    RUNTIME_CHECK(range_set->getType() == SetType::Range);
+
+    auto composite = std::dynamic_pointer_cast<CompositeSet<T>>(composite_set);
+    auto range = std::dynamic_pointer_cast<RangeSet<T>>(range_set);
+
+    CompositeSet<T> result;
+    for (const auto & set : composite->sets)
+    {
+        if (auto new_set = set->intersectWith(range); new_set)
+            result.sets.push_back(new_set);
+    }
+
+    return result.sets.empty() ? EmptySet::instance() : std::make_shared<CompositeSet<T>>(result);
+}
+
+template <typename T>
+IntegerSetPtr RangeSet<T>::unionWith(const IntegerSetPtr & other)
+{
+    auto type = other->getType();
+    switch (type)
+    {
+    case SetType::Value:
+        return ValueSet<T>::unionWithRangeSet(other, this->shared_from_this());
+    case SetType::Range:
+        return RangeSet<T>::unionWithRangeSet(this->shared_from_this(), other);
+    case SetType::Composite:
+        return RangeSet<T>::unionWithCompositeSet(other, this->shared_from_this());
+    case SetType::All:
+    case SetType::Empty:
+        return other->unionWith(this->shared_from_this());
+    }
+}
+
+template <typename T>
+IntegerSetPtr RangeSet<T>::unionWithRangeSet(const IntegerSetPtr & lhs, const IntegerSetPtr & rhs)
+{
+    RUNTIME_CHECK(lhs->getType() == SetType::Range);
+    RUNTIME_CHECK(rhs->getType() == SetType::Range);
+
+    auto left = std::dynamic_pointer_cast<RangeSet<T>>(lhs);
+    auto right = std::dynamic_pointer_cast<RangeSet<T>>(rhs);
+
+    T start = std::min(left->start, right->start);
+    T end = std::max(left->end, right->end);
+
+    if (left->end > right->start && right->end > left->start)
+        return start == std::numeric_limits<T>::min() && end == std::numeric_limits<T>::max()
+            ? AllSet::instance()
+            : std::make_shared<RangeSet<T>>(start, end);
+
+    return std::make_shared<CompositeSet<T>>(std::vector<IntegerSetPtr>{lhs, rhs});
+}
+
+template <typename T>
+IntegerSetPtr RangeSet<T>::unionWithCompositeSet(const IntegerSetPtr & composite_set, const IntegerSetPtr & range_set)
+{
+    RUNTIME_CHECK(composite_set->getType() == SetType::Composite);
+    RUNTIME_CHECK(range_set->getType() == SetType::Range);
+
+    auto composite = std::dynamic_pointer_cast<CompositeSet<T>>(composite_set);
+    auto range = std::dynamic_pointer_cast<RangeSet<T>>(range_set);
+
+    CompositeSet<T> result;
+    for (const auto & set : composite->sets)
+    {
+        auto new_set = set->unionWith(range);
+        if (new_set && new_set->getType() == SetType::All)
+            return AllSet::instance();
+        else if (new_set)
+            result.sets.push_back(new_set);
+    }
+
+    return std::make_shared<CompositeSet<T>>(result);
+}
+
+template <typename T>
+IntegerSetPtr RangeSet<T>::invert() const
+{
+    if (start == std::numeric_limits<T>::min() && end == std::numeric_limits<T>::max())
+        return EmptySet::instance();
+    if (start == std::numeric_limits<T>::min())
+        return std::make_shared<RangeSet<T>>(end + 1, std::numeric_limits<T>::max());
+    if (end == std::numeric_limits<T>::max())
+        return std::make_shared<RangeSet<T>>(std::numeric_limits<T>::min(), start - 1);
+    auto left = std::make_shared<RangeSet<T>>(std::numeric_limits<T>::min(), start - 1);
+    auto right = std::make_shared<RangeSet<T>>(end + 1, std::numeric_limits<T>::max());
+    return std::make_shared<CompositeSet<T>>(std::vector<IntegerSetPtr>{left, right});
+}
+
+template <typename T>
+BitmapFilterPtr RangeSet<T>::search(InvertedIndexReaderPtr inverted_index, size_t size)
+{
+    auto filter = std::make_shared<BitmapFilter>(size, false);
+    inverted_index->searchRange(filter, start, end);
+    return filter;
+}
+
+template <typename T>
+IntegerSetPtr CompositeSet<T>::intersectWith(const IntegerSetPtr & other)
+{
+    auto type = other->getType();
+    switch (type)
+    {
+    case SetType::Value:
+        return ValueSet<T>::intersectWithCompositeSet(this->shared_from_this(), other);
+    case SetType::Range:
+        return RangeSet<T>::intersectWithCompositeSet(this->shared_from_this(), other);
+    case SetType::Composite:
+    {
+        CompositeSet<T> result;
+        for (const auto & set : sets)
+        {
+            if (auto new_set = set->intersectWith(other); new_set)
+                result.sets.push_back(new_set);
+        }
+        return result.sets.empty() ? EmptySet::instance() : std::make_shared<CompositeSet<T>>(result);
+    }
+    case SetType::All:
+    case SetType::Empty:
+        return other->intersectWith(this->shared_from_this());
+    }
+}
+
+template <typename T>
+IntegerSetPtr CompositeSet<T>::unionWith(const IntegerSetPtr & other)
+{
+    auto type = other->getType();
+    switch (type)
+    {
+    case SetType::Value:
+        return ValueSet<T>::unionWithCompositeSet(other, this->shared_from_this());
+    case SetType::Range:
+        return RangeSet<T>::unionWithCompositeSet(other, this->shared_from_this());
+    case SetType::Composite:
+    {
+        CompositeSet<T> result;
+        for (const auto & set : sets)
+        {
+            auto new_set = set->unionWith(other);
+            if (new_set && new_set->getType() == SetType::All)
+                return AllSet::instance();
+            else if (new_set)
+                result.sets.push_back(new_set);
+        }
+        return std::make_shared<CompositeSet<T>>(result);
+    }
+    case SetType::All:
+    case SetType::Empty:
+        return other->unionWith(this->shared_from_this());
+    }
+}
+
+template <typename T>
+IntegerSetPtr CompositeSet<T>::invert() const
+{
+    CompositeSet<T> result;
+    for (const auto & set : sets)
+    {
+        if (auto new_set = set->invert(); new_set)
+            result.sets.push_back(new_set);
+    }
+
+    // Combine all sets
+    IntegerSetPtr result_set = result.sets.empty() ? EmptySet::instance() : result.sets.front();
+    for (const auto & set : result.sets)
+    {
+        if (!result_set)
+            break;
+
+        result_set = result_set->intersectWith(set);
+    }
+    return result_set;
+}
+
+template <typename T>
+BitmapFilterPtr CompositeSet<T>::search(InvertedIndexReaderPtr inverted_index, size_t size)
+{
+    BitmapFilterPtr filter = std::make_shared<BitmapFilter>(size, false);
+    for (const auto & set : sets)
+    {
+        switch (set->getType())
+        {
+        case SetType::All:
+            return std::make_shared<BitmapFilter>(size, true);
+        case SetType::Empty:
+            break;
+        case SetType::Value:
+        case SetType::Range:
+        case SetType::Composite:
+            auto sub_filter = set->search(inverted_index, size);
+            filter->merge(*sub_filter);
+            break;
+        }
+    }
+    return filter;
+}
+
+template class RangeSet<UInt8>;
+template class RangeSet<UInt16>;
+template class RangeSet<UInt32>;
+template class RangeSet<UInt64>;
+template class RangeSet<Int8>;
+template class RangeSet<Int16>;
+template class RangeSet<Int32>;
+template class RangeSet<Int64>;
+template class ValueSet<UInt8>;
+template class ValueSet<UInt16>;
+template class ValueSet<UInt32>;
+template class ValueSet<UInt64>;
+template class ValueSet<Int8>;
+template class ValueSet<Int16>;
+template class ValueSet<Int32>;
+template class ValueSet<Int64>;
+template class CompositeSet<UInt8>;
+template class CompositeSet<UInt16>;
+template class CompositeSet<UInt32>;
+template class CompositeSet<UInt64>;
+template class CompositeSet<Int8>;
+template class CompositeSet<Int16>;
+template class CompositeSet<Int32>;
+template class CompositeSet<Int64>;
+
+} // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/Filter/IntegerSet.cpp
+++ b/dbms/src/Storages/DeltaMerge/Filter/IntegerSet.cpp
@@ -63,7 +63,7 @@ IntegerSetPtr IntegerSet::createValueSet(TypeIndex type_index, const Fields & va
     }
 }
 
-IntegerSetPtr IntegerSet::createLessRangeSet(TypeIndex type_index, Field max, bool not_included)
+IntegerSetPtr IntegerSet::createLessRangeSet(TypeIndex type_index, const Field & max, bool not_included)
 {
     switch (type_index)
     {
@@ -102,7 +102,7 @@ IntegerSetPtr IntegerSet::createLessRangeSet(TypeIndex type_index, Field max, bo
     }
 }
 
-IntegerSetPtr IntegerSet::createGreaterRangeSet(TypeIndex type_index, Field min, bool not_included)
+IntegerSetPtr IntegerSet::createGreaterRangeSet(TypeIndex type_index, const Field & min, bool not_included)
 {
     switch (type_index)
     {

--- a/dbms/src/Storages/DeltaMerge/Filter/IntegerSet.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/IntegerSet.h
@@ -139,8 +139,8 @@ class ValueSet final : public IntegerSet
 public:
     ValueSet() = default;
 
-    explicit ValueSet(std::set<T> values_)
-        : values(values_)
+    explicit ValueSet(std::set<T> && values_)
+        : values(std::move(values_))
     {}
 
     explicit ValueSet(const Fields & values_)
@@ -171,19 +171,7 @@ public:
 
     BitmapFilterPtr search(InvertedIndexReaderPtr inverted_index, size_t size) override;
 
-    String toDebugString() override
-    {
-        FmtBuffer buf;
-        buf.append("{");
-        buf.joinStr(
-            values.begin(),
-            values.end(),
-            [](const auto & value, FmtBuffer & fb) { fb.fmtAppend("{}", value); },
-            ", ");
-        buf.append("}");
-
-        return buf.toString();
-    }
+    String toDebugString() override { return fmt::format("{{{}}}", values); }
 
 private:
     std::set<T> values;

--- a/dbms/src/Storages/DeltaMerge/Filter/IntegerSet.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/IntegerSet.h
@@ -43,9 +43,7 @@ enum class SetType : UInt8
 class IntegerSet : public std::enable_shared_from_this<IntegerSet>
 {
 public:
-    explicit IntegerSet(SetType type_)
-        : type(type_)
-    {}
+    IntegerSet() = default;
 
     virtual ~IntegerSet() = default;
 
@@ -72,11 +70,8 @@ public:
     virtual String toDebugString() = 0;
 
     static IntegerSetPtr createValueSet(TypeIndex type_index, const Fields & values);
-    static IntegerSetPtr createLessRangeSet(TypeIndex type_index, Field max, bool not_included = true);
-    static IntegerSetPtr createGreaterRangeSet(TypeIndex type_index, Field min, bool not_included = true);
-
-protected:
-    SetType type;
+    static IntegerSetPtr createLessRangeSet(TypeIndex type_index, const Field & max, bool not_included = true);
+    static IntegerSetPtr createGreaterRangeSet(TypeIndex type_index, const Field & min, bool not_included = true);
 };
 
 class EmptySet final : public IntegerSet
@@ -88,9 +83,7 @@ public:
         return instance;
     }
 
-    EmptySet()
-        : IntegerSet(SetType::Empty)
-    {}
+    EmptySet() = default;
 
     ~EmptySet() override = default;
 
@@ -119,9 +112,7 @@ public:
         return instance;
     }
 
-    AllSet()
-        : IntegerSet(SetType::All)
-    {}
+    AllSet() = default;
 
     ~AllSet() override = default;
 
@@ -146,17 +137,13 @@ template <typename T>
 class ValueSet final : public IntegerSet
 {
 public:
-    explicit ValueSet(std::set<T> values_)
-        : IntegerSet(SetType::Value)
-        , values(values_)
-    {}
+    ValueSet() = default;
 
-    ValueSet()
-        : ValueSet(std::set<T>{})
+    explicit ValueSet(std::set<T> values_)
+        : values(values_)
     {}
 
     explicit ValueSet(const Fields & values_)
-        : IntegerSet(SetType::Value)
     {
         for (const auto & value : values_)
             values.insert(value.get<T>());
@@ -210,8 +197,7 @@ class RangeSet final : public IntegerSet
 
 public:
     explicit RangeSet(T start_, T end_)
-        : IntegerSet(SetType::Range)
-        , start(start_)
+        : start(start_)
         , end(end_)
     {}
 
@@ -250,13 +236,10 @@ class CompositeSet : public IntegerSet
     friend class ValueSet<T>;
 
 public:
-    CompositeSet()
-        : IntegerSet(SetType::Composite)
-    {}
+    CompositeSet() = default;
 
     explicit CompositeSet(std::vector<IntegerSetPtr> sets_)
-        : IntegerSet(SetType::Composite)
-        , sets(sets_)
+        : sets(sets_)
     {}
 
     ~CompositeSet() override = default;

--- a/dbms/src/Storages/DeltaMerge/Filter/IntegerSet.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/IntegerSet.h
@@ -1,0 +1,292 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <Core/Field.h>
+#include <Storages/DeltaMerge/BitmapFilter/BitmapFilter.h>
+#include <Storages/DeltaMerge/Index/InvertedIndex/Reader_fwd.h>
+#include <common/types.h>
+
+#include <memory>
+
+namespace DB::DM
+{
+
+class IntegerSet;
+using IntegerSetPtr = std::shared_ptr<IntegerSet>;
+
+using Fields = std::vector<Field>;
+
+enum class SetType : UInt8
+{
+    Empty,
+    All,
+    Value,
+    Range,
+    Composite,
+};
+
+// IntegerSet is a collection of integer values.
+// It can be multiple values, a range of values, or a composite of multiple sets.
+class IntegerSet : public std::enable_shared_from_this<IntegerSet>
+{
+public:
+    explicit IntegerSet(SetType type_)
+        : type(type_)
+    {}
+
+    virtual ~IntegerSet() = default;
+
+    virtual SetType getType() const = 0;
+
+    // intersect the other set with this set.
+    // return the result set.
+    virtual IntegerSetPtr intersectWith(const IntegerSetPtr & other) = 0;
+
+    // union the other set with this set.
+    // return the result set.
+    virtual IntegerSetPtr unionWith(const IntegerSetPtr & other) = 0;
+
+    // invert the set.
+    // return the result set.
+    virtual IntegerSetPtr invert() const = 0;
+
+    // search the inverted index with the set.
+    // return the bitmap filter.
+    virtual BitmapFilterPtr search(InvertedIndexReaderPtr inverted_index, size_t size) = 0;
+
+    // return a string representation of the set.
+    // Only used in tests.
+    virtual String toDebugString() = 0;
+
+    static IntegerSetPtr createValueSet(TypeIndex type_index, const Fields & values);
+    static IntegerSetPtr createLessRangeSet(TypeIndex type_index, Field max, bool not_included = true);
+    static IntegerSetPtr createGreaterRangeSet(TypeIndex type_index, Field min, bool not_included = true);
+
+protected:
+    SetType type;
+};
+
+class EmptySet final : public IntegerSet
+{
+public:
+    static IntegerSetPtr instance()
+    {
+        static IntegerSetPtr instance = std::make_shared<EmptySet>();
+        return instance;
+    }
+
+    EmptySet()
+        : IntegerSet(SetType::Empty)
+    {}
+
+    ~EmptySet() override = default;
+
+    SetType getType() const override { return SetType::Empty; }
+
+    IntegerSetPtr intersectWith(const IntegerSetPtr &) override { return instance(); }
+
+    IntegerSetPtr unionWith(const IntegerSetPtr & other) override { return other; }
+
+    IntegerSetPtr invert() const override;
+
+    BitmapFilterPtr search(InvertedIndexReaderPtr, size_t size) override
+    {
+        return std::make_shared<BitmapFilter>(size, false);
+    }
+
+    String toDebugString() override { return "EMPTY"; }
+};
+
+class AllSet final : public IntegerSet
+{
+public:
+    static IntegerSetPtr instance()
+    {
+        static IntegerSetPtr instance = std::make_shared<AllSet>();
+        return instance;
+    }
+
+    AllSet()
+        : IntegerSet(SetType::All)
+    {}
+
+    ~AllSet() override = default;
+
+    SetType getType() const override { return SetType::All; }
+
+    IntegerSetPtr intersectWith(const IntegerSetPtr & other) override { return other; }
+
+    IntegerSetPtr unionWith(const IntegerSetPtr &) override { return instance(); }
+
+    IntegerSetPtr invert() const override { return EmptySet::instance(); }
+
+    BitmapFilterPtr search(InvertedIndexReaderPtr, size_t size) override
+    {
+        return std::make_shared<BitmapFilter>(size, true);
+    }
+
+    String toDebugString() override { return "ALL"; }
+};
+
+// {x1, x2, x3, ...}
+template <typename T>
+class ValueSet final : public IntegerSet
+{
+public:
+    explicit ValueSet(std::set<T> values_)
+        : IntegerSet(SetType::Value)
+        , values(values_)
+    {}
+
+    ValueSet()
+        : ValueSet(std::set<T>{})
+    {}
+
+    explicit ValueSet(const Fields & values_)
+        : IntegerSet(SetType::Value)
+    {
+        for (const auto & value : values_)
+            values.insert(value.get<T>());
+    }
+
+    ~ValueSet() override = default;
+
+    SetType getType() const override { return SetType::Value; }
+
+    IntegerSetPtr intersectWith(const IntegerSetPtr & other) override;
+
+    static IntegerSetPtr intersectWithValueSet(const IntegerSetPtr & lhs, const IntegerSetPtr & rhs);
+    static IntegerSetPtr intersectWithRangeSet(const IntegerSetPtr & range_set, const IntegerSetPtr & value_set);
+    static IntegerSetPtr intersectWithCompositeSet(
+        const IntegerSetPtr & composite_set,
+        const IntegerSetPtr & value_set);
+
+    IntegerSetPtr unionWith(const IntegerSetPtr & other) override;
+
+    static IntegerSetPtr unionWithValueSet(const IntegerSetPtr & lhs, const IntegerSetPtr & rhs);
+    static IntegerSetPtr unionWithRangeSet(const IntegerSetPtr & range_set, const IntegerSetPtr & value_set);
+    static IntegerSetPtr unionWithCompositeSet(const IntegerSetPtr & composite_set, const IntegerSetPtr & value_set);
+
+    IntegerSetPtr invert() const override;
+
+    BitmapFilterPtr search(InvertedIndexReaderPtr inverted_index, size_t size) override;
+
+    String toDebugString() override
+    {
+        FmtBuffer buf;
+        buf.append("{");
+        buf.joinStr(
+            values.begin(),
+            values.end(),
+            [](const auto & value, FmtBuffer & fb) { fb.fmtAppend("{}", value); },
+            ", ");
+        buf.append("}");
+
+        return buf.toString();
+    }
+
+private:
+    std::set<T> values;
+};
+
+// [start, end]
+template <typename T>
+class RangeSet final : public IntegerSet
+{
+    friend class ValueSet<T>;
+
+public:
+    explicit RangeSet(T start_, T end_)
+        : IntegerSet(SetType::Range)
+        , start(start_)
+        , end(end_)
+    {}
+
+    ~RangeSet() override = default;
+
+    SetType getType() const override { return SetType::Range; }
+
+    IntegerSetPtr intersectWith(const IntegerSetPtr & other) override;
+
+    static IntegerSetPtr intersectWithRangeSet(const IntegerSetPtr & lhs, const IntegerSetPtr & rhs);
+    static IntegerSetPtr intersectWithCompositeSet(
+        const IntegerSetPtr & composite_set,
+        const IntegerSetPtr & range_set);
+
+    IntegerSetPtr unionWith(const IntegerSetPtr & other) override;
+
+    static IntegerSetPtr unionWithRangeSet(const IntegerSetPtr & lhs, const IntegerSetPtr & rhs);
+    static IntegerSetPtr unionWithCompositeSet(const IntegerSetPtr & composite_set, const IntegerSetPtr & range_set);
+
+    IntegerSetPtr invert() const override;
+
+    BitmapFilterPtr search(InvertedIndexReaderPtr inverted_index, size_t size) override;
+
+    String toDebugString() override { return fmt::format("[{}, {}]", start, end); }
+
+private:
+    T start;
+    T end;
+};
+
+// {x1, x2, x3, ...} U [start1, end1] U ...
+template <typename T>
+class CompositeSet : public IntegerSet
+{
+    friend class RangeSet<T>;
+    friend class ValueSet<T>;
+
+public:
+    CompositeSet()
+        : IntegerSet(SetType::Composite)
+    {}
+
+    explicit CompositeSet(std::vector<IntegerSetPtr> sets_)
+        : IntegerSet(SetType::Composite)
+        , sets(sets_)
+    {}
+
+    ~CompositeSet() override = default;
+
+    SetType getType() const override { return SetType::Composite; }
+
+    IntegerSetPtr intersectWith(const IntegerSetPtr & other) override;
+
+    IntegerSetPtr unionWith(const IntegerSetPtr & other) override;
+
+    IntegerSetPtr invert() const override;
+
+    BitmapFilterPtr search(InvertedIndexReaderPtr inverted_index, size_t size) override;
+
+    String toDebugString() override
+    {
+        FmtBuffer buf;
+        buf.append("{");
+        buf.joinStr(
+            sets.begin(),
+            sets.end(),
+            [](const auto & set, FmtBuffer & fb) { fb.append(set->toDebugString()); },
+            ", ");
+        buf.append("}");
+
+        return buf.toString();
+    }
+
+private:
+    std::vector<IntegerSetPtr> sets;
+};
+
+} // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/Filter/IntegerSet.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/IntegerSet.h
@@ -171,7 +171,7 @@ public:
 
     BitmapFilterPtr search(InvertedIndexReaderPtr inverted_index, size_t size) override;
 
-    String toDebugString() override { return fmt::format("{{{}}}", values); }
+    String toDebugString() override { return fmt::format("{}", values); }
 
 private:
     std::set<T> values;

--- a/dbms/src/Storages/DeltaMerge/Filter/IsNull.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/IsNull.h
@@ -39,6 +39,8 @@ public:
         auto rs_index = getRSIndex(param, attr);
         return rs_index ? rs_index->minmax->checkIsNull(start_pack, pack_count) : RSResults(pack_count, RSResult::Some);
     }
+
+    ColumnRangePtr buildSets(const LocalIndexInfosSnapshot &) override { return UnsupportedColumnRange::create(); }
 };
 
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/Filter/Less.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/Less.h
@@ -35,6 +35,19 @@ public:
         std::transform(results.begin(), results.end(), results.begin(), [](RSResult result) { return !result; });
         return results;
     }
+
+    ColumnRangePtr buildSets(const LocalIndexInfosSnapshot & index_info) override
+    {
+        if (auto set = IntegerSet::createLessRangeSet(attr.type->getTypeId(), value, /*not_included=*/true); set)
+        {
+            auto iter = std::find_if(index_info->begin(), index_info->end(), [&](const auto & info) {
+                return info.column_id == attr.col_id && info.kind == TiDB::ColumnarIndexKind::Inverted;
+            });
+            if (iter != index_info->end())
+                return SingleColumnRange::create(iter->column_id, iter->index_id, set);
+        }
+        return UnsupportedColumnRange::create();
+    }
 };
 
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/Filter/LessEqual.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/LessEqual.h
@@ -35,6 +35,19 @@ public:
         std::transform(results.begin(), results.end(), results.begin(), [](const auto result) { return !result; });
         return results;
     }
+
+    ColumnRangePtr buildSets(const LocalIndexInfosSnapshot & index_info) override
+    {
+        if (auto set = IntegerSet::createLessRangeSet(attr.type->getTypeId(), value, /*not_included=*/false); set)
+        {
+            auto iter = std::find_if(index_info->begin(), index_info->end(), [&](const auto & info) {
+                return info.column_id == attr.col_id && info.kind == TiDB::ColumnarIndexKind::Inverted;
+            });
+            if (iter != index_info->end())
+                return SingleColumnRange::create(iter->column_id, iter->index_id, set);
+        }
+        return UnsupportedColumnRange::create();
+    }
 };
 
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/Filter/Like.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/Like.h
@@ -32,6 +32,8 @@ public:
     {
         return RSResults(pack_count, RSResult::Some);
     }
+
+    ColumnRangePtr buildSets(const LocalIndexInfosSnapshot &) override { return UnsupportedColumnRange::create(); }
 };
 
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/Filter/Not.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/Not.h
@@ -34,6 +34,12 @@ public:
         std::transform(results.begin(), results.end(), results.begin(), [](const auto result) { return !result; });
         return results;
     }
+
+    ColumnRangePtr buildSets(const LocalIndexInfosSnapshot & index_info) override
+    {
+        auto sets = children[0]->buildSets(index_info);
+        return sets->invert();
+    }
 };
 
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/Filter/Or.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/Or.h
@@ -43,6 +43,15 @@ public:
         }
         return res;
     }
+
+    ColumnRangePtr buildSets(const LocalIndexInfosSnapshot & index_info) override
+    {
+        ColumnRanges children_sets;
+        children_sets.reserve(children.size());
+        for (const auto & child : children)
+            children_sets.push_back(child->buildSets(index_info));
+        return OrColumnRange::create(children_sets);
+    }
 };
 
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/Filter/RSOperator.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/RSOperator.h
@@ -16,9 +16,12 @@
 
 #include <Common/FieldVisitors.h>
 #include <Storages/DeltaMerge/DeltaMergeDefines.h>
+#include <Storages/DeltaMerge/Filter/ColumnRange.h>
 #include <Storages/DeltaMerge/Filter/RSOperator_fwd.h>
+#include <Storages/DeltaMerge/Index/LocalIndexInfo.h>
 #include <Storages/DeltaMerge/Index/RSIndex.h>
 #include <Storages/DeltaMerge/Index/RSResult.h>
+#include <TiDB/Schema/TiDB.h>
 
 namespace DB
 {
@@ -51,6 +54,8 @@ public:
     virtual RSResults roughCheck(size_t start_pack, size_t pack_count, const RSCheckParam & param) = 0;
 
     virtual ColIds getColumnIDs() = 0;
+
+    virtual ColumnRangePtr buildSets(const LocalIndexInfosSnapshot & index_info) = 0;
 
     static RSOperatorPtr build(
         const std::unique_ptr<DAGQueryInfo> & dag_query,

--- a/dbms/src/Storages/DeltaMerge/Filter/Unsupported.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/Unsupported.h
@@ -38,6 +38,8 @@ public:
     {
         return RSResults(pack_count, RSResult::Some);
     }
+
+    ColumnRangePtr buildSets(const LocalIndexInfosSnapshot &) override { return UnsupportedColumnRange::create(); }
 };
 
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_inverted_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_inverted_index.cpp
@@ -151,26 +151,29 @@ public:
                 viewer->search(bitmap_filter, key);
                 ASSERT_EQ(bitmap_filter->count(), expected_count);
             };
-            std::mt19937 generator;
-            std::uniform_int_distribution<T> distribution_bc(0, block_count);
+
             std::vector<std::thread> threads;
             {
                 for (UInt32 i = 0; i < 10; ++i)
                 {
-                    threads.emplace_back([&v_search, &generator, &distribution_bc]() {
-                        auto random_v = distribution_bc(generator);
+                    threads.emplace_back([&v_search]() {
+                        std::mt19937 generator(std::random_device{}());
+                        std::uniform_int_distribution<T> distribution(0, block_count);
+                        auto random_v = distribution(generator);
                         v_search(random_v, block_size);
                     });
                 }
             }
-            std::uniform_int_distribution<T> distribution_fullrange(
-                std::numeric_limits<T>::min(),
-                std::numeric_limits<T>::max());
+
             {
                 for (UInt32 i = 0; i < 10; ++i)
                 {
-                    threads.emplace_back([&v_search, &generator, &distribution_fullrange]() {
-                        auto random_v = distribution_fullrange(generator);
+                    threads.emplace_back([&v_search]() {
+                        std::mt19937 generator(std::random_device{}());
+                        std::uniform_int_distribution<T> distribution(
+                            std::numeric_limits<T>::min(),
+                            std::numeric_limits<T>::max());
+                        auto random_v = distribution(generator);
                         v_search(random_v, (random_v >= block_count || random_v < 0) ? 0 : block_size);
                     });
                 }

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_inverted_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_inverted_index.cpp
@@ -114,7 +114,7 @@ public:
             };
             std::mt19937 generator;
             {
-                std::uniform_int_distribution<T> distribution(0, block_count);
+                std::uniform_int_distribution<T> distribution(0, block_count - 1);
                 for (UInt32 i = 0; i < 10; ++i)
                     v_search(distribution(generator), block_size);
             }
@@ -158,7 +158,7 @@ public:
                 {
                     threads.emplace_back([&v_search]() {
                         std::mt19937 generator(std::random_device{}());
-                        std::uniform_int_distribution<T> distribution(0, block_count);
+                        std::uniform_int_distribution<T> distribution(0, block_count - 1);
                         auto random_v = distribution(generator);
                         v_search(random_v, block_size);
                     });

--- a/dbms/src/Storages/tests/gtest_filter_parser.cpp
+++ b/dbms/src/Storages/tests/gtest_filter_parser.cpp
@@ -49,7 +49,7 @@ public:
         }
         catch (DB::Exception &)
         {
-            // Maybe another test has already registed, ignore exception here.
+            // Maybe another test has already registered, ignore exception here.
         }
     }
 
@@ -554,16 +554,14 @@ try
 
         auto rs_operator = generateRsOperator(
             table_info_json,
-            String("select * from default.t_111 where col_timestamp > cast_string_datetime('") + datetime
-                + String("')"),
+            fmt::format("select * from default.t_111 where col_timestamp > cast_string_datetime('{}')", datetime),
             timezone_info);
         EXPECT_EQ(rs_operator->name(), "greater");
         EXPECT_EQ(rs_operator->getColumnIDs().size(), 1);
         EXPECT_EQ(rs_operator->getColumnIDs()[0], 4);
         EXPECT_EQ(
             rs_operator->toDebugString(),
-            String("{\"op\":\"greater\",\"col\":\"col_timestamp\",\"value\":\"") + toString(converted_time)
-                + String("\"}"));
+            fmt::format(R"json({{"op":"greater","col":"col_timestamp","value":"{}"}})json", converted_time));
         auto sets = rs_operator->buildSets(snapshot);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), fmt::format("4: [{}, 18446744073709551615]", converted_time + 1));
@@ -578,16 +576,14 @@ try
 
         auto rs_operator = generateRsOperator(
             table_info_json,
-            String("select * from default.t_111 where col_timestamp > cast_string_datetime('") + datetime
-                + String("')"),
+            fmt::format("select * from default.t_111 where col_timestamp > cast_string_datetime('{}')", datetime),
             timezone_info);
         EXPECT_EQ(rs_operator->name(), "greater");
         EXPECT_EQ(rs_operator->getColumnIDs().size(), 1);
         EXPECT_EQ(rs_operator->getColumnIDs()[0], 4);
         EXPECT_EQ(
             rs_operator->toDebugString(),
-            String("{\"op\":\"greater\",\"col\":\"col_timestamp\",\"value\":\"") + toString(converted_time)
-                + String("\"}"));
+            fmt::format(R"json({{"op":"greater","col":"col_timestamp","value":"{}"}})json", converted_time));
         auto sets = rs_operator->buildSets(snapshot);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), fmt::format("4: [{}, 18446744073709551615]", converted_time + 1));
@@ -602,16 +598,14 @@ try
 
         auto rs_operator = generateRsOperator(
             table_info_json,
-            String("select * from default.t_111 where col_timestamp > cast_string_datetime('") + datetime
-                + String("')"),
+            fmt::format("select * from default.t_111 where col_timestamp > cast_string_datetime('{}')", datetime),
             timezone_info);
         EXPECT_EQ(rs_operator->name(), "greater");
         EXPECT_EQ(rs_operator->getColumnIDs().size(), 1);
         EXPECT_EQ(rs_operator->getColumnIDs()[0], 4);
         EXPECT_EQ(
             rs_operator->toDebugString(),
-            String("{\"op\":\"greater\",\"col\":\"col_timestamp\",\"value\":\"") + toString(converted_time)
-                + String("\"}"));
+            fmt::format(R"json({{"op":"greater","col":"col_timestamp","value":"{}"}})json", converted_time));
         auto sets = rs_operator->buildSets(snapshot);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), fmt::format("4: [{}, 18446744073709551615]", converted_time + 1));
@@ -621,15 +615,13 @@ try
         // Greater between Datetime col and Datetime literal
         auto rs_operator = generateRsOperator(
             table_info_json,
-            String("select * from default.t_111 where col_datetime > cast_string_datetime('") + datetime
-                + String("')"));
+            fmt::format("select * from default.t_111 where col_datetime > cast_string_datetime('{}')", datetime));
         EXPECT_EQ(rs_operator->name(), "greater");
         EXPECT_EQ(rs_operator->getColumnIDs().size(), 1);
         EXPECT_EQ(rs_operator->getColumnIDs()[0], 5);
         EXPECT_EQ(
             rs_operator->toDebugString(),
-            String("{\"op\":\"greater\",\"col\":\"col_datetime\",\"value\":\"") + toString(origin_time_stamp)
-                + String("\"}"));
+            fmt::format(R"json({{"op":"greater","col":"col_datetime","value":"{}"}})json", origin_time_stamp));
         auto sets = rs_operator->buildSets(snapshot);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), fmt::format("5: [{}, 18446744073709551615]", origin_time_stamp + 1));
@@ -639,14 +631,13 @@ try
         // Greater between Date col and Datetime literal
         auto rs_operator = generateRsOperator(
             table_info_json,
-            String("select * from default.t_111 where col_date > cast_string_datetime('") + datetime + String("')"));
+            fmt::format("select * from default.t_111 where col_date > cast_string_datetime('{}')", datetime));
         EXPECT_EQ(rs_operator->name(), "greater");
         EXPECT_EQ(rs_operator->getColumnIDs().size(), 1);
         EXPECT_EQ(rs_operator->getColumnIDs()[0], 6);
         EXPECT_EQ(
             rs_operator->toDebugString(),
-            String("{\"op\":\"greater\",\"col\":\"col_date\",\"value\":\"") + toString(origin_time_stamp)
-                + String("\"}"));
+            fmt::format(R"json({{"op":"greater","col":"col_date","value":"{}"}})json", origin_time_stamp));
         auto sets = rs_operator->buildSets(snapshot);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), fmt::format("6: [{}, 18446744073709551615]", origin_time_stamp + 1));

--- a/dbms/src/Storages/tests/gtest_filter_parser.cpp
+++ b/dbms/src/Storages/tests/gtest_filter_parser.cpp
@@ -238,6 +238,21 @@ try
     }
 
     {
+        // NotEqual Equal between literal and col
+        auto rs_operator
+            = generateRsOperator(table_info_json, "select * from default.t_111 where -9223372036854775808 != col_2");
+        EXPECT_EQ(rs_operator->name(), "not_equal");
+        EXPECT_EQ(rs_operator->getColumnIDs().size(), 1);
+        EXPECT_EQ(rs_operator->getColumnIDs()[0], 2);
+        EXPECT_EQ(
+            rs_operator->toDebugString(),
+            "{\"op\":\"not_equal\",\"col\":\"col_2\",\"value\":\"-9223372036854775808\"}");
+        auto sets = rs_operator->buildSets(snapshot);
+        EXPECT_TRUE(sets != nullptr);
+        EXPECT_EQ(sets->toDebugString(), "2: [-9223372036854775807, 9223372036854775807]");
+    }
+
+    {
         // NotEqual between literal and col (take care of direction)
         auto rs_operator = generateRsOperator(table_info_json, "select * from default.t_111 where 667 != col_2");
         EXPECT_EQ(rs_operator->name(), "not_equal");
@@ -370,6 +385,23 @@ try
         auto sets = rs_operator->buildSets(snapshot);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), "2: {777, 789}");
+    }
+
+    {
+        // OR
+        auto rs_operator
+            = generateRsOperator(table_info_json, "select * from default.t_111 where col_2 > 789 or col_2 < 791");
+        EXPECT_EQ(rs_operator->name(), "or");
+        EXPECT_EQ(rs_operator->getColumnIDs().size(), 2);
+        EXPECT_EQ(rs_operator->getColumnIDs()[0], 2);
+        EXPECT_EQ(rs_operator->getColumnIDs()[1], 2);
+        EXPECT_EQ(
+            rs_operator->toDebugString(),
+            "{\"op\":\"or\",\"children\":[{\"op\":\"greater\",\"col\":\"col_2\",\"value\":\"789\"},{\"op\":\"less\","
+            "\"col\":\"col_2\",\"value\":\"791\"}]}");
+        auto sets = rs_operator->buildSets(snapshot);
+        EXPECT_TRUE(sets != nullptr);
+        EXPECT_EQ(sets->toDebugString(), "2: ALL");
     }
 
     // More complicated

--- a/dbms/src/Storages/tests/gtest_filter_parser.cpp
+++ b/dbms/src/Storages/tests/gtest_filter_parser.cpp
@@ -35,10 +35,9 @@
 
 #include <regex>
 
-namespace DB
+namespace DB::tests
 {
-namespace tests
-{
+
 class FilterParserTest : public ::testing::Test
 {
 public:
@@ -137,6 +136,13 @@ try
     "comment":"Mocked.","id":30,"schema_version":-1,"state":0,"tiflash_replica":{"Count":0},"update_timestamp":1636471547239654
 })json";
 
+    std::vector<DM::LocalIndexInfo> local_index_infos;
+    {
+        auto definition = std::make_shared<TiDB::InvertedIndexDefinition>(false, 8);
+        local_index_infos.emplace_back(1, 2, definition);
+    }
+    auto snapshot = std::make_shared<const std::vector<DM::LocalIndexInfo>>(local_index_infos);
+
     {
         // Equal between col and literal
         auto rs_operator = generateRsOperator(table_info_json, "select * from default.t_111 where col_2 = 666");
@@ -144,6 +150,9 @@ try
         EXPECT_EQ(rs_operator->getColumnIDs().size(), 1);
         EXPECT_EQ(rs_operator->getColumnIDs()[0], 2);
         EXPECT_EQ(rs_operator->toDebugString(), "{\"op\":\"equal\",\"col\":\"col_2\",\"value\":\"666\"}");
+        auto sets = rs_operator->buildSets(snapshot);
+        EXPECT_TRUE(sets != nullptr);
+        EXPECT_EQ(sets->toDebugString(), "2: {666}");
     }
 
     {
@@ -153,6 +162,9 @@ try
         EXPECT_EQ(rs_operator->getColumnIDs().size(), 1);
         EXPECT_EQ(rs_operator->getColumnIDs()[0], 2);
         EXPECT_EQ(rs_operator->toDebugString(), "{\"op\":\"greater\",\"col\":\"col_2\",\"value\":\"666\"}");
+        auto sets = rs_operator->buildSets(snapshot);
+        EXPECT_TRUE(sets != nullptr);
+        EXPECT_EQ(sets->toDebugString(), "2: [667, 9223372036854775807]");
     }
 
     {
@@ -162,6 +174,9 @@ try
         EXPECT_EQ(rs_operator->getColumnIDs().size(), 1);
         EXPECT_EQ(rs_operator->getColumnIDs()[0], 2);
         EXPECT_EQ(rs_operator->toDebugString(), "{\"op\":\"greater_equal\",\"col\":\"col_2\",\"value\":\"667\"}");
+        auto sets = rs_operator->buildSets(snapshot);
+        EXPECT_TRUE(sets != nullptr);
+        EXPECT_EQ(sets->toDebugString(), "2: [667, 9223372036854775807]");
     }
 
     {
@@ -171,6 +186,9 @@ try
         EXPECT_EQ(rs_operator->getColumnIDs().size(), 1);
         EXPECT_EQ(rs_operator->getColumnIDs()[0], 2);
         EXPECT_EQ(rs_operator->toDebugString(), "{\"op\":\"less\",\"col\":\"col_2\",\"value\":\"777\"}");
+        auto sets = rs_operator->buildSets(snapshot);
+        EXPECT_TRUE(sets != nullptr);
+        EXPECT_EQ(sets->toDebugString(), "2: [-9223372036854775808, 776]");
     }
 
     {
@@ -180,6 +198,9 @@ try
         EXPECT_EQ(rs_operator->getColumnIDs().size(), 1);
         EXPECT_EQ(rs_operator->getColumnIDs()[0], 2);
         EXPECT_EQ(rs_operator->toDebugString(), "{\"op\":\"less_equal\",\"col\":\"col_2\",\"value\":\"776\"}");
+        auto sets = rs_operator->buildSets(snapshot);
+        EXPECT_TRUE(sets != nullptr);
+        EXPECT_EQ(sets->toDebugString(), "2: [-9223372036854775808, 776]");
     }
 }
 CATCH
@@ -195,6 +216,14 @@ try
     "name":{"L":"t_111","O":"t_111"},"partition":null,
     "comment":"Mocked.","id":30,"schema_version":-1,"state":0,"tiflash_replica":{"Count":0},"update_timestamp":1636471547239654
 })json";
+
+    std::vector<DM::LocalIndexInfo> local_index_infos;
+    {
+        auto definition = std::make_shared<TiDB::InvertedIndexDefinition>(false, 8);
+        local_index_infos.emplace_back(1, 2, definition);
+    }
+    auto snapshot = std::make_shared<const std::vector<DM::LocalIndexInfo>>(local_index_infos);
+
     // Test cases for literal and col (inverse direction)
     {
         // Equal between literal and col (take care of direction)
@@ -203,6 +232,9 @@ try
         EXPECT_EQ(rs_operator->getColumnIDs().size(), 1);
         EXPECT_EQ(rs_operator->getColumnIDs()[0], 2);
         EXPECT_EQ(rs_operator->toDebugString(), "{\"op\":\"equal\",\"col\":\"col_2\",\"value\":\"667\"}");
+        auto sets = rs_operator->buildSets(snapshot);
+        EXPECT_TRUE(sets != nullptr);
+        EXPECT_EQ(sets->toDebugString(), "2: {667}");
     }
 
     {
@@ -212,6 +244,9 @@ try
         EXPECT_EQ(rs_operator->getColumnIDs().size(), 1);
         EXPECT_EQ(rs_operator->getColumnIDs()[0], 2);
         EXPECT_EQ(rs_operator->toDebugString(), "{\"op\":\"not_equal\",\"col\":\"col_2\",\"value\":\"667\"}");
+        auto sets = rs_operator->buildSets(snapshot);
+        EXPECT_TRUE(sets != nullptr);
+        EXPECT_EQ(sets->toDebugString(), "2: {[-9223372036854775808, 666], [668, 9223372036854775807]}");
     }
 
     {
@@ -221,6 +256,9 @@ try
         EXPECT_EQ(rs_operator->getColumnIDs().size(), 1);
         EXPECT_EQ(rs_operator->getColumnIDs()[0], 2);
         EXPECT_EQ(rs_operator->toDebugString(), "{\"op\":\"greater\",\"col\":\"col_2\",\"value\":\"667\"}");
+        auto sets = rs_operator->buildSets(snapshot);
+        EXPECT_TRUE(sets != nullptr);
+        EXPECT_EQ(sets->toDebugString(), "2: [668, 9223372036854775807]");
     }
 
     {
@@ -230,6 +268,9 @@ try
         EXPECT_EQ(rs_operator->getColumnIDs().size(), 1);
         EXPECT_EQ(rs_operator->getColumnIDs()[0], 2);
         EXPECT_EQ(rs_operator->toDebugString(), "{\"op\":\"greater_equal\",\"col\":\"col_2\",\"value\":\"667\"}");
+        auto sets = rs_operator->buildSets(snapshot);
+        EXPECT_TRUE(sets != nullptr);
+        EXPECT_EQ(sets->toDebugString(), "2: [667, 9223372036854775807]");
     }
 
     {
@@ -239,6 +280,9 @@ try
         EXPECT_EQ(rs_operator->getColumnIDs().size(), 1);
         EXPECT_EQ(rs_operator->getColumnIDs()[0], 2);
         EXPECT_EQ(rs_operator->toDebugString(), "{\"op\":\"less\",\"col\":\"col_2\",\"value\":\"777\"}");
+        auto sets = rs_operator->buildSets(snapshot);
+        EXPECT_TRUE(sets != nullptr);
+        EXPECT_EQ(sets->toDebugString(), "2: [-9223372036854775808, 776]");
     }
 
     {
@@ -248,6 +292,9 @@ try
         EXPECT_EQ(rs_operator->getColumnIDs().size(), 1);
         EXPECT_EQ(rs_operator->getColumnIDs()[0], 2);
         EXPECT_EQ(rs_operator->toDebugString(), "{\"op\":\"less_equal\",\"col\":\"col_2\",\"value\":\"777\"}");
+        auto sets = rs_operator->buildSets(snapshot);
+        EXPECT_TRUE(sets != nullptr);
+        EXPECT_EQ(sets->toDebugString(), "2: [-9223372036854775808, 777]");
     }
 }
 CATCH
@@ -266,6 +313,18 @@ try
     "name":{"L":"t_111","O":"t_111"},"partition":null,
     "comment":"Mocked.","id":30,"schema_version":-1,"state":0,"tiflash_replica":{"Count":0},"update_timestamp":1636471547239654
 })json";
+
+    std::vector<DM::LocalIndexInfo> local_index_infos;
+    {
+        auto definition = std::make_shared<TiDB::InvertedIndexDefinition>(false, 8);
+        local_index_infos.emplace_back(1, 2, definition);
+    }
+    {
+        auto definition = std::make_shared<TiDB::InvertedIndexDefinition>(false, 8);
+        local_index_infos.emplace_back(2, 3, definition);
+    }
+    auto snapshot = std::make_shared<const std::vector<DM::LocalIndexInfo>>(local_index_infos);
+
     {
         // Not
         auto rs_operator
@@ -276,6 +335,9 @@ try
         EXPECT_EQ(
             rs_operator->toDebugString(),
             "{\"op\":\"not\",\"children\":[{\"op\":\"equal\",\"col\":\"col_2\",\"value\":\"666\"}]}");
+        auto sets = rs_operator->buildSets(snapshot);
+        EXPECT_TRUE(sets != nullptr);
+        EXPECT_EQ(sets->toDebugString(), "2: {[-9223372036854775808, 665], [667, 9223372036854775807]}");
     }
 
     {
@@ -288,6 +350,9 @@ try
         std::regex rx(
             R"(\{"op":"and","children":\[\{"op":"unsupported",.*\},\{"op":"equal","col":"col_2","value":"666"\}\]\})");
         EXPECT_TRUE(std::regex_search(rs_operator->toDebugString(), rx));
+        auto sets = rs_operator->buildSets(snapshot);
+        EXPECT_TRUE(sets != nullptr);
+        EXPECT_EQ(sets->toDebugString(), "2: {666}");
     }
 
     {
@@ -302,6 +367,9 @@ try
             rs_operator->toDebugString(),
             "{\"op\":\"or\",\"children\":[{\"op\":\"equal\",\"col\":\"col_2\",\"value\":\"789\"},{\"op\":\"equal\","
             "\"col\":\"col_2\",\"value\":\"777\"}]}");
+        auto sets = rs_operator->buildSets(snapshot);
+        EXPECT_TRUE(sets != nullptr);
+        EXPECT_EQ(sets->toDebugString(), "2: {777, 789}");
     }
 
     // More complicated
@@ -316,6 +384,9 @@ try
         std::regex rx(
             R"(\{"op":"and","children":\[\{"op":"unsupported",.*\},\{"op":"not","children":\[\{"op":"equal","col":"col_2","value":"666"\}\]\}\]\})");
         EXPECT_TRUE(std::regex_search(rs_operator->toDebugString(), rx));
+        auto sets = rs_operator->buildSets(snapshot);
+        EXPECT_TRUE(sets != nullptr);
+        EXPECT_EQ(sets->toDebugString(), "2: {[-9223372036854775808, 665], [667, 9223372036854775807]}");
     }
 
     {
@@ -330,6 +401,9 @@ try
             rs_operator->toDebugString(),
             "{\"op\":\"and\",\"children\":[{\"op\":\"equal\",\"col\":\"col_2\",\"value\":\"789\"},{\"op\":\"not\","
             "\"children\":[{\"op\":\"equal\",\"col\":\"col_3\",\"value\":\"666\"}]}]}");
+        auto sets = rs_operator->buildSets(snapshot);
+        EXPECT_TRUE(sets != nullptr);
+        EXPECT_EQ(sets->toDebugString(), "And[3: {[-9223372036854775808, 665], [667, 9223372036854775807]}, 2: {789}]");
     }
 
     {
@@ -347,6 +421,9 @@ try
             "{\"op\":\"and\",\"children\":[{\"op\":\"equal\",\"col\":\"col_2\",\"value\":\"789\"},{\"op\":\"or\","
             "\"children\":[{\"op\":\"equal\",\"col\":\"col_3\",\"value\":\"666\"},{\"op\":\"equal\",\"col\":\"col_3\","
             "\"value\":\"678\"}]}]}");
+        auto sets = rs_operator->buildSets(snapshot);
+        EXPECT_TRUE(sets != nullptr);
+        EXPECT_EQ(sets->toDebugString(), "And[3: {666, 678}, 2: {789}]");
     }
 
     {
@@ -359,6 +436,9 @@ try
         std::regex rx(
             R"(\{"op":"or","children":\[\{"op":"unsupported",.*\},\{"op":"equal","col":"col_2","value":"666"\}\]\})");
         EXPECT_TRUE(std::regex_search(rs_operator->toDebugString(), rx));
+        auto sets = rs_operator->buildSets(snapshot);
+        EXPECT_TRUE(sets != nullptr);
+        EXPECT_EQ(sets->toDebugString(), "Unsupported");
     }
 
     {
@@ -372,6 +452,9 @@ try
         std::regex rx(
             R"(\{"op":"or","children":\[\{"op":"unsupported",.*\},\{"op":"not","children":\[\{"op":"equal","col":"col_2","value":"666"\}\]\}\]\})");
         EXPECT_TRUE(std::regex_search(rs_operator->toDebugString(), rx));
+        auto sets = rs_operator->buildSets(snapshot);
+        EXPECT_TRUE(sets != nullptr);
+        EXPECT_EQ(sets->toDebugString(), "Unsupported");
     }
 
     {
@@ -386,6 +469,9 @@ try
             rs_operator->toDebugString(),
             "{\"op\":\"and\",\"children\":[{\"op\":\"equal\",\"col\":\"col_2\",\"value\":\"789\"},{\"op\":\"isnull\","
             "\"col\":\"col_3\"}]}");
+        auto sets = rs_operator->buildSets(snapshot);
+        EXPECT_TRUE(sets != nullptr);
+        EXPECT_EQ(sets->toDebugString(), "2: {789}");
     }
 
     {
@@ -395,6 +481,9 @@ try
         EXPECT_EQ(
             rs_operator->toDebugString(),
             R"raw({"op":"and","children":[{"op":"unsupported","reason":"child of logical and is not function, expr.tp=ColumnRef"},{"op":"unsupported","reason":"child of logical and is not function, expr.tp=Uint64"}]})raw");
+        auto sets = rs_operator->buildSets(snapshot);
+        EXPECT_TRUE(sets != nullptr);
+        EXPECT_EQ(sets->toDebugString(), "Unsupported");
     }
 
     {
@@ -404,12 +493,18 @@ try
         EXPECT_EQ(
             rs_operator->toDebugString(),
             R"raw({"op":"or","children":[{"op":"unsupported","reason":"child of logical operator is not function, child_type=ColumnRef"},{"op":"unsupported","reason":"child of logical operator is not function, child_type=Uint64"}]})raw");
+        auto sets = rs_operator->buildSets(snapshot);
+        EXPECT_TRUE(sets != nullptr);
+        EXPECT_EQ(sets->toDebugString(), "Unsupported");
     }
 
     {
         // IsNull with FunctionExpr (not supported since IsNull only support when child is ColumnExpr)
         auto rs_operator = generateRsOperator(table_info_json, "select * from default.t_111 where (col_2 > 1) is null");
         EXPECT_EQ(rs_operator->name(), "unsupported");
+        auto sets = rs_operator->buildSets(snapshot);
+        EXPECT_TRUE(sets != nullptr);
+        EXPECT_EQ(sets->toDebugString(), "Unsupported");
     }
 }
 CATCH
@@ -428,6 +523,21 @@ try
     "name":{"L":"t_111","O":"t_111"},"partition":null,
     "comment":"Mocked.","id":30,"schema_version":-1,"state":0,"tiflash_replica":{"Count":0},"update_timestamp":1636471547239654
 })json";
+
+    std::vector<DM::LocalIndexInfo> local_index_infos;
+    {
+        auto definition = std::make_shared<TiDB::InvertedIndexDefinition>(false, 8);
+        local_index_infos.emplace_back(1, 4, definition);
+    }
+    {
+        auto definition = std::make_shared<TiDB::InvertedIndexDefinition>(false, 8);
+        local_index_infos.emplace_back(2, 5, definition);
+    }
+    {
+        auto definition = std::make_shared<TiDB::InvertedIndexDefinition>(false, 8);
+        local_index_infos.emplace_back(3, 6, definition);
+    }
+    auto snapshot = std::make_shared<const std::vector<DM::LocalIndexInfo>>(local_index_infos);
 
     String datetime = "2021-10-26 17:00:00.00000";
     ReadBufferFromMemory read_buffer(datetime.c_str(), datetime.size());
@@ -454,6 +564,9 @@ try
             rs_operator->toDebugString(),
             String("{\"op\":\"greater\",\"col\":\"col_timestamp\",\"value\":\"") + toString(converted_time)
                 + String("\"}"));
+        auto sets = rs_operator->buildSets(snapshot);
+        EXPECT_TRUE(sets != nullptr);
+        EXPECT_EQ(sets->toDebugString(), fmt::format("4: [{}, 18446744073709551615]", converted_time + 1));
     }
 
     {
@@ -475,6 +588,9 @@ try
             rs_operator->toDebugString(),
             String("{\"op\":\"greater\",\"col\":\"col_timestamp\",\"value\":\"") + toString(converted_time)
                 + String("\"}"));
+        auto sets = rs_operator->buildSets(snapshot);
+        EXPECT_TRUE(sets != nullptr);
+        EXPECT_EQ(sets->toDebugString(), fmt::format("4: [{}, 18446744073709551615]", converted_time + 1));
     }
 
     {
@@ -496,6 +612,9 @@ try
             rs_operator->toDebugString(),
             String("{\"op\":\"greater\",\"col\":\"col_timestamp\",\"value\":\"") + toString(converted_time)
                 + String("\"}"));
+        auto sets = rs_operator->buildSets(snapshot);
+        EXPECT_TRUE(sets != nullptr);
+        EXPECT_EQ(sets->toDebugString(), fmt::format("4: [{}, 18446744073709551615]", converted_time + 1));
     }
 
     {
@@ -511,6 +630,9 @@ try
             rs_operator->toDebugString(),
             String("{\"op\":\"greater\",\"col\":\"col_datetime\",\"value\":\"") + toString(origin_time_stamp)
                 + String("\"}"));
+        auto sets = rs_operator->buildSets(snapshot);
+        EXPECT_TRUE(sets != nullptr);
+        EXPECT_EQ(sets->toDebugString(), fmt::format("5: [{}, 18446744073709551615]", origin_time_stamp + 1));
     }
 
     {
@@ -525,6 +647,9 @@ try
             rs_operator->toDebugString(),
             String("{\"op\":\"greater\",\"col\":\"col_date\",\"value\":\"") + toString(origin_time_stamp)
                 + String("\"}"));
+        auto sets = rs_operator->buildSets(snapshot);
+        EXPECT_TRUE(sets != nullptr);
+        EXPECT_EQ(sets->toDebugString(), fmt::format("6: [{}, 18446744073709551615]", origin_time_stamp + 1));
     }
 }
 CATCH
@@ -544,29 +669,45 @@ try
     "name":{"L":"t_111","O":"t_111"},"partition":null,
     "comment":"Mocked.","id":30,"schema_version":-1,"state":0,"tiflash_replica":{"Count":0},"update_timestamp":1636471547239654
 })json";
+
+    std::vector<DM::LocalIndexInfo> local_index_infos;
+    auto snapshot = std::make_shared<const std::vector<DM::LocalIndexInfo>>(local_index_infos);
+
     {
         // Greater between col and literal (not supported since the type of col_3 is floating point)
         auto rs_operator
             = generateRsOperator(table_info_json, "select * from default.t_111 where col_3 > 1234568.890123");
         EXPECT_EQ(rs_operator->name(), "unsupported");
+        auto sets = rs_operator->buildSets(snapshot);
+        EXPECT_TRUE(sets != nullptr);
+        EXPECT_EQ(sets->toDebugString(), "Unsupported");
     }
 
     {
         // Greater between col and literal (not supported since the type of col_1 is string)
         auto rs_operator = generateRsOperator(table_info_json, "select * from default.t_111 where col_1 > '123'");
         EXPECT_EQ(rs_operator->name(), "unsupported");
+        auto sets = rs_operator->buildSets(snapshot);
+        EXPECT_TRUE(sets != nullptr);
+        EXPECT_EQ(sets->toDebugString(), "Unsupported");
     }
 
     {
         // Greater between col and literal (not supported since the type of col_5 is decimal)
         auto rs_operator = generateRsOperator(table_info_json, "select * from default.t_111 where col_5 > 1");
         EXPECT_EQ(rs_operator->name(), "unsupported");
+        auto sets = rs_operator->buildSets(snapshot);
+        EXPECT_TRUE(sets != nullptr);
+        EXPECT_EQ(sets->toDebugString(), "Unsupported");
     }
 
     {
         // Not with literal (not supported since Not only support when child is ColumnExpr)
         auto rs_operator = generateRsOperator(table_info_json, "select * from default.t_111 where not 1");
         EXPECT_EQ(rs_operator->name(), "unsupported");
+        auto sets = rs_operator->buildSets(snapshot);
+        EXPECT_TRUE(sets != nullptr);
+        EXPECT_EQ(sets->toDebugString(), "Unsupported");
     }
 }
 CATCH
@@ -587,6 +728,9 @@ try
     "comment":"Mocked.","id":30,"schema_version":-1,"state":0,"tiflash_replica":{"Count":0},"update_timestamp":1636471547239654
 })json";
 
+    std::vector<DM::LocalIndexInfo> local_index_infos;
+    auto snapshot = std::make_shared<const std::vector<DM::LocalIndexInfo>>(local_index_infos);
+
     for (const auto & test_case : Strings{
              "select * from default.t_111 where col_2 = col_5", // col and col
              "select * from default.t_111 where 666 = 666", // literal and literal
@@ -601,9 +745,11 @@ try
     {
         auto rs_operator = generateRsOperator(table_info_json, test_case);
         EXPECT_EQ(rs_operator->name(), "unsupported");
+        auto sets = rs_operator->buildSets(snapshot);
+        EXPECT_TRUE(sets != nullptr);
+        EXPECT_EQ(sets->toDebugString(), "Unsupported");
     }
 }
 CATCH
 
-} // namespace tests
-} // namespace DB
+} // namespace DB::tests


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #9843

Problem Summary:

### What is changed and how it works?

```commit-message
Part 2 of inverted index, introduce `IntegerSet` and `ColumnRange`:

`IntegerSet` is a collection of discrete integer values, like `{0, 1, 8}`, `[10, 11)` and `{0, 1, 8} U [10, 11)`.

`ColumnRange` represents the range of values for columns, the range of values of a column is represented by `ColumnID` and `IntegerSet`. It supports all types of algebra of sets.

And we support convert `RSOperator` to `ColumnRange`.

For example, `RSOperator` a > 0 and a < 10 and b < 10 or c > 0` will be converted to `col_id_a: [1, 9] && col_id_b: [-inf, 9] || col_id_c: [0, inf]`
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
