### PR TITLE
Fix spill crash

### DIFF
--- a/dbms/src/DataStreams/MergeSortingBlockInputStream.cpp
+++ b/dbms/src/DataStreams/MergeSortingBlockInputStream.cpp
@@ -89,7 +89,7 @@ Block MergeSortingBlockInputStream::readImpl()
 
             SortHelper::removeConstantsFromBlock(block);
             if (block.columns() != header_without_constants.columns())
-                throw Exception("Unexpected number of constant columns in block in MergeSortingBlockInputStream.");
+                throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected number of constant columns in block in MergeSortingBlockInputStream, n_block={} n_header={}", block.columns(), header_without_constants.columns());
 
             blocks.push_back(block);
             sum_bytes_in_blocks += block.estimateBytesForSpill();

--- a/dbms/src/DataStreams/MergeSortingBlockInputStream.cpp
+++ b/dbms/src/DataStreams/MergeSortingBlockInputStream.cpp
@@ -88,6 +88,8 @@ Block MergeSortingBlockInputStream::readImpl()
                 return block;
 
             SortHelper::removeConstantsFromBlock(block);
+            if (block.columns() != header_without_constants.columns())
+                throw Exception("Unexpected number of constant columns in block in MergeSortingBlockInputStream.");
 
             blocks.push_back(block);
             sum_bytes_in_blocks += block.estimateBytesForSpill();

--- a/dbms/src/DataStreams/MergeSortingBlockInputStream.cpp
+++ b/dbms/src/DataStreams/MergeSortingBlockInputStream.cpp
@@ -88,8 +88,11 @@ Block MergeSortingBlockInputStream::readImpl()
                 return block;
 
             SortHelper::removeConstantsFromBlock(block);
-            if (block.columns() != header_without_constants.columns())
-                throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected number of constant columns in block in MergeSortingBlockInputStream, n_block={} n_header={}", block.columns(), header_without_constants.columns());
+            RUNTIME_CHECK_MSG(
+                block.columns() == header_without_constants.columns(),
+                "Unexpected number of constant columns in block in MergeSortingBlockInputStream, n_block={}, n_head={}",
+                block.columns(),
+                header_without_constants.columns());
 
             blocks.push_back(block);
             sum_bytes_in_blocks += block.estimateBytesForSpill();

--- a/dbms/src/Flash/tests/gtest_spill_sort.cpp
+++ b/dbms/src/Flash/tests/gtest_spill_sort.cpp
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Functions/FunctionHelpers.h>
 #include <Interpreters/Context.h>
 #include <TestUtils/ColumnGenerator.h>
 #include <TestUtils/ExecutorTestUtils.h>
 #include <TestUtils/mockExecutor.h>
-#include <Functions/FunctionHelpers.h>
 #include <common/types.h>
 
 namespace DB
@@ -202,8 +202,10 @@ try
         std::make_pair("e", true)};
 
     auto request = context.scan("spill_sort_test", "simple_table")
-        .filter(gt(col("d"), lit(toField(static_cast<Int8>(-128)))))
-        .topN(order_by_items, limit_size).project({gt(col("d"), lit(toField(static_cast<Int8>(-128))))}).build(context);
+                       .filter(gt(col("d"), lit(toField(static_cast<Int8>(-128)))))
+                       .topN(order_by_items, limit_size)
+                       .project({gt(col("d"), lit(toField(static_cast<Int8>(-128))))})
+                       .build(context);
     context.context->setSetting("max_block_size", Field(static_cast<UInt64>(max_block_size)));
 
     /// disable spill

--- a/dbms/src/Flash/tests/gtest_spill_sort.cpp
+++ b/dbms/src/Flash/tests/gtest_spill_sort.cpp
@@ -16,6 +16,8 @@
 #include <TestUtils/ColumnGenerator.h>
 #include <TestUtils/ExecutorTestUtils.h>
 #include <TestUtils/mockExecutor.h>
+#include <Functions/FunctionHelpers.h>
+#include <common/types.h>
 
 namespace DB
 {
@@ -163,6 +165,57 @@ try
             Field(static_cast<UInt64>(total_data_size / 100)));
         ASSERT_COLUMNS_EQ_UR(ref_columns, executeStreams(request, 1));
     }
+}
+CATCH
+
+TEST_F(SpillSortTestRunner, SpillAfterFilter)
+try
+{
+    DB::MockColumnInfoVec column_infos{
+        {"a", TiDB::TP::TypeTiny},
+        {"b", TiDB::TP::TypeTiny},
+        {"c", TiDB::TP::TypeTiny},
+        {"d", TiDB::TP::TypeTiny},
+        {"e", TiDB::TP::TypeTiny}};
+    ColumnsWithTypeAndName column_data;
+    size_t table_rows = 102400;
+    UInt64 max_block_size = 64;
+    size_t total_data_size = 0;
+    size_t limit_size = table_rows / 10 * 9;
+    for (const auto & column_info : mockColumnInfosToTiDBColumnInfos(column_infos))
+    {
+        ColumnGeneratorOpts opts{
+            table_rows,
+            getDataTypeByColumnInfoForComputingLayer(column_info)->getName(),
+            RANDOM,
+            column_info.name};
+        column_data.push_back(ColumnGenerator::instance().generate(opts));
+        total_data_size += column_data.back().column->byteSize();
+    }
+    context.addMockTable("spill_sort_test", "simple_table", column_infos, column_data, 8);
+
+    MockOrderByItemVec order_by_items{
+        std::make_pair("a", true),
+        std::make_pair("b", true),
+        std::make_pair("c", true),
+        std::make_pair("d", true),
+        std::make_pair("e", true)};
+
+    auto request = context.scan("spill_sort_test", "simple_table")
+        .filter(gt(col("d"), lit(toField(static_cast<Int8>(-128)))))
+        .topN(order_by_items, limit_size).project({gt(col("d"), lit(toField(static_cast<Int8>(-128))))}).build(context);
+    context.context->setSetting("max_block_size", Field(static_cast<UInt64>(max_block_size)));
+
+    /// disable spill
+    context.context->setSetting("max_bytes_before_external_sort", Field(static_cast<UInt64>(0)));
+    auto ref_columns = executeStreams(request, 1);
+
+    // The implementation of topN in the pipeline model is LocalSort, and the result of using multiple threads is unstable. Therefore, a single thread is used here instead.
+    enablePipeline(true);
+    context.context->setSetting("max_bytes_before_external_sort", Field(static_cast<UInt64>(total_data_size / 10)));
+    ASSERT_COLUMNS_EQ_R(ref_columns, executeStreams(request, 1));
+    context.context->setSetting("max_cached_data_bytes_in_spiller", Field(static_cast<UInt64>(total_data_size / 100)));
+    ASSERT_COLUMNS_EQ_R(ref_columns, executeStreams(request, 1));
 }
 CATCH
 

--- a/dbms/src/Operators/MergeSortTransformOp.cpp
+++ b/dbms/src/Operators/MergeSortTransformOp.cpp
@@ -149,6 +149,8 @@ OperatorStatus MergeSortTransformOp::transformImpl(Block & block)
 
         // store the sorted block in `sorted_blocks`.
         SortHelper::removeConstantsFromBlock(block);
+        if (block.columns() != header_without_constants.columns())
+            throw Exception("Unexpected number of constant columns in block in MergeSortTransformOp.");
         sum_bytes_in_blocks += block.estimateBytesForSpill();
         sorted_blocks.emplace_back(std::move(block));
 

--- a/dbms/src/Operators/MergeSortTransformOp.cpp
+++ b/dbms/src/Operators/MergeSortTransformOp.cpp
@@ -22,6 +22,8 @@
 
 #include <magic_enum.hpp>
 
+#include "Common/Exception.h"
+
 namespace DB
 {
 void MergeSortTransformOp::operatePrefixImpl()
@@ -149,8 +151,11 @@ OperatorStatus MergeSortTransformOp::transformImpl(Block & block)
 
         // store the sorted block in `sorted_blocks`.
         SortHelper::removeConstantsFromBlock(block);
-        if (block.columns() != header_without_constants.columns())
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected number of constant columns in block in MergeSortTransformOp, n_block={} n_header={}", block.columns(), header_without_constants.columns());
+        RUNTIME_CHECK_MSG(
+            block.columns() == header_without_constants.columns(),
+            "Unexpected number of constant columns in block in MergeSortTransformOp, n_block={}, n_head={}",
+            block.columns(),
+            header_without_constants.columns());
         sum_bytes_in_blocks += block.estimateBytesForSpill();
         sorted_blocks.emplace_back(std::move(block));
 

--- a/dbms/src/Operators/MergeSortTransformOp.cpp
+++ b/dbms/src/Operators/MergeSortTransformOp.cpp
@@ -150,7 +150,7 @@ OperatorStatus MergeSortTransformOp::transformImpl(Block & block)
         // store the sorted block in `sorted_blocks`.
         SortHelper::removeConstantsFromBlock(block);
         if (block.columns() != header_without_constants.columns())
-            throw Exception("Unexpected number of constant columns in block in MergeSortTransformOp.");
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected number of constant columns in block in MergeSortTransformOp, n_block={} n_header={}", block.columns(), header_without_constants.columns());
         sum_bytes_in_blocks += block.estimateBytesForSpill();
         sorted_blocks.emplace_back(std::move(block));
 

--- a/dbms/src/Operators/MergeSortTransformOp.cpp
+++ b/dbms/src/Operators/MergeSortTransformOp.cpp
@@ -22,8 +22,6 @@
 
 #include <magic_enum.hpp>
 
-#include "Common/Exception.h"
-
 namespace DB
 {
 void MergeSortTransformOp::operatePrefixImpl()


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9999

Problem Summary:

### What is changed and how it works?
The root cause is described in #9999, this pr fix the error and add some check in sort operator to avoid potential undefined fail when the input block of sort is not well generated.
```commit-message
Fix sort spill crash in some corner cases.
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix sort spill crash in some corner cases
```
