### PR TITLE
Optimize & Add serialization/deserialization interfaces in IColumn

### DIFF
--- a/dbms/src/Columns/ColumnAggregateFunction.h
+++ b/dbms/src/Columns/ColumnAggregateFunction.h
@@ -268,6 +268,22 @@ public:
         throw Exception("Method flushNTAlignBuffer is not supported for " + getName(), ErrorCodes::NOT_IMPLEMENTED);
     }
 
+    void deserializeAndAdvancePos(PaddedPODArray<char *> & /* pos */) const override
+    {
+        throw Exception(
+            "Method deserializeAndAdvancePos is not supported for " + getName(),
+            ErrorCodes::NOT_IMPLEMENTED);
+    }
+
+    void deserializeAndAdvancePosForColumnArray(
+        PaddedPODArray<char *> & /* pos */,
+        const IColumn::Offsets & /* array_offsets */) const override
+    {
+        throw Exception(
+            "Method deserializeAndAdvancePosForColumnArray is not supported for " + getName(),
+            ErrorCodes::NOT_IMPLEMENTED);
+    }
+
     void updateHashWithValue(size_t n, SipHash & hash, const TiDB::TiDBCollatorPtr &, String &) const override;
 
     void updateHashWithValues(IColumn::HashValues & hash_values, const TiDB::TiDBCollatorPtr &, String &)

--- a/dbms/src/Columns/ColumnAggregateFunction.h
+++ b/dbms/src/Columns/ColumnAggregateFunction.h
@@ -131,10 +131,12 @@ public:
             insertFrom(src_, n);
     }
 
-    void insertSelectiveFrom(const IColumn & src_, const Offsets & selective_offsets) override
+    void insertSelectiveRangeFrom(const IColumn & src_, const Offsets & selective_offsets, size_t start, size_t length)
+        override
     {
-        for (auto position : selective_offsets)
-            insertFrom(src_, position);
+        RUNTIME_CHECK(selective_offsets.size() >= start + length);
+        for (size_t i = start; i < start + length; ++i)
+            insertFrom(src_, selective_offsets[i]);
     }
 
     void insertFrom(ConstAggregateDataPtr __restrict place);
@@ -165,6 +167,10 @@ public:
 
     const char * deserializeAndInsertFromArena(const char * src_arena, const TiDB::TiDBCollatorPtr &) override;
 
+    void countSerializeByteSize(PaddedPODArray<size_t> & /* byte_size */) const override
+    {
+        throw Exception("Method countSerializeByteSize is not supported for " + getName(), ErrorCodes::NOT_IMPLEMENTED);
+    }
     void countSerializeByteSizeForCmp(
         PaddedPODArray<size_t> & /* byte_size */,
         const NullMap * /*nullmap*/,
@@ -174,9 +180,14 @@ public:
             "Method countSerializeByteSizeForCmp is not supported for " + getName(),
             ErrorCodes::NOT_IMPLEMENTED);
     }
-    void countSerializeByteSize(PaddedPODArray<size_t> & /* byte_size */) const override
+
+    void countSerializeByteSizeForColumnArray(
+        PaddedPODArray<size_t> & /* byte_size */,
+        const IColumn::Offsets & /* offsets */) const override
     {
-        throw Exception("Method countSerializeByteSize is not supported for " + getName(), ErrorCodes::NOT_IMPLEMENTED);
+        throw Exception(
+            "Method countSerializeByteSizeForColumnArray is not supported for " + getName(),
+            ErrorCodes::NOT_IMPLEMENTED);
     }
     void countSerializeByteSizeForCmpColumnArray(
         PaddedPODArray<size_t> & /* byte_size */,
@@ -188,15 +199,15 @@ public:
             "Method countSerializeByteSizeForCmpColumnArray is not supported for " + getName(),
             ErrorCodes::NOT_IMPLEMENTED);
     }
-    void countSerializeByteSizeForColumnArray(
-        PaddedPODArray<size_t> & /* byte_size */,
-        const IColumn::Offsets & /* offsets */) const override
-    {
-        throw Exception(
-            "Method countSerializeByteSizeForColumnArray is not supported for " + getName(),
-            ErrorCodes::NOT_IMPLEMENTED);
-    }
 
+    void serializeToPos(
+        PaddedPODArray<char *> & /* pos */,
+        size_t /* start */,
+        size_t /* length */,
+        bool /* has_null */) const override
+    {
+        throw Exception("Method serializeToPos is not supported for " + getName(), ErrorCodes::NOT_IMPLEMENTED);
+    }
     void serializeToPosForCmp(
         PaddedPODArray<char *> & /* pos */,
         size_t /* start */,
@@ -208,13 +219,17 @@ public:
     {
         throw Exception("Method serializeToPosForCmp is not supported for " + getName(), ErrorCodes::NOT_IMPLEMENTED);
     }
-    void serializeToPos(
+
+    void serializeToPosForColumnArray(
         PaddedPODArray<char *> & /* pos */,
         size_t /* start */,
         size_t /* length */,
-        bool /* has_null */) const override
+        bool /* has_null */,
+        const IColumn::Offsets & /* offsets */) const override
     {
-        throw Exception("Method serializeToPos is not supported for " + getName(), ErrorCodes::NOT_IMPLEMENTED);
+        throw Exception(
+            "Method serializeToPosForColumnArray is not supported for " + getName(),
+            ErrorCodes::NOT_IMPLEMENTED);
     }
     void serializeToPosForCmpColumnArray(
         PaddedPODArray<char *> & /* pos */,
@@ -230,40 +245,20 @@ public:
             "Method serializeToPosForCmpColumnArray is not supported for " + getName(),
             ErrorCodes::NOT_IMPLEMENTED);
     }
-    void serializeToPosForColumnArray(
-        PaddedPODArray<char *> & /* pos */,
-        size_t /* start */,
-        size_t /* length */,
-        bool /* has_null */,
-        const IColumn::Offsets & /* offsets */) const override
-    {
-        throw Exception(
-            "Method serializeToPosForColumnArray is not supported for " + getName(),
-            ErrorCodes::NOT_IMPLEMENTED);
-    }
 
-    void deserializeForCmpAndInsertFromPos(PaddedPODArray<char *> & /* pos */, bool /* use_nt_align_buffer */) override
-    {
-        throw Exception(
-            "Method deserializeForCmpAndInsertFromPos is not supported for " + getName(),
-            ErrorCodes::NOT_IMPLEMENTED);
-    }
     void deserializeAndInsertFromPos(PaddedPODArray<char *> & /* pos */, bool /* use_nt_align_buffer */) override
     {
         throw Exception(
             "Method deserializeAndInsertFromPos is not supported for " + getName(),
             ErrorCodes::NOT_IMPLEMENTED);
     }
-
-    void deserializeForCmpAndInsertFromPosColumnArray(
-        PaddedPODArray<char *> & /* pos */,
-        const IColumn::Offsets & /* array_offsets */,
-        bool /* use_nt_align_buffer */) override
+    void deserializeForCmpAndInsertFromPos(PaddedPODArray<char *> & /* pos */, bool /* use_nt_align_buffer */) override
     {
         throw Exception(
-            "Method deserializeForCmpAndInsertFromPosColumnArray is not supported for " + getName(),
+            "Method deserializeForCmpAndInsertFromPos is not supported for " + getName(),
             ErrorCodes::NOT_IMPLEMENTED);
     }
+
     void deserializeAndInsertFromPosForColumnArray(
         PaddedPODArray<char *> & /* pos */,
         const IColumn::Offsets & /* array_offsets */,
@@ -271,6 +266,15 @@ public:
     {
         throw Exception(
             "Method deserializeAndInsertFromPosForColumnArray is not supported for " + getName(),
+            ErrorCodes::NOT_IMPLEMENTED);
+    }
+    void deserializeForCmpAndInsertFromPosColumnArray(
+        PaddedPODArray<char *> & /* pos */,
+        const IColumn::Offsets & /* array_offsets */,
+        bool /* use_nt_align_buffer */) override
+    {
+        throw Exception(
+            "Method deserializeForCmpAndInsertFromPosColumnArray is not supported for " + getName(),
             ErrorCodes::NOT_IMPLEMENTED);
     }
 

--- a/dbms/src/Columns/ColumnAggregateFunction.h
+++ b/dbms/src/Columns/ColumnAggregateFunction.h
@@ -252,12 +252,6 @@ public:
             "Method deserializeAndInsertFromPos is not supported for " + getName(),
             ErrorCodes::NOT_IMPLEMENTED);
     }
-    void deserializeForCmpAndInsertFromPos(PaddedPODArray<char *> & /* pos */, bool /* use_nt_align_buffer */) override
-    {
-        throw Exception(
-            "Method deserializeForCmpAndInsertFromPos is not supported for " + getName(),
-            ErrorCodes::NOT_IMPLEMENTED);
-    }
 
     void deserializeAndInsertFromPosForColumnArray(
         PaddedPODArray<char *> & /* pos */,
@@ -266,15 +260,6 @@ public:
     {
         throw Exception(
             "Method deserializeAndInsertFromPosForColumnArray is not supported for " + getName(),
-            ErrorCodes::NOT_IMPLEMENTED);
-    }
-    void deserializeForCmpAndInsertFromPosColumnArray(
-        PaddedPODArray<char *> & /* pos */,
-        const IColumn::Offsets & /* array_offsets */,
-        bool /* use_nt_align_buffer */) override
-    {
-        throw Exception(
-            "Method deserializeForCmpAndInsertFromPosColumnArray is not supported for " + getName(),
             ErrorCodes::NOT_IMPLEMENTED);
     }
 

--- a/dbms/src/Columns/ColumnArray.cpp
+++ b/dbms/src/Columns/ColumnArray.cpp
@@ -376,18 +376,7 @@ void ColumnArray::serializeToPosImpl(
         getData().serializeToPosForColumnArray(pos, start, length, has_null, getOffsets());
 }
 
-void ColumnArray::deserializeForCmpAndInsertFromPos(PaddedPODArray<char *> & pos, bool use_nt_align_buffer)
-{
-    deserializeAndInsertFromPosImpl<true>(pos, use_nt_align_buffer);
-}
-
 void ColumnArray::deserializeAndInsertFromPos(PaddedPODArray<char *> & pos, bool use_nt_align_buffer)
-{
-    deserializeAndInsertFromPosImpl<false>(pos, use_nt_align_buffer);
-}
-
-template <bool compare_semantics>
-void ColumnArray::deserializeAndInsertFromPosImpl(PaddedPODArray<char *> & pos, bool use_nt_align_buffer)
 {
     auto & offsets = getOffsets();
     size_t prev_size = offsets.size();
@@ -402,10 +391,7 @@ void ColumnArray::deserializeAndInsertFromPosImpl(PaddedPODArray<char *> & pos, 
         pos[i] += sizeof(UInt32);
     }
 
-    if constexpr (compare_semantics)
-        getData().deserializeForCmpAndInsertFromPosColumnArray(pos, offsets, use_nt_align_buffer);
-    else
-        getData().deserializeAndInsertFromPosForColumnArray(pos, offsets, use_nt_align_buffer);
+    getData().deserializeAndInsertFromPosForColumnArray(pos, offsets, use_nt_align_buffer);
 }
 
 void ColumnArray::flushNTAlignBuffer()

--- a/dbms/src/Columns/ColumnArray.cpp
+++ b/dbms/src/Columns/ColumnArray.cpp
@@ -24,13 +24,12 @@
 #include <Common/HashTable/Hash.h>
 #include <Common/SipHash.h>
 #include <Common/typeid_cast.h>
+#include <Core/Defines.h>
 #include <DataStreams/ColumnGathererStream.h>
 #include <Functions/FunctionHelpers.h>
 #include <IO/Endian.h>
 #include <IO/WriteHelpers.h>
 #include <string.h> // memcpy
-
-#include "Core/Defines.h"
 
 
 namespace DB

--- a/dbms/src/Columns/ColumnArray.h
+++ b/dbms/src/Columns/ColumnArray.h
@@ -162,7 +162,6 @@ public:
     }
 
     void deserializeAndInsertFromPos(PaddedPODArray<char *> & pos, bool use_nt_align_buffer) override;
-    void deserializeForCmpAndInsertFromPos(PaddedPODArray<char *> & pos, bool use_nt_align_buffer) override;
 
     void deserializeAndInsertFromPosForColumnArray(
         PaddedPODArray<char *> & /* pos */,
@@ -171,15 +170,6 @@ public:
     {
         throw Exception(
             "Method deserializeAndInsertFromPosForColumnArray is not supported for " + getName(),
-            ErrorCodes::NOT_IMPLEMENTED);
-    }
-    void deserializeForCmpAndInsertFromPosColumnArray(
-        PaddedPODArray<char *> & /* pos */,
-        const IColumn::Offsets & /* array_offsets */,
-        bool /* use_nt_align_buffer */) override
-    {
-        throw Exception(
-            "Method deserializeForCmpAndInsertFromPosColumnArray is not supported for " + getName(),
             ErrorCodes::NOT_IMPLEMENTED);
     }
 

--- a/dbms/src/Columns/ColumnArray.h
+++ b/dbms/src/Columns/ColumnArray.h
@@ -170,6 +170,17 @@ public:
 
     void flushNTAlignBuffer() override;
 
+    void deserializeAndAdvancePos(PaddedPODArray<char *> & pos) const override;
+
+    void deserializeAndAdvancePosForColumnArray(
+        PaddedPODArray<char *> & /* pos */,
+        const IColumn::Offsets & /* array_offsets */) const override
+    {
+        throw Exception(
+            "Method deserializeAndAdvancePosForColumnArray is not supported for " + getName(),
+            ErrorCodes::NOT_IMPLEMENTED);
+    }
+
     void updateHashWithValue(size_t n, SipHash & hash, const TiDB::TiDBCollatorPtr &, String &) const override;
     void updateHashWithValues(IColumn::HashValues & hash_values, const TiDB::TiDBCollatorPtr &, String &)
         const override;

--- a/dbms/src/Columns/ColumnArray.h
+++ b/dbms/src/Columns/ColumnArray.h
@@ -44,24 +44,6 @@ private:
 
     ColumnArray(const ColumnArray &) = default;
 
-    template <bool compare_semantics>
-    void countSerializeByteSizeImpl(
-        PaddedPODArray<size_t> & byte_size,
-        const NullMap * nullmap,
-        const TiDB::TiDBCollatorPtr & collator) const;
-
-    template <bool has_null, bool compare_semantics, bool has_nullmap>
-    void serializeToPosImpl(
-        PaddedPODArray<char *> & pos,
-        size_t start,
-        size_t length,
-        const TiDB::TiDBCollatorPtr & collator,
-        String * sort_key_container,
-        const NullMap * nullmap) const;
-
-    template <bool compare_semantics>
-    void deserializeAndInsertFromPosImpl(PaddedPODArray<char *> & pos, bool use_nt_align_buffer);
-
 public:
     /** Create immutable column using immutable arguments. This arguments may be shared with other columns.
       * Use IColumn::mutate in order to make mutable column and mutate shared nested columns.
@@ -105,6 +87,11 @@ public:
         PaddedPODArray<size_t> & byte_size,
         const NullMap * nullmap,
         const TiDB::TiDBCollatorPtr & collator) const override;
+    template <bool compare_semantics>
+    void countSerializeByteSizeImpl(
+        PaddedPODArray<size_t> & byte_size,
+        const NullMap * nullmap,
+        const TiDB::TiDBCollatorPtr & collator) const;
 
     void countSerializeByteSizeForColumnArray(
         PaddedPODArray<size_t> & /* byte_size */,
@@ -134,6 +121,14 @@ public:
         const NullMap * nullmap,
         const TiDB::TiDBCollatorPtr & collator,
         String * sort_key_container) const override;
+    template <bool has_null, bool compare_semantics, bool has_nullmap>
+    void serializeToPosImpl(
+        PaddedPODArray<char *> & pos,
+        size_t start,
+        size_t length,
+        const TiDB::TiDBCollatorPtr & collator,
+        String * sort_key_container,
+        const NullMap * nullmap) const;
 
     void serializeToPosForColumnArray(
         PaddedPODArray<char *> & /* pos */,

--- a/dbms/src/Columns/ColumnConst.h
+++ b/dbms/src/Columns/ColumnConst.h
@@ -210,6 +210,22 @@ public:
         throw Exception("Method flushNTAlignBuffer is not supported for " + getName(), ErrorCodes::NOT_IMPLEMENTED);
     }
 
+    void deserializeAndAdvancePos(PaddedPODArray<char *> & /* pos */) const override
+    {
+        throw Exception(
+            "Method deserializeAndAdvancePos is not supported for " + getName(),
+            ErrorCodes::NOT_IMPLEMENTED);
+    }
+
+    void deserializeAndAdvancePosForColumnArray(
+        PaddedPODArray<char *> & /* pos */,
+        const IColumn::Offsets & /* array_offsets */) const override
+    {
+        throw Exception(
+            "Method deserializeAndAdvancePosForColumnArray is not supported for " + getName(),
+            ErrorCodes::NOT_IMPLEMENTED);
+    }
+
     void updateHashWithValue(
         size_t,
         SipHash & hash,

--- a/dbms/src/Columns/ColumnConst.h
+++ b/dbms/src/Columns/ColumnConst.h
@@ -194,12 +194,6 @@ public:
             "Method deserializeAndInsertFromPos is not supported for " + getName(),
             ErrorCodes::NOT_IMPLEMENTED);
     }
-    void deserializeForCmpAndInsertFromPos(PaddedPODArray<char *> & /* pos */, bool /* use_nt_align_buffer */) override
-    {
-        throw Exception(
-            "Method deserializeForCmpAndInsertFromPos is not supported for " + getName(),
-            ErrorCodes::NOT_IMPLEMENTED);
-    }
 
     void deserializeAndInsertFromPosForColumnArray(
         PaddedPODArray<char *> & /* pos */,
@@ -208,15 +202,6 @@ public:
     {
         throw Exception(
             "Method deserializeAndInsertFromPosForColumnArray is not supported for " + getName(),
-            ErrorCodes::NOT_IMPLEMENTED);
-    }
-    void deserializeForCmpAndInsertFromPosColumnArray(
-        PaddedPODArray<char *> & /* pos */,
-        const IColumn::Offsets & /* array_offsets */,
-        bool /* use_nt_align_buffer */) override
-    {
-        throw Exception(
-            "Method deserializeForCmpAndInsertFromPosColumnArray is not supported for " + getName(),
             ErrorCodes::NOT_IMPLEMENTED);
     }
 

--- a/dbms/src/Columns/ColumnConst.h
+++ b/dbms/src/Columns/ColumnConst.h
@@ -80,10 +80,7 @@ public:
 
     void insertManyFrom(const IColumn &, size_t, size_t length) override { s += length; }
 
-    void insertSelectiveFrom(const IColumn &, const Offsets & selective_offsets) override
-    {
-        s += selective_offsets.size();
-    }
+    void insertSelectiveRangeFrom(const IColumn &, const Offsets &, size_t, size_t length) override { s += length; }
 
     void insertMany(const Field &, size_t length) override { s += length; }
 
@@ -112,6 +109,10 @@ public:
         return res;
     }
 
+    void countSerializeByteSize(PaddedPODArray<size_t> & /* byte_size */) const override
+    {
+        throw Exception("Method countSerializeByteSize is not supported for " + getName(), ErrorCodes::NOT_IMPLEMENTED);
+    }
     void countSerializeByteSizeForCmp(
         PaddedPODArray<size_t> & /* byte_size */,
         const NullMap * /*nullmap*/,
@@ -121,11 +122,15 @@ public:
             "Method countSerializeByteSizeForCmp is not supported for " + getName(),
             ErrorCodes::NOT_IMPLEMENTED);
     }
-    void countSerializeByteSize(PaddedPODArray<size_t> & /* byte_size */) const override
-    {
-        throw Exception("Method countSerializeByteSize is not supported for " + getName(), ErrorCodes::NOT_IMPLEMENTED);
-    }
 
+    void countSerializeByteSizeForColumnArray(
+        PaddedPODArray<size_t> & /* byte_size */,
+        const IColumn::Offsets & /* array_offsets */) const override
+    {
+        throw Exception(
+            "Method countSerializeByteSizeForColumnArray is not supported for " + getName(),
+            ErrorCodes::NOT_IMPLEMENTED);
+    }
     void countSerializeByteSizeForCmpColumnArray(
         PaddedPODArray<size_t> & /* byte_size */,
         const IColumn::Offsets & /* array_offsets */,
@@ -136,15 +141,15 @@ public:
             "Method countSerializeByteSizeForCmpColumnArray is not supported for " + getName(),
             ErrorCodes::NOT_IMPLEMENTED);
     }
-    void countSerializeByteSizeForColumnArray(
-        PaddedPODArray<size_t> & /* byte_size */,
-        const IColumn::Offsets & /* array_offsets */) const override
-    {
-        throw Exception(
-            "Method countSerializeByteSizeForColumnArray is not supported for " + getName(),
-            ErrorCodes::NOT_IMPLEMENTED);
-    }
 
+    void serializeToPos(
+        PaddedPODArray<char *> & /* pos */,
+        size_t /* start */,
+        size_t /* length */,
+        bool /* has_null */) const override
+    {
+        throw Exception("Method serializeToPos is not supported for " + getName(), ErrorCodes::NOT_IMPLEMENTED);
+    }
     void serializeToPosForCmp(
         PaddedPODArray<char *> & /* pos */,
         size_t /* start */,
@@ -156,15 +161,18 @@ public:
     {
         throw Exception("Method serializeToPosForCmp is not supported for " + getName(), ErrorCodes::NOT_IMPLEMENTED);
     }
-    void serializeToPos(
+
+    void serializeToPosForColumnArray(
         PaddedPODArray<char *> & /* pos */,
         size_t /* start */,
         size_t /* length */,
-        bool /* has_null */) const override
+        bool /* has_null */,
+        const IColumn::Offsets & /* array_offsets */) const override
     {
-        throw Exception("Method serializeToPos is not supported for " + getName(), ErrorCodes::NOT_IMPLEMENTED);
+        throw Exception(
+            "Method serializeToPosForColumnArray is not supported for " + getName(),
+            ErrorCodes::NOT_IMPLEMENTED);
     }
-
     void serializeToPosForCmpColumnArray(
         PaddedPODArray<char *> & /* pos */,
         size_t /* start */,
@@ -179,40 +187,20 @@ public:
             "Method serializeToPosForCmpColumnArray is not supported for " + getName(),
             ErrorCodes::NOT_IMPLEMENTED);
     }
-    void serializeToPosForColumnArray(
-        PaddedPODArray<char *> & /* pos */,
-        size_t /* start */,
-        size_t /* length */,
-        bool /* has_null */,
-        const IColumn::Offsets & /* array_offsets */) const override
-    {
-        throw Exception(
-            "Method serializeToPosForColumnArray is not supported for " + getName(),
-            ErrorCodes::NOT_IMPLEMENTED);
-    }
 
-    void deserializeForCmpAndInsertFromPos(PaddedPODArray<char *> & /* pos */, bool /* use_nt_align_buffer */) override
-    {
-        throw Exception(
-            "Method deserializeForCmpAndInsertFromPos is not supported for " + getName(),
-            ErrorCodes::NOT_IMPLEMENTED);
-    }
     void deserializeAndInsertFromPos(PaddedPODArray<char *> & /* pos */, bool /* use_nt_align_buffer */) override
     {
         throw Exception(
             "Method deserializeAndInsertFromPos is not supported for " + getName(),
             ErrorCodes::NOT_IMPLEMENTED);
     }
-
-    void deserializeForCmpAndInsertFromPosColumnArray(
-        PaddedPODArray<char *> & /* pos */,
-        const IColumn::Offsets & /* array_offsets */,
-        bool /* use_nt_align_buffer */) override
+    void deserializeForCmpAndInsertFromPos(PaddedPODArray<char *> & /* pos */, bool /* use_nt_align_buffer */) override
     {
         throw Exception(
-            "Method deserializeForCmpAndInsertFromPosColumnArray is not supported for " + getName(),
+            "Method deserializeForCmpAndInsertFromPos is not supported for " + getName(),
             ErrorCodes::NOT_IMPLEMENTED);
     }
+
     void deserializeAndInsertFromPosForColumnArray(
         PaddedPODArray<char *> & /* pos */,
         const IColumn::Offsets & /* array_offsets */,
@@ -220,6 +208,15 @@ public:
     {
         throw Exception(
             "Method deserializeAndInsertFromPosForColumnArray is not supported for " + getName(),
+            ErrorCodes::NOT_IMPLEMENTED);
+    }
+    void deserializeForCmpAndInsertFromPosColumnArray(
+        PaddedPODArray<char *> & /* pos */,
+        const IColumn::Offsets & /* array_offsets */,
+        bool /* use_nt_align_buffer */) override
+    {
+        throw Exception(
+            "Method deserializeForCmpAndInsertFromPosColumnArray is not supported for " + getName(),
             ErrorCodes::NOT_IMPLEMENTED);
     }
 

--- a/dbms/src/Columns/ColumnDecimal.cpp
+++ b/dbms/src/Columns/ColumnDecimal.cpp
@@ -396,7 +396,7 @@ void ColumnDecimal<T>::serializeToPosForColumnArrayImpl(
         }
 
         size_t len = array_offsets[start + i] - array_offsets[start + i - 1];
-        auto start_idx = array_offsets[start + i - 1];
+        size_t start_idx = array_offsets[start + i - 1];
         if constexpr (compare_semantics && is_Decimal256)
         {
             auto * p = pos[i];
@@ -554,7 +554,7 @@ void ColumnDecimal<T>::deserializeAndInsertFromPosForColumnArray(
     for (size_t i = 0; i < size; ++i)
     {
         size_t len = array_offsets[start_point + i] - array_offsets[start_point + i - 1];
-        auto start_idx = array_offsets[start_point + i - 1];
+        size_t start_idx = array_offsets[start_point + i - 1];
         if (len <= 4)
         {
             auto * p = pos[i];

--- a/dbms/src/Columns/ColumnDecimal.cpp
+++ b/dbms/src/Columns/ColumnDecimal.cpp
@@ -922,14 +922,18 @@ void ColumnDecimal<T>::insertManyFrom(const IColumn & src, size_t position, size
 }
 
 template <typename T>
-void ColumnDecimal<T>::insertSelectiveFrom(const IColumn & src, const IColumn::Offsets & selective_offsets)
+void ColumnDecimal<T>::insertSelectiveRangeFrom(
+    const IColumn & src,
+    const IColumn::Offsets & selective_offsets,
+    size_t start,
+    size_t length)
 {
+    RUNTIME_CHECK(selective_offsets.size() >= start + length);
     const auto & src_data = static_cast<const ColumnDecimal &>(src).data;
     size_t old_size = data.size();
-    size_t to_add_size = selective_offsets.size();
-    data.resize(old_size + to_add_size);
-    for (size_t i = 0; i < to_add_size; ++i)
-        data[i + old_size] = src_data[selective_offsets[i]];
+    data.resize(old_size + length);
+    for (size_t i = 0; i < length; ++i)
+        data[i + old_size] = src_data[selective_offsets[i + start]];
 }
 
 #pragma GCC diagnostic pop

--- a/dbms/src/Columns/ColumnDecimal.cpp
+++ b/dbms/src/Columns/ColumnDecimal.cpp
@@ -142,21 +142,13 @@ const char * ColumnDecimal<T>::deserializeAndInsertFromArena(const char * pos, c
 }
 
 template <typename T>
-void ColumnDecimal<T>::countSerializeByteSizeForCmp(
-    PaddedPODArray<size_t> & byte_size,
-    const NullMap * nullmap,
-    const TiDB::TiDBCollatorPtr &) const
-{
-    if (nullmap != nullptr)
-        countSerializeByteSizeImpl<true, true>(byte_size, nullmap);
-    else
-        countSerializeByteSizeImpl<true, false>(byte_size, nullptr);
-}
-
-template <typename T>
 void ColumnDecimal<T>::countSerializeByteSize(PaddedPODArray<size_t> & byte_size) const
 {
-    countSerializeByteSizeImpl<false, false>(byte_size, nullptr);
+    RUNTIME_CHECK_MSG(byte_size.size() == size(), "size of byte_size({}) != column size({})", byte_size.size(), size());
+
+    size_t size = byte_size.size();
+    for (size_t i = 0; i < size; ++i)
+        byte_size[i] += sizeof(T);
 }
 
 template <typename T>
@@ -167,9 +159,9 @@ void ColumnDecimal<T>::countSerializeByteSizeForCmpColumnArray(
     const TiDB::TiDBCollatorPtr &) const
 {
     if (nullmap != nullptr)
-        countSerializeByteSizeForColumnArrayImpl<true, true>(byte_size, array_offsets, nullmap);
+        countSerializeByteSizeForColumnArrayImpl<true>(byte_size, array_offsets, nullmap);
     else
-        countSerializeByteSizeForColumnArrayImpl<true, false>(byte_size, array_offsets, nullptr);
+        countSerializeByteSizeForColumnArrayImpl<false>(byte_size, array_offsets, nullptr);
 }
 
 template <typename T>
@@ -177,40 +169,11 @@ void ColumnDecimal<T>::countSerializeByteSizeForColumnArray(
     PaddedPODArray<size_t> & byte_size,
     const IColumn::Offsets & array_offsets) const
 {
-    countSerializeByteSizeForColumnArrayImpl<false, false>(byte_size, array_offsets, nullptr);
+    countSerializeByteSizeForColumnArrayImpl<false>(byte_size, array_offsets, nullptr);
 }
 
 template <typename T>
-template <bool compare_semantics, bool has_nullmap>
-void ColumnDecimal<T>::countSerializeByteSizeImpl(PaddedPODArray<size_t> & byte_size, const NullMap * nullmap) const
-{
-    RUNTIME_CHECK_MSG(byte_size.size() == size(), "size of byte_size({}) != column size({})", byte_size.size(), size());
-
-    size_t size = byte_size.size();
-    static constexpr T def_val{};
-    for (size_t i = 0; i < size; ++i)
-    {
-        if constexpr (compare_semantics && is_Decimal256)
-        {
-            if constexpr (has_nullmap)
-            {
-                if (DB::isNullAt(*nullmap, i))
-                {
-                    byte_size[i] += getDecimal256BytesSize(def_val);
-                    continue;
-                }
-            }
-            byte_size[i] += getDecimal256BytesSize(data[i]);
-        }
-        else
-        {
-            byte_size[i] += sizeof(T);
-        }
-    }
-}
-
-template <typename T>
-template <bool compare_semantics, bool has_nullmap>
+template <bool has_nullmap>
 void ColumnDecimal<T>::countSerializeByteSizeForColumnArrayImpl(
     PaddedPODArray<size_t> & byte_size,
     const IColumn::Offsets & array_offsets,
@@ -230,18 +193,7 @@ void ColumnDecimal<T>::countSerializeByteSizeForColumnArrayImpl(
             if (DB::isNullAt(*nullmap, i))
                 continue;
         }
-        if constexpr (compare_semantics && is_Decimal256)
-        {
-            size_t cur_size = 0;
-            for (size_t j = array_offsets[i - 1]; j < array_offsets[i]; ++j)
-                cur_size += getDecimal256BytesSize(data[j]);
-
-            byte_size[i] += cur_size;
-        }
-        else
-        {
-            byte_size[i] += sizeof(T) * (array_offsets[i] - array_offsets[i - 1]);
-        }
+        byte_size[i] += sizeof(T) * (array_offsets[i] - array_offsets[i - 1]);
     }
 }
 
@@ -255,36 +207,27 @@ void ColumnDecimal<T>::serializeToPosForCmp(
     const TiDB::TiDBCollatorPtr &,
     String *) const
 {
+#define CALL(has_null, has_nullmap)                                                   \
+    {                                                                                 \
+        serializeToPosImpl<has_null, true, has_nullmap>(pos, start, length, nullmap); \
+    }
+
     if (has_null)
     {
         if (nullmap != nullptr)
-            serializeToPosImpl</*has_null=*/true, /*compare_semantics=*/true, /*has_nullmap=*/true>(
-                pos,
-                start,
-                length,
-                nullmap);
+            CALL(true, true)
         else
-            serializeToPosImpl</*has_null=*/true, /*compare_semantics=*/true, /*has_nullmap=*/false>(
-                pos,
-                start,
-                length,
-                nullptr);
+            CALL(true, false)
     }
     else
     {
         if (nullmap != nullptr)
-            serializeToPosImpl</*has_null=*/false, /*compare_semantics=*/true, /*has_nullmap=*/true>(
-                pos,
-                start,
-                length,
-                nullmap);
+            CALL(false, true)
         else
-            serializeToPosImpl</*has_null=*/false, /*compare_semantics=*/true, /*has_nullmap=*/false>(
-                pos,
-                start,
-                length,
-                nullptr);
+            CALL(false, false)
     }
+
+#undef CALL
 }
 
 template <typename T>
@@ -305,6 +248,53 @@ void ColumnDecimal<T>::serializeToPos(PaddedPODArray<char *> & pos, size_t start
 }
 
 template <typename T>
+template <bool has_null, bool compare_semantics, bool has_nullmap>
+void ColumnDecimal<T>::serializeToPosImpl(
+    PaddedPODArray<char *> & pos,
+    size_t start,
+    size_t length,
+    const NullMap * nullmap) const
+{
+    RUNTIME_CHECK_MSG(length <= pos.size(), "length({}) > size of pos({})", length, pos.size());
+    RUNTIME_CHECK_MSG(start + length <= size(), "start({}) + length({}) > size of column({})", start, length, size());
+
+    RUNTIME_CHECK(!has_nullmap || (nullmap && nullmap->size() == size()));
+
+    static constexpr T def_val{};
+    T tmp_val{};
+    for (size_t i = 0; i < length; ++i)
+    {
+        if constexpr (has_null)
+        {
+            if (pos[i] == nullptr)
+                continue;
+        }
+        if constexpr (has_nullmap)
+        {
+            if (DB::isNullAt(*nullmap, start + i))
+            {
+                tiflash_compiler_builtin_memcpy(pos[i], &def_val, sizeof(T));
+                pos[i] += sizeof(T);
+                continue;
+            }
+        }
+
+        if constexpr (compare_semantics && is_Decimal256)
+        {
+            // Clear the value and only set the necessary parts for compare semantic
+            memset(static_cast<void *>(&tmp_val), 0, sizeof(T));
+            tmp_val.value.backend().assign(data[start + i].value.backend());
+            tiflash_compiler_builtin_memcpy(pos[i], &tmp_val, sizeof(T));
+        }
+        else
+        {
+            tiflash_compiler_builtin_memcpy(pos[i], &data[start + i], sizeof(T));
+        }
+        pos[i] += sizeof(T);
+    }
+}
+
+template <typename T>
 void ColumnDecimal<T>::serializeToPosForCmpColumnArray(
     PaddedPODArray<char *> & pos,
     size_t start,
@@ -315,40 +305,27 @@ void ColumnDecimal<T>::serializeToPosForCmpColumnArray(
     const TiDB::TiDBCollatorPtr &,
     String *) const
 {
+#define CALL(has_null, has_nullmap)                                                                                \
+    {                                                                                                              \
+        serializeToPosForColumnArrayImpl<has_null, true, has_nullmap>(pos, start, length, array_offsets, nullmap); \
+    }
+
     if (has_null)
     {
         if (nullmap != nullptr)
-            serializeToPosForColumnArrayImpl</*has_null=*/true, /*compare_semantics=*/true, /*has_nullmap=*/true>(
-                pos,
-                start,
-                length,
-                array_offsets,
-                nullmap);
+            CALL(true, true)
         else
-            serializeToPosForColumnArrayImpl</*has_null=*/true, /*compare_semantics=*/true, /*has_nullmap=*/false>(
-                pos,
-                start,
-                length,
-                array_offsets,
-                nullptr);
+            CALL(true, false)
     }
     else
     {
         if (nullmap != nullptr)
-            serializeToPosForColumnArrayImpl</*has_null=*/false, /*compare_semantics=*/true, /*has_nullmap=*/true>(
-                pos,
-                start,
-                length,
-                array_offsets,
-                nullmap);
+            CALL(false, true)
         else
-            serializeToPosForColumnArrayImpl</*has_null=*/false, /*compare_semantics=*/true, /*has_nullmap=*/false>(
-                pos,
-                start,
-                length,
-                array_offsets,
-                nullptr);
+            CALL(false, false)
     }
+
+#undef CALL
 }
 
 template <typename T>
@@ -377,56 +354,6 @@ void ColumnDecimal<T>::serializeToPosForColumnArray(
 
 template <typename T>
 template <bool has_null, bool compare_semantics, bool has_nullmap>
-void ColumnDecimal<T>::serializeToPosImpl(
-    PaddedPODArray<char *> & pos,
-    size_t start,
-    size_t length,
-    const NullMap * nullmap) const
-{
-    RUNTIME_CHECK_MSG(length <= pos.size(), "length({}) > size of pos({})", length, pos.size());
-    RUNTIME_CHECK_MSG(start + length <= size(), "start({}) + length({}) > size of column({})", start, length, size());
-
-    RUNTIME_CHECK(!has_nullmap || (nullmap && nullmap->size() == size()));
-
-    static constexpr T def_val{};
-    for (size_t i = 0; i < length; ++i)
-    {
-        if constexpr (has_null)
-        {
-            if (pos[i] == nullptr)
-                continue;
-        }
-        if constexpr (has_nullmap)
-        {
-            if (DB::isNullAt(*nullmap, start + i))
-            {
-                if constexpr (compare_semantics && is_Decimal256)
-                {
-                    pos[i] = serializeDecimal256Helper(pos[i], def_val);
-                }
-                else
-                {
-                    tiflash_compiler_builtin_memcpy(pos[i], &def_val, sizeof(T));
-                    pos[i] += sizeof(T);
-                }
-                continue;
-            }
-        }
-
-        if constexpr (compare_semantics && is_Decimal256)
-        {
-            pos[i] = serializeDecimal256Helper(pos[i], data[start + i]);
-        }
-        else
-        {
-            tiflash_compiler_builtin_memcpy(pos[i], &data[start + i], sizeof(T));
-            pos[i] += sizeof(T);
-        }
-    }
-}
-
-template <typename T>
-template <bool has_null, bool compare_semantics, bool has_nullmap>
 void ColumnDecimal<T>::serializeToPosForColumnArrayImpl(
     PaddedPODArray<char *> & pos,
     size_t start,
@@ -449,6 +376,7 @@ void ColumnDecimal<T>::serializeToPosForColumnArrayImpl(
 
     RUNTIME_CHECK(!has_nullmap || (nullmap && nullmap->size() == array_offsets.size()));
 
+    T tmp_val{};
     for (size_t i = 0; i < length; ++i)
     {
         if constexpr (has_null)
@@ -465,75 +393,51 @@ void ColumnDecimal<T>::serializeToPosForColumnArrayImpl(
         size_t len = array_offsets[start + i] - array_offsets[start + i - 1];
         if constexpr (compare_semantics && is_Decimal256)
         {
+            auto * p = pos[i];
             for (size_t j = 0; j < len; ++j)
-                pos[i] = serializeDecimal256Helper(pos[i], data[array_offsets[start + i - 1] + j]);
+            {
+                // Clear the value and only set the necessary parts for compare semantic
+                memset(static_cast<void *>(&tmp_val), 0, sizeof(T));
+                tmp_val.value.backend().assign(data[start + i].value.backend());
+                tiflash_compiler_builtin_memcpy(p, &tmp_val, sizeof(T));
+                p += sizeof(T);
+            }
+            pos[i] = p;
         }
         else
         {
+            auto start_idx = array_offsets[start + i - 1];
             if (len <= 4)
             {
+                auto * p = pos[i];
                 for (size_t j = 0; j < len; ++j)
-                    tiflash_compiler_builtin_memcpy(
-                        pos[i] + j * sizeof(T),
-                        &data[array_offsets[start + i - 1] + j],
-                        sizeof(T));
+                {
+                    tiflash_compiler_builtin_memcpy(p, &data[start_idx + j], sizeof(T));
+                    p += sizeof(T);
+                }
+                pos[i] = p;
             }
             else
             {
-                inline_memcpy(pos[i], &data[array_offsets[start + i - 1]], len * sizeof(T));
+                inline_memcpy(pos[i], &data[start_idx], len * sizeof(T));
+                pos[i] += len * sizeof(T);
             }
-            pos[i] += len * sizeof(T);
         }
     }
 }
 
 template <typename T>
-void ColumnDecimal<T>::deserializeForCmpAndInsertFromPos(PaddedPODArray<char *> & pos, bool use_nt_align_buffer)
-{
-    deserializeAndInsertFromPosImpl<true>(pos, use_nt_align_buffer);
-}
-
-template <typename T>
-void ColumnDecimal<T>::deserializeAndInsertFromPos(PaddedPODArray<char *> & pos, bool use_nt_align_buffer)
-{
-    deserializeAndInsertFromPosImpl<false>(pos, use_nt_align_buffer);
-}
-
-template <typename T>
-void ColumnDecimal<T>::deserializeForCmpAndInsertFromPosColumnArray(
-    PaddedPODArray<char *> & pos,
-    const IColumn::Offsets & array_offsets,
-    bool use_nt_align_buffer)
-{
-    deserializeAndInsertFromPosForColumnArrayImpl<true>(pos, array_offsets, use_nt_align_buffer);
-}
-
-template <typename T>
-void ColumnDecimal<T>::deserializeAndInsertFromPosForColumnArray(
-    PaddedPODArray<char *> & pos,
-    const IColumn::Offsets & array_offsets,
-    bool use_nt_align_buffer)
-{
-    deserializeAndInsertFromPosForColumnArrayImpl<false>(pos, array_offsets, use_nt_align_buffer);
-}
-
-template <typename T>
-template <bool compare_semantics>
-void ColumnDecimal<T>::deserializeAndInsertFromPosImpl(
+void ColumnDecimal<T>::deserializeAndInsertFromPos(
     PaddedPODArray<char *> & pos,
     bool use_nt_align_buffer [[maybe_unused]])
 {
     size_t prev_size = data.size();
     size_t size = pos.size();
 
-    // is_complex_decimal256 is true means Decimal256 is serialized by [bool, limb_count, n * limb].
-    // NT optimization is not implemented for simplicity.
-    static const bool is_complex_decimal256 = (compare_semantics && is_Decimal256);
-
 #ifdef TIFLASH_ENABLE_AVX_SUPPORT
     if (use_nt_align_buffer)
     {
-        if constexpr ((FULL_VECTOR_SIZE_AVX2 % sizeof(T) == 0) && !is_complex_decimal256)
+        if constexpr ((FULL_VECTOR_SIZE_AVX2 % sizeof(T) == 0))
         {
             bool is_aligned = reinterpret_cast<std::uintptr_t>(&data[prev_size]) % FULL_VECTOR_SIZE_AVX2 == 0;
             if likely (is_aligned)
@@ -610,24 +514,21 @@ void ColumnDecimal<T>::deserializeAndInsertFromPosImpl(
 #endif
 
     data.resize(prev_size + size);
-    if constexpr (is_complex_decimal256)
+    for (size_t i = 0; i < size; ++i)
     {
-        for (size_t i = 0; i < size; ++i)
-            pos[i] = const_cast<char *>(deserializeDecimal256Helper(data[prev_size + i], pos[i]));
-    }
-    else
-    {
-        for (size_t i = 0; i < size; ++i)
-        {
-            tiflash_compiler_builtin_memcpy(&data[prev_size + i], pos[i], sizeof(T));
-            pos[i] += sizeof(T);
-        }
+        tiflash_compiler_builtin_memcpy(&data[prev_size + i], pos[i], sizeof(T));
+        pos[i] += sizeof(T);
     }
 }
 
 template <typename T>
-template <bool compare_semantics>
-void ColumnDecimal<T>::deserializeAndInsertFromPosForColumnArrayImpl(
+void ColumnDecimal<T>::deserializeForCmpAndInsertFromPos(PaddedPODArray<char *> & pos, bool use_nt_align_buffer)
+{
+    deserializeAndInsertFromPos(pos, use_nt_align_buffer);
+}
+
+template <typename T>
+void ColumnDecimal<T>::deserializeAndInsertFromPosForColumnArray(
     PaddedPODArray<char *> & pos,
     const IColumn::Offsets & array_offsets,
     bool use_nt_align_buffer [[maybe_unused]])
@@ -653,29 +554,32 @@ void ColumnDecimal<T>::deserializeAndInsertFromPosForColumnArrayImpl(
     for (size_t i = 0; i < size; ++i)
     {
         size_t len = array_offsets[start_point + i] - array_offsets[start_point + i - 1];
-        if constexpr (compare_semantics && is_Decimal256)
+        auto start_idx = array_offsets[start_point + i - 1];
+        if (len <= 4)
         {
+            auto * p = pos[i];
             for (size_t j = 0; j < len; ++j)
-                pos[i] = const_cast<char *>(
-                    deserializeDecimal256Helper(data[array_offsets[start_point + i - 1] + j], pos[i]));
+            {
+                tiflash_compiler_builtin_memcpy(&data[start_idx + j], p, sizeof(T));
+                p += sizeof(T);
+            }
+            pos[i] = p;
         }
         else
         {
-            if (len <= 4)
-            {
-                for (size_t j = 0; j < len; ++j)
-                    tiflash_compiler_builtin_memcpy(
-                        &data[array_offsets[start_point + i - 1] + j],
-                        pos[i] + j * sizeof(T),
-                        sizeof(T));
-            }
-            else
-            {
-                inline_memcpy(&data[array_offsets[start_point + i - 1]], pos[i], len * sizeof(T));
-            }
+            inline_memcpy(&data[start_idx], pos[i], len * sizeof(T));
             pos[i] += len * sizeof(T);
         }
     }
+}
+
+template <typename T>
+void ColumnDecimal<T>::deserializeForCmpAndInsertFromPosColumnArray(
+    PaddedPODArray<char *> & pos,
+    const IColumn::Offsets & array_offsets,
+    bool use_nt_align_buffer)
+{
+    deserializeAndInsertFromPosForColumnArray(pos, array_offsets, use_nt_align_buffer);
 }
 
 template <typename T>

--- a/dbms/src/Columns/ColumnDecimal.h
+++ b/dbms/src/Columns/ColumnDecimal.h
@@ -219,6 +219,14 @@ public:
 
     void flushNTAlignBuffer() override;
 
+    void deserializeAndAdvancePos(PaddedPODArray<char *> & pos) const override
+    {
+        IColumn::advancePosByOffset(pos, sizeof(T));
+    }
+
+    void deserializeAndAdvancePosForColumnArray(PaddedPODArray<char *> & pos, const IColumn::Offsets & array_offsets)
+        const override;
+
     void updateHashWithValue(size_t n, SipHash & hash, const TiDB::TiDBCollatorPtr &, String &) const override;
     void updateHashWithValues(IColumn::HashValues & hash_values, const TiDB::TiDBCollatorPtr &, String &)
         const override;

--- a/dbms/src/Columns/ColumnDecimal.h
+++ b/dbms/src/Columns/ColumnDecimal.h
@@ -155,7 +155,11 @@ public:
     void insert(const Field & x) override { data.push_back(DB::get<typename NearestFieldType<T>::Type>(x)); }
     void insertRangeFrom(const IColumn & src, size_t start, size_t length) override;
     void insertManyFrom(const IColumn & src_, size_t position, size_t length) override;
-    void insertSelectiveFrom(const IColumn & src_, const IColumn::Offsets & selective_offsets) override;
+    void insertSelectiveRangeFrom(
+        const IColumn & src_,
+        const IColumn::Offsets & selective_offsets,
+        size_t start,
+        size_t length) override;
     void popBack(size_t n) override { data.resize_assume_reserved(data.size() - n); }
 
     StringRef getRawData() const override
@@ -175,21 +179,22 @@ public:
         String &) const override;
     const char * deserializeAndInsertFromArena(const char * pos, const TiDB::TiDBCollatorPtr &) override;
 
+    void countSerializeByteSize(PaddedPODArray<size_t> & byte_size) const override;
     void countSerializeByteSizeForCmp(
         PaddedPODArray<size_t> & byte_size,
         const NullMap * nullmap,
         const TiDB::TiDBCollatorPtr &) const override;
-    void countSerializeByteSize(PaddedPODArray<size_t> & byte_size) const override;
 
+    void countSerializeByteSizeForColumnArray(
+        PaddedPODArray<size_t> & byte_size,
+        const IColumn::Offsets & array_offsets) const override;
     void countSerializeByteSizeForCmpColumnArray(
         PaddedPODArray<size_t> & byte_size,
         const IColumn::Offsets & array_offsets,
         const NullMap * nullmap,
         const TiDB::TiDBCollatorPtr &) const override;
-    void countSerializeByteSizeForColumnArray(
-        PaddedPODArray<size_t> & byte_size,
-        const IColumn::Offsets & array_offsets) const override;
 
+    void serializeToPos(PaddedPODArray<char *> & pos, size_t start, size_t length, bool has_null) const override;
     void serializeToPosForCmp(
         PaddedPODArray<char *> & pos,
         size_t start,
@@ -198,8 +203,13 @@ public:
         const NullMap * nullmap,
         const TiDB::TiDBCollatorPtr &,
         String *) const override;
-    void serializeToPos(PaddedPODArray<char *> & pos, size_t start, size_t length, bool has_null) const override;
 
+    void serializeToPosForColumnArray(
+        PaddedPODArray<char *> & pos,
+        size_t start,
+        size_t length,
+        bool has_null,
+        const IColumn::Offsets & array_offsets) const override;
     void serializeToPosForCmpColumnArray(
         PaddedPODArray<char *> & pos,
         size_t start,
@@ -209,21 +219,15 @@ public:
         const IColumn::Offsets & array_offsets,
         const TiDB::TiDBCollatorPtr &,
         String *) const override;
-    void serializeToPosForColumnArray(
-        PaddedPODArray<char *> & pos,
-        size_t start,
-        size_t length,
-        bool has_null,
-        const IColumn::Offsets & array_offsets) const override;
 
-    void deserializeForCmpAndInsertFromPos(PaddedPODArray<char *> & pos, bool use_nt_align_buffer) override;
     void deserializeAndInsertFromPos(PaddedPODArray<char *> & pos, bool use_nt_align_buffer) override;
+    void deserializeForCmpAndInsertFromPos(PaddedPODArray<char *> & pos, bool use_nt_align_buffer) override;
 
-    void deserializeForCmpAndInsertFromPosColumnArray(
+    void deserializeAndInsertFromPosForColumnArray(
         PaddedPODArray<char *> & pos,
         const IColumn::Offsets & array_offsets,
         bool use_nt_align_buffer) override;
-    void deserializeAndInsertFromPosForColumnArray(
+    void deserializeForCmpAndInsertFromPosColumnArray(
         PaddedPODArray<char *> & pos,
         const IColumn::Offsets & array_offsets,
         bool use_nt_align_buffer) override;

--- a/dbms/src/Columns/ColumnDecimal.h
+++ b/dbms/src/Columns/ColumnDecimal.h
@@ -101,33 +101,6 @@ private:
         , scale(src.scale)
     {}
 
-    template <bool compare_semantics, bool has_nullmap>
-    void countSerializeByteSizeImpl(PaddedPODArray<size_t> & byte_size, const NullMap * nullmap) const;
-    template <bool compare_semantics, bool has_nullmap>
-    void countSerializeByteSizeForColumnArrayImpl(
-        PaddedPODArray<size_t> & byte_size,
-        const IColumn::Offsets & array_offsets,
-        const NullMap * nullmap) const;
-
-    template <bool has_null, bool compare_semantics, bool has_nullmap>
-    void serializeToPosImpl(PaddedPODArray<char *> & pos, size_t start, size_t length, const NullMap * nullmap) const;
-    template <bool has_null, bool compare_semantics, bool has_nullmap>
-    void serializeToPosForColumnArrayImpl(
-        PaddedPODArray<char *> & pos,
-        size_t start,
-        size_t length,
-        const IColumn::Offsets & array_offsets,
-        const NullMap * nullmap) const;
-
-    template <bool compare_semantics>
-    void deserializeAndInsertFromPosImpl(PaddedPODArray<char *> & pos, bool use_nt_align_buffer [[maybe_unused]]);
-
-    template <bool compare_semantics>
-    void deserializeAndInsertFromPosForColumnArrayImpl(
-        PaddedPODArray<char *> & pos,
-        const IColumn::Offsets & array_offsets,
-        bool use_nt_align_buffer [[maybe_unused]]);
-
 public:
     const char * getFamilyName() const override { return TypeName<T>::get(); }
 
@@ -182,8 +155,11 @@ public:
     void countSerializeByteSize(PaddedPODArray<size_t> & byte_size) const override;
     void countSerializeByteSizeForCmp(
         PaddedPODArray<size_t> & byte_size,
-        const NullMap * nullmap,
-        const TiDB::TiDBCollatorPtr &) const override;
+        const NullMap * /* nullmap */,
+        const TiDB::TiDBCollatorPtr &) const override
+    {
+        countSerializeByteSize(byte_size);
+    }
 
     void countSerializeByteSizeForColumnArray(
         PaddedPODArray<size_t> & byte_size,
@@ -193,6 +169,11 @@ public:
         const IColumn::Offsets & array_offsets,
         const NullMap * nullmap,
         const TiDB::TiDBCollatorPtr &) const override;
+    template <bool has_nullmap>
+    void countSerializeByteSizeForColumnArrayImpl(
+        PaddedPODArray<size_t> & byte_size,
+        const IColumn::Offsets & array_offsets,
+        const NullMap * nullmap) const;
 
     void serializeToPos(PaddedPODArray<char *> & pos, size_t start, size_t length, bool has_null) const override;
     void serializeToPosForCmp(
@@ -203,6 +184,8 @@ public:
         const NullMap * nullmap,
         const TiDB::TiDBCollatorPtr &,
         String *) const override;
+    template <bool has_null, bool compare_semantics, bool has_nullmap>
+    void serializeToPosImpl(PaddedPODArray<char *> & pos, size_t start, size_t length, const NullMap * nullmap) const;
 
     void serializeToPosForColumnArray(
         PaddedPODArray<char *> & pos,
@@ -219,6 +202,13 @@ public:
         const IColumn::Offsets & array_offsets,
         const TiDB::TiDBCollatorPtr &,
         String *) const override;
+    template <bool has_null, bool compare_semantics, bool has_nullmap>
+    void serializeToPosForColumnArrayImpl(
+        PaddedPODArray<char *> & pos,
+        size_t start,
+        size_t length,
+        const IColumn::Offsets & array_offsets,
+        const NullMap * nullmap) const;
 
     void deserializeAndInsertFromPos(PaddedPODArray<char *> & pos, bool use_nt_align_buffer) override;
     void deserializeForCmpAndInsertFromPos(PaddedPODArray<char *> & pos, bool use_nt_align_buffer) override;

--- a/dbms/src/Columns/ColumnDecimal.h
+++ b/dbms/src/Columns/ColumnDecimal.h
@@ -211,13 +211,8 @@ public:
         const NullMap * nullmap) const;
 
     void deserializeAndInsertFromPos(PaddedPODArray<char *> & pos, bool use_nt_align_buffer) override;
-    void deserializeForCmpAndInsertFromPos(PaddedPODArray<char *> & pos, bool use_nt_align_buffer) override;
 
     void deserializeAndInsertFromPosForColumnArray(
-        PaddedPODArray<char *> & pos,
-        const IColumn::Offsets & array_offsets,
-        bool use_nt_align_buffer) override;
-    void deserializeForCmpAndInsertFromPosColumnArray(
         PaddedPODArray<char *> & pos,
         const IColumn::Offsets & array_offsets,
         bool use_nt_align_buffer) override;

--- a/dbms/src/Columns/ColumnFixedString.cpp
+++ b/dbms/src/Columns/ColumnFixedString.cpp
@@ -403,6 +403,23 @@ void ColumnFixedString::deserializeAndInsertFromPosForColumnArray(
     }
 }
 
+void ColumnFixedString::deserializeAndAdvancePosForColumnArray(
+    PaddedPODArray<char *> & pos,
+    const IColumn::Offsets & array_offsets) const
+{
+    RUNTIME_CHECK_MSG(
+        pos.size() == array_offsets.size(),
+        "size of pos({}) != size of array_offsets({})",
+        pos.size(),
+        array_offsets.size());
+    size_t size = pos.size();
+    for (size_t i = 0; i < size; ++i)
+    {
+        size_t len = array_offsets[i] - array_offsets[i - 1];
+        pos[i] += n * len;
+    }
+}
+
 void ColumnFixedString::updateHashWithValue(size_t index, SipHash & hash, const TiDB::TiDBCollatorPtr &, String &) const
 {
     hash.update(reinterpret_cast<const char *>(&chars[n * index]), n);

--- a/dbms/src/Columns/ColumnFixedString.cpp
+++ b/dbms/src/Columns/ColumnFixedString.cpp
@@ -89,16 +89,20 @@ void ColumnFixedString::insertManyFrom(const IColumn & src_, size_t position, si
         memcpySmallAllowReadWriteOverflow15(&chars[i], src_char_ptr, n);
 }
 
-void ColumnFixedString::insertSelectiveFrom(const IColumn & src_, const Offsets & selective_offsets)
+void ColumnFixedString::insertSelectiveRangeFrom(
+    const IColumn & src_,
+    const Offsets & selective_offsets,
+    size_t start,
+    size_t length)
 {
     const auto & src = static_cast<const ColumnFixedString &>(src_);
     if (n != src.getN())
         throw Exception("Size of FixedString doesn't match", ErrorCodes::SIZE_OF_FIXED_STRING_DOESNT_MATCH);
     size_t old_size = chars.size();
-    size_t new_size = old_size + selective_offsets.size() * n;
+    size_t new_size = old_size + length * n;
     chars.resize(new_size);
     const auto & src_chars = src.chars;
-    for (size_t i = old_size, j = 0; i < new_size; i += n, ++j)
+    for (size_t i = old_size, j = start; i < new_size; i += n, ++j)
         memcpySmallAllowReadWriteOverflow15(&chars[i], &src_chars[selective_offsets[j] * n], n);
 }
 

--- a/dbms/src/Columns/ColumnFixedString.h
+++ b/dbms/src/Columns/ColumnFixedString.h
@@ -169,6 +169,11 @@ public:
 
     void flushNTAlignBuffer() override {}
 
+    void deserializeAndAdvancePos(PaddedPODArray<char *> & pos) const override { IColumn::advancePosByOffset(pos, n); }
+
+    void deserializeAndAdvancePosForColumnArray(PaddedPODArray<char *> & pos, const IColumn::Offsets & array_offsets)
+        const override;
+
     void updateHashWithValue(size_t index, SipHash & hash, const TiDB::TiDBCollatorPtr &, String &) const override;
 
     void updateHashWithValues(IColumn::HashValues & hash_values, const TiDB::TiDBCollatorPtr &, String &)

--- a/dbms/src/Columns/ColumnFixedString.h
+++ b/dbms/src/Columns/ColumnFixedString.h
@@ -177,22 +177,11 @@ public:
         String *) const override;
 
     void deserializeAndInsertFromPos(PaddedPODArray<char *> & pos, bool use_nt_align_buffer) override;
-    void deserializeForCmpAndInsertFromPos(PaddedPODArray<char *> & pos, bool use_nt_align_buffer) override
-    {
-        deserializeAndInsertFromPos(pos, use_nt_align_buffer);
-    }
 
     void deserializeAndInsertFromPosForColumnArray(
         PaddedPODArray<char *> & pos,
         const IColumn::Offsets & array_offsets,
         bool use_nt_align_buffer) override;
-    void deserializeForCmpAndInsertFromPosColumnArray(
-        PaddedPODArray<char *> & pos,
-        const IColumn::Offsets & array_offsets,
-        bool use_nt_align_buffer) override
-    {
-        deserializeAndInsertFromPosForColumnArray(pos, array_offsets, use_nt_align_buffer);
-    }
 
     void flushNTAlignBuffer() override {}
 

--- a/dbms/src/Columns/ColumnFunction.h
+++ b/dbms/src/Columns/ColumnFunction.h
@@ -99,7 +99,7 @@ public:
         throw Exception("Cannot insert into " + getName(), ErrorCodes::NOT_IMPLEMENTED);
     }
 
-    void insertSelectiveFrom(const IColumn &, const Offsets &) override
+    void insertSelectiveRangeFrom(const IColumn &, const Offsets &, size_t, size_t) override
     {
         throw Exception("Cannot insert into " + getName(), ErrorCodes::NOT_IMPLEMENTED);
     }
@@ -120,6 +120,10 @@ public:
         throw Exception("Cannot deserialize to " + getName(), ErrorCodes::NOT_IMPLEMENTED);
     }
 
+    void countSerializeByteSize(PaddedPODArray<size_t> & /* byte_size */) const override
+    {
+        throw Exception("Method countSerializeByteSize is not supported for " + getName(), ErrorCodes::NOT_IMPLEMENTED);
+    }
     void countSerializeByteSizeForCmp(
         PaddedPODArray<size_t> & /* byte_size */,
         const NullMap * /*nullmap*/,
@@ -129,11 +133,15 @@ public:
             "Method countSerializeByteSizeForCmp is not supported for " + getName(),
             ErrorCodes::NOT_IMPLEMENTED);
     }
-    void countSerializeByteSize(PaddedPODArray<size_t> & /* byte_size */) const override
-    {
-        throw Exception("Method countSerializeByteSize is not supported for " + getName(), ErrorCodes::NOT_IMPLEMENTED);
-    }
 
+    void countSerializeByteSizeForColumnArray(
+        PaddedPODArray<size_t> & /* byte_size */,
+        const IColumn::Offsets & /* offsets */) const override
+    {
+        throw Exception(
+            "Method countSerializeByteSizeForColumnArray is not supported for " + getName(),
+            ErrorCodes::NOT_IMPLEMENTED);
+    }
     void countSerializeByteSizeForCmpColumnArray(
         PaddedPODArray<size_t> & /* byte_size */,
         const IColumn::Offsets & /* offsets */,
@@ -144,15 +152,15 @@ public:
             "Method countSerializeByteSizeForCmpColumnArray is not supported for " + getName(),
             ErrorCodes::NOT_IMPLEMENTED);
     }
-    void countSerializeByteSizeForColumnArray(
-        PaddedPODArray<size_t> & /* byte_size */,
-        const IColumn::Offsets & /* offsets */) const override
-    {
-        throw Exception(
-            "Method countSerializeByteSizeForColumnArray is not supported for " + getName(),
-            ErrorCodes::NOT_IMPLEMENTED);
-    }
 
+    void serializeToPos(
+        PaddedPODArray<char *> & /* pos */,
+        size_t /* start */,
+        size_t /* length */,
+        bool /* has_null */) const override
+    {
+        throw Exception("Method serializeToPos is not supported for " + getName(), ErrorCodes::NOT_IMPLEMENTED);
+    }
     void serializeToPosForCmp(
         PaddedPODArray<char *> & /* pos */,
         size_t /* start */,
@@ -164,15 +172,18 @@ public:
     {
         throw Exception("Method serializeToPosForCmp is not supported for " + getName(), ErrorCodes::NOT_IMPLEMENTED);
     }
-    void serializeToPos(
+
+    void serializeToPosForColumnArray(
         PaddedPODArray<char *> & /* pos */,
         size_t /* start */,
         size_t /* length */,
-        bool /* has_null */) const override
+        bool /* has_null */,
+        const IColumn::Offsets & /* array_offsets */) const override
     {
-        throw Exception("Method serializeToPos is not supported for " + getName(), ErrorCodes::NOT_IMPLEMENTED);
+        throw Exception(
+            "Method serializeToPosForColumnArray is not supported for " + getName(),
+            ErrorCodes::NOT_IMPLEMENTED);
     }
-
     void serializeToPosForCmpColumnArray(
         PaddedPODArray<char *> & /* pos */,
         size_t /* start */,
@@ -187,40 +198,20 @@ public:
             "Method serializeToPosForCmpColumnArray is not supported for " + getName(),
             ErrorCodes::NOT_IMPLEMENTED);
     }
-    void serializeToPosForColumnArray(
-        PaddedPODArray<char *> & /* pos */,
-        size_t /* start */,
-        size_t /* length */,
-        bool /* has_null */,
-        const IColumn::Offsets & /* array_offsets */) const override
-    {
-        throw Exception(
-            "Method serializeToPosForColumnArray is not supported for " + getName(),
-            ErrorCodes::NOT_IMPLEMENTED);
-    }
 
-    void deserializeForCmpAndInsertFromPos(PaddedPODArray<char *> & /* pos */, bool /* use_nt_align_buffer */) override
-    {
-        throw Exception(
-            "Method deserializeForCmpAndInsertFromPos is not supported for " + getName(),
-            ErrorCodes::NOT_IMPLEMENTED);
-    }
     void deserializeAndInsertFromPos(PaddedPODArray<char *> & /* pos */, bool /* use_nt_align_buffer */) override
     {
         throw Exception(
             "Method deserializeAndInsertFromPos is not supported for " + getName(),
             ErrorCodes::NOT_IMPLEMENTED);
     }
-
-    void deserializeForCmpAndInsertFromPosColumnArray(
-        PaddedPODArray<char *> & /* pos */,
-        const IColumn::Offsets & /* array_offsets */,
-        bool /* use_nt_align_buffer */) override
+    void deserializeForCmpAndInsertFromPos(PaddedPODArray<char *> & /* pos */, bool /* use_nt_align_buffer */) override
     {
         throw Exception(
-            "Method deserializeForCmpAndInsertFromPosColumnArray is not supported for " + getName(),
+            "Method deserializeForCmpAndInsertFromPos is not supported for " + getName(),
             ErrorCodes::NOT_IMPLEMENTED);
     }
+
     void deserializeAndInsertFromPosForColumnArray(
         PaddedPODArray<char *> & /* pos */,
         const IColumn::Offsets & /* array_offsets */,
@@ -228,6 +219,15 @@ public:
     {
         throw Exception(
             "Method deserializeAndInsertFromPosForColumnArray is not supported for " + getName(),
+            ErrorCodes::NOT_IMPLEMENTED);
+    }
+    void deserializeForCmpAndInsertFromPosColumnArray(
+        PaddedPODArray<char *> & /* pos */,
+        const IColumn::Offsets & /* array_offsets */,
+        bool /* use_nt_align_buffer */) override
+    {
+        throw Exception(
+            "Method deserializeForCmpAndInsertFromPosColumnArray is not supported for " + getName(),
             ErrorCodes::NOT_IMPLEMENTED);
     }
 

--- a/dbms/src/Columns/ColumnFunction.h
+++ b/dbms/src/Columns/ColumnFunction.h
@@ -221,6 +221,22 @@ public:
         throw Exception("Method flushNTAlignBuffer is not supported for " + getName(), ErrorCodes::NOT_IMPLEMENTED);
     }
 
+    void deserializeAndAdvancePos(PaddedPODArray<char *> & /* pos */) const override
+    {
+        throw Exception(
+            "Method deserializeAndAdvancePos is not supported for " + getName(),
+            ErrorCodes::NOT_IMPLEMENTED);
+    }
+
+    void deserializeAndAdvancePosForColumnArray(
+        PaddedPODArray<char *> & /* pos */,
+        const IColumn::Offsets & /* array_offsets */) const override
+    {
+        throw Exception(
+            "Method deserializeAndAdvancePosForColumnArray is not supported for " + getName(),
+            ErrorCodes::NOT_IMPLEMENTED);
+    }
+
     void updateHashWithValue(size_t, SipHash &, const TiDB::TiDBCollatorPtr &, String &) const override
     {
         throw Exception("updateHashWithValue is not implemented for " + getName(), ErrorCodes::NOT_IMPLEMENTED);

--- a/dbms/src/Columns/ColumnFunction.h
+++ b/dbms/src/Columns/ColumnFunction.h
@@ -205,12 +205,6 @@ public:
             "Method deserializeAndInsertFromPos is not supported for " + getName(),
             ErrorCodes::NOT_IMPLEMENTED);
     }
-    void deserializeForCmpAndInsertFromPos(PaddedPODArray<char *> & /* pos */, bool /* use_nt_align_buffer */) override
-    {
-        throw Exception(
-            "Method deserializeForCmpAndInsertFromPos is not supported for " + getName(),
-            ErrorCodes::NOT_IMPLEMENTED);
-    }
 
     void deserializeAndInsertFromPosForColumnArray(
         PaddedPODArray<char *> & /* pos */,
@@ -219,15 +213,6 @@ public:
     {
         throw Exception(
             "Method deserializeAndInsertFromPosForColumnArray is not supported for " + getName(),
-            ErrorCodes::NOT_IMPLEMENTED);
-    }
-    void deserializeForCmpAndInsertFromPosColumnArray(
-        PaddedPODArray<char *> & /* pos */,
-        const IColumn::Offsets & /* array_offsets */,
-        bool /* use_nt_align_buffer */) override
-    {
-        throw Exception(
-            "Method deserializeForCmpAndInsertFromPosColumnArray is not supported for " + getName(),
             ErrorCodes::NOT_IMPLEMENTED);
     }
 

--- a/dbms/src/Columns/ColumnNullable.cpp
+++ b/dbms/src/Columns/ColumnNullable.cpp
@@ -437,17 +437,15 @@ void ColumnNullable::insertManyFrom(const IColumn & src, size_t n, size_t length
     map.resize_fill(map.size() + length, src_concrete.getNullMapData()[n]);
 }
 
-void ColumnNullable::insertSelectiveFrom(const IColumn & src, const Offsets & selective_offsets)
+void ColumnNullable::insertSelectiveRangeFrom(
+    const IColumn & src,
+    const Offsets & selective_offsets,
+    size_t start,
+    size_t length)
 {
     const auto & src_concrete = static_cast<const ColumnNullable &>(src);
-    getNestedColumn().insertSelectiveFrom(src_concrete.getNestedColumn(), selective_offsets);
-    auto & map = getNullMapData();
-    const auto & src_map = src_concrete.getNullMapData();
-    size_t old_size = map.size();
-    size_t to_add_size = selective_offsets.size();
-    map.resize(old_size + to_add_size);
-    for (size_t i = 0; i < to_add_size; ++i)
-        map[i + old_size] = src_map[selective_offsets[i]];
+    getNestedColumn().insertSelectiveRangeFrom(src_concrete.getNestedColumn(), selective_offsets, start, length);
+    getNullMapColumn().insertSelectiveRangeFrom(src_concrete.getNullMapColumn(), selective_offsets, start, length);
 }
 
 void ColumnNullable::popBack(size_t n)

--- a/dbms/src/Columns/ColumnNullable.cpp
+++ b/dbms/src/Columns/ColumnNullable.cpp
@@ -392,6 +392,20 @@ void ColumnNullable::flushNTAlignBuffer()
     getNestedColumn().flushNTAlignBuffer();
 }
 
+void ColumnNullable::deserializeAndAdvancePos(PaddedPODArray<char *> & pos) const
+{
+    getNullMapColumn().deserializeAndAdvancePos(pos);
+    getNestedColumn().deserializeAndAdvancePos(pos);
+}
+
+void ColumnNullable::deserializeAndAdvancePosForColumnArray(
+    PaddedPODArray<char *> & pos,
+    const IColumn::Offsets & array_offsets) const
+{
+    getNullMapColumn().deserializeAndAdvancePosForColumnArray(pos, array_offsets);
+    getNestedColumn().deserializeAndAdvancePosForColumnArray(pos, array_offsets);
+}
+
 void ColumnNullable::insertRangeFrom(const IColumn & src, size_t start, size_t length)
 {
     const auto & nullable_col = static_cast<const ColumnNullable &>(src);

--- a/dbms/src/Columns/ColumnNullable.cpp
+++ b/dbms/src/Columns/ColumnNullable.cpp
@@ -282,6 +282,12 @@ const char * ColumnNullable::deserializeAndInsertFromArena(const char * pos, con
     return pos;
 }
 
+void ColumnNullable::countSerializeByteSize(PaddedPODArray<size_t> & byte_size) const
+{
+    getNullMapColumn().countSerializeByteSize(byte_size);
+    getNestedColumn().countSerializeByteSize(byte_size);
+}
+
 void ColumnNullable::countSerializeByteSizeForCmp(
     PaddedPODArray<size_t> & byte_size,
     const NullMap * nullmap,
@@ -292,10 +298,13 @@ void ColumnNullable::countSerializeByteSizeForCmp(
     getNullMapColumn().countSerializeByteSizeForCmp(byte_size, nullptr, collator);
     getNestedColumn().countSerializeByteSizeForCmp(byte_size, &getNullMapData(), collator);
 }
-void ColumnNullable::countSerializeByteSize(PaddedPODArray<size_t> & byte_size) const
+
+void ColumnNullable::countSerializeByteSizeForColumnArray(
+    PaddedPODArray<size_t> & byte_size,
+    const IColumn::Offsets & array_offsets) const
 {
-    getNullMapColumn().countSerializeByteSize(byte_size);
-    getNestedColumn().countSerializeByteSize(byte_size);
+    getNullMapColumn().countSerializeByteSizeForColumnArray(byte_size, array_offsets);
+    getNestedColumn().countSerializeByteSizeForColumnArray(byte_size, array_offsets);
 }
 
 void ColumnNullable::countSerializeByteSizeForCmpColumnArray(
@@ -306,15 +315,15 @@ void ColumnNullable::countSerializeByteSizeForCmpColumnArray(
 {
     // Unable to handle ColumnArray(ColumnNullable(ColumnXXX)).
     throw Exception(
-        "countSerializeByteSizeForCmpColumnArray cannot handle ColumnArray(" + getName() + ")",
+        "countSerializeByteSizeForCmpColumnArray cannot handle ColumnArray(ColumnNullable(ColumnXXX))" + getName()
+            + ")",
         ErrorCodes::NOT_IMPLEMENTED);
 }
-void ColumnNullable::countSerializeByteSizeForColumnArray(
-    PaddedPODArray<size_t> & byte_size,
-    const IColumn::Offsets & array_offsets) const
+
+void ColumnNullable::serializeToPos(PaddedPODArray<char *> & pos, size_t start, size_t length, bool has_null) const
 {
-    getNullMapColumn().countSerializeByteSizeForColumnArray(byte_size, array_offsets);
-    getNestedColumn().countSerializeByteSizeForColumnArray(byte_size, array_offsets);
+    getNullMapColumn().serializeToPos(pos, start, length, has_null);
+    getNestedColumn().serializeToPos(pos, start, length, has_null);
 }
 
 void ColumnNullable::serializeToPosForCmp(
@@ -333,10 +342,15 @@ void ColumnNullable::serializeToPosForCmp(
         .serializeToPosForCmp(pos, start, length, has_null, &getNullMapData(), collator, sort_key_container);
 }
 
-void ColumnNullable::serializeToPos(PaddedPODArray<char *> & pos, size_t start, size_t length, bool has_null) const
+void ColumnNullable::serializeToPosForColumnArray(
+    PaddedPODArray<char *> & pos,
+    size_t start,
+    size_t length,
+    bool has_null,
+    const IColumn::Offsets & array_offsets) const
 {
-    getNullMapColumn().serializeToPos(pos, start, length, has_null);
-    getNestedColumn().serializeToPos(pos, start, length, has_null);
+    getNullMapColumn().serializeToPosForColumnArray(pos, start, length, has_null, array_offsets);
+    getNestedColumn().serializeToPosForColumnArray(pos, start, length, has_null, array_offsets);
 }
 
 void ColumnNullable::serializeToPosForCmpColumnArray(
@@ -353,39 +367,16 @@ void ColumnNullable::serializeToPosForCmpColumnArray(
     // while ColumnNullable::nullmap corresponds to the rows of ColumnNullable.
     // This means it's not easy to correctly serialize the row in ColumnNullable to the corresponding position in pos.
     throw Exception(
-        "serializeToPosForCmpColumnArray cannot handle ColumnArray(" + getName() + ")",
+        "serializeToPosForCmpColumnArray cannot handle ColumnArray(ColumnNullable(ColumnXXX))" + getName() + ")",
         ErrorCodes::NOT_IMPLEMENTED);
 }
-void ColumnNullable::serializeToPosForColumnArray(
-    PaddedPODArray<char *> & pos,
-    size_t start,
-    size_t length,
-    bool has_null,
-    const IColumn::Offsets & array_offsets) const
-{
-    getNullMapColumn().serializeToPosForColumnArray(pos, start, length, has_null, array_offsets);
-    getNestedColumn().serializeToPosForColumnArray(pos, start, length, has_null, array_offsets);
-}
 
-void ColumnNullable::deserializeForCmpAndInsertFromPos(PaddedPODArray<char *> & pos, bool use_nt_align_buffer)
-{
-    getNullMapColumn().deserializeForCmpAndInsertFromPos(pos, use_nt_align_buffer);
-    getNestedColumn().deserializeForCmpAndInsertFromPos(pos, use_nt_align_buffer);
-}
 void ColumnNullable::deserializeAndInsertFromPos(PaddedPODArray<char *> & pos, bool use_nt_align_buffer)
 {
     getNullMapColumn().deserializeAndInsertFromPos(pos, use_nt_align_buffer);
     getNestedColumn().deserializeAndInsertFromPos(pos, use_nt_align_buffer);
 }
 
-void ColumnNullable::deserializeForCmpAndInsertFromPosColumnArray(
-    PaddedPODArray<char *> & pos,
-    const IColumn::Offsets & array_offsets,
-    bool use_nt_align_buffer)
-{
-    getNullMapColumn().deserializeForCmpAndInsertFromPosColumnArray(pos, array_offsets, use_nt_align_buffer);
-    getNestedColumn().deserializeForCmpAndInsertFromPosColumnArray(pos, array_offsets, use_nt_align_buffer);
-}
 void ColumnNullable::deserializeAndInsertFromPosForColumnArray(
     PaddedPODArray<char *> & pos,
     const IColumn::Offsets & array_offsets,

--- a/dbms/src/Columns/ColumnNullable.h
+++ b/dbms/src/Columns/ColumnNullable.h
@@ -80,21 +80,22 @@ public:
         String &) const override;
     const char * deserializeAndInsertFromArena(const char * pos, const TiDB::TiDBCollatorPtr &) override;
 
+    void countSerializeByteSize(PaddedPODArray<size_t> & byte_size) const override;
     void countSerializeByteSizeForCmp(
         PaddedPODArray<size_t> & byte_size,
         const NullMap * nullmap,
         const TiDB::TiDBCollatorPtr & collator) const override;
-    void countSerializeByteSize(PaddedPODArray<size_t> & byte_size) const override;
 
+    void countSerializeByteSizeForColumnArray(
+        PaddedPODArray<size_t> & byte_size,
+        const IColumn::Offsets & array_offsets) const override;
     void countSerializeByteSizeForCmpColumnArray(
         PaddedPODArray<size_t> & byte_size,
         const IColumn::Offsets & array_offsets,
         const NullMap * nullmap,
         const TiDB::TiDBCollatorPtr & collator) const override;
-    void countSerializeByteSizeForColumnArray(
-        PaddedPODArray<size_t> & byte_size,
-        const IColumn::Offsets & array_offsets) const override;
 
+    void serializeToPos(PaddedPODArray<char *> & pos, size_t start, size_t length, bool has_null) const override;
     void serializeToPosForCmp(
         PaddedPODArray<char *> & pos,
         size_t start,
@@ -103,8 +104,13 @@ public:
         const NullMap * nullmap,
         const TiDB::TiDBCollatorPtr & collator,
         String * sort_key_container) const override;
-    void serializeToPos(PaddedPODArray<char *> & pos, size_t start, size_t length, bool has_null) const override;
 
+    void serializeToPosForColumnArray(
+        PaddedPODArray<char *> & pos,
+        size_t start,
+        size_t length,
+        bool has_null,
+        const IColumn::Offsets & array_offsets) const override;
     void serializeToPosForCmpColumnArray(
         PaddedPODArray<char *> & pos,
         size_t start,
@@ -114,21 +120,15 @@ public:
         const IColumn::Offsets & array_offsets,
         const TiDB::TiDBCollatorPtr & collator,
         String * sort_key_container) const override;
-    void serializeToPosForColumnArray(
-        PaddedPODArray<char *> & pos,
-        size_t start,
-        size_t length,
-        bool has_null,
-        const IColumn::Offsets & array_offsets) const override;
 
-    void deserializeForCmpAndInsertFromPos(PaddedPODArray<char *> & pos, bool use_nt_align_buffer) override;
     void deserializeAndInsertFromPos(PaddedPODArray<char *> & pos, bool use_nt_align_buffer) override;
+    void deserializeForCmpAndInsertFromPos(PaddedPODArray<char *> & pos, bool use_nt_align_buffer) override;
 
-    void deserializeForCmpAndInsertFromPosColumnArray(
+    void deserializeAndInsertFromPosForColumnArray(
         PaddedPODArray<char *> & pos,
         const IColumn::Offsets & array_offsets,
         bool use_nt_align_buffer) override;
-    void deserializeAndInsertFromPosForColumnArray(
+    void deserializeForCmpAndInsertFromPosColumnArray(
         PaddedPODArray<char *> & pos,
         const IColumn::Offsets & array_offsets,
         bool use_nt_align_buffer) override;
@@ -140,7 +140,8 @@ public:
     void insert(const Field & x) override;
     void insertFrom(const IColumn & src, size_t n) override;
     void insertManyFrom(const IColumn & src, size_t n, size_t length) override;
-    void insertSelectiveFrom(const IColumn & src, const Offsets & selective_offsets) override;
+    void insertSelectiveRangeFrom(const IColumn & src, const Offsets & selective_offsets, size_t start, size_t length)
+        override;
 
     void insertDefault() override
     {

--- a/dbms/src/Columns/ColumnNullable.h
+++ b/dbms/src/Columns/ColumnNullable.h
@@ -130,6 +130,11 @@ public:
 
     void flushNTAlignBuffer() override;
 
+    void deserializeAndAdvancePos(PaddedPODArray<char *> & pos) const override;
+
+    void deserializeAndAdvancePosForColumnArray(PaddedPODArray<char *> & pos, const IColumn::Offsets & array_offsets)
+        const override;
+
     void insertRangeFrom(const IColumn & src, size_t start, size_t length) override;
 
     void insert(const Field & x) override;

--- a/dbms/src/Columns/ColumnNullable.h
+++ b/dbms/src/Columns/ColumnNullable.h
@@ -122,13 +122,8 @@ public:
         String * sort_key_container) const override;
 
     void deserializeAndInsertFromPos(PaddedPODArray<char *> & pos, bool use_nt_align_buffer) override;
-    void deserializeForCmpAndInsertFromPos(PaddedPODArray<char *> & pos, bool use_nt_align_buffer) override;
 
     void deserializeAndInsertFromPosForColumnArray(
-        PaddedPODArray<char *> & pos,
-        const IColumn::Offsets & array_offsets,
-        bool use_nt_align_buffer) override;
-    void deserializeForCmpAndInsertFromPosColumnArray(
         PaddedPODArray<char *> & pos,
         const IColumn::Offsets & array_offsets,
         bool use_nt_align_buffer) override;

--- a/dbms/src/Columns/ColumnString.h
+++ b/dbms/src/Columns/ColumnString.h
@@ -107,66 +107,6 @@ private:
         }
     }
 
-    template <bool need_decode_collator, bool has_nullmap>
-    void countSerializeByteSizeImpl(
-        PaddedPODArray<size_t> & byte_size,
-        const NullMap * nullmap,
-        const TiDB::TiDBCollatorPtr & collator) const;
-    template <bool need_decode_collator, bool has_nullmap>
-    void countSerializeByteSizeForColumnArrayImpl(
-        PaddedPODArray<size_t> & byte_size,
-        const IColumn::Offsets & array_offsets,
-        const NullMap * nullmap,
-        const TiDB::TiDBCollatorPtr & collator) const;
-
-    template <bool has_null, bool need_decode_collator, bool has_nullmap>
-    void serializeToPosImplType(
-        PaddedPODArray<char *> & pos,
-        size_t start,
-        size_t length,
-        const TiDB::TiDBCollatorPtr & collator,
-        String * sort_key_container,
-        const NullMap * nullmap) const;
-    template <bool has_null, bool need_decode_collator, typename DerivedCollator, bool has_nullmap>
-    void serializeToPosImpl(
-        PaddedPODArray<char *> & pos,
-        size_t start,
-        size_t length,
-        const TiDB::TiDBCollatorPtr & collator,
-        String * sort_key_container,
-        const NullMap * nullmap) const;
-
-    template <bool compare_semantics, bool has_null, bool need_decode_collator, bool has_nullmap>
-    void serializeToPosForColumnArrayImplType(
-        PaddedPODArray<char *> & pos,
-        size_t start,
-        size_t length,
-        const IColumn::Offsets & array_offsets,
-        const TiDB::TiDBCollatorPtr & collator,
-        String * sort_key_container,
-        const NullMap * nullmap) const;
-    template <
-        bool compare_semantics,
-        bool has_null,
-        bool need_decode_collator,
-        typename DerivedCollator,
-        bool has_nullmap>
-    void serializeToPosForColumnArrayImpl(
-        PaddedPODArray<char *> & pos,
-        size_t start,
-        size_t length,
-        const IColumn::Offsets & array_offsets,
-        const TiDB::TiDBCollatorPtr & collator,
-        String * sort_key_container,
-        const NullMap * nullmap) const;
-
-    void deserializeAndInsertFromPosImpl(PaddedPODArray<char *> & pos, bool use_nt_align_buffer);
-    template <bool compare_semantics>
-    void deserializeAndInsertFromPosForColumnArrayImpl(
-        PaddedPODArray<char *> & pos,
-        const IColumn::Offsets & array_offsets,
-        bool use_nt_align_buffer);
-
 public:
     const char * getFamilyName() const override { return "String"; }
 
@@ -317,6 +257,11 @@ public:
         PaddedPODArray<size_t> & byte_size,
         const NullMap * nullmap,
         const TiDB::TiDBCollatorPtr & collator) const override;
+    template <bool need_decode_collator, bool has_nullmap>
+    void countSerializeByteSizeImpl(
+        PaddedPODArray<size_t> & byte_size,
+        const NullMap * nullmap,
+        const TiDB::TiDBCollatorPtr & collator) const;
 
     void countSerializeByteSizeForColumnArray(
         PaddedPODArray<size_t> & byte_size,
@@ -326,6 +271,12 @@ public:
         const IColumn::Offsets & array_offsets,
         const NullMap * nullmap,
         const TiDB::TiDBCollatorPtr & collator) const override;
+    template <bool need_decode_collator, bool has_nullmap>
+    void countSerializeByteSizeForColumnArrayImpl(
+        PaddedPODArray<size_t> & byte_size,
+        const IColumn::Offsets & array_offsets,
+        const NullMap * nullmap,
+        const TiDB::TiDBCollatorPtr & collator) const;
 
     void serializeToPos(PaddedPODArray<char *> & pos, size_t start, size_t length, bool has_null) const override;
     void serializeToPosForCmp(
@@ -336,6 +287,14 @@ public:
         const NullMap * nullmap,
         const TiDB::TiDBCollatorPtr & collator,
         String * sort_key_container) const override;
+    template <bool has_null, bool need_decode_collator, typename DerivedCollator, bool has_nullmap>
+    void serializeToPosImpl(
+        PaddedPODArray<char *> & pos,
+        size_t start,
+        size_t length,
+        const TiDB::TiDBCollatorPtr & collator,
+        String * sort_key_container,
+        const NullMap * nullmap) const;
 
     void serializeToPosForColumnArray(
         PaddedPODArray<char *> & pos,
@@ -352,15 +311,19 @@ public:
         const IColumn::Offsets & array_offsets,
         const TiDB::TiDBCollatorPtr & collator,
         String * sort_key_container) const override;
+    template <bool has_null, bool need_decode_collator, typename DerivedCollator, bool has_nullmap>
+    void serializeToPosForColumnArrayImpl(
+        PaddedPODArray<char *> & pos,
+        size_t start,
+        size_t length,
+        const IColumn::Offsets & array_offsets,
+        const TiDB::TiDBCollatorPtr & collator,
+        String * sort_key_container,
+        const NullMap * nullmap) const;
 
     void deserializeAndInsertFromPos(PaddedPODArray<char *> & pos, bool use_nt_align_buffer) override;
-    void deserializeForCmpAndInsertFromPos(PaddedPODArray<char *> & pos, bool use_nt_align_buffer) override;
 
     void deserializeAndInsertFromPosForColumnArray(
-        PaddedPODArray<char *> & pos,
-        const IColumn::Offsets & array_offsets,
-        bool use_nt_align_buffer) override;
-    void deserializeForCmpAndInsertFromPosColumnArray(
         PaddedPODArray<char *> & pos,
         const IColumn::Offsets & array_offsets,
         bool use_nt_align_buffer) override;

--- a/dbms/src/Columns/ColumnTuple.h
+++ b/dbms/src/Columns/ColumnTuple.h
@@ -183,11 +183,6 @@ public:
         for (auto & column : columns)
             column->assumeMutableRef().deserializeAndInsertFromPos(pos, use_nt_align_buffer);
     }
-    void deserializeForCmpAndInsertFromPos(PaddedPODArray<char *> & pos, bool use_nt_align_buffer) override
-    {
-        for (auto & column : columns)
-            column->assumeMutableRef().deserializeForCmpAndInsertFromPos(pos, use_nt_align_buffer);
-    }
 
     void deserializeAndInsertFromPosForColumnArray(
         PaddedPODArray<char *> & pos,
@@ -196,17 +191,6 @@ public:
     {
         for (auto & column : columns)
             column->assumeMutableRef().deserializeAndInsertFromPosForColumnArray(
-                pos,
-                array_offsets,
-                use_nt_align_buffer);
-    }
-    void deserializeForCmpAndInsertFromPosColumnArray(
-        PaddedPODArray<char *> & pos,
-        const IColumn::Offsets & array_offsets,
-        bool use_nt_align_buffer) override
-    {
-        for (auto & column : columns)
-            column->assumeMutableRef().deserializeForCmpAndInsertFromPosColumnArray(
                 pos,
                 array_offsets,
                 use_nt_align_buffer);

--- a/dbms/src/Columns/ColumnTuple.h
+++ b/dbms/src/Columns/ColumnTuple.h
@@ -202,6 +202,19 @@ public:
             column->assumeMutableRef().flushNTAlignBuffer();
     }
 
+    void deserializeAndAdvancePos(PaddedPODArray<char *> & pos) const override
+    {
+        for (const auto & column : columns)
+            column->deserializeAndAdvancePos(pos);
+    }
+
+    void deserializeAndAdvancePosForColumnArray(PaddedPODArray<char *> & pos, const IColumn::Offsets & array_offsets)
+        const override
+    {
+        for (const auto & column : columns)
+            column->deserializeAndAdvancePosForColumnArray(pos, array_offsets);
+    }
+
     void updateHashWithValue(size_t n, SipHash & hash, const TiDB::TiDBCollatorPtr &, String &) const override;
     void updateHashWithValues(IColumn::HashValues & hash_values, const TiDB::TiDBCollatorPtr &, String &)
         const override;

--- a/dbms/src/Columns/ColumnTuple.h
+++ b/dbms/src/Columns/ColumnTuple.h
@@ -72,10 +72,12 @@ public:
             insertFrom(src_, n);
     }
 
-    void insertSelectiveFrom(const IColumn & src_, const Offsets & selective_offsets) override
+    void insertSelectiveRangeFrom(const IColumn & src_, const Offsets & selective_offsets, size_t start, size_t length)
+        override
     {
-        for (auto position : selective_offsets)
-            insertFrom(src_, position);
+        RUNTIME_CHECK(selective_offsets.size() >= start + length);
+        for (size_t i = start; i < start + length; ++i)
+            insertFrom(src_, selective_offsets[i]);
     }
 
     void insertDefault() override;
@@ -95,6 +97,11 @@ public:
         String &) const override;
     const char * deserializeAndInsertFromArena(const char * pos, const TiDB::TiDBCollatorPtr &) override;
 
+    void countSerializeByteSize(PaddedPODArray<size_t> & byte_size) const override
+    {
+        for (const auto & column : columns)
+            column->countSerializeByteSize(byte_size);
+    }
     void countSerializeByteSizeForCmp(
         PaddedPODArray<size_t> & byte_size,
         const NullMap * nullmap,
@@ -103,12 +110,14 @@ public:
         for (const auto & column : columns)
             column->countSerializeByteSizeForCmp(byte_size, nullmap, collator);
     }
-    void countSerializeByteSize(PaddedPODArray<size_t> & byte_size) const override
+
+    void countSerializeByteSizeForColumnArray(
+        PaddedPODArray<size_t> & byte_size,
+        const IColumn::Offsets & array_offsets) const override
     {
         for (const auto & column : columns)
-            column->countSerializeByteSize(byte_size);
+            column->countSerializeByteSizeForColumnArray(byte_size, array_offsets);
     }
-
     void countSerializeByteSizeForCmpColumnArray(
         PaddedPODArray<size_t> & byte_size,
         const IColumn::Offsets & array_offsets,
@@ -118,14 +127,12 @@ public:
         for (const auto & column : columns)
             column->countSerializeByteSizeForCmpColumnArray(byte_size, array_offsets, nullmap, collator);
     }
-    void countSerializeByteSizeForColumnArray(
-        PaddedPODArray<size_t> & byte_size,
-        const IColumn::Offsets & array_offsets) const override
+
+    void serializeToPos(PaddedPODArray<char *> & pos, size_t start, size_t length, bool has_null) const override
     {
         for (const auto & column : columns)
-            column->countSerializeByteSizeForColumnArray(byte_size, array_offsets);
+            column->serializeToPos(pos, start, length, has_null);
     }
-
     void serializeToPosForCmp(
         PaddedPODArray<char *> & pos,
         size_t start,
@@ -138,12 +145,17 @@ public:
         for (const auto & column : columns)
             column->serializeToPosForCmp(pos, start, length, has_null, nullmap, collator, sort_key_container);
     }
-    void serializeToPos(PaddedPODArray<char *> & pos, size_t start, size_t length, bool has_null) const override
+
+    void serializeToPosForColumnArray(
+        PaddedPODArray<char *> & pos,
+        size_t start,
+        size_t length,
+        bool has_null,
+        const IColumn::Offsets & array_offsets) const override
     {
         for (const auto & column : columns)
-            column->serializeToPos(pos, start, length, has_null);
+            column->serializeToPosForColumnArray(pos, start, length, has_null, array_offsets);
     }
-
     void serializeToPosForCmpColumnArray(
         PaddedPODArray<char *> & pos,
         size_t start,
@@ -165,39 +177,18 @@ public:
                 collator,
                 sort_key_container);
     }
-    void serializeToPosForColumnArray(
-        PaddedPODArray<char *> & pos,
-        size_t start,
-        size_t length,
-        bool has_null,
-        const IColumn::Offsets & array_offsets) const override
-    {
-        for (const auto & column : columns)
-            column->serializeToPosForColumnArray(pos, start, length, has_null, array_offsets);
-    }
 
-    void deserializeForCmpAndInsertFromPos(PaddedPODArray<char *> & pos, bool use_nt_align_buffer) override
-    {
-        for (auto & column : columns)
-            column->assumeMutableRef().deserializeForCmpAndInsertFromPos(pos, use_nt_align_buffer);
-    }
     void deserializeAndInsertFromPos(PaddedPODArray<char *> & pos, bool use_nt_align_buffer) override
     {
         for (auto & column : columns)
             column->assumeMutableRef().deserializeAndInsertFromPos(pos, use_nt_align_buffer);
     }
-
-    void deserializeForCmpAndInsertFromPosColumnArray(
-        PaddedPODArray<char *> & pos,
-        const IColumn::Offsets & array_offsets,
-        bool use_nt_align_buffer) override
+    void deserializeForCmpAndInsertFromPos(PaddedPODArray<char *> & pos, bool use_nt_align_buffer) override
     {
         for (auto & column : columns)
-            column->assumeMutableRef().deserializeForCmpAndInsertFromPosColumnArray(
-                pos,
-                array_offsets,
-                use_nt_align_buffer);
+            column->assumeMutableRef().deserializeForCmpAndInsertFromPos(pos, use_nt_align_buffer);
     }
+
     void deserializeAndInsertFromPosForColumnArray(
         PaddedPODArray<char *> & pos,
         const IColumn::Offsets & array_offsets,
@@ -205,6 +196,17 @@ public:
     {
         for (auto & column : columns)
             column->assumeMutableRef().deserializeAndInsertFromPosForColumnArray(
+                pos,
+                array_offsets,
+                use_nt_align_buffer);
+    }
+    void deserializeForCmpAndInsertFromPosColumnArray(
+        PaddedPODArray<char *> & pos,
+        const IColumn::Offsets & array_offsets,
+        bool use_nt_align_buffer) override
+    {
+        for (auto & column : columns)
+            column->assumeMutableRef().deserializeForCmpAndInsertFromPosColumnArray(
                 pos,
                 array_offsets,
                 use_nt_align_buffer);

--- a/dbms/src/Columns/ColumnVector.cpp
+++ b/dbms/src/Columns/ColumnVector.cpp
@@ -262,7 +262,7 @@ void ColumnVector<T>::serializeToPosForColumnArrayImpl(
                 continue;
         }
         size_t len = array_offsets[start + i] - array_offsets[start + i - 1];
-        auto start_idx = array_offsets[start + i - 1];
+        size_t start_idx = array_offsets[start + i - 1];
         if (len <= 4)
         {
             auto * p = pos[i];
@@ -403,7 +403,7 @@ void ColumnVector<T>::deserializeAndInsertFromPosForColumnArray(
     for (size_t i = 0; i < size; ++i)
     {
         size_t len = array_offsets[start_point + i] - array_offsets[start_point + i - 1];
-        auto start_idx = array_offsets[start_point + i - 1];
+        size_t start_idx = array_offsets[start_point + i - 1];
         if (len <= 4)
         {
             auto * p = pos[i];

--- a/dbms/src/Columns/ColumnVector.cpp
+++ b/dbms/src/Columns/ColumnVector.cpp
@@ -382,6 +382,9 @@ void ColumnVector<T>::deserializeAndInsertFromPosForColumnArray(
     const IColumn::Offsets & array_offsets,
     bool use_nt_align_buffer [[maybe_unused]])
 {
+    // Check if pos is empty is necessary.
+    // If pos is not empty, then array_offsets is not empty either due to pos.size() <= array_offsets.size().
+    // Then reading array_offsets[-1] and array_offsets.back() is valid.
     if unlikely (pos.empty())
         return;
     RUNTIME_CHECK_MSG(
@@ -439,6 +442,24 @@ void ColumnVector<T>::flushNTAlignBuffer()
         align_buffer_ptr.reset();
     }
 #endif
+}
+
+template <typename T>
+void ColumnVector<T>::deserializeAndAdvancePosForColumnArray(
+    PaddedPODArray<char *> & pos,
+    const IColumn::Offsets & array_offsets) const
+{
+    RUNTIME_CHECK_MSG(
+        pos.size() == array_offsets.size(),
+        "size of pos({}) != size of array_offsets({})",
+        pos.size(),
+        array_offsets.size());
+    size_t size = pos.size();
+    for (size_t i = 0; i < size; ++i)
+    {
+        size_t len = array_offsets[i] - array_offsets[i - 1];
+        pos[i] += len * sizeof(T);
+    }
 }
 
 template <typename T>

--- a/dbms/src/Columns/ColumnVector.h
+++ b/dbms/src/Columns/ColumnVector.h
@@ -388,6 +388,14 @@ public:
 
     void flushNTAlignBuffer() override;
 
+    void deserializeAndAdvancePos(PaddedPODArray<char *> & pos) const override
+    {
+        IColumn::advancePosByOffset(pos, sizeof(T));
+    }
+
+    void deserializeAndAdvancePosForColumnArray(PaddedPODArray<char *> & pos, const IColumn::Offsets & array_offsets)
+        const override;
+
     void updateHashWithValue(size_t n, SipHash & hash, const TiDB::TiDBCollatorPtr &, String &) const override;
     void updateHashWithValues(IColumn::HashValues & hash_values, const TiDB::TiDBCollatorPtr &, String &)
         const override;

--- a/dbms/src/Columns/ColumnVector.h
+++ b/dbms/src/Columns/ColumnVector.h
@@ -380,22 +380,11 @@ public:
         const NullMap * nullmap) const;
 
     void deserializeAndInsertFromPos(PaddedPODArray<char *> & pos, bool use_nt_align_buffer) override;
-    void deserializeForCmpAndInsertFromPos(PaddedPODArray<char *> & pos, bool use_nt_align_buffer) override
-    {
-        deserializeAndInsertFromPos(pos, use_nt_align_buffer);
-    }
 
     void deserializeAndInsertFromPosForColumnArray(
         PaddedPODArray<char *> & pos,
         const IColumn::Offsets & array_offsets,
         bool use_nt_align_buffer) override;
-    void deserializeForCmpAndInsertFromPosColumnArray(
-        PaddedPODArray<char *> & pos,
-        const IColumn::Offsets & array_offsets,
-        bool use_nt_align_buffer) override
-    {
-        deserializeAndInsertFromPosForColumnArray(pos, array_offsets, use_nt_align_buffer);
-    }
 
     void flushNTAlignBuffer() override;
 

--- a/dbms/src/Columns/ColumnVector.h
+++ b/dbms/src/Columns/ColumnVector.h
@@ -198,23 +198,6 @@ private:
         : data{il}
     {}
 
-    template <bool has_nullmap>
-    void countSerializeByteSizeForColumnArrayImpl(
-        PaddedPODArray<size_t> & byte_size,
-        const IColumn::Offsets & array_offsets,
-        const NullMap * nullmap) const;
-
-    template <bool has_null, bool has_nullmap>
-    void serializeToPosImpl(PaddedPODArray<char *> & pos, size_t start, size_t length, const NullMap * nullmap) const;
-
-    template <bool has_null, bool has_nullmap>
-    void serializeToPosForColumnArrayImpl(
-        PaddedPODArray<char *> & pos,
-        size_t start,
-        size_t length,
-        const IColumn::Offsets & array_offsets,
-        const NullMap * nullmap) const;
-
 public:
     bool isNumeric() const override { return is_arithmetic_v<T>; }
 
@@ -355,6 +338,11 @@ public:
         const IColumn::Offsets & array_offsets,
         const NullMap * nullmap,
         const TiDB::TiDBCollatorPtr &) const override;
+    template <bool has_nullmap>
+    void countSerializeByteSizeForColumnArrayImpl(
+        PaddedPODArray<size_t> & byte_size,
+        const IColumn::Offsets & array_offsets,
+        const NullMap * nullmap) const;
 
     void serializeToPos(PaddedPODArray<char *> & pos, size_t start, size_t length, bool has_null) const override;
     void serializeToPosForCmp(
@@ -365,6 +353,8 @@ public:
         const NullMap * nullmap,
         const TiDB::TiDBCollatorPtr &,
         String *) const override;
+    template <bool has_null, bool has_nullmap>
+    void serializeToPosImpl(PaddedPODArray<char *> & pos, size_t start, size_t length, const NullMap * nullmap) const;
 
     void serializeToPosForColumnArray(
         PaddedPODArray<char *> & pos,
@@ -381,6 +371,13 @@ public:
         const IColumn::Offsets & array_offsets,
         const TiDB::TiDBCollatorPtr &,
         String *) const override;
+    template <bool has_null, bool has_nullmap>
+    void serializeToPosForColumnArrayImpl(
+        PaddedPODArray<char *> & pos,
+        size_t start,
+        size_t length,
+        const IColumn::Offsets & array_offsets,
+        const NullMap * nullmap) const;
 
     void deserializeAndInsertFromPos(PaddedPODArray<char *> & pos, bool use_nt_align_buffer) override;
     void deserializeForCmpAndInsertFromPos(PaddedPODArray<char *> & pos, bool use_nt_align_buffer) override

--- a/dbms/src/Columns/IColumn.h
+++ b/dbms/src/Columns/IColumn.h
@@ -156,7 +156,16 @@ public:
     /// Note: the source column and the destination column must be of the same type, can not ColumnXXX->insertSelectiveFrom(ConstColumnXXX, ...)
     using Offset = UInt64;
     using Offsets = PaddedPODArray<Offset>;
-    virtual void insertSelectiveFrom(const IColumn & src, const Offsets & selective_offsets) = 0;
+    void insertSelectiveFrom(const IColumn & src, const Offsets & selective_offsets)
+    {
+        insertSelectiveRangeFrom(src, selective_offsets, 0, selective_offsets.size());
+    }
+    virtual void insertSelectiveRangeFrom(
+        const IColumn & src,
+        const Offsets & selective_offsets,
+        size_t start,
+        size_t length)
+        = 0;
 
     /// Appends one field multiple times. Can be optimized in inherited classes.
     virtual void insertMany(const Field & field, size_t length)
@@ -246,25 +255,25 @@ public:
 
     /// Count the serialize byte size and added to the byte_size.
     /// The byte_size.size() must be equal to the column size.
+    virtual void countSerializeByteSize(PaddedPODArray<size_t> & /* byte_size */) const = 0;
     virtual void countSerializeByteSizeForCmp(
         PaddedPODArray<size_t> & /* byte_size */,
-        const NullMap * /*nullmap*/,
+        const NullMap * /* nullmap */,
         const TiDB::TiDBCollatorPtr & /* collator */) const
         = 0;
-    virtual void countSerializeByteSize(PaddedPODArray<size_t> & /* byte_size */) const = 0;
 
     /// Count the serialize byte size and added to the byte_size called by ColumnArray.
     /// array_offsets is the offsets of ColumnArray.
     /// The byte_size.size() must be equal to the array_offsets.size().
-    virtual void countSerializeByteSizeForCmpColumnArray(
-        PaddedPODArray<size_t> & /* byte_size */,
-        const Offsets & /* array_offsets */,
-        const NullMap * /*nullmap*/,
-        const TiDB::TiDBCollatorPtr & /* collator */) const
-        = 0;
     virtual void countSerializeByteSizeForColumnArray(
         PaddedPODArray<size_t> & /* byte_size */,
         const Offsets & /* array_offsets */) const
+        = 0;
+    virtual void countSerializeByteSizeForCmpColumnArray(
+        PaddedPODArray<size_t> & /* byte_size */,
+        const Offsets & /* array_offsets */,
+        const NullMap * /* nullmap */,
+        const TiDB::TiDBCollatorPtr & /* collator */) const
         = 0;
 
     /// Serialize data of column from start to start + length into pointer of pos and forward each pos[i] to the end of
@@ -286,7 +295,7 @@ public:
         size_t /* start */,
         size_t /* length */,
         bool /* has_null */,
-        const NullMap * /*nullmap*/,
+        const NullMap * /* nullmap */,
         const TiDB::TiDBCollatorPtr & /* collator */,
         String * /* sort_key_container */) const
         = 0;
@@ -307,7 +316,7 @@ public:
         size_t /* start */,
         size_t /* length */,
         bool /* has_null */,
-        const NullMap * /*nullmap*/,
+        const NullMap * /* nullmap */,
         const Offsets & /* array_offsets */,
         const TiDB::TiDBCollatorPtr & /* collator */,
         String * /* sort_key_container */) const
@@ -331,20 +340,20 @@ public:
     ///     }
     ///     for (auto & column_ptr : mutable_columns)
     ///         column_ptr->flushNTAlignBuffer();
+    virtual void deserializeAndInsertFromPos(PaddedPODArray<char *> & /* pos */, bool /* use_nt_align_buffer */) = 0;
     virtual void deserializeForCmpAndInsertFromPos(PaddedPODArray<char *> & /* pos */, bool /* use_nt_align_buffer */)
         = 0;
-    virtual void deserializeAndInsertFromPos(PaddedPODArray<char *> & /* pos */, bool /* use_nt_align_buffer */) = 0;
 
     /// Deserialize and insert data from pos and forward each pos[i] to the end of serialized data.
     /// Only called by ColumnArray.
     /// array_offsets is the offsets of ColumnArray.
     /// The last pos.size() elements of array_offsets can be used to get the length of elements from each pos.
-    virtual void deserializeForCmpAndInsertFromPosColumnArray(
+    virtual void deserializeAndInsertFromPosForColumnArray(
         PaddedPODArray<char *> & /* pos */,
         const Offsets & /* array_offsets */,
         bool /* use_nt_align_buffer */)
         = 0;
-    virtual void deserializeAndInsertFromPosForColumnArray(
+    virtual void deserializeForCmpAndInsertFromPosColumnArray(
         PaddedPODArray<char *> & /* pos */,
         const Offsets & /* array_offsets */,
         bool /* use_nt_align_buffer */)

--- a/dbms/src/Columns/IColumn.h
+++ b/dbms/src/Columns/IColumn.h
@@ -341,19 +341,12 @@ public:
     ///     for (auto & column_ptr : mutable_columns)
     ///         column_ptr->flushNTAlignBuffer();
     virtual void deserializeAndInsertFromPos(PaddedPODArray<char *> & /* pos */, bool /* use_nt_align_buffer */) = 0;
-    virtual void deserializeForCmpAndInsertFromPos(PaddedPODArray<char *> & /* pos */, bool /* use_nt_align_buffer */)
-        = 0;
 
     /// Deserialize and insert data from pos and forward each pos[i] to the end of serialized data.
     /// Only called by ColumnArray.
     /// array_offsets is the offsets of ColumnArray.
     /// The last pos.size() elements of array_offsets can be used to get the length of elements from each pos.
     virtual void deserializeAndInsertFromPosForColumnArray(
-        PaddedPODArray<char *> & /* pos */,
-        const Offsets & /* array_offsets */,
-        bool /* use_nt_align_buffer */)
-        = 0;
-    virtual void deserializeForCmpAndInsertFromPosColumnArray(
         PaddedPODArray<char *> & /* pos */,
         const Offsets & /* array_offsets */,
         bool /* use_nt_align_buffer */)

--- a/dbms/src/Columns/IColumn.h
+++ b/dbms/src/Columns/IColumn.h
@@ -322,7 +322,7 @@ public:
         String * /* sort_key_container */) const
         = 0;
 
-    /// Deserialize and insert data from pos and forward each pos[i] to the end of serialized data.
+    /// Deserialize and insert data from pos and advance each pointer in pos to the end of serialized data.
     /// Note:
     /// 1. The pos pointer must not be nullptr.
     /// 2. If use_nt_align_buffer is true and AVX2 is enabled, non-temporal store may be used when data memory is aligned to FULL_VECTOR_SIZE_AVX2(64 bytes).
@@ -342,7 +342,7 @@ public:
     ///         column_ptr->flushNTAlignBuffer();
     virtual void deserializeAndInsertFromPos(PaddedPODArray<char *> & /* pos */, bool /* use_nt_align_buffer */) = 0;
 
-    /// Deserialize and insert data from pos and forward each pos[i] to the end of serialized data.
+    /// Deserialize and insert data from pos and advance each pointer in pos to the end of serialized data.
     /// Only called by ColumnArray.
     /// array_offsets is the offsets of ColumnArray.
     /// The last pos.size() elements of array_offsets can be used to get the length of elements from each pos.
@@ -352,8 +352,25 @@ public:
         bool /* use_nt_align_buffer */)
         = 0;
 
-    /// Flush the non-temporal align buffer if any.
+    /// Flush any remaining data in the non-temporal align buffer into the column data.
+    /// This function must be called after all deserializeAndInsertFromPos calls when use_nt_align_buffer is enabled.
     virtual void flushNTAlignBuffer() = 0;
+
+    /// Deserialize from pos and advance each pointer in pos to the end of serialized data.
+    virtual void deserializeAndAdvancePos(PaddedPODArray<char *> & /* pos */) const = 0;
+    /// Advance each pointer in 'pos' by a fixed offset.
+    static void advancePosByOffset(PaddedPODArray<char *> & pos, size_t offset)
+    {
+        for (auto & p : pos)
+            p += offset;
+    }
+
+    /// Deserialize from pos and advance each pointer in pos to the end of serialized data.
+    /// Only called by ColumnArray.
+    virtual void deserializeAndAdvancePosForColumnArray(
+        PaddedPODArray<char *> & /* pos */,
+        const Offsets & /* array_offsets */) const
+        = 0;
 
     /// Update state of hash function with value of n-th element.
     /// On subsequent calls of this method for sequence of column values of arbitary types,

--- a/dbms/src/Columns/IColumn.h
+++ b/dbms/src/Columns/IColumn.h
@@ -352,6 +352,7 @@ public:
         bool /* use_nt_align_buffer */)
         = 0;
 
+    /// Flush the non-temporal align buffer if any.
     virtual void flushNTAlignBuffer() = 0;
 
     /// Update state of hash function with value of n-th element.

--- a/dbms/src/Columns/IColumnDummy.h
+++ b/dbms/src/Columns/IColumnDummy.h
@@ -189,6 +189,22 @@ public:
         throw Exception("Method flushNTAlignBuffer is not supported for " + getName(), ErrorCodes::NOT_IMPLEMENTED);
     }
 
+    void deserializeAndAdvancePos(PaddedPODArray<char *> & /* pos */) const override
+    {
+        throw Exception(
+            "Method deserializeAndAdvancePos is not supported for " + getName(),
+            ErrorCodes::NOT_IMPLEMENTED);
+    }
+
+    void deserializeAndAdvancePosForColumnArray(
+        PaddedPODArray<char *> & /* pos */,
+        const IColumn::Offsets & /* array_offsets */) const override
+    {
+        throw Exception(
+            "Method deserializeAndAdvancePosForColumnArray is not supported for " + getName(),
+            ErrorCodes::NOT_IMPLEMENTED);
+    }
+
     void updateHashWithValue(size_t /*n*/, SipHash & /*hash*/, const TiDB::TiDBCollatorPtr &, String &) const override
     {}
 

--- a/dbms/src/Columns/IColumnDummy.h
+++ b/dbms/src/Columns/IColumnDummy.h
@@ -173,12 +173,6 @@ public:
             "Method deserializeAndInsertFromPos is not supported for " + getName(),
             ErrorCodes::NOT_IMPLEMENTED);
     }
-    void deserializeForCmpAndInsertFromPos(PaddedPODArray<char *> & /* pos */, bool /* use_nt_align_buffer */) override
-    {
-        throw Exception(
-            "Method deserializeForCmpAndInsertFromPos is not supported for " + getName(),
-            ErrorCodes::NOT_IMPLEMENTED);
-    }
 
     void deserializeAndInsertFromPosForColumnArray(
         PaddedPODArray<char *> & /* pos */,
@@ -187,15 +181,6 @@ public:
     {
         throw Exception(
             "Method deserializeAndInsertFromPosForColumnArray is not supported for " + getName(),
-            ErrorCodes::NOT_IMPLEMENTED);
-    }
-    void deserializeForCmpAndInsertFromPosColumnArray(
-        PaddedPODArray<char *> & /* pos */,
-        const IColumn::Offsets & /* array_offsets */,
-        bool /* use_nt_align_buffer */) override
-    {
-        throw Exception(
-            "Method deserializeForCmpAndInsertFromPosColumnArray is not supported for " + getName(),
             ErrorCodes::NOT_IMPLEMENTED);
     }
 

--- a/dbms/src/Columns/IColumnDummy.h
+++ b/dbms/src/Columns/IColumnDummy.h
@@ -88,6 +88,10 @@ public:
         return pos;
     }
 
+    void countSerializeByteSize(PaddedPODArray<size_t> & /* byte_size */) const override
+    {
+        throw Exception("Method countSerializeByteSize is not supported for " + getName(), ErrorCodes::NOT_IMPLEMENTED);
+    }
     void countSerializeByteSizeForCmp(
         PaddedPODArray<size_t> & /* byte_size */,
         const NullMap * /*nullmap*/,
@@ -97,11 +101,15 @@ public:
             "Method countSerializeByteSizeForCmp is not supported for " + getName(),
             ErrorCodes::NOT_IMPLEMENTED);
     }
-    void countSerializeByteSize(PaddedPODArray<size_t> & /* byte_size */) const override
-    {
-        throw Exception("Method countSerializeByteSize is not supported for " + getName(), ErrorCodes::NOT_IMPLEMENTED);
-    }
 
+    void countSerializeByteSizeForColumnArray(
+        PaddedPODArray<size_t> & /* byte_size */,
+        const IColumn::Offsets & /* array_offsets */) const override
+    {
+        throw Exception(
+            "Method countSerializeByteSizeForColumnArray is not supported for " + getName(),
+            ErrorCodes::NOT_IMPLEMENTED);
+    }
     void countSerializeByteSizeForCmpColumnArray(
         PaddedPODArray<size_t> & /* byte_size */,
         const IColumn::Offsets & /* array_offsets */,
@@ -112,15 +120,15 @@ public:
             "Method countSerializeByteSizeForCmpColumnArray is not supported for " + getName(),
             ErrorCodes::NOT_IMPLEMENTED);
     }
-    void countSerializeByteSizeForColumnArray(
-        PaddedPODArray<size_t> & /* byte_size */,
-        const IColumn::Offsets & /* array_offsets */) const override
-    {
-        throw Exception(
-            "Method countSerializeByteSizeForColumnArray is not supported for " + getName(),
-            ErrorCodes::NOT_IMPLEMENTED);
-    }
 
+    void serializeToPos(
+        PaddedPODArray<char *> & /* pos */,
+        size_t /* start */,
+        size_t /* length */,
+        bool /* has_null */) const override
+    {
+        throw Exception("Method serializeToPos is not supported for " + getName(), ErrorCodes::NOT_IMPLEMENTED);
+    }
     void serializeToPosForCmp(
         PaddedPODArray<char *> & /* pos */,
         size_t /* start */,
@@ -132,15 +140,18 @@ public:
     {
         throw Exception("Method serializeToPosForCmp is not supported for " + getName(), ErrorCodes::NOT_IMPLEMENTED);
     }
-    void serializeToPos(
+
+    void serializeToPosForColumnArray(
         PaddedPODArray<char *> & /* pos */,
         size_t /* start */,
         size_t /* length */,
-        bool /* has_null */) const override
+        bool /* has_null */,
+        const IColumn::Offsets & /* array_offsets */) const override
     {
-        throw Exception("Method serializeToPos is not supported for " + getName(), ErrorCodes::NOT_IMPLEMENTED);
+        throw Exception(
+            "Method serializeToPosForColumnArray is not supported for " + getName(),
+            ErrorCodes::NOT_IMPLEMENTED);
     }
-
     void serializeToPosForCmpColumnArray(
         PaddedPODArray<char *> & /* pos */,
         size_t /* start */,
@@ -155,40 +166,20 @@ public:
             "Method serializeToPosForCmpColumnArray is not supported for " + getName(),
             ErrorCodes::NOT_IMPLEMENTED);
     }
-    void serializeToPosForColumnArray(
-        PaddedPODArray<char *> & /* pos */,
-        size_t /* start */,
-        size_t /* length */,
-        bool /* has_null */,
-        const IColumn::Offsets & /* array_offsets */) const override
-    {
-        throw Exception(
-            "Method serializeToPosForColumnArray is not supported for " + getName(),
-            ErrorCodes::NOT_IMPLEMENTED);
-    }
 
-    void deserializeForCmpAndInsertFromPos(PaddedPODArray<char *> & /* pos */, bool /* use_nt_align_buffer */) override
-    {
-        throw Exception(
-            "Method deserializeForCmpAndInsertFromPos is not supported for " + getName(),
-            ErrorCodes::NOT_IMPLEMENTED);
-    }
     void deserializeAndInsertFromPos(PaddedPODArray<char *> & /* pos */, bool /* use_nt_align_buffer */) override
     {
         throw Exception(
             "Method deserializeAndInsertFromPos is not supported for " + getName(),
             ErrorCodes::NOT_IMPLEMENTED);
     }
-
-    void deserializeForCmpAndInsertFromPosColumnArray(
-        PaddedPODArray<char *> & /* pos */,
-        const IColumn::Offsets & /* array_offsets */,
-        bool /* use_nt_align_buffer */) override
+    void deserializeForCmpAndInsertFromPos(PaddedPODArray<char *> & /* pos */, bool /* use_nt_align_buffer */) override
     {
         throw Exception(
-            "Method deserializeForCmpAndInsertFromPosColumnArray is not supported for " + getName(),
+            "Method deserializeForCmpAndInsertFromPos is not supported for " + getName(),
             ErrorCodes::NOT_IMPLEMENTED);
     }
+
     void deserializeAndInsertFromPosForColumnArray(
         PaddedPODArray<char *> & /* pos */,
         const IColumn::Offsets & /* array_offsets */,
@@ -196,6 +187,15 @@ public:
     {
         throw Exception(
             "Method deserializeAndInsertFromPosForColumnArray is not supported for " + getName(),
+            ErrorCodes::NOT_IMPLEMENTED);
+    }
+    void deserializeForCmpAndInsertFromPosColumnArray(
+        PaddedPODArray<char *> & /* pos */,
+        const IColumn::Offsets & /* array_offsets */,
+        bool /* use_nt_align_buffer */) override
+    {
+        throw Exception(
+            "Method deserializeForCmpAndInsertFromPosColumnArray is not supported for " + getName(),
             ErrorCodes::NOT_IMPLEMENTED);
     }
 
@@ -217,10 +217,7 @@ public:
 
     void insertManyFrom(const IColumn &, size_t, size_t length) override { s += length; }
 
-    void insertSelectiveFrom(const IColumn &, const Offsets & selective_offsets) override
-    {
-        s += selective_offsets.size();
-    }
+    void insertSelectiveRangeFrom(const IColumn &, const Offsets &, size_t, size_t length) override { s += length; }
 
     void insertRangeFrom(const IColumn & /*src*/, size_t /*start*/, size_t length) override { s += length; }
 

--- a/dbms/src/Columns/tests/gtest_column_insertFrom.cpp
+++ b/dbms/src/Columns/tests/gtest_column_insertFrom.cpp
@@ -83,9 +83,17 @@ public:
             selective_offsets.push_back(4);
             for (size_t position : selective_offsets)
                 cols[0]->insertFrom(*column_ptr, position);
+            std::vector<std::pair<size_t, size_t>> range_test = {{0, 1}, {1, 2}, {0, 3}, {2, 1}, {1, 1}};
+            for (auto [start, length] : range_test)
+            {
+                for (size_t i = start; i < start + length; ++i)
+                    cols[0]->insertFrom(*column_ptr, selective_offsets[i]);
+            }
             for (size_t position : selective_offsets)
                 cols[0]->insertFrom(*column_ptr, position);
             cols[1]->insertSelectiveFrom(*column_ptr, selective_offsets);
+            for (auto [start, length] : range_test)
+                cols[1]->insertSelectiveRangeFrom(*column_ptr, selective_offsets, start, length);
             cols[1]->insertSelectiveFrom(*column_ptr, selective_offsets);
             {
                 ColumnWithTypeAndName ref(std::move(cols[0]), col_with_type_and_name.type, "");

--- a/dbms/src/Columns/tests/gtest_column_serialize_deserialize.cpp
+++ b/dbms/src/Columns/tests/gtest_column_serialize_deserialize.cpp
@@ -393,7 +393,7 @@ public:
         auto new_col_ptr = column_ptr->cloneEmpty();
         if (use_nt_align_buffer)
             new_col_ptr->reserveAlign(byte_size.size(), FULL_VECTOR_SIZE_AVX2);
-        new_col_ptr->deserializeForCmpAndInsertFromPos(ori_pos, use_nt_align_buffer);
+        new_col_ptr->deserializeAndInsertFromPos(ori_pos, use_nt_align_buffer);
 
         current_size = 0;
         pos.clear();
@@ -414,7 +414,7 @@ public:
             collator,
             sort_key_container);
 
-        new_col_ptr->deserializeForCmpAndInsertFromPos(ori_pos, use_nt_align_buffer);
+        new_col_ptr->deserializeAndInsertFromPos(ori_pos, use_nt_align_buffer);
 
         current_size = 0;
         pos.clear();
@@ -428,7 +428,7 @@ public:
             ori_pos.push_back(ptr);
 
         column_ptr->serializeToPosForCmp(pos, 0, byte_size.size(), false, nullptr, collator, sort_key_container);
-        new_col_ptr->deserializeForCmpAndInsertFromPos(ori_pos, use_nt_align_buffer);
+        new_col_ptr->deserializeAndInsertFromPos(ori_pos, use_nt_align_buffer);
 
         if (use_nt_align_buffer)
             new_col_ptr->flushNTAlignBuffer();
@@ -642,18 +642,7 @@ try
                                           .column;
         testCountSerializeByteSize(col_nullable_decimal_0, {49, 49, 49, 49, 49});
         testSerializeAndDeserialize(col_nullable_decimal_0);
-        // nullable + bool + size_t + n * 8
-        testCountSerializeByteSize(
-            col_nullable_decimal_0,
-            {
-                1 + 1 + 8 + 1 * 8,
-                1 + 1 + 8 + 2 * 8,
-                1 + 1 + 8 + 1 * 8,
-                1 + 1 + 8 + 1 * 8,
-                1 + 1 + 8 + 2 * 8,
-            },
-            true,
-            nullptr);
+        testCountSerializeByteSize(col_nullable_decimal_0, {49, 49, 49, 49, 49}, true, nullptr);
         testSerializeAndDeserialize(col_nullable_decimal_0, true, nullptr, nullptr);
     }
 
@@ -742,13 +731,7 @@ try
         auto col_nullable_array_dec = ColumnNullable::create(col_array_dec, createColumn<UInt8>({1, 0, 1}).column);
         testCountSerializeByteSize(col_nullable_array_dec, {1 + 4 + 48, 1 + 4 + 48 * 2, 1 + 4 + 48 * 3});
         testSerializeAndDeserialize(col_nullable_array_dec);
-        // 100.1111111111: (1 + 8 + 2 * 8)
-        // -11111111111111111111: (1 + 8 + 3 * 8)
-        testCountSerializeByteSize(
-            col_nullable_array_dec,
-            {1 + 4, 1 + 4 + (1 + 8 + 2 * 8) + (1 + 8 + 3 * 8), 1 + 4},
-            true,
-            nullptr);
+        testCountSerializeByteSize(col_nullable_array_dec, {1 + 4, 1 + 4 + 48 * 2, 1 + 4}, true, nullptr);
         testSerializeAndDeserialize(col_nullable_array_dec, true, nullptr, nullptr);
     }
 

--- a/dbms/src/Interpreters/Aggregator.h
+++ b/dbms/src/Interpreters/Aggregator.h
@@ -428,7 +428,7 @@ struct AggregationMethodSerialized
     static void insertKeyIntoColumnsBatch(PaddedPODArray<char *> & key_places, std::vector<IColumn *> & key_columns)
     {
         for (auto * key_column : key_columns)
-            key_column->deserializeForCmpAndInsertFromPos(key_places, false);
+            key_column->deserializeAndInsertFromPos(key_places, false);
     }
 };
 

--- a/dbms/src/TiDB/Collation/Collator.h
+++ b/dbms/src/TiDB/Collation/Collator.h
@@ -413,17 +413,25 @@ using BIN_COLLATOR_PADDING = BinCollator<char, true>;
 using BIN_COLLATOR_NON_PADDING = BinCollator<char, false>;
 } // namespace TiDB
 
-#define APPLY_FOR_COLLATOR_TYPES_WITH_VARS(VAR_PREFIX, M)                                                    \
-    M(VAR_PREFIX, utf8_general_ci, TiDB::GeneralCICollator, TiDB::ITiDBCollator::UTF8_GENERAL_CI)            \
-    M(VAR_PREFIX, utf8mb4_general_ci, TiDB::GeneralCICollator, TiDB::ITiDBCollator::UTF8MB4_GENERAL_CI)      \
-    M(VAR_PREFIX, utf8_unicode_ci, TiDB::UCACI_0400_PADDING, TiDB::ITiDBCollator::UTF8_UNICODE_CI)           \
-    M(VAR_PREFIX, utf8mb4_unicode_ci, TiDB::UCACI_0400_PADDING, TiDB::ITiDBCollator::UTF8MB4_UNICODE_CI)     \
-    M(VAR_PREFIX, utf8mb4_0900_ai_ci, TiDB::UCACI_0900_NON_PADDING, TiDB::ITiDBCollator::UTF8MB4_0900_AI_CI) \
-    M(VAR_PREFIX, utf8mb4_0900_bin, TiDB::UTF8MB4_0900_BIN_TYPE, TiDB::ITiDBCollator::UTF8MB4_0900_BIN)      \
-    M(VAR_PREFIX, utf8mb4_bin, TiDB::UTF8MB4_BIN_TYPE, TiDB::ITiDBCollator::UTF8MB4_BIN)                     \
-    M(VAR_PREFIX, latin1_bin, TiDB::BIN_COLLATOR_PADDING, TiDB::ITiDBCollator::LATIN1_BIN)                   \
-    M(VAR_PREFIX, binary, TiDB::BIN_COLLATOR_NON_PADDING, TiDB::ITiDBCollator::BINARY)                       \
-    M(VAR_PREFIX, ascii_bin, TiDB::BIN_COLLATOR_PADDING, TiDB::ITiDBCollator::ASCII_BIN)                     \
-    M(VAR_PREFIX, utf8_bin, TiDB::UTF8MB4_BIN_TYPE, TiDB::ITiDBCollator::UTF8_BIN)
+#define APPLY_FOR_COLLATOR_TYPES_WITH_VARS(VAR_PREFIX, M, ...)                                                         \
+    M(VAR_PREFIX, utf8_general_ci, TiDB::GeneralCICollator, TiDB::ITiDBCollator::UTF8_GENERAL_CI, ##__VA_ARGS__)       \
+    M(VAR_PREFIX, utf8mb4_general_ci, TiDB::GeneralCICollator, TiDB::ITiDBCollator::UTF8MB4_GENERAL_CI, ##__VA_ARGS__) \
+    M(VAR_PREFIX, utf8_unicode_ci, TiDB::UCACI_0400_PADDING, TiDB::ITiDBCollator::UTF8_UNICODE_CI, ##__VA_ARGS__)      \
+    M(VAR_PREFIX,                                                                                                      \
+      utf8mb4_unicode_ci,                                                                                              \
+      TiDB::UCACI_0400_PADDING,                                                                                        \
+      TiDB::ITiDBCollator::UTF8MB4_UNICODE_CI,                                                                         \
+      ##__VA_ARGS__)                                                                                                   \
+    M(VAR_PREFIX,                                                                                                      \
+      utf8mb4_0900_ai_ci,                                                                                              \
+      TiDB::UCACI_0900_NON_PADDING,                                                                                    \
+      TiDB::ITiDBCollator::UTF8MB4_0900_AI_CI,                                                                         \
+      ##__VA_ARGS__)                                                                                                   \
+    M(VAR_PREFIX, utf8mb4_0900_bin, TiDB::UTF8MB4_0900_BIN_TYPE, TiDB::ITiDBCollator::UTF8MB4_0900_BIN, ##__VA_ARGS__) \
+    M(VAR_PREFIX, utf8mb4_bin, TiDB::UTF8MB4_BIN_TYPE, TiDB::ITiDBCollator::UTF8MB4_BIN, ##__VA_ARGS__)                \
+    M(VAR_PREFIX, latin1_bin, TiDB::BIN_COLLATOR_PADDING, TiDB::ITiDBCollator::LATIN1_BIN, ##__VA_ARGS__)              \
+    M(VAR_PREFIX, binary, TiDB::BIN_COLLATOR_NON_PADDING, TiDB::ITiDBCollator::BINARY, ##__VA_ARGS__)                  \
+    M(VAR_PREFIX, ascii_bin, TiDB::BIN_COLLATOR_PADDING, TiDB::ITiDBCollator::ASCII_BIN, ##__VA_ARGS__)                \
+    M(VAR_PREFIX, utf8_bin, TiDB::UTF8MB4_BIN_TYPE, TiDB::ITiDBCollator::UTF8_BIN, ##__VA_ARGS__)
 
-#define APPLY_FOR_COLLATOR_TYPES(M) APPLY_FOR_COLLATOR_TYPES_WITH_VARS(tmp_, M)
+#define APPLY_FOR_COLLATOR_TYPES(M, ...) APPLY_FOR_COLLATOR_TYPES_WITH_VARS(tmp_, M, ##__VA_ARGS__)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/9060

Problem Summary:

### What is changed and how it works?
1. `Decimal256` uses another fixed-size way to serialize.
2. modify the serialization method of `ColumnString::serializeToPosForCmpColumnArray` from `<size><data><size><data>` to `<size><size><data><data>`. This way is the same as `ColumnString::serializeToPosForColumnArray`. Also, some micros are used to reduce some redundant code.
3. Due to 1 and 2, `IColumn::deserializeForCmpAndInsertFromPos` and `deserializeForCmpAndInsertFromPosColumnArray` are useless. They are removed in the PR.
4. Add `IColumn::deserializeAndAdvancePos`. It will be useful for right semi/anti/outer join.
5. Change `IColumn::insertSelectiveFrom` to `IColumn::insertSelectiveRangeFrom` to better support general use cases.

```commit-message
Optimize & Add serialization/deserialization interfaces in IColumn
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
