### PR TITLE
Storages: support inverted index

### DIFF
--- a/dbms/src/Debug/MockStorage.cpp
+++ b/dbms/src/Debug/MockStorage.cpp
@@ -186,6 +186,10 @@ std::tuple<StorageDeltaMergePtr, Names, SelectQueryInfo> MockStorage::prepareFor
     return {storage, column_names, query_info};
 }
 
+static const google::protobuf::RepeatedPtrField<tipb::Expr> empty_pushed_down_filters{};
+static const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> empty_used_indexes{};
+static const auto empty_ann_query_info = tipb::ANNQueryInfo{};
+
 BlockInputStreamPtr MockStorage::getStreamFromDeltaMerge(
     Context & context,
     Int64 table_id,
@@ -194,9 +198,6 @@ BlockInputStreamPtr MockStorage::getStreamFromDeltaMerge(
     std::vector<int> runtime_filter_ids,
     int rf_max_wait_time_ms)
 {
-    static const google::protobuf::RepeatedPtrField<tipb::Expr> empty_pushed_down_filters{};
-    static const auto empty_ann_query_info = tipb::ANNQueryInfo{};
-
     QueryProcessingStage::Enum stage;
     auto [storage, column_names, query_info] = prepareForRead(context, table_id, keep_order);
     if (filter_conditions && filter_conditions->hasValue())
@@ -207,6 +208,7 @@ BlockInputStreamPtr MockStorage::getStreamFromDeltaMerge(
             filter_conditions->conditions,
             empty_ann_query_info,
             empty_pushed_down_filters, // Not care now
+            empty_used_indexes, // Not care now
             scan_column_infos,
             runtime_filter_ids,
             rf_max_wait_time_ms,
@@ -236,6 +238,7 @@ BlockInputStreamPtr MockStorage::getStreamFromDeltaMerge(
             empty_filters,
             empty_ann_query_info,
             empty_pushed_down_filters, // Not care now
+            empty_used_indexes, // Not care now
             scan_column_infos,
             runtime_filter_ids,
             rf_max_wait_time_ms,
@@ -257,9 +260,6 @@ void MockStorage::buildExecFromDeltaMerge(
     std::vector<int> runtime_filter_ids,
     int rf_max_wait_time_ms)
 {
-    static const google::protobuf::RepeatedPtrField<tipb::Expr> empty_pushed_down_filters{};
-    static const auto empty_ann_query_info = tipb::ANNQueryInfo{};
-
     auto [storage, column_names, query_info] = prepareForRead(context, table_id, keep_order);
     if (filter_conditions && filter_conditions->hasValue())
     {
@@ -269,6 +269,7 @@ void MockStorage::buildExecFromDeltaMerge(
             filter_conditions->conditions,
             empty_ann_query_info,
             empty_pushed_down_filters, // Not care now
+            empty_used_indexes, // Not care now
             scan_column_infos,
             runtime_filter_ids,
             rf_max_wait_time_ms,
@@ -303,6 +304,7 @@ void MockStorage::buildExecFromDeltaMerge(
             empty_filters,
             empty_ann_query_info,
             empty_pushed_down_filters, // Not care now
+            empty_used_indexes, // Not care now
             scan_column_infos,
             runtime_filter_ids,
             rf_max_wait_time_ms,

--- a/dbms/src/Debug/MockTiDB.cpp
+++ b/dbms/src/Debug/MockTiDB.cpp
@@ -600,7 +600,7 @@ void MockTiDB::addVectorIndexToTable(
     version++;
 
     SchemaDiff diff;
-    diff.type = SchemaActionType::ActionAddVectorIndex;
+    diff.type = SchemaActionType::ActionAddColumnarIndex;
     diff.schema_id = table->database_id;
     diff.table_id = table->id();
     diff.version = version;

--- a/dbms/src/Flash/Coprocessor/DAGQueryInfo.h
+++ b/dbms/src/Flash/Coprocessor/DAGQueryInfo.h
@@ -15,8 +15,7 @@
 #pragma once
 
 #include <Interpreters/TimezoneInfo.h>
-#include <Storages/DeltaMerge/Index/LocalIndexInfo.h>
-#include <Storages/KVStore/Decode/DecodingStorageSchemaSnapshot.h>
+#include <TiDB/Schema/TiDB_fwd.h>
 #include <google/protobuf/repeated_ptr_field.h>
 #include <tipb/executor.pb.h>
 #include <tipb/expression.pb.h>
@@ -41,7 +40,7 @@ struct DAGQueryInfo
         , filters(filters_)
         , ann_query_info(ann_query_info_)
         , pushed_down_filters(pushed_down_filters_)
-        , used_indexes(DM::PBToLocalIndexInfos(used_indexes_))
+        , used_indexes(used_indexes_)
         , runtime_filter_ids(runtime_filter_ids_)
         , rf_max_wait_time_ms(rf_max_wait_time_ms_)
         , timezone_info(timezone_info_){};
@@ -55,7 +54,7 @@ struct DAGQueryInfo
     // filters have been push down to storage engine in dag request
     const google::protobuf::RepeatedPtrField<tipb::Expr> & pushed_down_filters;
     // used indexes in dag request
-    const DM::LocalIndexInfosPtr used_indexes;
+    const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & used_indexes;
 
     const std::vector<int> & runtime_filter_ids;
     const int rf_max_wait_time_ms;

--- a/dbms/src/Flash/Coprocessor/DAGQueryInfo.h
+++ b/dbms/src/Flash/Coprocessor/DAGQueryInfo.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <Interpreters/TimezoneInfo.h>
+#include <Storages/DeltaMerge/Index/LocalIndexInfo.h>
 #include <Storages/KVStore/Decode/DecodingStorageSchemaSnapshot.h>
 #include <google/protobuf/repeated_ptr_field.h>
 #include <tipb/executor.pb.h>
@@ -31,6 +32,7 @@ struct DAGQueryInfo
         const google::protobuf::RepeatedPtrField<tipb::Expr> & filters_,
         const tipb::ANNQueryInfo & ann_query_info_,
         const google::protobuf::RepeatedPtrField<tipb::Expr> & pushed_down_filters_,
+        const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & used_indexes_,
         const TiDB::ColumnInfos & source_columns_,
         const std::vector<int> & runtime_filter_ids_,
         const int rf_max_wait_time_ms_,
@@ -39,6 +41,7 @@ struct DAGQueryInfo
         , filters(filters_)
         , ann_query_info(ann_query_info_)
         , pushed_down_filters(pushed_down_filters_)
+        , used_indexes(DM::PBToLocalIndexInfos(used_indexes_))
         , runtime_filter_ids(runtime_filter_ids_)
         , rf_max_wait_time_ms(rf_max_wait_time_ms_)
         , timezone_info(timezone_info_){};
@@ -51,6 +54,8 @@ struct DAGQueryInfo
     const tipb::ANNQueryInfo & ann_query_info;
     // filters have been push down to storage engine in dag request
     const google::protobuf::RepeatedPtrField<tipb::Expr> & pushed_down_filters;
+    // used indexes in dag request
+    const DM::LocalIndexInfosPtr used_indexes;
 
     const std::vector<int> & runtime_filter_ids;
     const int rf_max_wait_time_ms;

--- a/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
@@ -917,6 +917,7 @@ std::unordered_map<TableID, SelectQueryInfo> DAGStorageInterpreter::generateSele
             filter_conditions.conditions,
             table_scan.getANNQueryInfo(),
             table_scan.getPushedDownFilters(),
+            table_scan.getUsedIndexes(),
             table_scan.getColumns(),
             table_scan.getRuntimeFilterIDs(),
             table_scan.getMaxWaitTimeMs(),

--- a/dbms/src/Flash/Coprocessor/TiDBTableScan.h
+++ b/dbms/src/Flash/Coprocessor/TiDBTableScan.h
@@ -44,6 +44,7 @@ public:
     int getMaxWaitTimeMs() const { return max_wait_time_ms; }
 
     const google::protobuf::RepeatedPtrField<tipb::Expr> & getPushedDownFilters() const { return pushed_down_filters; }
+    const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & getUsedIndexes() const { return used_indexes; }
 
     const tipb::ANNQueryInfo & getANNQueryInfo() const { return ann_query_info; }
 
@@ -66,6 +67,8 @@ private:
     /// pushed down to table scan by late materialization.
     /// They will be executed on Storage layer.
     const google::protobuf::RepeatedPtrField<tipb::Expr> pushed_down_filters;
+
+    const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> used_indexes;
 
     const tipb::ANNQueryInfo ann_query_info;
 

--- a/dbms/src/Storages/DeltaMerge/BitmapFilter/BitmapFilter.cpp
+++ b/dbms/src/Storages/DeltaMerge/BitmapFilter/BitmapFilter.cpp
@@ -141,6 +141,15 @@ void BitmapFilter::append(const BitmapFilter & other)
     all_match = all_match && other.all_match;
 }
 
+bool BitmapFilter::isAllNotMatch(size_t offset, size_t limit) const
+{
+    if (all_match)
+    {
+        return false;
+    }
+    return std::all_of(filter.cbegin() + offset, filter.cbegin() + offset + limit, [](const auto a) { return !a; });
+}
+
 void BitmapFilter::runOptimize()
 {
     all_match = std::find(filter.begin(), filter.end(), static_cast<UInt8>(false)) == filter.end();

--- a/dbms/src/Storages/DeltaMerge/BitmapFilter/BitmapFilter.cpp
+++ b/dbms/src/Storages/DeltaMerge/BitmapFilter/BitmapFilter.cpp
@@ -141,13 +141,14 @@ void BitmapFilter::append(const BitmapFilter & other)
     all_match = all_match && other.all_match;
 }
 
-bool BitmapFilter::isAllNotMatch(size_t offset, size_t limit) const
+bool BitmapFilter::isAllNotMatch(size_t start, size_t limit) const
 {
     if (all_match)
     {
         return false;
     }
-    return std::all_of(filter.cbegin() + offset, filter.cbegin() + offset + limit, [](const auto a) { return !a; });
+    assert(start + limit <= filter.size());
+    return std::all_of(filter.cbegin() + start, filter.cbegin() + start + limit, [](const auto a) { return !a; });
 }
 
 void BitmapFilter::runOptimize()

--- a/dbms/src/Storages/DeltaMerge/BitmapFilter/BitmapFilter.h
+++ b/dbms/src/Storages/DeltaMerge/BitmapFilter/BitmapFilter.h
@@ -47,7 +47,7 @@ public:
     // f = f + other
     void append(const BitmapFilter & other);
     // all_of(filter[start, start+limit), false)
-    bool isAllNotMatch(size_t offset, size_t limit) const;
+    bool isAllNotMatch(size_t start, size_t limit) const;
 
     void runOptimize();
 

--- a/dbms/src/Storages/DeltaMerge/BitmapFilter/BitmapFilter.h
+++ b/dbms/src/Storages/DeltaMerge/BitmapFilter/BitmapFilter.h
@@ -46,6 +46,8 @@ public:
     void logicalAnd(const BitmapFilter & other);
     // f = f + other
     void append(const BitmapFilter & other);
+    // all_of(filter[start, start+limit), false)
+    bool isAllNotMatch(size_t offset, size_t limit) const;
 
     void runOptimize();
 

--- a/dbms/src/Storages/DeltaMerge/DMSegmentThreadInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/DMSegmentThreadInputStream.h
@@ -17,7 +17,7 @@
 #include <Common/FailPoint.h>
 #include <DataStreams/IProfilingBlockInputStream.h>
 #include <Interpreters/Context.h>
-#include <Storages/DeltaMerge/DMContext.h>
+#include <Storages/DeltaMerge/DMContext_fwd.h>
 #include <Storages/DeltaMerge/Segment.h>
 #include <Storages/DeltaMerge/SegmentReadTaskPool.h>
 

--- a/dbms/src/Storages/DeltaMerge/DMSegmentThreadInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/DMSegmentThreadInputStream.h
@@ -17,7 +17,7 @@
 #include <Common/FailPoint.h>
 #include <DataStreams/IProfilingBlockInputStream.h>
 #include <Interpreters/Context.h>
-#include <Storages/DeltaMerge/DMContext_fwd.h>
+#include <Storages/DeltaMerge/DMContext.h>
 #include <Storages/DeltaMerge/Segment.h>
 #include <Storages/DeltaMerge/SegmentReadTaskPool.h>
 
@@ -42,7 +42,7 @@ public:
         const SegmentReadTaskPoolPtr & task_pool_,
         AfterSegmentRead after_segment_read_,
         const ColumnDefines & columns_to_read_,
-        const PushDownExecutorPtr & filter_,
+        const PushDownExecutorPtr & executor_,
         UInt64 start_ts_,
         size_t expected_block_size_,
         ReadMode read_mode_,
@@ -51,7 +51,7 @@ public:
         , task_pool(task_pool_)
         , after_segment_read(after_segment_read_)
         , columns_to_read(columns_to_read_)
-        , filter(filter_)
+        , executor(executor_)
         , header(toEmptyBlock(columns_to_read))
         , start_ts(start_ts_)
         , expected_block_size(expected_block_size_)
@@ -96,7 +96,7 @@ protected:
                     columns_to_read,
                     task->read_snapshot,
                     task->ranges,
-                    filter,
+                    executor,
                     start_ts,
                     block_size);
                 LOG_TRACE(log, "Start to read segment, segment={}", cur_segment->simpleInfo());
@@ -127,7 +127,7 @@ private:
     SegmentReadTaskPoolPtr task_pool;
     AfterSegmentRead after_segment_read;
     ColumnDefines columns_to_read;
-    PushDownExecutorPtr filter;
+    PushDownExecutorPtr executor;
     Block header;
     const UInt64 start_ts;
     const size_t expected_block_size;

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
@@ -460,7 +460,7 @@ public:
         const RowKeyRanges & sorted_ranges,
         size_t num_streams,
         UInt64 start_ts,
-        const PushDownExecutorPtr & filter,
+        const PushDownExecutorPtr & executor,
         const RuntimeFilteList & runtime_filter_list,
         int rf_max_wait_time_ms,
         const String & tracing_id,
@@ -485,7 +485,7 @@ public:
         const RowKeyRanges & sorted_ranges,
         size_t num_streams,
         UInt64 start_ts,
-        const PushDownExecutorPtr & filter,
+        const PushDownExecutorPtr & executor,
         const RuntimeFilteList & runtime_filter_list,
         int rf_max_wait_time_ms,
         const String & tracing_id,
@@ -588,7 +588,7 @@ public:
         const Context & db_context,
         bool is_fast_scan,
         bool keep_order,
-        const PushDownExecutorPtr & filter);
+        const PushDownExecutorPtr & executor);
 
     // Get a snap of local_index_infos for checking.
     // Note that this is just a shallow copy of `local_index_infos`, do not

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_Statistics.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore_Statistics.cpp
@@ -206,7 +206,7 @@ std::optional<LocalIndexesStats> DeltaMergeStore::genLocalIndexStatsByTableInfo(
         DM::LocalIndexStats index_stats;
         index_stats.column_id = index_info.column_id;
         index_stats.index_id = index_info.index_id;
-        index_stats.index_kind = "HNSW";
+        index_stats.index_kind = magic_enum::enum_name(index_info.kind); // like Vector
         stats.emplace_back(std::move(index_stats));
     }
     return stats;

--- a/dbms/src/Storages/DeltaMerge/File/DMFilePackFilterResult.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFilePackFilterResult.h
@@ -76,6 +76,10 @@ public:
         return minmax_index->getUInt64MinMax(pack_id).second;
     }
 
+    // Modify the pack_res according to the bitmap_filter.
+    // Return the count of skipped packs.
+    size_t modify(const DMFilePtr & dmfile, const BitmapFilterPtr & bitmap_filter, size_t offset);
+
     // None+NoneNull, Some+SomeNull, All, AllNull
     std::tuple<UInt64, UInt64, UInt64, UInt64> countPackRes() const;
 

--- a/dbms/src/Storages/DeltaMerge/File/DMFilePackFilterResult.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFilePackFilterResult.h
@@ -76,8 +76,8 @@ public:
         return minmax_index->getUInt64MinMax(pack_id).second;
     }
 
-    // Modify the pack_res according to the bitmap_filter.
-    // Return the count of skipped packs.
+    // Modify the pack_res according to the `bitmap_filter`.
+    // Return the count of skipped packs that benefits from `bitmap_filter`.
     size_t modify(const DMFilePtr & dmfile, const BitmapFilterPtr & bitmap_filter, size_t offset);
 
     // None+NoneNull, Some+SomeNull, All, AllNull

--- a/dbms/src/Storages/DeltaMerge/Filter/And.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/And.h
@@ -44,12 +44,12 @@ public:
         return res;
     }
 
-    ColumnRangePtr buildSets(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & index_info) override
+    ColumnRangePtr buildSets(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & index_infos) override
     {
         ColumnRanges children_sets;
         children_sets.reserve(children.size());
         for (const auto & child : children)
-            children_sets.push_back(child->buildSets(index_info));
+            children_sets.push_back(child->buildSets(index_infos));
         return AndColumnRange::create(children_sets);
     }
 };

--- a/dbms/src/Storages/DeltaMerge/Filter/And.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/And.h
@@ -44,7 +44,7 @@ public:
         return res;
     }
 
-    ColumnRangePtr buildSets(const LocalIndexInfosSnapshot & index_info) override
+    ColumnRangePtr buildSets(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & index_info) override
     {
         ColumnRanges children_sets;
         children_sets.reserve(children.size());

--- a/dbms/src/Storages/DeltaMerge/Filter/Equal.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/Equal.h
@@ -40,12 +40,12 @@ public:
         {
             auto iter = std::find_if(index_info.begin(), index_info.end(), [&](const auto & info) {
                 return info.index_type() == tipb::ColumnarIndexType::TypeInverted
-                    && info.invert_query_info().column_id() == attr.col_id;
+                    && info.inverted_query_info().column_id() == attr.col_id;
             });
             if (iter != index_info.end())
                 return SingleColumnRange::create(
-                    iter->invert_query_info().column_id(),
-                    iter->invert_query_info().index_id(),
+                    iter->inverted_query_info().column_id(),
+                    iter->inverted_query_info().index_id(),
                     set);
         }
         return UnsupportedColumnRange::create();

--- a/dbms/src/Storages/DeltaMerge/Filter/Equal.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/Equal.h
@@ -34,15 +34,15 @@ public:
         return minMaxCheckCmp<RoughCheck::CheckEqual>(start_pack, pack_count, param, attr, value);
     }
 
-    ColumnRangePtr buildSets(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & index_info) override
+    ColumnRangePtr buildSets(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & index_infos) override
     {
         if (auto set = IntegerSet::createValueSet(attr.type, {value}); set)
         {
-            auto iter = std::find_if(index_info.begin(), index_info.end(), [&](const auto & info) {
+            auto iter = std::find_if(index_infos.begin(), index_infos.end(), [&](const auto & info) {
                 return info.index_type() == tipb::ColumnarIndexType::TypeInverted
                     && info.inverted_query_info().column_id() == attr.col_id;
             });
-            if (iter != index_info.end())
+            if (iter != index_infos.end())
                 return SingleColumnRange::create(
                     iter->inverted_query_info().column_id(),
                     iter->inverted_query_info().index_id(),

--- a/dbms/src/Storages/DeltaMerge/Filter/Equal.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/Equal.h
@@ -36,7 +36,7 @@ public:
 
     ColumnRangePtr buildSets(const LocalIndexInfosSnapshot & index_info) override
     {
-        if (auto set = IntegerSet::createValueSet(attr.type->getTypeId(), {value}); set)
+        if (auto set = IntegerSet::createValueSet(attr.type, {value}); set)
         {
             auto iter = std::find_if(index_info->begin(), index_info->end(), [&](const auto & info) {
                 return info.column_id == attr.col_id && info.kind == TiDB::ColumnarIndexKind::Inverted;

--- a/dbms/src/Storages/DeltaMerge/Filter/Greater.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/Greater.h
@@ -34,15 +34,15 @@ public:
         return minMaxCheckCmp<RoughCheck::CheckGreater>(start_pack, pack_count, param, attr, value);
     }
 
-    ColumnRangePtr buildSets(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & index_info) override
+    ColumnRangePtr buildSets(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & index_infos) override
     {
         if (auto set = IntegerSet::createGreaterRangeSet(attr.type, value, /*not_included=*/true); set)
         {
-            auto iter = std::find_if(index_info.begin(), index_info.end(), [&](const auto & info) {
+            auto iter = std::find_if(index_infos.begin(), index_infos.end(), [&](const auto & info) {
                 return info.index_type() == tipb::ColumnarIndexType::TypeInverted
                     && info.inverted_query_info().column_id() == attr.col_id;
             });
-            if (iter != index_info.end())
+            if (iter != index_infos.end())
                 return SingleColumnRange::create(
                     iter->inverted_query_info().column_id(),
                     iter->inverted_query_info().index_id(),

--- a/dbms/src/Storages/DeltaMerge/Filter/Greater.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/Greater.h
@@ -40,12 +40,12 @@ public:
         {
             auto iter = std::find_if(index_info.begin(), index_info.end(), [&](const auto & info) {
                 return info.index_type() == tipb::ColumnarIndexType::TypeInverted
-                    && info.invert_query_info().column_id() == attr.col_id;
+                    && info.inverted_query_info().column_id() == attr.col_id;
             });
             if (iter != index_info.end())
                 return SingleColumnRange::create(
-                    iter->invert_query_info().column_id(),
-                    iter->invert_query_info().index_id(),
+                    iter->inverted_query_info().column_id(),
+                    iter->inverted_query_info().index_id(),
                     set);
         }
         return UnsupportedColumnRange::create();

--- a/dbms/src/Storages/DeltaMerge/Filter/Greater.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/Greater.h
@@ -36,7 +36,7 @@ public:
 
     ColumnRangePtr buildSets(const LocalIndexInfosSnapshot & index_info) override
     {
-        if (auto set = IntegerSet::createGreaterRangeSet(attr.type->getTypeId(), value, /*not_included=*/true); set)
+        if (auto set = IntegerSet::createGreaterRangeSet(attr.type, value, /*not_included=*/true); set)
         {
             auto iter = std::find_if(index_info->begin(), index_info->end(), [&](const auto & info) {
                 return info.column_id == attr.col_id && info.kind == TiDB::ColumnarIndexKind::Inverted;

--- a/dbms/src/Storages/DeltaMerge/Filter/Greater.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/Greater.h
@@ -34,15 +34,19 @@ public:
         return minMaxCheckCmp<RoughCheck::CheckGreater>(start_pack, pack_count, param, attr, value);
     }
 
-    ColumnRangePtr buildSets(const LocalIndexInfosSnapshot & index_info) override
+    ColumnRangePtr buildSets(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & index_info) override
     {
         if (auto set = IntegerSet::createGreaterRangeSet(attr.type, value, /*not_included=*/true); set)
         {
-            auto iter = std::find_if(index_info->begin(), index_info->end(), [&](const auto & info) {
-                return info.column_id == attr.col_id && info.kind == TiDB::ColumnarIndexKind::Inverted;
+            auto iter = std::find_if(index_info.begin(), index_info.end(), [&](const auto & info) {
+                return info.index_type() == tipb::ColumnarIndexType::TypeInverted
+                    && info.invert_query_info().column_id() == attr.col_id;
             });
-            if (iter != index_info->end())
-                return SingleColumnRange::create(iter->column_id, iter->index_id, set);
+            if (iter != index_info.end())
+                return SingleColumnRange::create(
+                    iter->invert_query_info().column_id(),
+                    iter->invert_query_info().index_id(),
+                    set);
         }
         return UnsupportedColumnRange::create();
     }

--- a/dbms/src/Storages/DeltaMerge/Filter/GreaterEqual.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/GreaterEqual.h
@@ -34,15 +34,15 @@ public:
         return minMaxCheckCmp<RoughCheck::CheckGreaterEqual>(start_pack, pack_count, param, attr, value);
     }
 
-    ColumnRangePtr buildSets(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & index_info) override
+    ColumnRangePtr buildSets(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & index_infos) override
     {
         if (auto set = IntegerSet::createGreaterRangeSet(attr.type, value, /*not_included=*/false); set)
         {
-            auto iter = std::find_if(index_info.begin(), index_info.end(), [&](const auto & info) {
+            auto iter = std::find_if(index_infos.begin(), index_infos.end(), [&](const auto & info) {
                 return info.index_type() == tipb::ColumnarIndexType::TypeInverted
                     && info.inverted_query_info().column_id() == attr.col_id;
             });
-            if (iter != index_info.end())
+            if (iter != index_infos.end())
                 return SingleColumnRange::create(
                     iter->inverted_query_info().column_id(),
                     iter->inverted_query_info().index_id(),

--- a/dbms/src/Storages/DeltaMerge/Filter/GreaterEqual.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/GreaterEqual.h
@@ -40,12 +40,12 @@ public:
         {
             auto iter = std::find_if(index_info.begin(), index_info.end(), [&](const auto & info) {
                 return info.index_type() == tipb::ColumnarIndexType::TypeInverted
-                    && info.invert_query_info().column_id() == attr.col_id;
+                    && info.inverted_query_info().column_id() == attr.col_id;
             });
             if (iter != index_info.end())
                 return SingleColumnRange::create(
-                    iter->invert_query_info().column_id(),
-                    iter->invert_query_info().index_id(),
+                    iter->inverted_query_info().column_id(),
+                    iter->inverted_query_info().index_id(),
                     set);
         }
         return UnsupportedColumnRange::create();

--- a/dbms/src/Storages/DeltaMerge/Filter/GreaterEqual.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/GreaterEqual.h
@@ -36,7 +36,7 @@ public:
 
     ColumnRangePtr buildSets(const LocalIndexInfosSnapshot & index_info) override
     {
-        if (auto set = IntegerSet::createGreaterRangeSet(attr.type->getTypeId(), value, /*not_included=*/false); set)
+        if (auto set = IntegerSet::createGreaterRangeSet(attr.type, value, /*not_included=*/false); set)
         {
             auto iter = std::find_if(index_info->begin(), index_info->end(), [&](const auto & info) {
                 return info.column_id == attr.col_id && info.kind == TiDB::ColumnarIndexKind::Inverted;

--- a/dbms/src/Storages/DeltaMerge/Filter/GreaterEqual.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/GreaterEqual.h
@@ -34,15 +34,19 @@ public:
         return minMaxCheckCmp<RoughCheck::CheckGreaterEqual>(start_pack, pack_count, param, attr, value);
     }
 
-    ColumnRangePtr buildSets(const LocalIndexInfosSnapshot & index_info) override
+    ColumnRangePtr buildSets(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & index_info) override
     {
         if (auto set = IntegerSet::createGreaterRangeSet(attr.type, value, /*not_included=*/false); set)
         {
-            auto iter = std::find_if(index_info->begin(), index_info->end(), [&](const auto & info) {
-                return info.column_id == attr.col_id && info.kind == TiDB::ColumnarIndexKind::Inverted;
+            auto iter = std::find_if(index_info.begin(), index_info.end(), [&](const auto & info) {
+                return info.index_type() == tipb::ColumnarIndexType::TypeInverted
+                    && info.invert_query_info().column_id() == attr.col_id;
             });
-            if (iter != index_info->end())
-                return SingleColumnRange::create(iter->column_id, iter->index_id, set);
+            if (iter != index_info.end())
+                return SingleColumnRange::create(
+                    iter->invert_query_info().column_id(),
+                    iter->invert_query_info().index_id(),
+                    set);
         }
         return UnsupportedColumnRange::create();
     }

--- a/dbms/src/Storages/DeltaMerge/Filter/In.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/In.h
@@ -60,15 +60,19 @@ public:
                         : RSResults(pack_count, RSResult::Some);
     }
 
-    ColumnRangePtr buildSets(const LocalIndexInfosSnapshot & index_info) override
+    ColumnRangePtr buildSets(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & index_info) override
     {
         if (auto set = IntegerSet::createValueSet(attr.type, values); set)
         {
-            auto iter = std::find_if(index_info->begin(), index_info->end(), [&](const auto & info) {
-                return info.column_id == attr.col_id && info.kind == TiDB::ColumnarIndexKind::Inverted;
+            auto iter = std::find_if(index_info.begin(), index_info.end(), [&](const auto & info) {
+                return info.index_type() == tipb::ColumnarIndexType::TypeInverted
+                    && info.invert_query_info().column_id() == attr.col_id;
             });
-            if (iter != index_info->end())
-                return SingleColumnRange::create(iter->column_id, iter->index_id, set);
+            if (iter != index_info.end())
+                return SingleColumnRange::create(
+                    iter->invert_query_info().column_id(),
+                    iter->invert_query_info().index_id(),
+                    set);
         }
         return UnsupportedColumnRange::create();
     }

--- a/dbms/src/Storages/DeltaMerge/Filter/In.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/In.h
@@ -60,15 +60,15 @@ public:
                         : RSResults(pack_count, RSResult::Some);
     }
 
-    ColumnRangePtr buildSets(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & index_info) override
+    ColumnRangePtr buildSets(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & index_infos) override
     {
         if (auto set = IntegerSet::createValueSet(attr.type, values); set)
         {
-            auto iter = std::find_if(index_info.begin(), index_info.end(), [&](const auto & info) {
+            auto iter = std::find_if(index_infos.begin(), index_infos.end(), [&](const auto & info) {
                 return info.index_type() == tipb::ColumnarIndexType::TypeInverted
                     && info.inverted_query_info().column_id() == attr.col_id;
             });
-            if (iter != index_info.end())
+            if (iter != index_infos.end())
                 return SingleColumnRange::create(
                     iter->inverted_query_info().column_id(),
                     iter->inverted_query_info().index_id(),

--- a/dbms/src/Storages/DeltaMerge/Filter/In.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/In.h
@@ -66,12 +66,12 @@ public:
         {
             auto iter = std::find_if(index_info.begin(), index_info.end(), [&](const auto & info) {
                 return info.index_type() == tipb::ColumnarIndexType::TypeInverted
-                    && info.invert_query_info().column_id() == attr.col_id;
+                    && info.inverted_query_info().column_id() == attr.col_id;
             });
             if (iter != index_info.end())
                 return SingleColumnRange::create(
-                    iter->invert_query_info().column_id(),
-                    iter->invert_query_info().index_id(),
+                    iter->inverted_query_info().column_id(),
+                    iter->inverted_query_info().index_id(),
                     set);
         }
         return UnsupportedColumnRange::create();

--- a/dbms/src/Storages/DeltaMerge/Filter/In.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/In.h
@@ -62,7 +62,7 @@ public:
 
     ColumnRangePtr buildSets(const LocalIndexInfosSnapshot & index_info) override
     {
-        if (auto set = IntegerSet::createValueSet(attr.type->getTypeId(), values); set)
+        if (auto set = IntegerSet::createValueSet(attr.type, values); set)
         {
             auto iter = std::find_if(index_info->begin(), index_info->end(), [&](const auto & info) {
                 return info.column_id == attr.col_id && info.kind == TiDB::ColumnarIndexKind::Inverted;

--- a/dbms/src/Storages/DeltaMerge/Filter/IntegerSet.cpp
+++ b/dbms/src/Storages/DeltaMerge/Filter/IntegerSet.cpp
@@ -27,8 +27,7 @@ namespace DB::DM
 
 IntegerSetPtr IntegerSet::createValueSet(const DataTypePtr & type, const Fields & values)
 {
-    auto type_id = type->isNullable() ? dynamic_cast<const DataTypeNullable &>(*type).getNestedType()->getTypeId()
-                                      : type->getTypeId();
+    auto type_id = removeNullable(type)->getTypeId();
     switch (type_id)
     {
     case TypeIndex::UInt8:
@@ -78,8 +77,7 @@ IntegerSetPtr IntegerSet::createLessRangeSet(const DataTypePtr & type, const Fie
             return std::make_shared<RangeSet<T>>(std::numeric_limits<T>::min(), max_value - not_included);
     };
 
-    auto type_id = type->isNullable() ? dynamic_cast<const DataTypeNullable &>(*type).getNestedType()->getTypeId()
-                                      : type->getTypeId();
+    auto type_id = removeNullable(type)->getTypeId();
     switch (type_id)
     {
     case TypeIndex::UInt8:
@@ -129,8 +127,7 @@ IntegerSetPtr IntegerSet::createGreaterRangeSet(const DataTypePtr & type, const 
             return std::make_shared<RangeSet<T>>(min_value + not_included, std::numeric_limits<T>::max());
     };
 
-    auto type_id = type->isNullable() ? dynamic_cast<const DataTypeNullable &>(*type).getNestedType()->getTypeId()
-                                      : type->getTypeId();
+    auto type_id = removeNullable(type)->getTypeId();
     switch (type_id)
     {
     case TypeIndex::UInt8:

--- a/dbms/src/Storages/DeltaMerge/Filter/IntegerSet.cpp
+++ b/dbms/src/Storages/DeltaMerge/Filter/IntegerSet.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <Common/Exception.h>
+#include <DataTypes/DataTypeNullable.h>
 #include <Storages/DeltaMerge/Filter/IntegerSet.h>
 #include <Storages/DeltaMerge/Index/InvertedIndex/Reader.h>
 
@@ -24,9 +25,11 @@
 namespace DB::DM
 {
 
-IntegerSetPtr IntegerSet::createValueSet(TypeIndex type_index, const Fields & values)
+IntegerSetPtr IntegerSet::createValueSet(const DataTypePtr & type, const Fields & values)
 {
-    switch (type_index)
+    auto type_id = type->isNullable() ? dynamic_cast<const DataTypeNullable &>(*type).getNestedType()->getTypeId()
+                                      : type->getTypeId();
+    switch (type_id)
     {
     case TypeIndex::UInt8:
         return std::make_shared<ValueSet<UInt8>>(values);
@@ -63,7 +66,7 @@ IntegerSetPtr IntegerSet::createValueSet(TypeIndex type_index, const Fields & va
     }
 }
 
-IntegerSetPtr IntegerSet::createLessRangeSet(TypeIndex type_index, const Field & max, bool not_included)
+IntegerSetPtr IntegerSet::createLessRangeSet(const DataTypePtr & type, const Field & max, bool not_included)
 {
     auto func = []<typename T>(const Field & max, bool not_included) -> IntegerSetPtr {
         auto max_value = max.get<T>();
@@ -75,7 +78,9 @@ IntegerSetPtr IntegerSet::createLessRangeSet(TypeIndex type_index, const Field &
             return std::make_shared<RangeSet<T>>(std::numeric_limits<T>::min(), max_value - not_included);
     };
 
-    switch (type_index)
+    auto type_id = type->isNullable() ? dynamic_cast<const DataTypeNullable &>(*type).getNestedType()->getTypeId()
+                                      : type->getTypeId();
+    switch (type_id)
     {
     case TypeIndex::UInt8:
         return func.template operator()<UInt8>(max, not_included);
@@ -112,7 +117,7 @@ IntegerSetPtr IntegerSet::createLessRangeSet(TypeIndex type_index, const Field &
     }
 }
 
-IntegerSetPtr IntegerSet::createGreaterRangeSet(TypeIndex type_index, const Field & min, bool not_included)
+IntegerSetPtr IntegerSet::createGreaterRangeSet(const DataTypePtr & type, const Field & min, bool not_included)
 {
     auto func = []<typename T>(const Field & min, bool not_included) -> IntegerSetPtr {
         auto min_value = min.get<T>();
@@ -124,7 +129,9 @@ IntegerSetPtr IntegerSet::createGreaterRangeSet(TypeIndex type_index, const Fiel
             return std::make_shared<RangeSet<T>>(min_value + not_included, std::numeric_limits<T>::max());
     };
 
-    switch (type_index)
+    auto type_id = type->isNullable() ? dynamic_cast<const DataTypeNullable &>(*type).getNestedType()->getTypeId()
+                                      : type->getTypeId();
+    switch (type_id)
     {
     case TypeIndex::UInt8:
         return func.template operator()<UInt8>(min, not_included);

--- a/dbms/src/Storages/DeltaMerge/Filter/IntegerSet.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/IntegerSet.h
@@ -69,9 +69,9 @@ public:
     // Only used in tests.
     virtual String toDebugString() = 0;
 
-    static IntegerSetPtr createValueSet(TypeIndex type_index, const Fields & values);
-    static IntegerSetPtr createLessRangeSet(TypeIndex type_index, const Field & max, bool not_included = true);
-    static IntegerSetPtr createGreaterRangeSet(TypeIndex type_index, const Field & min, bool not_included = true);
+    static IntegerSetPtr createValueSet(const DataTypePtr & type, const Fields & values);
+    static IntegerSetPtr createLessRangeSet(const DataTypePtr & type, const Field & max, bool not_included = true);
+    static IntegerSetPtr createGreaterRangeSet(const DataTypePtr & type, const Field & min, bool not_included = true);
 };
 
 class EmptySet final : public IntegerSet

--- a/dbms/src/Storages/DeltaMerge/Filter/IsNull.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/IsNull.h
@@ -40,7 +40,10 @@ public:
         return rs_index ? rs_index->minmax->checkIsNull(start_pack, pack_count) : RSResults(pack_count, RSResult::Some);
     }
 
-    ColumnRangePtr buildSets(const LocalIndexInfosSnapshot &) override { return UnsupportedColumnRange::create(); }
+    ColumnRangePtr buildSets(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> &) override
+    {
+        return UnsupportedColumnRange::create();
+    }
 };
 
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/Filter/Less.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/Less.h
@@ -36,15 +36,19 @@ public:
         return results;
     }
 
-    ColumnRangePtr buildSets(const LocalIndexInfosSnapshot & index_info) override
+    ColumnRangePtr buildSets(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & index_info) override
     {
         if (auto set = IntegerSet::createLessRangeSet(attr.type, value, /*not_included=*/true); set)
         {
-            auto iter = std::find_if(index_info->begin(), index_info->end(), [&](const auto & info) {
-                return info.column_id == attr.col_id && info.kind == TiDB::ColumnarIndexKind::Inverted;
+            auto iter = std::find_if(index_info.begin(), index_info.end(), [&](const auto & info) {
+                return info.index_type() == tipb::ColumnarIndexType::TypeInverted
+                    && info.invert_query_info().column_id() == attr.col_id;
             });
-            if (iter != index_info->end())
-                return SingleColumnRange::create(iter->column_id, iter->index_id, set);
+            if (iter != index_info.end())
+                return SingleColumnRange::create(
+                    iter->invert_query_info().column_id(),
+                    iter->invert_query_info().index_id(),
+                    set);
         }
         return UnsupportedColumnRange::create();
     }

--- a/dbms/src/Storages/DeltaMerge/Filter/Less.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/Less.h
@@ -36,15 +36,15 @@ public:
         return results;
     }
 
-    ColumnRangePtr buildSets(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & index_info) override
+    ColumnRangePtr buildSets(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & index_infos) override
     {
         if (auto set = IntegerSet::createLessRangeSet(attr.type, value, /*not_included=*/true); set)
         {
-            auto iter = std::find_if(index_info.begin(), index_info.end(), [&](const auto & info) {
+            auto iter = std::find_if(index_infos.begin(), index_infos.end(), [&](const auto & info) {
                 return info.index_type() == tipb::ColumnarIndexType::TypeInverted
                     && info.inverted_query_info().column_id() == attr.col_id;
             });
-            if (iter != index_info.end())
+            if (iter != index_infos.end())
                 return SingleColumnRange::create(
                     iter->inverted_query_info().column_id(),
                     iter->inverted_query_info().index_id(),

--- a/dbms/src/Storages/DeltaMerge/Filter/Less.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/Less.h
@@ -38,7 +38,7 @@ public:
 
     ColumnRangePtr buildSets(const LocalIndexInfosSnapshot & index_info) override
     {
-        if (auto set = IntegerSet::createLessRangeSet(attr.type->getTypeId(), value, /*not_included=*/true); set)
+        if (auto set = IntegerSet::createLessRangeSet(attr.type, value, /*not_included=*/true); set)
         {
             auto iter = std::find_if(index_info->begin(), index_info->end(), [&](const auto & info) {
                 return info.column_id == attr.col_id && info.kind == TiDB::ColumnarIndexKind::Inverted;

--- a/dbms/src/Storages/DeltaMerge/Filter/Less.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/Less.h
@@ -42,12 +42,12 @@ public:
         {
             auto iter = std::find_if(index_info.begin(), index_info.end(), [&](const auto & info) {
                 return info.index_type() == tipb::ColumnarIndexType::TypeInverted
-                    && info.invert_query_info().column_id() == attr.col_id;
+                    && info.inverted_query_info().column_id() == attr.col_id;
             });
             if (iter != index_info.end())
                 return SingleColumnRange::create(
-                    iter->invert_query_info().column_id(),
-                    iter->invert_query_info().index_id(),
+                    iter->inverted_query_info().column_id(),
+                    iter->inverted_query_info().index_id(),
                     set);
         }
         return UnsupportedColumnRange::create();

--- a/dbms/src/Storages/DeltaMerge/Filter/LessEqual.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/LessEqual.h
@@ -36,15 +36,15 @@ public:
         return results;
     }
 
-    ColumnRangePtr buildSets(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & index_info) override
+    ColumnRangePtr buildSets(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & index_infos) override
     {
         if (auto set = IntegerSet::createLessRangeSet(attr.type, value, /*not_included=*/false); set)
         {
-            auto iter = std::find_if(index_info.begin(), index_info.end(), [&](const auto & info) {
+            auto iter = std::find_if(index_infos.begin(), index_infos.end(), [&](const auto & info) {
                 return info.index_type() == tipb::ColumnarIndexType::TypeInverted
                     && info.inverted_query_info().column_id() == attr.col_id;
             });
-            if (iter != index_info.end())
+            if (iter != index_infos.end())
                 return SingleColumnRange::create(
                     iter->inverted_query_info().column_id(),
                     iter->inverted_query_info().index_id(),

--- a/dbms/src/Storages/DeltaMerge/Filter/LessEqual.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/LessEqual.h
@@ -38,7 +38,7 @@ public:
 
     ColumnRangePtr buildSets(const LocalIndexInfosSnapshot & index_info) override
     {
-        if (auto set = IntegerSet::createLessRangeSet(attr.type->getTypeId(), value, /*not_included=*/false); set)
+        if (auto set = IntegerSet::createLessRangeSet(attr.type, value, /*not_included=*/false); set)
         {
             auto iter = std::find_if(index_info->begin(), index_info->end(), [&](const auto & info) {
                 return info.column_id == attr.col_id && info.kind == TiDB::ColumnarIndexKind::Inverted;

--- a/dbms/src/Storages/DeltaMerge/Filter/LessEqual.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/LessEqual.h
@@ -42,12 +42,12 @@ public:
         {
             auto iter = std::find_if(index_info.begin(), index_info.end(), [&](const auto & info) {
                 return info.index_type() == tipb::ColumnarIndexType::TypeInverted
-                    && info.invert_query_info().column_id() == attr.col_id;
+                    && info.inverted_query_info().column_id() == attr.col_id;
             });
             if (iter != index_info.end())
                 return SingleColumnRange::create(
-                    iter->invert_query_info().column_id(),
-                    iter->invert_query_info().index_id(),
+                    iter->inverted_query_info().column_id(),
+                    iter->inverted_query_info().index_id(),
                     set);
         }
         return UnsupportedColumnRange::create();

--- a/dbms/src/Storages/DeltaMerge/Filter/LessEqual.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/LessEqual.h
@@ -36,15 +36,19 @@ public:
         return results;
     }
 
-    ColumnRangePtr buildSets(const LocalIndexInfosSnapshot & index_info) override
+    ColumnRangePtr buildSets(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & index_info) override
     {
         if (auto set = IntegerSet::createLessRangeSet(attr.type, value, /*not_included=*/false); set)
         {
-            auto iter = std::find_if(index_info->begin(), index_info->end(), [&](const auto & info) {
-                return info.column_id == attr.col_id && info.kind == TiDB::ColumnarIndexKind::Inverted;
+            auto iter = std::find_if(index_info.begin(), index_info.end(), [&](const auto & info) {
+                return info.index_type() == tipb::ColumnarIndexType::TypeInverted
+                    && info.invert_query_info().column_id() == attr.col_id;
             });
-            if (iter != index_info->end())
-                return SingleColumnRange::create(iter->column_id, iter->index_id, set);
+            if (iter != index_info.end())
+                return SingleColumnRange::create(
+                    iter->invert_query_info().column_id(),
+                    iter->invert_query_info().index_id(),
+                    set);
         }
         return UnsupportedColumnRange::create();
     }

--- a/dbms/src/Storages/DeltaMerge/Filter/Like.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/Like.h
@@ -33,7 +33,10 @@ public:
         return RSResults(pack_count, RSResult::Some);
     }
 
-    ColumnRangePtr buildSets(const LocalIndexInfosSnapshot &) override { return UnsupportedColumnRange::create(); }
+    ColumnRangePtr buildSets(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> &) override
+    {
+        return UnsupportedColumnRange::create();
+    }
 };
 
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/Filter/Not.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/Not.h
@@ -35,9 +35,9 @@ public:
         return results;
     }
 
-    ColumnRangePtr buildSets(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & index_info) override
+    ColumnRangePtr buildSets(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & index_infos) override
     {
-        auto sets = children[0]->buildSets(index_info);
+        auto sets = children[0]->buildSets(index_infos);
         return sets->invert();
     }
 };

--- a/dbms/src/Storages/DeltaMerge/Filter/Not.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/Not.h
@@ -35,7 +35,7 @@ public:
         return results;
     }
 
-    ColumnRangePtr buildSets(const LocalIndexInfosSnapshot & index_info) override
+    ColumnRangePtr buildSets(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & index_info) override
     {
         auto sets = children[0]->buildSets(index_info);
         return sets->invert();

--- a/dbms/src/Storages/DeltaMerge/Filter/NotEqual.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/NotEqual.h
@@ -44,12 +44,12 @@ public:
         {
             auto iter = std::find_if(index_info.begin(), index_info.end(), [&](const auto & info) {
                 return info.index_type() == tipb::ColumnarIndexType::TypeInverted
-                    && info.invert_query_info().column_id() == attr.col_id;
+                    && info.inverted_query_info().column_id() == attr.col_id;
             });
             if (iter != index_info.end())
                 return SingleColumnRange::create(
-                    iter->invert_query_info().column_id(),
-                    iter->invert_query_info().index_id(),
+                    iter->inverted_query_info().column_id(),
+                    iter->inverted_query_info().index_id(),
                     less->unionWith(greater));
         }
         return UnsupportedColumnRange::create();

--- a/dbms/src/Storages/DeltaMerge/Filter/NotEqual.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/NotEqual.h
@@ -38,8 +38,8 @@ public:
 
     ColumnRangePtr buildSets(const LocalIndexInfosSnapshot & index_info) override
     {
-        auto less = IntegerSet::createLessRangeSet(attr.type->getTypeId(), value, /*not_included=*/true);
-        auto greater = IntegerSet::createGreaterRangeSet(attr.type->getTypeId(), value, /*not_included=*/true);
+        auto less = IntegerSet::createLessRangeSet(attr.type, value, /*not_included=*/true);
+        auto greater = IntegerSet::createGreaterRangeSet(attr.type, value, /*not_included=*/true);
         if (less && greater)
         {
             auto iter = std::find_if(index_info->begin(), index_info->end(), [&](const auto & info) {

--- a/dbms/src/Storages/DeltaMerge/Filter/NotEqual.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/NotEqual.h
@@ -36,17 +36,17 @@ public:
         return results;
     }
 
-    ColumnRangePtr buildSets(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & index_info) override
+    ColumnRangePtr buildSets(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & index_infos) override
     {
         auto less = IntegerSet::createLessRangeSet(attr.type, value, /*not_included=*/true);
         auto greater = IntegerSet::createGreaterRangeSet(attr.type, value, /*not_included=*/true);
         if (less && greater)
         {
-            auto iter = std::find_if(index_info.begin(), index_info.end(), [&](const auto & info) {
+            auto iter = std::find_if(index_infos.begin(), index_infos.end(), [&](const auto & info) {
                 return info.index_type() == tipb::ColumnarIndexType::TypeInverted
                     && info.inverted_query_info().column_id() == attr.col_id;
             });
-            if (iter != index_info.end())
+            if (iter != index_infos.end())
                 return SingleColumnRange::create(
                     iter->inverted_query_info().column_id(),
                     iter->inverted_query_info().index_id(),

--- a/dbms/src/Storages/DeltaMerge/Filter/NotEqual.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/NotEqual.h
@@ -36,17 +36,21 @@ public:
         return results;
     }
 
-    ColumnRangePtr buildSets(const LocalIndexInfosSnapshot & index_info) override
+    ColumnRangePtr buildSets(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & index_info) override
     {
         auto less = IntegerSet::createLessRangeSet(attr.type, value, /*not_included=*/true);
         auto greater = IntegerSet::createGreaterRangeSet(attr.type, value, /*not_included=*/true);
         if (less && greater)
         {
-            auto iter = std::find_if(index_info->begin(), index_info->end(), [&](const auto & info) {
-                return info.column_id == attr.col_id && info.kind == TiDB::ColumnarIndexKind::Inverted;
+            auto iter = std::find_if(index_info.begin(), index_info.end(), [&](const auto & info) {
+                return info.index_type() == tipb::ColumnarIndexType::TypeInverted
+                    && info.invert_query_info().column_id() == attr.col_id;
             });
-            if (iter != index_info->end())
-                return SingleColumnRange::create(iter->column_id, iter->index_id, less->unionWith(greater));
+            if (iter != index_info.end())
+                return SingleColumnRange::create(
+                    iter->invert_query_info().column_id(),
+                    iter->invert_query_info().index_id(),
+                    less->unionWith(greater));
         }
         return UnsupportedColumnRange::create();
     }

--- a/dbms/src/Storages/DeltaMerge/Filter/Or.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/Or.h
@@ -44,12 +44,12 @@ public:
         return res;
     }
 
-    ColumnRangePtr buildSets(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & index_info) override
+    ColumnRangePtr buildSets(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & index_infos) override
     {
         ColumnRanges children_sets;
         children_sets.reserve(children.size());
         for (const auto & child : children)
-            children_sets.push_back(child->buildSets(index_info));
+            children_sets.push_back(child->buildSets(index_infos));
         return OrColumnRange::create(children_sets);
     }
 };

--- a/dbms/src/Storages/DeltaMerge/Filter/Or.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/Or.h
@@ -44,7 +44,7 @@ public:
         return res;
     }
 
-    ColumnRangePtr buildSets(const LocalIndexInfosSnapshot & index_info) override
+    ColumnRangePtr buildSets(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & index_info) override
     {
         ColumnRanges children_sets;
         children_sets.reserve(children.size());

--- a/dbms/src/Storages/DeltaMerge/Filter/PushDownExecutor.cpp
+++ b/dbms/src/Storages/DeltaMerge/Filter/PushDownExecutor.cpp
@@ -179,7 +179,7 @@ PushDownExecutorPtr PushDownExecutor::build(
     const SelectQueryInfo & query_info,
     const ColumnDefines & columns_to_read,
     const ColumnDefines & table_column_defines,
-    const LocalIndexInfosSnapshot & local_index_infos,
+    const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & used_indexes,
     const Context & context,
     const LoggerPtr & tracing_logger)
 {
@@ -196,7 +196,7 @@ PushDownExecutorPtr PushDownExecutor::build(
         context.getSettingsRef().dt_enable_rough_set_filter,
         tracing_logger);
     // build column_range
-    const auto column_range = rs_operator && local_index_infos ? rs_operator->buildSets(local_index_infos) : nullptr;
+    const auto column_range = rs_operator && used_indexes.empty() ? rs_operator->buildSets(used_indexes) : nullptr;
     // build ann_query_info
     ANNQueryInfoPtr ann_query_info = nullptr;
     if (dag_query->ann_query_info.query_type() != tipb::ANNQueryType::InvalidQueryType)

--- a/dbms/src/Storages/DeltaMerge/Filter/PushDownExecutor.cpp
+++ b/dbms/src/Storages/DeltaMerge/Filter/PushDownExecutor.cpp
@@ -196,7 +196,7 @@ PushDownExecutorPtr PushDownExecutor::build(
         context.getSettingsRef().dt_enable_rough_set_filter,
         tracing_logger);
     // build column_range
-    const auto column_range = rs_operator && used_indexes.empty() ? rs_operator->buildSets(used_indexes) : nullptr;
+    const auto column_range = rs_operator && !used_indexes.empty() ? rs_operator->buildSets(used_indexes) : nullptr;
     // build ann_query_info
     ANNQueryInfoPtr ann_query_info = nullptr;
     if (dag_query->ann_query_info.query_type() != tipb::ANNQueryType::InvalidQueryType)

--- a/dbms/src/Storages/DeltaMerge/Filter/PushDownExecutor.cpp
+++ b/dbms/src/Storages/DeltaMerge/Filter/PushDownExecutor.cpp
@@ -30,6 +30,7 @@ PushDownExecutorPtr PushDownExecutor::build(
     const TiDB::ColumnInfos & table_scan_column_info,
     const google::protobuf::RepeatedPtrField<tipb::Expr> & pushed_down_filters,
     const ColumnDefines & columns_to_read,
+    const ColumnRangePtr & column_range,
     const Context & context,
     const LoggerPtr & tracing_logger)
 {
@@ -49,7 +50,7 @@ PushDownExecutorPtr PushDownExecutor::build(
     if (pushed_down_filters.empty())
     {
         LOG_DEBUG(tracing_logger, "Push down filter is empty");
-        return std::make_shared<PushDownExecutor>(rs_operator, valid_ann_query_info);
+        return std::make_shared<PushDownExecutor>(rs_operator, valid_ann_query_info, column_range);
     }
     std::unordered_map<ColumnID, ColumnDefine> columns_to_read_map;
     for (const auto & column : columns_to_read)
@@ -170,13 +171,15 @@ PushDownExecutorPtr PushDownExecutor::build(
         filter_columns,
         filter_column_name,
         extra_cast,
-        columns_after_cast);
+        columns_after_cast,
+        column_range);
 }
 
 PushDownExecutorPtr PushDownExecutor::build(
     const SelectQueryInfo & query_info,
     const ColumnDefines & columns_to_read,
     const ColumnDefines & table_column_defines,
+    const LocalIndexInfosSnapshot & local_index_infos,
     const Context & context,
     const LoggerPtr & tracing_logger)
 {
@@ -192,6 +195,8 @@ PushDownExecutorPtr PushDownExecutor::build(
         table_column_defines,
         context.getSettingsRef().dt_enable_rough_set_filter,
         tracing_logger);
+    // build column_range
+    const auto column_range = rs_operator && local_index_infos ? rs_operator->buildSets(local_index_infos) : nullptr;
     // build ann_query_info
     ANNQueryInfoPtr ann_query_info = nullptr;
     if (dag_query->ann_query_info.query_type() != tipb::ANNQueryType::InvalidQueryType)
@@ -210,6 +215,7 @@ PushDownExecutorPtr PushDownExecutor::build(
             columns_to_read_info,
             merged_filters,
             columns_to_read,
+            column_range,
             context,
             tracing_logger);
     }
@@ -219,6 +225,7 @@ PushDownExecutorPtr PushDownExecutor::build(
         columns_to_read_info,
         pushed_down_filters,
         columns_to_read,
+        column_range,
         context,
         tracing_logger);
 }

--- a/dbms/src/Storages/DeltaMerge/Filter/PushDownExecutor.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/PushDownExecutor.h
@@ -42,7 +42,8 @@ public:
         const ColumnDefinesPtr & filter_columns_,
         const String filter_column_name_,
         const ExpressionActionsPtr & extra_cast_,
-        const ColumnDefinesPtr & columns_after_cast_)
+        const ColumnDefinesPtr & columns_after_cast_,
+        const ColumnRangePtr & column_range_)
         : rs_operator(rs_operator_)
         , before_where(beofre_where_)
         , project_after_where(project_after_where_)
@@ -51,11 +52,16 @@ public:
         , extra_cast(extra_cast_)
         , columns_after_cast(columns_after_cast_)
         , ann_query_info(ann_query_info_)
+        , column_range(column_range_)
     {}
 
-    explicit PushDownExecutor(const RSOperatorPtr & rs_operator_, const ANNQueryInfoPtr & ann_query_info_ = nullptr)
+    explicit PushDownExecutor(
+        const RSOperatorPtr & rs_operator_,
+        const ANNQueryInfoPtr & ann_query_info_ = nullptr,
+        const ColumnRangePtr & column_range_ = nullptr)
         : rs_operator(rs_operator_)
         , ann_query_info(ann_query_info_)
+        , column_range(column_range_)
     {}
 
     explicit PushDownExecutor(const ANNQueryInfoPtr & ann_query_info_)
@@ -69,6 +75,7 @@ public:
         const TiDB::ColumnInfos & table_scan_column_info,
         const google::protobuf::RepeatedPtrField<tipb::Expr> & pushed_down_filters,
         const ColumnDefines & columns_to_read,
+        const ColumnRangePtr & column_range,
         const Context & context,
         const LoggerPtr & tracing_logger);
 
@@ -77,6 +84,7 @@ public:
         const SelectQueryInfo & query_info,
         const ColumnDefines & columns_to_read,
         const ColumnDefines & table_column_defines,
+        const LocalIndexInfosSnapshot & local_index_infos,
         const Context & context,
         const LoggerPtr & tracing_logger);
 
@@ -96,8 +104,10 @@ public:
     const ExpressionActionsPtr extra_cast;
     // If the extra_cast is not null, the types of the columns may be changed
     const ColumnDefinesPtr columns_after_cast;
-    // The ANNQueryInfo contains the information of the ANN index
+    // The ann_query_info contains the information of the ANN index
     const ANNQueryInfoPtr ann_query_info;
+    // The column_range contains the column values of the pushed down filters
+    const ColumnRangePtr column_range;
 };
 
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/Filter/PushDownExecutor.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/PushDownExecutor.h
@@ -84,7 +84,7 @@ public:
         const SelectQueryInfo & query_info,
         const ColumnDefines & columns_to_read,
         const ColumnDefines & table_column_defines,
-        const LocalIndexInfosSnapshot & local_index_infos,
+        const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & used_indexes,
         const Context & context,
         const LoggerPtr & tracing_logger);
 

--- a/dbms/src/Storages/DeltaMerge/Filter/RSOperator.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/RSOperator.h
@@ -18,7 +18,6 @@
 #include <Storages/DeltaMerge/DeltaMergeDefines.h>
 #include <Storages/DeltaMerge/Filter/ColumnRange.h>
 #include <Storages/DeltaMerge/Filter/RSOperator_fwd.h>
-#include <Storages/DeltaMerge/Index/LocalIndexInfo.h>
 #include <Storages/DeltaMerge/Index/RSIndex.h>
 #include <Storages/DeltaMerge/Index/RSResult.h>
 #include <TiDB/Schema/TiDB.h>
@@ -55,7 +54,8 @@ public:
 
     virtual ColIds getColumnIDs() = 0;
 
-    virtual ColumnRangePtr buildSets(const LocalIndexInfosSnapshot & index_info) = 0;
+    virtual ColumnRangePtr buildSets(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & index_info)
+        = 0;
 
     static RSOperatorPtr build(
         const std::unique_ptr<DAGQueryInfo> & dag_query,

--- a/dbms/src/Storages/DeltaMerge/Filter/RSOperator.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/RSOperator.h
@@ -54,7 +54,7 @@ public:
 
     virtual ColIds getColumnIDs() = 0;
 
-    virtual ColumnRangePtr buildSets(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & index_info)
+    virtual ColumnRangePtr buildSets(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & index_infos)
         = 0;
 
     static RSOperatorPtr build(

--- a/dbms/src/Storages/DeltaMerge/Filter/Unsupported.h
+++ b/dbms/src/Storages/DeltaMerge/Filter/Unsupported.h
@@ -39,7 +39,10 @@ public:
         return RSResults(pack_count, RSResult::Some);
     }
 
-    ColumnRangePtr buildSets(const LocalIndexInfosSnapshot &) override { return UnsupportedColumnRange::create(); }
+    ColumnRangePtr buildSets(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> &) override
+    {
+        return UnsupportedColumnRange::create();
+    }
 };
 
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/Index/InvertedIndex/Reader.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/InvertedIndex/Reader.cpp
@@ -30,8 +30,7 @@ namespace DB::DM
 
 InvertedIndexReaderPtr InvertedIndexReader::view(const DataTypePtr & type, std::string_view path)
 {
-    auto type_id = type->isNullable() ? dynamic_cast<const DataTypeNullable &>(*type).getNestedType()->getTypeId()
-                                      : type->getTypeId();
+    auto type_id = removeNullable(type)->getTypeId();
     switch (type_id)
     {
     case TypeIndex::UInt8:
@@ -71,8 +70,7 @@ InvertedIndexReaderPtr InvertedIndexReader::view(const DataTypePtr & type, std::
 
 InvertedIndexReaderPtr InvertedIndexReader::view(const DataTypePtr & type, ReadBuffer & buf, size_t index_size)
 {
-    auto type_id = type->isNullable() ? dynamic_cast<const DataTypeNullable &>(*type).getNestedType()->getTypeId()
-                                      : type->getTypeId();
+    auto type_id = removeNullable(type)->getTypeId();
     switch (type_id)
     {
     case TypeIndex::UInt8:

--- a/dbms/src/Storages/DeltaMerge/Index/InvertedIndex/Reader.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/InvertedIndex/Reader.cpp
@@ -205,6 +205,7 @@ inline bool isKeyGreaterThanMax(const InvertedIndexReader::Key key)
 template <typename T>
 void InvertedIndexMemoryReader<T>::search(BitmapFilterPtr & bitmap_filter, const Key & key) const
 {
+    // handle wider data type
     if (isKeyOutOfRange<T>(key))
         return;
 
@@ -218,6 +219,7 @@ template <typename T>
 void InvertedIndexMemoryReader<T>::searchRange(BitmapFilterPtr & bitmap_filter, const Key & begin, const Key & end)
     const
 {
+    // handle wider data type
     if (isKeyGreaterThanMax<T>(begin) || isKeyLessThanMin<T>(end))
         return;
     T real_begin = begin;
@@ -264,6 +266,7 @@ void InvertedIndexFileReader<T>::loadMeta(ReadBuffer & read_buf, size_t index_si
 template <typename T>
 void InvertedIndexFileReader<T>::search(BitmapFilterPtr & bitmap_filter, const Key & key) const
 {
+    // handle wider data type
     if (isKeyOutOfRange<T>(key))
         return;
 
@@ -282,6 +285,7 @@ void InvertedIndexFileReader<T>::search(BitmapFilterPtr & bitmap_filter, const K
 template <typename T>
 void InvertedIndexFileReader<T>::searchRange(BitmapFilterPtr & bitmap_filter, const Key & begin, const Key & end) const
 {
+    // handle wider data type
     if (isKeyGreaterThanMax<T>(begin) || isKeyLessThanMin<T>(end))
         return;
     T real_begin = begin;

--- a/dbms/src/Storages/DeltaMerge/Index/InvertedIndex/Reader.h
+++ b/dbms/src/Storages/DeltaMerge/Index/InvertedIndex/Reader.h
@@ -23,6 +23,7 @@
 
 namespace DB::DM
 {
+
 /// Read a InvertedIndex file.
 class InvertedIndexReader : public ICacheableLocalIndexReader
 {
@@ -36,8 +37,13 @@ public:
     static InvertedIndexReaderPtr view(const DataTypePtr & type, std::string_view path);
     static InvertedIndexReaderPtr view(const DataTypePtr & type, ReadBuffer & buf, size_t index_size);
 
+    // All row ids that match the key will be set to 1 in bitmap_filter.
+    // Key can be wider than the index type range.
+    // But std::is_signed_v<Key> should equal to std::is_signed_v<T>.
+    // For example, if the index type is UInt32, key can be std::numeric_limits<UInt32>::max() + 1, but key can not be minus.
     virtual void search(BitmapFilterPtr & bitmap_filter, const Key & key) const = 0;
-    // [begin, end]
+    // All row ids that match the range [begin, end] will be set to 1 in bitmap_filter.
+    // Both begin and end can be wider than the index type range.
     virtual void searchRange(BitmapFilterPtr & bitmap_filter, const Key & begin, const Key & end) const = 0;
 };
 

--- a/dbms/src/Storages/DeltaMerge/Index/InvertedIndex/tests/gtest_dm_inverted_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/InvertedIndex/tests/gtest_dm_inverted_index.cpp
@@ -153,7 +153,7 @@ try
     {
         auto columnar_info = tipb::ColumnarIndexInfo();
         columnar_info.set_index_type(tipb::ColumnarIndexType::TypeInverted);
-        auto * inverted = columnar_info.mutable_invert_query_info();
+        auto * inverted = columnar_info.mutable_inverted_query_info();
         inverted->set_index_id(1);
         inverted->set_column_id(integer_column_id);
         used_indexes.Add(std::move(columnar_info));
@@ -292,7 +292,7 @@ try
     {
         auto columnar_info = tipb::ColumnarIndexInfo();
         columnar_info.set_index_type(tipb::ColumnarIndexType::TypeInverted);
-        auto * inverted = columnar_info.mutable_invert_query_info();
+        auto * inverted = columnar_info.mutable_inverted_query_info();
         inverted->set_index_id(1);
         inverted->set_column_id(integer_cd_1.id);
         used_indexes.Add(std::move(columnar_info));
@@ -300,7 +300,7 @@ try
     {
         auto columnar_info = tipb::ColumnarIndexInfo();
         columnar_info.set_index_type(tipb::ColumnarIndexType::TypeInverted);
-        auto * inverted = columnar_info.mutable_invert_query_info();
+        auto * inverted = columnar_info.mutable_inverted_query_info();
         inverted->set_index_id(2);
         inverted->set_column_id(integer_cd_2.id);
         used_indexes.Add(std::move(columnar_info));
@@ -558,7 +558,7 @@ try
     {
         auto columnar_info = tipb::ColumnarIndexInfo();
         columnar_info.set_index_type(tipb::ColumnarIndexType::TypeInverted);
-        auto * inverted = columnar_info.mutable_invert_query_info();
+        auto * inverted = columnar_info.mutable_inverted_query_info();
         inverted->set_index_id(1);
         inverted->set_column_id(integer_column_id);
         used_indexes.Add(std::move(columnar_info));
@@ -762,7 +762,7 @@ try
     {
         auto columnar_info = tipb::ColumnarIndexInfo();
         columnar_info.set_index_type(tipb::ColumnarIndexType::TypeInverted);
-        auto * inverted = columnar_info.mutable_invert_query_info();
+        auto * inverted = columnar_info.mutable_inverted_query_info();
         inverted->set_index_id(1);
         inverted->set_column_id(integer_cd_1.id);
         used_indexes.Add(std::move(columnar_info));
@@ -770,7 +770,7 @@ try
     {
         auto columnar_info = tipb::ColumnarIndexInfo();
         columnar_info.set_index_type(tipb::ColumnarIndexType::TypeInverted);
-        auto * inverted = columnar_info.mutable_invert_query_info();
+        auto * inverted = columnar_info.mutable_inverted_query_info();
         inverted->set_index_id(2);
         inverted->set_column_id(integer_cd_2.id);
         used_indexes.Add(std::move(columnar_info));

--- a/dbms/src/Storages/DeltaMerge/Index/InvertedIndex/tests/gtest_dm_inverted_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/InvertedIndex/tests/gtest_dm_inverted_index.cpp
@@ -149,6 +149,16 @@ try
     const auto snapshot = std::make_shared<const LocalIndexInfos>(index_infos);
     cols->emplace_back(integer_cd);
 
+    google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> used_indexes;
+    {
+        auto columnar_info = tipb::ColumnarIndexInfo();
+        columnar_info.set_index_type(tipb::ColumnarIndexType::TypeInverted);
+        auto * inverted = columnar_info.mutable_invert_query_info();
+        inverted->set_index_id(1);
+        inverted->set_column_id(integer_column_id);
+        used_indexes.Add(std::move(columnar_info));
+    }
+
     // Prepare DMFile
     {
         auto stream = std::make_shared<DMFileBlockOutputStream>(dbContext(), dm_file, *cols);
@@ -179,7 +189,7 @@ try
     {
         Attr attr{.col_name = integer_cd.name, .col_id = integer_cd.id, .type = integer_cd.type};
         auto rs_operator = createGreater(attr, Field(static_cast<UInt64>(1)));
-        auto column_range = rs_operator->buildSets(snapshot);
+        auto column_range = rs_operator->buildSets(used_indexes);
 
         InvertedIndexReaderFromDMFile reader(column_range, dm_file, dbContext().getLightLocalIndexCache());
         auto bitmap = reader.load();
@@ -190,7 +200,7 @@ try
     {
         Attr attr{.col_name = integer_cd.name, .col_id = integer_cd.id, .type = integer_cd.type};
         auto rs_operator = createLess(attr, Field(static_cast<UInt64>(7)));
-        auto column_range = rs_operator->buildSets(snapshot);
+        auto column_range = rs_operator->buildSets(used_indexes);
 
         InvertedIndexReaderFromDMFile reader(column_range, dm_file, dbContext().getLightLocalIndexCache());
         auto bitmap = reader.load();
@@ -201,7 +211,7 @@ try
     {
         Attr attr{.col_name = integer_cd.name, .col_id = integer_cd.id, .type = integer_cd.type};
         auto rs_operator = createEqual(attr, Field(static_cast<UInt64>(6)));
-        auto column_range = rs_operator->buildSets(snapshot);
+        auto column_range = rs_operator->buildSets(used_indexes);
 
         InvertedIndexReaderFromDMFile reader(column_range, dm_file, dbContext().getLightLocalIndexCache());
         auto bitmap = reader.load();
@@ -214,7 +224,7 @@ try
         auto rs_operator1 = createGreater(attr, Field(static_cast<UInt64>(1)));
         auto rs_operator2 = createLess(attr, Field(static_cast<UInt64>(10)));
         auto rs_operator = createAnd({rs_operator1, rs_operator2});
-        auto column_range = rs_operator->buildSets(snapshot);
+        auto column_range = rs_operator->buildSets(used_indexes);
 
         InvertedIndexReaderFromDMFile reader(column_range, dm_file, dbContext().getLightLocalIndexCache());
         auto bitmap = reader.load();
@@ -227,7 +237,7 @@ try
         auto rs_operator1 = createGreater(attr, Field(static_cast<UInt64>(5)));
         auto rs_operator2 = createUnsupported("unsupported");
         auto rs_operator = createAnd({rs_operator1, rs_operator2});
-        auto column_range = rs_operator->buildSets(snapshot);
+        auto column_range = rs_operator->buildSets(used_indexes);
 
         InvertedIndexReaderFromDMFile reader(column_range, dm_file, dbContext().getLightLocalIndexCache());
         auto bitmap = reader.load();
@@ -240,7 +250,7 @@ try
         auto rs_operator1 = createGreater(attr, Field(static_cast<UInt64>(1)));
         auto rs_operator2 = createUnsupported("unsupported");
         auto rs_operator = createOr({rs_operator1, rs_operator2});
-        auto column_range = rs_operator->buildSets(snapshot);
+        auto column_range = rs_operator->buildSets(used_indexes);
 
         InvertedIndexReaderFromDMFile reader(column_range, dm_file, dbContext().getLightLocalIndexCache());
         auto bitmap = reader.load();
@@ -278,6 +288,24 @@ try
     };
     const auto snapshot = std::make_shared<const LocalIndexInfos>(index_infos);
 
+    google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> used_indexes;
+    {
+        auto columnar_info = tipb::ColumnarIndexInfo();
+        columnar_info.set_index_type(tipb::ColumnarIndexType::TypeInverted);
+        auto * inverted = columnar_info.mutable_invert_query_info();
+        inverted->set_index_id(1);
+        inverted->set_column_id(integer_cd_1.id);
+        used_indexes.Add(std::move(columnar_info));
+    }
+    {
+        auto columnar_info = tipb::ColumnarIndexInfo();
+        columnar_info.set_index_type(tipb::ColumnarIndexType::TypeInverted);
+        auto * inverted = columnar_info.mutable_invert_query_info();
+        inverted->set_index_id(2);
+        inverted->set_column_id(integer_cd_2.id);
+        used_indexes.Add(std::move(columnar_info));
+    }
+
     // Prepare DMFile
     {
         auto stream = std::make_shared<DMFileBlockOutputStream>(dbContext(), dm_file, *cols);
@@ -314,7 +342,7 @@ try
         auto rs_operator1 = createGreater(attr_1, Field(static_cast<UInt64>(1)));
         auto rs_operator2 = createLess(attr_2, Field(static_cast<Int64>(7)));
         auto rs_operator = createAnd({rs_operator1, rs_operator2});
-        auto column_range = rs_operator->buildSets(snapshot);
+        auto column_range = rs_operator->buildSets(used_indexes);
 
         InvertedIndexReaderFromDMFile reader(column_range, dm_file, dbContext().getLightLocalIndexCache());
         auto bitmap = reader.load();
@@ -328,7 +356,7 @@ try
         auto rs_operator1 = createGreater(attr_1, Field(static_cast<UInt64>(5)));
         auto rs_operator2 = createLess(attr_2, Field(static_cast<Int64>(7)));
         auto rs_operator = createOr({rs_operator1, rs_operator2});
-        auto column_range = rs_operator->buildSets(snapshot);
+        auto column_range = rs_operator->buildSets(used_indexes);
 
         InvertedIndexReaderFromDMFile reader(column_range, dm_file, dbContext().getLightLocalIndexCache());
         auto bitmap = reader.load();
@@ -342,7 +370,7 @@ try
         auto rs_operator1 = createGreater(attr_1, Field(static_cast<UInt64>(10)));
         auto rs_operator2 = createLess(attr_2, Field(static_cast<Int64>(7)));
         auto rs_operator = createAnd({rs_operator1, rs_operator2});
-        auto column_range = rs_operator->buildSets(snapshot);
+        auto column_range = rs_operator->buildSets(used_indexes);
 
         InvertedIndexReaderFromDMFile reader(column_range, dm_file, dbContext().getLightLocalIndexCache());
         auto bitmap = reader.load();
@@ -356,7 +384,7 @@ try
         auto rs_operator1 = createLess(attr_1, Field(static_cast<UInt64>(1)));
         auto rs_operator2 = createGreater(attr_2, Field(static_cast<Int64>(1)));
         auto rs_operator = createOr({rs_operator1, rs_operator2});
-        auto column_range = rs_operator->buildSets(snapshot);
+        auto column_range = rs_operator->buildSets(used_indexes);
 
         InvertedIndexReaderFromDMFile reader(column_range, dm_file, dbContext().getLightLocalIndexCache());
         auto bitmap = reader.load();
@@ -371,7 +399,7 @@ try
         auto rs_operator2 = createEqual(attr_2, Field(static_cast<UInt64>(6)));
         auto rs_operator3 = createUnsupported("unsupported");
         auto rs_operator = createAnd({rs_operator1, rs_operator2, rs_operator3});
-        auto column_range = rs_operator->buildSets(snapshot);
+        auto column_range = rs_operator->buildSets(used_indexes);
 
         InvertedIndexReaderFromDMFile reader(column_range, dm_file, dbContext().getLightLocalIndexCache());
         auto bitmap = reader.load();
@@ -526,6 +554,16 @@ try
     const auto snapshot = std::make_shared<const LocalIndexInfos>(index_infos);
     cols->emplace_back(integer_cd);
 
+    google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> used_indexes;
+    {
+        auto columnar_info = tipb::ColumnarIndexInfo();
+        columnar_info.set_index_type(tipb::ColumnarIndexType::TypeInverted);
+        auto * inverted = columnar_info.mutable_invert_query_info();
+        inverted->set_index_id(1);
+        inverted->set_column_id(integer_column_id);
+        used_indexes.Add(std::move(columnar_info));
+    }
+
     // Prepare ColumnFilePersistedSet
     ColumnFilePersisteds persisted_files;
     {
@@ -561,7 +599,7 @@ try
     {
         Attr attr{.col_name = integer_cd.name, .col_id = integer_cd.id, .type = integer_cd.type};
         auto rs_operator = createGreater(attr, Field(static_cast<UInt64>(1)));
-        auto column_range = rs_operator->buildSets(snapshot);
+        auto column_range = rs_operator->buildSets(used_indexes);
 
         BitmapFilter bitmap_filter(0, false);
         for (const auto & tiny_file : tiny_files)
@@ -582,7 +620,7 @@ try
     {
         Attr attr{.col_name = integer_cd.name, .col_id = integer_cd.id, .type = integer_cd.type};
         auto rs_operator = createLess(attr, Field(static_cast<UInt64>(7)));
-        auto column_range = rs_operator->buildSets(snapshot);
+        auto column_range = rs_operator->buildSets(used_indexes);
 
         BitmapFilter bitmap_filter(0, false);
         for (const auto & tiny_file : tiny_files)
@@ -603,7 +641,7 @@ try
     {
         Attr attr{.col_name = integer_cd.name, .col_id = integer_cd.id, .type = integer_cd.type};
         auto rs_operator = createEqual(attr, Field(static_cast<UInt64>(6)));
-        auto column_range = rs_operator->buildSets(snapshot);
+        auto column_range = rs_operator->buildSets(used_indexes);
 
         BitmapFilter bitmap_filter(0, false);
         for (const auto & tiny_file : tiny_files)
@@ -626,7 +664,7 @@ try
         auto rs_operator1 = createGreater(attr, Field(static_cast<UInt64>(1)));
         auto rs_operator2 = createLess(attr, Field(static_cast<UInt64>(10)));
         auto rs_operator = createAnd({rs_operator1, rs_operator2});
-        auto column_range = rs_operator->buildSets(snapshot);
+        auto column_range = rs_operator->buildSets(used_indexes);
 
         BitmapFilter bitmap_filter(0, false);
         for (const auto & tiny_file : tiny_files)
@@ -649,7 +687,7 @@ try
         auto rs_operator1 = createGreater(attr, Field(static_cast<UInt64>(5)));
         auto rs_operator2 = createUnsupported("unsupported");
         auto rs_operator = createAnd({rs_operator1, rs_operator2});
-        auto column_range = rs_operator->buildSets(snapshot);
+        auto column_range = rs_operator->buildSets(used_indexes);
 
         BitmapFilter bitmap_filter(0, false);
         for (const auto & tiny_file : tiny_files)
@@ -672,7 +710,7 @@ try
         auto rs_operator1 = createGreater(attr, Field(static_cast<UInt64>(1)));
         auto rs_operator2 = createUnsupported("unsupported");
         auto rs_operator = createOr({rs_operator1, rs_operator2});
-        auto column_range = rs_operator->buildSets(snapshot);
+        auto column_range = rs_operator->buildSets(used_indexes);
 
         BitmapFilter bitmap_filter(0, false);
         for (const auto & tiny_file : tiny_files)
@@ -720,6 +758,24 @@ try
     };
     const auto snapshot = std::make_shared<const LocalIndexInfos>(index_infos);
 
+    google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> used_indexes;
+    {
+        auto columnar_info = tipb::ColumnarIndexInfo();
+        columnar_info.set_index_type(tipb::ColumnarIndexType::TypeInverted);
+        auto * inverted = columnar_info.mutable_invert_query_info();
+        inverted->set_index_id(1);
+        inverted->set_column_id(integer_cd_1.id);
+        used_indexes.Add(std::move(columnar_info));
+    }
+    {
+        auto columnar_info = tipb::ColumnarIndexInfo();
+        columnar_info.set_index_type(tipb::ColumnarIndexType::TypeInverted);
+        auto * inverted = columnar_info.mutable_invert_query_info();
+        inverted->set_index_id(2);
+        inverted->set_column_id(integer_cd_2.id);
+        used_indexes.Add(std::move(columnar_info));
+    }
+
     // Prepare ColumnFilePersistedSet
     ColumnFilePersisteds persisted_files;
     {
@@ -761,7 +817,7 @@ try
         auto rs_operator1 = createGreater(attr_1, Field(static_cast<UInt64>(1)));
         auto rs_operator2 = createLess(attr_2, Field(static_cast<Int64>(7)));
         auto rs_operator = createAnd({rs_operator1, rs_operator2});
-        auto column_range = rs_operator->buildSets(snapshot);
+        auto column_range = rs_operator->buildSets(used_indexes);
 
         BitmapFilter bitmap_filter(0, false);
         for (const auto & tiny_file : tiny_files)
@@ -785,7 +841,7 @@ try
         auto rs_operator1 = createGreater(attr_1, Field(static_cast<UInt64>(5)));
         auto rs_operator2 = createLess(attr_2, Field(static_cast<Int64>(7)));
         auto rs_operator = createOr({rs_operator1, rs_operator2});
-        auto column_range = rs_operator->buildSets(snapshot);
+        auto column_range = rs_operator->buildSets(used_indexes);
 
         BitmapFilter bitmap_filter(0, false);
         for (const auto & tiny_file : tiny_files)
@@ -809,7 +865,7 @@ try
         auto rs_operator1 = createGreater(attr_1, Field(static_cast<UInt64>(10)));
         auto rs_operator2 = createLess(attr_2, Field(static_cast<Int64>(7)));
         auto rs_operator = createAnd({rs_operator1, rs_operator2});
-        auto column_range = rs_operator->buildSets(snapshot);
+        auto column_range = rs_operator->buildSets(used_indexes);
 
         BitmapFilter bitmap_filter(0, false);
         for (const auto & tiny_file : tiny_files)
@@ -833,7 +889,7 @@ try
         auto rs_operator1 = createLess(attr_1, Field(static_cast<UInt64>(1)));
         auto rs_operator2 = createGreater(attr_2, Field(static_cast<Int64>(1)));
         auto rs_operator = createOr({rs_operator1, rs_operator2});
-        auto column_range = rs_operator->buildSets(snapshot);
+        auto column_range = rs_operator->buildSets(used_indexes);
 
         BitmapFilter bitmap_filter(0, false);
         for (const auto & tiny_file : tiny_files)
@@ -858,7 +914,7 @@ try
         auto rs_operator2 = createEqual(attr_2, Field(static_cast<UInt64>(6)));
         auto rs_operator3 = createUnsupported("unsupported");
         auto rs_operator = createAnd({rs_operator1, rs_operator2, rs_operator3});
-        auto column_range = rs_operator->buildSets(snapshot);
+        auto column_range = rs_operator->buildSets(used_indexes);
 
         BitmapFilter bitmap_filter(0, false);
         for (const auto & tiny_file : tiny_files)

--- a/dbms/src/Storages/DeltaMerge/Index/InvertedIndex/tests/gtest_inverted_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/InvertedIndex/tests/gtest_inverted_index.cpp
@@ -24,12 +24,12 @@
 namespace DB::DM::tests
 {
 
+static constexpr auto IndexFileName = "test.inverted_index";
+
 template <typename T>
 class InvertedIndexTest
 {
 public:
-    static constexpr auto IndexFileName = "test.inverted_index";
-
     InvertedIndexTest() = default;
 
     ~InvertedIndexTest() = default;
@@ -299,6 +299,47 @@ try
     InvertedIndexTest<Int16>::LargeTestCase::runMultiThread();
     InvertedIndexTest<Int32>::LargeTestCase::runMultiThread();
     InvertedIndexTest<Int64>::LargeTestCase::runMultiThread();
+}
+CATCH
+
+// TiDB support change integer type to larger type (e.g. Int8 -> Int16, UInt8 -> UInt16) without changing data.
+// This means the column will not be changed, and the index will not be rebuilt.
+// Then the type of the search key may be larger than the type of the index.
+TEST(InvertedIndex, ReadTypeLargerThanIndexType)
+try
+{
+    // Build UInt8 type index
+    {
+        auto builder = InvertedIndexWriterOnDisk<UInt8>(0, IndexFileName);
+        InvertedIndexTest<UInt8>::writeBlock(builder, {1, 2, 3, 4, 5, 6, 7, 8, 9, 255}, {0, 1, 0, 1, 0, 1, 0, 1, 0, 0});
+        InvertedIndexTest<UInt8>::writeBlock(builder, {1, 2, 3, 4, 5, 6, 7, 8, 9, 0}, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+        InvertedIndexTest<UInt8>::writeBlock(builder, {1, 2, 2, 2, 3, 3, 3, 4, 4, 128}, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+        builder.finalize();
+    }
+    auto viewer = std::make_shared<InvertedIndexMemoryReader<UInt8>>(IndexFileName);
+    // search key is in the range of UInt8
+    {
+        auto bitmap_filter = std::make_shared<BitmapFilter>(30, false);
+        viewer->search(bitmap_filter, 1);
+        ASSERT_EQ(bitmap_filter->toDebugString(), "100000000010000000001000000000");
+    }
+    {
+        auto bitmap_filter = std::make_shared<BitmapFilter>(30, false);
+        viewer->search(bitmap_filter, 255);
+        ASSERT_EQ(bitmap_filter->toDebugString(), "000000000100000000000000000000");
+    }
+    // search key is larger than UInt8
+    {
+        auto bitmap_filter = std::make_shared<BitmapFilter>(30, false);
+        viewer->search(bitmap_filter, 256);
+        ASSERT_EQ(bitmap_filter->toDebugString(), "000000000000000000000000000000");
+    }
+    {
+        auto bitmap_filter = std::make_shared<BitmapFilter>(30, false);
+        viewer->search(bitmap_filter, 1024);
+        ASSERT_EQ(bitmap_filter->toDebugString(), "000000000000000000000000000000");
+    }
+    Poco::File(IndexFileName).remove();
 }
 CATCH
 

--- a/dbms/src/Storages/DeltaMerge/Index/InvertedIndex/tests/gtest_inverted_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/InvertedIndex/tests/gtest_inverted_index.cpp
@@ -260,24 +260,36 @@ try
 }
 CATCH
 
-// Split the large test case into two parts to avoid long running time.
+// Split the large test case into multiple parts to avoid long running time.
 
 TEST(InvertedIndex, Large1)
 try
 {
     InvertedIndexTest<UInt8>::LargeTestCase::run();
-    InvertedIndexTest<UInt16>::LargeTestCase::run();
-    InvertedIndexTest<UInt32>::LargeTestCase::run();
-    InvertedIndexTest<UInt64>::LargeTestCase::run();
+    InvertedIndexTest<Int8>::LargeTestCase::run();
 }
 CATCH
 
 TEST(InvertedIndex, Large2)
 try
 {
-    InvertedIndexTest<Int8>::LargeTestCase::run();
+    InvertedIndexTest<UInt16>::LargeTestCase::run();
     InvertedIndexTest<Int16>::LargeTestCase::run();
+}
+CATCH
+
+TEST(InvertedIndex, Large3)
+try
+{
+    InvertedIndexTest<UInt32>::LargeTestCase::run();
     InvertedIndexTest<Int32>::LargeTestCase::run();
+}
+CATCH
+
+TEST(InvertedIndex, Large4)
+try
+{
+    InvertedIndexTest<UInt64>::LargeTestCase::run();
     InvertedIndexTest<Int64>::LargeTestCase::run();
 }
 CATCH

--- a/dbms/src/Storages/DeltaMerge/Index/LocalIndexInfo.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/LocalIndexInfo.cpp
@@ -271,7 +271,7 @@ LocalIndexInfosPtr PBToLocalIndexInfos(const google::protobuf::RepeatedPtrField<
             const auto & ann_query_info = idx.ann_query_info();
             local_index_infos->emplace_back(LocalIndexInfo(
                 ann_query_info.index_id(),
-                ann_query_info.column_id(),
+                ann_query_info.deprecated_column_id(),
                 TiDB::VectorIndexDefinitionPtr()));
             break;
         }

--- a/dbms/src/Storages/DeltaMerge/Index/LocalIndexInfo.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/LocalIndexInfo.cpp
@@ -259,39 +259,4 @@ String LocalIndexInfosChangeset::toString() const
     return buf.toString();
 }
 
-LocalIndexInfosPtr PBToLocalIndexInfos(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & indexes)
-{
-    auto local_index_infos = std::make_shared<LocalIndexInfos>();
-    for (const auto & idx : indexes)
-    {
-        switch (idx.index_type())
-        {
-        case tipb::ColumnarIndexType::TypeVector:
-        {
-            const auto & ann_query_info = idx.ann_query_info();
-            local_index_infos->emplace_back(LocalIndexInfo(
-                ann_query_info.index_id(),
-                ann_query_info.deprecated_column_id(),
-                TiDB::VectorIndexDefinitionPtr()));
-            break;
-        }
-        case tipb::ColumnarIndexType::TypeInverted:
-        {
-            const auto & inverted_query_info = idx.invert_query_info();
-            local_index_infos->emplace_back(LocalIndexInfo(
-                inverted_query_info.index_id(),
-                inverted_query_info.column_id(),
-                TiDB::InvertedIndexDefinitionPtr()));
-            break;
-        }
-        default:
-            throw Exception(
-                ErrorCodes::LOGICAL_ERROR,
-                "Unsupported columnar index type: {}",
-                tipb::ColumnarIndexType_Name(idx.index_type()));
-        }
-    }
-    return local_index_infos;
-}
-
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/Index/LocalIndexInfo.h
+++ b/dbms/src/Storages/DeltaMerge/Index/LocalIndexInfo.h
@@ -61,22 +61,10 @@ struct LocalIndexInfo
         , column_id(column_id_)
         , def_inverted_index(def)
     {}
-
-    dtpb::IndexFileKind getKindAsDtpb() const
-    {
-        switch (kind)
-        {
-        case TiDB::ColumnarIndexKind::Vector:
-            return dtpb::IndexFileKind::VECTOR_INDEX;
-        case TiDB::ColumnarIndexKind::Inverted:
-            return dtpb::IndexFileKind::INVERTED_INDEX;
-        default:
-            RUNTIME_CHECK_MSG(false, "Unsupported index kind: {}", magic_enum::enum_name(kind));
-        }
-    }
 };
 
 LocalIndexInfosPtr initLocalIndexInfos(const TiDB::TableInfo & table_info, const LoggerPtr & logger);
+LocalIndexInfosPtr PBToLocalIndexInfos(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & indexes);
 
 class LocalIndexInfosChangeset
 {

--- a/dbms/src/Storages/DeltaMerge/Index/LocalIndexInfo.h
+++ b/dbms/src/Storages/DeltaMerge/Index/LocalIndexInfo.h
@@ -64,8 +64,6 @@ struct LocalIndexInfo
 };
 
 LocalIndexInfosPtr initLocalIndexInfos(const TiDB::TableInfo & table_info, const LoggerPtr & logger);
-LocalIndexInfosPtr PBToLocalIndexInfos(const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> & indexes);
-
 class LocalIndexInfosChangeset
 {
 public:

--- a/dbms/src/Storages/DeltaMerge/Index/VectorIndex/tests/gtest_dm_delta_merge_store_vector_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/VectorIndex/tests/gtest_dm_delta_merge_store_vector_index.cpp
@@ -99,7 +99,7 @@ public:
         store->write(*db_context, db_context->getSettingsRef(), block);
     }
 
-    void read(const RowKeyRange & range, const PushDownExecutorPtr & filter, const ColumnWithTypeAndName & out)
+    void read(const RowKeyRange & range, const PushDownExecutorPtr & executor, const ColumnWithTypeAndName & out)
     {
         auto in = store->read(
             *db_context,
@@ -108,7 +108,7 @@ public:
             {range},
             /* num_streams= */ 1,
             /* start_ts= */ std::numeric_limits<UInt64>::max(),
-            filter,
+            executor,
             std::vector<RuntimeFilterPtr>{},
             0,
             TRACING_NAME,

--- a/dbms/src/Storages/DeltaMerge/Index/VectorIndex/tests/gtest_dm_vector_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/VectorIndex/tests/gtest_dm_vector_index.cpp
@@ -1965,7 +1965,7 @@ public:
     std::pair<BlockInputStreamPtr, DMContextPtr> createComputeNodeStream(
         const SegmentPtr & write_node_segment,
         const ColumnDefines & columns_to_read,
-        const PushDownExecutorPtr & filter,
+        const PushDownExecutorPtr & executor,
         const ScanContextPtr & read_scan_context = nullptr)
     {
         auto write_dm_context = dmContext();
@@ -2002,7 +2002,7 @@ public:
             columns_to_read,
             cn_segment_snap,
             {write_node_segment->getRowKeyRange()},
-            filter,
+            executor,
             std::numeric_limits<UInt64>::max(),
             DEFAULT_BLOCK_SIZE);
 

--- a/dbms/src/Storages/DeltaMerge/Index/VectorIndex/tests/gtest_dm_vector_index_utils.h
+++ b/dbms/src/Storages/DeltaMerge/Index/VectorIndex/tests/gtest_dm_vector_index_utils.h
@@ -180,7 +180,7 @@ public:
         store->write(*db_context, db_context->getSettingsRef(), block);
     }
 
-    void read(const RowKeyRange & range, const PushDownExecutorPtr & filter, const ColumnWithTypeAndName & out)
+    void read(const RowKeyRange & range, const PushDownExecutorPtr & executor, const ColumnWithTypeAndName & out)
     {
         auto in = store->read(
             *db_context,
@@ -189,7 +189,7 @@ public:
             {range},
             /* num_streams= */ 1,
             /* start_ts= */ std::numeric_limits<UInt64>::max(),
-            filter,
+            executor,
             std::vector<RuntimeFilterPtr>{},
             0,
             TRACING_NAME,

--- a/dbms/src/Storages/DeltaMerge/Index/tests/gtest_dm_minmax_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/tests/gtest_dm_minmax_index.cpp
@@ -34,6 +34,7 @@
 #include <ext/scope_guard.h>
 #include <memory>
 
+
 namespace DB::DM::tests
 {
 
@@ -2245,10 +2246,12 @@ try
     b.id = 2;
     TiDB::ColumnInfos column_infos = {a, b};
     const auto ann_query_info = tipb::ANNQueryInfo{};
+    static const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> empty_used_indexes{};
     auto dag_query = std::make_unique<DAGQueryInfo>(
         filters,
         ann_query_info,
         pushed_down_filters, // Not care now
+        empty_used_indexes,
         column_infos,
         std::vector<int>{},
         0,

--- a/dbms/src/Storages/DeltaMerge/Segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/Segment.cpp
@@ -3545,7 +3545,7 @@ BlockInputStreamPtr Segment::getBitmapFilterInputStream(
     if (executor && executor->column_range && executor->column_range->type != ColumnRangeType::Unsupported)
     {
         bool all_dmfile_packs_skipped
-            = std::any_of(pack_filter_results.begin(), pack_filter_results.end(), [](const auto & res) {
+            = std::all_of(pack_filter_results.begin(), pack_filter_results.end(), [](const auto & res) {
                   return res->countUsePack() == 0;
               });
         if (!all_dmfile_packs_skipped)

--- a/dbms/src/Storages/DeltaMerge/Segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/Segment.cpp
@@ -3553,8 +3553,10 @@ BlockInputStreamPtr Segment::getBitmapFilterInputStream(
             bitmap_filter = InvertedIndexReaderFromSegment::loadStable(
                 segment_snap,
                 executor->column_range,
-                dm_context.global_context.getLightLocalIndexCache());
+                dm_context.global_context.getLightLocalIndexCache(),
+                dm_context.scan_context);
             size_t skipped_pack = modifyPackFilterResults(segment_snap, pack_filter_results, bitmap_filter);
+            dm_context.scan_context->inverted_idx_search_skipped_packs += skipped_pack;
             LOG_DEBUG(
                 segment_snap->log,
                 "Finish load inverted index, column_range={}, bitmap_filter={}/{}, skipped_pack={}",
@@ -3586,7 +3588,8 @@ BlockInputStreamPtr Segment::getBitmapFilterInputStream(
             auto delta_index_bitmap = InvertedIndexReaderFromSegment::loadDelta(
                 segment_snap,
                 executor->column_range,
-                dm_context.global_context.getLightLocalIndexCache());
+                dm_context.global_context.getLightLocalIndexCache(),
+                dm_context.scan_context);
             bitmap_filter->append(*delta_index_bitmap);
         }
 

--- a/dbms/src/Storages/DeltaMerge/Segment.h
+++ b/dbms/src/Storages/DeltaMerge/Segment.h
@@ -734,17 +734,25 @@ public:
         const DMContext & dm_context,
         const SegmentSnapshotPtr & segment_snap,
         const RowKeyRanges & read_ranges,
+        const PushDownExecutorPtr & executor,
         const DMFilePackFilterResults & pack_filter_results,
         UInt64 start_ts,
-        size_t expected_block_size);
-    BitmapFilterPtr buildBitmapFilterNormal(
+        size_t build_bitmap_filter_block_rows);
+    BitmapFilterPtr buildMVCCBitmapFilter(
         const DMContext & dm_context,
         const SegmentSnapshotPtr & segment_snap,
         const RowKeyRanges & read_ranges,
         const DMFilePackFilterResults & pack_filter_results,
         UInt64 start_ts,
         size_t expected_block_size);
-    BitmapFilterPtr buildBitmapFilterStableOnly(
+    BitmapFilterPtr buildMVCCBitmapFilterNormal(
+        const DMContext & dm_context,
+        const SegmentSnapshotPtr & segment_snap,
+        const RowKeyRanges & read_ranges,
+        const DMFilePackFilterResults & pack_filter_results,
+        UInt64 start_ts,
+        size_t expected_block_size);
+    BitmapFilterPtr buildMVCCBitmapFilterStableOnly(
         const DMContext & dm_context,
         const SegmentSnapshotPtr & segment_snap,
         const RowKeyRanges & read_ranges,

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.cpp
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.cpp
@@ -97,7 +97,7 @@ BlockInputStreamPtr SegmentReadTaskPool::buildInputStream(SegmentReadTaskPtr & t
     t->initInputStream(
         columns_to_read,
         start_ts,
-        filter,
+        executor,
         read_mode,
         expected_block_size,
         t->dm_context->global_context.getSettingsRef().dt_enable_delta_index_error_fallback);
@@ -117,7 +117,7 @@ BlockInputStreamPtr SegmentReadTaskPool::buildInputStream(SegmentReadTaskPtr & t
 SegmentReadTaskPool::SegmentReadTaskPool(
     int extra_table_id_index_,
     const ColumnDefines & columns_to_read_,
-    const PushDownExecutorPtr & filter_,
+    const PushDownExecutorPtr & executor_,
     uint64_t start_ts_,
     size_t expected_block_size_,
     ReadMode read_mode_,
@@ -131,7 +131,7 @@ SegmentReadTaskPool::SegmentReadTaskPool(
     , mem_tracker(current_memory_tracker == nullptr ? nullptr : current_memory_tracker->shared_from_this())
     , extra_table_id_index(extra_table_id_index_)
     , columns_to_read(columns_to_read_)
-    , filter(filter_)
+    , executor(executor_)
     , start_ts(start_ts_)
     , expected_block_size(expected_block_size_)
     , read_mode(read_mode_)

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.h
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTaskPool.h
@@ -111,7 +111,7 @@ public:
     SegmentReadTaskPool(
         int extra_table_id_index_,
         const ColumnDefines & columns_to_read_,
-        const PushDownExecutorPtr & filter_,
+        const PushDownExecutorPtr & executor_,
         uint64_t start_ts_,
         size_t expected_block_size_,
         ReadMode read_mode_,
@@ -187,16 +187,16 @@ public:
 
     void appendRSOperator(RSOperatorPtr & new_filter) const
     {
-        if (filter->rs_operator == DM::EMPTY_RS_OPERATOR)
+        if (executor->rs_operator == DM::EMPTY_RS_OPERATOR)
         {
-            filter->rs_operator = new_filter;
+            executor->rs_operator = new_filter;
         }
         else
         {
             RSOperators children;
-            children.push_back(filter->rs_operator);
+            children.push_back(executor->rs_operator);
             children.push_back(new_filter);
-            filter->rs_operator = createAnd(children);
+            executor->rs_operator = createAnd(children);
         }
     }
 
@@ -214,7 +214,7 @@ private:
 
     const int extra_table_id_index;
     ColumnDefines columns_to_read;
-    PushDownExecutorPtr filter;
+    PushDownExecutorPtr executor;
     const uint64_t start_ts;
     const size_t expected_block_size;
     const ReadMode read_mode;

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store.cpp
@@ -4221,7 +4221,7 @@ try
         return block;
     };
 
-    auto check = [&](PushDownExecutorPtr filter, RSResult expected_res, const std::vector<Int64> & expected_data) {
+    auto check = [&](PushDownExecutorPtr executor, RSResult expected_res, const std::vector<Int64> & expected_data) {
         auto in = store->read(
             *db_context,
             db_context->getSettingsRef(),
@@ -4229,7 +4229,7 @@ try
             {RowKeyRange::newAll(store->isCommonHandle(), store->getRowKeyColumnSize())},
             /* num_streams= */ 1,
             /* start_ts= */ std::numeric_limits<UInt64>::max(),
-            filter,
+            executor,
             std::vector<RuntimeFilterPtr>{},
             0,
             "",
@@ -4350,7 +4350,7 @@ try
         return block;
     };
 
-    auto check = [&](PushDownExecutorPtr filter, RSResult expected_res, const std::vector<Int64> & expected_data) {
+    auto check = [&](PushDownExecutorPtr executor, RSResult expected_res, const std::vector<Int64> & expected_data) {
         auto in = store->read(
             *db_context,
             db_context->getSettingsRef(),
@@ -4358,7 +4358,7 @@ try
             {RowKeyRange::newAll(store->isCommonHandle(), store->getRowKeyColumnSize())},
             /* num_streams= */ 1,
             /* start_ts= */ std::numeric_limits<UInt64>::max(),
-            filter,
+            executor,
             std::vector<RuntimeFilterPtr>{},
             0,
             "",

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_segment.cpp
@@ -1093,7 +1093,7 @@ try
             auto pack_filter = DMFilePackFilter::loadFrom(*dm_context, file, true, real_ranges, EMPTY_RS_OPERATOR, {});
             pack_filter_results.push_back(pack_filter);
         }
-        auto bitmap_filter = segment->buildBitmapFilter( //
+        auto bitmap_filter = segment->buildMVCCBitmapFilter( //
             dmContext(),
             segment_snap,
             real_ranges,

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_storage_delta_merge.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_storage_delta_merge.cpp
@@ -56,10 +56,13 @@ namespace FailPoints
 extern const char exception_before_drop_segment[];
 extern const char exception_after_drop_segment[];
 } // namespace FailPoints
-namespace DM
+namespace DM::tests
 {
-namespace tests
-{
+
+static const google::protobuf::RepeatedPtrField<tipb::Expr> empty_pushed_down_filters{};
+static const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> empty_used_indexes{};
+static const auto empty_ann_query_info = tipb::ANNQueryInfo{};
+
 TEST(StorageDeltaMergeTest, ReadWriteCase1)
 try
 {
@@ -128,14 +131,13 @@ try
     // these field should live long enough because `DAGQueryInfo` only
     // keep a ref on them
     const google::protobuf::RepeatedPtrField<tipb::Expr> filters{};
-    const google::protobuf::RepeatedPtrField<tipb::Expr> pushed_down_filters{};
-    const auto ann_query_info = tipb::ANNQueryInfo{};
     TiDB::ColumnInfos source_columns{};
     const std::vector<int> runtime_filter_ids;
     query_info.dag_query = std::make_unique<DAGQueryInfo>(
         filters,
-        ann_query_info,
-        pushed_down_filters, // Not care now
+        empty_ann_query_info,
+        empty_pushed_down_filters, // Not care now
+        empty_used_indexes, // Not care now
         source_columns, // Not care now
         runtime_filter_ids,
         0,
@@ -686,14 +688,13 @@ try
     // these field should live long enough because `DAGQueryInfo` only
     // keep a ref on them
     const google::protobuf::RepeatedPtrField<tipb::Expr> filters{};
-    const google::protobuf::RepeatedPtrField<tipb::Expr> pushed_down_filters{};
-    const auto ann_query_info = tipb::ANNQueryInfo{};
     TiDB::ColumnInfos source_columns{};
     const std::vector<int> runtime_filter_ids;
     query_info.dag_query = std::make_unique<DAGQueryInfo>(
         filters,
-        ann_query_info,
-        pushed_down_filters, // Not care now
+        empty_ann_query_info,
+        empty_pushed_down_filters, // Not care now
+        empty_used_indexes, // Not care now
         source_columns, // Not care now
         runtime_filter_ids,
         0,
@@ -806,14 +807,13 @@ try
         // these field should live long enough because `DAGQueryInfo` only
         // keep a ref on them
         const google::protobuf::RepeatedPtrField<tipb::Expr> filters{};
-        const google::protobuf::RepeatedPtrField<tipb::Expr> pushed_down_filters{};
         TiDB::ColumnInfos source_columns{};
         const std::vector<int> runtime_filter_ids;
-        const auto ann_query_info = tipb::ANNQueryInfo{};
         query_info.dag_query = std::make_unique<DAGQueryInfo>(
             filters,
-            ann_query_info,
-            pushed_down_filters, // Not care now
+            empty_ann_query_info,
+            empty_pushed_down_filters, // Not care now
+            empty_used_indexes, // Not care now
             source_columns, // Not care now
             runtime_filter_ids,
             0,
@@ -887,6 +887,5 @@ try
 }
 CATCH
 
-} // namespace tests
-} // namespace DM
+} // namespace DM::tests
 } // namespace DB

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_bitmap.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_bitmap.cpp
@@ -458,7 +458,7 @@ TEST_P(SegmentBitmapFilterTest, CleanStable)
     ASSERT_EQ(seg->getDelta()->getRows(), 0);
     ASSERT_EQ(seg->getDelta()->getDeletes(), 0);
     ASSERT_EQ(seg->getStable()->getRows(), 25000);
-    auto bitmap_filter = seg->buildBitmapFilterStableOnly(
+    auto bitmap_filter = seg->buildMVCCBitmapFilterStableOnly(
         *dm_context,
         snap,
         {seg->getRowKeyRange()},
@@ -480,7 +480,7 @@ TEST_P(SegmentBitmapFilterTest, NotCleanStable)
     ASSERT_EQ(seg->getDelta()->getDeletes(), 0);
     ASSERT_EQ(seg->getStable()->getRows(), 20000);
     {
-        auto bitmap_filter = seg->buildBitmapFilterStableOnly(
+        auto bitmap_filter = seg->buildMVCCBitmapFilterStableOnly(
             *dm_context,
             snap,
             {seg->getRowKeyRange()},
@@ -500,7 +500,7 @@ TEST_P(SegmentBitmapFilterTest, NotCleanStable)
     {
         // Stale read
         ASSERT_EQ(version, 2);
-        auto bitmap_filter = seg->buildBitmapFilterStableOnly(
+        auto bitmap_filter = seg->buildMVCCBitmapFilterStableOnly(
             *dm_context,
             snap,
             {seg->getRowKeyRange()},
@@ -529,7 +529,7 @@ TEST_P(SegmentBitmapFilterTest, StableRange)
     ASSERT_EQ(seg->getStable()->getRows(), 50000);
 
     auto ranges = std::vector<RowKeyRange>{buildRowKeyRange(10000, 50000, is_common_handle)}; // [10000, 50000)
-    auto bitmap_filter = seg->buildBitmapFilterStableOnly(
+    auto bitmap_filter = seg->buildMVCCBitmapFilterStableOnly(
         *dm_context,
         snap,
         ranges,
@@ -590,7 +590,7 @@ try
         __LINE__);
 
     auto [seg, snap] = getSegmentForRead(SEG_ID);
-    auto bitmap_filter = seg->buildBitmapFilter(
+    auto bitmap_filter = seg->buildMVCCBitmapFilter(
         *dm_context,
         snap,
         {seg->getRowKeyRange()},
@@ -622,7 +622,7 @@ try
     // For Stable, all packs of DMFile will be considered in BitmapFilter.
     setRowKeyRange(275, 295, false); // Shrinking range
     auto [seg, snap] = getSegmentForRead(SEG_ID);
-    auto bitmap_filter = seg->buildBitmapFilter(
+    auto bitmap_filter = seg->buildMVCCBitmapFilter(
         *dm_context,
         snap,
         {seg->getRowKeyRange()},
@@ -699,8 +699,13 @@ TEST_P(SegmentBitmapFilterTest, testSkipPackStableOnly)
                 ASSERT_EQ(pack_res[i], RSResult::Some);
         }
 
-        auto bitmap_filter
-            = seg->buildBitmapFilterStableOnly(*dm_context, snap, ranges, pack_filter_results, 2, DEFAULT_BLOCK_SIZE);
+        auto bitmap_filter = seg->buildMVCCBitmapFilterStableOnly(
+            *dm_context,
+            snap,
+            ranges,
+            pack_filter_results,
+            2,
+            DEFAULT_BLOCK_SIZE);
 
         ASSERT_EQ(expect_result, bitmap_filter->toDebugString());
 
@@ -819,7 +824,7 @@ TEST_P(SegmentBitmapFilterTest, testSkipPackNormal)
             }
         }
 
-        auto bitmap_filter = seg->buildBitmapFilterNormal(
+        auto bitmap_filter = seg->buildMVCCBitmapFilterNormal(
             *dm_context,
             snap,
             ranges,

--- a/dbms/src/Storages/StorageDeltaMerge.cpp
+++ b/dbms/src/Storages/StorageDeltaMerge.cpp
@@ -850,7 +850,8 @@ BlockInputStreams StorageDeltaMerge::read(
         query_info,
         columns_to_read,
         store->getTableColumns(),
-        query_info.dag_query ? query_info.dag_query->used_indexes : nullptr,
+        query_info.dag_query ? query_info.dag_query->used_indexes
+                             : google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo>{},
         context,
         tracing_logger);
 
@@ -939,7 +940,8 @@ void StorageDeltaMerge::read(
         query_info,
         columns_to_read,
         store->getTableColumns(),
-        query_info.dag_query ? query_info.dag_query->used_indexes : nullptr,
+        query_info.dag_query ? query_info.dag_query->used_indexes
+                             : google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo>{},
         context,
         tracing_logger);
 

--- a/dbms/src/Storages/StorageDeltaMerge.cpp
+++ b/dbms/src/Storages/StorageDeltaMerge.cpp
@@ -846,8 +846,13 @@ BlockInputStreams StorageDeltaMerge::read(
         query_info.req_id,
         tracing_logger);
 
-    auto filter
-        = PushDownExecutor::build(query_info, columns_to_read, store->getTableColumns(), context, tracing_logger);
+    auto filter = PushDownExecutor::build(
+        query_info,
+        columns_to_read,
+        store->getTableColumns(),
+        query_info.dag_query->used_indexes,
+        context,
+        tracing_logger);
 
     auto runtime_filter_list = parseRuntimeFilterList(query_info, store->getTableColumns(), context, tracing_logger);
 
@@ -930,8 +935,13 @@ void StorageDeltaMerge::read(
         query_info.req_id,
         tracing_logger);
 
-    auto filter
-        = PushDownExecutor::build(query_info, columns_to_read, store->getTableColumns(), context, tracing_logger);
+    auto filter = PushDownExecutor::build(
+        query_info,
+        columns_to_read,
+        store->getTableColumns(),
+        query_info.dag_query->used_indexes,
+        context,
+        tracing_logger);
 
     auto runtime_filter_list = parseRuntimeFilterList(query_info, store->getTableColumns(), context, tracing_logger);
 

--- a/dbms/src/Storages/StorageDeltaMerge.cpp
+++ b/dbms/src/Storages/StorageDeltaMerge.cpp
@@ -850,7 +850,7 @@ BlockInputStreams StorageDeltaMerge::read(
         query_info,
         columns_to_read,
         store->getTableColumns(),
-        query_info.dag_query->used_indexes,
+        query_info.dag_query ? query_info.dag_query->used_indexes : nullptr,
         context,
         tracing_logger);
 
@@ -867,7 +867,7 @@ BlockInputStreams StorageDeltaMerge::read(
         /*start_ts=*/mvcc_query_info.start_ts,
         filter,
         runtime_filter_list,
-        query_info.dag_query == nullptr ? 0 : query_info.dag_query->rf_max_wait_time_ms,
+        query_info.dag_query ? query_info.dag_query->rf_max_wait_time_ms : 0,
         query_info.req_id,
         query_info.keep_order,
         /* is_fast_scan */ query_info.is_fast_scan,
@@ -939,7 +939,7 @@ void StorageDeltaMerge::read(
         query_info,
         columns_to_read,
         store->getTableColumns(),
-        query_info.dag_query->used_indexes,
+        query_info.dag_query ? query_info.dag_query->used_indexes : nullptr,
         context,
         tracing_logger);
 
@@ -958,7 +958,7 @@ void StorageDeltaMerge::read(
         /*start_ts=*/mvcc_query_info.start_ts,
         filter,
         runtime_filter_list,
-        query_info.dag_query == nullptr ? 0 : query_info.dag_query->rf_max_wait_time_ms,
+        query_info.dag_query ? query_info.dag_query->rf_max_wait_time_ms : 0,
         query_info.req_id,
         query_info.keep_order,
         /* is_fast_scan */ query_info.is_fast_scan,

--- a/dbms/src/Storages/StorageDisaggregated.h
+++ b/dbms/src/Storages/StorageDisaggregated.h
@@ -100,7 +100,9 @@ private:
     std::shared_ptr<disaggregated::EstablishDisaggTaskRequest> buildEstablishDisaggTaskReq(
         const Context & db_context,
         const pingcap::coprocessor::BatchCopTask & batch_cop_task);
-    DM::RSOperatorPtr buildRSOperator(const Context & db_context, const DM::ColumnDefinesPtr & columns_to_read);
+    std::tuple<DM::RSOperatorPtr, DM::ColumnRangePtr> buildRSOperatorAndColumnRange(
+        const Context & db_context,
+        const DM::ColumnDefinesPtr & columns_to_read);
     std::variant<DM::Remote::RNWorkersPtr, DM::SegmentReadTaskPoolPtr> packSegmentReadTasks(
         const Context & db_context,
         DM::SegmentReadTasks && read_tasks,

--- a/dbms/src/Storages/StorageDisaggregatedRemote.cpp
+++ b/dbms/src/Storages/StorageDisaggregatedRemote.cpp
@@ -502,10 +502,10 @@ std::tuple<DM::RSOperatorPtr, DM::ColumnRangePtr> StorageDisaggregated::buildRSO
         db_context.getTimezoneInfo());
     const auto rs_operator
         = DM::RSOperator::build(dag_query, table_scan.getColumns(), *columns_to_read, enable_rs_filter, log);
-    const auto & local_index_infos = dag_query->used_indexes;
+    const auto & used_indexes = dag_query->used_indexes;
 
     // build column_range
-    const auto column_range = rs_operator && local_index_infos ? rs_operator->buildSets(local_index_infos) : nullptr;
+    const auto column_range = rs_operator && used_indexes.empty() ? rs_operator->buildSets(used_indexes) : nullptr;
     return {rs_operator, column_range};
 }
 

--- a/dbms/src/Storages/StorageDisaggregatedRemote.cpp
+++ b/dbms/src/Storages/StorageDisaggregatedRemote.cpp
@@ -479,30 +479,34 @@ std::shared_ptr<disaggregated::EstablishDisaggTaskRequest> StorageDisaggregated:
     return establish_req;
 }
 
-DM::RSOperatorPtr StorageDisaggregated::buildRSOperator(
+std::tuple<DM::RSOperatorPtr, DM::ColumnRangePtr> StorageDisaggregated::buildRSOperatorAndColumnRange(
     const Context & db_context,
     const DM::ColumnDefinesPtr & columns_to_read)
 {
     if (!filter_conditions.hasValue())
-        return DM::EMPTY_RS_OPERATOR;
-
+        return {DM::EMPTY_RS_OPERATOR, nullptr};
     const bool enable_rs_filter = db_context.getSettingsRef().dt_enable_rough_set_filter;
     if (!enable_rs_filter)
     {
         LOG_DEBUG(log, "Rough set filter is disabled.");
-        return DM::EMPTY_RS_OPERATOR;
+        return {DM::EMPTY_RS_OPERATOR, nullptr};
     }
-
     auto dag_query = std::make_unique<DAGQueryInfo>(
         filter_conditions.conditions,
         table_scan.getANNQueryInfo(),
         table_scan.getPushedDownFilters(),
+        table_scan.getUsedIndexes(),
         table_scan.getColumns(),
         std::vector<int>{},
         0,
         db_context.getTimezoneInfo());
+    const auto rs_operator
+        = DM::RSOperator::build(dag_query, table_scan.getColumns(), *columns_to_read, enable_rs_filter, log);
+    const auto & local_index_infos = dag_query->used_indexes;
 
-    return DM::RSOperator::build(dag_query, table_scan.getColumns(), *columns_to_read, enable_rs_filter, log);
+    // build column_range
+    const auto column_range = rs_operator && local_index_infos ? rs_operator->buildSets(local_index_infos) : nullptr;
+    return {rs_operator, column_range};
 }
 
 std::variant<DM::Remote::RNWorkersPtr, DM::SegmentReadTaskPoolPtr> StorageDisaggregated::packSegmentReadTasks(
@@ -514,8 +518,8 @@ std::variant<DM::Remote::RNWorkersPtr, DM::SegmentReadTaskPoolPtr> StorageDisagg
 {
     const auto & executor_id = table_scan.getTableScanExecutorID();
 
-    // build the rough set operator
-    auto rs_operator = buildRSOperator(db_context, column_defines);
+    // build the rough set operator and column range
+    auto [rs_operator, column_range] = buildRSOperatorAndColumnRange(db_context, column_defines);
     // build ANN query info
     DM::ANNQueryInfoPtr ann_query_info = nullptr;
     if (table_scan.getANNQueryInfo().query_type() != tipb::ANNQueryType::InvalidQueryType)
@@ -527,6 +531,7 @@ std::variant<DM::Remote::RNWorkersPtr, DM::SegmentReadTaskPoolPtr> StorageDisagg
         table_scan.getColumns(),
         table_scan.getPushedDownFilters(),
         *column_defines,
+        column_range,
         db_context,
         log);
     const auto read_mode = DM::DeltaMergeStore::getReadMode(

--- a/dbms/src/Storages/StorageDisaggregatedRemote.cpp
+++ b/dbms/src/Storages/StorageDisaggregatedRemote.cpp
@@ -505,7 +505,7 @@ std::tuple<DM::RSOperatorPtr, DM::ColumnRangePtr> StorageDisaggregated::buildRSO
     const auto & used_indexes = dag_query->used_indexes;
 
     // build column_range
-    const auto column_range = rs_operator && used_indexes.empty() ? rs_operator->buildSets(used_indexes) : nullptr;
+    const auto column_range = rs_operator && !used_indexes.empty() ? rs_operator->buildSets(used_indexes) : nullptr;
     return {rs_operator, column_range};
 }
 

--- a/dbms/src/Storages/tests/gtest_filter_parser.cpp
+++ b/dbms/src/Storages/tests/gtest_filter_parser.cpp
@@ -35,6 +35,7 @@
 
 #include <regex>
 
+
 namespace DB::tests
 {
 
@@ -106,10 +107,12 @@ DM::RSOperatorPtr FilterParserTest::generateRsOperator(
     const auto ann_query_info = tipb::ANNQueryInfo{};
     const auto runtime_filter_ids = std::vector<int>();
     const google::protobuf::RepeatedPtrField<tipb::Expr> pushed_down_filters{}; // don't care pushed down filters
+    const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> empty_used_indexes{}; // don't care used indexes
     std::unique_ptr<DAGQueryInfo> dag_query = std::make_unique<DAGQueryInfo>(
         conditions,
         ann_query_info,
         pushed_down_filters,
+        empty_used_indexes,
         table_info.columns,
         runtime_filter_ids, // don't care runtime filter
         0,

--- a/dbms/src/Storages/tests/gtest_filter_parser.cpp
+++ b/dbms/src/Storages/tests/gtest_filter_parser.cpp
@@ -143,7 +143,7 @@ try
     {
         auto columnar_info = tipb::ColumnarIndexInfo();
         columnar_info.set_index_type(tipb::ColumnarIndexType::TypeInverted);
-        auto * inverted = columnar_info.mutable_invert_query_info();
+        auto * inverted = columnar_info.mutable_inverted_query_info();
         inverted->set_index_id(1);
         inverted->set_column_id(2);
         used_indexes.Add(std::move(columnar_info));
@@ -227,7 +227,7 @@ try
     {
         auto columnar_info = tipb::ColumnarIndexInfo();
         columnar_info.set_index_type(tipb::ColumnarIndexType::TypeInverted);
-        auto * inverted = columnar_info.mutable_invert_query_info();
+        auto * inverted = columnar_info.mutable_inverted_query_info();
         inverted->set_index_id(1);
         inverted->set_column_id(2);
         used_indexes.Add(std::move(columnar_info));
@@ -342,7 +342,7 @@ try
     {
         auto columnar_info = tipb::ColumnarIndexInfo();
         columnar_info.set_index_type(tipb::ColumnarIndexType::TypeInverted);
-        auto * inverted = columnar_info.mutable_invert_query_info();
+        auto * inverted = columnar_info.mutable_inverted_query_info();
         inverted->set_index_id(1);
         inverted->set_column_id(2);
         used_indexes.Add(std::move(columnar_info));
@@ -350,7 +350,7 @@ try
     {
         auto columnar_info = tipb::ColumnarIndexInfo();
         columnar_info.set_index_type(tipb::ColumnarIndexType::TypeInverted);
-        auto * inverted = columnar_info.mutable_invert_query_info();
+        auto * inverted = columnar_info.mutable_inverted_query_info();
         inverted->set_index_id(2);
         inverted->set_column_id(3);
         used_indexes.Add(std::move(columnar_info));
@@ -576,7 +576,7 @@ try
     {
         auto columnar_info = tipb::ColumnarIndexInfo();
         columnar_info.set_index_type(tipb::ColumnarIndexType::TypeInverted);
-        auto * inverted = columnar_info.mutable_invert_query_info();
+        auto * inverted = columnar_info.mutable_inverted_query_info();
         inverted->set_index_id(1);
         inverted->set_column_id(4);
         used_indexes.Add(std::move(columnar_info));
@@ -584,7 +584,7 @@ try
     {
         auto columnar_info = tipb::ColumnarIndexInfo();
         columnar_info.set_index_type(tipb::ColumnarIndexType::TypeInverted);
-        auto * inverted = columnar_info.mutable_invert_query_info();
+        auto * inverted = columnar_info.mutable_inverted_query_info();
         inverted->set_index_id(2);
         inverted->set_column_id(5);
         used_indexes.Add(std::move(columnar_info));
@@ -592,7 +592,7 @@ try
     {
         auto columnar_info = tipb::ColumnarIndexInfo();
         columnar_info.set_index_type(tipb::ColumnarIndexType::TypeInverted);
-        auto * inverted = columnar_info.mutable_invert_query_info();
+        auto * inverted = columnar_info.mutable_inverted_query_info();
         inverted->set_index_id(3);
         inverted->set_column_id(6);
         used_indexes.Add(std::move(columnar_info));

--- a/dbms/src/Storages/tests/gtest_filter_parser.cpp
+++ b/dbms/src/Storages/tests/gtest_filter_parser.cpp
@@ -139,12 +139,15 @@ try
     "comment":"Mocked.","id":30,"schema_version":-1,"state":0,"tiflash_replica":{"Count":0},"update_timestamp":1636471547239654
 })json";
 
-    std::vector<DM::LocalIndexInfo> local_index_infos;
+    google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> used_indexes;
     {
-        auto definition = std::make_shared<TiDB::InvertedIndexDefinition>(false, 8);
-        local_index_infos.emplace_back(1, 2, definition);
+        auto columnar_info = tipb::ColumnarIndexInfo();
+        columnar_info.set_index_type(tipb::ColumnarIndexType::TypeInverted);
+        auto * inverted = columnar_info.mutable_invert_query_info();
+        inverted->set_index_id(1);
+        inverted->set_column_id(2);
+        used_indexes.Add(std::move(columnar_info));
     }
-    auto snapshot = std::make_shared<const std::vector<DM::LocalIndexInfo>>(local_index_infos);
 
     {
         // Equal between col and literal
@@ -153,7 +156,7 @@ try
         EXPECT_EQ(rs_operator->getColumnIDs().size(), 1);
         EXPECT_EQ(rs_operator->getColumnIDs()[0], 2);
         EXPECT_EQ(rs_operator->toDebugString(), "{\"op\":\"equal\",\"col\":\"col_2\",\"value\":\"666\"}");
-        auto sets = rs_operator->buildSets(snapshot);
+        auto sets = rs_operator->buildSets(used_indexes);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), "2: {666}");
     }
@@ -165,7 +168,7 @@ try
         EXPECT_EQ(rs_operator->getColumnIDs().size(), 1);
         EXPECT_EQ(rs_operator->getColumnIDs()[0], 2);
         EXPECT_EQ(rs_operator->toDebugString(), "{\"op\":\"greater\",\"col\":\"col_2\",\"value\":\"666\"}");
-        auto sets = rs_operator->buildSets(snapshot);
+        auto sets = rs_operator->buildSets(used_indexes);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), "2: [667, 9223372036854775807]");
     }
@@ -177,7 +180,7 @@ try
         EXPECT_EQ(rs_operator->getColumnIDs().size(), 1);
         EXPECT_EQ(rs_operator->getColumnIDs()[0], 2);
         EXPECT_EQ(rs_operator->toDebugString(), "{\"op\":\"greater_equal\",\"col\":\"col_2\",\"value\":\"667\"}");
-        auto sets = rs_operator->buildSets(snapshot);
+        auto sets = rs_operator->buildSets(used_indexes);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), "2: [667, 9223372036854775807]");
     }
@@ -189,7 +192,7 @@ try
         EXPECT_EQ(rs_operator->getColumnIDs().size(), 1);
         EXPECT_EQ(rs_operator->getColumnIDs()[0], 2);
         EXPECT_EQ(rs_operator->toDebugString(), "{\"op\":\"less\",\"col\":\"col_2\",\"value\":\"777\"}");
-        auto sets = rs_operator->buildSets(snapshot);
+        auto sets = rs_operator->buildSets(used_indexes);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), "2: [-9223372036854775808, 776]");
     }
@@ -201,7 +204,7 @@ try
         EXPECT_EQ(rs_operator->getColumnIDs().size(), 1);
         EXPECT_EQ(rs_operator->getColumnIDs()[0], 2);
         EXPECT_EQ(rs_operator->toDebugString(), "{\"op\":\"less_equal\",\"col\":\"col_2\",\"value\":\"776\"}");
-        auto sets = rs_operator->buildSets(snapshot);
+        auto sets = rs_operator->buildSets(used_indexes);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), "2: [-9223372036854775808, 776]");
     }
@@ -220,12 +223,15 @@ try
     "comment":"Mocked.","id":30,"schema_version":-1,"state":0,"tiflash_replica":{"Count":0},"update_timestamp":1636471547239654
 })json";
 
-    std::vector<DM::LocalIndexInfo> local_index_infos;
+    google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> used_indexes;
     {
-        auto definition = std::make_shared<TiDB::InvertedIndexDefinition>(false, 8);
-        local_index_infos.emplace_back(1, 2, definition);
+        auto columnar_info = tipb::ColumnarIndexInfo();
+        columnar_info.set_index_type(tipb::ColumnarIndexType::TypeInverted);
+        auto * inverted = columnar_info.mutable_invert_query_info();
+        inverted->set_index_id(1);
+        inverted->set_column_id(2);
+        used_indexes.Add(std::move(columnar_info));
     }
-    auto snapshot = std::make_shared<const std::vector<DM::LocalIndexInfo>>(local_index_infos);
 
     // Test cases for literal and col (inverse direction)
     {
@@ -235,7 +241,7 @@ try
         EXPECT_EQ(rs_operator->getColumnIDs().size(), 1);
         EXPECT_EQ(rs_operator->getColumnIDs()[0], 2);
         EXPECT_EQ(rs_operator->toDebugString(), "{\"op\":\"equal\",\"col\":\"col_2\",\"value\":\"667\"}");
-        auto sets = rs_operator->buildSets(snapshot);
+        auto sets = rs_operator->buildSets(used_indexes);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), "2: {667}");
     }
@@ -250,7 +256,7 @@ try
         EXPECT_EQ(
             rs_operator->toDebugString(),
             "{\"op\":\"not_equal\",\"col\":\"col_2\",\"value\":\"-9223372036854775808\"}");
-        auto sets = rs_operator->buildSets(snapshot);
+        auto sets = rs_operator->buildSets(used_indexes);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), "2: [-9223372036854775807, 9223372036854775807]");
     }
@@ -262,7 +268,7 @@ try
         EXPECT_EQ(rs_operator->getColumnIDs().size(), 1);
         EXPECT_EQ(rs_operator->getColumnIDs()[0], 2);
         EXPECT_EQ(rs_operator->toDebugString(), "{\"op\":\"not_equal\",\"col\":\"col_2\",\"value\":\"667\"}");
-        auto sets = rs_operator->buildSets(snapshot);
+        auto sets = rs_operator->buildSets(used_indexes);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), "2: {[-9223372036854775808, 666], [668, 9223372036854775807]}");
     }
@@ -274,7 +280,7 @@ try
         EXPECT_EQ(rs_operator->getColumnIDs().size(), 1);
         EXPECT_EQ(rs_operator->getColumnIDs()[0], 2);
         EXPECT_EQ(rs_operator->toDebugString(), "{\"op\":\"greater\",\"col\":\"col_2\",\"value\":\"667\"}");
-        auto sets = rs_operator->buildSets(snapshot);
+        auto sets = rs_operator->buildSets(used_indexes);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), "2: [668, 9223372036854775807]");
     }
@@ -286,7 +292,7 @@ try
         EXPECT_EQ(rs_operator->getColumnIDs().size(), 1);
         EXPECT_EQ(rs_operator->getColumnIDs()[0], 2);
         EXPECT_EQ(rs_operator->toDebugString(), "{\"op\":\"greater_equal\",\"col\":\"col_2\",\"value\":\"667\"}");
-        auto sets = rs_operator->buildSets(snapshot);
+        auto sets = rs_operator->buildSets(used_indexes);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), "2: [667, 9223372036854775807]");
     }
@@ -298,7 +304,7 @@ try
         EXPECT_EQ(rs_operator->getColumnIDs().size(), 1);
         EXPECT_EQ(rs_operator->getColumnIDs()[0], 2);
         EXPECT_EQ(rs_operator->toDebugString(), "{\"op\":\"less\",\"col\":\"col_2\",\"value\":\"777\"}");
-        auto sets = rs_operator->buildSets(snapshot);
+        auto sets = rs_operator->buildSets(used_indexes);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), "2: [-9223372036854775808, 776]");
     }
@@ -310,7 +316,7 @@ try
         EXPECT_EQ(rs_operator->getColumnIDs().size(), 1);
         EXPECT_EQ(rs_operator->getColumnIDs()[0], 2);
         EXPECT_EQ(rs_operator->toDebugString(), "{\"op\":\"less_equal\",\"col\":\"col_2\",\"value\":\"777\"}");
-        auto sets = rs_operator->buildSets(snapshot);
+        auto sets = rs_operator->buildSets(used_indexes);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), "2: [-9223372036854775808, 777]");
     }
@@ -332,16 +338,23 @@ try
     "comment":"Mocked.","id":30,"schema_version":-1,"state":0,"tiflash_replica":{"Count":0},"update_timestamp":1636471547239654
 })json";
 
-    std::vector<DM::LocalIndexInfo> local_index_infos;
+    google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> used_indexes;
     {
-        auto definition = std::make_shared<TiDB::InvertedIndexDefinition>(false, 8);
-        local_index_infos.emplace_back(1, 2, definition);
+        auto columnar_info = tipb::ColumnarIndexInfo();
+        columnar_info.set_index_type(tipb::ColumnarIndexType::TypeInverted);
+        auto * inverted = columnar_info.mutable_invert_query_info();
+        inverted->set_index_id(1);
+        inverted->set_column_id(2);
+        used_indexes.Add(std::move(columnar_info));
     }
     {
-        auto definition = std::make_shared<TiDB::InvertedIndexDefinition>(false, 8);
-        local_index_infos.emplace_back(2, 3, definition);
+        auto columnar_info = tipb::ColumnarIndexInfo();
+        columnar_info.set_index_type(tipb::ColumnarIndexType::TypeInverted);
+        auto * inverted = columnar_info.mutable_invert_query_info();
+        inverted->set_index_id(2);
+        inverted->set_column_id(3);
+        used_indexes.Add(std::move(columnar_info));
     }
-    auto snapshot = std::make_shared<const std::vector<DM::LocalIndexInfo>>(local_index_infos);
 
     {
         // Not
@@ -353,7 +366,7 @@ try
         EXPECT_EQ(
             rs_operator->toDebugString(),
             "{\"op\":\"not\",\"children\":[{\"op\":\"equal\",\"col\":\"col_2\",\"value\":\"666\"}]}");
-        auto sets = rs_operator->buildSets(snapshot);
+        auto sets = rs_operator->buildSets(used_indexes);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), "2: {[-9223372036854775808, 665], [667, 9223372036854775807]}");
     }
@@ -368,7 +381,7 @@ try
         std::regex rx(
             R"(\{"op":"and","children":\[\{"op":"unsupported",.*\},\{"op":"equal","col":"col_2","value":"666"\}\]\})");
         EXPECT_TRUE(std::regex_search(rs_operator->toDebugString(), rx));
-        auto sets = rs_operator->buildSets(snapshot);
+        auto sets = rs_operator->buildSets(used_indexes);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), "2: {666}");
     }
@@ -385,7 +398,7 @@ try
             rs_operator->toDebugString(),
             "{\"op\":\"or\",\"children\":[{\"op\":\"equal\",\"col\":\"col_2\",\"value\":\"789\"},{\"op\":\"equal\","
             "\"col\":\"col_2\",\"value\":\"777\"}]}");
-        auto sets = rs_operator->buildSets(snapshot);
+        auto sets = rs_operator->buildSets(used_indexes);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), "2: {777, 789}");
     }
@@ -402,7 +415,7 @@ try
             rs_operator->toDebugString(),
             "{\"op\":\"or\",\"children\":[{\"op\":\"greater\",\"col\":\"col_2\",\"value\":\"789\"},{\"op\":\"less\","
             "\"col\":\"col_2\",\"value\":\"791\"}]}");
-        auto sets = rs_operator->buildSets(snapshot);
+        auto sets = rs_operator->buildSets(used_indexes);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), "2: ALL");
     }
@@ -419,7 +432,7 @@ try
         std::regex rx(
             R"(\{"op":"and","children":\[\{"op":"unsupported",.*\},\{"op":"not","children":\[\{"op":"equal","col":"col_2","value":"666"\}\]\}\]\})");
         EXPECT_TRUE(std::regex_search(rs_operator->toDebugString(), rx));
-        auto sets = rs_operator->buildSets(snapshot);
+        auto sets = rs_operator->buildSets(used_indexes);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), "2: {[-9223372036854775808, 665], [667, 9223372036854775807]}");
     }
@@ -436,7 +449,7 @@ try
             rs_operator->toDebugString(),
             "{\"op\":\"and\",\"children\":[{\"op\":\"equal\",\"col\":\"col_2\",\"value\":\"789\"},{\"op\":\"not\","
             "\"children\":[{\"op\":\"equal\",\"col\":\"col_3\",\"value\":\"666\"}]}]}");
-        auto sets = rs_operator->buildSets(snapshot);
+        auto sets = rs_operator->buildSets(used_indexes);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), "And[3: {[-9223372036854775808, 665], [667, 9223372036854775807]}, 2: {789}]");
     }
@@ -456,7 +469,7 @@ try
             "{\"op\":\"and\",\"children\":[{\"op\":\"equal\",\"col\":\"col_2\",\"value\":\"789\"},{\"op\":\"or\","
             "\"children\":[{\"op\":\"equal\",\"col\":\"col_3\",\"value\":\"666\"},{\"op\":\"equal\",\"col\":\"col_3\","
             "\"value\":\"678\"}]}]}");
-        auto sets = rs_operator->buildSets(snapshot);
+        auto sets = rs_operator->buildSets(used_indexes);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), "And[3: {666, 678}, 2: {789}]");
     }
@@ -471,7 +484,7 @@ try
         std::regex rx(
             R"(\{"op":"or","children":\[\{"op":"unsupported",.*\},\{"op":"equal","col":"col_2","value":"666"\}\]\})");
         EXPECT_TRUE(std::regex_search(rs_operator->toDebugString(), rx));
-        auto sets = rs_operator->buildSets(snapshot);
+        auto sets = rs_operator->buildSets(used_indexes);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), "Unsupported");
     }
@@ -487,7 +500,7 @@ try
         std::regex rx(
             R"(\{"op":"or","children":\[\{"op":"unsupported",.*\},\{"op":"not","children":\[\{"op":"equal","col":"col_2","value":"666"\}\]\}\]\})");
         EXPECT_TRUE(std::regex_search(rs_operator->toDebugString(), rx));
-        auto sets = rs_operator->buildSets(snapshot);
+        auto sets = rs_operator->buildSets(used_indexes);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), "Unsupported");
     }
@@ -504,7 +517,7 @@ try
             rs_operator->toDebugString(),
             "{\"op\":\"and\",\"children\":[{\"op\":\"equal\",\"col\":\"col_2\",\"value\":\"789\"},{\"op\":\"isnull\","
             "\"col\":\"col_3\"}]}");
-        auto sets = rs_operator->buildSets(snapshot);
+        auto sets = rs_operator->buildSets(used_indexes);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), "2: {789}");
     }
@@ -516,7 +529,7 @@ try
         EXPECT_EQ(
             rs_operator->toDebugString(),
             R"raw({"op":"and","children":[{"op":"unsupported","reason":"child of logical and is not function, expr.tp=ColumnRef"},{"op":"unsupported","reason":"child of logical and is not function, expr.tp=Uint64"}]})raw");
-        auto sets = rs_operator->buildSets(snapshot);
+        auto sets = rs_operator->buildSets(used_indexes);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), "Unsupported");
     }
@@ -528,7 +541,7 @@ try
         EXPECT_EQ(
             rs_operator->toDebugString(),
             R"raw({"op":"or","children":[{"op":"unsupported","reason":"child of logical operator is not function, child_type=ColumnRef"},{"op":"unsupported","reason":"child of logical operator is not function, child_type=Uint64"}]})raw");
-        auto sets = rs_operator->buildSets(snapshot);
+        auto sets = rs_operator->buildSets(used_indexes);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), "Unsupported");
     }
@@ -537,7 +550,7 @@ try
         // IsNull with FunctionExpr (not supported since IsNull only support when child is ColumnExpr)
         auto rs_operator = generateRsOperator(table_info_json, "select * from default.t_111 where (col_2 > 1) is null");
         EXPECT_EQ(rs_operator->name(), "unsupported");
-        auto sets = rs_operator->buildSets(snapshot);
+        auto sets = rs_operator->buildSets(used_indexes);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), "Unsupported");
     }
@@ -559,20 +572,31 @@ try
     "comment":"Mocked.","id":30,"schema_version":-1,"state":0,"tiflash_replica":{"Count":0},"update_timestamp":1636471547239654
 })json";
 
-    std::vector<DM::LocalIndexInfo> local_index_infos;
+    google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> used_indexes;
     {
-        auto definition = std::make_shared<TiDB::InvertedIndexDefinition>(false, 8);
-        local_index_infos.emplace_back(1, 4, definition);
+        auto columnar_info = tipb::ColumnarIndexInfo();
+        columnar_info.set_index_type(tipb::ColumnarIndexType::TypeInverted);
+        auto * inverted = columnar_info.mutable_invert_query_info();
+        inverted->set_index_id(1);
+        inverted->set_column_id(4);
+        used_indexes.Add(std::move(columnar_info));
     }
     {
-        auto definition = std::make_shared<TiDB::InvertedIndexDefinition>(false, 8);
-        local_index_infos.emplace_back(2, 5, definition);
+        auto columnar_info = tipb::ColumnarIndexInfo();
+        columnar_info.set_index_type(tipb::ColumnarIndexType::TypeInverted);
+        auto * inverted = columnar_info.mutable_invert_query_info();
+        inverted->set_index_id(2);
+        inverted->set_column_id(5);
+        used_indexes.Add(std::move(columnar_info));
     }
     {
-        auto definition = std::make_shared<TiDB::InvertedIndexDefinition>(false, 8);
-        local_index_infos.emplace_back(3, 6, definition);
+        auto columnar_info = tipb::ColumnarIndexInfo();
+        columnar_info.set_index_type(tipb::ColumnarIndexType::TypeInverted);
+        auto * inverted = columnar_info.mutable_invert_query_info();
+        inverted->set_index_id(3);
+        inverted->set_column_id(6);
+        used_indexes.Add(std::move(columnar_info));
     }
-    auto snapshot = std::make_shared<const std::vector<DM::LocalIndexInfo>>(local_index_infos);
 
     String datetime = "2021-10-26 17:00:00.00000";
     ReadBufferFromMemory read_buffer(datetime.c_str(), datetime.size());
@@ -597,7 +621,7 @@ try
         EXPECT_EQ(
             rs_operator->toDebugString(),
             fmt::format(R"json({{"op":"greater","col":"col_timestamp","value":"{}"}})json", converted_time));
-        auto sets = rs_operator->buildSets(snapshot);
+        auto sets = rs_operator->buildSets(used_indexes);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), fmt::format("4: [{}, 18446744073709551615]", converted_time + 1));
     }
@@ -619,7 +643,7 @@ try
         EXPECT_EQ(
             rs_operator->toDebugString(),
             fmt::format(R"json({{"op":"greater","col":"col_timestamp","value":"{}"}})json", converted_time));
-        auto sets = rs_operator->buildSets(snapshot);
+        auto sets = rs_operator->buildSets(used_indexes);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), fmt::format("4: [{}, 18446744073709551615]", converted_time + 1));
     }
@@ -641,7 +665,7 @@ try
         EXPECT_EQ(
             rs_operator->toDebugString(),
             fmt::format(R"json({{"op":"greater","col":"col_timestamp","value":"{}"}})json", converted_time));
-        auto sets = rs_operator->buildSets(snapshot);
+        auto sets = rs_operator->buildSets(used_indexes);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), fmt::format("4: [{}, 18446744073709551615]", converted_time + 1));
     }
@@ -657,7 +681,7 @@ try
         EXPECT_EQ(
             rs_operator->toDebugString(),
             fmt::format(R"json({{"op":"greater","col":"col_datetime","value":"{}"}})json", origin_time_stamp));
-        auto sets = rs_operator->buildSets(snapshot);
+        auto sets = rs_operator->buildSets(used_indexes);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), fmt::format("5: [{}, 18446744073709551615]", origin_time_stamp + 1));
     }
@@ -673,7 +697,7 @@ try
         EXPECT_EQ(
             rs_operator->toDebugString(),
             fmt::format(R"json({{"op":"greater","col":"col_date","value":"{}"}})json", origin_time_stamp));
-        auto sets = rs_operator->buildSets(snapshot);
+        auto sets = rs_operator->buildSets(used_indexes);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), fmt::format("6: [{}, 18446744073709551615]", origin_time_stamp + 1));
     }
@@ -696,15 +720,14 @@ try
     "comment":"Mocked.","id":30,"schema_version":-1,"state":0,"tiflash_replica":{"Count":0},"update_timestamp":1636471547239654
 })json";
 
-    std::vector<DM::LocalIndexInfo> local_index_infos;
-    auto snapshot = std::make_shared<const std::vector<DM::LocalIndexInfo>>(local_index_infos);
+    google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> used_indexes;
 
     {
         // Greater between col and literal (not supported since the type of col_3 is floating point)
         auto rs_operator
             = generateRsOperator(table_info_json, "select * from default.t_111 where col_3 > 1234568.890123");
         EXPECT_EQ(rs_operator->name(), "unsupported");
-        auto sets = rs_operator->buildSets(snapshot);
+        auto sets = rs_operator->buildSets(used_indexes);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), "Unsupported");
     }
@@ -713,7 +736,7 @@ try
         // Greater between col and literal (not supported since the type of col_1 is string)
         auto rs_operator = generateRsOperator(table_info_json, "select * from default.t_111 where col_1 > '123'");
         EXPECT_EQ(rs_operator->name(), "unsupported");
-        auto sets = rs_operator->buildSets(snapshot);
+        auto sets = rs_operator->buildSets(used_indexes);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), "Unsupported");
     }
@@ -722,7 +745,7 @@ try
         // Greater between col and literal (not supported since the type of col_5 is decimal)
         auto rs_operator = generateRsOperator(table_info_json, "select * from default.t_111 where col_5 > 1");
         EXPECT_EQ(rs_operator->name(), "unsupported");
-        auto sets = rs_operator->buildSets(snapshot);
+        auto sets = rs_operator->buildSets(used_indexes);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), "Unsupported");
     }
@@ -731,7 +754,7 @@ try
         // Not with literal (not supported since Not only support when child is ColumnExpr)
         auto rs_operator = generateRsOperator(table_info_json, "select * from default.t_111 where not 1");
         EXPECT_EQ(rs_operator->name(), "unsupported");
-        auto sets = rs_operator->buildSets(snapshot);
+        auto sets = rs_operator->buildSets(used_indexes);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), "Unsupported");
     }
@@ -754,8 +777,7 @@ try
     "comment":"Mocked.","id":30,"schema_version":-1,"state":0,"tiflash_replica":{"Count":0},"update_timestamp":1636471547239654
 })json";
 
-    std::vector<DM::LocalIndexInfo> local_index_infos;
-    auto snapshot = std::make_shared<const std::vector<DM::LocalIndexInfo>>(local_index_infos);
+    google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> used_indexes;
 
     for (const auto & test_case : Strings{
              "select * from default.t_111 where col_2 = col_5", // col and col
@@ -771,7 +793,7 @@ try
     {
         auto rs_operator = generateRsOperator(table_info_json, test_case);
         EXPECT_EQ(rs_operator->name(), "unsupported");
-        auto sets = rs_operator->buildSets(snapshot);
+        auto sets = rs_operator->buildSets(used_indexes);
         EXPECT_TRUE(sets != nullptr);
         EXPECT_EQ(sets->toDebugString(), "Unsupported");
     }

--- a/dbms/src/Storages/tests/gtests_parse_push_down_filter.cpp
+++ b/dbms/src/Storages/tests/gtests_parse_push_down_filter.cpp
@@ -103,10 +103,12 @@ DM::PushDownExecutorPtr generatePushDownExecutor(
     {
         columns_to_read.push_back(DM::ColumnDefine(column.id, column.name, getDataTypeByColumnInfo(column)));
     }
+    const google::protobuf::RepeatedPtrField<tipb::ColumnarIndexInfo> empty_used_indexes{}; // don't care used indexes
     std::unique_ptr<DAGQueryInfo> dag_query = std::make_unique<DAGQueryInfo>(
         conditions,
         ann_query_info,
         pushed_down_filters,
+        empty_used_indexes,
         table_info.columns,
         runtime_filter_ids, // don't care runtime filter
         0,
@@ -125,6 +127,7 @@ DM::PushDownExecutorPtr generatePushDownExecutor(
         table_info.columns,
         pushed_down_filters,
         columns_to_read,
+        nullptr,
         ctx,
         log);
     return push_down_executor;

--- a/dbms/src/TiDB/Schema/InvertedIndex.h
+++ b/dbms/src/TiDB/Schema/InvertedIndex.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include <Core/Types.h>
+#include <common/types.h>
 #include <fmt/format.h>
 
 namespace TiDB
@@ -53,7 +53,7 @@ struct fmt::formatter<TiDB::InvertedIndexDefinitionPtr>
     auto format(const TiDB::InvertedIndexDefinitionPtr & index, FormatContext & ctx) const -> decltype(ctx.out())
     {
         if (!index)
-            return fmt::format_to(ctx.out(), "");
+            return fmt::format_to(ctx.out(), "nullptr");
         return fmt::format_to(ctx.out(), "{}", *index);
     }
 };

--- a/dbms/src/TiDB/Schema/SchemaGetter.h
+++ b/dbms/src/TiDB/Schema/SchemaGetter.h
@@ -28,7 +28,7 @@
 namespace DB
 {
 // The enum results are completely the same as the DDL Action listed in the "parser/model/ddl.go" of TiDB codebase, which must be keeping in sync.
-// https://github.com/pingcap/tidb/blob/9dfbccb01b76e6a5f2fc6f6562b8645dd5a151b1/pkg/parser/model/ddl.go#L29-L30
+// https://github.com/pingcap/tidb/blob/84492a9a1e5bff0b4a4256955ab8231975c2dde1/pkg/meta/model/job.go#L35-L36
 enum class SchemaActionType : Int8
 {
     None = 0,
@@ -103,13 +103,13 @@ enum class SchemaActionType : Int8
     ActionDropResourceGroup = 70,
     ActionAlterTablePartitioning = 71,
     ActionRemovePartitioning = 72,
-    ActionAddVectorIndex = 73,
-
+    ActionAddColumnarIndex = 73,
+    ActionModifyEngineAttribute = 74,
 
     // If we support new type from TiDB.
     // MaxRecognizedType also needs to be changed.
     // It should always be equal to the maximum supported type + 1
-    MaxRecognizedType = 74,
+    MaxRecognizedType = 75,
 };
 
 struct AffectedOption

--- a/dbms/src/TiDB/Schema/TiDB.cpp
+++ b/dbms/src/TiDB/Schema/TiDB.cpp
@@ -111,7 +111,7 @@ using DB::Field;
 using DB::SchemaNameMapper;
 
 // The IndexType defined in TiDB
-// https://github.com/pingcap/tidb/blob/a5e07a2ed360f29216c912775ce482f536f4102b/pkg/parser/model/model.go#L193-L219
+// https://github.com/pingcap/tidb/blob/84492a9a1e5bff0b4a4256955ab8231975c2dde1/pkg/parser/ast/model.go#L217-L226
 enum class IndexType
 {
     INVALID = 0,
@@ -120,6 +120,7 @@ enum class IndexType
     RTREE = 3,
     HYPO = 4,
     HNSW = 5,
+    INVERTED = 6,
 };
 
 inline tipb::VectorIndexKind toVectorIndexKind(IndexType index_type)
@@ -170,6 +171,31 @@ Poco::JSON::Object::Ptr vectorIndexToJSON(const VectorIndexDefinitionPtr & vecto
     vector_index_json->set("dimension", vector_index->dimension);
     vector_index_json->set("distance_metric", tipb::VectorDistanceMetric_Name(vector_index->distance_metric));
     return vector_index_json;
+}
+
+InvertedIndexDefinitionPtr parseInvertedIndexFromJSON(IndexType index_type, const Poco::JSON::Object::Ptr & json)
+{
+    assert(json); // not nullptr
+
+    RUNTIME_CHECK(index_type == IndexType::INVERTED);
+    bool is_signed = json->getValue<bool>("is_signed");
+    auto type_size = json->getValue<UInt8>("type_size");
+    RUNTIME_CHECK(type_size > 0 && type_size <= sizeof(UInt64), type_size); // Just a protection
+    return std::make_shared<const InvertedIndexDefinition>(InvertedIndexDefinition{
+        .is_signed = is_signed,
+        .type_size = type_size,
+    });
+}
+
+Poco::JSON::Object::Ptr invertedIndexToJSON(const InvertedIndexDefinitionPtr & inverted_index)
+{
+    assert(inverted_index != nullptr);
+    RUNTIME_CHECK(inverted_index->type_size > 0 && inverted_index->type_size <= sizeof(UInt64));
+
+    Poco::JSON::Object::Ptr inverted_index_json = new Poco::JSON::Object();
+    inverted_index_json->set("is_signed", inverted_index->is_signed);
+    inverted_index_json->set("type_size", inverted_index->type_size);
+    return inverted_index_json;
 }
 
 ////////////////////////
@@ -887,6 +913,10 @@ try
     {
         json->set("vector_index", vectorIndexToJSON(vector_index));
     }
+    else if (inverted_index)
+    {
+        json->set("inverted_index", invertedIndexToJSON(inverted_index));
+    }
 
 #ifndef NDEBUG
     std::stringstream str;
@@ -932,6 +962,10 @@ try
     if (auto vector_index_json = json->getObject("vector_index"); vector_index_json)
     {
         vector_index = parseVectorIndexFromJSON(static_cast<IndexType>(index_type), vector_index_json);
+    }
+    if (auto inverted_index_json = json->getObject("inverted_index"); inverted_index_json)
+    {
+        inverted_index = parseInvertedIndexFromJSON(static_cast<IndexType>(index_type), inverted_index_json);
     }
 }
 catch (const Poco::Exception & e)
@@ -1061,7 +1095,7 @@ try
                 // always put the primary_index at the front of all index_info
                 index_infos.insert(index_infos.begin(), std::move(index_info));
             }
-            else if (index_info.hasColumnarIndex())
+            else if (index_info.isColumnarIndex())
             {
                 index_infos.emplace_back(std::move(index_info));
             }

--- a/dbms/src/TiDB/Schema/TiDB.h
+++ b/dbms/src/TiDB/Schema/TiDB.h
@@ -20,6 +20,7 @@
 #include <IO/WriteHelpers.h>
 #include <Storages/KVStore/StorageEngineType.h>
 #include <Storages/KVStore/Types.h>
+#include <TiDB/Schema/InvertedIndex.h>
 #include <TiDB/Schema/TiDBTypes.h>
 #include <TiDB/Schema/TiDB_fwd.h>
 #include <TiDB/Schema/VectorIndex.h>
@@ -247,7 +248,7 @@ struct IndexColumnInfo
 // - From TiFlash's perspective, it is a local index.
 enum class ColumnarIndexKind
 {
-    // Leave 0 intentionally for InvalidValues
+    Invalid = 0,
     Vector = 1,
     Inverted = 2,
 };
@@ -273,16 +274,18 @@ struct IndexInfo
     bool is_global = false;
 
     VectorIndexDefinitionPtr vector_index = nullptr;
+    InvertedIndexDefinitionPtr inverted_index = nullptr;
 
     ColumnarIndexKind columnarIndexKind() const
     {
-        RUNTIME_CHECK(hasColumnarIndex());
         if (vector_index)
             return ColumnarIndexKind::Vector;
+        if (inverted_index)
+            return ColumnarIndexKind::Inverted;
         RUNTIME_CHECK(false);
     }
 
-    bool hasColumnarIndex() const { return (vector_index != nullptr); }
+    bool isColumnarIndex() const { return vector_index || inverted_index; }
 };
 
 struct TableInfo


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #9843 

Problem Summary:

### What is changed and how it works?

```commit-message
Part 4 of the inverted index, use RSOperator to generate the column range, and puts the column range to `PushDownExecutor`. The reading path is:

1. Load stable inverted index, get `index_bitamp`.
2. Modify DMFilePackFilterResults according to `index_bitmap`.
3. Run MVCC, get `mvcc_bitmap`.
4. Load delta inverted index, append to `index_bitamp `.
5. `mvcc_bitmap` & `index_bitmap`, get `final_bitmap`
6. Modify DMFilePackFilterResults according to `final_bitmap `.
7. Read column data.
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
