### PR TITLE
KVStore: Fix fail to restore tikv value larger than 16MiB

### DIFF
--- a/dbms/src/IO/ReadHelpers.h
+++ b/dbms/src/IO/ReadHelpers.h
@@ -34,7 +34,11 @@
 #include <iterator>
 #include <type_traits>
 
-#define DEFAULT_MAX_STRING_SIZE 0x00FFFFFFULL
+static constexpr UInt64 DEFAULT_MAX_STRING_SIZE = 0x00FFFFFFULL; // 16777215, 16MiB-1
+
+// According to `txn-entry-size-limit` in TiDB, the max size of a TiKV key/value is 120MB.
+// https://docs.pingcap.com/tidb/stable/tidb-configuration-file/#txn-entry-size-limit-new-in-v4010-and-v500
+static constexpr UInt64 TIKV_MAX_VALUE_SIZE = 125829120;
 
 namespace DB
 {

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFilePersisted.cpp
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFilePersisted.cpp
@@ -181,6 +181,7 @@ ColumnFilePersisteds deserializeSavedColumnFiles(
     {
         dtpb::DeltaLayerMeta meta;
         String data;
+        // FIXME: if the data is too large, this may cause exception when restore.
         readStringBinary(data, buf);
         RUNTIME_CHECK_MSG(
             meta.ParseFromString(data),
@@ -217,6 +218,7 @@ ColumnFilePersisteds createColumnFilesFromCheckpoint( //
     {
         dtpb::DeltaLayerMeta meta;
         String data;
+        // FIXME: if the data is too large, this may cause exception when restore.
         readStringBinary(data, buf);
         RUNTIME_CHECK_MSG(
             meta.ParseFromString(data),

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFilePersisted.cpp
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFilePersisted.cpp
@@ -181,7 +181,8 @@ ColumnFilePersisteds deserializeSavedColumnFiles(
     {
         dtpb::DeltaLayerMeta meta;
         String data;
-        // FIXME: if the data is too large, this may cause exception when restore.
+        // Note: if the data is too large (DEFAULT_MAX_STRING_SIZE), this may cause exception when restore,
+        // but it is OK so far
         readStringBinary(data, buf);
         RUNTIME_CHECK_MSG(
             meta.ParseFromString(data),
@@ -218,7 +219,8 @@ ColumnFilePersisteds createColumnFilesFromCheckpoint( //
     {
         dtpb::DeltaLayerMeta meta;
         String data;
-        // FIXME: if the data is too large, this may cause exception when restore.
+        // Note: if the data is too large (DEFAULT_MAX_STRING_SIZE), this may cause exception when restore,
+        // but it is OK so far
         readStringBinary(data, buf);
         RUNTIME_CHECK_MSG(
             meta.ParseFromString(data),

--- a/dbms/src/Storages/DeltaMerge/Segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/Segment.cpp
@@ -384,7 +384,6 @@ void readSegmentMetaInfo(ReadBuffer & buf, Segment::SegmentMetaInfo & segment_in
     {
         dtpb::SegmentMeta meta;
         String data;
-        // FIXME: if the data is too large, this may cause exception when restore.
         readStringBinary(data, buf);
         RUNTIME_CHECK_MSG(
             meta.ParseFromString(data),

--- a/dbms/src/Storages/DeltaMerge/Segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/Segment.cpp
@@ -384,6 +384,7 @@ void readSegmentMetaInfo(ReadBuffer & buf, Segment::SegmentMetaInfo & segment_in
     {
         dtpb::SegmentMeta meta;
         String data;
+        // FIXME: if the data is too large, this may cause exception when restore.
         readStringBinary(data, buf);
         RUNTIME_CHECK_MSG(
             meta.ParseFromString(data),

--- a/dbms/src/Storages/KVStore/TiKVHelpers/TiKVKeyValue.h
+++ b/dbms/src/Storages/KVStore/TiKVHelpers/TiKVKeyValue.h
@@ -32,7 +32,7 @@ public:
         : Base(std::move(str_))
     {}
     StringObject(StringObject && obj)
-        : Base((Base &&) obj)
+        : Base((Base &&)obj)
     {}
     StringObject(const char * str, const size_t len)
         : Base(str, len)
@@ -54,12 +54,13 @@ public:
         if (this == &a)
             return *this;
 
-        (Base &)* this = (Base &&) a;
+        (Base &)* this = (Base &&)a;
         return *this;
     }
 
     const std::string & getStr() const { return *this; }
     size_t dataSize() const { return Base::size(); }
+    size_t size() const = delete;
     std::string toString() const { return *this; }
 
     // Format as a hex string for debugging. The value will be converted to '?' if redact-log is on
@@ -67,15 +68,14 @@ public:
 
     explicit operator bool() const { return !empty(); }
 
-    size_t serialize(WriteBuffer & buf) const { return writeBinary2((const Base &)*this, buf); }
+    size_t serialize(WriteBuffer & buf) const { return writeBinary2(static_cast<const Base &>(*this), buf); }
 
-    static StringObject deserialize(ReadBuffer & buf) { return StringObject(readBinary2<Base>(buf)); }
+    static StringObject deserialize(ReadBuffer & buf) { return StringObject(readTiKVStringBinary(buf)); }
 
 private:
     StringObject(const Base & str_)
         : Base(str_)
     {}
-    size_t size() const = delete;
 };
 
 using TiKVKey = StringObject<true>;

--- a/dbms/src/Storages/KVStore/Utils/SerializationHelper.h
+++ b/dbms/src/Storages/KVStore/Utils/SerializationHelper.h
@@ -60,6 +60,14 @@ inline size_t writeBinary2(const std::string & s, WriteBuffer & buf)
     return 4 + s.size();
 }
 
+inline std::string readStringWithLength(ReadBuffer & buf, size_t length)
+{
+    std::string s;
+    s.resize(length);
+    buf.readStrict(&s[0], length);
+    return s;
+}
+
 template <>
 inline std::string readBinary2<std::string>(ReadBuffer & buf)
 {
@@ -72,18 +80,23 @@ inline std::string readBinary2<std::string>(ReadBuffer & buf)
             "Too large string size, size={} max_size={}",
             size,
             DEFAULT_MAX_STRING_SIZE);
-    std::string s;
-    s.resize(size);
-    buf.readStrict(&s[0], size);
-    return s;
+
+    return readStringWithLength(buf, size);
 }
 
-inline std::string readStringWithLength(ReadBuffer & buf, size_t length)
+inline std::string readTiKVStringBinary(ReadBuffer & buf)
 {
-    std::string s;
-    s.resize(length);
-    buf.readStrict(&s[0], length);
-    return s;
+    UInt32 size = 0;
+    readIntBinary(size, buf);
+
+    if (size > TIKV_MAX_VALUE_SIZE)
+        throw Exception(
+            ErrorCodes::LOGICAL_ERROR,
+            "Too large tikv key/value size, size={} max_size={}",
+            size,
+            TIKV_MAX_VALUE_SIZE);
+
+    return readStringWithLength(buf, size);
 }
 
 size_t writeBinary2(const metapb::Peer & peer, WriteBuffer & buf);

--- a/dbms/src/Storages/KVStore/tests/gtest_region_persister.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_region_persister.cpp
@@ -257,10 +257,18 @@ try
 {
     TableID table_id = 100;
     auto region = makeTmpRegion();
+
     TiKVKey key = RecordKVFormat::genKey(table_id, 323, 9983);
     region->insertDebug("default", TiKVKey::copyFrom(key), TiKVValue("value1"));
     region->insertDebug("write", TiKVKey::copyFrom(key), RecordKVFormat::encodeWriteCfValue('P', 0));
     region->insertDebug("lock", TiKVKey::copyFrom(key), RecordKVFormat::encodeLockCfValue('P', "", 0, 0));
+
+    TiKVKey large_value_key = RecordKVFormat::genKey(table_id, 324, 9983);
+    region->insertDebug(
+        "default",
+        TiKVKey::copyFrom(large_value_key),
+        // slightly less than `TIKV_MAX_VALUE_SIZE` for other key-values
+        TiKVValue(String(static_cast<size_t>(TIKV_MAX_VALUE_SIZE - 1024), 'v')));
 
     region->updateRaftLogEagerIndex(1024);
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/10052

Problem Summary:

```
# tidb.toml
[performance]
txn-entry-size-limit = 125829120
# tiup edit
#    performance.txn-entry-size-limit: 125829120
```
```
# tikv.toml
[raftstore]
raft-entry-max-size = '120MiB'
# tiup edit
#     raftstore.raft-entry-max-size: '120MiB'
```

```
set global max_allowed_packet = 1073741824;
CREATE TABLE `t` (
  `id` bigint(21) unsigned NOT NULL,
  `text` longtext DEFAULT NULL
);
```

TiDB could allow a raft-log with 120MiB at max, while TiFlash `Region::deserialize` use `readBinary2<std::string>` only allow 16MiB at max. So if there are some raftlog larger than 16MiB and flushed to `RegionData`, then TiFlash could fail to restart when restoring Region data from disk.
If the raftlog is committed, the rows are decoded into `Block` and write down to `IStorage`. Reading/writing rows larger than `16MiB` in the `IStorage` layer does not cause any error.


### What is changed and how it works?

```commit-message
KVStore: Fix restoring large tikv value
Add function `readTiKVStringBinary` for `TiKVValue::deserialize` and `TiKVKey::deserialize` to allow restoring tikv key/values at most 120MiB
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix an issue that TiFlash may fail to restart when user write rows larger than 16MiB
```
