### PR TITLE
tests: Avoid disk IO in `RegionSeriTest`

### DIFF
--- a/dbms/src/Debug/dbgNaturalDag.h
+++ b/dbms/src/Debug/dbgNaturalDag.h
@@ -16,6 +16,7 @@
 
 #include <Flash/Coprocessor/RegionInfo.h>
 #include <Storages/KVStore/Decode/DecodedTiKVKeyValue.h>
+#include <Storages/KVStore/TiKVHelpers/TiKVKeyValue.h>
 #include <TiDB/Schema/TiDB.h>
 #include <kvproto/coprocessor.pb.h>
 #include <kvproto/mpp.pb.h>

--- a/dbms/src/IO/Buffer/WriteBufferFromString.h
+++ b/dbms/src/IO/Buffer/WriteBufferFromString.h
@@ -36,7 +36,7 @@ class StringHolder
 {
 public:
     StringHolder() = default;
-    StringHolder(size_t init_size) { value.resize(init_size); }
+    explicit StringHolder(size_t init_size) { value.resize(init_size); }
 
 protected:
     std::string value;
@@ -53,7 +53,7 @@ public:
         : WriteBufferFromString(value)
     {}
 
-    WriteBufferFromOwnString(size_t init_size)
+    explicit WriteBufferFromOwnString(size_t init_size)
         : detail::StringHolder(init_size)
         , WriteBufferFromString(value)
     {}

--- a/dbms/src/IO/Buffer/WriteBufferFromVector.h
+++ b/dbms/src/IO/Buffer/WriteBufferFromVector.h
@@ -16,8 +16,6 @@
 
 #include <IO/Buffer/WriteBuffer.h>
 
-#include <vector>
-
 namespace DB
 {
 namespace ErrorCodes

--- a/dbms/src/IO/ReadHelpers.h
+++ b/dbms/src/IO/ReadHelpers.h
@@ -34,7 +34,11 @@
 #include <iterator>
 #include <type_traits>
 
-#define DEFAULT_MAX_STRING_SIZE 0x00FFFFFFULL
+static constexpr UInt64 DEFAULT_MAX_STRING_SIZE = 0x00FFFFFFULL; // 16777215, 16MiB-1
+
+// According to `txn-entry-size-limit` in TiDB, the max size of a TiKV key/value is 120MB.
+// https://docs.pingcap.com/tidb/stable/tidb-configuration-file/#txn-entry-size-limit-new-in-v4010-and-v500
+static constexpr UInt64 TIKV_MAX_VALUE_SIZE = 125829120;
 
 namespace DB
 {

--- a/dbms/src/IO/ReadHelpers.h
+++ b/dbms/src/IO/ReadHelpers.h
@@ -34,11 +34,7 @@
 #include <iterator>
 #include <type_traits>
 
-static constexpr UInt64 DEFAULT_MAX_STRING_SIZE = 0x00FFFFFFULL; // 16777215, 16MiB-1
-
-// According to `txn-entry-size-limit` in TiDB, the max size of a TiKV key/value is 120MB.
-// https://docs.pingcap.com/tidb/stable/tidb-configuration-file/#txn-entry-size-limit-new-in-v4010-and-v500
-static constexpr UInt64 TIKV_MAX_VALUE_SIZE = 125829120;
+#define DEFAULT_MAX_STRING_SIZE 0x00FFFFFFULL
 
 namespace DB
 {

--- a/dbms/src/Storages/KVStore/Decode/DecodedTiKVKeyValue.h
+++ b/dbms/src/Storages/KVStore/Decode/DecodedTiKVKeyValue.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include <Storages/KVStore/TiKVHelpers/TiKVKeyValue.h>
+#include <Common/RedactHelpers.h>
 #include <Storages/KVStore/Types.h>
 
 namespace DB
@@ -32,14 +32,14 @@ struct DecodedTiKVKey
     {}
     DecodedTiKVKey() = default;
     DecodedTiKVKey(DecodedTiKVKey && obj)
-        : Base((Base &&) obj)
+        : Base((Base &&)obj)
     {}
     DecodedTiKVKey & operator=(DecodedTiKVKey && obj)
     {
         if (this == &obj)
             return *this;
 
-        (Base &)* this = (Base &&) obj;
+        (Base &)* this = (Base &&)obj;
         return *this;
     }
 

--- a/dbms/src/Storages/KVStore/MultiRaft/RegionRangeKeys.h
+++ b/dbms/src/Storages/KVStore/MultiRaft/RegionRangeKeys.h
@@ -16,6 +16,7 @@
 
 #include <Storages/KVStore/Decode/DecodedTiKVKeyValue.h>
 #include <Storages/KVStore/Decode/TiKVHandle.h>
+#include <Storages/KVStore/TiKVHelpers/TiKVKeyValue.h>
 
 namespace DB
 {

--- a/dbms/src/Storages/KVStore/TiKVHelpers/TiKVRecordFormat.h
+++ b/dbms/src/Storages/KVStore/TiKVHelpers/TiKVRecordFormat.h
@@ -20,6 +20,7 @@
 #include <IO/Endian.h>
 #include <Storages/KVStore/Decode/DecodedTiKVKeyValue.h>
 #include <Storages/KVStore/Decode/TiKVHandle.h>
+#include <Storages/KVStore/TiKVHelpers/TiKVKeyValue.h>
 #include <Storages/KVStore/TiKVHelpers/TiKVVarInt.h>
 #include <Storages/KVStore/Types.h>
 #include <TiDB/Decode/Datum.h>

--- a/dbms/src/Storages/KVStore/tests/gtest_region_persister.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_region_persister.cpp
@@ -17,8 +17,8 @@
 #include <Common/Stopwatch.h>
 #include <Common/SyncPoint/Ctl.h>
 #include <Debug/MockKVStore/MockUtils.h>
-#include <IO/Buffer/ReadBufferFromFile.h>
-#include <IO/Buffer/WriteBufferFromFile.h>
+#include <IO/Buffer/ReadBufferFromString.h>
+#include <IO/Buffer/WriteBufferFromString.h>
 #include <Interpreters/Context.h>
 #include <RaftStoreProxyFFI/ColumnFamily.h>
 #include <Storages/KVStore/MultiRaft/RegionManager.h>
@@ -35,7 +35,6 @@
 #include <common/types.h>
 
 #include <ext/scope_guard.h>
-#include <future>
 
 namespace DB
 {
@@ -260,17 +259,23 @@ try
 
     region->updateRaftLogEagerIndex(1024);
 
-    const auto path = dir_path + "/region.test";
-    WriteBufferFromFile write_buf(path, DBMS_DEFAULT_BUFFER_SIZE, O_WRONLY | O_CREAT);
-    size_t region_ser_size = std::get<0>(region->serialize(write_buf));
-    write_buf.next();
-    write_buf.sync();
-    ASSERT_EQ(region_ser_size, (size_t)Poco::File(path).getSize());
-
-    ReadBufferFromFile read_buf(path, DBMS_DEFAULT_BUFFER_SIZE, O_RDONLY);
-    auto new_region = Region::deserialize(read_buf);
-    ASSERT_REGION_EQ(*new_region, *region);
+    String serialized_str;
     {
+        WriteBufferFromOwnString write_buf;
+        size_t region_ser_size = std::get<0>(region->serialize(write_buf));
+        write_buf.next();
+        write_buf.finalize();
+        serialized_str = write_buf.releaseStr();
+        ASSERT_EQ(region_ser_size, serialized_str.size());
+        LOG_INFO(Logger::get(), "region_ser_size={}", region_ser_size);
+    }
+
+    {
+        ReadBufferFromString read_buf(serialized_str);
+        auto new_region = Region::deserialize(read_buf);
+        ASSERT_REGION_EQ(*new_region, *region);
+
+        // eager_truncated_index
         const auto & [eager_truncated_index, applied_index] = new_region->getRaftLogEagerGCRange();
         ASSERT_EQ(eager_truncated_index, 1024);
     }

--- a/dbms/src/TiDB/Decode/DatumCodec.h
+++ b/dbms/src/TiDB/Decode/DatumCodec.h
@@ -20,6 +20,7 @@
 #include <IO/Endian.h>
 #include <TiDB/Schema/TiDBTypes.h>
 #include <TiDB/Schema/TiDB_fwd.h>
+#include <common/StringRef.h>
 
 /// Functions in this file are used for individual datum codec, i.e. UInt/Int64, Float64, String/Bytes, Decimal, Enum, Set, etc.
 /// The internal representation of a datum in TiFlash is Field.

--- a/dbms/src/TiDB/Decode/RowCodec.h
+++ b/dbms/src/TiDB/Decode/RowCodec.h
@@ -17,6 +17,7 @@
 #include <Core/Block.h>
 #include <Storages/KVStore/Decode/DecodedTiKVKeyValue.h>
 #include <Storages/KVStore/Decode/DecodingStorageSchemaSnapshot.h>
+#include <Storages/KVStore/TiKVHelpers/TiKVKeyValue.h>
 
 namespace DB
 {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6233 

Problem Summary:

### What is changed and how it works?

```commit-message
tests: Avoid disk IO in `RegionSeriTest`
Use `WriteBufferFromOwnString`/`ReadBufferFromString` instead of `WriteBufferFromFile`/`ReadBufferFromFile` to make the time of running tests more stable
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
