### PR TITLE
Storages: add inverted index statistics to ScanContext

### DIFF
--- a/dbms/src/Storages/DeltaMerge/Index/InvertedIndex/Reader/ReaderFromColumnFileTiny.h
+++ b/dbms/src/Storages/DeltaMerge/Index/InvertedIndex/Reader/ReaderFromColumnFileTiny.h
@@ -18,6 +18,7 @@
 #include <Storages/DeltaMerge/ColumnFile/ColumnFileTiny.h>
 #include <Storages/DeltaMerge/Filter/ColumnRange_fwd.h>
 #include <Storages/DeltaMerge/Index/LocalIndexCache_fwd.h>
+#include <Storages/DeltaMerge/ScanContext_fwd.h>
 
 namespace DB::DM
 {
@@ -30,6 +31,7 @@ private:
     const ColumnRangePtr column_range;
     // Global local index cache
     const LocalIndexCachePtr local_index_cache;
+    const ScanContextPtr scan_context;
 
     bool loaded = false;
 
@@ -38,7 +40,8 @@ public:
         const ColumnRangePtr & column_range_,
         const ColumnFileTiny & tiny_file_,
         const IColumnFileDataProviderPtr & data_provider_,
-        const LocalIndexCachePtr & local_index_cache_);
+        const LocalIndexCachePtr & local_index_cache_,
+        const ScanContextPtr & scan_context_ = nullptr);
 
     ~InvertedIndexReaderFromColumnFileTiny();
 

--- a/dbms/src/Storages/DeltaMerge/Index/InvertedIndex/Reader/ReaderFromDMFile.h
+++ b/dbms/src/Storages/DeltaMerge/Index/InvertedIndex/Reader/ReaderFromDMFile.h
@@ -18,6 +18,7 @@
 #include <Storages/DeltaMerge/File/DMFile_fwd.h>
 #include <Storages/DeltaMerge/Filter/ColumnRange_fwd.h>
 #include <Storages/DeltaMerge/Index/LocalIndexCache_fwd.h>
+#include <Storages/DeltaMerge/ScanContext_fwd.h>
 
 namespace DB::DM
 {
@@ -29,6 +30,7 @@ private:
     const ColumnRangePtr column_range;
     // Global local index cache
     const LocalIndexCachePtr local_index_cache;
+    const ScanContextPtr scan_context;
 
     bool loaded = false;
 
@@ -36,7 +38,8 @@ public:
     InvertedIndexReaderFromDMFile(
         const ColumnRangePtr & column_range_,
         const DMFilePtr & dmfile_,
-        const LocalIndexCachePtr & local_index_cache_);
+        const LocalIndexCachePtr & local_index_cache_,
+        const ScanContextPtr & scan_context_ = nullptr);
 
     ~InvertedIndexReaderFromDMFile();
 

--- a/dbms/src/Storages/DeltaMerge/Index/InvertedIndex/Reader/ReaderFromSegment.h
+++ b/dbms/src/Storages/DeltaMerge/Index/InvertedIndex/Reader/ReaderFromSegment.h
@@ -17,6 +17,7 @@
 #include <Storages/DeltaMerge/BitmapFilter/BitmapFilter.h>
 #include <Storages/DeltaMerge/Filter/ColumnRange_fwd.h>
 #include <Storages/DeltaMerge/Index/LocalIndexCache_fwd.h>
+#include <Storages/DeltaMerge/ScanContext_fwd.h>
 
 namespace DB::DM
 {
@@ -31,25 +32,30 @@ private:
     const ColumnRangePtr column_range;
     // Global local index cache
     const LocalIndexCachePtr local_index_cache;
+    const ScanContextPtr scan_context;
 
 public:
     InvertedIndexReaderFromSegment(
         const SegmentSnapshotPtr & snapshot_,
         const ColumnRangePtr & column_range_,
-        const LocalIndexCachePtr & local_index_cache_)
+        const LocalIndexCachePtr & local_index_cache_,
+        const ScanContextPtr & scan_context_)
         : snapshot(snapshot_)
         , column_range(column_range_)
         , local_index_cache(local_index_cache_)
+        , scan_context(scan_context_)
     {}
 
     static BitmapFilterPtr loadStable(
         const SegmentSnapshotPtr & snapshot,
         const ColumnRangePtr & column_range,
-        const LocalIndexCachePtr & local_index_cache);
+        const LocalIndexCachePtr & local_index_cache,
+        const ScanContextPtr & scan_context);
     static BitmapFilterPtr loadDelta(
         const SegmentSnapshotPtr & snapshot,
         const ColumnRangePtr & column_range,
-        const LocalIndexCachePtr & local_index_cache);
+        const LocalIndexCachePtr & local_index_cache,
+        const ScanContextPtr & scan_context);
 
     ~InvertedIndexReaderFromSegment() = default;
 

--- a/dbms/src/Storages/DeltaMerge/Index/VectorIndex/Stream/InputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/VectorIndex/Stream/InputStream.cpp
@@ -114,14 +114,13 @@ void VectorIndexInputStream::initSearchResults()
     if (ctx->dm_context != nullptr && ctx->dm_context->scan_context != nullptr)
     {
         auto scan_context = ctx->dm_context->scan_context;
-        scan_context->total_vector_idx_load_from_s3 += ctx->perf->load_from_stable_s3;
-        scan_context->total_vector_idx_load_from_disk
-            += ctx->perf->load_from_stable_disk + ctx->perf->load_from_column_file;
-        scan_context->total_vector_idx_load_from_cache += ctx->perf->load_from_cache;
-        scan_context->total_vector_idx_load_time_ms += ctx->perf->total_load_ms;
-        scan_context->total_vector_idx_search_time_ms += ctx->perf->total_search_ms;
-        scan_context->total_vector_idx_search_visited_nodes += ctx->perf->visited_nodes;
-        scan_context->total_vector_idx_search_discarded_nodes += ctx->perf->discarded_nodes;
+        scan_context->vector_idx_load_from_s3 += ctx->perf->load_from_stable_s3;
+        scan_context->vector_idx_load_from_disk += ctx->perf->load_from_stable_disk + ctx->perf->load_from_column_file;
+        scan_context->vector_idx_load_from_cache += ctx->perf->load_from_cache;
+        scan_context->vector_idx_load_time_ms += ctx->perf->total_load_ms;
+        scan_context->vector_idx_search_time_ms += ctx->perf->total_search_ms;
+        scan_context->vector_idx_search_visited_nodes += ctx->perf->visited_nodes;
+        scan_context->vector_idx_search_discarded_nodes += ctx->perf->discarded_nodes;
     }
 
     searchResultsInited = true;
@@ -198,9 +197,8 @@ void VectorIndexInputStream::onReadFinished()
     if (ctx->dm_context != nullptr && ctx->dm_context->scan_context != nullptr)
     {
         auto scan_context = ctx->dm_context->scan_context;
-        scan_context->total_vector_idx_read_vec_time_ms
-            += ctx->perf->total_cf_read_vec_ms + ctx->perf->total_dm_read_vec_ms;
-        scan_context->total_vector_idx_read_others_time_ms
+        scan_context->vector_idx_read_vec_time_ms += ctx->perf->total_cf_read_vec_ms + ctx->perf->total_dm_read_vec_ms;
+        scan_context->vector_idx_read_others_time_ms
             += ctx->perf->total_cf_read_others_ms + ctx->perf->total_dm_read_others_ms;
     }
 }

--- a/dbms/src/Storages/DeltaMerge/Index/VectorIndex/tests/gtest_dm_vector_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/VectorIndex/tests/gtest_dm_vector_index.cpp
@@ -2230,9 +2230,9 @@ try
                 colVecFloat32("[5, 6)"),
             }));
 
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_cache, 0);
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_disk, 0);
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_s3, 1);
+        ASSERT_EQ(scan_context->vector_idx_load_from_cache, 0);
+        ASSERT_EQ(scan_context->vector_idx_load_from_disk, 0);
+        ASSERT_EQ(scan_context->vector_idx_load_from_s3, 1);
     }
     {
         auto * file_cache = FileCache::instance();
@@ -2252,9 +2252,9 @@ try
                 colVecFloat32("[5, 6)"),
             }));
 
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_cache, 1);
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_disk, 0);
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_s3, 0);
+        ASSERT_EQ(scan_context->vector_idx_load_from_cache, 1);
+        ASSERT_EQ(scan_context->vector_idx_load_from_disk, 0);
+        ASSERT_EQ(scan_context->vector_idx_load_from_s3, 0);
     }
 }
 CATCH
@@ -2281,9 +2281,9 @@ try
                     colVecFloat32("[5, 6)"),
                 }));
 
-            ASSERT_EQ(scan_context->total_vector_idx_load_from_cache, 0);
-            ASSERT_EQ(scan_context->total_vector_idx_load_from_disk, 0);
-            ASSERT_EQ(scan_context->total_vector_idx_load_from_s3, 1);
+            ASSERT_EQ(scan_context->vector_idx_load_from_cache, 0);
+            ASSERT_EQ(scan_context->vector_idx_load_from_disk, 0);
+            ASSERT_EQ(scan_context->vector_idx_load_from_s3, 1);
         }
         {
             auto * file_cache = FileCache::instance();
@@ -2303,9 +2303,9 @@ try
                     colVecFloat32("[5, 6)"),
                 }));
 
-            ASSERT_EQ(scan_context->total_vector_idx_load_from_cache, 1);
-            ASSERT_EQ(scan_context->total_vector_idx_load_from_disk, 0);
-            ASSERT_EQ(scan_context->total_vector_idx_load_from_s3, 0);
+            ASSERT_EQ(scan_context->vector_idx_load_from_cache, 1);
+            ASSERT_EQ(scan_context->vector_idx_load_from_disk, 0);
+            ASSERT_EQ(scan_context->vector_idx_load_from_s3, 0);
         }
     }
     {
@@ -2322,9 +2322,9 @@ try
                     colVecFloat32("[5, 6)"),
                 }));
 
-            ASSERT_EQ(scan_context->total_vector_idx_load_from_cache, 0);
-            ASSERT_EQ(scan_context->total_vector_idx_load_from_disk, 0);
-            ASSERT_EQ(scan_context->total_vector_idx_load_from_s3, 1);
+            ASSERT_EQ(scan_context->vector_idx_load_from_cache, 0);
+            ASSERT_EQ(scan_context->vector_idx_load_from_disk, 0);
+            ASSERT_EQ(scan_context->vector_idx_load_from_s3, 1);
         }
         {
             auto * file_cache = FileCache::instance();
@@ -2344,9 +2344,9 @@ try
                     colVecFloat32("[5, 6)"),
                 }));
 
-            ASSERT_EQ(scan_context->total_vector_idx_load_from_cache, 1);
-            ASSERT_EQ(scan_context->total_vector_idx_load_from_disk, 0);
-            ASSERT_EQ(scan_context->total_vector_idx_load_from_s3, 0);
+            ASSERT_EQ(scan_context->vector_idx_load_from_cache, 1);
+            ASSERT_EQ(scan_context->vector_idx_load_from_disk, 0);
+            ASSERT_EQ(scan_context->vector_idx_load_from_s3, 0);
         }
     }
 }
@@ -2371,9 +2371,9 @@ try
                 colVecFloat32("[5, 6)"),
             }));
 
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_cache, 0);
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_disk, 0);
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_s3, 1);
+        ASSERT_EQ(scan_context->vector_idx_load_from_cache, 0);
+        ASSERT_EQ(scan_context->vector_idx_load_from_disk, 0);
+        ASSERT_EQ(scan_context->vector_idx_load_from_s3, 1);
     }
     {
         auto * file_cache = FileCache::instance();
@@ -2402,9 +2402,9 @@ try
                 colVecFloat32("[5, 6)"),
             }));
 
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_cache, 0);
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_disk, 0);
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_s3, 1);
+        ASSERT_EQ(scan_context->vector_idx_load_from_cache, 0);
+        ASSERT_EQ(scan_context->vector_idx_load_from_disk, 0);
+        ASSERT_EQ(scan_context->vector_idx_load_from_s3, 1);
     }
     {
         // Read again, we should be reading from memory cache.
@@ -2419,9 +2419,9 @@ try
                 colVecFloat32("[5, 6)"),
             }));
 
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_cache, 1);
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_disk, 0);
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_s3, 0);
+        ASSERT_EQ(scan_context->vector_idx_load_from_cache, 1);
+        ASSERT_EQ(scan_context->vector_idx_load_from_disk, 0);
+        ASSERT_EQ(scan_context->vector_idx_load_from_s3, 0);
     }
 }
 CATCH
@@ -2445,9 +2445,9 @@ try
                 colVecFloat32("[5, 6)"),
             }));
 
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_cache, 0);
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_disk, 0);
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_s3, 1);
+        ASSERT_EQ(scan_context->vector_idx_load_from_cache, 0);
+        ASSERT_EQ(scan_context->vector_idx_load_from_disk, 0);
+        ASSERT_EQ(scan_context->vector_idx_load_from_s3, 1);
     }
     {
         auto * file_cache = FileCache::instance();
@@ -2481,9 +2481,9 @@ try
                 colVecFloat32("[5, 6)"),
             }));
 
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_cache, 0);
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_disk, 0);
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_s3, 1);
+        ASSERT_EQ(scan_context->vector_idx_load_from_cache, 0);
+        ASSERT_EQ(scan_context->vector_idx_load_from_disk, 0);
+        ASSERT_EQ(scan_context->vector_idx_load_from_s3, 1);
     }
     {
         // Read again, we should be reading from memory cache.
@@ -2498,9 +2498,9 @@ try
                 colVecFloat32("[5, 6)"),
             }));
 
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_cache, 1);
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_disk, 0);
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_s3, 0);
+        ASSERT_EQ(scan_context->vector_idx_load_from_cache, 1);
+        ASSERT_EQ(scan_context->vector_idx_load_from_disk, 0);
+        ASSERT_EQ(scan_context->vector_idx_load_from_s3, 0);
     }
 }
 CATCH
@@ -2524,9 +2524,9 @@ try
                 colVecFloat32("[5, 6)"),
             }));
 
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_cache, 0);
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_disk, 0);
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_s3, 1);
+        ASSERT_EQ(scan_context->vector_idx_load_from_cache, 0);
+        ASSERT_EQ(scan_context->vector_idx_load_from_disk, 0);
+        ASSERT_EQ(scan_context->vector_idx_load_from_s3, 1);
     }
     {
         auto * file_cache = FileCache::instance();
@@ -2548,9 +2548,9 @@ try
                 colVecFloat32("[5, 6)"),
             }));
 
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_cache, 0);
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_disk, 0);
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_s3, 1);
+        ASSERT_EQ(scan_context->vector_idx_load_from_cache, 0);
+        ASSERT_EQ(scan_context->vector_idx_load_from_disk, 0);
+        ASSERT_EQ(scan_context->vector_idx_load_from_s3, 1);
     }
     {
         // Read again, we should be reading from memory cache.
@@ -2565,9 +2565,9 @@ try
                 colVecFloat32("[5, 6)"),
             }));
 
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_cache, 1);
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_disk, 0);
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_s3, 0);
+        ASSERT_EQ(scan_context->vector_idx_load_from_cache, 1);
+        ASSERT_EQ(scan_context->vector_idx_load_from_disk, 0);
+        ASSERT_EQ(scan_context->vector_idx_load_from_s3, 0);
     }
 }
 CATCH
@@ -2591,9 +2591,9 @@ try
                 colVecFloat32("[5, 6)"),
             }));
 
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_cache, 0);
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_disk, 0);
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_s3, 1);
+        ASSERT_EQ(scan_context->vector_idx_load_from_cache, 0);
+        ASSERT_EQ(scan_context->vector_idx_load_from_disk, 0);
+        ASSERT_EQ(scan_context->vector_idx_load_from_s3, 1);
     }
     {
         auto * file_cache = FileCache::instance();
@@ -2621,9 +2621,9 @@ try
                 colVecFloat32("[5, 6)"),
             }));
 
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_cache, 0);
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_disk, 0);
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_s3, 1);
+        ASSERT_EQ(scan_context->vector_idx_load_from_cache, 0);
+        ASSERT_EQ(scan_context->vector_idx_load_from_disk, 0);
+        ASSERT_EQ(scan_context->vector_idx_load_from_s3, 1);
     }
     {
         // Read again, we should be reading from memory cache.
@@ -2638,9 +2638,9 @@ try
                 colVecFloat32("[5, 6)"),
             }));
 
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_cache, 1);
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_disk, 0);
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_s3, 0);
+        ASSERT_EQ(scan_context->vector_idx_load_from_cache, 1);
+        ASSERT_EQ(scan_context->vector_idx_load_from_disk, 0);
+        ASSERT_EQ(scan_context->vector_idx_load_from_s3, 0);
     }
 }
 CATCH
@@ -2668,9 +2668,9 @@ try
                 colVecFloat32("[5, 6)"),
             }));
 
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_cache, 0);
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_disk, 0);
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_s3, 1);
+        ASSERT_EQ(scan_context->vector_idx_load_from_cache, 0);
+        ASSERT_EQ(scan_context->vector_idx_load_from_disk, 0);
+        ASSERT_EQ(scan_context->vector_idx_load_from_s3, 1);
 
         ASSERT_EQ(PerfContext::file_cache.fg_download_from_s3, 1);
         ASSERT_EQ(PerfContext::file_cache.fg_wait_download_from_s3, 0);
@@ -2690,9 +2690,9 @@ try
                 colVecFloat32("[7, 8)"),
             }));
 
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_cache, 0);
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_disk, 0);
-        ASSERT_EQ(scan_context->total_vector_idx_load_from_s3, 1);
+        ASSERT_EQ(scan_context->vector_idx_load_from_cache, 0);
+        ASSERT_EQ(scan_context->vector_idx_load_from_disk, 0);
+        ASSERT_EQ(scan_context->vector_idx_load_from_s3, 1);
 
         ASSERT_EQ(PerfContext::file_cache.fg_download_from_s3, 0);
         ASSERT_EQ(PerfContext::file_cache.fg_wait_download_from_s3, 1);

--- a/dbms/src/Storages/DeltaMerge/ScanContext.cpp
+++ b/dbms/src/Storages/DeltaMerge/ScanContext.cpp
@@ -166,19 +166,19 @@ String ScanContext::toJson() const
     };
     json->set("region_num_of_instance", to_json_array(region_num_of_instance));
 
-    if (total_vector_idx_load_from_cache.load() //
-            + total_vector_idx_load_from_disk.load() //
-            + total_vector_idx_load_from_s3.load()
+    if (vector_idx_load_from_cache.load() //
+            + vector_idx_load_from_disk.load() //
+            + vector_idx_load_from_s3.load()
         > 0)
     {
         Poco::JSON::Object::Ptr vec_idx = new Poco::JSON::Object();
-        vec_idx->set("tot_load", total_vector_idx_load_time_ms.load());
-        vec_idx->set("load_s3", total_vector_idx_load_from_s3.load());
-        vec_idx->set("load_disk", total_vector_idx_load_from_disk.load());
-        vec_idx->set("load_cache", total_vector_idx_load_from_cache.load());
-        vec_idx->set("tot_search", total_vector_idx_search_time_ms.load());
-        vec_idx->set("read_vec", total_vector_idx_read_vec_time_ms.load());
-        vec_idx->set("read_others", total_vector_idx_read_others_time_ms.load());
+        vec_idx->set("tot_load", vector_idx_load_time_ms.load());
+        vec_idx->set("load_s3", vector_idx_load_from_s3.load());
+        vec_idx->set("load_disk", vector_idx_load_from_disk.load());
+        vec_idx->set("load_cache", vector_idx_load_from_cache.load());
+        vec_idx->set("tot_search", vector_idx_search_time_ms.load());
+        vec_idx->set("read_vec", vector_idx_read_vec_time_ms.load());
+        vec_idx->set("read_others", vector_idx_read_others_time_ms.load());
         json->set("vector_idx", vec_idx);
     }
 

--- a/dbms/src/Storages/DeltaMerge/ScanContext.h
+++ b/dbms/src/Storages/DeltaMerge/ScanContext.h
@@ -97,12 +97,12 @@ public:
     std::atomic<uint64_t> vector_idx_read_vec_time_ms{0};
     std::atomic<uint64_t> vector_idx_read_others_time_ms{0};
 
-    std::atomic<uint64_t> inverted_idx_load_from_s3{0};
-    std::atomic<uint64_t> inverted_idx_load_from_disk{0};
-    std::atomic<uint64_t> inverted_idx_load_from_cache{0};
+    std::atomic<uint32_t> inverted_idx_load_from_s3{0};
+    std::atomic<uint32_t> inverted_idx_load_from_disk{0};
+    std::atomic<uint32_t> inverted_idx_load_from_cache{0};
     std::atomic<uint64_t> inverted_idx_load_time_ms{0};
     std::atomic<uint64_t> inverted_idx_search_time_ms{0};
-    std::atomic<uint64_t> inverted_idx_search_skipped_packs{0};
+    std::atomic<uint32_t> inverted_idx_search_skipped_packs{0};
     std::atomic<uint64_t> inverted_idx_indexed_rows{0};
     std::atomic<uint64_t> inverted_idx_search_selected_rows{0};
 

--- a/dbms/src/Storages/DeltaMerge/ScanContext.h
+++ b/dbms/src/Storages/DeltaMerge/ScanContext.h
@@ -87,15 +87,24 @@ public:
     // Building bitmap
     std::atomic<uint64_t> build_bitmap_time_ns{0};
 
-    std::atomic<uint64_t> total_vector_idx_load_from_s3{0};
-    std::atomic<uint64_t> total_vector_idx_load_from_disk{0};
-    std::atomic<uint64_t> total_vector_idx_load_from_cache{0};
-    std::atomic<uint64_t> total_vector_idx_load_time_ms{0};
-    std::atomic<uint64_t> total_vector_idx_search_time_ms{0};
-    std::atomic<uint64_t> total_vector_idx_search_visited_nodes{0};
-    std::atomic<uint64_t> total_vector_idx_search_discarded_nodes{0};
-    std::atomic<uint64_t> total_vector_idx_read_vec_time_ms{0};
-    std::atomic<uint64_t> total_vector_idx_read_others_time_ms{0};
+    std::atomic<uint64_t> vector_idx_load_from_s3{0};
+    std::atomic<uint64_t> vector_idx_load_from_disk{0};
+    std::atomic<uint64_t> vector_idx_load_from_cache{0};
+    std::atomic<uint64_t> vector_idx_load_time_ms{0};
+    std::atomic<uint64_t> vector_idx_search_time_ms{0};
+    std::atomic<uint64_t> vector_idx_search_visited_nodes{0};
+    std::atomic<uint64_t> vector_idx_search_discarded_nodes{0};
+    std::atomic<uint64_t> vector_idx_read_vec_time_ms{0};
+    std::atomic<uint64_t> vector_idx_read_others_time_ms{0};
+
+    std::atomic<uint64_t> inverted_idx_load_from_s3{0};
+    std::atomic<uint64_t> inverted_idx_load_from_disk{0};
+    std::atomic<uint64_t> inverted_idx_load_from_cache{0};
+    std::atomic<uint64_t> inverted_idx_load_time_ms{0};
+    std::atomic<uint64_t> inverted_idx_search_time_ms{0};
+    std::atomic<uint64_t> inverted_idx_search_skipped_packs{0};
+    std::atomic<uint64_t> inverted_idx_indexed_rows{0};
+    std::atomic<uint64_t> inverted_idx_search_selected_rows{0};
 
     const String resource_group_name;
 
@@ -144,15 +153,24 @@ public:
 
         deserializeRegionNumberOfInstance(tiflash_scan_context_pb);
 
-        total_vector_idx_load_from_s3 = tiflash_scan_context_pb.total_vector_idx_load_from_s3();
-        total_vector_idx_load_from_disk = tiflash_scan_context_pb.total_vector_idx_load_from_disk();
-        total_vector_idx_load_from_cache = tiflash_scan_context_pb.total_vector_idx_load_from_cache();
-        total_vector_idx_load_time_ms = tiflash_scan_context_pb.total_vector_idx_load_time_ms();
-        total_vector_idx_search_time_ms = tiflash_scan_context_pb.total_vector_idx_search_time_ms();
-        total_vector_idx_search_visited_nodes = tiflash_scan_context_pb.total_vector_idx_search_visited_nodes();
-        total_vector_idx_search_discarded_nodes = tiflash_scan_context_pb.total_vector_idx_search_discarded_nodes();
-        total_vector_idx_read_vec_time_ms = tiflash_scan_context_pb.total_vector_idx_read_vec_time_ms();
-        total_vector_idx_read_others_time_ms = tiflash_scan_context_pb.total_vector_idx_read_others_time_ms();
+        vector_idx_load_from_s3 = tiflash_scan_context_pb.vector_idx_load_from_s3();
+        vector_idx_load_from_disk = tiflash_scan_context_pb.vector_idx_load_from_disk();
+        vector_idx_load_from_cache = tiflash_scan_context_pb.vector_idx_load_from_cache();
+        vector_idx_load_time_ms = tiflash_scan_context_pb.vector_idx_load_time_ms();
+        vector_idx_search_time_ms = tiflash_scan_context_pb.vector_idx_search_time_ms();
+        vector_idx_search_visited_nodes = tiflash_scan_context_pb.vector_idx_search_visited_nodes();
+        vector_idx_search_discarded_nodes = tiflash_scan_context_pb.vector_idx_search_discarded_nodes();
+        vector_idx_read_vec_time_ms = tiflash_scan_context_pb.vector_idx_read_vec_time_ms();
+        vector_idx_read_others_time_ms = tiflash_scan_context_pb.vector_idx_read_others_time_ms();
+
+        inverted_idx_load_from_s3 = tiflash_scan_context_pb.inverted_idx_load_from_s3();
+        inverted_idx_load_from_disk = tiflash_scan_context_pb.inverted_idx_load_from_disk();
+        inverted_idx_load_from_cache = tiflash_scan_context_pb.inverted_idx_load_from_cache();
+        inverted_idx_load_time_ms = tiflash_scan_context_pb.inverted_idx_load_time_ms();
+        inverted_idx_search_time_ms = tiflash_scan_context_pb.inverted_idx_search_time_ms();
+        inverted_idx_search_skipped_packs = tiflash_scan_context_pb.inverted_idx_search_skipped_packs();
+        inverted_idx_indexed_rows = tiflash_scan_context_pb.inverted_idx_indexed_rows();
+        inverted_idx_search_selected_rows = tiflash_scan_context_pb.inverted_idx_search_selected_rows();
     }
 
     tipb::TiFlashScanContext serialize()
@@ -195,15 +213,24 @@ public:
 
         serializeRegionNumOfInstance(tiflash_scan_context_pb);
 
-        tiflash_scan_context_pb.set_total_vector_idx_load_from_s3(total_vector_idx_load_from_s3);
-        tiflash_scan_context_pb.set_total_vector_idx_load_from_disk(total_vector_idx_load_from_disk);
-        tiflash_scan_context_pb.set_total_vector_idx_load_from_cache(total_vector_idx_load_from_cache);
-        tiflash_scan_context_pb.set_total_vector_idx_load_time_ms(total_vector_idx_load_time_ms);
-        tiflash_scan_context_pb.set_total_vector_idx_search_time_ms(total_vector_idx_search_time_ms);
-        tiflash_scan_context_pb.set_total_vector_idx_search_visited_nodes(total_vector_idx_search_visited_nodes);
-        tiflash_scan_context_pb.set_total_vector_idx_search_discarded_nodes(total_vector_idx_search_discarded_nodes);
-        tiflash_scan_context_pb.set_total_vector_idx_read_vec_time_ms(total_vector_idx_read_vec_time_ms);
-        tiflash_scan_context_pb.set_total_vector_idx_read_others_time_ms(total_vector_idx_read_others_time_ms);
+        tiflash_scan_context_pb.set_vector_idx_load_from_s3(vector_idx_load_from_s3);
+        tiflash_scan_context_pb.set_vector_idx_load_from_disk(vector_idx_load_from_disk);
+        tiflash_scan_context_pb.set_vector_idx_load_from_cache(vector_idx_load_from_cache);
+        tiflash_scan_context_pb.set_vector_idx_load_time_ms(vector_idx_load_time_ms);
+        tiflash_scan_context_pb.set_vector_idx_search_time_ms(vector_idx_search_time_ms);
+        tiflash_scan_context_pb.set_vector_idx_search_visited_nodes(vector_idx_search_visited_nodes);
+        tiflash_scan_context_pb.set_vector_idx_search_discarded_nodes(vector_idx_search_discarded_nodes);
+        tiflash_scan_context_pb.set_vector_idx_read_vec_time_ms(vector_idx_read_vec_time_ms);
+        tiflash_scan_context_pb.set_vector_idx_read_others_time_ms(vector_idx_read_others_time_ms);
+
+        tiflash_scan_context_pb.set_inverted_idx_load_from_s3(inverted_idx_load_from_s3);
+        tiflash_scan_context_pb.set_inverted_idx_load_from_disk(inverted_idx_load_from_disk);
+        tiflash_scan_context_pb.set_inverted_idx_load_from_cache(inverted_idx_load_from_cache);
+        tiflash_scan_context_pb.set_inverted_idx_load_time_ms(inverted_idx_load_time_ms);
+        tiflash_scan_context_pb.set_inverted_idx_search_time_ms(inverted_idx_search_time_ms);
+        tiflash_scan_context_pb.set_inverted_idx_search_skipped_packs(inverted_idx_search_skipped_packs);
+        tiflash_scan_context_pb.set_inverted_idx_indexed_rows(inverted_idx_indexed_rows);
+        tiflash_scan_context_pb.set_inverted_idx_search_selected_rows(inverted_idx_search_selected_rows);
 
         return tiflash_scan_context_pb;
     }
@@ -256,15 +283,24 @@ public:
 
         mergeRegionNumberOfInstance(other);
 
-        total_vector_idx_load_from_s3 += other.total_vector_idx_load_from_s3;
-        total_vector_idx_load_from_disk += other.total_vector_idx_load_from_disk;
-        total_vector_idx_load_from_cache += other.total_vector_idx_load_from_cache;
-        total_vector_idx_load_time_ms += other.total_vector_idx_load_time_ms;
-        total_vector_idx_search_time_ms += other.total_vector_idx_search_time_ms;
-        total_vector_idx_search_visited_nodes += other.total_vector_idx_search_visited_nodes;
-        total_vector_idx_search_discarded_nodes += other.total_vector_idx_search_discarded_nodes;
-        total_vector_idx_read_vec_time_ms += other.total_vector_idx_read_vec_time_ms;
-        total_vector_idx_read_others_time_ms += other.total_vector_idx_read_others_time_ms;
+        vector_idx_load_from_s3 += other.vector_idx_load_from_s3;
+        vector_idx_load_from_disk += other.vector_idx_load_from_disk;
+        vector_idx_load_from_cache += other.vector_idx_load_from_cache;
+        vector_idx_load_time_ms += other.vector_idx_load_time_ms;
+        vector_idx_search_time_ms += other.vector_idx_search_time_ms;
+        vector_idx_search_visited_nodes += other.vector_idx_search_visited_nodes;
+        vector_idx_search_discarded_nodes += other.vector_idx_search_discarded_nodes;
+        vector_idx_read_vec_time_ms += other.vector_idx_read_vec_time_ms;
+        vector_idx_read_others_time_ms += other.vector_idx_read_others_time_ms;
+
+        inverted_idx_load_from_s3 += other.inverted_idx_load_from_s3;
+        inverted_idx_load_from_disk += other.inverted_idx_load_from_disk;
+        inverted_idx_load_from_cache += other.inverted_idx_load_from_cache;
+        inverted_idx_load_time_ms += other.inverted_idx_load_time_ms;
+        inverted_idx_search_time_ms += other.inverted_idx_search_time_ms;
+        inverted_idx_search_skipped_packs += other.inverted_idx_search_skipped_packs;
+        inverted_idx_indexed_rows += other.inverted_idx_indexed_rows;
+        inverted_idx_search_selected_rows += other.inverted_idx_search_selected_rows;
     }
 
     void merge(const tipb::TiFlashScanContext & other)
@@ -308,15 +344,24 @@ public:
 
         mergeRegionNumberOfInstance(other);
 
-        total_vector_idx_load_from_s3 += other.total_vector_idx_load_from_s3();
-        total_vector_idx_load_from_disk += other.total_vector_idx_load_from_disk();
-        total_vector_idx_load_from_cache += other.total_vector_idx_load_from_cache();
-        total_vector_idx_load_time_ms += other.total_vector_idx_load_time_ms();
-        total_vector_idx_search_time_ms += other.total_vector_idx_search_time_ms();
-        total_vector_idx_search_visited_nodes += other.total_vector_idx_search_visited_nodes();
-        total_vector_idx_search_discarded_nodes += other.total_vector_idx_search_discarded_nodes();
-        total_vector_idx_read_vec_time_ms += other.total_vector_idx_read_vec_time_ms();
-        total_vector_idx_read_others_time_ms += other.total_vector_idx_read_others_time_ms();
+        vector_idx_load_from_s3 += other.vector_idx_load_from_s3();
+        vector_idx_load_from_disk += other.vector_idx_load_from_disk();
+        vector_idx_load_from_cache += other.vector_idx_load_from_cache();
+        vector_idx_load_time_ms += other.vector_idx_load_time_ms();
+        vector_idx_search_time_ms += other.vector_idx_search_time_ms();
+        vector_idx_search_visited_nodes += other.vector_idx_search_visited_nodes();
+        vector_idx_search_discarded_nodes += other.vector_idx_search_discarded_nodes();
+        vector_idx_read_vec_time_ms += other.vector_idx_read_vec_time_ms();
+        vector_idx_read_others_time_ms += other.vector_idx_read_others_time_ms();
+
+        inverted_idx_load_from_s3 += other.inverted_idx_load_from_s3();
+        inverted_idx_load_from_disk += other.inverted_idx_load_from_disk();
+        inverted_idx_load_from_cache += other.inverted_idx_load_from_cache();
+        inverted_idx_load_time_ms += other.inverted_idx_load_time_ms();
+        inverted_idx_search_time_ms += other.inverted_idx_search_time_ms();
+        inverted_idx_search_skipped_packs += other.inverted_idx_search_skipped_packs();
+        inverted_idx_indexed_rows += other.inverted_idx_indexed_rows();
+        inverted_idx_search_selected_rows += other.inverted_idx_search_selected_rows();
     }
 
     String toJson() const;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #9843 

Problem Summary:

### What is changed and how it works?

```commit-message
Part 5 of inverted index, add inverted index statistics to `ScanContext` to improve observability.

Other changes：
- rename `total_vector_idx_xxx` to `vector_idx_xxx`.
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
