### PR TITLE
CI: fix regex in interpreters OWNERS file

### DIFF
--- a/dbms/src/Interpreters/OWNERS
+++ b/dbms/src/Interpreters/OWNERS
@@ -2,6 +2,6 @@
 options:
   no_parent_owners: true
 filters:
-  "(OWNERS|Settings\\.h)$":
+  "^(OWNERS|Settings\\.h)$":
     approvers:
       - sig-critical-approvers-config


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:

https://github.com/pingcap/tiflash/pull/9191 which adds `dbms/src/Interpreters/JoinV2/HashJoinSettings.h` accidentally blocked by the `OWNERS` file 

### What is changed and how it works?

```commit-message
Only check the `Interpreters/Settings.h` file
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
