### PR TITLE
Disagg: Support VersionChain in StorageDisaggregated

### DIFF
--- a/dbms/src/Common/TiFlashMetrics.h
+++ b/dbms/src/Common/TiFlashMetrics.h
@@ -843,7 +843,7 @@ static_assert(RAFT_REGION_BIG_WRITE_THRES * 4 < RAFT_REGION_BIG_WRITE_MAX, "Inva
       "system calls duration in seconds",                                                                                           \
       Histogram,                                                                                                                    \
       F(type_fsync, {{"type", "fsync"}}, ExpBuckets{0.0001, 2, 20}))                                                                \
-    M(tiflash_storage_delta_index_cache, "", Counter, F(type_hit, {"type", "hit"}), F(type_miss, {"type", "miss"}))                 \
+    M(tiflash_storage_mvcc_index_cache, "", Counter, F(type_hit, {"type", "hit"}), F(type_miss, {"type", "miss"}))                  \
     M(tiflash_resource_group,                                                                                                       \
       "meta info of resource group",                                                                                                \
       Gauge,                                                                                                                        \

--- a/dbms/src/Interpreters/AsynchronousMetrics.cpp
+++ b/dbms/src/Interpreters/AsynchronousMetrics.cpp
@@ -207,10 +207,10 @@ void AsynchronousMetrics::update()
     }
 
     {
-        if (auto rn_delta_index_cache = context.getSharedContextDisagg()->rn_delta_index_cache)
+        if (auto rn_mvcc_index_cache = context.getSharedContextDisagg()->rn_mvcc_index_cache)
         {
-            set("RNDeltaIndexCacheBytes", rn_delta_index_cache->getCacheWeight());
-            set("RNDeltaIndexFiles", rn_delta_index_cache->getCacheCount());
+            set("RNMVCCIndexCacheBytes", rn_mvcc_index_cache->getCacheWeight());
+            set("RNMVCCIndexFiles", rn_mvcc_index_cache->getCacheCount());
         }
     }
 

--- a/dbms/src/Interpreters/SharedContexts/Disagg.cpp
+++ b/dbms/src/Interpreters/SharedContexts/Disagg.cpp
@@ -15,7 +15,7 @@
 #include <Interpreters/Context.h>
 #include <Interpreters/SharedContexts/Disagg.h>
 #include <Storages/DeltaMerge/Remote/DataStore/DataStoreS3.h>
-#include <Storages/DeltaMerge/Remote/RNDeltaIndexCache.h>
+#include <Storages/DeltaMerge/Remote/RNMVCCIndexCache.h>
 #include <Storages/DeltaMerge/Remote/RNLocalPageCache.h>
 #include <Storages/DeltaMerge/Remote/WNDisaggSnapshotManager.h>
 #include <Storages/KVStore/MultiRaft/Disagg/FastAddPeerContext.h>
@@ -70,12 +70,12 @@ void SharedContextDisagg::initReadNodePageCache(
 
 void SharedContextDisagg::initReadNodeDeltaIndexCache(size_t max_size)
 {
-    RUNTIME_CHECK(rn_delta_index_cache == nullptr);
+    RUNTIME_CHECK(rn_mvcc_index_cache == nullptr);
 
     if (max_size > 0)
     {
         LOG_INFO(Logger::get(), "Initialize Read Node delta index cache, max_size={}", max_size);
-        rn_delta_index_cache = std::make_shared<DM::Remote::RNDeltaIndexCache>(max_size);
+        rn_mvcc_index_cache = std::make_shared<DM::Remote::RNMVCCIndexCache>(max_size);
     }
     else
     {

--- a/dbms/src/Interpreters/SharedContexts/Disagg.cpp
+++ b/dbms/src/Interpreters/SharedContexts/Disagg.cpp
@@ -15,8 +15,8 @@
 #include <Interpreters/Context.h>
 #include <Interpreters/SharedContexts/Disagg.h>
 #include <Storages/DeltaMerge/Remote/DataStore/DataStoreS3.h>
-#include <Storages/DeltaMerge/Remote/RNMVCCIndexCache.h>
 #include <Storages/DeltaMerge/Remote/RNLocalPageCache.h>
+#include <Storages/DeltaMerge/Remote/RNMVCCIndexCache.h>
 #include <Storages/DeltaMerge/Remote/WNDisaggSnapshotManager.h>
 #include <Storages/KVStore/MultiRaft/Disagg/FastAddPeerContext.h>
 #include <Storages/Page/V3/Universal/UniversalPageStorageService.h>

--- a/dbms/src/Interpreters/SharedContexts/Disagg.cpp
+++ b/dbms/src/Interpreters/SharedContexts/Disagg.cpp
@@ -68,7 +68,7 @@ void SharedContextDisagg::initReadNodePageCache(
     }
 }
 
-void SharedContextDisagg::initReadNodeDeltaIndexCache(size_t max_size)
+void SharedContextDisagg::initReadNodeMVCCIndexCache(size_t max_size)
 {
     RUNTIME_CHECK(rn_mvcc_index_cache == nullptr);
 

--- a/dbms/src/Interpreters/SharedContexts/Disagg.h
+++ b/dbms/src/Interpreters/SharedContexts/Disagg.h
@@ -85,7 +85,7 @@ struct SharedContextDisagg : private boost::noncopyable
 
     /// Note that the unit of max_size is quantity, not byte size. It controls how
     /// **many** of delta index will be maintained.
-    void initReadNodeDeltaIndexCache(size_t max_size);
+    void initReadNodeMVCCIndexCache(size_t max_size);
 
     void initWriteNodeSnapManager();
 

--- a/dbms/src/Interpreters/SharedContexts/Disagg.h
+++ b/dbms/src/Interpreters/SharedContexts/Disagg.h
@@ -19,8 +19,8 @@
 #include <Interpreters/Context_fwd.h>
 #include <Interpreters/SharedContexts/Disagg_fwd.h>
 #include <Storages/DeltaMerge/Remote/DataStore/DataStore_fwd.h>
-#include <Storages/DeltaMerge/Remote/RNMVCCIndexCache_fwd.h>
 #include <Storages/DeltaMerge/Remote/RNLocalPageCache_fwd.h>
+#include <Storages/DeltaMerge/Remote/RNMVCCIndexCache_fwd.h>
 #include <Storages/DeltaMerge/Remote/WNDisaggSnapshotManager_fwd.h>
 #include <Storages/Page/V3/Universal/UniversalPageStorageService_fwd.h>
 #include <Storages/PathPool_fwd.h>

--- a/dbms/src/Interpreters/SharedContexts/Disagg.h
+++ b/dbms/src/Interpreters/SharedContexts/Disagg.h
@@ -66,7 +66,7 @@ struct SharedContextDisagg : private boost::noncopyable
     DB::DM::Remote::RNLocalPageCachePtr rn_page_cache;
 
     /// Only for read node.
-    /// It is a cache for the delta index, stores in the memory.
+    /// It is a cache for the mvcc index, stores in the memory.
     DB::DM::Remote::RNMVCCIndexCachePtr rn_mvcc_index_cache;
 
     static SharedContextDisaggPtr create(Context & global_context_)

--- a/dbms/src/Interpreters/SharedContexts/Disagg.h
+++ b/dbms/src/Interpreters/SharedContexts/Disagg.h
@@ -19,7 +19,7 @@
 #include <Interpreters/Context_fwd.h>
 #include <Interpreters/SharedContexts/Disagg_fwd.h>
 #include <Storages/DeltaMerge/Remote/DataStore/DataStore_fwd.h>
-#include <Storages/DeltaMerge/Remote/RNDeltaIndexCache_fwd.h>
+#include <Storages/DeltaMerge/Remote/RNMVCCIndexCache_fwd.h>
 #include <Storages/DeltaMerge/Remote/RNLocalPageCache_fwd.h>
 #include <Storages/DeltaMerge/Remote/WNDisaggSnapshotManager_fwd.h>
 #include <Storages/Page/V3/Universal/UniversalPageStorageService_fwd.h>
@@ -67,7 +67,7 @@ struct SharedContextDisagg : private boost::noncopyable
 
     /// Only for read node.
     /// It is a cache for the delta index, stores in the memory.
-    DB::DM::Remote::RNDeltaIndexCachePtr rn_delta_index_cache;
+    DB::DM::Remote::RNMVCCIndexCachePtr rn_mvcc_index_cache;
 
     static SharedContextDisaggPtr create(Context & global_context_)
     {

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -958,7 +958,7 @@ try
         LOG_INFO(log, "delta_index_cache_size={}", n);
         // In disaggregated compute node, we will not use DeltaIndexManager to cache the delta index.
         // Instead, we use RNMVCCIndexCache.
-        global_context->getSharedContextDisagg()->initReadNodeDeltaIndexCache(n);
+        global_context->getSharedContextDisagg()->initReadNodeMVCCIndexCache(n);
     }
     else
     {

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -957,7 +957,7 @@ try
         size_t n = config().getUInt64("delta_index_cache_size", default_delta_index_cache_size);
         LOG_INFO(log, "delta_index_cache_size={}", n);
         // In disaggregated compute node, we will not use DeltaIndexManager to cache the delta index.
-        // Instead, we use RNDeltaIndexCache.
+        // Instead, we use RNMVCCIndexCache.
         global_context->getSharedContextDisagg()->initReadNodeDeltaIndexCache(n);
     }
     else

--- a/dbms/src/Storages/DeltaMerge/Delta/DeltaValueSpace.h
+++ b/dbms/src/Storages/DeltaMerge/Delta/DeltaValueSpace.h
@@ -357,7 +357,7 @@ private:
     const bool is_update{false};
 
     // The delta index of cached.
-    const DeltaIndexPtr shared_delta_index;
+    DeltaIndexPtr shared_delta_index;
     const UInt64 delta_index_epoch;
 
     // mem-table may not be ready when the snapshot is creating under disagg arch, so it is not "const"
@@ -455,6 +455,9 @@ public:
     // But we need this because under disagg arch, we fetch the mem-table by streaming way.
     // After all mem-table fetched, we set the mem-table-set snapshot to the DeltaValueSnapshot.
     void setMemTableSetSnapshot(const ColumnFileSetSnapshotPtr & mem_table_snap_) { mem_table_snap = mem_table_snap_; }
+    // Under disagg arch, the DeltaIndex will be lazily fetched from the cache only before reading.
+    // Because we will decide whether to use DeltaIndex or VersionChain ​​before reading​​.
+    void setSharedDeltaIndex(const DeltaIndexPtr & delta_index) { shared_delta_index = delta_index; }
 };
 
 class DeltaValueReader

--- a/dbms/src/Storages/DeltaMerge/DeltaIndex/DeltaIndex.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaIndex/DeltaIndex.h
@@ -102,8 +102,7 @@ private:
         if (delta_tree_copy)
         {
             auto new_delta_tree = std::make_shared<DefaultDeltaTree>(*delta_tree_copy);
-            auto new_index
-                = std::make_shared<DeltaIndex>(new_delta_tree, placed_rows_copy, placed_deletes_copy);
+            auto new_index = std::make_shared<DeltaIndex>(new_delta_tree, placed_rows_copy, placed_deletes_copy);
             // try to do some updates before return it if need
             if (updates)
                 new_index->applyUpdates(*updates);
@@ -124,10 +123,7 @@ public:
         , placed_deletes(0)
     {}
 
-    DeltaIndex(
-        const DeltaTreePtr & delta_tree_,
-        size_t placed_rows_,
-        size_t placed_deletes_)
+    DeltaIndex(const DeltaTreePtr & delta_tree_, size_t placed_rows_, size_t placed_deletes_)
         : id(++NEXT_DELTA_INDEX_ID)
         , delta_tree(delta_tree_)
         , placed_rows(placed_rows_)

--- a/dbms/src/Storages/DeltaMerge/DeltaIndex/DeltaIndex.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaIndex/DeltaIndex.h
@@ -16,7 +16,6 @@
 
 #include <Storages/DeltaMerge/DeltaIndex/DeltaTree.h>
 #include <Storages/DeltaMerge/DeltaMergeDefines.h>
-#include <Storages/DeltaMerge/Remote/RNDeltaIndexCache.h>
 #include <Storages/Page/PageDefinesBase.h>
 namespace DB::DM
 {
@@ -30,8 +29,6 @@ class DeltaIndex
 private:
     // `id` is used as Key in LRUCache in non-disaggregated mode.
     const UInt64 id;
-    // `rn_cache_key` is used as Key in RNDeltaIndexCache in disaggregated mode.
-    const std::optional<Remote::RNDeltaIndexCache::CacheKey> rn_cache_key;
 
     DeltaTreePtr delta_tree;
 
@@ -106,7 +103,7 @@ private:
         {
             auto new_delta_tree = std::make_shared<DefaultDeltaTree>(*delta_tree_copy);
             auto new_index
-                = std::make_shared<DeltaIndex>(new_delta_tree, placed_rows_copy, placed_deletes_copy, rn_cache_key);
+                = std::make_shared<DeltaIndex>(new_delta_tree, placed_rows_copy, placed_deletes_copy);
             // try to do some updates before return it if need
             if (updates)
                 new_index->applyUpdates(*updates);
@@ -115,14 +112,13 @@ private:
         else
         {
             // Otherwise, create an empty new DeltaIndex.
-            return std::make_shared<DeltaIndex>(rn_cache_key);
+            return std::make_shared<DeltaIndex>();
         }
     }
 
 public:
-    explicit DeltaIndex(const std::optional<Remote::RNDeltaIndexCache::CacheKey> & rn_cache_key_ = std::nullopt)
+    explicit DeltaIndex()
         : id(++NEXT_DELTA_INDEX_ID)
-        , rn_cache_key(rn_cache_key_)
         , delta_tree(std::make_shared<DefaultDeltaTree>())
         , placed_rows(0)
         , placed_deletes(0)
@@ -131,10 +127,8 @@ public:
     DeltaIndex(
         const DeltaTreePtr & delta_tree_,
         size_t placed_rows_,
-        size_t placed_deletes_,
-        const std::optional<Remote::RNDeltaIndexCache::CacheKey> & rn_cache_key_ = std::nullopt)
+        size_t placed_deletes_)
         : id(++NEXT_DELTA_INDEX_ID)
-        , rn_cache_key(rn_cache_key_)
         , delta_tree(delta_tree_)
         , placed_rows(placed_rows_)
         , placed_deletes(placed_deletes_)
@@ -218,8 +212,6 @@ public:
         RUNTIME_CHECK_MSG(!updates.empty(), "Unexpected empty updates");
         return tryCloneInner(updates.front().rows_offset, updates.front().delete_ranges_offset, &updates);
     }
-
-    const std::optional<Remote::RNDeltaIndexCache::CacheKey> & getRNCacheKey() const { return rn_cache_key; }
 };
 
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/Index/VectorIndex/tests/gtest_dm_vector_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/VectorIndex/tests/gtest_dm_vector_index.cpp
@@ -1987,12 +1987,7 @@ public:
             nullptr);
 
         auto read_dm_context = dmContext(read_scan_context);
-        auto cn_segment_snap = Remote::Serializer::deserializeSegment(
-            *read_dm_context,
-            /* store_id */ 100,
-            /* keyspace_id */ 0,
-            /* table_id */ 100,
-            snap_proto);
+        auto cn_segment_snap = Remote::Serializer::deserializeSegment(*read_dm_context, snap_proto);
 
         auto stream = cn_segment->getInputStream(
             ReadMode::Bitmap,

--- a/dbms/src/Storages/DeltaMerge/Remote/RNDeltaIndexCache.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/RNDeltaIndexCache.h
@@ -16,6 +16,7 @@
 
 #include <Common/LRUCache.h>
 #include <Storages/DeltaMerge/Remote/RNDeltaIndexCache_fwd.h>
+#include <Storages/DeltaMerge/VersionChain/VersionChain_fwd.h>
 #include <Storages/KVStore/Types.h>
 #include <common/types.h>
 
@@ -43,23 +44,38 @@ public:
     struct CacheKey
     {
         UInt64 store_id;
-        KeyspaceID keyspace_id;
         Int64 table_id;
         UInt64 segment_id;
         UInt64 segment_epoch;
         UInt64 delta_index_epoch;
+        KeyspaceID keyspace_id;
+        bool is_version_chain;
 
         bool operator==(const CacheKey & other) const
         {
             return store_id == other.store_id && keyspace_id == other.keyspace_id && table_id == other.table_id
                 && segment_id == other.segment_id && segment_epoch == other.segment_epoch
-                && delta_index_epoch == other.delta_index_epoch;
+                && delta_index_epoch == other.delta_index_epoch && is_version_chain == other.is_version_chain;
         }
     };
 
-    struct CacheValue
+    // Returns a cached or newly created delta index, which is assigned to the specified segment(at)epoch.
+    DeltaIndexPtr getDeltaIndex(const CacheKey & key);
+    // `setDeltaIndex` will updated cache size and remove overflows if necessary.
+    void setDeltaIndex(const CacheKey & key, const DeltaIndexPtr & delta_index);
+
+    // Similar to `getDeltaIndex`, but this method is used to get version chain.
+    GenericVersionChainPtr getVersionChain(const CacheKey & key, bool is_common_handle);
+    // Similar to `setDeltaIndex`, but this method is used to set version chain.
+    void setVersionChain(const CacheKey & key, const GenericVersionChainPtr & version_chain);
+
+    size_t getCacheWeight() const { return cache.weight(); }
+    size_t getCacheCount() const { return cache.count(); }
+
+private:
+    struct CacheDeltaIndex
     {
-        CacheValue(const DeltaIndexPtr & delta_index_, size_t bytes_)
+        CacheDeltaIndex(const DeltaIndexPtr & delta_index_, size_t bytes_)
             : delta_index(delta_index_)
             , bytes(bytes_)
         {}
@@ -68,37 +84,50 @@ public:
         size_t bytes;
     };
 
+    struct CacheVersionChain
+    {
+        CacheVersionChain(const GenericVersionChainPtr & version_chain_, size_t bytes_)
+            : version_chain(version_chain_)
+            , bytes(bytes_)
+        {}
+
+        GenericVersionChainPtr version_chain;
+        size_t bytes;
+    };
+    struct CacheValue
+    {
+        std::variant<CacheDeltaIndex, CacheVersionChain> value;
+
+        size_t bytes() const
+        {
+            return std::visit([](const auto & v) { return v.bytes; }, value);
+        }
+
+        DeltaIndexPtr getDeltaIndex() const { return std::get<CacheDeltaIndex>(value).delta_index; }
+
+        GenericVersionChainPtr getVersionChain() const { return std::get<CacheVersionChain>(value).version_chain; }
+    };
+
     struct CacheKeyHasher
     {
         size_t operator()(const CacheKey & k) const
         {
-            using std::hash;
-
-            return hash<UInt64>()(k.store_id) ^ //
-                hash<UInt64>()(k.keyspace_id) ^ //
-                hash<Int64>()(k.table_id) ^ //
-                hash<UInt64>()(k.segment_id) ^ //
-                hash<UInt64>()(k.segment_epoch) ^ //
-                hash<UInt64>()(k.delta_index_epoch);
+            size_t seed = 0;
+            boost::hash_combine(seed, k.store_id);
+            boost::hash_combine(seed, k.table_id);
+            boost::hash_combine(seed, k.segment_id);
+            boost::hash_combine(seed, k.segment_epoch);
+            boost::hash_combine(seed, k.delta_index_epoch);
+            boost::hash_combine(seed, k.keyspace_id);
+            boost::hash_combine(seed, k.is_version_chain);
+            return seed;
         }
     };
 
     struct CacheValueWeight
     {
-        size_t operator()(const CacheKey & key, const CacheValue & v) const { return sizeof(key) + v.bytes; }
+        size_t operator()(const CacheKey & key, const CacheValue & v) const { return sizeof(key) + v.bytes(); }
     };
-
-    /**
-     * Returns a cached or newly created delta index, which is assigned to the specified segment(at)epoch.
-     */
-    DeltaIndexPtr getDeltaIndex(const CacheKey & key);
-
-    // `setDeltaIndex` will updated cache size and remove overflows if necessary.
-    void setDeltaIndex(const DeltaIndexPtr & delta_index);
-
-    size_t getCacheWeight() const { return cache.weight(); }
-    size_t getCacheCount() const { return cache.count(); }
-
 
 private:
     std::mutex mtx;

--- a/dbms/src/Storages/DeltaMerge/Remote/RNMVCCIndexCache.cpp
+++ b/dbms/src/Storages/DeltaMerge/Remote/RNMVCCIndexCache.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 PingCAP, Inc.
+// Copyright 2025 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dbms/src/Storages/DeltaMerge/Remote/RNMVCCIndexCache.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/RNMVCCIndexCache.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include <Common/LRUCache.h>
-#include <Storages/DeltaMerge/Remote/RNDeltaIndexCache_fwd.h>
+#include <Storages/DeltaMerge/Remote/RNMVCCIndexCache_fwd.h>
 #include <Storages/DeltaMerge/VersionChain/VersionChain_fwd.h>
 #include <Storages/KVStore/Types.h>
 #include <common/types.h>
@@ -34,10 +34,10 @@ namespace DB::DM::Remote
  * A LRU cache that holds delta-tree indexes from different remote write nodes.
  * Delta-tree indexes are used as much as possible when same segments are accessed multiple times.
  */
-class RNDeltaIndexCache : private boost::noncopyable
+class RNMVCCIndexCache : private boost::noncopyable
 {
 public:
-    explicit RNDeltaIndexCache(size_t max_cache_size)
+    explicit RNMVCCIndexCache(size_t max_cache_size)
         : cache(max_cache_size)
     {}
 

--- a/dbms/src/Storages/DeltaMerge/Remote/RNMVCCIndexCache_fwd.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/RNMVCCIndexCache_fwd.h
@@ -19,7 +19,7 @@
 namespace DB::DM::Remote
 {
 
-class RNDeltaIndexCache;
-using RNDeltaIndexCachePtr = std::shared_ptr<RNDeltaIndexCache>;
+class RNMVCCIndexCache;
+using RNMVCCIndexCachePtr = std::shared_ptr<RNMVCCIndexCache>;
 
 } // namespace DB::DM::Remote

--- a/dbms/src/Storages/DeltaMerge/Remote/Serializer.cpp
+++ b/dbms/src/Storages/DeltaMerge/Remote/Serializer.cpp
@@ -24,7 +24,6 @@
 #include <Storages/DeltaMerge/Remote/DataStore/DataStore.h>
 #include <Storages/DeltaMerge/Remote/DisaggSnapshot.h>
 #include <Storages/DeltaMerge/Remote/ObjectId.h>
-#include <Storages/DeltaMerge/Remote/RNDeltaIndexCache.h>
 #include <Storages/DeltaMerge/Remote/Serializer.h>
 #include <Storages/DeltaMerge/RowKeyRange.h>
 #include <Storages/DeltaMerge/Segment.h>

--- a/dbms/src/Storages/DeltaMerge/Remote/Serializer.cpp
+++ b/dbms/src/Storages/DeltaMerge/Remote/Serializer.cpp
@@ -122,12 +122,7 @@ RemotePb::RemoteSegment Serializer::serializeSegment(
     return remote;
 }
 
-SegmentSnapshotPtr Serializer::deserializeSegment(
-    const DMContext & dm_context,
-    StoreID remote_store_id,
-    KeyspaceID keyspace_id,
-    TableID table_id,
-    const RemotePb::RemoteSegment & proto)
+SegmentSnapshotPtr Serializer::deserializeSegment(const DMContext & dm_context, const RemotePb::RemoteSegment & proto)
 {
     RowKeyRange segment_range;
     {
@@ -140,21 +135,7 @@ SegmentSnapshotPtr Serializer::deserializeSegment(
     auto mem_snap = deserializeColumnFileSet(dm_context, proto.column_files_memtable(), data_store, segment_range);
     auto persisted_snap
         = deserializeColumnFileSet(dm_context, proto.column_files_persisted(), data_store, segment_range);
-    auto delta_index = [&]() {
-        auto delta_index_cache = dm_context.global_context.getSharedContextDisagg()->rn_delta_index_cache;
-        if (!delta_index_cache)
-        {
-            return std::make_shared<DeltaIndex>();
-        }
-        return delta_index_cache->getDeltaIndex({
-            .store_id = remote_store_id,
-            .keyspace_id = keyspace_id,
-            .table_id = table_id,
-            .segment_id = proto.segment_id(),
-            .segment_epoch = proto.segment_epoch(),
-            .delta_index_epoch = proto.delta_index_epoch(),
-        });
-    }();
+
     // Note: At this moment, we still cannot read from `delta_snap->mem_table_snap` and `delta_snap->persisted_files_snap`,
     // because they are constructed using ColumnFileDataProviderNop.
     auto delta_snap = std::make_shared<DeltaValueSnapshot>(
@@ -164,7 +145,7 @@ SegmentSnapshotPtr Serializer::deserializeSegment(
         std::move(persisted_snap),
         // There is no DeltaValueSpace in the disagg arch read node
         /*delta_vs*/ nullptr,
-        std::move(delta_index),
+        std::make_shared<DeltaIndex>(),
         // Actually we will not access delta_snap->delta_index_epoch in read node. Just for completeness.
         proto.delta_index_epoch());
 

--- a/dbms/src/Storages/DeltaMerge/Remote/Serializer.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/Serializer.h
@@ -64,12 +64,7 @@ public:
         MemTrackerWrapper & mem_tracker_wrapper,
         bool need_mem_data);
 
-    static SegmentSnapshotPtr deserializeSegment(
-        const DMContext & dm_context,
-        StoreID remote_store_id,
-        KeyspaceID keyspace_id,
-        TableID table_id,
-        const RemotePb::RemoteSegment & proto);
+    static SegmentSnapshotPtr deserializeSegment(const DMContext & dm_context, const RemotePb::RemoteSegment & proto);
 
     /// Note: This function always build a snapshot over nop data provider. In order to read from this snapshot,
     /// you must explicitly assign a proper data provider.

--- a/dbms/src/Storages/DeltaMerge/Segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/Segment.cpp
@@ -51,7 +51,7 @@
 #include <Storages/DeltaMerge/Range.h>
 #include <Storages/DeltaMerge/Remote/DataStore/DataStore.h>
 #include <Storages/DeltaMerge/Remote/ObjectId.h>
-#include <Storages/DeltaMerge/Remote/RNDeltaIndexCache.h>
+#include <Storages/DeltaMerge/Remote/RNMVCCIndexCache.h>
 #include <Storages/DeltaMerge/RowKeyRange.h>
 #include <Storages/DeltaMerge/ScanContext.h>
 #include <Storages/DeltaMerge/Segment.h>

--- a/dbms/src/Storages/DeltaMerge/Segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/Segment.cpp
@@ -2586,7 +2586,7 @@ void Segment::replayVersionChain(const DMContext & dm_context)
         [&dm_context, &segment_snap](auto & version_chain) {
             return version_chain.replaySnapshot(dm_context, *segment_snap);
         },
-        this->version_chain);
+        *(this->version_chain));
     GET_METRIC(tiflash_storage_version_chain_ms, type_bg_replay).Observe(sw.elapsedMilliseconds());
 }
 
@@ -2723,9 +2723,6 @@ Segment::ReadInfo Segment::getReadInfo(
                 "Segment updated delta index, my_delta_index={} {}",
                 my_delta_index->toString(),
                 simpleInfo());
-            // Update cache size.
-            if (auto cache = dm_context.global_context.getSharedContextDisagg()->rn_delta_index_cache; cache)
-                cache->setDeltaIndex(segment_snap->delta->getSharedDeltaIndex());
         }
     }
 
@@ -3139,7 +3136,7 @@ BitmapFilterPtr Segment::buildMVCCBitmapFilter(
             read_ranges,
             pack_filter_results,
             start_ts,
-            version_chain);
+            *version_chain);
     }
 
     if (readStableOnly(dm_context, segment_snap))

--- a/dbms/src/Storages/DeltaMerge/Segment.h
+++ b/dbms/src/Storages/DeltaMerge/Segment.h
@@ -669,6 +669,9 @@ public:
         }
     }
 
+    void setVersionChain(const GenericVersionChainPtr & version_chain_) { version_chain = version_chain_; }
+    const GenericVersionChainPtr & getVersionChain() const { return version_chain; }
+
 #ifndef DBMS_PUBLIC_GTEST
 private:
 #else
@@ -864,7 +867,7 @@ public:
     const LoggerPtr parent_log; // Used when constructing new segments in split
     const LoggerPtr log;
 
-    GenericVersionChain version_chain;
+    GenericVersionChainPtr version_chain;
 };
 
 void readSegmentMetaInfo(ReadBuffer & buf, Segment::SegmentMetaInfo & segment_info);

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTask.cpp
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTask.cpp
@@ -816,16 +816,16 @@ bool SegmentReadTask::hasColumnFileToFetch() const
         || std::any_of(persisted_cfs.cbegin(), persisted_cfs.cend(), need_to_fetch);
 }
 
-std::optional<Remote::RNDeltaIndexCache::CacheKey> SegmentReadTask::getRNMVCCIndexCacheKey(ReadMode read_mode) const
+std::optional<Remote::RNMVCCIndexCache::CacheKey> SegmentReadTask::getRNMVCCIndexCacheKey(ReadMode read_mode) const
 {
     if (!dm_context->global_context.getSharedContextDisagg()->isDisaggregatedComputeMode())
         return std::nullopt;
 
-    auto & cache = dm_context->global_context.getSharedContextDisagg()->rn_delta_index_cache;
+    auto & cache = dm_context->global_context.getSharedContextDisagg()->rn_mvcc_index_cache;
     if (!cache)
         return std::nullopt;
 
-    return Remote::RNDeltaIndexCache::CacheKey{
+    return Remote::RNMVCCIndexCache::CacheKey{
         .store_id = store_id,
         .table_id = dm_context->physical_table_id,
         .segment_id = segment->segmentId(),
@@ -842,7 +842,7 @@ size_t SegmentReadTask::prepareMVCCIndex(ReadMode read_mode)
     if (!cache_key)
         return 0;
 
-    auto & cache = dm_context->global_context.getSharedContextDisagg()->rn_delta_index_cache;
+    auto & cache = dm_context->global_context.getSharedContextDisagg()->rn_mvcc_index_cache;
     assert(cache != nullptr);
     if (cache_key->is_version_chain)
     {
@@ -864,7 +864,7 @@ void SegmentReadTask::updateMVCCIndexSize(ReadMode read_mode, size_t initial_ind
     if (!cache_key)
         return;
 
-    auto & cache = dm_context->global_context.getSharedContextDisagg()->rn_delta_index_cache;
+    auto & cache = dm_context->global_context.getSharedContextDisagg()->rn_mvcc_index_cache;
     assert(cache != nullptr);
     if (cache_key->is_version_chain && getVersionChainBytes(*(segment->getVersionChain())) != initial_index_bytes)
         cache->setVersionChain(*cache_key, segment->getVersionChain());

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTask.h
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTask.h
@@ -22,6 +22,7 @@
 #include <Storages/DeltaMerge/Segment.h>
 #include <Storages/KVStore/Types.h>
 #include <grpcpp/support/sync_stream.h>
+#include <Storages/DeltaMerge/Remote/RNMVCCIndexCache.h>
 
 namespace DB::DM
 {
@@ -123,7 +124,7 @@ public:
     String toString() const;
 
 private:
-    std::optional<Remote::RNDeltaIndexCache::CacheKey> getRNMVCCIndexCacheKey(ReadMode read_mode) const;
+    std::optional<Remote::RNMVCCIndexCache::CacheKey> getRNMVCCIndexCacheKey(ReadMode read_mode) const;
 
     std::vector<Remote::PageOID> buildRemotePageOID() const;
 

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTask.h
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTask.h
@@ -100,6 +100,9 @@ public:
 
     void fetchPages();
 
+    size_t prepareMVCCIndex(ReadMode read_mode);
+    void updateMVCCIndexSize(ReadMode read_mode, size_t initial_index_bytes);
+
     void initInputStream(
         const ColumnDefines & columns_to_read,
         UInt64 start_ts,
@@ -120,6 +123,8 @@ public:
     String toString() const;
 
 private:
+    std::optional<Remote::RNDeltaIndexCache::CacheKey> getRNMVCCIndexCacheKey(ReadMode read_mode) const;
+
     std::vector<Remote::PageOID> buildRemotePageOID() const;
 
     Remote::RNLocalPageCache::OccupySpaceResult blockingOccupySpaceForTask() const;

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTask.h
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTask.h
@@ -101,9 +101,6 @@ public:
 
     void fetchPages();
 
-    size_t prepareMVCCIndex(ReadMode read_mode);
-    void updateMVCCIndexSize(ReadMode read_mode, size_t initial_index_bytes);
-
     void initInputStream(
         const ColumnDefines & columns_to_read,
         UInt64 start_ts,
@@ -125,6 +122,8 @@ public:
 
 private:
     std::optional<Remote::RNMVCCIndexCache::CacheKey> getRNMVCCIndexCacheKey(ReadMode read_mode) const;
+    size_t prepareMVCCIndex(ReadMode read_mode);
+    void updateMVCCIndexSize(ReadMode read_mode, size_t initial_index_bytes);
 
     std::vector<Remote::PageOID> buildRemotePageOID() const;
 

--- a/dbms/src/Storages/DeltaMerge/SegmentReadTask.h
+++ b/dbms/src/Storages/DeltaMerge/SegmentReadTask.h
@@ -18,11 +18,11 @@
 #include <Storages/DeltaMerge/Remote/DisaggTaskId.h>
 #include <Storages/DeltaMerge/Remote/Proto/remote.pb.h>
 #include <Storages/DeltaMerge/Remote/RNLocalPageCache.h>
+#include <Storages/DeltaMerge/Remote/RNMVCCIndexCache.h>
 #include <Storages/DeltaMerge/RowKeyRange.h>
 #include <Storages/DeltaMerge/Segment.h>
 #include <Storages/KVStore/Types.h>
 #include <grpcpp/support/sync_stream.h>
-#include <Storages/DeltaMerge/Remote/RNMVCCIndexCache.h>
 
 namespace DB::DM
 {

--- a/dbms/src/Storages/DeltaMerge/VersionChain/NewHandleIndex.h
+++ b/dbms/src/Storages/DeltaMerge/VersionChain/NewHandleIndex.h
@@ -124,6 +124,13 @@ public:
         handle_to_row_id.swap(t);
     }
 
+    size_t getBytes() const
+    {
+        // In tests, about 2.3~2.5 bytes overhead for each entry in handle_to_row_id.
+        return sizeof(hasher)
+            + handle_to_row_id.size() * (sizeof(absl::btree_multimap<UInt32, RowID>::value_type) + 2.5);
+    }
+
 private:
     static MutableColumnPtr createHandleColumn()
     {

--- a/dbms/src/Storages/DeltaMerge/VersionChain/VersionChain.cpp
+++ b/dbms/src/Storages/DeltaMerge/VersionChain/VersionChain.cpp
@@ -390,6 +390,13 @@ DeltaValueReader VersionChain<HandleType>::createDeltaValueReader(
         ReadTag::MVCC};
 }
 
+template <ExtraHandleType HandleType>
+size_t VersionChain<HandleType>::getBytes() const
+{
+    // Ignore the size of `dmfile_or_delete_range_list` because it is small.
+    return base_versions->capacity() * sizeof(RowID) + new_handle_to_row_ids.getBytes();
+}
+
 template class VersionChain<Int64>;
 template class VersionChain<String>;
 

--- a/dbms/src/Storages/DeltaMerge/VersionChain/VersionChain.h
+++ b/dbms/src/Storages/DeltaMerge/VersionChain/VersionChain.h
@@ -19,6 +19,7 @@
 #include <Storages/DeltaMerge/VersionChain/Common.h>
 #include <Storages/DeltaMerge/VersionChain/DMFileHandleIndex.h>
 #include <Storages/DeltaMerge/VersionChain/NewHandleIndex.h>
+#include <Storages/DeltaMerge/VersionChain/VersionChain_fwd.h>
 
 namespace DB::DM
 {
@@ -69,6 +70,8 @@ public:
     [[nodiscard]] std::shared_ptr<const std::vector<RowID>> replaySnapshot(
         const DMContext & dm_context,
         const SegmentSnapshot & snapshot);
+
+    size_t getBytes() const;
 
 #ifdef DBMS_PUBLIC_GTEST
     [[nodiscard]] auto getReplayedRows() const { return base_versions->size(); }
@@ -154,14 +157,17 @@ private:
     std::vector<DMFileOrDeleteRange> dmfile_or_delete_range_list;
 };
 
-using GenericVersionChain = std::variant<VersionChain<Int64>, VersionChain<String>>;
-
-inline GenericVersionChain createVersionChain(bool is_common_handle)
+inline GenericVersionChainPtr createVersionChain(bool is_common_handle)
 {
     if (is_common_handle)
-        return GenericVersionChain{std::in_place_type<VersionChain<String>>};
+        return std::make_shared<GenericVersionChain>(std::in_place_type<VersionChain<String>>);
     else
-        return GenericVersionChain{std::in_place_type<VersionChain<Int64>>};
+        return std::make_shared<GenericVersionChain>(std::in_place_type<VersionChain<Int64>>);
+}
+
+inline size_t getVersionChainBytes(const GenericVersionChain & version_chain)
+{
+    return std::visit([](auto && v) { return v.getBytes(); }, version_chain);
 }
 
 enum class VersionChainMode : Int64

--- a/dbms/src/Storages/DeltaMerge/VersionChain/VersionChain_fwd.h
+++ b/dbms/src/Storages/DeltaMerge/VersionChain/VersionChain_fwd.h
@@ -1,0 +1,25 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <Storages/DeltaMerge/VersionChain/Common.h>
+
+namespace DB::DM
+{
+template <ExtraHandleType HandleType>
+class VersionChain;
+using GenericVersionChain = std::variant<VersionChain<Int64>, VersionChain<String>>;
+using GenericVersionChainPtr = std::shared_ptr<GenericVersionChain>;
+} // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/VersionChain/tests/gtest_mvcc_bitmap.cpp
+++ b/dbms/src/Storages/DeltaMerge/VersionChain/tests/gtest_mvcc_bitmap.cpp
@@ -38,13 +38,13 @@ try
     segment->placeDeltaIndex(*dm_context, segment_snapshot);
     ASSERT_EQ(segment_snapshot->delta->getSharedDeltaIndex()->getPlacedStatus().first, delta_rows);
 
-    std::visit([&](auto & version_chain) { ASSERT_EQ(version_chain.getReplayedRows(), 0); }, segment->version_chain);
+    std::visit([&](auto & version_chain) { ASSERT_EQ(version_chain.getReplayedRows(), 0); }, *(segment->version_chain));
     std::ignore = std::visit(
         [&](auto & version_chain) { return version_chain.replaySnapshot(*dm_context, *segment_snapshot); },
-        segment->version_chain);
+        *(segment->version_chain));
     std::visit(
         [&](auto & version_chain) { ASSERT_EQ(version_chain.getReplayedRows(), delta_rows); },
-        segment->version_chain);
+        *(segment->version_chain));
 
     auto rs_results = loadPackFilterResults(*dm_context, segment_snapshot, {segment->getRowKeyRange()});
     auto bitmap_filter_delta_index = segment->buildMVCCBitmapFilter(

--- a/dbms/src/Storages/DeltaMerge/VersionChain/tests/gtest_version_chain.cpp
+++ b/dbms/src/Storages/DeltaMerge/VersionChain/tests/gtest_version_chain.cpp
@@ -40,7 +40,7 @@ protected:
         auto [seg, snap] = getSegmentForRead(opts.seg_id);
         auto actual_base_versions = std::visit(
             [&](auto & version_chain) { return version_chain.replaySnapshot(*dm_context, *snap); },
-            seg->version_chain);
+            *(seg->version_chain));
         ASSERT_EQ(opts.expected_base_versions, *actual_base_versions) << "caller_line=" << opts.caller_line;
     }
 
@@ -54,7 +54,7 @@ protected:
                     version_chain.dmfile_or_delete_range_list.size(),
                 };
             },
-            seg->version_chain);
+            *(seg->version_chain));
         ASSERT_EQ(actutal_new_handle_count, expected_new_handle_count);
         ASSERT_EQ(actual_dmfile_or_delete_range_count, expected_dmfile_or_delete_range_count);
     }

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_bitmap.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_bitmap.cpp
@@ -1193,7 +1193,7 @@ try
             RUNTIME_CHECK(cfs[0]->isInMemoryFile(), cfs[0]->toString());
 
         auto vc = createVersionChain(is_common_handle);
-        return std::visit([&](auto & version_chain) { return version_chain.replaySnapshot(*dm_context, *snap); }, vc);
+        return std::visit([&](auto & version_chain) { return version_chain.replaySnapshot(*dm_context, *snap); }, *vc);
     };
     auto base_ver1 = get_base_versions(false);
     writeSegmentGeneric("flush_cache"); // Flush never sort data when version chain enabled.

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_read_task.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_read_task.cpp
@@ -84,8 +84,7 @@ protected:
         auto broken_delta_index = std::make_shared<DeltaIndex>(
             second_snap->delta->getSharedDeltaIndex()->getDeltaTree(),
             placed_rows,
-            placed_deletes,
-            first_snap->delta->getSharedDeltaIndex()->getRNCacheKey());
+            placed_deletes);
 
         // hack to change the "immutable" delta-index on delta-snapshot for testing
         (*const_cast<DeltaIndexPtr *>(&first_snap->delta->getSharedDeltaIndex())) = broken_delta_index;

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_replace_stable_data.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_replace_stable_data.cpp
@@ -483,12 +483,7 @@ public:
             nullptr);
 
         auto read_dm_context = dmContext();
-        auto cn_segment_snap = Remote::Serializer::deserializeSegment(
-            *read_dm_context,
-            /* store_id */ 100,
-            0,
-            /* table_id */ 100,
-            snap_proto);
+        auto cn_segment_snap = Remote::Serializer::deserializeSegment(*read_dm_context, snap_proto);
 
         return cn_segment_snap;
     }

--- a/metrics/grafana/tiflash_summary.json
+++ b/metrics/grafana/tiflash_summary.json
@@ -9230,7 +9230,7 @@
               "expr": "tiflash_system_asynchronous_metric_RNMVCCIndexCacheBytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}",
               "hide": false,
               "interval": "",
-              "legendFormat": "rn_delta_index_cache_{{instance}}",
+              "legendFormat": "rn_mvcc_index_cache_{{instance}}",
               "refId": "B"
             }
           ],
@@ -17771,7 +17771,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "DeltaIndexCache",
+          "title": "MVCCIndexCache",
           "tooltip": {
             "shared": true,
             "sort": 0,

--- a/metrics/grafana/tiflash_summary.json
+++ b/metrics/grafana/tiflash_summary.json
@@ -9227,7 +9227,7 @@
             },
             {
               "exemplar": true,
-              "expr": "tiflash_system_asynchronous_metric_RNDeltaIndexCacheBytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}",
+              "expr": "tiflash_system_asynchronous_metric_RNMVCCIndexCacheBytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}",
               "hide": false,
               "interval": "",
               "legendFormat": "rn_delta_index_cache_{{instance}}",
@@ -17750,7 +17750,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(rate(tiflash_storage_delta_index_cache{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (type, instance)",
+              "expr": "sum(rate(tiflash_storage_mvcc_index_cache{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (type, instance)",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -17760,7 +17760,7 @@
             },
             {
               "exemplar": true,
-              "expr": "sum(rate(tiflash_storage_delta_index_cache{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", type=~\"hit\"}[1m])) by (instance) /sum(rate(tiflash_storage_delta_index_cache{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (instance)",
+              "expr": "sum(rate(tiflash_storage_mvcc_index_cache{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", type=~\"hit\"}[1m])) by (instance) /sum(rate(tiflash_storage_mvcc_index_cache{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (instance)",
               "hide": false,
               "interval": "",
               "legendFormat": "hit_ratio-{{instance}}",


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #9963

Problem Summary:

### What is changed and how it works?

Support VersionChain in StorageDisaggregated.

```commit-message
1. Rename all DeltaIndexCache-related names to MVCCIndexCache.
2. Store DeltaIndex and VersionChain in MVCCIndexCache with different keys.
3. Lazily get DeltaIndex or VersionChain from MVCCIndexCache only before reading the segment.
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  - Run chbenchmark with version chain enabled.
  - Run chbenchmark with version chain disabled.
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
