### PR TITLE
Do not allocate memory for unit test in `HashJoinPointerTable::init`

### DIFF
--- a/dbms/src/Interpreters/JoinV2/HashJoin.cpp
+++ b/dbms/src/Interpreters/JoinV2/HashJoin.cpp
@@ -392,7 +392,8 @@ void HashJoin::workAfterBuildRowFinish()
         all_build_row_count,
         getHashValueByteSize(method),
         settings.probe_enable_prefetch_threshold,
-        enable_tagged_pointer);
+        enable_tagged_pointer,
+        false);
 
     LOG_INFO(
         log,

--- a/dbms/src/Interpreters/JoinV2/HashJoinPointerTable.cpp
+++ b/dbms/src/Interpreters/JoinV2/HashJoinPointerTable.cpp
@@ -57,7 +57,7 @@ void HashJoinPointerTable::init(
 
     pointer_table_size_mask = (pointer_table_size - 1) << (hash_value_bits - pointer_table_size_degree);
 
-    // If it's test, do not allocate memory
+    // Do not allocate memory to speed up the test
     if likely (!is_test)
     {
         pointer_table = static_cast<std::atomic<uintptr_t> *>(

--- a/dbms/src/Interpreters/JoinV2/HashJoinPointerTable.cpp
+++ b/dbms/src/Interpreters/JoinV2/HashJoinPointerTable.cpp
@@ -24,7 +24,8 @@ void HashJoinPointerTable::init(
     size_t row_count,
     size_t hash_value_bytes,
     size_t probe_prefetch_threshold,
-    bool enable_tagged_pointer_)
+    bool enable_tagged_pointer_,
+    bool is_test)
 {
     hash_value_bits = hash_value_bytes * 8;
     if (method == HashJoinKeyMethod::OneKey8)
@@ -56,8 +57,12 @@ void HashJoinPointerTable::init(
 
     pointer_table_size_mask = (pointer_table_size - 1) << (hash_value_bits - pointer_table_size_degree);
 
-    pointer_table = static_cast<std::atomic<uintptr_t> *>(
-        alloc.alloc(pointer_table_size * sizeof(std::atomic<uintptr_t>), sizeof(std::atomic<RowPtr>)));
+    // If it's test, do not allocate memory
+    if likely (!is_test)
+    {
+        pointer_table = static_cast<std::atomic<uintptr_t> *>(
+            alloc.alloc(pointer_table_size * sizeof(std::atomic<uintptr_t>), sizeof(std::atomic<RowPtr>)));
+    }
 
     enable_tagged_pointer = enable_tagged_pointer_;
 }

--- a/dbms/src/Interpreters/JoinV2/HashJoinPointerTable.cpp
+++ b/dbms/src/Interpreters/JoinV2/HashJoinPointerTable.cpp
@@ -25,7 +25,7 @@ void HashJoinPointerTable::init(
     size_t hash_value_bytes,
     size_t probe_prefetch_threshold,
     bool enable_tagged_pointer_,
-    bool is_test)
+    bool is_unit_test)
 {
     hash_value_bits = hash_value_bytes * 8;
     if (method == HashJoinKeyMethod::OneKey8)
@@ -57,8 +57,8 @@ void HashJoinPointerTable::init(
 
     pointer_table_size_mask = (pointer_table_size - 1) << (hash_value_bits - pointer_table_size_degree);
 
-    // Do not allocate memory to speed up the test
-    if likely (!is_test)
+    // Do not allocate memory to speed up the unit test
+    if likely (!is_unit_test)
     {
         pointer_table = static_cast<std::atomic<uintptr_t> *>(
             alloc.alloc(pointer_table_size * sizeof(std::atomic<uintptr_t>), sizeof(std::atomic<RowPtr>)));

--- a/dbms/src/Interpreters/JoinV2/HashJoinPointerTable.h
+++ b/dbms/src/Interpreters/JoinV2/HashJoinPointerTable.h
@@ -39,7 +39,8 @@ public:
         size_t row_count_hint,
         size_t hash_value_bytes,
         size_t probe_prefetch_threshold,
-        bool enable_tagged_pointer_);
+        bool enable_tagged_pointer_,
+        bool is_test);
 
     template <typename HashValueType>
     bool build(

--- a/dbms/src/Interpreters/JoinV2/HashJoinPointerTable.h
+++ b/dbms/src/Interpreters/JoinV2/HashJoinPointerTable.h
@@ -40,7 +40,7 @@ public:
         size_t hash_value_bytes,
         size_t probe_prefetch_threshold,
         bool enable_tagged_pointer_,
-        bool is_test);
+        bool is_unit_test);
 
     template <typename HashValueType>
     bool build(

--- a/dbms/src/Interpreters/tests/JoinV2/gtest_hash_join_pointer_table.cpp
+++ b/dbms/src/Interpreters/tests/JoinV2/gtest_hash_join_pointer_table.cpp
@@ -38,7 +38,13 @@ public:
     {
         {
             HashJoinPointerTable t;
-            t.init(method, row_count, hash_value_bytes, pointer_table_size > 1 ? pointer_table_size - 1 : 0, true);
+            t.init(
+                method,
+                row_count,
+                hash_value_bytes,
+                pointer_table_size > 1 ? pointer_table_size - 1 : 0,
+                true,
+                true);
             ASSERT_EQ(t.pointer_table_size, pointer_table_size);
             ASSERT_EQ(t.pointer_table_size_degree, pointer_table_size_degree);
             ASSERT_EQ(t.enable_probe_prefetch, true);
@@ -47,7 +53,7 @@ public:
         }
         {
             HashJoinPointerTable t;
-            t.init(method, row_count, hash_value_bytes, pointer_table_size + 1, false);
+            t.init(method, row_count, hash_value_bytes, pointer_table_size + 1, false, true);
             ASSERT_EQ(t.pointer_table_size, pointer_table_size);
             ASSERT_EQ(t.pointer_table_size_degree, pointer_table_size_degree);
             ASSERT_EQ(t.enable_probe_prefetch, false);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/10100

Problem Summary:

### What is changed and how it works?
See https://github.com/pingcap/tiflash/issues/10100.

```commit-message
Do not allocate memory for unit test in `HashJoinPointerTable::init`
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
