### PR TITLE
*: Fix configure when prebuilt libclara is specified

### DIFF
--- a/dbms/CMakeLists.txt
+++ b/dbms/CMakeLists.txt
@@ -340,7 +340,6 @@ if (ENABLE_TESTS)
         ${TiFlash_SOURCE_DIR}/dbms/src/Server/RaftConfigParser.cpp
         ${TiFlash_SOURCE_DIR}/dbms/src/AggregateFunctions/AggregateFunctionSum.cpp
     )
-    set_target_properties(gtests_dbms PROPERTIES BUILD_RPATH "$ORIGIN/")
     target_include_directories(gtests_dbms BEFORE PRIVATE ${SPARCEHASH_INCLUDE_DIR})
     target_compile_definitions(gtests_dbms PUBLIC DBMS_PUBLIC_GTEST)
     target_compile_definitions(dbms PUBLIC DBMS_PUBLIC_GTEST)
@@ -375,9 +374,16 @@ if (ENABLE_TESTS)
                 DESTINATION ".")
     endif ()
 
-    install (TARGETS clara_shared
-            COMPONENT tiflash-gtest
-            DESTINATION ".")
+    if (USE_INTERNAL_LIBCLARA)
+        install (TARGETS clara_shared
+                COMPONENT tiflash-gtest
+                DESTINATION ".")
+    endif()
+
+    set_target_properties(gtests_dbms PROPERTIES BUILD_RPATH "$ORIGIN/")
+    set_target_properties(gtests_dbms PROPERTIES INSTALL_RPATH "$ORIGIN/")
+
+    install (SCRIPT ${TiFlash_SOURCE_DIR}/libs/libclara-cmake/linux_post_install.cmake COMPONENT tiflash-gtest)
 
     target_compile_options(gtests_dbms PRIVATE -Wno-unknown-pragmas -Wno-deprecated-copy)
     add_check(gtests_dbms)

--- a/dbms/src/Server/CMakeLists.txt
+++ b/dbms/src/Server/CMakeLists.txt
@@ -124,9 +124,11 @@ if (OS_LINUX)
                 DESTINATION ".")
     endif()
 
-    install (TARGETS clara_shared
-            COMPONENT tiflash-release
-            DESTINATION ".")
+    if (USE_INTERNAL_LIBCLARA)
+        install (TARGETS clara_shared
+                COMPONENT tiflash-release
+                DESTINATION ".")
+    endif()
 
     if (NOT (CMAKE_BUILD_TYPE_UC STREQUAL "DEBUG" OR SAN_DEBUG))
         install (SCRIPT ${TiFlash_SOURCE_DIR}/cmake/tiflash_linux_post_install.cmake COMPONENT tiflash-release)
@@ -144,7 +146,7 @@ elseif(APPLE)
     install (RUNTIME_DEPENDENCY_SET tiflash-release-dependency
             COMPONENT tiflash-release
             DESTINATION "."
-            PRE_INCLUDE_REGEXES ".*proxy.*")
+            PRE_INCLUDE_REGEXES ".*proxy.*|.*clara.*")
 endif ()
 
 include(CMakePrintHelpers)

--- a/libs/libclara-cmake/linux_post_install.cmake
+++ b/libs/libclara-cmake/linux_post_install.cmake
@@ -12,10 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-find_program(OBJCOPY_EXECUTABLE "objcopy")
-if(OBJCOPY_EXECUTABLE)
-    message(STATUS "Compressing debug sections for libclara...")
-    execute_process(COMMAND ${OBJCOPY_EXECUTABLE} --compress-debug-sections=zlib-gnu ${CMAKE_INSTALL_PREFIX}/libclara_shared.so)
-else()
+find_program (OBJCOPY_EXECUTABLE "objcopy")
+if (OBJCOPY_EXECUTABLE)
+    message (STATUS "Compressing debug sections for libclara...")
+    # Note: CMAKE_SHARED_LIBRARY_PREFIX is not available in the cmake script mode. So we manually check the library name.
+    if (EXISTS ${CMAKE_INSTALL_PREFIX}/libclara_shared.so)
+        execute_process (COMMAND ${OBJCOPY_EXECUTABLE} --compress-debug-sections=zlib-gnu ${CMAKE_INSTALL_PREFIX}/libclara_shared.so)
+    elseif (EXISTS ${CMAKE_INSTALL_PREFIX}/libclara_sharedd.so)
+        execute_process (COMMAND ${OBJCOPY_EXECUTABLE} --compress-debug-sections=zlib-gnu ${CMAKE_INSTALL_PREFIX}/libclara_sharedd.so)
+    else ()
+        message (STATUS "libclara_shared.so or libclara_sharedd.so not found. Skipped debug section compression for libclara.")
+    endif ()
+else ()
     message(WARNING "objcopy not found in PATH. Skipped debug section compression for libclara.")
-endif()
+endif ()


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10080 

Problem Summary:

### What is changed and how it works?

```commit-message
Fix configure when a prebuilt libclara is specified.
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
