### PR TITLE
*: Fix build issue when ThinLTO is enabled

### DIFF
--- a/libs/libclara-cmake/CMakeLists.txt
+++ b/libs/libclara-cmake/CMakeLists.txt
@@ -67,13 +67,13 @@ add_custom_command(OUTPUT ${_CLARA_LIBRARY} ${_CLARA_GEN_SRC_FILES}
                 "${_CLARA_SOURCE_DIR}/Cargo.toml"
                 "${_CLARA_SOURCE_DIR}/rust-toolchain.toml")
 
-add_library(clara STATIC ${_CLARA_GEN_SRC_FILES})
-target_link_libraries(clara INTERFACE ${_CLARA_LIBRARY})
+add_library(clara ${_CLARA_GEN_SRC_FILES})
+target_link_libraries(clara PUBLIC ${_CLARA_LIBRARY})
 target_include_directories(clara PUBLIC ${_CLARA_INCLUDE_DIR})
 
 # Rust cannot generate a dynamic library with correct visibility, so we generate a static library first and then link it to a shared library.
 # The reason we use dynamic library is to avoid symbol conflicts.
 
 add_library(clara_shared SHARED "${TiFlash_SOURCE_DIR}/libs/libclara-cmake/dummy.cpp")
-target_link_libraries(clara_shared PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,clara>")
+target_link_libraries(clara_shared PUBLIC "$<LINK_LIBRARY:WHOLE_ARCHIVE,clara>")
 target_include_directories(clara_shared PUBLIC ${_CLARA_INCLUDE_DIR})

--- a/libs/libclara/Cargo.toml
+++ b/libs/libclara/Cargo.toml
@@ -3,5 +3,5 @@ members = ["clara", "clara_fts"]
 resolver = "2"
 
 [profile.release]
-debug = true
+debug = 1
 lto = "thin"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10080 

Problem Summary:

### What is changed and how it works?

```commit-message
- Fix build error when ThinLTO is enabled.
- Reduce libclara library size.
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

```shell
cmake .. -GNinja --fresh \
    -DCMAKE_BUILD_TYPE=RELWITHDEBINFO \
    -DCMAKE_C_COMPILER=clang \
    -DCMAKE_CXX_COMPILER=clang++ \
    -DENABLE_TESTING=OFF \
    -DENABLE_TESTS=OFF \
    -DENABLE_FAILPOINTS=OFF \
    -DENABLE_THINLTO=ON \
    -DTHINLTO_JOBS=70 && ninja tiflash
```

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
