### PR TITLE
Avoid data race in grpc alarm

### DIFF
--- a/dbms/src/Flash/EstablishCall.cpp
+++ b/dbms/src/Flash/EstablishCall.cpp
@@ -216,9 +216,9 @@ void EstablishCallData::initRpc()
     }
 }
 
-grpc::Alarm * EstablishCallData::getAlarm()
+grpc::Alarm & EstablishCallData::getAlarm()
 {
-    return &alarm;
+    return alarm;
 }
 
 void EstablishCallData::tryConnectTunnel()

--- a/dbms/src/Flash/EstablishCall.cpp
+++ b/dbms/src/Flash/EstablishCall.cpp
@@ -216,6 +216,11 @@ void EstablishCallData::initRpc()
     }
 }
 
+grpc::Alarm * EstablishCallData::getAlarm()
+{
+    return &alarm;
+}
+
 void EstablishCallData::tryConnectTunnel()
 {
     auto * task_manager = service->getContext()->getTMTContext().getMPPTaskManager().get();

--- a/dbms/src/Flash/EstablishCall.h
+++ b/dbms/src/Flash/EstablishCall.h
@@ -96,7 +96,7 @@ public:
     grpc::ServerContext * getGrpcContext() { return &ctx; }
 
     String getResourceGroupName() const { return resource_group_name; }
-    grpc::Alarm * getAlarm();
+    grpc::Alarm & getAlarm();
 
 
 private:

--- a/dbms/src/Flash/EstablishCall.h
+++ b/dbms/src/Flash/EstablishCall.h
@@ -19,6 +19,7 @@
 #include <Common/Stopwatch.h>
 #include <Flash/FlashService.h>
 #include <Flash/Mpp/MPPTaskId.h>
+#include <grpcpp/alarm.h>
 #include <kvproto/tikvpb.grpc.pb.h>
 #include <prometheus/gauge.h>
 
@@ -95,6 +96,8 @@ public:
     grpc::ServerContext * getGrpcContext() { return &ctx; }
 
     String getResourceGroupName() const { return resource_group_name; }
+    grpc::Alarm * getAlarm();
+
 
 private:
     /// WARNING: Since a event from one grpc completion queue may be handled by different
@@ -142,5 +145,6 @@ private:
     String resource_group_name;
     String connection_id;
     double waiting_task_time_ms = 0;
+    grpc::Alarm alarm{};
 };
 } // namespace DB

--- a/dbms/src/Flash/Mpp/MPPTaskManager.cpp
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.cpp
@@ -54,7 +54,7 @@ void MPPGatherTaskSet::cancelAlarmsBySenderTaskId(const MPPTaskId & task_id)
     if (alarm_it != alarms.end())
     {
         for (auto & alarm : alarm_it->second)
-            alarm.second.Cancel();
+            alarm.second->Cancel();
         alarms.erase(alarm_it);
     }
 }
@@ -185,13 +185,14 @@ std::pair<MPPTunnelPtr, String> MPPTaskManager::findAsyncTunnel(
                     context.getSettingsRef().auto_spill_check_min_interval_ms.get());
             if (gather_task_set == nullptr)
                 gather_task_set = query->addMPPGatherTaskSet(id.gather_id);
-            auto & alarm = gather_task_set->alarms[sender_task_id][receiver_task_id];
+            auto * alarm = call_data->getAlarm();
             call_data->setCallStateAndUpdateMetrics(
                 EstablishCallData::WAIT_TUNNEL,
                 GET_METRIC(tiflash_establish_calldata_count, type_wait_tunnel_calldata));
+            gather_task_set->alarms[sender_task_id][receiver_task_id] = alarm;
             if likely (cq != nullptr)
             {
-                alarm.Set(cq, Clock::now() + std::chrono::seconds(10), call_data->asGRPCKickTag());
+                alarm->Set(cq, Clock::now() + std::chrono::seconds(10), call_data->asGRPCKickTag());
             }
             return {nullptr, ""};
         }
@@ -220,7 +221,6 @@ std::pair<MPPTunnelPtr, String> MPPTaskManager::findAsyncTunnel(
         }
     }
     /// don't need to delete the alarm here because registerMPPTask will delete all the related alarm
-
     return task->getTunnel(request);
 }
 
@@ -315,7 +315,7 @@ void MPPTaskManager::abortMPPGather(const MPPGatherId & gather_id, const String 
         for (auto & alarms_per_task : gather_task_set->alarms)
         {
             for (auto & alarm : alarms_per_task.second)
-                alarm.second.Cancel();
+                alarm.second->Cancel();
         }
         gather_task_set->alarms.clear();
         if (!gather_task_set->hasMPPTask())

--- a/dbms/src/Flash/Mpp/MPPTaskManager.h
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.h
@@ -24,6 +24,7 @@
 
 #include <chrono>
 #include <condition_variable>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <unordered_map>
@@ -42,7 +43,7 @@ struct MPPGatherTaskSet
     State state = Normal;
     String error_message;
     /// <sender_task_id, <receiver_task_id, alarm>>
-    std::unordered_map<Int64, std::unordered_map<Int64, grpc::Alarm *>> alarms;
+    std::unordered_map<Int64, std::unordered_map<Int64, std::reference_wrapper<grpc::Alarm>>> alarms;
     /// only used in scheduler
     std::queue<MPPTaskId> waiting_tasks;
     bool isInNormalState() const { return state == Normal; }

--- a/dbms/src/Flash/Mpp/MPPTaskManager.h
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.h
@@ -42,7 +42,7 @@ struct MPPGatherTaskSet
     State state = Normal;
     String error_message;
     /// <sender_task_id, <receiver_task_id, alarm>>
-    std::unordered_map<Int64, std::unordered_map<Int64, grpc::Alarm>> alarms;
+    std::unordered_map<Int64, std::unordered_map<Int64, grpc::Alarm *>> alarms;
     /// only used in scheduler
     std::queue<MPPTaskId> waiting_tasks;
     bool isInNormalState() const { return state == Normal; }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10107

Problem Summary:

In current implementation, `Alarm` is hold by `MPPGatherTaskSet`, and in `MPPTaskManager::abortMPPGather`, all the `Alarm` will be deconstructed since it call `gather_task_set->alarms.clear();`
But when `gather_task_set->alarms.clear();` is called, the `EstablishCallData` may still inside grpc's core, and it hold a raw pointer of `AlarmImpl`, although inside `AlarmImpl`, it use atomic to try to make it thread-safe
```
 void Ref() { gpr_ref(&refs_); }
  void Unref() {
    if (gpr_unref(&refs_)) {
      delete this;
    }
  }
```
But `Unref/Ref` is not thread safe because in grpc's implementation, if `EstablishCallData` is put back to grpc's core, it does not call `Ref` immediately, instead, looks like grpc only call `Ref` if some event happens:
```
 void Set(::grpc::CompletionQueue* cq, gpr_timespec deadline, void* tag) {
    grpc_core::ApplicationCallbackExecCtx callback_exec_ctx;
    grpc_core::ExecCtx exec_ctx;
    GRPC_CQ_INTERNAL_REF(cq->cq(), "alarm");
    cq_ = cq->cq();
    tag_ = tag;
    GPR_ASSERT(grpc_cq_begin_op(cq_, this));
    GRPC_CLOSURE_INIT(
        &on_alarm_,
        [](void* arg, grpc_error_handle error) {
          // queue the op on the completion queue
          AlarmImpl* alarm = static_cast<AlarmImpl*>(arg);
          alarm->Ref();
          // Preserve the cq and reset the cq_ so that the alarm
          // can be reset when the alarm tag is delivered.
          grpc_completion_queue* cq = alarm->cq_;
          alarm->cq_ = nullptr;
          grpc_cq_end_op(
              cq, alarm, error,
              [](void* /*arg*/, grpc_cq_completion* /*completion*/) {}, arg,
              &alarm->completion_);
          GRPC_CQ_INTERNAL_UNREF(cq, "alarm");
        },
        this, grpc_schedule_on_exec_ctx);
    grpc_timer_init(&timer_, grpc_timespec_to_millis_round_up(deadline),
                    &on_alarm_);
  }
```
So there is a case that 2 threads try to delete the AlarmImpl concurrently.
|Time      | thread 1      | thread 2 |
|--------| ----------- | ----------- |
|        1     | call `gpr_unref(&refs_)`      |        |
|        2      | `gpr_unref(&refs_)` return true(refs is 0)   |        |
|       3     |                    | call `Ref()`   |
|       4    | call `delete this` |               |
|       5    |                     | call `Unref()`, and it will also try to delete `this` |
### What is changed and how it works?
This pr let `EstablishCallData` to hold the alarm, so it will never be constructed when `EstablishCallData` is inside grpc's core.
```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
