### PR TITLE
use logical cpu cores as the default pool size of grpc async client pool

### DIFF
--- a/dbms/src/Common/getNumberOfCPUCores.cpp
+++ b/dbms/src/Common/getNumberOfCPUCores.cpp
@@ -20,7 +20,7 @@
 namespace CPUCores
 {
 UInt16 number_of_logical_cpu_cores = std::thread::hardware_concurrency();
-UInt16 number_of_physical_cpu_cores = std::thread::hardware_concurrency() / 2;
+UInt16 number_of_physical_cpu_cores = std::max<UInt16>(1, std::thread::hardware_concurrency() / 2);
 } // namespace CPUCores
 
 

--- a/dbms/src/Common/getNumberOfCPUCores.cpp
+++ b/dbms/src/Common/getNumberOfCPUCores.cpp
@@ -20,6 +20,7 @@
 namespace CPUCores
 {
 UInt16 number_of_logical_cpu_cores = std::thread::hardware_concurrency();
+// physical cpu cores should not be 0
 UInt16 number_of_physical_cpu_cores = std::max<UInt16>(1, std::thread::hardware_concurrency() / 2);
 } // namespace CPUCores
 

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -1220,7 +1220,7 @@ try
         {
             auto size = settings.grpc_completion_queue_pool_size;
             if (size == 0)
-                size = std::thread::hardware_concurrency();
+                size = getNumberOfLogicalCPUCores();
             GRPCCompletionQueuePool::global_instance = std::make_unique<GRPCCompletionQueuePool>(size);
         }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6233

Problem Summary:

Currently, TiFlash use `std::thread::hardware_concurrency()` as the default pool size of grpc async client pool, it does not work well when TiFlash is in virtual environment, this pr use `CPUCores::number_of_logical_cpu_cores` as its default value.
### What is changed and how it works?

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
