### PR TITLE
*: fix release-8.5 darwin build

### DIFF
--- a/dbms/src/Storages/DeltaMerge/Index/LocalIndexInfo.h
+++ b/dbms/src/Storages/DeltaMerge/Index/LocalIndexInfo.h
@@ -72,18 +72,22 @@ public:
     std::span<const IndexID> keepIndexes() const
     {
         assert(added_indexes_offset <= all_indexes.size());
-        return std::span(all_indexes.begin(), all_indexes.begin() + added_indexes_offset);
+        return std::span<const IndexID>(&*all_indexes.begin(), added_indexes_offset);
     }
     std::span<const IndexID> addedIndexes() const
     {
         assert(added_indexes_offset <= dropped_indexes_offset && added_indexes_offset <= all_indexes.size());
         assert(dropped_indexes_offset <= all_indexes.size());
-        return std::span(all_indexes.begin() + added_indexes_offset, all_indexes.begin() + dropped_indexes_offset);
+        return std::span<const IndexID>(
+            &*(all_indexes.begin() + added_indexes_offset),
+            dropped_indexes_offset - added_indexes_offset);
     }
     std::span<const IndexID> droppedIndexes() const
     {
         assert(dropped_indexes_offset <= all_indexes.size());
-        return std::span(all_indexes.begin() + dropped_indexes_offset, all_indexes.end());
+        return std::span<const IndexID>(
+            &*(all_indexes.begin() + dropped_indexes_offset),
+            all_indexes.size() - dropped_indexes_offset);
     }
     std::vector<IndexID> copyDroppedIndexes() const
     {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10145

Problem Summary:

### What is changed and how it works?

```
[43m[📡 STDERR] [49m/Users/pingcap/workspace/bp-tiflash-release-darwin-arm64-l8px6-build-binaries/source/tiflash/dbms/src/Storages/DeltaMerge/Index/LocalIndexInfo.h:75:16: error: no viable constructor or deduction guide for deduction of template arguments of 'span'
    [43m[📡 STDERR] [49m        return std::span(all_indexes.begin(), all_indexes.begin() + added_indexes_offset);
    [43m[📡 STDERR] [49m               ^
    [43m[📡 STDERR] [49m/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/span:246:28: note: candidate template ignored: couldn't infer template argument '_Tp'
    [43m[📡 STDERR] [49m        constexpr explicit span(      _Container& __c,
    [43m[📡 STDERR] [49m                           ^
    [43m[📡 STDERR] [49m/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/span:254:28: note: candidate template ignored: couldn't infer template argument '_Tp'
    [43m[📡 STDERR] [49m        constexpr explicit span(const _Container& __c,
    [43m[📡 STDERR] [49m                           ^
    [43m[📡 STDERR] [49m/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/span:227:50: note: candidate template ignored: could not match 'pointer' (aka '_Tp *') against 'std::vector<long long>::const_iterator' (aka '__wrap_iter<const long long *>')
    [43m[📡 STDERR] [49m    _LIBCPP_INLINE_VISIBILITY constexpr explicit span(pointer __ptr, size_type __count) : __data{__ptr}
    [43m[📡 STDERR] [49m                                                 ^
    [43m[📡 STDERR] [49m/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/span:229:50: note: candidate template ignored: could not match 'pointer' (aka '_Tp *') against 'std::vector<long long>::const_iterator' (aka '__wrap_iter<const long long *>')
    [43m[📡 STDERR] [49m    _LIBCPP_INLINE_VISIBILITY constexpr explicit span(pointer __f, pointer __l) : __data{__f}
    [43m[📡 STDERR] [49m                                                 ^
    [43m[📡 STDERR] [49m/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/span:262:19: note: candidate template ignored: could not match 'span' against '__wrap_iter'
    [43m[📡 STDERR] [49m        constexpr span(const span<_OtherElementType, _Extent>& __other,
```

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
