### PR TITLE
Storages: Enable VersionChain

### DIFF
--- a/dbms/src/Interpreters/Settings.h
+++ b/dbms/src/Interpreters/Settings.h
@@ -182,7 +182,7 @@ struct Settings
     M(SettingUInt64, dt_merged_file_max_size, 16 * 1024 * 1024, "Small files are merged into one or more files not larger than dt_merged_file_max_size")                                                                                \
     M(SettingDouble, dt_page_gc_threshold, 0.5, "Max valid rate of deciding to do a GC in PageStorage")                                                                                                                                 \
     M(SettingDouble, dt_page_gc_threshold_raft_data, 0.05, "Max valid rate of deciding to do a GC for BlobFile storing PageData in PageStorage")                                                                                        \
-    M(SettingInt64, enable_version_chain, 0, "Enable version chain or not: 0 - disable, 1 - enabled. "                                                                                                                                  \
+    M(SettingInt64, enable_version_chain, 1, "Enable version chain or not: 0 - disable, 1 - enabled. "                                                                                                                                  \
                                              "More details are in the comments of `enum class VersionChainMode`."                                                                                                                       \
                                              "Modifying this configuration requires a restart to reset the in-memory state.")                                                                                                           \
     /* DeltaTree engine testing settings */\


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9963

Problem Summary:

### What is changed and how it works?

```commit-message
Storages: Enable VersionChain
Set profiles.default.enable_version_chain to 1 by default
```

#### Benchmark: VectorDBBench
Performance768D1M
Deploy on a single machine 16c 64GB

  | DeltaIndex | VersionChain | VersionChain/DeltaIndex
-- | -- | -- | --
QPS | 54.0482 | 117.2117 | 2.168651315


#### Benchmark: CHBenchmark 1500
Deploy on a single machine 16c 128GB

* For stable-only workload, the total query cost using VersionChain is almost the same as DeltaIndex
* For read-only with delta workload, non-clustered index, using VersionChain gain 30%~100% performance boost
* For read-only with delta workload, clustered index, using VersionChain gain 90% performance boost
* For read-write workload, non-clustered index, using VersionChain gain 13% performance boost
* For read-write workload, clustered index, using VersionChain gain 34% performance boost

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Enable VersionChain by default
```
