### PR TITLE
Fix address alignment error

### DIFF
--- a/dbms/src/Common/tests/gtest_arena.cpp
+++ b/dbms/src/Common/tests/gtest_arena.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 PingCAP, Inc.
+// Copyright 2025 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dbms/src/Common/tests/gtest_arena.cpp
+++ b/dbms/src/Common/tests/gtest_arena.cpp
@@ -26,15 +26,15 @@ TEST(ArenaTest, AlignedAlloc)
     auto pool = DB::Arena(1024);
     auto * p = pool.alloc(3);
     p = pool.alloc(2);
-    // the first allocation is not aligned
-    ASSERT_NE(reinterpret_cast<uintptr_t>(p) % 16, 0);
-    // the second allocation is aligned
     auto align = alignof(CachedColumnInfo);
+    // the first allocation is not aligned
+    ASSERT_NE(reinterpret_cast<uintptr_t>(p) % align, 0);
+    // the second allocation is aligned
     p = pool.alignedAlloc(sizeof(CachedColumnInfo), align);
     ASSERT_EQ(reinterpret_cast<uintptr_t>(p) % align, 0);
     auto * cached_column_info = reinterpret_cast<CachedColumnInfo *>(p);
     new (cached_column_info) CachedColumnInfo(nullptr);
-    // double check the alignment
+    // double check the alignment, will raise bus error if not aligned in some platforms
     cached_column_info->mu.lock();
     cached_column_info->mu.unlock();
 }

--- a/dbms/src/Common/tests/gtest_arena.cpp
+++ b/dbms/src/Common/tests/gtest_arena.cpp
@@ -1,0 +1,32 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Common/Arena.h>
+#include <Interpreters/JoinHashMap.h>
+#include <gtest/gtest.h>
+
+namespace DB::tests
+{
+TEST(ArenaTest, AlignedAlloc)
+{
+    auto pool = DB::Arena(1024);
+    auto * p = pool.alloc(3);
+    p = pool.alloc(2);
+    // the first allocation is not aligned
+    ASSERT_NE(reinterpret_cast<uintptr_t>(p) % 16, 0);
+    // the second allocation is aligned
+    p = pool.alignedAlloc(sizeof(CachedColumnInfo), 16);
+    ASSERT_EQ(reinterpret_cast<uintptr_t>(p) % 16, 0);
+}
+} // namespace DB::tests

--- a/dbms/src/Interpreters/JoinPartition.cpp
+++ b/dbms/src/Interpreters/JoinPartition.cpp
@@ -45,7 +45,7 @@ void insertRowToList(JoinArenaPool & pool, List * list, Elem * elem, size_t cach
         if unlikely (cache_columns_threshold == list->list_length)
         {
             auto * cached_column_info
-                = reinterpret_cast<CachedColumnInfo *>(pool.arena.alloc(sizeof(CachedColumnInfo)));
+                = reinterpret_cast<CachedColumnInfo *>(pool.arena.alignedAlloc(sizeof(CachedColumnInfo), 16));
             new (cached_column_info) CachedColumnInfo(list->next);
             pool.cached_column_infos.push_back(cached_column_info);
             list->cached_column_info = cached_column_info;

--- a/dbms/src/Interpreters/JoinPartition.cpp
+++ b/dbms/src/Interpreters/JoinPartition.cpp
@@ -20,7 +20,6 @@
 #include <Interpreters/ProbeProcessInfo.h>
 
 #include <ext/scope_guard.h>
-#include <type_traits>
 
 namespace DB
 {

--- a/dbms/src/Interpreters/JoinPartition.cpp
+++ b/dbms/src/Interpreters/JoinPartition.cpp
@@ -20,6 +20,7 @@
 #include <Interpreters/ProbeProcessInfo.h>
 
 #include <ext/scope_guard.h>
+#include <type_traits>
 
 namespace DB
 {
@@ -44,8 +45,8 @@ void insertRowToList(JoinArenaPool & pool, List * list, Elem * elem, size_t cach
     {
         if unlikely (cache_columns_threshold == list->list_length)
         {
-            auto * cached_column_info
-                = reinterpret_cast<CachedColumnInfo *>(pool.arena.alignedAlloc(sizeof(CachedColumnInfo), 16));
+            auto * cached_column_info = reinterpret_cast<CachedColumnInfo *>(
+                pool.arena.alignedAlloc(sizeof(CachedColumnInfo), alignof(CachedColumnInfo)));
             new (cached_column_info) CachedColumnInfo(list->next);
             pool.cached_column_infos.push_back(cached_column_info);
             list->cached_column_info = cached_column_info;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10163

Problem Summary:

Ref to #10163
### What is changed and how it works?

Use `alignAlloc` instead `alloc` to alloc memory for `CachedColumnInfo`
```commit-message
Fix TiFlash crash due to invalid address alignment
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
