### PR TITLE
ddl: Update integration test of expr index

### DIFF
--- a/tests/fullstack-test2/ddl/expression_index.test
+++ b/tests/fullstack-test2/ddl/expression_index.test
@@ -33,10 +33,10 @@ mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t o
 +----+
 
 mysql> CREATE INDEX idx_n ON test.t ((null));
-ERROR 3761 (HY000): The used storage engine cannot index the expression 'null'
+ERROR 3761 (HY000) at line 1: The used storage engine cannot index the expression 'null'
 
 mysql> drop table if exists test.t;
 
 mysql> CREATE TABLE test.t (id int, KEY idx_name ((null)));
-ERROR 3761 (HY000): The used storage engine cannot index the expression 'null'
+ERROR 3761 (HY000) at line 1: The used storage engine cannot index the expression 'null'
 mysql> drop table if exists test.t;

--- a/tests/fullstack-test2/ddl/expression_index.test
+++ b/tests/fullstack-test2/ddl/expression_index.test
@@ -15,7 +15,7 @@
 mysql> drop table if exists test.t;
 
 # test for null expression express tiflash#9891
-mysql> CREATE TABLE test.t (id int, KEY idx_name ((null)));
+mysql> CREATE TABLE test.t (id int);
 mysql> alter table test.t set tiflash replica 1;
 mysql> insert test.t values(0),(1);
 
@@ -33,15 +33,10 @@ mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.t o
 +----+
 
 mysql> CREATE INDEX idx_n ON test.t ((null));
-mysql> alter table test.t add column c1 int;
-mysql> set session tidb_isolation_read_engines='tiflash'; select id,c1 from test.t order by id;
-+------+------+
-| id   | c1   |
-+------+------+
-|    0 | NULL |
-|    1 | NULL |
-|    2 | NULL |
-|    3 | NULL |
-+------+------+
+ERROR 3761 (HY000): The used storage engine cannot index the expression 'null'
 
+mysql> drop table if exists test.t;
+
+mysql> CREATE TABLE test.t (id int, KEY idx_name ((null)));
+ERROR 3761 (HY000): The used storage engine cannot index the expression 'null'
 mysql> drop table if exists test.t;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/9891, ref https://github.com/pingcap/tidb/issues/61133

Problem Summary:

TiDB disable the invalid expression index `((null))` from being created by https://github.com/pingcap/tidb/pull/61135. Update the integration test cases

### What is changed and how it works?

```commit-message
ddl: Fix integration test of expr index
TiDB disable the invalid expression index `((null))` from being created by https://github.com/pingcap/tidb/pull/61135. Update the integration test cases
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
