### PR TITLE
Downgrade reportStatus log level from error to info

### DIFF
--- a/dbms/src/Flash/Mpp/MPPTask.cpp
+++ b/dbms/src/Flash/Mpp/MPPTask.cpp
@@ -719,13 +719,13 @@ void MPPTask::reportStatus(const String & err_msg)
         }
         if (resp.has_error())
         {
-            LOG_WARNING(log, "ReportMPPTaskStatus resp error: {}", resp.error().msg());
+            LOG_INFO(log, "ReportMPPTaskStatus resp error: {}", resp.error().msg());
         }
     }
     catch (...)
     {
         std::string local_err_msg = getCurrentExceptionMessage(true);
-        LOG_ERROR(log, "Failed to ReportMPPTaskStatus to {}, due to {}", meta.coordinator_address(), local_err_msg);
+        LOG_INFO(log, "Failed to ReportMPPTaskStatus to {}, due to {}", meta.coordinator_address(), local_err_msg);
     }
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6233 

Problem Summary:
Since reportStatus error doesn't affect query results, change to info level log instead.
### What is changed and how it works?

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
