### PR TITLE
Delay removing FAP snapshot for restoring applying snapshot

### DIFF
--- a/dbms/src/Common/TiFlashMetrics.h
+++ b/dbms/src/Common/TiFlashMetrics.h
@@ -405,6 +405,7 @@ static_assert(RAFT_REGION_BIG_WRITE_THRES * 4 < RAFT_REGION_BIG_WRITE_MAX, "Inva
       F(type_failed_repeated, {{"type", "failed_repeated"}}),                                                                       \
       F(type_failed_build_chkpt, {{"type", "failed_build_chkpt"}}),                                                                 \
       F(type_reuse_chkpt_cache, {{"type", "reuse_chkpt_cache"}}),                                                                   \
+      F(type_failed_query_state, {{"type", "failed_query_state"}}),                                                                 \
       F(type_restore, {{"type", "restore"}}),                                                                                       \
       F(type_succeed, {{"type", "succeed"}}))                                                                                       \
     M(tiflash_fap_task_state,                                                                                                       \

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
@@ -427,6 +427,19 @@ public:
         return ingestSegmentsFromCheckpointInfo(dm_context, range, checkpoint_info);
     }
 
+    UInt64 removeSegmentsFromCheckpointInfo(
+        const DMContextPtr & dm_context,
+        const CheckpointIngestInfo & checkpoint_info);
+
+    UInt64 removeSegmentsFromCheckpointInfo(
+        const Context & db_context,
+        const DB::Settings & db_settings,
+        const CheckpointIngestInfo & checkpoint_info)
+    {
+        auto dm_context = newDMContext(db_context, db_settings);
+        return removeSegmentsFromCheckpointInfo(dm_context, checkpoint_info);
+    }
+
     /// Read all rows without MVCC filtering
     BlockInputStreams readRaw(
         const Context & db_context,

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_Ingest.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore_Ingest.cpp
@@ -1218,6 +1218,45 @@ Segments DeltaMergeStore::buildSegmentsFromCheckpointInfo(
     return {};
 }
 
+UInt64 DeltaMergeStore::removeSegmentsFromCheckpointInfo(
+    const DMContextPtr & dm_context,
+    const CheckpointIngestInfo & checkpoint_info)
+{
+    if (unlikely(shutdown_called.load(std::memory_order_relaxed)))
+    {
+        const auto msg
+            = fmt::format("Try to remove checkpoint files from a shutdown table, ident={}", log->identifier());
+        LOG_WARNING(log, "{}", msg);
+        throw Exception(msg);
+    }
+
+    auto restored_segments = checkpoint_info.getRestoredSegments();
+
+    DM::WriteBatches wbs{*dm_context->storage_pool};
+    LOG_DEBUG(
+        log,
+        "Start remove segment by checkpoint ingest info, segment={}, region_id={}, peer_id={}",
+        restored_segments.size(),
+        checkpoint_info.regionId(),
+        checkpoint_info.peerId());
+    for (auto & segment : restored_segments)
+    {
+        auto delta = segment->getDelta();
+        auto stable = segment->getStable();
+        delta->recordRemoveColumnFilesPages(wbs);
+        stable->recordRemovePacksPages(wbs);
+        wbs.writeRemoves();
+        LOG_DEBUG(
+            log,
+            "Remove segment by checkpoint ingest info, segment={}, region_id={}, peer_id={}",
+            segment->simpleInfo(),
+            checkpoint_info.regionId(),
+            checkpoint_info.peerId());
+    }
+
+    return restored_segments.size();
+}
+
 UInt64 DeltaMergeStore::ingestSegmentsFromCheckpointInfo(
     const DMContextPtr & dm_context,
     const DM::RowKeyRange & range,
@@ -1256,16 +1295,6 @@ UInt64 DeltaMergeStore::ingestSegmentsFromCheckpointInfo(
         checkpoint_info->regionId(),
         restored_segments.size(),
         estimated_bytes);
-
-    WriteBatches wbs{*dm_context->storage_pool};
-    for (auto & segment : restored_segments)
-    {
-        auto delta = segment->getDelta();
-        auto stable = segment->getStable();
-        delta->recordRemoveColumnFilesPages(wbs);
-        stable->recordRemovePacksPages(wbs);
-        wbs.writeRemoves();
-    }
 
     // TODO(fap) This could be executed in a dedicated thread if it consumes too much time.
     for (auto & segment : updated_segments)

--- a/dbms/src/Storages/DeltaMerge/Remote/RNMVCCIndexCache.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/RNMVCCIndexCache.h
@@ -81,7 +81,7 @@ private:
         {}
 
         DeltaIndexPtr delta_index;
-        size_t bytes;
+        const size_t bytes;
     };
 
     struct CacheVersionChain
@@ -92,7 +92,7 @@ private:
         {}
 
         GenericVersionChainPtr version_chain;
-        size_t bytes;
+        const size_t bytes;
     };
     struct CacheValue
     {

--- a/dbms/src/Storages/DeltaMerge/VersionChain/MVCCBitmapFilter.cpp
+++ b/dbms/src/Storages/DeltaMerge/VersionChain/MVCCBitmapFilter.cpp
@@ -73,7 +73,7 @@ BitmapFilterPtr buildMVCCBitmapFilter(
 
     LOG_INFO(
         snapshot.log,
-        "filtered_out_rows: version={}, rowkey={}, delete={}"
+        "filtered_out_rows: version={}, rowkey={}, delete={} "
         "cost_ms: replay={}, version={}, rowkey={}, delete={}",
         rowkey_filtered_out_rows,
         version_filtered_out_rows,

--- a/dbms/src/Storages/KVStore/FFI/ProxyFFI.h
+++ b/dbms/src/Storages/KVStore/FFI/ProxyFFI.h
@@ -204,7 +204,7 @@ FapSnapshotState QueryFapSnapshotState(
     uint64_t peer_id,
     uint64_t index,
     uint64_t term);
-void ClearFapSnapshot(EngineStoreServerWrap * server, uint64_t region_id);
+void ClearFapSnapshot(EngineStoreServerWrap * server, uint64_t region_id, uint64_t state);
 bool KvstoreRegionExists(EngineStoreServerWrap * server, uint64_t region_id);
 void ReportThreadAllocateInfo(
     EngineStoreServerWrap *,

--- a/dbms/src/Storages/KVStore/MultiRaft/Disagg/CheckpointIngestInfo.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/Disagg/CheckpointIngestInfo.cpp
@@ -249,6 +249,36 @@ bool CheckpointIngestInfo::cleanOnSuccess(TMTContext & tmt, UInt64 region_id)
     auto log = DB::Logger::get();
     LOG_INFO(log, "Erase CheckpointIngestInfo from disk on success, region_id={}", region_id);
     removeFromLocal(tmt, region_id);
+    {
+        auto keyspace_id = region->getKeyspaceID();
+        auto table_id = region->getMappedTableID();
+        if (auto storage = tmt.getStorages().get(keyspace_id, table_id);
+            storage && storage->engineType() == TiDB::StorageEngine::DT)
+        {
+            auto dm_storage = std::dynamic_pointer_cast<StorageDeltaMerge>(storage);
+            if (dm_storage)
+            {
+                dm_storage->removeSegmentsFromCheckpointInfo(*this, tmt.getContext().getSettingsRef());
+            }
+            else
+            {
+                LOG_DEBUG(
+                    log,
+                    "Can't cast when delete checkpoint ingest info, region_id={}, peer_id={}",
+                    region_id,
+                    peer_id);
+            }
+        }
+        else
+        {
+            LOG_INFO(
+                log,
+                "Can't get table when delete checkpoint ingest info, table_id={} keyspace={} region_id={}",
+                keyspace_id,
+                table_id,
+                region_id);
+        }
+    }
     return true;
 }
 
@@ -259,6 +289,8 @@ bool CheckpointIngestInfo::forciblyClean(
     bool in_memory,
     CleanReason reason)
 {
+    // - If called by `ClearFapSnapshot`, then it would already be cleaned in `blockedCancelRunningTask`.
+    // - If called by `cleanTask`, it will also clean the memory structure.
     auto log = DB::Logger::get();
     // For most cases, ingest infos are deleted in `removeFromLocal`.
     auto checkpoint_ptr = CheckpointIngestInfo::restore(tmt, proxy_helper, region_id, 0);
@@ -274,6 +306,13 @@ bool CheckpointIngestInfo::forciblyClean(
         // First delete the page, it may cause dangling data.
         // However, never point to incomplete data then.
         removeFromLocal(tmt, region_id);
+        LOG_INFO(
+            log,
+            "Finish erase CheckpointIngestInfo from disk by force, region_id={} exist={} in_memory={} reason={}",
+            region_id,
+            checkpoint_ptr != nullptr,
+            in_memory,
+            magic_enum::enum_name(reason));
         CheckpointIngestInfo::deleteWrittenData(
             tmt,
             checkpoint_ptr->getRegion(),

--- a/dbms/src/Storages/KVStore/MultiRaft/Disagg/CheckpointIngestInfo.h
+++ b/dbms/src/Storages/KVStore/MultiRaft/Disagg/CheckpointIngestInfo.h
@@ -82,7 +82,7 @@ struct CheckpointIngestInfo
         UInt64 region_id,
         bool in_memory,
         CleanReason reason);
-    static bool cleanOnSuccess(TMTContext & tmt, UInt64 region_id);
+    bool cleanOnSuccess(TMTContext & tmt, UInt64 region_id);
 
     FastAddPeerProto::CheckpointIngestInfoPersisted serializeMeta() const;
 

--- a/dbms/src/Storages/KVStore/MultiRaft/Disagg/FastAddPeer.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/Disagg/FastAddPeer.cpp
@@ -398,30 +398,6 @@ FastAddPeerRes FastAddPeerImplWrite(
         return genFastAddPeerResFail(FastAddPeerStatus::Canceled);
     }
 
-    fap_ctx->insertCheckpointIngestInfo(
-        tmt,
-        region_id,
-        new_peer_id,
-        checkpoint_info->remote_store_id,
-        region,
-        std::move(segments),
-        start_time);
-    GET_METRIC(tiflash_fap_task_duration_seconds, type_write_stage_insert).Observe(watch.elapsedSecondsFromLastTime());
-
-    SYNC_FOR("in_FastAddPeerImplWrite::after_write_segments");
-    if (cancel_handle->isCanceled())
-    {
-        LOG_INFO(log, "FAP is canceled after write segments");
-        fap_ctx->cleanTask(tmt, proxy_helper, region_id, CheckpointIngestInfo::CleanReason::TiFlashCancel);
-        GET_METRIC(tiflash_fap_task_result, type_failed_cancel).Increment();
-        return genFastAddPeerResFail(FastAddPeerStatus::Canceled);
-    }
-
-    // Now, the FAP snapshot is persisted. And we will later send it to ourselves to have is acked by the raftstore.
-    // Later, we directly write the raft log into formal unips. We do this here because we store raft log seperately.
-
-    // TODO(fap) Currently, FAP only handle when the peer is newly created in this store,
-    // Move this to `ApplyFapSnapshot` and clean stale data, if FAP can later handle all snapshots.
     UniversalWriteBatch wb;
     RUNTIME_CHECK(checkpoint_info->temp_ps != nullptr);
     RaftDataReader raft_data_reader(*(checkpoint_info->temp_ps));
@@ -457,18 +433,47 @@ FastAddPeerRes FastAddPeerImplWrite(
         GET_METRIC(tiflash_fap_task_result, type_failed_cancel).Increment();
         return genFastAddPeerResFail(FastAddPeerStatus::Canceled);
     }
-    GET_METRIC(tiflash_fap_task_duration_seconds, type_write_stage_raft).Observe(watch.elapsedSecondsFromLastTime());
-    auto wn_ps = tmt.getContext().getWriteNodePageStorage();
-    RUNTIME_CHECK(wn_ps != nullptr);
-    wn_ps->write(std::move(wb));
-    SYNC_FOR("in_FastAddPeerImplWrite::after_write_raft_log");
+
+    SYNC_FOR("in_FastAddPeerImplWrite::after_build_raft_log");
     if (cancel_handle->isCanceled())
     {
-        LOG_INFO(log, "FAP is canceled after write raft log");
+        LOG_INFO(log, "FAP is canceled after build raft log");
         fap_ctx->cleanTask(tmt, proxy_helper, region_id, CheckpointIngestInfo::CleanReason::TiFlashCancel);
         GET_METRIC(tiflash_fap_task_result, type_failed_cancel).Increment();
         return genFastAddPeerResFail(FastAddPeerStatus::Canceled);
     }
+
+    // Write the fap snapshot.
+    fap_ctx->insertCheckpointIngestInfo(
+        tmt,
+        region_id,
+        new_peer_id,
+        checkpoint_info->remote_store_id,
+        region,
+        std::move(segments),
+        start_time);
+    GET_METRIC(tiflash_fap_task_duration_seconds, type_write_stage_insert).Observe(watch.elapsedSecondsFromLastTime());
+
+    SYNC_FOR("in_FastAddPeerImplWrite::after_write_segments");
+    if (cancel_handle->isCanceled())
+    {
+        LOG_INFO(log, "FAP is canceled after write segments");
+        fap_ctx->cleanTask(tmt, proxy_helper, region_id, CheckpointIngestInfo::CleanReason::TiFlashCancel);
+        GET_METRIC(tiflash_fap_task_result, type_failed_cancel).Increment();
+        return genFastAddPeerResFail(FastAddPeerStatus::Canceled);
+    }
+
+    // Now, the FAP snapshot is persisted. And we will later send it to ourselves to have it acked by the raftstore.
+    // Later, we directly write the raft log into formal unips.
+    // Since a raft snapshot doestn't hold raft logs, whether these logs is written doesn't affect the applying stage.
+    // That's the reason why we write those logs after FAP snapshot is written.
+    // However, we still write them in order to provide some later logs, so that the new peer is less likely to lag.
+    // TODO(fap) Currently, FAP only handle when the peer is newly created in this store,
+    // Move this to `ApplyFapSnapshot` and clean stale data, if FAP can later handle all snapshots.
+    GET_METRIC(tiflash_fap_task_duration_seconds, type_write_stage_raft).Observe(watch.elapsedSecondsFromLastTime());
+    auto wn_ps = tmt.getContext().getWriteNodePageStorage();
+    RUNTIME_CHECK(wn_ps != nullptr);
+    wn_ps->write(std::move(wb));
     LOG_DEBUG(log, "Finish write FAP snapshot, log_count={}", log_count);
     auto tmp_ps = checkpoint_info->checkpoint_data_holder->getUniversalPageStorage();
     return genFastAddPeerRes(
@@ -589,14 +594,36 @@ uint8_t ApplyFapSnapshotImpl(
         return false;
     }
     auto begin = checkpoint_ingest_info->beginTime();
-    if (kvstore->getRegion(region_id))
+    bool is_repeated = false;
+    if (auto kvr = kvstore->getRegion(region_id); kvr != nullptr)
     {
-        throw Exception(
-            ErrorCodes::LOGICAL_ERROR,
-            "Don't support FAP for an existing region, region_id={} peer_id={} begin_time={}",
-            region_id,
-            peer_id,
-            begin);
+        if (kvr->appliedIndex() == index && kvr->appliedIndexTerm() == term)
+        {
+            LOG_INFO(
+                log,
+                "Duplicate FAP snapshot ingest, maybe replayed after restart, region_id={} peer_id={} begin_time={} "
+                "index={} term={}",
+                region_id,
+                peer_id,
+                begin,
+                index,
+                term);
+            is_repeated = true;
+        }
+        else
+        {
+            throw Exception(
+                ErrorCodes::LOGICAL_ERROR,
+                "Don't support FAP for an existing region, region_id={} peer_id={} begin_time={} kvstore=({},{}) "
+                "snapshot=({},{})",
+                region_id,
+                peer_id,
+                begin,
+                kvr->appliedIndex(),
+                kvr->appliedIndexTerm(),
+                index,
+                term);
+        }
     }
     // `region_to_ingest` is not the region in kvstore.
     auto region_to_ingest = checkpoint_ingest_info->getRegion();
@@ -607,14 +634,16 @@ uint8_t ApplyFapSnapshotImpl(
         {
             throw Exception(
                 ErrorCodes::LOGICAL_ERROR,
-                "Mismatched region and term, expected=({},{}) actual=({},{}) region_id={} peer_id={} begin_time={}",
+                "Mismatched region and term, expected=({},{}) actual=({},{}) region_id={} peer_id={} begin_time={} "
+                "is_repeated={}",
                 index,
                 term,
                 region_to_ingest->appliedIndex(),
                 region_to_ingest->appliedIndexTerm(),
                 region_id,
                 peer_id,
-                begin);
+                begin,
+                is_repeated);
         }
         else
         {
@@ -622,7 +651,13 @@ uint8_t ApplyFapSnapshotImpl(
             return false;
         }
     }
-    LOG_INFO(log, "Begin apply fap snapshot, region_id={} peer_id={} begin_time={}", region_id, peer_id, begin);
+    LOG_INFO(
+        log,
+        "Begin apply fap snapshot, region_id={} peer_id={} begin_time={} is_repeated={}",
+        region_id,
+        peer_id,
+        begin,
+        is_repeated);
     // If there is `checkpoint_ingest_info`, it is exactly the data we want to ingest. Consider two scene:
     // 1. If there was a failed FAP which failed to clean, its data will be overwritten by current FAP which has finished phase 1.
     // 2. It is not possible that a restart happens at FAP phase 2, and a regular snapshot is sent, because snapshots can only be accepted once the previous snapshot it handled.
@@ -630,7 +665,7 @@ uint8_t ApplyFapSnapshotImpl(
         GET_METRIC(tiflash_fap_task_state, type_ingesting_stage).Increment();
         SCOPE_EXIT({ GET_METRIC(tiflash_fap_task_state, type_ingesting_stage).Decrement(); });
         kvstore->handleIngestCheckpoint(checkpoint_ingest_info->getRegion(), checkpoint_ingest_info, tmt);
-        fap_ctx->cleanTask(tmt, proxy_helper, region_id, CheckpointIngestInfo::CleanReason::Success);
+        // Delayed the clean stage until the proxy has persisted the ingestion after apply the fap snapshot
         GET_METRIC(tiflash_fap_task_duration_seconds, type_ingest_stage).Observe(watch_ingest.elapsedSeconds());
         auto current = FAPAsyncTasks::getCurrentMillis();
         auto elapsed = (current - begin) / 1000.0;
@@ -638,7 +673,13 @@ uint8_t ApplyFapSnapshotImpl(
         {
             GET_METRIC(tiflash_fap_task_duration_seconds, type_total).Observe(elapsed);
         }
-        LOG_INFO(log, "Finish apply fap snapshot, region_id={} peer_id={} elapsed={}", region_id, peer_id, elapsed);
+        LOG_INFO(
+            log,
+            "Finish apply fap snapshot, region_id={} peer_id={} elapsed={} is_repeated={}",
+            region_id,
+            peer_id,
+            elapsed,
+            is_repeated);
         GET_METRIC(tiflash_fap_task_result, type_succeed).Increment();
         return true;
     }
@@ -651,6 +692,9 @@ FapSnapshotState QueryFapSnapshotState(
     uint64_t index,
     uint64_t term)
 {
+    // It's called before pre_apply_snapshot, if we have an good fap snapshot, we use it.
+    // It's also called before post_apply_snapshot, if we have an good fap snapshot, we use it.
+    // If we don't, we will check if the arriving snapshot is a fap snapshot, and if so, we panic.
     try
     {
         RUNTIME_CHECK_MSG(server->tmt, "TMTContext is null");
@@ -672,10 +716,14 @@ FapSnapshotState QueryFapSnapshotState(
     }
     catch (...)
     {
-        DB::tryLogCurrentFatalException(
-            "QueryFapSnapshotState",
-            fmt::format("Failed query fap snapshot state region_id={} peer_id={}", region_id, peer_id));
-        exit(-1);
+        // If any exception happened, we consider the FAP snapshot is not found.
+        LOG_ERROR(
+            DB::Logger::get("QueryFapSnapshotState"),
+            "Failed query fap snapshot state region_id={} peer_id={}",
+            region_id,
+            peer_id);
+        GET_METRIC(tiflash_fap_task_result, type_failed_query_state).Increment();
+        return FapSnapshotState::NotFound;
     }
 }
 
@@ -797,12 +845,16 @@ FastAddPeerRes FastAddPeer(EngineStoreServerWrap * server, uint64_t region_id, u
                 auto prev_state = fap_ctx->tasks_trace->queryState(region_id);
                 LOG_INFO(
                     log,
-                    "Cancel FAP due to timeout region_id={} new_peer_id={} prev_state={}",
+                    "Cancel FAP due to timeout region_id={} new_peer_id={} prev_state={} elapsedMillis={} threshold={}",
                     region_id,
                     new_peer_id,
-                    magic_enum::enum_name(prev_state));
+                    magic_enum::enum_name(prev_state),
+                    elapsed,
+                    settings.fap_task_timeout_seconds);
                 GET_METRIC(tiflash_fap_task_state, type_blocking_cancel_stage).Increment();
                 {
+                    // TODO We can use `asyncCancelTask` here, and return WaitForData if the task is cancelling.
+                    // Otherwise, we will let the next polling do the check again.
                     [[maybe_unused]] auto s = fap_ctx->tasks_trace->blockedCancelRunningTask(region_id);
                 }
                 GET_METRIC(tiflash_fap_task_state, type_blocking_cancel_stage).Decrement();
@@ -836,7 +888,7 @@ FastAddPeerRes FastAddPeer(EngineStoreServerWrap * server, uint64_t region_id, u
     }
 }
 
-void ClearFapSnapshot(EngineStoreServerWrap * server, uint64_t region_id)
+void ClearFapSnapshot(EngineStoreServerWrap * server, uint64_t region_id, uint64_t state)
 {
     try
     {
@@ -844,12 +896,27 @@ void ClearFapSnapshot(EngineStoreServerWrap * server, uint64_t region_id)
         RUNTIME_CHECK_MSG(server->proxy_helper, "proxy_helper is null");
         if (!server->tmt->getContext().getSharedContextDisagg()->isDisaggregatedStorageMode())
             return;
-        CheckpointIngestInfo::forciblyClean(
-            *(server->tmt),
-            server->proxy_helper,
-            region_id,
-            false,
-            CheckpointIngestInfo::CleanReason::ProxyFallback);
+        if (state == 0)
+        {
+            // Failed
+            CheckpointIngestInfo::forciblyClean(
+                *(server->tmt),
+                server->proxy_helper,
+                region_id,
+                false,
+                CheckpointIngestInfo::CleanReason::ProxyFallback);
+        }
+        else
+        {
+            // Succeed
+            auto fap_ctx = server->tmt->getContext().getSharedContextDisagg()->fap_context;
+            if (fap_ctx)
+                fap_ctx->cleanTask(
+                    *(server->tmt),
+                    server->proxy_helper,
+                    region_id,
+                    CheckpointIngestInfo::CleanReason::Success);
+        }
     }
     catch (...)
     {

--- a/dbms/src/Storages/StorageDeltaMerge.cpp
+++ b/dbms/src/Storages/StorageDeltaMerge.cpp
@@ -1104,6 +1104,13 @@ UInt64 StorageDeltaMerge::ingestSegmentsFromCheckpointInfo(
     return getAndMaybeInitStore()->ingestSegmentsFromCheckpointInfo(global_context, settings, range, checkpoint_info);
 }
 
+UInt64 StorageDeltaMerge::removeSegmentsFromCheckpointInfo(
+    const CheckpointIngestInfo & checkpoint_info,
+    const Settings & settings)
+{
+    return getAndMaybeInitStore()->removeSegmentsFromCheckpointInfo(global_context, settings, checkpoint_info);
+}
+
 UInt64 StorageDeltaMerge::onSyncGc(Int64 limit, const GCOptions & gc_options)
 {
     if (storeInited())

--- a/dbms/src/Storages/StorageDeltaMerge.h
+++ b/dbms/src/Storages/StorageDeltaMerge.h
@@ -140,6 +140,8 @@ public:
         const CheckpointIngestInfoPtr & checkpoint_info,
         const Settings & settings);
 
+    UInt64 removeSegmentsFromCheckpointInfo(const CheckpointIngestInfo & checkpoint_info, const Settings & settings);
+
     UInt64 onSyncGc(Int64, const DM::GCOptions &) override;
 
     void rename(


### PR DESCRIPTION
backport of https://github.com/tidbcloud/tiflash-cse/pull/379

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/8673

Problem Summary:

```
2025-03-04 16:30:59 
[2025/03/04 08:30:59.004 +00:00] [FATAL] [Exception.cpp:106] ["Failed query fap snapshot state region_id=333200905 peer_id=338728629: Code: 0, e.displayText() = DB::Exception: fail to get normal id [page_id=0x78019D3374640000000000000074.211393] [seq=1070914] [resolve_id=0x78019D3374640000000000000074.211393] [resolve_ver=1070914.0], e.what() = DB::Exception, Stack trace:
  0xaaaac71808cc    StackTrace::StackTrace() [tiflash+34736332]
                    dbms/src/Common/StackTrace.cpp:23
  0xaaaac717de20    DB::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, int) [tiflash+34725408]
                    dbms/src/Common/Exception.h:46
  0xaaaacd491708    DB::PS::V3::PageDirectory<DB::PS::V3::universal::PageDirectoryTrait>::getNormalPageId(DB::UniversalPageId const&, std::__1::shared_ptr<DB::PageStorageSnapshot> const&, bool) const [tiflash+138614536]
                    dbms/src/Storages/Page/V3/PageDirectory.cpp:1358
  0xaaaacd4f11c0    DB::UniversalPageStorage::getNormalPageId(DB::UniversalPageId const&, std::__1::shared_ptr<DB::PageStorageSnapshot>, bool) const [tiflash+139006400]
                    dbms/src/Storages/Page/V3/Universal/UniversalPageStorage.cpp:366
  0xaaaacc33241c    DB::DM::restoreDMFileFromRemoteDataSource(DB::DM::DMContext const&, std::__1::shared_ptr<DB::DM::Remote::IDataStore>, unsigned long, unsigned long) [tiflash+120398876]
                    dbms/src/Storages/DeltaMerge/RestoreDMFile.cpp:37
  0xaaaacc32a184    DB::DM::StableValueSpace::restore(DB::DM::DMContext&, DB::ReadBuffer&, unsigned long) [tiflash+120365444]
                    dbms/src/Storages/DeltaMerge/StableValueSpace.cpp:197
  0xaaaacda25da8    DB::CheckpointIngestInfo::restore(DB::TMTContext&, DB::TiFlashRaftProxyHelper const*, unsigned long, unsigned long) [tiflash+144465320]
                    dbms/src/Storages/KVStore/MultiRaft/Disagg/CheckpointIngestInfo.cpp:94
  0xaaaacda341ac    DB::FastAddPeerContext::getOrRestoreCheckpointIngestInfo(DB::TMTContext&, DB::TiFlashRaftProxyHelper const*, unsigned long, unsigned long) [tiflash+144523692]
                    dbms/src/Storages/KVStore/MultiRaft/Disagg/FastAddPeerContext.cpp:135
  0xaaaacda1a2a8    QueryFapSnapshotState [tiflash+144417448]
                    dbms/src/Storages/KVStore/MultiRaft/Disagg/FastAddPeer.cpp:663
  0xffff8d1a8c2c    _$LT$engine_store_ffi..observer..TiFlashObserver$LT$T$C$ER$GT$$u20$as$u20$raftstore..coprocessor..ApplySnapshotObserver$GT$::post_apply_snapshot::he515761a36550e67 [libtiflash_proxy.so+24546348]
  0xffff8dde416c    raftstore::store::worker::region::Runner$LT$EK$C$R$C$T$GT$::handle_pending_applies::h60d208f854155e11 [libtiflash_proxy.so+37372268]
  0xffff8d77dd44    yatp::task::future::RawTask$LT$F$GT$::poll::hde1a5a5e881c34ed [libtiflash_proxy.so+30661956]
  0xffff8ea4a19c    _$LT$yatp..task..future..Runner$u20$as$u20$yatp..pool..runner..Runner$GT$::handle::hbfc26d1c9297a029 [libtiflash_proxy.so+50373020]
  0xffff8d2741fc    std::sys_common::backtrace::__rust_begin_short_backtrace::hc4741ff9ffd06ef3 [libtiflash_proxy.so+25379324]
  0xffff8d2bf578    core::ops::function::FnOnce::call_once$u7b$$u7b$vtable.shim$u7d$$u7d$::hd409dcf31749a72f [libtiflash_proxy.so+25687416]
  0xffff8e4f5bc0    std::sys::unix::thread::Thread::new::thread_start::h217098f6331af4d1 [libtiflash_proxy.so+44784576]
  0xffff8b76d5c8    start_thread [libc.so.6+513480]
                    ./nptl/./nptl/pthread_create.c:442
  0xffff8b7d5edc    thread_start [libc.so.6+941788]
                    ./misc/../sysdeps/unix/sysv/linux/aarch64/clone.S:79"] [source=QueryFapSnapshotState] [thread_id=2507]
```


The problem involves two engines, the KVStore engine in TiFlash, and the raftstore engine in TiFlash Proxy.
- When a snapshot is ingested, the snapshot is firstly ingest into KVStore by `post_apply_snapshot`
- Then it will be acked in raftstore region worker by overwritting peer state from `Applying` into `Normal`, and changing status into FINISHED.

If the second phase is not finished, the snapshot is replayed after a restart. Because raftstore can still read from peer state that the region is applying a snapshot, and then the snapshot is going to be found.

However, when applying FAP snapshot, the FAP snapshot is deleted after the first phase, so if there is a restart immediately after phase 1 and before phase 2, the fap snapshot can not be found and TiFlash will panic. The panic is not recoverable because an applied snapshot can't be canceled unless the region is removed.



### What is changed and how it works?

```commit-message

```


In order to fix the problem, we introduced a `on_apply_snapshot_committed` https://github.com/tidbcloud/cloud-storage-engine/commit/c0957c488a9557a883bbbfcb4705f789207c5f9a observer which will delete the fap snapshot once the phase 2 is finished.

Note that a stale fap snapshot is always permitted, so it is OK that a panic happens after phase2 and before `on_apply_snapshot_committed`. Such stale fap snapshot will be deleted when the region is destroyed, or when it received another snapshot.

Also in this PR:
- Move "put raft log" stage before `insertCheckpointIngestInfo`. This is because reading too many raft logs are time consuming. Previously, FAP may cancel after `insertCheckpointIngestInfo`, if the raft logs are too many. The cancel stage will erase the written FAP snapshot. Although it is OK to remove a FAP snapshot in writing stage, it is better if we just don't write it than write+delete. It it worthy noticing that the raft logs are written into a write batch before `insertCheckpointIngestInfo`, the write batch is committed after `insertCheckpointIngestInfo`. It's OK, because raft logs are not necessary part of FAP snapshot. We keep those raft logs so the new peer will spend less time fetching logs from leader.


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
