### PR TITLE
fix wrong check for agg when block.rows() is zero

### DIFF
--- a/dbms/src/Common/ColumnsHashing.h
+++ b/dbms/src/Common/ColumnsHashing.h
@@ -511,7 +511,6 @@ protected:
         // so there is no need to consider the performance impact of repeatedly calling countSerializeByteSizeForCmp.
         processed_row_idx = start_row;
         byte_size.resize_fill_zero(key_columns[0]->size());
-        RUNTIME_CHECK(!byte_size.empty());
         for (size_t i = 0; i < key_columns.size(); ++i)
             key_columns[i]->countSerializeByteSizeForCmp(
                 byte_size,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10079

Problem Summary:

before: `TestZeroBlock` will fail, check https://github.com/pingcap/tiflash/issues/10079#issuecomment-2948917192
after: success

### What is changed and how it works?

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
