### PR TITLE
Fix the issue that window function returns incorrect result when range type frame end is preceding

### DIFF
--- a/dbms/src/DataStreams/WindowTransformAction.cpp
+++ b/dbms/src/DataStreams/WindowTransformAction.cpp
@@ -660,7 +660,7 @@ std::tuple<RowNumber, bool> WindowTransformAction::stepToStartForRangeFrame()
 
 std::tuple<RowNumber, bool> WindowTransformAction::stepToEndForRangeFrame()
 {
-    if ((!end_preceding || (end_preceding && frame.end_offset == 0)) && !partition_ended)
+    if (!partition_ended)
         // If we find the frame end and the partition_ended is false.
         // Some previous blocks may be dropped, this is an unexpected behaviour.
         // So, we shouldn't do anything before the partition_ended is true.

--- a/dbms/src/DataStreams/WindowTransformAction.cpp
+++ b/dbms/src/DataStreams/WindowTransformAction.cpp
@@ -646,7 +646,7 @@ void WindowTransformAction::stepToFrameEnd()
 
 std::tuple<RowNumber, bool> WindowTransformAction::stepToStartForRangeFrame()
 {
-    if (!window_description.frame.begin_preceding && !partition_ended)
+    if (!partition_ended)
         // If we find the frame end and the partition_ended is false.
         // The prev_frame_start may be equal to partition_end which
         // will cause the assert fail in advancePartitionEnd function.

--- a/dbms/src/DataStreams/WindowTransformAction.cpp
+++ b/dbms/src/DataStreams/WindowTransformAction.cpp
@@ -660,8 +660,7 @@ std::tuple<RowNumber, bool> WindowTransformAction::stepToStartForRangeFrame()
 
 std::tuple<RowNumber, bool> WindowTransformAction::stepToEndForRangeFrame()
 {
-    auto end_preceding = window_description.frame.end_preceding;
-    if ((!end_preceding || (end_preceding && window_description.frame.end_offset == 0)) && !partition_ended)
+    if ((!end_preceding || (end_preceding && frame.end_offset == 0)) && !partition_ended)
         // If we find the frame end and the partition_ended is false.
         // Some previous blocks may be dropped, this is an unexpected behaviour.
         // So, we shouldn't do anything before the partition_ended is true.

--- a/dbms/src/DataStreams/WindowTransformAction.cpp
+++ b/dbms/src/DataStreams/WindowTransformAction.cpp
@@ -664,6 +664,11 @@ std::tuple<RowNumber, bool> WindowTransformAction::stepToEndForRangeFrame()
         // If we find the frame end and the partition_ended is false.
         // Some previous blocks may be dropped, this is an unexpected behaviour.
         // So, we shouldn't do anything before the partition_ended is true.
+        //
+        // Still return false even when end_preceding is true, because there may still
+        // same rows as current_row in the next block. So we cannot stop find the frame
+        // end until got the partition end(or got the first row that is greater than
+        // current_row).
         return std::make_tuple(RowNumber(), false);
 
     if (window_description.is_desc)

--- a/dbms/src/DataStreams/WindowTransformAction.cpp
+++ b/dbms/src/DataStreams/WindowTransformAction.cpp
@@ -660,7 +660,8 @@ std::tuple<RowNumber, bool> WindowTransformAction::stepToStartForRangeFrame()
 
 std::tuple<RowNumber, bool> WindowTransformAction::stepToEndForRangeFrame()
 {
-    if ((!end_preceding || (end_preceding && frame.end_offset == 0)) && !partition_ended)
+    auto end_preceding = window_description.frame.end_preceding;
+    if ((!end_preceding || (end_preceding && window_description.frame.end_offset == 0)) && !partition_ended)
         // If we find the frame end and the partition_ended is false.
         // Some previous blocks may be dropped, this is an unexpected behaviour.
         // So, we shouldn't do anything before the partition_ended is true.

--- a/dbms/src/DataStreams/WindowTransformAction.cpp
+++ b/dbms/src/DataStreams/WindowTransformAction.cpp
@@ -646,7 +646,7 @@ void WindowTransformAction::stepToFrameEnd()
 
 std::tuple<RowNumber, bool> WindowTransformAction::stepToStartForRangeFrame()
 {
-    if (!partition_ended)
+    if (!window_description.frame.begin_preceding && !partition_ended)
         // If we find the frame end and the partition_ended is false.
         // The prev_frame_start may be equal to partition_end which
         // will cause the assert fail in advancePartitionEnd function.
@@ -660,7 +660,7 @@ std::tuple<RowNumber, bool> WindowTransformAction::stepToStartForRangeFrame()
 
 std::tuple<RowNumber, bool> WindowTransformAction::stepToEndForRangeFrame()
 {
-    if (!window_description.frame.end_preceding && !partition_ended)
+    if (!partition_ended)
         // If we find the frame end and the partition_ended is false.
         // Some previous blocks may be dropped, this is an unexpected behaviour.
         // So, we shouldn't do anything before the partition_ended is true.

--- a/dbms/src/DataStreams/WindowTransformAction.cpp
+++ b/dbms/src/DataStreams/WindowTransformAction.cpp
@@ -660,7 +660,7 @@ std::tuple<RowNumber, bool> WindowTransformAction::stepToStartForRangeFrame()
 
 std::tuple<RowNumber, bool> WindowTransformAction::stepToEndForRangeFrame()
 {
-    if (!partition_ended)
+    if ((!end_preceding || (end_preceding && frame.end_offset == 0)) && !partition_ended)
         // If we find the frame end and the partition_ended is false.
         // Some previous blocks may be dropped, this is an unexpected behaviour.
         // So, we shouldn't do anything before the partition_ended is true.

--- a/dbms/src/DataStreams/WindowTransformAction.cpp
+++ b/dbms/src/DataStreams/WindowTransformAction.cpp
@@ -660,7 +660,8 @@ std::tuple<RowNumber, bool> WindowTransformAction::stepToStartForRangeFrame()
 
 std::tuple<RowNumber, bool> WindowTransformAction::stepToEndForRangeFrame()
 {
-    if (!partition_ended)
+    auto end_preceding = window_description.frame.end_preceding;
+    if ((!end_preceding || (end_preceding && window_description.frame.end_offset == 0)) && !partition_ended)
         // If we find the frame end and the partition_ended is false.
         // Some previous blocks may be dropped, this is an unexpected behaviour.
         // So, we shouldn't do anything before the partition_ended is true.

--- a/dbms/src/DataStreams/WindowTransformAction.cpp
+++ b/dbms/src/DataStreams/WindowTransformAction.cpp
@@ -662,11 +662,7 @@ std::tuple<RowNumber, bool> WindowTransformAction::stepToEndForRangeFrame()
 {
     auto end_preceding = window_description.frame.end_preceding;
     if ((!end_preceding || (end_preceding && window_description.frame.end_offset == 0)) && !partition_ended)
-        // If we find the frame end and the partition_ended is false.
-        // Some previous blocks may be dropped, this is an unexpected behaviour.
-        // So, we shouldn't do anything before the partition_ended is true.
-        //
-        // Still return false even when end_preceding is true, because there may still
+        // Still return false even when end_preceding is true and end_offset == 0, because there may still
         // same rows as current_row in the next block. So we cannot stop find the frame
         // end until got the partition end(or got the first row that is greater than
         // current_row).

--- a/dbms/src/WindowFunctions/tests/gtest_agg.cpp
+++ b/dbms/src/WindowFunctions/tests/gtest_agg.cpp
@@ -749,28 +749,21 @@ try
         ORDER_COL_NAME,
         false,
         static_cast<Int64>(0));
-
-    std::vector<tipb::WindowBoundType> window_bound_types{
+    frame.end = buildRangeFrameBound(
         tipb::WindowBoundType::Preceding,
-        tipb::WindowBoundType::Following};
+        tipb::RangeCmpDataType::Int,
+        ORDER_COL_NAME,
+        false,
+        static_cast<Int64>(0));
 
-    for (auto window_bound_type : window_bound_types)
-    {
-        frame.end = buildRangeFrameBound(
-            window_bound_type,
-            tipb::RangeCmpDataType::Int,
-            ORDER_COL_NAME,
-            false,
-            static_cast<Int64>(0));
 
-        executeFunctionAndAssert(
-            toNullableVec<Int64>(std::vector<std::optional<Int64>>{10, 10, 10, 10, 10, 10, 10, 10, 10, 10}),
-            Count(value_col),
-            {toVec<Int64>({0, 0, 0, 0, 0, 0, 0, 0, 0, 0}),
-             toVec<Int64>({0, 0, 0, 0, 0, 0, 0, 0, 0, 0}),
-             toVec<Int64>({0, 0, 0, 0, 0, 0, 0, 0, 0, 0})},
-            frame);
-    }
+    executeFunctionAndAssert(
+        toNullableVec<Int64>(std::vector<std::optional<Int64>>{10, 10, 10, 10, 10, 10, 10, 10, 10, 10}),
+        Count(value_col),
+        {toVec<Int64>({0, 0, 0, 0, 0, 0, 0, 0, 0, 0}),
+         toVec<Int64>({0, 0, 0, 0, 0, 0, 0, 0, 0, 0}),
+         toVec<Int64>({0, 0, 0, 0, 0, 0, 0, 0, 0, 0})},
+        frame);
 }
 CATCH
 } // namespace DB::tests

--- a/dbms/src/WindowFunctions/tests/gtest_agg.cpp
+++ b/dbms/src/WindowFunctions/tests/gtest_agg.cpp
@@ -749,21 +749,28 @@ try
         ORDER_COL_NAME,
         false,
         static_cast<Int64>(0));
-    frame.end = buildRangeFrameBound(
+
+    std::vector<tipb::WindowBoundType> window_bound_types{
         tipb::WindowBoundType::Preceding,
-        tipb::RangeCmpDataType::Int,
-        ORDER_COL_NAME,
-        false,
-        static_cast<Int64>(0));
+        tipb::WindowBoundType::Following};
 
+    for (auto window_bound_type : window_bound_types)
+    {
+        frame.end = buildRangeFrameBound(
+            window_bound_type,
+            tipb::RangeCmpDataType::Int,
+            ORDER_COL_NAME,
+            false,
+            static_cast<Int64>(0));
 
-    executeFunctionAndAssert(
-        toNullableVec<Int64>(std::vector<std::optional<Int64>>{10, 10, 10, 10, 10, 10, 10, 10, 10, 10}),
-        Count(value_col),
-        {toVec<Int64>({0, 0, 0, 0, 0, 0, 0, 0, 0, 0}),
-         toVec<Int64>({0, 0, 0, 0, 0, 0, 0, 0, 0, 0}),
-         toVec<Int64>({0, 0, 0, 0, 0, 0, 0, 0, 0, 0})},
-        frame);
+        executeFunctionAndAssert(
+            toNullableVec<Int64>(std::vector<std::optional<Int64>>{10, 10, 10, 10, 10, 10, 10, 10, 10, 10}),
+            Count(value_col),
+            {toVec<Int64>({0, 0, 0, 0, 0, 0, 0, 0, 0, 0}),
+             toVec<Int64>({0, 0, 0, 0, 0, 0, 0, 0, 0, 0}),
+             toVec<Int64>({0, 0, 0, 0, 0, 0, 0, 0, 0, 0})},
+            frame);
+    }
 }
 CATCH
 } // namespace DB::tests

--- a/dbms/src/WindowFunctions/tests/gtest_agg.cpp
+++ b/dbms/src/WindowFunctions/tests/gtest_agg.cpp
@@ -738,4 +738,32 @@ try
 }
 CATCH
 
+TEST_F(WindowAggFuncTest, issue10236)
+try
+{
+    MockWindowFrame frame;
+    frame.type = tipb::WindowFrameType::Ranges;
+    frame.start = buildRangeFrameBound(
+        tipb::WindowBoundType::Preceding,
+        tipb::RangeCmpDataType::Int,
+        ORDER_COL_NAME,
+        false,
+        static_cast<Int64>(0));
+    frame.end = buildRangeFrameBound(
+        tipb::WindowBoundType::Preceding,
+        tipb::RangeCmpDataType::Int,
+        ORDER_COL_NAME,
+        false,
+        static_cast<Int64>(0));
+
+
+    executeFunctionAndAssert(
+        toNullableVec<Int64>(std::vector<std::optional<Int64>>{10, 10, 10, 10, 10, 10, 10, 10, 10, 10}),
+        Count(value_col),
+        {toVec<Int64>({0, 0, 0, 0, 0, 0, 0, 0, 0, 0}),
+         toVec<Int64>({0, 0, 0, 0, 0, 0, 0, 0, 0, 0}),
+         toVec<Int64>({0, 0, 0, 0, 0, 0, 0, 0, 0, 0})},
+        frame);
+}
+CATCH
 } // namespace DB::tests


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10236

Problem Summary:

### What is changed and how it works?

```commit-message
Remove a wrong judgement
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix the issue that window function returns incorrect result when range type frame end is preceding
```
