### PR TITLE
*: Fix the performance degradation caused by using DataTypeFactory::get

### DIFF
--- a/dbms/src/Flash/Coprocessor/CHBlockChunkCodecV1.cpp
+++ b/dbms/src/Flash/Coprocessor/CHBlockChunkCodecV1.cpp
@@ -86,7 +86,7 @@ Block DecodeHeader(ReadBuffer & istr, const Block & header, size_t & total_rows)
                     i,
                     header.getByPosition(i).type->getName(),
                     type_name);
-            column.type = DataTypeFactory::instance().get(type_name); // Respect the type name from encoder
+            column.type = DataTypeFactory::instance().getOrSet(type_name); // Respect the type name from encoder
         }
         res.insert(std::move(column));
     }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10254

Problem Summary:

In CHBlockChunkCodecV1.cpp, DecoderHeader's improper use of DataTypeFactory::get() for type name resolution caused performance degradation:
https://github.com/pingcap/tiflash/blob/f518f4662dbf348cc891fab69acc21ca384cd7d8/dbms/src/Flash/Coprocessor/CHBlockChunkCodecV1.cpp#L89

It should use DataTypeFactory::getOrSet() like CHBlockChunkCodec.cpp:
https://github.com/pingcap/tiflash/blob/f518f4662dbf348cc891fab69acc21ca384cd7d8/dbms/src/Flash/Coprocessor/CHBlockChunkCodec.cpp#L235

### What is changed and how it works?

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
