### PR TITLE
Fix ExpressionAction Project miss block start offset

### DIFF
--- a/dbms/src/Core/Block.cpp
+++ b/dbms/src/Core/Block.cpp
@@ -746,6 +746,12 @@ void Block::swap(Block & other) noexcept
     std::swap(rs_result, other.rs_result);
 }
 
+void Block::swapCloumnData(Block & other) noexcept
+{
+    std::swap(info, other.info);
+    data.swap(other.data);
+    index_by_name.swap(other.index_by_name);
+}
 
 void Block::updateHash(SipHash & hash) const
 {

--- a/dbms/src/Core/Block.h
+++ b/dbms/src/Core/Block.h
@@ -153,7 +153,10 @@ public:
     Block sortColumns() const;
 
     void clear();
+    // swap all data.
     void swap(Block & other) noexcept;
+    // only swap column data.
+    void swapCloumnData(Block & other) noexcept;
 
     /** Updates SipHash of the Block, using update method of columns.
       * Returns hash for block, that could be used to differentiate blocks

--- a/dbms/src/Core/Block.h
+++ b/dbms/src/Core/Block.h
@@ -153,9 +153,11 @@ public:
     Block sortColumns() const;
 
     void clear();
-    // swap all data.
+    // The following functions will swap two block.
+    // `swap` will swap all data in blocks.
+    // And `swapCloumnData` will only swap column data,
+    // `start_offset` and `rs_result` will keep unchanged.
     void swap(Block & other) noexcept;
-    // only swap column data.
     void swapCloumnData(Block & other) noexcept;
 
     /** Updates SipHash of the Block, using update method of columns.

--- a/dbms/src/DataStreams/ExpandTransformAction.cpp
+++ b/dbms/src/DataStreams/ExpandTransformAction.cpp
@@ -34,8 +34,7 @@ bool ExpandTransformAction::tryOutput(Block & block)
 {
     if (!block_cache || i_th_project >= expand->getLevelProjectionNum())
         return false;
-    auto res_block = expand->next(block_cache, i_th_project++);
-    block.swapCloumnData(res_block);
+    block = expand->next(block_cache, i_th_project++);
     return true;
 }
 
@@ -50,7 +49,6 @@ void ExpandTransformAction::transform(Block & block)
     expand->getBeforeExpandActions()->execute(block);
     block_cache = block;
     i_th_project = 0;
-    auto res_block = expand->next(block_cache, i_th_project++);
-    block.swapCloumnData(res_block);
+    block = expand->next(block_cache, i_th_project++);
 }
 } // namespace DB

--- a/dbms/src/DataStreams/ExpandTransformAction.cpp
+++ b/dbms/src/DataStreams/ExpandTransformAction.cpp
@@ -16,7 +16,6 @@
 #include <Columns/countBytesInFilter.h>
 #include <DataStreams/ExpandTransformAction.h>
 
-#include <algorithm>
 
 namespace DB
 {
@@ -36,7 +35,7 @@ bool ExpandTransformAction::tryOutput(Block & block)
     if (!block_cache || i_th_project >= expand->getLevelProjectionNum())
         return false;
     auto res_block = expand->next(block_cache, i_th_project++);
-    block.swap(res_block);
+    block.swapCloumnData(res_block);
     return true;
 }
 
@@ -52,6 +51,6 @@ void ExpandTransformAction::transform(Block & block)
     block_cache = block;
     i_th_project = 0;
     auto res_block = expand->next(block_cache, i_th_project++);
-    block.swap(res_block);
+    block.swapCloumnData(res_block);
 }
 } // namespace DB

--- a/dbms/src/Interpreters/ExpressionActions.cpp
+++ b/dbms/src/Interpreters/ExpressionActions.cpp
@@ -299,7 +299,7 @@ void ExpressionAction::prepare(Block & sample_block)
             new_block.insert(std::move(column));
         }
 
-        sample_block.swap(new_block);
+        sample_block.swapCloumnData(new_block);
         break;
     }
 
@@ -402,9 +402,7 @@ void ExpressionAction::execute(Block & block) const
                 column.name = alias;
             new_block.insert(std::move(column));
         }
-        new_block.setRSResult(block.getRSResult());
-        new_block.setStartOffset(block.startOffset());
-        block.swap(new_block);
+        block.swapCloumnData(new_block);
 
         break;
     }

--- a/dbms/src/Interpreters/ExpressionActions.cpp
+++ b/dbms/src/Interpreters/ExpressionActions.cpp
@@ -403,6 +403,7 @@ void ExpressionAction::execute(Block & block) const
             new_block.insert(std::move(column));
         }
         new_block.setRSResult(block.getRSResult());
+        new_block.setStartOffset(block.startOffset());
         block.swap(new_block);
 
         break;

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeHelpers.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeHelpers.h
@@ -204,6 +204,7 @@ inline Block getNewBlockByHeader(const Block & header, const Block & block)
     for (const auto & c : header)
         new_block.insert(block.getByName(c.name));
     new_block.setSegmentRowIdCol(block.segmentRowIdCol());
+    new_block.setStartOffset(block.startOffset());
     return new_block;
 }
 

--- a/dbms/src/Storages/DeltaMerge/File/DMFileReader.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileReader.h
@@ -100,9 +100,6 @@ public:
     friend class tests::DMFileMetaV2Test;
 
 private:
-    // Initialize, called by constructor
-    void initPackOffset();
-
     // Split the first read block info to multiple read block infos accroding to `filter`
     // Used by readWithFilter, return new read block infos.
     std::vector<ReadBlockInfo> splitReadBlockInfos(const ReadBlockInfo & read_info, const IColumn::Filter & filter)
@@ -196,7 +193,7 @@ private:
 
     std::deque<ReadBlockInfo> read_block_infos;
     // row_offset of the given pack_id
-    std::vector<size_t> pack_offset;
+    const std::vector<size_t> pack_offset;
     // last read pack_id + 1, used by getSkippedRows
     size_t next_pack_id = 0;
 

--- a/tests/fullstack-test/expr/duration_filter_late_materialization.test
+++ b/tests/fullstack-test/expr/duration_filter_late_materialization.test
@@ -30,18 +30,26 @@ mysql> insert into test.t select * from test.t;
 mysql> insert into test.t select * from test.t;
 mysql> insert into test.t select * from test.t;
 mysql> insert into test.t select * from test.t;
+mysql> insert into test.t values ('08:20:00.00', 4), ('11:11:35.00', 5);
 
 mysql> alter table test.t set tiflash replica 1;
 
 func> wait_table test t
 
-mysql> select * from test.t where a = '500:11:11.123500';
 # success, but the result is empty
-mysql> select hour(a), i from test.t where a = '500:11:11.123500';
-mysql> select minute(a), i from test.t where a = '500:11:11.123500';
-mysql> select second(a), i from test.t where a = '500:11:11.123500';
-mysql> select a, i from test.t where hour(a) = 500;
-mysql> select a, i from test.t where minute(a) = 13;
-mysql> select a, i from test.t where second(a) = 14;
+mysql> set @@tidb_isolation_read_engines='tiflash'; select * from test.t where a = '500:11:11.123500';
+mysql> set @@tidb_isolation_read_engines='tiflash'; select hour(a), i from test.t where a = '500:11:11.123500';
+mysql> set @@tidb_isolation_read_engines='tiflash'; select minute(a), i from test.t where a = '500:11:11.123500';
+mysql> set @@tidb_isolation_read_engines='tiflash'; select second(a), i from test.t where a = '500:11:11.123500';
+mysql> set @@tidb_isolation_read_engines='tiflash'; select a, i from test.t where hour(a) = 500;
+mysql> set @@tidb_isolation_read_engines='tiflash'; select a, i from test.t where minute(a) = 13;
+mysql> set @@tidb_isolation_read_engines='tiflash'; select a, i from test.t where second(a) = 14;
+
+mysql> set @@tidb_isolation_read_engines='tiflash'; select bit_and(a) from test.t where i > 0 and a between '08:20:09.00' and '11:11:36.00' group by i;
++------------+
+| bit_and(a) |
++------------+
+|     111135 |
++------------+
 
 mysql> drop table test.t;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10264

Problem Summary:

### What is changed and how it works?

https://github.com/pingcap/tiflash/pull/9956 swap `start_offset` in `Block::swap`.

```
void Block::swap(Block & other) noexcept
{
    std::swap(info, other.info);
    data.swap(other.data);
    index_by_name.swap(other.index_by_name);
+    std::swap(start_offset, other.start_offset);
    std::swap(segment_row_id_col, other.segment_row_id_col);
    std::swap(rs_result, other.rs_result);
}
```

`new_block.startOffset()` has default value 0, after swap, `block.startOffset()` will be change to 0. Therefore, the block returned by `ExpressionBlockInputStream` if there is a `Project` action will always have `block.startOffset() == 0`.

Note: Only changes in dbms/src/Interpreters/ExpressionActions.cpp can fix this bug. Other changes are refactor.

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
