### PR TITLE
ddl: Fix invalid memory access in InterpreterCreateQuery

### DIFF
--- a/dbms/src/Interpreters/InterpreterCreateQuery.h
+++ b/dbms/src/Interpreters/InterpreterCreateQuery.h
@@ -64,7 +64,7 @@ private:
 
     ASTPtr query_ptr;
     Context & context;
-    std::string_view log_suffix;
+    std::string log_suffix;
 
     /// Using while loading database.
     ThreadPool * thread_pool = nullptr;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/10291

Problem Summary:

### What is changed and how it works?

```commit-message
Use string instead of string_view in InterpreterCreateQuery
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
