### PR TITLE
Revert "Support graceful shutdown in TiFlash"

### DIFF
--- a/dbms/src/Flash/Coprocessor/DAGDriver.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGDriver.cpp
@@ -29,7 +29,6 @@
 #include <Interpreters/ProcessList.h>
 #include <Storages/KVStore/Read/LockException.h>
 #include <Storages/KVStore/Read/RegionException.h>
-#include <Storages/KVStore/TMTContext.h>
 #include <pingcap/Exception.h>
 
 namespace DB

--- a/dbms/src/Flash/Mpp/MPPTaskManager.cpp
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.cpp
@@ -83,31 +83,6 @@ MPPGatherTaskSetPtr MPPQuery::addMPPGatherTaskSet(const MPPGatherId & gather_id)
     return ptr;
 }
 
-void MPPTaskMonitor::waitAllMPPTasksFinish(const std::unique_ptr<Context> & global_context)
-{
-    auto start = std::chrono::steady_clock::now();
-    // The maximum seconds TiFlash will wait for all current MPP tasks to finish before shutting down
-    static constexpr const char * GRACEFUL_WIAT_BEFORE_SHUTDOWN = "flash.graceful_wait_before_shutdown";
-    auto graceful_wait_before_shutdown = global_context->getUsersConfig()->getUInt64(GRACEFUL_WIAT_BEFORE_SHUTDOWN, 60);
-    auto max_wait_time = start + std::chrono::seconds(graceful_wait_before_shutdown);
-    while (true)
-    {
-        // The first sleep before checking to reduce the chance of missing MPP tasks that are still in the process of being dispatched
-        std::this_thread::sleep_for(std::chrono::milliseconds(200));
-        {
-            std::unique_lock lock(mu);
-            if (monitored_tasks.empty())
-                break;
-        }
-        auto current_time = std::chrono::steady_clock::now();
-        if (current_time >= max_wait_time)
-        {
-            LOG_WARNING(log, "Timed out waiting for MPP tasks to finish after {}s", graceful_wait_before_shutdown);
-            break;
-        }
-    }
-}
-
 MPPTaskManager::MPPTaskManager(MPPTaskSchedulerPtr scheduler_)
     : scheduler(std::move(scheduler_))
     , aborted_query_gather_cache(ABORTED_MPPGATHER_CACHE_SIZE)

--- a/dbms/src/Flash/Mpp/MPPTaskManager.h
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.h
@@ -194,8 +194,6 @@ public:
         return monitored_tasks.find(task_unique_id) != monitored_tasks.end();
     }
 
-    void waitAllMPPTasksFinish(const std::unique_ptr<Context> & global_context);
-
     std::mutex mu;
     std::condition_variable cv;
     bool is_shutdown = false;

--- a/dbms/src/Server/FlashGrpcServerHolder.cpp
+++ b/dbms/src/Server/FlashGrpcServerHolder.cpp
@@ -224,20 +224,17 @@ FlashGrpcServerHolder::~FlashGrpcServerHolder()
         *is_shutdown = true;
         // Wait all existed MPPTunnels done to prevent crash.
         // If all existed MPPTunnels are done, almost in all cases it means all existed MPPTasks and ExchangeReceivers are also done.
-        constexpr int wait_step = 200;
-        // Maximum wait for 1 minute
-        constexpr int max_wait_cnt = 60 * 1000 / wait_step;
+        const int max_wait_cnt = 300;
         int wait_cnt = 0;
         while (GET_METRIC(tiflash_object_count, type_count_of_mpptunnel).Value() >= 1 && (wait_cnt++ < max_wait_cnt))
-            std::this_thread::sleep_for(std::chrono::milliseconds(wait_step));
+            std::this_thread::sleep_for(std::chrono::seconds(1));
         if (GET_METRIC(tiflash_object_count, type_count_of_mpptunnel).Value() >= 1)
             LOG_WARNING(
                 log,
-                "Wait {} milliseconds for mpp tunnels shutdown, still some mpp tunnels are alive, potential resource "
-                "leak",
-                wait_cnt * wait_step);
+                "Wait {} seconds for mpp tunnels shutdown, still some mpp tunnels are alive, potential resource leak",
+                wait_cnt);
         else
-            LOG_INFO(log, "Wait {} milliseconds for mpp tunnels shutdown, all finished", wait_cnt * wait_step);
+            LOG_INFO(log, "Wait {} seconds for mpp tunnels shutdown, all finished", wait_cnt);
 
         for (auto & cq : cqs)
             cq->Shutdown();

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -1166,6 +1166,8 @@ try
             }
         }
 
+        SCOPE_EXIT({ proxy_machine.stopProxy(tmt_context); });
+
         {
             // Report the unix timestamp, git hash, release version
             Poco::Timestamp ts;
@@ -1223,8 +1225,7 @@ try
         }
 
         /// startup grpc server to serve raft and/or flash services.
-        auto flash_grpc_server_holder
-            = std::make_unique<FlashGrpcServerHolder>(this->context(), this->config(), raft_config, log);
+        FlashGrpcServerHolder flash_grpc_server_holder(this->context(), this->config(), raft_config, log);
 
         SCOPE_EXIT({
             // Stop LAC for AutoScaler managed CN before FlashGrpcServerHolder is destructed.
@@ -1236,6 +1237,8 @@ try
                 LocalAdmissionController::global_instance->safeStop();
         });
 
+        proxy_machine.runKVStore(tmt_context);
+
         try
         {
             // Bind CPU affinity after all threads started.
@@ -1246,24 +1249,8 @@ try
             LOG_ERROR(log, "CPUAffinityManager::bindThreadCPUAffinity throws exception.");
         }
 
-        // Ready to provide service
-        tmt_context.setStatusRunning();
-
         LOG_INFO(log, "Start to wait for terminal signal");
         waitForTerminationRequest();
-
-        LOG_INFO(log, "Set store context status Stopping");
-        tmt_context.setStatusStopping();
-
-        tmt_context.getMPPTaskManager()->getMPPTaskMonitor()->waitAllMPPTasksFinish(global_context);
-        proxy_machine.waitAllReadIndexTasksFinish(tmt_context);
-
-        LOG_INFO(log, "Set store context status Terminated");
-        tmt_context.setStatusTerminated();
-
-        // Stop grpc server before proxy_machine because it depends on a DiagnosticsService which will call proxy
-        flash_grpc_server_holder.reset();
-        proxy_machine.stopProxy(tmt_context);
 
         {
             // Set limiters stopping and wakeup threads in waitting queue.


### PR DESCRIPTION
This reverts commit bec1390d8be06e97612404a61867f0b38b3627b2.

### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/10266

Problem Summary:
https://github.com/pingcap/tiflash/pull/10267 does not support a real graceful shutdown because the read index request will be canceled if setting `stopping` to store status, which is not expected and can cause MPP tasks to fail.

### What is changed and how it works?
To make the upcoming cherry-pick easier, this PR reverts https://github.com/pingcap/tiflash/pull/10267 first. 
Then I will file a new PR to fix this issue.

```commit-message
Revert "Support graceful shutdown in TiFlash"
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
