### PR TITLE
Convert const column to vector before the execution of window aggregation functions

### DIFF
--- a/dbms/src/WindowFunctions/IWindowFunction.h
+++ b/dbms/src/WindowFunctions/IWindowFunction.h
@@ -68,5 +68,8 @@ struct WindowFunctionWorkspace
     ColumnNumbers arguments;
 
     UInt64 idx;
+
+    // Avoid the release of column pointer
+    Columns materialized_columns;
 };
 } // namespace DB

--- a/tests/fullstack-test/mpp/window_agg.test
+++ b/tests/fullstack-test/mpp/window_agg.test
@@ -1733,3 +1733,61 @@ mysql> use test; set tidb_enforce_mpp=1; select p, o, v, sum(v) over w as "sum",
 |    6 |    3 |    3 |    9 |     3 |    2 |    4 |
 |    6 |    3 |    4 |    9 |     3 |    2 |    4 |
 +------+------+------+------+-------+------+------+
+
+# Test issue 10270
+mysql> drop table if exists test.t10270;
+mysql> create table test.t10270(id INT auto_increment primary key , c0 datetime);
+mysql> alter table test.t10270 SET TIFLASH REPLICA 1;
+mysql> alter table test.t10270 modify c0 bool;
+mysql> insert into test.t10270(c0) VALUES (true);
+mysql> insert into test.t10270(c0) VALUES (true);
+mysql> insert into test.t10270(c0) VALUES (true);
+mysql> alter table test.t10270 set tiflash replica 1;
+
+func> wait_table test t10270
+
+mysql> use test; set tidb_enforce_mpp=1; select /*+ read_from_storage(tiflash[t10270]) */ min('518:57:14') over (partition by ('-1674028007') between (true) and ('2037-04-25 03:56:51'), (case t10270.c0 when t10270.id then t10270.id when t10270.c0 then t10270.c0 else t10270.id end)) AS wf_0 from t10270;
++-----------+
+| wf_0      |
++-----------+
+| 518:57:14 |
+| 518:57:14 |
+| 518:57:14 |
++-----------+
+
+mysql> use test; set tidb_enforce_mpp=1; select /*+ read_from_storage(tiflash[t10270]) */ max('518:57:14') over (partition by ('-1674028007') between (true) and ('2037-04-25 03:56:51'), (case t10270.c0 when t10270.id then t10270.id when t10270.c0 then t10270.c0 else t10270.id end)) AS wf_0 from t10270;
++-----------+
+| wf_0      |
++-----------+
+| 518:57:14 |
+| 518:57:14 |
+| 518:57:14 |
++-----------+
+
+mysql> use test; set tidb_enforce_mpp=1; select /*+ read_from_storage(tiflash[t10270]) */ count('518:57:14') over (partition by ('-1674028007') between (true) and ('2037-04-25 03:56:51'), (case t10270.c0 when t10270.id then t10270.id when t10270.c0 then t10270.c0 else t10270.id end)) AS wf_0 from t10270;
++------+
+| wf_0 |
++------+
+|    3 |
+|    3 |
+|    3 |
++------+
+
+mysql> use test; set tidb_enforce_mpp=1; select /*+ read_from_storage(tiflash[t10270]) */ sum(2) over (partition by ('-1674028007') between (true) and ('2037-04-25 03:56:51'), (case t10270.c0 when t10270.id then t10270.id when t10270.c0 then t10270.c0 else t10270.id end)) AS wf_0 from t10270;
++------+
+| wf_0 |
++------+
+|    6 |
+|    6 |
+|    6 |
++------+
+
+mysql> use test; set tidb_enforce_mpp=1; select /*+ read_from_storage(tiflash[t10270]) */ avg(3) over (partition by ('-1674028007') between (true) and ('2037-04-25 03:56:51'), (case t10270.c0 when t10270.id then t10270.id when t10270.c0 then t10270.c0 else t10270.id end)) AS wf_0 from t10270;
++--------+
+| wf_0   |
++--------+
+| 3.0000 |
+| 3.0000 |
+| 3.0000 |
++--------+
+


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10270

Problem Summary:

### What is changed and how it works?

```commit-message
Convert const column to vector before the execution of window aggregation functions
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix the issue that tiflash will crash when the input column is const in window aggregation function.
```
