### PR TITLE
Storages: Fix VersionChain::getBytes

### DIFF
--- a/dbms/src/Storages/DeltaMerge/Remote/RNMVCCIndexCache.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/RNMVCCIndexCache.h
@@ -19,6 +19,7 @@
 #include <Storages/DeltaMerge/VersionChain/VersionChain_fwd.h>
 #include <Storages/KVStore/Types.h>
 #include <common/types.h>
+#include <fmt/format.h>
 
 #include <boost/noncopyable.hpp>
 
@@ -56,6 +57,20 @@ public:
             return store_id == other.store_id && keyspace_id == other.keyspace_id && table_id == other.table_id
                 && segment_id == other.segment_id && segment_epoch == other.segment_epoch
                 && delta_index_epoch == other.delta_index_epoch && is_version_chain == other.is_version_chain;
+        }
+
+        String toString() const
+        {
+            return fmt::format(
+                "<store_id={}, table_id={}, segment_id={}, segment_epoch={}, "
+                "delta_index_epoch={}, keyspace_id={}, is_version_chain={}>",
+                store_id,
+                table_id,
+                segment_id,
+                segment_epoch,
+                delta_index_epoch,
+                keyspace_id,
+                is_version_chain);
         }
     };
 

--- a/dbms/src/Storages/DeltaMerge/Remote/RNMVCCIndexCache.h
+++ b/dbms/src/Storages/DeltaMerge/Remote/RNMVCCIndexCache.h
@@ -63,7 +63,7 @@ public:
         {
             return fmt::format(
                 "<store_id={}, table_id={}, segment_id={}, segment_epoch={}, "
-                "delta_index_epoch={}, keyspace_id={}, is_version_chain={}>",
+                "delta_index_epoch={}, keyspace={}, is_version_chain={}>",
                 store_id,
                 table_id,
                 segment_id,

--- a/dbms/src/Storages/DeltaMerge/VersionChain/VersionChain.cpp
+++ b/dbms/src/Storages/DeltaMerge/VersionChain/VersionChain.cpp
@@ -393,6 +393,7 @@ DeltaValueReader VersionChain<HandleType>::createDeltaValueReader(
 template <ExtraHandleType HandleType>
 size_t VersionChain<HandleType>::getBytes() const
 {
+    std::lock_guard lock(mtx);
     // Ignore the size of `dmfile_or_delete_range_list` because it is small.
     return base_versions->capacity() * sizeof(RowID) + new_handle_to_row_ids.getBytes();
 }

--- a/dbms/src/Storages/DeltaMerge/VersionChain/VersionChain.h
+++ b/dbms/src/Storages/DeltaMerge/VersionChain/VersionChain.h
@@ -142,7 +142,7 @@ private:
     friend class tests::NewHandleIndexTest;
     friend class tests::VersionChainTest;
 
-    std::mutex mtx;
+    mutable std::mutex mtx;
     UInt32 replayed_rows_and_deletes = 0; // delta.getRows() + delta.getDeletes()
     // After replaySnapshot, base_versions->size() == delta.getRows().
     // The records in delta correspond one-to-one with base_versions.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10323 
Problem Summary:

### What is changed and how it works?

- `VersionChain<HandleType>::getBytes()` requires locking.
- Logging if the size of VersionChain is larger than 1MB.

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
