### PR TITLE
catch exception in EventTask:: doFinalizeImpl

### DIFF
--- a/dbms/src/Flash/Pipeline/Exec/PipelineExec.cpp
+++ b/dbms/src/Flash/Pipeline/Exec/PipelineExec.cpp
@@ -92,7 +92,7 @@ void PipelineExec::executePrefix()
     for (auto it = transform_ops.rbegin(); it != transform_ops.rend(); ++it) // NOLINT(modernize-loop-convert)
         (*it)->operatePrefix();
     source_op->operatePrefix();
-    FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::random_pipeline_model_execute_suffix_failpoint);
+    FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::random_pipeline_model_execute_prefix_failpoint);
 }
 
 void PipelineExec::executeSuffix()
@@ -101,6 +101,7 @@ void PipelineExec::executeSuffix()
     for (auto it = transform_ops.rbegin(); it != transform_ops.rend(); ++it) // NOLINT(modernize-loop-convert)
         (*it)->operateSuffix();
     source_op->operateSuffix();
+    FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::random_pipeline_model_execute_suffix_failpoint);
 }
 
 void PipelineExec::notify()

--- a/dbms/src/Flash/Pipeline/Schedule/Tasks/Impls/EventTask.cpp
+++ b/dbms/src/Flash/Pipeline/Schedule/Tasks/Impls/EventTask.cpp
@@ -37,7 +37,14 @@ EventTask::EventTask(
 
 void EventTask::finalizeImpl()
 {
-    doFinalizeImpl();
+    try
+    {
+        doFinalizeImpl();
+    }
+    catch (...)
+    {
+        LOG_ERROR(log, getCurrentExceptionMessage(false, false));
+    }
     event->onTaskFinish(profile_info);
     event.reset();
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10334

Problem Summary: catch exception in EventTask:: doFinalizeImpl, otherwise PipelineExecutor maybe stuck because `PipelineExecutorContext::decActiveRefCount` will not be called.

### What is changed and how it works?

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
