### PR TITLE
Fix cte concurrent unit test

### DIFF
--- a/dbms/src/Operators/tests/gtest_cte.cpp
+++ b/dbms/src/Operators/tests/gtest_cte.cpp
@@ -226,6 +226,9 @@ void concurrentTest()
             cte->sourceExit();
     };
 
+    std::vector<size_t> exit_num_for_each_partition;
+    exit_num_for_each_partition.resize(EXPECTED_SINK_NUM, 0);
+
     auto sink_func = [&](size_t sink_idx, size_t partition_idx) {
         std::uniform_int_distribution<size_t> di1(1, 10);
         std::uniform_int_distribution<size_t> di2(10, 50);
@@ -243,7 +246,8 @@ void concurrentTest()
                 next_sink_idx = next_sink_idxs[sink_idx]++;
                 if unlikely (next_sink_idx >= sink_blocks[sink_idx].size())
                 {
-                    if (partition_idx == 0)
+                    ++exit_num_for_each_partition[sink_idx];
+                    if (exit_num_for_each_partition[sink_idx] == PARTITION_NUM)
                         cte->sinkExit<true>();
                     break;
                 }
@@ -312,7 +316,7 @@ void concurrentTest()
 TEST_F(TestCTE, Concurrent)
 try
 {
-    for (size_t i = 0; i < 5; i++)
+    for (size_t i = 0; i < 10; i++)
         concurrentTest();
 }
 CATCH


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10373
Problem Summary:

### What is changed and how it works?

```commit-message
We introduce a new variable to record how many threads have exited so that we can ensure that all blocks have been pushed into queue before `notifyEOF` is called.
```


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix flaky cte concurrent unit test
```
