### PR TITLE
Limit memory usage of exchange sender

### DIFF
--- a/dbms/src/Flash/Coprocessor/DAGDriver.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGDriver.cpp
@@ -20,6 +20,7 @@
 #include <DataStreams/copyData.h>
 #include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/DAGDriver.h>
+#include <Flash/Coprocessor/DAGUtils.h>
 #include <Flash/Coprocessor/StreamWriter.h>
 #include <Flash/Coprocessor/StreamingDAGResponseWriter.h>
 #include <Flash/Coprocessor/UnaryDAGResponseWriter.h>
@@ -171,6 +172,7 @@ try
             streaming_writer,
             context.getSettingsRef().dag_records_per_chunk,
             context.getSettingsRef().batch_send_min_limit,
+            getMaxBufferedBytesInResponseWriter(context.getSettingsRef().max_buffered_bytes_in_executor, 1),
             dag_context);
         response_writer->prepare(query_executor->getSampleBlock());
         query_executor
@@ -225,6 +227,7 @@ try
             streaming_writer,
             context.getSettingsRef().dag_records_per_chunk,
             context.getSettingsRef().batch_send_min_limit,
+            getMaxBufferedBytesInResponseWriter(context.getSettingsRef().max_buffered_bytes_in_executor, 1),
             dag_context);
         response_writer->prepare(query_executor->getSampleBlock());
         query_executor

--- a/dbms/src/Flash/Coprocessor/DAGResponseWriter.h
+++ b/dbms/src/Flash/Coprocessor/DAGResponseWriter.h
@@ -49,10 +49,17 @@ public:
 
     virtual ~DAGResponseWriter() = default;
 
+    bool needFlush() const { return buffered_bytes >= max_buffered_bytes || buffered_rows >= max_buffered_rows; }
+
 protected:
     Int64 records_per_chunk;
     DAGContext & dag_context;
     bool has_pending_flush = false;
+
+    UInt64 max_buffered_bytes = 0;
+    UInt64 max_buffered_rows = 0;
+    UInt64 buffered_bytes = 0;
+    UInt64 buffered_rows = 0;
 };
 
 } // namespace DB

--- a/dbms/src/Flash/Coprocessor/DAGUtils.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGUtils.cpp
@@ -1607,7 +1607,7 @@ tipb::ScalarFuncSig reverseGetFuncSigByFuncName(const String & name)
     return func_name_sig_map[name];
 }
 
-constexpr ssize_t MAX_BATCH_SEND_MIN_LIMIT_MEM_SIZE = 1024 * 1024 * 32; // 32: 8192 Rows * 256 Byte/row * 16 partitions
+constexpr ssize_t MAX_BATCH_SEND_MIN_LIMIT_MEM_SIZE = 1024 * 1024 * 32; // 32MB (8192 Rows * 256 Byte/row * 16 partitions)
 
 UInt64 getMaxBufferedBytesInResponseWriter(Int64 max_buffered_bytes_in_executor, size_t concurrency)
 {

--- a/dbms/src/Flash/Coprocessor/DAGUtils.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGUtils.cpp
@@ -1607,7 +1607,8 @@ tipb::ScalarFuncSig reverseGetFuncSigByFuncName(const String & name)
     return func_name_sig_map[name];
 }
 
-constexpr ssize_t MAX_BATCH_SEND_MIN_LIMIT_MEM_SIZE = 1024 * 1024 * 32; // 32MB (8192 Rows * 256 Byte/row * 16 partitions)
+constexpr ssize_t MAX_BATCH_SEND_MIN_LIMIT_MEM_SIZE
+    = 1024 * 1024 * 32; // 32MB (8192 Rows * 256 Byte/row * 16 partitions)
 
 UInt64 getMaxBufferedBytesInResponseWriter(Int64 max_buffered_bytes_in_executor, size_t concurrency)
 {

--- a/dbms/src/Flash/Coprocessor/DAGUtils.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGUtils.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <Common/FmtUtils.h>
+#include <Common/ThresholdUtils.h>
 #include <Common/TiFlashException.h>
 #include <Core/Types.h>
 #include <DataTypes/DataTypeNullable.h>
@@ -30,8 +31,6 @@
 #include <TiDB/Schema/TiDBTypes.h>
 
 #include <unordered_map>
-
-#include "Common/ThresholdUtils.h"
 
 namespace DB
 {

--- a/dbms/src/Flash/Coprocessor/DAGUtils.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGUtils.cpp
@@ -1608,8 +1608,7 @@ tipb::ScalarFuncSig reverseGetFuncSigByFuncName(const String & name)
     return func_name_sig_map[name];
 }
 
-constexpr ssize_t MAX_BATCH_SEND_MIN_LIMIT_MEM_SIZE
-    = 1024 * 1024 * 64; // 64MB: 8192 Rows * 256 Byte/row * 32 partitions
+constexpr ssize_t MAX_BATCH_SEND_MIN_LIMIT_MEM_SIZE = 1024 * 1024 * 32; // 32: 8192 Rows * 256 Byte/row * 16 partitions
 
 UInt64 getMaxBufferedBytesInResponseWriter(Int64 max_buffered_bytes_in_executor, size_t concurrency)
 {

--- a/dbms/src/Flash/Coprocessor/DAGUtils.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGUtils.cpp
@@ -31,6 +31,8 @@
 
 #include <unordered_map>
 
+#include "Common/ThresholdUtils.h"
+
 namespace DB
 {
 const Int8 VAR_SIZE = 0;
@@ -1605,4 +1607,19 @@ tipb::ScalarFuncSig reverseGetFuncSigByFuncName(const String & name)
         throw Exception(fmt::format("Unsupported function {}", name));
     return func_name_sig_map[name];
 }
+
+constexpr ssize_t MAX_BATCH_SEND_MIN_LIMIT_MEM_SIZE
+    = 1024 * 1024 * 64; // 64MB: 8192 Rows * 256 Byte/row * 32 partitions
+
+UInt64 getMaxBufferedBytesInResponseWriter(Int64 max_buffered_bytes_in_executor, size_t concurrency)
+{
+    // max buffered bytes in ExchangeSender, we don't want to send too many small chunks so there is a minimum limit of MAX_BATCH_SEND_MIN_LIMIT_MEM_SIZE
+    UInt64 ret = MAX_BATCH_SEND_MIN_LIMIT_MEM_SIZE;
+    if (max_buffered_bytes_in_executor > 0)
+    {
+        ret = std::max(ret, getAverageThreshold(max_buffered_bytes_in_executor, concurrency));
+    }
+    return ret;
+}
+
 } // namespace DB

--- a/dbms/src/Flash/Coprocessor/DAGUtils.h
+++ b/dbms/src/Flash/Coprocessor/DAGUtils.h
@@ -86,6 +86,8 @@ void assertBlockSchema(const DataTypes & expected_types, const Block & block, co
 
 void assertBlockSchema(const Block & header, const Block & block, const String & context_description);
 
+UInt64 getMaxBufferedBytesInResponseWriter(Int64 max_buffered_bytes_in_executor, size_t concurrency);
+
 class UniqueNameGenerator
 {
 private:

--- a/dbms/src/Flash/Coprocessor/StreamingDAGResponseWriter.cpp
+++ b/dbms/src/Flash/Coprocessor/StreamingDAGResponseWriter.cpp
@@ -38,12 +38,8 @@ StreamingDAGResponseWriter<StreamWriterPtr>::StreamingDAGResponseWriter(
     UInt64 max_buffered_bytes_,
     DAGContext & dag_context_)
     : DAGResponseWriter(records_per_chunk_, dag_context_)
-    , max_buffered_rows(batch_send_min_limit_)
-    , max_buffered_bytes(max_buffered_bytes_)
     , writer(writer_)
 {
-    rows_in_blocks = 0;
-    bytes_in_blocks = 0;
     switch (dag_context.encode_type)
     {
     case tipb::EncodeType::TypeDefault:
@@ -59,15 +55,20 @@ StreamingDAGResponseWriter<StreamWriterPtr>::StreamingDAGResponseWriter(
         throw TiFlashException("Unsupported EncodeType", Errors::Coprocessor::Internal);
     }
     /// For other encode types, we will use records_per_chunk to control the batch size sent.
-    max_buffered_rows
-        = dag_context.encode_type == tipb::EncodeType::TypeCHBlock ? max_buffered_rows : (records_per_chunk - 1);
+    auto batch_send_min_limit
+        = dag_context.encode_type == tipb::EncodeType::TypeCHBlock ? batch_send_min_limit_ : (records_per_chunk - 1);
+    if (batch_send_min_limit <= 0)
+        max_buffered_rows = 1;
+    else
+        max_buffered_rows = static_cast<UInt64>(batch_send_min_limit);
+    max_buffered_bytes = max_buffered_bytes_;
 }
 
 template <class StreamWriterPtr>
 WriteResult StreamingDAGResponseWriter<StreamWriterPtr>::flush()
 {
     has_pending_flush = false;
-    if (rows_in_blocks > 0)
+    if (buffered_rows > 0)
     {
         auto wait_res = waitForWritable();
         if (wait_res == WaitResult::Ready)
@@ -99,12 +100,12 @@ WriteResult StreamingDAGResponseWriter<StreamWriterPtr>::write(const Block & blo
     size_t rows = block.rows();
     if (rows > 0)
     {
-        rows_in_blocks += rows;
-        bytes_in_blocks += block.allocatedBytes();
+        buffered_rows += rows;
+        buffered_bytes += block.allocatedBytes();
         blocks.push_back(block);
     }
 
-    if (static_cast<Int64>(rows_in_blocks) > max_buffered_rows || bytes_in_blocks > max_buffered_bytes)
+    if (needFlush())
     {
         return flush();
     }
@@ -161,8 +162,8 @@ void StreamingDAGResponseWriter<StreamWriterPtr>::encodeThenWriteBlocks()
     }
 
     assert(blocks.empty());
-    rows_in_blocks = 0;
-    bytes_in_blocks = 0;
+    buffered_rows = 0;
+    buffered_bytes = 0;
     writer->write(response.getResponse());
 }
 

--- a/dbms/src/Flash/Coprocessor/StreamingDAGResponseWriter.h
+++ b/dbms/src/Flash/Coprocessor/StreamingDAGResponseWriter.h
@@ -46,12 +46,8 @@ private:
     void encodeThenWriteBlocks();
 
 private:
-    Int64 max_buffered_rows;
-    UInt64 max_buffered_bytes;
     StreamWriterPtr writer;
     std::vector<Block> blocks;
-    size_t rows_in_blocks;
-    size_t bytes_in_blocks;
     std::unique_ptr<ChunkCodecStream> chunk_codec_stream;
 };
 

--- a/dbms/src/Flash/Coprocessor/StreamingDAGResponseWriter.h
+++ b/dbms/src/Flash/Coprocessor/StreamingDAGResponseWriter.h
@@ -35,6 +35,7 @@ public:
         StreamWriterPtr writer_,
         Int64 records_per_chunk_,
         Int64 batch_send_min_limit_,
+        UInt64 max_buffered_bytes_,
         DAGContext & dag_context_);
     WaitResult waitForWritable() const override;
 
@@ -45,10 +46,12 @@ private:
     void encodeThenWriteBlocks();
 
 private:
-    Int64 batch_send_min_limit;
+    Int64 max_buffered_rows;
+    UInt64 max_buffered_bytes;
     StreamWriterPtr writer;
     std::vector<Block> blocks;
     size_t rows_in_blocks;
+    size_t bytes_in_blocks;
     std::unique_ptr<ChunkCodecStream> chunk_codec_stream;
 };
 

--- a/dbms/src/Flash/Coprocessor/tests/gtest_streaming_writer.cpp
+++ b/dbms/src/Flash/Coprocessor/tests/gtest_streaming_writer.cpp
@@ -24,6 +24,9 @@
 #include <gtest/gtest.h>
 
 #include <Flash/Coprocessor/StreamingDAGResponseWriter.cpp>
+#include <cstddef>
+
+#include "common/types.h"
 
 namespace DB
 {
@@ -113,6 +116,7 @@ try
         const size_t block_rows = 64;
         const size_t block_num = 64;
         const size_t batch_send_min_limit = 108;
+        const size_t max_buffered_bytes = 1024 * 1024 * 16;
 
         // 1. Build Blocks.
         std::vector<Block> blocks;
@@ -135,6 +139,7 @@ try
             mock_writer,
             batch_send_min_limit,
             batch_send_min_limit,
+            max_buffered_bytes,
             *dag_context_ptr);
         for (const auto & block : blocks)
             dag_writer->write(block);
@@ -165,6 +170,58 @@ try
             }
         }
         ASSERT_EQ(decoded_block_rows, expect_rows);
+    }
+}
+CATCH
+
+TEST_F(TestStreamingWriter, testMaxBufferedBytes)
+try
+{
+    std::vector<tipb::EncodeType> encode_types{
+        tipb::EncodeType::TypeDefault,
+        tipb::EncodeType::TypeChunk,
+        tipb::EncodeType::TypeCHBlock};
+    for (const auto & encode_type : encode_types)
+    {
+        dag_context_ptr->encode_type = encode_type;
+
+        const size_t block_rows = 64;
+        const size_t block_num = 64;
+        const size_t batch_send_min_limit = block_rows * block_num / 2;
+        const std::vector<UInt64> max_buffered_bytes_vec{1, 1024 * 1024 * 1024};
+        const std::vector<UInt64> expected_response_num{block_num, 2};
+
+        for (size_t i = 0; i < max_buffered_bytes_vec.size(); ++i)
+        {
+            // 1. Build Blocks.
+            std::vector<Block> blocks;
+            for (size_t i = 0; i < block_num; ++i)
+            {
+                blocks.emplace_back(prepareBlock(block_rows));
+                blocks.emplace_back(prepareBlock(0));
+            }
+            Block header = blocks.back();
+
+            // 2. Build MockStreamWriter.
+            std::vector<tipb::SelectResponse> write_report;
+            auto checker = [&write_report](tipb::SelectResponse & response) {
+                write_report.emplace_back(std::move(response));
+            };
+            auto mock_writer = std::make_shared<MockStreamWriter>(checker);
+
+            // 3. Write blocks
+            auto dag_writer = std::make_shared<StreamingDAGResponseWriter<std::shared_ptr<MockStreamWriter>>>(
+                mock_writer,
+                batch_send_min_limit,
+                batch_send_min_limit,
+                max_buffered_bytes_vec[i],
+                *dag_context_ptr);
+            for (const auto & block : blocks)
+                dag_writer->write(block);
+            dag_writer->flush();
+
+            ASSERT_EQ(write_report.size(), expected_response_num[i]);
+        }
     }
 }
 CATCH

--- a/dbms/src/Flash/Coprocessor/tests/gtest_streaming_writer.cpp
+++ b/dbms/src/Flash/Coprocessor/tests/gtest_streaming_writer.cpp
@@ -26,8 +26,6 @@
 #include <Flash/Coprocessor/StreamingDAGResponseWriter.cpp>
 #include <cstddef>
 
-#include "common/types.h"
-
 namespace DB
 {
 namespace tests

--- a/dbms/src/Flash/Coprocessor/tests/gtest_ti_remote_block_inputstream.cpp
+++ b/dbms/src/Flash/Coprocessor/tests/gtest_ti_remote_block_inputstream.cpp
@@ -345,6 +345,7 @@ public:
         auto dag_writer = std::make_shared<BroadcastOrPassThroughWriter<MockWriterPtr>>(
             writer,
             batch_send_min_limit,
+            1024 * 1024 * 16,
             *dag_context_ptr,
             MPPDataPacketVersion::MPPDataPacketV1,
             tipb::CompressionMode::FAST,
@@ -374,6 +375,7 @@ public:
             writer,
             0,
             batch_send_min_limit,
+            1024 * 1024 * 16,
             *dag_context_ptr);
 
         // 2. encode all blocks

--- a/dbms/src/Flash/Mpp/BroadcastOrPassThroughWriter.cpp
+++ b/dbms/src/Flash/Mpp/BroadcastOrPassThroughWriter.cpp
@@ -25,36 +25,39 @@ namespace DB
 template <class ExchangeWriterPtr>
 BroadcastOrPassThroughWriter<ExchangeWriterPtr>::BroadcastOrPassThroughWriter(
     ExchangeWriterPtr writer_,
-    Int64 batch_send_min_limit_,
+    Int64 max_buffered_rows_,
+    UInt64 max_buffered_bytes_,
     DAGContext & dag_context_,
     MPPDataPacketVersion data_codec_version_,
     tipb::CompressionMode compression_mode_,
     tipb::ExchangeType exchange_type_)
     : DAGResponseWriter(/*records_per_chunk=*/-1, dag_context_)
-    , batch_send_min_limit(batch_send_min_limit_)
+    , max_buffered_rows(max_buffered_rows_)
+    , max_buffered_bytes(max_buffered_bytes_)
     , writer(writer_)
     , exchange_type(exchange_type_)
     , data_codec_version(data_codec_version_)
     , compression_method(ToInternalCompressionMethod(compression_mode_))
 {
     rows_in_blocks = 0;
+    bytes_in_blocks = 0;
     RUNTIME_CHECK(dag_context.encode_type == tipb::EncodeType::TypeCHBlock);
     RUNTIME_CHECK(exchange_type == tipb::ExchangeType::Broadcast || exchange_type == tipb::ExchangeType::PassThrough);
 
     switch (data_codec_version)
     {
     case MPPDataPacketV0:
-        if (batch_send_min_limit <= 0)
-            batch_send_min_limit = 1;
+        if (max_buffered_rows <= 0)
+            max_buffered_rows = 1;
         break;
     case MPPDataPacketV1:
     default:
     {
         // make `batch_send_min_limit` always GT 0
-        if (batch_send_min_limit <= 0)
+        if (max_buffered_rows <= 0)
         {
             // set upper limit if not specified
-            batch_send_min_limit = 8 * 1024 /* 8K */;
+            max_buffered_rows = 8 * 1024 /* 8K */;
         }
         for (const auto & field_type : dag_context.result_field_types)
         {
@@ -103,10 +106,11 @@ WriteResult BroadcastOrPassThroughWriter<ExchangeWriterPtr>::write(const Block &
     if (rows > 0)
     {
         rows_in_blocks += rows;
+        bytes_in_blocks += block.allocatedBytes();
         blocks.push_back(block);
     }
 
-    if (static_cast<Int64>(rows_in_blocks) >= batch_send_min_limit)
+    if (static_cast<Int64>(rows_in_blocks) >= max_buffered_rows || bytes_in_blocks >= max_buffered_bytes)
     {
         return flush();
     }
@@ -131,6 +135,7 @@ void BroadcastOrPassThroughWriter<ExchangeWriterPtr>::writeBlocks()
         writer->passThroughWrite(blocks, data_codec_version, compression_method);
     blocks.clear();
     rows_in_blocks = 0;
+    bytes_in_blocks = 0;
 }
 
 template class BroadcastOrPassThroughWriter<SyncMPPTunnelSetWriterPtr>;

--- a/dbms/src/Flash/Mpp/BroadcastOrPassThroughWriter.h
+++ b/dbms/src/Flash/Mpp/BroadcastOrPassThroughWriter.h
@@ -45,12 +45,8 @@ private:
     void writeBlocks();
 
 private:
-    Int64 max_buffered_rows;
-    UInt64 max_buffered_bytes;
     ExchangeWriterPtr writer;
     std::vector<Block> blocks;
-    size_t rows_in_blocks;
-    size_t bytes_in_blocks;
     const tipb::ExchangeType exchange_type;
 
     // support data compression

--- a/dbms/src/Flash/Mpp/BroadcastOrPassThroughWriter.h
+++ b/dbms/src/Flash/Mpp/BroadcastOrPassThroughWriter.h
@@ -31,7 +31,8 @@ class BroadcastOrPassThroughWriter : public DAGResponseWriter
 public:
     BroadcastOrPassThroughWriter(
         ExchangeWriterPtr writer_,
-        Int64 batch_send_min_limit_,
+        Int64 max_buffered_rows_,
+        UInt64 max_buffered_bytes_,
         DAGContext & dag_context_,
         MPPDataPacketVersion data_codec_version_,
         tipb::CompressionMode compression_mode_,
@@ -44,10 +45,12 @@ private:
     void writeBlocks();
 
 private:
-    Int64 batch_send_min_limit;
+    Int64 max_buffered_rows;
+    UInt64 max_buffered_bytes;
     ExchangeWriterPtr writer;
     std::vector<Block> blocks;
     size_t rows_in_blocks;
+    size_t bytes_in_blocks;
     const tipb::ExchangeType exchange_type;
 
     // support data compression

--- a/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.cpp
+++ b/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.cpp
@@ -32,6 +32,7 @@ FineGrainedShuffleWriter<ExchangeWriterPtr>::FineGrainedShuffleWriter(
     std::vector<Int64> partition_col_ids_,
     TiDB::TiDBCollators collators_,
     DAGContext & dag_context_,
+    UInt64 max_buffered_bytes_,
     uint64_t fine_grained_shuffle_stream_count_,
     UInt64 fine_grained_shuffle_batch_size_,
     MPPDataPacketVersion data_codec_version_,
@@ -42,12 +43,12 @@ FineGrainedShuffleWriter<ExchangeWriterPtr>::FineGrainedShuffleWriter(
     , collators(std::move(collators_))
     , fine_grained_shuffle_stream_count(fine_grained_shuffle_stream_count_)
     , fine_grained_shuffle_batch_size(fine_grained_shuffle_batch_size_)
-    , batch_send_row_limit(fine_grained_shuffle_batch_size * fine_grained_shuffle_stream_count)
+    , max_buffered_rows(fine_grained_shuffle_batch_size * fine_grained_shuffle_stream_count)
+    , max_buffered_bytes(max_buffered_bytes_)
     , hash(0)
     , data_codec_version(data_codec_version_)
     , compression_method(ToInternalCompressionMethod(compression_mode_))
 {
-    rows_in_blocks = 0;
     partition_num = writer_->getPartitionNum();
     RUNTIME_CHECK(partition_num > 0);
     RUNTIME_CHECK(dag_context.encode_type == tipb::EncodeType::TypeCHBlock);
@@ -133,11 +134,12 @@ WriteResult FineGrainedShuffleWriter<ExchangeWriterPtr>::write(const Block & blo
     if (rows > 0)
     {
         rows_in_blocks += rows;
+        bytes_in_blocks += block.allocatedBytes();
         blocks.push_back(block);
     }
 
-    if (blocks.size() == fine_grained_shuffle_stream_count
-        || static_cast<UInt64>(rows_in_blocks) >= batch_send_row_limit)
+    if (blocks.size() == fine_grained_shuffle_stream_count || rows_in_blocks >= max_buffered_rows
+        || bytes_in_blocks >= max_buffered_bytes)
     {
         return flush();
     }
@@ -156,7 +158,11 @@ void FineGrainedShuffleWriter<ExchangeWriterPtr>::initScatterColumns()
         for (size_t chunk_id = 0; chunk_id < num_bucket; ++chunk_id)
         {
             scattered[col_id].emplace_back(column->cloneEmpty());
-            scattered[col_id][chunk_id]->reserve(1024);
+            if (scattered[col_id][chunk_id]->valuesHaveFixedSize())
+            {
+                // Reserve space for each chunk to avoid frequent memory allocation.
+                scattered[col_id][chunk_id]->reserve(1024);
+            }
         }
     }
 }
@@ -221,6 +227,7 @@ void FineGrainedShuffleWriter<ExchangeWriterPtr>::batchWriteFineGrainedShuffleIm
                 compression_method);
         }
         rows_in_blocks = 0;
+        bytes_in_blocks = 0;
     }
 }
 

--- a/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.h
+++ b/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.h
@@ -55,16 +55,14 @@ private:
     std::vector<Block> blocks;
     std::vector<Int64> partition_col_ids;
     TiDB::TiDBCollators collators;
-    size_t rows_in_blocks = 0;
-    size_t bytes_in_blocks = 0;
     uint16_t partition_num;
     UInt64 fine_grained_shuffle_stream_count;
     UInt64 fine_grained_shuffle_batch_size;
 
     Block header;
     bool prepared = false;
-    size_t num_columns = 0, num_bucket = 0, max_buffered_rows = 0,
-           max_buffered_bytes
+    size_t num_columns = 0,
+           num_bucket
         = 0; // Assign they initial values to pass clang-tidy check, they will be initialized in prepare method
     std::vector<String> partition_key_containers_for_reuse;
     WeakHash32 hash;

--- a/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.h
+++ b/dbms/src/Flash/Mpp/FineGrainedShuffleWriter.h
@@ -34,6 +34,7 @@ public:
         std::vector<Int64> partition_col_ids_,
         TiDB::TiDBCollators collators_,
         DAGContext & dag_context_,
+        UInt64 max_buffered_bytes_,
         UInt64 fine_grained_shuffle_stream_count_,
         UInt64 fine_grained_shuffle_batch_size,
         MPPDataPacketVersion data_codec_version_,
@@ -55,14 +56,15 @@ private:
     std::vector<Int64> partition_col_ids;
     TiDB::TiDBCollators collators;
     size_t rows_in_blocks = 0;
+    size_t bytes_in_blocks = 0;
     uint16_t partition_num;
     UInt64 fine_grained_shuffle_stream_count;
     UInt64 fine_grained_shuffle_batch_size;
 
     Block header;
     bool prepared = false;
-    size_t num_columns = 0, num_bucket = 0,
-           batch_send_row_limit
+    size_t num_columns = 0, num_bucket = 0, max_buffered_rows = 0,
+           max_buffered_bytes
         = 0; // Assign they initial values to pass clang-tidy check, they will be initialized in prepare method
     std::vector<String> partition_key_containers_for_reuse;
     WeakHash32 hash;

--- a/dbms/src/Flash/Mpp/HashPartitionWriter.cpp
+++ b/dbms/src/Flash/Mpp/HashPartitionWriter.cpp
@@ -68,7 +68,7 @@ HashPartitionWriter<ExchangeWriterPtr>::HashPartitionWriter(
         break;
     }
     }
-    max_buffered_rows_ = static_cast<UInt64>(max_buffered_rows_);
+    max_buffered_rows = static_cast<UInt64>(max_buffered_rows_);
     max_buffered_bytes = max_buffered_bytes_;
 }
 

--- a/dbms/src/Flash/Mpp/HashPartitionWriter.h
+++ b/dbms/src/Flash/Mpp/HashPartitionWriter.h
@@ -33,7 +33,8 @@ public:
         ExchangeWriterPtr writer_,
         std::vector<Int64> partition_col_ids_,
         TiDB::TiDBCollators collators_,
-        Int64 batch_send_min_limit_,
+        Int64 max_buffered_rows_,
+        UInt64 max_buffered_bytes_,
         DAGContext & dag_context_,
         MPPDataPacketVersion data_codec_version_,
         tipb::CompressionMode compression_mode_);
@@ -46,15 +47,15 @@ private:
     void partitionAndWriteBlocksV1();
 
 private:
-    Int64 batch_send_min_limit;
+    Int64 max_buffered_rows;
+    UInt64 max_buffered_bytes;
     ExchangeWriterPtr writer;
     std::vector<Block> blocks;
     std::vector<Int64> partition_col_ids;
     TiDB::TiDBCollators collators;
     size_t rows_in_blocks;
+    size_t bytes_in_blocks;
     uint16_t partition_num;
-    // support data compression
-    int64_t mem_size_in_blocks{};
     DataTypes expected_types;
     MPPDataPacketVersion data_codec_version;
     CompressionMethod compression_method{};

--- a/dbms/src/Flash/Mpp/HashPartitionWriter.h
+++ b/dbms/src/Flash/Mpp/HashPartitionWriter.h
@@ -47,14 +47,10 @@ private:
     void partitionAndWriteBlocksV1();
 
 private:
-    Int64 max_buffered_rows;
-    UInt64 max_buffered_bytes;
     ExchangeWriterPtr writer;
     std::vector<Block> blocks;
     std::vector<Int64> partition_col_ids;
     TiDB::TiDBCollators collators;
-    size_t rows_in_blocks;
-    size_t bytes_in_blocks;
     uint16_t partition_num;
     DataTypes expected_types;
     MPPDataPacketVersion data_codec_version;

--- a/dbms/src/Flash/Mpp/newMPPExchangeWriter.cpp
+++ b/dbms/src/Flash/Mpp/newMPPExchangeWriter.cpp
@@ -32,6 +32,7 @@ std::unique_ptr<DAGResponseWriter> buildMPPExchangeWriter(
     const tipb::ExchangeType & exchange_type,
     Int64 records_per_chunk,
     Int64 batch_send_min_limit,
+    UInt64 max_buffered_bytes,
     DAGContext & dag_context,
     bool enable_fine_grained_shuffle,
     UInt64 fine_grained_shuffle_stream_count,
@@ -50,6 +51,7 @@ std::unique_ptr<DAGResponseWriter> buildMPPExchangeWriter(
             writer,
             records_per_chunk,
             batch_send_min_limit,
+            max_buffered_bytes,
             dag_context);
     }
     else
@@ -68,6 +70,7 @@ std::unique_ptr<DAGResponseWriter> buildMPPExchangeWriter(
                     partition_col_ids,
                     partition_col_collators,
                     dag_context,
+                    max_buffered_bytes,
                     fine_grained_shuffle_stream_count,
                     fine_grained_shuffle_batch_size,
                     data_codec_version,
@@ -80,6 +83,7 @@ std::unique_ptr<DAGResponseWriter> buildMPPExchangeWriter(
                     partition_col_ids,
                     partition_col_collators,
                     chosen_batch_send_min_limit,
+                    max_buffered_bytes,
                     dag_context,
                     data_codec_version,
                     compression_mode);
@@ -91,6 +95,7 @@ std::unique_ptr<DAGResponseWriter> buildMPPExchangeWriter(
             return std::make_unique<BroadcastOrPassThroughWriter<ExchangeWriterPtr>>(
                 writer,
                 chosen_batch_send_min_limit,
+                max_buffered_bytes,
                 dag_context,
                 data_codec_version,
                 compression_mode,
@@ -106,6 +111,7 @@ std::unique_ptr<DAGResponseWriter> newMPPExchangeWriter(
     const tipb::ExchangeType & exchange_type,
     Int64 records_per_chunk,
     Int64 batch_send_min_limit,
+    UInt64 max_buffered_bytes,
     DAGContext & dag_context,
     bool enable_fine_grained_shuffle,
     UInt64 fine_grained_shuffle_stream_count,
@@ -127,6 +133,7 @@ std::unique_ptr<DAGResponseWriter> newMPPExchangeWriter(
             exchange_type,
             records_per_chunk,
             batch_send_min_limit,
+            max_buffered_bytes,
             dag_context,
             enable_fine_grained_shuffle,
             fine_grained_shuffle_stream_count,
@@ -145,6 +152,7 @@ std::unique_ptr<DAGResponseWriter> newMPPExchangeWriter(
             exchange_type,
             records_per_chunk,
             batch_send_min_limit,
+            max_buffered_bytes,
             dag_context,
             enable_fine_grained_shuffle,
             fine_grained_shuffle_stream_count,

--- a/dbms/src/Flash/Mpp/newMPPExchangeWriter.h
+++ b/dbms/src/Flash/Mpp/newMPPExchangeWriter.h
@@ -25,6 +25,7 @@ std::unique_ptr<DAGResponseWriter> newMPPExchangeWriter(
     const tipb::ExchangeType & exchange_type,
     Int64 records_per_chunk,
     Int64 batch_send_min_limit,
+    UInt64 max_buffered_bytes,
     DAGContext & dag_context,
     bool enable_fine_grained_shuffle,
     UInt64 fine_grained_shuffle_stream_count,

--- a/dbms/src/Storages/KVStore/tests/gtest_kvstore_fast_add_peer.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_kvstore_fast_add_peer.cpp
@@ -861,6 +861,7 @@ try
 }
 CATCH
 
+/* unstable test, disable it
 // Test cancel and regular snapshot
 TEST_F(RegionKVStoreTestFAP, Cancel4)
 try
@@ -950,6 +951,7 @@ try
     FailPointHelper::disableFailPoint(FailPoints::force_set_fap_candidate_store_id);
 }
 CATCH
+*/
 
 // Test cancel when building segments
 TEST_F(RegionKVStoreTestFAP, Cancel5)

--- a/dbms/src/Storages/KVStore/tests/gtest_kvstore_fast_add_peer.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_kvstore_fast_add_peer.cpp
@@ -234,7 +234,7 @@ template <typename F, typename FP>
 void eventuallyPredicateEx(F f, FP fp)
 {
     using namespace std::chrono_literals;
-    for (int i = 0; i < 10; i++)
+    for (int i = 0; i < 20; i++)
     {
         if (f())
             return;
@@ -861,7 +861,6 @@ try
 }
 CATCH
 
-/* unstable test, disable it
 // Test cancel and regular snapshot
 TEST_F(RegionKVStoreTestFAP, Cancel4)
 try
@@ -951,7 +950,6 @@ try
     FailPointHelper::disableFailPoint(FailPoints::force_set_fap_candidate_store_id);
 }
 CATCH
-*/
 
 // Test cancel when building segments
 TEST_F(RegionKVStoreTestFAP, Cancel5)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10337

Problem Summary:

The root cause is in current implementation, the buffered block number in ExchangeSender can be upto max_threads * max_threads * fine_grain_stream_count, so if max_threads is large, and the size of each row is big, the buffered block can consume very large memory.

This pr limit the memory usage of ExchangeSender by `max(MAX_BATCH_SEND_MIN_LIMIT_MEM_SIZE * max_threads, max_buffered_bytes_in_executor)`
### What is changed and how it works?

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
test in 2-tiflash's cluster, with max_threads = 32 and sort memory limit set to 5G
```
explain analyze select * from (select *, row_number() over(partition by ps_partkey order by ps_suppkey) as rn from test) d where rn = 10;
```
Where `test` has `40000000` rows, each row has ~1200 bytes.
Before this pr
peak memory of each TiFlash is about 30G
```
[2025/09/01 11:47:48.178 +08:00] [DEBUG] [MemoryTracker.cpp:110] ["Peak memory usage (for query): 33.13 GiB."] [source=MemoryTracker] [thread_id=813]
[2025/09/01 11:47:48.178 +08:00] [DEBUG] [MemoryTracker.cpp:110] ["Peak memory usage (total): 33.13 GiB."] [source=MemoryTracker] [thread_id=813]
```
After this pr
peak memory of each TiFlash is about 10G
```
[2025/09/01 11:42:28.895 +08:00] [DEBUG] [MemoryTracker.cpp:110] ["Peak memory usage (for query): 9.86 GiB."] [source=MemoryTracker] [thread_id=635]
[2025/09/01 11:42:28.895 +08:00] [DEBUG] [MemoryTracker.cpp:110] ["Peak memory usage (total): 9.86 GiB."] [source=MemoryTracker] [thread_id=635]
```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
