### PR TITLE
Storages: Fix the statistics of user_read_bytes and add metrics

### DIFF
--- a/dbms/src/Common/TiFlashMetrics.h
+++ b/dbms/src/Common/TiFlashMetrics.h
@@ -1299,7 +1299,6 @@ private:
     std::unordered_map<std::string, prometheus::Gauge *> registered_async_metrics;
 
     prometheus::Family<prometheus::Gauge> * registered_keypace_store_used_family;
-    using KeyspaceID = UInt32;
     std::unordered_map<KeyspaceID, prometheus::Gauge *> registered_keypace_store_used_metrics;
     prometheus::Gauge * store_used_total_metric;
 

--- a/dbms/src/Common/TiFlashMetrics.h
+++ b/dbms/src/Common/TiFlashMetrics.h
@@ -18,6 +18,7 @@
 #include <Common/ProcessCollector_fwd.h>
 #include <Common/TiFlashBuildInfo.h>
 #include <Common/nocopyable.h>
+#include <Storages/DeltaMerge/ReadMode.h>
 #include <common/types.h>
 #include <prometheus/counter.h>
 #include <prometheus/exposer.h>
@@ -1247,6 +1248,8 @@ namespace tests
 struct TiFlashMetricsHelper;
 }
 
+using KeyspaceID = UInt32;
+
 /// Centralized registry of TiFlash metrics.
 /// Cope with MetricsPrometheus by registering
 /// profile events, current metrics and customized metrics (as individual member for caller to access) into registry ahead of being updated.
@@ -1270,6 +1273,11 @@ public:
     void registerProxyThreadMemory(const std::string & k);
     void registerStorageThreadMemory(const std::string & k);
     void setProvideProxyProcessMetrics(bool v);
+
+    prometheus::Counter & getStorageRUReadBytesCounter(
+        KeyspaceID keyspace,
+        const String & resource_group,
+        const DM::ReadRUType type);
 
 private:
     TiFlashMetrics();
@@ -1307,6 +1315,11 @@ private:
     prometheus::Family<prometheus::Gauge> * registered_storage_thread_memory_usage_family;
     std::shared_mutex storage_thread_report_mtx;
     std::unordered_map<std::string, prometheus::Gauge *> registered_storage_thread_memory_usage_metrics;
+
+    prometheus::Family<prometheus::Counter> * registered_storage_ru_read_bytes_family;
+    std::shared_mutex storage_ru_read_bytes_mtx;
+    // {keyspace}_{resource_group}_{type} -> Counter
+    std::unordered_map<std::string, prometheus::Counter *> registered_storage_ru_read_bytes_metrics;
 
 public:
 #define MAKE_METRIC_MEMBER_M(family_name, help, type, ...) \

--- a/dbms/src/Flash/Coprocessor/DAGContext.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGContext.cpp
@@ -484,7 +484,7 @@ UInt64 DAGContext::getReadBytes() const
     for (const auto & [id, sc] : scan_context_map)
     {
         (void)id; // Disable unused variable warnning.
-        read_bytes += sc->user_read_bytes;
+        read_bytes += sc->userReadBytes();
     }
     return read_bytes;
 }

--- a/dbms/src/Storages/DeltaMerge/ConcatSkippableBlockInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/ConcatSkippableBlockInputStream.cpp
@@ -30,9 +30,7 @@ ConcatSkippableBlockInputStream<need_row_id>::ConcatSkippableBlockInputStream(
     : rows(std::move(rows_))
     , precede_stream_rows(0)
     , scan_context(scan_context_)
-    , lac_bytes_collector(
-          scan_context_ ? scan_context_->keyspace_id : NullspaceID,
-          scan_context_ ? scan_context_->resource_group_name : "")
+    , lac_bytes_collector(scan_context_ ? scan_context_->newLACBytesCollector(read_tag_) : std::nullopt)
     , read_tag(read_tag_)
 {
     assert(rows.size() == inputs_.size());
@@ -155,11 +153,7 @@ template <bool need_row_id>
 void ConcatSkippableBlockInputStream<need_row_id>::addReadBytes(UInt64 bytes)
 {
     if (likely(scan_context != nullptr))
-    {
-        scan_context->addUserReadBytes(bytes, read_tag);
-        if (read_tag == ReadTag::Query || read_tag == ReadTag::LMFilter)
-            lac_bytes_collector.collect(bytes);
-    }
+        scan_context->addUserReadBytes(bytes, read_tag, lac_bytes_collector);
 }
 
 template class ConcatSkippableBlockInputStream<false>;

--- a/dbms/src/Storages/DeltaMerge/ConcatSkippableBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/ConcatSkippableBlockInputStream.h
@@ -70,7 +70,7 @@ private:
     std::vector<size_t> rows;
     size_t precede_stream_rows;
     const ScanContextPtr scan_context;
-    LACBytesCollector lac_bytes_collector;
+    std::optional<LACBytesCollector> lac_bytes_collector;
     ReadTag read_tag;
 };
 

--- a/dbms/src/Storages/DeltaMerge/ConcatSkippableBlockInputStream.h
+++ b/dbms/src/Storages/DeltaMerge/ConcatSkippableBlockInputStream.h
@@ -16,9 +16,9 @@
 
 #include <Flash/ResourceControl/LocalAdmissionController.h>
 #include <Storages/DeltaMerge/ConcatSkippableBlockInputStream_fwd.h>
+#include <Storages/DeltaMerge/ReadMode.h>
 #include <Storages/DeltaMerge/ScanContext_fwd.h>
 #include <Storages/DeltaMerge/SkippableBlockInputStream.h>
-
 
 namespace DB::DM
 {
@@ -30,18 +30,21 @@ public:
     static auto create(
         SkippableBlockInputStreams && inputs_,
         std::vector<size_t> && rows_,
-        const ScanContextPtr & scan_context_)
+        const ScanContextPtr & scan_context_,
+        ReadTag read_tag_)
     {
         return std::make_shared<ConcatSkippableBlockInputStream<need_row_id>>(
             std::move(inputs_),
             std::move(rows_),
-            scan_context_);
+            scan_context_,
+            read_tag_);
     }
 
     ConcatSkippableBlockInputStream(
         SkippableBlockInputStreams && inputs_,
         std::vector<size_t> && rows_,
-        const ScanContextPtr & scan_context_);
+        const ScanContextPtr & scan_context_,
+        ReadTag read_tag_);
 
     void appendChild(SkippableBlockInputStreamPtr child, size_t rows_);
 
@@ -68,6 +71,7 @@ private:
     size_t precede_stream_rows;
     const ScanContextPtr scan_context;
     LACBytesCollector lac_bytes_collector;
+    ReadTag read_tag;
 };
 
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/Delta/DeltaValueSpace.h
+++ b/dbms/src/Storages/DeltaMerge/Delta/DeltaValueSpace.h
@@ -18,6 +18,7 @@
 #include <Common/CurrentMetrics.h>
 #include <Common/Exception.h>
 #include <Core/Block.h>
+#include <Flash/ResourceControl/LocalAdmissionController.h>
 #include <IO/WriteHelpers.h>
 #include <Storages/DeltaMerge/ColumnFile/ColumnFile.h>
 #include <Storages/DeltaMerge/ColumnFile/ColumnFileBig.h>
@@ -25,7 +26,7 @@
 #include <Storages/DeltaMerge/ColumnFile/ColumnFileInMemory.h>
 #include <Storages/DeltaMerge/ColumnFile/ColumnFileSetInputStream.h>
 #include <Storages/DeltaMerge/ColumnFile/ColumnFileTiny.h>
-#include <Storages/DeltaMerge/DMContext_fwd.h>
+#include <Storages/DeltaMerge/DMContext.h>
 #include <Storages/DeltaMerge/Delta/ColumnFilePersistedSet.h>
 #include <Storages/DeltaMerge/Delta/MemTableSet.h>
 #include <Storages/DeltaMerge/DeltaIndex/DeltaIndex.h>
@@ -33,9 +34,9 @@
 #include <Storages/DeltaMerge/DeltaMergeDefines.h>
 #include <Storages/DeltaMerge/DeltaMergeHelpers.h>
 #include <Storages/DeltaMerge/RowKeyRange.h>
+#include <Storages/DeltaMerge/ScanContext.h>
 #include <Storages/DeltaMerge/SegmentRowID.h>
 #include <Storages/Page/PageDefinesBase.h>
-
 
 namespace DB::DM
 {
@@ -482,11 +483,14 @@ private:
 
     const DMContext & dm_context;
     ReadTag read_tag;
+    std::optional<LACBytesCollector> lac_bytes_collector;
 
 private:
     DeltaValueReader(const DMContext & dm_context_, ReadTag read_tag_)
         : dm_context(dm_context_)
         , read_tag(read_tag_)
+        , lac_bytes_collector(
+              dm_context.scan_context ? dm_context.scan_context->newLACBytesCollector(read_tag_) : std::nullopt)
     {}
 
 public:

--- a/dbms/src/Storages/DeltaMerge/Delta/DeltaValueSpace.h
+++ b/dbms/src/Storages/DeltaMerge/Delta/DeltaValueSpace.h
@@ -480,8 +480,14 @@ private:
     ColumnDefinesPtr col_defs;
     RowKeyRange segment_range;
 
+    const DMContext & dm_context;
+    ReadTag read_tag;
+
 private:
-    DeltaValueReader() = default;
+    DeltaValueReader(const DMContext & dm_context_, ReadTag read_tag_)
+        : dm_context(dm_context_)
+        , read_tag(read_tag_)
+    {}
 
 public:
     DeltaValueReader(

--- a/dbms/src/Storages/DeltaMerge/Delta/Snapshot.cpp
+++ b/dbms/src/Storages/DeltaMerge/Delta/Snapshot.cpp
@@ -17,6 +17,7 @@
 #include <Storages/DeltaMerge/DMContext.h>
 #include <Storages/DeltaMerge/Delta/DeltaValueSpace.h>
 #include <Storages/DeltaMerge/RowKeyFilter.h>
+#include <Storages/DeltaMerge/ScanContext.h>
 #include <Storages/DeltaMerge/StoragePool/StoragePool.h>
 #include <Storages/DeltaMerge/convertColumnTypeHelpers.h>
 
@@ -91,11 +92,13 @@ DeltaValueReader::DeltaValueReader(
           read_tag_))
     , col_defs(col_defs_)
     , segment_range(segment_range_)
+    , dm_context(context)
+    , read_tag(read_tag_)
 {}
 
-DeltaValueReaderPtr DeltaValueReader::createNewReader(const ColumnDefinesPtr & new_col_defs, ReadTag read_tag)
+DeltaValueReaderPtr DeltaValueReader::createNewReader(const ColumnDefinesPtr & new_col_defs, ReadTag read_tag_)
 {
-    auto * new_reader = new DeltaValueReader();
+    auto * new_reader = new DeltaValueReader(dm_context, read_tag_);
     new_reader->delta_snap = delta_snap;
     new_reader->compacted_delta_index = compacted_delta_index;
     new_reader->persisted_files_reader = persisted_files_reader->createNewReader(new_col_defs, read_tag);
@@ -104,6 +107,14 @@ DeltaValueReaderPtr DeltaValueReader::createNewReader(const ColumnDefinesPtr & n
     new_reader->segment_range = segment_range;
 
     return std::shared_ptr<DeltaValueReader>(new_reader);
+}
+
+static size_t columnsBytes(const MutableColumns & columns)
+{
+    size_t bytes = 0;
+    for (auto & col : columns)
+        bytes += col->byteSize();
+    return bytes;
 }
 
 size_t DeltaValueReader::readRows(
@@ -136,6 +147,7 @@ size_t DeltaValueReader::readRows(
         ? 0
         : std::min(offset + limit - mem_table_rows_offset, total_delta_rows - mem_table_rows_offset);
 
+    const auto initial_bytes = columnsBytes(output_cols);
     size_t actual_read = 0;
     size_t persisted_read_rows = 0;
     if (persisted_files_start < persisted_files_end)
@@ -165,6 +177,12 @@ size_t DeltaValueReader::readRows(
             row_ids->cend(),
             row_ids->begin() + persisted_read_rows, // write to the same location
             [mem_table_rows_offset](UInt32 id) { return id + mem_table_rows_offset; });
+    }
+
+    if (dm_context.scan_context)
+    {
+        const auto final_bytes = columnsBytes(output_cols);
+        dm_context.scan_context->addUserReadBytes(final_bytes - initial_bytes, read_tag);
     }
 
     return actual_read;

--- a/dbms/src/Storages/DeltaMerge/Delta/Snapshot.cpp
+++ b/dbms/src/Storages/DeltaMerge/Delta/Snapshot.cpp
@@ -94,6 +94,8 @@ DeltaValueReader::DeltaValueReader(
     , segment_range(segment_range_)
     , dm_context(context)
     , read_tag(read_tag_)
+    , lac_bytes_collector(
+          dm_context.scan_context ? dm_context.scan_context->newLACBytesCollector(read_tag_) : std::nullopt)
 {}
 
 DeltaValueReaderPtr DeltaValueReader::createNewReader(const ColumnDefinesPtr & new_col_defs, ReadTag read_tag_)
@@ -182,7 +184,7 @@ size_t DeltaValueReader::readRows(
     if (dm_context.scan_context)
     {
         const auto final_bytes = columnsBytes(output_cols);
-        dm_context.scan_context->addUserReadBytes(final_bytes - initial_bytes, read_tag);
+        dm_context.scan_context->addUserReadBytes(final_bytes - initial_bytes, read_tag, lac_bytes_collector);
     }
 
     return actual_read;

--- a/dbms/src/Storages/DeltaMerge/Delta/Snapshot.cpp
+++ b/dbms/src/Storages/DeltaMerge/Delta/Snapshot.cpp
@@ -114,7 +114,7 @@ DeltaValueReaderPtr DeltaValueReader::createNewReader(const ColumnDefinesPtr & n
 static size_t columnsBytes(const MutableColumns & columns)
 {
     size_t bytes = 0;
-    for (auto & col : columns)
+    for (const auto & col : columns)
         bytes += col->byteSize();
     return bytes;
 }

--- a/dbms/src/Storages/DeltaMerge/Index/VectorIndex/tests/gtest_dm_vector_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/VectorIndex/tests/gtest_dm_vector_index.cpp
@@ -136,7 +136,8 @@ try
         return ConcatSkippableBlockInputStream<false>::create(
             {NopSkippableBlockInputStream::wrap(block1), NopSkippableBlockInputStream::wrap(block2)},
             {7, 4},
-            nullptr);
+            nullptr,
+            ReadTag::Query);
     };
 
     // VectorIndexInputStream does not need this information, but ctx needs at least a correct vec column.

--- a/dbms/src/Storages/DeltaMerge/Index/VectorIndex/tests/gtest_dm_vector_index_utils.h
+++ b/dbms/src/Storages/DeltaMerge/Index/VectorIndex/tests/gtest_dm_vector_index_utils.h
@@ -138,7 +138,8 @@ public:
         auto stream = ConcatSkippableBlockInputStream<false>::create(
             /* inputs */ {inner},
             /* rows */ {filter->size()},
-            /* ScanContext */ nullptr);
+            /* ScanContext */ nullptr,
+            ReadTag::Query);
         return VectorIndexInputStream::create(ctx, filter, stream);
     }
 };

--- a/dbms/src/Storages/DeltaMerge/ReadMode.h
+++ b/dbms/src/Storages/DeltaMerge/ReadMode.h
@@ -46,4 +46,11 @@ enum class ReadTag
     MVCC, // Read columns to build MVCC bitmap.
     LMFilter, // Read columns required by late-materialization filter.
 };
+
+enum class ReadRUType
+{
+    MVCC_ESTIMATE,
+    MVCC_READ,
+    QUERY_READ,
+};
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/ReadMode.h
+++ b/dbms/src/Storages/DeltaMerge/ReadMode.h
@@ -41,7 +41,7 @@ enum class ReadMode
 
 enum class ReadTag
 {
-    Internal, // Read columns required by some internal tasks.
+    Internal, // Read columns required by some internal tasks, such as building delta index, building version chain, compaction.
     Query, // Read columns required by queries.
     MVCC, // Read columns to build MVCC bitmap.
     LMFilter, // Read columns required by late-materialization filter.

--- a/dbms/src/Storages/DeltaMerge/ScanContext.h
+++ b/dbms/src/Storages/DeltaMerge/ScanContext.h
@@ -508,6 +508,13 @@ public:
 
     static void initCurrentInstanceId(Poco::Util::AbstractConfiguration & config, const LoggerPtr & log);
 
+    void addUserReadBytes(size_t bytes, ReadTag read_tag)
+    {
+        if (read_tag != ReadTag::Query && read_tag != ReadTag::LMFilter && read_tag != ReadTag::MVCC)
+            return;
+        user_read_bytes += bytes;
+    }
+
 private:
     void serializeRegionNumOfInstance(tipb::TiFlashScanContext & proto) const;
     void deserializeRegionNumberOfInstance(const tipb::TiFlashScanContext & proto);

--- a/dbms/src/Storages/DeltaMerge/ScanContext.h
+++ b/dbms/src/Storages/DeltaMerge/ScanContext.h
@@ -60,8 +60,6 @@ public:
     std::atomic<uint64_t> total_local_region_num{0};
     std::atomic<uint64_t> num_stale_read{0};
 
-    // the read bytes from delta layer and stable layer (in-mem, decompressed)
-    std::atomic<uint64_t> user_read_bytes{0};
     std::atomic<uint64_t> disagg_read_cache_hit_size{0};
     std::atomic<uint64_t> disagg_read_cache_miss_size{0};
 
@@ -175,7 +173,9 @@ public:
         create_snapshot_time_ns = tiflash_scan_context_pb.total_build_snapshot_ms() * 1000000;
         total_remote_region_num = tiflash_scan_context_pb.remote_regions();
         total_local_region_num = tiflash_scan_context_pb.local_regions();
-        user_read_bytes = tiflash_scan_context_pb.user_read_bytes();
+        // TODO: rename user_read_bytes to query_read_bytes in tipb.
+        query_read_bytes = tiflash_scan_context_pb.user_read_bytes();
+        // TODO: add mvcc_read_bytes in tipb.
         learner_read_ns = tiflash_scan_context_pb.total_learner_read_ms() * 1000000;
         disagg_read_cache_hit_size = tiflash_scan_context_pb.disagg_read_cache_hit_bytes();
         disagg_read_cache_miss_size = tiflash_scan_context_pb.disagg_read_cache_miss_bytes();
@@ -262,7 +262,9 @@ public:
         tiflash_scan_context_pb.set_total_build_snapshot_ms(create_snapshot_time_ns / 1000000);
         tiflash_scan_context_pb.set_remote_regions(total_remote_region_num);
         tiflash_scan_context_pb.set_local_regions(total_local_region_num);
-        tiflash_scan_context_pb.set_user_read_bytes(user_read_bytes);
+        // TODO: rename user_read_bytes to query_read_bytes in tipb.
+        tiflash_scan_context_pb.set_user_read_bytes(userReadBytes());
+        // TODO: add mvcc_read_bytes in tipb.
         tiflash_scan_context_pb.set_total_learner_read_ms(learner_read_ns / 1000000);
         tiflash_scan_context_pb.set_disagg_read_cache_hit_bytes(disagg_read_cache_hit_size);
         tiflash_scan_context_pb.set_disagg_read_cache_miss_bytes(disagg_read_cache_miss_size);
@@ -353,7 +355,8 @@ public:
 
         total_local_region_num += other.total_local_region_num;
         total_remote_region_num += other.total_remote_region_num;
-        user_read_bytes += other.user_read_bytes;
+        query_read_bytes += other.query_read_bytes;
+        mvcc_read_bytes += other.mvcc_read_bytes;
         disagg_read_cache_hit_size += other.disagg_read_cache_hit_size;
         disagg_read_cache_miss_size += other.disagg_read_cache_miss_size;
 
@@ -444,7 +447,9 @@ public:
         create_snapshot_time_ns += other.total_build_snapshot_ms() * 1000000;
         total_local_region_num += other.local_regions();
         total_remote_region_num += other.remote_regions();
-        user_read_bytes += other.user_read_bytes();
+        // TODO: rename user_read_bytes to query_read_bytes in tipb.
+        query_read_bytes += other.user_read_bytes();
+        // TODO: add mvcc_read_bytes in tipb.
         learner_read_ns += other.total_learner_read_ms() * 1000000;
         disagg_read_cache_hit_size += other.disagg_read_cache_hit_bytes();
         disagg_read_cache_miss_size += other.disagg_read_cache_miss_bytes();
@@ -526,6 +531,7 @@ public:
     // LACBytesCollector is not thread-safe, to avoid locking, we create a new one for each stream.
     std::optional<LACBytesCollector> newLACBytesCollector(ReadTag read_tag);
     void addUserReadBytes(size_t bytes, ReadTag read_tag, std::optional<LACBytesCollector> & lac_bytes_collector);
+    uint64_t userReadBytes() const { return query_read_bytes + mvcc_read_bytes; }
 
 private:
     void serializeRegionNumOfInstance(tipb::TiFlashScanContext & proto) const;
@@ -549,6 +555,9 @@ private:
     // It only used to identify which store generated the ScanContext object.
     inline static String current_instance_id;
 
+    // the read bytes from delta layer and stable layer (in-mem, decompressed)
+    std::atomic<uint64_t> query_read_bytes{0};
+    std::atomic<uint64_t> mvcc_read_bytes{0};
     prometheus::Counter * mvcc_read_bytes_counter = nullptr;
     prometheus::Counter * query_read_bytes_counter = nullptr;
 };

--- a/dbms/src/Storages/DeltaMerge/Segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/Segment.cpp
@@ -998,6 +998,9 @@ static void consumeBuildMVCCReadBytesRU(
     {
         const auto keyspace_id = dm_context.scan_context->keyspace_id;
         auto bytes = Segment::estimatedBytesOfInternalColumns(dm_context, segment_snap, pack_filter_results, start_ts);
+        TiFlashMetrics::instance()
+            .getStorageRUReadBytesCounter(keyspace_id, res_group_name, ReadRUType::MVCC_ESTIMATE)
+            .Increment(bytes);
         LocalAdmissionController::global_instance->consumeBytesResource(keyspace_id, res_group_name, bytesToRU(bytes));
     }
 }

--- a/dbms/src/Storages/DeltaMerge/Segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/Segment.cpp
@@ -2633,14 +2633,12 @@ Segment::ReadInfo Segment::getReadInfo(
     auto new_read_columns = arrangeReadColumns(getExtraHandleColumnDefine(is_common_handle), read_columns);
     auto pk_ver_col_defs = std::make_shared<ColumnDefines>(
         ColumnDefines{getExtraHandleColumnDefine(dm_context.is_common_handle), getVersionColumnDefine()});
-    // Create a reader that reads pk and version columns to update deltaindex.
-    // It related to MVCC, so always set a `ReadTag::MVCC` for it.
     auto delta_reader = std::make_shared<DeltaValueReader>(
         dm_context,
         segment_snap->delta,
         pk_ver_col_defs,
         this->rowkey_range,
-        ReadTag::MVCC);
+        ReadTag::Internal);
 
     auto [my_delta_index, fully_indexed] = ensurePlace(dm_context, segment_snap, delta_reader, read_ranges, start_ts);
     auto compacted_index = my_delta_index->getDeltaTree()->getCompactedEntries();
@@ -2932,7 +2930,7 @@ bool Segment::placeUpsert(
         compacted_index->begin(),
         compacted_index->end(),
         dm_context.stable_pack_rows,
-        ReadTag::MVCC);
+        ReadTag::Internal);
 
     if (do_sort)
         return DM::placeInsert<true>(
@@ -2984,7 +2982,7 @@ bool Segment::placeDelete(
             compacted_index->begin(),
             compacted_index->end(),
             dm_context.stable_pack_rows,
-            ReadTag::MVCC);
+            ReadTag::Internal);
 
         delete_stream = std::make_shared<DMRowKeyFilterBlockInputStream<true>>(delete_stream, delete_ranges, 0);
 
@@ -3021,7 +3019,7 @@ bool Segment::placeDelete(
             compacted_index->begin(),
             compacted_index->end(),
             dm_context.stable_pack_rows,
-            ReadTag::MVCC);
+            ReadTag::Internal);
         fully_indexed &= DM::placeDelete(
             merged_stream,
             block,

--- a/dbms/src/Storages/DeltaMerge/Segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/Segment.cpp
@@ -2636,6 +2636,8 @@ Segment::ReadInfo Segment::getReadInfo(
     auto new_read_columns = arrangeReadColumns(getExtraHandleColumnDefine(is_common_handle), read_columns);
     auto pk_ver_col_defs = std::make_shared<ColumnDefines>(
         ColumnDefines{getExtraHandleColumnDefine(dm_context.is_common_handle), getVersionColumnDefine()});
+    // Create a reader that reads pk and version columns to update delta-index.
+    // Updating delta-index is not count as MVCC, use `ReadTag::Internal` for it.
     auto delta_reader = std::make_shared<DeltaValueReader>(
         dm_context,
         segment_snap->delta,

--- a/dbms/src/Storages/DeltaMerge/StableValueSpace.cpp
+++ b/dbms/src/Storages/DeltaMerge/StableValueSpace.cpp
@@ -489,7 +489,8 @@ ConcatSkippableBlockInputStreamPtr<need_row_id> StableValueSpace::Snapshot::getI
     return ConcatSkippableBlockInputStream<need_row_id>::create(
         std::move(streams),
         std::move(rows),
-        dm_context.scan_context);
+        dm_context.scan_context,
+        read_tag);
 }
 
 template ConcatSkippableBlockInputStreamPtr<false> StableValueSpace::Snapshot::getInputStream(

--- a/dbms/src/Storages/DeltaMerge/VersionChain/Common.cpp
+++ b/dbms/src/Storages/DeltaMerge/VersionChain/Common.cpp
@@ -15,6 +15,7 @@
 #include <Interpreters/Context.h>
 #include <Storages/DeltaMerge/DMContext.h>
 #include <Storages/DeltaMerge/File/DMFilePackFilter.h>
+#include <Storages/DeltaMerge/ScanContext.h>
 #include <Storages/DeltaMerge/VersionChain/Common.h>
 
 namespace DB::DM
@@ -150,4 +151,10 @@ template std::optional<std::pair<Int64, Int64>> loadDMFileHandleRange<Int64>(
 template std::optional<std::pair<String, String>> loadDMFileHandleRange<String>(
     const DMContext & dm_context,
     const DMFile & dmfile);
+
+void addUserReadBytes(const DMContext & dm_context, size_t bytes)
+{
+    if (dm_context.scan_context)
+        dm_context.scan_context->addUserReadBytes(bytes, ReadTag::MVCC);
+}
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/VersionChain/Common.cpp
+++ b/dbms/src/Storages/DeltaMerge/VersionChain/Common.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Flash/ResourceControl/LocalAdmissionController.h>
 #include <Interpreters/Context.h>
 #include <Storages/DeltaMerge/DMContext.h>
 #include <Storages/DeltaMerge/File/DMFilePackFilter.h>
@@ -155,6 +156,9 @@ template std::optional<std::pair<String, String>> loadDMFileHandleRange<String>(
 void addUserReadBytes(const DMContext & dm_context, size_t bytes)
 {
     if (dm_context.scan_context)
-        dm_context.scan_context->addUserReadBytes(bytes, ReadTag::MVCC);
+    {
+        std::optional<LACBytesCollector> lac_bytes_collector;
+        dm_context.scan_context->addUserReadBytes(bytes, ReadTag::MVCC, lac_bytes_collector);
+    }
 }
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/VersionChain/Common.h
+++ b/dbms/src/Storages/DeltaMerge/VersionChain/Common.h
@@ -89,4 +89,5 @@ std::optional<std::pair<HandleType, HandleType>> loadDMFileHandleRange(
     const DMContext & dm_context,
     const DMFile & dmfile);
 
+void addUserReadBytes(const DMContext & dm_context, size_t bytes);
 } // namespace DB::DM

--- a/dbms/src/Storages/DeltaMerge/VersionChain/DMFileHandleIndex.h
+++ b/dbms/src/Storages/DeltaMerge/VersionChain/DMFileHandleIndex.h
@@ -170,7 +170,7 @@ private:
             dm_context.tracing_id,
             /*max_sharing_column_bytes_for_all*/ false,
             dm_context.scan_context,
-            ReadTag::MVCC);
+            ReadTag::Internal);
 
         const auto & pack_stats = dmfile->getPackStats();
         clipped_handle_packs.resize(clipped_pack_range.count);

--- a/dbms/src/Storages/DeltaMerge/VersionChain/DeleteMarkFilter.cpp
+++ b/dbms/src/Storages/DeltaMerge/VersionChain/DeleteMarkFilter.cpp
@@ -44,6 +44,7 @@ UInt32 buildDeleteMarkFilterBlock(
         "ColumnFile<{}> returns {} rows. Read all rows in one block is required!",
         cf.toString(),
         block.rows());
+    addUserReadBytes(dm_context, block.bytes());
     const auto deleteds = ColumnView<UInt8>(*(block.begin()->column));
     UInt32 filtered_out_rows = 0;
     for (UInt32 i = 0; i < deleteds.size(); ++i)
@@ -103,6 +104,7 @@ UInt32 buildDeleteMarkFilterDMFile(
     for (auto pack_id : *need_read_packs)
     {
         auto block = stream->read();
+        addUserReadBytes(dm_context, block.bytes());
         RUNTIME_CHECK(block.rows() == pack_stats[pack_id].rows, block.rows(), pack_stats[pack_id].rows);
         const auto deleteds = ColumnView<UInt8>(*(block.begin()->column));
         const auto itr = start_row_id_of_need_read_packs.find(pack_id);

--- a/dbms/src/Storages/DeltaMerge/VersionChain/RowKeyFilter.cpp
+++ b/dbms/src/Storages/DeltaMerge/VersionChain/RowKeyFilter.cpp
@@ -73,6 +73,7 @@ UInt32 buildRowKeyFilterBlock(
         "ColumnFile<{}> returns {} rows. Read all rows in one block is required!",
         cf.toString(),
         block.rows());
+    addUserReadBytes(dm_context, block.bytes());
 
     const auto handles = ColumnView<HandleType>(*(block.begin()->column));
     return buildRowKeyFilterVector<HandleType>(handles, delete_ranges, read_ranges, start_row_id, filter);
@@ -125,6 +126,7 @@ UInt32 buildRowKeyFilterDMFile(
     for (auto pack_id : *need_read_packs)
     {
         auto block = stream->read();
+        addUserReadBytes(dm_context, block.bytes());
         RUNTIME_CHECK(block.rows() == pack_stats[pack_id].rows, block.rows(), pack_stats[pack_id].rows);
         const auto handles = ColumnView<HandleType>(*(block.begin()->column));
         const auto itr = start_row_id_of_need_read_packs.find(pack_id);

--- a/dbms/src/Storages/DeltaMerge/VersionChain/VersionChain.cpp
+++ b/dbms/src/Storages/DeltaMerge/VersionChain/VersionChain.cpp
@@ -205,7 +205,8 @@ UInt32 VersionChain<HandleType>::replayBlock(
 {
     assert(cf.isInMemoryFile() || cf.isTinyFile());
 
-    auto cf_reader = cf.getReader(dm_context, data_provider, getHandleColumnDefinesPtr<HandleType>(), ReadTag::MVCC);
+    auto cf_reader
+        = cf.getReader(dm_context, data_provider, getHandleColumnDefinesPtr<HandleType>(), ReadTag::Internal);
     auto block = cf_reader->readNextBlock();
     RUNTIME_CHECK_MSG(
         cf.getRows() == block.rows(),
@@ -310,7 +311,7 @@ UInt32 VersionChain<HandleType>::replayColumnFileBig(
         dm_context,
         /*data_provider*/ nullptr,
         getHandleColumnDefinesPtr<HandleType>(),
-        ReadTag::MVCC);
+        ReadTag::Internal);
     UInt32 read_rows = 0;
     while (true)
     {
@@ -387,7 +388,7 @@ DeltaValueReader VersionChain<HandleType>::createDeltaValueReader(
         delta_snap,
         getHandleColumnDefinesPtr<HandleType>(),
         /*range*/ {},
-        ReadTag::MVCC};
+        ReadTag::Internal};
 }
 
 template <ExtraHandleType HandleType>

--- a/dbms/src/Storages/DeltaMerge/VersionChain/VersionFilter.cpp
+++ b/dbms/src/Storages/DeltaMerge/VersionChain/VersionFilter.cpp
@@ -89,6 +89,7 @@ UInt32 buildVersionFilterVector(
         auto block = cf_reader->readNextBlock();
         if (!block)
             break;
+        addUserReadBytes(dm_context, block.bytes());
 
         ++read_block_count;
         read_rows += block.rows();
@@ -169,6 +170,7 @@ template <ExtraHandleType HandleType>
     {
         auto block = stream->read();
         RUNTIME_CHECK(block.rows() == pack_stats[pack_id].rows, block.rows(), pack_stats[pack_id].rows);
+        addUserReadBytes(dm_context, block.bytes());
         const auto handles = ColumnView<HandleType>(*(block.getByPosition(0).column));
         const auto & versions = *toColumnVectorDataPtr<UInt64>(block.getByPosition(1).column);
         const auto itr = start_row_id_of_need_read_packs.find(pack_id);

--- a/dbms/src/Storages/DeltaMerge/VersionChain/tests/mvcc_test_utils.h
+++ b/dbms/src/Storages/DeltaMerge/VersionChain/tests/mvcc_test_utils.h
@@ -299,7 +299,7 @@ inline DeltaIndexPtr buildDeltaIndex(
         snapshot->delta,
         pk_ver_col_defs,
         segment.getRowKeyRange(),
-        ReadTag::MVCC);
+        ReadTag::Internal);
 
     auto [delta_index, fully_indexed] = segment.ensurePlace(
         dm_context,

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_delta_merge_store.cpp
@@ -4171,7 +4171,7 @@ void DeltaMergeStoreRWTest::dupHandleVersionAndDeltaIndexAdvancedThanSnapshot()
             seg_read_task->read_snapshot->delta,
             pk_ver_col_defs,
             RowKeyRange::newAll(store->isCommonHandle(), store->getRowKeyColumnSize()),
-            ReadTag::MVCC);
+            ReadTag::Internal);
         return seg_read_task->segment->ensurePlace(
             *dm_context,
             seg_read_task->read_snapshot,

--- a/metrics/grafana/tiflash_summary.json
+++ b/metrics/grafana/tiflash_summary.json
@@ -19283,6 +19283,14 @@
               "interval": "",
               "legendFormat": "query-sum-24h-{{cluster_id}}",
               "refId": "D"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(rate(tiflash_storage_ru_read_bytes[1m])) by (keyspace, resource_group, type) / (64 * 1024)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "storage-{{keyspace}}_{{resource_group}}_{{type}}",
+              "refId": "E"
             }
           ],
           "thresholds": [],


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10380

- `ConcatSkippableBlockInputStream`
  - When generating MVCC bitmaps using DeltaIndex, row_id is generated in `DeltaMergeBlockInputStream`. The `getPlacedStream` method sets the `need_row_id` parameter to **false** when obtaining the stable stream. Therefore, in **ConcatSkippableBlockInputStream**, `need_row_id` **cannot** be used to determine whether MVCC is involved.
  - This can be resolved by switching to a check based on read_tag.
- `DeltaValueReader`
  - When we use `getInputStreamNormal` to read data, delta data is read through `DeltaValueReader`. Thus, `DeltaValueReader` needs to add statistics for `user_read_bytes`.
- VersionChain
  - Track the read bytes consumed during the construction of MVCC bitmaps.
- ScanContext
  - Encapsulate the reporting of primary `user_read_bytes` and metrics within `ScanContext`.
- Mark the read operations for updating DeltaIndex and VersionChain as `ReadTag::Internal`.
- TiFlashMetrics
  - Add storage-layer RU (Resource Usage) monitoring.

<img width="1234" height="303" alt="image" src="https://github.com/user-attachments/assets/6865f5af-b444-4581-88be-7eb59e6c581d" />

<img width="1228" height="299" alt="image" src="https://github.com/user-attachments/assets/d4d411c2-2c2d-4fe4-8a83-df760bde0e9f" />

### What is changed and how it works?

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
