### PR TITLE
PageStorage: Fix an exception in gc when meet an empty WriteBatch

### DIFF
--- a/dbms/src/Storages/Page/V3/LogFile/LogFilename.h
+++ b/dbms/src/Storages/Page/V3/LogFile/LogFilename.h
@@ -76,6 +76,7 @@ struct LogFilenameCmp
         return lhs.log_num < rhs.log_num;
     }
 };
+// Sort log filename by <log_num, level_num> in increasing order
 using LogFilenameSet = std::set<LogFilename, LogFilenameCmp>;
 
 } // namespace DB::PS::V3

--- a/dbms/src/Storages/Page/V3/PageDirectory.cpp
+++ b/dbms/src/Storages/Page/V3/PageDirectory.cpp
@@ -128,7 +128,7 @@ void VersionedPageEntries<Trait>::createNewEntry(const PageVersion & ver, const 
             // to replace the entry with newer sequence.
             RUNTIME_CHECK_MSG(
                 last_iter->second.being_ref_count.getLatestRefCount() == 1 || last_iter->first.sequence >= ver.sequence,
-                "Try to replace normal entry with an newer seq [ver={}] [prev_ver={}] [last_entry={}]",
+                "Try to replace normal entry with an newer seq, ver={} prev_ver={} last_entry={}",
                 ver,
                 last_iter->first,
                 last_iter->second);
@@ -140,8 +140,8 @@ void VersionedPageEntries<Trait>::createNewEntry(const PageVersion & ver, const 
 
     throw Exception(
         ErrorCodes::PS_DIR_APPLY_INVALID_STATUS,
-        "try to create entry version with invalid state "
-        "[ver={}] [entry={}] [state={}]",
+        "try to create entry version with invalid state, "
+        "ver={} entry={} state={}",
         ver,
         entry,
         toDebugString());
@@ -186,7 +186,7 @@ typename VersionedPageEntries<Trait>::PageId VersionedPageEntries<Trait>::create
             // to replace the entry with newer sequence.
             RUNTIME_CHECK_MSG(
                 last_iter->second.being_ref_count.getLatestRefCount() == 1 || last_iter->first.sequence >= ver.sequence,
-                "Try to replace normal entry with an newer seq [ver={}] [prev_ver={}] [last_entry={}]",
+                "Try to replace normal entry with an newer seq, ver={} prev_ver={} last_entry={}",
                 ver,
                 last_iter->first,
                 last_iter->second);
@@ -228,8 +228,8 @@ typename VersionedPageEntries<Trait>::PageId VersionedPageEntries<Trait>::create
 
     throw Exception(
         ErrorCodes::PS_DIR_APPLY_INVALID_STATUS,
-        "try to create upsert entry version with invalid state "
-        "[ver={}] [entry={}] [state={}]",
+        "try to create upsert entry version with invalid state, "
+        "ver={} entry={} state={}",
         ver,
         entry,
         toDebugString());
@@ -288,8 +288,8 @@ std::shared_ptr<typename VersionedPageEntries<Trait>::PageId> VersionedPageEntri
 
     throw Exception(
         ErrorCodes::PS_DIR_APPLY_INVALID_STATUS,
-        "try to create external version with invalid state "
-        "[ver={}] [state={}]",
+        "try to create external version with invalid state, "
+        "ver={} state={}",
         ver,
         toDebugString());
 }
@@ -324,8 +324,8 @@ void VersionedPageEntries<Trait>::createDelete(const PageVersion & ver) NO_THREA
 
     throw Exception(
         ErrorCodes::LOGICAL_ERROR,
-        "try to create delete version with invalid state "
-        "[ver={}] [state={}]",
+        "try to create delete version with invalid state, "
+        "ver={} state={}",
         ver,
         toDebugString());
 }
@@ -375,8 +375,8 @@ bool VersionedPageEntries<Trait>::updateLocalCacheForRemotePage(
     }
     throw Exception(
         ErrorCodes::LOGICAL_ERROR,
-        "try to update remote page with invalid state "
-        "[ver={}] [state={}]",
+        "try to update remote page with invalid state, "
+        "ver={} state={}",
         ver,
         toDebugString());
 }
@@ -431,8 +431,8 @@ bool VersionedPageEntries<Trait>::createNewRef(const PageVersion & ver, const Pa
     // adding ref to replace put/external is not allowed
     throw Exception(
         ErrorCodes::PS_DIR_APPLY_INVALID_STATUS,
-        "try to create ref version with invalid state "
-        "[ver={}] [ori_page_id={}] [state={}]",
+        "try to create ref version with invalid state, "
+        "ver={} ori_page_id={} state={}",
         ver,
         ori_page_id_,
         toDebugString());
@@ -668,8 +668,8 @@ bool VersionedPageEntries<Trait>::isVisible(UInt64 seq) const NO_THREAD_SAFETY_A
 
     throw Exception(
         ErrorCodes::LOGICAL_ERROR,
-        "calling isDeleted with invalid state "
-        "[seq={}] [state={}]",
+        "calling isDeleted with invalid state, "
+        "seq={} state={}",
         seq,
         toDebugString());
 }
@@ -698,7 +698,7 @@ Int64 VersionedPageEntries<Trait>::incrRefCount(const PageVersion & target_ver, 
                 {
                     throw Exception(
                         ErrorCodes::LOGICAL_ERROR,
-                        "Try to add ref to a completely deleted entry [entry={}] [ver={}]",
+                        "Try to add ref to a completely deleted entry, entry={} ver={}",
                         iter->second,
                         target_ver);
                 }
@@ -719,7 +719,7 @@ Int64 VersionedPageEntries<Trait>::incrRefCount(const PageVersion & target_ver, 
     }
     throw Exception(
         ErrorCodes::LOGICAL_ERROR,
-        "The entry to be added ref count is not found [ver={}] [state={}]",
+        "The entry to be added ref count is not found, ver={} state={}",
         target_ver,
         toDebugString());
 }
@@ -916,7 +916,7 @@ bool VersionedPageEntries<Trait>::derefAndClean(
         {
             throw Exception(
                 ErrorCodes::LOGICAL_ERROR,
-                "Can not find entry for decreasing ref count [page_id={}] [ver={}] [deref_count={}]",
+                "Can not find entry for decreasing ref count, page_id={} ver={} deref_count={}",
                 page_id,
                 deref_ver,
                 deref_count);
@@ -932,7 +932,7 @@ bool VersionedPageEntries<Trait>::derefAndClean(
             // run into the begin of `entries`, but still can not find a valid entry to decrease the ref-count
             throw Exception(
                 ErrorCodes::LOGICAL_ERROR,
-                "Can not find entry for decreasing ref count till the begin [page_id={}] [ver={}] [deref_count={}]",
+                "Can not find entry for decreasing ref count till the begin, page_id={} ver={} deref_count={}",
                 page_id,
                 deref_ver,
                 deref_count);
@@ -1168,18 +1168,18 @@ typename PageDirectory<Trait>::PageIdAndEntry PageDirectory<Trait>::getByIDImpl(
             {
                 if (throw_on_not_exist)
                 {
-                    LOG_WARNING(log, "Dump state for invalid page id [page_id={}]", page_id);
+                    LOG_WARNING(log, "Dump state for invalid page id, page_id={}", page_id);
                     for (const auto & [dump_id, dump_entry] : mvcc_table_directory)
                     {
                         LOG_WARNING(
                             log,
-                            "Dumping state [page_id={}] [entry={}]",
+                            "Dumping state, page_id={} entry={}",
                             dump_id,
                             dump_entry == nullptr ? "<null>" : dump_entry->toDebugString());
                     }
                     throw Exception(
                         ErrorCodes::PS_ENTRY_NOT_EXISTS,
-                        "Invalid page id, entry not exist [page_id={}] [resolve_id={}]",
+                        "Invalid page id, entry not exist, page_id={} resolve_id={}",
                         page_id,
                         id_to_resolve);
                 }
@@ -1218,7 +1218,7 @@ typename PageDirectory<Trait>::PageIdAndEntry PageDirectory<Trait>::getByIDImpl(
     {
         throw Exception(
             ErrorCodes::PS_ENTRY_NO_VALID_VERSION,
-            "Fail to get entry [page_id={}] [seq={}] [resolve_id={}] [resolve_ver={}]",
+            "Fail to get entry, page_id={} seq={} resolve_id={} resolve_ver={}",
             page_id,
             snap->sequence,
             id_to_resolve,
@@ -1261,7 +1261,7 @@ std::pair<typename PageDirectory<Trait>::PageIdAndEntries, typename PageDirector
                     {
                         throw Exception(
                             ErrorCodes::PS_ENTRY_NOT_EXISTS,
-                            "Invalid page id, entry not exist [page_id={}] [resolve_id={}]",
+                            "Invalid page id, entry not exist, page_id={} resolve_id={}",
                             page_id,
                             id_to_resolve);
                     }
@@ -1299,7 +1299,7 @@ std::pair<typename PageDirectory<Trait>::PageIdAndEntries, typename PageDirector
         {
             throw Exception(
                 ErrorCodes::PS_ENTRY_NO_VALID_VERSION,
-                "Fail to get entry [page_id={}] [ver={}] [resolve_id={}] [resolve_ver={}] [idx={}]",
+                "Fail to get entry, page_id={} ver={} resolve_id={} resolve_ver={} idx={}",
                 page_id,
                 init_ver_to_resolve,
                 id_to_resolve,
@@ -1350,7 +1350,7 @@ typename PageDirectory<Trait>::PageId PageDirectory<Trait>::getNormalPageId(
                 {
                     throw Exception(
                         ErrorCodes::LOGICAL_ERROR,
-                        "Invalid page id [page_id={}] [resolve_id={}]",
+                        "Invalid page id, page_id={} resolve_id={}",
                         page_id,
                         id_to_resolve);
                 }
@@ -1388,7 +1388,7 @@ typename PageDirectory<Trait>::PageId PageDirectory<Trait>::getNormalPageId(
     {
         throw Exception(
             ErrorCodes::LOGICAL_ERROR,
-            "fail to get normal id [page_id={}] [seq={}] [resolve_id={}] [resolve_ver={}]",
+            "fail to get normal id, page_id={} seq={} resolve_id={} resolve_ver={}",
             page_id,
             snap->sequence,
             id_to_resolve,
@@ -1576,7 +1576,7 @@ void PageDirectory<Trait>::applyRefEditRecord(
     {
         throw Exception(
             ErrorCodes::LOGICAL_ERROR,
-            "Trying to add ref to non-exist page [page_id={}] [ori_id={}] [ver={}] [resolve_id={}] [resolve_ver={}]",
+            "Trying to add ref to non-exist page, page_id={} ori_id={} ver={} resolve_id={} resolve_ver={}",
             rec.page_id,
             rec.ori_page_id,
             version,
@@ -1600,7 +1600,7 @@ void PageDirectory<Trait>::applyRefEditRecord(
         {
             throw Exception(
                 ErrorCodes::LOGICAL_ERROR,
-                "The ori page id is not found [page_id={}] [ori_id={}] [ver={}] [resolved_id={}] [resolved_ver={}]",
+                "The ori page id is not found, page_id={} ori_id={} ver={} resolved_id={} resolved_ver={}",
                 rec.page_id,
                 rec.ori_page_id,
                 version,
@@ -1779,7 +1779,7 @@ std::unordered_set<String> PageDirectory<Trait>::apply(PageEntriesEdit && edit, 
                 case EditRecordType::UPDATE_DATA_FROM_REMOTE:
                     throw Exception(
                         ErrorCodes::LOGICAL_ERROR,
-                        "should not handle edit with invalid type [type={}]",
+                        "should not handle edit with invalid type, type={}",
                         magic_enum::enum_name(r.type));
                 }
 
@@ -1792,7 +1792,7 @@ std::unordered_set<String> PageDirectory<Trait>::apply(PageEntriesEdit && edit, 
             catch (DB::Exception & e)
             {
                 e.addMessage(fmt::format(
-                    " [type={}] [page_id={}] [ver={}] [edit_size={}]",
+                    " type={} page_id={} ver={} edit_size={}",
                     magic_enum::enum_name(r.type),
                     r.page_id,
                     r.version,
@@ -1875,7 +1875,7 @@ typename PageDirectory<Trait>::PageEntries PageDirectory<Trait>::updateLocalCach
             catch (DB::Exception & e)
             {
                 e.addMessage(fmt::format(
-                    " type={}, page_id={}, ver={}, seq={}",
+                    " type={} page_id={} ver={} seq={}",
                     magic_enum::enum_name(r.type),
                     r.page_id,
                     r.version,
@@ -2269,12 +2269,12 @@ typename PageDirectory<Trait>::PageEntries PageDirectory<Trait>::gcInMemEntries(
     LOG_IMPL(
         log,
         log_level,
-        "After MVCC gc in memory [lowest_seq={}] "
-        "clean [invalid_snapshot_nums={}] [invalid_page_nums={}] "
-        "[total_deref_counter={}] [all_del_entries={}]. "
-        "Still exist [snapshot_nums={}], [page_nums={}]. "
-        "Longest alive snapshot: [longest_alive_snapshot_time={}] "
-        "[longest_alive_snapshot_seq={}] [stale_snapshot_nums={}]",
+        "After MVCC gc in memory, lowest_seq={} "
+        "clean invalid_snapshot_nums={} invalid_page_nums={} "
+        "total_deref_counter={} all_del_entries={}. "
+        "Still exist, snapshot_nums={} page_nums={}. "
+        "Longest alive snapshot: longest_alive_snapshot_time={} "
+        "longest_alive_snapshot_seq={} stale_snapshot_nums={}",
         lowest_seq,
         invalid_snapshot_nums,
         invalid_page_nums,

--- a/dbms/src/Storages/Page/V3/PageDirectory.h
+++ b/dbms/src/Storages/Page/V3/PageDirectory.h
@@ -654,12 +654,15 @@ private:
 
 namespace details
 {
+// Get the max sequence number from a serialized edit record.
+// If the record is empty, return std::nullopt.
 template <typename Trait>
-UInt64 getMaxSequenceForRecord(const String & record)
+std::optional<UInt64> getMaxSequenceForRecord(const String & record)
 {
     auto edit = Trait::Serializer::deserializeFrom(record, nullptr);
     const auto & records = edit.getRecords();
-    RUNTIME_CHECK(!records.empty(), record.size());
+    if (records.empty())
+        return std::nullopt;
     return records.back().version.sequence;
 }
 } // namespace details

--- a/dbms/src/Storages/Page/V3/WAL/WALReader.h
+++ b/dbms/src/Storages/Page/V3/WAL/WALReader.h
@@ -75,7 +75,7 @@ public:
         const ReadLimiterPtr & read_limiter,
         LoggerPtr logger);
 
-    static String getLastRecordInLogFile(
+    static std::tuple<size_t, String> getLastRecordInLogFile(
         const LogFilename & filename,
         FileProviderPtr & provider,
         WALRecoveryMode recovery_mode,

--- a/dbms/src/Storages/Page/V3/WALStore.cpp
+++ b/dbms/src/Storages/Page/V3/WALStore.cpp
@@ -14,6 +14,7 @@
 
 #include <Common/Exception.h>
 #include <Common/Logger.h>
+#include <Common/RedactHelpers.h>
 #include <Common/SyncPoint/SyncPoint.h>
 #include <IO/FileProvider/FileProvider.h>
 #include <Poco/File.h>
@@ -164,10 +165,11 @@ void WALStore::updateDiskUsage(const LogFilenameSet & log_filenames)
     }
 }
 
+// Try to get a snapshot of log files that can be compacted according to the `snap_sequence`.
 WALStore::FilesSnapshot WALStore::tryGetFilesSnapshot(
     size_t max_persisted_log_files,
     UInt64 snap_sequence,
-    std::function<UInt64(const String & record)> max_sequence_getter,
+    std::function<std::optional<UInt64>(const String & record)> && max_sequence_getter,
     bool force)
 {
     // First we simply check whether the number of files is enough for compaction
@@ -197,18 +199,34 @@ WALStore::FilesSnapshot WALStore::tryGetFilesSnapshot(
         log_file.reset();
     }
 
-    // traverse in reverse order,
-    // so that once the first log file whose max sequence is smaller or equal to snap_sequence is found,
+    // Collect the log files that all records' max sequence is smaller or equal to snap_sequence to
+    // `snap_log_files`.
+    // These log files can be compacted safely after we dump the in-memory snapshot to disk.
+    // Traverse `persisted_log_files` in reverse order (from largest log num to smallest) so that
+    // once the first log file whose max sequence is smaller or equal to snap_sequence is found,
     // we don't need to check the max sequence for the rest log files.
     bool found_log_file_smaller_than_snap_sequence = false;
     LogFilenameSet snap_log_files;
     for (auto iter = persisted_log_files.rbegin(); iter != persisted_log_files.rend(); ++iter) // NOLINT
     {
+        // Ignore the logfiles that maybe writing by other threads
         if (iter->log_num >= current_writing_log_num)
             continue;
-        if (!found_log_file_smaller_than_snap_sequence
-            && getLogFileMaxSequence(*iter, max_sequence_getter) > snap_sequence)
-            continue;
+        if (!found_log_file_smaller_than_snap_sequence)
+        {
+            const auto max_seq = getLogFileMaxSequence(*iter, max_sequence_getter);
+            LOG_DEBUG(logger, "tryGetFilesSnapshot, log_file={} max_sequence={}", iter->filename(iter->stage), max_seq);
+            // If we can not parse the max sequence from the last record, we conservatively skip
+            // this log file in this GC round. These remain log_files will be compacted in
+            // the following rounds once we found a log_file has larger log_num and its
+            // max_seq <= snap_sequence.
+            if (!max_seq.has_value())
+                continue;
+            // If the max_seq in the log file is larger than snap_sequence, there are could be some
+            // records in the log file that are not included in the snapshot.
+            if (max_seq.value() > snap_sequence)
+                continue;
+        }
 
         found_log_file_smaller_than_snap_sequence = true;
         snap_log_files.emplace(*iter);
@@ -219,7 +237,7 @@ WALStore::FilesSnapshot WALStore::tryGetFilesSnapshot(
 }
 
 // In order to make `restore` in a reasonable time, we need to compact
-// log files.
+// log files. The files in `files_snap` should be compacted.
 bool WALStore::saveSnapshot(
     FilesSnapshot && files_snap,
     String && serialized_snap,
@@ -229,7 +247,7 @@ bool WALStore::saveSnapshot(
     if (files_snap.persisted_log_files.empty())
         return false;
 
-    LOG_INFO(logger, "Saving directory snapshot [num_records={}]", files_snap.num_records);
+    LOG_INFO(logger, "Saving directory snapshot, num_records={}", files_snap.num_records);
 
     // Use {largest_log_num, 1} to save the `edit`
     const auto log_num = files_snap.persisted_log_files.rbegin()->log_num;
@@ -296,26 +314,49 @@ void WALStore::removeLogFiles(const LogFilenameSet & log_filenames)
     }
 }
 
-UInt64 WALStore::getLogFileMaxSequence(
+// Get the max sequence in the log file.
+// If the log file is empty, return 0
+// If can not parse the max sequence from the last record, return nullopt.
+std::optional<UInt64> WALStore::getLogFileMaxSequence(
     const LogFilename & log_filename,
-    std::function<UInt64(const String & record)> max_sequence_getter)
+    std::function<std::optional<UInt64>(const String & record)> max_sequence_getter)
 {
     std::unique_lock<std::mutex> lock(log_file_max_sequences_cache_mutex);
     auto iter = log_file_max_sequences_cache.find(log_filename);
     if (iter != log_file_max_sequences_cache.end())
         return iter->second;
 
-    auto last_record = WALStoreReader::getLastRecordInLogFile(
+    auto [num_records, last_record] = WALStoreReader::getLastRecordInLogFile(
         log_filename,
         provider,
         config.getRecoverMode(),
         /*read_limiter*/ nullptr,
         logger);
-    if (last_record.empty())
-        return 0; // empty log file
+    if (num_records == 0)
+        return 0; // empty log file is always safe to be compacted
 
-    UInt64 max_sequence = max_sequence_getter(last_record);
-    log_file_max_sequences_cache.emplace(log_filename, max_sequence);
-    return max_sequence;
+    if (last_record.empty())
+    {
+        LOG_WARNING(
+            logger,
+            "Failed to read non-empty last record from log file, log_file={}",
+            log_filename.filename(log_filename.stage));
+        return std::nullopt;
+    }
+
+    std::optional<UInt64> max_sequence_opt = max_sequence_getter(last_record);
+    if (!max_sequence_opt.has_value())
+    {
+        LOG_WARNING(
+            logger,
+            "Failed to parse max_sequence from log file, log_file={} last_record={}",
+            log_filename.filename(log_filename.stage),
+            Redact::keyToHexString(last_record.data(), last_record.size()));
+        return std::nullopt;
+    }
+
+    // cache the result
+    log_file_max_sequences_cache.emplace(log_filename, max_sequence_opt.value());
+    return max_sequence_opt.value();
 }
 } // namespace DB::PS::V3

--- a/dbms/src/Storages/Page/V3/WALStore.cpp
+++ b/dbms/src/Storages/Page/V3/WALStore.cpp
@@ -279,14 +279,14 @@ bool WALStore::saveSnapshot(
 
     auto get_logging_str = [&]() {
         FmtBuffer fmt_buf;
-        fmt_buf.append("Dumped directory snapshot to log file done. files_snapshot=");
+        fmt_buf.append("Dumped directory snapshot to log file done. files_snapshot=[");
         fmt_buf.joinStr(
             files_snap.persisted_log_files.begin(),
             files_snap.persisted_log_files.end(),
             [](const auto & arg, FmtBuffer & fb) { fb.append(arg.filename(arg.stage)); },
             ", ");
         fmt_buf.fmtAppend(
-            " dump_cost={} num_records={} file={} size={}",
+            "] dump_cost={} num_records={} file={} size={}",
             files_snap.dump_elapsed_ms,
             files_snap.num_records,
             normal_fullname,

--- a/dbms/src/Storages/Page/V3/WALStore.h
+++ b/dbms/src/Storages/Page/V3/WALStore.h
@@ -94,7 +94,7 @@ public:
     FilesSnapshot tryGetFilesSnapshot(
         size_t max_persisted_log_files,
         UInt64 snap_sequence,
-        std::function<UInt64(const String & record)> max_sequence_getter,
+        std::function<std::optional<UInt64>(const String & record)> && max_sequence_getter,
         bool force);
 
     bool saveSnapshot(
@@ -126,9 +126,9 @@ private:
 
     void removeLogFiles(const LogFilenameSet & log_filenames);
 
-    UInt64 getLogFileMaxSequence(
+    std::optional<UInt64> getLogFileMaxSequence(
         const LogFilename & log_filename,
-        std::function<UInt64(const String & record)> max_sequence_getter);
+        std::function<std::optional<UInt64>(const String & record)> max_sequence_getter);
 
 private:
     const String storage_name;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/10401

Problem Summary:

In the previous code, if the last WriteBatch contains no changes is persisted in the LogFile, then it may lead to exception in `getMaxSequenceForRecord` as the issue describe.

### What is changed and how it works?

```commit-message
PageStorage: Fix an exception in gc when meet an empty WriteBatch
* If the last edit stored in Logfile is empty, then we won't collect that LogFile for compacting WAL in the current GC round
* These remain log_files will be compacted in the following rounds once we found a log_file has larger log_num and its max_seq <= snap_sequence.
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix an exception that may block data from being GCed
```
