### PR TITLE
Storage: Fix data race in `DeltaMergeStore::checkSegmentUpdate`

### DIFF
--- a/dbms/src/Storages/DeltaMerge/tests/gtest_key_range.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_key_range.cpp
@@ -193,9 +193,11 @@ TEST(RowKey, ToNextKeyIntHandle)
         key_end.insert(key_end.end(), rand_suffix.begin(), rand_suffix.end());
         LOG_INFO(
             Logger::get(),
-            "key_end={} rand_suffix={}",
+            "key_end={} rand_length={} rand_suffix={} rand_suffix_size={}",
             key_end.toDebugString(),
-            Redact::keyToDebugString(rand_suffix.data(), rand_length));
+            rand_length,
+            Redact::keyToDebugString(rand_suffix.data(), rand_length),
+            rand_suffix.size());
 
         const auto range_keys = std::make_shared<RegionRangeKeys>(
             RecordKVFormat::genKey(table_id, 0),


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/10455

Problem Summary:

### What is changed and how it works?

```commit-message
Storage: Fix data race in `DeltaMergeStore::checkSegmentUpdate`
```

And add more debug log for flaky test `RowKey.ToNextKeyIntHandle`
https://do.pingcap.net/jenkins/blue/organizations/jenkins/pingcap%2Ftiflash%2Frelease-8.5%2Fpull_unit_test/detail/pull_unit_test/259/pipeline
```
[0;33mNote: Google Test filter = RowKey.ToNextKeyIntHandle
[m[0;32m[==========] [mRunning 1 test from 1 test case.
[0;32m[----------] [mGlobal test environment set-up.
[0;32m[----------] [m1 test from RowKey
[0;32m[ RUN      ] [mRowKey.ToNextKeyIntHandle
[2025/09/26 00:05:24.222 +08:00] [WARN] [RowKeyRangeFromRegion.cpp:110] ["Meet rowkey which has extra suffix, keyspace=4294967295 table_id=1  end_key=7480000000000000015F72800000000000001400 end_key_extra_suffix=00 "] [thread_id=1]
[2025/09/26 00:05:24.223 +08:00] [WARN] [RowKeyRangeFromRegion.cpp:110] ["Meet rowkey which has extra suffix, keyspace=4294967295 table_id=1  end_key=7480000000000000015F72800000000000001401 end_key_extra_suffix=01 "] [thread_id=1]
[2025/09/26 00:05:24.223 +08:00] [INFO] [gtest_key_range.cpp:199] ["key_end=7480000000000000015F728000000000000014 rand_suffix="] [thread_id=1]
/home/jenkins/agent/workspace/tiflash-build-common/tiflash/dbms/src/Storages/DeltaMerge/tests/gtest_key_range.cpp:209: Failure
Expected equality of these values:
  next.toRowKeyValueRef()
    Which is: 32-byte object <00-E4 10-FF 4A-7F 00-00 19-D8 F9-F7 4A-7F 00-00 08-00 00-00 00-00 00-00 15-00 00-00 00-00 00-00>
  range.getEnd()
    Which is: 32-byte object <00-21 67-12 00-00 00-00 D9-DB F9-F7 4A-7F 00-00 08-00 00-00 00-00 00-00 14-00 00-00 00-00 00-00>
/home/jenkins/agent/workspace/tiflash-build-common/tiflash/dbms/src/Storages/DeltaMerge/tests/gtest_key_range.cpp:210: Failure
Expected equality of these values:
  range.getEnd().toDebugString()
    Which is: "20"
  "21"
[0;31m[  FAILED  ] [mRowKey.ToNextKeyIntHandle (1 ms)
[0;32m[----------] [m1 test from RowKey (1 ms total)

[0;32m[----------] [mGlobal test environment tear-down
[0;32m[==========] [m1 test from 1 test case ran. (1 ms total)
[0;32m[  PASSED  ] [m0 tests.
[0;31m[  FAILED  ] [m1 test, listed below:
[0;31m[  FAILED  ] [mRowKey.ToNextKeyIntHandle

 1 FAILED TEST
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
