### PR TITLE
tests: Fix flaky test "RowKey.ToNextKeyIntHandle" (#10475)

### DIFF
--- a/dbms/src/Storages/DeltaMerge/tests/gtest_key_range.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_key_range.cpp
@@ -188,7 +188,7 @@ TEST(RowKey, ToNextKeyIntHandle)
     {
         auto key_end = RecordKVFormat::genRawKey(table_id, 20);
         std::mt19937_64 rand_gen(std::random_device{}());
-        size_t rand_length = std::min(1, rand_gen() % 255); // ensure rand_length is at least 1
+        size_t rand_length = std::max(1, rand_gen() % 255); // ensure rand_length is at least 1
         auto rand_suffix = DB::random::randomString(rand_length);
         key_end.insert(key_end.end(), rand_suffix.begin(), rand_suffix.end());
         LOG_INFO(

--- a/dbms/src/Storages/S3/S3Common.cpp
+++ b/dbms/src/Storages/S3/S3Common.cpp
@@ -186,12 +186,6 @@ String normalizedRoot(String ori_root) // a copy for changing
     return ori_root;
 }
 
-TiFlashS3Client::TiFlashS3Client(const String & bucket_name_, const String & root_)
-    : bucket_name(bucket_name_)
-    , key_root(normalizedRoot(root_))
-    , log(Logger::get(fmt::format("bucket={} root={}", bucket_name, key_root)))
-{}
-
 TiFlashS3Client::TiFlashS3Client(
     const String & bucket_name_,
     const String & root_,
@@ -360,8 +354,8 @@ void ClientFactory::init(const StorageS3Config & config_, bool mock_s3_)
     }
     else
     {
-        // Disable IMDS for mock s3 client
-        Aws::Client::ClientConfiguration cfg(true, /*profileName=*/"standard", /*shouldDisableIMDS=*/true);
+        // Create a cfg for suppressing verbose but useless logging. For example, disable IMDS, use "standard" retry
+        Aws::Client::ClientConfiguration cfg(true, /*defaultMode=*/"standard", /*shouldDisableIMDS=*/true);
         cfg.region = Aws::Region::US_EAST_1; // default region
         Aws::Auth::AWSCredentials cred("mock_access_key", "mock_secret_key");
         shared_tiflash_client = std::make_unique<tests::MockS3Client>(config.bucket, config.root, cred, cfg);

--- a/dbms/src/Storages/S3/S3Common.h
+++ b/dbms/src/Storages/S3/S3Common.h
@@ -67,8 +67,6 @@ public:
     // Usually one tiflash instance only need access one bucket.
     // Store the bucket name to simplify some param passing.
 
-    TiFlashS3Client(const String & bucket_name_, const String & root_);
-
     TiFlashS3Client(
         const String & bucket_name_,
         const String & root_,

--- a/dbms/src/Storages/S3/S3GCManager.cpp
+++ b/dbms/src/Storages/S3/S3GCManager.cpp
@@ -81,7 +81,12 @@ std::optional<std::unordered_map<StoreID, metapb::Store>> getStoresFromPD(
         for (const auto & s : stores_from_pd)
         {
             auto [iter, inserted] = stores.emplace(s.id(), s);
-            RUNTIME_CHECK_MSG(inserted, "duplicated store id from pd response, duplicated_store_id={}", iter->first);
+            RUNTIME_CHECK_MSG(
+                inserted,
+                "duplicated store id from pd response, duplicated_store_id={} prev_store={} store={}",
+                iter->first,
+                iter->second.ShortDebugString(),
+                s.ShortDebugString());
         }
         return stores;
     }


### PR DESCRIPTION
cherry-pick https://github.com/pingcap/tiflash/pull/10475
* * *
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/10294

Problem Summary:

Should use `size_t rand_length = std::max(1, rand_gen() % 255);` to ensure rand_length is at least 1

### What is changed and how it works?

```commit-message
* Fix flaky test "RowKey.ToNextKeyIntHandle"
* Reduce some useless and verbose logging when running unit test
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
