### PR TITLE
Revert #10482

### DIFF
--- a/dbms/src/DataStreams/AggregatingBlockInputStream.cpp
+++ b/dbms/src/DataStreams/AggregatingBlockInputStream.cpp
@@ -90,9 +90,4 @@ Block AggregatingBlockInputStream::readImpl()
     return impl->read();
 }
 
-void AggregatingBlockInputStream::appendInfo(FmtBuffer & buffer) const
-{
-    buffer.fmtAppend(", enable_two_level_hashtable: {}", params.getGroupByTwoLevelThreshold() > 0);
-}
-
 } // namespace DB

--- a/dbms/src/DataStreams/AggregatingBlockInputStream.h
+++ b/dbms/src/DataStreams/AggregatingBlockInputStream.h
@@ -59,8 +59,6 @@ public:
 
     Block getHeader() const override;
 
-    void appendInfo(FmtBuffer & buffer) const override;
-
 protected:
     Block readImpl() override;
 

--- a/dbms/src/Flash/Coprocessor/AggregationInterpreterHelper.cpp
+++ b/dbms/src/Flash/Coprocessor/AggregationInterpreterHelper.cpp
@@ -39,10 +39,7 @@ bool isAllowToUseTwoLevelGroupBy(size_t before_agg_streams_size, const Settings 
       * 1. Parallel aggregation is done, and the results should be merged in parallel.
       * 2. An aggregation is done with store of temporary data on the disk, and they need to be merged in a memory efficient way.
       */
-    auto may_need_spill = settings.max_bytes_before_external_group_by != 0;
-    may_need_spill |= settings.max_memory_usage.getActualBytes(1024 * 1024 * 1024) > 0
-        && settings.auto_memory_revoke_trigger_threshold > 0;
-    return before_agg_streams_size > 1 || may_need_spill;
+    return before_agg_streams_size > 1 || settings.max_bytes_before_external_group_by != 0;
 }
 } // namespace
 

--- a/dbms/src/Flash/Planner/Plans/PhysicalAggregation.h
+++ b/dbms/src/Flash/Planner/Plans/PhysicalAggregation.h
@@ -67,12 +67,6 @@ public:
     const Block & getSampleBlock() const override;
 
 private:
-    Aggregator::Params genAggregatorParams(
-        const Block & before_agg_header,
-        Context & context,
-        size_t before_agg_streams_size,
-        size_t agg_streams_size) const;
-
     void buildBlockInputStreamImpl(DAGPipeline & pipeline, Context & context, size_t max_streams) override;
 
     void buildPipelineExecGroupImpl(

--- a/dbms/src/Flash/Planner/tests/gtest_physical_plan.cpp
+++ b/dbms/src/Flash/Planner/tests/gtest_physical_plan.cpp
@@ -216,7 +216,7 @@ try
         /*expected_streams=*/R"(
 Expression: <final projection>
  Expression: <expr after aggregation>
-  Aggregating, enable_two_level_hashtable: false
+  Aggregating
    MockExchangeReceiver)",
         {toNullableVec<String>({{}, "banana"}), toNullableVec<String>({{}, "banana"})});
 }

--- a/dbms/src/Flash/tests/gtest_planner_interpreter.out
+++ b/dbms/src/Flash/tests/gtest_planner_interpreter.out
@@ -117,27 +117,11 @@ Union: <for test>
 ~result:
 Expression: <final projection>
  Expression: <expr after aggregation>
-  Aggregating, enable_two_level_hashtable: false
+  Aggregating
    MockTableScan
 @
 ~test_suite_name: ParallelQuery
 ~result_index: 5
-~result:
-Expression: <final projection>
- Expression: <expr after aggregation>
-  Aggregating, enable_two_level_hashtable: true
-   MockTableScan
-@
-~test_suite_name: ParallelQuery
-~result_index: 6
-~result:
-Expression: <final projection>
- Expression: <expr after aggregation>
-  Aggregating, enable_two_level_hashtable: true
-   MockTableScan
-@
-~test_suite_name: ParallelQuery
-~result_index: 7
 ~result:
 Union: <for test>
  Expression x 5: <final projection>
@@ -147,7 +131,7 @@ Union: <for test>
      MockTableScan x 5
 @
 ~test_suite_name: ParallelQuery
-~result_index: 8
+~result_index: 6
 ~result:
 Expression: <final projection>
  MergeSorting, limit = 10
@@ -155,7 +139,7 @@ Expression: <final projection>
    MockTableScan
 @
 ~test_suite_name: ParallelQuery
-~result_index: 9
+~result_index: 7
 ~result:
 Union: <for test>
  Expression x 5: <final projection>
@@ -166,14 +150,14 @@ Union: <for test>
       MockTableScan
 @
 ~test_suite_name: ParallelQuery
-~result_index: 10
+~result_index: 8
 ~result:
 Expression: <final projection>
  Filter
   MockTableScan
 @
 ~test_suite_name: ParallelQuery
-~result_index: 11
+~result_index: 9
 ~result:
 Union: <for test>
  Expression x 5: <final projection>
@@ -181,7 +165,7 @@ Union: <for test>
    MockTableScan
 @
 ~test_suite_name: ParallelQuery
-~result_index: 12
+~result_index: 10
 ~result:
 Union: <for test>
  Expression x 10: <final projection>
@@ -195,16 +179,16 @@ Union: <for test>
          MockTableScan
 @
 ~test_suite_name: ParallelQuery
-~result_index: 13
+~result_index: 11
 ~result:
 Expression: <final projection>
  Expression: <expr after aggregation>
-  Aggregating, enable_two_level_hashtable: false
+  Aggregating
    Limit, limit = 10
     MockTableScan
 @
 ~test_suite_name: ParallelQuery
-~result_index: 14
+~result_index: 12
 ~result:
 Union: <for test>
  Expression x 10: <final projection>
@@ -218,17 +202,17 @@ Union: <for test>
          MockTableScan
 @
 ~test_suite_name: ParallelQuery
-~result_index: 15
+~result_index: 13
 ~result:
 Expression: <final projection>
  Expression: <expr after aggregation>
-  Aggregating, enable_two_level_hashtable: false
+  Aggregating
    MergeSorting, limit = 10
     PartialSorting: limit = 10
      MockTableScan
 @
 ~test_suite_name: ParallelQuery
-~result_index: 16
+~result_index: 14
 ~result:
 Union: <for test>
  Expression x 10: <final projection>
@@ -242,18 +226,18 @@ Union: <for test>
          MockTableScan x 10
 @
 ~test_suite_name: ParallelQuery
-~result_index: 17
+~result_index: 15
 ~result:
 Expression: <final projection>
  Expression: <expr after aggregation>
-  Aggregating, enable_two_level_hashtable: false
+  Aggregating
    Expression: <projection>
     Expression: <expr after aggregation>
-     Aggregating, enable_two_level_hashtable: false
+     Aggregating
       MockTableScan
 @
 ~test_suite_name: ParallelQuery
-~result_index: 18
+~result_index: 16
 ~result:
 Union: <for test>
  MockExchangeSender x 10
@@ -264,16 +248,16 @@ Union: <for test>
       MockTableScan x 10
 @
 ~test_suite_name: ParallelQuery
-~result_index: 19
+~result_index: 17
 ~result:
 MockExchangeSender
  Expression: <final projection>
   Expression: <expr after aggregation>
-   Aggregating, enable_two_level_hashtable: false
+   Aggregating
     MockTableScan
 @
 ~test_suite_name: ParallelQuery
-~result_index: 20
+~result_index: 18
 ~result:
 Union: <for test>
  MockExchangeSender x 10
@@ -285,7 +269,7 @@ Union: <for test>
        MockTableScan
 @
 ~test_suite_name: ParallelQuery
-~result_index: 21
+~result_index: 19
 ~result:
 MockExchangeSender
  Expression: <final projection>
@@ -294,7 +278,7 @@ MockExchangeSender
     MockTableScan
 @
 ~test_suite_name: ParallelQuery
-~result_index: 22
+~result_index: 20
 ~result:
 Union: <for test>
  MockExchangeSender x 10
@@ -306,7 +290,7 @@ Union: <for test>
        MockTableScan
 @
 ~test_suite_name: ParallelQuery
-~result_index: 23
+~result_index: 21
 ~result:
 MockExchangeSender
  Expression: <final projection>
@@ -314,7 +298,7 @@ MockExchangeSender
    MockTableScan
 @
 ~test_suite_name: ParallelQuery
-~result_index: 24
+~result_index: 22
 ~result:
 CreatingSets
  Union: <for join>
@@ -534,7 +518,7 @@ CreatingSets
 Union: <for test>
  Expression x 8: <final projection>
   Expression: <expr after aggregation>
-   Aggregating: <enable fine grained shuffle>, enable_two_level_hashtable: false
+   Aggregating: <enable fine grained shuffle>
     Expression: <before aggregation>
      MockExchangeReceiver
 @
@@ -679,7 +663,7 @@ Expression: <final projection>
  Limit, limit = 10
   Filter
    Expression: <expr after aggregation>
-    Aggregating, enable_two_level_hashtable: false
+    Aggregating
      Expression: <before aggregation>
       Filter
        MockTableScan

--- a/dbms/src/Flash/tests/gtest_split_tasks.cpp
+++ b/dbms/src/Flash/tests/gtest_split_tasks.cpp
@@ -64,7 +64,7 @@ try
         = {"MockExchangeSender\n"
            " Expression: <final projection>\n"
            "  Expression: <expr after aggregation>\n"
-           "   Aggregating, enable_two_level_hashtable: false\n"
+           "   Aggregating\n"
            "    Expression: <before aggregation>\n"
            "     Filter\n"
            "      MockTableScan",
@@ -75,7 +75,7 @@ try
            "    Expression: <before TopN>\n"
            "     Filter\n"
            "      Expression: <expr after aggregation>\n"
-           "       Aggregating, enable_two_level_hashtable: false\n"
+           "       Aggregating\n"
            "        MockExchangeReceiver"};
     for (size_t i = 0; i < task_size; ++i)
     {


### PR DESCRIPTION
This reverts commit e5a8d22d0f93a6ba578c423a53dae373d9f8ac75.

### What problem does this PR solve?

Issue Number: ref #10481

Problem Summary:

In #10482, it tries to disable using two-level hash table in the 2nd stage of fine grained hash agg because in the 2nd stage of fine grained hash agg, each thread is independent with each other, and convert hash table to two-level hash table can not help the performance.
However, we found that after this pr, there is a performance regression for the following case
```
explain analyze select /*+ mpp_1phase_agg() */
l_orderkey
from
lineitem
group by
l_orderkey having
sum(l_quantity) > 314
```

| before this pr | after this pr |
| --------------|-------------|
| ~1.0s               | ~1.4s            |


execution plan
```
+--------------------------------------+--------------+--------------+----------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| id                                   | estRows      | task         | access object  | operator info                                                                                                                                                           |
+--------------------------------------+--------------+--------------+----------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| TableReader_45                       | 59126579.20  | root         |                | MppVersion: 3, data:ExchangeSender_44                                                                                                                                   |
| └─ExchangeSender_44                  | 59126579.20  | mpp[tiflash] |                | ExchangeType: PassThrough                                                                                                                                               |
|   └─Projection_7                     | 59126579.20  | mpp[tiflash] |                | test.lineitem.l_orderkey                                                                                                                                                |
|     └─Selection_43                   | 59126579.20  | mpp[tiflash] |                | gt(Column#18, 314)                                                                                                                                                      |
|       └─Projection_40                | 73908224.00  | mpp[tiflash] |                | Column#18, test.lineitem.l_orderkey                                                                                                                                     |
|         └─HashAgg_38                 | 73908224.00  | mpp[tiflash] |                | group by:test.lineitem.l_orderkey, funcs:sum(test.lineitem.l_quantity)->Column#18, funcs:firstrow(test.lineitem.l_orderkey)->test.lineitem.l_orderkey, stream_count: 72 |
|           └─ExchangeReceiver_30      | 300005811.00 | mpp[tiflash] |                | stream_count: 72                                                                                                                                                        |
|             └─ExchangeSender_29      | 300005811.00 | mpp[tiflash] |                | ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.lineitem.l_orderkey, collate: binary], stream_count: 72                                          |
|               └─TableFullScan_28     | 300005811.00 | mpp[tiflash] | table:lineitem | keep order:false                                                                                                                                                        |
+--------------------------------------+--------------+--------------+----------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
9 rows in set (0.18 sec)
```
The root cause is although each thread in `HashAgg_38` is independent when calculating hash agg, it turns out they are not 100% independent with each other because all threads running `HashAgg_38` actually read data from the same source(`ExchangeReceiver_30`), in `ExchangeReceiver_30` it has a limited length of the source data queue, for a source data(a grpc response of `ExchangeSender_29`), it contains data for all threads that running `HashAgg_38`, only if all thread consume its own data, the source data can be poped from the source data queue. That is to say if any one thread is blocked due to some reason, all the other threads are actually blocked because it could not read more data from `ExchangeSender_29`.

So the problem is if each thread in `HashAgg_38` does not split hash table into two-level hash table, then if the hash table become large, it takes a lots of time of resizing, when any of the thread in `HashAgg_38` is resizing a large hash table, it may block other thread since the source data queue is blocked.


### What is changed and how it works?
This pr just revert #10482 
```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code: just revert existing pr

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
