### PR TITLE
KVStore: ignore non-exist IStorage instance in releasePreHandledSnapshot

### DIFF
--- a/dbms/src/Common/FailPoint.cpp
+++ b/dbms/src/Common/FailPoint.cpp
@@ -133,7 +133,8 @@ namespace DB
     M(force_join_v2_probe_enable_lm)                         \
     M(force_join_v2_probe_disable_lm)                        \
     M(force_s3_random_access_file_init_fail)                 \
-    M(force_s3_random_access_file_read_fail)
+    M(force_s3_random_access_file_read_fail)                 \
+    M(force_release_snap_meet_null_storage)
 
 #define APPLY_FOR_PAUSEABLE_FAILPOINTS_ONCE(M)    \
     M(pause_with_alter_locks_acquired)            \

--- a/dbms/src/Storages/KVStore/tests/gtest_raftstore_v2.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_raftstore_v2.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Storages/KVStore/MultiRaft/ApplySnapshot.h>
 #include <Storages/KVStore/Read/LearnerRead.h>
 #include <Storages/KVStore/tests/region_kvstore_test.h>
 
@@ -22,6 +23,7 @@ namespace FailPoints
 extern const char force_raise_prehandle_exception[];
 extern const char pause_before_prehandle_subtask[];
 extern const char force_set_sst_to_dtfile_block_size[];
+extern const char force_release_snap_meet_null_storage[];
 } // namespace FailPoints
 
 namespace tests
@@ -524,6 +526,120 @@ try
             sp.disable();
             t.join();
         }
+    }
+}
+CATCH
+
+// Test when a region is cancel during releasing pre-handled snapshot.
+// And the pre-handled snapshot contains no external files.
+TEST_F(RegionKVStoreV2Test, KVStoreSingleSnapReleaseNoExternalFiles)
+try
+{
+    auto & ctx = TiFlashTestEnv::getGlobalContext();
+    proxy_instance->cluster_ver = RaftstoreVer::V2;
+    ASSERT_NE(proxy_helper->sst_reader_interfaces.fn_key, nullptr);
+    ASSERT_NE(proxy_helper->fn_get_config_json, nullptr);
+    FailPointHelper::enableFailPoint(FailPoints::force_release_snap_meet_null_storage, static_cast<size_t>(0));
+    SCOPE_EXIT({ FailPointHelper::disableFailPoint(FailPoints::force_release_snap_meet_null_storage); });
+    UInt64 region_id = 2;
+    initStorages();
+    KVStore & kvs = getKVS();
+    TableID table_id = proxy_instance->bootstrapTable(ctx, kvs, ctx.getTMTContext());
+    auto start = RecordKVFormat::genKey(table_id, 0);
+    auto end = RecordKVFormat::genKey(table_id, 40);
+    proxy_instance->bootstrapWithRegion( //
+        kvs,
+        ctx.getTMTContext(),
+        region_id,
+        std::make_pair(start.toString(), end.toString()));
+    auto r1 = proxy_instance->getRegion(region_id);
+
+    auto [value_write, value_default] = proxy_instance->generateTiKVKeyValue(111, 999);
+    auto kkk = RecordKVFormat::decodeWriteCfValue(TiKVValue::copyFrom(value_write));
+    {
+        // mock an empty region
+        MockSSTReader::getMockSSTData().clear();
+        MockSSTGenerator default_cf{region_id, table_id, ColumnFamilyType::Default};
+        default_cf.finish_file(SSTFormatKind::KIND_TABLET);
+        default_cf.freeze();
+        MockSSTGenerator write_cf{region_id, table_id, ColumnFamilyType::Write};
+        write_cf.finish_file(SSTFormatKind::KIND_TABLET);
+        write_cf.freeze();
+        auto [prehandle_region, res] = proxy_instance->snapshot( //
+            kvs,
+            ctx.getTMTContext(),
+            region_id,
+            {default_cf, write_cf},
+            0,
+            0,
+            std::nullopt);
+        kvs.abortPreHandleSnapshot(region_id, ctx.getTMTContext());
+        RegionPtrWithSnapshotFiles region_with_snap(prehandle_region, {});
+        kvs.releasePreHandledSnapshot(region_with_snap, ctx.getTMTContext());
+    }
+}
+CATCH
+
+// Test when a region is cancel during releasing pre-handled snapshot.
+// And the pre-handled snapshot's storage is null.
+TEST_F(RegionKVStoreV2Test, KVStoreSingleSnapReleaseNullStorage)
+try
+{
+    auto & ctx = TiFlashTestEnv::getGlobalContext();
+    proxy_instance->cluster_ver = RaftstoreVer::V2;
+    ASSERT_NE(proxy_helper->sst_reader_interfaces.fn_key, nullptr);
+    ASSERT_NE(proxy_helper->fn_get_config_json, nullptr);
+    FailPointHelper::enableFailPoint(FailPoints::force_release_snap_meet_null_storage, static_cast<size_t>(0));
+    SCOPE_EXIT({ FailPointHelper::disableFailPoint(FailPoints::force_release_snap_meet_null_storage); });
+    UInt64 region_id = 2;
+    initStorages();
+    KVStore & kvs = getKVS();
+    TableID table_id = proxy_instance->bootstrapTable(ctx, kvs, ctx.getTMTContext());
+    auto start = RecordKVFormat::genKey(table_id, 0);
+    auto end = RecordKVFormat::genKey(table_id, 40);
+    HandleID sst_limit = 40;
+    proxy_instance->bootstrapWithRegion( //
+        kvs,
+        ctx.getTMTContext(),
+        region_id,
+        std::make_pair(start.toString(), end.toString()));
+    auto r1 = proxy_instance->getRegion(region_id);
+
+    auto [value_write, value_default] = proxy_instance->generateTiKVKeyValue(111, 999);
+    auto kkk = RecordKVFormat::decodeWriteCfValue(TiKVValue::copyFrom(value_write));
+    {
+        MockSSTReader::getMockSSTData().clear();
+        MockSSTGenerator default_cf{region_id, table_id, ColumnFamilyType::Default};
+        for (HandleID h = 1; h < sst_limit; h++)
+        {
+            auto k = RecordKVFormat::genKey(table_id, h, 111);
+            default_cf.insert_raw(k, value_default);
+        }
+        default_cf.finish_file(SSTFormatKind::KIND_TABLET);
+        default_cf.freeze();
+        MockSSTGenerator write_cf{region_id, table_id, ColumnFamilyType::Write};
+        for (HandleID h = 1; h < sst_limit; h++)
+        {
+            auto k = RecordKVFormat::genKey(table_id, h, 111);
+            write_cf.insert_raw(k, value_write);
+        }
+        write_cf.finish_file(SSTFormatKind::KIND_TABLET);
+        write_cf.freeze();
+
+        auto [prehandle_region, res] = proxy_instance->snapshot( //
+            kvs,
+            ctx.getTMTContext(),
+            region_id,
+            {default_cf, write_cf},
+            0,
+            0,
+            std::nullopt,
+            [] {
+                // set the function so that will call releasePreHandledSnapshot
+                // and verify the null storage handling logic
+                return nullptr;
+            });
+        UNUSED(prehandle_region, res);
     }
 }
 CATCH


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10606

Problem Summary:

1. During the BR restore process, TiDB first creates tables, performs region pre-splitting, and scatters the resulting regions across nodes. The regions created during this phase are empty.
2. TiFlash intentionally avoids creating IStorage objects when handling commands such as splits or snapshot applications for empty regions. This design choice helps reduce memory consumption and file fragmentation caused by empty tables in TiFlash.
3. However, in some cases, after a region is pre-split but before it finishes the PreHandleSnapshot stage, the region gets scheduled away (i.e., moved to another node). This triggers tiflash-proxy to call TiFlash’s releasePreHandledSnapshot.
4. Inside releasePreHandledSnapshot, the code retrieves an IStorage pointer from TMTStorages but fails to check whether it is a nullptr before directly invoking cleanPreIngestFiles. This missing null check leads to a null pointer dereference (NPE) and causes TiFlash to crash.

### What is changed and how it works?

```commit-message
KVStore: ignore non-exist IStorage instance in releasePreHandledSnapshot
* `KVStore::releasePreHandledSnapshot` skip for external files is empty or IStorage instance is not exist
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix a issue that TiFlash may panic during br restore
```
