### PR TITLE
Storage: Tune tiflash-compute default reserved_rate for next-gen

### DIFF
--- a/dbms/src/Server/StorageConfigParser.h
+++ b/dbms/src/Server/StorageConfigParser.h
@@ -67,7 +67,7 @@ struct StorageRemoteCacheConfig
     UInt64 capacity = 0;
     UInt64 dtfile_level = 100;
     double delta_rate = 0.1;
-    double reserved_rate = 0.1;
+    double reserved_rate = 0.15;
 
     bool isCacheEnabled() const;
     void initCacheDir() const;


### PR DESCRIPTION
Increase reserved_rate from 0.1 to 0.15

### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/10205

Problem Summary:
Tune the default value of storage.remote.cache.reserved_rate from 0.1 to 0.15 for next-gen

### What is changed and how it works?

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
