### PR TITLE
Fix error "Compatibility with CMake < 3.5 has been removed from CMake" for CMake 4.0+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,9 @@ project (TiFlash LANGUAGES C CXX ASM)
 
 cmake_policy(SET CMP0048 NEW)
 
+# Bypass the CMake error "Compatibility with CMake < 3.5 has been removed" since CMake 4.0.
+set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
+
 set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY true)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${TiFlash_SOURCE_DIR}/cmake/Modules/")
 set(CMAKE_MACOSX_RPATH 1)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10639

Problem Summary:

Since CMake 4.0, compatibility with versions older than 3.5 has been entirely removed and will result in an error if specified. Many of third-party libraries declare cmake_minimum_required() lower than 3.5, resulting in build error.

### What is changed and how it works?

This PR sets CMAKE_POLICY_VERSION_MINIMUM in the top-level CMakeLists (before any add_subdirectory() of thrid-party projects) and bypass this error.

```commit-message
Fix error "Compatibility with CMake < 3.5 has been removed from CMake" for CMake 4.0+
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to set a minimum CMake policy version, preventing compatibility errors with newer CMake releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->