### PR TITLE
Fix libdivide operator== bug

### DIFF
--- a/contrib/libdivide/libdivide.h
+++ b/contrib/libdivide/libdivide.h
@@ -2365,7 +2365,7 @@ class divider {
     T recover() const { return div.recover(); }
 
     bool operator==(const divider<T, ALGO> &other) const {
-        return div.denom.magic == other.denom.magic && div.denom.more == other.denom.more;
+        return div.denom.magic == other.div.denom.magic && div.denom.more == other.div.denom.more;
     }
 
     bool operator!=(const divider<T, ALGO> &other) const { return !(*this == other); }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10651

Problem Summary:

### What is changed and how it works?

```commit-message
Fix incorrect member access in divider::operator== where `other.denom` should be `other.div.denom` to access the denom member through the div wrapper object.
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an equality comparison bug in divider objects that could produce incorrect results when checking if two dividers are equivalent. The equality operator was accessing incorrect internal field values during comparison. It now properly references all divider properties, ensuring reliable and accurate equality checks between dividers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->