### PR TITLE
tests: increase sanitizer wait in ComputeServerRunner.testCancelMPPGather

### DIFF
--- a/dbms/src/Flash/tests/gtest_compute_server.cpp
+++ b/dbms/src/Flash/tests/gtest_compute_server.cpp
@@ -1581,7 +1581,7 @@ try
         single_gather_properties.gather_id = 1;
         addOneGather(running_queries, gather_ids, single_gather_properties);
         using namespace std::literals::chrono_literals;
-        ADAPTIVE_SLEEP(4s, 16s);
+        ADAPTIVE_SLEEP(4s, 32s);
         /// 6 gathers, but two query
         ASSERT_TRUE(
             TiFlashMetrics::instance()


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close https://github.com/pingcap/tiflash/issues/10641

Problem Summary:
`ComputeServerRunner.testCancelMPPGather` is flaky in sanitizer CI.
With sanitizer overhead, the fixed wait (`ADAPTIVE_SLEEP(4s, 16s)`) can be insufficient before asserting `active_queries_count == 2`, causing intermittent failures.

### What is changed and how it works?

```commit-message
tests: increase sanitizer wait in cancel mpp gather test
```

In `dbms/src/Flash/tests/gtest_compute_server.cpp`, increase the sanitizer-side adaptive sleep in `testCancelMPPGather`:

- `ADAPTIVE_SLEEP(4s, 16s)` -> `ADAPTIVE_SLEEP(4s, 32s)`

This is a test-only timing adjustment to reduce sanitizer flakiness.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Local test execution was not run in this task; validation is expected via CI.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
