### PR TITLE
docs: add note about TiFlash DDL sync design flaw

### DIFF
--- a/docs/note/TiFlashDDLDesignFlaw.md
+++ b/docs/note/TiFlashDDLDesignFlaw.md
@@ -1,13 +1,13 @@
-## A known design flaw between TiFlash DDL sync and RaftLog decoding
+# A known design flaw between TiFlash DDL sync and RaftLog decoding
 
 - Unlike TiKV, TiFlash must decode row values into columns before writing to its columnar engine, so decoding depends on correct schema.
 - TiFlash does **not** enforce strong DDL consistency between TiDB and TiFlash. Instead, it relies on **schema mismatch detection** during RaftLog decode or query execution.
 - On mismatch, TiFlash **syncs the latest schema** for the table and retries decode/query. A background task also syncs schema on a fixed interval.
-- When decoding with its current schema, TiFlash uses a **best‑effort** strategy; if it still cannot decode after schema sync, it may fail fast(TiFlash panic).
+- When decoding with its current schema, TiFlash uses a **best‑effort** strategy; if it still cannot decode after schema sync, it may fail fast (terminate the TiFlash process).
 
 ## Why did TiFlash choose weak DDL sync design?
 
-A "strong consistency" mechanism for DDL sync is expensive. SchemaDiffs (TableInfo changes) and DML Raft logs live in **different Regions**, and their arrival order is not guaranteed for a Raft learner. Validating SchemaDiffs for every Raft entry would introduce prohibitive latency and scalability costs. We must leverage additional information beside the RaftLog to mitigate this overhead.
-Having TiDB push DDL changes to TiFlash with strong consistency is also problematic: if TiFlash is unavailable or network partitioned, TiDB latency would increase and violate the design principle that TiFlash failures should not impact the OLTP path. Having a weak push between TiDB to TiFlash, the SchemaDiffs can arrive after Raft entries encoded with the new schema.
-Unlike TiCDC that only need to handle RaftLog after a specified commit_ts. TiFlash also has to **decode old data with the latest schema** when it first builds a replica (e.g. tiflash/issues/8419) or Region transferred between instances. SchemaDiff history may be GC‑ed, so decoding cannot rely on a complete diff chain.
+A "strong consistency" mechanism for DDL sync is expensive. SchemaDiffs (TableInfo changes) and DML Raft logs live in **different Regions**, and their arrival order is not guaranteed for a Raft learner. Validating SchemaDiffs for every Raft entry would introduce prohibitive latency and scalability costs. To mitigate this overhead, TiFlash must leverage additional information besides the RaftLog.
+Having TiDB push DDL changes to TiFlash with strong consistency is also problematic: if TiFlash is unavailable or network partitioned, TiDB latency would increase and violate the design principle that TiFlash failures should not impact the OLTP path. With a weak push from TiDB to TiFlash, the SchemaDiffs can arrive after Raft entries encoded with the new schema.
+Unlike TiCDC, which only needs to handle RaftLog after a specified commit_ts, TiFlash also has to **decode old data with the latest schema** when it first builds a replica (e.g. issue `tiflash#8419`) or when a Region is transferred between instances. SchemaDiff history may be GC‑ed, so decoding cannot rely on a complete diff chain.
 Given these constraints, TiFlash chose: **decode with current schema → detect mismatch → sync → retry**. This has been workable, but only if mismatch detection is conservative enough.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6233 

Problem Summary:

Add an internal design note that explains a known flaw in TiFlash DDL synchronization and why TiFlash uses weak DDL sync with schema mismatch detection and retry. This design flaw leads to DDL issue like https://github.com/pingcap/tiflash/issues/10680

Add a note doc so that contributors and agents could know the background of TiFlash DDL design.

### What is changed and how it works?

```commit-message
docs: add TiFlash DDL design flaw note
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation explaining TiFlash's DDL synchronization approach and related schema handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->