### PR TITLE
Flash: add MPP sql digest and connection metadata tracing

### DIFF
--- a/dbms/src/Flash/Coprocessor/DAGContext.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGContext.cpp
@@ -104,6 +104,7 @@ DAGContext::DAGContext(tipb::DAGRequest & dag_request_, const mpp::TaskMeta & me
     , resource_group_name(meta_.resource_group_name())
     , connection_id(meta_.connection_id())
     , connection_alias(meta_.connection_alias())
+    , sql_digest(meta_.sql_digest())
 {
     if (dag_request->has_div_precision_increment())
         div_precision_increment = dag_request->div_precision_increment();
@@ -483,7 +484,7 @@ UInt64 DAGContext::getReadBytes() const
     UInt64 read_bytes = 0;
     for (const auto & [id, sc] : scan_context_map)
     {
-        (void)id; // Disable unused variable warnning.
+        (void)id; // Disable unused variable warning.
         read_bytes += sc->userReadBytes();
     }
     return read_bytes;

--- a/dbms/src/Flash/Coprocessor/DAGContext.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGContext.cpp
@@ -105,6 +105,7 @@ DAGContext::DAGContext(tipb::DAGRequest & dag_request_, const mpp::TaskMeta & me
     , connection_id(meta_.connection_id())
     , connection_alias(meta_.connection_alias())
     , sql_digest(meta_.sql_digest())
+    , plan_digest(meta_.plan_digest())
 {
     if (dag_request->has_div_precision_increment())
         div_precision_increment = dag_request->div_precision_increment();

--- a/dbms/src/Flash/Coprocessor/DAGContext.h
+++ b/dbms/src/Flash/Coprocessor/DAGContext.h
@@ -362,6 +362,7 @@ public:
     UInt64 getConnectionID() const { return connection_id; }
     const String & getConnectionAlias() const { return connection_alias; }
     const String & getSQLDigest() const { return sql_digest; }
+    const String & getPlanDigest() const { return plan_digest; }
 
     MPPReceiverSetPtr getMPPReceiverSet() const { return mpp_receiver_set; }
 
@@ -546,6 +547,7 @@ private:
     // It's the session alias between mysql client and tidb
     String connection_alias;
     String sql_digest;
+    String plan_digest;
 
     String query_id_and_cte_id_for_sink;
     std::unordered_map<size_t, String> query_id_and_cte_id_for_sources;

--- a/dbms/src/Flash/Coprocessor/DAGContext.h
+++ b/dbms/src/Flash/Coprocessor/DAGContext.h
@@ -361,6 +361,7 @@ public:
 
     UInt64 getConnectionID() const { return connection_id; }
     const String & getConnectionAlias() const { return connection_alias; }
+    const String & getSQLDigest() const { return sql_digest; }
 
     MPPReceiverSetPtr getMPPReceiverSet() const { return mpp_receiver_set; }
 
@@ -544,6 +545,7 @@ private:
     UInt64 connection_id;
     // It's the session alias between mysql client and tidb
     String connection_alias;
+    String sql_digest;
 
     String query_id_and_cte_id_for_sink;
     std::unordered_map<size_t, String> query_id_and_cte_id_for_sources;

--- a/dbms/src/Flash/FlashService.cpp
+++ b/dbms/src/Flash/FlashService.cpp
@@ -495,12 +495,14 @@ grpc::Status FlashService::DispatchMPPTask(
     const auto & resource_group = task_meta.resource_group_name();
     LOG_INFO(
         log,
-        "Handling mpp dispatch request, task: {}, resource_group: {}, conn_id: {}, conn_alias: {}, sql_digest: {}",
+        "Handling mpp dispatch request, task: {}, resource_group: {}, conn_id: {}, conn_alias: {}, "
+        "sql_digest: {}, plan_digest: {}",
         MPPTaskId(task_meta).toString(),
         resource_group,
         task_meta.connection_id(),
         task_meta.connection_alias(),
-        task_meta.sql_digest());
+        task_meta.sql_digest(),
+        task_meta.plan_digest());
     auto check_result = checkGrpcContext(grpc_context);
     if (!check_result.ok())
         return check_result;

--- a/dbms/src/Flash/FlashService.cpp
+++ b/dbms/src/Flash/FlashService.cpp
@@ -495,11 +495,12 @@ grpc::Status FlashService::DispatchMPPTask(
     const auto & resource_group = task_meta.resource_group_name();
     LOG_INFO(
         log,
-        "Handling mpp dispatch request, task: {}, resource_group: {}, conn_id: {}, conn_alias: {}",
+        "Handling mpp dispatch request, task: {}, resource_group: {}, conn_id: {}, conn_alias: {}, sql_digest: {}",
         MPPTaskId(task_meta).toString(),
         resource_group,
         task_meta.connection_id(),
-        task_meta.connection_alias());
+        task_meta.connection_alias(),
+        task_meta.sql_digest());
     auto check_result = checkGrpcContext(grpc_context);
     if (!check_result.ok())
         return check_result;

--- a/dbms/src/Flash/Mpp/MPPTaskStatistics.cpp
+++ b/dbms/src/Flash/Mpp/MPPTaskStatistics.cpp
@@ -77,6 +77,8 @@ void MPPTaskStatistics::initializeExecutorDAG(DAGContext * dag_context_)
 
     is_root = dag_context->isRootMPPTask();
     sender_executor_id = root_executor.executor_id();
+    connection_id = dag_context->getConnectionID();
+    connection_alias = dag_context->getConnectionAlias();
     sql_digest = dag_context->getSQLDigest();
     executor_statistics_collector.initialize(dag_context);
 }
@@ -110,7 +112,8 @@ void MPPTaskStatistics::logTracingJson()
         log,
         /// don't use info log for initializing status since it does not contains too many information
         status == INITIALIZING ? Poco::Message::PRIO_DEBUG : Poco::Message::PRIO_INFORMATION,
-        R"({{"query_tso":{},"task_id":{},"is_root":{},"sender_executor_id":"{}","executors":{},"host":"{}","sql_digest":"{}")"
+        R"({{"query_tso":{},"task_id":{},"is_root":{},"sender_executor_id":"{}","executors":{},"host":"{}")"
+        R"(,"connection_id":{},"connection_alias":"{}","sql_digest":"{}")"
         R"(,"task_init_timestamp":{},"task_start_timestamp":{},"task_end_timestamp":{})"
         R"(,"compile_start_timestamp":{},"compile_end_timestamp":{})"
         R"(,"read_wait_index_start_timestamp":{},"read_wait_index_end_timestamp":{})"
@@ -122,6 +125,8 @@ void MPPTaskStatistics::logTracingJson()
         sender_executor_id,
         executor_statistics_collector.profilesToJson(),
         host,
+        connection_id,
+        connection_alias,
         sql_digest,
         toNanoseconds(task_init_timestamp),
         toNanoseconds(task_start_timestamp),

--- a/dbms/src/Flash/Mpp/MPPTaskStatistics.cpp
+++ b/dbms/src/Flash/Mpp/MPPTaskStatistics.cpp
@@ -77,6 +77,7 @@ void MPPTaskStatistics::initializeExecutorDAG(DAGContext * dag_context_)
 
     is_root = dag_context->isRootMPPTask();
     sender_executor_id = root_executor.executor_id();
+    sql_digest = dag_context->getSQLDigest();
     executor_statistics_collector.initialize(dag_context);
 }
 
@@ -109,7 +110,7 @@ void MPPTaskStatistics::logTracingJson()
         log,
         /// don't use info log for initializing status since it does not contains too many information
         status == INITIALIZING ? Poco::Message::PRIO_DEBUG : Poco::Message::PRIO_INFORMATION,
-        R"({{"query_tso":{},"task_id":{},"is_root":{},"sender_executor_id":"{}","executors":{},"host":"{}")"
+        R"({{"query_tso":{},"task_id":{},"is_root":{},"sender_executor_id":"{}","executors":{},"host":"{}","sql_digest":"{}")"
         R"(,"task_init_timestamp":{},"task_start_timestamp":{},"task_end_timestamp":{})"
         R"(,"compile_start_timestamp":{},"compile_end_timestamp":{})"
         R"(,"read_wait_index_start_timestamp":{},"read_wait_index_end_timestamp":{})"
@@ -121,6 +122,7 @@ void MPPTaskStatistics::logTracingJson()
         sender_executor_id,
         executor_statistics_collector.profilesToJson(),
         host,
+        sql_digest,
         toNanoseconds(task_init_timestamp),
         toNanoseconds(task_start_timestamp),
         toNanoseconds(task_end_timestamp),

--- a/dbms/src/Flash/Mpp/MPPTaskStatistics.cpp
+++ b/dbms/src/Flash/Mpp/MPPTaskStatistics.cpp
@@ -80,6 +80,7 @@ void MPPTaskStatistics::initializeExecutorDAG(DAGContext * dag_context_)
     connection_id = dag_context->getConnectionID();
     connection_alias = dag_context->getConnectionAlias();
     sql_digest = dag_context->getSQLDigest();
+    plan_digest = dag_context->getPlanDigest();
     executor_statistics_collector.initialize(dag_context);
 }
 
@@ -113,7 +114,7 @@ void MPPTaskStatistics::logTracingJson()
         /// don't use info log for initializing status since it does not contains too many information
         status == INITIALIZING ? Poco::Message::PRIO_DEBUG : Poco::Message::PRIO_INFORMATION,
         R"({{"query_tso":{},"task_id":{},"is_root":{},"sender_executor_id":"{}","executors":{},"host":"{}")"
-        R"(,"connection_id":{},"connection_alias":"{}","sql_digest":"{}")"
+        R"(,"connection_id":{},"connection_alias":"{}","sql_digest":"{}","plan_digest":"{}")"
         R"(,"task_init_timestamp":{},"task_start_timestamp":{},"task_end_timestamp":{})"
         R"(,"compile_start_timestamp":{},"compile_end_timestamp":{})"
         R"(,"read_wait_index_start_timestamp":{},"read_wait_index_end_timestamp":{})"
@@ -128,6 +129,7 @@ void MPPTaskStatistics::logTracingJson()
         connection_id,
         connection_alias,
         sql_digest,
+        plan_digest,
         toNanoseconds(task_init_timestamp),
         toNanoseconds(task_start_timestamp),
         toNanoseconds(task_end_timestamp),

--- a/dbms/src/Flash/Mpp/MPPTaskStatistics.h
+++ b/dbms/src/Flash/Mpp/MPPTaskStatistics.h
@@ -89,6 +89,7 @@ private:
     // executor dag
     bool is_root = false;
     String sender_executor_id;
+    String sql_digest;
 
     // resource
     RUConsumption ru_info{.cpu_ru = 0.0, .cpu_time_ns = 0, .read_ru = 0.0, .read_bytes = 0};

--- a/dbms/src/Flash/Mpp/MPPTaskStatistics.h
+++ b/dbms/src/Flash/Mpp/MPPTaskStatistics.h
@@ -89,6 +89,8 @@ private:
     // executor dag
     bool is_root = false;
     String sender_executor_id;
+    UInt64 connection_id = 0;
+    String connection_alias;
     String sql_digest;
 
     // resource

--- a/dbms/src/Flash/Mpp/MPPTaskStatistics.h
+++ b/dbms/src/Flash/Mpp/MPPTaskStatistics.h
@@ -92,6 +92,7 @@ private:
     UInt64 connection_id = 0;
     String connection_alias;
     String sql_digest;
+    String plan_digest;
 
     // resource
     RUConsumption ru_info{.cpu_ru = 0.0, .cpu_time_ns = 0, .read_ru = 0.0, .read_bytes = 0};


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/10830

ref https://github.com/pingcap/tidb/issues/66762
rely on https://github.com/pingcap/kvproto/pull/1428

Problem Summary:
- MPP task tracing logs miss SQL digest and connection metadata, making it harder to correlate TiDB session/query information during diagnosis.
- Dispatch logs also do not include SQL digest, reducing observability on request ingress.

### What is changed and how it works?

```commit-message
Flash: add MPP sql digest logging and update kvproto
Flash: include connection metadata in MPP task tracing logs
```

- Plumb `TaskMeta.sql_digest` into `DAGContext` and expose it via getter.
- Extend MPP tracing JSON (`MPPTaskStatistics::logTracingJson`) to print `sql_digest`, `connection_id`, and `connection_alias`.
- Extend `FlashService::DispatchMPPTask` handling log with `sql_digest`.
- Update `contrib/kvproto` submodule pointer to include matched proto changes.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced diagnostic logging for distributed query tasks to include SQL and plan digests.
  * Extended task execution tracing to include connection context (ID and alias) and digest fields in traces.
  * Updated a third-party submodule to a newer commit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->