### PR TITLE
Schema: handle mview out-of-place refresh cutover

### DIFF
--- a/dbms/src/TiDB/Schema/SchemaBuilder.cpp
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.cpp
@@ -296,6 +296,7 @@ void SchemaBuilder<Getter, NameMapper>::applyDiff(const SchemaDiff & diff)
     // So in TiFlash schema sync, these actions follow the same path as CreateTable.
     case SchemaActionType::ActionCreateMaterializedViewLog:
     case SchemaActionType::ActionCreateMaterializedView:
+    case SchemaActionType::ActionCreateMaterializedViewShadow:
     {
         /// Because we can't ensure set tiflash replica is earlier than insert,
         /// so we have to update table_id_map when create table.
@@ -309,6 +310,14 @@ void SchemaBuilder<Getter, NameMapper>::applyDiff(const SchemaDiff & diff)
     {
         // Materialized view alter actions only change metadata in TiDB.
         // No schema update is needed for TiFlash local storage.
+        break;
+    }
+    case SchemaActionType::ActionMViewRefreshOutOfPlaceCutover:
+    {
+        // Cutover keeps the shadow table ID, updates its display metadata to the logical MV name,
+        // and removes the old MV table ID in the same schema version.
+        applyRenameTable(diff.schema_id, diff.table_id);
+        applyDropTable(diff.schema_id, diff.old_table_id, magic_enum::enum_name(diff.type));
         break;
     }
     case SchemaActionType::RecoverTable:

--- a/dbms/src/TiDB/Schema/SchemaGetter.h
+++ b/dbms/src/TiDB/Schema/SchemaGetter.h
@@ -109,12 +109,14 @@ enum class SchemaActionType : Int8
     ActionAlterMaterializedViewRefresh = 76,
     ActionAlterMaterializedViewLogPurge = 77,
     ActionAlterMaterializedViewAttributes = 78,
+    ActionMViewRefreshOutOfPlaceCutover = 79,
+    ActionCreateMaterializedViewShadow = 80,
 
 
     // If we support new type from TiDB.
     // MaxRecognizedType also needs to be changed.
     // It should always be equal to the maximum supported type + 1
-    MaxRecognizedType = 79,
+    MaxRecognizedType = 81,
 };
 
 struct AffectedOption

--- a/dbms/src/TiDB/Schema/tests/gtest_schema_sync.cpp
+++ b/dbms/src/TiDB/Schema/tests/gtest_schema_sync.cpp
@@ -33,6 +33,7 @@
 #include <Storages/registerStorages.h>
 #include <TestUtils/TiFlashTestBasic.h>
 #include <TestUtils/TiFlashTestEnv.h>
+#include <TiDB/Schema/SchemaBuilder.h>
 #include <TiDB/Schema/SchemaSyncService.h>
 #include <TiDB/Schema/TiDBSchemaManager.h>
 #include <common/defines.h>
@@ -241,6 +242,62 @@ try
     std::string data = "{\"version\":40,\"type\":31,\"schema_id\":69,\"table_id\":71,\"old_table_id\":0,\"old_schema_"
                        "id\":0,\"affected_options\":null}";
     ASSERT_NO_THROW(diff.deserialize(data));
+}
+CATCH
+
+TEST_F(SchemaSyncTest, MViewRefreshOutOfPlaceSchemaDiffs)
+try
+{
+    auto pd_client = global_ctx.getTMTContext().getPDClient();
+
+    const String db_name = "mock_db";
+    MockTiDB::instance().newDataBase(db_name);
+
+    auto cols = ColumnsDescription({
+        {"col1", typeFromString("String")},
+        {"col2", typeFromString("Int64")},
+    });
+    const auto old_mview_id = MockTiDB::instance().newTable(db_name, "mv", cols, pd_client->getTS(), "");
+    const auto shadow_table_id = MockTiDB::instance().newTable(db_name, "__mv_shadow_1", cols, pd_client->getTS(), "");
+
+    auto [db_exists, db_id] = MockTiDB::instance().getDBIDByName(db_name);
+    ASSERT_TRUE(db_exists);
+
+    MockSchemaGetter getter;
+    DatabaseInfoCache databases;
+    TableIDMap table_id_map(Logger::get("SchemaSyncTest"));
+    SchemaBuilder<MockSchemaGetter, SchemaNameMapper> builder(getter, global_ctx, databases, table_id_map);
+
+    SchemaDiff create_old_mview_diff;
+    create_old_mview_diff.type = SchemaActionType::CreateTable;
+    create_old_mview_diff.schema_id = db_id;
+    create_old_mview_diff.table_id = old_mview_id;
+    builder.applyDiff(create_old_mview_diff);
+    ASSERT_TRUE(builder.applyTable(db_id, old_mview_id, old_mview_id, true));
+
+    SchemaDiff create_shadow_diff;
+    create_shadow_diff.type = SchemaActionType::ActionCreateMaterializedViewShadow;
+    create_shadow_diff.schema_id = db_id;
+    create_shadow_diff.table_id = shadow_table_id;
+    builder.applyDiff(create_shadow_diff);
+    ASSERT_TRUE(table_id_map.tableIDInDatabaseIdMap(shadow_table_id));
+    ASSERT_TRUE(builder.applyTable(db_id, shadow_table_id, shadow_table_id, true));
+    ASSERT_EQ(mustGetSyncedTable(shadow_table_id)->getTableInfo().name, "__mv_shadow_1");
+
+    MockTiDB::instance().dropTable(global_ctx, db_name, "mv", false);
+    MockTiDB::instance().renameTable(db_name, "__mv_shadow_1", "mv");
+
+    SchemaDiff cutover_diff;
+    cutover_diff.type = SchemaActionType::ActionMViewRefreshOutOfPlaceCutover;
+    cutover_diff.schema_id = db_id;
+    cutover_diff.table_id = shadow_table_id;
+    cutover_diff.old_table_id = old_mview_id;
+    builder.applyDiff(cutover_diff);
+
+    // The old MV keeps its table ID mapping until SchemaSyncService physically drops the tombstoned table.
+    ASSERT_TRUE(table_id_map.tableIDInDatabaseIdMap(old_mview_id));
+    ASSERT_TRUE(mustGetSyncedTable(old_mview_id)->isTombstone());
+    ASSERT_EQ(mustGetSyncedTable(shadow_table_id)->getTableInfo().name, "mv");
 }
 CATCH
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10773

Problem Summary:

TiFlash schema sync does not understand the schema actions used by materialized view out-of-place complete refresh. Without these actions, TiFlash can miss the shadow MV creation or leave local metadata inconsistent during cutover.

### What is changed and how it works?

```commit-message
Schema: handle mview out-of-place refresh cutover
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for materialized view out-of-place refresh operations, enabling safe schema synchronization of refreshed materialized views through an intermediate shadow table mechanism.

* **Tests**
  * Added test coverage for materialized view refresh out-of-place schema synchronization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->