### PR TITLE
tests: support overriding HUB_ADDR/PD_IMAGE/TIKV_IMAGE/TIDB_IMAGE via env vars in next-gen fullstack test

### DIFF
--- a/tests/docker/next-gen-utils/Makefile
+++ b/tests/docker/next-gen-utils/Makefile
@@ -11,10 +11,10 @@
 # limitations under the License.
 
 DOCKER ?= docker
-TIKV_IMAGE ?= us-docker.pkg.dev/pingcap-testing-account/hub/tikv/tikv/image:dedicated-next-gen
-PD_IMAGE ?= us-docker.pkg.dev/pingcap-testing-account/hub/tikv/pd/image:master-next-gen
-TIDB_IMAGE ?= us-docker.pkg.dev/pingcap-testing-account/hub/pingcap/tidb/images/tidb-server:master-next-gen
-TIFLASH_IMAGE ?= us-docker.pkg.dev/pingcap-testing-account/hub/pingcap/tiflash/image:master-next-gen
+TIKV_IMAGE ?= us-docker.pkg.dev/pingcap-testing-account/tidbx/tikv/tikv/image:cloud-engine-next-gen
+PD_IMAGE ?= us-docker.pkg.dev/pingcap-testing-account/tidbx/tikv/pd/image:master-next-gen
+TIDB_IMAGE ?= us-docker.pkg.dev/pingcap-testing-account/tidbx/pingcap/tidb/images/tidb-server:master-next-gen
+TIFLASH_IMAGE ?= us-docker.pkg.dev/pingcap-testing-account/tidbx/pingcap/tiflash/image:master-next-gen
 
 # Set PULL to 1 to always pull the latest image
 PULL ?= 0

--- a/tests/docker/next-gen-yaml/cluster.yaml
+++ b/tests/docker/next-gen-yaml/cluster.yaml
@@ -37,7 +37,7 @@ services:
     command: --name=pd0 --client-urls=http://0.0.0.0:2379 --peer-urls=http://0.0.0.0:2380 --advertise-client-urls=http://pd0:2379 --advertise-peer-urls=http://pd0:2380 --initial-cluster=pd0=http://pd0:2380 --config=/pd.toml --data-dir=/data --log-file=/log/pd.log
     restart: on-failure
   tikv0:
-    image: ${TIKV_IMAGE:-us-docker.pkg.dev/pingcap-testing-account/hub/tikv/tikv/image:dedicated-next-gen}
+    image: ${TIKV_IMAGE:-us-docker.pkg.dev/pingcap-testing-account/hub/tikv/tikv/image:cloud-engine-next-gen}
     security_opt:
       - seccomp:unconfined
     volumes:
@@ -50,7 +50,7 @@ services:
       - "minio0"
     restart: on-failure
   tikv-worker0:
-    image: ${TIKV_IMAGE:-us-docker.pkg.dev/pingcap-testing-account/hub/tikv/tikv/image:dedicated-next-gen}
+    image: ${TIKV_IMAGE:-us-docker.pkg.dev/pingcap-testing-account/hub/tikv/tikv/image:cloud-engine-next-gen}
     security_opt:
       - seccomp:unconfined
     volumes:

--- a/tests/docker/next-gen-yaml/cluster.yaml
+++ b/tests/docker/next-gen-yaml/cluster.yaml
@@ -27,7 +27,7 @@ services:
     # Use entrypoint instead, create bucket "tiflash-test" on minio at startup
     entrypoint: sh -c 'mkdir -p /data/tiflash-test && minio server /data --console-address ":9001" > /log/minio.log 2>&1'
   pd0:
-    image: ${PD_IMAGE:-us-docker.pkg.dev/pingcap-testing-account/hub/tikv/pd/image:master-next-gen}
+    image: ${PD_IMAGE:-us-docker.pkg.dev/pingcap-testing-account/tidbx/tikv/pd/image:master-next-gen}
     security_opt:
       - seccomp:unconfined
     volumes:
@@ -37,7 +37,7 @@ services:
     command: --name=pd0 --client-urls=http://0.0.0.0:2379 --peer-urls=http://0.0.0.0:2380 --advertise-client-urls=http://pd0:2379 --advertise-peer-urls=http://pd0:2380 --initial-cluster=pd0=http://pd0:2380 --config=/pd.toml --data-dir=/data --log-file=/log/pd.log
     restart: on-failure
   tikv0:
-    image: ${TIKV_IMAGE:-us-docker.pkg.dev/pingcap-testing-account/hub/tikv/tikv/image:cloud-engine-next-gen}
+    image: ${TIKV_IMAGE:-us-docker.pkg.dev/pingcap-testing-account/tidbx/tikv/tikv/image:cloud-engine-next-gen}
     security_opt:
       - seccomp:unconfined
     volumes:
@@ -50,7 +50,7 @@ services:
       - "minio0"
     restart: on-failure
   tikv-worker0:
-    image: ${TIKV_IMAGE:-us-docker.pkg.dev/pingcap-testing-account/hub/tikv/tikv/image:cloud-engine-next-gen}
+    image: ${TIKV_IMAGE:-us-docker.pkg.dev/pingcap-testing-account/tidbx/tikv/tikv/image:cloud-engine-next-gen}
     security_opt:
       - seccomp:unconfined
     volumes:
@@ -63,7 +63,7 @@ services:
       - "pd0"
     restart: on-failure
   tidb0:
-    image: ${TIDB_IMAGE:-us-docker.pkg.dev/pingcap-testing-account/hub/pingcap/tidb/images/tidb-server:master-next-gen}
+    image: ${TIDB_IMAGE:-us-docker.pkg.dev/pingcap-testing-account/tidbx/pingcap/tidb/images/tidb-server:master-next-gen}
     security_opt:
       - seccomp:unconfined
     volumes:

--- a/tests/fullstack-test-next-gen/run.sh
+++ b/tests/fullstack-test-next-gen/run.sh
@@ -38,19 +38,19 @@ if [[ -n "$ENABLE_NEXT_GEN" && "$ENABLE_NEXT_GEN" != "false" && "$ENABLE_NEXT_GE
     echo "Running fullstack test on next-gen TiFlash"
 
     # set images for next-gen TiFlash cluster
-    HUB_ADDR="us-docker.pkg.dev/pingcap-testing-account/hub"
+    HUB_ADDR="${HUB_ADDR:-us-docker.pkg.dev/pingcap-testing-account/tidbx}"
     if [[ -z "${PD_BRANCH}" || "${PD_BRANCH}" == "master" ]]; then
         PD_BRANCH="master-next-gen"
     fi
-    if [[ -z "${TIKV_BRANCH}" || "${TIKV_BRANCH}" == "dedicated" ]]; then
-        TIKV_BRANCH="dedicated-next-gen"
+    if [[ -z "${TIKV_BRANCH}" || "${TIKV_BRANCH}" == "cloud-engine" ]]; then
+        TIKV_BRANCH="cloud-engine-next-gen"
     fi
     if [[ -z "${TIDB_BRANCH}" || "${TIDB_BRANCH}" == "master" ]]; then
         TIDB_BRANCH="master-next-gen"
     fi
-    export PD_IMAGE="${HUB_ADDR}/tikv/pd/image:${PD_BRANCH}"
-    export TIKV_IMAGE="${HUB_ADDR}/tikv/tikv/image:${TIKV_BRANCH}"
-    export TIDB_IMAGE="${HUB_ADDR}/pingcap/tidb/images/tidb-server:${TIDB_BRANCH}"
+    export PD_IMAGE="${PD_IMAGE:-${HUB_ADDR}/tikv/pd/image:${PD_BRANCH}}"
+    export TIKV_IMAGE="${TIKV_IMAGE:-${HUB_ADDR}/tikv/tikv/image:${TIKV_BRANCH}}"
+    export TIDB_IMAGE="${TIDB_IMAGE:-${HUB_ADDR}/pingcap/tidb/images/tidb-server:${TIDB_BRANCH}}"
 
     # clean up previous docker instances, data and log
     ${COMPOSE} -f next-gen-cluster.yaml -f "${DISAGG_TIFLASH_YAML}" down


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6233 

Problem Summary:

### What is changed and how it works?

```commit-message
tests: support overriding HUB_ADDR/PD_IMAGE/TIKV_IMAGE/TIDB_IMAGE via env vars in next-gen fullstack test
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Made Docker registry override optional, using a default only when unset.
  * Changed default branch/tag selection for TiKV used by tests.
  * Updated default image references/tags for TiKV, PD, TiDB, and TiFlash to new registry defaults.
  * Preserve any preexisting PD/TiKV/TiDB image environment variables instead of always overwriting them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->