### PR TITLE
disagg: bound stream retries and reopen large forward seeks

### DIFF
--- a/dbms/src/Common/FailPoint.cpp
+++ b/dbms/src/Common/FailPoint.cpp
@@ -137,6 +137,7 @@ namespace DB
     M(force_join_v2_probe_disable_lm)                        \
     M(force_s3_random_access_file_init_fail)                 \
     M(force_s3_random_access_file_read_fail)                 \
+    M(force_s3_random_access_file_seek_fail)                 \
     M(force_s3_random_access_file_seek_chunked)              \
     M(force_release_snap_meet_null_storage)
 

--- a/dbms/src/Common/ProfileEvents.cpp
+++ b/dbms/src/Common/ProfileEvents.cpp
@@ -141,6 +141,7 @@
     M(S3IORead)                                \
     M(S3IOReadError)                           \
     M(S3IOSeek)                                \
+    M(S3IOSeekReopen)                          \
     M(S3IOSeekError)                           \
     M(S3IOSeekBackward)                        \
     M(FileCacheHit)                            \

--- a/dbms/src/Storages/S3/MockS3Client.cpp
+++ b/dbms/src/Storages/S3/MockS3Client.cpp
@@ -67,6 +67,8 @@ String MockS3Client::normalizedKey(String ori_key)
 Model::GetObjectOutcome MockS3Client::GetObject(const Model::GetObjectRequest & request) const
 {
     std::lock_guard lock(mtx);
+    get_object_count += 1;
+    last_get_object_range = request.RangeHasBeenSet() ? request.GetRange() : String{};
     auto itr = storage.find(request.GetBucket());
     if (itr == storage.end())
     {
@@ -99,6 +101,25 @@ Model::GetObjectOutcome MockS3Client::GetObject(const Model::GetObjectRequest & 
     result.ReplaceBody(ss);
     result.SetContentLength(size);
     return result;
+}
+
+void MockS3Client::resetGetObjectObservations() const
+{
+    std::lock_guard lock(mtx);
+    get_object_count = 0;
+    last_get_object_range.clear();
+}
+
+UInt64 MockS3Client::getGetObjectCount() const
+{
+    std::lock_guard lock(mtx);
+    return get_object_count;
+}
+
+String MockS3Client::getLastGetObjectRange() const
+{
+    std::lock_guard lock(mtx);
+    return last_get_object_range;
 }
 
 Model::PutObjectOutcome MockS3Client::PutObject(const Model::PutObjectRequest & request) const

--- a/dbms/src/Storages/S3/MockS3Client.h
+++ b/dbms/src/Storages/S3/MockS3Client.h
@@ -71,6 +71,12 @@ public:
         FAILED,
     };
     static void setPutObjectStatus(S3Status status) { put_object_status = status; }
+    /// Reset the GetObject observation state used by unit tests.
+    void resetGetObjectObservations() const;
+    /// Return the number of GetObject requests observed since the last reset.
+    UInt64 getGetObjectCount() const;
+    /// Return the latest Range header observed by GetObject, or empty when unset.
+    String getLastGetObjectRange() const;
 
 private:
     inline static S3Status put_object_status = S3Status::NORMAL;
@@ -86,5 +92,7 @@ private:
     mutable std::unordered_map<String, BucketStorage> storage;
     mutable std::unordered_map<String, BucketStorageTagging> storage_tagging;
     mutable std::unordered_map<String, UploadParts> upload_parts;
+    mutable UInt64 get_object_count = 0;
+    mutable String last_get_object_range;
 };
 } // namespace DB::S3::tests

--- a/dbms/src/Storages/S3/S3RandomAccessFile.cpp
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.cpp
@@ -47,6 +47,7 @@ extern const Event S3GetObjectRetry;
 extern const Event S3IORead;
 extern const Event S3IOReadError;
 extern const Event S3IOSeek;
+extern const Event S3IOSeekReopen;
 extern const Event S3IOSeekError;
 extern const Event S3IOSeekBackward;
 } // namespace ProfileEvents
@@ -64,7 +65,7 @@ namespace
 {
 constexpr size_t s3_read_limiter_preferred_chunk_size = 128 * 1024;
 constexpr size_t s3_forward_seek_reopen_threshold = 128 * 1024;
-}
+} // namespace
 
 String S3RandomAccessFile::summary() const
 {
@@ -279,10 +280,19 @@ off_t S3RandomAccessFile::seekImpl(off_t offset_, int whence)
     }
 
     auto bytes_to_ignore = static_cast<size_t>(offset_ - cur_offset);
-    if (shouldReopenForForwardSeek(bytes_to_ignore))
+    // whether a forward seek should reopen instead of draining the current stream body
+    if (bytes_to_ignore > s3_forward_seek_reopen_threshold)
     {
         Stopwatch sw;
         ProfileEvents::increment(ProfileEvents::S3IOSeek, 1);
+        ProfileEvents::increment(ProfileEvents::S3IOSeekReopen, 1);
+        LOG_DEBUG(
+            log,
+            "Forward seek reopens S3 stream: cur_offset={} target_offset={} bytes_to_ignore={} reopen_threshold={}",
+            cur_offset,
+            offset_,
+            bytes_to_ignore,
+            s3_forward_seek_reopen_threshold);
         // Large forward seeks are treated as logical repositioning. Reopen avoids draining the old body stream.
         reopenAt(offset_, "seek forward by reopen");
         return recordSuccessfulSeek(offset_, bytes_to_ignore, /* remote_read_bytes */ 0, sw);
@@ -372,11 +382,6 @@ void S3RandomAccessFile::reopenAt(off_t target_offset, std::string_view action)
     // Each reopen starts a fresh initialize session. Stream-side retries must not inherit old GetObject debt.
     cur_retry = 0;
     initialize(action);
-}
-
-bool S3RandomAccessFile::shouldReopenForForwardSeek(size_t bytes_to_skip) const
-{
-    return bytes_to_skip > s3_forward_seek_reopen_threshold;
 }
 
 off_t S3RandomAccessFile::recordSuccessfulSeek(

--- a/dbms/src/Storages/S3/S3RandomAccessFile.cpp
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.cpp
@@ -54,6 +54,7 @@ namespace DB::FailPoints
 {
 extern const char force_s3_random_access_file_init_fail[];
 extern const char force_s3_random_access_file_read_fail[];
+extern const char force_s3_random_access_file_seek_fail[];
 extern const char force_s3_random_access_file_seek_chunked[];
 } // namespace DB::FailPoints
 
@@ -112,17 +113,22 @@ bool isRetryableError(int ret, int err)
 {
     return ret == S3StreamError || err == ECONNRESET || err == EAGAIN || err == EINPROGRESS;
 }
+
+bool shouldRetryStreamError(Int32 retried_times, int ret, int err, Int32 max_retry_times)
+{
+    return retried_times + 1 < max_retry_times && isRetryableError(ret, err);
+}
 } // namespace
 
 ssize_t S3RandomAccessFile::read(char * buf, size_t size)
 {
-    while (true)
+    for (Int32 stream_retry_times = 0;; ++stream_retry_times)
     {
         auto n = readImpl(buf, size);
-        if (unlikely(n < 0 && isRetryableError(n, errno)))
+        if (unlikely(n < 0 && shouldRetryStreamError(stream_retry_times, n, errno, max_retry)))
         {
-            // If it is a retryable error, then initialize again and retry read
-            initialize("read meet retryable error");
+            // Stream-side retries reopen from the last committed offset instead of sharing initialize state.
+            reopenAt(cur_offset, "read meet retryable error");
             continue;
         }
         return n;
@@ -235,13 +241,13 @@ ssize_t S3RandomAccessFile::finalizeRead(
 
 off_t S3RandomAccessFile::seek(off_t offset_, int whence)
 {
-    while (true)
+    for (Int32 stream_retry_times = 0;; ++stream_retry_times)
     {
         auto off = seekImpl(offset_, whence);
-        if (unlikely(off < 0 && isRetryableError(off, errno)))
+        if (unlikely(off < 0 && shouldRetryStreamError(stream_retry_times, off, errno, max_retry)))
         {
-            // If it is a retryable error, then initialize again and retry seek
-            initialize("seek meet retryable error");
+            // Retry the seek from the last committed offset rather than from a partially drained stream.
+            reopenAt(cur_offset, "seek meet retryable error");
             continue;
         }
         return off;
@@ -267,9 +273,7 @@ off_t S3RandomAccessFile::seekImpl(off_t offset_, int whence)
     {
         ProfileEvents::increment(ProfileEvents::S3IOSeekBackward, 1);
         // The current body stream is forward-only. Re-open from the target offset.
-        cur_offset = offset_;
-        cur_retry = 0;
-        initialize("seek backward");
+        reopenAt(offset_, "seek backward");
         return cur_offset;
     }
 
@@ -320,6 +324,11 @@ off_t S3RandomAccessFile::finalizeSeek(
 {
     // Keep post-seek handling shared so limiter and non-limiter paths emit identical retries, logging and
     // observability signals.
+    fiu_do_on(FailPoints::force_s3_random_access_file_seek_fail, {
+        LOG_WARNING(log, "failpoint force_s3_random_access_file_seek_fail is triggered, return S3StreamError");
+        return S3StreamError;
+    });
+
     if (actual_size < requested_size)
     {
         ProfileEvents::increment(ProfileEvents::S3IOSeekError);
@@ -368,6 +377,15 @@ off_t S3RandomAccessFile::finalizeSeek(
     cur_offset = target_offset;
     return cur_offset;
 }
+
+void S3RandomAccessFile::reopenAt(off_t target_offset, std::string_view action)
+{
+    cur_offset = target_offset;
+    // Each reopen starts a fresh initialize session. Stream-side retries must not inherit old GetObject debt.
+    cur_retry = 0;
+    initialize(action);
+}
+
 String S3RandomAccessFile::readRangeOfObject()
 {
     return fmt::format("bytes={}-", cur_offset);
@@ -386,6 +404,8 @@ Int64 calculateDelayForNextRetry(Int64 attempted_retries)
 
 void S3RandomAccessFile::initialize(std::string_view action)
 {
+    // `cur_retry` is per-initialize state, so every new initialize action starts from a clean budget.
+    cur_retry = 0;
     while (cur_retry < max_retry)
     {
         Stopwatch sw_get_object;

--- a/dbms/src/Storages/S3/S3RandomAccessFile.cpp
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.cpp
@@ -378,10 +378,20 @@ off_t S3RandomAccessFile::finalizeSeek(
 
 void S3RandomAccessFile::reopenAt(off_t target_offset, std::string_view action)
 {
-    cur_offset = target_offset;
-    // Each reopen starts a fresh initialize session. Stream-side retries must not inherit old GetObject debt.
-    cur_retry = 0;
-    initialize(action);
+    const auto previous_offset = cur_offset;
+    const auto previous_retry = cur_retry;
+    try
+    {
+        cur_offset = target_offset;
+        initialize(action);
+    }
+    catch (...)
+    {
+        // Reopen either commits the new initialize session or keeps the previous committed state intact.
+        cur_offset = previous_offset;
+        cur_retry = previous_retry;
+        throw;
+    }
 }
 
 off_t S3RandomAccessFile::recordSuccessfulSeek(

--- a/dbms/src/Storages/S3/S3RandomAccessFile.cpp
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.cpp
@@ -63,6 +63,7 @@ namespace DB::S3
 namespace
 {
 constexpr size_t s3_read_limiter_preferred_chunk_size = 128 * 1024;
+constexpr size_t s3_forward_seek_reopen_threshold = 128 * 1024;
 }
 
 String S3RandomAccessFile::summary() const
@@ -277,6 +278,16 @@ off_t S3RandomAccessFile::seekImpl(off_t offset_, int whence)
         return cur_offset;
     }
 
+    auto bytes_to_ignore = static_cast<size_t>(offset_ - cur_offset);
+    if (shouldReopenForForwardSeek(bytes_to_ignore))
+    {
+        Stopwatch sw;
+        ProfileEvents::increment(ProfileEvents::S3IOSeek, 1);
+        // Large forward seeks are treated as logical repositioning. Reopen avoids draining the old body stream.
+        reopenAt(offset_, "seek forward by reopen");
+        return recordSuccessfulSeek(offset_, bytes_to_ignore, /* remote_read_bytes */ 0, sw);
+    }
+
     if (read_limiter != nullptr && read_limiter->maxReadBytesPerSec() > 0)
         return seekChunked(offset_);
 
@@ -284,7 +295,6 @@ off_t S3RandomAccessFile::seekImpl(off_t offset_, int whence)
     Stopwatch sw;
     ProfileEvents::increment(ProfileEvents::S3IOSeek, 1);
     auto & istr = read_result.GetBody();
-    auto bytes_to_ignore = static_cast<size_t>(offset_ - cur_offset);
     istr.ignore(bytes_to_ignore);
     return finalizeSeek(offset_, bytes_to_ignore, istr.gcount(), sw, istr);
 }
@@ -353,29 +363,7 @@ off_t S3RandomAccessFile::finalizeSeek(
         return (state & std::ios_base::failbit || state & std::ios_base::badbit) ? S3StreamError : S3UnknownError;
     }
 
-    auto elapsed_secs = sw.elapsedSeconds();
-    if (scan_context)
-    {
-        scan_context->disagg_s3file_seek_time_ms += elapsed_secs * 1000;
-        scan_context->disagg_s3file_seek_count += 1;
-        scan_context->disagg_s3file_seek_bytes += actual_size;
-    }
-    GET_METRIC(tiflash_storage_s3_request_seconds, type_read_stream).Observe(elapsed_secs);
-    if (elapsed_secs > 0.01)
-    {
-        LOG_DEBUG(
-            log,
-            "ignore_count={} cur_offset={} content_length={} cost={:.3f}s",
-            actual_size,
-            cur_offset,
-            content_length,
-            elapsed_secs);
-    }
-    ProfileEvents::increment(ProfileEvents::S3ReadBytes, actual_size);
-    if (read_metrics_recorder != nullptr)
-        read_metrics_recorder->recordBytes(actual_size, S3ReadSource::DirectRead);
-    cur_offset = target_offset;
-    return cur_offset;
+    return recordSuccessfulSeek(target_offset, requested_size, actual_size, sw);
 }
 
 void S3RandomAccessFile::reopenAt(off_t target_offset, std::string_view action)
@@ -384,6 +372,47 @@ void S3RandomAccessFile::reopenAt(off_t target_offset, std::string_view action)
     // Each reopen starts a fresh initialize session. Stream-side retries must not inherit old GetObject debt.
     cur_retry = 0;
     initialize(action);
+}
+
+bool S3RandomAccessFile::shouldReopenForForwardSeek(size_t bytes_to_skip) const
+{
+    return bytes_to_skip > s3_forward_seek_reopen_threshold;
+}
+
+off_t S3RandomAccessFile::recordSuccessfulSeek(
+    off_t target_offset,
+    size_t logical_seek_size,
+    size_t remote_read_bytes,
+    const Stopwatch & sw)
+{
+    auto elapsed_secs = sw.elapsedSeconds();
+    if (scan_context)
+    {
+        scan_context->disagg_s3file_seek_time_ms += elapsed_secs * 1000;
+        scan_context->disagg_s3file_seek_count += 1;
+        scan_context->disagg_s3file_seek_bytes += logical_seek_size;
+    }
+    GET_METRIC(tiflash_storage_s3_request_seconds, type_read_stream).Observe(elapsed_secs);
+    if (elapsed_secs > 0.01)
+    {
+        LOG_DEBUG(
+            log,
+            "target_offset={} logical_seek_size={} remote_read_bytes={} cur_offset={} content_length={} cost={:.3f}s",
+            target_offset,
+            logical_seek_size,
+            remote_read_bytes,
+            cur_offset,
+            content_length,
+            elapsed_secs);
+    }
+    if (remote_read_bytes > 0)
+    {
+        ProfileEvents::increment(ProfileEvents::S3ReadBytes, remote_read_bytes);
+        if (read_metrics_recorder != nullptr)
+            read_metrics_recorder->recordBytes(remote_read_bytes, S3ReadSource::DirectRead);
+    }
+    cur_offset = target_offset;
+    return cur_offset;
 }
 
 String S3RandomAccessFile::readRangeOfObject()

--- a/dbms/src/Storages/S3/S3RandomAccessFile.h
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.h
@@ -46,6 +46,7 @@ namespace DB::S3
 class S3RandomAccessFile final : public RandomAccessFile
 {
 public:
+    /// Create a random-access S3 file reader for the remote object key.
     static RandomAccessFilePtr create(const String & remote_fname);
 
     S3RandomAccessFile(
@@ -55,15 +56,17 @@ public:
 
     ~S3RandomAccessFile() override;
 
-    // Can only seek forward.
+    /// Seek to `offset` with `SEEK_SET`.
+    /// Forward seeks may reuse the current stream or reopen it depending on the implementation path.
     [[nodiscard]] off_t seek(off_t offset, int whence) override;
 
+    /// Read up to `size` bytes from the current offset and advance on success.
     [[nodiscard]] ssize_t read(char * buf, size_t size) override;
 
-    // Note that this will return "{S3Client.bucket_name}/{remote_fname}"
+    /// Return the fully qualified remote path as "{bucket}/{remote_fname}".
     std::string getFileName() const override;
 
-    // Return "remote_fname"
+    /// Return the object key without the bucket prefix.
     std::string getInitialFileName() const override;
 
     [[nodiscard]] ssize_t pread(char * /*buf*/, size_t /*size*/, off_t /*offset*/) const override
@@ -89,10 +92,14 @@ public:
         return ext::make_scope_guard([]() { read_file_info.reset(); });
     }
 
+    /// Return a short diagnostic string for logging and tests.
     String summary() const;
 
 private:
+    /// Open or reopen the body stream for the current `cur_offset`.
     void initialize(std::string_view action);
+    /// Reopen the object stream from `target_offset` and reset per-initialize retry state.
+    void reopenAt(off_t target_offset, std::string_view action);
     off_t seekImpl(off_t offset, int whence);
     ssize_t readImpl(char * buf, size_t size);
     String readRangeOfObject();
@@ -123,6 +130,7 @@ private:
     DB::LoggerPtr log;
     bool is_close = false;
 
+    /// Count GetObject failures within the current initialize session only.
     Int32 cur_retry = 0;
     static constexpr Int32 max_retry = 3;
     DM::ScanContextPtr scan_context;

--- a/dbms/src/Storages/S3/S3RandomAccessFile.h
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.h
@@ -100,8 +100,6 @@ private:
     void initialize(std::string_view action);
     /// Reopen the object stream from `target_offset` and reset per-initialize retry state.
     void reopenAt(off_t target_offset, std::string_view action);
-    /// Return true when a forward seek should reopen instead of draining the current stream body.
-    bool shouldReopenForForwardSeek(size_t bytes_to_skip) const;
     off_t seekImpl(off_t offset, int whence);
     ssize_t readImpl(char * buf, size_t size);
     String readRangeOfObject();

--- a/dbms/src/Storages/S3/S3RandomAccessFile.h
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.h
@@ -100,11 +100,18 @@ private:
     void initialize(std::string_view action);
     /// Reopen the object stream from `target_offset` and reset per-initialize retry state.
     void reopenAt(off_t target_offset, std::string_view action);
+    /// Return true when a forward seek should reopen instead of draining the current stream body.
+    bool shouldReopenForForwardSeek(size_t bytes_to_skip) const;
     off_t seekImpl(off_t offset, int whence);
     ssize_t readImpl(char * buf, size_t size);
     String readRangeOfObject();
     ssize_t readChunked(char * buf, size_t size);
     ssize_t finalizeRead(size_t requested_size, size_t actual_size, const Stopwatch & sw, std::istream & istr);
+    off_t recordSuccessfulSeek(
+        off_t target_offset,
+        size_t logical_seek_size,
+        size_t remote_read_bytes,
+        const Stopwatch & sw);
     off_t finalizeSeek(
         off_t target_offset,
         size_t requested_size,

--- a/dbms/src/Storages/S3/tests/gtest_s3file.cpp
+++ b/dbms/src/Storages/S3/tests/gtest_s3file.cpp
@@ -14,6 +14,7 @@
 
 #include <Common/Exception.h>
 #include <Common/FailPoint.h>
+#include <Common/ProfileEvents.h>
 #include <Common/SyncPoint/Ctl.h>
 #include <IO/BaseFile/PosixWritableFile.h>
 #include <IO/Buffer/ReadBufferFromRandomAccessFile.h>
@@ -71,6 +72,11 @@ extern const char force_s3_random_access_file_read_fail[];
 extern const char force_s3_random_access_file_seek_fail[];
 extern const char force_s3_random_access_file_seek_chunked[];
 } // namespace DB::FailPoints
+
+namespace ProfileEvents
+{
+extern const Event S3ReadBytes;
+} // namespace ProfileEvents
 
 namespace DB::tests
 {
@@ -458,6 +464,70 @@ try
     ASSERT_EQ(
         std::vector<char>(buff.begin(), buff.begin() + buf_unit.size()),
         std::vector<char>(buf_unit.begin(), buf_unit.begin() + buf_unit.size()));
+}
+CATCH
+
+TEST_P(S3FileTest, SmallForwardSeekKeepsCurrentStream)
+try
+{
+    auto * mock_s3_client = dynamic_cast<DB::S3::tests::MockS3Client *>(s3_client.get());
+    if (mock_s3_client == nullptr)
+        return;
+
+    const String key = "/a/b/c/small_forward_seek";
+    const size_t size = 1024 * 1024;
+    writeFile(key, size, WriteSettings{});
+
+    S3RandomAccessFile file(s3_client, key, nullptr);
+    mock_s3_client->resetGetObjectObservations();
+
+    constexpr off_t target_offset = 128 * 1024;
+    ASSERT_EQ(file.seek(target_offset, SEEK_SET), target_offset);
+    ASSERT_EQ(mock_s3_client->getGetObjectCount(), 0);
+    ASSERT_TRUE(mock_s3_client->getLastGetObjectRange().empty());
+}
+CATCH
+
+TEST_P(S3FileTest, LargeForwardSeekReopensFromTargetOffset)
+try
+{
+    auto * mock_s3_client = dynamic_cast<DB::S3::tests::MockS3Client *>(s3_client.get());
+    if (mock_s3_client == nullptr)
+        return;
+
+    const String key = "/a/b/c/large_forward_seek";
+    const size_t size = 1024 * 1024;
+    writeFile(key, size, WriteSettings{});
+
+    S3RandomAccessFile file(s3_client, key, nullptr);
+    mock_s3_client->resetGetObjectObservations();
+
+    constexpr off_t target_offset = 128 * 1024 + 1;
+    ASSERT_EQ(file.seek(target_offset, SEEK_SET), target_offset);
+    ASSERT_EQ(mock_s3_client->getGetObjectCount(), 1);
+    ASSERT_EQ(mock_s3_client->getLastGetObjectRange(), fmt::format("bytes={}-", target_offset));
+}
+CATCH
+
+TEST_P(S3FileTest, LargeForwardSeekDoesNotChargeSkippedBytesAsRemoteRead)
+try
+{
+    const String key = "/a/b/c/large_forward_seek_read_bytes";
+    const size_t size = 1024 * 1024;
+    writeFile(key, size, WriteSettings{});
+
+    S3RandomAccessFile file(s3_client, key, nullptr);
+
+    constexpr off_t target_offset = 128 * 1024 + 1;
+    const auto read_bytes_before_seek = ProfileEvents::get(ProfileEvents::S3ReadBytes);
+    ASSERT_EQ(file.seek(target_offset, SEEK_SET), target_offset);
+    const auto read_bytes_after_seek = ProfileEvents::get(ProfileEvents::S3ReadBytes);
+    ASSERT_EQ(read_bytes_after_seek - read_bytes_before_seek, 0);
+
+    std::vector<char> buff(256, 0x00);
+    ASSERT_EQ(file.read(buff.data(), buff.size()), buff.size());
+    const auto read_bytes_after_read = ProfileEvents::get(ProfileEvents::S3ReadBytes);
+    ASSERT_EQ(read_bytes_after_read - read_bytes_after_seek, buff.size());
 }
 CATCH
 

--- a/dbms/src/Storages/S3/tests/gtest_s3file.cpp
+++ b/dbms/src/Storages/S3/tests/gtest_s3file.cpp
@@ -531,6 +531,39 @@ try
 }
 CATCH
 
+TEST_P(S3FileTest, ReopenFailureRestoresCommittedState)
+try
+{
+    const String key = "/a/b/c/reopen_failure_restore_state";
+    const size_t size = 1024 * 1024;
+    writeFile(key, size, WriteSettings{});
+
+    S3RandomAccessFile file(s3_client, key, nullptr);
+    std::vector<char> buff(buf_unit.size(), 0x00);
+    ASSERT_EQ(file.read(buff.data(), buff.size()), buff.size());
+
+    constexpr off_t committed_offset = 256;
+    constexpr off_t target_offset = committed_offset + 128 * 1024 + 1;
+    ASSERT_NE(file.summary().find(fmt::format("cur_offset={}", committed_offset)), String::npos);
+
+    FailPointHelper::enableFailPoint(FailPoints::force_s3_random_access_file_init_fail);
+    SCOPE_EXIT({ FailPointHelper::disableFailPoint(FailPoints::force_s3_random_access_file_init_fail); });
+    ASSERT_THROW(
+        {
+            const auto off = file.seek(target_offset, SEEK_SET);
+            static_cast<void>(off);
+        },
+        DB::Exception);
+
+    ASSERT_NE(file.summary().find(fmt::format("cur_offset={}", committed_offset)), String::npos);
+    ASSERT_NE(file.summary().find("cur_retry=0"), String::npos);
+
+    std::fill(buff.begin(), buff.end(), 0x00);
+    ASSERT_EQ(file.read(buff.data(), buff.size()), buff.size());
+    ASSERT_EQ(buff, buf_unit);
+}
+CATCH
+
 TEST_P(S3FileTest, WriteRead)
 try
 {

--- a/dbms/src/Storages/S3/tests/gtest_s3file.cpp
+++ b/dbms/src/Storages/S3/tests/gtest_s3file.cpp
@@ -68,6 +68,7 @@ extern const char force_set_mocked_s3_object_mtime[];
 extern const char force_syncpoint_on_s3_upload[];
 extern const char force_s3_random_access_file_init_fail[];
 extern const char force_s3_random_access_file_read_fail[];
+extern const char force_s3_random_access_file_seek_fail[];
 extern const char force_s3_random_access_file_seek_chunked[];
 } // namespace DB::FailPoints
 
@@ -384,6 +385,79 @@ try
             ASSERT_LT(nread, 0);
         },
         DB::Exception);
+}
+CATCH
+
+TEST_P(S3FileTest, ReadRetryIsBoundedOnStreamFailure)
+try
+{
+    const String key = "/a/b/c/read_retry_bounded";
+    const size_t size = 5 * 1024;
+    writeFile(key, size, WriteSettings{});
+
+    S3RandomAccessFile file(s3_client, key, nullptr);
+    std::vector<char> buff(256, 0x00);
+
+    FailPointHelper::enableFailPoint(FailPoints::force_s3_random_access_file_read_fail);
+    SCOPE_EXIT({ FailPointHelper::disableFailPoint(FailPoints::force_s3_random_access_file_read_fail); });
+
+    auto nread = file.read(buff.data(), buff.size());
+    ASSERT_LT(nread, 0);
+    ASSERT_NE(file.summary().find("cur_retry=0"), String::npos);
+}
+CATCH
+
+TEST_P(S3FileTest, SeekRetryIsBoundedOnStreamFailure)
+try
+{
+    const String key = "/a/b/c/seek_retry_bounded";
+    const size_t size = 5 * 1024;
+    writeFile(key, size, WriteSettings{});
+
+    S3RandomAccessFile file(s3_client, key, nullptr);
+    std::vector<char> buff(256, 0x00);
+    ASSERT_EQ(file.read(buff.data(), buff.size()), buff.size());
+
+    FailPointHelper::enableFailPoint(FailPoints::force_s3_random_access_file_seek_fail);
+    SCOPE_EXIT({ FailPointHelper::disableFailPoint(FailPoints::force_s3_random_access_file_seek_fail); });
+
+    auto offset = file.seek(1024, SEEK_SET);
+    ASSERT_LT(offset, 0);
+    ASSERT_NE(file.summary().find("cur_retry=0"), String::npos);
+}
+CATCH
+
+TEST_P(S3FileTest, InitializeRetryBudgetResetsAcrossReopenSessions)
+try
+{
+    const String key = "/a/b/c/reopen_reset_retry_budget";
+    const size_t size = 5 * 1024;
+    writeFile(key, size, WriteSettings{});
+
+    S3RandomAccessFile file(s3_client, key, nullptr);
+    std::vector<char> buff(256, 0x00);
+    ASSERT_EQ(file.read(buff.data(), buff.size()), buff.size());
+
+    {
+        FailPointHelper::enableFailPoint(FailPoints::force_s3_random_access_file_read_fail);
+        FailPointHelper::enableFailPoint(FailPoints::force_s3_random_access_file_init_fail);
+        SCOPE_EXIT({
+            FailPointHelper::disableFailPoint(FailPoints::force_s3_random_access_file_read_fail);
+            FailPointHelper::disableFailPoint(FailPoints::force_s3_random_access_file_init_fail);
+        });
+        ASSERT_THROW(
+            {
+                auto nread = file.read(buff.data(), buff.size());
+                ASSERT_LT(nread, 0);
+            },
+            DB::Exception);
+    }
+
+    ASSERT_EQ(file.seek(0, SEEK_SET), 0);
+    ASSERT_EQ(file.read(buff.data(), buff.size()), buff.size());
+    ASSERT_EQ(
+        std::vector<char>(buff.begin(), buff.begin() + buf_unit.size()),
+        std::vector<char>(buf_unit.begin(), buf_unit.begin() + buf_unit.size()));
 }
 CATCH
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10794

Problem Summary:

`S3RandomAccessFile` could retry forever after a retryable stream-side `read()` / `ignore()` failure. In the reported OSS case, repeated `206` range responses could keep ending with stream errors, and the unbounded outer retry loop could stall DeltaMerge GC. Forward seek was also still draining the current HTTP body with `ignore()`, which is fragile for large skips.

### What is changed and how it works?

```commit-message
S3RandomAccessFile: bound stream-side retries and normalize initialize retry state
S3RandomAccessFile: use 128 KiB threshold for forward seek reopen
```

The change does two things:

- bounds stream-side retries in `read()` / `seek()` to `max_retry = 3` total attempts, while keeping `cur_retry` scoped to per-initialize `GetObject` failures only
- adds `reopenAt(...)` so backward seek and stream retry recovery reopen from a committed offset with a fresh initialize budget
- changes forward seek to use a `128 KiB` threshold: small skips still drain the current stream, while large skips reopen from the target offset directly
- fixes accounting so reopen-based forward seek still records logical seek bytes, but does not charge skipped bytes into remote read bytes
- extends `MockS3Client` to observe `GetObject` count and last range so the threshold split can be asserted in unit tests

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Forward seeks that jump far now reopen the remote stream at the target, avoiding draining data.

* **Bug Fixes**
  * Improved and bounded retry behavior for remote file read/seek operations; retry budget resets on reopen.
  * Seek/reopen logic now avoids charging skipped bytes as remote reads.

* **Observability**
  * Added a profiling metric to track reopen-on-seek events.

* **Tests**
  * Added tests covering retry, reopen-on-seek, and reopen failure scenarios.
  * Exposed test hooks to observe/reset remote GET call counts and ranges.
* **Chores**
  * Added a failpoint to inject seek failures for testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->