### PR TITLE
disagg: adapt GC merge fan-in after S3 read failures

### DIFF
--- a/dbms/src/Common/FailPoint.cpp
+++ b/dbms/src/Common/FailPoint.cpp
@@ -135,6 +135,8 @@ namespace DB
     M(force_set_proxy_state_machine_cpu_cores)               \
     M(force_join_v2_probe_enable_lm)                         \
     M(force_join_v2_probe_disable_lm)                        \
+    M(force_gc_try_segment_merge_generic_error)              \
+    M(force_gc_try_segment_merge_s3_error)                   \
     M(force_s3_random_access_file_init_fail)                 \
     M(force_s3_random_access_file_read_fail)                 \
     M(force_s3_random_access_file_seek_fail)                 \

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
@@ -454,6 +454,12 @@ public:
     /// Iterator over all segments and apply gc jobs.
     UInt64 onSyncGc(Int64 limit, const GCOptions & gc_options);
 
+    /// Test hook for verifying the background GC merge fan-in cap.
+    UInt32 getGcMergeableSegmentsCapForTest() const;
+
+    /// Test hook for overriding the background GC merge fan-in cap.
+    void setGcMergeableSegmentsCapForTest(UInt32 cap);
+
     /**
      * Try to merge the segment in the current thread as the GC operation.
      * This function may be blocking, and should be called in the GC background thread.
@@ -551,6 +557,10 @@ private:
     void waitForWrite(const DMContextPtr & context, const SegmentPtr & segment);
 
     void waitForDeleteRange(const DMContextPtr & context, const SegmentPtr & segment);
+
+    bool shouldReduceGcMergeableSegmentsCap(const Exception & e) const;
+    void reduceGcMergeableSegmentsCap(std::string_view reason);
+    void recoverGcMergeableSegmentsCap(std::string_view reason);
 
     /// Should be called after every write into DeltaMergeStore.
     /// If the delta cache reaches the foreground flush limit, it will also trigger a KVStore flush of related regions,
@@ -834,6 +844,10 @@ private:
 public:
 #endif
 
+    static constexpr UInt32 gc_mergeable_segments_cap_default = 32;
+    static constexpr UInt32 gc_mergeable_segments_cap_min = 2;
+    static constexpr UInt32 gc_mergeable_segments_cap_recover_step = 2;
+
     /**
       * Ensure the segment has delta index.
       * If the segment has no delta index, it will be built in background.
@@ -918,6 +932,7 @@ public:
     MergeDeltaTaskPool background_tasks;
 
     std::atomic<DB::Timestamp> latest_gc_safe_point = 0;
+    std::atomic<UInt32> gc_mergeable_segments_cap = gc_mergeable_segments_cap_default;
 
     RowKeyValue next_gc_check_key;
 

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore.h
@@ -558,7 +558,6 @@ private:
 
     void waitForDeleteRange(const DMContextPtr & context, const SegmentPtr & segment);
 
-    bool shouldReduceGcMergeableSegmentsCap(const Exception & e) const;
     void reduceGcMergeableSegmentsCap(std::string_view reason);
     void recoverGcMergeableSegmentsCap(std::string_view reason);
 

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalBg.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalBg.cpp
@@ -387,11 +387,6 @@ std::vector<SegmentPtr> DeltaMergeStore::getMergeableSegments(
     return results;
 }
 
-bool DeltaMergeStore::shouldReduceGcMergeableSegmentsCap(const Exception & e) const
-{
-    return e.code() == ErrorCodes::S3_ERROR;
-}
-
 void DeltaMergeStore::reduceGcMergeableSegmentsCap(std::string_view reason)
 {
     auto old_cap = gc_mergeable_segments_cap.load(std::memory_order_relaxed);
@@ -822,8 +817,8 @@ SegmentPtr DeltaMergeStore::gcTrySegmentMerge(const DMContextPtr & dm_context, c
     auto new_segment = segmentMerge(*dm_context, segments_to_merge, SegmentMergeReason::BackgroundGCThread);
     if (new_segment)
     {
-        recoverGcMergeableSegmentsCap("background_gc_merge_success");
         checkSegmentUpdate(dm_context, new_segment, ThreadType::BG_GC, InputType::NotRaft);
+        recoverGcMergeableSegmentsCap("background_gc_merge_success");
     }
 
     return new_segment;
@@ -1020,7 +1015,18 @@ UInt64 DeltaMergeStore::onSyncGc(Int64 limit, const GCOptions & gc_options)
         {
             SegmentPtr new_seg = nullptr;
             if (!new_seg && gc_options.do_merge)
-                new_seg = gcTrySegmentMerge(dm_context, segment);
+            {
+                try
+                {
+                    new_seg = gcTrySegmentMerge(dm_context, segment);
+                }
+                catch (Exception & e)
+                {
+                    if (e.code() == ErrorCodes::S3_ERROR)
+                        reduceGcMergeableSegmentsCap("background_gc_merge_s3_error");
+                    throw;
+                }
+            }
             if (!new_seg && gc_options.do_merge_delta)
                 new_seg = gcTrySegmentMergeDelta(dm_context, segment, prev_segment, next_segment, gc_safe_point);
 
@@ -1034,8 +1040,6 @@ UInt64 DeltaMergeStore::onSyncGc(Int64 limit, const GCOptions & gc_options)
         }
         catch (Exception & e)
         {
-            if (gc_options.do_merge && shouldReduceGcMergeableSegmentsCap(e))
-                reduceGcMergeableSegmentsCap("background_gc_merge_s3_error");
             e.addMessage(
                 fmt::format("Error while GC segment, segment={} log_ident={}", segment->info(), log->identifier()));
             e.rethrow();

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalBg.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalBg.cpp
@@ -39,12 +39,30 @@ namespace DB
 {
 namespace FailPoints
 {
+extern const char force_gc_try_segment_merge_generic_error[];
+extern const char force_gc_try_segment_merge_s3_error[];
 extern const char pause_before_dt_background_delta_merge[];
 extern const char pause_until_dt_background_delta_merge[];
 } // namespace FailPoints
 
+namespace ErrorCodes
+{
+extern const int LOGICAL_ERROR;
+extern const int S3_ERROR;
+} // namespace ErrorCodes
+
 namespace DM
 {
+UInt32 DeltaMergeStore::getGcMergeableSegmentsCapForTest() const
+{
+    return gc_mergeable_segments_cap.load(std::memory_order_relaxed);
+}
+
+void DeltaMergeStore::setGcMergeableSegmentsCapForTest(UInt32 cap)
+{
+    gc_mergeable_segments_cap.store(std::max(cap, gc_mergeable_segments_cap_min), std::memory_order_relaxed);
+}
+
 // A callback class for scanning the DMFiles on local filesystem
 class LocalDMFileGcScanner final
 {
@@ -326,6 +344,7 @@ std::vector<SegmentPtr> DeltaMergeStore::getMergeableSegments(
     // segment merging for this case in future.
     auto max_total_rows = context->segment_limit_rows;
     auto max_total_bytes = context->segment_limit_bytes;
+    const auto max_mergeable_segments = gc_mergeable_segments_cap.load(std::memory_order_relaxed);
 
     std::vector<SegmentPtr> results;
     {
@@ -342,6 +361,8 @@ std::vector<SegmentPtr> DeltaMergeStore::getMergeableSegments(
         auto it = segments.upper_bound(base_segment->getRowKeyRange().getEnd());
         while (it != segments.end())
         {
+            if (results.size() >= max_mergeable_segments)
+                break;
             const auto & this_seg = it->second;
             const auto this_rows = this_seg->getEstimatedRows();
             const auto this_bytes = this_seg->getEstimatedBytes();
@@ -364,6 +385,56 @@ std::vector<SegmentPtr> DeltaMergeStore::getMergeableSegments(
         return {};
 
     return results;
+}
+
+bool DeltaMergeStore::shouldReduceGcMergeableSegmentsCap(const Exception & e) const
+{
+    return e.code() == ErrorCodes::S3_ERROR;
+}
+
+void DeltaMergeStore::reduceGcMergeableSegmentsCap(std::string_view reason)
+{
+    auto old_cap = gc_mergeable_segments_cap.load(std::memory_order_relaxed);
+    while (true)
+    {
+        const auto new_cap = std::max(gc_mergeable_segments_cap_min, old_cap / 2);
+        if (new_cap == old_cap)
+            return;
+        if (gc_mergeable_segments_cap.compare_exchange_weak(old_cap, new_cap, std::memory_order_relaxed))
+        {
+            LOG_INFO(
+                log,
+                "GC - Reduce mergeable segments cap, table_id={} old_cap={} new_cap={} reason={}",
+                physical_table_id,
+                old_cap,
+                new_cap,
+                reason);
+            return;
+        }
+    }
+}
+
+void DeltaMergeStore::recoverGcMergeableSegmentsCap(std::string_view reason)
+{
+    auto old_cap = gc_mergeable_segments_cap.load(std::memory_order_relaxed);
+    while (true)
+    {
+        const auto new_cap
+            = std::min(gc_mergeable_segments_cap_default, old_cap + gc_mergeable_segments_cap_recover_step);
+        if (new_cap == old_cap)
+            return;
+        if (gc_mergeable_segments_cap.compare_exchange_weak(old_cap, new_cap, std::memory_order_relaxed))
+        {
+            LOG_INFO(
+                log,
+                "GC - Recover mergeable segments cap, table_id={} old_cap={} new_cap={} reason={}",
+                physical_table_id,
+                old_cap,
+                new_cap,
+                reason);
+            return;
+        }
+    }
 }
 
 bool DeltaMergeStore::updateGCSafePoint()
@@ -736,9 +807,22 @@ SegmentPtr DeltaMergeStore::gcTrySegmentMerge(const DMContextPtr & dm_context, c
     }
 
     LOG_INFO(log, "GC - Trigger Merge, segment={}", segment->simpleInfo());
+    fiu_do_on(FailPoints::force_gc_try_segment_merge_s3_error, {
+        throw Exception(
+            ErrorCodes::S3_ERROR,
+            "Injected S3_ERROR in gcTrySegmentMerge, segment={}",
+            segment->simpleInfo());
+    });
+    fiu_do_on(FailPoints::force_gc_try_segment_merge_generic_error, {
+        throw Exception(
+            ErrorCodes::LOGICAL_ERROR,
+            "Injected non-S3 error in gcTrySegmentMerge, segment={}",
+            segment->simpleInfo());
+    });
     auto new_segment = segmentMerge(*dm_context, segments_to_merge, SegmentMergeReason::BackgroundGCThread);
     if (new_segment)
     {
+        recoverGcMergeableSegmentsCap("background_gc_merge_success");
         checkSegmentUpdate(dm_context, new_segment, ThreadType::BG_GC, InputType::NotRaft);
     }
 
@@ -950,6 +1034,8 @@ UInt64 DeltaMergeStore::onSyncGc(Int64 limit, const GCOptions & gc_options)
         }
         catch (Exception & e)
         {
+            if (gc_options.do_merge && shouldReduceGcMergeableSegmentsCap(e))
+                reduceGcMergeableSegmentsCap("background_gc_merge_s3_error");
             e.addMessage(
                 fmt::format("Error while GC segment, segment={} log_ident={}", segment->info(), log->identifier()));
             e.rethrow();

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_store_background.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_store_background.cpp
@@ -26,6 +26,8 @@ namespace DB
 {
 namespace FailPoints
 {
+extern const char force_gc_try_segment_merge_generic_error[];
+extern const char force_gc_try_segment_merge_s3_error[];
 extern const char skip_check_segment_update[];
 } // namespace FailPoints
 
@@ -136,6 +138,59 @@ try
 
     ASSERT_EQ(200, getRowsN(0, 200));
     ASSERT_EQ(2000, getRowsN());
+}
+CATCH
+
+TEST_F(DeltaMergeStoreGCMergeTest, MergeableSegmentsCapLimitsFanIn)
+try
+{
+    ensureSegmentBreakpoints({0, 10, 20, 30, 40, 50});
+    db_context->getGlobalContext().getSettingsRef().dt_segment_limit_rows = 1000;
+    db_context->getGlobalContext().getSettingsRef().dt_segment_limit_size = 1ULL << 30;
+
+    store->setGcMergeableSegmentsCapForTest(3);
+    auto segments_to_merge = store->getMergeableSegments(dm_context, getSegmentAt(0));
+    ASSERT_EQ(segments_to_merge.size(), 3);
+    ASSERT_EQ(store->getGcMergeableSegmentsCapForTest(), 3);
+}
+CATCH
+
+TEST_F(DeltaMergeStoreGCMergeTest, S3ErrorReducesCapAndSuccessfulMergeRecoversIt)
+try
+{
+    ensureSegmentBreakpoints({0, 10, 20, 30, 40, 50});
+    db_context->getGlobalContext().getSettingsRef().dt_segment_limit_rows = 1000;
+
+    ASSERT_EQ(store->getGcMergeableSegmentsCapForTest(), DeltaMergeStore::gc_mergeable_segments_cap_default);
+
+    FailPointHelper::enableFailPoint(FailPoints::force_gc_try_segment_merge_s3_error);
+    ASSERT_THROW(store->onSyncGc(1, gc_options), DB::Exception);
+    ASSERT_EQ(store->getGcMergeableSegmentsCapForTest(), DeltaMergeStore::gc_mergeable_segments_cap_default / 2);
+
+    ASSERT_THROW(store->onSyncGc(1, gc_options), DB::Exception);
+    ASSERT_EQ(store->getGcMergeableSegmentsCapForTest(), DeltaMergeStore::gc_mergeable_segments_cap_default / 4);
+
+    FailPointHelper::disableFailPoint(FailPoints::force_gc_try_segment_merge_s3_error);
+    ASSERT_EQ(store->onSyncGc(1, gc_options), 1);
+    ASSERT_EQ(
+        store->getGcMergeableSegmentsCapForTest(),
+        DeltaMergeStore::gc_mergeable_segments_cap_default / 4
+            + DeltaMergeStore::gc_mergeable_segments_cap_recover_step);
+}
+CATCH
+
+TEST_F(DeltaMergeStoreGCMergeTest, NonS3ErrorDoesNotReduceCap)
+try
+{
+    ensureSegmentBreakpoints({0, 10, 20, 30, 40, 50});
+    db_context->getGlobalContext().getSettingsRef().dt_segment_limit_rows = 1000;
+    store->setGcMergeableSegmentsCapForTest(8);
+
+    FailPointHelper::enableFailPoint(FailPoints::force_gc_try_segment_merge_generic_error);
+    SCOPE_EXIT({ FailPointHelper::disableFailPoint(FailPoints::force_gc_try_segment_merge_generic_error); });
+
+    ASSERT_THROW(store->onSyncGc(1, gc_options), DB::Exception);
+    ASSERT_EQ(store->getGcMergeableSegmentsCapForTest(), 8);
 }
 CATCH
 

--- a/dbms/src/Storages/S3/S3RandomAccessFile.cpp
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.cpp
@@ -141,14 +141,23 @@ ssize_t S3RandomAccessFile::read(char * buf, size_t size)
     {
         auto n = readImpl(buf, size);
         const auto err = errno;
-        if (unlikely(n < 0 && shouldRetryStreamError(stream_retry_times, n, err, max_retry)))
+        if (unlikely(n < 0))
         {
-            // Stream-side retries reopen from the last committed offset instead of sharing initialize state.
-            reopenAt(cur_offset, "read meet retryable error");
-            continue;
+            const auto retryable = isRetryableError(n, err);
+            const auto can_retry = shouldRetryStreamError(stream_retry_times, n, err, max_retry);
+            if (can_retry)
+            {
+                // Stream-side retries reopen from the last committed offset instead of sharing initialize state.
+                reopenAt(cur_offset, "read meet retryable error");
+                continue;
+            }
+            if (retryable)
+            {
+                // The failure is still retryable, but this call has already used up the bounded stream-side
+                // retries. Convert it to S3_ERROR here so upper layers can classify the final remote read.
+                throwRetryExhaustedError("read", n, err);
+            }
         }
-        if (unlikely(n < 0 && isRetryableError(n, err)))
-            throwRetryExhaustedError("read", n, err);
         return n;
     }
 }
@@ -263,14 +272,23 @@ off_t S3RandomAccessFile::seek(off_t offset_, int whence)
     {
         auto off = seekImpl(offset_, whence);
         const auto err = errno;
-        if (unlikely(off < 0 && shouldRetryStreamError(stream_retry_times, off, err, max_retry)))
+        if (unlikely(off < 0))
         {
-            // Retry the seek from the last committed offset rather than from a partially drained stream.
-            reopenAt(cur_offset, "seek meet retryable error");
-            continue;
+            const auto retryable = isRetryableError(off, err);
+            const auto can_retry = shouldRetryStreamError(stream_retry_times, off, err, max_retry);
+            if (can_retry)
+            {
+                // Retry the seek from the last committed offset rather than from a partially drained stream.
+                reopenAt(cur_offset, "seek meet retryable error");
+                continue;
+            }
+            if (retryable)
+            {
+                // The failure is still retryable, but this call has already used up the bounded stream-side
+                // retries. Convert it to S3_ERROR here so upper layers can classify the final remote read.
+                throwRetryExhaustedError("seek", off, err);
+            }
         }
-        if (unlikely(off < 0 && isRetryableError(off, err)))
-            throwRetryExhaustedError("seek", off, err);
         return off;
     }
 }

--- a/dbms/src/Storages/S3/S3RandomAccessFile.cpp
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.cpp
@@ -120,6 +120,19 @@ bool shouldRetryStreamError(Int32 retried_times, int ret, int err, Int32 max_ret
 {
     return retried_times + 1 < max_retry_times && isRetryableError(ret, err);
 }
+
+const char * retryableErrorName(int ret, int err)
+{
+    if (ret == S3StreamError)
+        return "stream_error";
+    if (err == ECONNRESET)
+        return "ECONNRESET";
+    if (err == EAGAIN)
+        return "EAGAIN";
+    if (err == EINPROGRESS)
+        return "EINPROGRESS";
+    return "unknown";
+}
 } // namespace
 
 ssize_t S3RandomAccessFile::read(char * buf, size_t size)
@@ -127,12 +140,15 @@ ssize_t S3RandomAccessFile::read(char * buf, size_t size)
     for (Int32 stream_retry_times = 0;; ++stream_retry_times)
     {
         auto n = readImpl(buf, size);
-        if (unlikely(n < 0 && shouldRetryStreamError(stream_retry_times, n, errno, max_retry)))
+        const auto err = errno;
+        if (unlikely(n < 0 && shouldRetryStreamError(stream_retry_times, n, err, max_retry)))
         {
             // Stream-side retries reopen from the last committed offset instead of sharing initialize state.
             reopenAt(cur_offset, "read meet retryable error");
             continue;
         }
+        if (unlikely(n < 0 && isRetryableError(n, err)))
+            throwRetryExhaustedError("read", n, err);
         return n;
     }
 }
@@ -246,14 +262,31 @@ off_t S3RandomAccessFile::seek(off_t offset_, int whence)
     for (Int32 stream_retry_times = 0;; ++stream_retry_times)
     {
         auto off = seekImpl(offset_, whence);
-        if (unlikely(off < 0 && shouldRetryStreamError(stream_retry_times, off, errno, max_retry)))
+        const auto err = errno;
+        if (unlikely(off < 0 && shouldRetryStreamError(stream_retry_times, off, err, max_retry)))
         {
             // Retry the seek from the last committed offset rather than from a partially drained stream.
             reopenAt(cur_offset, "seek meet retryable error");
             continue;
         }
+        if (unlikely(off < 0 && isRetryableError(off, err)))
+            throwRetryExhaustedError("seek", off, err);
         return off;
     }
+}
+
+void S3RandomAccessFile::throwRetryExhaustedError(std::string_view action, int ret, int err) const
+{
+    throw Exception(
+        ErrorCodes::S3_ERROR,
+        "S3RandomAccessFile {} failed after {} stream retries, key={}, cur_offset={}, ret={}, errno={} ({})",
+        action,
+        max_retry,
+        remote_fname,
+        cur_offset,
+        ret,
+        err,
+        retryableErrorName(ret, err));
 }
 
 off_t S3RandomAccessFile::seekImpl(off_t offset_, int whence)

--- a/dbms/src/Storages/S3/S3RandomAccessFile.cpp
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.cpp
@@ -64,7 +64,7 @@ namespace DB::S3
 namespace
 {
 constexpr size_t s3_read_limiter_preferred_chunk_size = 128 * 1024;
-constexpr size_t s3_forward_seek_reopen_threshold = 128 * 1024;
+constexpr size_t s3_forward_seek_reopen_threshold = 64 * 1024;
 } // namespace
 
 String S3RandomAccessFile::summary() const

--- a/dbms/src/Storages/S3/S3RandomAccessFile.h
+++ b/dbms/src/Storages/S3/S3RandomAccessFile.h
@@ -39,7 +39,8 @@ class TiFlashS3Client;
 namespace DB::ErrorCodes
 {
 extern const int NOT_IMPLEMENTED;
-}
+extern const int S3_ERROR;
+} // namespace DB::ErrorCodes
 
 namespace DB::S3
 {
@@ -58,9 +59,11 @@ public:
 
     /// Seek to `offset` with `SEEK_SET`.
     /// Forward seeks may reuse the current stream or reopen it depending on the implementation path.
+    /// Throws `ErrorCodes::S3_ERROR` when the remote stream keeps failing after the bounded retry budget is exhausted.
     [[nodiscard]] off_t seek(off_t offset, int whence) override;
 
     /// Read up to `size` bytes from the current offset and advance on success.
+    /// Throws `ErrorCodes::S3_ERROR` when the remote stream keeps failing after the bounded retry budget is exhausted.
     [[nodiscard]] ssize_t read(char * buf, size_t size) override;
 
     /// Return the fully qualified remote path as "{bucket}/{remote_fname}".
@@ -100,6 +103,8 @@ private:
     void initialize(std::string_view action);
     /// Reopen the object stream from `target_offset` and reset per-initialize retry state.
     void reopenAt(off_t target_offset, std::string_view action);
+    /// Convert the final retry-exhausted remote read/seek failure into a stable S3-specific error code.
+    [[noreturn]] void throwRetryExhaustedError(std::string_view action, int ret, int err) const;
     off_t seekImpl(off_t offset, int whence);
     ssize_t readImpl(char * buf, size_t size);
     String readRangeOfObject();

--- a/dbms/src/Storages/S3/tests/gtest_s3file.cpp
+++ b/dbms/src/Storages/S3/tests/gtest_s3file.cpp
@@ -78,6 +78,11 @@ namespace ProfileEvents
 extern const Event S3ReadBytes;
 } // namespace ProfileEvents
 
+namespace ErrorCodes
+{
+extern const int S3_ERROR;
+} // namespace ErrorCodes
+
 namespace DB::tests
 {
 using DMFileBlockOutputStreamPtr = std::shared_ptr<DMFileBlockOutputStream>;
@@ -407,8 +412,15 @@ try
     FailPointHelper::enableFailPoint(FailPoints::force_s3_random_access_file_read_fail);
     SCOPE_EXIT({ FailPointHelper::disableFailPoint(FailPoints::force_s3_random_access_file_read_fail); });
 
-    auto nread = file.read(buff.data(), buff.size());
-    ASSERT_LT(nread, 0);
+    try
+    {
+        static_cast<void>(file.read(buff.data(), buff.size()));
+        FAIL() << "expected S3_ERROR";
+    }
+    catch (const DB::Exception & e)
+    {
+        ASSERT_EQ(e.code(), ErrorCodes::S3_ERROR);
+    }
     ASSERT_NE(file.summary().find("cur_retry=0"), String::npos);
 }
 CATCH
@@ -427,8 +439,15 @@ try
     FailPointHelper::enableFailPoint(FailPoints::force_s3_random_access_file_seek_fail);
     SCOPE_EXIT({ FailPointHelper::disableFailPoint(FailPoints::force_s3_random_access_file_seek_fail); });
 
-    auto offset = file.seek(1024, SEEK_SET);
-    ASSERT_LT(offset, 0);
+    try
+    {
+        static_cast<void>(file.seek(1024, SEEK_SET));
+        FAIL() << "expected S3_ERROR";
+    }
+    catch (const DB::Exception & e)
+    {
+        ASSERT_EQ(e.code(), ErrorCodes::S3_ERROR);
+    }
     ASSERT_NE(file.summary().find("cur_retry=0"), String::npos);
 }
 CATCH

--- a/dbms/src/Storages/S3/tests/gtest_s3file.cpp
+++ b/dbms/src/Storages/S3/tests/gtest_s3file.cpp
@@ -481,7 +481,7 @@ try
     S3RandomAccessFile file(s3_client, key, nullptr);
     mock_s3_client->resetGetObjectObservations();
 
-    constexpr off_t target_offset = 128 * 1024;
+    constexpr off_t target_offset = 64 * 1024;
     ASSERT_EQ(file.seek(target_offset, SEEK_SET), target_offset);
     ASSERT_EQ(mock_s3_client->getGetObjectCount(), 0);
     ASSERT_TRUE(mock_s3_client->getLastGetObjectRange().empty());
@@ -502,7 +502,7 @@ try
     S3RandomAccessFile file(s3_client, key, nullptr);
     mock_s3_client->resetGetObjectObservations();
 
-    constexpr off_t target_offset = 128 * 1024 + 1;
+    constexpr off_t target_offset = 64 * 1024 + 1;
     ASSERT_EQ(file.seek(target_offset, SEEK_SET), target_offset);
     ASSERT_EQ(mock_s3_client->getGetObjectCount(), 1);
     ASSERT_EQ(mock_s3_client->getLastGetObjectRange(), fmt::format("bytes={}-", target_offset));
@@ -518,7 +518,7 @@ try
 
     S3RandomAccessFile file(s3_client, key, nullptr);
 
-    constexpr off_t target_offset = 128 * 1024 + 1;
+    constexpr off_t target_offset = 64 * 1024 + 1;
     const auto read_bytes_before_seek = ProfileEvents::get(ProfileEvents::S3ReadBytes);
     ASSERT_EQ(file.seek(target_offset, SEEK_SET), target_offset);
     const auto read_bytes_after_seek = ProfileEvents::get(ProfileEvents::S3ReadBytes);
@@ -543,7 +543,7 @@ try
     ASSERT_EQ(file.read(buff.data(), buff.size()), buff.size());
 
     constexpr off_t committed_offset = 256;
-    constexpr off_t target_offset = committed_offset + 128 * 1024 + 1;
+    constexpr off_t target_offset = committed_offset + 64 * 1024 + 1;
     ASSERT_NE(file.summary().find(fmt::format("cur_offset={}", committed_offset)), String::npos);
 
     FailPointHelper::enableFailPoint(FailPoints::force_s3_random_access_file_init_fail);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10798, ref #10794

Problem Summary:

Background GC merges can still fan in too many segments after bounded S3 stream retries are exhausted. That keeps a single GC merge exposed to long remote-read windows, while medium forward seeks still prefer draining the existing stream instead of reopening from the target offset.

### What is changed and how it works?

```commit-message
33e66a4a07 disagg: tighten S3 forward seek reopen threshold
bd070ca5fe disagg: classify retry-exhausted S3 reads
7cbe1147ae disagg: adapt GC merge fan-in after S3 errors
085cb158be disagg: clarify S3 retry exhaustion flow
1f87ade691 disagg: narrow GC cap adjustment triggers
```

- tighten the S3 forward-seek reopen threshold from 128 KiB to 64 KiB and update the boundary tests
- let `S3RandomAccessFile::read` and `S3RandomAccessFile::seek` throw `ErrorCodes::S3_ERROR` after the bounded stream retry budget is exhausted, with doc comments for the public APIs and concise comments around the retry-exhaustion branch
- add a table-level `gc_mergeable_segments_cap` so background GC merge fan-in is capped and can be reduced after `S3_ERROR`
- only reduce the cap when `gcTrySegmentMerge` fails with `S3_ERROR`, and recover the cap only after `checkSegmentUpdate` succeeds
- add failpoints and unit tests for cap limiting, S3-error-triggered reduction, recovery, and non-S3 failures

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Background garbage collection now dynamically adjusts merge concurrency based on S3 error conditions, automatically recovering when operations succeed.
  * S3 operations now throw explicit error codes when retry budgets are exhausted, improving error handling clarity.

* **Chores**
  * Adjusted S3 stream forwarding threshold from 128KB to 64KB for optimized performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->