### PR TITLE
tici: consume columnar search results in tiflash

### DIFF
--- a/dbms/src/Storages/Tantivy/TantivyInputStream.h
+++ b/dbms/src/Storages/Tantivy/TantivyInputStream.h
@@ -37,8 +37,9 @@
 #include <common/types.h>
 #include <fcntl.h>
 #include <fmt/os.h>
-#include <stdexcept>
 #include <tici-search-lib/src/lib.rs.h>
+
+#include <stdexcept>
 #include <unordered_map>
 
 namespace DB::TS
@@ -172,11 +173,25 @@ protected:
 
         for (const auto & column_data : search_result.i64_columns)
         {
-            installIntegerLikeColumn(res, name_to_pos, filled, return_columns, column_data.col_name, column_data.values, column_data.null_map);
+            installIntegerLikeColumn(
+                res,
+                name_to_pos,
+                filled,
+                return_columns,
+                column_data.col_name,
+                column_data.values,
+                column_data.null_map);
         }
         for (const auto & column_data : search_result.u64_columns)
         {
-            installIntegerLikeColumn(res, name_to_pos, filled, return_columns, column_data.col_name, column_data.values, column_data.null_map);
+            installIntegerLikeColumn(
+                res,
+                name_to_pos,
+                filled,
+                return_columns,
+                column_data.col_name,
+                column_data.values,
+                column_data.null_map);
         }
         for (const auto & column_data : search_result.f64_columns)
         {
@@ -313,8 +328,10 @@ private:
         if (typeid_cast<const DataTypeMyDateTime *>(nested_type.get()))
             return buildNumericColumn<DataTypeMyDateTime::FieldType>(name_and_type, values, null_map);
 
-        throw std::runtime_error(
-            fmt::format("unsupported integer-like target type {} for column {}", nested_type->getName(), name_and_type.name));
+        throw std::runtime_error(fmt::format(
+            "unsupported integer-like target type {} for column {}",
+            nested_type->getName(),
+            name_and_type.name));
     }
 
     static MutableColumnPtr buildFloatColumn(
@@ -358,7 +375,9 @@ private:
                 offsets[i] = static_cast<ColumnString::Offset>(column_data.offsets[i]);
 
             if (name_and_type.type->isNullable())
-                return ColumnNullable::create(std::move(nested_column), buildNullMapColumn(row_count, column_data.null_map));
+                return ColumnNullable::create(
+                    std::move(nested_column),
+                    buildNullMapColumn(row_count, column_data.null_map));
             return nested_column;
         }
         auto column = name_and_type.type->createColumn();
@@ -375,7 +394,8 @@ private:
             if (i < column_data.null_map.size() && column_data.null_map[i] != 0)
                 column->insertDefault();
             else
-                column->insert(Field(String(reinterpret_cast<const char *>(&column_data.chars[prev_offset]), value_size)));
+                column->insert(
+                    Field(String(reinterpret_cast<const char *>(&column_data.chars[prev_offset]), value_size)));
             prev_offset = current_offset;
         }
 

--- a/dbms/src/Storages/Tantivy/TantivyInputStream.h
+++ b/dbms/src/Storages/Tantivy/TantivyInputStream.h
@@ -97,15 +97,16 @@ public:
     Block readImpl() override
     {
         if (done)
+        {
             return {};
-
+        }
         Block ret = readFromS3(is_count);
         done = true;
         return ret;
     }
 
 protected:
-    Block readFromS3(bool is_count_search)
+    Block readFromS3(bool is_count)
     {
         auto return_fields = getFields(return_columns);
         auto shard_info = query_shard_info;
@@ -114,18 +115,22 @@ protected:
 
         rust::Vec<rust::String> tici_sort_column_names;
         for (const auto & sort_column_id : sort_column_ids)
+        {
             tici_sort_column_names.push_back(rust::String("column_" + std::to_string(sort_column_id)));
+        }
 
         rust::Vec<bool> tici_sort_column_asc;
         for (const auto & asc : sort_column_asc)
+        {
             tici_sort_column_asc.push_back(asc);
+        }
 
         SearchParam search_param{
             .limit = static_cast<size_t>(limit),
             .sort_field_names = std::move(tici_sort_column_names),
             .is_asc = std::move(tici_sort_column_asc),
         };
-        if (is_count_search)
+        if (is_count)
             return_fields = {};
 
         RUNTIME_CHECK(shards_snapshot != nullptr);
@@ -145,7 +150,7 @@ protected:
             read_ts);
 
         Block res(return_columns);
-        if (is_count_search)
+        if (is_count)
         {
             RUNTIME_CHECK_MSG(return_columns.size() == 1, "count search should return one column");
             auto & column = res.getByPosition(0).column->assumeMutableRef();
@@ -438,7 +443,9 @@ private:
     {
         rust::Vec<rust::String> fields;
         for (auto & name_and_type : columns)
+        {
             fields.push_back(name_and_type.name);
+        }
         return fields;
     }
 

--- a/dbms/src/Storages/Tantivy/TantivyInputStream.h
+++ b/dbms/src/Storages/Tantivy/TantivyInputStream.h
@@ -39,7 +39,9 @@
 #include <fmt/os.h>
 #include <tici-search-lib/src/lib.rs.h>
 
+#include <cstring>
 #include <stdexcept>
+#include <type_traits>
 #include <unordered_map>
 
 namespace DB::TS
@@ -283,11 +285,14 @@ private:
                 null_map.size());
         }
 
-        for (size_t i = 0; i < row_count; ++i)
+        if constexpr (std::is_same_v<TargetType, SourceType>)
         {
-            if (has_null_map && null_map[i] != 0)
-                data[i] = TargetType{};
-            else
+            if (row_count != 0)
+                std::memcpy(data.data(), values.data(), row_count * sizeof(TargetType));
+        }
+        else
+        {
+            for (size_t i = 0; i < row_count; ++i)
                 data[i] = static_cast<TargetType>(values[i]);
         }
 

--- a/dbms/src/Storages/Tantivy/TantivyInputStream.h
+++ b/dbms/src/Storages/Tantivy/TantivyInputStream.h
@@ -14,11 +14,19 @@
 
 #pragma once
 
+#include <Columns/ColumnNullable.h>
+#include <Columns/ColumnString.h>
+#include <Columns/ColumnsNumber.h>
 #include <Common/Logger.h>
+#include <Common/typeid_cast.h>
 #include <Core/Block.h>
 #include <Core/NamesAndTypes.h>
 #include <DataStreams/IBlockInputStream.h>
 #include <DataStreams/IProfilingBlockInputStream.h>
+#include <DataTypes/DataTypeDate.h>
+#include <DataTypes/DataTypeDateTime.h>
+#include <DataTypes/DataTypeMyDate.h>
+#include <DataTypes/DataTypeMyDateTime.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <Flash/Coprocessor/DAGCodec.h>
@@ -29,7 +37,9 @@
 #include <common/types.h>
 #include <fcntl.h>
 #include <fmt/os.h>
+#include <stdexcept>
 #include <tici-search-lib/src/lib.rs.h>
+#include <unordered_map>
 
 namespace DB::TS
 {
@@ -49,8 +59,6 @@ inline UInt64 convertPackedU64WithTimezone(UInt64 from_time, const TimezoneInfo 
 class TantivyInputStream : public IProfilingBlockInputStream
 {
     static constexpr auto NAME = "TantivyInputStream";
-
-    static constexpr auto version_column_name = "column_-1024";
 
 public:
     TantivyInputStream(
@@ -89,16 +97,15 @@ public:
     Block readImpl() override
     {
         if (done)
-        {
             return {};
-        }
+
         Block ret = readFromS3(is_count);
         done = true;
         return ret;
     }
 
 protected:
-    Block readFromS3(bool is_count)
+    Block readFromS3(bool is_count_search)
     {
         auto return_fields = getFields(return_columns);
         auto shard_info = query_shard_info;
@@ -107,21 +114,18 @@ protected:
 
         rust::Vec<rust::String> tici_sort_column_names;
         for (const auto & sort_column_id : sort_column_ids)
-        {
             tici_sort_column_names.push_back(rust::String("column_" + std::to_string(sort_column_id)));
-        }
+
         rust::Vec<bool> tici_sort_column_asc;
         for (const auto & asc : sort_column_asc)
-        {
             tici_sort_column_asc.push_back(asc);
-        }
 
         SearchParam search_param{
             .limit = static_cast<size_t>(limit),
             .sort_field_names = std::move(tici_sort_column_names),
             .is_asc = std::move(tici_sort_column_asc),
         };
-        if (is_count)
+        if (is_count_search)
             return_fields = {};
 
         RUNTIME_CHECK(shards_snapshot != nullptr);
@@ -141,7 +145,7 @@ protected:
             read_ts);
 
         Block res(return_columns);
-        if (is_count)
+        if (is_count_search)
         {
             RUNTIME_CHECK_MSG(return_columns.size() == 1, "count search should return one column");
             auto & column = res.getByPosition(0).column->assumeMutableRef();
@@ -149,101 +153,41 @@ protected:
             return res;
         }
 
-        auto documents = search_result.rows;
-        if (documents.empty())
-        {
-            return res;
-        }
-        for (auto & name_and_type : return_columns)
-        {
-            int idx = -1;
-            for (size_t j = 0; j < documents[0].fieldValues.size(); j++)
-            {
-                if (documents[0].fieldValues[j].field_name == name_and_type.name)
-                {
-                    idx = j;
-                    break;
-                }
-            }
-            if (idx == -1)
-            {
-                if (name_and_type.name == version_column_name)
-                {
-                    auto col = res.getByName(name_and_type.name).column->assumeMutable();
-                    for (auto & doc : documents)
-                    {
-                        col->insert(Field(doc.version));
-                    }
-                    continue;
-                }
-                for (size_t j = 0; j < documents.size(); j++)
-                {
-                    // Insert default value for missing fields
-                    res.getByName(name_and_type.name).column->assumeMutable()->insertDefault();
-                }
-                continue;
-            }
+        RUNTIME_CHECK_MSG(
+            search_result.result_type == result_type_rows(),
+            "expected row search result, got type {}",
+            search_result.result_type);
 
-            auto col = res.getByName(name_and_type.name).column->assumeMutable();
-            bool has_null = false;
-            if (removeNullable(name_and_type.type)->isStringOrFixedString())
-            {
-                for (auto & doc : documents)
-                {
-                    const auto & field_value = doc.fieldValues[idx];
-                    if (field_value.is_null)
-                    {
-                        has_null = true;
-                        col->insert(Field());
-                    }
-                    else
-                    {
-                        const auto & v = field_value.string_value;
-                        col->insert(Field(String(v.begin(), v.end())));
-                    }
-                }
-            }
-            if (removeNullable(name_and_type.type)->isInteger())
-            {
-                for (auto & doc : documents)
-                {
-                    const auto & field_value = doc.fieldValues[idx];
-                    if (field_value.is_null)
-                    {
-                        has_null = true;
-                        col->insert(Field());
-                    }
-                    else
-                    {
-                        col->insert(Field(field_value.int_value));
-                    }
-                }
-            }
-            if (removeNullable(name_and_type.type)->isDateOrDateTime())
-            {
-                for (auto & doc : documents)
-                {
-                    const auto & field_value = doc.fieldValues[idx];
-                    if (field_value.is_null)
-                    {
-                        has_null = true;
-                        col->insert(Field());
-                    }
-                    else
-                    {
-                        auto t = static_cast<UInt64>(field_value.int_value);
-                        col->insert(Field(t));
-                    }
-                }
-            }
-            if (has_null)
-            {
-                RUNTIME_CHECK_MSG(
-                    col->isColumnNullable(),
-                    "column {} is not nullable, but got null value from TiCI",
-                    name_and_type.name);
-            }
+        const auto row_count = static_cast<size_t>(search_result.row_count);
+        if (row_count == 0)
+            return res;
+
+        auto name_to_pos = buildColumnPositionMap(return_columns);
+        std::vector<bool> filled(return_columns.size(), false);
+
+        for (const auto & column_data : search_result.i64_columns)
+        {
+            installIntegerLikeColumn(res, name_to_pos, filled, return_columns, column_data.col_name, column_data.values, column_data.null_map);
         }
+        for (const auto & column_data : search_result.u64_columns)
+        {
+            installIntegerLikeColumn(res, name_to_pos, filled, return_columns, column_data.col_name, column_data.values, column_data.null_map);
+        }
+        for (const auto & column_data : search_result.f64_columns)
+        {
+            installFloatColumn(res, name_to_pos, filled, return_columns, column_data);
+        }
+        for (const auto & column_data : search_result.bytes_columns)
+        {
+            installBytesColumn(res, name_to_pos, filled, return_columns, column_data);
+        }
+
+        for (size_t i = 0; i < return_columns.size(); ++i)
+        {
+            if (!filled[i])
+                fillDefaultColumn(res.getByPosition(i), row_count);
+        }
+
         return res;
     }
 
@@ -264,13 +208,270 @@ private:
     bool is_count;
     std::shared_ptr<rust::Box<ShardsSnapshot>> shards_snapshot;
 
+    static bool isNullableType(const DataTypePtr & type)
+    {
+        return typeid_cast<const DataTypeNullable *>(type.get()) != nullptr;
+    }
+
+    static std::unordered_map<String, size_t> buildColumnPositionMap(const NamesAndTypes & columns)
+    {
+        std::unordered_map<String, size_t> positions;
+        positions.reserve(columns.size());
+        for (size_t i = 0; i < columns.size(); ++i)
+            positions.emplace(columns[i].name, i);
+        return positions;
+    }
+
+    static bool hasNullValues(const rust::Vec<::std::uint8_t> & null_map)
+    {
+        for (size_t i = 0; i < null_map.size(); ++i)
+        {
+            if (null_map[i] != 0)
+                return true;
+        }
+        return false;
+    }
+
+    static ColumnUInt8::MutablePtr buildNullMapColumn(size_t row_count, const rust::Vec<::std::uint8_t> & null_map)
+    {
+        auto null_map_column = ColumnUInt8::create(row_count, 0);
+        if (null_map.size() == 0)
+            return null_map_column;
+
+        RUNTIME_CHECK_MSG(
+            null_map.size() == row_count,
+            "null map size mismatch, expect {}, got {}",
+            row_count,
+            null_map.size());
+        auto & dst = null_map_column->getData();
+        for (size_t i = 0; i < row_count; ++i)
+            dst[i] = null_map[i];
+        return null_map_column;
+    }
+
+    static void checkNonNullableColumnHasNoNulls(
+        const NameAndTypePair & name_and_type,
+        const rust::Vec<::std::uint8_t> & null_map)
+    {
+        RUNTIME_CHECK_MSG(
+            !hasNullValues(null_map),
+            "column {} is not nullable, but got null value from TiCI",
+            name_and_type.name);
+    }
+
+    static void fillDefaultColumn(ColumnWithTypeAndName & column, size_t row_count)
+    {
+        auto mutable_column = column.type->createColumn();
+        for (size_t i = 0; i < row_count; ++i)
+            mutable_column->insertDefault();
+        column.column = std::move(mutable_column);
+    }
+
+    template <typename TargetType, typename SourceType>
+    static MutableColumnPtr buildNumericColumn(
+        const NameAndTypePair & name_and_type,
+        const rust::Vec<SourceType> & values,
+        const rust::Vec<::std::uint8_t> & null_map)
+    {
+        const auto row_count = values.size();
+        auto nested_column = ColumnVector<TargetType>::create(row_count);
+        auto & data = nested_column->getData();
+        const bool has_null_map = null_map.size() != 0;
+
+        if (has_null_map)
+        {
+            RUNTIME_CHECK_MSG(
+                null_map.size() == row_count,
+                "null map size mismatch for column {}, expect {}, got {}",
+                name_and_type.name,
+                row_count,
+                null_map.size());
+        }
+
+        for (size_t i = 0; i < row_count; ++i)
+        {
+            if (has_null_map && null_map[i] != 0)
+                data[i] = TargetType{};
+            else
+                data[i] = static_cast<TargetType>(values[i]);
+        }
+
+        if (isNullableType(name_and_type.type))
+            return ColumnNullable::create(std::move(nested_column), buildNullMapColumn(row_count, null_map));
+
+        checkNonNullableColumnHasNoNulls(name_and_type, null_map);
+        return nested_column;
+    }
+
+    template <typename SourceType>
+    static MutableColumnPtr buildIntegerLikeColumn(
+        const NameAndTypePair & name_and_type,
+        const rust::Vec<SourceType> & values,
+        const rust::Vec<::std::uint8_t> & null_map)
+    {
+        const auto nested_type = removeNullable(name_and_type.type);
+        if (typeid_cast<const DataTypeInt8 *>(nested_type.get()))
+            return buildNumericColumn<Int8>(name_and_type, values, null_map);
+        if (typeid_cast<const DataTypeInt16 *>(nested_type.get()))
+            return buildNumericColumn<Int16>(name_and_type, values, null_map);
+        if (typeid_cast<const DataTypeInt32 *>(nested_type.get()))
+            return buildNumericColumn<Int32>(name_and_type, values, null_map);
+        if (typeid_cast<const DataTypeInt64 *>(nested_type.get()))
+            return buildNumericColumn<Int64>(name_and_type, values, null_map);
+        if (typeid_cast<const DataTypeUInt8 *>(nested_type.get()))
+            return buildNumericColumn<UInt8>(name_and_type, values, null_map);
+        if (typeid_cast<const DataTypeUInt16 *>(nested_type.get()))
+            return buildNumericColumn<UInt16>(name_and_type, values, null_map);
+        if (typeid_cast<const DataTypeUInt32 *>(nested_type.get()))
+            return buildNumericColumn<UInt32>(name_and_type, values, null_map);
+        if (typeid_cast<const DataTypeUInt64 *>(nested_type.get()))
+            return buildNumericColumn<UInt64>(name_and_type, values, null_map);
+        if (typeid_cast<const DataTypeDate *>(nested_type.get()))
+            return buildNumericColumn<DataTypeDate::FieldType>(name_and_type, values, null_map);
+        if (typeid_cast<const DataTypeDateTime *>(nested_type.get()))
+            return buildNumericColumn<DataTypeDateTime::FieldType>(name_and_type, values, null_map);
+        if (typeid_cast<const DataTypeMyDate *>(nested_type.get()))
+            return buildNumericColumn<DataTypeMyDate::FieldType>(name_and_type, values, null_map);
+        if (typeid_cast<const DataTypeMyDateTime *>(nested_type.get()))
+            return buildNumericColumn<DataTypeMyDateTime::FieldType>(name_and_type, values, null_map);
+
+        throw std::runtime_error(
+            fmt::format("unsupported integer-like target type {} for column {}", nested_type->getName(), name_and_type.name));
+    }
+
+    static MutableColumnPtr buildFloatColumn(
+        const NameAndTypePair & name_and_type,
+        const rust::Vec<double> & values,
+        const rust::Vec<::std::uint8_t> & null_map)
+    {
+        const auto nested_type = removeNullable(name_and_type.type);
+        if (typeid_cast<const DataTypeFloat32 *>(nested_type.get()))
+            return buildNumericColumn<Float32>(name_and_type, values, null_map);
+        if (typeid_cast<const DataTypeFloat64 *>(nested_type.get()))
+            return buildNumericColumn<Float64>(name_and_type, values, null_map);
+
+        throw std::runtime_error(
+            fmt::format("unsupported float target type {} for column {}", nested_type->getName(), name_and_type.name));
+    }
+
+    static MutableColumnPtr buildBytesColumn(const NameAndTypePair & name_and_type, const BytesColumnData & column_data)
+    {
+        const auto row_count = column_data.offsets.size();
+        if (column_data.offsets.size() != 0)
+        {
+            RUNTIME_CHECK_MSG(
+                column_data.offsets[column_data.offsets.size() - 1] == column_data.chars.size(),
+                "string offsets and chars size mismatch for column {}",
+                name_and_type.name);
+        }
+
+        if (removeNullable(name_and_type.type)->isString())
+        {
+            auto nested_column = ColumnString::create();
+            auto & chars = nested_column->getChars();
+            auto & offsets = nested_column->getOffsets();
+
+            chars.resize(column_data.chars.size());
+            for (size_t i = 0; i < column_data.chars.size(); ++i)
+                chars[i] = column_data.chars[i];
+
+            offsets.resize(row_count);
+            for (size_t i = 0; i < row_count; ++i)
+                offsets[i] = static_cast<ColumnString::Offset>(column_data.offsets[i]);
+
+            if (isNullableType(name_and_type.type))
+                return ColumnNullable::create(std::move(nested_column), buildNullMapColumn(row_count, column_data.null_map));
+
+            checkNonNullableColumnHasNoNulls(name_and_type, column_data.null_map);
+            return nested_column;
+        }
+
+        auto column = name_and_type.type->createColumn();
+        if (!isNullableType(name_and_type.type))
+            checkNonNullableColumnHasNoNulls(name_and_type, column_data.null_map);
+
+        size_t prev_offset = 0;
+        for (size_t i = 0; i < row_count; ++i)
+        {
+            const auto current_offset = static_cast<size_t>(column_data.offsets[i]);
+            RUNTIME_CHECK_MSG(
+                current_offset >= prev_offset && current_offset > 0,
+                "invalid string offset {} for column {}",
+                current_offset,
+                name_and_type.name);
+            const auto value_size = current_offset - prev_offset - 1;
+            if (i < column_data.null_map.size() && column_data.null_map[i] != 0)
+                column->insertDefault();
+            else
+                column->insert(Field(String(reinterpret_cast<const char *>(&column_data.chars[prev_offset]), value_size)));
+            prev_offset = current_offset;
+        }
+
+        return column;
+    }
+
+    template <typename ValueType>
+    static void installIntegerLikeColumn(
+        Block & res,
+        const std::unordered_map<String, size_t> & name_to_pos,
+        std::vector<bool> & filled,
+        const NamesAndTypes & columns,
+        const rust::String & col_name,
+        const rust::Vec<ValueType> & values,
+        const rust::Vec<::std::uint8_t> & null_map)
+    {
+        const String column_name(col_name);
+        const auto it = name_to_pos.find(column_name);
+        RUNTIME_CHECK_MSG(it != name_to_pos.end(), "unexpected column {} returned from TiCI", column_name);
+
+        const auto pos = it->second;
+        RUNTIME_CHECK_MSG(!filled[pos], "duplicate column {} returned from TiCI", column_name);
+        auto & result_column = res.getByPosition(pos);
+        result_column.column = buildIntegerLikeColumn(columns[pos], values, null_map);
+        filled[pos] = true;
+    }
+
+    static void installFloatColumn(
+        Block & res,
+        const std::unordered_map<String, size_t> & name_to_pos,
+        std::vector<bool> & filled,
+        const NamesAndTypes & columns,
+        const F64ColumnData & column_data)
+    {
+        const String column_name(column_data.col_name);
+        const auto it = name_to_pos.find(column_name);
+        RUNTIME_CHECK_MSG(it != name_to_pos.end(), "unexpected column {} returned from TiCI", column_name);
+
+        const auto pos = it->second;
+        RUNTIME_CHECK_MSG(!filled[pos], "duplicate column {} returned from TiCI", column_name);
+        auto & result_column = res.getByPosition(pos);
+        result_column.column = buildFloatColumn(columns[pos], column_data.values, column_data.null_map);
+        filled[pos] = true;
+    }
+
+    static void installBytesColumn(
+        Block & res,
+        const std::unordered_map<String, size_t> & name_to_pos,
+        std::vector<bool> & filled,
+        const NamesAndTypes & columns,
+        const BytesColumnData & column_data)
+    {
+        const String column_name(column_data.col_name);
+        const auto it = name_to_pos.find(column_name);
+        RUNTIME_CHECK_MSG(it != name_to_pos.end(), "unexpected column {} returned from TiCI", column_name);
+
+        const auto pos = it->second;
+        RUNTIME_CHECK_MSG(!filled[pos], "duplicate column {} returned from TiCI", column_name);
+        auto & result_column = res.getByPosition(pos);
+        result_column.column = buildBytesColumn(columns[pos], column_data);
+        filled[pos] = true;
+    }
+
     static rust::Vec<rust::String> getFields(NamesAndTypes & columns)
     {
         rust::Vec<rust::String> fields;
         for (auto & name_and_type : columns)
-        {
             fields.push_back(name_and_type.name);
-        }
         return fields;
     }
 

--- a/dbms/src/Storages/Tantivy/TantivyInputStream.h
+++ b/dbms/src/Storages/Tantivy/TantivyInputStream.h
@@ -372,8 +372,8 @@ private:
             auto & offsets = nested_column->getOffsets();
 
             chars.resize(column_data.chars.size());
-            for (size_t i = 0; i < column_data.chars.size(); ++i)
-                chars[i] = column_data.chars[i];
+            if (!column_data.chars.empty())
+                std::memcpy(chars.data(), column_data.chars.data(), column_data.chars.size());
 
             offsets.resize(row_count);
             for (size_t i = 0; i < row_count; ++i)
@@ -385,26 +385,10 @@ private:
                     buildNullMapColumn(row_count, column_data.null_map));
             return nested_column;
         }
-        auto column = name_and_type.type->createColumn();
-        size_t prev_offset = 0;
-        for (size_t i = 0; i < row_count; ++i)
-        {
-            const auto current_offset = static_cast<size_t>(column_data.offsets[i]);
-            RUNTIME_CHECK_MSG(
-                current_offset >= prev_offset && current_offset > 0,
-                "invalid string offset {} for column {}",
-                current_offset,
-                name_and_type.name);
-            const auto value_size = current_offset - prev_offset - 1;
-            if (i < column_data.null_map.size() && column_data.null_map[i] != 0)
-                column->insertDefault();
-            else
-                column->insert(
-                    Field(String(reinterpret_cast<const char *>(&column_data.chars[prev_offset]), value_size)));
-            prev_offset = current_offset;
-        }
-
-        return column;
+        throw std::runtime_error(fmt::format(
+            "unsupported bytes target type {} for column {}",
+            name_and_type.type->getName(),
+            name_and_type.name));
     }
 
     template <typename ValueType>

--- a/dbms/src/Storages/Tantivy/TantivyInputStream.h
+++ b/dbms/src/Storages/Tantivy/TantivyInputStream.h
@@ -208,11 +208,6 @@ private:
     bool is_count;
     std::shared_ptr<rust::Box<ShardsSnapshot>> shards_snapshot;
 
-    static bool isNullableType(const DataTypePtr & type)
-    {
-        return typeid_cast<const DataTypeNullable *>(type.get()) != nullptr;
-    }
-
     static std::unordered_map<String, size_t> buildColumnPositionMap(const NamesAndTypes & columns)
     {
         std::unordered_map<String, size_t> positions;
@@ -220,16 +215,6 @@ private:
         for (size_t i = 0; i < columns.size(); ++i)
             positions.emplace(columns[i].name, i);
         return positions;
-    }
-
-    static bool hasNullValues(const rust::Vec<::std::uint8_t> & null_map)
-    {
-        for (size_t i = 0; i < null_map.size(); ++i)
-        {
-            if (null_map[i] != 0)
-                return true;
-        }
-        return false;
     }
 
     static ColumnUInt8::MutablePtr buildNullMapColumn(size_t row_count, const rust::Vec<::std::uint8_t> & null_map)
@@ -247,16 +232,6 @@ private:
         for (size_t i = 0; i < row_count; ++i)
             dst[i] = null_map[i];
         return null_map_column;
-    }
-
-    static void checkNonNullableColumnHasNoNulls(
-        const NameAndTypePair & name_and_type,
-        const rust::Vec<::std::uint8_t> & null_map)
-    {
-        RUNTIME_CHECK_MSG(
-            !hasNullValues(null_map),
-            "column {} is not nullable, but got null value from TiCI",
-            name_and_type.name);
     }
 
     static void fillDefaultColumn(ColumnWithTypeAndName & column, size_t row_count)
@@ -296,10 +271,8 @@ private:
                 data[i] = static_cast<TargetType>(values[i]);
         }
 
-        if (isNullableType(name_and_type.type))
+        if (name_and_type.type->isNullable())
             return ColumnNullable::create(std::move(nested_column), buildNullMapColumn(row_count, null_map));
-
-        checkNonNullableColumnHasNoNulls(name_and_type, null_map);
         return nested_column;
     }
 
@@ -379,17 +352,11 @@ private:
             for (size_t i = 0; i < row_count; ++i)
                 offsets[i] = static_cast<ColumnString::Offset>(column_data.offsets[i]);
 
-            if (isNullableType(name_and_type.type))
+            if (name_and_type.type->isNullable())
                 return ColumnNullable::create(std::move(nested_column), buildNullMapColumn(row_count, column_data.null_map));
-
-            checkNonNullableColumnHasNoNulls(name_and_type, column_data.null_map);
             return nested_column;
         }
-
         auto column = name_and_type.type->createColumn();
-        if (!isNullableType(name_and_type.type))
-            checkNonNullableColumnHasNoNulls(name_and_type, column_data.null_map);
-
         size_t prev_offset = 0;
         for (size_t i = 0; i < row_count; ++i)
         {

--- a/dbms/src/Storages/Tantivy/TantivyInputStream.h
+++ b/dbms/src/Storages/Tantivy/TantivyInputStream.h
@@ -17,6 +17,7 @@
 #include <Columns/ColumnNullable.h>
 #include <Columns/ColumnString.h>
 #include <Columns/ColumnsNumber.h>
+#include <Common/Exception.h>
 #include <Common/Logger.h>
 #include <Common/typeid_cast.h>
 #include <Core/Block.h>
@@ -40,7 +41,6 @@
 #include <tici-search-lib/src/lib.rs.h>
 
 #include <cstring>
-#include <stdexcept>
 #include <type_traits>
 #include <unordered_map>
 
@@ -251,16 +251,15 @@ private:
             row_count,
             null_map.size());
         auto & dst = null_map_column->getData();
-        for (size_t i = 0; i < row_count; ++i)
-            dst[i] = null_map[i];
+        if (row_count != 0)
+            std::memcpy(dst.data(), null_map.data(), row_count * sizeof(UInt8));
         return null_map_column;
     }
 
     static void fillDefaultColumn(ColumnWithTypeAndName & column, size_t row_count)
     {
         auto mutable_column = column.type->createColumn();
-        for (size_t i = 0; i < row_count; ++i)
-            mutable_column->insertDefault();
+        mutable_column->insertManyDefaults(row_count);
         column.column = std::move(mutable_column);
     }
 
@@ -333,10 +332,11 @@ private:
         if (typeid_cast<const DataTypeMyDateTime *>(nested_type.get()))
             return buildNumericColumn<DataTypeMyDateTime::FieldType>(name_and_type, values, null_map);
 
-        throw std::runtime_error(fmt::format(
+        throw Exception(
+            ErrorCodes::LOGICAL_ERROR,
             "unsupported integer-like target type {} for column {}",
             nested_type->getName(),
-            name_and_type.name));
+            name_and_type.name);
     }
 
     static MutableColumnPtr buildFloatColumn(
@@ -350,8 +350,11 @@ private:
         if (typeid_cast<const DataTypeFloat64 *>(nested_type.get()))
             return buildNumericColumn<Float64>(name_and_type, values, null_map);
 
-        throw std::runtime_error(
-            fmt::format("unsupported float target type {} for column {}", nested_type->getName(), name_and_type.name));
+        throw Exception(
+            ErrorCodes::LOGICAL_ERROR,
+            "unsupported float target type {} for column {}",
+            nested_type->getName(),
+            name_and_type.name);
     }
 
     static MutableColumnPtr buildBytesColumn(const NameAndTypePair & name_and_type, const BytesColumnData & column_data)
@@ -385,10 +388,11 @@ private:
                     buildNullMapColumn(row_count, column_data.null_map));
             return nested_column;
         }
-        throw std::runtime_error(fmt::format(
+        throw Exception(
+            ErrorCodes::LOGICAL_ERROR,
             "unsupported bytes target type {} for column {}",
             name_and_type.type->getName(),
-            name_and_type.name));
+            name_and_type.name);
     }
 
     template <typename ValueType>


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Problem Summary:

Consume the new columnar TiCI search result format in TiFlash so Tantivy reads no longer need row-wise result materialization. This PR now points `contrib/tici` at the latest merged `master`.

### What is changed and how it works?

```commit-message
tici: consume columnar search results in tiflash

tiflash: update contrib/tici to latest master

Simplify Tantivy nullable handling

Restore Tantivy formatting
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Manual test steps:

- start a TiCI playground cluster with custom TiDB/TiKV/TiCDC/TiCI/TiFlash binaries
- update `contrib/tici` to the latest merged `master` and build TiFlash with `./.tmp_script/docker-dev.sh build`
- verify pure `cop[tici]` FTS queries and returned values for signed/unsigned integers, floats, datetime/timestamp, string, bytes, and nullable alternating rows
- compare pure `cop[tici]` query latency before and after the columnar search result change

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
