### PR TITLE
KVStore: reduce log

### DIFF
--- a/dbms/src/Storages/KVStore/KVStore.h
+++ b/dbms/src/Storages/KVStore/KVStore.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <string_view>
+
 #include <Interpreters/Context_fwd.h>
 #include <Parsers/IAST_fwd.h>
 #include <Storages/DeltaMerge/DeltaMergeInterfaces.h>
@@ -372,13 +374,14 @@ private:
         TMTContext & tmt,
         const RegionTaskLock & region_task_lock,
         UInt64 index,
-        UInt64 term) const;
+        UInt64 term,
+        std::string_view persist_extra_msg) const;
 
     void persistRegion(
         const Region & region,
         const RegionTaskLock & region_task_lock,
         PersistRegionReason reason,
-        const char * extra_msg) const;
+        std::string_view extra_msg) const;
 
     bool tryRegisterEagerRaftLogGCTask(const RegionPtr & region, RegionTaskLock &);
 

--- a/dbms/src/Storages/KVStore/KVStore.h
+++ b/dbms/src/Storages/KVStore/KVStore.h
@@ -14,8 +14,6 @@
 
 #pragma once
 
-#include <string_view>
-
 #include <Interpreters/Context_fwd.h>
 #include <Parsers/IAST_fwd.h>
 #include <Storages/DeltaMerge/DeltaMergeInterfaces.h>
@@ -31,6 +29,7 @@
 #include <Storages/KVStore/StorageEngineType.h>
 
 #include <magic_enum.hpp>
+#include <string_view>
 
 namespace TiDB
 {

--- a/dbms/src/Storages/KVStore/MultiRaft/Persistence.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/Persistence.cpp
@@ -133,12 +133,15 @@ bool KVStore::tryFlushRegionData(
     // force persist
     auto & curr_region = *curr_region_ptr;
     const auto force_persist_msg = fmt::format("by force, term={} index={}", term, index);
-    LOG_DEBUG(
-        log,
-        "{} flush region due to tryFlushRegionData {}",
-        curr_region.toString(false),
-        force_persist_msg);
-    if (!forceFlushRegionDataImpl(curr_region, try_until_succeed, tmt, region_task_lock, index, term, force_persist_msg))
+    LOG_DEBUG(log, "{} flush region due to tryFlushRegionData {}", curr_region.toString(false), force_persist_msg);
+    if (!forceFlushRegionDataImpl(
+            curr_region,
+            try_until_succeed,
+            tmt,
+            region_task_lock,
+            index,
+            term,
+            force_persist_msg))
     {
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Force flush region failed, region_id={}", region_id);
     }
@@ -218,7 +221,8 @@ bool KVStore::canFlushRegionDataImpl(
     {
         // This rarely happens when there are too may raft logs, which don't trigger a proactive flush.
         const auto flush_msg = fmt::format(
-            "index {} term {} truncated_index {} truncated_term {} gap {}/{} table_in_mem_size={} table_id={} keyspace={}",
+            "index {} term {} truncated_index {} truncated_term {} gap {}/{} table_in_mem_size={} table_id={} "
+            "keyspace={}",
             index,
             term,
             truncated_index,
@@ -228,11 +232,7 @@ bool KVStore::canFlushRegionDataImpl(
             curr_region_ptr->getRegionTableSize(),
             curr_region_ptr->getMappedTableID(),
             curr_region_ptr->getKeyspaceID());
-        LOG_DEBUG(
-            log,
-            "{} flush region due to tryFlushRegionData, {}",
-            curr_region.toString(false),
-            flush_msg);
+        LOG_DEBUG(log, "{} flush region due to tryFlushRegionData, {}", curr_region.toString(false), flush_msg);
         GET_METRIC(tiflash_raft_region_flush_bytes, type_flushed).Observe(size_bytes);
         return forceFlushRegionDataImpl(curr_region, try_until_succeed, tmt, region_task_lock, index, term, flush_msg);
     }

--- a/dbms/src/Storages/KVStore/MultiRaft/Persistence.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/Persistence.cpp
@@ -28,7 +28,7 @@ void KVStore::persistRegion(
     const Region & region,
     const RegionTaskLock & region_task_lock,
     PersistRegionReason reason,
-    const char * extra_msg) const
+    std::string_view extra_msg) const
 {
     RUNTIME_CHECK_MSG(
         region_persister,
@@ -36,7 +36,9 @@ void KVStore::persistRegion(
         StackTrace().toString());
 
     auto reason_id = magic_enum::enum_underlying(reason);
-    std::string caller = fmt::format("{} {}", PersistRegionReasonMap[reason_id], extra_msg);
+    std::string caller = fmt::format("{}", PersistRegionReasonMap[reason_id]);
+    if (!extra_msg.empty())
+        caller = fmt::format("{} {}", caller, extra_msg);
     LOG_INFO(
         log,
         "Start to persist {}, cache size: {} bytes for `{}`",
@@ -130,13 +132,13 @@ bool KVStore::tryFlushRegionData(
 
     // force persist
     auto & curr_region = *curr_region_ptr;
+    const auto force_persist_msg = fmt::format("by force, term={} index={}", term, index);
     LOG_DEBUG(
         log,
-        "flush region due to tryFlushRegionData by force, region_id={} term={} index={}",
-        curr_region.id(),
-        term,
-        index);
-    if (!forceFlushRegionDataImpl(curr_region, try_until_succeed, tmt, region_task_lock, index, term))
+        "{} flush region due to tryFlushRegionData {}",
+        curr_region.toString(false),
+        force_persist_msg);
+    if (!forceFlushRegionDataImpl(curr_region, try_until_succeed, tmt, region_task_lock, index, term, force_persist_msg))
     {
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Force flush region failed, region_id={}", region_id);
     }
@@ -215,11 +217,8 @@ bool KVStore::canFlushRegionDataImpl(
     if (can_flush && flush_if_possible)
     {
         // This rarely happens when there are too may raft logs, which don't trigger a proactive flush.
-        LOG_INFO(
-            log,
-            "{} flush region due to tryFlushRegionData, index {} term {} truncated_index {} truncated_term {}"
-            " gap {}/{} table_in_mem_size={} table_id={} keyspace={}",
-            curr_region.toString(false),
+        const auto flush_msg = fmt::format(
+            "index {} term {} truncated_index {} truncated_term {} gap {}/{} table_in_mem_size={} table_id={} keyspace={}",
             index,
             term,
             truncated_index,
@@ -229,8 +228,13 @@ bool KVStore::canFlushRegionDataImpl(
             curr_region_ptr->getRegionTableSize(),
             curr_region_ptr->getMappedTableID(),
             curr_region_ptr->getKeyspaceID());
+        LOG_DEBUG(
+            log,
+            "{} flush region due to tryFlushRegionData, {}",
+            curr_region.toString(false),
+            flush_msg);
         GET_METRIC(tiflash_raft_region_flush_bytes, type_flushed).Observe(size_bytes);
-        return forceFlushRegionDataImpl(curr_region, try_until_succeed, tmt, region_task_lock, index, term);
+        return forceFlushRegionDataImpl(curr_region, try_until_succeed, tmt, region_task_lock, index, term, flush_msg);
     }
     else
     {
@@ -246,7 +250,8 @@ bool KVStore::forceFlushRegionDataImpl(
     TMTContext & tmt,
     const RegionTaskLock & region_task_lock,
     UInt64 index,
-    UInt64 term) const
+    UInt64 term,
+    std::string_view persist_extra_msg) const
 {
     Stopwatch watch;
     if (index)
@@ -261,7 +266,7 @@ bool KVStore::forceFlushRegionDataImpl(
     }
 
     // flush cache in storage level is done, persist the region info
-    persistRegion(curr_region, region_task_lock, PersistRegionReason::Flush, "");
+    persistRegion(curr_region, region_task_lock, PersistRegionReason::Flush, persist_extra_msg);
     // CompactLog will be done in proxy soon, we advance the eager truncate index in TiFlash
     curr_region.updateRaftLogEagerIndex(index);
     curr_region.cleanApproxMemCacheInfo();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10814

Problem Summary:

### What is changed and how it works?

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Storage persistence now accepts and forwards optional textual messages through flush paths.
  * Logging adjusted to include those messages only when present and to reduce noise by lowering some flush logs to debug.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->