### PR TITLE
*: reduce getGCState freq

### DIFF
--- a/dbms/src/Common/TiFlashMetrics.h
+++ b/dbms/src/Common/TiFlashMetrics.h
@@ -200,6 +200,7 @@ static_assert(RAFT_REGION_BIG_WRITE_THRES * 4 < RAFT_REGION_BIG_WRITE_MAX, "Inva
       Counter,                                                                                                                      \
       F(type_get_gc_state, {{"type", "get_gc_state"}}),                                                                             \
       F(type_zero_gc_safe_point, {{"type", "zero_gc_safe_point"}}),                                                                 \
+      F(type_rewind, {{"type", "rewind"}}),                                                                                         \
       F(type_pd_response_error, {{"type", "pd_response_error"}}),                                                                   \
       F(type_request_exception, {{"type", "request_exception"}}),                                                                   \
       F(type_backoff_error, {{"type", "backoff_error"}}))                                                                           \

--- a/dbms/src/Debug/dbgFuncSchema.cpp
+++ b/dbms/src/Debug/dbgFuncSchema.cpp
@@ -186,7 +186,6 @@ void dbgFuncGcSchemas(Context & context, const ASTs & args, DBGInvoker::Printer 
         gc_safe_point = PDClientHelper::getGCSafePointWithRetry(
             context.getTMTContext().getPDClient(),
             NullspaceID,
-            true,
             30,
             context.getSettingsRef().safe_point_get_max_backoff_ms);
     if (!args.empty())

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalBg.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalBg.cpp
@@ -439,7 +439,6 @@ bool DeltaMergeStore::updateGCSafePoint()
         auto safe_point = PDClientHelper::getGCSafePointWithRetry(
             pd_client,
             keyspace_id,
-            /* ignore_cache= */ false,
             global_context.getSettingsRef().safe_point_update_interval_seconds,
             global_context.getSettingsRef().safe_point_get_max_backoff_ms);
         latest_gc_safe_point.store(safe_point, std::memory_order_release);

--- a/dbms/src/Storages/KVStore/MultiRaft/PrehandleSnapshot.cpp
+++ b/dbms/src/Storages/KVStore/MultiRaft/PrehandleSnapshot.cpp
@@ -728,7 +728,6 @@ PrehandleResult KVStore::preHandleSSTsToDTFiles(
                 gc_safepoint = PDClientHelper::getGCSafePointWithRetry(
                     pd_client,
                     keyspace_id,
-                    /* ignore_cache= */ false,
                     context.getSettingsRef().safe_point_update_interval_seconds,
                     context.getSettingsRef().safe_point_get_max_backoff_ms);
             }

--- a/dbms/src/Storages/KVStore/TiKVHelpers/PDTiKVClient.h
+++ b/dbms/src/Storages/KVStore/TiKVHelpers/PDTiKVClient.h
@@ -46,6 +46,16 @@ namespace FailPoints
 extern const char force_pd_grpc_error[];
 } // namespace FailPoints
 
+enum class GCSafepointFetchStrategy
+{
+    // Return the cached value directly. If the keyspace has not been refreshed yet,
+    // return 0 and leave cache advancement to the existing background / GC paths.
+    CacheOnly,
+    // Keep the original behavior: use a valid cache entry when possible, otherwise
+    // refresh from PD and update the shared cache.
+    UpdateCacheIfNeeded,
+};
+
 // The GC safepoint and its update time for a keyspace.
 struct KeyspaceGCInfo
 {
@@ -174,7 +184,8 @@ struct PDClientHelper
         KeyspaceID keyspace_id,
         bool ignore_cache = true,
         Int64 safe_point_update_interval_seconds = 30,
-        Int64 safe_point_get_max_backoff_ms = 120000)
+        Int64 safe_point_get_max_backoff_ms = 120000,
+        GCSafepointFetchStrategy fetch_strategy = GCSafepointFetchStrategy::UpdateCacheIfNeeded)
     {
         UInt64 backoff_count = 0;
         auto observe_backoff_count = [&](bool success) {
@@ -186,18 +197,31 @@ struct PDClientHelper
 
         if (!ignore_cache)
         {
-            // In order to avoid too frequent requests to PD,
-            // we cache the safe point for a while.
-            // at least one second
-            const auto min_interval = std::max(static_cast<Int64>(1), safe_point_update_interval_seconds);
-            auto ks_gc_info = ks_gc_sp_map.getGCSafepointIfValid(keyspace_id, min_interval);
-            if (ks_gc_info.has_value())
+            if (fetch_strategy == GCSafepointFetchStrategy::CacheOnly)
             {
-                // Still valid, return the cached gc safepoint
+                // Query paths use the last globally observed safepoint only. They never
+                // push the cache forward on their own, which avoids PD traffic growing
+                // linearly with query concurrency. Returning 0 on cache miss preserves
+                // the best-effort semantics expected by the caller.
+                auto ks_gc_info = ks_gc_sp_map.getGCSafepoint(keyspace_id);
                 observe_backoff_count(true);
-                return ks_gc_info->gc_safepoint;
+                return ks_gc_info.has_value() ? ks_gc_info->gc_safepoint : 0;
             }
-            // else fallback to fetch from PD
+            else
+            {
+                // In order to avoid too frequent requests to PD,
+                // we cache the safe point for a while.
+                // at least one second
+                const auto min_interval = std::max(static_cast<Int64>(1), safe_point_update_interval_seconds);
+                auto ks_gc_info = ks_gc_sp_map.getGCSafepointIfValid(keyspace_id, min_interval);
+                if (ks_gc_info.has_value())
+                {
+                    // Still valid, return the cached gc safepoint
+                    observe_backoff_count(true);
+                    return ks_gc_info->gc_safepoint;
+                }
+                // else fallback to fetch from PD
+            }
         }
 
         pingcap::kv::Backoffer bo(std::max(static_cast<Int64>(0), safe_point_get_max_backoff_ms));

--- a/dbms/src/Storages/KVStore/TiKVHelpers/PDTiKVClient.h
+++ b/dbms/src/Storages/KVStore/TiKVHelpers/PDTiKVClient.h
@@ -182,7 +182,6 @@ struct PDClientHelper
     static Timestamp getGCSafePointWithRetry(
         const pingcap::pd::ClientPtr & pd_client,
         KeyspaceID keyspace_id,
-        bool ignore_cache = true,
         Int64 safe_point_update_interval_seconds = 30,
         Int64 safe_point_get_max_backoff_ms = 120000,
         GCSafepointFetchStrategy fetch_strategy = GCSafepointFetchStrategy::UpdateCacheIfNeeded)
@@ -195,33 +194,30 @@ struct PDClientHelper
                 GET_METRIC(tiflash_gc_safepoint_backoff_count, type_failure).Observe(backoff_count);
         };
 
-        if (!ignore_cache)
+        if (fetch_strategy == GCSafepointFetchStrategy::CacheOnly)
         {
-            if (fetch_strategy == GCSafepointFetchStrategy::CacheOnly)
+            // Query paths use the last globally observed safepoint only. They never
+            // push the cache forward on their own, which avoids PD traffic growing
+            // linearly with query concurrency. Returning 0 on cache miss preserves
+            // the best-effort semantics expected by the caller.
+            auto ks_gc_info = ks_gc_sp_map.getGCSafepoint(keyspace_id);
+            observe_backoff_count(true);
+            return ks_gc_info.has_value() ? ks_gc_info->gc_safepoint : 0;
+        }
+        else
+        {
+            // In order to avoid too frequent requests to PD,
+            // we cache the safe point for a while.
+            // at least one second
+            const auto min_interval = std::max(static_cast<Int64>(1), safe_point_update_interval_seconds);
+            auto ks_gc_info = ks_gc_sp_map.getGCSafepointIfValid(keyspace_id, min_interval);
+            if (ks_gc_info.has_value())
             {
-                // Query paths use the last globally observed safepoint only. They never
-                // push the cache forward on their own, which avoids PD traffic growing
-                // linearly with query concurrency. Returning 0 on cache miss preserves
-                // the best-effort semantics expected by the caller.
-                auto ks_gc_info = ks_gc_sp_map.getGCSafepoint(keyspace_id);
+                // Still valid, return the cached gc safepoint
                 observe_backoff_count(true);
-                return ks_gc_info.has_value() ? ks_gc_info->gc_safepoint : 0;
+                return ks_gc_info->gc_safepoint;
             }
-            else
-            {
-                // In order to avoid too frequent requests to PD,
-                // we cache the safe point for a while.
-                // at least one second
-                const auto min_interval = std::max(static_cast<Int64>(1), safe_point_update_interval_seconds);
-                auto ks_gc_info = ks_gc_sp_map.getGCSafepointIfValid(keyspace_id, min_interval);
-                if (ks_gc_info.has_value())
-                {
-                    // Still valid, return the cached gc safepoint
-                    observe_backoff_count(true);
-                    return ks_gc_info->gc_safepoint;
-                }
-                // else fallback to fetch from PD
-            }
+            // else fallback to fetch from PD
         }
 
         pingcap::kv::Backoffer bo(std::max(static_cast<Int64>(0), safe_point_get_max_backoff_ms));

--- a/dbms/src/Storages/KVStore/TiKVHelpers/PDTiKVClient.h
+++ b/dbms/src/Storages/KVStore/TiKVHelpers/PDTiKVClient.h
@@ -33,6 +33,7 @@
 #include <common/logger_useful.h>
 #include <fiu.h>
 
+#include <algorithm>
 #include <atomic>
 #include <magic_enum.hpp>
 
@@ -92,14 +93,25 @@ public:
     KeyspacesGCInfo() = default;
 
     // Update GCSafepoint for a keyspace.
-    void updateGCSafepoint(KeyspaceID keyspace_id, Timestamp gc_safepoint)
+    Timestamp updateGCSafepoint(KeyspaceID keyspace_id, Timestamp gc_safepoint)
     {
         // guard for invalid gc safe point
         if (gc_safepoint == 0)
-            return;
+            return 0;
 
         std::unique_lock lock(mtx);
-        gc_safepoint_map[keyspace_id] = KeyspaceGCInfo(gc_safepoint);
+        auto iter = gc_safepoint_map.find(keyspace_id);
+        if (iter == gc_safepoint_map.end())
+        {
+            gc_safepoint_map[keyspace_id] = KeyspaceGCInfo(gc_safepoint);
+            return gc_safepoint;
+        }
+
+        if (gc_safepoint < iter->second.gc_safepoint)
+            GET_METRIC(tiflash_gc_safepoint_request_count, type_rewind).Increment();
+        const auto merged_gc_safepoint = std::max(iter->second.gc_safepoint, gc_safepoint);
+        iter->second = KeyspaceGCInfo(merged_gc_safepoint);
+        return merged_gc_safepoint;
     }
 
     // Get GCSafepoint for a keyspace.
@@ -266,7 +278,7 @@ struct PDClientHelper
                 if (safe_point != 0)
                 {
                     // add to cache
-                    ks_gc_sp_map.updateGCSafepoint(keyspace_id, safe_point);
+                    safe_point = ks_gc_sp_map.updateGCSafepoint(keyspace_id, safe_point);
                 }
                 else
                 {

--- a/dbms/src/Storages/KVStore/tests/gtest_new_kvstore.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_new_kvstore.cpp
@@ -1101,4 +1101,195 @@ TEST(KeyspacesGCInfoTest, Basic)
     ASSERT_EQ(info.getGCSafepoint(1), std::nullopt);
 }
 
+namespace
+{
+
+class CountingPDClient : public pingcap::pd::IClient
+{
+public:
+    explicit CountingPDClient(uint64_t gc_safe_point_)
+        : gc_safe_point(gc_safe_point_)
+    {}
+
+    uint64_t getTS() override { return 0; }
+
+    pdpb::GetRegionResponse getRegionByKey(const std::string &) override
+    {
+        throw pingcap::Exception("not implemented", pingcap::ErrorCodes::UnknownError);
+    }
+
+    pdpb::GetRegionResponse getRegionByID(uint64_t) override
+    {
+        throw pingcap::Exception("not implemented", pingcap::ErrorCodes::UnknownError);
+    }
+
+    metapb::Store getStore(uint64_t) override { throw pingcap::Exception("not implemented", pingcap::ErrorCodes::UnknownError); }
+
+    bool isClusterBootstrapped() override { return true; }
+
+    std::vector<metapb::Store> getAllStores(bool) override
+    {
+        throw pingcap::Exception("not implemented", pingcap::ErrorCodes::UnknownError);
+    }
+
+    uint64_t getGCSafePoint() override { return gc_safe_point; }
+
+    uint64_t getGCSafePointV2(KeyspaceID) override { return gc_safe_point; }
+
+    pdpb::GetGCStateResponse getGCState(KeyspaceID keyspace_id) override
+    {
+        ++gc_state_call_count;
+
+        pdpb::GetGCStateResponse gc_state;
+        auto * hdr = gc_state.mutable_header();
+        hdr->set_cluster_id(1);
+        hdr->mutable_error()->set_type(pdpb::ErrorType::OK);
+        auto * state = gc_state.mutable_gc_state();
+        state->mutable_keyspace_scope()->set_keyspace_id(keyspace_id);
+        state->set_is_keyspace_level_gc(true);
+        state->set_txn_safe_point(gc_safe_point);
+        state->set_gc_safe_point(gc_safe_point);
+        return gc_state;
+    }
+
+    pdpb::GetAllKeyspacesGCStatesResponse getAllKeyspacesGCStates() override
+    {
+        throw pingcap::Exception("not implemented", pingcap::ErrorCodes::UnknownError);
+    }
+
+    KeyspaceID getKeyspaceID(const std::string &) override
+    {
+        throw pingcap::Exception("not implemented", pingcap::ErrorCodes::UnknownError);
+    }
+
+    void update(const std::vector<std::string> &, const pingcap::ClusterConfig &) override
+    {
+        throw pingcap::Exception("not implemented", pingcap::ErrorCodes::UnknownError);
+    }
+
+    bool isMock() override { return false; }
+
+    std::string getLeaderUrl() override { throw pingcap::Exception("not implemented", pingcap::ErrorCodes::UnknownError); }
+
+    resource_manager::ListResourceGroupsResponse listResourceGroups(const resource_manager::ListResourceGroupsRequest &) override
+    {
+        throw pingcap::Exception("not implemented", pingcap::ErrorCodes::UnknownError);
+    }
+
+    resource_manager::GetResourceGroupResponse getResourceGroup(const resource_manager::GetResourceGroupRequest &) override
+    {
+        throw pingcap::Exception("not implemented", pingcap::ErrorCodes::UnknownError);
+    }
+
+    resource_manager::PutResourceGroupResponse addResourceGroup(const resource_manager::PutResourceGroupRequest &) override
+    {
+        throw pingcap::Exception("not implemented", pingcap::ErrorCodes::UnknownError);
+    }
+
+    resource_manager::PutResourceGroupResponse modifyResourceGroup(const resource_manager::PutResourceGroupRequest &) override
+    {
+        throw pingcap::Exception("not implemented", pingcap::ErrorCodes::UnknownError);
+    }
+
+    resource_manager::DeleteResourceGroupResponse deleteResourceGroup(const resource_manager::DeleteResourceGroupRequest &) override
+    {
+        throw pingcap::Exception("not implemented", pingcap::ErrorCodes::UnknownError);
+    }
+
+    resource_manager::TokenBucketsResponse acquireTokenBuckets(const resource_manager::TokenBucketsRequest &) override
+    {
+        throw pingcap::Exception("not implemented", pingcap::ErrorCodes::UnknownError);
+    }
+
+    uint64_t gc_safe_point;
+    size_t gc_state_call_count = 0;
+};
+
+} // namespace
+
+TEST(PDClientHelperTest, CacheOnlyReadPathDoesNotFetchFromPD)
+{
+    constexpr KeyspaceID keyspace_id = 9527;
+    PDClientHelper::removeKeyspaceGCSafepoint(keyspace_id);
+
+    auto pd_client = std::make_shared<CountingPDClient>(123456);
+
+    // Read path should not warm the cache on a miss.
+    auto safe_point = PDClientHelper::getGCSafePointWithRetry(
+        pd_client,
+        keyspace_id,
+        /* ignore_cache= */ false,
+        /* safe_point_update_interval_seconds= */ 30,
+        /* safe_point_get_max_backoff_ms= */ 1000,
+        GCSafepointFetchStrategy::CacheOnly);
+    ASSERT_EQ(safe_point, 0);
+    ASSERT_EQ(pd_client->gc_state_call_count, 0);
+
+    // Existing non-query paths still refresh the cache from PD.
+    safe_point = PDClientHelper::getGCSafePointWithRetry(
+        pd_client,
+        keyspace_id,
+        /* ignore_cache= */ false,
+        /* safe_point_update_interval_seconds= */ 30,
+        /* safe_point_get_max_backoff_ms= */ 1000);
+    ASSERT_EQ(safe_point, 123456);
+    ASSERT_EQ(pd_client->gc_state_call_count, 1);
+
+    // Once refreshed by other paths, read path consumes the cached value only.
+    safe_point = PDClientHelper::getGCSafePointWithRetry(
+        pd_client,
+        keyspace_id,
+        /* ignore_cache= */ false,
+        /* safe_point_update_interval_seconds= */ 30,
+        /* safe_point_get_max_backoff_ms= */ 1000,
+        GCSafepointFetchStrategy::CacheOnly);
+    ASSERT_EQ(safe_point, 123456);
+    ASSERT_EQ(pd_client->gc_state_call_count, 1);
+
+    PDClientHelper::removeKeyspaceGCSafepoint(keyspace_id);
+}
+
+TEST(PDClientHelperTest, CacheOnlyReadPathCanReturnExpiredCache)
+{
+    constexpr KeyspaceID keyspace_id = 9528;
+    PDClientHelper::removeKeyspaceGCSafepoint(keyspace_id);
+
+    auto pd_client = std::make_shared<CountingPDClient>(223344);
+
+    auto safe_point = PDClientHelper::getGCSafePointWithRetry(
+        pd_client,
+        keyspace_id,
+        /* ignore_cache= */ false,
+        /* safe_point_update_interval_seconds= */ 30,
+        /* safe_point_get_max_backoff_ms= */ 1000);
+    ASSERT_EQ(safe_point, 223344);
+    ASSERT_EQ(pd_client->gc_state_call_count, 1);
+
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    // The read path keeps using the last observed safepoint even after the cache is
+    // stale. Only non-query callers are allowed to advance it via PD.
+    safe_point = PDClientHelper::getGCSafePointWithRetry(
+        pd_client,
+        keyspace_id,
+        /* ignore_cache= */ false,
+        /* safe_point_update_interval_seconds= */ 1,
+        /* safe_point_get_max_backoff_ms= */ 1000,
+        GCSafepointFetchStrategy::CacheOnly);
+    ASSERT_EQ(safe_point, 223344);
+    ASSERT_EQ(pd_client->gc_state_call_count, 1);
+
+    pd_client->gc_safe_point = 223355;
+    safe_point = PDClientHelper::getGCSafePointWithRetry(
+        pd_client,
+        keyspace_id,
+        /* ignore_cache= */ false,
+        /* safe_point_update_interval_seconds= */ 1,
+        /* safe_point_get_max_backoff_ms= */ 1000);
+    ASSERT_EQ(safe_point, 223355);
+    ASSERT_EQ(pd_client->gc_state_call_count, 2);
+
+    PDClientHelper::removeKeyspaceGCSafepoint(keyspace_id);
+}
+
 } // namespace DB::tests

--- a/dbms/src/Storages/KVStore/tests/gtest_new_kvstore.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_new_kvstore.cpp
@@ -1123,7 +1123,10 @@ public:
         throw pingcap::Exception("not implemented", pingcap::ErrorCodes::UnknownError);
     }
 
-    metapb::Store getStore(uint64_t) override { throw pingcap::Exception("not implemented", pingcap::ErrorCodes::UnknownError); }
+    metapb::Store getStore(uint64_t) override
+    {
+        throw pingcap::Exception("not implemented", pingcap::ErrorCodes::UnknownError);
+    }
 
     bool isClusterBootstrapped() override { return true; }
 
@@ -1169,29 +1172,37 @@ public:
 
     bool isMock() override { return false; }
 
-    std::string getLeaderUrl() override { throw pingcap::Exception("not implemented", pingcap::ErrorCodes::UnknownError); }
-
-    resource_manager::ListResourceGroupsResponse listResourceGroups(const resource_manager::ListResourceGroupsRequest &) override
+    std::string getLeaderUrl() override
     {
         throw pingcap::Exception("not implemented", pingcap::ErrorCodes::UnknownError);
     }
 
-    resource_manager::GetResourceGroupResponse getResourceGroup(const resource_manager::GetResourceGroupRequest &) override
+    resource_manager::ListResourceGroupsResponse listResourceGroups(
+        const resource_manager::ListResourceGroupsRequest &) override
     {
         throw pingcap::Exception("not implemented", pingcap::ErrorCodes::UnknownError);
     }
 
-    resource_manager::PutResourceGroupResponse addResourceGroup(const resource_manager::PutResourceGroupRequest &) override
+    resource_manager::GetResourceGroupResponse getResourceGroup(
+        const resource_manager::GetResourceGroupRequest &) override
     {
         throw pingcap::Exception("not implemented", pingcap::ErrorCodes::UnknownError);
     }
 
-    resource_manager::PutResourceGroupResponse modifyResourceGroup(const resource_manager::PutResourceGroupRequest &) override
+    resource_manager::PutResourceGroupResponse addResourceGroup(
+        const resource_manager::PutResourceGroupRequest &) override
     {
         throw pingcap::Exception("not implemented", pingcap::ErrorCodes::UnknownError);
     }
 
-    resource_manager::DeleteResourceGroupResponse deleteResourceGroup(const resource_manager::DeleteResourceGroupRequest &) override
+    resource_manager::PutResourceGroupResponse modifyResourceGroup(
+        const resource_manager::PutResourceGroupRequest &) override
+    {
+        throw pingcap::Exception("not implemented", pingcap::ErrorCodes::UnknownError);
+    }
+
+    resource_manager::DeleteResourceGroupResponse deleteResourceGroup(
+        const resource_manager::DeleteResourceGroupRequest &) override
     {
         throw pingcap::Exception("not implemented", pingcap::ErrorCodes::UnknownError);
     }

--- a/dbms/src/Storages/KVStore/tests/gtest_new_kvstore.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_new_kvstore.cpp
@@ -1231,7 +1231,6 @@ TEST(PDClientHelperTest, CacheOnlyReadPathDoesNotFetchFromPD)
     auto safe_point = PDClientHelper::getGCSafePointWithRetry(
         pd_client,
         keyspace_id,
-        /* ignore_cache= */ false,
         /* safe_point_update_interval_seconds= */ 30,
         /* safe_point_get_max_backoff_ms= */ 1000,
         GCSafepointFetchStrategy::CacheOnly);
@@ -1242,7 +1241,6 @@ TEST(PDClientHelperTest, CacheOnlyReadPathDoesNotFetchFromPD)
     safe_point = PDClientHelper::getGCSafePointWithRetry(
         pd_client,
         keyspace_id,
-        /* ignore_cache= */ false,
         /* safe_point_update_interval_seconds= */ 30,
         /* safe_point_get_max_backoff_ms= */ 1000);
     ASSERT_EQ(safe_point, 123456);
@@ -1252,7 +1250,6 @@ TEST(PDClientHelperTest, CacheOnlyReadPathDoesNotFetchFromPD)
     safe_point = PDClientHelper::getGCSafePointWithRetry(
         pd_client,
         keyspace_id,
-        /* ignore_cache= */ false,
         /* safe_point_update_interval_seconds= */ 30,
         /* safe_point_get_max_backoff_ms= */ 1000,
         GCSafepointFetchStrategy::CacheOnly);
@@ -1272,7 +1269,6 @@ TEST(PDClientHelperTest, CacheOnlyReadPathCanReturnExpiredCache)
     auto safe_point = PDClientHelper::getGCSafePointWithRetry(
         pd_client,
         keyspace_id,
-        /* ignore_cache= */ false,
         /* safe_point_update_interval_seconds= */ 30,
         /* safe_point_get_max_backoff_ms= */ 1000);
     ASSERT_EQ(safe_point, 223344);
@@ -1285,7 +1281,6 @@ TEST(PDClientHelperTest, CacheOnlyReadPathCanReturnExpiredCache)
     safe_point = PDClientHelper::getGCSafePointWithRetry(
         pd_client,
         keyspace_id,
-        /* ignore_cache= */ false,
         /* safe_point_update_interval_seconds= */ 1,
         /* safe_point_get_max_backoff_ms= */ 1000,
         GCSafepointFetchStrategy::CacheOnly);
@@ -1296,7 +1291,6 @@ TEST(PDClientHelperTest, CacheOnlyReadPathCanReturnExpiredCache)
     safe_point = PDClientHelper::getGCSafePointWithRetry(
         pd_client,
         keyspace_id,
-        /* ignore_cache= */ false,
         /* safe_point_update_interval_seconds= */ 1,
         /* safe_point_get_max_backoff_ms= */ 1000);
     ASSERT_EQ(safe_point, 223355);

--- a/dbms/src/Storages/KVStore/tests/gtest_new_kvstore.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_new_kvstore.cpp
@@ -1111,6 +1111,8 @@ public:
         : gc_safe_point(gc_safe_point_)
     {}
 
+    uint64_t getClusterID() override { return 1; }
+
     uint64_t getTS() override { return 0; }
 
     pdpb::GetRegionResponse getRegionByKey(const std::string &) override

--- a/dbms/src/Storages/KVStore/tests/gtest_new_kvstore.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_new_kvstore.cpp
@@ -1088,10 +1088,20 @@ TEST(KeyspacesGCInfoTest, Basic)
     gc_info = info.getGCSafepoint(1);
     ASSERT_TRUE(gc_info.has_value());
     ASSERT_EQ(gc_info->gc_safepoint, 10086);
+    // update with a smaller safepoint should not move cache backwards
+    ASSERT_EQ(info.updateGCSafepoint(1, 10085), 10086);
+    gc_info = info.getGCSafepoint(1);
+    ASSERT_TRUE(gc_info.has_value());
+    ASSERT_EQ(gc_info->gc_safepoint, 10086);
+    // update with a larger safepoint should advance the cache
+    ASSERT_EQ(info.updateGCSafepoint(1, 10087), 10087);
+    gc_info = info.getGCSafepoint(1);
+    ASSERT_TRUE(gc_info.has_value());
+    ASSERT_EQ(gc_info->gc_safepoint, 10087);
     // get with valid seconds, not expired
     gc_info = info.getGCSafepointIfValid(1, 10);
     ASSERT_TRUE(gc_info.has_value());
-    ASSERT_EQ(gc_info->gc_safepoint, 10086);
+    ASSERT_EQ(gc_info->gc_safepoint, 10087);
     std::this_thread::sleep_for(std::chrono::seconds(2));
     // get with valid seconds, expired
     gc_info = info.getGCSafepointIfValid(1, 1);
@@ -1287,6 +1297,45 @@ TEST(PDClientHelperTest, CacheOnlyReadPathCanReturnExpiredCache)
         /* safe_point_update_interval_seconds= */ 1,
         /* safe_point_get_max_backoff_ms= */ 1000);
     ASSERT_EQ(safe_point, 223355);
+    ASSERT_EQ(pd_client->gc_state_call_count, 2);
+
+    PDClientHelper::removeKeyspaceGCSafepoint(keyspace_id);
+}
+
+TEST(PDClientHelperTest, CacheRefreshDoesNotMoveSafepointBackwards)
+{
+    constexpr KeyspaceID keyspace_id = 9529;
+    PDClientHelper::removeKeyspaceGCSafepoint(keyspace_id);
+
+    auto pd_client = std::make_shared<CountingPDClient>(334455);
+
+    auto safe_point = PDClientHelper::getGCSafePointWithRetry(
+        pd_client,
+        keyspace_id,
+        /* ignore_cache= */ false,
+        /* safe_point_update_interval_seconds= */ 30,
+        /* safe_point_get_max_backoff_ms= */ 1000);
+    ASSERT_EQ(safe_point, 334455);
+    ASSERT_EQ(pd_client->gc_state_call_count, 1);
+
+    pd_client->gc_safe_point = 334400;
+    safe_point = PDClientHelper::getGCSafePointWithRetry(
+        pd_client,
+        keyspace_id,
+        /* ignore_cache= */ true,
+        /* safe_point_update_interval_seconds= */ 30,
+        /* safe_point_get_max_backoff_ms= */ 1000);
+    ASSERT_EQ(safe_point, 334455);
+    ASSERT_EQ(pd_client->gc_state_call_count, 2);
+
+    safe_point = PDClientHelper::getGCSafePointWithRetry(
+        pd_client,
+        keyspace_id,
+        /* ignore_cache= */ false,
+        /* safe_point_update_interval_seconds= */ 30,
+        /* safe_point_get_max_backoff_ms= */ 1000,
+        GCSafepointFetchStrategy::CacheOnly);
+    ASSERT_EQ(safe_point, 334455);
     ASSERT_EQ(pd_client->gc_state_call_count, 2);
 
     PDClientHelper::removeKeyspaceGCSafepoint(keyspace_id);

--- a/dbms/src/Storages/KVStore/tests/gtest_new_kvstore.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_new_kvstore.cpp
@@ -1319,18 +1319,18 @@ TEST(PDClientHelperTest, CacheRefreshDoesNotMoveSafepointBackwards)
     auto safe_point = PDClientHelper::getGCSafePointWithRetry(
         pd_client,
         keyspace_id,
-        /* ignore_cache= */ false,
         /* safe_point_update_interval_seconds= */ 30,
         /* safe_point_get_max_backoff_ms= */ 1000);
     ASSERT_EQ(safe_point, 334455);
     ASSERT_EQ(pd_client->gc_state_call_count, 1);
 
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
     pd_client->gc_safe_point = 334400;
     safe_point = PDClientHelper::getGCSafePointWithRetry(
         pd_client,
         keyspace_id,
-        /* ignore_cache= */ true,
-        /* safe_point_update_interval_seconds= */ 30,
+        /* safe_point_update_interval_seconds= */ 1,
         /* safe_point_get_max_backoff_ms= */ 1000);
     ASSERT_EQ(safe_point, 334455);
     ASSERT_EQ(pd_client->gc_state_call_count, 2);
@@ -1338,7 +1338,6 @@ TEST(PDClientHelperTest, CacheRefreshDoesNotMoveSafepointBackwards)
     safe_point = PDClientHelper::getGCSafePointWithRetry(
         pd_client,
         keyspace_id,
-        /* ignore_cache= */ false,
         /* safe_point_update_interval_seconds= */ 30,
         /* safe_point_get_max_backoff_ms= */ 1000,
         GCSafepointFetchStrategy::CacheOnly);

--- a/dbms/src/Storages/StorageDeltaMerge.cpp
+++ b/dbms/src/Storages/StorageDeltaMerge.cpp
@@ -729,7 +729,6 @@ void checkStartTs(UInt64 start_ts, const Context & context, const String & req_i
     auto safe_point = PDClientHelper::getGCSafePointWithRetry(
         pd_client,
         keyspace_id,
-        /* ignore_cache= */ false,
         context.getSettingsRef().safe_point_update_interval_seconds,
         context.getSettingsRef().safe_point_get_max_backoff_ms,
         GCSafepointFetchStrategy::CacheOnly);

--- a/dbms/src/Storages/StorageDeltaMerge.cpp
+++ b/dbms/src/Storages/StorageDeltaMerge.cpp
@@ -723,12 +723,16 @@ void checkStartTs(UInt64 start_ts, const Context & context, const String & req_i
     auto pd_client = tmt.getPDClient();
     if (unlikely(pd_client->isMock()))
         return;
+    // Query paths only consume the last safepoint observed by TiFlash. Cache
+    // advancement is still handled by the existing non-query callers so that
+    // PD traffic does not scale with read concurrency.
     auto safe_point = PDClientHelper::getGCSafePointWithRetry(
         pd_client,
         keyspace_id,
         /* ignore_cache= */ false,
         context.getSettingsRef().safe_point_update_interval_seconds,
-        context.getSettingsRef().safe_point_get_max_backoff_ms);
+        context.getSettingsRef().safe_point_get_max_backoff_ms,
+        GCSafepointFetchStrategy::CacheOnly);
     if (start_ts < safe_point)
     {
         throw TiFlashException(

--- a/dbms/src/TiDB/Schema/SchemaSyncService.cpp
+++ b/dbms/src/TiDB/Schema/SchemaSyncService.cpp
@@ -105,7 +105,6 @@ void SchemaSyncService::addKeyspaceGCTasks()
                     auto gc_safe_point = PDClientHelper::getGCSafePointWithRetry(
                         context.getTMTContext().getPDClient(),
                         keyspace,
-                        true,
                         30,
                         context.getSettingsRef().safe_point_get_max_backoff_ms);
                     done_anything = gc(gc_safe_point, keyspace);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10818

Problem Summary:

### What is changed and how it works?

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable GC safepoint fetch strategy, including a cache-only mode to avoid remote fetches.

* **Behavior**
  * Query paths now prefer cache-only safepoint reads to prevent unexpected remote calls and keep query execution predictable.

* **Tests**
  * Added tests covering safepoint caching, cache-only reads, and prevention of safepoint regression.

* **Monitoring**
  * Extended safepoint request metrics with an additional request-type label for better observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->