### PR TITLE
*: replace BenMeadowcroft with likidu in OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,5 +1,5 @@
 # Sort the member alphabetically.
 aliases:
   sig-critical-approvers-config:
-    - BenMeadowcroft
+    - likidu
     - yudongusa


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10823

Problem Summary:
- Replace `BenMeadowcroft` with `likidu` in `OWNERS_ALIASES` on `release-8.5`.

### What is changed and how it works?

```commit-message
*: replace BenMeadowcroft with likidu in OWNERS_ALIASES
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration and permissions settings.

---

**Note:** This release primarily contains internal administrative updates with no impact on end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->