### PR TITLE
flash: handle TiCI estimate count RPC

### DIFF
--- a/dbms/src/Flash/EstimateTiCICountHandler.cpp
+++ b/dbms/src/Flash/EstimateTiCICountHandler.cpp
@@ -1,0 +1,133 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Common/Exception.h>
+#include <Common/TiFlashException.h>
+#include <Flash/Coprocessor/RequestUtils.h>
+#include <Flash/EstimateTiCICountHandler.h>
+#include <Interpreters/TimezoneInfo.h>
+#include <Storages/Tantivy/TiCIRequestUtils.h>
+#include <common/logger_useful.h>
+#include <tici-search-lib/src/lib.rs.h>
+#include <tipb/executor.pb.h>
+
+namespace DB
+{
+namespace
+{
+TimezoneInfo buildEstimateTimezoneInfo(const coprocessor::TiCIEstimateCountRequest & request)
+{
+    TimezoneInfo timezone_info;
+    if (!request.time_zone_name().empty())
+        timezone_info.resetByTimezoneName(request.time_zone_name());
+    else
+        timezone_info.resetByTimezoneOffset(request.time_zone_offset());
+    return timezone_info;
+}
+
+tipb::FTSQueryInfo parseEstimateQueryInfo(const coprocessor::TiCIEstimateCountRequest & request)
+{
+    tipb::FTSQueryInfo query_info;
+    if (!query_info.ParseFromString(request.fts_query_info()))
+        throw TiFlashException("Failed to parse fts_query_info", Errors::Coprocessor::BadRequest);
+    if (query_info.match_expr_size() == 0)
+        throw TiFlashException("Empty TiCI estimate query expression", Errors::Coprocessor::BadRequest);
+    return query_info;
+}
+
+rust::Vec<::ShardWithRange> buildEstimateShardRanges(const coprocessor::TiCIEstimateCountRequest & request)
+{
+    rust::Vec<::ShardWithRange> shards;
+    for (const auto & shard_info : request.shard_infos())
+    {
+        shards.push_back({
+            .shard_id = shard_info.shard_id(),
+            .ranges = TS::getKeyRanges(shard_info.ranges()),
+        });
+    }
+    return shards;
+}
+} // namespace
+
+EstimateTiCICountHandler::EstimateTiCICountHandler(
+    const coprocessor::TiCIEstimateCountRequest * request_,
+    coprocessor::TiCIEstimateCountResponse * response_,
+    const String & identifier)
+    : request(request_)
+    , response(response_)
+    , log(Logger::get(identifier))
+{}
+
+grpc::Status EstimateTiCICountHandler::execute()
+{
+    try
+    {
+        if (request->shard_infos_size() == 0)
+            return grpc::Status::OK;
+
+        const auto keyspace_id = RequestUtils::deriveKeyspaceID(request->context());
+        const auto fts_query_info = parseEstimateQueryInfo(*request);
+        const auto timezone_info = buildEstimateTimezoneInfo(*request);
+        auto [query, column_ids] = TS::tipbToTiCIExpr(fts_query_info.match_expr(), timezone_info);
+        (void)column_ids;
+
+        auto shard_ranges = buildEstimateShardRanges(*request);
+        const auto estimate_result = estimate_count(keyspace_id, shard_ranges, query);
+        response->set_est_count(estimate_result.estimated_total_count);
+        LOG_DEBUG(
+            log,
+            "GetEstimateTiCICount done, est_count={}, input_shards={}, available_shards={}, sampled_shards={}",
+            response->est_count(),
+            request->shard_infos_size(),
+            estimate_result.available_shards,
+            estimate_result.sampled_shards);
+    }
+    catch (const TiFlashException & e)
+    {
+        LOG_WARNING(
+            log,
+            "GetEstimateTiCICount failed with TiFlash exception: {}\n{}",
+            e.displayText(),
+            e.getStackTrace().toString());
+        response->set_other_error(e.standardText());
+    }
+    catch (const Exception & e)
+    {
+        LOG_WARNING(
+            log,
+            "GetEstimateTiCICount failed with DB exception: {}\n{}",
+            e.message(),
+            e.getStackTrace().toString());
+        response->set_other_error(e.message());
+    }
+    catch (const pingcap::Exception & e)
+    {
+        LOG_WARNING(log, "GetEstimateTiCICount failed with KV exception: {}", e.message());
+        response->set_other_error(e.message());
+    }
+    catch (const std::exception & e)
+    {
+        LOG_WARNING(log, "GetEstimateTiCICount failed: {}", e.what());
+        response->set_other_error(e.what());
+    }
+    catch (...)
+    {
+        LOG_WARNING(log, "GetEstimateTiCICount failed with unknown exception");
+        response->set_other_error("other exception");
+    }
+
+    return grpc::Status::OK;
+}
+
+} // namespace DB

--- a/dbms/src/Flash/EstimateTiCICountHandler.h
+++ b/dbms/src/Flash/EstimateTiCICountHandler.h
@@ -1,0 +1,40 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <Core/Types.h>
+#include <common/logger_useful.h>
+#include <grpcpp/support/status.h>
+#include <kvproto/coprocessor.pb.h>
+
+namespace DB
+{
+class EstimateTiCICountHandler
+{
+public:
+    EstimateTiCICountHandler(
+        const coprocessor::TiCIEstimateCountRequest * request_,
+        coprocessor::TiCIEstimateCountResponse * response_,
+        const String & identifier);
+
+    grpc::Status execute();
+
+private:
+    const coprocessor::TiCIEstimateCountRequest * request;
+    coprocessor::TiCIEstimateCountResponse * response;
+    const LoggerPtr log;
+};
+
+} // namespace DB

--- a/dbms/src/Flash/FlashService.cpp
+++ b/dbms/src/Flash/FlashService.cpp
@@ -27,6 +27,7 @@
 #include <Flash/Disaggregated/WNEstablishDisaggTaskHandler.h>
 #include <Flash/Disaggregated/WNFetchPagesStreamWriter.h>
 #include <Flash/EstablishCall.h>
+#include <Flash/EstimateTiCICountHandler.h>
 #include <Flash/FlashService.h>
 #include <Flash/Management/ManualCompact.h>
 #include <Flash/Mpp/MPPHandler.h>
@@ -38,7 +39,6 @@
 #include <IO/IOThreadPools.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/SharedContexts/Disagg.h>
-#include <Interpreters/TimezoneInfo.h>
 #include <Interpreters/executeQuery.h>
 #include <Poco/Message.h>
 #include <Server/IServer.h>
@@ -49,14 +49,11 @@
 #include <Storages/KVStore/Read/RegionException.h>
 #include <Storages/KVStore/TMTContext.h>
 #include <Storages/S3/S3Common.h>
-#include <Storages/Tantivy/TiCIRequestUtils.h>
 #include <common/logger_useful.h>
 #include <grpcpp/server_builder.h>
 #include <grpcpp/support/status.h>
 #include <grpcpp/support/status_code_enum.h>
 #include <kvproto/disaggregated.pb.h>
-#include <tici-search-lib/src/lib.rs.h>
-#include <tipb/executor.pb.h>
 
 #include <chrono>
 #include <ext/scope_guard.h>
@@ -196,39 +193,6 @@ void updateSettingsForAutoSpill(ContextPtr & context, const LoggerPtr & log)
         if (need_log_warning)
             LOG_WARNING(log, "auto spill is enabled, so per operator's memory threshold is disabled");
     }
-}
-
-TimezoneInfo buildEstimateTimezoneInfo(const coprocessor::TiCIEstimateCountRequest & request)
-{
-    TimezoneInfo timezone_info;
-    if (!request.time_zone_name().empty())
-        timezone_info.resetByTimezoneName(request.time_zone_name());
-    else
-        timezone_info.resetByTimezoneOffset(request.time_zone_offset());
-    return timezone_info;
-}
-
-tipb::FTSQueryInfo parseEstimateQueryInfo(const coprocessor::TiCIEstimateCountRequest & request)
-{
-    tipb::FTSQueryInfo query_info;
-    if (!query_info.ParseFromString(request.fts_query_info()))
-        throw TiFlashException("Failed to parse fts_query_info", Errors::Coprocessor::BadRequest);
-    if (query_info.match_expr_size() == 0)
-        throw TiFlashException("Empty TiCI estimate query expression", Errors::Coprocessor::BadRequest);
-    return query_info;
-}
-
-rust::Vec<::ShardWithRange> buildEstimateShardRanges(const coprocessor::TiCIEstimateCountRequest & request)
-{
-    rust::Vec<::ShardWithRange> shards;
-    for (const auto & shard_info : request.shard_infos())
-    {
-        shards.push_back({
-            .shard_id = shard_info.shard_id(),
-            .ranges = TS::getKeyRanges(shard_info.ranges()),
-        });
-    }
-    return shards;
 }
 } // namespace
 
@@ -931,63 +895,8 @@ grpc::Status FlashService::GetEstimateTiCICount(
     if (!check_result.ok())
         return check_result;
 
-    try
-    {
-        if (request->shard_infos_size() == 0)
-            return grpc::Status::OK;
-
-        const auto keyspace_id = RequestUtils::deriveKeyspaceID(request->context());
-        const auto fts_query_info = parseEstimateQueryInfo(*request);
-        const auto timezone_info = buildEstimateTimezoneInfo(*request);
-        auto [query, column_ids] = TS::tipbToTiCIExpr(fts_query_info.match_expr(), timezone_info);
-        (void)column_ids;
-
-        auto shard_ranges = buildEstimateShardRanges(*request);
-        const auto estimate_result = estimate_count(keyspace_id, shard_ranges, query);
-        response->set_est_count(estimate_result.estimated_total_count);
-        LOG_DEBUG(
-            log,
-            "GetEstimateTiCICount done, est_count={}, input_shards={}, available_shards={}, sampled_shards={}",
-            response->est_count(),
-            request->shard_infos_size(),
-            estimate_result.available_shards,
-            estimate_result.sampled_shards);
-    }
-    catch (const TiFlashException & e)
-    {
-        LOG_WARNING(
-            log,
-            "GetEstimateTiCICount failed with TiFlash exception: {}\n{}",
-            e.displayText(),
-            e.getStackTrace().toString());
-        response->set_other_error(e.standardText());
-    }
-    catch (const Exception & e)
-    {
-        LOG_WARNING(
-            log,
-            "GetEstimateTiCICount failed with DB exception: {}\n{}",
-            e.message(),
-            e.getStackTrace().toString());
-        response->set_other_error(e.message());
-    }
-    catch (const pingcap::Exception & e)
-    {
-        LOG_WARNING(log, "GetEstimateTiCICount failed with KV exception: {}", e.message());
-        response->set_other_error(e.message());
-    }
-    catch (const std::exception & e)
-    {
-        LOG_WARNING(log, "GetEstimateTiCICount failed: {}", e.what());
-        response->set_other_error(e.what());
-    }
-    catch (...)
-    {
-        LOG_WARNING(log, "GetEstimateTiCICount failed with unknown exception");
-        response->set_other_error("other exception");
-    }
-
-    return grpc::Status::OK;
+    EstimateTiCICountHandler handler(request, response, log->identifier());
+    return handler.execute();
 }
 
 grpc::Status FlashService::tryAddLock(

--- a/dbms/src/Flash/FlashService.cpp
+++ b/dbms/src/Flash/FlashService.cpp
@@ -252,18 +252,14 @@ rust::Vec<::Shard> buildEstimateShards(const coprocessor::TiCIEstimateCountReque
 
 rust::Vec<::ShardWithRange> buildEstimateShardRanges(
     const coprocessor::TiCIEstimateCountRequest & request,
-    const rust::Vec<bool> & local_results,
-    coprocessor::TiCIEstimateCountResponse * response)
+    const rust::Vec<bool> & local_results)
 {
     rust::Vec<::ShardWithRange> shards;
     for (int i = 0; i < request.shard_infos_size(); ++i)
     {
         const auto & shard_info = request.shard_infos(i);
         if (i >= static_cast<int>(local_results.size()) || !local_results[static_cast<size_t>(i)])
-        {
-            response->add_retry_shards()->CopyFrom(shard_info);
             continue;
-        }
         shards.push_back({
             .shard_id = shard_info.shard_id(),
             .ranges = buildEstimateKeyRanges(shard_info.ranges()),
@@ -962,7 +958,7 @@ grpc::Status FlashService::Compact(
     return manual_compact_manager->handleRequest(request, response);
 }
 
-grpc::Status FlashService::EstimateTiCICount(
+grpc::Status FlashService::GetEstimateTiCICount(
     grpc::ServerContext * grpc_context,
     const coprocessor::TiCIEstimateCountRequest * request,
     coprocessor::TiCIEstimateCountResponse * response)
@@ -986,16 +982,7 @@ grpc::Status FlashService::EstimateTiCICount(
         auto shards = buildEstimateShards(*request, keyspace_id);
         rust::Vec<bool> local_results;
         [[maybe_unused]] auto snapshot = check_shards_and_acquire_snapshot(shards, local_results);
-        auto shard_ranges = buildEstimateShardRanges(*request, local_results, response);
-        if (response->retry_shards_size() > 0)
-        {
-            LOG_INFO(
-                log,
-                "EstimateTiCICount requires shard refresh, retry_shards={}, input_shards={}",
-                response->retry_shards_size(),
-                request->shard_infos_size());
-            return grpc::Status::OK;
-        }
+        auto shard_ranges = buildEstimateShardRanges(*request, local_results);
         if (shard_ranges.empty())
             return grpc::Status::OK;
 
@@ -1003,7 +990,7 @@ grpc::Status FlashService::EstimateTiCICount(
         response->set_est_count(estimate_result.estimated_total_count);
         LOG_INFO(
             log,
-            "EstimateTiCICount done, est_count={}, input_shards={}, available_shards={}, sampled_shards={}",
+            "GetEstimateTiCICount done, est_count={}, input_shards={}, available_shards={}, sampled_shards={}",
             response->est_count(),
             request->shard_infos_size(),
             estimate_result.available_shards,
@@ -1011,17 +998,17 @@ grpc::Status FlashService::EstimateTiCICount(
     }
     catch (const pingcap::Exception & e)
     {
-        LOG_WARNING(log, "EstimateTiCICount failed with KV exception: {}", e.message());
+        LOG_WARNING(log, "GetEstimateTiCICount failed with KV exception: {}", e.message());
         response->set_other_error(e.message());
     }
     catch (const std::exception & e)
     {
-        LOG_WARNING(log, "EstimateTiCICount failed: {}", e.what());
+        LOG_WARNING(log, "GetEstimateTiCICount failed: {}", e.what());
         response->set_other_error(e.what());
     }
     catch (...)
     {
-        LOG_WARNING(log, "EstimateTiCICount failed with unknown exception");
+        LOG_WARNING(log, "GetEstimateTiCICount failed with unknown exception");
         response->set_other_error("other exception");
     }
 

--- a/dbms/src/Flash/FlashService.cpp
+++ b/dbms/src/Flash/FlashService.cpp
@@ -49,7 +49,7 @@
 #include <Storages/KVStore/Read/RegionException.h>
 #include <Storages/KVStore/TMTContext.h>
 #include <Storages/S3/S3Common.h>
-#include <Storages/Tantivy/TiCIReadTaskPool.h>
+#include <Storages/Tantivy/TiCIRequestUtils.h>
 #include <common/logger_useful.h>
 #include <grpcpp/server_builder.h>
 #include <grpcpp/support/status.h>
@@ -939,7 +939,7 @@ grpc::Status FlashService::GetEstimateTiCICount(
         const auto keyspace_id = RequestUtils::deriveKeyspaceID(request->context());
         const auto fts_query_info = parseEstimateQueryInfo(*request);
         const auto timezone_info = buildEstimateTimezoneInfo(*request);
-        auto [query, column_ids] = TS::TiCIReadTaskPool::tipbToTiCIExpr(fts_query_info.match_expr(), timezone_info);
+        auto [query, column_ids] = TS::tipbToTiCIExpr(fts_query_info.match_expr(), timezone_info);
         (void)column_ids;
 
         auto shard_ranges = buildEstimateShardRanges(*request);

--- a/dbms/src/Flash/FlashService.cpp
+++ b/dbms/src/Flash/FlashService.cpp
@@ -943,9 +943,6 @@ grpc::Status FlashService::GetEstimateTiCICount(
         (void)column_ids;
 
         auto shard_ranges = buildEstimateShardRanges(*request);
-        if (shard_ranges.empty())
-            return grpc::Status::OK;
-
         const auto estimate_result = estimate_count(keyspace_id, shard_ranges, query);
         response->set_est_count(estimate_result.estimated_total_count);
         LOG_DEBUG(
@@ -955,6 +952,24 @@ grpc::Status FlashService::GetEstimateTiCICount(
             request->shard_infos_size(),
             estimate_result.available_shards,
             estimate_result.sampled_shards);
+    }
+    catch (const TiFlashException & e)
+    {
+        LOG_WARNING(
+            log,
+            "GetEstimateTiCICount failed with TiFlash exception: {}\n{}",
+            e.displayText(),
+            e.getStackTrace().toString());
+        response->set_other_error(e.standardText());
+    }
+    catch (const Exception & e)
+    {
+        LOG_WARNING(
+            log,
+            "GetEstimateTiCICount failed with DB exception: {}\n{}",
+            e.message(),
+            e.getStackTrace().toString());
+        response->set_other_error(e.message());
     }
     catch (const pingcap::Exception & e)
     {

--- a/dbms/src/Flash/FlashService.cpp
+++ b/dbms/src/Flash/FlashService.cpp
@@ -38,6 +38,7 @@
 #include <IO/IOThreadPools.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/SharedContexts/Disagg.h>
+#include <Interpreters/TimezoneInfo.h>
 #include <Interpreters/executeQuery.h>
 #include <Poco/Message.h>
 #include <Server/IServer.h>
@@ -48,11 +49,14 @@
 #include <Storages/KVStore/Read/RegionException.h>
 #include <Storages/KVStore/TMTContext.h>
 #include <Storages/S3/S3Common.h>
+#include <Storages/Tantivy/TiCIReadTaskPool.h>
 #include <common/logger_useful.h>
 #include <grpcpp/server_builder.h>
 #include <grpcpp/support/status.h>
 #include <grpcpp/support/status_code_enum.h>
 #include <kvproto/disaggregated.pb.h>
+#include <tici-search-lib/src/lib.rs.h>
+#include <tipb/executor.pb.h>
 
 #include <chrono>
 #include <ext/scope_guard.h>
@@ -192,6 +196,80 @@ void updateSettingsForAutoSpill(ContextPtr & context, const LoggerPtr & log)
         if (need_log_warning)
             LOG_WARNING(log, "auto spill is enabled, so per operator's memory threshold is disabled");
     }
+}
+
+rust::Vec<::Range> buildEstimateKeyRanges(const google::protobuf::RepeatedPtrField<coprocessor::KeyRange> & key_ranges)
+{
+    rust::Vec<::Range> ranges;
+    for (const auto & key_range : key_ranges)
+    {
+        ranges.push_back({
+            .start = rust::Slice<const std::uint8_t>(
+                reinterpret_cast<const std::uint8_t *>(key_range.start().data()),
+                key_range.start().size()),
+            .end = rust::Slice<const std::uint8_t>(
+                reinterpret_cast<const std::uint8_t *>(key_range.end().data()),
+                key_range.end().size()),
+        });
+    }
+    return ranges;
+}
+
+TimezoneInfo buildEstimateTimezoneInfo(const coprocessor::TiCIEstimateCountRequest & request)
+{
+    TimezoneInfo timezone_info;
+    if (!request.time_zone_name().empty())
+        timezone_info.resetByTimezoneName(request.time_zone_name());
+    else
+        timezone_info.resetByTimezoneOffset(request.time_zone_offset());
+    return timezone_info;
+}
+
+tipb::FTSQueryInfo parseEstimateQueryInfo(const coprocessor::TiCIEstimateCountRequest & request)
+{
+    tipb::FTSQueryInfo query_info;
+    if (!query_info.ParseFromString(request.fts_query_info()))
+        throw TiFlashException("Failed to parse fts_query_info", Errors::Coprocessor::BadRequest);
+    if (query_info.match_expr_size() == 0)
+        throw TiFlashException("Empty TiCI estimate query expression", Errors::Coprocessor::BadRequest);
+    return query_info;
+}
+
+rust::Vec<::Shard> buildEstimateShards(const coprocessor::TiCIEstimateCountRequest & request, UInt32 keyspace_id)
+{
+    rust::Vec<::Shard> shards;
+    for (const auto & shard_info : request.shard_infos())
+    {
+        shards.push_back({
+            .keyspace_id = keyspace_id,
+            .index_id = request.index_id(),
+            .shard_id = shard_info.shard_id(),
+            .shard_epoch = shard_info.shard_epoch(),
+        });
+    }
+    return shards;
+}
+
+rust::Vec<::ShardWithRange> buildEstimateShardRanges(
+    const coprocessor::TiCIEstimateCountRequest & request,
+    const rust::Vec<bool> & local_results,
+    coprocessor::TiCIEstimateCountResponse * response)
+{
+    rust::Vec<::ShardWithRange> shards;
+    for (int i = 0; i < request.shard_infos_size(); ++i)
+    {
+        const auto & shard_info = request.shard_infos(i);
+        if (i >= static_cast<int>(local_results.size()) || !local_results[static_cast<size_t>(i)])
+        {
+            response->add_retry_shards()->CopyFrom(shard_info);
+            continue;
+        }
+        shards.push_back({
+            .shard_id = shard_info.shard_id(),
+            .ranges = buildEstimateKeyRanges(shard_info.ranges()),
+        });
+    }
+    return shards;
 }
 } // namespace
 
@@ -882,6 +960,72 @@ grpc::Status FlashService::Compact(
         return check_result;
 
     return manual_compact_manager->handleRequest(request, response);
+}
+
+grpc::Status FlashService::EstimateTiCICount(
+    grpc::ServerContext * grpc_context,
+    const coprocessor::TiCIEstimateCountRequest * request,
+    coprocessor::TiCIEstimateCountResponse * response)
+{
+    CPUAffinityManager::getInstance().bindSelfGrpcThread();
+    auto check_result = checkGrpcContext(grpc_context);
+    if (!check_result.ok())
+        return check_result;
+
+    try
+    {
+        if (request->shard_infos_size() == 0)
+            return grpc::Status::OK;
+
+        const auto keyspace_id = RequestUtils::deriveKeyspaceID(request->context());
+        const auto fts_query_info = parseEstimateQueryInfo(*request);
+        const auto timezone_info = buildEstimateTimezoneInfo(*request);
+        auto [query, column_ids] = TS::TiCIReadTaskPool::tipbToTiCIExpr(fts_query_info.match_expr(), timezone_info);
+        (void)column_ids;
+
+        auto shards = buildEstimateShards(*request, keyspace_id);
+        rust::Vec<bool> local_results;
+        [[maybe_unused]] auto snapshot = check_shards_and_acquire_snapshot(shards, local_results);
+        auto shard_ranges = buildEstimateShardRanges(*request, local_results, response);
+        if (response->retry_shards_size() > 0)
+        {
+            LOG_INFO(
+                log,
+                "EstimateTiCICount requires shard refresh, retry_shards={}, input_shards={}",
+                response->retry_shards_size(),
+                request->shard_infos_size());
+            return grpc::Status::OK;
+        }
+        if (shard_ranges.empty())
+            return grpc::Status::OK;
+
+        const auto estimate_result = estimate_count(keyspace_id, shard_ranges, query);
+        response->set_est_count(estimate_result.estimated_total_count);
+        LOG_INFO(
+            log,
+            "EstimateTiCICount done, est_count={}, input_shards={}, available_shards={}, sampled_shards={}",
+            response->est_count(),
+            request->shard_infos_size(),
+            estimate_result.available_shards,
+            estimate_result.sampled_shards);
+    }
+    catch (const pingcap::Exception & e)
+    {
+        LOG_WARNING(log, "EstimateTiCICount failed with KV exception: {}", e.message());
+        response->set_other_error(e.message());
+    }
+    catch (const std::exception & e)
+    {
+        LOG_WARNING(log, "EstimateTiCICount failed: {}", e.what());
+        response->set_other_error(e.what());
+    }
+    catch (...)
+    {
+        LOG_WARNING(log, "EstimateTiCICount failed with unknown exception");
+        response->set_other_error("other exception");
+    }
+
+    return grpc::Status::OK;
 }
 
 grpc::Status FlashService::tryAddLock(

--- a/dbms/src/Flash/FlashService.cpp
+++ b/dbms/src/Flash/FlashService.cpp
@@ -198,23 +198,6 @@ void updateSettingsForAutoSpill(ContextPtr & context, const LoggerPtr & log)
     }
 }
 
-rust::Vec<::Range> buildEstimateKeyRanges(const google::protobuf::RepeatedPtrField<coprocessor::KeyRange> & key_ranges)
-{
-    rust::Vec<::Range> ranges;
-    for (const auto & key_range : key_ranges)
-    {
-        ranges.push_back({
-            .start = rust::Slice<const std::uint8_t>(
-                reinterpret_cast<const std::uint8_t *>(key_range.start().data()),
-                key_range.start().size()),
-            .end = rust::Slice<const std::uint8_t>(
-                reinterpret_cast<const std::uint8_t *>(key_range.end().data()),
-                key_range.end().size()),
-        });
-    }
-    return ranges;
-}
-
 TimezoneInfo buildEstimateTimezoneInfo(const coprocessor::TiCIEstimateCountRequest & request)
 {
     TimezoneInfo timezone_info;
@@ -240,9 +223,10 @@ rust::Vec<::ShardWithRange> buildEstimateShardRanges(const coprocessor::TiCIEsti
     rust::Vec<::ShardWithRange> shards;
     for (const auto & shard_info : request.shard_infos())
     {
+        ShardInfo query_shard_info(shard_info);
         shards.push_back({
-            .shard_id = shard_info.shard_id(),
-            .ranges = buildEstimateKeyRanges(shard_info.ranges()),
+            .shard_id = query_shard_info.shard_id,
+            .ranges = TS::getKeyRanges(query_shard_info.key_ranges),
         });
     }
     return shards;

--- a/dbms/src/Flash/FlashService.cpp
+++ b/dbms/src/Flash/FlashService.cpp
@@ -235,31 +235,11 @@ tipb::FTSQueryInfo parseEstimateQueryInfo(const coprocessor::TiCIEstimateCountRe
     return query_info;
 }
 
-rust::Vec<::Shard> buildEstimateShards(const coprocessor::TiCIEstimateCountRequest & request, UInt32 keyspace_id)
-{
-    rust::Vec<::Shard> shards;
-    for (const auto & shard_info : request.shard_infos())
-    {
-        shards.push_back({
-            .keyspace_id = keyspace_id,
-            .index_id = request.index_id(),
-            .shard_id = shard_info.shard_id(),
-            .shard_epoch = shard_info.shard_epoch(),
-        });
-    }
-    return shards;
-}
-
-rust::Vec<::ShardWithRange> buildEstimateShardRanges(
-    const coprocessor::TiCIEstimateCountRequest & request,
-    const rust::Vec<bool> & local_results)
+rust::Vec<::ShardWithRange> buildEstimateShardRanges(const coprocessor::TiCIEstimateCountRequest & request)
 {
     rust::Vec<::ShardWithRange> shards;
-    for (int i = 0; i < request.shard_infos_size(); ++i)
+    for (const auto & shard_info : request.shard_infos())
     {
-        const auto & shard_info = request.shard_infos(i);
-        if (i >= static_cast<int>(local_results.size()) || !local_results[static_cast<size_t>(i)])
-            continue;
         shards.push_back({
             .shard_id = shard_info.shard_id(),
             .ranges = buildEstimateKeyRanges(shard_info.ranges()),
@@ -979,16 +959,13 @@ grpc::Status FlashService::GetEstimateTiCICount(
         auto [query, column_ids] = TS::TiCIReadTaskPool::tipbToTiCIExpr(fts_query_info.match_expr(), timezone_info);
         (void)column_ids;
 
-        auto shards = buildEstimateShards(*request, keyspace_id);
-        rust::Vec<bool> local_results;
-        [[maybe_unused]] auto snapshot = check_shards_and_acquire_snapshot(shards, local_results);
-        auto shard_ranges = buildEstimateShardRanges(*request, local_results);
+        auto shard_ranges = buildEstimateShardRanges(*request);
         if (shard_ranges.empty())
             return grpc::Status::OK;
 
         const auto estimate_result = estimate_count(keyspace_id, shard_ranges, query);
         response->set_est_count(estimate_result.estimated_total_count);
-        LOG_INFO(
+        LOG_DEBUG(
             log,
             "GetEstimateTiCICount done, est_count={}, input_shards={}, available_shards={}, sampled_shards={}",
             response->est_count(),

--- a/dbms/src/Flash/FlashService.cpp
+++ b/dbms/src/Flash/FlashService.cpp
@@ -223,10 +223,9 @@ rust::Vec<::ShardWithRange> buildEstimateShardRanges(const coprocessor::TiCIEsti
     rust::Vec<::ShardWithRange> shards;
     for (const auto & shard_info : request.shard_infos())
     {
-        ShardInfo query_shard_info(shard_info);
         shards.push_back({
-            .shard_id = query_shard_info.shard_id,
-            .ranges = TS::getKeyRanges(query_shard_info.key_ranges),
+            .shard_id = shard_info.shard_id(),
+            .ranges = TS::getKeyRanges(shard_info.ranges()),
         });
     }
     return shards;

--- a/dbms/src/Flash/FlashService.h
+++ b/dbms/src/Flash/FlashService.h
@@ -100,6 +100,10 @@ public:
         const kvrpcpb::CompactRequest * request,
         kvrpcpb::CompactResponse * response) override;
 
+    grpc::Status EstimateTiCICount(
+        grpc::ServerContext * grpc_context,
+        const coprocessor::TiCIEstimateCountRequest * request,
+        coprocessor::TiCIEstimateCountResponse * response) override;
 
     // For S3 Lock Service
     grpc::Status tryAddLock(

--- a/dbms/src/Flash/FlashService.h
+++ b/dbms/src/Flash/FlashService.h
@@ -100,7 +100,7 @@ public:
         const kvrpcpb::CompactRequest * request,
         kvrpcpb::CompactResponse * response) override;
 
-    grpc::Status EstimateTiCICount(
+    grpc::Status GetEstimateTiCICount(
         grpc::ServerContext * grpc_context,
         const coprocessor::TiCIEstimateCountRequest * request,
         coprocessor::TiCIEstimateCountResponse * response) override;

--- a/dbms/src/Storages/Tantivy/TantivyInputStream.h
+++ b/dbms/src/Storages/Tantivy/TantivyInputStream.h
@@ -30,9 +30,8 @@
 #include <DataTypes/DataTypeMyDateTime.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypesNumber.h>
-#include <Flash/Coprocessor/DAGCodec.h>
-#include <Flash/Coprocessor/DAGUtils.h>
 #include <Flash/Coprocessor/ShardInfo.h>
+#include <Storages/Tantivy/TiCIRequestUtils.h>
 #include <TiDB/Schema/TiDBTypes.h>
 #include <common/logger_useful.h>
 #include <common/types.h>
@@ -46,37 +45,6 @@
 
 namespace DB::TS
 {
-
-// convert literal value from timezone specified in cop request to UTC in-place
-inline UInt64 convertPackedU64WithTimezone(UInt64 from_time, const TimezoneInfo & timezone_info)
-{
-    static const auto & time_zone_utc = DateLUT::instance("UTC");
-    UInt64 result_time = from_time;
-    if (timezone_info.is_name_based)
-        convertTimeZone(from_time, result_time, *timezone_info.timezone, time_zone_utc);
-    else if (timezone_info.timezone_offset != 0)
-        convertTimeZoneByOffset(from_time, result_time, false, timezone_info.timezone_offset);
-    return result_time;
-}
-
-inline rust::Vec<::Range> getKeyRanges(const ShardInfo::KeyRanges & key_ranges)
-{
-    rust::Vec<::Range> res;
-    for (const auto & range : key_ranges)
-    {
-        rust::Slice<::std::uint8_t const> start(
-            reinterpret_cast<const unsigned char *>(range.start().c_str()),
-            range.start().size());
-        rust::Slice<::std::uint8_t const> end(
-            reinterpret_cast<const unsigned char *>(range.end().c_str()),
-            range.end().size());
-        res.push_back({
-            .start = std::move(start),
-            .end = std::move(end),
-        });
-    }
-    return res;
-}
 
 class TantivyInputStream : public IProfilingBlockInputStream
 {

--- a/dbms/src/Storages/Tantivy/TantivyInputStream.h
+++ b/dbms/src/Storages/Tantivy/TantivyInputStream.h
@@ -59,6 +59,25 @@ inline UInt64 convertPackedU64WithTimezone(UInt64 from_time, const TimezoneInfo 
     return result_time;
 }
 
+inline rust::Vec<::Range> getKeyRanges(const ShardInfo::KeyRanges & key_ranges)
+{
+    rust::Vec<::Range> res;
+    for (const auto & range : key_ranges)
+    {
+        rust::Slice<::std::uint8_t const> start(
+            reinterpret_cast<const unsigned char *>(range.start().c_str()),
+            range.start().size());
+        rust::Slice<::std::uint8_t const> end(
+            reinterpret_cast<const unsigned char *>(range.end().c_str()),
+            range.end().size());
+        res.push_back({
+            .start = std::move(start),
+            .end = std::move(end),
+        });
+    }
+    return res;
+}
+
 class TantivyInputStream : public IProfilingBlockInputStream
 {
     static constexpr auto NAME = "TantivyInputStream";
@@ -459,25 +478,6 @@ private:
             fields.push_back(name_and_type.name);
         }
         return fields;
-    }
-
-    static rust::Vec<::Range> getKeyRanges(ShardInfo::KeyRanges & key_ranges)
-    {
-        rust::Vec<::Range> res;
-        for (const auto & range : key_ranges)
-        {
-            rust::Slice<::std::uint8_t const> start(
-                reinterpret_cast<const unsigned char *>(range.start().c_str()),
-                range.start().size());
-            rust::Slice<::std::uint8_t const> end(
-                reinterpret_cast<const unsigned char *>(range.end().c_str()),
-                range.end().size());
-            res.push_back({
-                .start = std::move(start),
-                .end = std::move(end),
-            });
-        }
-        return res;
     }
 };
 } // namespace DB::TS

--- a/dbms/src/Storages/Tantivy/TiCIReadTaskPool.h
+++ b/dbms/src/Storages/Tantivy/TiCIReadTaskPool.h
@@ -332,7 +332,7 @@ public:
     }
 
     static std::tuple<::Expr, std::vector<ColumnID>> tipbToTiCIExpr(
-        google::protobuf::RepeatedPtrField<tipb::Expr> exprs,
+        const google::protobuf::RepeatedPtrField<tipb::Expr> & exprs,
         const TimezoneInfo & tz)
     {
         if (exprs.empty())

--- a/dbms/src/Storages/Tantivy/TiCIReadTaskPool.h
+++ b/dbms/src/Storages/Tantivy/TiCIReadTaskPool.h
@@ -171,6 +171,7 @@ private:
     bool is_count;
     std::shared_ptr<rust::Box<ShardsSnapshot>> shards_snapshot;
 
+public:
     static std::tuple<::Expr, std::vector<ColumnID>> tipbToTiCIExpr(
         const tipb::Expr & expr,
         const TimezoneInfo & timezone_info)

--- a/dbms/src/Storages/Tantivy/TiCIReadTaskPool.h
+++ b/dbms/src/Storages/Tantivy/TiCIReadTaskPool.h
@@ -117,7 +117,7 @@ public:
             return_columns.end(),
             [](const auto & nt, FmtBuffer & fb) { fb.fmtAppend("{}:{}", nt.name, nt.type->getName()); },
             ", ");
-        auto [expr, cids] = tipbToTiCIExpr(match_expr_, timezone_info_);
+        auto [expr, cids] = TS::tipbToTiCIExpr(match_expr_, timezone_info_);
         match_expr = std::move(expr);
         LOG_DEBUG(log, "columns: [{}], match columns: {}", buf.toString(), cids);
     }
@@ -171,22 +171,6 @@ private:
     ::Expr match_expr;
     bool is_count;
     std::shared_ptr<rust::Box<ShardsSnapshot>> shards_snapshot;
-
-public:
-    static std::tuple<::Expr, std::vector<ColumnID>> tipbToTiCIExpr(
-        const tipb::Expr & expr,
-        const TimezoneInfo & timezone_info)
-    {
-        return TS::tipbToTiCIExpr(expr, timezone_info);
-    }
-
-    static std::tuple<::Expr, std::vector<ColumnID>> tipbToTiCIExpr(
-        const google::protobuf::RepeatedPtrField<tipb::Expr> & exprs,
-        const TimezoneInfo & tz)
-    {
-        return TS::tipbToTiCIExpr(exprs, tz);
-    }
-
 };
 
 using TiCIReadTaskPoolPtr = std::shared_ptr<TiCIReadTaskPool>;

--- a/dbms/src/Storages/Tantivy/TiCIReadTaskPool.h
+++ b/dbms/src/Storages/Tantivy/TiCIReadTaskPool.h
@@ -17,6 +17,7 @@
 #include <DataStreams/IBlockInputStream.h>
 #include <Flash/Coprocessor/ShardInfo.h>
 #include <Storages/Tantivy/TantivyInputStream.h>
+#include <Storages/Tantivy/TiCIRequestUtils.h>
 
 namespace DB::TS
 {
@@ -176,182 +177,16 @@ public:
         const tipb::Expr & expr,
         const TimezoneInfo & timezone_info)
     {
-        ::Expr ret;
-        switch (expr.tp())
-        {
-        case tipb::ExprType::ScalarFunc:
-        {
-            std::vector<ColumnID> children_cids;
-            ret.tp = tipb::ExprType::ScalarFunc;
-            for (const auto & child : expr.children())
-            {
-                auto [child_expr, child_cids] = tipbToTiCIExpr(child, timezone_info);
-                ret.children.push_back(child_expr);
-                children_cids.insert(children_cids.end(), child_cids.begin(), child_cids.end());
-            }
-            switch (expr.sig())
-            {
-            case tipb::ScalarFuncSig::FTSMatchWord:
-            case tipb::ScalarFuncSig::FTSMatchPrefix:
-            case tipb::ScalarFuncSig::FTSMatchPhrase:
-            case tipb::ScalarFuncSig::LogicalAnd:
-            case tipb::ScalarFuncSig::LogicalOr:
-            case tipb::ScalarFuncSig::UnaryNotInt:
-            case tipb::ScalarFuncSig::UnaryNotReal:
-            case tipb::ScalarFuncSig::EQInt:
-            case tipb::ScalarFuncSig::NEInt:
-            case tipb::ScalarFuncSig::LTInt:
-            case tipb::ScalarFuncSig::LEInt:
-            case tipb::ScalarFuncSig::GTInt:
-            case tipb::ScalarFuncSig::GEInt:
-            case tipb::ScalarFuncSig::EQString:
-            case tipb::ScalarFuncSig::NEString:
-            case tipb::ScalarFuncSig::LTString:
-            case tipb::ScalarFuncSig::LEString:
-            case tipb::ScalarFuncSig::GTString:
-            case tipb::ScalarFuncSig::GEString:
-            case tipb::ScalarFuncSig::EQReal:
-            case tipb::ScalarFuncSig::NEReal:
-            case tipb::ScalarFuncSig::LTReal:
-            case tipb::ScalarFuncSig::LEReal:
-            case tipb::ScalarFuncSig::GTReal:
-            case tipb::ScalarFuncSig::GEReal:
-            case tipb::ScalarFuncSig::EQDecimal:
-            case tipb::ScalarFuncSig::NEDecimal:
-            case tipb::ScalarFuncSig::LTDecimal:
-            case tipb::ScalarFuncSig::LEDecimal:
-            case tipb::ScalarFuncSig::GTDecimal:
-            case tipb::ScalarFuncSig::GEDecimal:
-            case tipb::ScalarFuncSig::InInt:
-            case tipb::ScalarFuncSig::InString:
-            case tipb::ScalarFuncSig::InReal:
-            case tipb::ScalarFuncSig::InDecimal:
-                ret.sig = expr.sig();
-                break;
-            case tipb::ScalarFuncSig::EQTime:
-            case tipb::ScalarFuncSig::NETime:
-            case tipb::ScalarFuncSig::LTTime:
-            case tipb::ScalarFuncSig::LETime:
-            case tipb::ScalarFuncSig::GTTime:
-            case tipb::ScalarFuncSig::GETime:
-            {
-                ret.sig = expr.sig();
-                size_t col_idx = 0, val_idx = 1;
-                if (isColumnExpr(expr.children(1)))
-                    std::swap(col_idx, val_idx);
-                if (expr.children(col_idx).field_type().tp() == TiDB::TypeTimestamp)
-                {
-                    const auto & child_expr = expr.children(val_idx);
-                    if (isLiteralExpr(child_expr))
-                    {
-                        UInt64 val = decodeDAGUInt64(child_expr.val());
-                        val = convertPackedU64WithTimezone(val, timezone_info);
-                        WriteBufferFromOwnString ss;
-                        encodeDAGUInt64(val, ss);
-                        ret.children[val_idx].val.clear();
-                        auto str = ss.releaseStr();
-                        std::copy(str.begin(), str.end(), std::back_inserter(ret.children[val_idx].val));
-                    }
-                }
-                break;
-            }
-            case tipb::ScalarFuncSig::InTime:
-            {
-                ret.sig = expr.sig();
-                if (expr.children(0).field_type().tp() == TiDB::TypeTimestamp)
-                {
-                    for (int val_idx = 1; val_idx < expr.children_size(); ++val_idx)
-                    {
-                        const auto & child_expr = expr.children(val_idx);
-                        if (isLiteralExpr(child_expr))
-                        {
-                            UInt64 val = decodeDAGUInt64(child_expr.val());
-                            val = convertPackedU64WithTimezone(val, timezone_info);
-                            WriteBufferFromOwnString ss;
-                            encodeDAGUInt64(val, ss);
-                            ret.children[val_idx].val.clear();
-                            auto str = ss.releaseStr();
-                            std::copy(str.begin(), str.end(), std::back_inserter(ret.children[val_idx].val));
-                        }
-                        else
-                        {
-                            throw TiFlashException(
-                                "InTime only support literal values",
-                                Errors::Coprocessor::BadRequest);
-                        }
-                    }
-                }
-                break;
-            }
-            default:
-                throw std::runtime_error("Unsupported expression sig");
-            }
-
-            return {ret, children_cids};
-        }
-        case tipb::ExprType::ColumnRef:
-        {
-            ret.tp = expr.tp();
-            auto id = decodeDAGInt64(expr.val());
-            auto str = fmt::format("column_{}", id);
-            std::copy(str.begin(), str.end(), std::back_inserter(ret.val));
-            return {ret, {id}};
-        }
-        case tipb::ExprType::String:
-        case tipb::ExprType::Int64:
-        case tipb::ExprType::Uint64:
-        case tipb::ExprType::Float32:
-        case tipb::ExprType::Float64:
-        case tipb::ExprType::MysqlTime:
-        {
-            ret.tp = expr.tp();
-            std::copy(expr.val().begin(), expr.val().end(), std::back_inserter(ret.val));
-            return {ret, {}};
-        }
-        case tipb::ExprType::MysqlDecimal:
-        {
-            ret.tp = expr.tp();
-            auto field = decodeDAGDecimal(expr.val());
-            String str;
-            if (field.getType() == Field::Types::Decimal32)
-                str = field.get<DecimalField<Decimal32>>().toString();
-            else if (field.getType() == Field::Types::Decimal64)
-                str = field.get<DecimalField<Decimal64>>().toString();
-            else if (field.getType() == Field::Types::Decimal128)
-                str = field.get<DecimalField<Decimal128>>().toString();
-            else if (field.getType() == Field::Types::Decimal256)
-                str = field.get<DecimalField<Decimal256>>().toString();
-            else
-                throw TiFlashException("Not decimal literal" + expr.DebugString(), Errors::Coprocessor::BadRequest);
-            std::copy(str.begin(), str.end(), std::back_inserter(ret.val));
-            return {ret, {}};
-        }
-        default:
-            throw std::runtime_error("Unsupported expression type");
-        }
+        return TS::tipbToTiCIExpr(expr, timezone_info);
     }
 
     static std::tuple<::Expr, std::vector<ColumnID>> tipbToTiCIExpr(
         const google::protobuf::RepeatedPtrField<tipb::Expr> & exprs,
         const TimezoneInfo & tz)
     {
-        if (exprs.empty())
-        {
-            throw std::runtime_error("Empty match expression");
-        }
-        auto [ret, cids] = tipbToTiCIExpr(exprs[0], tz);
-        for (auto i = 1; i < exprs.size(); ++i)
-        {
-            auto [child_expr, child_cids] = tipbToTiCIExpr(exprs[i], tz);
-            ret = {
-                .tp = tipb::ExprType::ScalarFunc,
-                .children = {ret, child_expr},
-                .sig = tipb::ScalarFuncSig::LogicalAnd,
-            };
-            cids.insert(cids.end(), child_cids.begin(), child_cids.end());
-        }
-        return {ret, cids};
+        return TS::tipbToTiCIExpr(exprs, tz);
     }
+
 };
 
 using TiCIReadTaskPoolPtr = std::shared_ptr<TiCIReadTaskPool>;

--- a/dbms/src/Storages/Tantivy/TiCIRequestUtils.h
+++ b/dbms/src/Storages/Tantivy/TiCIRequestUtils.h
@@ -1,0 +1,249 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <Common/MyTime.h>
+#include <Common/TiFlashException.h>
+#include <Flash/Coprocessor/DAGCodec.h>
+#include <Flash/Coprocessor/DAGUtils.h>
+#include <Flash/Coprocessor/ShardInfo.h>
+#include <IO/Buffer/WriteBufferFromString.h>
+#include <Interpreters/TimezoneInfo.h>
+#include <TiDB/Schema/TiDBTypes.h>
+#include <fmt/format.h>
+#include <google/protobuf/repeated_field.h>
+#include <tici-search-lib/src/lib.rs.h>
+#include <tipb/executor.pb.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <iterator>
+#include <stdexcept>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+namespace DB::TS
+{
+
+// Convert literal value from timezone specified in cop request to UTC in-place.
+inline UInt64 convertPackedU64WithTimezone(UInt64 from_time, const TimezoneInfo & timezone_info)
+{
+    static const auto & time_zone_utc = DateLUT::instance("UTC");
+    UInt64 result_time = from_time;
+    if (timezone_info.is_name_based)
+        convertTimeZone(from_time, result_time, *timezone_info.timezone, time_zone_utc);
+    else if (timezone_info.timezone_offset != 0)
+        convertTimeZoneByOffset(from_time, result_time, false, timezone_info.timezone_offset);
+    return result_time;
+}
+
+inline rust::Vec<::Range> getKeyRanges(const ShardInfo::KeyRanges & key_ranges)
+{
+    rust::Vec<::Range> res;
+    for (const auto & range : key_ranges)
+    {
+        rust::Slice<::std::uint8_t const> start(
+            reinterpret_cast<const unsigned char *>(range.start().c_str()),
+            range.start().size());
+        rust::Slice<::std::uint8_t const> end(
+            reinterpret_cast<const unsigned char *>(range.end().c_str()),
+            range.end().size());
+        res.push_back({
+            .start = std::move(start),
+            .end = std::move(end),
+        });
+    }
+    return res;
+}
+
+inline std::tuple<::Expr, std::vector<ColumnID>> tipbToTiCIExpr(
+    const tipb::Expr & expr,
+    const TimezoneInfo & timezone_info)
+{
+    ::Expr ret;
+    switch (expr.tp())
+    {
+    case tipb::ExprType::ScalarFunc:
+    {
+        std::vector<ColumnID> children_cids;
+        ret.tp = tipb::ExprType::ScalarFunc;
+        for (const auto & child : expr.children())
+        {
+            auto [child_expr, child_cids] = tipbToTiCIExpr(child, timezone_info);
+            ret.children.push_back(child_expr);
+            children_cids.insert(children_cids.end(), child_cids.begin(), child_cids.end());
+        }
+        switch (expr.sig())
+        {
+        case tipb::ScalarFuncSig::FTSMatchWord:
+        case tipb::ScalarFuncSig::FTSMatchPrefix:
+        case tipb::ScalarFuncSig::FTSMatchPhrase:
+        case tipb::ScalarFuncSig::LogicalAnd:
+        case tipb::ScalarFuncSig::LogicalOr:
+        case tipb::ScalarFuncSig::UnaryNotInt:
+        case tipb::ScalarFuncSig::UnaryNotReal:
+        case tipb::ScalarFuncSig::EQInt:
+        case tipb::ScalarFuncSig::NEInt:
+        case tipb::ScalarFuncSig::LTInt:
+        case tipb::ScalarFuncSig::LEInt:
+        case tipb::ScalarFuncSig::GTInt:
+        case tipb::ScalarFuncSig::GEInt:
+        case tipb::ScalarFuncSig::EQString:
+        case tipb::ScalarFuncSig::NEString:
+        case tipb::ScalarFuncSig::LTString:
+        case tipb::ScalarFuncSig::LEString:
+        case tipb::ScalarFuncSig::GTString:
+        case tipb::ScalarFuncSig::GEString:
+        case tipb::ScalarFuncSig::EQReal:
+        case tipb::ScalarFuncSig::NEReal:
+        case tipb::ScalarFuncSig::LTReal:
+        case tipb::ScalarFuncSig::LEReal:
+        case tipb::ScalarFuncSig::GTReal:
+        case tipb::ScalarFuncSig::GEReal:
+        case tipb::ScalarFuncSig::EQDecimal:
+        case tipb::ScalarFuncSig::NEDecimal:
+        case tipb::ScalarFuncSig::LTDecimal:
+        case tipb::ScalarFuncSig::LEDecimal:
+        case tipb::ScalarFuncSig::GTDecimal:
+        case tipb::ScalarFuncSig::GEDecimal:
+        case tipb::ScalarFuncSig::InInt:
+        case tipb::ScalarFuncSig::InString:
+        case tipb::ScalarFuncSig::InReal:
+        case tipb::ScalarFuncSig::InDecimal:
+            ret.sig = expr.sig();
+            break;
+        case tipb::ScalarFuncSig::EQTime:
+        case tipb::ScalarFuncSig::NETime:
+        case tipb::ScalarFuncSig::LTTime:
+        case tipb::ScalarFuncSig::LETime:
+        case tipb::ScalarFuncSig::GTTime:
+        case tipb::ScalarFuncSig::GETime:
+        {
+            ret.sig = expr.sig();
+            size_t col_idx = 0, val_idx = 1;
+            if (isColumnExpr(expr.children(1)))
+                std::swap(col_idx, val_idx);
+            if (expr.children(col_idx).field_type().tp() == TiDB::TypeTimestamp)
+            {
+                const auto & child_expr = expr.children(val_idx);
+                if (isLiteralExpr(child_expr))
+                {
+                    UInt64 val = decodeDAGUInt64(child_expr.val());
+                    val = convertPackedU64WithTimezone(val, timezone_info);
+                    WriteBufferFromOwnString ss;
+                    encodeDAGUInt64(val, ss);
+                    ret.children[val_idx].val.clear();
+                    auto str = ss.releaseStr();
+                    std::copy(str.begin(), str.end(), std::back_inserter(ret.children[val_idx].val));
+                }
+            }
+            break;
+        }
+        case tipb::ScalarFuncSig::InTime:
+        {
+            ret.sig = expr.sig();
+            if (expr.children(0).field_type().tp() == TiDB::TypeTimestamp)
+            {
+                for (int val_idx = 1; val_idx < expr.children_size(); ++val_idx)
+                {
+                    const auto & child_expr = expr.children(val_idx);
+                    if (isLiteralExpr(child_expr))
+                    {
+                        UInt64 val = decodeDAGUInt64(child_expr.val());
+                        val = convertPackedU64WithTimezone(val, timezone_info);
+                        WriteBufferFromOwnString ss;
+                        encodeDAGUInt64(val, ss);
+                        ret.children[val_idx].val.clear();
+                        auto str = ss.releaseStr();
+                        std::copy(str.begin(), str.end(), std::back_inserter(ret.children[val_idx].val));
+                    }
+                    else
+                    {
+                        throw TiFlashException("InTime only support literal values", Errors::Coprocessor::BadRequest);
+                    }
+                }
+            }
+            break;
+        }
+        default:
+            throw std::runtime_error("Unsupported expression sig");
+        }
+
+        return {ret, children_cids};
+    }
+    case tipb::ExprType::ColumnRef:
+    {
+        ret.tp = expr.tp();
+        auto id = decodeDAGInt64(expr.val());
+        auto str = fmt::format("column_{}", id);
+        std::copy(str.begin(), str.end(), std::back_inserter(ret.val));
+        return {ret, {id}};
+    }
+    case tipb::ExprType::String:
+    case tipb::ExprType::Int64:
+    case tipb::ExprType::Uint64:
+    case tipb::ExprType::Float32:
+    case tipb::ExprType::Float64:
+    case tipb::ExprType::MysqlTime:
+    {
+        ret.tp = expr.tp();
+        std::copy(expr.val().begin(), expr.val().end(), std::back_inserter(ret.val));
+        return {ret, {}};
+    }
+    case tipb::ExprType::MysqlDecimal:
+    {
+        ret.tp = expr.tp();
+        auto field = decodeDAGDecimal(expr.val());
+        String str;
+        if (field.getType() == Field::Types::Decimal32)
+            str = field.get<DecimalField<Decimal32>>().toString();
+        else if (field.getType() == Field::Types::Decimal64)
+            str = field.get<DecimalField<Decimal64>>().toString();
+        else if (field.getType() == Field::Types::Decimal128)
+            str = field.get<DecimalField<Decimal128>>().toString();
+        else if (field.getType() == Field::Types::Decimal256)
+            str = field.get<DecimalField<Decimal256>>().toString();
+        else
+            throw TiFlashException("Not decimal literal" + expr.DebugString(), Errors::Coprocessor::BadRequest);
+        std::copy(str.begin(), str.end(), std::back_inserter(ret.val));
+        return {ret, {}};
+    }
+    default:
+        throw std::runtime_error("Unsupported expression type");
+    }
+}
+
+inline std::tuple<::Expr, std::vector<ColumnID>> tipbToTiCIExpr(
+    const google::protobuf::RepeatedPtrField<tipb::Expr> & exprs,
+    const TimezoneInfo & tz)
+{
+    if (exprs.empty())
+        throw std::runtime_error("Empty match expression");
+    auto [ret, cids] = tipbToTiCIExpr(exprs[0], tz);
+    for (auto i = 1; i < exprs.size(); ++i)
+    {
+        auto [child_expr, child_cids] = tipbToTiCIExpr(exprs[i], tz);
+        ret = {
+            .tp = tipb::ExprType::ScalarFunc,
+            .children = {ret, child_expr},
+            .sig = tipb::ScalarFuncSig::LogicalAnd,
+        };
+        cids.insert(cids.end(), child_cids.begin(), child_cids.end());
+    }
+    return {ret, cids};
+}
+
+} // namespace DB::TS

--- a/dbms/src/Storages/Tantivy/TiCIRequestUtils.h
+++ b/dbms/src/Storages/Tantivy/TiCIRequestUtils.h
@@ -179,7 +179,11 @@ inline std::tuple<::Expr, std::vector<ColumnID>> tipbToTiCIExpr(
             break;
         }
         default:
-            throw std::runtime_error("Unsupported expression sig");
+            throw std::runtime_error(fmt::format(
+                "Unsupported expression sig: tp={}, sig={}, expr={}",
+                static_cast<int>(expr.tp()),
+                static_cast<int>(expr.sig()),
+                expr.DebugString()));
         }
 
         return {ret, children_cids};
@@ -217,12 +221,15 @@ inline std::tuple<::Expr, std::vector<ColumnID>> tipbToTiCIExpr(
         else if (field.getType() == Field::Types::Decimal256)
             str = field.get<DecimalField<Decimal256>>().toString();
         else
-            throw TiFlashException("Not decimal literal" + expr.DebugString(), Errors::Coprocessor::BadRequest);
+            throw TiFlashException("Not decimal literal: " + expr.DebugString(), Errors::Coprocessor::BadRequest);
         std::copy(str.begin(), str.end(), std::back_inserter(ret.val));
         return {ret, {}};
     }
     default:
-        throw std::runtime_error("Unsupported expression type");
+        throw std::runtime_error(fmt::format(
+            "Unsupported expression type: tp={}, expr={}",
+            static_cast<int>(expr.tp()),
+            expr.DebugString()));
     }
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Problem Summary:

TiDB needs TiFlash to expose TiCI-side estimate count so the optimizer can use sampled TiCI fulltext cardinality instead of relying only on local planner estimates.

### What is changed and how it works?

```commit-message
flash: handle GetEstimateTiCICount RPC for TiCI fulltext stats
```

- Add FlashService handling for GetEstimateTiCICount.
- Build TiCI estimate input from the request expression and shard/range list.
- Return TiCI estimate count to TiDB and ignore missing shards during estimate.
- Update kvproto to the branch containing the estimate count RPC definitions.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Manual test:

- TiUP playground tag: `tici-estimate-skew-20260426-2240`.
- Query: `EXPLAIN SELECT COUNT(*) FROM estimate_skew WHERE MATCH(content) AGAINST ('heavyhit' IN BOOLEAN MODE);`.
- Result: TiDB used TiCI estimate `4321`; exact match count was `4000`; total table row count was `9400`.
- Logs confirmed TiFlash `GetEstimateTiCICount done, est_count=4321` and TiCI `EstimateCountResult { estimated_total_count: 4321, ... }`.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
