### PR TITLE
Storage: Fix bug when reading string column from the columnar

### DIFF
--- a/dbms/CMakeLists.txt
+++ b/dbms/CMakeLists.txt
@@ -451,6 +451,6 @@ add_target_pch("pch-stl.h" libprotobuf kvproto tipb libprotoc)
 add_target_pch("pch-stl.h" Net Crypto Util Data NetSSL)
 add_target_pch("$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/pch-stl.h>" Foundation JSON)
 
-# Show the import build flags and related proxy information for verification.
+# Show the important build flags and related proxy information for verification.
 message (STATUS "Important build flags: CMAKE_BUILD_TYPE:${CMAKE_BUILD_TYPE}, ENABLE_NEXT_GEN:${ENABLE_NEXT_GEN}, ENABLE_NEXT_GEN_COLUMNAR:${ENABLE_NEXT_GEN_COLUMNAR}")
 message (STATUS "Will build TiFlash ${TIFLASH_RELEASE_VERSION} with proxy:${_TIFLASH_PROXY_SOURCE_DIR}")

--- a/dbms/CMakeLists.txt
+++ b/dbms/CMakeLists.txt
@@ -451,4 +451,6 @@ add_target_pch("pch-stl.h" libprotobuf kvproto tipb libprotoc)
 add_target_pch("pch-stl.h" Net Crypto Util Data NetSSL)
 add_target_pch("$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/pch-stl.h>" Foundation JSON)
 
-message (STATUS "Will build TiFlash ${TIFLASH_RELEASE_VERSION}")
+# Show the import build flags and related proxy information for verification.
+message (STATUS "Important build flags: CMAKE_BUILD_TYPE:${CMAKE_BUILD_TYPE}, ENABLE_NEXT_GEN:${ENABLE_NEXT_GEN}, ENABLE_NEXT_GEN_COLUMNAR:${ENABLE_NEXT_GEN_COLUMNAR}")
+message (STATUS "Will build TiFlash ${TIFLASH_RELEASE_VERSION} with proxy:${_TIFLASH_PROXY_SOURCE_DIR}")

--- a/dbms/src/Storages/StorageDisaggregated.cpp
+++ b/dbms/src/Storages/StorageDisaggregated.cpp
@@ -92,7 +92,7 @@ void StorageDisaggregated::read(
 
 bool StorageDisaggregated::isReadColumnar()
 {
-#if ENABLE_NEXT_GEN_COLUMNAR == 0
+#if ENABLE_NEXT_GEN_COLUMNAR == 1
     return context.getSharedContextDisagg()->use_columnar;
 #else
     static_cast<void>(table_scan);

--- a/dbms/src/Storages/StorageDisaggregatedColumnar.cpp
+++ b/dbms/src/Storages/StorageDisaggregatedColumnar.cpp
@@ -21,7 +21,9 @@
 #include <Core/NamesAndTypes.h>
 #include <DataStreams/AddExtraTableIDColumnTransformAction.h>
 #include <DataStreams/IBlockInputStream.h>
+#include <DataTypes/DataTypeFactory.h>
 #include <DataTypes/IDataType.h>
+#include <Flash/Coprocessor/CodecUtils.h>
 #include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/DAGExpressionAnalyzer.h>
 #include <Flash/Coprocessor/DAGPipeline.h>
@@ -84,13 +86,24 @@ std::vector<std::tuple<UInt64, String, DataTypePtr>> genGeneratedColumnInfosForD
     return generated_column_infos;
 }
 
-std::tuple<DM::ColumnDefinesPtr, int> genColumnDefinesForDisaggregatedReadThroughProxy(const TiDBTableScan & table_scan)
+std::tuple<DM::ColumnDefinesPtr, int> genColumnDefinesForDisaggregatedReadThroughColumnar(
+    const TiDBTableScan & table_scan)
 {
     DM::ColumnDefinesPtr column_defines;
     int extra_table_id_index;
     std::vector<std::tuple<UInt64, String, DataTypePtr>> generated_column_infos;
     std::tie(column_defines, extra_table_id_index, generated_column_infos)
         = genColumnDefinesForDisaggregatedRead(table_scan);
+
+    // Columnar only support the legacy string format for now, so convert the data type to legacy one.
+    // We can remove this when columnar supports the new string data type.
+    for (auto & cd : *column_defines)
+    {
+        const auto & converted_type = CodecUtils::convertDataType(*cd.type);
+        if (&converted_type != cd.type.get())
+            cd.type = DataTypeFactory::instance().getOrSet(converted_type.getName());
+    }
+
     bool has_generated_column = false;
     for (const auto & ci : table_scan.getColumns())
     {
@@ -292,7 +305,7 @@ void StorageDisaggregated::readThroughColumnar(
         remote_table_ranges,
         num_streams);
     const auto generated_column_infos = genGeneratedColumnInfosForDisaggregatedRead(table_scan);
-    auto [column_defines, extra_table_id_index] = genColumnDefinesForDisaggregatedReadThroughProxy(table_scan);
+    auto [column_defines, extra_table_id_index] = genColumnDefinesForDisaggregatedReadThroughColumnar(table_scan);
     for (auto & task : read_proxy_tasks)
     {
         group_builder.addConcurrency(RNProxySourceOp::create({
@@ -547,7 +560,7 @@ RNProxyReaderPtr RNProxyReader::createProxyReader(
     }
 
     // Create input stream.
-    auto [column_defines, extra_table_id_index] = genColumnDefinesForDisaggregatedReadThroughProxy(table_scan);
+    auto [column_defines, extra_table_id_index] = genColumnDefinesForDisaggregatedReadThroughColumnar(table_scan);
     BlockInputStreamPtr input_stream = RNProxyInputStream::create({
         .context = context,
         .debug_tag = log->identifier(),

--- a/tests/docker/next-gen-utils/README.md
+++ b/tests/docker/next-gen-utils/README.md
@@ -1,5 +1,15 @@
 # next-gen binaries download script
 
+Note that the images under `us-docker.pkg.dev` are private. You need to acquire the access token and login before using this script.
+
+```bash
+docker login -u oauth2accesstoken --password-stdin us-docker.pkg.dev
+# or using podman instead of docker
+# podman login -u oauth2accesstoken --password-stdin us-docker.pkg.dev
+```
+
+Download the binaries and start a tiup cluster.
+
 ```bash
 # copy the binaries from tikv/tidb/pd/tiflash images to local
 make download


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10844

Problem Summary: #9673 introduced a new serde format for String columns (`StringV2`) to improve performance with short strings. However, the columnar reader in `tiflash-proxy` still only supports the legacy String format, so when TiFlash passes `StringV2`-typed column metadata to the columnar reader, deserialization fails with an error when reading string-like columns from the columnar data source.

In addition, the `isReadColumnar()` guard had an inverted condition (`ENABLE_NEXT_GEN_COLUMNAR == 0` instead of `== 1`), which silently disabled the columnar read path entirely.

### What is changed and how it works?
```
* Convert String column types to legacy format before constructing the columnar reader
   Added a post-processing step that iterates over the resolved `ColumnDefines` and calls
   `CodecUtils::convertDataType` on each column type. So that the columnar reader always
   receives the legacy String descriptor it understands.
* Fix inverted preprocessor condition in `StorageDisaggregated::isReadColumnar()`
* Improve CMake build-flag logging, making it easier to verify the correct feature flags were used at configure time.
```
### Check List

Tests

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

```sql
CREATE TABLE event_log1 (
  event_timestamp bigint NOT NULL,
  approximate_arrival_timestamp datetime NOT NULL,
  action_params text DEFAULT NULL -- text type
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T! SHARD_ROW_ID_BITS=4 PRE_SPLIT_REGIONS=2 */
PARTITION BY RANGE COLUMNS(approximate_arrival_timestamp)
(PARTITION p202603 VALUES LESS THAN ('2026-04-01 00:00:00'),
 PARTITION p202604 VALUES LESS THAN ('2026-05-01 00:00:00'),
 PARTITION p202605 VALUES LESS THAN ('2026-06-01 00:00:00'),
 PARTITION p202606 VALUES LESS THAN ('2026-07-01 00:00:00'));
INSERT INTO event_log1
  (event_timestamp,approximate_arrival_timestamp,action_params) VALUES
  (1747312496000,'2026-05-15 12:34:56','{"popup_id":"123"}'),
  (1747312556000,'2026-05-15 12:35:56','{"popup_id":"123"}'),
  (1747312616000,'2026-05-15 12:36:56','{"popup_id":"0"}'),
  (1747312676000,'2026-05-15 12:37:56','{"popup_id":"456"}'),
  (1747312736000,'2026-05-15 12:38:56','{"popup_id":"789"}');
ALTER TABLE event_log1 SET TIFLASH REPLICA 1;

SET SESSION tidb_isolation_read_engines='tiflash';
select action_params from event_log1;
```

No code

Side effects
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```
None
```
