### PR TITLE
columnar: Fix partition table reading and columnar OOB crash on generated columns

### DIFF
--- a/dbms/src/Core/NamesAndTypes.h
+++ b/dbms/src/Core/NamesAndTypes.h
@@ -21,8 +21,6 @@
 
 #include <initializer_list>
 #include <list>
-#include <map>
-#include <set>
 #include <string>
 
 

--- a/dbms/src/Flash/Planner/Plans/PhysicalTableScan.cpp
+++ b/dbms/src/Flash/Planner/Plans/PhysicalTableScan.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <Common/TiFlashException.h>
+#include <Core/NamesAndTypes.h>
 #include <Flash/Coprocessor/ChunkCodec.h>
 #include <Flash/Coprocessor/DAGPipeline.h>
 #include <Flash/Coprocessor/DAGStorageInterpreter.h>
@@ -38,13 +39,14 @@ NamesWithAliases buildTableScanProjectionCols(
 {
     if (unlikely(schema.size() != storage_header.columns()))
         throw TiFlashException(
-            fmt::format(
-                "The tidb table scan schema size {} is different from the tiflash storage schema size {}, table id is "
-                "{}",
-                schema.size(),
-                storage_header.columns(),
-                logical_table_id),
-            Errors::Planner::BadRequest);
+            Errors::Planner::BadRequest,
+            "The tidb table scan schema size {} is different from the tiflash storage schema size {}, table_id={} "
+            "schema={} storage_header={}",
+            schema.size(),
+            storage_header.columns(),
+            logical_table_id,
+            dumpJsonStructure(schema),
+            storage_header.dumpJsonStructure());
     NamesWithAliases schema_project_cols;
     for (size_t i = 0; i < schema.size(); ++i)
     {
@@ -54,19 +56,17 @@ NamesWithAliases buildTableScanProjectionCols(
         const auto & storage_col_type = storage_header.getColumnsWithTypeAndName()[i].type;
         if (unlikely(!table_scan_col_type->equals(*storage_col_type)))
             throw TiFlashException(
-                fmt::format(
-                    R"(The data type {} from tidb table scan schema is different from the data type {} from tiflash storage schema, 
-                    table id is {}, 
-                    column index is {}, 
-                    column name from tidb table scan is {}, 
+                Errors::Planner::BadRequest,
+                R"(The data type {} from tidb table scan schema is different from the data type {} from tiflash storage schema,
+                    table_id={} column_index={}
+                    column name from tidb table scan is {},
                     column name from tiflash storage is {})",
-                    table_scan_col_type->getName(),
-                    storage_col_type->getName(),
-                    logical_table_id,
-                    i,
-                    table_scan_col_name,
-                    storage_col_name),
-                Errors::Planner::BadRequest);
+                table_scan_col_type->getName(),
+                storage_col_type->getName(),
+                logical_table_id,
+                i,
+                table_scan_col_name,
+                storage_col_name);
         schema_project_cols.emplace_back(storage_col_name, table_scan_col_name);
     }
     return schema_project_cols;

--- a/dbms/src/Storages/KVStore/TMTContext.cpp
+++ b/dbms/src/Storages/KVStore/TMTContext.cpp
@@ -258,15 +258,19 @@ void TMTContext::restore(PathPool & path_pool, const TiFlashRaftProxyHelper * pr
     if (context.getSharedContextDisagg()->use_columnar)
         context.getSharedContextDisagg()->setColumnarProxyHelper(proxy_helper);
 
-    // For tiflash_compute mode, kvstore should be nullptr, no need to restore region_table.
+    // For tiflash_compute with autoscaler, kvstore should be nullptr, no need to restore region_table.
     if (context.getSharedContextDisagg()->isDisaggregatedComputeMode()
         && context.getSharedContextDisagg()->use_autoscaler)
     {
         return;
     }
 
-    kvstore->restore(path_pool, proxy_helper);
-    region_table.restore();
+    // For tiflash_compute with use_columnar, we don't need kvstore
+    if (!context.getSharedContextDisagg()->use_columnar)
+    {
+        kvstore->restore(path_pool, proxy_helper);
+        region_table.restore();
+    }
     store_status = StoreStatus::Ready;
 
     if (proxy_helper != nullptr)

--- a/dbms/src/Storages/StorageDisaggregatedColumnar.cpp
+++ b/dbms/src/Storages/StorageDisaggregatedColumnar.cpp
@@ -341,7 +341,7 @@ RNProxyReaderPtr RNProxyReader::createProxyReader(
             normalizeTimestampCompareDateTimeLiteralToUTC(*pushed_down_filters->Mutable(i), timezone_info);
     }
     auto table_scan_data = table_scan_pb.SerializeAsString();
-    BaseBuffView table_scan_view = BaseBuffView{table_scan_data.data(), table_scan_data.size()};
+    auto table_scan_view = BaseBuffView{table_scan_data.data(), table_scan_data.size()};
     auto conditions = filter_conditions.conditions;
     for (int i = 0; i < conditions.size(); ++i)
         normalizeTimestampCompareDateTimeLiteralToUTC(*conditions.Mutable(i), timezone_info);
@@ -368,7 +368,7 @@ RNProxyReaderPtr RNProxyReader::createProxyReader(
         tables_range_data.append(reinterpret_cast<const char *>(&ranges_data_size), sizeof(ranges_data_size));
         tables_range_data.append(ranges_data.data(), ranges_data.size());
     }
-    BaseBuffView tables_range_view = BaseBuffView{tables_range_data.data(), tables_range_data.size()};
+    auto tables_range_view = BaseBuffView{tables_range_data.data(), tables_range_data.size()};
     String filter_conditions_data;
     for (const auto & condition : conditions)
     {
@@ -379,14 +379,14 @@ RNProxyReaderPtr RNProxyReader::createProxyReader(
     }
     tipb::TableInfo table_info;
     bool is_partition_scan = table_scan.isPartitionTableScan();
-    const auto & tidbColumns = table_scan.getColumns();
+    const auto & tidb_columns = table_scan.getColumns();
     if (is_partition_scan)
     {
         for (const auto & column : table_scan_pb.partition_table_scan().columns())
         {
             const auto column_id = column.column_id();
             bool is_generated_column = false;
-            for (const auto & ci : tidbColumns)
+            for (const auto & ci : tidb_columns)
             {
                 if (ci.id == column_id && ci.hasGeneratedColumnFlag())
                 {
@@ -405,7 +405,7 @@ RNProxyReaderPtr RNProxyReader::createProxyReader(
         {
             const auto column_id = column.column_id();
             bool is_generated_column = false;
-            for (const auto & ci : tidbColumns)
+            for (const auto & ci : tidb_columns)
             {
                 if (ci.id == column_id && ci.hasGeneratedColumnFlag())
                 {
@@ -419,14 +419,14 @@ RNProxyReaderPtr RNProxyReader::createProxyReader(
         }
     }
     auto table_info_data = table_info.SerializeAsString();
-    BaseBuffView columns = BaseBuffView{table_info_data.data(), table_info_data.size()};
-    BaseBuffView filter_conditions_view = BaseBuffView{filter_conditions_data.data(), filter_conditions_data.size()};
-    auto ann_query_info_pb = table_scan.getANNQueryInfo();
-    auto fts_query_info_pb = table_scan.getFTSQueryInfo();
+    auto columns = BaseBuffView{table_info_data.data(), table_info_data.size()};
+    auto filter_conditions_view = BaseBuffView{filter_conditions_data.data(), filter_conditions_data.size()};
+    const auto & ann_query_info_pb = table_scan.getANNQueryInfo();
+    const auto & fts_query_info_pb = table_scan.getFTSQueryInfo();
     auto ann_query_info_data = ann_query_info_pb.SerializeAsString();
     auto fts_query_info_data = fts_query_info_pb.SerializeAsString();
-    BaseBuffView ann_query_info_view = BaseBuffView{ann_query_info_data.data(), ann_query_info_data.size()};
-    BaseBuffView fts_query_info_view = BaseBuffView{fts_query_info_data.data(), fts_query_info_data.size()};
+    auto ann_query_info_view = BaseBuffView{ann_query_info_data.data(), ann_query_info_data.size()};
+    auto fts_query_info_view = BaseBuffView{fts_query_info_data.data(), fts_query_info_data.size()};
     const Context & global_ctx = context.getGlobalContext();
     auto * cluster = global_ctx.getTMTContext().getKVCluster();
     const TiFlashRaftProxyHelper * proxy_helper = global_ctx.getSharedContextDisagg()->getColumnarProxyHelper();
@@ -470,7 +470,7 @@ RNProxyReaderPtr RNProxyReader::createProxyReader(
                 region_id_ver = std::to_string(region.id()) + ":" + std::to_string(region_ver) + ":"
                     + std::to_string(region.region_epoch().conf_ver());
             }
-            auto _guard = std::lock_guard(output_lock);
+            auto guard = std::lock_guard(output_lock);
             cluster->region_cache->dropRegion(region_ver_id);
             LOG_WARNING(
                 log,
@@ -506,7 +506,7 @@ RNProxyReaderPtr RNProxyReader::createProxyReader(
                     std::to_string(region_id),
                     region_error.ShortDebugString());
             }
-            auto _guard = std::lock_guard(output_lock);
+            auto guard = std::lock_guard(output_lock);
             cluster->region_cache->dropRegion(region_ver_id);
             throw RegionException(
                 std::move(unavailable_regions),
@@ -523,7 +523,7 @@ RNProxyReaderPtr RNProxyReader::createProxyReader(
         pingcap::kv::Backoffer bo(pingcap::kv::copNextMaxBackoff);
         std::vector<uint64_t> pushed;
         std::vector<pingcap::kv::LockPtr> locks{std::make_shared<pingcap::kv::Lock>(lock_info)};
-        auto _guard = std::lock_guard(output_lock);
+        auto guard = std::lock_guard(output_lock);
         auto before_expired = cluster->lock_resolver->resolveLocks(bo, start_ts, locks, pushed);
         LOG_WARNING(log, "Finished resolve locks, before_expired={}", before_expired);
         throw Exception("lock error", ErrorCodes::COLUMNAR_SNAPSHOT_ERROR);
@@ -543,7 +543,10 @@ RNProxyReaderPtr RNProxyReader::createProxyReader(
             uint8_t(columnar_reader.error_type),
             error_msg);
         throw Exception(
-            fmt::format("columnar reader error_type={}, error={}", uint8_t(columnar_reader.error_type), error_msg),
+            fmt::format(
+                "columnar reader error_type={}, error={}",
+                static_cast<uint8_t>(columnar_reader.error_type),
+                error_msg),
             ErrorCodes::COLUMNAR_SNAPSHOT_ERROR);
     }
 
@@ -636,7 +639,7 @@ std::vector<RNProxyReadTaskPtr> RNProxyReadTask::buildProxyReadTask(
     pingcap::kv::Cluster * cluster = context.getTMTContext().getKVCluster();
     pingcap::kv::Backoffer bo(pingcap::kv::copBuildTaskMaxBackoff);
     auto & region_cache = cluster->region_cache;
-    for (auto idx = 0; idx < int(ranges_for_each_physical_table.size()); idx++)
+    for (auto idx = 0; idx < static_cast<int>(ranges_for_each_physical_table.size()); idx++)
     {
         const auto physical_table_id = physical_table_ids[idx];
         const auto ranges = ranges_for_each_physical_table[idx];
@@ -826,7 +829,7 @@ Block RNProxyInputStream::readImpl([[maybe_unused]] FilterPtr & res_filter, [[ma
 
     TableID physical_table_id = -1;
     Block header = getHeader();
-    const ColumnsWithTypeAndName col_type_and_name = header.getColumnsWithTypeAndName();
+    const ColumnsWithTypeAndName & col_type_and_name = header.getColumnsWithTypeAndName();
     // Construct block from proxy column data.
     MutableColumns columns = header.cloneEmptyColumns();
     for (UInt32 i = 0; i < col_type_and_name.size(); ++i)
@@ -961,11 +964,11 @@ OperatorStatus RNProxySourceOp::executeIOImpl()
     }
     else
     {
-        if (current_reader_idx == Int32(task->getProxyReaders().size() - 1))
+        if (current_reader_idx == static_cast<Int32>(task->getProxyReaders().size() - 1))
         {
             done = true;
         }
-        else if (current_reader_idx < Int32(task->getProxyReaders().size() - 1))
+        else if (current_reader_idx < static_cast<Int32>(task->getProxyReaders().size() - 1))
         {
             ++current_reader_idx;
         }

--- a/dbms/src/Storages/StorageDisaggregatedColumnar.cpp
+++ b/dbms/src/Storages/StorageDisaggregatedColumnar.cpp
@@ -380,21 +380,23 @@ RNProxyReaderPtr RNProxyReader::createProxyReader(
     tipb::TableInfo table_info;
     bool is_partition_scan = table_scan.isPartitionTableScan();
     const auto & tidb_columns = table_scan.getColumns();
+    const auto should_skip_column_for_columnar_table_info = [&](ColumnID column_id) {
+        // _tidb_tid is filled locally by TiFlash, consistent with genColumnDefinesForDisaggregatedRead().
+        if (column_id == MutSup::extra_table_id_col_id)
+            return true;
+        // Generated columns are not stored in kvengine; executeGeneratedColumnPlaceholder fills them later.
+        for (const auto & ci : tidb_columns)
+        {
+            if (ci.id == column_id && ci.hasGeneratedColumnFlag())
+                return true;
+        }
+        return false;
+    };
     if (is_partition_scan)
     {
         for (const auto & column : table_scan_pb.partition_table_scan().columns())
         {
-            const auto column_id = column.column_id();
-            bool is_generated_column = false;
-            for (const auto & ci : tidb_columns)
-            {
-                if (ci.id == column_id && ci.hasGeneratedColumnFlag())
-                {
-                    is_generated_column = true;
-                    break;
-                }
-            }
-            if (is_generated_column)
+            if (should_skip_column_for_columnar_table_info(column.column_id()))
                 continue;
             *table_info.add_columns() = column;
         }
@@ -403,17 +405,7 @@ RNProxyReaderPtr RNProxyReader::createProxyReader(
     {
         for (const auto & column : table_scan_pb.tbl_scan().columns())
         {
-            const auto column_id = column.column_id();
-            bool is_generated_column = false;
-            for (const auto & ci : tidb_columns)
-            {
-                if (ci.id == column_id && ci.hasGeneratedColumnFlag())
-                {
-                    is_generated_column = true;
-                    break;
-                }
-            }
-            if (is_generated_column)
+            if (should_skip_column_for_columnar_table_info(column.column_id()))
                 continue;
             *table_info.add_columns() = column;
         }

--- a/dbms/src/Storages/StorageDisaggregatedColumnar.cpp
+++ b/dbms/src/Storages/StorageDisaggregatedColumnar.cpp
@@ -522,24 +522,20 @@ RNProxyReaderPtr RNProxyReader::createProxyReader(
     }
     else if (columnar_reader.error_type == ColumnarReaderErrorType::PdClientError)
     {
-        auto error_msg = String(columnar_reader.error.buff.data, columnar_reader.error.buff.len);
-        LOG_WARNING(log, "create columnar reader failed, pd client error: {}", error_msg);
-        throw Exception(fmt::format("pd client error: {}", error_msg), ErrorCodes::COLUMNAR_SNAPSHOT_ERROR);
+        auto error_msg = fmt::format(
+            "create columnar reader failed, pd client error: {}",
+            String(columnar_reader.error.buff.data, columnar_reader.error.buff.len));
+        LOG_WARNING(log, "{}", error_msg);
+        throw Exception(ErrorCodes::COLUMNAR_SNAPSHOT_ERROR, "{}", error_msg);
     }
     else if (columnar_reader.error_type != ColumnarReaderErrorType::OK)
     {
-        auto error_msg = String(columnar_reader.error.buff.data, columnar_reader.error.buff.len);
-        LOG_WARNING(
-            log,
-            "create columnar reader failed, error_type={}, error={}",
-            uint8_t(columnar_reader.error_type),
-            error_msg);
-        throw Exception(
-            fmt::format(
-                "columnar reader error_type={}, error={}",
-                static_cast<uint8_t>(columnar_reader.error_type),
-                error_msg),
-            ErrorCodes::COLUMNAR_SNAPSHOT_ERROR);
+        auto error_msg = fmt::format(
+            "create columnar reader failed, error_type={} error={}",
+            static_cast<uint8_t>(columnar_reader.error_type),
+            String(columnar_reader.error.buff.data, columnar_reader.error.buff.len));
+        LOG_WARNING(log, "{}", error_msg);
+        throw Exception(ErrorCodes::COLUMNAR_SNAPSHOT_ERROR, "{}", error_msg);
     }
 
     // Create input stream.

--- a/dbms/src/Storages/StorageDisaggregatedColumnar.cpp
+++ b/dbms/src/Storages/StorageDisaggregatedColumnar.cpp
@@ -104,30 +104,9 @@ std::tuple<DM::ColumnDefinesPtr, int> genColumnDefinesForDisaggregatedReadThroug
             cd.type = DataTypeFactory::instance().getOrSet(converted_type.getName());
     }
 
-    bool has_generated_column = false;
-    for (const auto & ci : table_scan.getColumns())
-    {
-        if (ci.hasGeneratedColumnFlag())
-        {
-            has_generated_column = true;
-            break;
-        }
-    }
-    if (!has_generated_column)
-        return {std::move(column_defines), extra_table_id_index};
-
-    auto filtered_column_defines = std::make_shared<DM::ColumnDefines>();
-    filtered_column_defines->reserve(column_defines->size());
-    int filtered_extra_table_id_index = MutSup::invalid_col_id;
-    for (Int32 i = 0; i < table_scan.getColumnSize(); ++i)
-    {
-        if (table_scan.getColumns()[i].hasGeneratedColumnFlag())
-            continue;
-        if (i == extra_table_id_index)
-            filtered_extra_table_id_index = static_cast<int>(filtered_column_defines->size());
-        filtered_column_defines->push_back((*column_defines)[i]);
-    }
-    return {std::move(filtered_column_defines), filtered_extra_table_id_index};
+    // genColumnDefinesForDisaggregatedRead already skips generated columns.
+    // executeGeneratedColumnPlaceholder fills virtual columns later in the pipeline.
+    return {std::move(column_defines), extra_table_id_index};
 }
 
 bool isProxyFilterComparableExpr(tipb::ScalarFuncSig sig)
@@ -304,7 +283,6 @@ void StorageDisaggregated::readThroughColumnar(
         filter_conditions,
         remote_table_ranges,
         num_streams);
-    const auto generated_column_infos = genGeneratedColumnInfosForDisaggregatedRead(table_scan);
     auto [column_defines, extra_table_id_index] = genColumnDefinesForDisaggregatedReadThroughColumnar(table_scan);
     for (auto & task : read_proxy_tasks)
     {
@@ -318,6 +296,7 @@ void StorageDisaggregated::readThroughColumnar(
         }));
     }
 
+    const auto generated_column_infos = genGeneratedColumnInfosForDisaggregatedRead(table_scan);
     executeGeneratedColumnPlaceholder(exec_context, group_builder, generated_column_infos, log);
 
     NamesAndTypes source_columns;

--- a/dbms/src/Storages/StorageDisaggregatedColumnar.h
+++ b/dbms/src/Storages/StorageDisaggregatedColumnar.h
@@ -59,7 +59,7 @@ public:
         RegionID region_id,
         RegionVersion region_ver,
         UInt64 region_conf_ver,
-        const std::vector<std::tuple<TableID, pingcap::coprocessor::KeyRanges>> & partition_table_ranges,
+        const std::vector<std::tuple<TableID, pingcap::coprocessor::KeyRanges>> & physical_table_ranges,
         UInt64 start_ts,
         const TiDBTableScan & table_scan,
         const FilterConditions & filter_conditions,

--- a/dbms/src/Storages/StorageDisaggregatedColumnar.h
+++ b/dbms/src/Storages/StorageDisaggregatedColumnar.h
@@ -155,7 +155,8 @@ public:
         , table_id(options.table_id)
         , executor_id(options.executor_id)
     {
-        setHeader(toEmptyBlock(options.columns_to_read));
+        // Keep header aligned with genNamesAndTypesForTableScan when TiDB requests _tidb_tid on partition scans.
+        setHeader(action.getHeader());
     }
 
     static BlockInputStreamPtr create(const Options & options) { return std::make_shared<RNProxyInputStream>(options); }
@@ -199,7 +200,8 @@ public:
         , task(options.task)
         , action(options.columns_to_read, options.extra_table_id_index)
     {
-        setHeader(toEmptyBlock(options.columns_to_read));
+        // Keep header aligned with genNamesAndTypesForTableScan when TiDB requests _tidb_tid on partition scans.
+        setHeader(action.getHeader());
     }
 
     static SourceOpPtr create(const Options & options) { return std::make_unique<RNProxySourceOp>(options); }

--- a/tests/fullstack-test-next-gen/placement/placement_in_sql.test
+++ b/tests/fullstack-test-next-gen/placement/placement_in_sql.test
@@ -17,6 +17,7 @@ mysql> drop table if exists test.t1
 mysql> create table test.t1 (a int, b int, c int, d int);
 mysql> insert into test.t1 values(1,2,3,4);
 
+mysql> DROP PLACEMENT POLICY IF EXISTS evict_sata_dw;
 # creating placement policy should NOT lead to TiFlash compute node or TiFlash write node panic
 mysql> CREATE PLACEMENT POLICY evict_sata_dw CONSTRAINTS='[-disk=sata, -disk=dw-ssd]' SURVIVAL_PREFERENCES='[host]';
 mysql> ALTER TABLE test.t1 PLACEMENT POLICY=evict_sata_dw;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10856, close #10862

Problem Summary:

- Partition table scan could fail to read correctly due to incorrect column handling in the disaggregated columnar read path.
- When reading tables with generated columns through columnar, a redundant second-pass filter loop indexed `column_defines` with `table_scan` indices. Since `genColumnDefinesForDisaggregatedRead` already excludes generated columns, this misalignment could cause out-of-bounds access and `std::bad_alloc`.
- On next-gen columnar reads with late materialization, `select *` on a partitioned table includes virtual column `_tidb_tid` (`-3`). `createProxyReader()` passed this virtual column to kvengine in `table_info`, but kvengine tries to decode it from memtable/row data and fails with `Schema out of date: col:-3 read null for not null column`.

### What is changed and how it works?

```commit-message
columnar: fix partition table reading, generated-column OOB, and _tidb_tid proxy read

- Fix partition table reading in PhysicalTableScan and related disaggregated columnar column define handling.
- Remove redundant generated-column filter loop in genColumnDefinesForDisaggregatedReadThroughColumnar; generated columns are already excluded by genColumnDefinesForDisaggregatedRead and filled later by executeGeneratedColumnPlaceholder.
- Skip `_tidb_tid` (`MutSup::extra_table_id_col_id`) when building `table_info` in createProxyReader(), consistent with genColumnDefinesForDisaggregatedRead(); TiFlash fills it locally via AddExtraTableIDColumnTransformAction.
- Skip kvstore restore on columnar compute nodes.
- Make placement_in_sql.test reentrant.
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Manual test:

```bash
# #10862: partition table late materialization with _tidb_tid
cd tests/fullstack-test-next-gen
./compose.sh exec -T tiflash-cn0 bash -c \
  'cd /tests && ENABLE_NEXT_GEN=true verbose=true ./run-test.sh fullstack-test/mpp/late_materialization_extra_table_id_column.test'
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix TiFlash next-gen columnar read failures on partition tables with late materialization and generated columns, including crashes caused by misaligned column defines and errors when reading virtual column `_tidb_tid`.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for table schema validation to provide clearer diagnostic information when schema mismatches occur between storage layers.
  * Enhanced placement policy test setup to prevent conflicts from prior test runs.

* **Refactor**
  * Internal optimization of column handling and storage initialization logic for better consistency and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tiflash/pull/10858?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->