### PR TITLE
contrib: wait cluster bootstrap before put store to pd

### DIFF
--- a/contrib/tiflash-columnar-hub/Cargo.lock
+++ b/contrib/tiflash-columnar-hub/Cargo.lock
@@ -63,7 +63,7 @@ dependencies = [
 [[package]]
 name = "aliyun"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a86aa722f8c18fb1fb0b90e9e8455518175006d3"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
 dependencies = [
  "async-trait",
  "aws",
@@ -167,7 +167,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 [[package]]
 name = "api_version"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a86aa722f8c18fb1fb0b90e9e8455518175006d3"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
 dependencies = [
  "bitflags 1.3.2",
  "bytes",
@@ -361,7 +361,7 @@ dependencies = [
 [[package]]
 name = "aws"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a86aa722f8c18fb1fb0b90e9e8455518175006d3"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -1112,7 +1112,7 @@ dependencies = [
 [[package]]
 name = "builtin_dfs"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a86aa722f8c18fb1fb0b90e9e8455518175006d3"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
 dependencies = [
  "api_version",
  "async-trait",
@@ -1183,7 +1183,7 @@ dependencies = [
 [[package]]
 name = "case_macros"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a86aa722f8c18fb1fb0b90e9e8455518175006d3"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
 dependencies = [
  "workspace-hack",
 ]
@@ -1390,7 +1390,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 [[package]]
 name = "clara_fts"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a86aa722f8c18fb1fb0b90e9e8455518175006d3"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
 dependencies = [
  "anyhow",
  "charabia",
@@ -1411,7 +1411,7 @@ dependencies = [
 [[package]]
 name = "cloud"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a86aa722f8c18fb1fb0b90e9e8455518175006d3"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -1431,7 +1431,7 @@ dependencies = [
 [[package]]
 name = "cloud_encryption"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a86aa722f8c18fb1fb0b90e9e8455518175006d3"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
 dependencies = [
  "aliyun",
  "aws",
@@ -1476,7 +1476,7 @@ dependencies = [
 [[package]]
 name = "codec"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a86aa722f8c18fb1fb0b90e9e8455518175006d3"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
 dependencies = [
  "byteorder",
  "error_code",
@@ -1501,7 +1501,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a86aa722f8c18fb1fb0b90e9e8455518175006d3"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
 dependencies = [
  "fxhash",
  "tikv_alloc",
@@ -2088,7 +2088,7 @@ dependencies = [
 [[package]]
 name = "encryption"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a86aa722f8c18fb1fb0b90e9e8455518175006d3"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -2124,7 +2124,7 @@ dependencies = [
 [[package]]
 name = "engine_traits"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a86aa722f8c18fb1fb0b90e9e8455518175006d3"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
 dependencies = [
  "bytes",
  "case_macros",
@@ -2227,7 +2227,7 @@ dependencies = [
 [[package]]
 name = "error_code"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a86aa722f8c18fb1fb0b90e9e8455518175006d3"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
 dependencies = [
  "grpcio",
  "kvproto",
@@ -2335,7 +2335,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 [[package]]
 name = "file_system"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a86aa722f8c18fb1fb0b90e9e8455518175006d3"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
 dependencies = [
  "collections",
  "crc32fast",
@@ -3424,7 +3424,7 @@ dependencies = [
 [[package]]
 name = "keys"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a86aa722f8c18fb1fb0b90e9e8455518175006d3"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
 dependencies = [
  "byteorder",
  "kvproto",
@@ -3438,7 +3438,7 @@ dependencies = [
 [[package]]
 name = "kvengine"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a86aa722f8c18fb1fb0b90e9e8455518175006d3"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
 dependencies = [
  "aligned-vec",
  "aliyun",
@@ -3546,7 +3546,7 @@ dependencies = [
 [[package]]
 name = "kvenginepb"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a86aa722f8c18fb1fb0b90e9e8455518175006d3"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
 dependencies = [
  "protobuf 2.8.0",
  "protobuf-codegen-pure",
@@ -3845,7 +3845,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 [[package]]
 name = "log_wrappers"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a86aa722f8c18fb1fb0b90e9e8455518175006d3"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
 dependencies = [
  "hex 0.4.3",
  "protobuf 2.8.0",
@@ -4317,7 +4317,7 @@ checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
 [[package]]
 name = "online_config"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a86aa722f8c18fb1fb0b90e9e8455518175006d3"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
 dependencies = [
  "online_config_derive",
  "serde",
@@ -4327,7 +4327,7 @@ dependencies = [
 [[package]]
 name = "online_config_derive"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a86aa722f8c18fb1fb0b90e9e8455518175006d3"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4524,7 +4524,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 [[package]]
 name = "pd_client"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a86aa722f8c18fb1fb0b90e9e8455518175006d3"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
 dependencies = [
  "async-trait",
  "bstr",
@@ -5330,7 +5330,7 @@ dependencies = [
 [[package]]
 name = "recovery"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a86aa722f8c18fb1fb0b90e9e8455518175006d3"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
 dependencies = [
  "dashmap 6.2.1",
  "http 0.2.12",
@@ -5831,7 +5831,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a86aa722f8c18fb1fb0b90e9e8455518175006d3"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
 dependencies = [
  "api_version",
  "async-trait",
@@ -5880,7 +5880,7 @@ dependencies = [
 [[package]]
 name = "security"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a86aa722f8c18fb1fb0b90e9e8455518175006d3"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
 dependencies = [
  "aliyun",
  "aws",
@@ -6658,7 +6658,7 @@ dependencies = [
 [[package]]
 name = "tencentcloud"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a86aa722f8c18fb1fb0b90e9e8455518175006d3"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
 dependencies = [
  "async-trait",
  "aws",
@@ -6757,7 +6757,7 @@ dependencies = [
 [[package]]
 name = "tidb_query_common"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a86aa722f8c18fb1fb0b90e9e8455518175006d3"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
 dependencies = [
  "anyhow",
  "api_version",
@@ -6785,7 +6785,7 @@ dependencies = [
 [[package]]
 name = "tidb_query_datatype"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a86aa722f8c18fb1fb0b90e9e8455518175006d3"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
 dependencies = [
  "api_version",
  "base64 0.13.1",
@@ -6901,7 +6901,7 @@ dependencies = [
 [[package]]
 name = "tikv_alloc"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a86aa722f8c18fb1fb0b90e9e8455518175006d3"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
 dependencies = [
  "fxhash",
  "lazy_static",
@@ -6912,7 +6912,7 @@ dependencies = [
 [[package]]
 name = "tikv_util"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a86aa722f8c18fb1fb0b90e9e8455518175006d3"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
 dependencies = [
  "async-speed-limit",
  "backtrace",
@@ -7227,7 +7227,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 [[package]]
 name = "trace_event"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a86aa722f8c18fb1fb0b90e9e8455518175006d3"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
 dependencies = [
  "arc-swap 1.9.1",
  "bitflags 1.3.2",
@@ -7317,7 +7317,7 @@ dependencies = [
 [[package]]
 name = "tracker"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a86aa722f8c18fb1fb0b90e9e8455518175006d3"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
 dependencies = [
  "collections",
  "crossbeam-utils",
@@ -7341,7 +7341,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "txn_types"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a86aa722f8c18fb1fb0b90e9e8455518175006d3"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",

--- a/contrib/tiflash-columnar-hub/hub-runtime/src/run.rs
+++ b/contrib/tiflash-columnar-hub/hub-runtime/src/run.rs
@@ -1241,6 +1241,7 @@ pub unsafe fn run_proxy(argc: c_int, argv: *const *const c_char, helper_ptr: *co
         Some(server)
     };
 
+    info!("wait for engine-store server to start");
     let mut engine_store_status = helper.handle_get_engine_store_server_status();
     while matches!(engine_store_status, EngineStoreServerStatus::Idle) {
         thread::sleep(Duration::from_millis(200));
@@ -1248,6 +1249,9 @@ pub unsafe fn run_proxy(argc: c_int, argv: *const *const c_char, helper_ptr: *co
     }
 
     if matches!(engine_store_status, EngineStoreServerStatus::Running) {
+        info!("engine-store server is running");
+
+        // Only register the store and start the heartbeat loop after the engine-store server is running. This ensures that TiFlash does not register itself before the PD successfully bootstrapped the cluster with init TiKV servers.
         if let Some((store, start_time)) = store_registration.take() {
             let store_id = store.get_id();
             pd_client.put_store(store).unwrap_or_else(|err| {
@@ -1294,12 +1298,19 @@ pub unsafe fn run_proxy(argc: c_int, argv: *const *const c_char, helper_ptr: *co
         engine_store_status = helper.handle_get_engine_store_server_status();
     }
 
+    info!(
+        "found engine-store server status is {:?}, start to stop all services in columnar hub",
+        engine_store_status
+    );
+
     if let Some(handle) = heartbeat_handle.take() {
         let _ = handle.join();
     }
     if let Some(server) = status_server.take() {
         server.stop();
     }
+
+    info!("TiFlash Columnar Hub has been stopped");
 }
 
 #[cfg(test)]

--- a/contrib/tiflash-columnar-hub/hub-runtime/src/run.rs
+++ b/contrib/tiflash-columnar-hub/hub-runtime/src/run.rs
@@ -1188,6 +1188,7 @@ pub unsafe fn run_proxy(argc: c_int, argv: *const *const c_char, helper_ptr: *co
     })
     .unwrap_or_default();
     let status_config_json = build_status_config_json(&config);
+    let mut store_registration: Option<(metapb::Store, u32)> = None;
     let mut heartbeat_context: Option<(u64, u32)> = None;
     let heartbeat_shutdown = Arc::new(AtomicBool::new(false));
     let mut heartbeat_handle: Option<thread::JoinHandle<()>> = None;
@@ -1196,13 +1197,7 @@ pub unsafe fn run_proxy(argc: c_int, argv: *const *const c_char, helper_ptr: *co
         let store_id = ensure_store_id(pd_client.as_ref(), &data_dir);
         let store = build_store(&config, store_id);
         let start_time = store.get_start_timestamp() as u32;
-        pd_client.put_store(store).unwrap_or_else(|err| {
-            panic!(
-                "failed to register TiFlash Columnar Hub store {} to PD: {}",
-                store_id, err
-            )
-        });
-        heartbeat_context = Some((store_id, start_time));
+        store_registration = Some((store, start_time));
     }
 
     let cloud_helper = CloudHelper::new(
@@ -1246,26 +1241,38 @@ pub unsafe fn run_proxy(argc: c_int, argv: *const *const c_char, helper_ptr: *co
         Some(server)
     };
 
-    while matches!(
-        helper.handle_get_engine_store_server_status(),
-        EngineStoreServerStatus::Idle
-    ) {
+    let mut engine_store_status = helper.handle_get_engine_store_server_status();
+    while matches!(engine_store_status, EngineStoreServerStatus::Idle) {
         thread::sleep(Duration::from_millis(200));
+        engine_store_status = helper.handle_get_engine_store_server_status();
     }
 
-    hub.set_status(RaftProxyStatus::Running);
-    if let Some((store_id, start_time)) = heartbeat_context {
-        heartbeat_handle = Some(spawn_store_heartbeat_loop(
-            pd_client.clone(),
-            store_id,
-            start_time,
-            data_dir.clone(),
-            heartbeat_shutdown.clone(),
-        ));
+    if matches!(engine_store_status, EngineStoreServerStatus::Running) {
+        if let Some((store, start_time)) = store_registration.take() {
+            let store_id = store.get_id();
+            pd_client.put_store(store).unwrap_or_else(|err| {
+                panic!(
+                    "failed to register TiFlash Columnar Hub store {} to PD: {}",
+                    store_id, err
+                )
+            });
+            heartbeat_context = Some((store_id, start_time));
+        }
+
+        hub.set_status(RaftProxyStatus::Running);
+        if let Some((store_id, start_time)) = heartbeat_context {
+            heartbeat_handle = Some(spawn_store_heartbeat_loop(
+                pd_client.clone(),
+                store_id,
+                start_time,
+                data_dir.clone(),
+                heartbeat_shutdown.clone(),
+            ));
+        }
     }
 
     loop {
-        match helper.handle_get_engine_store_server_status() {
+        match engine_store_status {
             EngineStoreServerStatus::Running => thread::sleep(Duration::from_millis(200)),
             EngineStoreServerStatus::Stopping => {
                 hub.set_status(RaftProxyStatus::Stopped);
@@ -1284,6 +1291,7 @@ pub unsafe fn run_proxy(argc: c_int, argv: *const *const c_char, helper_ptr: *co
             }
             EngineStoreServerStatus::Idle => thread::sleep(Duration::from_millis(200)),
         }
+        engine_store_status = helper.handle_get_engine_store_server_status();
     }
 
     if let Some(handle) = heartbeat_handle.take() {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10859 

Problem Summary:
Panic when cluster not bootstrapped in columnar mode.

### What is changed and how it works?

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```

### Manual test
```
[2026/05/22 19:08:23.773 +08:00] [ERROR] [TCPServersHolder.cpp:158] ["tls config is set but tcp_port_secure is not set."] [thread_id=1]
[2026/05/22 19:08:23.773 +08:00] [INFO] [TCPServersHolder.cpp:167] ["Listening tcp: 0.0.0.0:9001"] [thread_id=1]
[2026/05/22 19:08:23.773 +08:00] [INFO] [Server.cpp:1183] ["Available RAM = 101332271104; physical cores = 56; logical cores = 56."] [thread_id=1]
[2026/05/22 19:08:23.774 +08:00] [INFO] [Server.cpp:1186] ["Ready for connections."] [thread_id=1]
[2026/05/22 19:08:23.774 +08:00] [INFO] [MetricsPrometheus.cpp:237] ["Config: status.metrics_interval = 15"] [source=Prometheus] [thread_id=1]
[2026/05/22 19:08:23.774 +08:00] [INFO] [MetricsPrometheus.cpp:242] ["Disable prometheus push mode, cause status.metrics_addr is not set!"] [source=Prometheus] [thread_id=1]
[2026/05/22 19:08:23.777 +08:00] [INFO] [MetricsPrometheus.cpp:290] ["Enable prometheus secure pull mode; Listen Host = 0.0.0.0, Metrics Port = 8235"] [source=Prometheus] [thread_id=1]
[2026/05/22 19:08:23.778 +08:00] [INFO] [ProxyStateMachine.h:352] ["Waiting for TiKV cluster to be bootstrapped"] [thread_id=1]
[2026/05/22 19:08:23.779 +08:00] [ERROR] [ProxyStateMachine.h:359] ["Waiting for cluster to be bootstrapped, we will sleep for 3 seconds and try again."] [thread_id=1]
[2026/05/22 19:08:25.778 +08:00] [INFO] [KVStoreConfig.cpp:75] ["Region compact log thresholds, rows=40960 bytes=33554432 gap=200 eager_gc_gap=4096"] [thread_id=3]
[2026/05/22 19:08:25.778 +08:00] [INFO] [KVStoreConfig.cpp:97] ["read-index timeout: 10000ms; wait-index timeout: 300000ms; wait-region-ready timeout: 1200s; read-index-worker-tick: 10ms"] [thread_id=3]
[2026/05/22 19:08:25.779 +08:00] [INFO] [RateLimiter.cpp:511] ["storage.io_rate_limit is not found in config, use default config."] [source=IORateLimiter] [thread_id=3]
[2026/05/22 19:08:25.779 +08:00] [INFO] [RateLimiter.cpp:515] ["storage.io_rate_limit is not changed."] [source=IORateLimiter] [thread_id=3]
[2026/05/22 19:08:25.780 +08:00] [INFO] [Context.cpp:693] ["reload delta tree "] [source=Context] [thread_id=3]
[2026/05/22 19:08:26.781 +08:00] [ERROR] [ProxyStateMachine.h:359] ["Waiting for cluster to be bootstrapped, we will sleep for 3 seconds and try again."] [thread_id=1]
^C[2026/05/22 19:08:28.750 +08:00] [INFO] [BaseDaemon.cpp:1293] ["Received termination signal (Interrupt)"] [source=Application] [thread_id=4]
[2026/05/22 19:08:28.751 +08:00] [ERROR] [ProxyStateMachine.h:359] ["Waiting for cluster to be bootstrapped, we will sleep for 3 seconds and try again."] [thread_id=1]
^C[2026/05/22 19:08:29.238 +08:00] [INFO] [BaseDaemon.cpp:1293] ["Received termination signal (Interrupt)"] [source=Application] [thread_id=4]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Startup now defers store registration and heartbeat initialization until the engine-store server reports Running, avoiding premature registration.
  * Shutdown loop refreshes server status each iteration, joins the heartbeat thread, stops the status server cleanly, and adds clearer logging.
  * No public API changes; tests unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tiflash/pull/10863?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->