### PR TITLE
columnar: fix BIGINT clustered PK at INT64_MAX missing on TiFlash read

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,15 @@ For more detailed information on specific subsystems, refer to:
   - Search for `SyncPointCtl` or `SYNC_FOR` for syncpoints in the code.
 - **Build artifacts:** If `compile_commands.json` is missing, ensure you configured with a preset.
 
+## 🔀 Issues & Pull Requests
+
+When creating an **issue** or **pull request**, read the repo templates first and follow their structure:
+
+- **Issue:** `.github/ISSUE_TEMPLATE/` — pick the template that matches the request (bug, enhancement, feature, question, performance).
+- **PR:** `.github/pull_request_template.md` — use it for the PR title/body, checklists, and release note.
+
+Typical fork workflow: branch from `upstream/master`, push to `origin`, open the PR against `pingcap/tiflash` (`master`).
+
 ## 📖 References
 - `docs/DEVELOPMENT.md`: General engineering practices.
 - `docs/design/`: Design documents for major features.

--- a/contrib/tiflash-columnar-hub/AGENTS.md
+++ b/contrib/tiflash-columnar-hub/AGENTS.md
@@ -1,0 +1,145 @@
+# TiFlash Columnar Hub Guide
+
+This directory is the Rust FFI proxy for **next-gen columnar-only** TiFlash (`ENABLE_NEXT_GEN` + `ENABLE_NEXT_GEN_COLUMNAR`). It replaces `contrib/tiflash-proxy` / `contrib/tiflash-proxy-next-gen` in that build mode.
+
+## Role in TiFlash
+
+When CMake enables columnar next-gen, TiFlash links against a shared library built here:
+
+| Artifact | Description |
+|----------|-------------|
+| `libtiflash_proxy.so` | Rust `cdylib` (`hub-runtime`, crate name `tiflash_proxy`) |
+| FFI headers | Under `hub-runtime/ffi/src/` (included as `TIFLASH_PROXY_INCLUDE_DIR`) |
+
+CMake builds it via `contrib/tiflash-proxy-cmake/CMakeLists.txt` (`make release` or `make debug` in this directory). The resulting library is installed next to the `tiflash` binary (for example `tests/.build/tiflash/libtiflash_proxy.so`).
+
+TiFlash C++ talks to this library through the same proxy FFI surface used elsewhere (`run_raftstore_proxy_ffi`, columnar reader APIs, and so on). In columnar-only mode the runtime is much thinner than classic `tiflash-proxy`: there is no full raftstore learner stack in this repo.
+
+## Directory layout
+
+```
+contrib/tiflash-columnar-hub/
+├── Cargo.toml              # workspace; pins cloud-storage-engine git deps
+├── Cargo.lock
+├── Makefile                # `make release` / `make debug` entry for CMake
+├── rust-toolchain.toml     # nightly toolchain for this workspace
+├── workspace-hack/         # local workspace-hack override (avoid jemalloc in cdylib)
+└── hub-runtime/            # main crate, builds libtiflash_proxy.so
+    ├── Cargo.toml
+    ├── ffi/src/            # C ABI / generated FFI bindings for TiFlash C++
+    └── src/
+        ├── run.rs           # proxy process startup, config, service loop
+        ├── hub.rs           # ColumnarHub runtime host
+        ├── cloud_helper.rs  # TiKV snapshot / DFS / kvengine SnapAccess integration
+        ├── columnar_impls.rs# FFI wrappers around kvengine::CloudColumnarReaders
+        ├── domain_impls.rs  # Rust pointer / error helpers for FFI
+        ├── basic_ffi_impls.rs
+        ├── engine_store_helper.rs
+        ├── interfaces.rs
+        ├── status_server.rs
+        └── profile.rs
+```
+
+## What the code does
+
+**Columnar read path (important):** MPP / disaggregated columnar scans in TiFlash C++ eventually call into this library. `cloud_helper.rs` fetches kvengine snapshots from TiKV (`/kvengine/snapshot/...`), and `columnar_impls.rs` drives `kvengine::CloudColumnarReaders` to decode columnar blocks and return them over FFI.
+
+That means **kvengine inside this repo**, not kvengine inside the `tikv-server` binary, owns columnar range decoding and `CloudColumnarReader` behavior on the compute node. Keep proxy and TiKV versions aligned when debugging columnar correctness issues.
+
+**Other responsibilities:**
+
+- Start and host the columnar hub process (`run.rs`)
+- Expose proxy status / profiling / metrics hooks expected by TiFlash
+- Wire DFS (S3 / builtin), encryption, PD client, and caches through cloud-storage-engine crates
+
+## cloud-storage-engine dependency
+
+All cloud-storage-engine crates are declared once in the workspace root `Cargo.toml` under `[workspace.dependencies]`:
+
+- `kvengine`, `kvenginepb`
+- `api_version`, `builtin_dfs`, `cloud_encryption`, `keys`
+- `pd_client`, `security`, `tikv_util`
+
+They must share the **same git source and revision**. Do not bump only `kvengine` and leave the others on an older commit.
+
+Upstream repository: `https://github.com/tidbcloud/cloud-storage-engine.git`
+
+### Option A: Pin a git revision (default for CI / reproducible builds)
+
+1. Edit `Cargo.toml` and set the same `rev` on every `[workspace.dependencies]` entry sourced from cloud-storage-engine:
+
+   ```toml
+   kvengine = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", rev = "<full-or-short-commit>" }
+   ```
+
+2. Refresh the lockfile:
+
+   ```bash
+   cd contrib/tiflash-columnar-hub
+   cargo update -p kvengine -p kvenginepb -p api_version -p builtin_dfs \
+     -p cloud_encryption -p keys -p pd_client -p security -p tikv_util
+   ```
+
+3. Sanity-check the build:
+
+   ```bash
+   cargo check --manifest-path hub-runtime/Cargo.toml
+   # or
+   make release
+   ```
+
+4. Rebuild TiFlash so the new `libtiflash_proxy.so` is picked up:
+
+   ```bash
+   cmake --build <build-dir> --target tiflash
+   cmake --install <build-dir> --component=tiflash-release --prefix=tests/.build/tiflash
+   ```
+
+5. For integration tests, restart the columnar cluster so `tiflash-cn0` loads the new proxy library.
+
+Verify the resolved revision in `Cargo.lock`:
+
+```bash
+rg 'source = "git\+https://github.com/tidbcloud/cloud-storage-engine.git' Cargo.lock | head -3
+```
+
+### Option B: Track a branch
+
+Replace `rev = "..."` with `branch = "cloud-engine"` (or another branch) on all workspace entries, then run the same `cargo update` and TiFlash rebuild steps. Branch tracking is convenient for local development but less reproducible than a pinned `rev`.
+
+### Option C: Local path override (fast iteration)
+
+Uncomment the `[patch."https://github.com/tidbcloud/cloud-storage-engine.git"]` block at the bottom of `Cargo.toml` and point crates to a local checkout, for example:
+
+```toml
+kvengine = { path = "../../../cloud-storage-engine/components/kvengine" }
+```
+
+Adjust paths relative to `contrib/tiflash-columnar-hub/`. Then run `cargo check` / `make release` and rebuild TiFlash. Remember to revert path patches before committing lockfile changes meant for upstream CI.
+
+## Standalone commands
+
+```bash
+cd contrib/tiflash-columnar-hub
+
+# Same as CMake release build
+make release
+
+# Debug build
+make debug
+
+# Direct cargo (output under hub-runtime/target or CARGO_TARGET_DIR from CMake)
+cargo build --release --manifest-path hub-runtime/Cargo.toml
+```
+
+Optional feature flag when TiFlash uses external jemalloc (CMake sets this automatically for columnar builds):
+
+```bash
+make release ENABLE_FEATURES=external-jemalloc
+```
+
+## Notes
+
+- `workspace-hack/` intentionally overrides cloud-storage-engine's generated workspace-hack so the cdylib does not export a second jemalloc into the TiFlash process.
+- Changing `Cargo.lock` alone is not enough for runtime behavior: always rebuild and redeploy `libtiflash_proxy.so`.
+- Columnar integration tests under `tests/fullstack-test-next-gen-columnar/` also use separate TiKV / TiDB binaries from `_env.sh`; upgrading proxy kvengine does not upgrade TiKV. For end-to-end columnar behavior, consider keeping proxy and TiKV cloud-storage-engine commits compatible.

--- a/contrib/tiflash-columnar-hub/Cargo.lock
+++ b/contrib/tiflash-columnar-hub/Cargo.lock
@@ -63,7 +63,7 @@ dependencies = [
 [[package]]
 name = "aliyun"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "async-trait",
  "aws",
@@ -167,7 +167,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 [[package]]
 name = "api_version"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "bitflags 1.3.2",
  "bytes",
@@ -361,7 +361,7 @@ dependencies = [
 [[package]]
 name = "aws"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -1112,7 +1112,7 @@ dependencies = [
 [[package]]
 name = "builtin_dfs"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "api_version",
  "async-trait",
@@ -1183,7 +1183,7 @@ dependencies = [
 [[package]]
 name = "case_macros"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "workspace-hack",
 ]
@@ -1390,7 +1390,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 [[package]]
 name = "clara_fts"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "anyhow",
  "charabia",
@@ -1411,7 +1411,7 @@ dependencies = [
 [[package]]
 name = "cloud"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -1431,7 +1431,7 @@ dependencies = [
 [[package]]
 name = "cloud_encryption"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "aliyun",
  "aws",
@@ -1476,7 +1476,7 @@ dependencies = [
 [[package]]
 name = "codec"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "byteorder",
  "error_code",
@@ -1501,7 +1501,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "fxhash",
  "tikv_alloc",
@@ -2088,7 +2088,7 @@ dependencies = [
 [[package]]
 name = "encryption"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -2124,7 +2124,7 @@ dependencies = [
 [[package]]
 name = "engine_traits"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "bytes",
  "case_macros",
@@ -2227,7 +2227,7 @@ dependencies = [
 [[package]]
 name = "error_code"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "grpcio",
  "kvproto",
@@ -2335,7 +2335,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 [[package]]
 name = "file_system"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "collections",
  "crc32fast",
@@ -3424,7 +3424,7 @@ dependencies = [
 [[package]]
 name = "keys"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "byteorder",
  "kvproto",
@@ -3438,7 +3438,7 @@ dependencies = [
 [[package]]
 name = "kvengine"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "aligned-vec",
  "aliyun",
@@ -3546,7 +3546,7 @@ dependencies = [
 [[package]]
 name = "kvenginepb"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "protobuf 2.8.0",
  "protobuf-codegen-pure",
@@ -3845,7 +3845,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 [[package]]
 name = "log_wrappers"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "hex 0.4.3",
  "protobuf 2.8.0",
@@ -4317,7 +4317,7 @@ checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
 [[package]]
 name = "online_config"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "online_config_derive",
  "serde",
@@ -4327,7 +4327,7 @@ dependencies = [
 [[package]]
 name = "online_config_derive"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4524,7 +4524,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 [[package]]
 name = "pd_client"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "async-trait",
  "bstr",
@@ -5330,7 +5330,7 @@ dependencies = [
 [[package]]
 name = "recovery"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "dashmap 6.2.1",
  "http 0.2.12",
@@ -5831,7 +5831,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "api_version",
  "async-trait",
@@ -5880,7 +5880,7 @@ dependencies = [
 [[package]]
 name = "security"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "aliyun",
  "aws",
@@ -6658,7 +6658,7 @@ dependencies = [
 [[package]]
 name = "tencentcloud"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "async-trait",
  "aws",
@@ -6757,7 +6757,7 @@ dependencies = [
 [[package]]
 name = "tidb_query_common"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "anyhow",
  "api_version",
@@ -6785,7 +6785,7 @@ dependencies = [
 [[package]]
 name = "tidb_query_datatype"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "api_version",
  "base64 0.13.1",
@@ -6901,7 +6901,7 @@ dependencies = [
 [[package]]
 name = "tikv_alloc"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "fxhash",
  "lazy_static",
@@ -6912,7 +6912,7 @@ dependencies = [
 [[package]]
 name = "tikv_util"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "async-speed-limit",
  "backtrace",
@@ -7227,7 +7227,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 [[package]]
 name = "trace_event"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "arc-swap 1.9.1",
  "bitflags 1.3.2",
@@ -7317,7 +7317,7 @@ dependencies = [
 [[package]]
 name = "tracker"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "collections",
  "crossbeam-utils",
@@ -7341,7 +7341,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "txn_types"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#0bbdec544e26c1500f34e04a28f37959f05523cf"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",

--- a/contrib/tiflash-columnar-hub/Cargo.lock
+++ b/contrib/tiflash-columnar-hub/Cargo.lock
@@ -63,7 +63,7 @@ dependencies = [
 [[package]]
 name = "aliyun"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "async-trait",
  "aws",
@@ -167,7 +167,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 [[package]]
 name = "api_version"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "bitflags 1.3.2",
  "bytes",
@@ -361,7 +361,7 @@ dependencies = [
 [[package]]
 name = "aws"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -1112,7 +1112,7 @@ dependencies = [
 [[package]]
 name = "builtin_dfs"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "api_version",
  "async-trait",
@@ -1183,7 +1183,7 @@ dependencies = [
 [[package]]
 name = "case_macros"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "workspace-hack",
 ]
@@ -1390,7 +1390,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 [[package]]
 name = "clara_fts"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "anyhow",
  "charabia",
@@ -1411,7 +1411,7 @@ dependencies = [
 [[package]]
 name = "cloud"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -1431,7 +1431,7 @@ dependencies = [
 [[package]]
 name = "cloud_encryption"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "aliyun",
  "aws",
@@ -1476,7 +1476,7 @@ dependencies = [
 [[package]]
 name = "codec"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "byteorder",
  "error_code",
@@ -1501,7 +1501,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "fxhash",
  "tikv_alloc",
@@ -2088,7 +2088,7 @@ dependencies = [
 [[package]]
 name = "encryption"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -2124,7 +2124,7 @@ dependencies = [
 [[package]]
 name = "engine_traits"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "bytes",
  "case_macros",
@@ -2227,7 +2227,7 @@ dependencies = [
 [[package]]
 name = "error_code"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "grpcio",
  "kvproto",
@@ -2335,7 +2335,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 [[package]]
 name = "file_system"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "collections",
  "crc32fast",
@@ -3424,7 +3424,7 @@ dependencies = [
 [[package]]
 name = "keys"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "byteorder",
  "kvproto",
@@ -3438,7 +3438,7 @@ dependencies = [
 [[package]]
 name = "kvengine"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "aligned-vec",
  "aliyun",
@@ -3546,7 +3546,7 @@ dependencies = [
 [[package]]
 name = "kvenginepb"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "protobuf 2.8.0",
  "protobuf-codegen-pure",
@@ -3845,7 +3845,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 [[package]]
 name = "log_wrappers"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "hex 0.4.3",
  "protobuf 2.8.0",
@@ -4317,7 +4317,7 @@ checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
 [[package]]
 name = "online_config"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "online_config_derive",
  "serde",
@@ -4327,7 +4327,7 @@ dependencies = [
 [[package]]
 name = "online_config_derive"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4524,7 +4524,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 [[package]]
 name = "pd_client"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "async-trait",
  "bstr",
@@ -5330,7 +5330,7 @@ dependencies = [
 [[package]]
 name = "recovery"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "dashmap 6.2.1",
  "http 0.2.12",
@@ -5831,7 +5831,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "api_version",
  "async-trait",
@@ -5880,7 +5880,7 @@ dependencies = [
 [[package]]
 name = "security"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "aliyun",
  "aws",
@@ -6658,7 +6658,7 @@ dependencies = [
 [[package]]
 name = "tencentcloud"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "async-trait",
  "aws",
@@ -6757,7 +6757,7 @@ dependencies = [
 [[package]]
 name = "tidb_query_common"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "anyhow",
  "api_version",
@@ -6785,7 +6785,7 @@ dependencies = [
 [[package]]
 name = "tidb_query_datatype"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "api_version",
  "base64 0.13.1",
@@ -6901,7 +6901,7 @@ dependencies = [
 [[package]]
 name = "tikv_alloc"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "fxhash",
  "lazy_static",
@@ -6912,7 +6912,7 @@ dependencies = [
 [[package]]
 name = "tikv_util"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "async-speed-limit",
  "backtrace",
@@ -7227,7 +7227,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 [[package]]
 name = "trace_event"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "arc-swap 1.9.1",
  "bitflags 1.3.2",
@@ -7317,7 +7317,7 @@ dependencies = [
 [[package]]
 name = "tracker"
 version = "0.0.1"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "collections",
  "crossbeam-utils",
@@ -7341,7 +7341,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "txn_types"
 version = "0.1.0"
-source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",

--- a/contrib/tiflash-columnar-hub/Cargo.toml
+++ b/contrib/tiflash-columnar-hub/Cargo.toml
@@ -3,15 +3,15 @@ members = ["hub-runtime"]
 resolver = "2"
 
 [workspace.dependencies]
-api_version = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", branch = "cloud-engine" }
-builtin_dfs = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", branch = "cloud-engine" }
-cloud_encryption = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", branch = "cloud-engine" }
-keys = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", branch = "cloud-engine" }
-kvengine = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", branch = "cloud-engine" }
-kvenginepb = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", branch = "cloud-engine" }
-pd_client = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", branch = "cloud-engine", default-features = false }
-security = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", branch = "cloud-engine", default-features = false }
-tikv_util = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", branch = "cloud-engine" }
+api_version = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", rev = "a9d93252f2ad0cba95eec51a857cd867cd5e6567" }
+builtin_dfs = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", rev = "a9d93252f2ad0cba95eec51a857cd867cd5e6567" }
+cloud_encryption = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", rev = "a9d93252f2ad0cba95eec51a857cd867cd5e6567" }
+keys = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", rev = "a9d93252f2ad0cba95eec51a857cd867cd5e6567" }
+kvengine = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", rev = "a9d93252f2ad0cba95eec51a857cd867cd5e6567" }
+kvenginepb = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", rev = "a9d93252f2ad0cba95eec51a857cd867cd5e6567" }
+pd_client = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", rev = "a9d93252f2ad0cba95eec51a857cd867cd5e6567", default-features = false }
+security = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", rev = "a9d93252f2ad0cba95eec51a857cd867cd5e6567", default-features = false }
+tikv_util = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", rev = "a9d93252f2ad0cba95eec51a857cd867cd5e6567" }
 
 [patch.crates-io]
 raft = { git = "https://github.com/tikv/raft-rs", branch = "master" }

--- a/contrib/tiflash-columnar-hub/Cargo.toml
+++ b/contrib/tiflash-columnar-hub/Cargo.toml
@@ -3,15 +3,15 @@ members = ["hub-runtime"]
 resolver = "2"
 
 [workspace.dependencies]
-api_version = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", rev = "a9d93252f2ad0cba95eec51a857cd867cd5e6567" }
-builtin_dfs = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", rev = "a9d93252f2ad0cba95eec51a857cd867cd5e6567" }
-cloud_encryption = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", rev = "a9d93252f2ad0cba95eec51a857cd867cd5e6567" }
-keys = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", rev = "a9d93252f2ad0cba95eec51a857cd867cd5e6567" }
-kvengine = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", rev = "a9d93252f2ad0cba95eec51a857cd867cd5e6567" }
-kvenginepb = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", rev = "a9d93252f2ad0cba95eec51a857cd867cd5e6567" }
-pd_client = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", rev = "a9d93252f2ad0cba95eec51a857cd867cd5e6567", default-features = false }
-security = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", rev = "a9d93252f2ad0cba95eec51a857cd867cd5e6567", default-features = false }
-tikv_util = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", rev = "a9d93252f2ad0cba95eec51a857cd867cd5e6567" }
+api_version = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", branch = "cloud-engine" }
+builtin_dfs = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", branch = "cloud-engine" }
+cloud_encryption = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", branch = "cloud-engine" }
+keys = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", branch = "cloud-engine" }
+kvengine = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", branch = "cloud-engine" }
+kvenginepb = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", branch = "cloud-engine" }
+pd_client = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", branch = "cloud-engine", default-features = false }
+security = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", branch = "cloud-engine", default-features = false }
+tikv_util = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", branch = "cloud-engine" }
 
 [patch.crates-io]
 raft = { git = "https://github.com/tikv/raft-rs", branch = "master" }

--- a/contrib/tiflash-columnar-hub/hub-runtime/build.rs
+++ b/contrib/tiflash-columnar-hub/hub-runtime/build.rs
@@ -1,0 +1,65 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::PathBuf;
+
+fn main() {
+    let lock_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../Cargo.lock");
+    println!("cargo:rerun-if-changed={}", lock_path.display());
+
+    let hash = std::fs::read_to_string(&lock_path)
+        .ok()
+        .and_then(|content| extract_kvengine_git_hash(&content))
+        .unwrap_or_else(|| "Unknown".to_string());
+
+    println!("cargo:rustc-env=CLOUD_STORAGE_ENGINE_GIT_HASH={hash}");
+}
+
+fn extract_kvengine_git_hash(content: &str) -> Option<String> {
+    for block in content.split("[[package]]") {
+        if !block.contains("name = \"kvengine\"") {
+            continue;
+        }
+        for line in block.lines() {
+            let Some(source) = line.strip_prefix("source = \"") else {
+                continue;
+            };
+            if let Some(rev_start) = source.find("?rev=") {
+                let rev_part = &source[rev_start + "?rev=".len()..];
+                let hash = rev_part.split('#').next()?.trim_end_matches('"');
+                return Some(hash.to_string());
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_kvengine_git_hash;
+
+    #[test]
+    fn test_extract_kvengine_git_hash() {
+        let lock = r#"
+[[package]]
+name = "kvengine"
+version = "0.0.1"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
+"#;
+        assert_eq!(
+            extract_kvengine_git_hash(lock),
+            Some("a9d93252f2ad0cba95eec51a857cd867cd5e6567".to_string())
+        );
+    }
+}

--- a/contrib/tiflash-columnar-hub/hub-runtime/build.rs
+++ b/contrib/tiflash-columnar-hub/hub-runtime/build.rs
@@ -26,6 +26,25 @@ fn main() {
     println!("cargo:rustc-env=CLOUD_STORAGE_ENGINE_GIT_HASH={hash}");
 }
 
+fn extract_git_hash_from_source(source: &str) -> Option<String> {
+    if let Some(hash_start) = source.rfind('#') {
+        let hash = source[hash_start + 1..].trim_end_matches('"');
+        if !hash.is_empty() {
+            return Some(hash.to_string());
+        }
+    }
+
+    if let Some(rev_start) = source.find("?rev=") {
+        let rev_part = &source[rev_start + "?rev=".len()..];
+        let hash = rev_part.split('#').next()?.trim_end_matches('"');
+        if !hash.is_empty() {
+            return Some(hash.to_string());
+        }
+    }
+
+    None
+}
+
 fn extract_kvengine_git_hash(content: &str) -> Option<String> {
     for block in content.split("[[package]]") {
         if !block.contains("name = \"kvengine\"") {
@@ -35,10 +54,8 @@ fn extract_kvengine_git_hash(content: &str) -> Option<String> {
             let Some(source) = line.strip_prefix("source = \"") else {
                 continue;
             };
-            if let Some(rev_start) = source.find("?rev=") {
-                let rev_part = &source[rev_start + "?rev=".len()..];
-                let hash = rev_part.split('#').next()?.trim_end_matches('"');
-                return Some(hash.to_string());
+            if let Some(hash) = extract_git_hash_from_source(source) {
+                return Some(hash);
             }
         }
     }
@@ -50,12 +67,26 @@ mod tests {
     use super::extract_kvengine_git_hash;
 
     #[test]
-    fn test_extract_kvengine_git_hash() {
+    fn test_extract_kvengine_git_hash_from_rev() {
         let lock = r#"
 [[package]]
 name = "kvengine"
 version = "0.0.1"
 source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?rev=a9d93252f2ad0cba95eec51a857cd867cd5e6567#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
+"#;
+        assert_eq!(
+            extract_kvengine_git_hash(lock),
+            Some("a9d93252f2ad0cba95eec51a857cd867cd5e6567".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_kvengine_git_hash_from_branch() {
+        let lock = r#"
+[[package]]
+name = "kvengine"
+version = "0.0.1"
+source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud-engine#a9d93252f2ad0cba95eec51a857cd867cd5e6567"
 "#;
         assert_eq!(
             extract_kvengine_git_hash(lock),

--- a/contrib/tiflash-columnar-hub/hub-runtime/src/lib.rs
+++ b/contrib/tiflash-columnar-hub/hub-runtime/src/lib.rs
@@ -50,15 +50,21 @@ pub use self::{
 
 use std::os::raw::{c_char, c_int};
 
-fn proxy_version_info() -> String {
+pub(crate) fn proxy_version_info() -> String {
     let fallback = "Unknown";
     format!(
-        "Git Commit Hash:   {}\nGit Commit Branch: {}\nRust Version:      {}\nProfile:           {}",
-        option_env!("PROXY_BUILD_GIT_HASH").unwrap_or(fallback),
-        option_env!("PROXY_BUILD_GIT_BRANCH").unwrap_or(fallback),
+        "Git Commit Hash:   {}\nRust Version:      {}\nProfile:           {}",
+        option_env!("CLOUD_STORAGE_ENGINE_GIT_HASH").unwrap_or(fallback),
         option_env!("PROXY_BUILD_RUSTC_VERSION").unwrap_or(fallback),
         option_env!("PROXY_PROFILE").unwrap_or(fallback),
     )
+}
+
+pub(crate) fn log_columnar_hub_info() {
+    info!("Welcome to TiFlash Columnar");
+    for line in proxy_version_info().lines() {
+        info!("{}", line);
+    }
 }
 
 #[no_mangle]

--- a/contrib/tiflash-columnar-hub/hub-runtime/src/lib.rs
+++ b/contrib/tiflash-columnar-hub/hub-runtime/src/lib.rs
@@ -60,13 +60,6 @@ pub(crate) fn proxy_version_info() -> String {
     )
 }
 
-pub(crate) fn log_columnar_hub_info() {
-    info!("Welcome to TiFlash Columnar");
-    for line in proxy_version_info().lines() {
-        info!("{}", line);
-    }
-}
-
 #[no_mangle]
 pub unsafe extern "C" fn print_raftstore_proxy_version() {
     println!("{}", proxy_version_info());

--- a/contrib/tiflash-columnar-hub/hub-runtime/src/run.rs
+++ b/contrib/tiflash-columnar-hub/hub-runtime/src/run.rs
@@ -1178,6 +1178,7 @@ pub unsafe fn run_proxy(argc: c_int, argv: *const *const c_char, helper_ptr: *co
     let mut config = load_config(matches.value_of_os("config"));
     let init_only = overwrite_config_with_cmd_args(&mut config, &matches);
     init_hub_logger(&config);
+    crate::log_columnar_hub_info();
     config.security.override_from_env();
     config.dfs.override_from_env();
     config.pd.validate().unwrap();

--- a/contrib/tiflash-columnar-hub/hub-runtime/src/run.rs
+++ b/contrib/tiflash-columnar-hub/hub-runtime/src/run.rs
@@ -517,6 +517,13 @@ fn init_hub_logger(config: &ConfigFile) {
     }
 }
 
+fn log_columnar_hub_info() {
+    info!("Welcome to TiFlash Columnar");
+    for line in crate::proxy_version_info().lines() {
+        info!("{}", line);
+    }
+}
+
 fn build_cli_app<'a, 'b>() -> App<'a, 'b> {
     App::new("TiFlash Columnar Hub")
         .arg(
@@ -1178,7 +1185,7 @@ pub unsafe fn run_proxy(argc: c_int, argv: *const *const c_char, helper_ptr: *co
     let mut config = load_config(matches.value_of_os("config"));
     let init_only = overwrite_config_with_cmd_args(&mut config, &matches);
     init_hub_logger(&config);
-    crate::log_columnar_hub_info();
+    log_columnar_hub_info();
     config.security.override_from_env();
     config.dfs.override_from_env();
     config.pd.validate().unwrap();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10852

Problem Summary:

On next-gen / disaggregated columnar read path, queries succeed but omit the row whose clustered BIGINT PK is `9223372036854775807` (`i64::MAX`). For example, `SELECT * FROM t WHERE a > INT64_MIN` returns only the `0` row on TiFlash instead of both `0` and `INT64_MAX`. Full table scan and `COUNT(*)` also report 2 rows instead of 3.

Root cause is in `cloud-storage-engine` / `kvengine`: when building columnar handle index, `next_handle + 1` overflows at `i64::MAX`, so no sentinel is appended and the last pack cannot be read via seek.

### What is changed and how it works?

```commit-message
columnar-hub: bump cloud-storage-engine to a9d93252f and add AGENTS.md
columnar-hub: report cloud-storage-engine version at startup
```

- Bump `cloud-storage-engine` (kvengine and related crates) to revision `a9d93252f`, which fixes handle-index sentinel handling when max clustered PK is `i64::MAX`.
- Add `contrib/tiflash-columnar-hub/AGENTS.md` documenting how to maintain the columnar-hub dependency.
- Embed kvengine git rev from `Cargo.lock` in version output and log it at startup for easier on-cluster debugging.

After deploying, rebuild/restart TiFlash and rebuild or re-compact columnar files for affected tables before re-running SQL verification.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix next-gen columnar read missing rows when clustered BIGINT primary key is INT64_MAX.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive guide for the columnar hub architecture and operational workflows.
  * Added contribution guidelines documenting fork and pull request procedures.

* **Improvements**
  * Enhanced startup logging to display version information, now including cloud-storage-engine Git hash.
  * Version details are now logged at startup for better operational visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tiflash/pull/10869?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->