### PR TITLE
columnar: fix null pointer panic

### DIFF
--- a/dbms/src/Storages/StorageDisaggregatedColumnar.cpp
+++ b/dbms/src/Storages/StorageDisaggregatedColumnar.cpp
@@ -803,13 +803,15 @@ RNProxyInputStream::~RNProxyInputStream()
             total_bytes,
             duration_read_sec,
             duration_deserialize_sec);
-        auto * dag_context = context.getDAGContext();
-        if (auto it = dag_context->scan_context_map.find(executor_id); it != dag_context->scan_context_map.end())
+        if (auto * dag_context = context.getDAGContext(); dag_context != nullptr)
         {
-            if (it->second)
+            if (auto it = dag_context->scan_context_map.find(executor_id); it != dag_context->scan_context_map.end())
             {
-                std::optional<LACBytesCollector> lac_bytes_collector;
-                it->second->addUserReadBytes(total_bytes, DM::ReadTag::Query, lac_bytes_collector);
+                if (it->second)
+                {
+                    std::optional<LACBytesCollector> lac_bytes_collector;
+                    it->second->addUserReadBytes(total_bytes, DM::ReadTag::Query, lac_bytes_collector);
+                }
             }
         }
     }

--- a/dbms/src/Storages/StorageDisaggregatedColumnar.h
+++ b/dbms/src/Storages/StorageDisaggregatedColumnar.h
@@ -167,7 +167,7 @@ private:
     ColumnarReaderPtr reader;
     AddExtraTableIDColumnTransformAction action;
     TableID table_id;
-    const String & executor_id;
+    const String executor_id;
     Block header;
 
     bool done = false;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10873 

Problem Summary:
NULL pointer exception during tpch benchmark.

### What is changed and how it works?
Use value to save `executor_id` instead of reference to avoid dangling pointer.

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below) tpch-50 & tpch-500
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Resolved a potential crash in data stream retrieval operations by adding proper null validation during resource cleanup, improving system stability when handling unavailable contexts.
* Enhanced internal memory management for storage components to ensure safer and more predictable handling of resource lifecycles and object ownership semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tiflash/pull/10875?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->