### PR TITLE
Support FTS no-score queries in DeltaMerge

### DIFF
--- a/dbms/src/Storages/DeltaMerge/Index/FullTextIndex/Stream/BruteScoreInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/FullTextIndex/Stream/BruteScoreInputStream.cpp
@@ -86,7 +86,7 @@ Block FullTextBruteScoreInputStream::read()
     // will not do a TopK again for unindexed data.
     {
         const auto top_k = ctx->fts_query_info->top_k();
-        if (top_k < ctx->results.size())
+        if (ctx->fts_query_info->query_type() == tipb::FTSQueryTypeWithScore && top_k < ctx->results.size())
         {
             std::nth_element( //
                 ctx->results.begin(),
@@ -116,7 +116,8 @@ Block FullTextBruteScoreInputStream::read()
 
     // Finally, reassemble the block.
     // The current layout of block is `noindex_read_schema` which is `rest_col_schema + fts_col`.
-    // The target layout of block is `schema` which is `rest_col_schema + (possibly fts column somewhere) + score_col`.
+    // The target layout of block is `schema` which is `rest_col_schema + (possibly fts column somewhere) +
+    // optional score_col`.
     {
         // 1. Remove the FTS column at last
         const auto fts_column_filtered = block.safeGetByPosition(block.columns() - 1).column;
@@ -135,20 +136,23 @@ Block FullTextBruteScoreInputStream::read()
                     ctx->fts_cd_in_schema->name,
                     ctx->fts_cd_in_schema->id));
         }
-        // 3. Add Score column at last
-        auto score_column = ctx->score_cd_in_schema.type->createColumn();
-        score_column->reserve(ctx->results.size());
-        // ctx->results are already sorted by rowid, so let's just insert them sequentially.
-        // An alternative is to first create a score Column with full length, then assign the scores according to rowid
-        // and finally filter the column. This does not need to sort the `results` by `doc_id`. However this requires
-        // allocating large bulk of memory and could be slower then the current approach.
-        for (const auto & result : ctx->results)
-            score_column->insert(static_cast<Float64>(result.score));
-        block.insert(ColumnWithTypeAndName( //
-            std::move(score_column),
-            ctx->score_cd_in_schema.type,
-            ctx->score_cd_in_schema.name,
-            ctx->score_cd_in_schema.id));
+        // 3. Add Score column at last if requested
+        if (ctx->score_cd_in_schema.has_value())
+        {
+            auto score_column = ctx->score_cd_in_schema->type->createColumn();
+            score_column->reserve(ctx->results.size());
+            // ctx->results are already sorted by rowid, so let's just insert them sequentially.
+            // An alternative is to first create a score Column with full length, then assign the scores according to
+            // rowid and finally filter the column. This does not need to sort the `results` by `doc_id`. However this
+            // requires allocating large bulk of memory and could be slower then the current approach.
+            for (const auto & result : ctx->results)
+                score_column->insert(static_cast<Float64>(result.score));
+            block.insert(ColumnWithTypeAndName( //
+                std::move(score_column),
+                ctx->score_cd_in_schema->type,
+                ctx->score_cd_in_schema->name,
+                ctx->score_cd_in_schema->id));
+        }
     }
 
     RUNTIME_CHECK(block.columns() == ctx->schema->size());

--- a/dbms/src/Storages/DeltaMerge/Index/FullTextIndex/Stream/ColumnFileInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/FullTextIndex/Stream/ColumnFileInputStream.cpp
@@ -107,6 +107,7 @@ Block ColumnFileProvideFullTextIndexInputStream::read()
     }
     // Fill score column
     MutableColumnPtr score_col_p = nullptr;
+    if (ctx->score_cd_in_schema.has_value())
     {
         score_col_p = ColumnFloat32::create();
         auto * score_col = typeid_cast<ColumnFloat32 *>(score_col_p.get());
@@ -150,12 +151,13 @@ Block ColumnFileProvideFullTextIndexInputStream::read()
                 ctx->fts_cd_in_schema->name,
                 ctx->fts_cd_in_schema->id));
     }
+    if (ctx->score_cd_in_schema.has_value())
     {
         block.insert(ColumnWithTypeAndName( //
             std::move(score_col_p),
-            ctx->score_cd_in_schema.type,
-            ctx->score_cd_in_schema.name,
-            ctx->score_cd_in_schema.id));
+            ctx->score_cd_in_schema->type,
+            ctx->score_cd_in_schema->name,
+            ctx->score_cd_in_schema->id));
     }
 
     // After a successful read, clear out the ordered_return_rows so that

--- a/dbms/src/Storages/DeltaMerge/Index/FullTextIndex/Stream/Ctx.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/FullTextIndex/Stream/Ctx.cpp
@@ -49,18 +49,23 @@ auto buildCtx(
     RUNTIME_CHECK(fts_query_info != nullptr);
     RUNTIME_CHECK(schema != nullptr);
 
-    // Currently only TopK is supported.
-    RUNTIME_CHECK(fts_query_info->query_type() == tipb::FTSQueryTypeWithScore);
+    RUNTIME_CHECK(
+        fts_query_info->query_type() == tipb::FTSQueryTypeWithScore
+        || fts_query_info->query_type() == tipb::FTSQueryTypeNoScore);
     RUNTIME_CHECK(fts_query_info->has_index_id());
     RUNTIME_CHECK(fts_query_info->columns().size() == 1);
 
     RUNTIME_CHECK(!schema->empty());
-    auto score_cd_in_schema = schema->back();
-    RUNTIME_CHECK(score_cd_in_schema.id == FullTextIndexStreamCtx::VIRTUAL_SCORE_CD.id);
-    RUNTIME_CHECK(score_cd_in_schema.type->equals(*FullTextIndexStreamCtx::VIRTUAL_SCORE_CD.type));
+    std::optional<ColumnDefine> score_cd_in_schema;
+    if (fts_query_info->query_type() == tipb::FTSQueryTypeWithScore)
+    {
+        score_cd_in_schema.emplace(schema->back());
+        RUNTIME_CHECK(score_cd_in_schema->id == FullTextIndexStreamCtx::VIRTUAL_SCORE_CD.id);
+        RUNTIME_CHECK(score_cd_in_schema->type->equals(*FullTextIndexStreamCtx::VIRTUAL_SCORE_CD.type));
+    }
 
     auto rest_col_schema = std::make_shared<ColumnDefines>();
-    rest_col_schema->reserve(schema->size() - 1);
+    rest_col_schema->reserve(schema->size() - (score_cd_in_schema.has_value() ? 1 : 0));
 
     ColumnID fts_col_id = fts_query_info->columns()[0].column_id();
     std::optional<size_t> fts_idx_in_schema;
@@ -73,7 +78,7 @@ auto buildCtx(
             fts_idx_in_schema.emplace(i);
             fts_cd_in_schema.emplace(cd);
         }
-        if (cd.id != score_cd_in_schema.id && cd.id != fts_col_id)
+        if ((!score_cd_in_schema.has_value() || cd.id != score_cd_in_schema->id) && cd.id != fts_col_id)
         {
             rest_col_schema->emplace_back(cd);
         }

--- a/dbms/src/Storages/DeltaMerge/Index/FullTextIndex/Stream/Ctx.h
+++ b/dbms/src/Storages/DeltaMerge/Index/FullTextIndex/Stream/Ctx.h
@@ -37,16 +37,13 @@ struct FullTextIndexStreamCtx
     /// Notice: name must not be used because ExchangeReceiver expects some different names
     static const ColumnDefine VIRTUAL_SCORE_CD;
 
-    // Note: Currently FTSQueryInfo always asks Storage layer to return
-    // an additional score column, with columnId=-2050.
-
     const LocalIndexCachePtr index_cache_light; // nullable
     const LocalIndexCachePtr index_cache_heavy; // nullable
     const FTSQueryInfoPtr fts_query_info;
 
     /// This is what TiDB asks TiFlashTableScan to return (i.e. TableScan's schema)
-    /// It always contains the score column at last. The score column must match the constant
-    //// VIRTUAL_SCORE_CD.
+    /// It contains the score column at last only when FTSQueryTypeWithScore is requested.
+    /// The score column must match the constant VIRTUAL_SCORE_CD.
     /// It may, or may not contain the FTS column, depends on whether user asks for it.
     const ColumnDefinesPtr schema;
     /// The FTS column index in the `schema`, if exists. This may be `nullopt`
@@ -55,10 +52,10 @@ struct FullTextIndexStreamCtx
     /// The ColumnDefinition of the FTS column when it is presented in `schema`.
     /// It could be `nullopt` if the FTS column is not in the schema.
     const std::optional<ColumnDefine> fts_cd_in_schema;
-    /// The ColumnDefinition of the score column in `schema`.
+    /// The ColumnDefinition of the score column in `schema`, if FTSQueryTypeWithScore is requested.
     /// It should be the same as `VIRTUAL_SCORE_CD` except the name (which may be changed by ExchangeReceiver).
-    const ColumnDefine score_cd_in_schema;
-    /// Roughtly, `rest_col_schema=schema-score_col-optional_fts_col`. This is used
+    const std::optional<ColumnDefine> score_cd_in_schema;
+    /// Roughtly, `rest_col_schema=schema-optional_score_col-optional_fts_col`. This is used
     /// to fill the content of the block after we have finished FullTextSearch.
     /// The column order must be the same as in `schema`.
     const ColumnDefinesPtr rest_col_schema;
@@ -96,6 +93,8 @@ struct FullTextIndexStreamCtx
     rust::String text_value;
     /// reused in each read()
     rust::Vec<ClaraFTS::ScoredResult> results;
+    /// reused in each read() when score is not needed.
+    rust::Vec<UInt32> no_score_results;
     /// reused in each read() when a scoring on-demand search is needed.
     /// Use ensureBruteScoredSearcher() for an easy access.
     std::optional<rust::Box<ClaraFTS::BruteScoredSearcher>> brute_searcher;

--- a/dbms/src/Storages/DeltaMerge/Index/FullTextIndex/Stream/DMFileInputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/FullTextIndex/Stream/DMFileInputStream.cpp
@@ -83,6 +83,7 @@ Block DMFileInputStreamProvideFullTextIndex::read()
     }
     // Fill score column
     MutableColumnPtr score_col_p = nullptr;
+    if (ctx->score_cd_in_schema.has_value())
     {
         score_col_p = ColumnFloat32::create();
         auto * score_col = typeid_cast<ColumnFloat32 *>(score_col_p.get());
@@ -128,12 +129,13 @@ Block DMFileInputStreamProvideFullTextIndex::read()
                                   ctx->fts_cd_in_schema->name,
                                   ctx->fts_cd_in_schema->id});
     }
+    if (ctx->score_cd_in_schema.has_value())
     {
         block.insert(ColumnWithTypeAndName( //
             std::move(score_col_p),
-            ctx->score_cd_in_schema.type,
-            ctx->score_cd_in_schema.name,
-            ctx->score_cd_in_schema.id));
+            ctx->score_cd_in_schema->type,
+            ctx->score_cd_in_schema->name,
+            ctx->score_cd_in_schema->id));
     }
 
     block.setStartOffset(start_row_offset);

--- a/dbms/src/Storages/DeltaMerge/Index/FullTextIndex/Stream/InputStream.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/FullTextIndex/Stream/InputStream.cpp
@@ -39,6 +39,8 @@ void FullTextIndexInputStream::initSearchResults()
     // Note, we do not reserve size=topN, because we first append all matching results, then perform the topn.
     search_results->reserve(bitmap_filter->size() / 2);
 
+    const bool with_score = ctx->fts_query_info->query_type() == tipb::FTSQueryTypeWithScore;
+
     // 1. Do full text search for all index streams.
     for (size_t i = 0, i_max = stream->children.size(); i < i_max; ++i)
     {
@@ -47,16 +49,36 @@ void FullTextIndexInputStream::initSearchResults()
             auto reader = index_stream->getFullTextIndexReader();
             RUNTIME_CHECK(reader != nullptr);
             auto current_filter = BitmapFilterView(bitmap_filter, precedes_rows, stream->rows[i]);
-            reader->searchScored(ctx->perf, ctx->fts_query_info->query_text(), current_filter, ctx->results);
-            const size_t results_n = ctx->results.size();
-            for (size_t i = 0; i < results_n; ++i)
+            if (with_score)
             {
-                search_results->emplace_back(IProvideFullTextIndex::SearchResult{
-                    // We need to sort globally so convert it to a global offset temporarily.
-                    // We will convert it back to local offset when we feed it back to substreams.
-                    .rowid = ctx->results[i].doc_id + precedes_rows,
-                    .score = ctx->results[i].score,
-                });
+                reader->searchScored(ctx->perf, ctx->fts_query_info->query_text(), current_filter, ctx->results);
+                const size_t results_n = ctx->results.size();
+                for (size_t i = 0; i < results_n; ++i)
+                {
+                    search_results->emplace_back(IProvideFullTextIndex::SearchResult{
+                        // We need to sort globally so convert it to a global offset temporarily.
+                        // We will convert it back to local offset when we feed it back to substreams.
+                        .rowid = ctx->results[i].doc_id + precedes_rows,
+                        .score = ctx->results[i].score,
+                    });
+                }
+            }
+            else
+            {
+                reader->searchNoScore(
+                    ctx->perf,
+                    ctx->fts_query_info->query_text(),
+                    current_filter,
+                    ctx->no_score_results);
+                const size_t results_n = ctx->no_score_results.size();
+                for (size_t i = 0; i < results_n; ++i)
+                {
+                    search_results->emplace_back(IProvideFullTextIndex::SearchResult{
+                        // We need to sort globally so convert it to a global offset temporarily.
+                        // We will convert it back to local offset when we feed it back to substreams.
+                        .rowid = ctx->no_score_results[i] + precedes_rows,
+                    });
+                }
             }
         }
         precedes_rows += stream->rows[i];
@@ -65,7 +87,7 @@ void FullTextIndexInputStream::initSearchResults()
     // 2. Keep the top k minimum scored rows.
     // [0, top_k) will be the top k largest score rows. (However it is not sorted)
     const auto top_k = ctx->fts_query_info->top_k();
-    if (top_k < search_results->size())
+    if (with_score && top_k < search_results->size())
     {
         std::nth_element( //
             search_results->begin(),

--- a/dbms/src/Storages/DeltaMerge/Index/FullTextIndex/tests/gtest_dm_fulltext_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/FullTextIndex/tests/gtest_dm_fulltext_index.cpp
@@ -175,6 +175,30 @@ protected:
             std::make_shared<BitmapFilter>(mvcc_bitmap_init));
     }
 
+    BlockInputStreamPtr searchFromDMFileNoScore(
+        FtsQueryInfoNoScoreOptions options,
+        std::initializer_list<UInt8> mvcc_bitmap_init)
+    {
+        auto read_cols = std::make_shared<ColumnDefines>();
+        read_cols->emplace_back(getExtraHandleColumnDefine(/* common_handle */ false));
+        if (!test_no_fts_column)
+            read_cols->emplace_back(cdFts());
+
+        DMFileBlockInputStreamBuilder builder(dbContext());
+
+        auto fts_idx_ctx = FullTextIndexStreamCtx::createForStableOnlyTests(ftsQueryInfoNoScore(options), read_cols);
+        auto stream = builder.setFtsIndexQuery(fts_idx_ctx)
+                          .build(
+                              dm_file,
+                              *read_cols,
+                              RowKeyRanges{RowKeyRange::newAll(false, 1)},
+                              std::make_shared<ScanContext>());
+        return FullTextIndexTestUtils::wrapFTSStream( //
+            fts_idx_ctx,
+            stream,
+            std::make_shared<BitmapFilter>(mvcc_bitmap_init));
+    }
+
     Block searchFromDMFileAndSort(FtsQueryInfoTopKOptions options, std::initializer_list<UInt8> mvcc_bitmap_init)
     {
         auto stream = searchFromDMFile(options, mvcc_bitmap_init);
@@ -332,6 +356,37 @@ try
                 createColumn<String>({}),
             }));
     }
+}
+CATCH
+
+TEST_P(FullTextIndexDMFileTestWithNoIndex, OnePackNoScore)
+try
+{
+    writeDMFile({
+        "Who knew the people would adore me so much?",
+        "Being too popular can be such a hassle",
+        "The world is but a stage.",
+    });
+    dm_file = restoreDMFile();
+    if (!test_no_index)
+        dm_file = buildIndex(TiDB::FullTextIndexDefinition{
+            .parser_type = "STANDARD_V1",
+        });
+
+    // top_k should not truncate rows for NoScore queries.
+    auto stream = searchFromDMFileNoScore( //
+        {.query = "the", .top_k = 1},
+        /* bitmap_filter */ {1, 1, 1});
+    ASSERT_INPUTSTREAM_COLS_UR(
+        stream,
+        createColumnNames(),
+        createColumnData({
+            createColumn<Int64>({0, 2}),
+            createColumn<String>({
+                "Who knew the people would adore me so much?",
+                "The world is but a stage.",
+            }),
+        }));
 }
 CATCH
 
@@ -565,6 +620,22 @@ public:
             segment_end_key,
             *read_cols,
             ftsQueryInfoTopK({.query = query, .top_k = top_k}));
+    }
+
+    BlockInputStreamPtr ftsQueryNoScore(PageIdU64 segment_id, const String & query, UInt32 top_k = 0)
+    {
+        auto read_cols = std::make_shared<ColumnDefines>();
+        read_cols->emplace_back(getExtraHandleColumnDefine(/* common_handle */ false));
+        if (!test_no_fts_column)
+            read_cols->emplace_back(cdFts());
+
+        auto [segment_start_key, segment_end_key] = getSegmentKeyRange(segment_id);
+        return read(
+            segment_id,
+            segment_start_key,
+            segment_end_key,
+            *read_cols,
+            ftsQueryInfoNoScore({.query = query, .top_k = top_k}));
     }
 
     BlockInputStreamPtr ftsQueryAll(PageIdU64 segment_id, const String & query)
@@ -840,6 +911,23 @@ try
     assertStreamOut(stream, "[20, 21)");
 
     stream = ftsQueryAll(DELTA_MERGE_FIRST_SEGMENT_ID, "word");
+    assertStreamOut(stream, "[0, 5)|[20, 30)");
+}
+CATCH
+
+TEST_P(FullTextIndexSegmentTest1, HybridStableAndDeltaNoScore)
+try
+{
+    ingestDTFileIntoDelta(DELTA_MERGE_FIRST_SEGMENT_ID, 5, /* at */ 0, /* clear */ false);
+    flushSegmentCache(DELTA_MERGE_FIRST_SEGMENT_ID);
+    mergeSegmentDelta(DELTA_MERGE_FIRST_SEGMENT_ID);
+    ensureSegmentStableLocalIndex(DELTA_MERGE_FIRST_SEGMENT_ID, indexInfo());
+
+    writeSegment(DELTA_MERGE_FIRST_SEGMENT_ID, 10, /* at */ 20);
+
+    // NoScore should filter both stable index data and delta fallback data without returning a score column.
+    // It should also ignore top_k because scores are not requested.
+    auto stream = ftsQueryNoScore(DELTA_MERGE_FIRST_SEGMENT_ID, "word", /* top_k */ 1);
     assertStreamOut(stream, "[0, 5)|[20, 30)");
 }
 CATCH

--- a/dbms/src/Storages/DeltaMerge/Index/FullTextIndex/tests/gtest_dm_fulltext_index_utils.h
+++ b/dbms/src/Storages/DeltaMerge/Index/FullTextIndex/tests/gtest_dm_fulltext_index_utils.h
@@ -70,10 +70,33 @@ public:
         Int64 index_id = 42; // fts_index_id
     };
 
+    struct FtsQueryInfoNoScoreOptions
+    {
+        String query;
+        UInt32 top_k = 0;
+        Int64 column_id = 130; // fts_column_id
+        Int64 index_id = 42; // fts_index_id
+    };
+
     static FTSQueryInfoPtr ftsQueryInfoTopK(FtsQueryInfoTopKOptions options)
     {
         auto fts_query_info = std::make_shared<tipb::FTSQueryInfo>();
         fts_query_info->set_query_type(tipb::FTSQueryType::FTSQueryTypeWithScore);
+        fts_query_info->set_index_id(options.index_id);
+        auto * column_info = fts_query_info->add_columns();
+        column_info->set_column_id(options.column_id);
+        column_info->set_tp(TiDB::TP::TypeString);
+        column_info->set_flag(TiDB::ColumnFlagNotNull);
+        fts_query_info->set_top_k(options.top_k);
+        fts_query_info->set_query_text(options.query);
+        fts_query_info->set_query_tokenizer("STANDARD_V1");
+        return fts_query_info;
+    }
+
+    static FTSQueryInfoPtr ftsQueryInfoNoScore(FtsQueryInfoNoScoreOptions options)
+    {
+        auto fts_query_info = std::make_shared<tipb::FTSQueryInfo>();
+        fts_query_info->set_query_type(tipb::FTSQueryType::FTSQueryTypeNoScore);
         fts_query_info->set_index_id(options.index_id);
         auto * column_info = fts_query_info->add_columns();
         column_info->set_column_id(options.column_id);
@@ -104,7 +127,8 @@ public:
         auto stream = ConcatSkippableBlockInputStream<false>::create(
             /* inputs */ {inner},
             /* rows */ {filter->size()},
-            /* ScanContext */ nullptr);
+            /* ScanContext */ nullptr,
+            /* read_tag */ ReadTag::Internal);
         return FullTextIndexInputStream::create(ctx, filter, stream);
     }
 };


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Full-text index queries now support execution without score results, allowing queries to omit the score column from output data.

* **Tests**
  * Added test coverage for no-score full-text index queries and operations across stable and delta data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->