### PR TITLE
Reject duplicate pending MPP connection requests

### DIFF
--- a/dbms/src/Flash/Mpp/MPPTaskManager.cpp
+++ b/dbms/src/Flash/Mpp/MPPTaskManager.cpp
@@ -249,10 +249,20 @@ std::pair<MPPTunnelPtr, String> MPPTaskManager::findAsyncTunnel(
             if (gather_task_set == nullptr)
                 gather_task_set = query->addMPPGatherTaskSet(id.gather_id);
             auto & alarm = call_data->getAlarm();
+            auto & alarms_by_receiver_task_id = gather_task_set->alarms[sender_task_id];
+            if (alarms_by_receiver_task_id.find(receiver_task_id) != alarms_by_receiver_task_id.end())
+            {
+                return {
+                    nullptr,
+                    fmt::format(
+                        "{}: duplicated establish mpp connection request while waiting for task [{}]",
+                        req_info,
+                        id.toString())};
+            }
             call_data->setCallStateAndUpdateMetrics(
                 EstablishCallData::WAIT_TUNNEL,
                 GET_METRIC(tiflash_establish_calldata_count, type_wait_tunnel_calldata));
-            gather_task_set->alarms[sender_task_id].emplace(receiver_task_id, std::ref(alarm));
+            alarms_by_receiver_task_id.emplace(receiver_task_id, std::ref(alarm));
             if likely (cq != nullptr)
             {
                 alarm.Set(cq, Clock::now() + std::chrono::seconds(10), call_data->asGRPCKickTag());

--- a/dbms/src/Flash/Mpp/tests/gtest_mpp_task_manager.cpp
+++ b/dbms/src/Flash/Mpp/tests/gtest_mpp_task_manager.cpp
@@ -118,6 +118,32 @@ try
 }
 CATCH
 
+TEST_F(TestMPPTaskManager, testDuplicatePendingAsyncTunnel)
+try
+{
+    auto context = createContextForTest();
+
+    mpp::EstablishMPPConnectionRequest establish_req;
+    auto gather_id = MPPGatherId(1, MPPQueryId(1, 1, 1, 1, "", 1, ""));
+    auto * receiver_meta = establish_req.mutable_receiver_meta();
+    fillTaskMeta(receiver_meta, 2, gather_id);
+    auto * sender_meta = establish_req.mutable_sender_meta();
+    fillTaskMeta(sender_meta, 1, gather_id);
+    auto mpp_task_manager = context->getTMTContext().getMPPTaskManager();
+
+    EstablishCallData first_call_data;
+    auto find_tunnel_result = mpp_task_manager->findAsyncTunnel(&establish_req, &first_call_data, nullptr, *context);
+    ASSERT_TRUE(find_tunnel_result.first == nullptr && find_tunnel_result.second.empty());
+    ASSERT_TRUE(first_call_data.isWaitingTunnelState());
+
+    EstablishCallData duplicate_call_data;
+    find_tunnel_result = mpp_task_manager->findAsyncTunnel(&establish_req, &duplicate_call_data, nullptr, *context);
+    ASSERT_TRUE(find_tunnel_result.first == nullptr);
+    ASSERT_TRUE(!find_tunnel_result.second.empty());
+    ASSERT_FALSE(duplicate_call_data.isWaitingTunnelState());
+}
+CATCH
+
 TEST_F(TestMPPTaskManager, testDuplicateMPPTaskId)
 try
 {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10889

Problem Summary:

Duplicate pending MPP establish connection requests for the same sender/receiver pair can overwrite the stored grpc alarm reference in `MPPTaskManager`, leaving the previous pending call data/alarm unmanaged.

### What is changed and how it works?

```commit-message
Reject duplicate pending MPP connection requests
```

When an MPP establish connection request arrives before the sender task is visible, TiFlash stores the grpc alarm by `<sender_task_id, receiver_task_id>`. This PR rejects a second pending request for the same pair instead of storing another alarm reference.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Reject duplicate pending MPP establish connection requests.
```