### PR TITLE
release: Add github action for tiflash builder image for the internal CD pipeline

### DIFF
--- a/.github/workflows/build-tiflash-llvm-base-image.yml
+++ b/.github/workflows/build-tiflash-llvm-base-image.yml
@@ -1,0 +1,235 @@
+name: Build TiFlash LLVM Base Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_name:
+        description: "Target GHCR image name. Leave empty to use ghcr.io/<owner>/<repo>/tiflash-llvm-base."
+        required: false
+        type: string
+      tag:
+        description: "Tag for the merged multi-arch image."
+        required: true
+        default: "llvm17-rocky8"
+        type: string
+      upload_artifacts:
+        description: "Upload downloadable image archives after publishing the multi-arch image."
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_DOCKERFILE: ./release-linux-llvm/dockerfiles/Dockerfile-tiflash-llvm-base
+  IMAGE_BUILD_CONTEXT: ./release-linux-llvm/dockerfiles
+
+jobs:
+  build:
+    name: Build ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+            docker_arch: amd64
+            tiflash_arch: x86_64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            docker_arch: arm64
+            tiflash_arch: aarch64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare image metadata
+        id: meta
+        shell: bash
+        env:
+          INPUT_IMAGE_NAME: ${{ inputs.image_name }}
+        run: |
+          set -euo pipefail
+
+          if [[ -n "${INPUT_IMAGE_NAME}" ]]; then
+            image_name="${INPUT_IMAGE_NAME}"
+          else
+            image_name="ghcr.io/${GITHUB_REPOSITORY}/tiflash-llvm-base"
+          fi
+
+          image_name="${image_name,,}"
+          if [[ "${image_name}" != ghcr.io/* ]]; then
+            echo "This workflow logs in with GITHUB_TOKEN and only supports ghcr.io image names." >&2
+            exit 1
+          fi
+
+          echo "image_name=${image_name}" >> "${GITHUB_OUTPUT}"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: ${{ env.IMAGE_BUILD_CONTEXT }}
+          file: ${{ env.IMAGE_DOCKERFILE }}
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            arch=${{ matrix.tiflash_arch }}
+          outputs: type=image,name=${{ steps.meta.outputs.image_name }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p "${RUNNER_TEMP}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${RUNNER_TEMP}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.docker_arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge and package image
+    runs-on: ubuntu-24.04
+    needs: build
+
+    steps:
+      - name: Prepare image metadata
+        id: meta
+        shell: bash
+        env:
+          INPUT_IMAGE_NAME: ${{ inputs.image_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+
+          if [[ -n "${INPUT_IMAGE_NAME}" ]]; then
+            image_name="${INPUT_IMAGE_NAME}"
+          else
+            image_name="ghcr.io/${GITHUB_REPOSITORY}/tiflash-llvm-base"
+          fi
+
+          image_name="${image_name,,}"
+          if [[ "${image_name}" != ghcr.io/* ]]; then
+            echo "This workflow logs in with GITHUB_TOKEN and only supports ghcr.io image names." >&2
+            exit 1
+          fi
+
+          if [[ ! "${INPUT_TAG}" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+            echo "Invalid Docker tag: ${INPUT_TAG}" >&2
+            exit 1
+          fi
+
+          echo "image_name=${image_name}" >> "${GITHUB_OUTPUT}"
+          echo "image_tag=${INPUT_TAG}" >> "${GITHUB_OUTPUT}"
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create multi-arch manifest
+        shell: bash
+        env:
+          IMAGE_NAME: ${{ steps.meta.outputs.image_name }}
+          IMAGE_TAG: ${{ steps.meta.outputs.image_tag }}
+        run: |
+          set -euo pipefail
+
+          mapfile -t digests < <(find "${RUNNER_TEMP}/digests" -maxdepth 1 -type f -exec basename {} \; | sort)
+          if [[ "${#digests[@]}" -eq 0 ]]; then
+            echo "No digests were downloaded." >&2
+            exit 1
+          fi
+
+          sources=()
+          for digest in "${digests[@]}"; do
+            sources+=("${IMAGE_NAME}@sha256:${digest}")
+          done
+
+          docker buildx imagetools create \
+            --tag "${IMAGE_NAME}:${IMAGE_TAG}" \
+            "${sources[@]}"
+
+          docker buildx imagetools inspect "${IMAGE_NAME}:${IMAGE_TAG}"
+
+      - name: Install packaging tools
+        if: ${{ inputs.upload_artifacts }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          sudo apt-get update
+          sudo apt-get install -y skopeo
+
+      - name: Package downloadable image archives
+        if: ${{ inputs.upload_artifacts }}
+        shell: bash
+        env:
+          IMAGE_NAME: ${{ steps.meta.outputs.image_name }}
+          IMAGE_TAG: ${{ steps.meta.outputs.image_tag }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p dist
+          safe_name="$(echo "${IMAGE_NAME#*/}" | tr '/:' '--')"
+          safe_tag="$(echo "${IMAGE_TAG}" | tr '/:' '--')"
+
+          echo "${{ secrets.GITHUB_TOKEN }}" | skopeo login ghcr.io \
+            --username "${{ github.actor }}" \
+            --password-stdin
+
+          skopeo copy --all \
+            "docker://${IMAGE_NAME}:${IMAGE_TAG}" \
+            "oci-archive:dist/${safe_name}-${safe_tag}-multiarch.oci.tar"
+
+          skopeo copy --override-os linux --override-arch amd64 \
+            "docker://${IMAGE_NAME}:${IMAGE_TAG}" \
+            "docker-archive:dist/${safe_name}-${safe_tag}-linux-amd64.docker.tar:${IMAGE_NAME}:${IMAGE_TAG}"
+
+          skopeo copy --override-os linux --override-arch arm64 \
+            "docker://${IMAGE_NAME}:${IMAGE_TAG}" \
+            "docker-archive:dist/${safe_name}-${safe_tag}-linux-arm64.docker.tar:${IMAGE_NAME}:${IMAGE_TAG}"
+
+          sha256sum dist/* > dist/SHA256SUMS
+
+      - name: Upload image archives
+        if: ${{ inputs.upload_artifacts }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: tiflash-llvm-base-image-archives
+          path: dist/*
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 1

--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ release-linux-llvm/tiflash
 release-linux-llvm/tiflash-columnar
 release-linux-llvm/build-release
 release-linux-llvm/build-release-columnar
+release-linux-llvm/.cargo/
 
 
 gtest_10x_workdir/

--- a/release-linux-llvm/Makefile
+++ b/release-linux-llvm/Makefile
@@ -55,12 +55,11 @@ build_tiflash_next_gen_release:
 # Interactive shell with the same settings as build_tiflash_next_gen_release.
 .PHONY: shell_tiflash_next_gen_release
 shell_tiflash_next_gen_release:
-	@test -d "$(HOME)/.ssh" || (echo "error: $(HOME)/.ssh is required for private git access" && exit 1)
+	@mkdir -p $(realpath .)/.cargo/registry
 	$(DOCKER) run -it --rm \
 		-e ENABLE_NEXT_GEN=true \
-		$(BUILD_TIFLASH_SSH_ENV) \
-		$(BUILD_TIFLASH_SSH_VOLUME) \
 		-v $(realpath ..):/build/tics \
+		-v $(realpath .)/.cargo/registry:/root/.cargo/registry \
 		$(TIFLASH_BUILDER_IMAGE) \
 		/bin/bash
 

--- a/release-linux-llvm/Makefile
+++ b/release-linux-llvm/Makefile
@@ -18,14 +18,6 @@ ARCH = $(shell uname -m)
 
 TIFLASH_BUILDER_IMAGE := ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8$(SUFFIX)
 
-# Mount host SSH into the build container for private git deps (e.g. cloud-storage-engine).
-BUILD_TIFLASH_SSH_VOLUME := -v $(HOME)/.ssh:/root/.ssh:ro
-BUILD_TIFLASH_SSH_ENV := -e GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=accept-new"
-ifneq ($(SSH_AUTH_SOCK),)
-BUILD_TIFLASH_SSH_VOLUME += -v $(SSH_AUTH_SOCK):/ssh-agent
-BUILD_TIFLASH_SSH_ENV += -e SSH_AUTH_SOCK=/ssh-agent
-endif
-
 # Base docker files with prerequisites build tools
 image_tiflash_llvm_base:
 	$(DOCKER) buildx build dockerfiles -f dockerfiles/Dockerfile-tiflash-llvm-base --progress plain --build-arg arch="$(ARCH)" -t $(TIFLASH_BUILDER_IMAGE)
@@ -43,12 +35,11 @@ image_tiflash_release:
 
 # Build tiflash binaries with next-gen features under directory "tiflash" and "tiflash-columnar"
 build_tiflash_next_gen_release:
-	@test -d "$(HOME)/.ssh" || (echo "error: $(HOME)/.ssh is required for private git access" && exit 1)
+	@mkdir -p $(realpath .)/.cargo/registry
 	$(DOCKER) run --rm \
 		-e ENABLE_NEXT_GEN=true \
-		$(BUILD_TIFLASH_SSH_ENV) \
-		$(BUILD_TIFLASH_SSH_VOLUME) \
 		-v $(realpath ..):/build/tics \
+		-v $(realpath .)/.cargo/registry:/root/.cargo/registry \
 		$(TIFLASH_BUILDER_IMAGE) \
 		/build/tics/release-linux-llvm/scripts/build-release.sh
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/10844

Problem Summary:

### What is changed and how it works?

```commit-message
release: 
* Add a manually trigger for tiflash builder image for the internal CD pipeline
* Adjust the  `release-linux-llvm/Makefile`
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
   - Verify the builder image release action workable in my fork `JaySon-Huang/tiflash` https://github.com/JaySon-Huang/tiflash/actions/runs/27005334331
   - Verify building tiflash binaries using the builder image in the internal CD pieline
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
