### PR TITLE
columnar: fix columnar hub version to cloud engine kvengine commit hash

### DIFF
--- a/contrib/tiflash-columnar-hub/hub-runtime/build.rs
+++ b/contrib/tiflash-columnar-hub/hub-runtime/build.rs
@@ -12,18 +12,92 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::path::PathBuf;
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 fn main() {
-    let lock_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../Cargo.lock");
-    println!("cargo:rerun-if-changed={}", lock_path.display());
+    let workspace_dir = PathBuf::from(
+        std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string()),
+    )
+    .join("..");
+    let lock_path = workspace_dir.join("Cargo.lock");
+    let cloud_storage_engine_repo = workspace_dir.join("../cloud-storage-engine");
 
-    let hash = std::fs::read_to_string(&lock_path)
-        .ok()
-        .and_then(|content| extract_kvengine_git_hash(&content))
+    println!("cargo:rerun-if-changed={}", lock_path.display());
+    watch_git_head(&cloud_storage_engine_repo);
+
+    // The workspace patches cloud-storage-engine crates to local paths, so the
+    // lockfile may not carry a git source for `kvengine`. Prefer the local
+    // submodule HEAD and keep the lockfile parser as a fallback.
+    let hash = get_repo_git_hash(&cloud_storage_engine_repo)
+        .or_else(|| {
+            std::fs::read_to_string(&lock_path)
+                .ok()
+                .and_then(|content| extract_kvengine_git_hash(&content))
+        })
         .unwrap_or_else(|| "Unknown".to_string());
 
     println!("cargo:rustc-env=CLOUD_STORAGE_ENGINE_GIT_HASH={hash}");
+}
+
+fn get_repo_git_hash(repo_path: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo_path)
+        .arg("rev-parse")
+        .arg("HEAD")
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let hash = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    if hash.is_empty() {
+        None
+    } else {
+        Some(hash)
+    }
+}
+
+fn watch_git_head(repo_path: &Path) {
+    let dot_git_path = repo_path.join(".git");
+    println!("cargo:rerun-if-changed={}", dot_git_path.display());
+
+    let Some(git_dir) = resolve_git_dir(&dot_git_path) else {
+        return;
+    };
+
+    let head_path = git_dir.join("HEAD");
+    println!("cargo:rerun-if-changed={}", head_path.display());
+    println!(
+        "cargo:rerun-if-changed={}",
+        git_dir.join("packed-refs").display()
+    );
+
+    let Ok(head_content) = std::fs::read_to_string(&head_path) else {
+        return;
+    };
+    let Some(head_ref) = head_content.strip_prefix("ref: ") else {
+        return;
+    };
+    println!(
+        "cargo:rerun-if-changed={}",
+        git_dir.join(head_ref.trim()).display()
+    );
+}
+
+fn resolve_git_dir(dot_git_path: &Path) -> Option<PathBuf> {
+    if dot_git_path.is_dir() {
+        return Some(dot_git_path.to_path_buf());
+    }
+
+    let git_dir = std::fs::read_to_string(dot_git_path).ok()?;
+    let git_dir = git_dir.strip_prefix("gitdir: ")?.trim();
+    let git_dir = dot_git_path.parent()?.join(git_dir);
+    Some(git_dir)
 }
 
 fn extract_git_hash_from_source(source: &str) -> Option<String> {
@@ -64,7 +138,16 @@ fn extract_kvengine_git_hash(content: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::extract_kvengine_git_hash;
+    use super::{extract_kvengine_git_hash, resolve_git_dir};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_temp_dir(name: &str) -> std::path::PathBuf {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("{}_{}", name, suffix))
+    }
 
     #[test]
     fn test_extract_kvengine_git_hash_from_rev() {
@@ -92,5 +175,43 @@ source = "git+https://github.com/tidbcloud/cloud-storage-engine.git?branch=cloud
             extract_kvengine_git_hash(lock),
             Some("a9d93252f2ad0cba95eec51a857cd867cd5e6567".to_string())
         );
+    }
+
+    #[test]
+    fn test_resolve_git_dir_from_directory() {
+        let tmp_dir = unique_temp_dir("hub_build_rs_git_dir");
+        let git_dir = tmp_dir.join(".git");
+        std::fs::create_dir_all(&git_dir).unwrap();
+
+        assert_eq!(resolve_git_dir(&git_dir), Some(git_dir));
+
+        std::fs::remove_dir_all(tmp_dir).unwrap();
+    }
+
+    #[test]
+    fn test_resolve_git_dir_from_file() {
+        let tmp_dir = unique_temp_dir("hub_build_rs_git_file");
+        let repo_dir = tmp_dir.join("repo");
+        let actual_git_dir = tmp_dir.join("actual-git-dir");
+        std::fs::create_dir_all(&repo_dir).unwrap();
+        std::fs::create_dir_all(&actual_git_dir).unwrap();
+        std::fs::write(
+            repo_dir.join(".git"),
+            format!("gitdir: {}\n", actual_git_dir.display()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            resolve_git_dir(&repo_dir.join(".git")),
+            Some(actual_git_dir.clone())
+        );
+
+        std::fs::write(repo_dir.join(".git"), "gitdir: ../actual-git-dir\n").unwrap();
+        assert_eq!(
+            resolve_git_dir(&repo_dir.join(".git")),
+            Some(repo_dir.join("../actual-git-dir"))
+        );
+
+        std::fs::remove_dir_all(tmp_dir).unwrap();
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10894 

Problem Summary:
tiflash version can not show columnar hub version properly.

### What is changed and how it works?

```commit-message

```
```

Set columnar hub version to kvengine commit hash.

TiFlash
Release Version: v9.0.0-beta.2.pre-171-g5e47cac572
Edition:         Community
Git Commit Hash: 5e47cac572852b0ffd7874f715f4b93919f245ac
Git Branch:      fix-columnar-hub-commit-hash
UTC Build Time:  2026-06-09 12:36:27
Enable Features: jemalloc sm4(GmSSL) mem-profiling avx2 avx512 unwind next-gen columnar hnsw.l2=haswell hnsw.cosine=haswell vec.l2=haswell vec.cos=haswell
Profile:         DEBUG
Compiler:        clang++-17 17.0.6

TiFlash Columnar Hub
Git Commit Hash:   a9d93252f2ad0cba95eec51a857cd867cd5e6567
Rust Version:      rustc 1.87.0-nightly (96cfc7558 2025-02-27)
Profile:           debug
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build process reliability with enhanced version information retrieval and fallback mechanisms.

* **Tests**
  * Expanded test coverage for build configuration handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->