### PR TITLE
test: fix flaky DisaggReadSnapshot — skip background tasks during write+mergeDeltaAll

### DIFF
--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_read_task.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_read_task.cpp
@@ -656,9 +656,8 @@ try
         // flush/merge tasks, avoiding a race where background placeDeltaIndex or
         // merge delta holds is_updating and causes mergeDeltaAll() to fail silently.
         FailPointHelper::enableFailPoint(FailPoints::skip_check_segment_update);
-        auto fp_guard = ext::make_scope_guard([]() {
-            FailPointHelper::disableFailPoint(FailPoints::skip_check_segment_update);
-        });
+        auto fp_guard
+            = ext::make_scope_guard([]() { FailPointHelper::disableFailPoint(FailPoints::skip_check_segment_update); });
 
         auto block = DMTestEnv::prepareSimpleWriteBlock(0, 4096, false);
         store->write(*db_context, db_context->getSettingsRef(), block);

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_segment_read_task.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_segment_read_task.cpp
@@ -652,6 +652,14 @@ try
 
     // stable
     {
+        // skip_check_segment_update prevents write() from scheduling background
+        // flush/merge tasks, avoiding a race where background placeDeltaIndex or
+        // merge delta holds is_updating and causes mergeDeltaAll() to fail silently.
+        FailPointHelper::enableFailPoint(FailPoints::skip_check_segment_update);
+        auto fp_guard = ext::make_scope_guard([]() {
+            FailPointHelper::disableFailPoint(FailPoints::skip_check_segment_update);
+        });
+
         auto block = DMTestEnv::prepareSimpleWriteBlock(0, 4096, false);
         store->write(*db_context, db_context->getSettingsRef(), block);
         store->mergeDeltaAll(*db_context);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10897

Problem Summary:
`DMStoreForSegmentReadTaskTest.DisaggReadSnapshot` is flaky — the initial `write(4096)` schedules a background flush task
whose completion handler (`placeDeltaIndex`) and follow-up background merge delta both acquire `is_updating` on
`DeltaValueSpace`. When `mergeDeltaAll()` runs before these background tasks release the lock, it fails silently,
leaving 5 persisted column files instead of the expected 4.

### What is changed and how it works?

Enable `skip_check_segment_update` failpoint before the initial `write(4096)` + `mergeDeltaAll()` block in the test,
with a scoped guard that disables it on exit. This prevents `checkSegmentUpdate` from scheduling any background
flush/merge tasks during the setup phase, eliminating the race entirely.

This is consistent with other tests in the same file (`fetchPagesNoTinyNoInMem`, `fetchPagesTinyNoInMem`,
`fetchPagesTinyInMem`) which already enable `skip_check_segment_update` via `disableFlushCache()` before their
write+mergeDeltaAll blocks.

### Check List

Tests

- [x] Unit test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of segment snapshot comparison tests by adding explicit control around the stable write/merge sequence used during setup, and ensuring that control is cleaned up afterward. This reduces flaky behavior during snapshot validation and makes test outcomes more consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->