### PR TITLE
fix(storages): reject shared locks at disaggregated resolver

### DIFF
--- a/dbms/src/Storages/StorageDisaggregatedColumnar.cpp
+++ b/dbms/src/Storages/StorageDisaggregatedColumnar.cpp
@@ -841,7 +841,7 @@ ColumnarReaderPtr createColumnarReader(
         // Try to resolve locks.
         pingcap::kv::Backoffer bo(pingcap::kv::copNextMaxBackoff);
         std::vector<uint64_t> pushed;
-        std::vector<pingcap::kv::LockPtr> locks{std::make_shared<pingcap::kv::Lock>(lock_info)};
+        std::vector<pingcap::kv::LockPtr> locks{makeLockForDisaggResolve(lock_info)};
         auto guard = std::lock_guard(*shared_context.output_lock);
         auto before_expired = cluster->lock_resolver->resolveLocks(bo, shared_context.start_ts, locks, pushed);
         LOG_WARNING(log, "Finished resolve locks, before_expired={}", before_expired);

--- a/dbms/src/Storages/StorageDisaggregatedHelpers.h
+++ b/dbms/src/Storages/StorageDisaggregatedHelpers.h
@@ -16,8 +16,12 @@
 #include <Storages/KVStore/Types.h>
 #include <kvproto/coprocessor.pb.h>
 #include <kvproto/disaggregated.pb.h>
+#include <kvproto/kvrpcpb.pb.h>
+#include <pingcap/kv/LockResolver.h>
 
+#include <memory>
 #include <unordered_set>
+#include <vector>
 
 namespace DB
 {
@@ -25,6 +29,35 @@ namespace ErrorCodes
 {
 extern const int LOGICAL_ERROR;
 } // namespace ErrorCodes
+
+// Convert lock errors from disaggregated read responses into client-c locks.
+// This boundary intentionally rejects SharedLock wrappers: normal TiFlash read
+// paths should treat them as read-compatible and skip them before reporting a
+// lock conflict, so resolving one here would hide an upstream invariant break.
+inline pingcap::kv::LockPtr makeLockForDisaggResolve(const kvrpcpb::LockInfo & lock_info)
+{
+    if (lock_info.lock_type() == kvrpcpb::Op::SharedLock)
+    {
+        // TiFlash read paths must skip shared locks before reporting a lock conflict.
+        // Seeing a SharedLock here means an upstream read path violated that invariant.
+        // Do not resolve the wrapper: its txn fields are intentionally invalid.
+        throw Exception(
+            ErrorCodes::LOGICAL_ERROR,
+            "Unexpected SharedLock in TiFlash disaggregated lock resolver; shared locks are read-compatible and should "
+            "be skipped before producing locked errors");
+    }
+    return std::make_shared<pingcap::kv::Lock>(lock_info);
+}
+
+inline std::vector<pingcap::kv::LockPtr> makeLocksForDisaggResolve(
+    const google::protobuf::RepeatedPtrField<kvrpcpb::LockInfo> & lock_infos)
+{
+    std::vector<pingcap::kv::LockPtr> locks;
+    locks.reserve(lock_infos.size());
+    for (const auto & lock_info : lock_infos)
+        locks.emplace_back(makeLockForDisaggResolve(lock_info));
+    return locks;
+}
 
 template <typename RegionCachePtr>
 void dropRegionCache(

--- a/dbms/src/Storages/StorageDisaggregatedHelpers.h
+++ b/dbms/src/Storages/StorageDisaggregatedHelpers.h
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <Common/Exception.h>
+#include <Common/RedactHelpers.h>
 #include <Storages/KVStore/Types.h>
 #include <kvproto/coprocessor.pb.h>
 #include <kvproto/disaggregated.pb.h>
@@ -44,7 +45,15 @@ inline pingcap::kv::LockPtr makeLockForDisaggResolve(const kvrpcpb::LockInfo & l
         throw Exception(
             ErrorCodes::LOGICAL_ERROR,
             "Unexpected SharedLock in TiFlash disaggregated lock resolver; shared locks are read-compatible and should "
-            "be skipped before producing locked errors");
+            "be skipped before producing locked errors, lock_key={}, lock_version={}, lock_ttl={}, min_commit_ts={}, "
+            "lock_for_update_ts={}, txn_size={}, shared_lock_count={}",
+            Redact::keyToDebugString(lock_info.key().data(), lock_info.key().size()),
+            lock_info.lock_version(),
+            lock_info.lock_ttl(),
+            lock_info.min_commit_ts(),
+            lock_info.lock_for_update_ts(),
+            lock_info.txn_size(),
+            lock_info.shared_lock_infos_size());
     }
     return std::make_shared<pingcap::kv::Lock>(lock_info);
 }

--- a/dbms/src/Storages/StorageDisaggregatedRemote.cpp
+++ b/dbms/src/Storages/StorageDisaggregatedRemote.cpp
@@ -378,7 +378,7 @@ void StorageDisaggregated::buildReadTaskForWriteNode(
             const auto & error = resp.error().error_locked();
 
             String error_msg = fmt::format(
-                "Received EstablishDisaggTask response with retryable error: {}, addr={} lock_info_size={}",
+                "Received EstablishDisaggTask response with locked error: {}, addr={} lock_info_size={}",
                 error.msg(),
                 batch_cop_task.store_addr,
                 error.locked().size());
@@ -389,9 +389,7 @@ void StorageDisaggregated::buildReadTaskForWriteNode(
             // Try to resolve all locks.
             kv::Backoffer bo(kv::copNextMaxBackoff);
             std::vector<uint64_t> pushed;
-            std::vector<kv::LockPtr> locks{};
-            for (const auto & lock_info : error.locked())
-                locks.emplace_back(std::make_shared<kv::Lock>(lock_info));
+            auto locks = makeLocksForDisaggResolve(error.locked());
             auto before_expired = cluster->lock_resolver->resolveLocks(
                 bo,
                 sender_target_mpp_task_id.gather_id.query_id.start_ts,

--- a/dbms/src/Storages/tests/gtest_disagg_remote.cpp
+++ b/dbms/src/Storages/tests/gtest_disagg_remote.cpp
@@ -18,6 +18,7 @@
 #include <Storages/StorageDisaggregatedHelpers.h>
 #include <TestUtils/TiFlashTestBasic.h>
 #include <kvproto/disaggregated.pb.h>
+#include <kvproto/kvrpcpb.pb.h>
 #include <pingcap/coprocessor/Client.h>
 #include <pingcap/kv/Backoff.h>
 
@@ -117,6 +118,59 @@ TEST_F(StorageDisaggregatedHelpersTest, DropRegionCacheWithDuplicateID)
     ASSERT_EQ(region_cache->dropped_id[1].id, 23917);
     ASSERT_EQ(region_cache->dropped_id[1].conf_ver, 9);
     ASSERT_EQ(region_cache->dropped_id[1].ver, 98);
+}
+
+TEST_F(StorageDisaggregatedHelpersTest, MakeLocksForDisaggResolveKeepsNormalLock)
+{
+    // Baseline for the shared-lock guard: ordinary lock errors are still
+    // converted to client-c locks and can continue through lock resolution.
+    kvrpcpb::LockInfo lock_info;
+    lock_info.set_key("row-key");
+    lock_info.set_primary_lock("primary-key");
+    lock_info.set_lock_version(42);
+    lock_info.set_lock_ttl(3000);
+    lock_info.set_lock_type(kvrpcpb::Op::Put);
+
+    google::protobuf::RepeatedPtrField<kvrpcpb::LockInfo> lock_infos;
+    lock_infos.Add()->CopyFrom(lock_info);
+
+    auto locks = makeLocksForDisaggResolve(lock_infos);
+    ASSERT_EQ(locks.size(), 1);
+    ASSERT_EQ(locks[0]->key, "row-key");
+    ASSERT_EQ(locks[0]->primary, "primary-key");
+    ASSERT_EQ(locks[0]->txn_id, 42);
+    ASSERT_EQ(locks[0]->ttl, 3000);
+    ASSERT_EQ(locks[0]->lock_type, kvrpcpb::Op::Put);
+}
+
+TEST_F(StorageDisaggregatedHelpersTest, MakeLocksForDisaggResolveRejectsSharedLockWrapper)
+{
+    // A SharedLock LockInfo is a wrapper around holder locks, not a resolvable
+    // lock for TiFlash reads. If one reaches this disaggregated resolver
+    // boundary, fail fast instead of interpreting the wrapper's invalid txn
+    // fields as a real pessimistic lock.
+    kvrpcpb::LockInfo shared_lock_wrapper;
+    shared_lock_wrapper.set_key("row-key");
+    shared_lock_wrapper.set_lock_type(kvrpcpb::Op::SharedLock);
+
+    auto * holder = shared_lock_wrapper.add_shared_lock_infos();
+    holder->set_key("row-key");
+    holder->set_primary_lock("holder-primary");
+    holder->set_lock_version(101);
+    holder->set_lock_ttl(5000);
+    holder->set_lock_type(kvrpcpb::Op::Lock);
+
+    try
+    {
+        auto lock = makeLockForDisaggResolve(shared_lock_wrapper);
+        (void)lock;
+        FAIL() << "SharedLock wrappers must not reach TiFlash disaggregated lock resolution";
+    }
+    catch (const DB::Exception & e)
+    {
+        ASSERT_EQ(e.code(), ErrorCodes::LOGICAL_ERROR);
+        ASSERT_NE(std::string(e.message()).find("Unexpected SharedLock"), std::string::npos);
+    }
 }
 
 } // namespace DB::tests

--- a/dbms/src/Storages/tests/gtest_disagg_remote.cpp
+++ b/dbms/src/Storages/tests/gtest_disagg_remote.cpp
@@ -151,6 +151,11 @@ TEST_F(StorageDisaggregatedHelpersTest, MakeLocksForDisaggResolveRejectsSharedLo
     // fields as a real pessimistic lock.
     kvrpcpb::LockInfo shared_lock_wrapper;
     shared_lock_wrapper.set_key("row-key");
+    shared_lock_wrapper.set_lock_version(88);
+    shared_lock_wrapper.set_lock_ttl(3000);
+    shared_lock_wrapper.set_min_commit_ts(99);
+    shared_lock_wrapper.set_lock_for_update_ts(77);
+    shared_lock_wrapper.set_txn_size(2);
     shared_lock_wrapper.set_lock_type(kvrpcpb::Op::SharedLock);
 
     auto * holder = shared_lock_wrapper.add_shared_lock_infos();
@@ -169,7 +174,15 @@ TEST_F(StorageDisaggregatedHelpersTest, MakeLocksForDisaggResolveRejectsSharedLo
     catch (const DB::Exception & e)
     {
         ASSERT_EQ(e.code(), ErrorCodes::LOGICAL_ERROR);
-        ASSERT_NE(std::string(e.message()).find("Unexpected SharedLock"), std::string::npos);
+        const auto message = std::string(e.message());
+        ASSERT_NE(message.find("Unexpected SharedLock"), std::string::npos);
+        ASSERT_NE(message.find("lock_key=726F772D6B6579"), std::string::npos);
+        ASSERT_NE(message.find("lock_version=88"), std::string::npos);
+        ASSERT_NE(message.find("lock_ttl=3000"), std::string::npos);
+        ASSERT_NE(message.find("min_commit_ts=99"), std::string::npos);
+        ASSERT_NE(message.find("lock_for_update_ts=77"), std::string::npos);
+        ASSERT_NE(message.find("txn_size=2"), std::string::npos);
+        ASSERT_NE(message.find("shared_lock_count=1"), std::string::npos);
     }
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10902 ref https://github.com/pingcap/tiflash/issues/10704

Problem Summary:

TiFlash read paths should treat shared locks as read-compatible and skip them before reporting locked errors. If a shared-lock wrapper reaches the disaggregated lock resolver, resolving it would hide an upstream invariant violation and could interpret invalid wrapper transaction fields as a real lock.

### What is changed and how it works?

```commit-message
fix(storages): reject shared locks at disaggregated resolver

TiFlash read paths should skip shared locks before emitting locked errors. Treat a shared-lock wrapper at the disaggregated resolver as an invariant violation so it is not retried or resolved with invalid wrapper txn fields.

Keep ordinary lock conversion covered so existing lock-resolution behavior remains intact.
```

This PR documents the shared-lock test coverage design, rejects shared-lock wrappers at the two disaggregated lock resolver boundaries, and adds unit coverage for both ordinary lock conversion and shared-lock wrapper rejection.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Unit test:

```bash
release-linux-llvm/build-unit-tests-shared-lock/dbms/gtests_dbms --gtest_filter=StorageDisaggregatedHelpersTest.MakeLocksForDisaggResolve*'
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Refactor**
  * Standardized conversion of disaggregated lock information into lock objects used during lock resolution.

* **Bug Fixes**
  * Improved locked-error handling for disaggregated reads with clearer “locked error” wording while retaining the same lock details for debugging.

* **Tests**
  * Added unit tests covering lock conversion behavior (key/primary/transaction/TTL/lock type preservation) and verification that unsupported shared-lock inputs are rejected with a logical error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->