### PR TITLE
columnar: add scan details stats

### DIFF
--- a/contrib/tiflash-columnar-hub/Cargo.lock
+++ b/contrib/tiflash-columnar-hub/Cargo.lock
@@ -319,6 +319,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atomic"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -983,6 +992,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bigdecimal"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,6 +1080,9 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "bitpacking"
@@ -1553,6 +1584,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "const_fn"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1626,6 +1663,21 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32c"
@@ -1729,9 +1781,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.10.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
+checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
 dependencies = [
  "generic-array",
  "subtle",
@@ -1904,6 +1956,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1911,6 +1974,16 @@ checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
  "serde",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -1990,6 +2063,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -2016,6 +2090,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2032,6 +2123,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encoding"
@@ -2257,7 +2351,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2333,12 +2427,6 @@ dependencies = [
  "once_cell",
  "rand 0.8.6",
 ]
-
-[[package]]
-name = "fallible-iterator"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fallible-iterator"
@@ -2496,7 +2584,7 @@ checksum = "09a5a3f0acb82df800ca3aa50c0d60d286c5d13d4cfc3114b3a9663f13b032fe"
 dependencies = [
  "arrayvec",
  "cfg-if",
- "fallible-iterator 0.3.0",
+ "fallible-iterator",
  "gimli 0.31.1",
  "macho-unwind-info",
  "pe-unwind-info",
@@ -2589,6 +2677,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot 0.12.5",
 ]
 
 [[package]]
@@ -2752,7 +2851,7 @@ version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 dependencies = [
- "fallible-iterator 0.3.0",
+ "fallible-iterator",
  "stable_deref_trait",
 ]
 
@@ -2854,6 +2953,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
  "zerocopy",
 ]
 
@@ -2897,6 +2997,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2910,9 +3019,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "heck"
@@ -2948,31 +3054,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hexhex"
-version = "1.1.1"
+name = "hkdf"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56592988a798d4df9155ea41f1d83d1e9a3eefd50fb0c31eb861b6c273ed2fc"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hexhex_impl",
- "hexhex_macros",
-]
-
-[[package]]
-name = "hexhex_impl"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f530c66081961311028f67d22da8e3f739dab6979fc200f199c3ef0fb2e194a"
-dependencies = [
- "fallible-iterator 0.2.0",
-]
-
-[[package]]
-name = "hexhex_macros"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0ae2c93351a14664ef0fa185c434a56783fb83a71b158a3389d594dd391e1f"
-dependencies = [
- "hexhex_impl",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -3157,7 +3244,7 @@ dependencies = [
  "http 0.2.12",
  "hyper 0.14.26",
  "log",
- "rustls",
+ "rustls 0.21.12",
  "rustls-native-certs",
  "tokio",
  "tokio-rustls",
@@ -3249,6 +3336,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3262,12 +3431,23 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.5.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -3398,7 +3578,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3552,7 +3732,6 @@ dependencies = [
  "fslock",
  "futures 0.3.32",
  "hex 0.4.3",
- "hexhex",
  "http 0.2.12",
  "hyper 0.14.26",
  "hyper-rustls",
@@ -3716,7 +3895,10 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
+ "bitflags 2.11.1",
  "libc",
+ "plain",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -3900,6 +4082,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -4114,12 +4302,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "mnt"
-version = "0.3.1"
+name = "mountinfo"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1587ebb20a5b04738f16cffa7e2526f1b8496b84f92920facd518362ff1559eb"
+checksum = "6341a1c48d5425a185c43f75480227dc738cf85ecc6a4bc8ca847406d44f1c17"
 dependencies = [
- "libc",
+ "regex",
 ]
 
 [[package]]
@@ -4252,6 +4440,22 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.6",
+ "smallvec",
+ "zeroize",
 ]
 
 [[package]]
@@ -4698,6 +4902,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4794,10 +5007,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "powerfmt"
@@ -5516,6 +5765,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5535,7 +5793,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata 0.4.14",
- "regex-syntax 0.8.10",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -5543,9 +5801,6 @@ name = "regex-automata"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
-]
 
 [[package]]
 name = "regex-automata"
@@ -5555,7 +5810,7 @@ checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.10",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -5563,12 +5818,6 @@ name = "regex-lite"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -5601,7 +5850,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.21.12",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
@@ -5618,7 +5867,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.25.4",
  "winreg 0.50.0",
 ]
 
@@ -5710,6 +5959,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "921904a62e410e37e215c40381b7117f830d9d89ba60ab5236170541dd25646b"
 dependencies = [
  "xmlparser",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -5882,7 +6151,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5895,7 +6164,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5906,8 +6175,22 @@ checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.103.13",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -5956,6 +6239,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -6057,7 +6351,7 @@ dependencies = [
  "kvproto",
  "lazy_static",
  "prometheus",
- "rustls",
+ "rustls 0.21.12",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_derive",
@@ -6114,7 +6408,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6341,6 +6635,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6495,6 +6799,98 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64 0.22.1",
+ "bigdecimal",
+ "bytes",
+ "chrono",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener 5.4.1",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink",
+ "indexmap 2.14.0",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rustls 0.23.40",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bigdecimal",
+ "bitflags 2.11.1",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "digest 0.10.7",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex 0.4.3",
+ "hkdf",
+ "hmac 0.12.1",
+ "itoa",
+ "log",
+ "md-5 0.10.6",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.6",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2 0.10.9",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6511,6 +6907,17 @@ name = "str_stack"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f446288b699d66d0fd2e30d1cfe7869194312524b3b9252594868ed26ef056a"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -6574,9 +6981,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.4.1"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symbolic-common"
@@ -6628,6 +7035,17 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "sysinfo"
@@ -6762,7 +7180,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d60769b80ad7953d8a7b2c70cdfe722bbcdcac6bccc8ac934c40c034d866fc18"
 dependencies = [
  "byteorder",
- "regex-syntax 0.8.10",
+ "regex-syntax",
  "utf8-ranges",
 ]
 
@@ -6824,7 +7242,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7142,7 +7560,7 @@ dependencies = [
  "libc",
  "log",
  "log_wrappers",
- "mnt",
+ "mountinfo",
  "nix 0.24.3",
  "num-traits",
  "num_cpus",
@@ -7195,7 +7613,7 @@ version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
- "deranged",
+ "deranged 0.4.0",
  "itoa",
  "js-sys",
  "libc",
@@ -7221,6 +7639,16 @@ checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -7315,7 +7743,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.12",
  "tokio",
 ]
 
@@ -7386,7 +7814,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost 0.12.6",
- "rustls",
+ "rustls 0.21.12",
  "rustls-pemfile 1.0.4",
  "tokio",
  "tokio-rustls",
@@ -7611,6 +8039,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7642,14 +8076,15 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -7673,6 +8108,12 @@ name = "utf8-ranges"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -7805,6 +8246,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7923,6 +8370,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.8",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "whatlang"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7942,6 +8407,16 @@ dependencies = [
  "home",
  "once_cell",
  "rustix 0.38.44",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
 ]
 
 [[package]]
@@ -7966,7 +8441,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8378,17 +8853,21 @@ dependencies = [
  "ahash",
  "aho-corasick",
  "base64 0.21.7",
+ "base64 0.22.1",
+ "bitflags 2.11.1",
  "bytes",
  "cc",
  "chrono",
  "clap 2.34.0",
  "clap 3.2.25",
+ "concurrent-queue",
  "crossbeam-queue",
  "crossbeam-utils",
  "data-encoding",
- "deranged",
+ "deranged 0.5.8",
  "digest 0.10.7",
  "either",
+ "event-listener 5.4.1",
  "flate2",
  "futures 0.3.32",
  "futures-channel",
@@ -8400,9 +8879,9 @@ dependencies = [
  "futures-util",
  "grpcio",
  "grpcio-sys",
+ "half",
  "hashbrown 0.14.5",
  "hashbrown 0.15.5",
- "heck 0.4.1",
  "indexmap 1.9.3",
  "indexmap 2.14.0",
  "instant",
@@ -8411,6 +8890,7 @@ dependencies = [
  "libc",
  "lindera-dictionary",
  "log",
+ "md-5 0.10.6",
  "memchr",
  "multimap 0.8.3",
  "nom 7.1.3",
@@ -8421,6 +8901,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "openssl",
+ "percent-encoding",
  "phf_shared",
  "proc-macro2",
  "prost 0.11.9",
@@ -8429,15 +8910,20 @@ dependencies = [
  "rand 0.8.6",
  "rand_core 0.6.4",
  "regex",
- "regex-automata 0.1.10",
  "regex-automata 0.4.14",
- "regex-syntax 0.8.10",
+ "regex-syntax",
  "reqwest 0.11.27",
- "rustls",
+ "rustls 0.21.12",
  "serde",
+ "serde_core",
  "serde_json",
+ "sha1",
+ "sha2 0.10.9",
  "slog",
  "smallvec",
+ "sqlx-core",
+ "sqlx-mysql",
+ "stable_deref_trait",
  "strum 0.27.2",
  "syn 1.0.109",
  "syn 2.0.117",
@@ -8452,12 +8938,16 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-core",
- "unicode-bidi",
- "unicode-normalization",
  "url",
  "uuid 1.23.1",
  "zstd-sys",
 ]
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xattr"
@@ -8522,6 +9012,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8542,10 +9055,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zmij"

--- a/contrib/tiflash-columnar-hub/Cargo.lock
+++ b/contrib/tiflash-columnar-hub/Cargo.lock
@@ -90,6 +90,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1298,16 +1304,17 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/contrib/tiflash-columnar-hub/Cargo.toml
+++ b/contrib/tiflash-columnar-hub/Cargo.toml
@@ -12,6 +12,7 @@ kvenginepb = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", br
 pd_client = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", branch = "cloud-engine", default-features = false }
 security = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", branch = "cloud-engine", default-features = false }
 tikv_util = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", branch = "cloud-engine" }
+url = { version = "2", default-features = true }
 
 [patch.crates-io]
 raft = { git = "https://github.com/tikv/raft-rs", branch = "master" }

--- a/contrib/tiflash-columnar-hub/Cargo.toml
+++ b/contrib/tiflash-columnar-hub/Cargo.toml
@@ -5,6 +5,7 @@ resolver = "2"
 [workspace.dependencies]
 api_version = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", branch = "cloud-engine" }
 builtin_dfs = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", branch = "cloud-engine" }
+chrono = { version = "=0.4.34", default-features = true }
 cloud_encryption = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", branch = "cloud-engine" }
 keys = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", branch = "cloud-engine" }
 kvengine = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", branch = "cloud-engine" }

--- a/contrib/tiflash-columnar-hub/hub-runtime/Cargo.toml
+++ b/contrib/tiflash-columnar-hub/hub-runtime/Cargo.toml
@@ -52,4 +52,4 @@ tokio = { version = "=1.26.0", features = ["fs", "full", "macros", "net", "proce
 # Keep tokio-executor aligned with the tokio-timer hotfix used by tikv_util.
 tokio-executor = "=0.1.9"
 toml = "0.5"
-url = "2"
+url = { workspace = true }

--- a/contrib/tiflash-columnar-hub/hub-runtime/ffi/src/RaftStoreProxyFFI/ProxyFFI.h
+++ b/contrib/tiflash-columnar-hub/hub-runtime/ffi/src/RaftStoreProxyFFI/ProxyFFI.h
@@ -211,6 +211,22 @@ struct RustStrWithViewVec {
   RawRustPtr inner;
 };
 
+struct ColumnarScanStats {
+  uint64_t mvcc_input_rows;
+  uint64_t mvcc_input_bytes;
+  uint64_t mvcc_output_rows;
+  uint64_t read_block_ns;
+  uint64_t serialize_ns;
+  uint64_t init_reader_ns;
+  uint64_t prefetch_ns;
+  uint64_t rough_check_total_packs;
+  uint64_t rough_check_selected_packs;
+  uint64_t rough_check_skipped_packs;
+  uint64_t rough_check_unknown_packs;
+  uint64_t remote_segments;
+  uint64_t total_segments;
+};
+
 struct SSTReaderInterfaces {
   SSTReaderPtr (*fn_get_sst_reader)(SSTView, RaftStoreProxyPtr);
   uint8_t (*fn_remained)(SSTReaderPtr, ColumnFamilyType);
@@ -242,6 +258,7 @@ struct CloudStorageEngineInterfaces {
   RustStrWithView (*fn_read_version)(ColumnarReaderPtr);
   RustStrWithView (*fn_read_column)(ColumnarReaderPtr, int64_t);
   int64_t (*fn_physical_table_id)(ColumnarReaderPtr);
+  ColumnarScanStats (*fn_columnar_scan_stats)(ColumnarReaderPtr);
 };
 
 enum class MsgPBType : uint32_t {

--- a/contrib/tiflash-columnar-hub/hub-runtime/src/cloud_helper.rs
+++ b/contrib/tiflash-columnar-hub/hub-runtime/src/cloud_helper.rs
@@ -60,7 +60,10 @@ use quick_cache::{
 use security::SecurityManager;
 use thiserror::Error;
 use tikv_util::{
-    config::AbsoluteOrPercentSize, memory::MemoryLimiter, sys::SysQuota, time::Instant,
+    config::AbsoluteOrPercentSize,
+    memory::{MemoryLimiter, MemoryQuota},
+    sys::SysQuota,
+    time::Instant,
 };
 use tipb::ColumnInfo;
 
@@ -767,6 +770,8 @@ async fn request_snapshot_from_leader(
                     read_columnar: true,
                     columnar_meta_cache: ColumnarMetaCache::default(),
                     encryption_key_manager: Arc::new(cloud_encryption::EncryptionKeyManager::new()),
+                    strict_file_memory_quota_wait_timeout: Duration::from_secs(30),
+                    strict_file_memory_quota: Arc::new(MemoryQuota::new(usize::MAX)),
                 };
                 let memory_limiter = MemoryLimiter::new(u64::MAX, None);
                 let (snap, _) = SnapAccess::construct_snapshot(

--- a/contrib/tiflash-columnar-hub/hub-runtime/src/columnar_impls.rs
+++ b/contrib/tiflash-columnar-hub/hub-runtime/src/columnar_impls.rs
@@ -255,6 +255,5 @@ pub unsafe extern "C" fn ffi_physical_table_id(mut reader: ColumnarReaderPtr) ->
 
 pub unsafe extern "C" fn ffi_columnar_scan_stats(
     mut reader: ColumnarReaderPtr,
-) -> ColumnarScanStats {
-    reader.as_mut().take_columnar_runtime_stats().into()
-}
+) -> ColumnarScanStats
+{ reader.as_mut().runtime_stats().into() }

--- a/contrib/tiflash-columnar-hub/hub-runtime/src/columnar_impls.rs
+++ b/contrib/tiflash-columnar-hub/hub-runtime/src/columnar_impls.rs
@@ -20,8 +20,8 @@ use protobuf::{parse_from_bytes, Message};
 use crate::{
     build_from_string, build_from_vec_string,
     interfaces_ffi::{
-        BaseBuffView, ColumnarReaderErrorType, ColumnarReaderPtr, RaftStoreProxyPtr, RawRustPtr,
-        RawVoidPtr, RustStrWithView, RustStrWithViewVec,
+        BaseBuffView, ColumnarReaderErrorType, ColumnarReaderPtr, ColumnarScanStats,
+        RaftStoreProxyPtr, RawRustPtr, RawVoidPtr, RustStrWithView, RustStrWithViewVec,
     },
     RawRustPtrType,
 };
@@ -69,6 +69,26 @@ impl From<crate::Error> for ColumnarReaderPtr {
                 error: build_from_string(err.into_bytes()),
                 error_type: ColumnarReaderErrorType::Other,
             },
+        }
+    }
+}
+
+impl From<kvengine::table::columnar::ColumnarRuntimeStats> for ColumnarScanStats {
+    fn from(stats: kvengine::table::columnar::ColumnarRuntimeStats) -> Self {
+        Self {
+            mvcc_input_rows: stats.mvcc_input_rows,
+            mvcc_input_bytes: stats.mvcc_input_bytes,
+            mvcc_output_rows: stats.mvcc_output_rows,
+            read_block_ns: stats.read_block_ns,
+            serialize_ns: stats.serialize_ns,
+            init_reader_ns: stats.init_reader_ns,
+            prefetch_ns: stats.prefetch_ns,
+            rough_check_total_packs: stats.rough_check_total_packs,
+            rough_check_selected_packs: stats.rough_check_selected_packs,
+            rough_check_skipped_packs: stats.rough_check_skipped_packs,
+            rough_check_unknown_packs: stats.rough_check_unknown_packs,
+            remote_segments: stats.remote_segments,
+            total_segments: stats.total_segments,
         }
     }
 }
@@ -231,4 +251,10 @@ pub unsafe extern "C" fn ffi_read_column(
 
 pub unsafe extern "C" fn ffi_physical_table_id(mut reader: ColumnarReaderPtr) -> i64 {
     reader.as_mut().ffi_physical_table_id()
+}
+
+pub unsafe extern "C" fn ffi_columnar_scan_stats(
+    mut reader: ColumnarReaderPtr,
+) -> ColumnarScanStats {
+    reader.as_mut().take_columnar_runtime_stats().into()
 }

--- a/contrib/tiflash-columnar-hub/hub-runtime/src/interfaces.rs
+++ b/contrib/tiflash-columnar-hub/hub-runtime/src/interfaces.rs
@@ -279,6 +279,23 @@ pub mod root {
             pub inner: root::DB::RawRustPtr,
         }
         #[repr(C)]
+        #[derive(Debug, Default, Copy, Clone)]
+        pub struct ColumnarScanStats {
+            pub mvcc_input_rows: u64,
+            pub mvcc_input_bytes: u64,
+            pub mvcc_output_rows: u64,
+            pub read_block_ns: u64,
+            pub serialize_ns: u64,
+            pub init_reader_ns: u64,
+            pub prefetch_ns: u64,
+            pub rough_check_total_packs: u64,
+            pub rough_check_selected_packs: u64,
+            pub rough_check_skipped_packs: u64,
+            pub rough_check_unknown_packs: u64,
+            pub remote_segments: u64,
+            pub total_segments: u64,
+        }
+        #[repr(C)]
         #[derive(Debug)]
         pub struct SSTReaderInterfaces {
             pub fn_get_sst_reader: ::std::option::Option<
@@ -400,6 +417,11 @@ pub mod root {
             >,
             pub fn_physical_table_id: ::std::option::Option<
                 unsafe extern "C" fn(arg1: root::DB::ColumnarReaderPtr) -> i64,
+            >,
+            pub fn_columnar_scan_stats: ::std::option::Option<
+                unsafe extern "C" fn(
+                    arg1: root::DB::ColumnarReaderPtr,
+                ) -> root::DB::ColumnarScanStats,
             >,
         }
         #[repr(u32)]

--- a/contrib/tiflash-columnar-hub/hub-runtime/src/run.rs
+++ b/contrib/tiflash-columnar-hub/hub-runtime/src/run.rs
@@ -55,9 +55,9 @@ use tikv_util::{
 use crate::{
     cloud_helper::{CloudEngineBackends, CloudHelper},
     columnar_impls::{
-        ffi_clear_shared_snap_access_by_start_ts, ffi_get_region_bucket_keys,
-        ffi_make_columnar_reader, ffi_physical_table_id, ffi_read_block, ffi_read_column,
-        ffi_read_handle, ffi_read_version,
+        ffi_clear_shared_snap_access_by_start_ts, ffi_columnar_scan_stats,
+        ffi_get_region_bucket_keys, ffi_make_columnar_reader, ffi_physical_table_id,
+        ffi_read_block, ffi_read_column, ffi_read_handle, ffi_read_version,
     },
     domain_impls::ffi_gc_rust_ptr,
     engine_store_helper::{
@@ -1156,6 +1156,7 @@ fn build_hub_ffi_helper(hub: &ColumnarHub) -> RaftStoreProxyFFIHelper {
             fn_read_version: Some(ffi_read_version),
             fn_read_column: Some(ffi_read_column),
             fn_physical_table_id: Some(ffi_physical_table_id),
+            fn_columnar_scan_stats: Some(ffi_columnar_scan_stats),
         },
         fn_server_info: Some(ffi_server_info),
         fn_make_read_index_task: None,

--- a/dbms/src/Flash/Coprocessor/ColumnarScanContext.h
+++ b/dbms/src/Flash/Coprocessor/ColumnarScanContext.h
@@ -1,0 +1,199 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <Storages/KVStore/FFI/ProxyFFI.h>
+#include <common/types.h>
+#include <fmt/format.h>
+#include <tipb/executor.pb.h>
+
+#include <algorithm>
+#include <atomic>
+
+namespace DB
+{
+class ColumnarScanContext
+{
+public:
+    std::atomic<uint64_t> regions{0};
+    std::atomic<uint64_t> read_tasks{0};
+    std::atomic<uint64_t> physical_tables{0};
+    std::atomic<uint64_t> columns{0};
+    std::atomic<uint64_t> user_read_bytes{0};
+
+    std::atomic<uint64_t> mvcc_input_rows{0};
+    std::atomic<uint64_t> mvcc_input_bytes{0};
+    std::atomic<uint64_t> mvcc_output_rows{0};
+
+    std::atomic<uint64_t> total_read_block_ns{0};
+    std::atomic<uint64_t> total_serialize_block_ns{0};
+    std::atomic<uint64_t> total_init_reader_ns{0};
+    std::atomic<uint64_t> total_prefetch_ns{0};
+    std::atomic<uint64_t> total_deserialize_block_ns{0};
+
+    std::atomic<uint64_t> rough_check_total_packs{0};
+    std::atomic<uint64_t> rough_check_selected_packs{0};
+    std::atomic<uint64_t> rough_check_skipped_packs{0};
+    std::atomic<uint64_t> rough_check_unknown_packs{0};
+
+    std::atomic<uint64_t> remote_segments{0};
+    std::atomic<uint64_t> total_segments{0};
+
+    void deserialize(const tipb::ColumnarScanContext & pb)
+    {
+        regions = pb.regions();
+        read_tasks = pb.read_tasks();
+        physical_tables = pb.physical_tables();
+        columns = pb.columns();
+        user_read_bytes = pb.user_read_bytes();
+        mvcc_input_rows = pb.mvcc_input_rows();
+        mvcc_input_bytes = pb.mvcc_input_bytes();
+        mvcc_output_rows = pb.mvcc_output_rows();
+        total_read_block_ns = pb.total_read_block_ms() * 1000000;
+        total_serialize_block_ns = pb.total_serialize_block_ms() * 1000000;
+        total_init_reader_ns = pb.total_init_reader_ms() * 1000000;
+        total_prefetch_ns = pb.total_prefetch_ms() * 1000000;
+        rough_check_total_packs = pb.rough_check_total_packs();
+        rough_check_selected_packs = pb.rough_check_selected_packs();
+        rough_check_skipped_packs = pb.rough_check_skipped_packs();
+        rough_check_unknown_packs = pb.rough_check_unknown_packs();
+        remote_segments = pb.remote_segments();
+        total_segments = pb.total_segments();
+        total_deserialize_block_ns = pb.total_deserialize_block_ms() * 1000000;
+    }
+
+    tipb::ColumnarScanContext serialize() const
+    {
+        tipb::ColumnarScanContext pb;
+        pb.set_regions(regions.load());
+        pb.set_read_tasks(read_tasks.load());
+        pb.set_physical_tables(physical_tables.load());
+        pb.set_columns(columns.load());
+        pb.set_user_read_bytes(user_read_bytes.load());
+        pb.set_mvcc_input_rows(mvcc_input_rows.load());
+        pb.set_mvcc_input_bytes(mvcc_input_bytes.load());
+        pb.set_mvcc_output_rows(mvcc_output_rows.load());
+        pb.set_total_read_block_ms(total_read_block_ns.load() / 1000000);
+        pb.set_total_serialize_block_ms(total_serialize_block_ns.load() / 1000000);
+        pb.set_total_init_reader_ms(total_init_reader_ns.load() / 1000000);
+        pb.set_total_prefetch_ms(total_prefetch_ns.load() / 1000000);
+        pb.set_rough_check_total_packs(rough_check_total_packs.load());
+        pb.set_rough_check_selected_packs(rough_check_selected_packs.load());
+        pb.set_rough_check_skipped_packs(rough_check_skipped_packs.load());
+        pb.set_rough_check_unknown_packs(rough_check_unknown_packs.load());
+        pb.set_remote_segments(remote_segments.load());
+        pb.set_total_segments(total_segments.load());
+        pb.set_total_deserialize_block_ms(total_deserialize_block_ns.load() / 1000000);
+        return pb;
+    }
+
+    void merge(const ColumnarScanContext & other)
+    {
+        regions += other.regions.load();
+        read_tasks += other.read_tasks.load();
+        physical_tables = std::max(physical_tables.load(), other.physical_tables.load());
+        columns = std::max(columns.load(), other.columns.load());
+        user_read_bytes += other.user_read_bytes.load();
+        mvcc_input_rows += other.mvcc_input_rows.load();
+        mvcc_input_bytes += other.mvcc_input_bytes.load();
+        mvcc_output_rows += other.mvcc_output_rows.load();
+        total_read_block_ns += other.total_read_block_ns.load();
+        total_serialize_block_ns += other.total_serialize_block_ns.load();
+        total_init_reader_ns += other.total_init_reader_ns.load();
+        total_prefetch_ns += other.total_prefetch_ns.load();
+        total_deserialize_block_ns += other.total_deserialize_block_ns.load();
+        rough_check_total_packs += other.rough_check_total_packs.load();
+        rough_check_selected_packs += other.rough_check_selected_packs.load();
+        rough_check_skipped_packs += other.rough_check_skipped_packs.load();
+        rough_check_unknown_packs += other.rough_check_unknown_packs.load();
+        remote_segments += other.remote_segments.load();
+        total_segments += other.total_segments.load();
+    }
+
+    void merge(const tipb::ColumnarScanContext & other)
+    {
+        regions += other.regions();
+        read_tasks += other.read_tasks();
+        physical_tables = std::max(physical_tables.load(), other.physical_tables());
+        columns = std::max(columns.load(), other.columns());
+        user_read_bytes += other.user_read_bytes();
+        mvcc_input_rows += other.mvcc_input_rows();
+        mvcc_input_bytes += other.mvcc_input_bytes();
+        mvcc_output_rows += other.mvcc_output_rows();
+        total_read_block_ns += other.total_read_block_ms() * 1000000;
+        total_serialize_block_ns += other.total_serialize_block_ms() * 1000000;
+        total_init_reader_ns += other.total_init_reader_ms() * 1000000;
+        total_prefetch_ns += other.total_prefetch_ms() * 1000000;
+        total_deserialize_block_ns += other.total_deserialize_block_ms() * 1000000;
+        rough_check_total_packs += other.rough_check_total_packs();
+        rough_check_selected_packs += other.rough_check_selected_packs();
+        rough_check_skipped_packs += other.rough_check_skipped_packs();
+        rough_check_unknown_packs += other.rough_check_unknown_packs();
+        remote_segments += other.remote_segments();
+        total_segments += other.total_segments();
+    }
+
+    void merge(const ColumnarScanStats & other)
+    {
+        mvcc_input_rows += other.mvcc_input_rows;
+        mvcc_input_bytes += other.mvcc_input_bytes;
+        mvcc_output_rows += other.mvcc_output_rows;
+        total_read_block_ns += other.read_block_ns;
+        total_serialize_block_ns += other.serialize_ns;
+        total_init_reader_ns += other.init_reader_ns;
+        total_prefetch_ns += other.prefetch_ns;
+        rough_check_total_packs += other.rough_check_total_packs;
+        rough_check_selected_packs += other.rough_check_selected_packs;
+        rough_check_skipped_packs += other.rough_check_skipped_packs;
+        rough_check_unknown_packs += other.rough_check_unknown_packs;
+        remote_segments += other.remote_segments;
+        total_segments += other.total_segments;
+    }
+
+    String toJson() const
+    {
+        static constexpr double NS_TO_MS_SCALE = 1'000'000.0;
+        return fmt::format(
+            R"({{"scan_type":"columnar","mvcc_input_rows":{},"mvcc_input_bytes":{},"mvcc_output_rows":{})"
+            R"(,"regions":{},"read_tasks":{},"physical_tables":{},"columns":{})"
+            R"(,"user_read_bytes":{},"read_block":"{:.3f}ms","serialize_block":"{:.3f}ms")"
+            R"(,"init_reader":"{:.3f}ms","prefetch":"{:.3f}ms","deserialize_block":"{:.3f}ms")"
+            R"(,"rough_check":{{"total":{},"selected":{},"skipped":{},"unknown":{}}})"
+            R"(,"remote_segments":{},"total_segments":{}}})",
+            mvcc_input_rows.load(),
+            mvcc_input_bytes.load(),
+            mvcc_output_rows.load(),
+            regions.load(),
+            read_tasks.load(),
+            physical_tables.load(),
+            columns.load(),
+            user_read_bytes.load(),
+            total_read_block_ns.load() / NS_TO_MS_SCALE,
+            total_serialize_block_ns.load() / NS_TO_MS_SCALE,
+            total_init_reader_ns.load() / NS_TO_MS_SCALE,
+            total_prefetch_ns.load() / NS_TO_MS_SCALE,
+            total_deserialize_block_ns.load() / NS_TO_MS_SCALE,
+            rough_check_total_packs.load(),
+            rough_check_selected_packs.load(),
+            rough_check_skipped_packs.load(),
+            rough_check_unknown_packs.load(),
+            remote_segments.load(),
+            total_segments.load());
+    }
+
+    void addUserReadBytes(size_t bytes) { user_read_bytes += bytes; }
+    void addDeserializeBlockNs(uint64_t ns) { total_deserialize_block_ns += ns; }
+};
+} // namespace DB

--- a/dbms/src/Flash/Coprocessor/ColumnarScanContext.h
+++ b/dbms/src/Flash/Coprocessor/ColumnarScanContext.h
@@ -199,9 +199,7 @@ private:
     static void mergeMax(std::atomic<UInt64> & target, UInt64 value)
     {
         auto current = target.load();
-        while (current < value && !target.compare_exchange_weak(current, value))
-        {
-        }
+        while (current < value && !target.compare_exchange_weak(current, value)) {}
     }
 };
 } // namespace DB

--- a/dbms/src/Flash/Coprocessor/ColumnarScanContext.h
+++ b/dbms/src/Flash/Coprocessor/ColumnarScanContext.h
@@ -19,7 +19,6 @@
 #include <fmt/format.h>
 #include <tipb/executor.pb.h>
 
-#include <algorithm>
 #include <atomic>
 
 namespace DB
@@ -27,29 +26,29 @@ namespace DB
 class ColumnarScanContext
 {
 public:
-    std::atomic<uint64_t> regions{0};
-    std::atomic<uint64_t> read_tasks{0};
-    std::atomic<uint64_t> physical_tables{0};
-    std::atomic<uint64_t> columns{0};
-    std::atomic<uint64_t> user_read_bytes{0};
+    std::atomic<UInt64> regions{0};
+    std::atomic<UInt64> read_tasks{0};
+    std::atomic<UInt64> physical_tables{0};
+    std::atomic<UInt64> columns{0};
+    std::atomic<UInt64> user_read_bytes{0};
 
-    std::atomic<uint64_t> mvcc_input_rows{0};
-    std::atomic<uint64_t> mvcc_input_bytes{0};
-    std::atomic<uint64_t> mvcc_output_rows{0};
+    std::atomic<UInt64> mvcc_input_rows{0};
+    std::atomic<UInt64> mvcc_input_bytes{0};
+    std::atomic<UInt64> mvcc_output_rows{0};
 
-    std::atomic<uint64_t> total_read_block_ns{0};
-    std::atomic<uint64_t> total_serialize_block_ns{0};
-    std::atomic<uint64_t> total_init_reader_ns{0};
-    std::atomic<uint64_t> total_prefetch_ns{0};
-    std::atomic<uint64_t> total_deserialize_block_ns{0};
+    std::atomic<UInt64> total_read_block_ns{0};
+    std::atomic<UInt64> total_serialize_block_ns{0};
+    std::atomic<UInt64> total_init_reader_ns{0};
+    std::atomic<UInt64> total_prefetch_ns{0};
+    std::atomic<UInt64> total_deserialize_block_ns{0};
 
-    std::atomic<uint64_t> rough_check_total_packs{0};
-    std::atomic<uint64_t> rough_check_selected_packs{0};
-    std::atomic<uint64_t> rough_check_skipped_packs{0};
-    std::atomic<uint64_t> rough_check_unknown_packs{0};
+    std::atomic<UInt64> rough_check_total_packs{0};
+    std::atomic<UInt64> rough_check_selected_packs{0};
+    std::atomic<UInt64> rough_check_skipped_packs{0};
+    std::atomic<UInt64> rough_check_unknown_packs{0};
 
-    std::atomic<uint64_t> remote_segments{0};
-    std::atomic<uint64_t> total_segments{0};
+    std::atomic<UInt64> remote_segments{0};
+    std::atomic<UInt64> total_segments{0};
 
     void deserialize(const tipb::ColumnarScanContext & pb)
     {
@@ -103,8 +102,8 @@ public:
     {
         regions += other.regions.load();
         read_tasks += other.read_tasks.load();
-        physical_tables = std::max(physical_tables.load(), other.physical_tables.load());
-        columns = std::max(columns.load(), other.columns.load());
+        mergeMax(physical_tables, other.physical_tables.load());
+        mergeMax(columns, other.columns.load());
         user_read_bytes += other.user_read_bytes.load();
         mvcc_input_rows += other.mvcc_input_rows.load();
         mvcc_input_bytes += other.mvcc_input_bytes.load();
@@ -126,8 +125,8 @@ public:
     {
         regions += other.regions();
         read_tasks += other.read_tasks();
-        physical_tables = std::max(physical_tables.load(), other.physical_tables());
-        columns = std::max(columns.load(), other.columns());
+        mergeMax(physical_tables, other.physical_tables());
+        mergeMax(columns, other.columns());
         user_read_bytes += other.user_read_bytes();
         mvcc_input_rows += other.mvcc_input_rows();
         mvcc_input_bytes += other.mvcc_input_bytes();
@@ -194,6 +193,15 @@ public:
     }
 
     void addUserReadBytes(size_t bytes) { user_read_bytes += bytes; }
-    void addDeserializeBlockNs(uint64_t ns) { total_deserialize_block_ns += ns; }
+    void addDeserializeBlockNs(UInt64 ns) { total_deserialize_block_ns += ns; }
+
+private:
+    static void mergeMax(std::atomic<UInt64> & target, UInt64 value)
+    {
+        auto current = target.load();
+        while (current < value && !target.compare_exchange_weak(current, value))
+        {
+        }
+    }
 };
 } // namespace DB

--- a/dbms/src/Flash/Coprocessor/ColumnarScanContext.h
+++ b/dbms/src/Flash/Coprocessor/ColumnarScanContext.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <Common/config.h> // for ENABLE_NEXT_GEN_COLUMNAR
 #include <Storages/KVStore/FFI/ProxyFFI.h>
 #include <common/types.h>
 #include <fmt/format.h>
@@ -144,6 +145,7 @@ public:
         total_segments += other.total_segments();
     }
 
+#if ENABLE_NEXT_GEN_COLUMNAR
     void merge(const ColumnarScanStats & other)
     {
         mvcc_input_rows += other.mvcc_input_rows;
@@ -160,6 +162,7 @@ public:
         remote_segments += other.remote_segments;
         total_segments += other.total_segments;
     }
+#endif
 
     String toJson() const
     {

--- a/dbms/src/Flash/Coprocessor/ColumnarScanContext_fwd.h
+++ b/dbms/src/Flash/Coprocessor/ColumnarScanContext_fwd.h
@@ -1,0 +1,23 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+
+namespace DB
+{
+class ColumnarScanContext;
+using ColumnarScanContextPtr = std::shared_ptr<ColumnarScanContext>;
+} // namespace DB

--- a/dbms/src/Flash/Coprocessor/DAGContext.h
+++ b/dbms/src/Flash/Coprocessor/DAGContext.h
@@ -32,11 +32,11 @@
 #include <Core/TaskOperatorSpillContexts.h>
 #include <DataStreams/BlockIO.h>
 #include <DataStreams/IBlockInputStream.h>
+#include <Flash/Coprocessor/ColumnarScanContext_fwd.h>
 #include <Flash/Coprocessor/DAGRequest.h>
 #include <Flash/Coprocessor/FineGrainedShuffle.h>
 #include <Flash/Coprocessor/RuntimeFilterMgr.h>
 #include <Flash/Coprocessor/TablesRegionsInfo.h>
-#include <Flash/Coprocessor/ColumnarScanContext_fwd.h>
 #include <Flash/Executor/toRU.h>
 #include <Flash/Mpp/MPPTaskId.h>
 #include <Interpreters/SubqueryForSet.h>

--- a/dbms/src/Flash/Coprocessor/DAGContext.h
+++ b/dbms/src/Flash/Coprocessor/DAGContext.h
@@ -36,6 +36,7 @@
 #include <Flash/Coprocessor/FineGrainedShuffle.h>
 #include <Flash/Coprocessor/RuntimeFilterMgr.h>
 #include <Flash/Coprocessor/TablesRegionsInfo.h>
+#include <Flash/Coprocessor/ColumnarScanContext_fwd.h>
 #include <Flash/Executor/toRU.h>
 #include <Flash/Mpp/MPPTaskId.h>
 #include <Interpreters/SubqueryForSet.h>
@@ -473,6 +474,7 @@ public:
     /// While when we support collcate join later, scan_context_map.size() may > 1,
     /// thus we need to pay attention to scan_context_map usage that time.
     std::unordered_map<String, DM::ScanContextPtr> scan_context_map;
+    std::unordered_map<String, ColumnarScanContextPtr> columnar_scan_context_map;
 
     RuntimeFilterMgr runtime_filter_mgr;
 

--- a/dbms/src/Flash/Coprocessor/ExecutionSummary.cpp
+++ b/dbms/src/Flash/Coprocessor/ExecutionSummary.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <Common/Exception.h>
+#include <Flash/Coprocessor/ColumnarScanContext.h>
 #include <Flash/Coprocessor/ExecutionSummary.h>
 #include <Flash/Statistics/BaseRuntimeStatistics.h>
 #include <Storages/DeltaMerge/ScanContext.h>
@@ -43,6 +44,12 @@ void ExecutionSummary::merge(const ExecutionSummary & other)
     inter_zone_receive_bytes += other.inter_zone_receive_bytes;
     ru_consumption = mergeRUConsumption(ru_consumption, other.ru_consumption);
     scan_context->merge(*other.scan_context);
+    if (other.columnar_scan_context)
+    {
+        if (!columnar_scan_context)
+            columnar_scan_context = std::make_shared<ColumnarScanContext>();
+        columnar_scan_context->merge(*other.columnar_scan_context);
+    }
 }
 
 void ExecutionSummary::merge(const tipb::ExecutorExecutionSummary & other)
@@ -62,7 +69,14 @@ void ExecutionSummary::merge(const tipb::ExecutorExecutionSummary & other)
     inter_zone_send_bytes += other.tiflash_network_summary().inter_zone_send_bytes();
     inter_zone_receive_bytes += other.tiflash_network_summary().inter_zone_receive_bytes();
     ru_consumption = mergeRUConsumption(ru_consumption, parseRUConsumption(other));
-    scan_context->merge(other.tiflash_scan_context());
+    if (other.has_tiflash_scan_context())
+        scan_context->merge(other.tiflash_scan_context());
+    if (other.has_columnar_scan_context())
+    {
+        if (!columnar_scan_context)
+            columnar_scan_context = std::make_shared<ColumnarScanContext>();
+        columnar_scan_context->merge(other.columnar_scan_context());
+    }
 }
 
 void ExecutionSummary::fill(const BaseRuntimeStatistics & other)
@@ -94,7 +108,13 @@ void ExecutionSummary::init(const tipb::ExecutorExecutionSummary & other)
     inter_zone_send_bytes = other.tiflash_network_summary().inter_zone_send_bytes();
     inter_zone_receive_bytes = other.tiflash_network_summary().inter_zone_receive_bytes();
     ru_consumption = parseRUConsumption(other);
-    scan_context->deserialize(other.tiflash_scan_context());
+    if (other.has_tiflash_scan_context())
+        scan_context->deserialize(other.tiflash_scan_context());
+    if (other.has_columnar_scan_context())
+    {
+        columnar_scan_context = std::make_shared<ColumnarScanContext>();
+        columnar_scan_context->deserialize(other.columnar_scan_context());
+    }
 }
 
 resource_manager::Consumption parseRUConsumption(const tipb::ExecutorExecutionSummary & pb)

--- a/dbms/src/Flash/Coprocessor/ExecutionSummary.h
+++ b/dbms/src/Flash/Coprocessor/ExecutionSummary.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <Flash/Coprocessor/ColumnarScanContext_fwd.h>
 #include <Storages/DeltaMerge/ScanContext_fwd.h>
 #include <common/types.h>
 #include <kvproto/resource_manager.pb.h>
@@ -42,6 +43,7 @@ struct ExecutionSummary
     resource_manager::Consumption ru_consumption{};
 
     DM::ScanContextPtr scan_context;
+    ColumnarScanContextPtr columnar_scan_context;
 
     ExecutionSummary();
 

--- a/dbms/src/Flash/Statistics/ExecutionSummaryHelper.cpp
+++ b/dbms/src/Flash/Statistics/ExecutionSummaryHelper.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <Common/TiFlashMetrics.h>
+#include <Flash/Coprocessor/ColumnarScanContext.h>
 #include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Statistics/ExecutionSummaryHelper.h>
 #include <Storages/DeltaMerge/ScanContext.h>
@@ -31,7 +32,10 @@ void fillTiExecutionSummary(
     execution_summary->set_num_produced_rows(current.num_produced_rows);
     execution_summary->set_num_iterations(current.num_iterations);
     execution_summary->set_concurrency(current.concurrency);
-    execution_summary->mutable_tiflash_scan_context()->CopyFrom(current.scan_context->serialize());
+    if (current.columnar_scan_context)
+        execution_summary->mutable_columnar_scan_context()->CopyFrom(current.columnar_scan_context->serialize());
+    else
+        execution_summary->mutable_tiflash_scan_context()->CopyFrom(current.scan_context->serialize());
     execution_summary->mutable_tiflash_wait_summary()->set_mintso_wait_ns(current.time_minTSO_wait_ns);
     execution_summary->mutable_tiflash_wait_summary()->set_pipeline_breaker_wait_ns(
         current.time_pipeline_breaker_wait_ns);

--- a/dbms/src/Flash/Statistics/ExecutorStatisticsCollector.cpp
+++ b/dbms/src/Flash/Statistics/ExecutorStatisticsCollector.cpp
@@ -14,6 +14,7 @@
 
 #include <Common/FmtUtils.h>
 #include <DataStreams/TiRemoteBlockInputStream.h>
+#include <Flash/Coprocessor/ColumnarScanContext.h>
 #include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/RemoteExecutionSummary.h>
 #include <Flash/Statistics/CommonExecutorImpl.h>
@@ -175,6 +176,13 @@ void ExecutorStatisticsCollector::fillExecutionSummary(
     // merge detailed table scan profile
     if (const auto & iter = scan_context_map.find(executor_id); iter != scan_context_map.end())
         current.scan_context->merge(*(iter->second));
+    if (const auto & iter = dag_context->columnar_scan_context_map.find(executor_id);
+        iter != dag_context->columnar_scan_context_map.end() && iter->second)
+    {
+        if (!current.columnar_scan_context)
+            current.columnar_scan_context = std::make_shared<ColumnarScanContext>();
+        current.columnar_scan_context->merge(*iter->second);
+    }
 
     current.time_processed_ns += dag_context->compile_time_ns;
     current.time_processed_ns += dag_context->minTSO_wait_time_ns;

--- a/dbms/src/Flash/Statistics/TableScanImpl.cpp
+++ b/dbms/src/Flash/Statistics/TableScanImpl.cpp
@@ -14,6 +14,7 @@
 
 #include <Common/formatReadable.h>
 #include <DataStreams/TiRemoteBlockInputStream.h>
+#include <Flash/Coprocessor/ColumnarScanContext.h>
 #include <Flash/Statistics/ConnectionProfileInfo.h>
 #include <Flash/Statistics/TableScanImpl.h>
 #include <Interpreters/Join.h>
@@ -55,14 +56,28 @@ String RemoteTableScanDetail::toJson() const
 }
 void TableScanStatistics::appendExtraJson(FmtBuffer & fmt_buffer) const
 {
+    auto columnar_scan_ctx_it = dag_context.columnar_scan_context_map.find(executor_id);
     auto scan_ctx_it = dag_context.scan_context_map.find(executor_id);
+    // A table scan runs on either the columnar path or the DeltaMerge path, so tracing should only show one.
+    const bool has_columnar_scan_ctx
+        = columnar_scan_ctx_it != dag_context.columnar_scan_context_map.end() && columnar_scan_ctx_it->second;
+    const char * scan_details = "{}";
+    String scan_details_buf;
+    if (has_columnar_scan_ctx)
+    {
+        scan_details_buf = columnar_scan_ctx_it->second->toJson();
+        scan_details = scan_details_buf.c_str();
+    }
+    else if (scan_ctx_it != dag_context.scan_context_map.end() && scan_ctx_it->second)
+    {
+        scan_details_buf = scan_ctx_it->second->toJson();
+        scan_details = scan_details_buf.c_str();
+    }
     fmt_buffer.fmtAppend(
         R"("connection_details":[{},{}],"scan_details":{})",
         local_table_scan_detail.toJson(),
         remote_table_scan_detail.toJson(),
-        scan_ctx_it != dag_context.scan_context_map.end() ? scan_ctx_it->second->toJson()
-                                                          : "{}" // empty json object for nullptr
-    );
+        scan_details);
 }
 
 void TableScanStatistics::updateTableScanDetail(const std::vector<ConnectionProfileInfo> & connection_profile_infos)

--- a/dbms/src/Storages/StorageDisaggregatedColumnar.cpp
+++ b/dbms/src/Storages/StorageDisaggregatedColumnar.cpp
@@ -24,6 +24,7 @@
 #include <DataTypes/DataTypeFactory.h>
 #include <DataTypes/IDataType.h>
 #include <Flash/Coprocessor/CodecUtils.h>
+#include <Flash/Coprocessor/ColumnarScanContext.h>
 #include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/DAGExpressionAnalyzer.h>
 #include <Flash/Coprocessor/DAGPipeline.h>
@@ -1269,6 +1270,14 @@ std::vector<RNColumnarReadTaskPtr> RNColumnarReadTask::buildColumnarReadTask(
         enable_bucket_parallel,
         total_max_reader_num);
 
+    auto columnar_scan_context = std::make_shared<ColumnarScanContext>();
+    columnar_scan_context->regions = region_num;
+    columnar_scan_context->read_tasks = total_max_reader_num;
+    columnar_scan_context->physical_tables = physical_table_num;
+    columnar_scan_context->columns
+        = shared_reader_context->column_defines != nullptr ? shared_reader_context->column_defines->size() : 0;
+    dag_context->columnar_scan_context_map[table_scan.getTableScanExecutorID()] = columnar_scan_context;
+
     std::vector<RNColumnarReaderPlan> all_reader_plans;
     all_reader_plans.reserve(total_max_reader_num);
 
@@ -1342,17 +1351,44 @@ bool RNColumnarInputStream::ensureReader()
 
 void RNColumnarInputStream::releaseReader()
 {
+    mergeReaderStats();
     if (reader.has_value() && reader->inner.ptr != nullptr)
         RustGcHelper::instance().gcRustPtr(reader->inner.ptr, reader->inner.type);
     reader.reset();
     current_reader_work.reset();
 }
 
+void RNColumnarInputStream::mergeReaderStats()
+{
+    if (!reader.has_value() || reader->inner.ptr == nullptr)
+        return;
+
+    const auto * dag_context = context.getDAGContext();
+    if (dag_context == nullptr)
+        return;
+
+    auto scan_ctx_iter = dag_context->columnar_scan_context_map.find(executor_id);
+    if (scan_ctx_iter == dag_context->columnar_scan_context_map.end() || !scan_ctx_iter->second)
+        return;
+
+    const auto & global_ctx = context.getGlobalContext();
+    const TiFlashRaftProxyHelper * proxy_helper = global_ctx.getSharedContextDisagg()->getColumnarProxyHelper();
+    if (proxy_helper == nullptr || proxy_helper->cloud_storage_engine_interfaces.fn_columnar_scan_stats == nullptr)
+        return;
+
+    const auto stats = proxy_helper->cloud_storage_engine_interfaces.fn_columnar_scan_stats(reader.value());
+    scan_ctx_iter->second->merge(stats);
+}
+
 RNColumnarInputStream::~RNColumnarInputStream()
 {
     SCOPE_EXIT({
-        if (reader.has_value() && reader->inner.ptr != nullptr)
-            RustGcHelper::instance().gcRustPtr(reader->inner.ptr, reader->inner.type);
+        try
+        {
+            releaseReader();
+        }
+        catch (...)
+        {}
     });
     try
     {
@@ -1376,6 +1412,12 @@ RNColumnarInputStream::~RNColumnarInputStream()
                     std::optional<LACBytesCollector> lac_bytes_collector;
                     it->second->addUserReadBytes(total_bytes, DM::ReadTag::Query, lac_bytes_collector);
                 }
+            }
+            if (auto it = dag_context->columnar_scan_context_map.find(executor_id);
+                it != dag_context->columnar_scan_context_map.end() && it->second)
+            {
+                it->second->addUserReadBytes(total_bytes);
+                it->second->addDeserializeBlockNs(static_cast<uint64_t>(duration_deserialize_sec * 1000000000.0));
             }
         }
     }

--- a/dbms/src/Storages/StorageDisaggregatedColumnar.h
+++ b/dbms/src/Storages/StorageDisaggregatedColumnar.h
@@ -223,6 +223,7 @@ public:
 
 private:
     bool ensureReader();
+    void mergeReaderStats();
     void releaseReader();
 
     const Context & context;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10906

Problem Summary:
There is no execute summary info in explain when query columnar.

### What is changed and how it works?
Add columnar stats in explain and logs.

```
TiDB root@localhost:test> explain analyze select * from t;
+----------------------+---------+---------+--------------+---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------+----------+------+
| id                   | estRows | actRows | task         | access object | execution info                                                                                                                                                                                                                                                                                                                                                                                                | operator info                             | memory   | disk |
+----------------------+---------+---------+--------------+---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------+----------+------+
| TableReader_12       | 8204.00 | 8204    | root         | partition:all | time:63.5ms, loops:10, RU:5.38, cop_task: {num: 2, max: 0s, min: 0s, avg: 0s, p95: 0s, copr_cache_hit_ratio: 0.00}                                                                                                                                                                                                                                                                                            | MppVersion: 2, data:ExchangeSender_11     | 192.7 KB | N/A  |
| └─ExchangeSender_11  | 8204.00 | 8204    | mpp[tiflash] |               | tiflash_task:{time:52.8ms, loops:1, threads:1}                                                                                                                                                                                                                                                                                                                                                                | ExchangeType: PassThrough                 | N/A      | N/A  |
|   └─TableFullScan_10 | 8204.00 | 8204    | mpp[tiflash] | table:t       | tiflash_task:{time:44.8ms, loops:1, threads:1}, columnar_scan:{mvcc_input_rows:8204, mvcc_input_bytes:360976, mvcc_output_rows:8204, regions:1, read_tasks:1, physical_tables:3, columns:3, user_read_bytes:155876, read_block:8ms, serialize_block:0ms, init_reader:12ms, prefetch:0ms, deserialize_block:4ms, rough_check:{total:0, selected:0, skipped:0, unknown:0}, remote_segments:0, total_segments:4} | keep order:false, PartitionTableScan:true | N/A      | N/A  |
+----------------------+---------+---------+--------------+---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------+----------+------+

3 rows in set
Time: 0.077s
```

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added end-to-end columnar scan metrics collection (MVCC rows/bytes, timing breakdowns, rough-check counters, segment counts) surfaced through the engine callback interface.
  * Execution summaries and scan trace JSON now include columnar scan context data when available.

* **Bug Fixes**
  * Improved correctness of scan metrics by merging reader statistics during reader release/cleanup.
  * Scan trace serialization now prefers columnar context and avoids emitting incomplete traces.

* **Chores**
  * Updated subproject references and workspace dependency alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->