### PR TITLE
[release-8.5] ddl: Fix default value filling with finer granularity (#10682)

### DIFF
--- a/dbms/src/Storages/KVStore/Decode/RegionBlockReader.cpp
+++ b/dbms/src/Storages/KVStore/Decode/RegionBlockReader.cpp
@@ -302,12 +302,12 @@ bool RegionBlockReader::readImpl(Block & block, const ReadList & data_list, bool
                 if constexpr (pk_type == TMTPKType::INT64)
                     static_cast<ColumnInt64 *>(raw_pk_column)->getData().push_back(handle_value);
                 else if constexpr (pk_type == TMTPKType::UINT64)
-                    static_cast<ColumnUInt64 *>(raw_pk_column)->getData().push_back(UInt64(handle_value));
+                    static_cast<ColumnUInt64 *>(raw_pk_column)->getData().push_back(static_cast<UInt64>(handle_value));
                 else
                 {
                     // The pk_type must be Int32/UInt32 or more narrow type
                     // so cannot tell its' exact type here, just use `insert(Field)`
-                    raw_pk_column->insert(Field(handle_value));
+                    raw_pk_column->insert(Field{handle_value});
                     if (unlikely(raw_pk_column->getInt(index) != handle_value))
                     {
                         if (!force_decode)

--- a/dbms/src/Storages/KVStore/Decode/RegionBlockReader.cpp
+++ b/dbms/src/Storages/KVStore/Decode/RegionBlockReader.cpp
@@ -179,6 +179,7 @@ bool RegionBlockReader::readImpl(Block & block, const ReadList & data_list, bool
 {
     VersionColResolver<ReadList> version_col_resolver;
     version_col_resolver.check(block, schema_snapshot->column_defines->size());
+    // The column_ids to read according to schema_snapshot, each elem is (column_id, block_pos)
     const auto & read_column_ids = schema_snapshot->getColId2BlockPosMap();
     const auto & pk_column_ids = schema_snapshot->pk_column_ids;
     const auto & pk_pos_map = schema_snapshot->pk_pos_map;
@@ -269,6 +270,8 @@ bool RegionBlockReader::readImpl(Block & block, const ReadList & data_list, bool
             else
             {
                 // Parse column value from encoded value
+                // Decode the column_ids from `column_ids_iter` to `read_column_ids.end()`
+                // and insert into `block` at position starting from `next_column_pos`
                 if (!appendRowToBlock(
                         *value_ptr,
                         column_ids_iter,

--- a/dbms/src/Storages/KVStore/tests/gtest_region_block_reader.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_region_block_reader.cpp
@@ -691,5 +691,178 @@ try
 }
 CATCH
 
+TEST_F(RegionBlockReaderTest, ReadFromRegionDefaultValue)
+try
+{
+    // With this table_info, column "c1" is "NOT NULL" and has no origin default
+    TableInfo table_info_c1_not_null_no_origin_default(
+        R"({"cols":[{"id":1,"name":{"L":"c0","O":"c0"},"offset":0,"state":5,"type":{"Charset":"binary","Collate":"binary","Decimal":0,"Flag":0,"Flen":4,"Tp":1}},{"id":2,"name":{"L":"handle","O":"handle"},"offset":1,"state":5,"type":{"Charset":"binary","Collate":"binary","Decimal":0,"Flag":515,"Flen":11,"Tp":3}},{"default":"-56083770","id":7,"name":{"L":"c1","O":"c1"},"offset":2,"state":5,"type":{"Charset":"binary","Collate":"binary","Decimal":0,"Flag":1,"Flen":20,"Tp":8}},{"id":4,"name":{"L":"c2","O":"c2"},"offset":3,"origin_default":"0.07954397","state":5,"type":{"Charset":"binary","Collate":"binary","Decimal":-1,"Flag":4097,"Flen":12,"Tp":4}},{"id":5,"name":{"L":"c5","O":"c5"},"offset":4,"origin_default":"0","state":5,"type":{"Charset":"binary","Collate":"binary","Decimal":0,"Flag":0,"Flen":10,"Tp":246}},{"default":"247262911","id":6,"name":{"L":"c4","O":"c4"},"offset":5,"origin_default":"247262911","state":5,"type":{"Charset":"binary","Collate":"binary","Decimal":0,"Flag":0,"Flen":10,"Tp":246}}],"id":636,"index_info":[],"is_common_handle":false,"keyspace_id":4294967295,"name":{"L":"t0","O":"t0"},"pk_is_handle":true,"state":5,"tiflash_replica":{"Available":true,"Count":1},"update_timestamp":463845180343844895})",
+        NullspaceID);
+
+    // With this table_info, column "c1" is "NOT NULL" and has no default value
+    TableInfo table_info_c1_not_null_no_default_value(
+        R"({"cols":[{"id":1,"name":{"L":"c0","O":"c0"},"offset":0,"state":5,"type":{"Charset":"binary","Collate":"binary","Decimal":0,"Flag":0,"Flen":4,"Tp":1}},{"id":2,"name":{"L":"handle","O":"handle"},"offset":1,"state":5,"type":{"Charset":"binary","Collate":"binary","Decimal":0,"Flag":515,"Flen":11,"Tp":3}},{"id":7,"name":{"L":"c1","O":"c1"},"offset":2,"state":5,"type":{"Charset":"binary","Collate":"binary","Decimal":0,"Flag":4097,"Flen":20,"Tp":8}},{"id":4,"name":{"L":"c2","O":"c2"},"offset":3,"origin_default":"0.07954397","state":5,"type":{"Charset":"binary","Collate":"binary","Decimal":-1,"Flag":4097,"Flen":12,"Tp":4}},{"id":5,"name":{"L":"c5","O":"c5"},"offset":4,"origin_default":"0","state":5,"type":{"Charset":"binary","Collate":"binary","Decimal":0,"Flag":0,"Flen":10,"Tp":246}},{"default":"247262911","id":6,"name":{"L":"c4","O":"c4"},"offset":5,"origin_default":"247262911","state":5,"type":{"Charset":"binary","Collate":"binary","Decimal":0,"Flag":0,"Flen":10,"Tp":246}}],"id":636,"index_info":[],"is_common_handle":false,"keyspace_id":4294967295,"name":{"L":"t0","O":"t0"},"pk_is_handle":true,"state":5,"tiflash_replica":{"Available":true,"Count":1},"update_timestamp":463845180343844895})",
+        NullspaceID);
+
+    // With this table_info, column "c1" has the "NOT NULL" flag and has origin default "-56083770"
+    TableInfo table_info_c1_not_null_with_origin_default(
+        R"({"cols":[{"id":1,"name":{"L":"c0","O":"c0"},"offset":0,"state":5,"type":{"Charset":"binary","Collate":"binary","Decimal":0,"Flag":0,"Flen":4,"Tp":1}},{"id":2,"name":{"L":"handle","O":"handle"},"offset":1,"state":5,"type":{"Charset":"binary","Collate":"binary","Decimal":0,"Flag":515,"Flen":11,"Tp":3}},{"origin_default":"-56083770","id":7,"name":{"L":"c1","O":"c1"},"offset":2,"state":5,"type":{"Charset":"binary","Collate":"binary","Decimal":0,"Flag":1,"Flen":20,"Tp":8}},{"id":4,"name":{"L":"c2","O":"c2"},"offset":3,"origin_default":"0.07954397","state":5,"type":{"Charset":"binary","Collate":"binary","Decimal":-1,"Flag":4097,"Flen":12,"Tp":4}},{"id":5,"name":{"L":"c5","O":"c5"},"offset":4,"origin_default":"0","state":5,"type":{"Charset":"binary","Collate":"binary","Decimal":0,"Flag":0,"Flen":10,"Tp":246}},{"default":"247262911","id":6,"name":{"L":"c4","O":"c4"},"offset":5,"origin_default":"247262911","state":5,"type":{"Charset":"binary","Collate":"binary","Decimal":0,"Flag":0,"Flen":10,"Tp":246}}],"id":636,"index_info":[],"is_common_handle":false,"keyspace_id":4294967295,"name":{"L":"t0","O":"t0"},"pk_is_handle":true,"state":5,"tiflash_replica":{"Available":true,"Count":1},"update_timestamp":463845180343844895})",
+        NullspaceID);
+
+    // With this table_info, column "c1" has the "NOT NULL" flag and has origin default "-56083770", but the state is not public
+    TableInfo table_info_c1_not_null_with_origin_default_non_public(
+        R"({"cols":[{"id":1,"name":{"L":"c0","O":"c0"},"offset":0,"state":5,"type":{"Charset":"binary","Collate":"binary","Decimal":0,"Flag":0,"Flen":4,"Tp":1}},{"id":2,"name":{"L":"handle","O":"handle"},"offset":1,"state":5,"type":{"Charset":"binary","Collate":"binary","Decimal":0,"Flag":515,"Flen":11,"Tp":3}},{"origin_default":"-56083770","id":7,"name":{"L":"c1","O":"c1"},"offset":2,"state":3,"type":{"Charset":"binary","Collate":"binary","Decimal":0,"Flag":1,"Flen":20,"Tp":8}},{"id":4,"name":{"L":"c2","O":"c2"},"offset":3,"origin_default":"0.07954397","state":5,"type":{"Charset":"binary","Collate":"binary","Decimal":-1,"Flag":4097,"Flen":12,"Tp":4}},{"id":5,"name":{"L":"c5","O":"c5"},"offset":4,"origin_default":"0","state":5,"type":{"Charset":"binary","Collate":"binary","Decimal":0,"Flag":0,"Flen":10,"Tp":246}},{"default":"247262911","id":6,"name":{"L":"c4","O":"c4"},"offset":5,"origin_default":"247262911","state":5,"type":{"Charset":"binary","Collate":"binary","Decimal":0,"Flag":0,"Flen":10,"Tp":246}}],"id":636,"index_info":[],"is_common_handle":false,"keyspace_id":4294967295,"name":{"L":"t0","O":"t0"},"pk_is_handle":true,"state":5,"tiflash_replica":{"Available":true,"Count":1},"update_timestamp":463845180343844895})",
+        NullspaceID);
+
+    // With this table_info, column "c1" does not have the "NOT NULL" flag
+    TableInfo table_info_c1_nullable(
+        R"({"cols":[{"id":1,"name":{"L":"c0","O":"c0"},"offset":0,"state":5,"type":{"Charset":"binary","Collate":"binary","Decimal":0,"Flag":0,"Flen":4,"Tp":1}},{"id":2,"name":{"L":"handle","O":"handle"},"offset":1,"state":5,"type":{"Charset":"binary","Collate":"binary","Decimal":0,"Flag":515,"Flen":11,"Tp":3}},{"id":7,"name":{"L":"c1","O":"c1"},"offset":2,"state":5,"type":{"Charset":"binary","Collate":"binary","Decimal":0,"Flag":0,"Flen":20,"Tp":8}},{"id":4,"name":{"L":"c2","O":"c2"},"offset":3,"origin_default":"0.07954397","state":5,"type":{"Charset":"binary","Collate":"binary","Decimal":-1,"Flag":4097,"Flen":12,"Tp":4}},{"id":5,"name":{"L":"c5","O":"c5"},"offset":4,"origin_default":"0","state":5,"type":{"Charset":"binary","Collate":"binary","Decimal":0,"Flag":0,"Flen":10,"Tp":246}},{"default":"247262911","id":6,"name":{"L":"c4","O":"c4"},"offset":5,"origin_default":"247262911","state":5,"type":{"Charset":"binary","Collate":"binary","Decimal":0,"Flag":0,"Flen":10,"Tp":246}}],"id":636,"index_info":[],"is_common_handle":false,"keyspace_id":4294967295,"name":{"L":"t0","O":"t0"},"pk_is_handle":true,"state":5,"tiflash_replica":{"Available":true,"Count":1},"update_timestamp":463844343842340870})",
+        NullspaceID);
+
+    RegionID region_id = 4;
+    // the start_key and end_key for table_id = 68
+    String region_start_key(bytesFromHexString("7480000000000002FF7C5F720000000000FA"));
+    String region_end_key(bytesFromHexString("7480000000000002FF7D00000000000000F8"));
+    auto region = RegionBench::makeRegionForRange(region_id, region_start_key, region_end_key);
+    // the hex kv dump from RaftLog
+    std::vector<std::tuple<std::string_view, std::string_view>> kvs = {
+        {
+            "7480000000000002FFA95F728000000000FF0000010000000000FAF9901806DEF7FFDA",
+            "50A380A08892FFF9B706762C8000040000000405060708000F0016001A00BFDC4011A00000000A0080000000000A008000003CA339"
+            "1ABC85",
+        },
+        {
+            "7480000000000002FFA95F728000000000FF0000010000000000FAF9901806DEF7FFD8",
+            "50A680A08892FFF9B706762C8000040000000405060708000F0016001A00BFDC4011A00000000A008033E04D600A008000003CA339"
+            "1ABC85",
+        },
+        {
+            "7480000000000002FFA95F728000000000FF0000020000000000FAF9901806DE33FFE8",
+            "509680B08E92FFF9B706762580000300000004050608000F001600BF720CDD400000000A0080000000010A00800000393C",
+        },
+    };
+    for (const auto & [k, v] : kvs)
+    {
+        region->insertDebug("write", TiKVKey(bytesFromHexString(k)), TiKVValue(bytesFromHexString(v)));
+    }
+
+    auto data_list_read = ReadRegionCommitCache(region, true);
+    ASSERT_TRUE(data_list_read.has_value());
+
+    // Test with `table_info_c1_not_null_no_origin_default`
+    auto decoding_schema = getDecodingStorageSchemaSnapshot(table_info_c1_not_null_no_origin_default);
+    {
+        // force_decode=false can not decode because there are
+        // missing value for column with not null flag.
+        auto reader = RegionBlockReader(decoding_schema);
+        Block res_block = createBlockSortByColumnID(decoding_schema);
+        ASSERT_FALSE(reader.read(res_block, *data_list_read, false));
+    }
+    {
+        // force_decode=true can decode the block, and filling the default value for c1
+        auto reader = RegionBlockReader(decoding_schema);
+        Block res_block = createBlockSortByColumnID(decoding_schema);
+        ASSERT_TRUE(reader.read(res_block, *data_list_read, true));
+        LOG_INFO(
+            Logger::get(),
+            "Decoded block:\n{}",
+            DB::tests::getColumnsContent(res_block.getColumnsWithTypeAndName()));
+        ASSERT_EQ(res_block.getByName("c1").type->getName(), "Int64");
+        // verify the default value is filled correctly
+        ASSERT_COLUMN_EQ( //
+            res_block.getByName("c1"),
+            createColumn<Int64>({-2051270087, -2051270087, 0}));
+    }
+
+    // Test with `table_info_c1_not_null_no_default_value`
+    decoding_schema = getDecodingStorageSchemaSnapshot(table_info_c1_not_null_no_default_value);
+    {
+        // force_decode=false can not decode because there are
+        // missing value for column with not null flag.
+        auto reader = RegionBlockReader(decoding_schema);
+        Block res_block = createBlockSortByColumnID(decoding_schema);
+        ASSERT_FALSE(reader.read(res_block, *data_list_read, false));
+    }
+    {
+        // force_decode=true can decode the block, and filling the default value for c1
+        auto reader = RegionBlockReader(decoding_schema);
+        Block res_block = createBlockSortByColumnID(decoding_schema);
+        ASSERT_TRUE(reader.read(res_block, *data_list_read, true));
+        LOG_INFO(
+            Logger::get(),
+            "Decoded block:\n{}",
+            DB::tests::getColumnsContent(res_block.getColumnsWithTypeAndName()));
+        ASSERT_EQ(res_block.getByName("c1").type->getName(), "Int64");
+        // verify the default value is filled correctly
+        ASSERT_COLUMN_EQ( //
+            res_block.getByName("c1"),
+            createColumn<Int64>({-2051270087, -2051270087, 0}));
+    }
+
+    // Test with `table_info_c1_not_null_with_origin_default`
+    decoding_schema = getDecodingStorageSchemaSnapshot(table_info_c1_not_null_with_origin_default);
+    {
+        // force_decode=false can decode because origin_default exists and NoDefaultValue flag is not set
+        // so RegionBlockReader can use origin_default to fill the missing value`
+        auto reader = RegionBlockReader(decoding_schema);
+        Block res_block = createBlockSortByColumnID(decoding_schema);
+        ASSERT_TRUE(reader.read(res_block, *data_list_read, false));
+        LOG_INFO(
+            Logger::get(),
+            "Decoded block:\n{}",
+            DB::tests::getColumnsContent(res_block.getColumnsWithTypeAndName()));
+        ASSERT_EQ(res_block.getByName("c1").type->getName(), "Int64");
+        // verify the default value is filled correctly
+        ASSERT_COLUMN_EQ( //
+            res_block.getByName("c1"),
+            // the thrid elem is filled wih origin_default
+            createColumn<Int64>({-2051270087, -2051270087, -56083770}));
+    }
+
+    // Test with `table_info_c1_not_null_with_origin_default_non_public`
+    decoding_schema = getDecodingStorageSchemaSnapshot(table_info_c1_not_null_with_origin_default_non_public);
+    {
+        // force_decode=false can not decode because there are
+        // missing value for column with not null flag and the state is not public
+        auto reader = RegionBlockReader(decoding_schema);
+        Block res_block = createBlockSortByColumnID(decoding_schema);
+        ASSERT_FALSE(reader.read(res_block, *data_list_read, false));
+    }
+    {
+        // force_decode=true can decode the block, and filling the default value for c1
+        auto reader = RegionBlockReader(decoding_schema);
+        Block res_block = createBlockSortByColumnID(decoding_schema);
+        ASSERT_TRUE(reader.read(res_block, *data_list_read, true));
+        LOG_INFO(
+            Logger::get(),
+            "Decoded block:\n{}",
+            DB::tests::getColumnsContent(res_block.getColumnsWithTypeAndName()));
+        ASSERT_EQ(res_block.getByName("c1").type->getName(), "Int64");
+        // verify the default value is filled correctly
+        ASSERT_COLUMN_EQ( //
+            res_block.getByName("c1"),
+            // the thrid elem is filled wih origin_default
+            createColumn<Int64>({-2051270087, -2051270087, -56083770}));
+    }
+
+    // Test with `table_info_c1_nullable`
+    decoding_schema = getDecodingStorageSchemaSnapshot(table_info_c1_nullable);
+    {
+        // force_decode=false should be able to decode because c1 is nullable
+        auto reader = RegionBlockReader(decoding_schema);
+        Block res_block = createBlockSortByColumnID(decoding_schema);
+        ASSERT_TRUE(reader.read(res_block, *data_list_read, false));
+        LOG_INFO(
+            Logger::get(),
+            "Decoded block:\n{}",
+            DB::tests::getColumnsContent(res_block.getColumnsWithTypeAndName()));
+        ASSERT_EQ(res_block.getByName("c1").type->getName(), "Nullable(Int64)");
+        // verify the default value is filled with NULL correctly at the last row
+        ASSERT_COLUMN_EQ( //
+            res_block.getByName("c1"),
+            createNullableColumn<Int64>({-2051270087, -2051270087, 0}, {0, 0, 1}));
+    }
+}
+CATCH
 
 } // namespace DB::tests

--- a/dbms/src/Storages/KVStore/tests/gtest_region_block_reader.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_region_block_reader.cpp
@@ -743,7 +743,7 @@ try
     };
     for (const auto & [k, v] : kvs)
     {
-        region->insertDebug("write", TiKVKey(bytesFromHexString(k)), TiKVValue(bytesFromHexString(v)));
+        region->insert(ColumnFamilyType::Write, TiKVKey(bytesFromHexString(k)), TiKVValue(bytesFromHexString(v)));
     }
 
     auto data_list_read = ReadRegionCommitCache(region, true);

--- a/dbms/src/Storages/KVStore/tests/gtest_region_block_reader.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_region_block_reader.cpp
@@ -723,7 +723,7 @@ try
     // the start_key and end_key for table_id = 68
     String region_start_key(bytesFromHexString("7480000000000002FF7C5F720000000000FA"));
     String region_end_key(bytesFromHexString("7480000000000002FF7D00000000000000F8"));
-    auto region = RegionBench::makeRegionForRange(region_id, region_start_key, region_end_key);
+    auto region = makeRegion(region_id, region_start_key, region_end_key);
     // the hex kv dump from RaftLog
     std::vector<std::tuple<std::string_view, std::string_view>> kvs = {
         {

--- a/dbms/src/TiDB/Decode/RowCodec.cpp
+++ b/dbms/src/TiDB/Decode/RowCodec.cpp
@@ -388,6 +388,20 @@ bool appendRowToBlock(
     }
 }
 
+// When a column is missing in the encoded row, decide whether we can append a value
+// (NULL or origin default) to `block` or we must trigger schema sync.
+//
+// Background
+// - TiDB encode semantics, see [tables.CanSkip](https://github.com/pingcap/tidb/blob/v8.5.5/pkg/table/tables/tables.go#L1463-L1489)
+// - PK handle columns may be omitted from the value part and decoded from the key.
+// - A NULL column may be omitted only when BOTH DefaultValue and OriginDefaultValue are empty.
+// - For NOT NULL columns, TiDB must encode the value in the row unless the column did not
+//   exist in the writer schema (old data); in that case OriginDefaultValue is expected.
+//
+// Policy here:
+// - If the omission is clearly valid under the current schema, we fill a value and return true.
+// - Otherwise return false (force_decode == false) to let the caller sync schema and retry.
+// - If force_decode == true, we fall back to best-effort filling.
 inline bool addDefaultValueToColumnIfPossible(
     const ColumnInfo & column_info,
     Block & block,
@@ -395,33 +409,45 @@ inline bool addDefaultValueToColumnIfPossible(
     bool ignore_pk_if_absent,
     bool force_decode)
 {
-    // We consider a missing column could be safely filled with NULL, unless it has not default value and is NOT NULL.
-    // This could saves lots of unnecessary schema syncs for old data with a newer schema that has newly added columns.
-
+    // 1) Primary-key columns can be decoded from the key for pk_is_handle / common-handle tables.
+    //    Skip value-part filling here if allowed.
     if (column_info.hasPriKeyFlag())
     {
-        // For clustered index or pk_is_handle, if the pk column does not exists, it can still be decoded from the key
         if (ignore_pk_if_absent)
             return true;
 
-        assert(!ignore_pk_if_absent);
+        // For non-clustered tables, a missing PK column implies schema mismatch.
         if (!force_decode)
             return false;
-        // Else non-clustered index, and not pk_is_handle, it could be a row encoded by older schema,
-        // we need to fill the column wich has primary key flag with default value.
-        // fallthrough to fill default value when force_decode
+        // fallthrough for best-effort fill when force_decode == true
     }
 
-    if (column_info.hasNoDefaultValueFlag() && column_info.hasNotNullFlag())
+    // 2) NOT NULL columns:
+    //    - If the column has NO DEFAULT, TiDB should always encode a value. Missing datum implies mismatch.
+    //    - If the column has NO origin default, missing datum may come from a newer schema where the column
+    //      became NULLABLE and was skipped; require schema sync.
+    //    - If the column state is NOT public, missing datum may come from a newer schema where the column
+    //      became PUBLIC and then became NULLABLE, the datum was skipped; require schema sync.
+    //    - If origin default exists, missing datum can be from older rows before the column was added; safe to fill.
+    //
+    // Note that for a non-public column, TiDB could use the `origin_default_value` to fill missing datum for backfilling
+    // during schema change. And before the column state becomes public, TiDB will reset the `origin_default_value` to null.
+    // So when all following conditions are met, it implies schema mismatch and TiFlash should require schema sync:
+    //  - the column datum is missing
+    //  - the column has not null flag
+    //  - the column state is not public
+    if (!force_decode && column_info.hasNotNullFlag())
     {
-        if (!force_decode)
+        if (column_info.hasNoDefaultValueFlag() //
+            || column_info.state != TiDB::SchemaState::StatePublic //
+            || !column_info.hasOriginDefaultValue())
             return false;
-        // Else the row does not contain this "not null" / "no default value" column,
-        // it could be a row encoded by older schema.
-        // fallthrough to fill default value when force_decode
     }
-    // not null or has no default value, tidb will fill with specific value.
-    auto * raw_column = const_cast<IColumn *>((block.getByPosition(block_column_pos)).column.get());
+
+    // 3) Fill using origin default or NULL.
+    //    Note: defaultValueToField() uses origin_default_value/origin_default_bit_value,
+    //    and falls back to NULL (nullable) or GenDefaultField (NOT NULL) when they are empty.
+    auto * raw_column = const_cast<IColumn *>(block.getByPosition(block_column_pos).column.get());
     raw_column->insert(column_info.defaultValueToField());
     return true;
 }
@@ -460,7 +486,9 @@ bool appendRowV2ToBlockImpl(
         num_not_null_columns,
         value_offsets);
     size_t values_start_pos = cursor;
+    // how many not null columns have been processed
     size_t idx_not_null = 0;
+    // how many null columns have been processed
     size_t idx_null = 0;
     // Merge ordered not null/null columns to keep order.
     while (idx_not_null < not_null_column_ids.size() || idx_null < null_column_ids.size())
@@ -481,12 +509,13 @@ bool appendRowV2ToBlockImpl(
         const auto next_column_id = column_ids_iter->first;
         if (next_column_id > next_datum_column_id)
         {
-            // The next column id to read is bigger than the column id of next datum in encoded row.
+            // The next_column_id to read is bigger than the next_datum_column_id in encoded row.
             // It means this is the datum of extra column. May happen when reading after dropping
             // a column.
+            // For `force_decode == false`, we should return false to let upper layer trigger schema sync.
             if (!force_decode)
                 return false;
-            // Ignore the extra column and continue to parse other datum
+            // For `force_decode == true`, we just skip this extra column and continue to parse other datum.
             if (is_null)
                 idx_null++;
             else
@@ -494,7 +523,7 @@ bool appendRowV2ToBlockImpl(
         }
         else if (next_column_id < next_datum_column_id)
         {
-            // The next column id to read is less than the column id of next datum in encoded row.
+            // The next_column_id to read is less than the next_datum_column_id in encoded row.
             // It means this is the datum of missing column. May happen when reading after adding
             // a column.
             // Fill with default value and continue to read data for next column id.
@@ -505,7 +534,10 @@ bool appendRowV2ToBlockImpl(
                     block_column_pos,
                     ignore_pk_if_absent,
                     force_decode))
+            {
+                // If failed to fill default value, return false to let upper layer trigger schema sync.
                 return false;
+            }
             column_ids_iter++;
             block_column_pos++;
         }
@@ -570,8 +602,12 @@ bool appendRowV2ToBlockImpl(
             block_column_pos++;
         }
     }
+
+    // There are more columns to read other than the datum encoded in the row.
     while (column_ids_iter != column_ids_iter_end)
     {
+        // Skip if the column_id is the same as `pk_handle_id`. The value of column
+        // `pk_handle_id` will be filled in upper layer but not in this function.
         if (column_ids_iter->first != pk_handle_id)
         {
             const auto & column_info = column_infos[column_ids_iter->second];
@@ -581,7 +617,10 @@ bool appendRowV2ToBlockImpl(
                     block_column_pos,
                     ignore_pk_if_absent,
                     force_decode))
+            {
+                // If failed to fill default value, return false to let upper layer trigger schema sync.
                 return false;
+            }
         }
         column_ids_iter++;
         block_column_pos++;

--- a/dbms/src/TiDB/Schema/TiDB.cpp
+++ b/dbms/src/TiDB/Schema/TiDB.cpp
@@ -192,6 +192,23 @@ ColumnInfo::ColumnInfo(Poco::JSON::Object::Ptr json)
     }
 
 
+bool ColumnInfo::hasOriginDefaultValue() const
+{
+    // Whether `origin_default_value` or `origin_default_bit_value` is set.
+    return !origin_default_value.isEmpty() || !origin_default_bit_value.isEmpty();
+}
+
+// Convert the column's *origin default* into a Field for storage decoding/backfill.
+//
+// Note: TiFlash intentionally uses origin_default_value/origin_default_bit_value
+// instead of ColumnInfo::default_value, because TiDB’s encoding/CanSkip logic is
+// based on origin defaults.
+//
+// Semantics:
+// - If both origin defaults are empty and the column is nullable -> return NULL Field.
+// - If both are empty and the column is NOT NULL -> return GenDefaultField (type-specific zero).
+// - Otherwise parse/convert the origin default according to column type
+//   (time/decimal/enum/set/bit/json/etc.).
 Field ColumnInfo::defaultValueToField() const
 {
     const auto & value = origin_default_value;

--- a/dbms/src/TiDB/Schema/TiDB.h
+++ b/dbms/src/TiDB/Schema/TiDB.h
@@ -138,6 +138,7 @@ struct ColumnInfo
     COLUMN_FLAGS(M)
 #undef M
 
+    bool hasOriginDefaultValue() const;
     DB::Field defaultValueToField() const;
     CodecFlag getCodecFlag() const;
     DB::Field getDecimalValue(const String &) const;

--- a/dbms/src/TiDB/Schema/tests/gtest_table_info.cpp
+++ b/dbms/src/TiDB/Schema/tests/gtest_table_info.cpp
@@ -65,6 +65,8 @@ try
                 [](const TableInfo & table_info) {
                     ASSERT_EQ(table_info.name, "t");
                     ASSERT_EQ(table_info.id, 45L);
+                    ASSERT_EQ(table_info.columns.size(), 1U);
+                    ASSERT_FALSE(table_info.columns[0].hasOriginDefaultValue());
                 }},
             // Test with tiflash_replica information
             ParseCase{
@@ -77,6 +79,8 @@ try
             ParseCase{
                 R"json({"id":45,"name":{"O":"t","L":"t"},"charset":"utf8mb4","collate":"utf8mb4_bin","cols":[{"id":1,"name":{"O":"t","L":"t"},"offset":0,"origin_default":"\u0000\u00124","origin_default_bit":null,"default":null,"default_bit":null,"default_is_expr":false,"generated_expr_string":"","generated_stored":false,"dependences":null,"type":{"Tp":254,"Flag":129,"Flen":4,"Decimal":0,"Charset":"binary","Collate":"binary","Elems":null},"state":5,"comment":"","hidden":false,"change_state_info":null,"version":2}],"index_info":null,"constraint_info":null,"fk_info":null,"state":5,"pk_is_handle":false,"is_common_handle":false,"comment":"","auto_inc_id":0,"auto_id_cache":0,"auto_rand_id":0,"max_col_id":1,"max_idx_id":0,"max_cst_id":0,"update_timestamp":418683341902184450,"ShardRowIDBits":0,"max_shard_row_id_bits":0,"auto_random_bits":0,"pre_split_regions":0,"partition":null,"compression":"","view":null,"sequence":null,"Lock":null,"version":3,"tiflash_replica":{"Count":1,"LocationLabels":[],"Available":false,"AvailablePartitionIDs":null}})json",
                 [](const TableInfo & table_info) {
+                    ASSERT_EQ(table_info.columns.size(), 1U);
+                    ASSERT_EQ(table_info.columns[0].hasOriginDefaultValue(), true);
                     ASSERT_EQ(
                         table_info.columns[0].defaultValueToField().get<String>(),
                         Field(String(
@@ -89,6 +93,8 @@ try
             ParseCase{
                 R"json({"id":45,"name":{"O":"t","L":"t"},"charset":"utf8mb4","collate":"utf8mb4_bin","cols":[{"id":1,"name":{"O":"t","L":"t"},"offset":0,"origin_default":"\u0000\u00124","origin_default_bit":null,"default":null,"default_bit":null,"default_is_expr":false,"generated_expr_string":"","generated_stored":false,"dependences":null,"type":{"Tp":254,"Flag":129,"Flen":3,"Decimal":0,"Charset":"binary","Collate":"binary","Elems":null},"state":5,"comment":"","hidden":false,"change_state_info":null,"version":2}],"index_info":null,"constraint_info":null,"fk_info":null,"state":5,"pk_is_handle":false,"is_common_handle":false,"comment":"","auto_inc_id":0,"auto_id_cache":0,"auto_rand_id":0,"max_col_id":1,"max_idx_id":0,"max_cst_id":0,"update_timestamp":418683341902184450,"ShardRowIDBits":0,"max_shard_row_id_bits":0,"auto_random_bits":0,"pre_split_regions":0,"partition":null,"compression":"","view":null,"sequence":null,"Lock":null,"version":3,"tiflash_replica":{"Count":1,"LocationLabels":[],"Available":false,"AvailablePartitionIDs":null}})json",
                 [](const TableInfo & table_info) {
+                    ASSERT_EQ(table_info.columns.size(), 1U);
+                    ASSERT_EQ(table_info.columns[0].hasOriginDefaultValue(), true);
                     ASSERT_EQ(
                         table_info.columns[0].defaultValueToField().get<String>(),
                         Field(String(
@@ -134,6 +140,34 @@ try
                     ASSERT_EQ(col_1.tp, TiDB::TP::TypeNull);
                     ASSERT_TRUE(col_1.hasMultipleKeyFlag());
                     ASSERT_TRUE(col_1.hasBinaryFlag());
+                }},
+            // Check the "origin_default" value parsing
+            // See https://github.com/pingcap/tiflash/issues/10663 for more details.
+            ParseCase{
+                R"json({"cols":[{"id":1,"name":{"L":"a","O":"a"},"offset":0,"state":5,"type":{"Charset":"binary","Collate":"binary","Decimal":0,"Flag":3,"Flen":11,"Tp":3}},{"id":2,"name":{"L":"b","O":"b"},"offset":1,"state":5,"type":{"Charset":"binary","Collate":"binary","Decimal":0,"Flag":0,"Flen":11,"Tp":3}},{"default":"","id":3,"name":{"L":"site_code","O":"site_code"},"offset":2,"origin_default":"100","state":5,"type":{"Charset":"utf8mb4","Collate":"utf8mb4_bin","Decimal":0,"Flag":3,"Flen":64,"Tp":15}}],"id":130,"index_info":[{"id":1,"idx_cols":[{"length":-1,"name":{"L":"a","O":"a"},"offset":0},{"length":-1,"name":{"L":"site_code","O":"site_code"},"offset":2}],"idx_name":{"L":"primary","O":"primary"},"index_type":1,"is_global":false,"is_invisible":false,"is_primary":true,"is_unique":true,"state":5}],"is_common_handle":false,"keyspace_id":4294967295,"name":{"L":"t1","O":"t1"},"pk_is_handle":false,"state":5,"tiflash_replica":{"Available":true,"Count":1},"update_timestamp":463590354027544590})json",
+                [](const TableInfo & table_info) {
+                    ASSERT_EQ(table_info.name, "t1");
+                    ASSERT_EQ(table_info.id, 130);
+                    ASSERT_EQ(table_info.columns.size(), 3);
+                    auto col_3 = table_info.getColumnInfo(3);
+                    ASSERT_EQ(col_3.tp, TiDB::TP::TypeVarchar);
+                    ASSERT_TRUE(col_3.hasNotNullFlag());
+                    ASSERT_TRUE(col_3.hasOriginDefaultValue());
+                    // The "origin_default" is "100", which is used for filling default value for old rows that is inserted before this column is added.
+                    ASSERT_EQ(col_3.defaultValueToField().get<String>(), "100");
+                }},
+            ParseCase{
+                // Similar to the previous case, but the default value is different
+                R"json({"cols":[{"id":1,"name":{"L":"a","O":"a"},"offset":0,"state":5,"type":{"Charset":"binary","Collate":"binary","Decimal":0,"Flag":3,"Flen":11,"Tp":3}},{"id":2,"name":{"L":"b","O":"b"},"offset":1,"state":5,"type":{"Charset":"binary","Collate":"binary","Decimal":0,"Flag":0,"Flen":11,"Tp":3}},{"default":"","id":3,"name":{"L":"site_code","O":"site_code"},"offset":2,"origin_default":"200","state":5,"type":{"Charset":"utf8mb4","Collate":"utf8mb4_bin","Decimal":0,"Flag":3,"Flen":64,"Tp":15}}],"id":139,"index_info":[{"id":1,"idx_cols":[{"length":-1,"name":{"L":"a","O":"a"},"offset":0},{"length":-1,"name":{"L":"site_code","O":"site_code"},"offset":2}],"idx_name":{"L":"primary","O":"primary"},"index_type":1,"is_global":false,"is_invisible":false,"is_primary":true,"is_unique":true,"state":5}],"is_common_handle":false,"keyspace_id":4294967295,"name":{"L":"t1","O":"t1"},"pk_is_handle":false,"state":5,"tiflash_replica":{"Available":true,"Count":1},"update_timestamp":463590371866443800})json",
+                [](const TableInfo & table_info) {
+                    ASSERT_EQ(table_info.name, "t1");
+                    ASSERT_EQ(table_info.id, 139);
+                    ASSERT_EQ(table_info.columns.size(), 3);
+                    auto col_3 = table_info.getColumnInfo(3);
+                    ASSERT_EQ(col_3.tp, TiDB::TP::TypeVarchar);
+                    ASSERT_TRUE(col_3.hasNotNullFlag());
+                    // The "origin_default" is "200", which is used for filling default value for old rows that is inserted before this column is added.
+                    ASSERT_EQ(col_3.defaultValueToField().get<String>(), "200");
                 }},
     };
 

--- a/dbms/src/TiDB/tests/RowCodecTestUtils.h
+++ b/dbms/src/TiDB/tests/RowCodecTestUtils.h
@@ -123,6 +123,7 @@ ColumnInfo getColumnInfo(ColumnID id)
         column_info.setUnsignedFlag();
     if constexpr (!nullable)
         column_info.setNotNullFlag();
+    column_info.state = TiDB::SchemaState::StatePublic;
     return column_info;
 }
 

--- a/tests/fullstack-test2/ddl/alter_column_nullable.test
+++ b/tests/fullstack-test2/ddl/alter_column_nullable.test
@@ -144,3 +144,124 @@ mysql> set session tidb_isolation_read_engines='tiflash'; select * from test.alt
 +------+---+----+
 
 mysql> drop table if exists test.alt2
+
+#############
+# issue 10680, TiFlash data inconsistent with TiKV after modifying a column from NOT NULL to NULL
+mysql> DROP DATABASE IF EXISTS db_1483421321;
+mysql> CREATE DATABASE db_1483421321;
+mysql> CREATE TABLE db_1483421321.t0(c0 TINYINT, handle INT NOT NULL AUTO_INCREMENT, PRIMARY KEY(handle));
+mysql> ALTER TABLE db_1483421321.t0 SET TIFLASH REPLICA 1;
+func> wait_table db_1483421321 t0
+# empty table
+mysql> set session tidb_isolation_read_engines='tiflash'; SELECT * FROM db_1483421321.t0 order by handle;
+mysql> set session tidb_isolation_read_engines='tikv'; SELECT * FROM db_1483421321.t0 order by handle;
+
+mysql> ALTER TABLE db_1483421321.t0 ADD COLUMN c1 DECIMAL NULL;
+mysql> ALTER TABLE db_1483421321.t0 ADD COLUMN c2 FLOAT NULL DEFAULT 0.0795439693286002;
+mysql> ALTER TABLE db_1483421321.t0 ADD COLUMN c5 DECIMAL NOT NULL;
+mysql> ALTER TABLE db_1483421321.t0 ADD COLUMN c4 DECIMAL DEFAULT 247262911;
+mysql> ALTER TABLE db_1483421321.t0 MODIFY COLUMN c2 FLOAT NOT NULL;
+mysql> ALTER TABLE db_1483421321.t0 MODIFY COLUMN c5 DECIMAL NULL;
+mysql> ALTER TABLE db_1483421321.t0 MODIFY COLUMN c1 BIGINT DEFAULT -56083770 NOT NULL;
+
+# insert handle == 1
+mysql> INSERT INTO db_1483421321.t0 (c1, c2, c5, c4) VALUES (-2051270087, 0.44141045099028775, 0.0, 15523);
+# update handle == 1
+mysql> UPDATE db_1483421321.t0 SET c5 = 870337888;
+
+mysql> ALTER TABLE db_1483421321.t0 MODIFY COLUMN c1 BIGINT NULL;
+# insert handle == 2
+mysql> INSERT INTO db_1483421321.t0 (c2, c5, c4) VALUES (0.004406799693866592, 0.8752311290235516, 14652);
+mysql> set session tidb_isolation_read_engines='tiflash'; SELECT * FROM db_1483421321.t0 order by handle;
++------+--------+-------------+--------------+-----------+-------+
+| c0   | handle | c1          | c2           | c5        | c4    |
++------+--------+-------------+--------------+-----------+-------+
+| NULL |      1 | -2051270087 |   0.44141045 | 870337888 | 15523 |
+| NULL |      2 |        NULL | 0.0044067996 |         1 | 14652 |
++------+--------+-------------+--------------+-----------+-------+
+mysql> set session tidb_isolation_read_engines='tikv'; SELECT * FROM db_1483421321.t0 order by handle;
++------+--------+-------------+--------------+-----------+-------+
+| c0   | handle | c1          | c2           | c5        | c4    |
++------+--------+-------------+--------------+-----------+-------+
+| NULL |      1 | -2051270087 |   0.44141045 | 870337888 | 15523 |
+| NULL |      2 |        NULL | 0.0044067996 |         1 | 14652 |
++------+--------+-------------+--------------+-----------+-------+
+
+# insert handle == 3
+mysql> INSERT INTO db_1483421321.t0 (c2, c5, c4) VALUES (0.004406799693866592, 0.8752311290235516, 14652);
+mysql> set session tidb_isolation_read_engines='tiflash'; SELECT * FROM db_1483421321.t0 order by handle;
++------+--------+-------------+--------------+-----------+-------+
+| c0   | handle | c1          | c2           | c5        | c4    |
++------+--------+-------------+--------------+-----------+-------+
+| NULL |      1 | -2051270087 |   0.44141045 | 870337888 | 15523 |
+| NULL |      2 |        NULL | 0.0044067996 |         1 | 14652 |
+| NULL |      3 |        NULL | 0.0044067996 |         1 | 14652 |
++------+--------+-------------+--------------+-----------+-------+
+mysql> set session tidb_isolation_read_engines='tikv'; SELECT * FROM db_1483421321.t0 order by handle;
++------+--------+-------------+--------------+-----------+-------+
+| c0   | handle | c1          | c2           | c5        | c4    |
++------+--------+-------------+--------------+-----------+-------+
+| NULL |      1 | -2051270087 |   0.44141045 | 870337888 | 15523 |
+| NULL |      2 |        NULL | 0.0044067996 |         1 | 14652 |
+| NULL |      3 |        NULL | 0.0044067996 |         1 | 14652 |
++------+--------+-------------+--------------+-----------+-------+
+
+mysql> drop table if exists db_1483421321.t0
+
+#############
+# issue 10680 variation, TiFlash data inconsistent with TiKV after modifying a column from NULL TO NOT NULL then to NULL again
+mysql> DROP DATABASE IF EXISTS db_1483421321;
+mysql> CREATE DATABASE db_1483421321;
+mysql> CREATE TABLE db_1483421321.t1(c0 TINYINT, handle INT NOT NULL AUTO_INCREMENT, PRIMARY KEY(handle));
+mysql> ALTER TABLE db_1483421321.t1 SET TIFLASH REPLICA 1;
+func> wait_table db_1483421321 t1
+# empty table
+mysql> set session tidb_isolation_read_engines='tiflash'; SELECT * FROM db_1483421321.t1 order by handle;
+mysql> set session tidb_isolation_read_engines='tikv'; SELECT * FROM db_1483421321.t1 order by handle;
+
+mysql> ALTER TABLE db_1483421321.t1 ADD COLUMN c1 DECIMAL NULL;
+mysql> ALTER TABLE db_1483421321.t1 ADD COLUMN c2 FLOAT NULL DEFAULT 0.0795439693286002;
+mysql> ALTER TABLE db_1483421321.t1 ADD COLUMN c5 DECIMAL NOT NULL;
+mysql> ALTER TABLE db_1483421321.t1 ADD COLUMN c4 DECIMAL DEFAULT 247262911;
+
+mysql> INSERT INTO db_1483421321.t1 (c1, c2, c5, c4) VALUES (-2051270087, 0.44141045099028775, 0.0, 15523);
+
+mysql> ALTER TABLE db_1483421321.t1 MODIFY COLUMN c1 BIGINT DEFAULT -56083770 NOT NULL;
+mysql> UPDATE db_1483421321.t1 SET c5 = 870337888;
+
+mysql> ALTER TABLE db_1483421321.t1 MODIFY COLUMN c1 BIGINT NULL;
+mysql> INSERT INTO db_1483421321.t1 (c2, c5, c4) VALUES (0.004406799693866592, 0.8752311290235516, 14652);
+mysql> set session tidb_isolation_read_engines='tiflash'; SELECT * FROM db_1483421321.t1 order by handle;
++------+--------+-------------+--------------+-----------+-------+
+| c0   | handle | c1          | c2           | c5        | c4    |
++------+--------+-------------+--------------+-----------+-------+
+| NULL |      1 | -2051270087 |   0.44141045 | 870337888 | 15523 |
+| NULL |      2 |        NULL | 0.0044067996 |         1 | 14652 |
++------+--------+-------------+--------------+-----------+-------+
+mysql> set session tidb_isolation_read_engines='tikv'; SELECT * FROM db_1483421321.t1 order by handle;
++------+--------+-------------+--------------+-----------+-------+
+| c0   | handle | c1          | c2           | c5        | c4    |
++------+--------+-------------+--------------+-----------+-------+
+| NULL |      1 | -2051270087 |   0.44141045 | 870337888 | 15523 |
+| NULL |      2 |        NULL | 0.0044067996 |         1 | 14652 |
++------+--------+-------------+--------------+-----------+-------+
+
+mysql> INSERT INTO db_1483421321.t1 (c2, c5, c4) VALUES (0.44444, 0.8888, 22222);
+mysql> set session tidb_isolation_read_engines='tiflash'; SELECT * FROM db_1483421321.t1 order by handle;
++------+--------+-------------+--------------+-----------+-------+
+| c0   | handle | c1          | c2           | c5        | c4    |
++------+--------+-------------+--------------+-----------+-------+
+| NULL |      1 | -2051270087 |   0.44141045 | 870337888 | 15523 |
+| NULL |      2 |        NULL | 0.0044067996 |         1 | 14652 |
+| NULL |      3 |        NULL |      0.44444 |         1 | 22222 |
++------+--------+-------------+--------------+-----------+-------+
+mysql> set session tidb_isolation_read_engines='tikv'; SELECT * FROM db_1483421321.t1 order by handle;
++------+--------+-------------+--------------+-----------+-------+
+| c0   | handle | c1          | c2           | c5        | c4    |
++------+--------+-------------+--------------+-----------+-------+
+| NULL |      1 | -2051270087 |   0.44141045 | 870337888 | 15523 |
+| NULL |      2 |        NULL | 0.0044067996 |         1 | 14652 |
+| NULL |      3 |        NULL |      0.44444 |         1 | 22222 |
++------+--------+-------------+--------------+-----------+-------+
+
+mysql> drop table if exists db_1483421321.t1


### PR DESCRIPTION
### What changed

Cherry-pick pingcap/tiflash#10682 to release-8.5-20260622-v8.5.4.

This backports the default value filling fix so missing NOT NULL columns without origin default trigger schema sync instead of silently filling zero, keeping TiFlash results consistent with TiKV after altering a column from NOT NULL to NULL.

### Notes

- Cherry-picked merge commit 01b12dd900eff5a6f3463047dc5cb506335bdf1d with `-x -m 1`.
- Resolved small context conflicts in `RowCodec.cpp` and `gtest_table_info.cpp`.

### Checks

- Not run, per request.

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fixed a TiFlash/TiKV mismatch after altering a column from NOT NULL to NULL
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved row decoding when encoded data is missing columns (especially during schema changes), with more reliable handling for NOT NULL and primary-key/handle-related columns.
  * Enhanced default/backfill behavior to better respect origin-default values and correct value construction for handle/primary-key columns.

* **Tests**
  * Added unit tests for RegionBlockReader default handling and TiDB row codec missing-column scenarios (including origin-default parsing).
  * Added fullstack coverage to validate TiFlash/TiKV result consistency across NULLability transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->