### PR TITLE
Storages: use-after-free race between SegmentReadTaskScheduler and SegmentReaderPoolManager shutdown

### DIFF
--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -1111,6 +1111,9 @@ try
           *  table engines could use Context on destroy.
           */
         LOG_INFO(log, "Shutting down storages.");
+        // Stop scheduler first to avoid use-after-free: schedLoop may try to
+        // push MergedTask to already-destroyed reader_pools.
+        DB::DM::SegmentReadTaskScheduler::instance().stop();
         // `SegmentReader` threads may hold a segment and its delta-index for read.
         // `Context::shutdown()` will destroy `DeltaIndexManager`.
         // So, stop threads explicitly before `TiFlashTestEnv::shutdown()`.

--- a/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.cpp
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.cpp
@@ -43,6 +43,15 @@ void SegmentReadTaskScheduler::stop()
     }
 }
 
+void SegmentReadTaskScheduler::pushMergedTask(const MergedTaskPtr & p)
+{
+    // After stop(), the schedLoop is no longer running and merged_task_pool
+    // will never be drained. Discard re-queued tasks to avoid resource leak.
+    if (isStop())
+        return;
+    merged_task_pool.push(p);
+}
+
 void SegmentReadTaskScheduler::add(const SegmentReadTaskPoolPtr & pool)
 {
     // To avoid schedule from always failing to acquire the pending_mtx.

--- a/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.cpp
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.cpp
@@ -31,6 +31,11 @@ SegmentReadTaskScheduler::SegmentReadTaskScheduler(bool run_sched_thread)
 
 SegmentReadTaskScheduler::~SegmentReadTaskScheduler()
 {
+    stop();
+}
+
+void SegmentReadTaskScheduler::stop()
+{
     setStop();
     if (likely(sched_thread.joinable()))
     {
@@ -223,12 +228,12 @@ std::optional<std::pair<GlobalSegmentID, std::vector<UInt64>>> SegmentReadTaskSc
 
 void SegmentReadTaskScheduler::setStop()
 {
-    stop.store(true, std::memory_order_relaxed);
+    stop_flag.store(true, std::memory_order_relaxed);
 }
 
 bool SegmentReadTaskScheduler::isStop() const
 {
-    return stop.load(std::memory_order_relaxed);
+    return stop_flag.load(std::memory_order_relaxed);
 }
 
 std::tuple<UInt64, UInt64, UInt64> SegmentReadTaskScheduler::scheduleOneRound()

--- a/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.h
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.h
@@ -33,7 +33,7 @@ class SegmentReadTasksPoolTest;
 //
 // - `sched_thread` will scheduling read tasks.
 // - Call path: schedLoop -> schedule -> reapPendingPools -> scheduleOneRound
-// - reapPeningPools will swap the `pending_pools` and add these pools to `read_pools` and `merging_segments`.
+// - reapPendingPools will swap the `pending_pools` and add these pools to `read_pools` and `merging_segments`.
 // - scheduleOneRound will scan `read_pools` and choose segments to read.
 class SegmentReadTaskScheduler
 {
@@ -45,6 +45,11 @@ public:
     }
 
     ~SegmentReadTaskScheduler();
+
+    // Must be called before SegmentReaderPoolManager::stop() during shutdown to avoid
+    // use-after-free: schedLoop may still try to push MergedTask to destroyed reader_pools.
+    void stop();
+
     DISALLOW_COPY_AND_MOVE(SegmentReadTaskScheduler);
 
     // Add `pool` to `pending_pools`.
@@ -96,7 +101,7 @@ private:
 
     MergedTaskPool merged_task_pool;
 
-    std::atomic<bool> stop{false};
+    std::atomic<bool> stop_flag{false};
     bool enable_data_sharing{true};
     std::thread sched_thread;
 

--- a/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.h
+++ b/dbms/src/Storages/DeltaMerge/ReadThread/SegmentReadTaskScheduler.h
@@ -55,7 +55,7 @@ public:
     // Add `pool` to `pending_pools`.
     void add(const SegmentReadTaskPoolPtr & pool);
 
-    void pushMergedTask(const MergedTaskPtr & p) { merged_task_pool.push(p); }
+    void pushMergedTask(const MergedTaskPtr & p);
 
     void updateConfig(const Settings & settings);
 

--- a/dbms/src/TestUtils/gtests_dbms_main.cpp
+++ b/dbms/src/TestUtils/gtests_dbms_main.cpp
@@ -78,13 +78,13 @@ int main(int argc, char ** argv)
     DB::DM::SegmentReaderPoolManager::instance().init(4, 1.0);
     DB::DM::SegmentReadTaskScheduler::instance();
 
-    DB::GlobalThreadPool::initialize(/*max_threads*/ 100, /*max_free_threds*/ 10, /*queue_size*/ 1000);
-    DB::S3FileCachePool::initialize(/*max_threads*/ 20, /*max_free_threds*/ 10, /*queue_size*/ 1000);
-    DB::DataStoreS3Pool::initialize(/*max_threads*/ 20, /*max_free_threds*/ 10, /*queue_size*/ 1000);
-    DB::BuildReadTaskForWNPool::initialize(/*max_threads*/ 20, /*max_free_threds*/ 10, /*queue_size*/ 1000);
-    DB::BuildReadTaskForWNTablePool::initialize(/*max_threads*/ 20, /*max_free_threds*/ 10, /*queue_size*/ 1000);
-    DB::BuildReadTaskPool::initialize(/*max_threads*/ 20, /*max_free_threds*/ 10, /*queue_size*/ 1000);
-    DB::RNWritePageCachePool::initialize(/*max_threads*/ 20, /*max_free_threds*/ 10, /*queue_size*/ 1000);
+    DB::GlobalThreadPool::initialize(/*max_threads*/ 100, /*max_free_threads*/ 10, /*queue_size*/ 1000);
+    DB::S3FileCachePool::initialize(/*max_threads*/ 20, /*max_free_threads*/ 10, /*queue_size*/ 1000);
+    DB::DataStoreS3Pool::initialize(/*max_threads*/ 20, /*max_free_threads*/ 10, /*queue_size*/ 1000);
+    DB::BuildReadTaskForWNPool::initialize(/*max_threads*/ 20, /*max_free_threads*/ 10, /*queue_size*/ 1000);
+    DB::BuildReadTaskForWNTablePool::initialize(/*max_threads*/ 20, /*max_free_threads*/ 10, /*queue_size*/ 1000);
+    DB::BuildReadTaskPool::initialize(/*max_threads*/ 20, /*max_free_threads*/ 10, /*queue_size*/ 1000);
+    DB::RNWritePageCachePool::initialize(/*max_threads*/ 20, /*max_free_threads*/ 10, /*queue_size*/ 1000);
     const auto s3_endpoint = Poco::Environment::get("S3_ENDPOINT", "");
     const auto s3_bucket = Poco::Environment::get("S3_BUCKET", "mockbucket");
     const auto s3_root = Poco::Environment::get("S3_ROOT", "tiflash_ut/");
@@ -119,6 +119,9 @@ int main(int argc, char ** argv)
 
     auto ret = RUN_ALL_TESTS();
 
+    // Stop scheduler first to avoid use-after-free: schedLoop may try to
+    // push MergedTask to already-destroyed reader_pools.
+    DB::DM::SegmentReadTaskScheduler::instance().stop();
     // `SegmentReader` threads may hold a segment and its delta-index for read.
     // `TiFlashTestEnv::shutdown()` will destroy `DeltaIndexManager`.
     // Stop threads explicitly before `TiFlashTestEnv::shutdown()`.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10903

Problem Summary:

During shutdown, `SegmentReaderPoolManager::stop()` destroys all `reader_pools` and their `WorkQueue` mutexes, but `SegmentReadTaskScheduler`'s `schedLoop` background thread is still running. When `schedLoop` wakes from its 2ms sleep, it calls `scheduleOneRound()` → `SegmentReaderPoolManager::addTask()` → accesses already-destroyed `reader_pools`, causing SIGSEGV (use-after-free).

### What is changed and how it works?

```commit-message
Add a public `stop()` method to `SegmentReadTaskScheduler` that sets the stop flag and joins the background thread. Call it **before** `SegmentReaderPoolManager::stop()` in both production (`Server.cpp`) and test (`gtests_dbms_main.cpp`) shutdown paths.

- `SegmentReadTaskScheduler.h`: expose `stop()` as public method; rename `std::atomic<bool> stop` → `stop_flag` to avoid name collision
- `SegmentReadTaskScheduler.cpp`: implement `stop()`, destructor delegates to it
- `Server.cpp`: call `SegmentReadTaskScheduler::instance().stop()` before `SegmentReaderPoolManager::instance().stop()`
- `gtests_dbms_main.cpp`: same reorder

Also fix two minor typos along the way:
- `reapPeningPools` → `reapPendingPools` in class comment
- `max_free_threds` → `max_free_threads` in test main
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Manual test: `./gtests_dbms --gtest_filter="DeltaMergeStoreTest.ReadLegacyStringDataCFTiny"` — test passes and process exits cleanly without SIGSEGV.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved shutdown stability by ensuring the segment read task scheduler stops before dependent reader pools are torn down, reducing risk of invalid task enqueuing during shutdown.
* **Tests**
  * Corrected a thread-pool initialization parameter name in the test harness to ensure consistent setup and teardown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->