### PR TITLE
tests: enable shared lock foreign key check in next-gen configs

### DIFF
--- a/tests/docker/next-gen-columnar-config/tidb.toml
+++ b/tests/docker/next-gen-columnar-config/tidb.toml
@@ -35,3 +35,8 @@ tidb_service_scope = "dxf_service"
 tcp-keep-alive = true
 [security]
 enable-sem = false
+
+# Turn on the experimental feature to allow related testing
+# Related PR: https://github.com/pingcap/tidb/pull/69167
+[experimental]
+allow-enable-foreign-key-check-in-shared-lock = true

--- a/tests/docker/next-gen-config/tidb.toml
+++ b/tests/docker/next-gen-config/tidb.toml
@@ -31,3 +31,8 @@ tidb_service_scope = "dxf_service"
 tcp-keep-alive = true
 [security]
 enable-sem = false
+
+# Turn on the experimental feature to allow related testing
+# Related PR: https://github.com/pingcap/tidb/pull/69167
+[experimental]
+allow-enable-foreign-key-check-in-shared-lock = true


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/10902, close https://github.com/pingcap/tiflash/issues/11028

Problem Summary:

Next-gen test configurations need to opt in to TiDB experimental behavior for shared-lock foreign key check coverage.

### What is changed and how it works?

```commit-message
tune tidb config
```

Enable `allow-enable-foreign-key-check-in-shared-lock` under `[experimental]` in both next-gen Docker TiDB configs:

- `tests/docker/next-gen-config/tidb.toml`
- `tests/docker/next-gen-columnar-config/tidb.toml`

This follows the related TiDB change: https://github.com/pingcap/tidb/pull/69167.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
