### PR TITLE
Support min_count/max_count agg funcs in TiFlash

### DIFF
--- a/dbms/src/AggregateFunctions/AggregateFunctionFactory.cpp
+++ b/dbms/src/AggregateFunctions/AggregateFunctionFactory.cpp
@@ -65,7 +65,15 @@ void AggregateFunctionFactory::registerFunction(
 /// Combinator will check if nested_function was created.
 /// TODO Consider replace with function property. See also https://github.com/ClickHouse/ClickHouse/pull/11661
 extern const std::unordered_set<String> hacking_return_non_null_agg_func_names
-    = {"count", "uniq", "uniqHLL12", "uniqExact", "uniqCombined", uniq_raw_res_name, count_second_stage};
+    = {"count",
+       "min_count",
+       "max_count",
+       "uniq",
+       "uniqHLL12",
+       "uniqExact",
+       "uniqCombined",
+       uniq_raw_res_name,
+       count_second_stage};
 
 AggregateFunctionPtr AggregateFunctionFactory::get(
     const Context & context,

--- a/dbms/src/AggregateFunctions/AggregateFunctionMinMaxAny.cpp
+++ b/dbms/src/AggregateFunctions/AggregateFunctionMinMaxAny.cpp
@@ -121,6 +121,32 @@ AggregateFunctionPtr createAggregateFunctionArgMax(
         createAggregateFunctionArgMinMax<AggregateFunctionMaxData>(name, argument_types, parameters));
 }
 
+AggregateFunctionPtr createAggregateFunctionMinCount(
+    const Context & /* context not used */,
+    const std::string & name,
+    const DataTypes & argument_types,
+    const Array & parameters)
+{
+    return AggregateFunctionPtr(
+        createAggregateFunctionSingleValue<AggregateFunctionsSingleValueMinMaxCount, AggregateFunctionMinCountData>(
+            name,
+            argument_types,
+            parameters));
+}
+
+AggregateFunctionPtr createAggregateFunctionMaxCount(
+    const Context & /* context not used */,
+    const std::string & name,
+    const DataTypes & argument_types,
+    const Array & parameters)
+{
+    return AggregateFunctionPtr(
+        createAggregateFunctionSingleValue<AggregateFunctionsSingleValueMinMaxCount, AggregateFunctionMaxCountData>(
+            name,
+            argument_types,
+            parameters));
+}
+
 } // namespace
 
 void registerAggregateFunctionsMinMaxAny(AggregateFunctionFactory & factory)
@@ -131,6 +157,8 @@ void registerAggregateFunctionsMinMaxAny(AggregateFunctionFactory & factory)
     factory.registerFunction("anyHeavy", createAggregateFunctionAnyHeavy);
     factory.registerFunction("min", createAggregateFunctionMin, AggregateFunctionFactory::CaseInsensitive);
     factory.registerFunction("max", createAggregateFunctionMax, AggregateFunctionFactory::CaseInsensitive);
+    factory.registerFunction("min_count", createAggregateFunctionMinCount, AggregateFunctionFactory::CaseInsensitive);
+    factory.registerFunction("max_count", createAggregateFunctionMaxCount, AggregateFunctionFactory::CaseInsensitive);
     factory.registerFunction("argMin", createAggregateFunctionArgMin);
     factory.registerFunction("argMax", createAggregateFunctionArgMax);
 }

--- a/dbms/src/AggregateFunctions/AggregateFunctionMinMaxAny.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionMinMaxAny.h
@@ -21,8 +21,10 @@
 #include <Columns/ColumnString.h>
 #include <Columns/ColumnVector.h>
 #include <Common/typeid_cast.h>
+#include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/IDataType.h>
 #include <IO/ReadHelpers.h>
+#include <IO/VarInt.h>
 #include <IO/WriteHelpers.h>
 #include <common/StringRef.h>
 
@@ -771,6 +773,114 @@ struct AggregateFunctionAnyHeavyData : Data
     static const char * name() { return "anyHeavy"; }
 };
 
+template <typename Data>
+struct AggregateFunctionMinCountData : Data
+{
+    using Self = AggregateFunctionMinCountData<Data>;
+
+    UInt64 count = 0;
+
+    bool changeIfBetter(const IColumn & column, size_t row_num, Arena * arena)
+    {
+        if (this->changeIfLess(column, row_num, arena))
+        {
+            count = 1;
+            return true;
+        }
+        if (this->isEqualTo(column, row_num))
+        {
+            ++count;
+            return true;
+        }
+        return false;
+    }
+
+    bool changeIfBetter(const Self & to, Arena * arena)
+    {
+        if (!to.has())
+            return false;
+        if (this->changeIfLess(to, arena))
+        {
+            count = to.count;
+            return true;
+        }
+        if (this->isEqualTo(to))
+        {
+            count += to.count;
+            return true;
+        }
+        return false;
+    }
+
+    void write(WriteBuffer & buf, const IDataType & data_type) const
+    {
+        Data::write(buf, data_type);
+        writeVarUInt(count, buf);
+    }
+
+    void read(ReadBuffer & buf, const IDataType & data_type, Arena * arena)
+    {
+        Data::read(buf, data_type, arena);
+        readVarUInt(count, buf);
+    }
+
+    static const char * name() { return "min_count"; }
+};
+
+template <typename Data>
+struct AggregateFunctionMaxCountData : Data
+{
+    using Self = AggregateFunctionMaxCountData<Data>;
+
+    UInt64 count = 0;
+
+    bool changeIfBetter(const IColumn & column, size_t row_num, Arena * arena)
+    {
+        if (this->changeIfGreater(column, row_num, arena))
+        {
+            count = 1;
+            return true;
+        }
+        if (this->isEqualTo(column, row_num))
+        {
+            ++count;
+            return true;
+        }
+        return false;
+    }
+
+    bool changeIfBetter(const Self & to, Arena * arena)
+    {
+        if (!to.has())
+            return false;
+        if (this->changeIfGreater(to, arena))
+        {
+            count = to.count;
+            return true;
+        }
+        if (this->isEqualTo(to))
+        {
+            count += to.count;
+            return true;
+        }
+        return false;
+    }
+
+    void write(WriteBuffer & buf, const IDataType & data_type) const
+    {
+        Data::write(buf, data_type);
+        writeVarUInt(count, buf);
+    }
+
+    void read(ReadBuffer & buf, const IDataType & data_type, Arena * arena)
+    {
+        Data::read(buf, data_type, arena);
+        readVarUInt(count, buf);
+    }
+
+    static const char * name() { return "max_count"; }
+};
+
 
 template <typename Data>
 class AggregateFunctionsSingleValue final
@@ -839,6 +949,59 @@ public:
     const char * getHeaderFilePath() const override { return __FILE__; }
 
     bool allocatesMemoryInArena() const override { return Data::needArena(); }
+};
+
+template <typename Data>
+class AggregateFunctionsSingleValueMinMaxCount final
+    : public IAggregateFunctionDataHelper<Data, AggregateFunctionsSingleValueMinMaxCount<Data>, true>
+{
+private:
+    DataTypePtr type;
+
+public:
+    explicit AggregateFunctionsSingleValueMinMaxCount(const DataTypePtr & type_)
+        : type(type_)
+    {
+        if (StringRef(Data::name()) == StringRef("min_count") || StringRef(Data::name()) == StringRef("max_count"))
+        {
+            if (!type->isComparable())
+                throw Exception(
+                    "Illegal type " + type->getName() + " of argument of aggregate function " + getName()
+                        + " because the values of that data type are not comparable",
+                    ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+        }
+    }
+
+    String getName() const override { return Data::name(); }
+
+    DataTypePtr getReturnType() const override { return std::make_shared<DataTypeUInt64>(); }
+
+    void add(AggregateDataPtr __restrict place, const IColumn ** columns, size_t row_num, Arena * arena) const override
+    {
+        this->data(place).changeIfBetter(*columns[0], row_num, arena);
+    }
+
+    void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs, Arena * arena) const override
+    {
+        this->data(place).changeIfBetter(this->data(rhs), arena);
+    }
+
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf) const override
+    {
+        this->data(place).write(buf, *type.get());
+    }
+
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, Arena * arena) const override
+    {
+        this->data(place).read(buf, *type.get(), arena);
+    }
+
+    void insertResultInto(ConstAggregateDataPtr __restrict place, IColumn & to, Arena *) const override
+    {
+        static_cast<ColumnUInt64 &>(to).getData().push_back(this->data(place).count);
+    }
+
+    const char * getHeaderFilePath() const override { return __FILE__; }
 };
 
 } // namespace DB

--- a/dbms/src/AggregateFunctions/AggregateFunctionMinMaxAny.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionMinMaxAny.h
@@ -1002,6 +1002,8 @@ public:
     }
 
     const char * getHeaderFilePath() const override { return __FILE__; }
+
+    bool allocatesMemoryInArena() const override { return Data::needArena(); }
 };
 
 } // namespace DB

--- a/dbms/src/AggregateFunctions/tests/gtest_agg_func_return_type.cpp
+++ b/dbms/src/AggregateFunctions/tests/gtest_agg_func_return_type.cpp
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 #include <AggregateFunctions/AggregateFunctionSum.h>
+#include <Columns/ColumnsNumber.h>
 #include <DataTypes/DataTypeDecimal.h>
 #include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypesNumber.h>
 #include <TestUtils/AggregationTestUtils.h>
 #include <TestUtils/TiFlashTestBasic.h>
 #include <TestUtils/mockExecutor.h>
@@ -67,6 +69,27 @@ public:
 
         return ::testing::AssertionSuccess();
     }
+
+    UInt64 evalCountAgg(const String & agg_name, const DataTypePtr & data_type, const std::vector<Field> & values)
+    {
+        AggregateFunctionPtr agg_ptr
+            = DB::AggregateFunctionFactory::instance().get(*TiFlashTestEnv::getContext(), agg_name, {data_type}, {});
+        auto data_col = data_type->createColumn();
+        for (const auto & value : values)
+            data_col->insert(value);
+
+        Arena arena;
+        auto * place = arena.alignedAlloc(agg_ptr->sizeOfData(), agg_ptr->alignOfData());
+        agg_ptr->create(place);
+        const IColumn * cols[] = {data_col.get()};
+        for (size_t i = 0; i < values.size(); ++i)
+            agg_ptr->add(place, cols, i, &arena);
+
+        auto result_col = agg_ptr->getReturnType()->createColumn();
+        agg_ptr->insertResultInto(place, *result_col, &arena);
+        agg_ptr->destroy(place);
+        return typeid_cast<const ColumnUInt64 &>(*result_col).getData()[0];
+    }
 };
 
 TEST_F(ExecutorAggFuncReturnTypeTestRunner, AggregationSum)
@@ -77,6 +100,26 @@ try
     ASSERT_TRUE(testSumOnPartialResult<Decimal64>());
     ASSERT_TRUE(testSumOnPartialResult<Decimal128>());
     ASSERT_TRUE(testSumOnPartialResult<Decimal256>());
+}
+CATCH
+
+TEST_F(ExecutorAggFuncReturnTypeTestRunner, AggregationMinMaxCount)
+try
+{
+    auto int_type = std::make_shared<DataTypeInt64>();
+    auto nullable_int_type = makeNullable(int_type);
+
+    ASSERT_EQ(
+        evalCountAgg("max_count", int_type, {Field(Int64(1)), Field(Int64(3)), Field(Int64(3)), Field(Int64(2))}),
+        2);
+    ASSERT_EQ(
+        evalCountAgg(
+            "min_count",
+            nullable_int_type,
+            {Field(), Field(Int64(2)), Field(Int64(1)), Field(Int64(1)), Field()}),
+        2);
+    ASSERT_EQ(evalCountAgg("max_count", nullable_int_type, {Field(), Field(), Field()}), 0);
+    ASSERT_EQ(evalCountAgg("min_count", nullable_int_type, {Field(), Field(), Field()}), 0);
 }
 CATCH
 

--- a/dbms/src/AggregateFunctions/tests/gtest_agg_func_return_type.cpp
+++ b/dbms/src/AggregateFunctions/tests/gtest_agg_func_return_type.cpp
@@ -16,6 +16,7 @@
 #include <Columns/ColumnsNumber.h>
 #include <DataTypes/DataTypeDecimal.h>
 #include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <TestUtils/AggregationTestUtils.h>
 #include <TestUtils/TiFlashTestBasic.h>
@@ -72,8 +73,7 @@ public:
 
     UInt64 evalCountAgg(const String & agg_name, const DataTypePtr & data_type, const std::vector<Field> & values)
     {
-        AggregateFunctionPtr agg_ptr
-            = DB::AggregateFunctionFactory::instance().get(*TiFlashTestEnv::getContext(), agg_name, {data_type}, {});
+        AggregateFunctionPtr agg_ptr = getCountAgg(agg_name, data_type);
         auto data_col = data_type->createColumn();
         for (const auto & value : values)
             data_col->insert(value);
@@ -89,6 +89,11 @@ public:
         agg_ptr->insertResultInto(place, *result_col, &arena);
         agg_ptr->destroy(place);
         return typeid_cast<const ColumnUInt64 &>(*result_col).getData()[0];
+    }
+
+    AggregateFunctionPtr getCountAgg(const String & agg_name, const DataTypePtr & data_type)
+    {
+        return DB::AggregateFunctionFactory::instance().get(*TiFlashTestEnv::getContext(), agg_name, {data_type}, {});
     }
 };
 
@@ -108,6 +113,14 @@ try
 {
     auto int_type = std::make_shared<DataTypeInt64>();
     auto nullable_int_type = makeNullable(int_type);
+    auto string_type = std::make_shared<DataTypeString>();
+    const String long_min(128, 'a');
+    const String long_max(128, 'z');
+
+    ASSERT_FALSE(getCountAgg("max_count", int_type)->allocatesMemoryInArena());
+    ASSERT_FALSE(getCountAgg("min_count", int_type)->allocatesMemoryInArena());
+    ASSERT_TRUE(getCountAgg("max_count", string_type)->allocatesMemoryInArena());
+    ASSERT_TRUE(getCountAgg("min_count", string_type)->allocatesMemoryInArena());
 
     ASSERT_EQ(
         evalCountAgg("max_count", int_type, {Field(Int64(1)), Field(Int64(3)), Field(Int64(3)), Field(Int64(2))}),
@@ -120,6 +133,18 @@ try
         2);
     ASSERT_EQ(evalCountAgg("max_count", nullable_int_type, {Field(), Field(), Field()}), 0);
     ASSERT_EQ(evalCountAgg("min_count", nullable_int_type, {Field(), Field(), Field()}), 0);
+    ASSERT_EQ(
+        evalCountAgg(
+            "max_count",
+            string_type,
+            {Field(long_min), Field(long_max), Field(long_max), Field(String("middle"))}),
+        2);
+    ASSERT_EQ(
+        evalCountAgg(
+            "min_count",
+            string_type,
+            {Field(long_max), Field(long_min), Field(String("middle")), Field(long_min)}),
+        2);
 }
 CATCH
 

--- a/dbms/src/Debug/MockExecutor/AggregationBinder.cpp
+++ b/dbms/src/Debug/MockExecutor/AggregationBinder.cpp
@@ -202,7 +202,8 @@ void AggregationBinder::buildAggFunc(tipb::Expr * agg_func, const ASTFunction * 
     auto agg_sig = agg_sig_it->second;
     agg_func->set_tp(agg_sig);
 
-    if (agg_sig == tipb::ExprType::Count || agg_sig == tipb::ExprType::Sum || agg_sig == tipb::ExprType::SumInt)
+    if (agg_sig == tipb::ExprType::Count || agg_sig == tipb::ExprType::Sum || agg_sig == tipb::ExprType::SumInt
+        || agg_sig == tipb::ExprType::MinCount || agg_sig == tipb::ExprType::MaxCount)
     {
         auto * ft = agg_func->mutable_field_type();
         ft->set_tp(TiDB::TypeLongLong);
@@ -269,7 +270,7 @@ ExecutorBinderPtr compileAggregation(
             }
 
             TiDB::ColumnInfo ci;
-            if (func->name == "count")
+            if (func->name == "count" || func->name == "max_count" || func->name == "min_count")
             {
                 ci.tp = TiDB::TypeLongLong;
                 ci.flag = TiDB::ColumnFlagUnsigned | TiDB::ColumnFlagNotNull;

--- a/dbms/src/Debug/MockExecutor/FuncSigMap.cpp
+++ b/dbms/src/Debug/MockExecutor/FuncSigMap.cpp
@@ -89,6 +89,8 @@ std::unordered_map<String, tipb::ExprType> agg_func_name_to_sig({
     {"max", tipb::ExprType::Max},
     {"min_for_window", tipb::ExprType::Min},
     {"max_for_window", tipb::ExprType::Max},
+    {"min_count", tipb::ExprType::MinCount},
+    {"max_count", tipb::ExprType::MaxCount},
     {"count", tipb::ExprType::Count},
     {"sum", tipb::ExprType::Sum},
     {"sum_int", tipb::ExprType::SumInt},

--- a/dbms/src/Flash/Coprocessor/DAGUtils.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGUtils.cpp
@@ -64,6 +64,8 @@ const std::unordered_map<tipb::ExprType, String> agg_func_map({
     {tipb::ExprType::SumInt, "sum"},
     {tipb::ExprType::Min, "min"},
     {tipb::ExprType::Max, "max"},
+    {tipb::ExprType::MinCount, "min_count"},
+    {tipb::ExprType::MaxCount, "max_count"},
     {tipb::ExprType::First, "first_row"},
     {tipb::ExprType::ApproxCountDistinct, uniq_raw_res_name},
     {tipb::ExprType::GroupConcat, "groupArray"},
@@ -1034,6 +1036,8 @@ String exprToString(const tipb::Expr & expr, const std::vector<NameAndTypePair> 
     case tipb::ExprType::Avg:
     case tipb::ExprType::Min:
     case tipb::ExprType::Max:
+    case tipb::ExprType::MinCount:
+    case tipb::ExprType::MaxCount:
     case tipb::ExprType::First:
     case tipb::ExprType::ApproxCountDistinct:
     case tipb::ExprType::GroupConcat:
@@ -1091,6 +1095,8 @@ bool isAggFunctionExpr(const tipb::Expr & expr)
     case tipb::ExprType::Avg:
     case tipb::ExprType::Min:
     case tipb::ExprType::Max:
+    case tipb::ExprType::MinCount:
+    case tipb::ExprType::MaxCount:
     case tipb::ExprType::First:
     case tipb::ExprType::GroupConcat:
     case tipb::ExprType::Agg_BitAnd:


### PR DESCRIPTION
ref pingcap/tiflash#10741

### What problem does this PR solve?

Issue Number: close #10741

Problem Summary:

### What is changed and how it works?
This pr cherry-pick #10742 to master branch
```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
support min_count/max_count
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `min_count` and `max_count` aggregate functions.
  * They return the number of rows tied for the selected minimum/maximum value (as a `UInt64`).
  * Integrated support across aggregation planning, execution, and coprocessor/window handling so the functions work consistently.

* **Bug Fixes**
  * Improved behavior for empty and nullable inputs for these aggregates, including returning `0` when no valid values are present.
  * Updated aggregation return-type handling to match the new functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->