### PR TITLE
tests: stop the tests and keep logs if meet error

### DIFF
--- a/tests/fullstack-test-next-gen-columnar/run.sh
+++ b/tests/fullstack-test-next-gen-columnar/run.sh
@@ -20,7 +20,7 @@ source ./_env.sh
 
 set_branch
 
-set -x
+set -xe
 
 export verbose=${verbose:-"false"}
 
@@ -49,7 +49,7 @@ if [[ -n "$ENABLE_NEXT_GEN" && "$ENABLE_NEXT_GEN" != "false" && "$ENABLE_NEXT_GE
 
     # run fullstack-tests
     wait_next_gen_columnar_env
-    ENV_ARGS="ENABLE_NEXT_GEN=true verbose=${verbose} continue_on_error=true"
+    ENV_ARGS="ENABLE_NEXT_GEN=true verbose=${verbose}"
     # most failpoints are expected to be set on the compute layer, use tiflash-cn0 to run tests
     ${COMPOSE} "${COMPOSE_FILES[@]}" exec -T tiflash-cn0 bash -c "cd /tests ; ${ENV_ARGS} ./run-test.sh fullstack-test/sample.test"
     #${COMPOSE} "${COMPOSE_FILES[@]}" exec -T tiflash-cn0 bash -c "cd /tests ; ${ENV_ARGS} ./run-test.sh fullstack-test-index"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/10844

Problem Summary:
integration tests 

https://prow.tidb.net/jenkins/job/pingcap/job/tiflash/job/pull_integration_next_gen_columnar/100/console
```
fullstack-test2/clustered_index/issue_1514.test: OK [1.451 s]
fullstack-test2/clustered_index/prefixNext.test: Running
  File: fullstack-test2/clustered_index/prefixNext.test
  Error line: 21
  Error: wait_table test t1
  Error: test timed out after 120s
fullstack-test2/clustered_index/prefixNext.test: Failed
fullstack-test2/clustered_index/query.test: Running
  File: fullstack-test2/clustered_index/query.test
  Error line: 33
  Error: wait_table test t_1
  Error: test timed out after 120s
fullstack-test2/clustered_index/query.test: Failed
Total failed: 2 test(s)
+ docker-compose -f next-gen-cluster.yaml -f disagg_tiflash.yaml exec -T tiflash-cn0 bash -c 'cd /tests ; ENABLE_NEXT_GEN=true verbose=false continue_on_error=true ./run-test.sh fullstack-test2/dml'
fullstack-test2/dml/foreign_key_shared_lock_wide_row.test: Running
fullstack-test2/dml/foreign_key_shared_lock_wide_row.test: OK [62.099 s]
```

### What is changed and how it works?

```commit-message
tests: use `set -xe` and remove `continue_on_error=true` to stop the tests and keep logs if meet error
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the fullstack test run to use stricter shell tracing and standard failure handling, so test runs stop on errors by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->