### PR TITLE
tests: Enlarge unittest timeout

### DIFF
--- a/tests/gtest_parallel.py
+++ b/tests/gtest_parallel.py
@@ -253,6 +253,7 @@ class Task(object):
             try:
                 self.exit_code = sigint_handler.wait(task)
             except sigint_handler.ProcessWasInterrupted:
+                self.runtime_ms = int(1000 * (time.time() - begin))
                 thread.exit()
         self.runtime_ms = int(1000 * (time.time() - begin))
         self.last_execution_time = None if self.exit_code else self.runtime_ms
@@ -366,13 +367,27 @@ class FilterFormat(object):
     def print_tests(self, message, tasks, print_try_number):
         self.out.permanent_line("%s (%s/%s):" %
                                 (message, len(tasks), self.total_tasks))
+        is_interrupted = message == 'INTERRUPTED TESTS'
         for task in sorted(tasks):
+            try_number_suffix = (
+                (" (try #%d)" % task.execution_number) if print_try_number else "")
+            if is_interrupted:
+                if task.runtime_ms is not None:
+                    self.out.permanent_line(
+                        "Interrupted: %d ms: %s %s%s" % (
+                            task.runtime_ms, task.test_binary, task.test_name,
+                            try_number_suffix))
+                else:
+                    self.out.permanent_line(
+                        "Interrupted: %s %s%s" % (
+                            task.test_binary, task.test_name, try_number_suffix))
+                continue
+
             runtime_ms = 'Interrupted'
             if task.runtime_ms is not None:
                 runtime_ms = '%d ms' % task.runtime_ms
             self.out.permanent_line("%11s: %s %s%s" % (
-                runtime_ms, task.test_binary, task.test_name,
-                (" (try #%d)" % task.execution_number) if print_try_number else ""))
+                runtime_ms, task.test_binary, task.test_name, try_number_suffix))
 
     def log_exit(self, task):
         with self.stdout_lock:

--- a/tests/run-gtest.sh
+++ b/tests/run-gtest.sh
@@ -56,8 +56,8 @@ function run_test_parallel() {
 		args="--gtest_break_on_failure --gtest_catch_exceptions=0"
 	fi
 
-	# run with 60 min timeout
-	python ${SRC_TESTS_PATH}/gtest_parallel.py ${test_bins} --workers=${NPROC} ${args} --print_test_times --timeout=3600
+	# run with 90 min timeout
+	python ${SRC_TESTS_PATH}/gtest_parallel.py ${test_bins} --workers=${NPROC} ${args} --print_test_times --timeout=5400
 }
 
 set -e


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6233 

Problem Summary:

### What is changed and how it works?

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed interrupted test runs so elapsed runtime is now recorded and shown consistently.
  * Improved interrupted test output formatting for clearer reporting during parallel runs.

* **Chores**
  * Increased the gtest parallel run timeout from 60 minutes to 90 minutes to reduce unexpected timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->