### PR TITLE
Storages: Enhance storage logging details

### DIFF
--- a/dbms/src/Flash/Statistics/TableScanImpl.cpp
+++ b/dbms/src/Flash/Statistics/TableScanImpl.cpp
@@ -74,7 +74,8 @@ void TableScanStatistics::appendExtraJson(FmtBuffer & fmt_buffer) const
         scan_details = scan_details_buf.c_str();
     }
     fmt_buffer.fmtAppend(
-        R"("connection_details":[{},{}],"scan_details":{})",
+        R"("is_partition_table_scan":{},"connection_details":[{},{}],"scan_details":{})",
+        is_partition_table_scan,
         local_table_scan_detail.toJson(),
         remote_table_scan_detail.toJson(),
         scan_details);
@@ -233,5 +234,6 @@ void TableScanStatistics::collectExtraRuntimeDetail()
 
 TableScanStatistics::TableScanStatistics(const tipb::Executor * executor, DAGContext & dag_context_)
     : TableScanStatisticsBase(executor, dag_context_)
+    , is_partition_table_scan(executor->has_partition_table_scan())
 {}
 } // namespace DB

--- a/dbms/src/Flash/Statistics/TableScanImpl.h
+++ b/dbms/src/Flash/Statistics/TableScanImpl.h
@@ -76,5 +76,7 @@ protected:
 private:
     void updateTableScanDetail(const std::vector<ConnectionProfileInfo> & connection_profile_infos);
     void updateTableScanDetailForDisaggIfNecessary(const IProfilingBlockInputStream * stream);
+
+    bool is_partition_table_scan = false;
 };
 } // namespace DB

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_Ingest.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore_Ingest.cpp
@@ -228,6 +228,25 @@ Segments DeltaMergeStore::ingestDTFilesUsingColumnFile(
     return updated_segments;
 }
 
+namespace
+{
+constexpr double slow_split_ingest_log_threshold_seconds = 10.0;
+
+struct SplitIngestLogContext
+{
+    const Stopwatch & watch;
+
+    bool isSlow() const { return watch.elapsedSeconds() > slow_split_ingest_log_threshold_seconds; }
+
+    double elapsedSeconds() const { return watch.elapsedSeconds(); }
+
+    Poco::Message::Priority debugOrInfoLevel() const
+    {
+        return isSlow() ? Poco::Message::PRIO_INFORMATION : Poco::Message::PRIO_DEBUG;
+    }
+};
+} // namespace
+
 /**
  * Accept a target ingest range and a vector of DTFiles, ingest these DTFiles (clipped by the target ingest range)
  * using logical split.
@@ -245,6 +264,9 @@ Segments DeltaMergeStore::ingestDTFilesUsingSplit(
     const DMFiles & files,
     bool clear_data_in_range)
 {
+    Stopwatch watch;
+    SplitIngestLogContext split_ingest_log{watch};
+
     {
         RUNTIME_CHECK(files.size() == external_files.size(), files.size(), external_files.size());
         for (size_t i = 0; i < files.size(); ++i)
@@ -331,9 +353,11 @@ Segments DeltaMergeStore::ingestDTFilesUsingSplit(
      *                                  ↑ The segment we ingest DMFile into
      */
 
-    LOG_DEBUG(
+    LOG_IMPL(
         log,
-        "Table ingest using split - split ingest phase - begin, ingest_range={}, files_n={}",
+        split_ingest_log.debugOrInfoLevel(),
+        "Table ingest using split - split ingest phase - begin, elapsed_seconds={:.3f} ingest_range={} files_n={}",
+        split_ingest_log.elapsedSeconds(),
         ingest_range.toDebugString(),
         files.size());
 
@@ -389,8 +413,10 @@ Segments DeltaMergeStore::ingestDTFilesUsingSplit(
 
             LOG_INFO(
                 log,
-                "Table ingest using split - split ingest phase - Try to ingest file into segment, file_idx={} "
+                "Table ingest using split - split ingest phase - Try to ingest file into segment, "
+                "elapsed_seconds={:.3f} file_idx={} "
                 "file_id=dmf_{} file_ingest_range={} segment={} segment_ingest_range={}",
+                split_ingest_log.elapsedSeconds(),
                 file_idx,
                 files[file_idx]->fileId(),
                 file_ingest_range.toDebugString(),
@@ -412,15 +438,17 @@ Segments DeltaMergeStore::ingestDTFilesUsingSplit(
             }
             else
             {
-                // this segment is abandoned, or may be split into multiples.
+                // this segment is abandoned, or may be split into multiples, or running segmentMerge/segmentMergeDelta, etc.
                 // retry with current range and file and find segment again.
             }
         }
     }
 
-    LOG_DEBUG(
+    LOG_IMPL(
         log,
-        "Table ingest using split - split ingest phase - finished, updated_segments_n={}",
+        split_ingest_log.debugOrInfoLevel(),
+        "Table ingest using split - split ingest phase - finished, elapsed_seconds={:.3f} updated_segments_n={}",
+        split_ingest_log.elapsedSeconds(),
         updated_segments.size());
 
     return std::vector<SegmentPtr>(updated_segments.begin(), updated_segments.end());
@@ -787,10 +815,21 @@ UInt64 DeltaMergeStore::ingestFiles(
         if (has_segments || !external_files.empty())
         {
             if (use_split_replace)
-                updated_segments
-                    = ingestDTFilesUsingSplit(dm_context, range, external_files, files, clear_data_in_range);
+            {
+                // For large files, we use split+replace to ingest the files into stable layer directly.
+                // Check the `ingestDTFilesUsingSplit` for the details steps.
+                updated_segments = ingestDTFilesUsingSplit( //
+                    dm_context,
+                    range,
+                    external_files,
+                    files,
+                    clear_data_in_range);
+            }
             else
+            {
+                // For small files, we ingest them into the delta layer directly, which is more efficient than split+replace.
                 updated_segments = ingestDTFilesUsingColumnFile(dm_context, range, files, clear_data_in_range);
+            }
         }
     }
 

--- a/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalSegment.cpp
+++ b/dbms/src/Storages/DeltaMerge/DeltaMergeStore_InternalSegment.cpp
@@ -279,8 +279,10 @@ SegmentPair DeltaMergeStore::segmentSplit(
 
         LOG_INFO(
             log,
-            "Split - {} - Finish, segment is split into two, old_segment={} new_left={} new_right={}",
+            "Split - {} - Finish, segment is split into two, reason={} "
+            ", old_segment={} new_left={} new_right={}",
             split_info.is_logical ? "SplitLogical" : "SplitPhysical",
+            magic_enum::enum_name(reason),
             segment->info(),
             new_left->info(),
             new_right->info());
@@ -331,6 +333,7 @@ SegmentPtr DeltaMergeStore::segmentMerge(
         dm_context.min_version,
         Segment::simpleInfo(ordered_segments));
 
+    // keep "for_update=true" snapshot for all related segments
     std::vector<SegmentSnapshotPtr> ordered_snapshots;
     ordered_snapshots.reserve(ordered_segments.size());
     ColumnDefinesPtr schema_snap;
@@ -775,7 +778,7 @@ void DeltaMergeStore::segmentEnsureStableLocalIndex(
         DMFile::info(index_build_info.dm_files));
 
     // 3. Update the meta version of the segments to the latest one.
-    // To avoid logical split between step 2 and 3, get lastest segments to update again.
+    // To avoid logical split between step 2 and 3, get latest segments to update again.
     // If TiFlash crashes during updating the meta version, some segments' meta are updated and some are not.
     // So after TiFlash restarts, we will update meta versions to latest versions again.
     {
@@ -1307,7 +1310,9 @@ SegmentPtr DeltaMergeStore::segmentMergeDelta(
 
         LOG_INFO(
             log,
-            "MergeDelta - Finish, delta is merged, old_segment={} new_segment={}",
+            "MergeDelta - Finish, delta is merged, reason={} "
+            "old_segment={} new_segment={}",
+            magic_enum::enum_name(reason),
             segment->info(),
             new_segment->info());
     }

--- a/dbms/src/Storages/DeltaMerge/File/DMFile.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFile.h
@@ -132,6 +132,7 @@ public:
     const DMFileMeta::PackProperties & getPackProperties() const { return meta->pack_properties; }
     const ColumnStats & getColumnStats() const { return meta->column_stats; }
     const std::unordered_set<ColId> & getColumnIndices() const { return meta->column_indices; }
+    size_t getNumColumns() const { return meta->column_stats.size(); }
 
     // only used in gtest
     void clearPackProperties() const { meta->pack_properties.clear_property(); }

--- a/dbms/src/Storages/DeltaMerge/Segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/Segment.cpp
@@ -2555,7 +2555,8 @@ String Segment::info() const
         "<segment_id={} epoch={} range={}{} next_segment_id={} "
         "delta_rows={} delta_bytes={} delta_deletes={} "
         "stable_file={} stable_rows={} stable_bytes={} "
-        "dmf_rows={} dmf_bytes={} dmf_packs={}>",
+        "stable_cols={} "
+        "dmf_rows={} dmf_bytes={} dmf_disk_bytes={} dmf_packs={}>",
         segment_id,
         epoch,
         rowkey_range.toDebugString(),
@@ -2569,9 +2570,11 @@ String Segment::info() const
         stable->getDMFilesString(),
         stable->getRows(),
         stable->getBytes(),
+        stable->getDMFilesNumColumns(),
 
         stable->getDMFilesRows(),
         stable->getDMFilesBytes(),
+        stable->getDMFilesBytesOnDisk(),
         stable->getDMFilesPacks());
 }
 

--- a/dbms/src/Storages/DeltaMerge/StableValueSpace.cpp
+++ b/dbms/src/Storages/DeltaMerge/StableValueSpace.cpp
@@ -267,6 +267,14 @@ size_t StableValueSpace::getDMFilesBytes() const
     return bytes;
 }
 
+size_t StableValueSpace::getDMFilesNumColumns() const
+{
+    size_t num_columns = 0;
+    for (const auto & file : files)
+        num_columns = std::max(num_columns, file->getNumColumns());
+    return num_columns;
+}
+
 String StableValueSpace::getDMFilesString()
 {
     return DMFile::info(files);

--- a/dbms/src/Storages/DeltaMerge/StableValueSpace.h
+++ b/dbms/src/Storages/DeltaMerge/StableValueSpace.h
@@ -87,6 +87,11 @@ public:
     String getDMFilesString();
 
     /**
+     * Return the number of columns of the underlying DTFiles.
+     */
+    size_t getDMFilesNumColumns() const;
+
+    /**
      * Return the total on-disk size of the underlying DTFiles.
      * DTFiles are not fully included in the segment range will be also counted in.
      * Note: Out-of-range DTFiles may be produced by logical split.

--- a/dbms/src/Storages/KVStore/tests/gtest_kvstore_fast_add_peer.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_kvstore_fast_add_peer.cpp
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// FIXME: Disabled because the flaky test result errors in CI.
+// And we don't plan to support enable FAP in short time.
+#if 0
 #include <Debug/MockKVStore/MockRaftStoreProxy.h>
 #include <Debug/TiFlashTestEnv.h>
 #include <Interpreters/SharedContexts/Disagg.h>
@@ -1206,3 +1209,4 @@ CATCH
 
 } // namespace tests
 } // namespace DB
+#endif

--- a/dbms/src/Storages/S3/FileCache.cpp
+++ b/dbms/src/Storages/S3/FileCache.cpp
@@ -1302,7 +1302,11 @@ void downloadToLocal(
     wbuf.sync();
 }
 
-void FileCache::downloadImpl(const String & s3_key, FileSegmentPtr & file_seg, const WriteLimiterPtr & write_limiter)
+void FileCache::downloadImpl(
+    const String & s3_key,
+    FileSegmentPtr & file_seg,
+    const WriteLimiterPtr & write_limiter,
+    DownloadType download_type)
 {
     Stopwatch sw;
     auto client = S3::ClientFactory::instance().sharedTiFlashClient();
@@ -1368,7 +1372,8 @@ void FileCache::downloadImpl(const String & s3_key, FileSegmentPtr & file_seg, c
     file_seg->setComplete(content_length);
     LOG_INFO(
         log,
-        "Download success, s3_key={} local={} size={} cost={}ms",
+        "Download success, type={} s3_key={} local={} size={} cost={}ms",
+        magic_enum::enum_name(download_type),
         s3_key,
         local_fname,
         content_length,
@@ -1393,7 +1398,7 @@ void FileCache::bgDownloadExecutor(
         SYNC_FOR("before_FileCache::bgDownloadExecutor_fail_point");
         FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::file_cache_bg_download_fail);
         GET_METRIC(tiflash_storage_remote_cache, type_dtfile_download).Increment();
-        downloadImpl(s3_key, file_seg, write_limiter);
+        downloadImpl(s3_key, file_seg, write_limiter, DownloadType::Background);
     }
     catch (...)
     {
@@ -1481,7 +1486,7 @@ void FileCache::fgDownload(const String & s3_key, FileSegmentPtr & file_seg)
         FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::file_cache_fg_download_fail);
         GET_METRIC(tiflash_storage_remote_cache, type_dtfile_download).Increment();
         // not limit write speed for foreground download now
-        downloadImpl(s3_key, file_seg, nullptr);
+        downloadImpl(s3_key, file_seg, nullptr, DownloadType::Foreground);
     }
     catch (...)
     {

--- a/dbms/src/Storages/S3/FileCache.h
+++ b/dbms/src/Storages/S3/FileCache.h
@@ -374,7 +374,18 @@ public:
         Int64 running_limit);
     void finishBgDownload(const String & s3_key, Int64 running_limit);
     void cleanupFailedDownload(const String & s3_key, FileSegmentPtr & file_seg);
-    void downloadImpl(const String & s3_key, FileSegmentPtr & file_seg, const WriteLimiterPtr & write_limiter);
+
+    enum class DownloadType
+    {
+        Foreground,
+        Background,
+    };
+
+    void downloadImpl(
+        const String & s3_key,
+        FileSegmentPtr & file_seg,
+        const WriteLimiterPtr & write_limiter,
+        DownloadType download_type);
 
     static String toTemporaryFilename(const String & fname);
     static bool isTemporaryFilename(const String & fname);

--- a/tests/docker/next-gen-columnar-yaml/cluster.yaml
+++ b/tests/docker/next-gen-columnar-yaml/cluster.yaml
@@ -25,7 +25,7 @@ services:
     # Use entrypoint instead, create bucket "tiflash-test" on minio at startup
     entrypoint: sh -c 'mkdir -p /data/tiflash-test && minio server /data --console-address ":9001" > /log/minio.log 2>&1'
   pd0:
-    image: ${PD_IMAGE:-us-docker.pkg.dev/pingcap-testing-account/tidbx/tikv/pd/image:master-next-gen}
+    image: ${PD_IMAGE:-us-docker.pkg.dev/pingcap-testing-account/tidbx/tikv/pd/image:master-nextgen}
     security_opt:
       - seccomp:unconfined
     volumes:
@@ -35,7 +35,7 @@ services:
     command: --name=pd0 --client-urls=http://0.0.0.0:2379 --peer-urls=http://0.0.0.0:2380 --advertise-client-urls=http://pd0:2379 --advertise-peer-urls=http://pd0:2380 --initial-cluster=pd0=http://pd0:2380 --config=/pd.toml --data-dir=/data --log-file=/log/pd.log
     restart: on-failure
   tikv0:
-    image: ${TIKV_IMAGE:-us-docker.pkg.dev/pingcap-testing-account/tidbx/tikv/tikv/image:cloud-engine-next-gen}
+    image: ${TIKV_IMAGE:-us-docker.pkg.dev/pingcap-testing-account/tidbx/tikv/tikv/image:cloud-engine-nextgen}
     security_opt:
       - seccomp:unconfined
     volumes:
@@ -48,7 +48,7 @@ services:
       - "minio0"
     restart: on-failure
   tikv-worker0:
-    image: ${TIKV_IMAGE:-us-docker.pkg.dev/pingcap-testing-account/tidbx/tikv/tikv/image:cloud-engine-next-gen}
+    image: ${TIKV_IMAGE:-us-docker.pkg.dev/pingcap-testing-account/tidbx/tikv/tikv/image:cloud-engine-nextgen}
     security_opt:
       - seccomp:unconfined
     volumes:
@@ -61,7 +61,7 @@ services:
       - "pd0"
     restart: on-failure
   tidb0:
-    image: ${TIDB_IMAGE:-us-docker.pkg.dev/pingcap-testing-account/tidbx/pingcap/tidb/images/tidb-server:master-next-gen}
+    image: ${TIDB_IMAGE:-us-docker.pkg.dev/pingcap-testing-account/tidbx/pingcap/tidb/images/tidb-server:master-nextgen}
     security_opt:
       - seccomp:unconfined
     volumes:

--- a/tests/docker/next-gen-utils/Makefile
+++ b/tests/docker/next-gen-utils/Makefile
@@ -11,10 +11,10 @@
 # limitations under the License.
 
 DOCKER ?= docker
-TIKV_IMAGE ?= us-docker.pkg.dev/pingcap-testing-account/tidbx/tikv/tikv/image:cloud-engine-next-gen
-PD_IMAGE ?= us-docker.pkg.dev/pingcap-testing-account/tidbx/tikv/pd/image:master-next-gen
-TIDB_IMAGE ?= us-docker.pkg.dev/pingcap-testing-account/tidbx/pingcap/tidb/images/tidb-server:master-next-gen
-TIFLASH_IMAGE ?= us-docker.pkg.dev/pingcap-testing-account/tidbx/pingcap/tiflash/image:master-next-gen
+TIKV_IMAGE ?= us-docker.pkg.dev/pingcap-testing-account/tidbx/tikv/tikv/image:cloud-engine-nextgen
+PD_IMAGE ?= us-docker.pkg.dev/pingcap-testing-account/tidbx/tikv/pd/image:master-nextgen
+TIDB_IMAGE ?= us-docker.pkg.dev/pingcap-testing-account/tidbx/pingcap/tidb/images/tidb-server:master-nextgen
+TIFLASH_IMAGE ?= us-docker.pkg.dev/pingcap-testing-account/tidbx/pingcap/tiflash/image:master-nextgen
 
 # Set PULL to 1 to always pull the latest image
 PULL ?= 0

--- a/tests/docker/next-gen-yaml/cluster.yaml
+++ b/tests/docker/next-gen-yaml/cluster.yaml
@@ -25,7 +25,7 @@ services:
     # Use entrypoint instead, create bucket "tiflash-test" on minio at startup
     entrypoint: sh -c 'mkdir -p /data/tiflash-test && minio server /data --console-address ":9001" > /log/minio.log 2>&1'
   pd0:
-    image: ${PD_IMAGE:-us-docker.pkg.dev/pingcap-testing-account/tidbx/tikv/pd/image:master-next-gen}
+    image: ${PD_IMAGE:-us-docker.pkg.dev/pingcap-testing-account/tidbx/tikv/pd/image:master-nextgen}
     security_opt:
       - seccomp:unconfined
     volumes:
@@ -35,7 +35,7 @@ services:
     command: --name=pd0 --client-urls=http://0.0.0.0:2379 --peer-urls=http://0.0.0.0:2380 --advertise-client-urls=http://pd0:2379 --advertise-peer-urls=http://pd0:2380 --initial-cluster=pd0=http://pd0:2380 --config=/pd.toml --data-dir=/data --log-file=/log/pd.log
     restart: on-failure
   tikv0:
-    image: ${TIKV_IMAGE:-us-docker.pkg.dev/pingcap-testing-account/tidbx/tikv/tikv/image:cloud-engine-next-gen}
+    image: ${TIKV_IMAGE:-us-docker.pkg.dev/pingcap-testing-account/tidbx/tikv/tikv/image:cloud-engine-nextgen}
     security_opt:
       - seccomp:unconfined
     volumes:
@@ -48,7 +48,7 @@ services:
       - "minio0"
     restart: on-failure
   tikv-worker0:
-    image: ${TIKV_IMAGE:-us-docker.pkg.dev/pingcap-testing-account/tidbx/tikv/tikv/image:cloud-engine-next-gen}
+    image: ${TIKV_IMAGE:-us-docker.pkg.dev/pingcap-testing-account/tidbx/tikv/tikv/image:cloud-engine-nextgen}
     security_opt:
       - seccomp:unconfined
     volumes:
@@ -61,7 +61,7 @@ services:
       - "pd0"
     restart: on-failure
   tidb0:
-    image: ${TIDB_IMAGE:-us-docker.pkg.dev/pingcap-testing-account/tidbx/pingcap/tidb/images/tidb-server:master-next-gen}
+    image: ${TIDB_IMAGE:-us-docker.pkg.dev/pingcap-testing-account/tidbx/pingcap/tidb/images/tidb-server:master-nextgen}
     security_opt:
       - seccomp:unconfined
     volumes:

--- a/tests/fullstack-test-next-gen-columnar/_env.sh
+++ b/tests/fullstack-test-next-gen-columnar/_env.sh
@@ -30,19 +30,19 @@ export LOCAL_TiFLASH_BIN_DIR="${LOCAL_TiFLASH_BIN_DIR:-../.build/tiflash}"
 
 export HUB_ADDR="${HUB_ADDR:-us-docker.pkg.dev/pingcap-testing-account/tidbx}"
 
-export PD_BRANCH="${PD_BRANCH:-master-next-gen}"
+export PD_BRANCH="${PD_BRANCH:-master-nextgen}"
 if [[ "${PD_BRANCH}" == "master" ]]; then
-  export PD_BRANCH="master-next-gen"
+  export PD_BRANCH="master-nextgen"
 fi
 
-export TIKV_BRANCH="${TIKV_BRANCH:-cloud-engine-next-gen}"
+export TIKV_BRANCH="${TIKV_BRANCH:-cloud-engine-nextgen}"
 if [[ "${TIKV_BRANCH}" == "cloud-engine" ]]; then
-  export TIKV_BRANCH="cloud-engine-next-gen"
+  export TIKV_BRANCH="cloud-engine-nextgen"
 fi
 
-export TIDB_BRANCH="${TIDB_BRANCH:-master-next-gen}"
+export TIDB_BRANCH="${TIDB_BRANCH:-master-nextgen}"
 if [[ "${TIDB_BRANCH}" == "master" ]]; then
-  export TIDB_BRANCH="master-next-gen"
+  export TIDB_BRANCH="master-nextgen"
 fi
 
 export PD_IMAGE="${PD_IMAGE:-${HUB_ADDR}/tikv/pd/image:${PD_BRANCH}}"

--- a/tests/fullstack-test-next-gen/_env.sh
+++ b/tests/fullstack-test-next-gen/_env.sh
@@ -29,19 +29,19 @@ export LOCAL_TiFLASH_BIN_DIR="${LOCAL_TiFLASH_BIN_DIR:-../.build/tiflash}"
 
 export HUB_ADDR="${HUB_ADDR:-us-docker.pkg.dev/pingcap-testing-account/tidbx}"
 
-export PD_BRANCH="${PD_BRANCH:-master-next-gen}"
+export PD_BRANCH="${PD_BRANCH:-master-nextgen}"
 if [[ "${PD_BRANCH}" == "master" ]]; then
-  export PD_BRANCH="master-next-gen"
+  export PD_BRANCH="master-nextgen"
 fi
 
-export TIKV_BRANCH="${TIKV_BRANCH:-cloud-engine-next-gen}"
+export TIKV_BRANCH="${TIKV_BRANCH:-cloud-engine-nextgen}"
 if [[ "${TIKV_BRANCH}" == "cloud-engine" ]]; then
-  export TIKV_BRANCH="cloud-engine-next-gen"
+  export TIKV_BRANCH="cloud-engine-nextgen"
 fi
 
-export TIDB_BRANCH="${TIDB_BRANCH:-master-next-gen}"
+export TIDB_BRANCH="${TIDB_BRANCH:-master-nextgen}"
 if [[ "${TIDB_BRANCH}" == "master" ]]; then
-  export TIDB_BRANCH="master-next-gen"
+  export TIDB_BRANCH="master-nextgen"
 fi
 
 export PD_IMAGE="${PD_IMAGE:-${HUB_ADDR}/tikv/pd/image:${PD_BRANCH}}"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10950

Problem Summary:

When diagnosing TiFlash storage and query issues in production, existing logs and execution summaries lack enough context to distinguish scan types and understand slow storage operations:

- TableScan execution summary JSON does not indicate whether the scan is a regular `TableScan` or `PartitionTableScan`.
- Split-based ingest logs are mostly at DEBUG level and do not include elapsed time, making slow ingest hard to spot.
- Segment split/merge-delta finish logs do not include the trigger reason.
- Segment info strings miss stable column count and on-disk DMFile size.
- FileCache download success logs do not distinguish foreground vs background downloads.
- `gtest_kvstore_fast_add_peer` is flaky in CI and FAP is not planned for short-term support.

### What is changed and how it works?

```commit-message
Add observability improvements for TableScan statistics and storage layer logging.

- Expose `is_partition_table_scan` in TableScan execution summary JSON.
- Add elapsed-time logging for split ingest; promote slow paths (>10s) from DEBUG to INFO.
- Log split/merge-delta reason in segment operation finish logs.
- Enrich Segment::info() with stable column count and DMFile on-disk bytes.
- Log FileCache download type (Foreground/Background) on successful download.
- Disable flaky gtest_kvstore_fast_add_peer test.
```

**TableScan statistics**

- Cache `is_partition_table_scan` in `TableScanStatistics` constructor via `executor->has_partition_table_scan()`.
- Output `"is_partition_table_scan": true/false` in `appendExtraJson`, so execution summary / slow query analysis can tell partition scans apart.

**DeltaMerge storage logging**

- Introduce `SplitIngestLogContext` in `ingestDTFilesUsingSplit`:
  - Track elapsed time across split ingest phases.
  - Use `LOG_IMPL` to emit begin/finish logs at INFO when elapsed > 10s, otherwise DEBUG.
  - Add `elapsed_seconds` to per-file ingest attempt logs (INFO).
- Log `reason` in `segmentSplit` and `segmentMergeDelta` finish logs via `magic_enum::enum_name(reason)`.
- Extend `Segment::info()` with `stable_cols` and `dmf_disk_bytes`.
- Add `DMFile::getNumColumns()` and `StableValueSpace::getDMFilesNumColumns()`.

**S3 FileCache**

- Add `FileCache::DownloadType` (`Foreground` / `Background`).
- Include download type in `downloadImpl` success log for easier disagg read path analysis.

**Tests**

- Wrap `gtest_kvstore_fast_add_peer.cpp` with `#if 0` and document why (flaky CI, FAP not planned for short-term support).

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced table-scan status details with partition-scan indicator and added stable scan summary fields.
  * Added column-count reporting to segment/stable summaries.
  * S3 file-download logging now distinguishes foreground vs background transfers.
* **Bug Fixes**
  * Improved split-ingest and completion logging with elapsed time and “reason” context for easier troubleshooting.
  * Disabled a flaky KV store test from building/running.
* **Refactor**
  * Clarified the split-vs-column-file ingest branching for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->