### PR TITLE
flash: avoid bad_optional_access when stopping LocalAdmissionController

### DIFF
--- a/dbms/src/Flash/ResourceControl/LocalAdmissionController.cpp
+++ b/dbms/src/Flash/ResourceControl/LocalAdmissionController.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <Flash/ResourceControl/LocalAdmissionController.h>
+#include <common/logger_useful.h>
 #include <etcd/rpc.pb.h>
 
 #include <algorithm>
@@ -1045,12 +1046,14 @@ void LocalAdmissionController::stop()
     // 2. clear GAC's unique_client_id by setting acquire_tokens as zero to avoid affecting burst limit calculation.
     // This can happen when disagg CN is scaled-in/out frequently.
     // NOTE: Make sure all threads have been joined before call buildGACRequest().
-    const auto gac_req = buildGACRequest(/*is_final_report=*/true);
-    RUNTIME_CHECK(keyspace_resource_groups.empty() || gac_req.has_value());
-    auto resp = cluster->pd_client->acquireTokenBuckets(gac_req.value());
-
-    if (resp.has_error())
-        LOG_ERROR(log, "LAC stop got error: {}", resp.error().message());
+    if (const auto gac_req = buildGACRequest(/*is_final_report=*/true); //
+        gac_req.has_value())
+    {
+        LOG_INFO(log, "LAC({}) stop final report to GAC: {}", unique_client_id, gac_req->ShortDebugString());
+        auto resp = cluster->pd_client->acquireTokenBuckets(gac_req.value());
+        if (resp.has_error())
+            LOG_WARNING(log, "LAC stop got error: {}", resp.error().message());
+    }
 
     if (need_reset_unique_client_id.load())
     {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10964

Problem Summary:

When `LocalAdmissionController::stop()` runs with an empty `keyspace_resource_groups`, `buildGACRequest(/*is_final_report=*/true)` may return an empty optional. The previous code still called `.value()` unconditionally, which can throw `std::bad_optional_access` during shutdown.

### What is changed and how it works?

```commit-message
flash: avoid bad_optional_access when stopping LocalAdmissionController

Guard the final `acquireTokenBuckets` call with `gac_req.has_value()` in `LocalAdmissionController::stop()`. This prevents dereferencing an empty optional during shutdown when no resource-group report is needed.
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Manual test steps:
1. Reproduce shutdown path where no resource group is cached.
2. Stop TiFlash and verify no `std::bad_optional_access` is logged from `LocalAdmissionController::stop()`.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown handling for resource usage reporting so the final report is only sent when a valid request is available.
  * Added clearer logging around final report submission and downgraded report-send failures to warnings to avoid noisy error logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->