### PR TITLE
metrics: fix tiflash-summary grafana when deploy with tiflash-columnar

### DIFF
--- a/metrics/grafana/tiflash_summary.json
+++ b/metrics/grafana/tiflash_summary.json
@@ -52,7 +52,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1775402037950,
+  "iteration": 1783577500370,
   "links": [],
   "panels": [
     {
@@ -25347,7 +25347,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_TEST-CLUSTER}",
-        "definition": "label_values(tiflash_proxy_tikv_engine_size_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}, instance)",
+        "definition": "label_values(tiflash_proxy_process_cpu_seconds_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}, instance)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -25357,7 +25357,7 @@
         "name": "proxy_instance",
         "options": [],
         "query": {
-          "query": "label_values(tiflash_proxy_tikv_engine_size_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}, instance)",
+          "query": "label_values(tiflash_proxy_process_cpu_seconds_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}, instance)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/10844

Problem Summary:

When deploy with next-gen columnar mode, there is no "tiflash_proxy_tikv_engine_size_bytes". We need another way to collect `proxy_instance` for grafana

### What is changed and how it works?

```commit-message

```
use `tiflash_proxy_process_cpu_seconds_total` instead of `tiflash_proxy_tikv_engine_size_bytes` for collecting proxy_instance in Grafana.

Before
There are 3 tiflash instance. 1 is tiflash-write, the other 2 is tiflash-columnar. But proxy_instance does not include the 2 tiflash-columnar instances.
<img width="4998" height="2098" alt="image" src="https://github.com/user-attachments/assets/92119140-0749-448e-b517-f9ce01f184c4" />

After
<img width="4988" height="2094" alt="image" src="https://github.com/user-attachments/assets/2ff59ade-cd56-41c5-84df-98bb243fff3f" />


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
