### PR TITLE
Optimize blobstore read syscalls

### DIFF
--- a/dbms/src/Storages/Page/V3/BlobStore.cpp
+++ b/dbms/src/Storages/Page/V3/BlobStore.cpp
@@ -910,7 +910,6 @@ typename BlobStore<Trait>::PageMap BlobStore<Trait>::read(FieldReadInfos & to_re
         return page_map;
     }
 
-
     // Allocate one for holding all pages data
     char * shared_data_buf = static_cast<char *>(alloc(buf_size));
     MemHolder shared_mem_holder = createMemHolder(shared_data_buf, [&, buf_size](char * p) { free(p, buf_size); });
@@ -921,40 +920,63 @@ typename BlobStore<Trait>::PageMap BlobStore<Trait>::read(FieldReadInfos & to_re
     {
         size_t read_size_this_entry = 0;
         char * write_offset = pos;
-        for (const auto field_index : fields)
+        size_t field_idx = 0;
+        while (field_idx < fields.size())
         {
-            // TODO: Continuously fields can read by one system call.
-            const auto [beg_offset, end_offset] = entry.getFieldOffsets(field_index);
-            const auto size_to_read = end_offset - beg_offset;
-            read(page_id_v3, entry.file_id, entry.offset + beg_offset, write_offset, size_to_read, read_limiter);
-            fields_offset_in_page.emplace(field_index, read_size_this_entry);
+            size_t start_field_index = fields[field_idx];
+            const auto [beg_offset, _1] = entry.getFieldOffsets(start_field_index);
 
-            if constexpr (BLOBSTORE_CHECKSUM_ON_READ)
+            size_t end_field_index = start_field_index;
+            while (field_idx + 1 < fields.size() && fields[field_idx + 1] == fields[field_idx] + 1)
             {
-                const auto expect_checksum = entry.field_offsets[field_index].second;
-                ChecksumClass digest;
-                digest.update(write_offset, size_to_read);
-                auto field_checksum = digest.checksum();
-                if (unlikely(entry.size != 0 && field_checksum != expect_checksum))
-                {
-                    throw Exception(
-                        ErrorCodes::CHECKSUM_DOESNT_MATCH,
-                        "Reading with fields meet checksum not match "
-                        "page_id={} expected=0x{:X} actual=0x{:X} "
-                        "field_index={} field_offset={} field_size={} "
-                        "entry={}",
-                        page_id_v3,
-                        expect_checksum,
-                        field_checksum,
-                        field_index,
-                        beg_offset,
-                        size_to_read,
-                        entry);
-                }
+                ++field_idx;
+                end_field_index = fields[field_idx];
             }
 
-            read_size_this_entry += size_to_read;
+            const auto [_2, end_offset] = entry.getFieldOffsets(end_field_index);
+            const auto size_to_read = end_offset - beg_offset;
+
+            read(page_id_v3, entry.file_id, entry.offset + beg_offset, write_offset, size_to_read, read_limiter);
+
+            size_t field_offset_in_buffer = 0;
+            for (size_t i = start_field_index; i <= end_field_index; ++i)
+            {
+                const auto [field_beg, field_end] = entry.getFieldOffsets(i);
+                const auto field_size = field_end - field_beg;
+                const auto field_offset_in_entry = field_beg - beg_offset;
+
+                fields_offset_in_page.emplace(i, read_size_this_entry);
+
+                if constexpr (BLOBSTORE_CHECKSUM_ON_READ)
+                {
+                    const auto expect_checksum = entry.field_offsets[i].second;
+                    ChecksumClass digest;
+                    digest.update(write_offset + field_offset_in_entry, field_size);
+                    auto field_checksum = digest.checksum();
+                    if (unlikely(entry.size != 0 && field_checksum != expect_checksum))
+                    {
+                        throw Exception(
+                            ErrorCodes::CHECKSUM_DOESNT_MATCH,
+                            "Reading with fields meet checksum not match "
+                            "page_id={} expected=0x{:X} actual=0x{:X} "
+                            "field_index={} field_offset={} field_size={} "
+                            "entry={}",
+                            page_id_v3,
+                            expect_checksum,
+                            field_checksum,
+                            i,
+                            field_beg,
+                            field_size,
+                            entry);
+                    }
+                }
+
+                read_size_this_entry += field_size;
+                field_offset_in_buffer += field_size;
+            }
+
             write_offset += size_to_read;
+            ++field_idx;
         }
 
         Page page(Trait::PageIdTrait::getU64ID(page_id_v3));
@@ -985,6 +1007,7 @@ typename BlobStore<Trait>::PageMap BlobStore<Trait>::read(FieldReadInfos & to_re
             pos,
             buf.toString());
     }
+
     return page_map;
 }
 

--- a/dbms/src/Storages/Page/V3/BlobStore.cpp
+++ b/dbms/src/Storages/Page/V3/BlobStore.cpp
@@ -847,7 +847,6 @@ void BlobStore<Trait>::removePosFromStats(BlobFileId blob_id, BlobFileOffset off
 template <typename Trait>
 typename BlobStore<Trait>::PageMap BlobStore<Trait>::read(FieldReadInfos & to_read, const ReadLimiterPtr & read_limiter)
 {
-    
     if (to_read.empty())
     {
         return {};
@@ -1010,7 +1009,6 @@ typename BlobStore<Trait>::PageMap BlobStore<Trait>::read(FieldReadInfos & to_re
             buf.toString());
     }
 
-   
 
     return page_map;
 }

--- a/dbms/src/Storages/Page/V3/BlobStore.cpp
+++ b/dbms/src/Storages/Page/V3/BlobStore.cpp
@@ -926,7 +926,7 @@ typename BlobStore<Trait>::PageMap BlobStore<Trait>::read(FieldReadInfos & to_re
         while (field_idx < fields.size())
         {
             size_t start_field_index = fields[field_idx];
-            const auto [beg_offset, _1] = entry.getFieldOffsets(start_field_index);
+            const auto beg_offset = entry.getFieldOffsets(start_field_index).first;
 
             size_t end_field_index = start_field_index;
             while (field_idx + 1 < fields.size() && fields[field_idx + 1] == fields[field_idx] + 1)
@@ -935,7 +935,7 @@ typename BlobStore<Trait>::PageMap BlobStore<Trait>::read(FieldReadInfos & to_re
                 end_field_index = fields[field_idx];
             }
 
-            const auto [_2, end_offset] = entry.getFieldOffsets(end_field_index);
+            const auto end_offset = entry.getFieldOffsets(end_field_index).second;
             const auto size_to_read = end_offset - beg_offset;
 
             read(page_id_v3, entry.file_id, entry.offset + beg_offset, write_offset, size_to_read, read_limiter);

--- a/dbms/src/Storages/Page/V3/BlobStore.cpp
+++ b/dbms/src/Storages/Page/V3/BlobStore.cpp
@@ -847,6 +847,7 @@ void BlobStore<Trait>::removePosFromStats(BlobFileId blob_id, BlobFileOffset off
 template <typename Trait>
 typename BlobStore<Trait>::PageMap BlobStore<Trait>::read(FieldReadInfos & to_read, const ReadLimiterPtr & read_limiter)
 {
+    
     if (to_read.empty())
     {
         return {};
@@ -860,6 +861,7 @@ typename BlobStore<Trait>::PageMap BlobStore<Trait>::read(FieldReadInfos & to_re
     });
 
     // allocate data_buf that can hold all pages with specify fields
+
 
     size_t buf_size = 0;
     for (auto & [page_id, entry, fields] : to_read)
@@ -938,6 +940,9 @@ typename BlobStore<Trait>::PageMap BlobStore<Trait>::read(FieldReadInfos & to_re
 
             read(page_id_v3, entry.file_id, entry.offset + beg_offset, write_offset, size_to_read, read_limiter);
 
+
+
+
             size_t field_offset_in_buffer = 0;
             for (size_t i = start_field_index; i <= end_field_index; ++i)
             {
@@ -1007,6 +1012,8 @@ typename BlobStore<Trait>::PageMap BlobStore<Trait>::read(FieldReadInfos & to_re
             pos,
             buf.toString());
     }
+
+   
 
     return page_map;
 }

--- a/dbms/src/Storages/Page/V3/BlobStore.cpp
+++ b/dbms/src/Storages/Page/V3/BlobStore.cpp
@@ -942,8 +942,6 @@ typename BlobStore<Trait>::PageMap BlobStore<Trait>::read(FieldReadInfos & to_re
 #ifdef DBMS_PUBLIC_GTEST
             ++field_read_call_count;
 #endif
-
-            size_t field_offset_in_buffer = 0;
             for (size_t i = start_field_index; i <= end_field_index; ++i)
             {
                 const auto [field_beg, field_end] = entry.getFieldOffsets(i);
@@ -977,7 +975,6 @@ typename BlobStore<Trait>::PageMap BlobStore<Trait>::read(FieldReadInfos & to_re
                 }
 
                 read_size_this_entry += field_size;
-                field_offset_in_buffer += field_size;
             }
 
             write_offset += size_to_read;

--- a/dbms/src/Storages/Page/V3/BlobStore.cpp
+++ b/dbms/src/Storages/Page/V3/BlobStore.cpp
@@ -939,7 +939,7 @@ typename BlobStore<Trait>::PageMap BlobStore<Trait>::read(FieldReadInfos & to_re
 
             read(page_id_v3, entry.file_id, entry.offset + beg_offset, write_offset, size_to_read, read_limiter);
 #ifdef DBMS_PUBLIC_GTEST
-            ++field_read_call_count;
+            field_read_call_count.fetch_add(1, std::memory_order_relaxed);
 #endif
             for (size_t i = start_field_index; i <= end_field_index; ++i)
             {

--- a/dbms/src/Storages/Page/V3/BlobStore.cpp
+++ b/dbms/src/Storages/Page/V3/BlobStore.cpp
@@ -939,9 +939,9 @@ typename BlobStore<Trait>::PageMap BlobStore<Trait>::read(FieldReadInfos & to_re
             const auto size_to_read = end_offset - beg_offset;
 
             read(page_id_v3, entry.file_id, entry.offset + beg_offset, write_offset, size_to_read, read_limiter);
-
-
-
+#ifdef DBMS_PUBLIC_GTEST
+            ++field_read_call_count;
+#endif
 
             size_t field_offset_in_buffer = 0;
             for (size_t i = start_field_index; i <= end_field_index; ++i)

--- a/dbms/src/Storages/Page/V3/BlobStore.h
+++ b/dbms/src/Storages/Page/V3/BlobStore.h
@@ -118,8 +118,8 @@ public:
     PageMap read(FieldReadInfos & to_read, const ReadLimiterPtr & read_limiter = nullptr);
 
 #ifdef DBMS_PUBLIC_GTEST
-    void resetFieldReadCallCount() { field_read_call_count = 0; }
-    size_t getFieldReadCallCount() { return field_read_call_count; }
+    void resetFieldReadCallCount() { field_read_call_count.store(0, std::memory_order_relaxed); }
+    size_t getFieldReadCallCount() { return field_read_call_count.load(std::memory_order_relaxed); }
 
 #endif
 
@@ -181,7 +181,7 @@ private:
     std::unordered_map<BlobFileId, BlobFilePtr> blob_files;
 
 #ifdef DBMS_PUBLIC_GTEST
-    size_t field_read_call_count = 0;
+    std::atomic<size_t> field_read_call_count{0};
 #endif
 };
 namespace u128

--- a/dbms/src/Storages/Page/V3/BlobStore.h
+++ b/dbms/src/Storages/Page/V3/BlobStore.h
@@ -181,9 +181,8 @@ private:
     std::unordered_map<BlobFileId, BlobFilePtr> blob_files;
 
 #ifdef DBMS_PUBLIC_GTEST
-   size_t field_read_call_count = 0;
+    size_t field_read_call_count = 0;
 #endif
-
 };
 namespace u128
 {

--- a/dbms/src/Storages/Page/V3/BlobStore.h
+++ b/dbms/src/Storages/Page/V3/BlobStore.h
@@ -117,6 +117,12 @@ public:
     using FieldReadInfos = std::vector<FieldReadInfo>;
     PageMap read(FieldReadInfos & to_read, const ReadLimiterPtr & read_limiter = nullptr);
 
+#ifdef DBMS_PUBLIC_GTEST
+    void resetFieldReadCallCount() { field_read_call_count = 0; }
+    size_t getFieldReadCallCount() { return field_read_call_count; }
+
+#endif
+
 #ifndef DBMS_PUBLIC_GTEST
 private:
 #endif
@@ -173,6 +179,11 @@ private:
 
     std::mutex mtx_blob_files;
     std::unordered_map<BlobFileId, BlobFilePtr> blob_files;
+
+#ifdef DBMS_PUBLIC_GTEST
+   size_t field_read_call_count;
+#endif
+
 };
 namespace u128
 {

--- a/dbms/src/Storages/Page/V3/BlobStore.h
+++ b/dbms/src/Storages/Page/V3/BlobStore.h
@@ -181,7 +181,7 @@ private:
     std::unordered_map<BlobFileId, BlobFilePtr> blob_files;
 
 #ifdef DBMS_PUBLIC_GTEST
-   size_t field_read_call_count;
+   size_t field_read_call_count = 0;
 #endif
 
 };

--- a/dbms/src/Storages/Page/V3/tests/gtest_blob_store.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_blob_store.cpp
@@ -1923,4 +1923,62 @@ try
     }
 }
 CATCH
+
+TEST_F(BlobStoreTest, ReadByFieldReadInfosContinuousFields)
+try
+{
+    const auto file_provider = DB::tests::TiFlashTestEnv::getDefaultFileProvider();
+    PageIdU64 page_id = 50;
+    size_t buff_size = 20;
+
+    auto blob_store = BlobStore(
+        getCurrentTestName(),
+        file_provider,
+        delegator,
+        BlobConfig{},
+        page_type_and_config);
+
+    std::vector<char> c_buff(buff_size);
+    for (size_t j = 0; j < buff_size; ++j)
+    {
+        c_buff[j] = static_cast<char>(j);
+    }
+
+    ReadBufferPtr buff = std::make_shared<ReadBufferFromMemory>(c_buff.data(), buff_size);
+    PageFieldSizes field_sizes{1, 2, 4, 8, (buff_size - 1 - 2 - 4 - 8)};
+    WriteBatch wb;
+    wb.putPage(page_id, /* tag */ 0, buff, buff_size, field_sizes);
+    PageEntriesEdit edit = blob_store.write(std::move(wb));
+    const auto & records = edit.getRecords();
+    ASSERT_EQ(records.size(), 1);
+    auto entry = records[0].entry;
+
+    std::cout << "=== Test 1: Continuous fields {0,1,2,3,4} ===" << std::endl;
+    {
+        BlobStore::FieldReadInfos read_infos;
+        read_infos.emplace_back(BlobStore::FieldReadInfo(buildV3Id(TEST_NAMESPACE_ID, page_id), entry, {0, 1, 2, 3, 4}));
+        auto page_map = blob_store.read(read_infos);
+        Page page = page_map.at(page_id);
+        ASSERT_EQ(page.fieldSize(), 5);
+    }
+
+    std::cout << "=== Test 2: Fields with hole {0,1,3,4} ===" << std::endl;
+    {
+        BlobStore::FieldReadInfos read_infos;
+        read_infos.emplace_back(BlobStore::FieldReadInfo(buildV3Id(TEST_NAMESPACE_ID, page_id), entry, {0, 1, 3, 4}));
+        auto page_map = blob_store.read(read_infos);
+        Page page = page_map.at(page_id);
+        ASSERT_EQ(page.fieldSize(), 4);
+    }
+
+    std::cout << "=== Test 3: Scattered fields {0,2,4} ===" << std::endl;
+    {
+        BlobStore::FieldReadInfos read_infos;
+        read_infos.emplace_back(BlobStore::FieldReadInfo(buildV3Id(TEST_NAMESPACE_ID, page_id), entry, {0, 2, 4}));
+        auto page_map = blob_store.read(read_infos);
+        Page page = page_map.at(page_id);
+        ASSERT_EQ(page.fieldSize(), 3);
+    }
+}
+CATCH
 } // namespace DB::PS::V3::tests

--- a/dbms/src/Storages/Page/V3/tests/gtest_blob_store.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_blob_store.cpp
@@ -1931,12 +1931,7 @@ try
     PageIdU64 page_id = 50;
     size_t buff_size = 20;
 
-    auto blob_store = BlobStore(
-        getCurrentTestName(),
-        file_provider,
-        delegator,
-        BlobConfig{},
-        page_type_and_config);
+    auto blob_store = BlobStore(getCurrentTestName(), file_provider, delegator, BlobConfig{}, page_type_and_config);
 
     std::vector<char> c_buff(buff_size);
     for (size_t j = 0; j < buff_size; ++j)
@@ -1957,7 +1952,8 @@ try
     {
         blob_store.resetFieldReadCallCount();
         BlobStore::FieldReadInfos read_infos;
-        read_infos.emplace_back(BlobStore::FieldReadInfo(buildV3Id(TEST_NAMESPACE_ID, page_id), entry, {0, 1, 2, 3, 4}));
+        read_infos.emplace_back(
+            BlobStore::FieldReadInfo(buildV3Id(TEST_NAMESPACE_ID, page_id), entry, {0, 1, 2, 3, 4}));
         auto page_map = blob_store.read(read_infos);
         Page page = page_map.at(page_id);
         ASSERT_EQ(page.fieldSize(), 5);

--- a/dbms/src/Storages/Page/V3/tests/gtest_blob_store.cpp
+++ b/dbms/src/Storages/Page/V3/tests/gtest_blob_store.cpp
@@ -1953,31 +1953,37 @@ try
     ASSERT_EQ(records.size(), 1);
     auto entry = records[0].entry;
 
-    std::cout << "=== Test 1: Continuous fields {0,1,2,3,4} ===" << std::endl;
+    // Test 1: Continuous fields {0,1,2,3,4}
     {
+        blob_store.resetFieldReadCallCount();
         BlobStore::FieldReadInfos read_infos;
         read_infos.emplace_back(BlobStore::FieldReadInfo(buildV3Id(TEST_NAMESPACE_ID, page_id), entry, {0, 1, 2, 3, 4}));
         auto page_map = blob_store.read(read_infos);
         Page page = page_map.at(page_id);
         ASSERT_EQ(page.fieldSize(), 5);
+        ASSERT_EQ(blob_store.getFieldReadCallCount(), 1);
     }
 
-    std::cout << "=== Test 2: Fields with hole {0,1,3,4} ===" << std::endl;
+    // Test 2: Fields with hole {0,1,3,4}
     {
+        blob_store.resetFieldReadCallCount();
         BlobStore::FieldReadInfos read_infos;
         read_infos.emplace_back(BlobStore::FieldReadInfo(buildV3Id(TEST_NAMESPACE_ID, page_id), entry, {0, 1, 3, 4}));
         auto page_map = blob_store.read(read_infos);
         Page page = page_map.at(page_id);
         ASSERT_EQ(page.fieldSize(), 4);
+        ASSERT_EQ(blob_store.getFieldReadCallCount(), 2);
     }
 
-    std::cout << "=== Test 3: Scattered fields {0,2,4} ===" << std::endl;
+    // Test 3: Scattered fields {0,2,4}
     {
+        blob_store.resetFieldReadCallCount();
         BlobStore::FieldReadInfos read_infos;
         read_infos.emplace_back(BlobStore::FieldReadInfo(buildV3Id(TEST_NAMESPACE_ID, page_id), entry, {0, 2, 4}));
         auto page_map = blob_store.read(read_infos);
         Page page = page_map.at(page_id);
         ASSERT_EQ(page.fieldSize(), 3);
+        ASSERT_EQ(blob_store.getFieldReadCallCount(), 3);
     }
 }
 CATCH


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #5078

Problem Summary: Optimize field-level read in BlobStore by merging continuous fields into single system call to reduce IOPS and improve read performance.

### What is changed and how it works?

storage/v3: merge continuous field reads into single system call (#5078)

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Improved blob-backed field reads for continuous, hole (skipped), and scattered field selections.
  * Reduced redundant underlying blob reads by batching contiguous field byte ranges, while preserving per-field offsets and on-read checksum validation (when enabled).

* **Tests**
  * Added a new gtest case covering continuous, hole, and scattered field-selection patterns.
  * Added test-only counters to verify the expected reduction in blob read calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->