### PR TITLE
executor: Improve HashAgg string collation key caching

### DIFF
--- a/dbms/src/Common/ColumnsHashing.h
+++ b/dbms/src/Common/ColumnsHashing.h
@@ -19,6 +19,7 @@
 #include <Columns/ColumnString.h>
 #include <Common/Arena.h>
 #include <Common/ColumnsHashingImpl.h>
+#include <Common/HashTable/HashMap.h>
 #include <Common/HashTable/HashTable.h>
 #include <Common/HashTable/HashTableKeyHolder.h>
 #include <Common/assert_cast.h>
@@ -38,6 +39,9 @@ extern const int LOGICAL_ERROR;
 
 namespace ColumnsHashing
 {
+static constexpr size_t min_rows_to_use_collation_sort_key_cache = 1024;
+static constexpr size_t max_collation_sort_key_cache_distinct_ratio = 32;
+
 /// For the case when there is one numeric key.
 /// UInt8/16/32/64 for any type with corresponding bit width.
 template <typename Value, typename Mapped, typename FieldType, bool use_cache = true>
@@ -95,6 +99,67 @@ private:
     size_t processed_row_idx = 0;
     std::vector<String> sort_key_containers{};
     std::vector<StringRef> batch_rows{};
+    bool collation_sort_key_cache_active = false;
+    bool collation_sort_key_cache_fallback = false;
+    size_t collation_sort_key_cache_distinct_limit = 0;
+    HashMap<StringRef, size_t, StringRefHash> raw_to_sort_key_index;
+    std::vector<String> cached_sort_keys{};
+
+    template <typename DerivedCollator>
+    StringRef getSortKeyWithCache(
+        const DerivedCollator & collator,
+        const StringRef & raw_key,
+        std::string & sort_key_container)
+    {
+        if (!collation_sort_key_cache_active)
+            return collator.sortKey(raw_key.data, raw_key.size, sort_key_container);
+
+        if (auto it = raw_to_sort_key_index.find(raw_key); it != nullptr)
+        {
+            const auto & sort_key = cached_sort_keys[it->getMapped()];
+            return {sort_key.data(), sort_key.size()};
+        }
+
+        if (raw_to_sort_key_index.size() >= collation_sort_key_cache_distinct_limit)
+        {
+            collation_sort_key_cache_active = false;
+            collation_sort_key_cache_fallback = true;
+            return collator.sortKey(raw_key.data, raw_key.size, sort_key_container);
+        }
+
+        const auto sort_key_index = cached_sort_keys.size();
+        cached_sort_keys.emplace_back();
+        auto sort_key = collator.sortKey(raw_key.data, raw_key.size, cached_sort_keys.back());
+
+        typename decltype(raw_to_sort_key_index)::LookupResult it;
+        bool inserted = false;
+        raw_to_sort_key_index.emplace(raw_key, it, inserted);
+        RUNTIME_CHECK(inserted);
+        it->getMapped() = sort_key_index;
+
+        return sort_key;
+    }
+
+    template <typename DerivedCollator, bool use_cache>
+    void prepareNextBatchWithCollator(
+        const UInt8 * chars,
+        const IColumn::Offsets & offsets,
+        size_t cur_batch_size,
+        const DerivedCollator & collator)
+    {
+        for (size_t i = 0; i < cur_batch_size; ++i)
+        {
+            const auto row = processed_row_idx + i;
+            const auto last_offset = offsets[row - 1];
+            // Remove last zero byte.
+            StringRef key(chars + last_offset, offsets[row] - last_offset - 1);
+            if constexpr (use_cache)
+                key = getSortKeyWithCache(collator, key, sort_key_containers[i]);
+            else
+                key = collator.sortKey(key.data, key.size, sort_key_containers[i]);
+            batch_rows[i] = key;
+        }
+    }
 
     template <typename DerivedCollator, bool has_collator>
     void prepareNextBatchType(
@@ -108,23 +173,48 @@ private:
 
         batch_rows.resize(cur_batch_size);
 
-        const auto * derived_collator = static_cast<const DerivedCollator *>(collator);
-        for (size_t i = 0; i < cur_batch_size; ++i)
+        if constexpr (has_collator)
         {
-            const auto row = processed_row_idx + i;
-            const auto last_offset = offsets[row - 1];
-            // Remove last zero byte.
-            StringRef key(chars + last_offset, offsets[row] - last_offset - 1);
-            if constexpr (has_collator)
-                key = derived_collator->sortKey(key.data, key.size, sort_key_containers[i]);
-
-            batch_rows[i] = key;
+            const auto & derived_collator = *static_cast<const DerivedCollator *>(collator);
+            if (collation_sort_key_cache_active)
+                prepareNextBatchWithCollator<DerivedCollator, true>(
+                    chars,
+                    offsets,
+                    cur_batch_size,
+                    derived_collator);
+            else
+                prepareNextBatchWithCollator<DerivedCollator, false>(
+                    chars,
+                    offsets,
+                    cur_batch_size,
+                    derived_collator);
+        }
+        else
+        {
+            for (size_t i = 0; i < cur_batch_size; ++i)
+            {
+                const auto row = processed_row_idx + i;
+                const auto last_offset = offsets[row - 1];
+                // Remove last zero byte.
+                batch_rows[i] = StringRef(chars + last_offset, offsets[row] - last_offset - 1);
+            }
         }
         processed_row_idx += cur_batch_size;
     }
 
 protected:
     bool inited() const { return !sort_key_containers.empty(); }
+    bool hasCollationSortKeyCacheFallback() const { return collation_sort_key_cache_fallback; }
+
+    void initCollationSortKeyCache(size_t rows)
+    {
+        if (rows < min_rows_to_use_collation_sort_key_cache)
+            return;
+
+        collation_sort_key_cache_active = true;
+        collation_sort_key_cache_distinct_limit = rows / max_collation_sort_key_cache_distinct_ratio;
+        cached_sort_keys.reserve(collation_sort_key_cache_distinct_limit + 1);
+    }
 
     void init(size_t start_row, size_t max_batch_size)
     {
@@ -206,6 +296,14 @@ struct HashMethodString
         if (!collators.empty())
             collator = collators[0];
     }
+
+    void initCollationSortKeyCache(size_t rows)
+    {
+        if (collator != nullptr && collator->isCI())
+            BatchHandlerBase::initCollationSortKeyCache(rows);
+    }
+
+    bool hasCollationSortKeyCacheFallback() const { return BatchHandlerBase::hasCollationSortKeyCacheFallback(); }
 
     void initBatchHandler(size_t start_row, size_t max_batch_size)
     {

--- a/dbms/src/Common/ColumnsHashing.h
+++ b/dbms/src/Common/ColumnsHashing.h
@@ -128,8 +128,10 @@ private:
         }
 
         const auto sort_key_index = cached_sort_keys.size();
-        cached_sort_keys.emplace_back();
-        auto sort_key = collator.sortKey(raw_key.data, raw_key.size, cached_sort_keys.back());
+        auto & cached_sort_key = cached_sort_keys.emplace_back();
+        const auto sort_key_size = collator.sortKey(raw_key.data, raw_key.size, cached_sort_key).size;
+        // Collators may resize the container to their worst-case output size.
+        cached_sort_key.resize(sort_key_size);
 
         typename decltype(raw_to_sort_key_index)::LookupResult it;
         bool inserted = false;
@@ -137,7 +139,7 @@ private:
         RUNTIME_CHECK(inserted);
         it->getMapped() = sort_key_index;
 
-        return sort_key;
+        return {cached_sort_key.data(), cached_sort_key.size()};
     }
 
     template <typename DerivedCollator, bool use_cache>
@@ -177,17 +179,9 @@ private:
         {
             const auto & derived_collator = *static_cast<const DerivedCollator *>(collator);
             if (collation_sort_key_cache_active)
-                prepareNextBatchWithCollator<DerivedCollator, true>(
-                    chars,
-                    offsets,
-                    cur_batch_size,
-                    derived_collator);
+                prepareNextBatchWithCollator<DerivedCollator, true>(chars, offsets, cur_batch_size, derived_collator);
             else
-                prepareNextBatchWithCollator<DerivedCollator, false>(
-                    chars,
-                    offsets,
-                    cur_batch_size,
-                    derived_collator);
+                prepareNextBatchWithCollator<DerivedCollator, false>(chars, offsets, cur_batch_size, derived_collator);
         }
         else
         {

--- a/dbms/src/Common/ColumnsHashing.h
+++ b/dbms/src/Common/ColumnsHashing.h
@@ -207,6 +207,7 @@ protected:
 
         collation_sort_key_cache_active = true;
         collation_sort_key_cache_distinct_limit = rows / max_collation_sort_key_cache_distinct_ratio;
+        raw_to_sort_key_index.reserve(collation_sort_key_cache_distinct_limit + 1);
         cached_sort_keys.reserve(collation_sort_key_cache_distinct_limit + 1);
     }
 

--- a/dbms/src/Common/ColumnsHashing.h
+++ b/dbms/src/Common/ColumnsHashing.h
@@ -111,7 +111,7 @@ private:
         const StringRef & raw_key,
         std::string & sort_key_container)
     {
-        if (!collation_sort_key_cache_active)
+        if unlikely (!collation_sort_key_cache_active)
             return collator.sortKey(raw_key.data, raw_key.size, sort_key_container);
 
         if (auto it = raw_to_sort_key_index.find(raw_key); it != nullptr)

--- a/dbms/src/Common/ColumnsHashingImpl.h
+++ b/dbms/src/Common/ColumnsHashingImpl.h
@@ -129,6 +129,9 @@ public:
     using Cache = LastElementCache<Value, consecutive_keys_optimization>;
     using Derived = TDerived;
 
+    void initCollationSortKeyCache(size_t) {}
+    bool hasCollationSortKeyCacheFallback() const { return false; }
+
     template <typename Data>
     ALWAYS_INLINE inline EmplaceResult emplaceKey(
         Data & data,

--- a/dbms/src/Flash/tests/bench_aggregation_hash_map.cpp
+++ b/dbms/src/Flash/tests/bench_aggregation_hash_map.cpp
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <AggregateFunctions/AggregateFunctionFactory.h>
 #include <AggregateFunctions/registerAggregateFunctions.h>
 #include <Columns/ColumnDecimal.h>
+#include <Common/ColumnsHashing.h>
 #include <Common/Stopwatch.h>
 #include <DataTypes/DataTypeDate.h>
 #include <DataTypes/DataTypeDecimal.h>
@@ -27,6 +29,7 @@
 #include <Interpreters/Aggregator.h>
 #include <Interpreters/Context.h>
 #include <TestUtils/TiFlashTestBasic.h>
+#include <TiDB/Collation/Collator.h>
 #include <benchmark/benchmark.h>
 #include <google/protobuf/util/json_util.h>
 #include <tipb/executor.pb.h>
@@ -338,6 +341,240 @@ try
 }
 CATCH
 BENCHMARK_REGISTER_F(BenchProbeAggHashMap, basic);
+
+class BenchStringCollationKeyCache : public ::benchmark::Fixture
+{
+public:
+    void SetUp(const ::benchmark::State &) override
+    try
+    {
+        if (!AggregateFunctionFactory::instance().isAggregateFunctionName("count"))
+            DB::registerAggregateFunctions();
+
+        context = TiFlashTestEnv::getContext();
+        params = buildParams();
+    }
+    CATCH
+
+    void TearDown(benchmark::State &) override { context.reset(); }
+
+protected:
+    static constexpr size_t rows_per_block = DEFAULT_BLOCK_SIZE;
+    static constexpr size_t block_num = 128;
+    static constexpr size_t total_rows = rows_per_block * block_num;
+    static constexpr size_t low_ndv = 64;
+    static constexpr size_t high_ndv = rows_per_block;
+    static constexpr size_t cache_distinct_limit
+        = rows_per_block / ColumnsHashing::max_collation_sort_key_cache_distinct_ratio;
+    static constexpr size_t ndv_transition_block = block_num / 2;
+    static constexpr const char * key_column_name = "key";
+    static constexpr const char * count_column_name = "count(key)";
+
+    static std::vector<String> generateKeys(size_t distinct_keys)
+    {
+        std::vector<String> keys;
+        keys.reserve(distinct_keys);
+        for (size_t i = 0; i < distinct_keys; ++i)
+        {
+            if (i % 2 == 0)
+                keys.push_back(fmt::format("customer-region-{:05}-AlphaBetaGamma", i));
+            else
+                keys.push_back(fmt::format("CUSTOMER-REGION-{:05}-alphabetagamma", i));
+        }
+        return keys;
+    }
+
+    static BlockPtr generateBlock(
+        const std::shared_ptr<DataTypeString> & data_type_string,
+        const std::vector<String> & keys,
+        size_t block_index)
+    {
+        auto col_key = data_type_string->createColumn();
+        col_key->reserve(rows_per_block);
+        for (size_t row = 0; row < rows_per_block; ++row)
+        {
+            const auto & key = keys[(block_index * rows_per_block + row) % keys.size()];
+            col_key->insertData(key.data(), key.size());
+        }
+
+        ColumnsWithTypeAndName cols{
+            ColumnWithTypeAndName(std::move(col_key), data_type_string, String(key_column_name)),
+        };
+        return std::make_shared<Block>(cols);
+    }
+
+    static std::vector<BlockPtr> generateData(size_t distinct_keys)
+    {
+        auto data_type_string = std::make_shared<DataTypeString>();
+        auto keys = generateKeys(distinct_keys);
+        std::vector<BlockPtr> blocks;
+        blocks.reserve(block_num);
+        for (size_t block_index = 0; block_index < block_num; ++block_index)
+            blocks.push_back(generateBlock(data_type_string, keys, block_index));
+        return blocks;
+    }
+
+    static std::vector<BlockPtr> generateDataWithNDVTransition(
+        size_t first_distinct_keys,
+        size_t second_distinct_keys,
+        size_t transition_block)
+    {
+        RUNTIME_CHECK(transition_block < block_num);
+        auto data_type_string = std::make_shared<DataTypeString>();
+        auto first_keys = generateKeys(first_distinct_keys);
+        auto second_keys = generateKeys(second_distinct_keys);
+
+        std::vector<BlockPtr> blocks;
+        blocks.reserve(block_num);
+        for (size_t block_index = 0; block_index < block_num; ++block_index)
+        {
+            const auto & keys = block_index < transition_block ? first_keys : second_keys;
+            blocks.push_back(generateBlock(data_type_string, keys, block_index));
+        }
+        return blocks;
+    }
+
+    std::unique_ptr<Aggregator::Params> buildParams()
+    {
+        auto data_type_string = std::make_shared<DataTypeString>();
+        Block src_header(NamesAndTypes{{String(key_column_name), data_type_string}});
+
+        AggregateDescription count_desc;
+        count_desc.function
+            = AggregateFunctionFactory::instance().get(*context, "count", {data_type_string}, {}, 0, false);
+        count_desc.arguments = {0};
+        count_desc.argument_names = {String(key_column_name)};
+        count_desc.column_name = String(count_column_name);
+        AggregateDescriptions aggregate_desc{std::move(count_desc)};
+
+        const auto & settings = context->getSettingsRef();
+        SpillConfig spill_config(
+            context->getTemporaryPath(),
+            "BenchStringCollationKeyCache",
+            settings.max_cached_data_bytes_in_spiller,
+            settings.max_spilled_rows_per_file,
+            settings.max_spilled_bytes_per_file,
+            context->getFileProvider(),
+            /*for_all_constant_max_streams=*/1,
+            /*for_all_constant_block_size=*/rows_per_block);
+        TiDB::TiDBCollators collators{TiDB::ITiDBCollator::getCollator(TiDB::ITiDBCollator::UTF8MB4_GENERAL_CI)};
+
+        return std::make_unique<Aggregator::Params>(
+            src_header,
+            ColumnNumbers{0},
+            KeyRefAggFuncMap{},
+            AggFuncRefKeyMap{},
+            aggregate_desc,
+            /*group_by_two_level_threshold=*/0,
+            /*group_by_two_level_threshold_bytes=*/0,
+            /*max_bytes_before_external_group_by=*/0,
+            /*empty_result_for_aggregation_by_empty_set=*/false,
+            spill_config,
+            /*max_block_size=*/rows_per_block,
+            /*use_magic_hash=*/false,
+            collators);
+    }
+
+    static size_t runAggregation(const Aggregator::Params & params, const std::vector<BlockPtr> & blocks)
+    {
+        std::shared_ptr<Aggregator> aggregator;
+        auto data_variants = std::make_shared<AggregatedDataVariants>();
+        RegisterOperatorSpillContext register_operator_spill_context;
+        aggregator = std::make_shared<Aggregator>(
+            params,
+            "BenchStringCollationKeyCache",
+            /*concurrency=*/1,
+            register_operator_spill_context,
+            /*is_auto_pass_through=*/false,
+            params.use_magic_hash);
+        data_variants->aggregator = aggregator.get();
+
+        Aggregator::AggProcessInfo agg_process_info(aggregator.get());
+        for (const auto & block : blocks)
+        {
+            agg_process_info.resetBlock(*block);
+            do
+            {
+                aggregator->executeOnBlock(agg_process_info, *data_variants, 1);
+            } while (!agg_process_info.allBlockDataHandled());
+        }
+
+        std::vector<AggregatedDataVariantsPtr> variants{data_variants};
+        auto merging_buckets = aggregator->mergeAndConvertToBlocks(variants, /*final=*/true, /*max_threads=*/1);
+
+        size_t output_rows = 0;
+        for (;;)
+        {
+            auto block = merging_buckets->getData(0);
+            if (!block)
+                break;
+            output_rows += block.rows();
+        }
+        return output_rows;
+    }
+
+    void run(benchmark::State & state, const std::vector<BlockPtr> & blocks, const Aggregator::Params & params)
+    {
+        size_t output_rows = 0;
+        for (const auto & _ : state)
+            output_rows = runAggregation(params, blocks);
+
+        benchmark::DoNotOptimize(output_rows);
+        state.SetItemsProcessed(static_cast<int64_t>(state.iterations() * total_rows));
+        state.counters["rows_per_second"]
+            = benchmark::Counter(static_cast<double>(state.iterations() * total_rows), benchmark::Counter::kIsRate);
+        state.counters["output_rows"] = static_cast<double>(output_rows);
+    }
+
+    ContextPtr context;
+    std::unique_ptr<Aggregator::Params> params;
+};
+
+BENCHMARK_DEFINE_F(BenchStringCollationKeyCache, low_ndv)(benchmark::State & state)
+try
+{
+    auto blocks = generateData(low_ndv);
+    run(state, blocks, *params);
+}
+CATCH
+
+BENCHMARK_DEFINE_F(BenchStringCollationKeyCache, ndv_at_cache_limit)(benchmark::State & state)
+try
+{
+    auto blocks = generateData(cache_distinct_limit);
+    run(state, blocks, *params);
+}
+CATCH
+
+BENCHMARK_DEFINE_F(BenchStringCollationKeyCache, ndv_over_cache_limit)(benchmark::State & state)
+try
+{
+    auto blocks = generateData(cache_distinct_limit + 1);
+    run(state, blocks, *params);
+}
+CATCH
+
+BENCHMARK_DEFINE_F(BenchStringCollationKeyCache, high_ndv)(benchmark::State & state)
+try
+{
+    auto blocks = generateData(high_ndv);
+    run(state, blocks, *params);
+}
+CATCH
+
+BENCHMARK_DEFINE_F(BenchStringCollationKeyCache, low_then_high_ndv)(benchmark::State & state)
+try
+{
+    auto blocks = generateDataWithNDVTransition(low_ndv, high_ndv, ndv_transition_block);
+    run(state, blocks, *params);
+}
+CATCH
+
+BENCHMARK_REGISTER_F(BenchStringCollationKeyCache, low_ndv);
+BENCHMARK_REGISTER_F(BenchStringCollationKeyCache, ndv_at_cache_limit);
+BENCHMARK_REGISTER_F(BenchStringCollationKeyCache, ndv_over_cache_limit);
+BENCHMARK_REGISTER_F(BenchStringCollationKeyCache, high_ndv);
+BENCHMARK_REGISTER_F(BenchStringCollationKeyCache, low_then_high_ndv);
 
 } // namespace tests
 } // namespace DB

--- a/dbms/src/Flash/tests/bench_aggregation_hash_map.cpp
+++ b/dbms/src/Flash/tests/bench_aggregation_hash_map.cpp
@@ -495,7 +495,7 @@ protected:
             agg_process_info.resetBlock(*block);
             do
             {
-                aggregator->executeOnBlock(agg_process_info, *data_variants, 1);
+                aggregator->executeOnBlock(agg_process_info, *data_variants, 0);
             } while (!agg_process_info.allBlockDataHandled());
         }
 

--- a/dbms/src/Flash/tests/gtest_aggregation_executor.cpp
+++ b/dbms/src/Flash/tests/gtest_aggregation_executor.cpp
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include <Core/BlockUtils.h>
+#include <DataTypes/DataTypeString.h>
+#include <Flash/Coprocessor/AggregationInterpreterHelper.h>
 #include <Interpreters/Context.h>
 #include <TestUtils/ColumnGenerator.h>
 #include <TestUtils/ExecutorTestUtils.h>
@@ -1253,6 +1255,189 @@ try
     }
     FailPointHelper::disableFailPoint(FailPoints::force_agg_prefetch);
 #undef WRAP_FOR_AGG_CHANGE_SETTINGS
+}
+CATCH
+
+TEST_F(AggExecutorTestRunner, StringCollationKeyCacheGeneralCISemantics)
+try
+{
+    const String db_name = "test_db";
+    constexpr size_t rows = 1024;
+    DB::MockColumnInfoVec table_column_infos{
+        {"key", TiDB::TP::TypeString, false, Poco::Dynamic::Var("utf8mb4_general_ci")}};
+
+    context.setCollation(TiDB::ITiDBCollator::UTF8MB4_GENERAL_CI);
+    context.context->setSetting("group_by_collation_sensitive", Field(static_cast<UInt64>(1)));
+    context.context->setSetting("max_block_size", Field(static_cast<UInt64>(rows)));
+    context.context->setSetting("group_by_two_level_threshold_bytes", Field(static_cast<UInt64>(0)));
+
+    const String tbl_name = "string_collation_key_cache_general_ci_semantics";
+    std::vector<String> keys(rows);
+    for (size_t i = 0; i < rows; ++i)
+    {
+        switch (i % 4)
+        {
+        case 0:
+            keys[i] = "AAA";
+            break;
+        case 1:
+            keys[i] = "aaa";
+            break;
+        case 2:
+            keys[i] = "BBB";
+            break;
+        default:
+            keys[i] = "bbb";
+            break;
+        }
+    }
+    context.addMockTable({db_name, tbl_name}, table_column_infos, {toVec<String>("key", keys)});
+
+    auto request
+        = buildDAGRequest({db_name, tbl_name}, {Count(lit(Field(static_cast<UInt64>(1))))}, {col("key")}, {"count(1)"});
+    executeAndAssertColumnsEqual(request, {toVec<UInt64>("count(1)", ColumnWithUInt64{rows / 2, rows / 2})});
+}
+CATCH
+
+TEST_F(AggExecutorTestRunner, StringCollationKeyCacheGeneralCILowAndHighNDV)
+try
+{
+    const String db_name = "test_db";
+    constexpr size_t rows = 1024;
+    DB::MockColumnInfoVec table_column_infos{
+        {"key", TiDB::TP::TypeString, false, Poco::Dynamic::Var("utf8mb4_general_ci")}};
+
+    context.setCollation(TiDB::ITiDBCollator::UTF8MB4_GENERAL_CI);
+    context.context->setSetting("group_by_collation_sensitive", Field(static_cast<UInt64>(1)));
+    context.context->setSetting("max_block_size", Field(static_cast<UInt64>(rows)));
+    context.context->setSetting("group_by_two_level_threshold_bytes", Field(static_cast<UInt64>(0)));
+
+    {
+        const String tbl_name = "string_collation_key_cache_low_ndv";
+        std::vector<String> keys(rows);
+        for (size_t i = 0; i < rows; ++i)
+        {
+            switch (i % 4)
+            {
+            case 0:
+                keys[i] = "AAA";
+                break;
+            case 1:
+                keys[i] = "BBB";
+                break;
+            case 2:
+                keys[i] = "CCC";
+                break;
+            default:
+                keys[i] = "DDD";
+                break;
+            }
+        }
+        context.addMockTable({db_name, tbl_name}, table_column_infos, {toVec<String>("key", keys)});
+
+        auto request = buildDAGRequest(
+            {db_name, tbl_name},
+            {Count(lit(Field(static_cast<UInt64>(1))))},
+            {col("key")},
+            {"count(1)"});
+        executeAndAssertColumnsEqual(
+            request,
+            {toVec<UInt64>("count(1)", ColumnWithUInt64{rows / 4, rows / 4, rows / 4, rows / 4})});
+    }
+
+    {
+        const String tbl_name = "string_collation_key_cache_high_ndv";
+        std::vector<String> keys(rows);
+        ColumnWithUInt64 counts(rows, 1);
+        for (size_t i = 0; i < rows; ++i)
+            keys[i] = fmt::format("key_{:04}", i);
+        context.addMockTable({db_name, tbl_name}, table_column_infos, {toVec<String>("key", keys)});
+
+        auto request = buildDAGRequest(
+            {db_name, tbl_name},
+            {Count(lit(Field(static_cast<UInt64>(1))))},
+            {col("key")},
+            {"count(1)"});
+        executeAndAssertColumnsEqual(request, {toVec<UInt64>("count(1)", counts)});
+    }
+}
+CATCH
+
+TEST_F(AggExecutorTestRunner, StringCollationKeyCacheWorkerLevelOnceFallback)
+try
+{
+    constexpr size_t rows = 1024;
+    const String key_column_name = "key";
+    auto data_type_string = std::make_shared<DataTypeString>();
+    Block src_header(NamesAndTypes{{key_column_name, data_type_string}});
+
+    context.context->setSetting("group_by_two_level_threshold", Field(static_cast<UInt64>(0)));
+    context.context->setSetting("group_by_two_level_threshold_bytes", Field(static_cast<UInt64>(0)));
+    context.context->setSetting("max_bytes_before_external_group_by", Field(static_cast<UInt64>(0)));
+
+    const auto & settings = context.context->getSettingsRef();
+    SpillConfig spill_config(
+        context.context->getTemporaryPath(),
+        "StringCollationKeyCacheWorkerLevelOnceFallback",
+        settings.max_cached_data_bytes_in_spiller,
+        settings.max_spilled_rows_per_file,
+        settings.max_spilled_bytes_per_file,
+        context.context->getFileProvider(),
+        settings.max_threads,
+        settings.max_block_size);
+    std::unordered_map<String, TiDB::TiDBCollatorPtr> collators{
+        {key_column_name, TiDB::ITiDBCollator::getCollator(TiDB::ITiDBCollator::UTF8MB4_GENERAL_CI)}};
+    auto params = AggregationInterpreterHelper::buildParams(
+        *context.context,
+        src_header,
+        /*before_agg_streams_size=*/2,
+        /*agg_streams_size=*/2,
+        {key_column_name},
+        {},
+        {},
+        collators,
+        {},
+        /*is_final_agg=*/true,
+        spill_config);
+
+    RegisterOperatorSpillContext register_operator_spill_context;
+    auto aggregator = std::make_shared<Aggregator>(
+        *params,
+        "StringCollationKeyCacheWorkerLevelOnceFallback",
+        /*concurrency=*/2,
+        register_operator_spill_context,
+        /*is_auto_pass_through=*/false,
+        params->use_magic_hash);
+
+    auto execute_block = [&](AggregatedDataVariants & data_variants, size_t distinct_keys, size_t thread_num) {
+        auto column = data_type_string->createColumn();
+        column->reserve(rows);
+        for (size_t row = 0; row < rows; ++row)
+        {
+            const auto key = fmt::format("key_{:04}", row % distinct_keys);
+            column->insertData(key.data(), key.size());
+        }
+        Block block(ColumnsWithTypeAndName{
+            ColumnWithTypeAndName(std::move(column), data_type_string, key_column_name),
+        });
+        Aggregator::AggProcessInfo agg_process_info(aggregator.get());
+        agg_process_info.resetBlock(block);
+        do
+        {
+            ASSERT_TRUE(aggregator->executeOnBlock(agg_process_info, data_variants, thread_num));
+        } while (!agg_process_info.allBlockDataHandled());
+    };
+
+    AggregatedDataVariants high_ndv_worker;
+    execute_block(high_ndv_worker, rows, /*thread_num=*/0);
+    EXPECT_TRUE(high_ndv_worker.string_collation_key_cache_fallback);
+
+    execute_block(high_ndv_worker, /*distinct_keys=*/4, /*thread_num=*/0);
+    EXPECT_TRUE(high_ndv_worker.string_collation_key_cache_fallback);
+
+    AggregatedDataVariants low_ndv_worker;
+    execute_block(low_ndv_worker, /*distinct_keys=*/4, /*thread_num=*/1);
+    EXPECT_FALSE(low_ndv_worker.string_collation_key_cache_fallback);
 }
 CATCH
 

--- a/dbms/src/Flash/tests/gtest_aggregation_executor.cpp
+++ b/dbms/src/Flash/tests/gtest_aggregation_executor.cpp
@@ -21,6 +21,8 @@
 #include <TestUtils/mockExecutor.h>
 #include <TiDB/Decode/TypeMapping.h>
 
+#include <array>
+
 namespace DB
 {
 namespace FailPoints
@@ -1296,6 +1298,53 @@ try
     auto request
         = buildDAGRequest({db_name, tbl_name}, {Count(lit(Field(static_cast<UInt64>(1))))}, {col("key")}, {"count(1)"});
     executeAndAssertColumnsEqual(request, {toVec<UInt64>("count(1)", ColumnWithUInt64{rows / 2, rows / 2})});
+}
+CATCH
+
+TEST_F(AggExecutorTestRunner, StringCollationKeyCacheEffectiveSortKeySize)
+try
+{
+    const String db_name = "test_db";
+    constexpr size_t rows = 1024;
+
+    auto execute_case = [&](Int64 collator_id,
+                            const String & collation_name,
+                            const String & tbl_name,
+                            const std::array<String, 2> & raw_keys) {
+        DB::MockColumnInfoVec table_column_infos{
+            {"key", TiDB::TP::TypeString, false, Poco::Dynamic::Var(collation_name)}};
+        std::vector<String> keys(rows);
+        for (size_t i = 0; i < rows; ++i)
+            keys[i] = raw_keys[i % raw_keys.size()];
+
+        context.setCollation(collator_id);
+        context.context->setSetting("group_by_collation_sensitive", Field(static_cast<UInt64>(1)));
+        context.context->setSetting("max_block_size", Field(static_cast<UInt64>(rows)));
+        context.addMockTable({db_name, tbl_name}, table_column_infos, {toVec<String>("key", keys)});
+
+        auto request = buildDAGRequest(
+            {db_name, tbl_name},
+            {Count(lit(Field(static_cast<UInt64>(1))))},
+            {col("key")},
+            {"count(1)"});
+        executeAndAssertColumnsEqual(request, {toVec<UInt64>("count(1)", ColumnWithUInt64{rows / 2, rows / 2})});
+    };
+
+    execute_case(
+        TiDB::ITiDBCollator::UTF8_UNICODE_CI,
+        "utf8_unicode_ci",
+        "string_collation_key_cache_unicode_ci_effective_size",
+        {"Alpha", "Beta"});
+    execute_case(
+        TiDB::ITiDBCollator::UTF8MB4_GENERAL_CI,
+        "utf8mb4_general_ci",
+        "string_collation_key_cache_general_ci_effective_size",
+        {"Alpha ", "Beta  "});
+    execute_case(
+        TiDB::ITiDBCollator::UTF8MB4_0900_AI_CI,
+        "utf8mb4_0900_ai_ci",
+        "string_collation_key_cache_0900_ai_ci_effective_size",
+        {"Alpha", "Alpha "});
 }
 CATCH
 

--- a/dbms/src/Interpreters/Aggregator.cpp
+++ b/dbms/src/Interpreters/Aggregator.cpp
@@ -641,6 +641,8 @@ void Aggregator::executeImplInner(
 {
     auto * aggregates_pool = result.aggregates_pool;
     typename Method::State state(agg_process_info.key_columns, key_sizes, collators);
+    if (!result.string_collation_key_cache_fallback)
+        state.initCollationSortKeyCache(agg_process_info.end_row - agg_process_info.start_row);
 
     // For key_serialized, memory allocation and key serialization will be batch-wise.
     // For key_string, collation decode will be batch-wise.
@@ -673,6 +675,8 @@ void Aggregator::executeImplInner(
             aggregates_pool,
             agg_process_info);
     }
+
+    result.string_collation_key_cache_fallback |= state.hasCollationSortKeyCacheFallback();
 }
 
 template <bool only_lookup, typename Method, typename KeyHolderType>

--- a/dbms/src/Interpreters/Aggregator.h
+++ b/dbms/src/Interpreters/Aggregator.h
@@ -478,6 +478,9 @@ struct AggregatedDataVariants : private boost::noncopyable
     // This is done both for better performance and because currently, batch and non-batch methods are not compatible.
     bool batch_get_key_holder = false;
 
+    // Once a block exceeds the sort-key cache distinct limit, this worker skips cache attempts for later blocks.
+    bool string_collation_key_cache_fallback = false;
+
     using AggregationMethod_key8 = AggregationMethodOneNumber<UInt8, AggregatedDataWithUInt8Key, false>;
     using AggregationMethod_key16 = AggregationMethodOneNumber<UInt16, AggregatedDataWithUInt16Key, false>;
     using AggregationMethod_key32 = AggregationMethodOneNumber<UInt32, AggregatedDataWithUInt64Key>;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10979 

## Problem Summary

For string `GROUP BY` keys using a case-insensitive collation such as `utf8mb4_general_ci`, HashAgg needs to generate a collation sort key before probing or inserting into the hash table.

Previously, the sort key was generated for every input row. When the grouped column has a low number of distinct raw values, the same raw string is converted to the same sort key repeatedly, causing unnecessary collation processing and memory writes.

For example:

```sql
SELECT l_shipmode, COUNT(*)
FROM lineitem
GROUP BY l_shipmode;
```

`l_shipmode` usually has a very low NDV. If it uses `utf8mb4_general_ci`, repeatedly generating sort keys for millions of rows can consume a significant portion of the HashAgg execution time.

At the same time, unconditionally caching sort keys is not suitable for high-NDV inputs because maintaining the cache may introduce additional hash lookups and memory usage without enough cache hits. Therefore, the optimization needs to provide substantial benefits for low-NDV workloads while keeping the high-NDV overhead small and bounded.

## What is changed and how it works

This PR adds an always-on collation sort-key cache to the batch string-key processing path of HashAgg.

For each input Block, the cache maps a raw string value to its generated collation sort key:

```text
raw string -> collation sort key
```

When processing a row:

1. Look up the raw string in the cache.
2. If it is found, reuse the cached sort key.
3. If it is not found, generate the sort key once and insert it into the cache.
4. Use the resulting sort key for the existing hash-table lookup or insertion.

The cache is enabled only when all of the following conditions are satisfied:

- HashAgg uses the batch string-key processing path.
- The string key uses a supported case-insensitive collation.
- The current processing range contains at least 1,024 rows.

To bound the cost for high-NDV inputs, the maximum number of cached distinct values is calculated from the number of rows in the current Block:

```text
cache distinct limit = rows in the Block / 32
```

For a typical maximum runtime Block containing 65,536 rows, the cache can hold at most 2,048 distinct raw values.

If a cache miss occurs after the distinct-value limit has been reached, the current Block falls back to direct sort-key generation. The fallback state is also recorded in the worker's `AggregatedDataVariants`, so subsequent Blocks processed by the same aggregation worker do not attempt to initialize the cache again. This worker-level once-fallback behavior prevents high-NDV workloads from repeatedly paying the cache construction and lookup overhead for every Block.

The cache itself remains local to one Block. It only stores references to raw strings owned by that Block, so no input-column memory needs to be retained across Blocks. Only the fallback decision is preserved across Blocks.

The optimization does not change collation or grouping semantics. Hash-table keys are still the sort keys generated by the existing collator; the change only avoids regenerating an identical sort key for repeated raw string values.

The benchmark uses 128 Blocks with 65,536 rows per Block:

Workload | Baseline | With cache | Change
-- | -- | -- | --
NDV 64 | 27.16 M rows/s | 73.41 M rows/s | +170.3%
NDV 2,048 | 26.05 M rows/s | 55.71 M rows/s | +113.9%
NDV 2,049, fallback | 26.95 M rows/s | 26.85 M rows/s | -0.4%
NDV 65,536, fallback | 24.17 M rows/s | 23.99 M rows/s | -0.7%
First 64 Blocks low NDV, remaining Blocks high NDV | 25.40 M rows/s | 35.75 M rows/s | +40.8%

The results show substantial improvements for low-NDV and mixed workloads, while the worker-level fallback keeps the high-NDV overhead below 1% in the benchmark.

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved aggregation performance for case-insensitive string data by reusing collation sort keys during batch processing.
  * Automatically switches to uncached processing when distinct values exceed the cache threshold, helping maintain predictable performance.

* **Bug Fixes**
  * Improved consistency when processing subsequent batches after cache fallback.

* **Tests**
  * Added coverage for collation-sensitive grouping, varying distinct-value counts, and fallback behavior.
  * Added benchmarks for cached and uncached aggregation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->