### PR TITLE
Columnar Hub: fix engine-addr CLI arg unconditionally overwriting config file value

### DIFF
--- a/contrib/tiflash-columnar-hub/hub-runtime/src/run.rs
+++ b/contrib/tiflash-columnar-hub/hub-runtime/src/run.rs
@@ -373,9 +373,18 @@ fn overwrite_config_with_cmd_args(config: &mut ConfigFile, matches: &clap::ArgMa
     if let Some(engine_git_hash) = matches.value_of("engine-git-hash") {
         config.server.engine_git_hash = engine_git_hash.to_owned();
     }
-    if let Some(engine_addr) = matches.value_of("engine-addr") {
-        config.server.engine_addr = engine_addr.to_owned();
+    // The special case is engine-addr:
+    // 1. If we have set our own engine-addr (from config file), we just ignore
+    //    what TiFlash gives us.
+    // 2. However, if we have not set our own value, we use what TiFlash gives us.
+    if config.server.engine_addr.is_empty() {
+        if let Some(engine_addr) = matches.value_of("engine-addr") {
+            config.server.engine_addr = engine_addr.to_owned();
+        }
     }
+
+    // advertise-engine-addr always overrides, regardless of what is in the
+    // config file. This is the same behavior as the proxy server path.
     if let Some(engine_addr) = matches.value_of("advertise-engine-addr") {
         config.server.engine_addr = engine_addr.to_owned();
     }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10983

Problem Summary:

When TiFlash is deployed in disaggregated compute mode (`tiflash_compute`) with the Columnar Hub, the store address registered to PD is `"0.0.0.0:3930"` (the wildcard bind address from `flash.service_addr`) instead of the routable FQDN configured in `proxy.toml`'s `server.engine-addr`.

Root cause: The Columnar Hub's `overwrite_config_with_cmd_args` unconditionally applies the `--engine-addr` CLI argument (which TiFlash derives from `flash.service_addr` as a fallback when `flash.proxy.engine-addr` is not explicitly set). This overwrites the correct FQDN that was already loaded from the config file. The Proxy Server path (`setup.rs`) correctly guards against this with an `is_empty()` check, but the Hub path was missing the same guard.

### What is changed and how it works?

```commit-message
Columnar Hub: fix engine-addr CLI arg unconditionally overwriting config file value

In `overwrite_config_with_cmd_args`, add an `is_empty()` guard before
applying the `--engine-addr` CLI argument. This matches the existing
behavior in the Proxy Server path (setup.rs). The config file value now
takes precedence, while `--advertise-engine-addr` continues to
unconditionally override.
```

The fix follows the exact same pattern already used in `contrib/tiflash-proxy/proxy_components/proxy_server/src/setup.rs:85-89`:

```rust
// Before (Hub path):
if let Some(engine_addr) = matches.value_of("engine-addr") {
    config.server.engine_addr = engine_addr.to_owned();
}

// After (matches Proxy Server path):
if config.server.engine_addr.is_empty() {
    if let Some(engine_addr) = matches.value_of("engine-addr") {
        config.server.engine_addr = engine_addr.to_owned();
    }
}
```

### Check List

Tests

- [x] Unit test (existing tests continue to pass; `ConfigFile::default()` has empty `engine_addr`, so CLI arg still applies in tests)
- [ ] Integration test
- [x] Manual test (verified via `investigate.md` analysis that the config file value now survives CLI override)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix the issue that Columnar Hub registers 0.0.0.0 as the store address to PD when
`flash.proxy.engine-addr` is not explicitly set, ignoring the FQDN in proxy.toml.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the engine address configured in the configuration file instead of always replacing it with the command-line value.
  * Continued to support command-line overrides when no engine address is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->