### PR TITLE
Optimize lock handling in MPP local read

### DIFF
--- a/dbms/src/Flash/BatchCoprocessorHandler.cpp
+++ b/dbms/src/Flash/BatchCoprocessorHandler.cpp
@@ -25,6 +25,8 @@
 #include <TiDB/Schema/SchemaSyncer.h>
 
 #include <ext/scope_guard.h>
+#include <memory>
+#include <unordered_set>
 
 namespace DB
 {
@@ -65,10 +67,12 @@ grpc::Status BatchCoprocessorHandler::execute()
             SCOPE_EXIT({ GET_METRIC(tiflash_coprocessor_handling_request_count, type_batch_executing).Decrement(); });
 
             auto dag_request = getDAGRequestFromStringWithRetry(cop_request->data());
+            auto bypass_lock_ts = std::make_unique<std::unordered_set<UInt64>>();
             auto tables_regions_info = TablesRegionsInfo::create(
                 cop_request->regions(),
                 cop_request->table_regions(),
-                cop_context.db_context.getTMTContext());
+                cop_context.db_context.getTMTContext(),
+                bypass_lock_ts.get());
             LOG_DEBUG(
                 log,
                 "Handling {} regions from {} physical tables in DAG request: {}",
@@ -86,6 +90,7 @@ grpc::Status BatchCoprocessorHandler::execute()
                 cop_request->connection_id(),
                 cop_request->connection_alias(),
                 Logger::get(log->identifier()));
+            dag_context.setBypassLockTs(std::move(bypass_lock_ts));
             cop_context.db_context.setDAGContext(&dag_context);
 
             DAGDriver<DAGRequestKind::BatchCop> driver(

--- a/dbms/src/Flash/Coprocessor/DAGContext.h
+++ b/dbms/src/Flash/Coprocessor/DAGContext.h
@@ -41,6 +41,9 @@
 #include <Storages/DeltaMerge/Remote/DisaggTaskId.h>
 #include <Storages/DeltaMerge/ScanContext_fwd.h>
 
+#include <memory>
+#include <unordered_set>
+
 namespace DB
 {
 class Context;
@@ -267,6 +270,17 @@ public:
 
     bool containsRegionsInfoForTable(Int64 table_id) const;
 
+    std::unordered_set<UInt64> & getBypassLockTs()
+    {
+        if (bypass_lock_ts == nullptr)
+            bypass_lock_ts = std::make_unique<std::unordered_set<UInt64>>();
+        return *bypass_lock_ts;
+    }
+    void setBypassLockTs(std::unique_ptr<std::unordered_set<UInt64>> && bypass_lock_ts_)
+    {
+        bypass_lock_ts = std::move(bypass_lock_ts_);
+    }
+
     UInt64 getFlags() const { return flags; }
     void setFlags(UInt64 f) { flags = f; }
     void addFlag(UInt64 f) { flags |= f; }
@@ -378,6 +392,7 @@ public:
     // `tunnel_set` is always set by `MPPTask` and is used later.
     MPPTunnelSetPtr tunnel_set;
     TablesRegionsInfo tables_regions_info;
+    std::unique_ptr<std::unordered_set<UInt64>> bypass_lock_ts;
     // part of regions_for_local_read + regions_for_remote_read, only used for batch-cop
     RegionInfoList retry_regions;
 

--- a/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
@@ -97,7 +97,7 @@ bool tryAddBypassLockTsForLocalRetry(
         return false;
 
     std::vector<UInt64> bypass_lock_ts;
-    bool has_pending_resolve = false;
+    pingcap::kv::TryGetBypassLockResult bypass_lock_result;
     try
     {
         auto * cluster = tmt.getKVCluster();
@@ -114,7 +114,7 @@ bool tryAddBypassLockTsForLocalRetry(
         }
 
         pingcap::kv::Backoffer bo(try_get_bypass_lock_max_backoff_ms);
-        has_pending_resolve = cluster->lock_resolver->tryGetBypassLock(bo, read_tso, e.locks, bypass_lock_ts);
+        bypass_lock_result = cluster->lock_resolver->tryGetBypassLock(bo, read_tso, e.locks, bypass_lock_ts);
     }
     catch (const pingcap::Exception & ex)
     {
@@ -138,6 +138,16 @@ bool tryAddBypassLockTsForLocalRetry(
             ex.displayText());
         return false;
     }
+    catch (...)
+    {
+        LOG_WARNING(
+            log,
+            "Failed to check bypass locks for local retry, lock_regions={} lock_txns={} read_tso={} error=unknown",
+            e.lock_region.size(),
+            e.locks.size(),
+            read_tso);
+        return false;
+    }
 
     if (!bypass_lock_ts.empty())
     {
@@ -145,19 +155,20 @@ bool tryAddBypassLockTsForLocalRetry(
         query_bypass_lock_ts.insert(bypass_lock_ts.begin(), bypass_lock_ts.end());
     }
 
-    const bool should_retry_local = has_pending_resolve || !bypass_lock_ts.empty();
+    const bool should_retry_local = bypass_lock_result.has_pending_resolve || !bypass_lock_ts.empty();
     LOG_INFO(
         log,
         "Check bypass locks for local retry, lock_regions={} lock_txns={} bypass_lock_ts={} "
-        "has_pending_resolve={} retry_local={} read_tso={}",
+        "has_pending_resolve={} need_wait_bg_resolve={} retry_local={} read_tso={}",
         e.lock_region.size(),
         e.locks.size(),
         bypass_lock_ts.size(),
-        has_pending_resolve,
+        bypass_lock_result.has_pending_resolve,
+        bypass_lock_result.need_wait_bg_resolve,
         should_retry_local,
         read_tso);
 
-    if (has_pending_resolve)
+    if (bypass_lock_result.need_wait_bg_resolve)
         std::this_thread::sleep_for(std::chrono::milliseconds(wait_bg_resolve_lock_ms));
 
     return should_retry_local;
@@ -970,6 +981,8 @@ LearnerReadSnapshot DAGStorageInterpreter::doBatchCopLearnerRead()
             if (tmt.checkShuttingDown())
                 throw TiFlashException("TiFlash server is terminating", Errors::Coprocessor::Internal);
             // For normal unavailable regions, let MakeRegionQueryInfos move them to remote read in the next loop.
+            // Local lock regions are handled separately: try local retry with bypass_lock_ts first, and fall back
+            // to remote read if bypass is not available.
             force_retry.insert(e.unavailable_region.begin(), e.unavailable_region.end());
 
             if (!e.lock_region.empty())

--- a/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
+++ b/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.cpp
@@ -59,7 +59,13 @@
 #include <TiDB/Schema/TiDBSchemaManager.h>
 #include <common/logger_useful.h>
 #include <kvproto/coprocessor.pb.h>
+#include <pingcap/Exception.h>
+#include <pingcap/kv/Backoff.h>
+#include <pingcap/kv/Cluster.h>
 #include <tipb/select.pb.h>
+
+#include <chrono>
+#include <thread>
 
 namespace DB
 {
@@ -77,6 +83,86 @@ extern const char random_trigger_remote_read[];
 
 namespace
 {
+constexpr UInt64 wait_bg_resolve_lock_ms = 20;
+constexpr UInt64 try_get_bypass_lock_max_backoff_ms = 500;
+
+bool tryAddBypassLockTsForLocalRetry(
+    const RegionException & e,
+    UInt64 read_tso,
+    TMTContext & tmt,
+    DAGContext & dag_context,
+    const LoggerPtr & log)
+{
+    if (e.lock_region.empty())
+        return false;
+
+    std::vector<UInt64> bypass_lock_ts;
+    bool has_pending_resolve = false;
+    try
+    {
+        auto * cluster = tmt.getKVCluster();
+        if (cluster == nullptr || cluster->lock_resolver == nullptr)
+        {
+            LOG_WARNING(
+                log,
+                "Skip local retry with bypass locks because lock resolver is not available, lock_regions={} "
+                "lock_txns={} read_tso={}",
+                e.lock_region.size(),
+                e.locks.size(),
+                read_tso);
+            return false;
+        }
+
+        pingcap::kv::Backoffer bo(try_get_bypass_lock_max_backoff_ms);
+        has_pending_resolve = cluster->lock_resolver->tryGetBypassLock(bo, read_tso, e.locks, bypass_lock_ts);
+    }
+    catch (const pingcap::Exception & ex)
+    {
+        LOG_WARNING(
+            log,
+            "Failed to check bypass locks for local retry, lock_regions={} lock_txns={} read_tso={} error={}",
+            e.lock_region.size(),
+            e.locks.size(),
+            read_tso,
+            ex.displayText());
+        return false;
+    }
+    catch (const Poco::Exception & ex)
+    {
+        LOG_WARNING(
+            log,
+            "Failed to check bypass locks for local retry, lock_regions={} lock_txns={} read_tso={} error={}",
+            e.lock_region.size(),
+            e.locks.size(),
+            read_tso,
+            ex.displayText());
+        return false;
+    }
+
+    if (!bypass_lock_ts.empty())
+    {
+        auto & query_bypass_lock_ts = dag_context.getBypassLockTs();
+        query_bypass_lock_ts.insert(bypass_lock_ts.begin(), bypass_lock_ts.end());
+    }
+
+    const bool should_retry_local = has_pending_resolve || !bypass_lock_ts.empty();
+    LOG_INFO(
+        log,
+        "Check bypass locks for local retry, lock_regions={} lock_txns={} bypass_lock_ts={} "
+        "has_pending_resolve={} retry_local={} read_tso={}",
+        e.lock_region.size(),
+        e.locks.size(),
+        bypass_lock_ts.size(),
+        has_pending_resolve,
+        should_retry_local,
+        read_tso);
+
+    if (has_pending_resolve)
+        std::this_thread::sleep_for(std::chrono::milliseconds(wait_bg_resolve_lock_ms));
+
+    return should_retry_local;
+}
+
 RegionException::RegionReadStatus GetRegionReadStatus(
     const RegionInfo & check_info,
     const RegionPtr & current_region,
@@ -842,6 +928,7 @@ LearnerReadSnapshot DAGStorageInterpreter::doBatchCopLearnerRead()
     if (regions_for_local_read.empty())
         return {};
     std::unordered_set<RegionID> force_retry;
+    bool should_try_bypass_locks = true;
     for (;;)
     {
         try
@@ -882,9 +969,26 @@ LearnerReadSnapshot DAGStorageInterpreter::doBatchCopLearnerRead()
 
             if (tmt.checkShuttingDown())
                 throw TiFlashException("TiFlash server is terminating", Errors::Coprocessor::Internal);
-            // By now, RegionException will contain all region id of MvccQueryInfo, which is needed by CHSpark.
-            // When meeting RegionException, we can let MakeRegionQueryInfos to check in next loop.
+            // For normal unavailable regions, let MakeRegionQueryInfos move them to remote read in the next loop.
             force_retry.insert(e.unavailable_region.begin(), e.unavailable_region.end());
+
+            if (!e.lock_region.empty())
+            {
+                if (should_try_bypass_locks)
+                {
+                    should_try_bypass_locks = false;
+                    if (tryAddBypassLockTsForLocalRetry(
+                            e,
+                            mvcc_query_info->start_ts,
+                            tmt,
+                            *context.getDAGContext(),
+                            log))
+                    {
+                        continue;
+                    }
+                }
+                force_retry.insert(e.lock_region.begin(), e.lock_region.end());
+            }
         }
         catch (DB::Exception & e)
         {

--- a/dbms/src/Flash/Coprocessor/TablesRegionsInfo.cpp
+++ b/dbms/src/Flash/Coprocessor/TablesRegionsInfo.cpp
@@ -71,7 +71,8 @@ static void insertRegionInfoToTablesRegionInfo(
     Int64 table_id,
     TablesRegionsInfo & tables_region_infos,
     std::unordered_set<RegionID> & local_region_id_set,
-    const TMTContext & tmt_context)
+    const TMTContext & tmt_context,
+    const std::unordered_set<UInt64> * bypass_lock_ts)
 {
     auto & table_region_info = tables_region_infos.getOrCreateTableRegionInfoByTableID(table_id);
     for (int i = 0; i < regions.size(); ++i) // NOLINT
@@ -82,7 +83,7 @@ static void insertRegionInfoToTablesRegionInfo(
             r.region_epoch().version(),
             r.region_epoch().conf_ver(),
             genCopKeyRange(r.ranges()),
-            nullptr);
+            bypass_lock_ts);
         if (region_info.key_ranges.empty())
         {
             throw TiFlashException(
@@ -121,7 +122,8 @@ static void insertRegionInfoToTablesRegionInfo(
 TablesRegionsInfo TablesRegionsInfo::create(
     const google::protobuf::RepeatedPtrField<coprocessor::RegionInfo> & regions,
     const google::protobuf::RepeatedPtrField<coprocessor::TableRegions> & table_regions,
-    const TMTContext & tmt_context)
+    const TMTContext & tmt_context,
+    const std::unordered_set<UInt64> * bypass_lock_ts)
 {
     assert(regions.empty() || table_regions.empty());
     TablesRegionsInfo tables_regions_info(!regions.empty());
@@ -132,7 +134,8 @@ TablesRegionsInfo TablesRegionsInfo::create(
             InvalidTableID,
             tables_regions_info,
             local_region_id_set,
-            tmt_context);
+            tmt_context,
+            bypass_lock_ts);
     else
     {
         for (const auto & table_region : table_regions)
@@ -143,7 +146,8 @@ TablesRegionsInfo TablesRegionsInfo::create(
                 table_region.physical_table_id(),
                 tables_regions_info,
                 local_region_id_set,
-                tmt_context);
+                tmt_context,
+                bypass_lock_ts);
         }
         assert(static_cast<UInt64>(table_regions.size()) == tables_regions_info.tableCount());
     }

--- a/dbms/src/Flash/Coprocessor/TablesRegionsInfo.h
+++ b/dbms/src/Flash/Coprocessor/TablesRegionsInfo.h
@@ -43,7 +43,8 @@ public:
     static TablesRegionsInfo create(
         const google::protobuf::RepeatedPtrField<coprocessor::RegionInfo> & regions,
         const google::protobuf::RepeatedPtrField<coprocessor::TableRegions> & table_regions,
-        const TMTContext & tmt_context);
+        const TMTContext & tmt_context,
+        const std::unordered_set<UInt64> * bypass_lock_ts = nullptr);
     TablesRegionsInfo()
         : is_single_table(false)
     {}

--- a/dbms/src/Flash/Disaggregated/WNEstablishDisaggTaskHandler.cpp
+++ b/dbms/src/Flash/Disaggregated/WNEstablishDisaggTaskHandler.cpp
@@ -28,6 +28,9 @@
 #include <Storages/KVStore/TMTContext.h>
 #include <kvproto/disaggregated.pb.h>
 
+#include <memory>
+#include <unordered_set>
+
 namespace DB
 {
 
@@ -46,8 +49,9 @@ void WNEstablishDisaggTaskHandler::prepare(const disaggregated::EstablishDisaggT
     const auto & meta = request->meta();
 
     auto & tmt_context = context->getTMTContext();
+    auto bypass_lock_ts = std::make_unique<std::unordered_set<UInt64>>();
     TablesRegionsInfo tables_regions_info
-        = TablesRegionsInfo::create(request->regions(), request->table_regions(), tmt_context);
+        = TablesRegionsInfo::create(request->regions(), request->table_regions(), tmt_context, bypass_lock_ts.get());
     LOG_INFO(
         log,
         "DisaggregatedTask handling {} regions from {} physical tables",
@@ -77,6 +81,7 @@ void WNEstablishDisaggTaskHandler::prepare(const disaggregated::EstablishDisaggT
         std::move(tables_regions_info),
         context->getClientInfo().current_address.toString(),
         log);
+    dag_context->setBypassLockTs(std::move(bypass_lock_ts));
     context->setDAGContext(dag_context.get());
 }
 

--- a/dbms/src/Flash/Mpp/MPPTask.cpp
+++ b/dbms/src/Flash/Mpp/MPPTask.cpp
@@ -40,6 +40,8 @@
 #include <ext/scope_guard.h>
 #include <magic_enum.hpp>
 #include <map>
+#include <memory>
+#include <unordered_set>
 
 namespace DB
 {
@@ -393,8 +395,12 @@ void MPPTask::prepare(const mpp::DispatchTaskRequest & task_request)
     TMTContext & tmt_context = context->getTMTContext();
     /// MPP task will only use key ranges in mpp::DispatchTaskRequest::regions/mpp::DispatchTaskRequest::table_regions.
     /// The ones defined in tipb::TableScan will never be used and can be removed later.
-    TablesRegionsInfo tables_regions_info
-        = TablesRegionsInfo::create(task_request.regions(), task_request.table_regions(), tmt_context);
+    auto bypass_lock_ts = std::make_unique<std::unordered_set<UInt64>>();
+    TablesRegionsInfo tables_regions_info = TablesRegionsInfo::create(
+        task_request.regions(),
+        task_request.table_regions(),
+        tmt_context,
+        bypass_lock_ts.get());
     LOG_DEBUG(
         log,
         "Handling {} regions from {} physical tables in MPP task",
@@ -443,6 +449,7 @@ void MPPTask::prepare(const mpp::DispatchTaskRequest & task_request)
     dag_context = std::make_unique<DAGContext>(dag_req, task_request.meta(), is_root_mpp_task);
     dag_context->log = log;
     dag_context->tables_regions_info = std::move(tables_regions_info);
+    dag_context->setBypassLockTs(std::move(bypass_lock_ts));
     dag_context->tidb_host = context->getClientInfo().current_address.toString();
 
     context->setDAGContext(dag_context.get());

--- a/dbms/src/Storages/KVStore/Read/LearnerReadWorker.cpp
+++ b/dbms/src/Storages/KVStore/Read/LearnerReadWorker.cpp
@@ -301,7 +301,7 @@ void LearnerReadWorker::recordReadIndexError(
         else if (resp.has_locked())
         {
             GET_METRIC(tiflash_raft_learner_read_failures_count, type_tikv_lock).Increment();
-            unavailable_regions.addRegionLockAsUnavailableRegion(region_id, LockInfoPtr(resp.release_locked()));
+            unavailable_regions.addReadIndexLockAsUnavailableRegion(region_id, LockInfoPtr(resp.release_locked()));
         }
         else
         {

--- a/dbms/src/Storages/KVStore/Read/LearnerReadWorker.cpp
+++ b/dbms/src/Storages/KVStore/Read/LearnerReadWorker.cpp
@@ -37,8 +37,13 @@ void UnavailableRegions::tryThrowRegionException()
     if (!batch_cop && !region_locks.empty())
         throw LockException(std::move(region_locks));
 
-    if (!ids.empty())
-        throw RegionException(std::move(ids), status, extra_msg.c_str());
+    if (!unavailable_region_ids.empty() || !lock_region_ids.empty())
+        throw RegionException(
+            std::move(unavailable_region_ids),
+            std::move(lock_region_ids),
+            std::move(locks),
+            status,
+            extra_msg.c_str());
 }
 
 void UnavailableRegions::addRegionWaitIndexTimeout(
@@ -296,7 +301,7 @@ void LearnerReadWorker::recordReadIndexError(
         else if (resp.has_locked())
         {
             GET_METRIC(tiflash_raft_learner_read_failures_count, type_tikv_lock).Increment();
-            unavailable_regions.addRegionLock(region_id, LockInfoPtr(resp.release_locked()));
+            unavailable_regions.addRegionLockAsUnavailableRegion(region_id, LockInfoPtr(resp.release_locked()));
         }
         else
         {

--- a/dbms/src/Storages/KVStore/Read/LearnerReadWorker.h
+++ b/dbms/src/Storages/KVStore/Read/LearnerReadWorker.h
@@ -65,8 +65,12 @@ struct UnavailableRegions
         extra_msg = std::move(extra_msg_);
     }
 
-    void addRegionLockAsUnavailableRegion(RegionID region_id_, LockInfoPtr && region_lock_)
+    void addReadIndexLockAsUnavailableRegion(RegionID region_id_, LockInfoPtr && region_lock_)
     {
+        // Read-index locks are reported by the leader-side memory lock check before TiFlash gets a local read
+        // index. Current read-index requests cannot carry bypass_lock_ts/resolved_locks to the leader, so local
+        // bypass retry cannot skip these locks. Keep them out of lock_region_ids and use the existing
+        // unavailable-region/LockException handling.
         region_locks.emplace_back(region_id_, std::move(region_lock_));
         unavailable_region_ids.emplace(region_id_);
     }

--- a/dbms/src/Storages/KVStore/Read/LearnerReadWorker.h
+++ b/dbms/src/Storages/KVStore/Read/LearnerReadWorker.h
@@ -14,6 +14,7 @@
 
 #include <Common/Logger.h>
 #include <Storages/KVStore/Read/LearnerRead.h>
+#include <Storages/KVStore/Read/RegionException.h>
 #include <Storages/KVStore/TMTContext.h>
 #include <Storages/RegionQueryInfo_fwd.h>
 
@@ -48,23 +49,36 @@ struct UnavailableRegions
         , is_wn_disagg_read(is_wn_disagg_read_)
     {}
 
-    size_t size() const { return ids.size(); }
+    size_t size() const { return unavailable_region_ids.size() + lock_region_ids.size(); }
 
-    bool empty() const { return ids.empty(); }
+    bool empty() const { return unavailable_region_ids.empty() && lock_region_ids.empty(); }
 
-    bool contains(RegionID region_id) const { return ids.contains(region_id); }
+    bool contains(RegionID region_id) const
+    {
+        return unavailable_region_ids.contains(region_id) || lock_region_ids.contains(region_id);
+    }
 
     void addStatus(RegionID id, RegionException::RegionReadStatus status_, std::string && extra_msg_)
     {
         status = status_;
-        ids.emplace(id);
+        unavailable_region_ids.emplace(id);
         extra_msg = std::move(extra_msg_);
+    }
+
+    void addRegionLockAsUnavailableRegion(RegionID region_id_, LockInfoPtr && region_lock_)
+    {
+        region_locks.emplace_back(region_id_, std::move(region_lock_));
+        unavailable_region_ids.emplace(region_id_);
     }
 
     void addRegionLock(RegionID region_id_, LockInfoPtr && region_lock_)
     {
+        if (region_lock_)
+        {
+            locks[region_lock_->lock_version()].push_back(std::make_shared<pingcap::kv::Lock>(*region_lock_));
+        }
         region_locks.emplace_back(region_id_, std::move(region_lock_));
-        ids.emplace(region_id_);
+        lock_region_ids.emplace(region_id_);
     }
 
     void tryThrowRegionException();
@@ -74,10 +88,16 @@ struct UnavailableRegions
     String toDebugString() const
     {
         FmtBuffer buffer;
-        buffer.append("{ids=[");
+        buffer.append("{unavailable_ids=[");
         buffer.joinStr(
-            ids.begin(),
-            ids.end(),
+            unavailable_region_ids.begin(),
+            unavailable_region_ids.end(),
+            [](const auto & v, FmtBuffer & f) { f.fmtAppend("{}", v); },
+            "|");
+        buffer.append("] lock_ids=[");
+        buffer.joinStr(
+            lock_region_ids.begin(),
+            lock_region_ids.end(),
             [](const auto & v, FmtBuffer & f) { f.fmtAppend("{}", v); },
             "|");
         buffer.append("] locks=");
@@ -95,7 +115,9 @@ private:
     const bool batch_cop;
     const bool is_wn_disagg_read;
 
-    RegionException::UnavailableRegions ids;
+    RegionException::UnavailableRegions unavailable_region_ids;
+    RegionException::UnavailableRegions lock_region_ids;
+    RegionException::LocksByTxn locks;
     std::vector<std::pair<RegionID, LockInfoPtr>> region_locks;
     RegionException::RegionReadStatus status{RegionException::RegionReadStatus::NOT_FOUND};
     std::string extra_msg;

--- a/dbms/src/Storages/KVStore/Read/RegionException.h
+++ b/dbms/src/Storages/KVStore/Read/RegionException.h
@@ -16,8 +16,12 @@
 
 #include <Common/Exception.h>
 #include <Storages/KVStore/Types.h>
+#include <pingcap/kv/LockResolver.h>
 
 #include <magic_enum.hpp>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 namespace DB
 {
@@ -43,6 +47,7 @@ public:
     };
 
     using UnavailableRegions = std::unordered_set<RegionID>;
+    using LocksByTxn = std::unordered_map<UInt64, std::vector<pingcap::kv::LockPtr>>;
 
 public:
     RegionException(UnavailableRegions && unavailable_region_, RegionReadStatus status_, const char * extra_msg)
@@ -51,8 +56,24 @@ public:
         , status(status_)
     {}
 
+    RegionException(
+        UnavailableRegions && unavailable_region_,
+        UnavailableRegions && lock_region_,
+        LocksByTxn && locks_,
+        RegionReadStatus status_,
+        const char * extra_msg)
+        : Exception(fmt::format("Region error {}({})", magic_enum::enum_name(status_), extra_msg ? extra_msg : ""))
+        , unavailable_region(std::move(unavailable_region_))
+        , lock_region(std::move(lock_region_))
+        , locks(std::move(locks_))
+        , status(status_)
+    {}
+
     /// Region could be found with correct epoch, but unavailable (e.g. its lease in proxy has not been built with leader).
     UnavailableRegions unavailable_region;
+    /// Regions that hit local lock CF after wait-index succeeds. They may be retried locally with bypass_lock_ts.
+    UnavailableRegions lock_region;
+    LocksByTxn locks;
     RegionReadStatus status;
 };
 

--- a/dbms/src/Storages/KVStore/tests/gtest_learner_read.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_learner_read.cpp
@@ -41,6 +41,18 @@ protected:
         return resp;
     }
 
+    static LockInfoPtr makeLockInfo(UInt64 lock_version)
+    {
+        auto lock_info = std::make_unique<kvrpcpb::LockInfo>();
+        lock_info->set_key("key");
+        lock_info->set_primary_lock("primary");
+        lock_info->set_lock_version(lock_version);
+        lock_info->set_lock_ttl(3000);
+        lock_info->set_txn_size(1);
+        lock_info->set_lock_type(kvrpcpb::Op::Put);
+        return lock_info;
+    }
+
     // helper function for testing private method
     static std::vector<kvrpcpb::ReadIndexRequest> buildBatchReadIndex( //
         LearnerReadWorker & worker,
@@ -57,6 +69,11 @@ protected:
         RegionsReadIndexResult & read_index_result)
     {
         worker.recordReadIndexError(regions_snapshot, read_index_result);
+    }
+
+    static void throwUnavailableRegions(LearnerReadWorker & worker)
+    {
+        worker.unavailable_regions.tryThrowRegionException();
     }
 
 protected:
@@ -173,6 +190,67 @@ try
     ASSERT_EQ(1024, mvcc_query_info.getReadIndexRes(202));
     ASSERT_EQ(10000, mvcc_query_info.getReadIndexRes(203));
     ASSERT_EQ(0, mvcc_query_info.getReadIndexRes(999)); // not exist region_id
+}
+CATCH
+
+TEST_F(LearnerReadTest, ReadIndexLockIsUnavailableRegion)
+try
+{
+    auto & global_ctx = TiFlashTestEnv::getGlobalContext();
+    auto & tmt = global_ctx.getTMTContext();
+
+    const RegionID region_id = 200;
+    const UInt64 lock_version = 12345;
+
+    MvccQueryInfo mvcc_query_info(false, 10000, nullptr);
+    LearnerReadWorker worker(mvcc_query_info, tmt, true, false, log);
+
+    kvrpcpb::ReadIndexResponse resp;
+    resp.mutable_locked()->CopyFrom(*makeLockInfo(lock_version));
+
+    RegionsReadIndexResult read_index_result;
+    read_index_result.emplace(region_id, std::move(resp));
+
+    recordReadIndexError({}, worker, read_index_result);
+
+    try
+    {
+        throwUnavailableRegions(worker);
+        FAIL() << "read-index lock should throw RegionException for batch cop";
+    }
+    catch (const RegionException & e)
+    {
+        ASSERT_TRUE(e.unavailable_region.contains(region_id));
+        ASSERT_TRUE(e.lock_region.empty());
+        ASSERT_TRUE(e.locks.empty());
+        ASSERT_EQ(e.status, RegionException::RegionReadStatus::NOT_FOUND);
+    }
+}
+CATCH
+
+TEST_F(LearnerReadTest, LocalLockIsRetryableLockRegion)
+try
+{
+    const RegionID region_id = 200;
+    const UInt64 lock_version = 12345;
+
+    UnavailableRegions unavailable_regions(true, false);
+    unavailable_regions.addRegionLock(region_id, makeLockInfo(lock_version));
+
+    try
+    {
+        unavailable_regions.tryThrowRegionException();
+        FAIL() << "local lock should throw RegionException for batch cop";
+    }
+    catch (const RegionException & e)
+    {
+        ASSERT_TRUE(e.unavailable_region.empty());
+        ASSERT_TRUE(e.lock_region.contains(region_id));
+        ASSERT_TRUE(e.locks.contains(lock_version));
+        ASSERT_EQ(e.locks.at(lock_version).size(), 1);
+        ASSERT_EQ(e.locks.at(lock_version).front()->txn_id, lock_version);
+        ASSERT_EQ(e.status, RegionException::RegionReadStatus::NOT_FOUND);
+    }
 }
 CATCH
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Problem Summary:

Optimize TiFlash MPP/batch cop local learner read lock handling to reduce unnecessary remote reads when local LockCF locks can be handled by a local retry.

### What is changed and how it works?

```commit-message
Optimize lock handling in MPP local read
```

- Add a best-effort local retry path for lock regions hit after local wait-index succeeds.
- Keep read-index locks as unavailable regions because current read-index requests cannot carry bypass lock information to the leader-side memory lock check.
- Retry local learner read with collected bypass lock information when the lock can be safely bypassed.
- Wait briefly before retrying only when the lock needs to be physically resolved first.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Built affected objects locally:

- `dbms/src/Flash/CMakeFiles/flash_service.dir/Coprocessor/DAGStorageInterpreter.cpp.o`
- `dbms/src/Storages/KVStore/CMakeFiles/kvstore.dir/Read/LearnerReadWorker.cpp.o`

Ran learner read unit tests locally:

- `/Users/feixu/dev/pingcap/tiflash/cmake-build-debug/dbms/gtests_dbms --gtest_filter=LearnerReadTest.*`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved learner read error handling by separating unavailable regions from lock-related regions and ensuring lock details are included in thrown region exceptions for more accurate retry decisions.
  - Enhanced batch/cop learner read retries with a bypass-lock-based local retry path (with remote fallback when bypass locks aren’t applicable).
- **Tests**
  - Added/extended learner read tests to validate read-index lock handling and local bypass-lock retry classification.
- **Chores**
  - Updated the bundled client C component to a newer revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->