### PR TITLE
executor: skip probe for empty hash joins

### DIFF
--- a/dbms/src/DataStreams/HashJoinProbeExec.cpp
+++ b/dbms/src/DataStreams/HashJoinProbeExec.cpp
@@ -128,6 +128,9 @@ PartitionBlock HashJoinProbeExec::getProbeBlock()
 
 Block HashJoinProbeExec::probe()
 {
+    if (probe_process_info.all_rows_joined_finish && join->shouldSkipProbe())
+        return {};
+
     if (probe_process_info.all_rows_joined_finish)
     {
         auto partition_block = getProbeBlock();

--- a/dbms/src/DataStreams/HashJoinProbeExec.cpp
+++ b/dbms/src/DataStreams/HashJoinProbeExec.cpp
@@ -128,7 +128,7 @@ PartitionBlock HashJoinProbeExec::getProbeBlock()
 
 Block HashJoinProbeExec::probe()
 {
-    if (probe_process_info.all_rows_joined_finish && join->shouldSkipProbe())
+    if (join->shouldSkipProbe())
         return {};
 
     if (probe_process_info.all_rows_joined_finish)

--- a/dbms/src/Flash/Pipeline/Exec/PipelineExec.cpp
+++ b/dbms/src/Flash/Pipeline/Exec/PipelineExec.cpp
@@ -91,9 +91,17 @@ PipelineExec::PipelineExec(
 void PipelineExec::executePrefix()
 {
     sink_op->operatePrefix();
+    bool skip_source = false;
     for (auto it = transform_ops.rbegin(); it != transform_ops.rend(); ++it) // NOLINT(modernize-loop-convert)
+    {
         (*it)->operatePrefix();
-    source_op->operatePrefix();
+        skip_source |= (*it)->shouldSkipSource();
+    }
+    if (!skip_source)
+    {
+        source_op->operatePrefix();
+        source_prefix_executed = true;
+    }
     FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::random_pipeline_model_execute_prefix_failpoint);
 }
 
@@ -102,7 +110,8 @@ void PipelineExec::executeSuffix()
     sink_op->operateSuffix();
     for (auto it = transform_ops.rbegin(); it != transform_ops.rend(); ++it) // NOLINT(modernize-loop-convert)
         (*it)->operateSuffix();
-    source_op->operateSuffix();
+    if (source_prefix_executed)
+        source_op->operateSuffix();
     FAIL_POINT_TRIGGER_EXCEPTION(FailPoints::random_pipeline_model_execute_suffix_failpoint);
 }
 

--- a/dbms/src/Flash/Pipeline/Exec/PipelineExec.h
+++ b/dbms/src/Flash/Pipeline/Exec/PipelineExec.h
@@ -80,6 +80,7 @@ private:
     TransformOps transform_ops;
     SinkOpPtr sink_op;
     bool has_pipeline_breaker_wait_time = false;
+    bool source_prefix_executed = false;
 
     // hold the operator which is ready for executing await.
     Operator * awaitable = nullptr;

--- a/dbms/src/Flash/Pipeline/Exec/tests/gtest_simple_operator.cpp
+++ b/dbms/src/Flash/Pipeline/Exec/tests/gtest_simple_operator.cpp
@@ -51,6 +51,60 @@ protected:
 private:
     ResultHandler result_handler;
 };
+
+struct SourceLifecycle
+{
+    size_t prefix_count = 0;
+    size_t read_count = 0;
+    size_t suffix_count = 0;
+};
+
+class LifecycleSourceOp : public SourceOp
+{
+public:
+    LifecycleSourceOp(PipelineExecutorContext & exec_context_, const std::shared_ptr<SourceLifecycle> & lifecycle_)
+        : SourceOp(exec_context_, "")
+        , lifecycle(lifecycle_)
+    {}
+
+    String getName() const override { return "LifecycleSourceOp"; }
+
+protected:
+    void operatePrefixImpl() override { ++lifecycle->prefix_count; }
+    void operateSuffixImpl() override { ++lifecycle->suffix_count; }
+
+    OperatorStatus readImpl(Block & block) override
+    {
+        ++lifecycle->read_count;
+        block = {};
+        return OperatorStatus::HAS_OUTPUT;
+    }
+
+private:
+    std::shared_ptr<SourceLifecycle> lifecycle;
+};
+
+class SkipSourceTransformOp : public TransformOp
+{
+public:
+    explicit SkipSourceTransformOp(PipelineExecutorContext & exec_context_)
+        : TransformOp(exec_context_, "")
+    {}
+
+    String getName() const override { return "SkipSourceTransformOp"; }
+    bool shouldSkipSource() const override { return true; }
+
+protected:
+    OperatorStatus transformImpl(Block &) override { return OperatorStatus::HAS_OUTPUT; }
+
+    OperatorStatus tryOutputImpl(Block & block) override
+    {
+        block = {};
+        return OperatorStatus::HAS_OUTPUT;
+    }
+
+    void transformHeaderImpl(Block &) override {}
+};
 } // namespace
 
 class SimpleOperatorTestRunner : public DB::tests::ExecutorTest
@@ -141,6 +195,29 @@ try
     auto op_pipeline = build(request, result_handler, exec_context);
     exec_context.cancel();
     ASSERT_EQ(op_pipeline->execute(), OperatorStatus::CANCELLED);
+}
+CATCH
+
+TEST_F(SimpleOperatorTestRunner, SkipSourceWhenTransformCanFinish)
+try
+{
+    PipelineExecutorContext exec_context;
+    auto lifecycle = std::make_shared<SourceLifecycle>();
+    auto source = std::make_unique<LifecycleSourceOp>(exec_context, lifecycle);
+    TransformOps transforms;
+    transforms.push_back(std::make_unique<SkipSourceTransformOp>(exec_context));
+    ResultHandler result_handler{[](const Block &) {
+    }};
+    auto sink = std::make_unique<SimpleGetResultSinkOp>(exec_context, "", std::move(result_handler));
+    PipelineExec pipeline(std::move(source), std::move(transforms), std::move(sink), false);
+
+    pipeline.executePrefix();
+    ASSERT_EQ(pipeline.execute(), OperatorStatus::FINISHED);
+    pipeline.executeSuffix();
+
+    ASSERT_EQ(lifecycle->prefix_count, 0);
+    ASSERT_EQ(lifecycle->read_count, 0);
+    ASSERT_EQ(lifecycle->suffix_count, 0);
 }
 CATCH
 

--- a/dbms/src/Flash/tests/gtest_join_executor.cpp
+++ b/dbms/src/Flash/tests/gtest_join_executor.cpp
@@ -256,6 +256,217 @@ try
 }
 CATCH
 
+TEST_F(JoinExecutorTestRunner, EmptyBuildInnerJoinSkipsProbe)
+try
+{
+    context.addMockTable(
+        "empty_build_join",
+        "probe_table",
+        {{"a", TiDB::TP::TypeLong}},
+        {toNullableVec<Int32>("a", {1, 2, 3})});
+    context.addExchangeReceiver("empty_build_receiver", {{"a", TiDB::TP::TypeLong}});
+
+    auto request = context.scan("empty_build_join", "probe_table")
+                       .join(context.receive("empty_build_receiver"), tipb::JoinType::TypeInnerJoin, {col("a")})
+                       .build(context);
+
+    WRAP_FOR_TEST_BEGIN
+    WRAP_FOR_JOIN_TEST_BEGIN
+    if (!enable_pipeline && cfg.enable_join_v2)
+        continue;
+
+    Expect expect{{"table_scan_0", {0, 10}}, {"exchange_receiver_1", {0, 10}}, {"Join_2", {0, 10}}};
+    testForExecutionSummary(request, expect);
+    WRAP_FOR_JOIN_TEST_END
+    WRAP_FOR_TEST_END
+}
+CATCH
+
+TEST_F(JoinExecutorTestRunner, BuildWithOnlyNullKeysInnerJoinSkipsProbe)
+try
+{
+    context.addMockTable(
+        "null_key_build_join",
+        "probe_table",
+        {{"a", TiDB::TP::TypeLong}},
+        {toNullableVec<Int32>("a", {1, 2, 3})});
+    context.addExchangeReceiver(
+        "null_key_build_receiver",
+        {{"a", TiDB::TP::TypeLong}},
+        {toNullableVec<Int32>("a", {{}})});
+
+    auto request = context.scan("null_key_build_join", "probe_table")
+                       .join(context.receive("null_key_build_receiver"), tipb::JoinType::TypeInnerJoin, {col("a")})
+                       .build(context);
+
+    WRAP_FOR_TEST_BEGIN
+    WRAP_FOR_JOIN_TEST_BEGIN
+    if (!enable_pipeline && cfg.enable_join_v2)
+        continue;
+
+    Expect expect{{"table_scan_0", {0, 10}}, {"exchange_receiver_1", {1, 10}}, {"Join_2", {0, 10}}};
+    testForExecutionSummary(request, expect);
+    WRAP_FOR_JOIN_TEST_END
+    WRAP_FOR_TEST_END
+}
+CATCH
+
+TEST_F(JoinExecutorTestRunner, EmptyBuildSemiJoinSkipsProbe)
+try
+{
+    context.addMockTable(
+        "empty_build_semi_join",
+        "probe_table",
+        {{"a", TiDB::TP::TypeLong}},
+        {toNullableVec<Int32>("a", {1, 2, 3})});
+    context.addExchangeReceiver("empty_build_semi_receiver", {{"a", TiDB::TP::TypeLong}});
+
+    auto request = context.scan("empty_build_semi_join", "probe_table")
+                       .join(context.receive("empty_build_semi_receiver"), tipb::JoinType::TypeSemiJoin, {col("a")})
+                       .build(context);
+
+    WRAP_FOR_TEST_BEGIN
+    WRAP_FOR_JOIN_TEST_BEGIN
+    if (!enable_pipeline && cfg.enable_join_v2)
+        continue;
+
+    Expect expect{{"table_scan_0", {0, 10}}, {"exchange_receiver_1", {0, 10}}, {"Join_2", {0, 10}}};
+    testForExecutionSummary(request, expect);
+    WRAP_FOR_JOIN_TEST_END
+    WRAP_FOR_TEST_END
+}
+CATCH
+
+TEST_F(JoinExecutorTestRunner, BuildWithOnlyNullKeysSemiJoinSkipsProbe)
+try
+{
+    context.addMockTable(
+        "null_key_build_semi_join",
+        "probe_table",
+        {{"a", TiDB::TP::TypeLong}},
+        {toNullableVec<Int32>("a", {1, 2, 3})});
+    context.addExchangeReceiver(
+        "null_key_build_semi_receiver",
+        {{"a", TiDB::TP::TypeLong}},
+        {toNullableVec<Int32>("a", {{}})});
+
+    auto request = context.scan("null_key_build_semi_join", "probe_table")
+                       .join(context.receive("null_key_build_semi_receiver"), tipb::JoinType::TypeSemiJoin, {col("a")})
+                       .build(context);
+
+    WRAP_FOR_TEST_BEGIN
+    WRAP_FOR_JOIN_TEST_BEGIN
+    if (!enable_pipeline && cfg.enable_join_v2)
+        continue;
+
+    Expect expect{{"table_scan_0", {0, 10}}, {"exchange_receiver_1", {1, 10}}, {"Join_2", {0, 10}}};
+    testForExecutionSummary(request, expect);
+    WRAP_FOR_JOIN_TEST_END
+    WRAP_FOR_TEST_END
+}
+CATCH
+
+TEST_F(JoinExecutorTestRunner, EmptyBuildRightSemiJoinSkipsProbe)
+try
+{
+    context.addMockTable("empty_build_right_semi_join", "build_table", {{"a", TiDB::TP::TypeLong}});
+    context.addExchangeReceiver(
+        "empty_build_right_semi_receiver",
+        {{"a", TiDB::TP::TypeLong}},
+        {toNullableVec<Int32>("a", {1, 2, 3})});
+
+    auto request = context.scan("empty_build_right_semi_join", "build_table")
+                       .join(
+                           context.receive("empty_build_right_semi_receiver"),
+                           tipb::JoinType::TypeSemiJoin,
+                           {col("a")},
+                           {},
+                           {},
+                           {},
+                           {},
+                           0,
+                           false,
+                           0)
+                       .build(context);
+
+    WRAP_FOR_TEST_BEGIN
+    WRAP_FOR_JOIN_TEST_BEGIN
+    if (!enable_pipeline && cfg.enable_join_v2)
+        continue;
+
+    Expect expect{{"table_scan_0", {0, 10}}, {"exchange_receiver_1", {0, 10}}, {"Join_2", {0, 10}}};
+    testForExecutionSummary(request, expect);
+    WRAP_FOR_JOIN_TEST_END
+    WRAP_FOR_TEST_END
+}
+CATCH
+
+TEST_F(JoinExecutorTestRunner, BuildWithOnlyNullKeysRightSemiJoinSkipsProbe)
+try
+{
+    context.addMockTable(
+        "null_key_build_right_semi_join",
+        "build_table",
+        {{"a", TiDB::TP::TypeLong}},
+        {toNullableVec<Int32>("a", {{}})});
+    context.addExchangeReceiver(
+        "null_key_build_right_semi_receiver",
+        {{"a", TiDB::TP::TypeLong}},
+        {toNullableVec<Int32>("a", {1, 2, 3})});
+
+    auto request = context.scan("null_key_build_right_semi_join", "build_table")
+                       .join(
+                           context.receive("null_key_build_right_semi_receiver"),
+                           tipb::JoinType::TypeSemiJoin,
+                           {col("a")},
+                           {},
+                           {},
+                           {},
+                           {},
+                           0,
+                           false,
+                           0)
+                       .build(context);
+
+    WRAP_FOR_TEST_BEGIN
+    WRAP_FOR_JOIN_TEST_BEGIN
+    if (!enable_pipeline && cfg.enable_join_v2)
+        continue;
+
+    Expect expect{{"table_scan_0", {1, 10}}, {"exchange_receiver_1", {0, 10}}, {"Join_2", {0, 10}}};
+    testForExecutionSummary(request, expect);
+    WRAP_FOR_JOIN_TEST_END
+    WRAP_FOR_TEST_END
+}
+CATCH
+
+TEST_F(JoinExecutorTestRunner, EmptyBuildAntiSemiJoinStillReadsProbe)
+try
+{
+    context.addMockTable(
+        "empty_build_anti_semi_join",
+        "probe_table",
+        {{"a", TiDB::TP::TypeLong}},
+        {toNullableVec<Int32>("a", {1, 2, 3})});
+    context.addExchangeReceiver("empty_build_anti_semi_receiver", {{"a", TiDB::TP::TypeLong}});
+
+    auto request
+        = context.scan("empty_build_anti_semi_join", "probe_table")
+              .join(context.receive("empty_build_anti_semi_receiver"), tipb::JoinType::TypeAntiSemiJoin, {col("a")})
+              .build(context);
+
+    WRAP_FOR_TEST_BEGIN
+    WRAP_FOR_JOIN_TEST_BEGIN
+    if (!enable_pipeline && cfg.enable_join_v2)
+        continue;
+
+    Expect expect{{"table_scan_0", {3, 10}}, {"exchange_receiver_1", {0, 10}}, {"Join_2", {3, 10}}};
+    testForExecutionSummary(request, expect);
+    WRAP_FOR_JOIN_TEST_END
+    WRAP_FOR_TEST_END
+}
+CATCH
+
 TEST_F(JoinExecutorTestRunner, MultiJoin)
 try
 {

--- a/dbms/src/Flash/tests/gtest_join_executor.cpp
+++ b/dbms/src/Flash/tests/gtest_join_executor.cpp
@@ -366,6 +366,49 @@ try
 }
 CATCH
 
+TEST_F(JoinExecutorTestRunner, BuildRowsFilteredOutInnerAndSemiJoinSkipsProbe)
+try
+{
+    context.addMockTable(
+        "filtered_build_join",
+        "probe_table",
+        {{"a", TiDB::TP::TypeLong}},
+        {toNullableVec<Int32>("a", {1, 2, 3})});
+    context.addMockTable(
+        "filtered_build_join",
+        "build_table",
+        {{"a", TiDB::TP::TypeLong}},
+        {toNullableVec<Int32>("a", {1, 2, 3})});
+
+    /// Keep non-empty build input, but filter every build row before it reaches the join.
+    for (const auto join_type : {tipb::JoinType::TypeInnerJoin, tipb::JoinType::TypeSemiJoin})
+    {
+        auto request = context.scan("filtered_build_join", "probe_table")
+                           .join(
+                               context.scan("filtered_build_join", "build_table")
+                                   .filter(gt(col("a"), lit(Field(static_cast<Int64>(100))))),
+                               join_type,
+                               {col("a")})
+                           .build(context);
+
+        WRAP_FOR_TEST_BEGIN
+        WRAP_FOR_JOIN_TEST_BEGIN
+        if (!enable_pipeline && cfg.enable_join_v2)
+            continue;
+
+        executeAndAssertColumnsEqual(request, {});
+        Expect expect{
+            {"table_scan_0", {0, 10}},
+            {"table_scan_1", {3, 10}},
+            {"selection_2", {0, 10}},
+            {"Join_3", {0, 10}}};
+        testForExecutionSummary(request, expect);
+        WRAP_FOR_JOIN_TEST_END
+        WRAP_FOR_TEST_END
+    }
+}
+CATCH
+
 TEST_F(JoinExecutorTestRunner, EmptyBuildRightSemiJoinSkipsProbe)
 try
 {

--- a/dbms/src/Flash/tests/gtest_spill_join.cpp
+++ b/dbms/src/Flash/tests/gtest_spill_join.cpp
@@ -267,7 +267,15 @@ try
     context.context->setSetting("max_bytes_before_external_join", Field(static_cast<UInt64>(10000)));
 
     WRAP_FOR_SPILL_TEST_BEGIN
-    ASSERT_COLUMNS_EQ_UR(empty_result, executeStreams(request, 10));
+    DAGContext dag_context(*request, "empty_hash_after_spill", 10);
+    ASSERT_COLUMNS_EQ_UR(empty_result, executeStreams(&dag_context));
+
+    const auto & join_execute_info = dag_context.getJoinExecuteInfoMap().at("Join_2");
+    ASSERT_TRUE(join_execute_info.join_profile_info->is_spilled);
+
+    // A spilled hash join must not skip its probe side even when no build row enters the hash table.
+    Expect expect{{"table_scan_0", {3, 10}}, {"table_scan_1", {8192, 10}}, {"Join_2", {0, 10}}};
+    testForExecutionSummary(request, expect);
     WRAP_FOR_SPILL_TEST_END
 }
 CATCH

--- a/dbms/src/Flash/tests/gtest_spill_join.cpp
+++ b/dbms/src/Flash/tests/gtest_spill_join.cpp
@@ -238,6 +238,40 @@ try
 }
 CATCH
 
+TEST_F(SpillJoinTestRunner, EmptyHashTableAfterSpillStillReadsProbe)
+try
+{
+    constexpr size_t build_rows = 8192;
+    /// All build keys are NULL, so the hash table has no entries. The payload makes the build side spill.
+    std::vector<std::optional<Int64>> null_keys(build_rows);
+    std::vector<std::optional<String>> payload(build_rows, String(128, 'x'));
+
+    context.addMockTable(
+        "empty_hash_after_spill",
+        "probe_table",
+        {{"a", TiDB::TP::TypeLong}},
+        {toNullableVec<Int32>("a", {1, 2, 3})});
+    context.addMockTable(
+        "empty_hash_after_spill",
+        "build_table",
+        {{"a", TiDB::TP::TypeLong}, {"payload", TiDB::TP::TypeString}},
+        {toNullableVec<Int32>("a", null_keys), toNullableVec<String>("payload", payload)});
+
+    auto request
+        = context.scan("empty_hash_after_spill", "probe_table")
+              .join(context.scan("empty_hash_after_spill", "build_table"), tipb::JoinType::TypeInnerJoin, {col("a")})
+              .build(context);
+    ColumnsWithTypeAndName empty_result;
+
+    context.context->getSettingsRef().enable_hash_join_v2 = false;
+    context.context->setSetting("max_bytes_before_external_join", Field(static_cast<UInt64>(10000)));
+
+    WRAP_FOR_SPILL_TEST_BEGIN
+    ASSERT_COLUMNS_EQ_UR(empty_result, executeStreams(request, 10));
+    WRAP_FOR_SPILL_TEST_END
+}
+CATCH
+
 TEST_F(SpillJoinTestRunner, ScanHashMapAfterProbeDataWithSpillEnabledAndSpillTriggered)
 try
 {

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -1802,6 +1802,8 @@ void Join::workAfterBuildFinish(size_t stream_index)
 
         has_build_data_in_memory = !original_blocks.empty();
     }
+
+    build_side_empty.store(!isSpilled() && getTotalRowCount() == 0, std::memory_order_release);
 }
 
 void Join::finalizeNullAwareSemiFamilyBuild()
@@ -1984,6 +1986,13 @@ Block Join::joinBlock(ProbeProcessInfo & probe_process_info) const
         LOG_WARNING(log, "JoinBlock without non zero active_build_threads, return empty block");
         return {};
     }
+
+    if unlikely (shouldSkipProbe())
+    {
+        probe_process_info.updateEndRow<false>(probe_process_info.block.rows());
+        return output_block_after_finalize;
+    }
+
     std::shared_lock lock(rwlock);
 
     Block block{};

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -1987,12 +1987,6 @@ Block Join::joinBlock(ProbeProcessInfo & probe_process_info) const
         return {};
     }
 
-    if unlikely (shouldSkipProbe())
-    {
-        probe_process_info.updateEndRow<false>(probe_process_info.block.rows());
-        return output_block_after_finalize;
-    }
-
     std::shared_lock lock(rwlock);
 
     Block block{};

--- a/dbms/src/Interpreters/Join.h
+++ b/dbms/src/Interpreters/Join.h
@@ -247,6 +247,16 @@ public:
 
     ASTTableJoin::Kind getKind() const { return kind; }
 
+    /// Inner/Semi cannot produce rows without build entries. RightSemi has no matched build rows to output.
+    /// This is available after finalizeBuild and can be used to avoid reading the probe side.
+    bool shouldSkipProbe() const
+    {
+        const bool can_skip_probe = kind == ASTTableJoin::Kind::Inner || kind == ASTTableJoin::Kind::Semi
+            || kind == ASTTableJoin::Kind::RightSemi;
+        return can_skip_probe && build_finished.load(std::memory_order_acquire)
+            && build_side_empty.load(std::memory_order_acquire);
+    }
+
     const Names & getLeftJoinKeys() const { return key_names_left; }
 
     void setInitActiveBuildThreads()
@@ -436,6 +446,7 @@ private:
     const LoggerPtr log;
 
     std::atomic<size_t> total_input_build_rows{0};
+    std::atomic_bool build_side_empty{false};
 
     /** Protect state for concurrent use in insertFromBlock and joinBlock.
       * Note that these methods could be called simultaneously only while use of StorageJoin,

--- a/dbms/src/Interpreters/JoinV2/HashJoin.cpp
+++ b/dbms/src/Interpreters/JoinV2/HashJoin.cpp
@@ -465,6 +465,7 @@ void HashJoin::workAfterBuildRowFinish()
     size_t all_build_row_count = 0;
     for (size_t i = 0; i < build_concurrency; ++i)
         all_build_row_count += build_workers_data[i].row_count;
+    build_side_empty.store(all_build_row_count == 0, std::memory_order_release);
 
     bool enable_tagged_pointer = settings.enable_tagged_pointer;
     for (size_t i = 0; i < build_concurrency; ++i)
@@ -621,6 +622,13 @@ Block HashJoin::probeBlock(JoinProbeContext & ctx, size_t stream_index)
 
     Stopwatch all_watch;
     SCOPE_EXIT({ probe_workers_data[stream_index].probe_time += all_watch.elapsedFromLastTime(); });
+
+    if unlikely (shouldSkipProbe())
+    {
+        ctx.current_row_idx = ctx.rows;
+        probe_workers_data[stream_index].probe_handle_rows += ctx.rows;
+        return output_block_after_finalize;
+    }
 
     const NameSet & probe_output_name_set = has_other_condition
         ? output_columns_names_set_for_other_condition_after_finalize

--- a/dbms/src/Interpreters/JoinV2/HashJoin.cpp
+++ b/dbms/src/Interpreters/JoinV2/HashJoin.cpp
@@ -623,13 +623,6 @@ Block HashJoin::probeBlock(JoinProbeContext & ctx, size_t stream_index)
     Stopwatch all_watch;
     SCOPE_EXIT({ probe_workers_data[stream_index].probe_time += all_watch.elapsedFromLastTime(); });
 
-    if unlikely (shouldSkipProbe())
-    {
-        ctx.current_row_idx = ctx.rows;
-        probe_workers_data[stream_index].probe_handle_rows += ctx.rows;
-        return output_block_after_finalize;
-    }
-
     const NameSet & probe_output_name_set = has_other_condition
         ? output_columns_names_set_for_other_condition_after_finalize
         : output_column_names_set_after_finalize;

--- a/dbms/src/Interpreters/JoinV2/HashJoin.h
+++ b/dbms/src/Interpreters/JoinV2/HashJoin.h
@@ -74,6 +74,14 @@ public:
     size_t getBuildConcurrency() const { return build_concurrency; }
     size_t getProbeConcurrency() const { return probe_concurrency; }
 
+    /// Inner/Semi cannot produce rows if no build row is inserted into the hash table.
+    /// The probe pipeline is scheduled after the build pointer-table event, so build_side_empty is already published.
+    bool shouldSkipProbe() const
+    {
+        const bool can_skip_probe = kind == ASTTableJoin::Kind::Inner || kind == ASTTableJoin::Kind::Semi;
+        return can_skip_probe && build_side_empty.load(std::memory_order_acquire);
+    }
+
     const JoinProfileInfoPtr & getProfileInfo() const { return profile_info; }
 
 private:
@@ -145,6 +153,7 @@ private:
     size_t build_concurrency = 0;
     std::vector<JoinBuildWorkerData> build_workers_data;
     std::atomic<size_t> active_build_worker = 0;
+    std::atomic_bool build_side_empty{false};
 
     HashJoinPointerTable pointer_table;
 

--- a/dbms/src/Operators/HashJoinProbeTransformOp.cpp
+++ b/dbms/src/Operators/HashJoinProbeTransformOp.cpp
@@ -163,9 +163,12 @@ OperatorStatus HashJoinProbeTransformOp::tryOutputImpl(Block & block)
 {
     if (status == ProbeStatus::PROBE && probe_process_info.all_rows_joined_finish)
     {
-        if (auto ret = probe_transform->tryFillProcessInfoInProbeStage(probe_process_info);
-            ret != OperatorStatus::HAS_OUTPUT)
-            return ret;
+        if (!probe_transform->shouldSkipProbe())
+        {
+            if (auto ret = probe_transform->tryFillProcessInfoInProbeStage(probe_process_info);
+                ret != OperatorStatus::HAS_OUTPUT)
+                return ret;
+        }
     }
 
     return onOutput(block);

--- a/dbms/src/Operators/HashJoinProbeTransformOp.cpp
+++ b/dbms/src/Operators/HashJoinProbeTransformOp.cpp
@@ -163,6 +163,8 @@ OperatorStatus HashJoinProbeTransformOp::tryOutputImpl(Block & block)
 {
     if (status == ProbeStatus::PROBE && probe_process_info.all_rows_joined_finish)
     {
+        // For an empty build, do not fill a probe block. onOutput below still advances
+        // V1's shared probe completion state machine, including RightSemi post-processing.
         if (!probe_transform->shouldSkipProbe())
         {
             if (auto ret = probe_transform->tryFillProcessInfoInProbeStage(probe_process_info);

--- a/dbms/src/Operators/HashJoinProbeTransformOp.h
+++ b/dbms/src/Operators/HashJoinProbeTransformOp.h
@@ -33,6 +33,8 @@ public:
 
     String getName() const override { return "HashJoinProbeTransformOp"; }
 
+    bool shouldSkipSource() const override { return origin_join->shouldSkipProbe(); }
+
 protected:
     OperatorStatus transformImpl(Block & block) override;
 

--- a/dbms/src/Operators/HashJoinProbeTransformOp.h
+++ b/dbms/src/Operators/HashJoinProbeTransformOp.h
@@ -33,7 +33,7 @@ public:
 
     String getName() const override { return "HashJoinProbeTransformOp"; }
 
-    bool shouldSkipSource() const override { return origin_join->shouldSkipProbe(); }
+    bool shouldSkipSource() const override { return probe_transform->shouldSkipProbe(); }
 
 protected:
     OperatorStatus transformImpl(Block & block) override;

--- a/dbms/src/Operators/HashJoinV2ProbeTransformOp.cpp
+++ b/dbms/src/Operators/HashJoinV2ProbeTransformOp.cpp
@@ -80,6 +80,13 @@ OperatorStatus HashJoinV2ProbeTransformOp::tryOutputImpl(Block & block)
         block = {};
         return OperatorStatus::HAS_OUTPUT;
     }
+    if unlikely (probe_context.isAllFinished() && join_ptr->shouldSkipProbe())
+    {
+        join_ptr->finishOneProbe(op_index);
+        probe_context.input_is_finished = true;
+        block = join_ptr->probeLastResultBlock(op_index);
+        return OperatorStatus::HAS_OUTPUT;
+    }
     if (probe_context.isAllFinished())
         return OperatorStatus::NEED_INPUT;
     return onOutput(block);

--- a/dbms/src/Operators/HashJoinV2ProbeTransformOp.cpp
+++ b/dbms/src/Operators/HashJoinV2ProbeTransformOp.cpp
@@ -80,11 +80,11 @@ OperatorStatus HashJoinV2ProbeTransformOp::tryOutputImpl(Block & block)
         block = {};
         return OperatorStatus::HAS_OUTPUT;
     }
-    if unlikely (probe_context.isAllFinished() && join_ptr->shouldSkipProbe())
+    if unlikely (join_ptr->shouldSkipProbe())
     {
         join_ptr->finishOneProbe(op_index);
         probe_context.input_is_finished = true;
-        block = join_ptr->probeLastResultBlock(op_index);
+        block = {};
         return OperatorStatus::HAS_OUTPUT;
     }
     if (probe_context.isAllFinished())

--- a/dbms/src/Operators/HashJoinV2ProbeTransformOp.cpp
+++ b/dbms/src/Operators/HashJoinV2ProbeTransformOp.cpp
@@ -82,6 +82,8 @@ OperatorStatus HashJoinV2ProbeTransformOp::tryOutputImpl(Block & block)
     }
     if unlikely (join_ptr->shouldSkipProbe())
     {
+        // Do not call onOutput here: it only processes an unfinished ProbeContext.
+        // Finish this worker and emit EOF directly when the build side is empty.
         join_ptr->finishOneProbe(op_index);
         probe_context.input_is_finished = true;
         block = {};

--- a/dbms/src/Operators/HashJoinV2ProbeTransformOp.h
+++ b/dbms/src/Operators/HashJoinV2ProbeTransformOp.h
@@ -31,6 +31,8 @@ public:
 
     String getName() const override { return "HashJoinV2ProbeTransformOp"; }
 
+    bool shouldSkipSource() const override { return join_ptr->shouldSkipProbe(); }
+
 protected:
     OperatorStatus transformImpl(Block & block) override;
 

--- a/dbms/src/Operators/HashProbeTransformExec.h
+++ b/dbms/src/Operators/HashProbeTransformExec.h
@@ -68,6 +68,7 @@ public:
         join->dispatchProbeBlock(block, partition_blocks_list, op_index);
     }
     bool finishOneProbe() { return join->finishOneProbe(op_index); }
+    bool shouldSkipProbe() const { return join->shouldSkipProbe(); }
     bool hasMarkedSpillData() const { return join->hasProbeSideMarkedSpillData(op_index); }
     bool isProbeFinishedForPipeline() const { return join->isProbeFinishedForPipeline(); }
     void finalizeProbe() { join->finalizeProbe(); }

--- a/dbms/src/Operators/Operator.h
+++ b/dbms/src/Operators/Operator.h
@@ -148,6 +148,11 @@ public:
     OperatorStatus transform(Block & block);
     virtual OperatorStatus transformImpl(Block & block) = 0;
 
+    /// Return true only when this transform can finish the pipeline without source input.
+    /// PipelineExec uses it to avoid starting the source operator. The transform must be able to emit an EOF block
+    /// from tryOutputImpl so that downstream transforms and the sink can finish normally.
+    virtual bool shouldSkipSource() const { return false; }
+
     virtual void transformHeaderImpl(Block & header_) = 0;
     void transformHeader(Block & header_)
     {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #11000 

## Problem Summary

When the build side of a hash join is empty after filtering, the join result may already be known without reading the probe side. However, the current execution pipeline can still scan the entire probe side and perform unnecessary hash lookups against an empty hash table.

For example:

```sql
SELECT *
FROM orders
INNER JOIN lineitem
    ON l_comment = o_comment
WHERE o_clerk = 'Clerk#000000000';
```

The filter produces an empty build side, but the profile shows:

```text
Build actRows:              0
Probe actRows:              59,986,052
lineitem data_scanned_rows: 59,987,779
Query time:                 about 715 ms
```

This causes unnecessary probe-side I/O, block processing, pipeline scheduling, and hash-table lookup overhead. The same problem also applies to eligible Semi Join cases.

## What is changed and how it works

This change allows supported hash joins to terminate the probe side early when the finalized build hash table is empty.

The implementation has two parts:

1. Track whether the finalized build side is empty.

   - V1 publishes the build-empty state after build finalization.
   - V1 only enables this state when no actual spill has happened.
   - V2 publishes the state after all build workers finish.
   - The check is based on effective hash-table entries, so a build input containing only NULL join keys is also treated as empty.

2. Skip probe processing at both the join and pipeline levels.

   - At the join level, incoming probe blocks are marked as processed without probing the hash table.
   - At the pipeline level, the probe transform can indicate that its source is no longer needed.
   - `PipelineExec` then avoids reading the probe source and finishes the transform normally, without relying on source EOF or repeatedly producing empty blocks.
   - This prevents unnecessary local probe scans and avoids repeated lookups against an empty hash table.

The optimization is enabled for:

```text
V1: Inner Join, Semi Join, RightSemi Join
V2: Inner Join, Semi Join
```

RightSemi Join is not currently supported by Hash Join V2 and therefore falls back to the V1 implementation.

Join types whose output still depends on every probe row, such as AntiSemi Join and LeftOuterSemi Join, are not included in this optimization. V1 also keeps the existing behavior when an actual external join spill has occurred.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Performance Improvements
* Improved hash join execution when the build side is empty by avoiding unnecessary probing and source reads.
* Reduced pipeline work when joins can complete without reading probe data.
* Preserved probe processing for join types that require it.

## Bug Fixes
* Improved completion and output handling when probe processing is skipped.
* Corrected behavior for spilled joins with empty hash tables.

## Tests
* Added coverage for empty and null-only build inputs across multiple join types.
* Added tests confirming skipped sources are not executed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->