### PR TITLE
columnar: install set_panic_hook so panics are logged via slog

### DIFF
--- a/contrib/tiflash-columnar-hub/hub-runtime/src/run.rs
+++ b/contrib/tiflash-columnar-hub/hub-runtime/src/run.rs
@@ -1445,6 +1445,7 @@ pub unsafe fn run_proxy(argc: c_int, argv: *const *const c_char, helper_ptr: *co
         )
     });
     let data_dir_str = data_dir.to_string_lossy().to_string();
+    tikv_util::set_panic_hook(false, &data_dir_str);
     let hub_config_str = serde_json::to_string(&HubConfigSummary {
         server: HubServerSummary {
             engine_addr: resolve_engine_addr(&config),


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #11007

Problem Summary:

Columnar Hub does not register `tikv_util::set_panic_hook` at startup (unlike `tiflash-proxy` / `proxy-next-gen`). When a Rust panic happens on the columnar read path (e.g. inside `ffi_read_block` → `CloudColumnarReader::read_block_with_range`), the panic is **not** written to the hub slog log (`tiflash_tikv.log`). Operators only see the default Rust panic on stderr, then a secondary `panic in a function that cannot unwind` because the panic crosses an `extern "C"` FFI boundary, followed by process abort and C++ `Received signal Aborted(6)` in `tiflash_error.log` — often without the original Rust panic message / usable stack in the normal log pipeline.

### What is changed and how it works?

```commit-message
Columnar Hub: install set_panic_hook so panics are logged via slog
```

Call `tikv_util::set_panic_hook(false, &data_dir_str)` in `run_proxy` after the data directory is created and after `init_hub_logger`, matching TiKV/proxy behavior (`abort_on_panic = false` → `_exit(1)`).

After this change, a panic is logged as a structured `[FATAL]` entry in `tiflash_tikv.log` with message, location, and backtrace.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

#### Manual test: temporary panic injection

To verify the hook, temporarily inject an unconditional panic deep in the read path (not committed):

```rust
// contrib/cloud-storage-engine/components/kvengine/src/read.rs
// CloudColumnarReader::read_block_with_range
pub async fn read_block_with_range(&mut self, read_limit: usize) -> Result<usize> {
    // TEMP: remove after testing
    panic!(
        "TEMP injected panic in CloudColumnarReader::read_block_with_range, read_limit={}",
        read_limit
    );
    loop { /* ... */ }
}
```

Then run a disaggregated columnar query that hits `ffi_read_block`.

**With this PR (`set_panic_hook` installed):** `tiflash_tikv.log` gets a `[FATAL]` line, e.g.

```text
[FATAL] [lib.rs:658] ["TEMP injected panic in CloudColumnarReader::read_block_with_range, read_limit=10240"]
[backtrace=...]
[location=.../kvengine/src/read.rs:3971]
```

Observed backtrace frames (abbreviated, bottom → panic site conceptually includes C++ callers):

1. `CloudColumnarReader::read_block_with_range` (`read.rs`)
2. `tokio::...::block_on` → `CloudColumnarReader::ffi_read_block`
3. `CloudColumnarReaders::sequential_read_block` → `CloudColumnarReaders::ffi_read_block`
4. `tiflash_proxy::columnar_impls::ffi_read_block`
5. `DB::RNColumnarInputStream::readImpl` (`StorageDisaggregatedColumnar.cpp`)
6. Pipeline IO path: `RNColumnarSourceOp` → `PipelineExec` → `TaskThreadPool<IOImpl>`

**Without `set_panic_hook` (control):** no new `[FATAL]` in `tiflash_tikv.log`; panic only appears in `tiflash_stderr.log` as Rust default `thread '...' panicked at ...` + `stack backtrace:`, then `panic in a function that cannot unwind`, and `tiflash_error.log` shows `Received signal Aborted(6)`.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Columnar Hub: register set_panic_hook so Rust panics are logged to tiflash_tikv.log with backtraces
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup handling for the TiFlash Columnar Hub runtime by preventing unintended panic-hook behavior and ensuring it uses the resolved data directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->