### PR TITLE
Invalidate read-index cache when lock is found

### DIFF
--- a/dbms/src/Storages/KVStore/KVStore.h
+++ b/dbms/src/Storages/KVStore/KVStore.h
@@ -256,6 +256,7 @@ public: // Raft Read
     void addReadIndexEvent(Int64 f) { read_index_event_flag += f; }
     Int64 getReadIndexEvent() const { return read_index_event_flag; }
     BatchReadIndexRes batchReadIndex(const std::vector<kvrpcpb::ReadIndexRequest> & req, uint64_t timeout_ms) const;
+    void invalidateReadIndexCache(RegionID region_id) const;
     /// Initialize read-index worker context. It only can be invoked once.
     /// `worker_coefficient` means `worker_coefficient * runner_cnt` workers will be created.
     /// `runner_cnt` means number of runner which controls behavior of worker.

--- a/dbms/src/Storages/KVStore/Read/LearnerReadWorker.cpp
+++ b/dbms/src/Storages/KVStore/Read/LearnerReadWorker.cpp
@@ -471,11 +471,8 @@ void LearnerReadWorker::waitIndex(
 
         // Wait index timeout is disabled; or timeout is enabled but not happen yet, wait index for
         // a specify Region.
-        const auto [wait_res, time_cost] = region->waitIndex(
-            index_to_wait,
-            timeout_ms,
-            [this]() { return tmt.checkRunning(); },
-            log);
+        const auto [wait_res, time_cost]
+            = region->waitIndex(index_to_wait, timeout_ms, [this]() { return tmt.checkRunning(); }, log);
         if (wait_res != WaitIndexStatus::Finished)
         {
             auto current = region->appliedIndex();
@@ -505,7 +502,11 @@ void LearnerReadWorker::waitIndex(
 
         std::visit(
             variant_op::overloaded{
-                [&](LockInfoPtr & lock) { unavailable_regions.addRegionLock(region->id(), std::move(lock)); },
+                [&](LockInfoPtr & lock) {
+                    kvstore->invalidateReadIndexCache(region_to_query.region_id);
+                    mvcc_query_info.invalidateReadIndexResCache(region_to_query.region_id);
+                    unavailable_regions.addRegionLock(region->id(), std::move(lock));
+                },
                 [&](RegionException::RegionReadStatus & status) {
                     if (status != RegionException::RegionReadStatus::OK)
                     {

--- a/dbms/src/Storages/KVStore/Read/LearnerReadWorker.cpp
+++ b/dbms/src/Storages/KVStore/Read/LearnerReadWorker.cpp
@@ -471,8 +471,11 @@ void LearnerReadWorker::waitIndex(
 
         // Wait index timeout is disabled; or timeout is enabled but not happen yet, wait index for
         // a specify Region.
-        const auto [wait_res, time_cost]
-            = region->waitIndex(index_to_wait, timeout_ms, [this]() { return tmt.checkRunning(); }, log);
+        const auto [wait_res, time_cost] = region->waitIndex(
+            index_to_wait,
+            timeout_ms,
+            [this]() { return tmt.checkRunning(); },
+            log);
         if (wait_res != WaitIndexStatus::Finished)
         {
             auto current = region->appliedIndex();

--- a/dbms/src/Storages/KVStore/Read/LockException.h
+++ b/dbms/src/Storages/KVStore/Read/LockException.h
@@ -16,6 +16,7 @@
 
 #include <Common/Exception.h>
 #include <Common/config.h> // for ENABLE_NEXT_GEN
+#include <Common/FmtUtils.h>
 #include <Storages/KVStore/Read/RegionLockInfo.h>
 #include <Storages/KVStore/TiKVHelpers/TiKVKeyValue.h>
 #include <pingcap/kv/RegionCache.h>
@@ -40,7 +41,11 @@ public:
         for (const auto & lock : locks)
             locked_regions.insert(lock.first);
 
-        this->message(fmt::format("Key is locked ({} locks in regions {})", locks.size(), locked_regions));
+        this->message(fmt::format(
+            "Key is locked ({} locks in regions {}, first_lock_info={})",
+            locks.size(),
+            locked_regions,
+            firstLockInfoToDebugString(locks)));
 #else
         std::set<std::string> keys;
         std::set<std::string> primary_keys;
@@ -53,15 +58,33 @@ public:
             primary_keys.insert(TiKVKey(primary_key.data(), primary_key.size()).toDebugString());
         }
         this->message(fmt::format(
-            "Key is locked ({} locks in regions {} key {} primary {})",
+            "Key is locked ({} locks in regions {} key {} primary {} first_lock_info={})",
             locks.size(),
             locked_regions,
             keys,
-            primary_keys));
+            primary_keys,
+            firstLockInfoToDebugString(locks)));
 #endif
     }
 
     std::vector<std::pair<RegionID, LockInfoPtr>> locks;
+
+private:
+    static String firstLockInfoToDebugString(const std::vector<std::pair<RegionID, LockInfoPtr>> & locks)
+    {
+        if (locks.empty())
+            return "<none>";
+
+        FmtBuffer buffer;
+        const auto & lock = locks.front();
+        buffer.fmtAppend("{}(", lock.first);
+        if (lock.second)
+            buffer.append(lock.second->ShortDebugString());
+        else
+            buffer.append("<null>");
+        buffer.append(")");
+        return buffer.toString();
+    }
 };
 
 } // namespace DB

--- a/dbms/src/Storages/KVStore/Read/LockException.h
+++ b/dbms/src/Storages/KVStore/Read/LockException.h
@@ -58,12 +58,11 @@ public:
             primary_keys.insert(TiKVKey(primary_key.data(), primary_key.size()).toDebugString());
         }
         this->message(fmt::format(
-            "Key is locked ({} locks in regions {} key {} primary {} first_lock_info={})",
+            "Key is locked ({} locks in regions {} key {} primary {})",
             locks.size(),
             locked_regions,
             keys,
-            primary_keys,
-            firstLockInfoToDebugString(locks)));
+            primary_keys));
 #endif
     }
 

--- a/dbms/src/Storages/KVStore/Read/LockException.h
+++ b/dbms/src/Storages/KVStore/Read/LockException.h
@@ -15,8 +15,8 @@
 #pragma once
 
 #include <Common/Exception.h>
-#include <Common/config.h> // for ENABLE_NEXT_GEN
 #include <Common/FmtUtils.h>
+#include <Common/config.h> // for ENABLE_NEXT_GEN
 #include <Storages/KVStore/Read/RegionLockInfo.h>
 #include <Storages/KVStore/TiKVHelpers/TiKVKeyValue.h>
 #include <pingcap/kv/RegionCache.h>

--- a/dbms/src/Storages/KVStore/Read/ReadIndex.cpp
+++ b/dbms/src/Storages/KVStore/Read/ReadIndex.cpp
@@ -349,6 +349,12 @@ BatchReadIndexRes KVStore::batchReadIndex(const std::vector<kvrpcpb::ReadIndexRe
     }
 }
 
+void KVStore::invalidateReadIndexCache(RegionID region_id) const
+{
+    if (read_index_worker_manager)
+        read_index_worker_manager->invalidateReadIndexCache(region_id);
+}
+
 void KVStore::initReadIndexWorkers(
     ReadIndexWorkerManager::FnGetTickTime && fn_min_dur_handle_region,
     size_t runner_cnt,

--- a/dbms/src/Storages/KVStore/Read/ReadIndexDataNode.cpp
+++ b/dbms/src/Storages/KVStore/Read/ReadIndexDataNode.cpp
@@ -285,6 +285,12 @@ void ReadIndexDataNode::consume(const TiFlashRaftProxyHelper & helper, Timestamp
     }
 }
 
+void ReadIndexDataNode::invalidateReadIndexCache() NO_THREAD_SAFETY_ANALYSIS
+{
+    auto _ = genLockGuard();
+    history_success_tasks.reset();
+}
+
 ReadIndexDataNode::~ReadIndexDataNode() NO_THREAD_SAFETY_ANALYSIS
 {
     auto _ = genLockGuard();

--- a/dbms/src/Storages/KVStore/Read/ReadIndexWorker.cpp
+++ b/dbms/src/Storages/KVStore/Read/ReadIndexWorker.cpp
@@ -150,12 +150,11 @@ ReadIndexFuturePtr ReadIndexWorker::genReadIndexFuture(const kvrpcpb::ReadIndexR
     return res;
 }
 
-void ReadIndexWorker::invalidateReadIndexCache(RegionID region_id)
+void ReadIndexWorker::invalidateReadIndexCache(RegionID region_id) const
 {
     if (auto data = data_map.tryGetDataNode(region_id); data)
         data->invalidateReadIndexCache();
 }
-
 
 void ReadIndexWorker::runOneRound(SteadyClock::duration min_dur)
 {

--- a/dbms/src/Storages/KVStore/Read/ReadIndexWorker.cpp
+++ b/dbms/src/Storages/KVStore/Read/ReadIndexWorker.cpp
@@ -150,6 +150,12 @@ ReadIndexFuturePtr ReadIndexWorker::genReadIndexFuture(const kvrpcpb::ReadIndexR
     return res;
 }
 
+void ReadIndexWorker::invalidateReadIndexCache(RegionID region_id)
+{
+    if (auto data = data_map.tryGetDataNode(region_id); data)
+        data->invalidateReadIndexCache();
+}
+
 
 void ReadIndexWorker::runOneRound(SteadyClock::duration min_dur)
 {

--- a/dbms/src/Storages/KVStore/Read/ReadIndexWorker.h
+++ b/dbms/src/Storages/KVStore/Read/ReadIndexWorker.h
@@ -95,6 +95,7 @@ public:
     void stop();
     ~ReadIndexWorkerManager();
     BatchReadIndexRes batchReadIndex(const std::vector<kvrpcpb::ReadIndexRequest> & reqs, uint64_t timeout_ms);
+    void invalidateReadIndexCache(RegionID region_id);
 
     static std::unique_ptr<ReadIndexWorkerManager> newReadIndexWorkerManager(
         const TiFlashRaftProxyHelper & proxy_helper,
@@ -237,6 +238,8 @@ struct ReadIndexDataNode : MutexLockWrap
 
     void consume(const TiFlashRaftProxyHelper & helper, Timestamp ts);
 
+    void invalidateReadIndexCache();
+
     void runOneRound(const TiFlashRaftProxyHelper & helper, const ReadIndexNotifyCtrlPtr & notify);
 
     ReadIndexFuturePtr insertTask(const kvrpcpb::ReadIndexRequest & req);
@@ -280,6 +283,8 @@ struct ReadIndexWorker
     void consumeRegionNotifies(SteadyClock::duration min_dur);
 
     ReadIndexFuturePtr genReadIndexFuture(const kvrpcpb::ReadIndexRequest & req);
+
+    void invalidateReadIndexCache(RegionID region_id);
 
     // try to consume read-index response notifications & region waiting list
     void runOneRound(SteadyClock::duration min_dur);

--- a/dbms/src/Storages/KVStore/Read/ReadIndexWorker.h
+++ b/dbms/src/Storages/KVStore/Read/ReadIndexWorker.h
@@ -284,7 +284,7 @@ struct ReadIndexWorker
 
     ReadIndexFuturePtr genReadIndexFuture(const kvrpcpb::ReadIndexRequest & req);
 
-    void invalidateReadIndexCache(RegionID region_id);
+    void invalidateReadIndexCache(RegionID region_id) const;
 
     // try to consume read-index response notifications & region waiting list
     void runOneRound(SteadyClock::duration min_dur);

--- a/dbms/src/Storages/KVStore/Read/ReadIndexWorkerManager.cpp
+++ b/dbms/src/Storages/KVStore/Read/ReadIndexWorkerManager.cpp
@@ -78,6 +78,11 @@ void ReadIndexWorkerManager::stop()
         runner->stop();
 }
 
+void ReadIndexWorkerManager::invalidateReadIndexCache(RegionID region_id)
+{
+    getWorkerByRegion(region_id).invalidateReadIndexCache(region_id);
+}
+
 ReadIndexWorkerManager::~ReadIndexWorkerManager()
 {
     stop();

--- a/dbms/src/Storages/KVStore/tests/gtest_read_index_worker.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_read_index_worker.cpp
@@ -385,6 +385,15 @@ void ReadIndexTest::testNormal()
             ASSERT_EQ(computeCntUseHistoryTasks(*manager), expect_cnt_use_history_tasks);
         }
         {
+            proxy_instance.regions[0]->updateCommitIndex(670);
+            manager->invalidateReadIndexCache(0);
+
+            reqs = {make_read_index_reqs(0, 9)};
+            auto resps = manager->batchReadIndex(reqs);
+            ASSERT_EQ(resps[0].first.read_index(), 670);
+            ASSERT_EQ(computeCntUseHistoryTasks(*manager), expect_cnt_use_history_tasks);
+        }
+        {
             // Set region id to let mock proxy drop all related tasks.
             proxy_instance.unsafeInvokeForTest(
                 [](MockRaftStoreProxy & proxy) { proxy.mock_read_index.region_id_to_drop.emplace(1); });

--- a/dbms/src/Storages/KVStore/tests/gtest_read_index_worker.cpp
+++ b/dbms/src/Storages/KVStore/tests/gtest_read_index_worker.cpp
@@ -389,7 +389,7 @@ void ReadIndexTest::testNormal()
             manager->invalidateReadIndexCache(0);
 
             reqs = {make_read_index_reqs(0, 9)};
-            auto resps = manager->batchReadIndex(reqs);
+            auto resps = manager->batchReadIndex(reqs, 10 * 1000);
             ASSERT_EQ(resps[0].first.read_index(), 670);
             ASSERT_EQ(computeCntUseHistoryTasks(*manager), expect_cnt_use_history_tasks);
         }

--- a/dbms/src/Storages/RegionQueryInfo.h
+++ b/dbms/src/Storages/RegionQueryInfo.h
@@ -80,6 +80,7 @@ public:
     explicit MvccQueryInfo(bool resolve_locks_ = false, UInt64 start_ts_ = 0, DM::ScanContextPtr scan_ctx = nullptr);
 
     void addReadIndexResToCache(RegionID region_id, UInt64 read_index) { read_index_res_cache[region_id] = read_index; }
+    void invalidateReadIndexResCache(RegionID region_id) { read_index_res_cache.erase(region_id); }
     UInt64 getReadIndexRes(RegionID region_id) const
     {
         if (auto it = read_index_res_cache.find(region_id); it != read_index_res_cache.end())


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/10985

Problem Summary:

When TiFlash local learner read meets a lock, the read-index result for that region may still be cached. Later retries can reuse the old read-index result even though the lock needs a newer apply progress to be resolved, which can cause unnecessary remote reads or repeated lock handling.

### What is changed and how it works?

```commit-message
Invalidate read index cache when lock is found
Print first lock info in lock exception
```

This PR invalidates the read-index cache when a local lock is found, so later retries need to obtain a fresh read-index result for that region.

It also prints the first lock's detailed info in `LockException`, making it easier to identify the blocking lock from TiFlash logs without dumping every lock.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix the issue that TiFlash may reuse stale read-index cache after meeting a local lock.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved read consistency by clearing cached read-index results when lock resolution detects a conflicting lock.
  * Reduced the risk of stale commit-index data being returned for affected regions.
  * Enhanced lock-related error messages with first-lock details and additional debugging information.
  * Ensured related cached query results are refreshed after invalidation.

* **Tests**
  * Added coverage confirming invalidated read-index data refreshes and reflects the latest commit index.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->