### PR TITLE
Support decimal rough set minmax filter

### DIFF
--- a/dbms/src/Storages/DeltaMerge/File/DMFileWriter.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileWriter.cpp
@@ -60,10 +60,12 @@ DMFileWriter::DMFileWriter(
 
     for (auto & cd : write_columns)
     {
-        // TODO: currently we only generate index for Integers, Date, DateTime types, and this should be configurable by user.
+        // TODO: currently we only generate index for Integers, Date, DateTime, Decimal types, and this should be
+        // configurable by user.
         /// for handle column always generate index
         auto type = removeNullable(cd.type);
-        bool do_index = cd.id == EXTRA_HANDLE_COLUMN_ID || type->isInteger() || type->isDateOrDateTime();
+        bool do_index
+            = cd.id == EXTRA_HANDLE_COLUMN_ID || type->isInteger() || type->isDateOrDateTime() || type->isDecimal();
 
         addStreams(cd.id, cd.type, do_index);
         dmfile->meta->getColumnStats().emplace(

--- a/dbms/src/Storages/DeltaMerge/FilterParser/FilterParser.cpp
+++ b/dbms/src/Storages/DeltaMerge/FilterParser/FilterParser.cpp
@@ -55,6 +55,9 @@ inline bool isRoughSetFilterSupportType(const Int32 field_type)
     case TiDB::TypeDatetime:
     case TiDB::TypeTimestamp: // For timestamp, should take time_zone into consideration while parsing `literal`
         return true;
+    case TiDB::TypeDecimal:
+    case TiDB::TypeNewDecimal:
+        return true;
     // For these types, should take collation into consideration. Disable them.
     case TiDB::TypeVarchar:
     case TiDB::TypeJSON:
@@ -67,8 +70,6 @@ inline bool isRoughSetFilterSupportType(const Int32 field_type)
         return false;
     // Unknown.
     case TiDB::TypeTiDBVectorFloat32:
-    case TiDB::TypeDecimal:
-    case TiDB::TypeNewDecimal:
     case TiDB::TypeFloat:
     case TiDB::TypeDouble:
     case TiDB::TypeNull:

--- a/dbms/src/Storages/DeltaMerge/Index/MinMaxIndex.cpp
+++ b/dbms/src/Storages/DeltaMerge/Index/MinMaxIndex.cpp
@@ -12,12 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Columns/ColumnDecimal.h>
 #include <Columns/ColumnString.h>
 #include <Columns/ColumnVector.h>
 #include <Columns/IColumn.h>
 #include <Common/Exception.h>
+#include <Common/assert_cast.h>
 #include <DataTypes/DataTypeDate.h>
 #include <DataTypes/DataTypeDateTime.h>
+#include <DataTypes/DataTypeDecimal.h>
 #include <DataTypes/DataTypeEnum.h>
 #include <DataTypes/DataTypeFixedString.h>
 #include <DataTypes/DataTypeMyDate.h>
@@ -38,6 +41,15 @@ static constexpr size_t NONE_EXIST = std::numeric_limits<size_t>::max();
 
 namespace details
 {
+template <typename T>
+ALWAYS_INLINE const auto & minMaxColumnData(const IColumn & column)
+{
+    if constexpr (IsDecimal<T>)
+        return assert_cast<const ColumnDecimal<T> &>(column).getData();
+    else
+        return toColumnVectorData<T>(column);
+}
+
 inline std::pair<size_t, size_t> minmax(
     const IColumn & column,
     const ColumnVector<UInt8> * del_mark,
@@ -285,7 +297,7 @@ RSResults MinMaxIndex::checkNullableInImpl(
     const DataTypePtr & type)
 {
     RSResults results(pack_count, RSResult::SomeNull);
-    const auto & minmaxes_data = toColumnVectorData<T>(column_nullable.getNestedColumnPtr());
+    const auto & minmaxes_data = details::minMaxColumnData<T>(*column_nullable.getNestedColumnPtr());
     for (size_t i = start_pack; i < start_pack + pack_count; ++i)
     {
         if (details::minIsNull(null_map, i))
@@ -313,6 +325,11 @@ RSResults MinMaxIndex::checkNullableIn(
         return checkNullableInImpl<TYPE>(column_nullable, null_map, start_pack, pack_count, values, type);
     FOR_NUMERIC_TYPES(DISPATCH)
 #undef DISPATCH
+#define DISPATCH_DECIMAL(FIELD_TYPE, DATA_TYPE)   \
+    if (typeid_cast<const DATA_TYPE *>(raw_type)) \
+        return checkNullableInImpl<FIELD_TYPE>(column_nullable, null_map, start_pack, pack_count, values, type);
+    FOR_DECIMAL_TYPES(DISPATCH_DECIMAL)
+#undef DISPATCH_DECIMAL
     if (typeid_cast<const DataTypeMyDateTime *>(raw_type) || typeid_cast<const DataTypeMyDate *>(raw_type))
     {
         // For DataTypeMyDateTime / DataTypeMyDate, simply compare them as comparing UInt64 is OK.
@@ -379,7 +396,7 @@ RSResults MinMaxIndex::checkInImpl(
     const DataTypePtr & type)
 {
     RSResults results(pack_count, RSResult::None);
-    const auto & minmaxes_data = toColumnVectorData<T>(minmaxes);
+    const auto & minmaxes_data = details::minMaxColumnData<T>(*minmaxes);
     for (size_t i = start_pack; i < start_pack + pack_count; ++i)
     {
         if (!has_value_marks[i])
@@ -408,6 +425,11 @@ RSResults MinMaxIndex::checkIn(
         return checkInImpl<TYPE>(start_pack, pack_count, values, type);
     FOR_NUMERIC_TYPES(DISPATCH)
 #undef DISPATCH
+#define DISPATCH_DECIMAL(FIELD_TYPE, DATA_TYPE)   \
+    if (typeid_cast<const DATA_TYPE *>(raw_type)) \
+        return checkInImpl<FIELD_TYPE>(start_pack, pack_count, values, type);
+    FOR_DECIMAL_TYPES(DISPATCH_DECIMAL)
+#undef DISPATCH_DECIMAL
     if (typeid_cast<const DataTypeMyDateTime *>(raw_type) || typeid_cast<const DataTypeMyDate *>(raw_type))
     {
         // For DataTypeMyDateTime / DataTypeMyDate, simply compare them as comparing UInt64 is OK.
@@ -451,7 +473,7 @@ template <typename Op, typename T>
 RSResults MinMaxIndex::checkCmpImpl(size_t start_pack, size_t pack_count, const Field & value, const DataTypePtr & type)
 {
     RSResults results(pack_count, RSResult::None);
-    const auto & minmaxes_data = toColumnVectorData<T>(minmaxes);
+    const auto & minmaxes_data = details::minMaxColumnData<T>(*minmaxes);
     for (size_t i = start_pack; i < start_pack + pack_count; ++i)
     {
         if (!has_value_marks[i])
@@ -481,6 +503,11 @@ RSResults MinMaxIndex::checkCmp(size_t start_pack, size_t pack_count, const Fiel
         return checkCmpImpl<Op, TYPE>(start_pack, pack_count, value, type);
     FOR_NUMERIC_TYPES(DISPATCH)
 #undef DISPATCH
+#define DISPATCH_DECIMAL(FIELD_TYPE, DATA_TYPE)   \
+    if (typeid_cast<const DATA_TYPE *>(raw_type)) \
+        return checkCmpImpl<Op, FIELD_TYPE>(start_pack, pack_count, value, type);
+    FOR_DECIMAL_TYPES(DISPATCH_DECIMAL)
+#undef DISPATCH_DECIMAL
     if (typeid_cast<const DataTypeMyDateTime *>(raw_type) || typeid_cast<const DataTypeMyDate *>(raw_type))
     {
         // For DataTypeMyDateTime / DataTypeMyDate, simply compare them as comparing UInt64 is OK.
@@ -546,7 +573,7 @@ RSResults MinMaxIndex::checkNullableNullEqualImpl(
     const DataTypePtr & type)
 {
     RSResults results(pack_count, RSResult::Some);
-    const auto & minmaxes_data = toColumnVectorData<T>(column_nullable.getNestedColumnPtr());
+    const auto & minmaxes_data = details::minMaxColumnData<T>(*column_nullable.getNestedColumnPtr());
     for (size_t i = start_pack; i < start_pack + pack_count; ++i)
     {
         if (details::minIsNull(null_map, i))
@@ -584,6 +611,11 @@ RSResults MinMaxIndex::checkNullableNullEqual(
         return checkNullableNullEqualImpl<TYPE>(column_nullable, null_map, start_pack, pack_count, value, type);
     FOR_NUMERIC_TYPES(DISPATCH)
 #undef DISPATCH
+#define DISPATCH_DECIMAL(FIELD_TYPE, DATA_TYPE)   \
+    if (typeid_cast<const DATA_TYPE *>(raw_type)) \
+        return checkNullableNullEqualImpl<FIELD_TYPE>(column_nullable, null_map, start_pack, pack_count, value, type);
+    FOR_DECIMAL_TYPES(DISPATCH_DECIMAL)
+#undef DISPATCH_DECIMAL
     if (typeid_cast<const DataTypeMyDateTime *>(raw_type) || typeid_cast<const DataTypeMyDate *>(raw_type))
     {
         // For DataTypeMyDateTime / DataTypeMyDate, simply compare them as comparing UInt64 is OK.
@@ -676,7 +708,7 @@ RSResults MinMaxIndex::checkNullableCmpImpl(
     const DataTypePtr & type)
 {
     RSResults results(pack_count, RSResult::SomeNull);
-    const auto & minmaxes_data = toColumnVectorData<T>(column_nullable.getNestedColumnPtr());
+    const auto & minmaxes_data = details::minMaxColumnData<T>(*column_nullable.getNestedColumnPtr());
     for (size_t i = start_pack; i < start_pack + pack_count; ++i)
     {
         if (details::minIsNull(null_map, i))
@@ -705,6 +737,11 @@ RSResults MinMaxIndex::checkNullableCmp(
         return checkNullableCmpImpl<Op, TYPE>(column_nullable, null_map, start_pack, pack_count, value, type);
     FOR_NUMERIC_TYPES(DISPATCH)
 #undef DISPATCH
+#define DISPATCH_DECIMAL(FIELD_TYPE, DATA_TYPE)   \
+    if (typeid_cast<const DATA_TYPE *>(raw_type)) \
+        return checkNullableCmpImpl<Op, FIELD_TYPE>(column_nullable, null_map, start_pack, pack_count, value, type);
+    FOR_DECIMAL_TYPES(DISPATCH_DECIMAL)
+#undef DISPATCH_DECIMAL
     if (typeid_cast<const DataTypeMyDateTime *>(raw_type) || typeid_cast<const DataTypeMyDate *>(raw_type))
     {
         // For DataTypeMyDateTime / DataTypeMyDate, simply compare them as comparing UInt64 is OK.

--- a/dbms/src/Storages/DeltaMerge/Index/ValueComparison.h
+++ b/dbms/src/Storages/DeltaMerge/Index/ValueComparison.h
@@ -149,7 +149,7 @@ private:
                     fmt::format("Illegal compare {} with {}", left_field.getTypeName(), compareTypeToString(right)));
             return true;
         }
-        else if constexpr (LeftGroupType == Decimal || RightGroupType == Decimal)
+        else if constexpr (LeftGroupType == Decimal && RightGroupType == Decimal)
         {
             // clang-format off
             if (compareDecimalLeftType<Field::Types::Which::Decimal32, Decimal32>(left_field, right_type, right, res)
@@ -158,6 +158,12 @@ private:
                 || compareDecimalLeftType<Field::Types::Which::Decimal256, Decimal256>(left_field, right_type, right, res))
                 return true;
             // clang-format on
+            return false;
+        }
+        else if constexpr (LeftGroupType == Decimal || RightGroupType == Decimal)
+        {
+            // Mixed decimal comparison is intentionally unsupported here. Decimal values need scale information from
+            // both sides; returning false makes rough check fall back conservatively.
             return false;
         }
         else if constexpr (LeftGroupType == String && RightGroupType == String)

--- a/dbms/src/Storages/DeltaMerge/Index/ValueComparison.h
+++ b/dbms/src/Storages/DeltaMerge/Index/ValueComparison.h
@@ -20,6 +20,7 @@
 #include <Core/Types.h>
 #include <DataTypes/DataTypeDate.h>
 #include <DataTypes/DataTypeDateTime.h>
+#include <DataTypes/DataTypeDecimal.h>
 #include <DataTypes/DataTypeEnum.h>
 #include <DataTypes/DataTypeFixedString.h>
 #include <DataTypes/DataTypeString.h>
@@ -93,6 +94,13 @@ private:
         Generic,
     };
 
+    template <typename T>
+    static constexpr bool isDecimalFieldType()
+    {
+        return std::is_same_v<T, DecimalField<Decimal32>> || std::is_same_v<T, DecimalField<Decimal64>>
+            || std::is_same_v<T, DecimalField<Decimal128>> || std::is_same_v<T, DecimalField<Decimal256>>;
+    }
+
     static ValueGroupType getGroupType(const Field & field)
     {
         switch (field.getType())
@@ -117,17 +125,10 @@ private:
     template <typename T>
     static constexpr ValueGroupType getGroupType()
     {
-        if constexpr (is_arithmetic_v<T>)
-            return Number;
-        else if constexpr (
-            // clang-format off
-            std::is_same_v<T, DecimalField<Decimal32>>
-            || std::is_same_v<T, DecimalField<Decimal64>>
-            || std::is_same_v<T, DecimalField<Decimal128>>
-            || std::is_same_v<T, DecimalField<Decimal256>>
-            // clang-format on
-        )
+        if constexpr (IsDecimal<T> || isDecimalFieldType<T>())
             return Decimal;
+        else if constexpr (is_arithmetic_v<T>)
+            return Number;
         else if constexpr (std::is_same_v<T, std::string>)
             return String;
         else
@@ -150,20 +151,13 @@ private:
         }
         else if constexpr (LeftGroupType == Decimal || RightGroupType == Decimal)
         {
-            // TODO: support decimal comparison.
             // clang-format off
-//            if (!(compareDecimalLeftType<Field::Types::Which::UInt64, UInt64, Number>(left_field, right, res)
-//                  || compareDecimalLeftType<Field::Types::Which::Int64, Int64, Number>(left_field, right, res)
-//                  || compareDecimalLeftType<Field::Types::Which::Float64, Float64, Number>(left_field, right, res)
-//                  || compareDecimalLeftType<Field::Types::Which::Int128, Int128, Number>(left_field, right, res)
-//                  || compareDecimalLeftType<Field::Types::Which::Int256, Int256, Number>(left_field, right, res)
-//                  || compareDecimalLeftType<Field::Types::Which::Decimal32, DecimalField<Decimal32>, Decimal>(left_field, right, res)
-//                  || compareDecimalLeftType<Field::Types::Which::Decimal64, DecimalField<Decimal64>, Decimal>(left_field, right, res)
-//                  || compareDecimalLeftType<Field::Types::Which::Decimal128, DecimalField<Decimal128>, Decimal>(left_field, right, res)
-//                  || compareDecimalLeftType<Field::Types::Which::Decimal256, DecimalField<Decimal256>, Decimal>(left_field, right, res)))
-//                throw Exception("Illegal compare " + std::string(left_field.getTypeName()) + " with " + compareTypeToString(right));
+            if (compareDecimalLeftType<Field::Types::Which::Decimal32, Decimal32>(left_field, right_type, right, res)
+                || compareDecimalLeftType<Field::Types::Which::Decimal64, Decimal64>(left_field, right_type, right, res)
+                || compareDecimalLeftType<Field::Types::Which::Decimal128, Decimal128>(left_field, right_type, right, res)
+                || compareDecimalLeftType<Field::Types::Which::Decimal256, Decimal256>(left_field, right_type, right, res))
+                return true;
             // clang-format on
-            // return true;
             return false;
         }
         else if constexpr (LeftGroupType == String && RightGroupType == String)
@@ -218,30 +212,31 @@ private:
     template <
         Field::Types::Which LeftFieldType,
         typename Left,
-        ValueGroupType LeftGroupType,
         typename Right,
         ValueGroupType RightGroupType = getGroupType<Right>()>
-    static bool compareDecimalLeftType(const Field & left_field, const Right & right, bool & res)
+    static bool compareDecimalLeftType(
+        const Field & left_field,
+        const DataTypePtr & right_type,
+        const Right & right,
+        bool & res)
     {
         if (left_field.getType() != LeftFieldType)
             return false;
-        if constexpr (LeftGroupType != Decimal && RightGroupType != Decimal)
+        if constexpr (RightGroupType != Decimal || !IsDecimal<Right>)
+        {
             return false;
+        }
+        else
+        {
+            const auto & left = left_field.safeGet<DecimalField<Left>>();
+            res = DecimalComparison<Left, Right, Op, true>::compare(
+                left.getValue(),
+                right,
+                left.getScale(),
+                getDecimalScale(*right_type, 0));
 
-        auto & left = left_field.safeGet<Left>();
-        UInt32 left_scale = 1;
-        UInt32 right_scale = 1;
-
-        if constexpr (LeftGroupType == Decimal)
-            left_scale = left.getScale();
-        if constexpr (RightGroupType == Decimal)
-            right_scale = right.getScale();
-        else if constexpr (
-            (LeftGroupType == Number || LeftGroupType == Decimal)
-            && (RightGroupType == Number || RightGroupType == Decimal))
-            res = DecimalComparison<Left, Right, Op, true>::compare(left, right, left_scale, right_scale);
-
-        return true;
+            return true;
+        }
     }
 
     static void compareStringLeftType(const Field & left_field, const std::string & right, bool & res)

--- a/dbms/src/Storages/DeltaMerge/Index/ValueComparison.h
+++ b/dbms/src/Storages/DeltaMerge/Index/ValueComparison.h
@@ -228,12 +228,16 @@ private:
         }
         else
         {
+            const auto * decimal_type = typeid_cast<const DataTypeDecimal<Right> *>(right_type.get());
+            if (decimal_type == nullptr)
+                return false;
+
             const auto & left = left_field.safeGet<DecimalField<Left>>();
             res = DecimalComparison<Left, Right, Op, true>::compare(
                 left.getValue(),
                 right,
                 left.getScale(),
-                getDecimalScale(*right_type, 0));
+                decimal_type->getScale());
 
             return true;
         }

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_minmax_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_minmax_index.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <Common/Logger.h>
+#include <DataTypes/DataTypeDecimal.h>
 #include <DataTypes/DataTypeEnum.h>
 #include <Flash/Coprocessor/DAGCodec.h>
 #include <Flash/Coprocessor/DAGQueryInfo.h>
@@ -20,6 +21,10 @@
 #include <Interpreters/convertFieldToType.h>
 #include <Storages/DeltaMerge/DMContext.h>
 #include <Storages/DeltaMerge/DeltaMergeStore.h>
+#include <Storages/DeltaMerge/File/DMFile.h>
+#include <Storages/DeltaMerge/File/DMFileMetaV2.h>
+#include <Storages/DeltaMerge/File/DMFileUtil.h>
+#include <Storages/DeltaMerge/File/DMFileWriter.h>
 #include <Storages/DeltaMerge/Filter/RSOperator.h>
 #include <Storages/DeltaMerge/FilterParser/FilterParser.h>
 #include <Storages/DeltaMerge/Index/RSResult.h>
@@ -29,6 +34,7 @@
 #include <Storages/DeltaMerge/tests/DMTestEnv.h>
 #include <TestUtils/FunctionTestUtils.h>
 #include <TestUtils/InputStreamTestUtils.h>
+#include <TestUtils/TiFlashStorageTestBasic.h>
 #include <TestUtils/TiFlashTestBasic.h>
 
 #include <ext/scope_guard.h>
@@ -54,6 +60,58 @@ protected:
 protected:
     // a ptr to context, we can reload context with different settings if need.
     ContextPtr context;
+};
+
+class MinMaxIndexWriteTest : public DB::base::TiFlashStorageTestBasic
+{
+protected:
+    void SetUp() override
+    {
+        TiFlashStorageTestBasic::SetUp();
+        parent_path = getTemporaryPath();
+        file_provider = db_context->getFileProvider();
+    }
+
+    static constexpr ColId decimal_col_id = 100;
+
+    static ColumnDefinesPtr makeColumns()
+    {
+        auto cols = DMTestEnv::getDefaultColumns(DMTestEnv::PkType::HiddenTiDBRowID, /*add_nullable*/ false);
+        cols->emplace_back(ColumnDefine{decimal_col_id, "decimal_col", std::make_shared<DataTypeDecimal64>(20, 5)});
+        return cols;
+    }
+
+    static Block makeBlock()
+    {
+        Block block = DMTestEnv::prepareSimpleWriteBlock(0, 4, /*reversed*/ false);
+        auto type = std::make_shared<DataTypeDecimal64>(20, 5);
+        auto col = DB::tests::createColumn<Decimal64>(
+                       std::make_tuple(20, 5),
+                       std::vector<String>{"1.23000", "2.34000", "3.45000", "4.56000"})
+                       .column;
+        block.insert(ColumnWithTypeAndName(std::move(col), type, "decimal_col", decimal_col_id));
+        return block;
+    }
+
+    DMFilePtr writeDMFile()
+    {
+        auto dm_file = DMFile::create(
+            /*file_id*/ 1,
+            parent_path,
+            std::make_optional<DMChecksumConfig>(),
+            128 * 1024,
+            16 * 1024 * 1024,
+            NullspaceID,
+            DMFileFormat::V3);
+        auto cols = makeColumns();
+        DMFileWriter writer(dm_file, *cols, file_provider, db_context->getWriteLimiter(), DMFileWriter::Options{});
+        writer.write(makeBlock(), DMFileWriter::BlockProperty{0, 0, 0, 0});
+        writer.finalize();
+        return dm_file;
+    }
+
+    String parent_path;
+    FileProviderPtr file_provider;
 };
 
 namespace
@@ -247,6 +305,15 @@ Decimal64 getDecimal64(String s)
     return expected_default_value;
 }
 
+template <typename DecimalType>
+DecimalField<DecimalType> getDecimalField(const String & s, PrecType precision, ScaleType scale)
+{
+    DecimalType value;
+    ReadBufferFromString buf(s);
+    readDecimalText(value, buf, precision, scale);
+    return DecimalField<DecimalType>(value, scale);
+}
+
 constexpr Int64 Int64_Match_DATA = 100;
 constexpr Int64 Int64_Greater_DATA = 10000;
 constexpr Int64 Int64_Smaller_DATA = -1;
@@ -264,7 +331,8 @@ const String MyDateTime_Greater_DATE = "2022-09-27";
 const String MyDateTime_Smaller_DATE = "1997-09-27";
 
 const String Decimal_Match_DATA = "100.25566";
-const String Decimal_UnMatch_DATA = "100.25500";
+const String Decimal_Greater_DATA = "101.00000";
+const String Decimal_Smaller_DATA = "99.00000";
 
 std::pair<String, CSVTuples> generateTypeValue(MinMaxTestDatatype data_type, bool has_null)
 {
@@ -439,7 +507,7 @@ RSOperatorPtr generateEqualOperator(MinMaxTestDatatype data_type, bool is_match)
         {
             return createEqual(
                 attr("Decimal(20,5)"),
-                Field(DecimalField<Decimal64>(getDecimal64(Decimal_UnMatch_DATA), 5)));
+                Field(DecimalField<Decimal64>(getDecimal64(Decimal_Smaller_DATA), 5)));
         }
     }
     case Test_Nullable_Decimal64:
@@ -454,7 +522,7 @@ RSOperatorPtr generateEqualOperator(MinMaxTestDatatype data_type, bool is_match)
         {
             return createEqual(
                 attr("Nullable(Decimal(20,5))"),
-                Field(DecimalField<Decimal64>(getDecimal64(Decimal_UnMatch_DATA), 5)));
+                Field(DecimalField<Decimal64>(getDecimal64(Decimal_Smaller_DATA), 5)));
         }
     }
     default:
@@ -566,7 +634,7 @@ RSOperatorPtr generateInOperator(MinMaxTestDatatype data_type, bool is_match)
         {
             return createIn(
                 attr("Decimal(20,5)"),
-                {Field(DecimalField<Decimal64>(getDecimal64(Decimal_UnMatch_DATA), 5))});
+                {Field(DecimalField<Decimal64>(getDecimal64(Decimal_Smaller_DATA), 5))});
         }
     }
     case Test_Nullable_Decimal64:
@@ -581,7 +649,7 @@ RSOperatorPtr generateInOperator(MinMaxTestDatatype data_type, bool is_match)
         {
             return createIn(
                 attr("Nullable(Decimal(20,5))"),
-                {Field(DecimalField<Decimal64>(getDecimal64(Decimal_UnMatch_DATA), 5))});
+                {Field(DecimalField<Decimal64>(getDecimal64(Decimal_Smaller_DATA), 5))});
         }
     }
     default:
@@ -687,13 +755,13 @@ RSOperatorPtr generateGreaterOperator(MinMaxTestDatatype data_type, bool is_matc
         {
             return createGreater(
                 attr("Decimal(20,5)"),
-                Field(DecimalField<Decimal64>(getDecimal64(Decimal_Match_DATA), 5)));
+                Field(DecimalField<Decimal64>(getDecimal64(Decimal_Smaller_DATA), 5)));
         }
         else
         {
             return createGreater(
                 attr("Decimal(20,5)"),
-                Field(DecimalField<Decimal64>(getDecimal64(Decimal_UnMatch_DATA), 5)));
+                Field(DecimalField<Decimal64>(getDecimal64(Decimal_Match_DATA), 5)));
         }
     }
     case Test_Nullable_Decimal64:
@@ -702,13 +770,13 @@ RSOperatorPtr generateGreaterOperator(MinMaxTestDatatype data_type, bool is_matc
         {
             return createGreater(
                 attr("Nullable(Decimal(20,5))"),
-                Field(DecimalField<Decimal64>(getDecimal64(Decimal_Match_DATA), 5)));
+                Field(DecimalField<Decimal64>(getDecimal64(Decimal_Smaller_DATA), 5)));
         }
         else
         {
             return createGreater(
                 attr("Nullable(Decimal(20,5))"),
-                Field(DecimalField<Decimal64>(getDecimal64(Decimal_UnMatch_DATA), 5)));
+                Field(DecimalField<Decimal64>(getDecimal64(Decimal_Match_DATA), 5)));
         }
     }
     default:
@@ -820,7 +888,7 @@ RSOperatorPtr generateGreaterEqualOperator(MinMaxTestDatatype data_type, bool is
         {
             return createGreaterEqual(
                 attr("Decimal(20,5)"),
-                Field(DecimalField<Decimal64>(getDecimal64(Decimal_UnMatch_DATA), 5)));
+                Field(DecimalField<Decimal64>(getDecimal64(Decimal_Greater_DATA), 5)));
         }
     }
     case Test_Nullable_Decimal64:
@@ -835,7 +903,7 @@ RSOperatorPtr generateGreaterEqualOperator(MinMaxTestDatatype data_type, bool is
         {
             return createGreaterEqual(
                 attr("Nullable(Decimal(20,5))"),
-                Field(DecimalField<Decimal64>(getDecimal64(Decimal_UnMatch_DATA), 5)));
+                Field(DecimalField<Decimal64>(getDecimal64(Decimal_Greater_DATA), 5)));
         }
     }
     default:
@@ -941,13 +1009,13 @@ RSOperatorPtr generateLessOperator(MinMaxTestDatatype data_type, bool is_match)
         {
             return createLess(
                 attr("Decimal(20,5)"),
-                Field(DecimalField<Decimal64>(getDecimal64(Decimal_Match_DATA), 5)));
+                Field(DecimalField<Decimal64>(getDecimal64(Decimal_Greater_DATA), 5)));
         }
         else
         {
             return createLess(
                 attr("Decimal(20,5)"),
-                Field(DecimalField<Decimal64>(getDecimal64(Decimal_UnMatch_DATA), 5)));
+                Field(DecimalField<Decimal64>(getDecimal64(Decimal_Match_DATA), 5)));
         }
     }
     case Test_Nullable_Decimal64:
@@ -956,13 +1024,13 @@ RSOperatorPtr generateLessOperator(MinMaxTestDatatype data_type, bool is_match)
         {
             return createLess(
                 attr("Nullable(Decimal(20,5))"),
-                Field(DecimalField<Decimal64>(getDecimal64(Decimal_Match_DATA), 5)));
+                Field(DecimalField<Decimal64>(getDecimal64(Decimal_Greater_DATA), 5)));
         }
         else
         {
             return createLess(
                 attr("Nullable(Decimal(20,5))"),
-                Field(DecimalField<Decimal64>(getDecimal64(Decimal_UnMatch_DATA), 5)));
+                Field(DecimalField<Decimal64>(getDecimal64(Decimal_Match_DATA), 5)));
         }
     }
     default:
@@ -1074,7 +1142,7 @@ RSOperatorPtr generateLessEqualOperator(MinMaxTestDatatype data_type, bool is_ma
         {
             return createLessEqual(
                 attr("Decimal(20,5)"),
-                Field(DecimalField<Decimal64>(getDecimal64(Decimal_UnMatch_DATA), 5)));
+                Field(DecimalField<Decimal64>(getDecimal64(Decimal_Smaller_DATA), 5)));
         }
     }
     case Test_Nullable_Decimal64:
@@ -1089,7 +1157,7 @@ RSOperatorPtr generateLessEqualOperator(MinMaxTestDatatype data_type, bool is_ma
         {
             return createLessEqual(
                 attr("Nullable(Decimal(20,5))"),
-                Field(DecimalField<Decimal64>(getDecimal64(Decimal_UnMatch_DATA), 5)));
+                Field(DecimalField<Decimal64>(getDecimal64(Decimal_Smaller_DATA), 5)));
         }
     }
     default:
@@ -1191,7 +1259,7 @@ try
 
     for (size_t operater_type = Test_Equal; operater_type < Test_MaxOperator; operater_type++)
     {
-        for (size_t datatype = Test_Int64; datatype < Test_Decimal64; datatype++)
+        for (size_t datatype = Test_Int64; datatype < Test_Max; datatype++)
         {
             {
                 // not null
@@ -1239,66 +1307,6 @@ try
                             true)));
                 ASSERT_EQ(
                     false,
-                    checkMatch(
-                        case_name,
-                        *context,
-                        type_value_pair.first,
-                        type_value_pair.second,
-                        generateRSOperator(
-                            static_cast<MinMaxTestDatatype>(datatype),
-                            static_cast<MinMaxTestOperator>(operater_type),
-                            false)));
-            }
-        }
-        // datatypes which not support minmax index
-        for (size_t datatype = Test_Decimal64; datatype < Test_Max; datatype++)
-        {
-            {
-                // not null
-                auto type_value_pair = generateTypeValue(static_cast<MinMaxTestDatatype>(datatype), false);
-                ASSERT_EQ(
-                    true,
-                    checkMatch(
-                        case_name,
-                        *context,
-                        type_value_pair.first,
-                        type_value_pair.second,
-                        generateRSOperator(
-                            static_cast<MinMaxTestDatatype>(datatype),
-                            static_cast<MinMaxTestOperator>(operater_type),
-                            true)));
-                ASSERT_EQ(
-                    true,
-                    checkMatch(
-                        case_name,
-                        *context,
-                        type_value_pair.first,
-                        type_value_pair.second,
-                        generateRSOperator(
-                            static_cast<MinMaxTestDatatype>(datatype),
-                            static_cast<MinMaxTestOperator>(operater_type),
-                            false)));
-            }
-            {
-                // has null
-                if (!isNullableDateType(static_cast<MinMaxTestDatatype>(datatype)))
-                {
-                    continue;
-                }
-                auto type_value_pair = generateTypeValue(static_cast<MinMaxTestDatatype>(datatype), true);
-                ASSERT_EQ(
-                    true,
-                    checkMatch(
-                        case_name,
-                        *context,
-                        type_value_pair.first,
-                        type_value_pair.second,
-                        generateRSOperator(
-                            static_cast<MinMaxTestDatatype>(datatype),
-                            static_cast<MinMaxTestOperator>(operater_type),
-                            true)));
-                ASSERT_EQ(
-                    true,
                     checkMatch(
                         case_name,
                         *context,
@@ -1321,7 +1329,7 @@ try
 
     for (size_t operater_type = Test_Equal; operater_type < Test_MaxOperator; operater_type++)
     {
-        for (size_t datatype = Test_Int64; datatype < Test_Decimal64; datatype++)
+        for (size_t datatype = Test_Int64; datatype < Test_Max; datatype++)
         {
             {
                 // not null
@@ -1358,67 +1366,6 @@ try
                 auto type_value_pair = generateTypeValue(static_cast<MinMaxTestDatatype>(datatype), true);
                 ASSERT_EQ(
                     false,
-                    checkMatch(
-                        case_name,
-                        *context,
-                        type_value_pair.first,
-                        type_value_pair.second,
-                        createNot(generateRSOperator(
-                            static_cast<MinMaxTestDatatype>(datatype),
-                            static_cast<MinMaxTestOperator>(operater_type),
-                            true))));
-                ASSERT_EQ(
-                    true,
-                    checkMatch(
-                        case_name,
-                        *context,
-                        type_value_pair.first,
-                        type_value_pair.second,
-                        createNot(generateRSOperator(
-                            static_cast<MinMaxTestDatatype>(datatype),
-                            static_cast<MinMaxTestOperator>(operater_type),
-                            false))));
-            }
-        }
-
-        // datatypes which not support minmax index
-        for (size_t datatype = Test_Decimal64; datatype < Test_Max; datatype++)
-        {
-            {
-                // not null
-                auto type_value_pair = generateTypeValue(static_cast<MinMaxTestDatatype>(datatype), false);
-                ASSERT_EQ(
-                    true,
-                    checkMatch(
-                        case_name,
-                        *context,
-                        type_value_pair.first,
-                        type_value_pair.second,
-                        createNot(generateRSOperator(
-                            static_cast<MinMaxTestDatatype>(datatype),
-                            static_cast<MinMaxTestOperator>(operater_type),
-                            true))));
-                ASSERT_EQ(
-                    true,
-                    checkMatch(
-                        case_name,
-                        *context,
-                        type_value_pair.first,
-                        type_value_pair.second,
-                        createNot(generateRSOperator(
-                            static_cast<MinMaxTestDatatype>(datatype),
-                            static_cast<MinMaxTestOperator>(operater_type),
-                            false))));
-            }
-            {
-                // has null
-                if (!isNullableDateType(static_cast<MinMaxTestDatatype>(datatype)))
-                {
-                    continue;
-                }
-                auto type_value_pair = generateTypeValue(static_cast<MinMaxTestDatatype>(datatype), true);
-                ASSERT_EQ(
-                    true,
                     checkMatch(
                         case_name,
                         *context,
@@ -1454,7 +1401,7 @@ try
     {
         for (size_t operater_right_type = Test_Equal; operater_right_type < Test_MaxOperator; operater_right_type++)
         {
-            for (size_t datatype = Test_Int64; datatype < Test_Decimal64; datatype++)
+            for (size_t datatype = Test_Int64; datatype < Test_Max; datatype++)
             {
                 {
                     // not null
@@ -1519,81 +1466,6 @@ try
                         false);
                     ASSERT_EQ(
                         false,
-                        checkMatch(
-                            case_name,
-                            *context,
-                            type_value_pair.first,
-                            type_value_pair.second,
-                            createAnd({left_rs_operator, right_rs_operator_not_match})));
-                }
-            }
-            // datatypes which not support minmax index
-            for (size_t datatype = Test_Decimal64; datatype < Test_Max; datatype++)
-            {
-                {
-                    // not null
-                    auto type_value_pair = generateTypeValue(static_cast<MinMaxTestDatatype>(datatype), false);
-                    auto left_rs_operator = generateRSOperator(
-                        static_cast<MinMaxTestDatatype>(datatype),
-                        static_cast<MinMaxTestOperator>(operater_left_type),
-                        true);
-                    auto right_rs_operator = generateRSOperator(
-                        static_cast<MinMaxTestDatatype>(datatype),
-                        static_cast<MinMaxTestOperator>(operater_right_type),
-                        true);
-                    ASSERT_EQ(
-                        true,
-                        checkMatch(
-                            case_name,
-                            *context,
-                            type_value_pair.first,
-                            type_value_pair.second,
-                            createAnd({left_rs_operator, right_rs_operator})));
-
-                    auto right_rs_operator_not_match = generateRSOperator(
-                        static_cast<MinMaxTestDatatype>(datatype),
-                        static_cast<MinMaxTestOperator>(operater_right_type),
-                        false);
-                    ASSERT_EQ(
-                        true,
-                        checkMatch(
-                            case_name,
-                            *context,
-                            type_value_pair.first,
-                            type_value_pair.second,
-                            createAnd({left_rs_operator, right_rs_operator_not_match})));
-                }
-                {
-                    // has null
-                    if (!isNullableDateType(static_cast<MinMaxTestDatatype>(datatype)))
-                    {
-                        continue;
-                    }
-                    auto type_value_pair = generateTypeValue(static_cast<MinMaxTestDatatype>(datatype), true);
-                    auto left_rs_operator = generateRSOperator(
-                        static_cast<MinMaxTestDatatype>(datatype),
-                        static_cast<MinMaxTestOperator>(operater_left_type),
-                        true);
-                    auto right_rs_operator = generateRSOperator(
-                        static_cast<MinMaxTestDatatype>(datatype),
-                        static_cast<MinMaxTestOperator>(operater_right_type),
-                        true);
-
-                    ASSERT_EQ(
-                        true,
-                        checkMatch(
-                            case_name,
-                            *context,
-                            type_value_pair.first,
-                            type_value_pair.second,
-                            createAnd({left_rs_operator, right_rs_operator})));
-
-                    auto right_rs_operator_not_match = generateRSOperator(
-                        static_cast<MinMaxTestDatatype>(datatype),
-                        static_cast<MinMaxTestOperator>(operater_right_type),
-                        false);
-                    ASSERT_EQ(
-                        true,
                         checkMatch(
                             case_name,
                             *context,
@@ -1616,7 +1488,7 @@ try
     {
         for (size_t operater_right_type = Test_Equal; operater_right_type < Test_MaxOperator; operater_right_type++)
         {
-            for (size_t datatype = Test_Int64; datatype < Test_Decimal64; datatype++)
+            for (size_t datatype = Test_Int64; datatype < Test_Max; datatype++)
             {
                 {
                     // not null
@@ -1687,55 +1559,6 @@ try
                             type_value_pair.first,
                             type_value_pair.second,
                             createOr({left_rs_operator_not_match, right_rs_operator})));
-                }
-            }
-            // datatypes which not support minmax index
-            for (size_t datatype = Test_Decimal64; datatype < Test_Max; datatype++)
-            {
-                {
-                    // not null
-                    auto type_value_pair = generateTypeValue(static_cast<MinMaxTestDatatype>(datatype), false);
-                    auto left_rs_operator = generateRSOperator(
-                        static_cast<MinMaxTestDatatype>(datatype),
-                        static_cast<MinMaxTestOperator>(operater_left_type),
-                        false);
-                    auto right_rs_operator = generateRSOperator(
-                        static_cast<MinMaxTestDatatype>(datatype),
-                        static_cast<MinMaxTestOperator>(operater_right_type),
-                        false);
-                    ASSERT_EQ(
-                        true,
-                        checkMatch(
-                            case_name,
-                            *context,
-                            type_value_pair.first,
-                            type_value_pair.second,
-                            createOr({left_rs_operator, right_rs_operator})));
-                }
-                {
-                    // has null
-                    if (!isNullableDateType(static_cast<MinMaxTestDatatype>(datatype)))
-                    {
-                        continue;
-                    }
-                    auto type_value_pair = generateTypeValue(static_cast<MinMaxTestDatatype>(datatype), true);
-                    auto left_rs_operator = generateRSOperator(
-                        static_cast<MinMaxTestDatatype>(datatype),
-                        static_cast<MinMaxTestOperator>(operater_left_type),
-                        false);
-                    auto right_rs_operator = generateRSOperator(
-                        static_cast<MinMaxTestDatatype>(datatype),
-                        static_cast<MinMaxTestOperator>(operater_right_type),
-                        false);
-
-                    ASSERT_EQ(
-                        true,
-                        checkMatch(
-                            case_name,
-                            *context,
-                            type_value_pair.first,
-                            type_value_pair.second,
-                            createOr({left_rs_operator, right_rs_operator})));
                 }
             }
         }
@@ -1750,7 +1573,7 @@ try
 
     auto operater_type = Test_IsNull;
 
-    for (size_t datatype = Test_Int64; datatype < Test_Decimal64; datatype++)
+    for (size_t datatype = Test_Int64; datatype < Test_Max; datatype++)
     {
         {
             // not null
@@ -1768,67 +1591,6 @@ try
                         true)));
             ASSERT_EQ(
                 false,
-                checkMatch(
-                    case_name,
-                    *context,
-                    type_value_pair.first,
-                    type_value_pair.second,
-                    generateRSOperator(
-                        static_cast<MinMaxTestDatatype>(datatype),
-                        static_cast<MinMaxTestOperator>(operater_type),
-                        false)));
-        }
-        {
-            // has null
-            if (!isNullableDateType(static_cast<MinMaxTestDatatype>(datatype)))
-            {
-                continue;
-            }
-            auto type_value_pair = generateTypeValue(static_cast<MinMaxTestDatatype>(datatype), true);
-            ASSERT_EQ(
-                true,
-                checkMatch(
-                    case_name,
-                    *context,
-                    type_value_pair.first,
-                    type_value_pair.second,
-                    generateRSOperator(
-                        static_cast<MinMaxTestDatatype>(datatype),
-                        static_cast<MinMaxTestOperator>(operater_type),
-                        true)));
-            ASSERT_EQ(
-                true,
-                checkMatch(
-                    case_name,
-                    *context,
-                    type_value_pair.first,
-                    type_value_pair.second,
-                    generateRSOperator(
-                        static_cast<MinMaxTestDatatype>(datatype),
-                        static_cast<MinMaxTestOperator>(operater_type),
-                        false)));
-        }
-    }
-
-    // datatypes which not support minmax index
-    for (size_t datatype = Test_Decimal64; datatype < Test_Max; datatype++)
-    {
-        {
-            // not null
-            auto type_value_pair = generateTypeValue(static_cast<MinMaxTestDatatype>(datatype), false);
-            ASSERT_EQ(
-                true,
-                checkMatch(
-                    case_name,
-                    *context,
-                    type_value_pair.first,
-                    type_value_pair.second,
-                    generateRSOperator(
-                        static_cast<MinMaxTestDatatype>(datatype),
-                        static_cast<MinMaxTestOperator>(operater_type),
-                        true)));
-            ASSERT_EQ(
-                true,
                 checkMatch(
                     case_name,
                     *context,
@@ -2035,6 +1797,8 @@ try
     // Generate a minmax index with the min value is null as a old version(before v6.4) minmax index.
     PaddedPODArray<UInt8> has_null_marks(1);
     PaddedPODArray<UInt8> has_value_marks(1);
+    has_null_marks[0] = 1;
+    has_value_marks[0] = 1;
     MutableColumnPtr minmaxes = data_type->createColumn();
 
     auto column = data_type->createColumn();
@@ -2176,22 +1940,14 @@ try
     auto type = std::make_shared<DataTypeInt64>();
     auto data_type = makeNullable(type);
 
-    PaddedPODArray<UInt8> has_null_marks(1);
-    PaddedPODArray<UInt8> has_value_marks(1);
-    MutableColumnPtr minmaxes = data_type->createColumn();
-
     auto column = data_type->createColumn();
 
     column->insert(Field(static_cast<Int64>(1))); // insert value 1
     column->insert(Field(static_cast<Int64>(2))); // insert value 2
     column->insertDefault(); // insert null value
 
-    auto * col = column.get();
-    minmaxes->insertFrom(*col, 0); // insert min index
-    minmaxes->insertFrom(*col, 1); // insert max index
-
-    auto minmax
-        = std::make_shared<MinMaxIndex>(std::move(has_null_marks), std::move(has_value_marks), std::move(minmaxes));
+    auto minmax = std::make_shared<MinMaxIndex>(*data_type);
+    minmax->addPack(*column, nullptr);
 
     auto index = RSIndex(data_type, minmax);
     param.indexes.emplace(DEFAULT_COL_ID, index);
@@ -2226,6 +1982,31 @@ try
         auto filter = createNot(createIn(attr("Nullable(Int64)"), {Field(static_cast<Int64>(3))}));
         ASSERT_EQ(filter->roughCheck(0, 1, param)[0], RSResult::AllNull);
     }
+}
+CATCH
+
+TEST_F(MinMaxIndexWriteTest, WriteDecimalMinMaxIndex)
+try
+{
+    auto dm_file = writeDMFile();
+
+    EXPECT_GT(dm_file->getColumnStat(decimal_col_id).index_bytes, 0u);
+
+    const auto * meta = typeid_cast<const DMFileMetaV2 *>(dm_file->meta.get());
+    ASSERT_NE(meta, nullptr);
+    const auto fname = colIndexFileName(DB::toString(decimal_col_id));
+    auto itr = meta->merged_sub_file_infos.find(fname);
+    ASSERT_NE(itr, meta->merged_sub_file_infos.end());
+    EXPECT_GT(itr->second.size, 0u);
+
+    auto restored = DMFile::restore(
+        file_provider,
+        dm_file->fileId(),
+        dm_file->pageId(),
+        parent_path,
+        DMFileMeta::ReadMode::all(),
+        /*meta_version*/ 0);
+    EXPECT_GT(restored->getColumnStat(decimal_col_id).index_bytes, 0u);
 }
 CATCH
 
@@ -2488,6 +2269,122 @@ MinMaxIndexPtr createMinMaxIndex(const IDataType & col_type, const T & cases)
     return minmax_index;
 }
 } // namespace
+
+TEST_F(MinMaxIndexTest, CheckDecimal)
+try
+{
+    struct DecimalTestData
+    {
+        std::vector<std::optional<String>> column_data;
+        std::vector<UInt64> del_mark;
+    };
+
+    const auto cases = std::array{
+        DecimalTestData{
+            .column_data = {String("1.23000"), String("2.34000"), std::nullopt},
+            .del_mark = {0, 0, 0},
+        },
+        DecimalTestData{
+            .column_data = {String("5.00000"), String("5.00000")},
+            .del_mark = {0, 0},
+        },
+        DecimalTestData{
+            .column_data = {std::nullopt, std::nullopt},
+            .del_mark = {0, 0},
+        },
+    };
+
+    auto col_type = makeNullable(std::make_shared<DataTypeDecimal64>(20, 5));
+    auto minmax_index = std::make_shared<MinMaxIndex>(*col_type);
+    for (const auto & c : cases)
+    {
+        RUNTIME_CHECK(c.column_data.size(), c.del_mark.size());
+        auto col_data = createColumn<Nullable<Decimal64>>(std::make_tuple(20, 5), c.column_data).column;
+        auto del_mark_col = createColumn<UInt8>(c.del_mark).column;
+        minmax_index->addPack(*col_data, static_cast<const ColumnVector<UInt8> *>(del_mark_col.get()));
+    }
+
+    auto check_results = [&](const RSResults & actual, const std::array<RSResult, 3> & expected, String test_case) {
+        for (size_t i = 0; i < expected.size(); ++i)
+        {
+            ASSERT_EQ(actual[i], expected[i])
+                << fmt::format("{} pack={} actual={} expected={}", test_case, i, actual[i], expected[i]);
+        }
+    };
+
+    check_results(
+        minmax_index->checkCmp<RoughCheck::CheckEqual>(
+            0,
+            cases.size(),
+            Field(getDecimalField<Decimal32>("1.23", 9, 2)),
+            col_type),
+        {RSResult::SomeNull, RSResult::None, RSResult::SomeNull},
+        "decimal32 equal decimal64");
+
+    check_results(
+        minmax_index->checkIn(
+            0,
+            cases.size(),
+            {Field(getDecimalField<Decimal32>("1.23", 9, 2)), Field(getDecimalField<Decimal64>("7.77", 20, 2))},
+            col_type),
+        {RSResult::SomeNull, RSResult::None, RSResult::SomeNull},
+        "decimal in");
+
+    check_results(
+        minmax_index->checkCmp<RoughCheck::CheckGreater>(
+            0,
+            cases.size(),
+            Field(getDecimalField<Decimal64>("2.34", 20, 2)),
+            col_type),
+        {RSResult::NoneNull, RSResult::All, RSResult::SomeNull},
+        "decimal greater");
+
+    check_results(
+        minmax_index->checkCmp<RoughCheck::CheckGreaterEqual>(
+            0,
+            cases.size(),
+            Field(getDecimalField<Decimal64>("5.00", 20, 2)),
+            col_type),
+        {RSResult::NoneNull, RSResult::All, RSResult::SomeNull},
+        "decimal greater equal");
+
+    check_results(
+        minmax_index->checkNullEqual(0, cases.size(), Field(getDecimalField<Decimal32>("5.00", 9, 2)), col_type),
+        {RSResult::None, RSResult::All, RSResult::None},
+        "decimal null equal");
+
+    const auto decimal64_type = std::make_shared<DataTypeDecimal64>(20, 5);
+    ASSERT_EQ(
+        RoughCheck::Cmp<EqualsOp>::compare(
+            Field(getDecimalField<Decimal32>("1.23", 9, 2)),
+            decimal64_type,
+            getDecimalField<Decimal64>("1.23000", 20, 5).getValue()),
+        ValueCompareResult::True);
+
+    const auto decimal128_type = std::make_shared<DataTypeDecimal128>(38, 6);
+    ASSERT_EQ(
+        RoughCheck::Cmp<LessOp>::compare(
+            Field(getDecimalField<Decimal64>("1.23", 20, 2)),
+            decimal128_type,
+            getDecimalField<Decimal128>("1.230001", 38, 6).getValue()),
+        ValueCompareResult::True);
+
+    const auto decimal256_type = std::make_shared<DataTypeDecimal256>(65, 8);
+    ASSERT_EQ(
+        RoughCheck::Cmp<GreaterOrEqualsOp>::compare(
+            Field(getDecimalField<Decimal128>("1.23000000", 38, 8)),
+            decimal256_type,
+            getDecimalField<Decimal256>("1.23000000", 65, 8).getValue()),
+        ValueCompareResult::True);
+
+    ASSERT_EQ(
+        RoughCheck::Cmp<EqualsOp>::compare(
+            Field(static_cast<Int64>(5)),
+            decimal64_type,
+            getDecimalField<Decimal64>("5.00000", 20, 5).getValue()),
+        ValueCompareResult::CanNotCompare);
+}
+CATCH
 
 TEST_F(MinMaxIndexTest, CheckIsNull)
 try

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_minmax_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_minmax_index.cpp
@@ -39,6 +39,7 @@
 
 #include <ext/scope_guard.h>
 #include <memory>
+#include <string_view>
 
 namespace DB::DM::tests
 {
@@ -306,7 +307,7 @@ Decimal64 getDecimal64(String s)
 }
 
 template <typename DecimalType>
-DecimalField<DecimalType> getDecimalField(const String & s, PrecType precision, ScaleType scale)
+DecimalField<DecimalType> getDecimalField(std::string_view s, PrecType precision, ScaleType scale)
 {
     DecimalType value;
     ReadBufferFromString buf(s);
@@ -1898,7 +1899,7 @@ try
     auto minmax_index = std::make_shared<MinMaxIndex>(*col_type);
     for (const auto & c : cases)
     {
-        RUNTIME_CHECK(c.column_data.size(), c.del_mark.size());
+        RUNTIME_CHECK(c.column_data.size() == c.del_mark.size());
         auto col_data = createColumn<Nullable<String>>(c.column_data).column;
         auto del_mark_col = createColumn<UInt8>(c.del_mark).column;
         minmax_index->addPack(*col_data, static_cast<const ColumnVector<UInt8> *>(del_mark_col.get()));
@@ -2261,7 +2262,7 @@ MinMaxIndexPtr createMinMaxIndex(const IDataType & col_type, const T & cases)
     auto minmax_index = std::make_shared<MinMaxIndex>(col_type);
     for (const auto & c : cases)
     {
-        RUNTIME_CHECK(c.column_data.size(), c.del_mark.size());
+        RUNTIME_CHECK(c.column_data.size() == c.del_mark.size());
         auto col_data = createColumn<Nullable<Int64>>(c.column_data).column;
         auto del_mark_col = createColumn<UInt8>(c.del_mark).column;
         minmax_index->addPack(*col_data, static_cast<const ColumnVector<UInt8> *>(del_mark_col.get()));
@@ -2298,19 +2299,20 @@ try
     auto minmax_index = std::make_shared<MinMaxIndex>(*col_type);
     for (const auto & c : cases)
     {
-RUNTIME_CHECK(c.column_data.size() == c.del_mark.size());
+        RUNTIME_CHECK(c.column_data.size() == c.del_mark.size());
         auto col_data = createColumn<Nullable<Decimal64>>(std::make_tuple(20, 5), c.column_data).column;
         auto del_mark_col = createColumn<UInt8>(c.del_mark).column;
         minmax_index->addPack(*col_data, static_cast<const ColumnVector<UInt8> *>(del_mark_col.get()));
     }
 
-    auto check_results = [&](const RSResults & actual, const std::array<RSResult, 3> & expected, String test_case) {
-        for (size_t i = 0; i < expected.size(); ++i)
-        {
-            ASSERT_EQ(actual[i], expected[i])
-                << fmt::format("{} pack={} actual={} expected={}", test_case, i, actual[i], expected[i]);
-        }
-    };
+    auto check_results
+        = [&](const RSResults & actual, const std::array<RSResult, 3> & expected, std::string_view test_case) {
+              for (size_t i = 0; i < expected.size(); ++i)
+              {
+                  ASSERT_EQ(actual[i], expected[i])
+                      << fmt::format("{} pack={} actual={} expected={}", test_case, i, actual[i], expected[i]);
+              }
+          };
 
     check_results(
         minmax_index->checkCmp<RoughCheck::CheckEqual>(

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_minmax_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_minmax_index.cpp
@@ -2298,7 +2298,7 @@ try
     auto minmax_index = std::make_shared<MinMaxIndex>(*col_type);
     for (const auto & c : cases)
     {
-        RUNTIME_CHECK(c.column_data.size(), c.del_mark.size());
+RUNTIME_CHECK(c.column_data.size() == c.del_mark.size());
         auto col_data = createColumn<Nullable<Decimal64>>(std::make_tuple(20, 5), c.column_data).column;
         auto del_mark_col = createColumn<UInt8>(c.del_mark).column;
         minmax_index->addPack(*col_data, static_cast<const ColumnVector<UInt8> *>(del_mark_col.get()));

--- a/dbms/src/Storages/DeltaMerge/tests/gtest_dm_minmax_index.cpp
+++ b/dbms/src/Storages/DeltaMerge/tests/gtest_dm_minmax_index.cpp
@@ -2385,6 +2385,13 @@ try
             decimal64_type,
             getDecimalField<Decimal64>("5.00000", 20, 5).getValue()),
         ValueCompareResult::CanNotCompare);
+
+    ASSERT_EQ(
+        RoughCheck::Cmp<EqualsOp>::compare(
+            Field(getDecimalField<Decimal64>("5.00000", 20, 5)),
+            std::make_shared<DataTypeInt64>(),
+            static_cast<Int64>(5)),
+        ValueCompareResult::CanNotCompare);
 }
 CATCH
 

--- a/dbms/src/Storages/tests/gtest_filter_parser.cpp
+++ b/dbms/src/Storages/tests/gtest_filter_parser.cpp
@@ -89,11 +89,8 @@ DM::RSOperatorPtr FilterParserTest::generateRsOperator(
     const TiDB::TableInfo table_info(table_info_json, NullspaceID);
 
     QueryTasks query_tasks;
-    std::tie(query_tasks, std::ignore) = compileQuery(
-        *ctx,
-        query,
-        [&](const String &, const String &) { return table_info; },
-        getDAGProperties(""));
+    std::tie(query_tasks, std::ignore)
+        = compileQuery(*ctx, query, [&](const String &, const String &) { return table_info; }, getDAGProperties(""));
     auto & dag_request = *query_tasks[0].dag_request;
     DAGContext dag_context(dag_request, {}, NullspaceID, "", DAGRequestKind::Cop, "", 0, "", log);
     ctx->setDAGContext(&dag_context);
@@ -1023,6 +1020,32 @@ try
 }
 CATCH
 
+TEST_F(FilterParserTest, DecimalColumn)
+try
+{
+    const String table_info_json = R"json({
+    "cols":[
+        {"comment":"","default":null,"default_bit":null,"id":5,"name":{"L":"col_decimal","O":"col_decimal"},"offset":-1,"origin_default":null,"state":0,"type":{"Charset":null,"Collate":null,"Decimal":2,"Elems":null,"Flag":4097,"Flen":9,"Tp":246}}
+    ],
+    "pk_is_handle":false,"index_info":[],"is_common_handle":false,
+    "name":{"L":"t_111","O":"t_111"},"partition":null,
+    "comment":"Mocked.","id":30,"schema_version":-1,"state":0,"tiflash_replica":{"Count":0},"update_timestamp":1636471547239654
+})json";
+
+    auto expect_rs_operator = [&](const String & query, const String & expected_name) {
+        auto rs_operator = generateRsOperator(table_info_json, query);
+        EXPECT_EQ(rs_operator->name(), expected_name) << rs_operator->toDebugString();
+        EXPECT_EQ(rs_operator->getColumnIDs().size(), 1);
+        EXPECT_EQ(rs_operator->getColumnIDs()[0], 5);
+    };
+
+    expect_rs_operator("select * from default.t_111 where col_decimal > 1", "greater");
+    expect_rs_operator("select * from default.t_111 where col_decimal = 1", "equal");
+    expect_rs_operator("select * from default.t_111 where col_decimal in (1, 2)", "in");
+    expect_rs_operator("select * from default.t_111 where col_decimal is null", "isnull");
+}
+CATCH
+
 // Test cases for unsupported column type
 TEST_F(FilterParserTest, UnsupportedColumnType)
 try
@@ -1048,12 +1071,6 @@ try
     {
         // Greater between col and literal (not supported since the type of col_1 is string)
         auto rs_operator = generateRsOperator(table_info_json, "select * from default.t_111 where col_1 > '123'");
-        EXPECT_EQ(rs_operator->name(), "unsupported");
-    }
-
-    {
-        // Greater between col and literal (not supported since the type of col_5 is decimal)
-        auto rs_operator = generateRsOperator(table_info_json, "select * from default.t_111 where col_5 > 1");
         EXPECT_EQ(rs_operator->name(), "unsupported");
     }
 

--- a/dbms/src/Storages/tests/gtest_filter_parser.cpp
+++ b/dbms/src/Storages/tests/gtest_filter_parser.cpp
@@ -89,8 +89,11 @@ DM::RSOperatorPtr FilterParserTest::generateRsOperator(
     const TiDB::TableInfo table_info(table_info_json, NullspaceID);
 
     QueryTasks query_tasks;
-    std::tie(query_tasks, std::ignore)
-        = compileQuery(*ctx, query, [&](const String &, const String &) { return table_info; }, getDAGProperties(""));
+    std::tie(query_tasks, std::ignore) = compileQuery(
+        *ctx,
+        query,
+        [&](const String &, const String &) { return table_info; },
+        getDAGProperties(""));
     auto & dag_request = *query_tasks[0].dag_request;
     DAGContext dag_context(dag_request, {}, NullspaceID, "", DAGRequestKind::Cop, "", 0, "", log);
     ctx->setDAGContext(&dag_context);

--- a/docs/note/rough_set_filter_support_decimal.md
+++ b/docs/note/rough_set_filter_support_decimal.md
@@ -1,0 +1,288 @@
+# Rough Set MinMax Filter Support Decimal
+
+## Background
+
+TiFlash rough set min/max filter currently supports several scalar types, but decimal support needs special handling.
+
+TiFlash has four decimal physical types:
+
+- `Decimal32`
+- `Decimal64`
+- `Decimal128`
+- `Decimal256`
+
+The min/max values stored in `MinMaxIndex` for decimal columns are raw decimal integer values inside `ColumnDecimal<T>`. These raw values do not carry scale information. The scale belongs to the column type, `DataTypeDecimal<T>`.
+
+SQL constants are represented as `Field`. Decimal constants are stored as `DecimalField<T>`, and `DecimalField<T>` carries its own scale.
+
+Because of this, rough set min/max filtering must compare logical decimal values instead of directly comparing raw integer storage values.
+
+For example:
+
+```text
+1.23    scale=2 raw=123
+1.23000 scale=5 raw=123000
+```
+
+These two values are logically equal, although their raw stored values are different.
+
+## Goal
+
+Support rough set min/max filtering for decimal columns when the pushed down predicate constant is also decimal.
+
+Target predicates include:
+
+```sql
+decimal_col = 1.23
+decimal_col > 1.23
+decimal_col >= 1.23
+decimal_col < 1.23
+decimal_col <= 1.23
+decimal_col IN (1.23, 4.56)
+decimal_col <=> 1.23
+```
+
+The implementation should support decimal comparisons across physical decimal types and scales, for example:
+
+- `Decimal64` column vs `Decimal64` literal with the same scale
+- `Decimal64` column vs `Decimal32` literal with a different scale
+- `Decimal128` column vs `Decimal64` literal
+- `Decimal256` column vs `Decimal128` literal
+
+## Non-Goal
+
+This change should only support decimal-vs-decimal comparison.
+
+Do not support decimal min/max comparison with non-decimal constants in this change.
+
+Examples intentionally not optimized by rough set:
+
+```sql
+decimal_col = 1
+decimal_col = 1.23e0
+decimal_col = '1.23'
+```
+
+The assumption is that TiDB should normally cast constants to decimal before pushing predicates to TiFlash when the target column is decimal.
+
+If TiFlash receives a non-decimal constant for a decimal column, rough set should return `ValueCompareResult::CanNotCompare`. The upper layer should then conservatively treat the pack as `RSResult::Some`.
+
+This preserves correctness. The worst case is losing a rough set filtering opportunity.
+
+## Existing Flow
+
+`MinMaxIndex` stores per-pack min/max values in `minmaxes`.
+
+The rough set check entry points include:
+
+- `MinMaxIndex::checkCmp`
+- `MinMaxIndex::checkIn`
+- `MinMaxIndex::checkNullEqual`
+
+These methods dispatch by column type and then call `RoughCheck`.
+
+`RoughCheck` delegates the actual constant-vs-min/max comparison to:
+
+```cpp
+ValueComparision<Op>::compare(left_field, type, right_value)
+```
+
+Here:
+
+- `left_field` is the predicate constant represented as `Field`.
+- `type` is the column type.
+- `right_value` is the raw min or max value read from `MinMaxIndex`.
+
+## Design
+
+### Decimal Column Dispatch
+
+Add decimal dispatch in `MinMaxIndex` check paths:
+
+```cpp
+FOR_DECIMAL_TYPES(DISPATCH_DECIMAL)
+```
+
+The dispatch should cover nullable and non-nullable paths:
+
+- `checkIn`
+- `checkNullableIn`
+- `checkCmp`
+- `checkNullableCmp`
+- `checkNullableNullEqual`
+
+`checkNullEqual` can keep delegating to `checkCmp<RoughCheck::CheckEqual>` for non-nullable columns and `checkNullableNullEqual` for nullable columns.
+
+### Decimal Index Generation
+
+`DMFileWriter` must also create ordinary min/max index streams for decimal columns.
+
+The write-side index predicate should include decimal explicitly:
+
+```cpp
+bool do_index = cd.id == EXTRA_HANDLE_COLUMN_ID || type->isInteger() || type->isDateOrDateTime()
+    || type->isDecimal();
+```
+
+Do not expand this to all `isValueRepresentedByNumber()` types in this change. The intended scope is decimal only.
+
+This change is required for real DMFiles. Without it, decimal comparison support in `MinMaxIndex` only works for manually constructed indexes in unit tests, but persisted DMFiles will not have decimal ordinary min/max payloads to load during rough set filtering.
+
+### Decimal Min/Max Data Access
+
+For normal numeric types, the existing code reads min/max data from `ColumnVector<T>`.
+
+For decimal types, min/max data must be read from `ColumnDecimal<T>`:
+
+```cpp
+assert_cast<const ColumnDecimal<T> &>(column).getData()
+```
+
+A small helper can avoid duplicating the access logic:
+
+```cpp
+template <typename T>
+const auto & minMaxColumnData(const IColumn & column)
+{
+    if constexpr (IsDecimal<T>)
+        return assert_cast<const ColumnDecimal<T> &>(column).getData();
+    else
+        return toColumnVectorData<T>(column);
+}
+```
+
+### Decimal Value Comparison
+
+Extend `ValueComparision` to recognize decimal types on both sides.
+
+Supported literal-side types:
+
+- `DecimalField<Decimal32>`
+- `DecimalField<Decimal64>`
+- `DecimalField<Decimal128>`
+- `DecimalField<Decimal256>`
+
+Supported min/max-side types:
+
+- `Decimal32`
+- `Decimal64`
+- `Decimal128`
+- `Decimal256`
+
+The supported decimal comparison pattern is:
+
+```text
+Field(DecimalField<L>) vs Decimal<R>
+```
+
+The literal side should be extracted as:
+
+```cpp
+const auto & left = left_field.safeGet<DecimalField<L>>();
+auto left_value = left.getValue();
+auto left_scale = left.getScale();
+```
+
+The min/max side should be handled as:
+
+```cpp
+auto right_value = right;
+auto right_scale = getDecimalScale(*right_type, 0);
+```
+
+The actual comparison should use the existing execution-layer decimal comparison utility:
+
+```cpp
+DecimalComparison<LeftRaw, RightRaw, Op, true>::compare(
+    left_value,
+    right_value,
+    left_scale,
+    right_scale);
+```
+
+This avoids reimplementing scale alignment, cross-type comparison, and overflow handling.
+
+### Unsupported Comparisons
+
+If the comparison is not decimal-vs-decimal, `ValueComparision` should return `CanNotCompare` instead of throwing.
+
+For rough set, unsupported comparison means the pack cannot be filtered by min/max and should be treated as `RSResult::Some`.
+
+This is required for correctness. A failed rough set optimization must not reject packs.
+
+## Correctness Notes
+
+Decimal raw values cannot be compared directly when scales differ.
+
+Literal scale and column scale must be provided separately:
+
+- Literal scale comes from `DecimalField<T>::getScale()`.
+- Column min/max scale comes from `DataTypeDecimal<T>::getScale()` through `getDecimalScale(*type, 0)`.
+
+Nullable decimal should follow existing nullable rough set semantics:
+
+- Packs with both NULL and non-NULL values should keep the current `SomeNull` style behavior.
+- All-NULL packs should not match a non-NULL decimal constant.
+- For `<=> decimal_literal`, if all non-NULL values match but the pack also contains NULL rows, the result should not be upgraded to `All`, because NULL rows do not match a non-NULL `<=>` literal.
+
+## Test Plan
+
+Update existing min/max rough set tests so `Decimal64` is no longer treated as unsupported.
+
+Add targeted decimal tests covering a nullable decimal column such as:
+
+```text
+Nullable(Decimal64(20,5))
+```
+
+Suggested pack layout:
+
+```text
+pack0: 1.23000, 2.34000, NULL
+pack1: 5.00000, 5.00000
+pack2: NULL, NULL
+```
+
+Suggested checks:
+
+- `col = 1.23`
+- `col IN (1.23, 7.77)`
+- `col > 2.34`
+- `col >= 5.00`
+- `col < 5.00`
+- `col <= 1.23`
+- `col <=> 5.00`
+
+At minimum, include one cross-subtype and cross-scale comparison:
+
+```text
+Decimal64 column with scale 5 vs Decimal32 literal with scale 2
+```
+
+Also add a DMFile write-side regression test to verify `DMFileWriter` creates and persists the ordinary min/max `.idx`
+payload for decimal columns. This guards against a read-side-only implementation where decimal rough set logic exists
+but real DMFiles never contain decimal min/max indexes.
+
+If practical, add direct `ValueComparision` tests for:
+
+- `Decimal32` literal vs `Decimal64` min/max
+- `Decimal64` literal vs `Decimal128` min/max
+- `Decimal128` literal vs `Decimal256` min/max
+
+## Validation
+
+Run formatting for modified C++ files.
+
+Run targeted gtest for min/max index:
+
+```bash
+gtests_dbms --gtest_filter='MinMaxIndexTest.*'
+```
+
+If full min/max index gtest is too expensive, run the focused decimal and comparison cases:
+
+```bash
+gtests_dbms --gtest_filter='MinMaxIndexTest.CheckDecimal:MinMaxIndexTest.CheckIn:MinMaxIndexTest.CheckCmpEqual:MinMaxIndexTest.CheckCmpGreater:MinMaxIndexTest.CheckCmpGreaterEqual:MinMaxIndexTest.CheckNullEqual'
+```
+
+Do not run Bazel for this change unless explicitly requested.

--- a/docs/note/rough_set_filter_support_decimal.md
+++ b/docs/note/rough_set_filter_support_decimal.md
@@ -282,7 +282,7 @@ gtests_dbms --gtest_filter='MinMaxIndexTest.*'
 If full min/max index gtest is too expensive, run the focused decimal and comparison cases:
 
 ```bash
-gtests_dbms --gtest_filter='MinMaxIndexTest.CheckDecimal:MinMaxIndexTest.CheckIn:MinMaxIndexTest.CheckCmpEqual:MinMaxIndexTest.CheckCmpGreater:MinMaxIndexTest.CheckCmpGreaterEqual:MinMaxIndexTest.CheckNullEqual'
+gtests_dbms --gtest_filter='MinMaxIndexTest.CheckDecimal:MinMaxIndexTest.CheckIn:MinMaxIndexTest.CheckCmpEqual:MinMaxIndexTest.CheckCmpGreater:MinMaxIndexTest.CheckCmpGreaterEqual:MinMaxIndexWriteTest.WriteDecimalMinMaxIndex'
 ```
 
 Do not run Bazel for this change unless explicitly requested.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/11031

Problem Summary:

Decimal columns were not supported by rough set min/max filtering. The read-side comparison needs scale-aware decimal comparison, and the write-side must persist ordinary min/max indexes for decimal columns.

### What is changed and how it works?

```commit-message
Support decimal rough set minmax filter
```

- Add decimal dispatch in min/max rough set check paths.
- Use existing execution-layer decimal comparison utility for Decimal-vs-Decimal comparisons across physical decimal types and scales.
- Keep Decimal-vs-non-Decimal comparisons conservative by returning `CanNotCompare`.
- Generate ordinary min/max index payloads for decimal columns in `DMFileWriter`.
- Add a dev note and regression coverage for decimal min/max filtering and DMFile write-side index generation.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Manual test:

```bash
ninja -C cmake-build-debug dbms/gtests_dbms
./cmake-build-debug/dbms/gtests_dbms --gtest_filter=MinMaxIndexTest.*:MinMaxIndexWriteTest.* > /tmp/minmax_decimal.log 2>&1
git diff --check
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Support rough set min/max filter for decimal columns in TiFlash.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added min/max indexing and rough-set filtering for Decimal columns.
  - Enabled scale-aware Decimal comparisons across supported predicates and precisions.
  - Added Decimal index generation when writing data files.

- **Bug Fixes**
  - Improved nullable and non-nullable filtering for Decimal values.
  - Preserved conservative handling for unsupported Decimal comparisons.

- **Tests**
  - Expanded coverage for persisted indexes, comparisons, nullability, and varying Decimal widths.

- **Documentation**
  - Added guidance on Decimal filtering behavior and supported comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->