### PR TITLE
metrics: bump CSE meta cache metrics and fix prefetch cache hit ratio panel

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -13,4 +13,5 @@
 # limitations under the License.
 
 # Add directories or file patterns to ignore during indexing (e.g. foo/ or *.csv)
-contrib/
+contrib/aws*
+contrib/grpc

--- a/contrib/tiflash-columnar-hub/AGENTS.md
+++ b/contrib/tiflash-columnar-hub/AGENTS.md
@@ -117,6 +117,25 @@ kvengine = { path = "../../../cloud-storage-engine/components/kvengine" }
 
 Adjust paths relative to `contrib/tiflash-columnar-hub/`. Then run `cargo check` / `make release` and rebuild TiFlash. Remember to revert path patches before committing lockfile changes meant for upstream CI.
 
+### Lockfile out of sync after cloud-storage-engine commit bump
+
+When the cloud-storage-engine commit is bumped, `Cargo.toml` files inside it may change (new / removed dependencies). The committed `Cargo.lock` then no longer matches the resolved dependency graph, and the build fails with:
+
+```
+error: cannot update the lock file contrib/tiflash-columnar-hub/Cargo.lock because --locked was passed to prevent this
+```
+
+To fix:
+
+```bash
+cd contrib/tiflash-columnar-hub
+cargo update -p workspace-hack   # re-resolve; commit submodule pointer + Cargo.lock together:
+```
+
+Notes:
+
+- `cargo update -p workspace-hack` is enough in most cases; the resolver may also pick up a few compatible upgrades because it re-solves the whole graph — that is fine as long as `make release` builds.
+
 ## Standalone commands
 
 ```bash
@@ -140,6 +159,6 @@ make release ENABLE_FEATURES=external-jemalloc
 
 ## Notes
 
-- `workspace-hack/` intentionally overrides cloud-storage-engine's generated workspace-hack so the cdylib does not export a second jemalloc into the TiFlash process.
+- `workspace-hack/` exists to override cloud-storage-engine's generated workspace-hack so the cdylib does not export a second jemalloc into the TiFlash process. Note the `[patch]` in `Cargo.toml` does not actually take effect (path dependencies inside the submodule cannot be patched), yet the built `libtiflash_proxy.so` contains no jemalloc symbols, because the linker drops un-referenced allocator code from the cdylib.
 - Changing `Cargo.lock` alone is not enough for runtime behavior: always rebuild and redeploy `libtiflash_proxy.so`.
 - Columnar integration tests under `tests/fullstack-test-next-gen-columnar/` also use separate TiKV / TiDB binaries from `_env.sh`; upgrading proxy kvengine does not upgrade TiKV. For end-to-end columnar behavior, consider keeping proxy and TiKV cloud-storage-engine commits compatible.

--- a/contrib/tiflash-columnar-hub/Cargo.lock
+++ b/contrib/tiflash-columnar-hub/Cargo.lock
@@ -2368,7 +2368,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3575,7 +3575,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3693,6 +3693,7 @@ dependencies = [
  "aliyun",
  "anyhow",
  "api_version",
+ "arc-swap 1.9.1",
  "arrow-buffer",
  "async-once-cell",
  "async-recursion 1.1.1",
@@ -3718,6 +3719,7 @@ dependencies = [
  "crc32fast",
  "crossbeam",
  "crossbeam-queue",
+ "crossbeam-skiplist",
  "dashmap 5.5.3",
  "dyn-clone",
  "engine_traits",
@@ -3763,6 +3765,7 @@ dependencies = [
  "rusoto_s3",
  "schema",
  "security",
+ "seize",
  "serde",
  "serde_derive",
  "serde_json",
@@ -4392,7 +4395,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5206,7 +5209,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap 0.10.1",
@@ -5935,7 +5938,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6121,7 +6124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7007,7 +7010,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7028,7 +7031,10 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "slog",
+ "slog-global",
  "thiserror 1.0.69",
+ "tokio",
  "workspace-hack",
 ]
 
@@ -7038,7 +7044,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8208,7 +8214,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/metrics/grafana/tiflash_summary.dashboard.py
+++ b/metrics/grafana/tiflash_summary.dashboard.py
@@ -1855,9 +1855,11 @@ def ColumnarStorage() -> RowPanel:
                 instance_selector=PROXY_LABEL_SELECTORS,
             ),
             duration_panel(
-                "Columnar Prefetch Cache Hit Duration",
+                "Columnar Prefetch Cache Hit Ratio",
                 "tiflash_proxy_kv_engine_columnar_prefetch_cache_hit",
                 instance_selector=PROXY_LABEL_SELECTORS,
+                # Observe hit_ratio*100 with linear percent buckets (not duration).
+                unit="percent",
             ),
         ]
     )

--- a/metrics/grafana/tiflash_summary.json
+++ b/metrics/grafana/tiflash_summary.json
@@ -13033,7 +13033,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Columnar Prefetch Cache Hit Duration",
+          "title": "Columnar Prefetch Cache Hit Ratio",
           "tooltip": {
             "msResolution": true,
             "shared": true,
@@ -13052,7 +13052,7 @@
           "yaxes": [
             {
               "decimals": null,
-              "format": "s",
+              "format": "percent",
               "label": null,
               "logBase": 1,
               "max": null,

--- a/metrics/grafana/tiflash_summary.json.sha256
+++ b/metrics/grafana/tiflash_summary.json.sha256
@@ -1,1 +1,1 @@
-6ed50a4a0e9d4dc79211ec7fa1a4a23e412ae04a82ba52c3a6b073b847afdd7d  ./metrics/grafana/tiflash_summary.json
+c16590c8f5fe7a7c777e0e5f7bfa814c2d398f66e0d0d0a0f79be500d2619866  ./metrics/grafana/tiflash_summary.json


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #11039

Problem Summary:

Bump `cloud-storage-engine` so TiFlash picks up the new columnar meta cache metrics, and fix TiFlash Summary which incorrectly plots `tiflash_proxy_kv_engine_columnar_prefetch_cache_hit` as a duration (seconds). That metric observes `hit_ratio * 100` with percent buckets, so the panel should use a percent Y-axis and a ratio title.

### What is changed and how it works?

```commit-message
metrics: bump CSE for columnar meta cache metrics and fix prefetch cache hit panel unit.
```

- Update `contrib/cloud-storage-engine` submodule (includes columnar meta cache metrics) and regenerate related `Cargo.lock` / proxy AGENTS notes for workspace-hack resolution.
- Change TiFlash Summary panel **Columnar Prefetch Cache Hit Duration** → **Columnar Prefetch Cache Hit Ratio** with `unit="percent"`, then regenerate dashboard JSON/checksum.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Manual test:

1. Regenerate dashboard: `cd metrics/grafana && ./generate_dashboard.sh`
2. Confirm generated panel title is `Columnar Prefetch Cache Hit Ratio` and left Y-axis format is `percent`.
3. Import/update test Grafana dashboard and verify the panel reads as a hit-ratio distribution (0–100%), not seconds. Verified on `http://10.2.12.81:21530/d/jmd6Payvz/jsonnet-tiflash-summary`.
4. Confirm proxy/CSE build still works with the bumped submodule (prior sync commit notes verified `libtiflash_proxy.so` build / no jemalloc symbols).

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
TiFlash Summary: show columnar prefetch cache hit as percent ratio; bump CSE for columnar meta cache metrics.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Monitoring**
  - Updated the Columnar Storage dashboard to show prefetch cache hit ratio as a percentage, replacing the previous duration display.

- **Documentation**
  - Added troubleshooting guidance for lockfile updates after cloud-storage-engine revisions.
  - Clarified allocator-related build behavior.

- **Maintenance**
  - Updated the cloud-storage-engine revision.
  - Refined repository ignore patterns.
  - Refreshed the dashboard configuration checksum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->