### PR TITLE
copr: fix chunk decode for String & StringV2

### DIFF
--- a/contrib/tiflash-columnar-hub/Cargo.lock
+++ b/contrib/tiflash-columnar-hub/Cargo.lock
@@ -2353,15 +2353,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "erased-serde"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6431,15 +6422,9 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 
 [[package]]
 name = "slog"
-version = "2.8.2"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b3b8565691b22d2bdfc066426ed48f837fc0c5f2c8cad8d9718f7f99d6995c1"
-dependencies = [
- "anyhow",
- "erased-serde",
- "rustversion",
- "serde_core",
-]
+checksum = "1cc9c640a4adbfbcc11ffb95efe5aa7af7309e002adab54b185507dbf2377b99"
 
 [[package]]
 name = "slog-async"

--- a/contrib/tiflash-columnar-hub/hub-runtime/Cargo.toml
+++ b/contrib/tiflash-columnar-hub/hub-runtime/Cargo.toml
@@ -42,7 +42,7 @@ regex = "1"
 security = { workspace = true }
 serde = { version = "1.0.194", features = ["derive"] }
 serde_json = { version = "1.0.140", features = ["preserve_order"] }
-slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
+slog = { version = "=2.5.2", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9", default-features = true }
 tempfile = "3"
 thiserror = "1.0.44"

--- a/dbms/src/Flash/Coprocessor/ChunkDecodeAndSquash.cpp
+++ b/dbms/src/Flash/Coprocessor/ChunkDecodeAndSquash.cpp
@@ -72,8 +72,15 @@ std::optional<Block> CHBlockChunkDecodeAndSquash::decodeAndSquashV1Impl(ReadBuff
     else
     {
         size_t rows{};
-        DecodeHeader(istr, codec.header, rows);
-        DecodeColumns(istr, *accumulated_block, rows, 0);
+        Block block = DecodeHeader(istr, codec.header, rows);
+        // The chunk header determines its serialization format. It can use legacy
+        // String even when the receiver's output header uses StringV2.
+        DecodeColumns(istr, block, rows, 0);
+        auto mutable_columns = accumulated_block->mutateColumns();
+        const auto & chunk_columns = block.getColumns();
+        for (size_t i = 0; i < mutable_columns.size(); ++i)
+            mutable_columns[i]->insertRangeFrom(*chunk_columns[i], 0, chunk_columns[i]->size());
+        accumulated_block->setColumns(std::move(mutable_columns));
     }
 
     if (accumulated_block && accumulated_block->rows() >= rows_limit)

--- a/dbms/src/Flash/Coprocessor/ChunkDecodeAndSquash.cpp
+++ b/dbms/src/Flash/Coprocessor/ChunkDecodeAndSquash.cpp
@@ -75,12 +75,9 @@ std::optional<Block> CHBlockChunkDecodeAndSquash::decodeAndSquashV1Impl(ReadBuff
         Block block = DecodeHeader(istr, codec.header, rows);
         // The chunk header determines its serialization format. It can use legacy
         // String even when the receiver's output header uses StringV2.
+        block.setColumns(accumulated_block->mutateColumns());
         DecodeColumns(istr, block, rows, 0);
-        auto mutable_columns = accumulated_block->mutateColumns();
-        const auto & chunk_columns = block.getColumns();
-        for (size_t i = 0; i < mutable_columns.size(); ++i)
-            mutable_columns[i]->insertRangeFrom(*chunk_columns[i], 0, chunk_columns[i]->size());
-        accumulated_block->setColumns(std::move(mutable_columns));
+        accumulated_block->setColumns(block.mutateColumns());
     }
 
     if (accumulated_block && accumulated_block->rows() >= rows_limit)

--- a/dbms/src/Flash/Coprocessor/tests/gtest_block_chunk_codec.cpp
+++ b/dbms/src/Flash/Coprocessor/tests/gtest_block_chunk_codec.cpp
@@ -451,4 +451,37 @@ try
     }
 }
 CATCH
+
+TEST(CHBlockChunkCodecTest, DecodeAndSquashMixedStringFormats)
+try
+{
+    static constexpr auto compression_mode = CompressionMethod::NONE;
+    static const auto legacy_type_names = std::vector{DataTypeString::LegacyName, DataTypeString::NullableLegacyName};
+    static const auto v2_type_names = std::vector{DataTypeString::NameV2, DataTypeString::NullableNameV2};
+    auto legacy_block = prepareBlockWithString(4, legacy_type_names);
+    auto v2_block = prepareBlockWithString(5, v2_type_names);
+    auto legacy_chunk
+        = CHBlockChunkCodecV1{legacy_block.cloneEmpty(), MPPDataPacketV2}.encode(legacy_block, compression_mode);
+    auto v2_chunk = CHBlockChunkCodecV1{v2_block.cloneEmpty(), MPPDataPacketV2}.encode(v2_block, compression_mode);
+
+    CHBlockChunkDecodeAndSquash decoder(v2_block.cloneEmpty(), 8);
+    ASSERT_FALSE(decoder.decodeAndSquashV1(legacy_chunk));
+    auto result = decoder.decodeAndSquashV1(v2_chunk);
+    ASSERT_TRUE(result);
+    ASSERT_EQ(result->rows(), legacy_block.rows() + v2_block.rows());
+    ASSERT_EQ(result->getByPosition(0).type->getName(), DataTypeString::NameV2);
+    ASSERT_EQ(result->getByPosition(1).type->getName(), DataTypeString::NullableNameV2);
+    for (size_t i = 0; i < result->columns(); ++i)
+    {
+        for (size_t row = 0; row < legacy_block.rows(); ++row)
+            ASSERT_EQ(
+                legacy_block.getByPosition(i).column->operator[](row),
+                result->getByPosition(i).column->operator[](row));
+        for (size_t row = 0; row < v2_block.rows(); ++row)
+            ASSERT_EQ(
+                v2_block.getByPosition(i).column->operator[](row),
+                result->getByPosition(i).column->operator[](legacy_block.rows() + row));
+    }
+}
+CATCH
 } // namespace DB::tests


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #11017 

Problem Summary:
Decode failed for String and StringV2 in same Block column.

### What is changed and how it works?

```commit-message
copr: fix chunk decode for String & StringV2
```
Tolerate StringV2 & String format co-exists in columnar block read String and computing-layer header block StringV2.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```

### Manual Test
1. Restore dataset tpcds10 to cluster.
2. Run tpcds69 query 10000 times without exception.
```
select 
  cd_gender,
  cd_marital_status,
  cd_education_status,
  count(*) cnt1,
  cd_purchase_estimate,
  count(*) cnt2,
  cd_credit_rating,
  count(*) cnt3
 from
  customer c,customer_address ca,customer_demographics
 where
  c.c_current_addr_sk = ca.ca_address_sk and
  ca_state in ('CO','IL','MN') and
  cd_demo_sk = c.c_current_cdemo_sk and
  exists (select *
          from store_sales,date_dim
          where c.c_customer_sk = ss_customer_sk and
                ss_sold_date_sk = d_date_sk and
                d_year = 1999 and
                d_moy between 1 and 1+2) and
   (not exists (select *
            from web_sales,date_dim
            where c.c_customer_sk = ws_bill_customer_sk and
                  ws_sold_date_sk = d_date_sk and
                  d_year = 1999 and
                  d_moy between 1 and 1+2) and
    not exists (select *
            from catalog_sales,date_dim
            where c.c_customer_sk = cs_ship_customer_sk and
                  cs_sold_date_sk = d_date_sk and
                  d_year = 1999 and
                  d_moy between 1 and 1+2))
 group by cd_gender,
          cd_marital_status,
          cd_education_status,
          cd_purchase_estimate,
          cd_credit_rating
 order by cd_gender,
          cd_marital_status,
          cd_education_status,
          cd_purchase_estimate,
          cd_credit_rating
 limit 100;
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Improved processing of mixed-format data chunks, allowing legacy and current string representations to be combined correctly.
- Preserved all rows and values during chunk decoding and consolidation.
- Ensured resulting string columns use the current format consistently.

## Tests
- Added coverage validating successful consolidation of chunks with different string formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->