### PR TITLE
cmake: make sure use v2x.x.x version for nextgen

### DIFF
--- a/dbms/cmake/version.cmake
+++ b/dbms/cmake/version.cmake
@@ -19,14 +19,36 @@ set (TIFLASH_NAME "TiFlash")
 # Release version that follows PD/TiKV/TiDB convention.
 # Variables bellow are important, use `COMMAND_ERROR_IS_FATAL ANY`(since cmake 3.19) to confirm that there is output.
 
-execute_process(
-  # Do not execute with --dirty, because checking dirty state is extremely slow.
-  COMMAND git describe --tags --always
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-  OUTPUT_VARIABLE TIFLASH_RELEASE_VERSION
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-  COMMAND_ERROR_IS_FATAL ANY
-  )
+if (ENABLE_NEXT_GEN)
+  set(TIFLASH_NEXT_GEN_DEFAULT_VERSION "v27.0.0-pre" CACHE STRING
+      "Fallback release version for next-gen builds")
+
+  # Prefer a next-gen release tag when it is reachable from the current commit.
+  # Development branches may not contain a next-gen tag, so use the default
+  # next-gen version when Git returns a commit hash or an unrelated tag.
+  execute_process(
+    COMMAND git describe --tags --always
+            --match "v2[0-9].*"
+            --match "v3[0-9].*"
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE TIFLASH_RELEASE_VERSION
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    COMMAND_ERROR_IS_FATAL ANY
+    )
+
+  if (NOT "${TIFLASH_RELEASE_VERSION}" MATCHES "^v(2[0-9]|3[0-9])\\.[0-9]+\\.[0-9]+([-.].*)?$")
+    set(TIFLASH_RELEASE_VERSION "${TIFLASH_NEXT_GEN_DEFAULT_VERSION}")
+  endif ()
+else ()
+  execute_process(
+    # Do not execute with --dirty, because checking dirty state is extremely slow.
+    COMMAND git describe --tags --always
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE TIFLASH_RELEASE_VERSION
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    COMMAND_ERROR_IS_FATAL ANY
+    )
+endif ()
 
 # Extract the major version number
 string(REGEX REPLACE "^v([0-9]+).*" "\\1" TIFLASH_VERSION_MAJOR ${TIFLASH_RELEASE_VERSION})
@@ -35,7 +57,8 @@ string(REGEX REPLACE "^v[0-9]+\\.([0-9]+).*" "\\1" TIFLASH_VERSION_MINOR ${TIFLA
 # Extract the patch version number
 string(REGEX REPLACE "^v[0-9]+\\.[0-9]+\\.([0-9]+).*" "\\1" TIFLASH_VERSION_PATCH ${TIFLASH_RELEASE_VERSION})
 # Extract the extra information if it exists
-if (${TIFLASH_RELEASE_VERSION} MATCHES "-.*")
+set(TIFLASH_VERSION_EXTRA "")
+if ("${TIFLASH_RELEASE_VERSION}" MATCHES "-.*")
   string(REGEX REPLACE "^v[0-9]+\\.[0-9]+\\.[0-9]+-(.*)$" "\\1" TIFLASH_VERSION_EXTRA ${TIFLASH_RELEASE_VERSION})
   set(TIFLASH_VERSION "${TIFLASH_VERSION_MAJOR}.${TIFLASH_VERSION_MINOR}.${TIFLASH_VERSION_PATCH}-${TIFLASH_VERSION_EXTRA}")
 else ()


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #11060 

Problem Summary:
Version incompatiable for binary built from master with `ENABLE_NEXT_GEN`.

### What is changed and how it works?

```commit-message

```
Use another version for next-gen build.

```
  Behavior:

  - ENABLE_NEXT_GEN=OFF
      - Preserves the existing git describe --tags --always behavior.

  - ENABLE_NEXT_GEN=ON
      - Searches only for reachable v20.x.x to v39.x.x tags.
      - Uses a matching tag such as v26.3.10 or v26.3.10-N-g<sha> when available.
      - Falls back to v27.0.0-pre when no matching tag exists.
      - The fallback can be overridden through the TIFLASH_NEXT_GEN_DEFAULT_VERSION CMake cache variable.

  Validation completed:

  - Regular build configuration generated:
    v9.0.0-beta.2.pre-218-gfc9a89cad2

  - Next-gen build configuration generated:
    v27.0.0-pre

  - Next-gen major/minor/patch values are:
    27 / 0 / 0

  - Matching works for v26.3.10 and the release-nextgen-202603 reference.
  - git diff --check passed.

  No existing unrelated worktree changes were modified.
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version detection for next-generation builds by restricting recognized release tags.
  * Added a reliable fallback version when no matching release tag is available.
  * Improved handling of additional version information to ensure consistent version output.

* **Build and Release**
  * Preserved existing version detection behavior for standard builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->