### PR TITLE
build: update cloud-storage-engine to 6222d2dd

### DIFF
--- a/contrib/tiflash-columnar-hub/Cargo.lock
+++ b/contrib/tiflash-columnar-hub/Cargo.lock
@@ -178,7 +178,7 @@ dependencies = [
  "bytes",
  "codec",
  "engine_traits",
- "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git?rev=9327469)",
+ "kvproto",
  "match-template",
  "thiserror 1.0.69",
  "tikv_alloc",
@@ -386,7 +386,7 @@ dependencies = [
  "http 0.2.12",
  "hyper 0.14.26",
  "hyper-tls",
- "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git?rev=9327469)",
+ "kvproto",
  "lazy_static",
  "md5",
  "prometheus",
@@ -1135,7 +1135,7 @@ dependencies = [
  "http 0.2.12",
  "hyper 0.14.26",
  "kvengine",
- "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git?rev=9327469)",
+ "kvproto",
  "pd_client",
  "rand 0.8.6",
  "serde",
@@ -1464,7 +1464,7 @@ dependencies = [
  "derive_more",
  "error_code",
  "futures-io",
- "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git?rev=9327469)",
+ "kvproto",
  "lazy_static",
  "openssl",
  "prometheus",
@@ -1489,7 +1489,7 @@ dependencies = [
  "fxhash",
  "hmac 0.10.1",
  "kvenginepb",
- "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git?rev=9327469)",
+ "kvproto",
  "lazy_static",
  "log",
  "openssl",
@@ -2225,7 +2225,7 @@ dependencies = [
  "futures 0.3.32",
  "futures-util",
  "hex 0.4.3",
- "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git?rev=9327469)",
+ "kvproto",
  "lazy_static",
  "online_config",
  "openssl",
@@ -2252,7 +2252,7 @@ dependencies = [
  "error_code",
  "fail 0.5.1",
  "file_system",
- "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git?rev=9327469)",
+ "kvproto",
  "log_wrappers",
  "protobuf 2.8.0",
  "quick_cache",
@@ -2333,7 +2333,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2341,7 +2341,7 @@ name = "error_code"
 version = "0.0.1"
 dependencies = [
  "grpcio",
- "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git?rev=9327469)",
+ "kvproto",
  "lazy_static",
  "raft",
  "serde",
@@ -3540,7 +3540,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3642,7 +3642,7 @@ name = "keys"
 version = "0.1.0"
 dependencies = [
  "byteorder",
- "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git?rev=9327469)",
+ "kvproto",
  "log_wrappers",
  "thiserror 1.0.69",
  "tikv_alloc",
@@ -3702,7 +3702,7 @@ dependencies = [
  "itertools 0.10.5",
  "keys",
  "kvenginepb",
- "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git?rev=9327469)",
+ "kvproto",
  "lazy_static",
  "libc",
  "log_wrappers",
@@ -3764,19 +3764,6 @@ dependencies = [
  "protobuf 2.8.0",
  "protobuf-codegen-pure",
  "workspace-hack",
-]
-
-[[package]]
-name = "kvproto"
-version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git?rev=059694ae4472276644613acccefa24cbc89d959f#059694ae4472276644613acccefa24cbc89d959f"
-dependencies = [
- "bytes",
- "futures 0.3.32",
- "grpcio",
- "protobuf 2.8.0",
- "protobuf-build",
- "raft-proto",
 ]
 
 [[package]]
@@ -4763,7 +4750,7 @@ dependencies = [
  "grpcio",
  "hex 0.4.3",
  "http 0.2.12",
- "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git?rev=9327469)",
+ "kvproto",
  "lazy_static",
  "log",
  "log_wrappers",
@@ -5850,7 +5837,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5863,7 +5850,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6001,7 +5988,7 @@ dependencies = [
  "hyper 1.10.1",
  "hyper-rustls",
  "hyper-util",
- "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git?rev=9327469)",
+ "kvproto",
  "lazy_static",
  "prometheus",
  "rustls",
@@ -6049,7 +6036,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6919,7 +6906,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7039,7 +7026,7 @@ dependencies = [
  "derive_more",
  "error_code",
  "futures 0.3.32",
- "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git?rev=9327469)",
+ "kvproto",
  "lazy_static",
  "log_wrappers",
  "maybe-async",
@@ -7073,7 +7060,7 @@ dependencies = [
  "encoding_rs 0.8.29",
  "error_code",
  "hex 0.4.3",
- "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git?rev=9327469)",
+ "kvproto",
  "lazy_static",
  "log_wrappers",
  "match-template",
@@ -7117,7 +7104,7 @@ dependencies = [
  "keys",
  "kvengine",
  "kvenginepb",
- "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git?rev=059694ae4472276644613acccefa24cbc89d959f)",
+ "kvproto",
  "lazy_static",
  "num_cpus",
  "pd_client",
@@ -7234,7 +7221,7 @@ dependencies = [
  "grpcio",
  "http 0.2.12",
  "hyper 0.14.26",
- "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git?rev=9327469)",
+ "kvproto",
  "lazy_static",
  "libc",
  "log",
@@ -7662,7 +7649,7 @@ version = "0.0.1"
 dependencies = [
  "collections",
  "crossbeam-utils",
- "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git?rev=9327469)",
+ "kvproto",
  "lazy_static",
  "parking_lot 0.12.5",
  "pin-project",
@@ -7700,7 +7687,7 @@ dependencies = [
  "collections",
  "error_code",
  "farmhash",
- "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git?rev=9327469)",
+ "kvproto",
  "log_wrappers",
  "slog",
  "thiserror 1.0.69",
@@ -8133,7 +8120,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/contrib/tiflash-columnar-hub/Cargo.lock
+++ b/contrib/tiflash-columnar-hub/Cargo.lock
@@ -178,7 +178,7 @@ dependencies = [
  "bytes",
  "codec",
  "engine_traits",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git?rev=9327469)",
  "match-template",
  "thiserror 1.0.69",
  "tikv_alloc",
@@ -386,7 +386,7 @@ dependencies = [
  "http 0.2.12",
  "hyper 0.14.26",
  "hyper-tls",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git?rev=9327469)",
  "lazy_static",
  "md5",
  "prometheus",
@@ -1135,7 +1135,7 @@ dependencies = [
  "http 0.2.12",
  "hyper 0.14.26",
  "kvengine",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git?rev=9327469)",
  "pd_client",
  "rand 0.8.6",
  "serde",
@@ -1464,7 +1464,7 @@ dependencies = [
  "derive_more",
  "error_code",
  "futures-io",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git?rev=9327469)",
  "lazy_static",
  "openssl",
  "prometheus",
@@ -1489,7 +1489,7 @@ dependencies = [
  "fxhash",
  "hmac 0.10.1",
  "kvenginepb",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git?rev=9327469)",
  "lazy_static",
  "log",
  "openssl",
@@ -2225,7 +2225,7 @@ dependencies = [
  "futures 0.3.32",
  "futures-util",
  "hex 0.4.3",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git?rev=9327469)",
  "lazy_static",
  "online_config",
  "openssl",
@@ -2252,7 +2252,7 @@ dependencies = [
  "error_code",
  "fail 0.5.1",
  "file_system",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git?rev=9327469)",
  "log_wrappers",
  "protobuf 2.8.0",
  "quick_cache",
@@ -2341,7 +2341,7 @@ name = "error_code"
 version = "0.0.1"
 dependencies = [
  "grpcio",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git?rev=9327469)",
  "lazy_static",
  "raft",
  "serde",
@@ -3642,7 +3642,7 @@ name = "keys"
 version = "0.1.0"
 dependencies = [
  "byteorder",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git?rev=9327469)",
  "log_wrappers",
  "thiserror 1.0.69",
  "tikv_alloc",
@@ -3658,7 +3658,6 @@ dependencies = [
  "aliyun",
  "anyhow",
  "api_version",
- "arc-swap 1.9.1",
  "arrow-buffer",
  "async-once-cell",
  "async-recursion 1.1.1",
@@ -3703,7 +3702,7 @@ dependencies = [
  "itertools 0.10.5",
  "keys",
  "kvenginepb",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git?rev=9327469)",
  "lazy_static",
  "libc",
  "log_wrappers",
@@ -3771,6 +3770,19 @@ dependencies = [
 name = "kvproto"
 version = "0.0.2"
 source = "git+https://github.com/pingcap/kvproto.git?rev=059694ae4472276644613acccefa24cbc89d959f#059694ae4472276644613acccefa24cbc89d959f"
+dependencies = [
+ "bytes",
+ "futures 0.3.32",
+ "grpcio",
+ "protobuf 2.8.0",
+ "protobuf-build",
+ "raft-proto",
+]
+
+[[package]]
+name = "kvproto"
+version = "0.0.2"
+source = "git+https://github.com/pingcap/kvproto.git?rev=9327469#9327469bb3ce7bec31507d3090b39d2127f019d3"
 dependencies = [
  "bytes",
  "futures 0.3.32",
@@ -4751,7 +4763,7 @@ dependencies = [
  "grpcio",
  "hex 0.4.3",
  "http 0.2.12",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git?rev=9327469)",
  "lazy_static",
  "log",
  "log_wrappers",
@@ -5989,7 +6001,7 @@ dependencies = [
  "hyper 1.10.1",
  "hyper-rustls",
  "hyper-util",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git?rev=9327469)",
  "lazy_static",
  "prometheus",
  "rustls",
@@ -7027,7 +7039,7 @@ dependencies = [
  "derive_more",
  "error_code",
  "futures 0.3.32",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git?rev=9327469)",
  "lazy_static",
  "log_wrappers",
  "maybe-async",
@@ -7061,7 +7073,7 @@ dependencies = [
  "encoding_rs 0.8.29",
  "error_code",
  "hex 0.4.3",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git?rev=9327469)",
  "lazy_static",
  "log_wrappers",
  "match-template",
@@ -7105,7 +7117,7 @@ dependencies = [
  "keys",
  "kvengine",
  "kvenginepb",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git?rev=059694ae4472276644613acccefa24cbc89d959f)",
  "lazy_static",
  "num_cpus",
  "pd_client",
@@ -7222,7 +7234,7 @@ dependencies = [
  "grpcio",
  "http 0.2.12",
  "hyper 0.14.26",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git?rev=9327469)",
  "lazy_static",
  "libc",
  "log",
@@ -7650,7 +7662,7 @@ version = "0.0.1"
 dependencies = [
  "collections",
  "crossbeam-utils",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git?rev=9327469)",
  "lazy_static",
  "parking_lot 0.12.5",
  "pin-project",
@@ -7674,7 +7686,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.7.3",
+ "rand 0.8.6",
  "static_assertions",
 ]
 
@@ -7688,7 +7700,7 @@ dependencies = [
  "collections",
  "error_code",
  "farmhash",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git?rev=9327469)",
  "log_wrappers",
  "slog",
  "thiserror 1.0.69",

--- a/contrib/tiflash-columnar-hub/Cargo.toml
+++ b/contrib/tiflash-columnar-hub/Cargo.toml
@@ -10,7 +10,7 @@ cloud_encryption = { git = "https://github.com/tidbcloud/cloud-storage-engine.gi
 keys = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", branch = "cloud-engine" }
 kvengine = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", branch = "cloud-engine" }
 kvenginepb = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", branch = "cloud-engine" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", rev = "059694ae4472276644613acccefa24cbc89d959f" }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", rev = "9327469" }
 pd_client = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", branch = "cloud-engine", default-features = false }
 prometheus = { version = "=0.13.0", features = ["nightly", "push"], default-features = true }
 security = { git = "https://github.com/tidbcloud/cloud-storage-engine.git", branch = "cloud-engine", default-features = false }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #11057

Problem Summary:

TiFlash needs the latest cloud-storage-engine updates on the cloud-engine branch, including the explicit initial FTS field layout.

### What is changed and how it works?

Update the contrib/cloud-storage-engine submodule from 1d499d0bf424a84750967ff22331a948b47bde48 to 6222d2dd10be219f658dbe1ebcbe311b5a03c5b4.

```commit-message
build: update cloud-storage-engine to 6222d2dd
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Verified that the submodule HEAD resolves exactly to 6222d2dd10be219f658dbe1ebcbe311b5a03c5b4 and ran git diff --check.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores

- Updated cloud storage and columnar data integrations to newer revisions.
- Included the latest maintenance improvements and compatibility updates for these components.
- No changes were made to public APIs, configuration, or user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->