### PR TITLE
executor: report hash table stats to TiDB

### DIFF
--- a/dbms/src/Flash/Coprocessor/DAGContext.h
+++ b/dbms/src/Flash/Coprocessor/DAGContext.h
@@ -70,6 +70,9 @@ struct JoinProfileInfo
     UInt64 peak_build_bytes_usage = 0;
     bool is_spill_enabled = false;
     bool is_spilled = false;
+    bool has_hash_table_stats = false;
+    UInt64 hash_table_rows = 0;
+    UInt64 hash_table_bytes = 0;
 };
 using JoinProfileInfoPtr = std::shared_ptr<JoinProfileInfo>;
 struct JoinExecuteInfo

--- a/dbms/src/Flash/Coprocessor/DAGContext.h
+++ b/dbms/src/Flash/Coprocessor/DAGContext.h
@@ -35,6 +35,7 @@
 #include <Flash/Coprocessor/ColumnarScanContext_fwd.h>
 #include <Flash/Coprocessor/DAGRequest.h>
 #include <Flash/Coprocessor/FineGrainedShuffle.h>
+#include <Flash/Coprocessor/HashTableStats.h>
 #include <Flash/Coprocessor/RuntimeFilterMgr.h>
 #include <Flash/Coprocessor/TablesRegionsInfo.h>
 #include <Flash/Executor/toRU.h>
@@ -47,6 +48,7 @@
 #include <Storages/DeltaMerge/ScanContext_fwd.h>
 
 #include <memory>
+#include <optional>
 #include <unordered_set>
 
 namespace DB
@@ -70,9 +72,8 @@ struct JoinProfileInfo
     UInt64 peak_build_bytes_usage = 0;
     bool is_spill_enabled = false;
     bool is_spilled = false;
-    bool has_hash_table_stats = false;
-    UInt64 hash_table_rows = 0;
-    UInt64 hash_table_bytes = 0;
+    /// Statistics for this physical join. The execution summary keeps one value per executor ID.
+    std::optional<HashTableStats> hash_table_stats;
 };
 using JoinProfileInfoPtr = std::shared_ptr<JoinProfileInfo>;
 struct JoinExecuteInfo

--- a/dbms/src/Flash/Coprocessor/DAGContext.h
+++ b/dbms/src/Flash/Coprocessor/DAGContext.h
@@ -85,8 +85,9 @@ struct JoinProfileInfo
     {
         std::lock_guard lock(hash_table_stats_mutex);
         if (!hash_table_stats)
-            hash_table_stats.emplace();
-        hash_table_stats->merge(stats);
+            hash_table_stats = stats;
+        else
+            hash_table_stats->merge(stats);
     }
 
     std::optional<HashTableStats> getHashTableStats() const

--- a/dbms/src/Flash/Coprocessor/DAGContext.h
+++ b/dbms/src/Flash/Coprocessor/DAGContext.h
@@ -72,8 +72,31 @@ struct JoinProfileInfo
     UInt64 peak_build_bytes_usage = 0;
     bool is_spill_enabled = false;
     bool is_spilled = false;
-    /// Statistics for this physical join. The execution summary keeps one value per executor ID.
+    /// Empty only for a cross join, which does not have a hash table.
     std::optional<HashTableStats> hash_table_stats;
+
+    void setHashTableStats(const HashTableStats & stats)
+    {
+        std::lock_guard lock(hash_table_stats_mutex);
+        hash_table_stats = stats;
+    }
+
+    void mergeHashTableStats(const HashTableStats & stats)
+    {
+        std::lock_guard lock(hash_table_stats_mutex);
+        if (!hash_table_stats)
+            hash_table_stats.emplace();
+        hash_table_stats->merge(stats);
+    }
+
+    std::optional<HashTableStats> getHashTableStats() const
+    {
+        std::lock_guard lock(hash_table_stats_mutex);
+        return hash_table_stats;
+    }
+
+private:
+    mutable std::mutex hash_table_stats_mutex;
 };
 using JoinProfileInfoPtr = std::shared_ptr<JoinProfileInfo>;
 struct JoinExecuteInfo

--- a/dbms/src/Flash/Coprocessor/ExecutionSummary.cpp
+++ b/dbms/src/Flash/Coprocessor/ExecutionSummary.cpp
@@ -42,6 +42,12 @@ void ExecutionSummary::merge(const ExecutionSummary & other)
     inner_zone_receive_bytes += other.inner_zone_receive_bytes;
     inter_zone_send_bytes += other.inter_zone_send_bytes;
     inter_zone_receive_bytes += other.inter_zone_receive_bytes;
+    if (other.has_hash_table_stats)
+    {
+        has_hash_table_stats = true;
+        hash_table_rows += other.hash_table_rows;
+        hash_table_bytes += other.hash_table_bytes;
+    }
     ru_consumption = mergeRUConsumption(ru_consumption, other.ru_consumption);
     scan_context->merge(*other.scan_context);
     if (other.columnar_scan_context)
@@ -68,6 +74,12 @@ void ExecutionSummary::merge(const tipb::ExecutorExecutionSummary & other)
     inner_zone_receive_bytes += other.tiflash_network_summary().inner_zone_receive_bytes();
     inter_zone_send_bytes += other.tiflash_network_summary().inter_zone_send_bytes();
     inter_zone_receive_bytes += other.tiflash_network_summary().inter_zone_receive_bytes();
+    if (other.has_tiflash_hash_table_stats())
+    {
+        has_hash_table_stats = true;
+        hash_table_rows += other.tiflash_hash_table_stats().ndv();
+        hash_table_bytes += other.tiflash_hash_table_stats().bytes();
+    }
     ru_consumption = mergeRUConsumption(ru_consumption, parseRUConsumption(other));
     if (other.has_tiflash_scan_context())
         scan_context->merge(other.tiflash_scan_context());
@@ -107,6 +119,12 @@ void ExecutionSummary::init(const tipb::ExecutorExecutionSummary & other)
     inner_zone_receive_bytes = other.tiflash_network_summary().inner_zone_receive_bytes();
     inter_zone_send_bytes = other.tiflash_network_summary().inter_zone_send_bytes();
     inter_zone_receive_bytes = other.tiflash_network_summary().inter_zone_receive_bytes();
+    if (other.has_tiflash_hash_table_stats())
+    {
+        has_hash_table_stats = true;
+        hash_table_rows = other.tiflash_hash_table_stats().ndv();
+        hash_table_bytes = other.tiflash_hash_table_stats().bytes();
+    }
     ru_consumption = parseRUConsumption(other);
     if (other.has_tiflash_scan_context())
         scan_context->deserialize(other.tiflash_scan_context());

--- a/dbms/src/Flash/Coprocessor/ExecutionSummary.cpp
+++ b/dbms/src/Flash/Coprocessor/ExecutionSummary.cpp
@@ -42,11 +42,11 @@ void ExecutionSummary::merge(const ExecutionSummary & other)
     inner_zone_receive_bytes += other.inner_zone_receive_bytes;
     inter_zone_send_bytes += other.inter_zone_send_bytes;
     inter_zone_receive_bytes += other.inter_zone_receive_bytes;
-    if (other.has_hash_table_stats)
+    if (other.hash_table_stats)
     {
-        has_hash_table_stats = true;
-        hash_table_rows += other.hash_table_rows;
-        hash_table_bytes += other.hash_table_bytes;
+        if (!hash_table_stats)
+            hash_table_stats.emplace();
+        hash_table_stats->merge(*other.hash_table_stats);
     }
     ru_consumption = mergeRUConsumption(ru_consumption, other.ru_consumption);
     scan_context->merge(*other.scan_context);
@@ -76,9 +76,10 @@ void ExecutionSummary::merge(const tipb::ExecutorExecutionSummary & other)
     inter_zone_receive_bytes += other.tiflash_network_summary().inter_zone_receive_bytes();
     if (other.has_tiflash_hash_table_stats())
     {
-        has_hash_table_stats = true;
-        hash_table_rows += other.tiflash_hash_table_stats().ndv();
-        hash_table_bytes += other.tiflash_hash_table_stats().bytes();
+        if (!hash_table_stats)
+            hash_table_stats.emplace();
+        hash_table_stats->row_count += other.tiflash_hash_table_stats().ndv();
+        hash_table_stats->bytes += other.tiflash_hash_table_stats().bytes();
     }
     ru_consumption = mergeRUConsumption(ru_consumption, parseRUConsumption(other));
     if (other.has_tiflash_scan_context())
@@ -121,9 +122,9 @@ void ExecutionSummary::init(const tipb::ExecutorExecutionSummary & other)
     inter_zone_receive_bytes = other.tiflash_network_summary().inter_zone_receive_bytes();
     if (other.has_tiflash_hash_table_stats())
     {
-        has_hash_table_stats = true;
-        hash_table_rows = other.tiflash_hash_table_stats().ndv();
-        hash_table_bytes = other.tiflash_hash_table_stats().bytes();
+        hash_table_stats = HashTableStats{
+            .row_count = other.tiflash_hash_table_stats().ndv(),
+            .bytes = other.tiflash_hash_table_stats().bytes()};
     }
     ru_consumption = parseRUConsumption(other);
     if (other.has_tiflash_scan_context())

--- a/dbms/src/Flash/Coprocessor/ExecutionSummary.cpp
+++ b/dbms/src/Flash/Coprocessor/ExecutionSummary.cpp
@@ -78,7 +78,7 @@ void ExecutionSummary::merge(const tipb::ExecutorExecutionSummary & other)
     {
         if (!hash_table_stats)
             hash_table_stats.emplace();
-        hash_table_stats->row_count += other.tiflash_hash_table_stats().ndv();
+        hash_table_stats->ndv += other.tiflash_hash_table_stats().ndv();
         hash_table_stats->bytes += other.tiflash_hash_table_stats().bytes();
     }
     ru_consumption = mergeRUConsumption(ru_consumption, parseRUConsumption(other));
@@ -123,7 +123,7 @@ void ExecutionSummary::init(const tipb::ExecutorExecutionSummary & other)
     if (other.has_tiflash_hash_table_stats())
     {
         hash_table_stats = HashTableStats{
-            .row_count = other.tiflash_hash_table_stats().ndv(),
+            .ndv = other.tiflash_hash_table_stats().ndv(),
             .bytes = other.tiflash_hash_table_stats().bytes()};
     }
     ru_consumption = parseRUConsumption(other);

--- a/dbms/src/Flash/Coprocessor/ExecutionSummary.cpp
+++ b/dbms/src/Flash/Coprocessor/ExecutionSummary.cpp
@@ -70,8 +70,9 @@ void ExecutionSummary::merge(const ExecutionSummary & other)
     if (other.hash_table_stats)
     {
         if (!hash_table_stats)
-            hash_table_stats.emplace();
-        hash_table_stats->merge(*other.hash_table_stats);
+            hash_table_stats = other.hash_table_stats;
+        else
+            hash_table_stats->merge(*other.hash_table_stats);
     }
     ru_consumption = mergeRUConsumption(ru_consumption, other.ru_consumption);
     scan_context->merge(*other.scan_context);

--- a/dbms/src/Flash/Coprocessor/ExecutionSummary.cpp
+++ b/dbms/src/Flash/Coprocessor/ExecutionSummary.cpp
@@ -21,6 +21,31 @@
 
 namespace DB
 {
+namespace
+{
+HashTableSizeKind toHashTableSizeKind(tipb::TiFlashHashTableSizeKind size_kind)
+{
+    switch (size_kind)
+    {
+    case tipb::TIFLASH_HASH_TABLE_SIZE_KIND_DISTINCT_KEY_COUNT:
+        return HashTableSizeKind::DistinctKeyCount;
+    case tipb::TIFLASH_HASH_TABLE_SIZE_KIND_BUILD_ROW_COUNT:
+        return HashTableSizeKind::BuildRowCount;
+    default:
+        throw Exception("Unknown TiFlash hash table size kind", ErrorCodes::LOGICAL_ERROR);
+    }
+}
+
+HashTableStats toHashTableStats(const tipb::TiFlashHashTableStats & stats)
+{
+    return {
+        .size = stats.size(),
+        .size_kind = toHashTableSizeKind(stats.size_kind()),
+        .memory_bytes = stats.memory_bytes(),
+    };
+}
+} // namespace
+
 ExecutionSummary::ExecutionSummary()
     : scan_context(std::make_shared<DM::ScanContext>())
 {}
@@ -76,10 +101,11 @@ void ExecutionSummary::merge(const tipb::ExecutorExecutionSummary & other)
     inter_zone_receive_bytes += other.tiflash_network_summary().inter_zone_receive_bytes();
     if (other.has_tiflash_hash_table_stats())
     {
+        const auto other_hash_table_stats = toHashTableStats(other.tiflash_hash_table_stats());
         if (!hash_table_stats)
-            hash_table_stats.emplace();
-        hash_table_stats->ndv += other.tiflash_hash_table_stats().ndv();
-        hash_table_stats->bytes += other.tiflash_hash_table_stats().bytes();
+            hash_table_stats = other_hash_table_stats;
+        else
+            hash_table_stats->merge(other_hash_table_stats);
     }
     ru_consumption = mergeRUConsumption(ru_consumption, parseRUConsumption(other));
     if (other.has_tiflash_scan_context())
@@ -121,11 +147,7 @@ void ExecutionSummary::init(const tipb::ExecutorExecutionSummary & other)
     inter_zone_send_bytes = other.tiflash_network_summary().inter_zone_send_bytes();
     inter_zone_receive_bytes = other.tiflash_network_summary().inter_zone_receive_bytes();
     if (other.has_tiflash_hash_table_stats())
-    {
-        hash_table_stats = HashTableStats{
-            .ndv = other.tiflash_hash_table_stats().ndv(),
-            .bytes = other.tiflash_hash_table_stats().bytes()};
-    }
+        hash_table_stats = toHashTableStats(other.tiflash_hash_table_stats());
     ru_consumption = parseRUConsumption(other);
     if (other.has_tiflash_scan_context())
         scan_context->deserialize(other.tiflash_scan_context());

--- a/dbms/src/Flash/Coprocessor/ExecutionSummary.h
+++ b/dbms/src/Flash/Coprocessor/ExecutionSummary.h
@@ -15,12 +15,14 @@
 #pragma once
 
 #include <Flash/Coprocessor/ColumnarScanContext_fwd.h>
+#include <Flash/Coprocessor/HashTableStats.h>
 #include <Storages/DeltaMerge/ScanContext_fwd.h>
 #include <common/types.h>
 #include <kvproto/resource_manager.pb.h>
 #include <tipb/select.pb.h>
 
 #include <memory>
+#include <optional>
 
 namespace DB
 {
@@ -40,9 +42,9 @@ struct ExecutionSummary
     UInt64 inner_zone_receive_bytes = 0;
     UInt64 inter_zone_send_bytes = 0;
     UInt64 inter_zone_receive_bytes = 0;
-    bool has_hash_table_stats = false;
-    UInt64 hash_table_rows = 0;
-    UInt64 hash_table_bytes = 0;
+    /// This summary belongs to one physical executor, identified by executor_id in the protobuf.
+    /// Therefore each hash-table operator gets an independent value; merge only combines fragments of the same operator.
+    std::optional<HashTableStats> hash_table_stats;
     resource_manager::Consumption ru_consumption{};
 
     DM::ScanContextPtr scan_context;

--- a/dbms/src/Flash/Coprocessor/ExecutionSummary.h
+++ b/dbms/src/Flash/Coprocessor/ExecutionSummary.h
@@ -40,6 +40,9 @@ struct ExecutionSummary
     UInt64 inner_zone_receive_bytes = 0;
     UInt64 inter_zone_send_bytes = 0;
     UInt64 inter_zone_receive_bytes = 0;
+    bool has_hash_table_stats = false;
+    UInt64 hash_table_rows = 0;
+    UInt64 hash_table_bytes = 0;
     resource_manager::Consumption ru_consumption{};
 
     DM::ScanContextPtr scan_context;

--- a/dbms/src/Flash/Coprocessor/HashTableStats.h
+++ b/dbms/src/Flash/Coprocessor/HashTableStats.h
@@ -1,0 +1,34 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <common/types.h>
+
+namespace DB
+{
+/// Statistics for one hash table owned by a physical hash-table operator.
+struct HashTableStats
+{
+    /// The protocol field is named `ndv` for compatibility, but stores the number of rows in the hash table.
+    UInt64 row_count = 0;
+    UInt64 bytes = 0;
+
+    void merge(const HashTableStats & other)
+    {
+        row_count += other.row_count;
+        bytes += other.bytes;
+    }
+};
+} // namespace DB

--- a/dbms/src/Flash/Coprocessor/HashTableStats.h
+++ b/dbms/src/Flash/Coprocessor/HashTableStats.h
@@ -14,23 +14,31 @@
 
 #pragma once
 
+#include <Common/Exception.h>
 #include <common/types.h>
 
 namespace DB
 {
+enum class HashTableSizeKind : UInt8
+{
+    DistinctKeyCount,
+    BuildRowCount,
+};
+
 /// Statistics for one hash table owned by a physical hash-table operator.
 struct HashTableStats
 {
-    /// The protocol field is named `ndv`, but its executor-specific meaning is intentionally different:
     /// Join V1 reports distinct hash entries, while Join V2 reports build-side row count because its
     /// pointer table does not maintain a distinct-key count. This is the current by-design behavior.
-    UInt64 ndv = 0;
-    UInt64 bytes = 0;
+    UInt64 size = 0;
+    HashTableSizeKind size_kind = HashTableSizeKind::DistinctKeyCount;
+    UInt64 memory_bytes = 0;
 
     void merge(const HashTableStats & other)
     {
-        ndv += other.ndv;
-        bytes += other.bytes;
+        RUNTIME_CHECK(size_kind == other.size_kind);
+        size += other.size;
+        memory_bytes += other.memory_bytes;
     }
 };
 } // namespace DB

--- a/dbms/src/Flash/Coprocessor/HashTableStats.h
+++ b/dbms/src/Flash/Coprocessor/HashTableStats.h
@@ -21,13 +21,14 @@ namespace DB
 /// Statistics for one hash table owned by a physical hash-table operator.
 struct HashTableStats
 {
-    /// The protocol field is named `ndv` for compatibility, but stores the number of rows in the hash table.
-    UInt64 row_count = 0;
+    /// The protocol field is named `ndv`. For Join V1 this is the number of distinct hash entries;
+    /// for Join V2 this is the number of build-side rows used to size the hash table.
+    UInt64 ndv = 0;
     UInt64 bytes = 0;
 
     void merge(const HashTableStats & other)
     {
-        row_count += other.row_count;
+        ndv += other.ndv;
         bytes += other.bytes;
     }
 };

--- a/dbms/src/Flash/Coprocessor/HashTableStats.h
+++ b/dbms/src/Flash/Coprocessor/HashTableStats.h
@@ -21,8 +21,9 @@ namespace DB
 /// Statistics for one hash table owned by a physical hash-table operator.
 struct HashTableStats
 {
-    /// The protocol field is named `ndv`. For Join V1 this is the number of distinct hash entries;
-    /// for Join V2 this is the number of build-side rows used to size the hash table.
+    /// The protocol field is named `ndv`, but its executor-specific meaning is intentionally different:
+    /// Join V1 reports distinct hash entries, while Join V2 reports build-side row count because its
+    /// pointer table does not maintain a distinct-key count. This is the current by-design behavior.
     UInt64 ndv = 0;
     UInt64 bytes = 0;
 

--- a/dbms/src/Flash/Statistics/ExecutionSummaryHelper.cpp
+++ b/dbms/src/Flash/Statistics/ExecutionSummaryHelper.cpp
@@ -32,11 +32,11 @@ void fillTiExecutionSummary(
     execution_summary->set_num_produced_rows(current.num_produced_rows);
     execution_summary->set_num_iterations(current.num_iterations);
     execution_summary->set_concurrency(current.concurrency);
-    if (current.has_hash_table_stats)
+    if (current.hash_table_stats)
     {
         auto * hash_table_stats = execution_summary->mutable_tiflash_hash_table_stats();
-        hash_table_stats->set_ndv(current.hash_table_rows);
-        hash_table_stats->set_bytes(current.hash_table_bytes);
+        hash_table_stats->set_ndv(current.hash_table_stats->row_count);
+        hash_table_stats->set_bytes(current.hash_table_stats->bytes);
     }
     if (current.columnar_scan_context)
         execution_summary->mutable_columnar_scan_context()->CopyFrom(current.columnar_scan_context->serialize());

--- a/dbms/src/Flash/Statistics/ExecutionSummaryHelper.cpp
+++ b/dbms/src/Flash/Statistics/ExecutionSummaryHelper.cpp
@@ -32,6 +32,12 @@ void fillTiExecutionSummary(
     execution_summary->set_num_produced_rows(current.num_produced_rows);
     execution_summary->set_num_iterations(current.num_iterations);
     execution_summary->set_concurrency(current.concurrency);
+    if (current.has_hash_table_stats)
+    {
+        auto * hash_table_stats = execution_summary->mutable_tiflash_hash_table_stats();
+        hash_table_stats->set_ndv(current.hash_table_rows);
+        hash_table_stats->set_bytes(current.hash_table_bytes);
+    }
     if (current.columnar_scan_context)
         execution_summary->mutable_columnar_scan_context()->CopyFrom(current.columnar_scan_context->serialize());
     else

--- a/dbms/src/Flash/Statistics/ExecutionSummaryHelper.cpp
+++ b/dbms/src/Flash/Statistics/ExecutionSummaryHelper.cpp
@@ -35,8 +35,12 @@ void fillTiExecutionSummary(
     if (current.hash_table_stats)
     {
         auto * hash_table_stats = execution_summary->mutable_tiflash_hash_table_stats();
-        hash_table_stats->set_ndv(current.hash_table_stats->ndv);
-        hash_table_stats->set_bytes(current.hash_table_stats->bytes);
+        hash_table_stats->set_size(current.hash_table_stats->size);
+        hash_table_stats->set_size_kind(
+            current.hash_table_stats->size_kind == HashTableSizeKind::DistinctKeyCount
+                ? tipb::TIFLASH_HASH_TABLE_SIZE_KIND_DISTINCT_KEY_COUNT
+                : tipb::TIFLASH_HASH_TABLE_SIZE_KIND_BUILD_ROW_COUNT);
+        hash_table_stats->set_memory_bytes(current.hash_table_stats->memory_bytes);
     }
     if (current.columnar_scan_context)
         execution_summary->mutable_columnar_scan_context()->CopyFrom(current.columnar_scan_context->serialize());

--- a/dbms/src/Flash/Statistics/ExecutionSummaryHelper.cpp
+++ b/dbms/src/Flash/Statistics/ExecutionSummaryHelper.cpp
@@ -35,7 +35,7 @@ void fillTiExecutionSummary(
     if (current.hash_table_stats)
     {
         auto * hash_table_stats = execution_summary->mutable_tiflash_hash_table_stats();
-        hash_table_stats->set_ndv(current.hash_table_stats->row_count);
+        hash_table_stats->set_ndv(current.hash_table_stats->ndv);
         hash_table_stats->set_bytes(current.hash_table_stats->bytes);
     }
     if (current.columnar_scan_context)

--- a/dbms/src/Flash/Statistics/ExecutorStatisticsBase.h
+++ b/dbms/src/Flash/Statistics/ExecutorStatisticsBase.h
@@ -18,6 +18,8 @@
 
 namespace DB
 {
+struct ExecutionSummary;
+
 class ExecutorStatisticsBase
 {
 public:
@@ -28,6 +30,8 @@ public:
     virtual void setChildren(const std::vector<String> & children) = 0;
 
     virtual void collectRuntimeDetail() = 0;
+
+    virtual void fillExtraExecutionSummary(ExecutionSummary &) const {}
 
     bool isSourceExecutor() const { return is_source_executor; }
 

--- a/dbms/src/Flash/Statistics/ExecutorStatisticsCollector.cpp
+++ b/dbms/src/Flash/Statistics/ExecutorStatisticsCollector.cpp
@@ -197,6 +197,7 @@ void ExecutorStatisticsCollector::fillExecutionSummary(
     {
         current.time_minTSO_wait_ns = dag_context->minTSO_wait_time_ns;
     }
+    profiles.at(executor_id)->fillExtraExecutionSummary(current);
     fillTiExecutionSummary(
         *dag_context,
         response.add_execution_summaries(),

--- a/dbms/src/Flash/Statistics/JoinImpl.cpp
+++ b/dbms/src/Flash/Statistics/JoinImpl.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Flash/Coprocessor/ExecutionSummary.h>
 #include <Flash/Statistics/JoinImpl.h>
 #include <Interpreters/Join.h>
 
@@ -46,6 +47,9 @@ void JoinStatistics::collectExtraRuntimeDetail()
         build_side_child = join_execute_info.build_side_root_executor_id;
         is_spill_enabled = join_execute_info.join_profile_info->is_spill_enabled;
         is_spilled = join_execute_info.join_profile_info->is_spilled;
+        has_hash_table_stats = join_execute_info.join_profile_info->has_hash_table_stats;
+        hash_table_rows = join_execute_info.join_profile_info->hash_table_rows;
+        hash_table_bytes = join_execute_info.join_profile_info->hash_table_bytes;
         switch (dag_context.getExecutionMode())
         {
         case ExecutionMode::None:
@@ -62,6 +66,16 @@ void JoinStatistics::collectExtraRuntimeDetail()
                 join_build_base.append(*join_build_profile_info);
             break;
         }
+    }
+}
+
+void JoinStatistics::fillExtraExecutionSummary(ExecutionSummary & summary) const
+{
+    if (has_hash_table_stats)
+    {
+        summary.has_hash_table_stats = true;
+        summary.hash_table_rows = hash_table_rows;
+        summary.hash_table_bytes = hash_table_bytes;
     }
 }
 

--- a/dbms/src/Flash/Statistics/JoinImpl.cpp
+++ b/dbms/src/Flash/Statistics/JoinImpl.cpp
@@ -47,9 +47,7 @@ void JoinStatistics::collectExtraRuntimeDetail()
         build_side_child = join_execute_info.build_side_root_executor_id;
         is_spill_enabled = join_execute_info.join_profile_info->is_spill_enabled;
         is_spilled = join_execute_info.join_profile_info->is_spilled;
-        has_hash_table_stats = join_execute_info.join_profile_info->has_hash_table_stats;
-        hash_table_rows = join_execute_info.join_profile_info->hash_table_rows;
-        hash_table_bytes = join_execute_info.join_profile_info->hash_table_bytes;
+        hash_table_stats = join_execute_info.join_profile_info->hash_table_stats;
         switch (dag_context.getExecutionMode())
         {
         case ExecutionMode::None:
@@ -71,12 +69,8 @@ void JoinStatistics::collectExtraRuntimeDetail()
 
 void JoinStatistics::fillExtraExecutionSummary(ExecutionSummary & summary) const
 {
-    if (has_hash_table_stats)
-    {
-        summary.has_hash_table_stats = true;
-        summary.hash_table_rows = hash_table_rows;
-        summary.hash_table_bytes = hash_table_bytes;
-    }
+    if (hash_table_stats)
+        summary.hash_table_stats = hash_table_stats;
 }
 
 JoinStatistics::JoinStatistics(const tipb::Executor * executor, DAGContext & dag_context_)

--- a/dbms/src/Flash/Statistics/JoinImpl.cpp
+++ b/dbms/src/Flash/Statistics/JoinImpl.cpp
@@ -47,7 +47,7 @@ void JoinStatistics::collectExtraRuntimeDetail()
         build_side_child = join_execute_info.build_side_root_executor_id;
         is_spill_enabled = join_execute_info.join_profile_info->is_spill_enabled;
         is_spilled = join_execute_info.join_profile_info->is_spilled;
-        hash_table_stats = join_execute_info.join_profile_info->hash_table_stats;
+        hash_table_stats = join_execute_info.join_profile_info->getHashTableStats();
         switch (dag_context.getExecutionMode())
         {
         case ExecutionMode::None:

--- a/dbms/src/Flash/Statistics/JoinImpl.h
+++ b/dbms/src/Flash/Statistics/JoinImpl.h
@@ -14,8 +14,11 @@
 
 #pragma once
 
+#include <Flash/Coprocessor/HashTableStats.h>
 #include <Flash/Statistics/ExecutorStatistics.h>
 #include <tipb/executor.pb.h>
+
+#include <optional>
 
 namespace DB
 {
@@ -42,9 +45,7 @@ private:
     String build_side_child;
     bool is_spill_enabled = false;
     bool is_spilled = false;
-    bool has_hash_table_stats = false;
-    UInt64 hash_table_rows = 0;
-    UInt64 hash_table_bytes = 0;
+    std::optional<HashTableStats> hash_table_stats;
 
     BaseRuntimeStatistics join_build_base;
 

--- a/dbms/src/Flash/Statistics/JoinImpl.h
+++ b/dbms/src/Flash/Statistics/JoinImpl.h
@@ -42,11 +42,15 @@ private:
     String build_side_child;
     bool is_spill_enabled = false;
     bool is_spilled = false;
+    bool has_hash_table_stats = false;
+    UInt64 hash_table_rows = 0;
+    UInt64 hash_table_bytes = 0;
 
     BaseRuntimeStatistics join_build_base;
 
 protected:
     void appendExtraJson(FmtBuffer &) const override;
     void collectExtraRuntimeDetail() override;
+    void fillExtraExecutionSummary(ExecutionSummary &) const override;
 };
 } // namespace DB

--- a/dbms/src/Flash/tests/gtest_execution_summary.cpp
+++ b/dbms/src/Flash/tests/gtest_execution_summary.cpp
@@ -14,6 +14,7 @@
 
 #include <Flash/Mpp/MPPTaskStatistics.h>
 #include <Flash/Mpp/MPPTunnelSet.h>
+#include <Flash/Statistics/ExecutorStatisticsCollector.h>
 #include <Interpreters/Context.h>
 #include <TestUtils/ExecutorTestUtils.h>
 #include <TestUtils/mockExecutor.h>
@@ -57,6 +58,39 @@ public:
     }
 
     static constexpr size_t concurrency = 10;
+
+    void testHashTableStats(bool enable_join_v2)
+    {
+        context.context->getSettingsRef().enable_hash_join_v2 = enable_join_v2;
+        enablePipeline(enable_join_v2);
+
+        auto t1 = context.scan("test_db", "test_table");
+        auto t2 = context.scan("test_db", "test_table");
+        auto request = t1.join(t2, tipb::JoinType::TypeInnerJoin, {col("s1")}).build(context);
+        request->set_collect_execution_summaries(true);
+
+        DAGContext dag_context(*request, "test_execution_summary", concurrency);
+        executeStreams(&dag_context);
+        ExecutorStatisticsCollector statistics_collector("test_execution_summary", true);
+        statistics_collector.initialize(&dag_context);
+        statistics_collector.setLocalRUConsumption(
+            RUConsumption{.cpu_ru = 0.0, .cpu_time_ns = 0, .read_ru = 0.0, .read_bytes = 0});
+        const auto summaries = statistics_collector.genExecutionSummaryResponse().execution_summaries();
+
+        const tipb::ExecutorExecutionSummary * join_summary = nullptr;
+        for (const auto & summary : summaries)
+        {
+            if (summary.has_executor_id() && summary.executor_id() == "Join_2")
+            {
+                join_summary = &summary;
+                break;
+            }
+        }
+        ASSERT_NE(join_summary, nullptr);
+        ASSERT_TRUE(join_summary->has_tiflash_hash_table_stats());
+        ASSERT_EQ(join_summary->tiflash_hash_table_stats().ndv(), 8);
+        ASSERT_GT(join_summary->tiflash_hash_table_stats().bytes(), 0);
+    }
 
 #define WRAP_FOR_EXCUTION_SUMMARY_TEST_BEGIN                                      \
     std::vector<DAGRequestType> type{DAGRequestType::tree, DAGRequestType::list}; \
@@ -150,6 +184,14 @@ try
             {"Join_2", {64, concurrency}}};
         testForExecutionSummary(request, expect);
     }
+}
+CATCH
+
+TEST_F(ExecutionSummaryTestRunner, hashTableStats)
+try
+{
+    testHashTableStats(false);
+    testHashTableStats(true);
 }
 CATCH
 

--- a/dbms/src/Flash/tests/gtest_execution_summary.cpp
+++ b/dbms/src/Flash/tests/gtest_execution_summary.cpp
@@ -15,6 +15,7 @@
 #include <Flash/Mpp/MPPTaskStatistics.h>
 #include <Flash/Mpp/MPPTunnelSet.h>
 #include <Flash/Statistics/ExecutorStatisticsCollector.h>
+#include <Flash/Statistics/traverseExecutors.h>
 #include <Interpreters/Context.h>
 #include <TestUtils/ExecutorTestUtils.h>
 #include <TestUtils/mockExecutor.h>
@@ -90,6 +91,53 @@ public:
         ASSERT_TRUE(join_summary->has_tiflash_hash_table_stats());
         ASSERT_EQ(join_summary->tiflash_hash_table_stats().ndv(), 8);
         ASSERT_GT(join_summary->tiflash_hash_table_stats().bytes(), 0);
+    }
+
+    void testHashTableStatsForMultipleJoins(bool enable_join_v2)
+    {
+        context.context->getSettingsRef().enable_hash_join_v2 = enable_join_v2;
+        enablePipeline(enable_join_v2);
+
+        auto t1 = context.scan("test_db", "test_table");
+        auto t2 = context.scan("test_db", "test_table");
+        auto t3 = context.scan("test_db", "test_table");
+        auto request = t1.join(t2, tipb::JoinType::TypeInnerJoin, {col("s1")})
+                           .join(t3, tipb::JoinType::TypeInnerJoin, {col("s1")})
+                           .build(context);
+        request->set_collect_execution_summaries(true);
+
+        std::vector<String> join_executor_ids;
+        traverseExecutors(request.get(), [&](const tipb::Executor & executor) {
+            if (executor.has_join())
+                join_executor_ids.push_back(executor.executor_id());
+            return true;
+        });
+        ASSERT_EQ(join_executor_ids.size(), 2);
+
+        DAGContext dag_context(*request, "test_execution_summary", concurrency);
+        executeStreams(&dag_context);
+        ExecutorStatisticsCollector statistics_collector("test_execution_summary", true);
+        statistics_collector.initialize(&dag_context);
+        statistics_collector.setLocalRUConsumption(
+            RUConsumption{.cpu_ru = 0.0, .cpu_time_ns = 0, .read_ru = 0.0, .read_bytes = 0});
+        const auto summaries = statistics_collector.genExecutionSummaryResponse().execution_summaries();
+
+        for (const auto & join_executor_id : join_executor_ids)
+        {
+            const tipb::ExecutorExecutionSummary * join_summary = nullptr;
+            for (const auto & summary : summaries)
+            {
+                if (summary.has_executor_id() && summary.executor_id() == join_executor_id)
+                {
+                    join_summary = &summary;
+                    break;
+                }
+            }
+            ASSERT_NE(join_summary, nullptr);
+            ASSERT_TRUE(join_summary->has_tiflash_hash_table_stats());
+            ASSERT_EQ(join_summary->tiflash_hash_table_stats().ndv(), 8);
+            ASSERT_GT(join_summary->tiflash_hash_table_stats().bytes(), 0);
+        }
     }
 
 #define WRAP_FOR_EXCUTION_SUMMARY_TEST_BEGIN                                      \
@@ -192,6 +240,14 @@ try
 {
     testHashTableStats(false);
     testHashTableStats(true);
+}
+CATCH
+
+TEST_F(ExecutionSummaryTestRunner, hashTableStatsForMultipleJoins)
+try
+{
+    testHashTableStatsForMultipleJoins(false);
+    testHashTableStatsForMultipleJoins(true);
 }
 CATCH
 

--- a/dbms/src/Flash/tests/gtest_execution_summary.cpp
+++ b/dbms/src/Flash/tests/gtest_execution_summary.cpp
@@ -89,8 +89,12 @@ public:
         }
         ASSERT_NE(join_summary, nullptr);
         ASSERT_TRUE(join_summary->has_tiflash_hash_table_stats());
-        ASSERT_EQ(join_summary->tiflash_hash_table_stats().ndv(), enable_join_v2 ? 8 : 1);
-        ASSERT_GT(join_summary->tiflash_hash_table_stats().bytes(), 0);
+        ASSERT_EQ(join_summary->tiflash_hash_table_stats().size(), enable_join_v2 ? 8 : 1);
+        ASSERT_EQ(
+            join_summary->tiflash_hash_table_stats().size_kind(),
+            enable_join_v2 ? tipb::TIFLASH_HASH_TABLE_SIZE_KIND_BUILD_ROW_COUNT
+                           : tipb::TIFLASH_HASH_TABLE_SIZE_KIND_DISTINCT_KEY_COUNT);
+        ASSERT_GT(join_summary->tiflash_hash_table_stats().memory_bytes(), 0);
     }
 
     void testHashTableStatsForMultipleJoins(bool enable_join_v2)
@@ -135,8 +139,12 @@ public:
             }
             ASSERT_NE(join_summary, nullptr);
             ASSERT_TRUE(join_summary->has_tiflash_hash_table_stats());
-            ASSERT_EQ(join_summary->tiflash_hash_table_stats().ndv(), enable_join_v2 ? 8 : 1);
-            ASSERT_GT(join_summary->tiflash_hash_table_stats().bytes(), 0);
+            ASSERT_EQ(join_summary->tiflash_hash_table_stats().size(), enable_join_v2 ? 8 : 1);
+            ASSERT_EQ(
+                join_summary->tiflash_hash_table_stats().size_kind(),
+                enable_join_v2 ? tipb::TIFLASH_HASH_TABLE_SIZE_KIND_BUILD_ROW_COUNT
+                               : tipb::TIFLASH_HASH_TABLE_SIZE_KIND_DISTINCT_KEY_COUNT);
+            ASSERT_GT(join_summary->tiflash_hash_table_stats().memory_bytes(), 0);
         }
     }
 

--- a/dbms/src/Flash/tests/gtest_execution_summary.cpp
+++ b/dbms/src/Flash/tests/gtest_execution_summary.cpp
@@ -89,7 +89,7 @@ public:
         }
         ASSERT_NE(join_summary, nullptr);
         ASSERT_TRUE(join_summary->has_tiflash_hash_table_stats());
-        ASSERT_EQ(join_summary->tiflash_hash_table_stats().ndv(), 8);
+        ASSERT_EQ(join_summary->tiflash_hash_table_stats().ndv(), enable_join_v2 ? 8 : 1);
         ASSERT_GT(join_summary->tiflash_hash_table_stats().bytes(), 0);
     }
 
@@ -135,7 +135,7 @@ public:
             }
             ASSERT_NE(join_summary, nullptr);
             ASSERT_TRUE(join_summary->has_tiflash_hash_table_stats());
-            ASSERT_EQ(join_summary->tiflash_hash_table_stats().ndv(), 8);
+            ASSERT_EQ(join_summary->tiflash_hash_table_stats().ndv(), enable_join_v2 ? 8 : 1);
             ASSERT_GT(join_summary->tiflash_hash_table_stats().bytes(), 0);
         }
     }

--- a/dbms/src/Flash/tests/gtest_spill_join.cpp
+++ b/dbms/src/Flash/tests/gtest_spill_join.cpp
@@ -238,6 +238,41 @@ try
 }
 CATCH
 
+TEST_F(SpillJoinTestRunner, HashTableStatsAfterSpill)
+try
+{
+    context.addMockTable(
+        "hash_table_stats_spill",
+        "probe_table",
+        {{"a", TiDB::TP::TypeLong, false}},
+        {toVec<Int32>("a", {1, 2, 3, 4, 5, 6, 7, 8, 9, 0})});
+    context.addMockTable(
+        "hash_table_stats_spill",
+        "build_table",
+        {{"a", TiDB::TP::TypeLong, false}, {"payload", TiDB::TP::TypeString, false}},
+        {toVec<Int32>("a", {1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 7, 8, 8, 8, 9, 9, 9, 0, 0, 0}),
+         toVec<String>("payload", std::vector<String>(30, String(128, 'x')))});
+
+    auto request
+        = context.scan("hash_table_stats_spill", "probe_table")
+              .join(context.scan("hash_table_stats_spill", "build_table"), tipb::JoinType::TypeInnerJoin, {col("a")})
+              .build(context);
+    request->set_collect_execution_summaries(true);
+    context.context->getSettingsRef().enable_hash_join_v2 = false;
+    context.context->setSetting("max_bytes_before_external_join", Field(static_cast<UInt64>(10000)));
+
+    DAGContext dag_context(*request, "hash_table_stats_spill", 10);
+    executeStreams(&dag_context);
+
+    const auto & join_execute_info = dag_context.getJoinExecuteInfoMap().at("Join_2");
+    ASSERT_TRUE(join_execute_info.join_profile_info->is_spilled);
+    const auto hash_table_stats = join_execute_info.join_profile_info->getHashTableStats();
+    ASSERT_TRUE(hash_table_stats.has_value());
+    ASSERT_EQ(hash_table_stats->ndv, 10);
+    ASSERT_GT(hash_table_stats->bytes, 0);
+}
+CATCH
+
 TEST_F(SpillJoinTestRunner, EmptyHashTableAfterSpillStillReadsProbe)
 try
 {

--- a/dbms/src/Flash/tests/gtest_spill_join.cpp
+++ b/dbms/src/Flash/tests/gtest_spill_join.cpp
@@ -268,8 +268,9 @@ try
     ASSERT_TRUE(join_execute_info.join_profile_info->is_spilled);
     const auto hash_table_stats = join_execute_info.join_profile_info->getHashTableStats();
     ASSERT_TRUE(hash_table_stats.has_value());
-    ASSERT_EQ(hash_table_stats->ndv, 10);
-    ASSERT_GT(hash_table_stats->bytes, 0);
+    ASSERT_EQ(hash_table_stats->size, 10);
+    ASSERT_EQ(hash_table_stats->size_kind, HashTableSizeKind::DistinctKeyCount);
+    ASSERT_GT(hash_table_stats->memory_bytes, 0);
 }
 CATCH
 

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -262,6 +262,25 @@ size_t Join::getTotalHashTableAndPoolByteCount()
     return res;
 }
 
+bool Join::getHashTableStats(UInt64 & row_count, UInt64 & bytes) const
+{
+    if (isCrossJoin(kind) || isSpilled())
+        return false;
+
+    std::shared_lock rw_lock(rwlock);
+    size_t total_rows = 0;
+    size_t total_bytes = 0;
+    for (const auto & partition : partitions)
+    {
+        auto partition_lock = partition->lockPartition();
+        total_rows += partition->getHashTableRowCount();
+        total_bytes += partition->getHashMapAndPoolByteCount();
+    }
+    row_count = total_rows;
+    bytes = total_bytes;
+    return true;
+}
+
 size_t Join::getTotalByteCount()
 {
     size_t res = 0;
@@ -1820,6 +1839,7 @@ void Join::workAfterBuildFinish(size_t stream_index)
         has_build_data_in_memory = !original_blocks.empty();
     }
 
+    finalizeHashTableStats();
     build_side_empty.store(!isSpilled() && getTotalRowCount() == 0, std::memory_order_release);
 }
 
@@ -1888,6 +1908,22 @@ void Join::finalizeProfileInfo()
     profile_info->is_spill_enabled = isEnableSpill();
     profile_info->is_spilled = isSpilled();
     profile_info->peak_build_bytes_usage = getPeakBuildBytesUsage();
+    finalizeHashTableStats();
+}
+
+void Join::finalizeHashTableStats()
+{
+    if (profile_info->has_hash_table_stats)
+        return;
+
+    UInt64 row_count = 0;
+    UInt64 bytes = 0;
+    if (getHashTableStats(row_count, bytes))
+    {
+        profile_info->has_hash_table_stats = true;
+        profile_info->hash_table_rows = row_count;
+        profile_info->hash_table_bytes = bytes;
+    }
 }
 
 void Join::workAfterProbeFinish(size_t stream_index)

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -1913,17 +1913,13 @@ void Join::finalizeProfileInfo()
 
 void Join::finalizeHashTableStats()
 {
-    if (profile_info->has_hash_table_stats)
+    if (profile_info->hash_table_stats)
         return;
 
     UInt64 row_count = 0;
     UInt64 bytes = 0;
     if (getHashTableStats(row_count, bytes))
-    {
-        profile_info->has_hash_table_stats = true;
-        profile_info->hash_table_rows = row_count;
-        profile_info->hash_table_bytes = bytes;
-    }
+        profile_info->hash_table_stats = HashTableStats{.row_count = row_count, .bytes = bytes};
 }
 
 void Join::workAfterProbeFinish(size_t stream_index)

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -277,6 +277,7 @@ bool Join::getHashTableStats(UInt64 & ndv, UInt64 & bytes) const
         if (partition->isSpill())
             continue;
         auto partition_lock = partition->lockPartition();
+        /// Join V1 maps one entry to each distinct join key, so this is the V1 `ndv` by design.
         total_ndv += partition->getRowCount();
         total_bytes += partition->getHashMapAndPoolByteCount();
     }

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -264,7 +264,7 @@ size_t Join::getTotalHashTableAndPoolByteCount()
 
 bool Join::getHashTableStats(UInt64 & ndv, UInt64 & bytes) const
 {
-    if (isCrossJoin(kind) || isSpilled())
+    if (isCrossJoin(kind))
         return false;
 
     std::shared_lock rw_lock(rwlock);
@@ -272,6 +272,10 @@ bool Join::getHashTableStats(UInt64 & ndv, UInt64 & bytes) const
     size_t total_bytes = 0;
     for (const auto & partition : partitions)
     {
+        /// A spilled partition has released its in-memory hash table. Its data will be counted by the
+        /// restore Join after the partition is rebuilt successfully.
+        if (partition->isSpill())
+            continue;
         auto partition_lock = partition->lockPartition();
         total_ndv += partition->getRowCount();
         total_bytes += partition->getHashMapAndPoolByteCount();
@@ -407,6 +411,7 @@ std::shared_ptr<Join> Join::createRestoreJoin(size_t max_bytes_before_external_j
     ret->output_column_names_set_after_finalize = output_column_names_set_after_finalize;
     ret->output_columns_names_set_for_other_condition_after_finalize
         = output_columns_names_set_for_other_condition_after_finalize;
+    ret->profile_info = profile_info;
     ret->required_columns = required_columns;
     ret->output_block_after_finalize = output_block_after_finalize;
     ret->finalized = true;
@@ -1905,21 +1910,31 @@ void Join::finalizeCrossJoinBuild()
 
 void Join::finalizeProfileInfo()
 {
-    profile_info->is_spill_enabled = isEnableSpill();
-    profile_info->is_spilled = isSpilled();
-    profile_info->peak_build_bytes_usage = getPeakBuildBytesUsage();
+    if (!isRestoreJoin())
+    {
+        profile_info->is_spill_enabled = isEnableSpill();
+        profile_info->is_spilled = isSpilled();
+        profile_info->peak_build_bytes_usage = getPeakBuildBytesUsage();
+    }
     finalizeHashTableStats();
 }
 
 void Join::finalizeHashTableStats()
 {
-    if (profile_info->hash_table_stats)
+    if (hash_table_stats_finalized)
         return;
 
     UInt64 ndv = 0;
     UInt64 bytes = 0;
-    if (getHashTableStats(ndv, bytes))
-        profile_info->hash_table_stats = HashTableStats{.ndv = ndv, .bytes = bytes};
+    if (!getHashTableStats(ndv, bytes))
+        return;
+
+    const HashTableStats stats{.ndv = ndv, .bytes = bytes};
+    if (isRestoreJoin())
+        profile_info->mergeHashTableStats(stats);
+    else
+        profile_info->setHashTableStats(stats);
+    hash_table_stats_finalized = true;
 }
 
 void Join::workAfterProbeFinish(size_t stream_index)

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -412,7 +412,7 @@ std::shared_ptr<Join> Join::createRestoreJoin(size_t max_bytes_before_external_j
     ret->output_column_names_set_after_finalize = output_column_names_set_after_finalize;
     ret->output_columns_names_set_for_other_condition_after_finalize
         = output_columns_names_set_for_other_condition_after_finalize;
-    ret->profile_info = profile_info;
+    ret->hash_table_stats_profile_info = hash_table_stats_profile_info;
     ret->required_columns = required_columns;
     ret->output_block_after_finalize = output_block_after_finalize;
     ret->finalized = true;
@@ -1911,12 +1911,9 @@ void Join::finalizeCrossJoinBuild()
 
 void Join::finalizeProfileInfo()
 {
-    if (!isRestoreJoin())
-    {
-        profile_info->is_spill_enabled = isEnableSpill();
-        profile_info->is_spilled = isSpilled();
-        profile_info->peak_build_bytes_usage = getPeakBuildBytesUsage();
-    }
+    profile_info->is_spill_enabled = isEnableSpill();
+    profile_info->is_spilled = isSpilled();
+    profile_info->peak_build_bytes_usage = getPeakBuildBytesUsage();
     finalizeHashTableStats();
 }
 
@@ -1931,10 +1928,9 @@ void Join::finalizeHashTableStats()
         return;
 
     const HashTableStats stats{.ndv = ndv, .bytes = bytes};
+    profile_info->setHashTableStats(stats);
     if (isRestoreJoin())
-        profile_info->mergeHashTableStats(stats);
-    else
-        profile_info->setHashTableStats(stats);
+        hash_table_stats_profile_info->mergeHashTableStats(stats);
     hash_table_stats_finalized = true;
 }
 

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -262,21 +262,21 @@ size_t Join::getTotalHashTableAndPoolByteCount()
     return res;
 }
 
-bool Join::getHashTableStats(UInt64 & row_count, UInt64 & bytes) const
+bool Join::getHashTableStats(UInt64 & ndv, UInt64 & bytes) const
 {
     if (isCrossJoin(kind) || isSpilled())
         return false;
 
     std::shared_lock rw_lock(rwlock);
-    size_t total_rows = 0;
+    size_t total_ndv = 0;
     size_t total_bytes = 0;
     for (const auto & partition : partitions)
     {
         auto partition_lock = partition->lockPartition();
-        total_rows += partition->getHashTableRowCount();
+        total_ndv += partition->getRowCount();
         total_bytes += partition->getHashMapAndPoolByteCount();
     }
-    row_count = total_rows;
+    ndv = total_ndv;
     bytes = total_bytes;
     return true;
 }
@@ -1916,10 +1916,10 @@ void Join::finalizeHashTableStats()
     if (profile_info->hash_table_stats)
         return;
 
-    UInt64 row_count = 0;
+    UInt64 ndv = 0;
     UInt64 bytes = 0;
-    if (getHashTableStats(row_count, bytes))
-        profile_info->hash_table_stats = HashTableStats{.row_count = row_count, .bytes = bytes};
+    if (getHashTableStats(ndv, bytes))
+        profile_info->hash_table_stats = HashTableStats{.ndv = ndv, .bytes = bytes};
 }
 
 void Join::workAfterProbeFinish(size_t stream_index)

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -262,14 +262,14 @@ size_t Join::getTotalHashTableAndPoolByteCount()
     return res;
 }
 
-bool Join::getHashTableStats(UInt64 & ndv, UInt64 & bytes) const
+bool Join::getHashTableStats(UInt64 & size, UInt64 & memory_bytes) const
 {
     if (isCrossJoin(kind))
         return false;
 
     std::shared_lock rw_lock(rwlock);
-    size_t total_ndv = 0;
-    size_t total_bytes = 0;
+    size_t total_size = 0;
+    size_t total_memory_bytes = 0;
     for (const auto & partition : partitions)
     {
         /// A spilled partition has released its in-memory hash table. Its data will be counted by the
@@ -277,12 +277,12 @@ bool Join::getHashTableStats(UInt64 & ndv, UInt64 & bytes) const
         if (partition->isSpill())
             continue;
         auto partition_lock = partition->lockPartition();
-        /// Join V1 maps one entry to each distinct join key, so this is the V1 `ndv` by design.
-        total_ndv += partition->getRowCount();
-        total_bytes += partition->getHashMapAndPoolByteCount();
+        /// Join V1 maps one entry to each distinct join key.
+        total_size += partition->getRowCount();
+        total_memory_bytes += partition->getHashMapAndPoolByteCount();
     }
-    ndv = total_ndv;
-    bytes = total_bytes;
+    size = total_size;
+    memory_bytes = total_memory_bytes;
     return true;
 }
 
@@ -1922,12 +1922,15 @@ void Join::finalizeHashTableStats()
     if (hash_table_stats_finalized)
         return;
 
-    UInt64 ndv = 0;
-    UInt64 bytes = 0;
-    if (!getHashTableStats(ndv, bytes))
+    UInt64 size = 0;
+    UInt64 memory_bytes = 0;
+    if (!getHashTableStats(size, memory_bytes))
         return;
 
-    const HashTableStats stats{.ndv = ndv, .bytes = bytes};
+    const HashTableStats stats{
+        .size = size,
+        .size_kind = HashTableSizeKind::DistinctKeyCount,
+        .memory_bytes = memory_bytes};
     profile_info->setHashTableStats(stats);
     if (isRestoreJoin())
         hash_table_stats_profile_info->mergeHashTableStats(stats);

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -412,7 +412,7 @@ std::shared_ptr<Join> Join::createRestoreJoin(size_t max_bytes_before_external_j
     ret->output_column_names_set_after_finalize = output_column_names_set_after_finalize;
     ret->output_columns_names_set_for_other_condition_after_finalize
         = output_columns_names_set_for_other_condition_after_finalize;
-    ret->hash_table_stats_profile_info = hash_table_stats_profile_info;
+    ret->profile_info = profile_info;
     ret->required_columns = required_columns;
     ret->output_block_after_finalize = output_block_after_finalize;
     ret->finalized = true;
@@ -1911,9 +1911,14 @@ void Join::finalizeCrossJoinBuild()
 
 void Join::finalizeProfileInfo()
 {
-    profile_info->is_spill_enabled = isEnableSpill();
-    profile_info->is_spilled = isSpilled();
-    profile_info->peak_build_bytes_usage = getPeakBuildBytesUsage();
+    if (!isRestoreJoin())
+    {
+        profile_info->is_spill_enabled = isEnableSpill();
+        profile_info->is_spilled = isSpilled();
+        profile_info->peak_build_bytes_usage = getPeakBuildBytesUsage();
+    }
+    // TODO: Aggregate restore join profile fields, such as peak build memory usage, when exposing
+    // them in execution summaries.
     finalizeHashTableStats();
 }
 
@@ -1931,9 +1936,10 @@ void Join::finalizeHashTableStats()
         .size = size,
         .size_kind = HashTableSizeKind::DistinctKeyCount,
         .memory_bytes = memory_bytes};
-    profile_info->setHashTableStats(stats);
     if (isRestoreJoin())
-        hash_table_stats_profile_info->mergeHashTableStats(stats);
+        profile_info->mergeHashTableStats(stats);
+    else
+        profile_info->setHashTableStats(stats);
     hash_table_stats_finalized = true;
 }
 

--- a/dbms/src/Interpreters/Join.h
+++ b/dbms/src/Interpreters/Join.h
@@ -235,6 +235,9 @@ public:
     /// The peak build bytes usage, if spill is not enabled, the same as getTotalByteCount
     size_t getPeakBuildBytesUsage();
 
+    /// Get the number of rows and bytes currently stored in the hash table.
+    bool getHashTableStats(UInt64 & row_count, UInt64 & bytes) const;
+
     void checkAndMarkPartitionSpilledIfNeeded(size_t stream_index);
 
     void checkAndMarkPartitionSpilledIfNeededInternal(
@@ -535,6 +538,7 @@ private:
     void cancelRuntimeFilter(const String & reason);
 
     void finalizeProfileInfo();
+    void finalizeHashTableStats();
 
     void finalizeNullAwareSemiFamilyBuild();
 

--- a/dbms/src/Interpreters/Join.h
+++ b/dbms/src/Interpreters/Join.h
@@ -235,8 +235,8 @@ public:
     /// The peak build bytes usage, if spill is not enabled, the same as getTotalByteCount
     size_t getPeakBuildBytesUsage();
 
-    /// Get the number of rows and bytes currently stored in the hash table.
-    bool getHashTableStats(UInt64 & row_count, UInt64 & bytes) const;
+    /// Get the number of distinct hash entries and bytes currently stored in the hash table.
+    bool getHashTableStats(UInt64 & ndv, UInt64 & bytes) const;
 
     void checkAndMarkPartitionSpilledIfNeeded(size_t stream_index);
 

--- a/dbms/src/Interpreters/Join.h
+++ b/dbms/src/Interpreters/Join.h
@@ -235,7 +235,8 @@ public:
     /// The peak build bytes usage, if spill is not enabled, the same as getTotalByteCount
     size_t getPeakBuildBytesUsage();
 
-    /// Get the number of distinct hash entries and bytes currently stored in the hash table.
+    /// Get the number of distinct hash entries and bytes currently stored in the in-memory hash tables.
+    /// Partitions already spilled to disk are not included.
     bool getHashTableStats(UInt64 & ndv, UInt64 & bytes) const;
 
     void checkAndMarkPartitionSpilledIfNeeded(size_t stream_index);
@@ -336,7 +337,10 @@ public:
     // used to name the column that records matched map entry before other conditions filter
     const String flag_mapped_entry_helper_name;
 
-    const JoinProfileInfoPtr profile_info = std::make_shared<JoinProfileInfo>();
+    JoinProfileInfoPtr profile_info = std::make_shared<JoinProfileInfo>();
+    /// A restore join shares profile_info with its parent. Keep this flag per Join object so every
+    /// completed restore hash table is merged exactly once.
+    bool hash_table_stats_finalized = false;
     HashJoinSpillContextPtr hash_join_spill_context;
     const Block & getOutputBlock() const { return finalized ? output_block_after_finalize : output_block; }
     const Names & getRequiredColumns() const { return required_columns; }

--- a/dbms/src/Interpreters/Join.h
+++ b/dbms/src/Interpreters/Join.h
@@ -337,9 +337,11 @@ public:
     // used to name the column that records matched map entry before other conditions filter
     const String flag_mapped_entry_helper_name;
 
-    JoinProfileInfoPtr profile_info = std::make_shared<JoinProfileInfo>();
-    /// A restore join shares profile_info with its parent. Keep this flag per Join object so every
-    /// completed restore hash table is merged exactly once.
+    const JoinProfileInfoPtr profile_info = std::make_shared<JoinProfileInfo>();
+    /// Restore joins keep their own profile info, but contribute hash table stats to this shared
+    /// profile info after their hash table is successfully built.
+    JoinProfileInfoPtr hash_table_stats_profile_info = profile_info;
+    /// Keep this flag per Join object so every completed restore hash table is merged exactly once.
     bool hash_table_stats_finalized = false;
     HashJoinSpillContextPtr hash_join_spill_context;
     const Block & getOutputBlock() const { return finalized ? output_block_after_finalize : output_block; }

--- a/dbms/src/Interpreters/Join.h
+++ b/dbms/src/Interpreters/Join.h
@@ -235,9 +235,9 @@ public:
     /// The peak build bytes usage, if spill is not enabled, the same as getTotalByteCount
     size_t getPeakBuildBytesUsage();
 
-    /// Get the number of distinct hash entries and bytes currently stored in the in-memory hash tables.
+    /// Get the number of distinct hash entries and memory bytes currently stored in the in-memory hash tables.
     /// Partitions already spilled to disk are not included.
-    bool getHashTableStats(UInt64 & ndv, UInt64 & bytes) const;
+    bool getHashTableStats(UInt64 & size, UInt64 & memory_bytes) const;
 
     void checkAndMarkPartitionSpilledIfNeeded(size_t stream_index);
 

--- a/dbms/src/Interpreters/Join.h
+++ b/dbms/src/Interpreters/Join.h
@@ -337,10 +337,9 @@ public:
     // used to name the column that records matched map entry before other conditions filter
     const String flag_mapped_entry_helper_name;
 
-    const JoinProfileInfoPtr profile_info = std::make_shared<JoinProfileInfo>();
-    /// Restore joins keep their own profile info, but contribute hash table stats to this shared
-    /// profile info after their hash table is successfully built.
-    JoinProfileInfoPtr hash_table_stats_profile_info = profile_info;
+    /// Root and restore joins of the same logical join share one profile. Only the root join updates
+    /// per-instance fields; every join contributes its final hash table stats.
+    JoinProfileInfoPtr profile_info = std::make_shared<JoinProfileInfo>();
     /// Keep this flag per Join object so every completed restore hash table is merged exactly once.
     bool hash_table_stats_finalized = false;
     HashJoinSpillContextPtr hash_join_spill_context;

--- a/dbms/src/Interpreters/JoinPartition.cpp
+++ b/dbms/src/Interpreters/JoinPartition.cpp
@@ -241,14 +241,15 @@ void JoinPartition::updateHashMapAndPoolMemoryUsage()
     hash_table_pool_memory_usage = getHashMapAndPoolByteCount();
 }
 
-size_t JoinPartition::getHashMapAndPoolByteCount()
+size_t JoinPartition::getHashMapAndPoolByteCount() const
 {
     size_t ret = 0;
     ret += getByteCountImpl(maps_any, join_map_method);
     ret += getByteCountImpl(maps_all, join_map_method);
     ret += getByteCountImpl(maps_all_full, join_map_method);
     ret += getByteCountImpl(maps_all_full_with_row_flag, join_map_method);
-    ret += pool->size();
+    if (pool)
+        ret += pool->size();
     return ret;
 }
 
@@ -459,7 +460,7 @@ struct KeyGetterForType
 template <ASTTableJoin::Strictness STRICTNESS, typename Map, typename KeyGetter>
 struct Inserter
 {
-    static void insert(
+    static bool insert(
         Map & map,
         const typename Map::key_type & key,
         Block * stored_block,
@@ -472,7 +473,7 @@ struct Inserter
 template <typename Map, typename KeyGetter>
 struct Inserter<ASTTableJoin::Strictness::Any, Map, KeyGetter>
 {
-    static void insert(
+    static bool insert(
         Map & map,
         KeyGetter & key_getter,
         Block * stored_block,
@@ -488,6 +489,7 @@ struct Inserter<ASTTableJoin::Strictness::Any, Map, KeyGetter>
             if (emplace_result.isInserted())
                 new (&emplace_result.getMapped()) typename Map::mapped_type(stored_block, i);
         }
+        return emplace_result.isInserted();
     }
 };
 
@@ -495,7 +497,7 @@ template <typename Map, typename KeyGetter>
 struct Inserter<ASTTableJoin::Strictness::All, Map, KeyGetter>
 {
     using MappedType = typename Map::mapped_type;
-    static void insert(
+    static bool insert(
         Map & map,
         KeyGetter & key_getter,
         Block * stored_block,
@@ -519,6 +521,7 @@ struct Inserter<ASTTableJoin::Strictness::All, Map, KeyGetter>
             new (elem) typename Map::mapped_type(stored_block, i);
             insertRowToList(pool, &emplace_result.getMapped(), elem, cache_column_threshold);
         }
+        return true;
     }
 };
 
@@ -563,14 +566,15 @@ void NO_INLINE insertBlockIntoMapTypeCase(
             }
         }
 
-        Inserter<STRICTNESS, Map, KeyGetter>::insert(
-            map,
-            key_getter,
-            stored_block,
-            i,
-            pool,
-            sort_key_containers,
-            probe_cache_column_threshold);
+        if (Inserter<STRICTNESS, Map, KeyGetter>::insert(
+                map,
+                key_getter,
+                stored_block,
+                i,
+                pool,
+                sort_key_containers,
+                probe_cache_column_threshold))
+            join_partition.addHashTableRowCount(1);
     }
 }
 
@@ -657,14 +661,15 @@ void NO_INLINE insertBlockIntoMapsTypeCase(
     auto & current_map = (join_partition) -> getHashMap<Map>(); \
     for (auto & s_i : (segment_index))                          \
     {                                                           \
-        Inserter<STRICTNESS, Map, KeyGetter>::insert(           \
-            current_map,                                        \
-            key_getter,                                         \
-            stored_block,                                       \
-            s_i,                                                \
-            pool,                                               \
-            sort_key_containers,                                \
-            probe_cache_column_threshold);                      \
+        if (Inserter<STRICTNESS, Map, KeyGetter>::insert(       \
+                current_map,                                    \
+                key_getter,                                     \
+                stored_block,                                   \
+                s_i,                                            \
+                pool,                                           \
+                sort_key_containers,                            \
+                probe_cache_column_threshold))                  \
+            (join_partition)->addHashTableRowCount(1);          \
     }
 
 #define INSERT_TO_NOT_INSERTED_MAP                                                                      \

--- a/dbms/src/Interpreters/JoinPartition.cpp
+++ b/dbms/src/Interpreters/JoinPartition.cpp
@@ -658,7 +658,7 @@ void NO_INLINE insertBlockIntoMapsTypeCase(
     auto & current_map = (join_partition) -> getHashMap<Map>(); \
     for (auto & s_i : (segment_index))                          \
     {                                                           \
-        Inserter<STRICTNESS, Map, KeyGetter>::insert(            \
+        Inserter<STRICTNESS, Map, KeyGetter>::insert(           \
             current_map,                                        \
             key_getter,                                         \
             stored_block,                                       \

--- a/dbms/src/Interpreters/JoinPartition.cpp
+++ b/dbms/src/Interpreters/JoinPartition.cpp
@@ -460,7 +460,7 @@ struct KeyGetterForType
 template <ASTTableJoin::Strictness STRICTNESS, typename Map, typename KeyGetter>
 struct Inserter
 {
-    static bool insert(
+    static void insert(
         Map & map,
         const typename Map::key_type & key,
         Block * stored_block,
@@ -473,7 +473,7 @@ struct Inserter
 template <typename Map, typename KeyGetter>
 struct Inserter<ASTTableJoin::Strictness::Any, Map, KeyGetter>
 {
-    static bool insert(
+    static void insert(
         Map & map,
         KeyGetter & key_getter,
         Block * stored_block,
@@ -489,7 +489,6 @@ struct Inserter<ASTTableJoin::Strictness::Any, Map, KeyGetter>
             if (emplace_result.isInserted())
                 new (&emplace_result.getMapped()) typename Map::mapped_type(stored_block, i);
         }
-        return emplace_result.isInserted();
     }
 };
 
@@ -497,7 +496,7 @@ template <typename Map, typename KeyGetter>
 struct Inserter<ASTTableJoin::Strictness::All, Map, KeyGetter>
 {
     using MappedType = typename Map::mapped_type;
-    static bool insert(
+    static void insert(
         Map & map,
         KeyGetter & key_getter,
         Block * stored_block,
@@ -521,7 +520,6 @@ struct Inserter<ASTTableJoin::Strictness::All, Map, KeyGetter>
             new (elem) typename Map::mapped_type(stored_block, i);
             insertRowToList(pool, &emplace_result.getMapped(), elem, cache_column_threshold);
         }
-        return true;
     }
 };
 
@@ -566,15 +564,14 @@ void NO_INLINE insertBlockIntoMapTypeCase(
             }
         }
 
-        if (Inserter<STRICTNESS, Map, KeyGetter>::insert(
-                map,
-                key_getter,
-                stored_block,
-                i,
-                pool,
-                sort_key_containers,
-                probe_cache_column_threshold))
-            join_partition.addHashTableRowCount(1);
+        Inserter<STRICTNESS, Map, KeyGetter>::insert(
+            map,
+            key_getter,
+            stored_block,
+            i,
+            pool,
+            sort_key_containers,
+            probe_cache_column_threshold);
     }
 }
 
@@ -661,15 +658,14 @@ void NO_INLINE insertBlockIntoMapsTypeCase(
     auto & current_map = (join_partition) -> getHashMap<Map>(); \
     for (auto & s_i : (segment_index))                          \
     {                                                           \
-        if (Inserter<STRICTNESS, Map, KeyGetter>::insert(       \
-                current_map,                                    \
-                key_getter,                                     \
-                stored_block,                                   \
-                s_i,                                            \
-                pool,                                           \
-                sort_key_containers,                            \
-                probe_cache_column_threshold))                  \
-            (join_partition)->addHashTableRowCount(1);          \
+        Inserter<STRICTNESS, Map, KeyGetter>::insert(            \
+            current_map,                                        \
+            key_getter,                                         \
+            stored_block,                                       \
+            s_i,                                                \
+            pool,                                               \
+            sort_key_containers,                                \
+            probe_cache_column_threshold);                      \
     }
 
 #define INSERT_TO_NOT_INSERTED_MAP                                                                      \

--- a/dbms/src/Interpreters/JoinPartition.h
+++ b/dbms/src/Interpreters/JoinPartition.h
@@ -115,7 +115,9 @@ public:
     void insertBlockForBuild(Block && block);
     void insertBlockForProbe(Block && block);
     size_t getRowCount();
-    size_t getHashMapAndPoolByteCount();
+    size_t getHashTableRowCount() const { return hash_table_row_count; }
+    size_t getHashMapAndPoolByteCount() const;
+    void addHashTableRowCount(size_t count) { hash_table_row_count += count; }
     void setResizeCallbackIfNeeded();
     void updateHashMapAndPoolMemoryUsage();
     size_t getHashMapAndPoolMemoryUsage() const { return hash_table_pool_memory_usage; }
@@ -127,7 +129,7 @@ public:
             return rows_not_inserted_to_map.get();
         }
         return nullptr;
-    };
+    }
     Blocks trySpillProbePartition()
     {
         std::unique_lock lock(partition_mutex);
@@ -265,6 +267,7 @@ private:
     /// all writes to it is protected by lock
     std::atomic<size_t> block_data_memory_usage{0};
     std::atomic<size_t> hash_table_pool_memory_usage{0};
+    size_t hash_table_row_count = 0;
     const LoggerPtr log;
 };
 } // namespace DB

--- a/dbms/src/Interpreters/JoinPartition.h
+++ b/dbms/src/Interpreters/JoinPartition.h
@@ -115,9 +115,7 @@ public:
     void insertBlockForBuild(Block && block);
     void insertBlockForProbe(Block && block);
     size_t getRowCount();
-    size_t getHashTableRowCount() const { return hash_table_row_count; }
     size_t getHashMapAndPoolByteCount() const;
-    void addHashTableRowCount(size_t count) { hash_table_row_count += count; }
     void setResizeCallbackIfNeeded();
     void updateHashMapAndPoolMemoryUsage();
     size_t getHashMapAndPoolMemoryUsage() const { return hash_table_pool_memory_usage; }
@@ -267,7 +265,6 @@ private:
     /// all writes to it is protected by lock
     std::atomic<size_t> block_data_memory_usage{0};
     std::atomic<size_t> hash_table_pool_memory_usage{0};
-    size_t hash_table_row_count = 0;
     const LoggerPtr log;
 };
 } // namespace DB

--- a/dbms/src/Interpreters/JoinV2/HashJoin.cpp
+++ b/dbms/src/Interpreters/JoinV2/HashJoin.cpp
@@ -479,6 +479,12 @@ void HashJoin::workAfterBuildRowFinish()
         enable_tagged_pointer,
         false);
 
+    profile_info->has_hash_table_stats = method != HashJoinKeyMethod::Cross;
+    profile_info->hash_table_rows = all_build_row_count;
+    profile_info->hash_table_bytes = pointer_table.getMemoryUsage();
+    for (const auto & container : multi_row_containers)
+        profile_info->hash_table_bytes += container->memoryUsage();
+
     /// Conservative threshold: trigger late materialization when lm_row_size average >= 16 bytes.
     constexpr size_t trigger_lm_row_size_threshold = 16;
     bool late_materialization = false;

--- a/dbms/src/Interpreters/JoinV2/HashJoin.cpp
+++ b/dbms/src/Interpreters/JoinV2/HashJoin.cpp
@@ -479,11 +479,15 @@ void HashJoin::workAfterBuildRowFinish()
         enable_tagged_pointer,
         false);
 
-    profile_info->has_hash_table_stats = method != HashJoinKeyMethod::Cross;
-    profile_info->hash_table_rows = all_build_row_count;
-    profile_info->hash_table_bytes = pointer_table.getMemoryUsage();
-    for (const auto & container : multi_row_containers)
-        profile_info->hash_table_bytes += container->memoryUsage();
+    if (method != HashJoinKeyMethod::Cross)
+    {
+        HashTableStats hash_table_stats;
+        hash_table_stats.row_count = all_build_row_count;
+        hash_table_stats.bytes = pointer_table.getMemoryUsage();
+        for (const auto & container : multi_row_containers)
+            hash_table_stats.bytes += container->memoryUsage();
+        profile_info->hash_table_stats = hash_table_stats;
+    }
 
     /// Conservative threshold: trigger late materialization when lm_row_size average >= 16 bytes.
     constexpr size_t trigger_lm_row_size_threshold = 16;

--- a/dbms/src/Interpreters/JoinV2/HashJoin.cpp
+++ b/dbms/src/Interpreters/JoinV2/HashJoin.cpp
@@ -482,12 +482,12 @@ void HashJoin::workAfterBuildRowFinish()
     if (method != HashJoinKeyMethod::Cross)
     {
         HashTableStats hash_table_stats;
-        /// By design, V2 reports build-side rows in the protocol `ndv` field: the pointer table does
-        /// not track distinct hash keys.
-        hash_table_stats.ndv = all_build_row_count;
-        hash_table_stats.bytes = pointer_table.getMemoryUsage();
+        /// V2 reports build-side rows because the pointer table does not track distinct hash keys.
+        hash_table_stats.size = all_build_row_count;
+        hash_table_stats.size_kind = HashTableSizeKind::BuildRowCount;
+        hash_table_stats.memory_bytes = pointer_table.getMemoryUsage();
         for (const auto & container : multi_row_containers)
-            hash_table_stats.bytes += container->memoryUsage();
+            hash_table_stats.memory_bytes += container->memoryUsage();
         profile_info->setHashTableStats(hash_table_stats);
     }
 

--- a/dbms/src/Interpreters/JoinV2/HashJoin.cpp
+++ b/dbms/src/Interpreters/JoinV2/HashJoin.cpp
@@ -486,7 +486,7 @@ void HashJoin::workAfterBuildRowFinish()
         hash_table_stats.bytes = pointer_table.getMemoryUsage();
         for (const auto & container : multi_row_containers)
             hash_table_stats.bytes += container->memoryUsage();
-        profile_info->hash_table_stats = hash_table_stats;
+        profile_info->setHashTableStats(hash_table_stats);
     }
 
     /// Conservative threshold: trigger late materialization when lm_row_size average >= 16 bytes.

--- a/dbms/src/Interpreters/JoinV2/HashJoin.cpp
+++ b/dbms/src/Interpreters/JoinV2/HashJoin.cpp
@@ -482,7 +482,7 @@ void HashJoin::workAfterBuildRowFinish()
     if (method != HashJoinKeyMethod::Cross)
     {
         HashTableStats hash_table_stats;
-        hash_table_stats.row_count = all_build_row_count;
+        hash_table_stats.ndv = all_build_row_count;
         hash_table_stats.bytes = pointer_table.getMemoryUsage();
         for (const auto & container : multi_row_containers)
             hash_table_stats.bytes += container->memoryUsage();

--- a/dbms/src/Interpreters/JoinV2/HashJoin.cpp
+++ b/dbms/src/Interpreters/JoinV2/HashJoin.cpp
@@ -482,6 +482,8 @@ void HashJoin::workAfterBuildRowFinish()
     if (method != HashJoinKeyMethod::Cross)
     {
         HashTableStats hash_table_stats;
+        /// By design, V2 reports build-side rows in the protocol `ndv` field: the pointer table does
+        /// not track distinct hash keys.
         hash_table_stats.ndv = all_build_row_count;
         hash_table_stats.bytes = pointer_table.getMemoryUsage();
         for (const auto & container : multi_row_containers)

--- a/dbms/src/Interpreters/JoinV2/HashJoinPointerTable.h
+++ b/dbms/src/Interpreters/JoinV2/HashJoinPointerTable.h
@@ -54,6 +54,10 @@ public:
     }
 
     size_t getPointerTableSize() const { return pointer_table_size; }
+    size_t getMemoryUsage() const
+    {
+        return pointer_table == nullptr ? 0 : pointer_table_size * sizeof(std::atomic<uintptr_t>);
+    }
 
     bool enableProbePrefetch() const { return enable_probe_prefetch; }
     bool enableTaggedPointer() const { return enable_tagged_pointer; }

--- a/dbms/src/Interpreters/JoinV2/HashJoinRowLayout.h
+++ b/dbms/src/Interpreters/JoinV2/HashJoinRowLayout.h
@@ -101,6 +101,21 @@ struct alignas(CPU_CACHE_LINE_SIZE) MultipleRowContainer
     std::vector<RowContainer> column_rows;
     size_t all_row_count = 0;
 
+    size_t memoryUsage() const
+    {
+        size_t ret = column_rows.capacity() * sizeof(RowContainer);
+        for (const auto & row : column_rows)
+        {
+            if (row.data.capacity() > 0)
+                ret += row.data.allocated_bytes();
+            if (row.offsets.capacity() > 0)
+                ret += row.offsets.allocated_bytes();
+            if (row.hashes.capacity() > 0)
+                ret += row.hashes.allocated_bytes();
+        }
+        return ret;
+    }
+
     size_t build_table_index = 0;
     size_t scan_table_index = 0;
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #11075

Problem Summary:

TiDB needs hash table runtime statistics from TiFlash HashJoin operators, including the cardinality measure available from the active hash join implementation and memory usage.

### What is changed and how it works?

- Report `size`, `size_kind`, and `memory_bytes` through TiFlash execution summaries for HashJoin V1 and HashJoin V2.
- `size_kind` lets TiDB interpret `size` correctly:
  - HashJoin V1 reports `DISTINCT_KEY_COUNT`, the number of distinct hash-table entries.
  - HashJoin V2 reports `BUILD_ROW_COUNT`, because its pointer table does not maintain a distinct-key count.
- Serialize and deserialize the hash table stats in execution summaries, preserving the size kind while merging MPP-task summaries.
- Preserve valid V1 stats after spill by excluding released partitions and merging the final in-memory hash tables built by restore joins.
- Add unit coverage for V1/V2 execution summaries, multiple joins, and the V1 spill path.

```commit-message
executor: report hash table stats to TiDB
```

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```