### PR TITLE
ddl: Handle materialized view DDL actions in TiFlash

### DIFF
--- a/dbms/src/TiDB/Schema/SchemaBuilder.cpp
+++ b/dbms/src/TiDB/Schema/SchemaBuilder.cpp
@@ -295,11 +295,23 @@ void SchemaBuilder<Getter, NameMapper>::applyDiff(const SchemaDiff & diff)
         break;
     }
     case SchemaActionType::CreateTable:
+    // In TiDB metadata, CREATE MATERIALIZED VIEW/VIEW LOG creates physical TableInfo entries.
+    // So in TiFlash schema sync, these actions follow the same path as CreateTable.
+    case SchemaActionType::ActionCreateMaterializedViewLog:
+    case SchemaActionType::ActionCreateMaterializedView:
     {
         /// Because we can't ensure set tiflash replica is earlier than insert,
         /// so we have to update table_id_map when create table.
         /// the table will not be created physically here.
         applyCreateTable(diff.schema_id, diff.table_id, magic_enum::enum_name(diff.type));
+        break;
+    }
+    case SchemaActionType::ActionAlterMaterializedViewRefresh:
+    case SchemaActionType::ActionAlterMaterializedViewLogPurge:
+    case SchemaActionType::ActionAlterMaterializedViewAttributes:
+    {
+        // Materialized view alter actions only change metadata in TiDB.
+        // No schema update is needed for TiFlash local storage.
         break;
     }
     case SchemaActionType::RecoverTable:
@@ -309,6 +321,8 @@ void SchemaBuilder<Getter, NameMapper>::applyDiff(const SchemaDiff & diff)
     }
     case SchemaActionType::DropTable:
     case SchemaActionType::DropView:
+    case SchemaActionType::ActionDropMaterializedViewLog:
+    case SchemaActionType::ActionDropMaterializedView:
     {
         applyDropTable(diff.schema_id, diff.table_id, magic_enum::enum_name(diff.type));
         break;

--- a/dbms/src/TiDB/Schema/SchemaGetter.h
+++ b/dbms/src/TiDB/Schema/SchemaGetter.h
@@ -108,11 +108,25 @@ enum class SchemaActionType : Int8
     ActionAlterTableMode = 75,
     ActionRefreshMeta = 76,
     ActionModifySchemaReadOnly = 77,
+    ActionAlterTableAffinity = 78,
+    ActionAlterTableSoftDeleteInfo = 79,
+    ActionModifySchemaSoftDeleteAndActiveActive = 80,
+    ActionCreateMaskingPolicy = 81,
+    ActionAlterMaskingPolicy = 82,
+    ActionDropMaskingPolicy = 83,
+    ActionAlterTableSetRegionSplitPolicy = 84,
+    ActionCreateMaterializedViewLog = 85,
+    ActionCreateMaterializedView = 86,
+    ActionDropMaterializedViewLog = 87,
+    ActionDropMaterializedView = 88,
+    ActionAlterMaterializedViewRefresh = 89,
+    ActionAlterMaterializedViewLogPurge = 90,
+    ActionAlterMaterializedViewAttributes = 91,
 
     // If we support new type from TiDB.
     // MaxRecognizedType also needs to be changed.
     // It should always be equal to the maximum supported type + 1
-    MaxRecognizedType = 78,
+    MaxRecognizedType = 92,
 };
 
 struct AffectedOption


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10757

Problem Summary:

TiDB master has introduced dedicated materialized view DDL action types. TiFlash schema sync must recognize these actions so materialized view and materialized view log storage lifecycle stays synchronized with TiDB.

### What is changed and how it works?

```commit-message
ddl: Handle materialized view DDL actions in TiFlash
```

- Align `SchemaActionType` values with TiDB master through the materialized view DDL actions.
- Handle materialized view and materialized view log creation through the existing `CreateTable` schema-sync path.
- Handle materialized view and materialized view log drops through the existing `DropTable` path, including tombstone and later physical GC handling.
- Ignore materialized view refresh, materialized view log purge, and materialized view attribute changes because they only update TiDB metadata and do not require a local TiFlash schema change.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Verified with:

```
cmake --build cmake-build-debug --target gtests_dbms -j 16
cmake-build-debug/dbms/gtests_dbms --gtest_filter='SchemaSyncTest.SchemaDiff:SchemaSyncTest.PhysicalDropTable:SchemaSyncTest.PhysicalDropTableMeetsUnRemovedRegions:SchemaSyncTest.SyncDroppedTableSchemaAfterDropBeforeStorageCreated'
```

All 4 selected tests passed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing TiDB materialized view creation and deletion schema changes.
  * Materialized views are now reflected in the schema alongside related table and view updates.
  * Added recognition for additional TiDB schema operations, including affinity, soft-delete, masking policy, and region split policy changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->