### PR TITLE
Support _tidb_commit_ts for tiflash in next-gen and next-gen-columnar

### DIFF
--- a/dbms/src/Flash/Coprocessor/GenSchemaAndColumn.cpp
+++ b/dbms/src/Flash/Coprocessor/GenSchemaAndColumn.cpp
@@ -13,17 +13,49 @@
 // limitations under the License.
 
 #include <DataStreams/GeneratedColumnPlaceholderBlockInputStream.h>
+#include <DataTypes/DataTypeFactory.h>
+#include <DataTypes/DataTypeNullable.h>
+#include <Flash/Coprocessor/CodecUtils.h>
+#include <Flash/Coprocessor/DAGCodec.h>
+#include <Flash/Coprocessor/DAGUtils.h>
 #include <Flash/Coprocessor/GenSchemaAndColumn.h>
+#include <IO/Buffer/WriteBufferFromString.h>
 #include <Storages/DeltaMerge/DeltaMergeDefines.h>
 #include <Storages/MutableSupport.h>
 #include <TiDB/Decode/TypeMapping.h>
 #include <TiDB/Schema/TiDB.h>
+
+#include <unordered_map>
 
 
 namespace DB
 {
 namespace
 {
+void remapColumnRefsForLateMaterialization(
+    tipb::Expr & expr,
+    const std::vector<TiDB::ColumnInfo> & scan_columns,
+    const std::unordered_map<ColumnID, size_t> & early_column_indexes)
+{
+    if (expr.tp() == tipb::ExprType::ColumnRef)
+    {
+        const auto column_id = getStorageColumnIDForColumnarRead(getColumnIDForColumnExpr(expr, scan_columns));
+        const auto it = early_column_indexes.find(column_id);
+        if (it == early_column_indexes.end())
+            throw Exception(
+                ErrorCodes::LOGICAL_ERROR,
+                "Late-materialization predicate column {} is absent from the early projection",
+                column_id);
+
+        WriteBufferFromOwnString buffer;
+        encodeDAGInt64(static_cast<Int64>(it->second), buffer);
+        expr.set_val(buffer.releaseStr());
+    }
+
+    for (int i = 0; i < expr.children_size(); ++i)
+        remapColumnRefsForLateMaterialization(*expr.mutable_children(i), scan_columns, early_column_indexes);
+}
+
 DataTypePtr getPkType(const TiDB::ColumnInfo & column_info)
 {
     const auto & pk_data_type = getDataTypeByColumnInfoForComputingLayer(column_info);
@@ -136,7 +168,10 @@ std::tuple<DM::ColumnDefinesPtr, int, std::vector<std::tuple<UInt64, String, Dat
             break;
         }
         case MutSup::extra_commit_ts_col_id:
-            throw Exception("Not supported in disaggregated read now");
+            // Read the MVCC version using its storage ID and type. The computing
+            // layer casts it to the type requested by TiDB after the scan.
+            column_defines->emplace_back(MutSup::version_col_id, output_name, MutSup::getVersionColumnType());
+            break;
         default:
             column_defines->emplace_back(DM::ColumnDefine{
                 column_info.id,
@@ -147,6 +182,105 @@ std::tuple<DM::ColumnDefinesPtr, int, std::vector<std::tuple<UInt64, String, Dat
         }
     }
     return {std::move(column_defines), extra_table_id_index, std::move(generated_column_infos)};
+}
+
+google::protobuf::RepeatedPtrField<tipb::Expr> remapColumnarFilterConditions(
+    const google::protobuf::RepeatedPtrField<tipb::Expr> & filter_conditions,
+    const TiDB::ColumnInfos & scan_columns,
+    const Block & early_block)
+{
+    std::unordered_map<ColumnID, size_t> early_column_indexes;
+    early_column_indexes.reserve(early_block.columns());
+    for (size_t index = 0; index < early_block.columns(); ++index)
+    {
+        const auto [it, inserted] = early_column_indexes.emplace(early_block.getByPosition(index).column_id, index);
+        if (!inserted)
+            throw Exception(
+                ErrorCodes::LOGICAL_ERROR,
+                "Late-materialization early projection contains duplicate column ID {} at indexes {} and {}",
+                it->first,
+                it->second,
+                index);
+    }
+
+    auto conditions = filter_conditions;
+    for (int i = 0; i < conditions.size(); ++i)
+        remapColumnRefsForLateMaterialization(*conditions.Mutable(i), scan_columns, early_column_indexes);
+    return conditions;
+}
+
+ColumnID getStorageColumnIDForColumnarRead(ColumnID column_id)
+{
+    return column_id == MutSup::extra_commit_ts_col_id ? MutSup::version_col_id : column_id;
+}
+
+tipb::Executor genTableScanForColumnarRead(const TiDBTableScan & table_scan)
+{
+    auto executor = *table_scan.getTableScanPB();
+    auto * columns = table_scan.isPartitionTableScan() ? executor.mutable_partition_table_scan()->mutable_columns()
+                                                       : executor.mutable_tbl_scan()->mutable_columns();
+    // ColumnRef offsets stay unchanged; only the IDs used by storage filters change.
+    for (auto & column : *columns)
+        column.set_column_id(getStorageColumnIDForColumnarRead(column.column_id()));
+    return executor;
+}
+
+tipb::TableInfo genTableInfoForColumnarRead(const TiDBTableScan & table_scan)
+{
+    tipb::TableInfo table_info;
+    bool needs_version = false;
+    bool has_handle = false;
+    const auto & columns = table_scan.isPartitionTableScan()
+        ? table_scan.getTableScanPB()->partition_table_scan().columns()
+        : table_scan.getTableScanPB()->tbl_scan().columns();
+    for (int i = 0; i < columns.size(); ++i)
+    {
+        const auto & column = columns[i];
+        if (table_scan.getColumns()[i].hasGeneratedColumnFlag() || column.column_id() == MutSup::extra_table_id_col_id)
+            continue;
+        if (column.column_id() == MutSup::extra_commit_ts_col_id)
+        {
+            needs_version = true;
+            continue;
+        }
+        *table_info.add_columns() = column;
+        has_handle |= column.column_id() == MutSup::extra_handle_id || column.pk_handle();
+    }
+    if (needs_version && !has_handle)
+    {
+        // CSE pack clean reads synthesize dummy handles AND versions when neither
+        // is requested. Request the handle to require real MVCC buffers. CSE uses
+        // the stored handle schema (including common handles) for this system ID;
+        // this dependency is not added to the TiFlash output columns.
+        auto * handle = table_info.add_columns();
+        handle->set_column_id(MutSup::extra_handle_id);
+        handle->set_tp(TiDB::TypeLongLong);
+        handle->set_flag(TiDB::ColumnFlagNotNull);
+    }
+    return table_info;
+}
+
+std::tuple<DM::ColumnDefinesPtr, int> genColumnDefinesForDisaggregatedReadThroughColumnar(
+    const TiDBTableScan & table_scan)
+{
+    auto [column_defines, extra_table_id_index, generated_column_infos]
+        = genColumnDefinesForDisaggregatedRead(table_scan);
+    for (auto & column : *column_defines)
+    {
+        if (column.id == MutSup::version_col_id)
+        {
+            // CSE's version buffer is nullable: the null map represents tombstones.
+            // MVCC removes them, but the FFI wire format still includes the null map.
+            column.type = makeNullable(MutSup::getVersionColumnType());
+        }
+        else
+        {
+            const auto & converted_type = CodecUtils::convertDataType(*column.type);
+            if (&converted_type != column.type.get())
+                column.type = DataTypeFactory::instance().getOrSet(converted_type.getName());
+        }
+    }
+    return {std::move(column_defines), extra_table_id_index};
 }
 
 ColumnsWithTypeAndName getColumnWithTypeAndName(const NamesAndTypes & names_and_types)

--- a/dbms/src/Flash/Coprocessor/GenSchemaAndColumn.h
+++ b/dbms/src/Flash/Coprocessor/GenSchemaAndColumn.h
@@ -38,4 +38,17 @@ NamesAndTypes toNamesAndTypes(const DAGSchema & dag_schema);
 std::tuple<DM::ColumnDefinesPtr, int, std::vector<std::tuple<UInt64, String, DataTypePtr>>> genColumnDefinesForDisaggregatedRead(
     const TiDBTableScan & table_scan);
 
+// Map filters against the original storage projection, before casts discard column IDs.
+google::protobuf::RepeatedPtrField<tipb::Expr> remapColumnarFilterConditions(
+    const google::protobuf::RepeatedPtrField<tipb::Expr> & filter_conditions,
+    const TiDB::ColumnInfos & scan_columns,
+    const Block & early_block);
+
+// Columnar keeps MVCC versions outside its business-column schema.
+ColumnID getStorageColumnIDForColumnarRead(ColumnID column_id);
+tipb::Executor genTableScanForColumnarRead(const TiDBTableScan & table_scan);
+tipb::TableInfo genTableInfoForColumnarRead(const TiDBTableScan & table_scan);
+std::tuple<DM::ColumnDefinesPtr, int> genColumnDefinesForDisaggregatedReadThroughColumnar(
+    const TiDBTableScan & table_scan);
+
 } // namespace DB

--- a/dbms/src/Storages/StorageDisaggregated.cpp
+++ b/dbms/src/Storages/StorageDisaggregated.cpp
@@ -224,7 +224,8 @@ ExpressionActionsPtr StorageDisaggregated::getExtraCastExpr(
     {
         if (col.hasGeneratedColumnFlag() || col.id == -1)
             continue;
-        if ((need_timezone_cast && col.tp == TiDB::TypeTimestamp) || col.tp == TiDB::TypeTime)
+        if ((need_timezone_cast && col.tp == TiDB::TypeTimestamp) || col.tp == TiDB::TypeTime
+            || col.id == MutSup::extra_commit_ts_col_id)
         {
             has_cast_candidate = true;
             break;

--- a/dbms/src/Storages/StorageDisaggregatedColumnar.cpp
+++ b/dbms/src/Storages/StorageDisaggregatedColumnar.cpp
@@ -207,30 +207,6 @@ void checkRustStrWithView(const RustStrWithView & value, const char * function_n
         throw Exception(ErrorCodes::LOGICAL_ERROR, "{} returned a default RustStrWithView", function_name);
 }
 
-void remapColumnRefsForLateMaterialization(
-    tipb::Expr & expr,
-    const std::vector<TiDB::ColumnInfo> & scan_columns,
-    const std::unordered_map<ColumnID, size_t> & early_column_indexes)
-{
-    if (expr.tp() == tipb::ExprType::ColumnRef)
-    {
-        const auto column_id = getColumnIDForColumnExpr(expr, scan_columns);
-        const auto it = early_column_indexes.find(column_id);
-        if (it == early_column_indexes.end())
-            throw Exception(
-                ErrorCodes::LOGICAL_ERROR,
-                "Late-materialization predicate column {} is absent from the early projection",
-                column_id);
-
-        WriteBufferFromOwnString buffer;
-        encodeDAGInt64(static_cast<Int64>(it->second), buffer);
-        expr.set_val(buffer.releaseStr());
-    }
-
-    for (int i = 0; i < expr.children_size(); ++i)
-        remapColumnRefsForLateMaterialization(*expr.mutable_children(i), scan_columns, early_column_indexes);
-}
-
 void normalizeTimestampCompareDateTimeLiteralToUTC(tipb::Expr & expr, const TimezoneInfo & timezone_info);
 
 struct BucketSplitResult
@@ -423,29 +399,6 @@ std::vector<std::tuple<UInt64, String, DataTypePtr>> genGeneratedColumnInfosForD
     return generated_column_infos;
 }
 
-std::tuple<DM::ColumnDefinesPtr, int> genColumnDefinesForDisaggregatedReadThroughColumnar(
-    const TiDBTableScan & table_scan)
-{
-    DM::ColumnDefinesPtr column_defines;
-    int extra_table_id_index;
-    std::vector<std::tuple<UInt64, String, DataTypePtr>> generated_column_infos;
-    std::tie(column_defines, extra_table_id_index, generated_column_infos)
-        = genColumnDefinesForDisaggregatedRead(table_scan);
-
-    // Columnar only support the legacy string format for now, so convert the data type to legacy one.
-    // We can remove this when columnar supports the new string data type.
-    for (auto & cd : *column_defines)
-    {
-        const auto & converted_type = CodecUtils::convertDataType(*cd.type);
-        if (&converted_type != cd.type.get())
-            cd.type = DataTypeFactory::instance().getOrSet(converted_type.getName());
-    }
-
-    // genColumnDefinesForDisaggregatedRead already skips generated columns.
-    // executeGeneratedColumnPlaceholder fills virtual columns later in the pipeline.
-    return {std::move(column_defines), extra_table_id_index};
-}
-
 std::shared_ptr<RNColumnarReaderSharedContext> buildColumnarReaderSharedContext(
     const LoggerPtr & log,
     const Context & context,
@@ -473,7 +426,7 @@ std::shared_ptr<RNColumnarReaderSharedContext> buildColumnarReaderSharedContext(
         = genColumnDefinesForDisaggregatedReadThroughColumnar(table_scan);
     shared_context->scan_columns = table_scan.getColumns();
 
-    auto table_scan_pb = *table_scan.getTableScanPB();
+    auto table_scan_pb = genTableScanForColumnarRead(table_scan);
     const auto & timezone_info = context.getTimezoneInfo();
     if (table_scan_pb.tp() == tipb::TypePartitionTableScan)
     {
@@ -507,37 +460,7 @@ std::shared_ptr<RNColumnarReaderSharedContext> buildColumnarReaderSharedContext(
     shared_context->has_pushed_down_filter_conditions = !pushed_down_filters.empty();
     shared_context->exact_filter_conditions.MergeFrom(pushed_down_filters);
 
-    tipb::TableInfo table_info;
-    bool is_partition_scan = table_scan.isPartitionTableScan();
-    const auto & tidb_columns = table_scan.getColumns();
-    const auto should_skip_column_for_columnar_table_info = [&](ColumnID column_id) {
-        if (column_id == MutSup::extra_table_id_col_id)
-            return true;
-        for (const auto & ci : tidb_columns)
-        {
-            if (ci.id == column_id && ci.hasGeneratedColumnFlag())
-                return true;
-        }
-        return false;
-    };
-    if (is_partition_scan)
-    {
-        for (const auto & column : table_scan_pb.partition_table_scan().columns())
-        {
-            if (should_skip_column_for_columnar_table_info(column.column_id()))
-                continue;
-            *table_info.add_columns() = column;
-        }
-    }
-    else
-    {
-        for (const auto & column : table_scan_pb.tbl_scan().columns())
-        {
-            if (should_skip_column_for_columnar_table_info(column.column_id()))
-                continue;
-            *table_info.add_columns() = column;
-        }
-    }
+    const auto table_info = genTableInfoForColumnarRead(table_scan);
     shared_context->table_info_data = table_info.SerializeAsString();
     shared_context->ann_query_info_data = table_scan.getANNQueryInfo().SerializeAsString();
     shared_context->fts_query_info_data = table_scan.getFTSQueryInfo().SerializeAsString();
@@ -992,6 +915,11 @@ const DM::ColumnDefines & RNColumnarReadTask::getColumnsToRead() const
     return *shared_reader_context->column_defines;
 }
 
+const TiDB::ColumnInfos & RNColumnarReadTask::getScanColumns() const
+{
+    return shared_reader_context->scan_columns;
+}
+
 int RNColumnarReadTask::getExtraTableIDIndex() const
 {
     return shared_reader_context->extra_table_id_index;
@@ -1010,27 +938,10 @@ const String & RNColumnarReadTask::getExecutorID() const
 google::protobuf::RepeatedPtrField<tipb::Expr> RNColumnarReadTask::getLateMaterializationFilterConditions(
     const Block & early_block) const
 {
-    std::unordered_map<ColumnID, size_t> early_column_indexes;
-    early_column_indexes.reserve(early_block.columns());
-    for (size_t index = 0; index < early_block.columns(); ++index)
-    {
-        const auto [it, inserted] = early_column_indexes.emplace(early_block.getByPosition(index).column_id, index);
-        if (!inserted)
-            throw Exception(
-                ErrorCodes::LOGICAL_ERROR,
-                "Late-materialization early projection contains duplicate column ID {} at indexes {} and {}",
-                it->first,
-                it->second,
-                index);
-    }
-
-    auto conditions = shared_reader_context->exact_filter_conditions;
-    for (int i = 0; i < conditions.size(); ++i)
-        remapColumnRefsForLateMaterialization(
-            *conditions.Mutable(i),
-            shared_reader_context->scan_columns,
-            early_column_indexes);
-    return conditions;
+    return remapColumnarFilterConditions(
+        shared_reader_context->exact_filter_conditions,
+        shared_reader_context->scan_columns,
+        early_block);
 }
 
 std::unordered_set<ColumnID> RNColumnarReadTask::getExactFilterColumnIDs() const
@@ -1044,6 +955,7 @@ std::unordered_set<ColumnID> RNColumnarReadTask::getExactFilterColumnIDs() const
 std::unordered_set<ColumnID> RNColumnarReadTask::getLateMaterializationEarlyColumnIDs() const
 {
     auto column_ids = getExactFilterColumnIDs();
+    column_ids.erase(MutSup::extra_commit_ts_col_id);
     column_ids.insert(MutSup::extra_handle_id);
     column_ids.insert(MutSup::version_col_id);
     for (const auto & column : shared_reader_context->scan_columns)
@@ -1742,6 +1654,7 @@ void RNColumnarInputStream::releaseReader()
     current_reader_work.reset();
     late_materialization_interfaces = nullptr;
     late_materialization_filter_action.reset();
+    late_materialization_extra_cast.reset();
     late_materialization_initialized = false;
     late_materialization_probed = false;
 }
@@ -1901,7 +1814,42 @@ Block RNColumnarInputStream::readLateMaterializedBlock()
         for (const auto & column : filter_header)
             early_names_and_types.emplace_back(column.name, column.type);
         DAGExpressionAnalyzer lm_analyzer(std::move(early_names_and_types), context);
-        auto filter_conditions = task->getLateMaterializationFilterConditions(filter_header);
+        // The early projection still uses the FFI Nullable(UInt64) version type.
+        // Cast commit_ts before evaluating predicates, keeping the original early
+        // block for materializing the selected output rows.
+        TiDB::ColumnInfos early_column_infos;
+        std::vector<UInt8> need_cast;
+        for (const auto & column : filter_header)
+        {
+            const auto & scan_columns = task->getScanColumns();
+            const auto it = std::find_if(scan_columns.begin(), scan_columns.end(), [&](const auto & info) {
+                return getStorageColumnIDForColumnarRead(info.id) == column.column_id;
+            });
+            RUNTIME_CHECK(it != scan_columns.end(), column.column_id);
+            early_column_infos.push_back(*it);
+            need_cast.push_back(it->id == MutSup::extra_commit_ts_col_id);
+        }
+        ExpressionActionsChain cast_chain;
+        auto & cast_step = lm_analyzer.initAndGetLastStep(cast_chain);
+        auto [has_cast, casted_columns]
+            = lm_analyzer.buildExtraCastsAfterTS(cast_step.actions, need_cast, early_column_infos);
+        if (has_cast)
+        {
+            NamesWithAliases projection;
+            for (size_t i = 0; i < filter_header.columns(); ++i)
+            {
+                const auto & name = filter_header.getByPosition(i).name;
+                projection.emplace_back(casted_columns[i], name);
+                cast_step.required_output.push_back(name);
+            }
+            cast_step.actions->add(ExpressionAction::project(projection));
+            late_materialization_extra_cast = cast_chain.getLastActions();
+            cast_chain.finalize();
+            late_materialization_extra_cast->execute(filter_header);
+        }
+        // Cast results have no storage column ID. Use the original projection
+        // for ID-to-offset mapping; the cast projection preserves its order.
+        auto filter_conditions = task->getLateMaterializationFilterConditions(early_block);
         auto filter_actions = lm_analyzer.buildPushDownFilter(filter_conditions, true);
         late_materialization_filter_action = std::make_unique<FilterTransformAction>(
             filter_header,
@@ -1910,6 +1858,8 @@ Block RNColumnarInputStream::readLateMaterializedBlock()
     }
     auto & filter_action = *late_materialization_filter_action;
     Block evaluation_block = early_block;
+    if (late_materialization_extra_cast)
+        late_materialization_extra_cast->execute(evaluation_block);
     FilterPtr selection = nullptr;
     bool any_selected = !filter_action.alwaysFalse();
     if (any_selected)
@@ -2113,8 +2063,11 @@ Block RNColumnarInputStream::readLegacyBlock(const TiFlashRaftProxyHelper * prox
         else
         {
             (void)w.elapsedSecondsFromLastTime();
-            RustStrWithView col_data
-                = proxy_helper->cloud_storage_engine_interfaces.fn_read_column(reader.value(), col_id);
+            // MVCC versions live in a separate buffer, not in the business columns.
+            const auto & interfaces = proxy_helper->cloud_storage_engine_interfaces;
+            RustStrWithView col_data = col_id == MutSup::version_col_id
+                ? interfaces.fn_read_version(reader.value())
+                : interfaces.fn_read_column(reader.value(), col_id);
             duration_read_sec += w.elapsedSecondsFromLastTime();
             SCOPE_EXIT({ RustGcHelper::instance().gcRustPtr(col_data.inner.ptr, col_data.inner.type); });
             physical_table_id = proxy_helper->cloud_storage_engine_interfaces.fn_physical_table_id(reader.value());

--- a/dbms/src/Storages/StorageDisaggregatedColumnar.h
+++ b/dbms/src/Storages/StorageDisaggregatedColumnar.h
@@ -149,6 +149,7 @@ public:
     const LoggerPtr & getLog() const;
 
     const DM::ColumnDefines & getColumnsToRead() const;
+    const TiDB::ColumnInfos & getScanColumns() const;
 
     int getExtraTableIDIndex() const;
 
@@ -255,6 +256,7 @@ private:
     const String executor_id;
     Block header;
     const ColumnarLateMaterializationInterfaces * late_materialization_interfaces = nullptr;
+    ExpressionActionsPtr late_materialization_extra_cast;
     std::unique_ptr<FilterTransformAction> late_materialization_filter_action;
     bool late_materialization_initialized = false;
     bool late_materialization_probed = false;

--- a/dbms/src/Storages/tests/gtest_hidden_commit_ts_column.cpp
+++ b/dbms/src/Storages/tests/gtest_hidden_commit_ts_column.cpp
@@ -12,13 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <DataStreams/BlocksListBlockInputStream.h>
 #include <Flash/Coprocessor/DAGCodec.h>
+#include <Flash/Coprocessor/DAGContext.h>
 #include <Flash/Coprocessor/DAGExpressionAnalyzer.h>
 #include <Flash/Coprocessor/DAGQueryInfo.h>
 #include <Flash/Coprocessor/DAGUtils.h>
+#include <Flash/Coprocessor/GenSchemaAndColumn.h>
 #include <Functions/registerFunctions.h>
+#include <IO/Buffer/ReadBufferFromMemory.h>
 #include <IO/Buffer/WriteBufferFromString.h>
+#include <IO/WriteHelpers.h>
 #include <Interpreters/Context.h>
+#include <Storages/DeltaMerge/DMVersionFilterBlockInputStream.h>
 #include <Storages/DeltaMerge/DeltaMergeDefines.h>
 #include <Storages/DeltaMerge/Filter/PushDownExecutor.h>
 #include <Storages/DeltaMerge/Filter/RSOperator.h>
@@ -51,6 +57,326 @@ protected:
     LoggerPtr log = Logger::get();
     ContextPtr ctx = TiFlashTestEnv::getContext();
 };
+
+TEST_F(HiddenCommitTSColumnTest, DisaggregatedReadCommitTS)
+try
+{
+    for (bool partition_scan : {false, true})
+    {
+        for (UInt32 flags : {static_cast<UInt32>(0), static_cast<UInt32>(TiDB::ColumnFlagNotNull | TiDB::ColumnFlagUnsigned)})
+        {
+            SCOPED_TRACE(fmt::format("partition_scan={} flags={}", partition_scan, flags));
+            tipb::Executor executor;
+            executor.set_tp(partition_scan ? tipb::TypePartitionTableScan : tipb::TypeTableScan);
+            auto * columns = partition_scan ? executor.mutable_partition_table_scan()->mutable_columns()
+                                            : executor.mutable_tbl_scan()->mutable_columns();
+            if (partition_scan)
+                executor.mutable_partition_table_scan()->set_table_id(100);
+            else
+                executor.mutable_tbl_scan()->set_table_id(100);
+            auto * handle = columns->Add();
+            handle->set_column_id(MutSup::extra_handle_id);
+            handle->set_tp(TiDB::TypeLongLong);
+            handle->set_flag(TiDB::ColumnFlagNotNull);
+            auto * commit_ts = columns->Add();
+            commit_ts->set_column_id(MutSup::extra_commit_ts_col_id);
+            commit_ts->set_tp(TiDB::TypeLongLong);
+            commit_ts->set_flag(flags);
+            auto * table_id = columns->Add();
+            table_id->set_column_id(MutSup::extra_table_id_col_id);
+            table_id->set_tp(TiDB::TypeLongLong);
+            table_id->set_flag(TiDB::ColumnFlagNotNull);
+
+            DAGContext dag_context(1024);
+            TiDBTableScan table_scan(&executor, "table_scan", dag_context);
+            auto [column_defines, extra_table_id_index, generated_columns]
+                = genColumnDefinesForDisaggregatedRead(table_scan);
+            ASSERT_EQ(column_defines->size(), 2);
+            EXPECT_EQ(extra_table_id_index, 2);
+            EXPECT_TRUE(generated_columns.empty());
+            const auto & version = column_defines->at(1);
+            EXPECT_EQ(version.id, MutSup::version_col_id);
+            EXPECT_EQ(version.name, genNameForExchangeReceiver(1));
+            EXPECT_TRUE(version.type->equals(*MutSup::getVersionColumnType()));
+
+            // Both normal scans and late materialization must preserve the real
+            // version values while converting the exchange receiver column type.
+            const auto & commit_ts_info = table_scan.getColumns()[1];
+            const auto expected_type = getDataTypeByColumnInfoForComputingLayer(commit_ts_info);
+            for (bool pushed_down : {false, true})
+            {
+                SCOPED_TRACE(pushed_down);
+                Block stored_block{
+                    toVec<Int64>(MutSup::extra_handle_column_name, {1, 1, 2, 3, 3, 4}),
+                    toVec<UInt64>(MutSup::version_column_name, {0, 1, 123456789, 456789012, 999999999, 1}),
+                    toVec<UInt8>(MutSup::delmark_column_name, {0, 0, 0, 0, 0, 1}),
+                };
+                stored_block.getByPosition(0).column_id = MutSup::extra_handle_id;
+                stored_block.getByPosition(1).column_id = MutSup::version_col_id;
+                stored_block.getByPosition(2).column_id = MutSup::delmark_col_id;
+                auto input = std::make_shared<BlocksListBlockInputStream>(BlocksList{stored_block});
+                DM::DMVersionFilterBlockInputStream<DM::DMVersionFilterMode::MVCC> stream(
+                    input,
+                    {version},
+                    /*version_limit=*/500000000,
+                    /*is_common_handle=*/false);
+                stream.readPrefix();
+                auto block = stream.read();
+                ASSERT_FALSE(stream.read());
+                stream.readSuffix();
+                ExpressionActionsPtr cast;
+                if (pushed_down)
+                {
+                    google::protobuf::RepeatedPtrField<tipb::Expr> filters;
+                    auto * condition = filters.Add();
+                    condition->set_tp(tipb::ExprType::ColumnRef);
+                    WriteBufferFromOwnString buffer;
+                    encodeDAGInt64(0, buffer);
+                    condition->set_val(buffer.releaseStr());
+                    condition->mutable_field_type()->set_tp(TiDB::TypeLongLong);
+                    condition->mutable_field_type()->set_flag(flags);
+                    auto push_down = DM::PushDownExecutor::build(
+                        DM::EMPTY_RS_OPERATOR,
+                        nullptr,
+#if ENABLE_CLARA
+                        nullptr,
+#endif
+                        {commit_ts_info},
+                        filters,
+                        {version},
+                        nullptr,
+                        *ctx,
+                        log);
+                    ASSERT_TRUE(push_down->filter_columns);
+                    ASSERT_EQ(push_down->filter_columns->size(), 1);
+                    EXPECT_EQ(push_down->filter_columns->at(0).id, MutSup::version_col_id);
+                    EXPECT_EQ(push_down->filter_columns->at(0).name, version.name);
+                    cast = push_down->extra_cast;
+                }
+                else
+                {
+                    DAGExpressionAnalyzer analyzer{block, *ctx};
+                    ExpressionActionsChain chain;
+                    auto & step = analyzer.initAndGetLastStep(chain);
+                    auto [has_cast, casted_columns]
+                        = analyzer.buildExtraCastsAfterTS(step.actions, {1}, {commit_ts_info});
+                    if (has_cast)
+                    {
+                        step.actions->add(
+                            ExpressionAction::project(NamesWithAliases{{casted_columns[0], version.name}}));
+                        step.required_output.push_back(version.name);
+                        cast = chain.getLastActions();
+                        chain.finalize();
+                    }
+                }
+                EXPECT_EQ(bool(cast), !version.type->equals(*expected_type));
+                if (cast)
+                    cast->execute(block);
+                const auto & result = block.getByName(version.name);
+                EXPECT_TRUE(result.type->equals(*expected_type));
+                ASSERT_EQ(result.column->size(), 3);
+                for (size_t i = 0; i < 3; ++i)
+                {
+                    const auto value = (*result.column)[i];
+                    const Int64 actual = flags == 0 ? value.safeGet<Int64>() : value.safeGet<UInt64>();
+                    EXPECT_EQ(actual, (std::vector<Int64>{1, 123456789, 456789012})[i]);
+                }
+            }
+        }
+    }
+}
+CATCH
+
+TEST_F(HiddenCommitTSColumnTest, ColumnarCommitTSRequestAndWireFormat)
+try
+{
+    for (bool partition_scan : {false, true})
+    {
+        for (UInt32 flags :
+             {static_cast<UInt32>(0),
+              static_cast<UInt32>(TiDB::ColumnFlagUnsigned),
+              static_cast<UInt32>(TiDB::ColumnFlagNotNull),
+              static_cast<UInt32>(TiDB::ColumnFlagNotNull | TiDB::ColumnFlagUnsigned)})
+        {
+            SCOPED_TRACE(fmt::format("partition_scan={} flags={}", partition_scan, flags));
+            tipb::Executor executor;
+            executor.set_tp(partition_scan ? tipb::TypePartitionTableScan : tipb::TypeTableScan);
+            auto * columns = partition_scan ? executor.mutable_partition_table_scan()->mutable_columns()
+                                            : executor.mutable_tbl_scan()->mutable_columns();
+            if (partition_scan)
+                executor.mutable_partition_table_scan()->set_table_id(100);
+            else
+                executor.mutable_tbl_scan()->set_table_id(100);
+            auto * commit_ts = columns->Add();
+            commit_ts->set_column_id(MutSup::extra_commit_ts_col_id);
+            commit_ts->set_tp(TiDB::TypeLongLong);
+            commit_ts->set_flag(flags);
+            DAGContext dag_context(1024);
+            TiDBTableScan scan(&executor, "scan", dag_context);
+            auto [defines, table_id_index] = genColumnDefinesForDisaggregatedReadThroughColumnar(scan);
+            ASSERT_EQ(defines->size(), 1);
+            EXPECT_EQ(table_id_index, MutSup::invalid_col_id);
+            const auto & version = defines->front();
+            EXPECT_EQ(version.id, MutSup::version_col_id);
+            EXPECT_EQ(version.name, genNameForExchangeReceiver(0));
+            EXPECT_EQ(version.type->getName(), "Nullable(UInt64)");
+
+            const auto table_info = genTableInfoForColumnarRead(scan);
+            // A version-only projection must still request real MVCC buffers.
+            // Requesting the handle disables CSE's dummy-version pack clean read.
+            ASSERT_EQ(table_info.columns_size(), 1);
+            EXPECT_EQ(table_info.columns(0).column_id(), MutSup::extra_handle_id);
+            const auto storage_scan = genTableScanForColumnarRead(scan);
+            const auto & storage_columns
+                = partition_scan ? storage_scan.partition_table_scan().columns() : storage_scan.tbl_scan().columns();
+            ASSERT_EQ(storage_columns.size(), 1);
+            EXPECT_EQ(storage_columns[0].column_id(), MutSup::version_col_id);
+            EXPECT_EQ(scan.getColumns()[0].id, MutSup::extra_commit_ts_col_id);
+            EXPECT_EQ(getStorageColumnIDForColumnarRead(MutSup::extra_commit_ts_col_id), version.id);
+            EXPECT_EQ(getStorageColumnIDForColumnarRead(42), 42);
+
+            // ffi_read_version serializes a null map followed by UInt64 values.
+            // Visible versions are never null, but their null-map bytes remain.
+            const std::vector<UInt64> timestamps{1, 123456789, 456789012};
+            WriteBufferFromOwnString output;
+            for (size_t i = 0; i < timestamps.size(); ++i)
+                writeBinary(static_cast<UInt32>(0), output);
+            for (auto ts : timestamps)
+                writeBinary(ts, output);
+            const auto bytes = output.releaseStr();
+            ReadBufferFromMemory input(bytes.data(), bytes.size());
+            auto column = version.type->createColumn();
+            version.type->deserializeBinaryBulkWithMultipleStreams(
+                *column,
+                [&](const IDataType::SubstreamPath &) { return &input; },
+                timestamps.size(),
+                -1.0,
+                true,
+                {});
+            EXPECT_TRUE(input.eof());
+            Block block{{std::move(column), version.type, version.name, version.id}};
+            DAGExpressionAnalyzer analyzer{block, *ctx};
+            ExpressionActionsChain chain;
+            if (analyzer.appendExtraCastsAfterTS(chain, {1}, scan))
+            {
+                auto actions = chain.getLastActions();
+                chain.finalize();
+                actions->execute(block);
+            }
+            const auto & result = block.getByName(version.name);
+            EXPECT_TRUE(result.type->equals(*getDataTypeByColumnInfoForComputingLayer(scan.getColumns()[0])));
+            ASSERT_EQ(result.column->size(), timestamps.size());
+            for (size_t i = 0; i < timestamps.size(); ++i)
+            {
+                const auto value = (*result.column)[i];
+                const UInt64 actual
+                    = flags & TiDB::ColumnFlagUnsigned ? value.safeGet<UInt64>() : value.safeGet<Int64>();
+                EXPECT_EQ(actual, timestamps[i]);
+            }
+        }
+    }
+}
+CATCH
+
+TEST_F(HiddenCommitTSColumnTest, ColumnarFilterRemappingUsesStorageProjectionBeforeCast)
+try
+{
+    for (UInt32 flags : {static_cast<UInt32>(0), static_cast<UInt32>(TiDB::ColumnFlagNotNull | TiDB::ColumnFlagUnsigned)})
+    {
+        SCOPED_TRACE(flags);
+        TiDB::ColumnInfo business;
+        business.id = 10;
+        business.tp = TiDB::TypeLongLong;
+        TiDB::ColumnInfo commit_ts;
+        commit_ts.id = MutSup::extra_commit_ts_col_id;
+        commit_ts.tp = TiDB::TypeLongLong;
+        commit_ts.flag = flags;
+        const auto name = genNameForExchangeReceiver(1);
+        Block early_block{{createNullableColumn<UInt64>({0, 11, 22}, {0, 0, 0}, name, MutSup::version_col_id)}};
+
+        google::protobuf::RepeatedPtrField<tipb::Expr> filters;
+        auto * condition = filters.Add();
+        condition->set_tp(tipb::ExprType::ColumnRef);
+        WriteBufferFromOwnString buffer;
+        encodeDAGInt64(1, buffer); // Original scan: business column, commit_ts.
+        condition->set_val(buffer.releaseStr());
+        condition->mutable_field_type()->set_tp(TiDB::TypeLongLong);
+        condition->mutable_field_type()->set_flag(flags);
+
+        DAGExpressionAnalyzer analyzer{early_block, *ctx};
+        ExpressionActionsChain chain;
+        auto & step = analyzer.initAndGetLastStep(chain);
+        auto [has_cast, casted_columns] = analyzer.buildExtraCastsAfterTS(step.actions, {1}, {commit_ts});
+        ASSERT_TRUE(has_cast);
+        step.actions->add(ExpressionAction::project(NamesWithAliases{{casted_columns[0], name}}));
+        step.required_output.push_back(name);
+        auto cast = chain.getLastActions();
+        chain.finalize();
+        Block filter_header = early_block.cloneEmpty();
+        cast->execute(filter_header);
+        ASSERT_EQ(filter_header.getByName(name).column_id, 0);
+        EXPECT_THROW(remapColumnarFilterConditions(filters, {business, commit_ts}, filter_header), DB::Exception);
+
+        // The production path maps offsets using the uncast projection, then
+        // evaluates those offsets against the cast columns in the same order.
+        const auto remapped = remapColumnarFilterConditions(filters, {business, commit_ts}, early_block);
+        EXPECT_EQ(decodeDAGInt64(remapped[0].val()), 0);
+        auto [before_where, filter_name, project] = analyzer.buildPushDownFilter(remapped, true);
+        Block evaluation_block = early_block;
+        cast->execute(evaluation_block);
+        before_where->execute(evaluation_block);
+        const auto & mask = evaluation_block.getByName(filter_name).column;
+        ASSERT_EQ(mask->size(), 3);
+        EXPECT_EQ((*mask)[0].safeGet<UInt64>(), 0);
+        EXPECT_EQ((*mask)[1].safeGet<UInt64>(), 1);
+        EXPECT_EQ((*mask)[2].safeGet<UInt64>(), 1);
+        EXPECT_EQ(early_block.getByName(name).column_id, MutSup::version_col_id);
+        EXPECT_EQ(early_block.getByName(name).type->getName(), "Nullable(UInt64)");
+    }
+}
+CATCH
+
+TEST_F(HiddenCommitTSColumnTest, ColumnarCommitTSMixedProjection)
+try
+{
+    for (bool common_handle : {false, true})
+    {
+        tipb::Executor executor;
+        executor.set_tp(tipb::TypeTableScan);
+        auto * scan_pb = executor.mutable_tbl_scan();
+        scan_pb->set_table_id(100);
+        const std::vector<ColumnID>
+            ids{10, MutSup::extra_commit_ts_col_id, MutSup::extra_table_id_col_id, MutSup::extra_handle_id, 11};
+        for (auto id : ids)
+        {
+            auto * column = scan_pb->add_columns();
+            column->set_column_id(id);
+            column->set_tp(id == MutSup::extra_handle_id && common_handle ? TiDB::TypeVarString : TiDB::TypeLongLong);
+            column->set_flag(TiDB::ColumnFlagNotNull | (id == 10 ? TiDB::ColumnFlagGeneratedColumn : 0));
+        }
+        DAGContext dag_context(1024);
+        TiDBTableScan scan(&executor, "scan", dag_context);
+        const auto table_info = genTableInfoForColumnarRead(scan);
+        ASSERT_EQ(table_info.columns_size(), 2);
+        EXPECT_EQ(table_info.columns(0).column_id(), MutSup::extra_handle_id);
+        EXPECT_EQ(table_info.columns(0).tp(), common_handle ? TiDB::TypeVarString : TiDB::TypeLongLong);
+        EXPECT_EQ(table_info.columns(1).column_id(), 11);
+        auto [defines, table_id_index] = genColumnDefinesForDisaggregatedReadThroughColumnar(scan);
+        ASSERT_EQ(defines->size(), 3);
+        EXPECT_EQ(table_id_index, 2);
+        EXPECT_EQ(defines->at(0).id, MutSup::version_col_id);
+        EXPECT_EQ(defines->at(0).name, genNameForExchangeReceiver(1));
+        EXPECT_EQ(defines->at(1).id, MutSup::extra_handle_id);
+        EXPECT_EQ(defines->at(1).name, genNameForExchangeReceiver(3));
+        EXPECT_EQ(defines->at(2).id, 11);
+        EXPECT_EQ(defines->at(2).name, genNameForExchangeReceiver(4));
+        const auto storage_scan = genTableScanForColumnarRead(scan);
+        ASSERT_EQ(storage_scan.tbl_scan().columns_size(), ids.size());
+        for (size_t i = 0; i < ids.size(); ++i)
+            EXPECT_EQ(storage_scan.tbl_scan().columns(i).column_id(), getStorageColumnIDForColumnarRead(ids[i]));
+    }
+}
+CATCH
 
 TEST_F(HiddenCommitTSColumnTest, PushDownFilterAliasAndCast)
 try


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10733

Problem Summary:

### What is changed and how it works?

```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved disaggregated columnar reads involving hidden commit timestamps and MVCC version data.
  * Added support for late-materialization filters across projected and cast columns.
  * Improved handling of mixed column projections, generated columns, tombstones, and missing handles.

* **Bug Fixes**
  * Corrected commit-timestamp casting and filtering during columnar reads.
  * Fixed legacy reads to retrieve MVCC version values correctly.

* **Tests**
  * Added coverage for hidden commit timestamps, columnar wire formats, filter remapping, and mixed projections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->